### PR TITLE
iOS: Unified Input attachment follow-up

### DIFF
--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalletes/DefaultColorPalette.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalletes/DefaultColorPalette.swift
@@ -46,6 +46,9 @@ struct DefaultColorPalette: ColorPaletteDefinition {
     private static let x4D4D4D = Color(0x4D4D4D)
     private static let x1C1C1C = Color(0x1C1C1C)
     private static let x7295F6 = Color(0x7295F6)
+    private static let xF6CDD1 = Color(0xF6CDD1)
+    private static let x5A2A2A = Color(0x5A2A2A)
+    private static let xD4452F = Color(0xD4452F)
 
     // URL bar
     private static let urlBar = DynamicColor(lightColor: .white, darkColor: x474747)
@@ -276,6 +279,12 @@ struct DefaultColorPalette: ColorPaletteDefinition {
             return DynamicColor(lightColor: .white, darkColor: x3D3D3D)
         case .unifiedToggleInputStopButtonBackground:
             return DynamicColor(lightColor: .shade(0.06), darkColor: .tint(0.12))
+        case .unifiedToggleInputAttachmentErrorBannerBackground:
+            return DynamicColor(lightColor: xF6CDD1, darkColor: x5A2A2A)
+        case .unifiedToggleInputAttachmentErrorText:
+            return DynamicColor(lightColor: .black.opacity(0.84), darkColor: .white.opacity(0.88))
+        case .unifiedToggleInputAttachmentErrorIcon:
+            return DynamicColor(staticColor: xD4452F)
         case .tabSwitcherTrackerCountBackground:
             return DynamicColor(lightColor: .green0, darkColor: .x2C3A2A)
         case let .rebranding(rebrandingColor):

--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SingleUseColor.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SingleUseColor.swift
@@ -35,6 +35,9 @@ public enum SingleUseColor {
 
     /// Card background for the unified toggle input bar (white in light, #3D3D3D in dark)
     case unifiedToggleInputCardBackground
+    case unifiedToggleInputAttachmentErrorBannerBackground
+    case unifiedToggleInputAttachmentErrorText
+    case unifiedToggleInputAttachmentErrorIcon
 
     /// Stop-generating button background in the unified toggle input bar: translucent overlay on the card (6% black in light, 12% white in dark).
     case unifiedToggleInputStopButtonBackground

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1695,6 +1695,7 @@
 		AABB0001000100010001000B /* UTIModelStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0001000100010001000C /* UTIModelStore.swift */; };
 		AABB0001000100010001000D /* UTIModelStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0001000100010001000E /* UTIModelStoreTests.swift */; };
 		AABB0001000100010001000F /* UTIToolsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB00010001000100010010 /* UTIToolsController.swift */; };
+		AABB00010001000100010101 /* UnifiedToggleInputViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB00010001000100010100 /* UnifiedToggleInputViewTests.swift */; };
 		AB98765432109876543210BA /* ProductionSubscriptionPurchaseDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12345678901234567890AB /* ProductionSubscriptionPurchaseDebugView.swift */; };
 		ABA18ED2F9373DE1F5B57B66 /* RebrandedOnboardingAddressBarPositionPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392856D96DBE03E4E18EFCF8 /* RebrandedOnboardingAddressBarPositionPicker.swift */; };
 		B2258FABEA7BDFCEF297DCFE /* RebrandedOnboardingView+SearchExperienceContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF81E0C6EDC46254CF28AFCB /* RebrandedOnboardingView+SearchExperienceContent.swift */; };
@@ -4294,6 +4295,7 @@
 		AABB0001000100010001000C /* UTIModelStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIModelStore.swift; sourceTree = "<group>"; };
 		AABB0001000100010001000E /* UTIModelStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIModelStoreTests.swift; sourceTree = "<group>"; };
 		AABB00010001000100010010 /* UTIToolsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIToolsController.swift; sourceTree = "<group>"; };
+		AABB00010001000100010100 /* UnifiedToggleInputViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputViewTests.swift; sourceTree = "<group>"; };
 		AB12345678901234567890AB /* ProductionSubscriptionPurchaseDebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductionSubscriptionPurchaseDebugView.swift; sourceTree = "<group>"; };
 		AD8CF8E4B152CDB3A4ACB14C /* StartupOnboardingCover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupOnboardingCover.swift; sourceTree = "<group>"; };
 		AF81E0C6EDC46254CF28AFCB /* RebrandedOnboardingView+SearchExperienceContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "RebrandedOnboardingView+SearchExperienceContent.swift"; sourceTree = "<group>"; };
@@ -9250,6 +9252,7 @@
 				A1B2C3D4E5F60013A1B2C3D4 /* UnifiedToggleInputReasoningTests.swift */,
 				9AD3EE389CF6162AB1F6B023 /* UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift */,
 				AABB0001000100010001000A /* UTIAttachmentPolicyTests.swift */,
+				AABB00010001000100010100 /* UnifiedToggleInputViewTests.swift */,
 				AABB0001000100010001000E /* UTIModelStoreTests.swift */,
 				AABB00010001000100010004 /* UTIRenderStateTests.swift */,
 				33CC9145E578E99B3052757F /* UnifiedToggleInputModelMenuTests.swift */,
@@ -13647,6 +13650,7 @@
 				A1B2C3D4E5F60014A1B2C3D4 /* UnifiedToggleInputReasoningTests.swift in Sources */,
 				F101D53CD31E95F9C9FE2AC1 /* UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift in Sources */,
 				AABB00010001000100010009 /* UTIAttachmentPolicyTests.swift in Sources */,
+				AABB00010001000100010101 /* UnifiedToggleInputViewTests.swift in Sources */,
 				AABB0001000100010001000D /* UTIModelStoreTests.swift in Sources */,
 				AABB00010001000100010003 /* UTIRenderStateTests.swift in Sources */,
 				275A9E842551836ECC9E6873 /* UnifiedToggleInputModelMenuTests.swift in Sources */,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -546,7 +546,7 @@ extension MainViewController {
             floatingVC.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
         ])
         floatingVC.didMove(toParent: self)
-        floatingVC.subscribe(to: coordinator.textChangePublisher)
+        floatingVC.subscribe(to: coordinator.floatingSubmitStatePublisher)
         floatingVC.view.isHidden = true
     }
 
@@ -746,9 +746,7 @@ extension MainViewController: UnifiedToggleInputFloatingSubmitDelegate {
 
     func floatingSubmitDidTapSubmit() {
         guard let coordinator = unifiedToggleInputCoordinator else { return }
-        let text = coordinator.currentText
-        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-        coordinator.switchBarHandler.submitText(text)
+        coordinator.submitCurrentInputFromFloatingSubmit()
     }
 
     func floatingSubmitDidTapVoice() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/TabInputState.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/TabInputState.swift
@@ -24,7 +24,7 @@ typealias TabUID = String
 struct TabInputState: Equatable {
     var text: String
     var toggleMode: TextEntryMode
-    var attachments: [AIChatImageAttachment]
+    var attachments: [UnifiedToggleInputAttachment]
     var selectedModelID: String?
     var selectedReasoningMode: AIChatReasoningMode?
     var selectedTool: AIChatRAGTool?
@@ -32,7 +32,7 @@ struct TabInputState: Equatable {
     init(
         text: String = "",
         toggleMode: TextEntryMode = .search,
-        attachments: [AIChatImageAttachment] = [],
+        attachments: [UnifiedToggleInputAttachment] = [],
         selectedModelID: String? = nil,
         selectedReasoningMode: AIChatReasoningMode? = nil,
         selectedTool: AIChatRAGTool? = nil
@@ -45,7 +45,6 @@ struct TabInputState: Equatable {
         self.selectedTool = selectedTool
     }
 
-    // AIChatImageAttachment is Identifiable but not Equatable, so compare attachments by id.
     static func == (lhs: TabInputState, rhs: TabInputState) -> Bool {
         lhs.text == rhs.text
             && lhs.toggleMode == rhs.toggleMode

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIAttachmentPolicy.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIAttachmentPolicy.swift
@@ -19,6 +19,7 @@
 
 import AIChat
 import Foundation
+import UniformTypeIdentifiers
 
 struct UTIAttachmentPolicy {
 
@@ -270,10 +271,10 @@ private extension UTIAttachmentPolicy {
     }
 
     var acceptedFileTypeNames: [String] {
-        model?.supportedFileTypes.compactMap(Self.fileTypeName(for:)) ?? []
+        model?.supportedFileTypes.map(Self.fileTypeName(for:)) ?? []
     }
 
-    static func fileTypeName(for mimeType: String) -> String? {
+    static func fileTypeName(for mimeType: String) -> String {
         switch mimeType {
         case "application/pdf":
             return "PDF"
@@ -286,7 +287,12 @@ private extension UTIAttachmentPolicy {
         case "image/gif":
             return "GIF"
         default:
-            return nil
+            if let filenameExtension = UTType(mimeType: mimeType)?.preferredFilenameExtension {
+                return filenameExtension.uppercased()
+            }
+
+            let subtype = mimeType.split(separator: "/").last.map(String.init) ?? mimeType
+            return (subtype.split(separator: ".").last.map(String.init) ?? subtype).uppercased()
         }
     }
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIAttachmentPolicy.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIAttachmentPolicy.swift
@@ -121,10 +121,11 @@ struct UTIAttachmentPolicy {
     }
 
     func fileSubmissionValidationMessage() -> String? {
-        let pendingFiles = pendingAttachments.compactMap { attachment -> AIChatFileAttachment? in
-            guard case .file(let fileAttachment) = attachment else { return nil }
-            return fileAttachment
+        if let invalidAttachment = pendingAttachments.first(where: \.isInvalid) {
+            return invalidAttachment.validationMessage
         }
+
+        let pendingFiles = pendingAttachments.compactMap(\.fileAttachment)
         guard !pendingFiles.isEmpty else { return nil }
         guard model?.supportsFileUpload == true else {
             return UserText.aiChatAttachmentUnsupportedFileType
@@ -187,6 +188,8 @@ struct UTIAttachmentPolicy {
         case .image:
             return model?.supportsImageUpload == true
         case .file(let fileAttachment):
+            return model?.supportedFileTypes.contains(fileAttachment.mimeType) == true
+        case .invalidFile(let fileAttachment):
             return model?.supportedFileTypes.contains(fileAttachment.mimeType) == true
         }
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIAttachmentPolicy.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIAttachmentPolicy.swift
@@ -213,11 +213,11 @@ private extension UTIAttachmentPolicy {
     }
 
     var pendingFileCount: Int {
-        pendingAttachments.filter(\.isFile).count
+        pendingAttachments.compactMap(\.fileAttachment).count
     }
 
     var pendingFileSizeBytes: Int {
-        pendingAttachments.reduce(0) { $0 + $1.fileSizeBytes }
+        pendingAttachments.compactMap(\.fileAttachment).reduce(0) { $0 + $1.fileSizeBytes }
     }
 
     var maxImagesPerTurn: Int? {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachment.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachment.swift
@@ -28,7 +28,6 @@ struct UnifiedToggleInputInvalidFileAttachment: Identifiable {
     let fileSizeBytes: Int
     let validationMessage: String
     let sourceURL: URL?
-    let recoverableFileAttachment: AIChatFileAttachment?
 
     init(
         id: UUID = UUID(),
@@ -36,8 +35,7 @@ struct UnifiedToggleInputInvalidFileAttachment: Identifiable {
         mimeType: String,
         fileSizeBytes: Int,
         validationMessage: String,
-        sourceURL: URL? = nil,
-        recoverableFileAttachment: AIChatFileAttachment? = nil
+        sourceURL: URL? = nil
     ) {
         self.id = id
         self.fileName = fileName
@@ -45,7 +43,6 @@ struct UnifiedToggleInputInvalidFileAttachment: Identifiable {
         self.fileSizeBytes = fileSizeBytes
         self.validationMessage = validationMessage
         self.sourceURL = sourceURL
-        self.recoverableFileAttachment = recoverableFileAttachment
     }
 }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachment.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachment.swift
@@ -21,15 +21,40 @@ import AIChat
 import Foundation
 import UIKit
 
+struct UnifiedToggleInputInvalidFileAttachment: Identifiable {
+    let id: UUID
+    let fileName: String
+    let mimeType: String
+    let fileSizeBytes: Int
+    let validationMessage: String
+
+    init(
+        id: UUID = UUID(),
+        fileName: String,
+        mimeType: String,
+        fileSizeBytes: Int,
+        validationMessage: String
+    ) {
+        self.id = id
+        self.fileName = fileName
+        self.mimeType = mimeType
+        self.fileSizeBytes = fileSizeBytes
+        self.validationMessage = validationMessage
+    }
+}
+
 enum UnifiedToggleInputAttachment: Identifiable {
     case image(AIChatImageAttachment)
     case file(AIChatFileAttachment)
+    case invalidFile(UnifiedToggleInputInvalidFileAttachment)
 
     var id: UUID {
         switch self {
         case .image(let attachment):
             return attachment.id
         case .file(let attachment):
+            return attachment.id
+        case .invalidFile(let attachment):
             return attachment.id
         }
     }
@@ -40,6 +65,8 @@ enum UnifiedToggleInputAttachment: Identifiable {
             return attachment.fileName
         case .file(let attachment):
             return attachment.fileName
+        case .invalidFile(let attachment):
+            return attachment.fileName
         }
     }
 
@@ -48,6 +75,8 @@ enum UnifiedToggleInputAttachment: Identifiable {
         case .image:
             return 0
         case .file(let attachment):
+            return attachment.fileSizeBytes
+        case .invalidFile(let attachment):
             return attachment.fileSizeBytes
         }
     }
@@ -60,10 +89,40 @@ enum UnifiedToggleInputAttachment: Identifiable {
     }
 
     var isFile: Bool {
-        if case .file = self {
+        switch self {
+        case .file, .invalidFile:
+            return true
+        case .image:
+            return false
+        }
+    }
+
+    var isInvalid: Bool {
+        if case .invalidFile = self {
             return true
         }
         return false
+    }
+
+    var validationMessage: String? {
+        guard case .invalidFile(let attachment) = self else { return nil }
+        return attachment.validationMessage
+    }
+
+    var fileAttachment: AIChatFileAttachment? {
+        guard case .file(let attachment) = self else { return nil }
+        return attachment
+    }
+
+    var mimeType: String? {
+        switch self {
+        case .image:
+            return nil
+        case .file(let attachment):
+            return attachment.mimeType
+        case .invalidFile(let attachment):
+            return attachment.mimeType
+        }
     }
 
     var image: UIImage? {
@@ -71,10 +130,4 @@ enum UnifiedToggleInputAttachment: Identifiable {
         return attachment.image
     }
 
-    var fileExtensionDisplayName: String? {
-        guard case .file = self else { return nil }
-        let pathExtension = (fileName as NSString).pathExtension
-        guard !pathExtension.isEmpty else { return nil }
-        return pathExtension.uppercased()
-    }
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachment.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachment.swift
@@ -27,19 +27,25 @@ struct UnifiedToggleInputInvalidFileAttachment: Identifiable {
     let mimeType: String
     let fileSizeBytes: Int
     let validationMessage: String
+    let sourceURL: URL?
+    let recoverableFileAttachment: AIChatFileAttachment?
 
     init(
         id: UUID = UUID(),
         fileName: String,
         mimeType: String,
         fileSizeBytes: Int,
-        validationMessage: String
+        validationMessage: String,
+        sourceURL: URL? = nil,
+        recoverableFileAttachment: AIChatFileAttachment? = nil
     ) {
         self.id = id
         self.fileName = fileName
         self.mimeType = mimeType
         self.fileSizeBytes = fileSizeBytes
         self.validationMessage = validationMessage
+        self.sourceURL = sourceURL
+        self.recoverableFileAttachment = recoverableFileAttachment
     }
 }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentPresenter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentPresenter.swift
@@ -39,8 +39,8 @@ final class UnifiedToggleInputAttachmentPresenter: NSObject {
     var onFileValidationFailed: ((String, FileMetadata) -> Void)?
     var fileMetadataValidationMessage: ((FileMetadata) -> String?)?
 
-    nonisolated static func recoverFileAttachment(from metadata: FileMetadata) -> AIChatFileAttachment? {
-        fileAttachment(from: metadata)
+    nonisolated static func recoverFileAttachment(from metadata: FileMetadata, id: UUID = UUID()) -> AIChatFileAttachment? {
+        fileAttachment(from: metadata, id: id)
     }
 
     func makeAttachmentMenu(
@@ -159,7 +159,7 @@ private extension UnifiedToggleInputAttachmentPresenter {
         return FileMetadata(fileName: url.lastPathComponent, mimeType: mimeType, fileSizeBytes: nil, url: url)
     }
 
-    nonisolated static func fileAttachment(from metadata: FileMetadata) -> AIChatFileAttachment? {
+    nonisolated static func fileAttachment(from metadata: FileMetadata, id: UUID = UUID()) -> AIChatFileAttachment? {
         let hasScopedAccess = metadata.url.startAccessingSecurityScopedResource()
         defer {
             if hasScopedAccess {
@@ -172,6 +172,7 @@ private extension UnifiedToggleInputAttachmentPresenter {
             let pdfInspection = Self.inspectPDF(data: data, mimeType: metadata.mimeType)
 
             return AIChatFileAttachment(
+                id: id,
                 data: data,
                 fileName: metadata.fileName,
                 mimeType: metadata.mimeType,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentPresenter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentPresenter.swift
@@ -30,14 +30,18 @@ final class UnifiedToggleInputAttachmentPresenter: NSObject {
         let fileName: String
         let mimeType: String
         let fileSizeBytes: Int?
-        fileprivate let url: URL
+        let url: URL
     }
 
     var onExpandIfNeeded: (() -> Void)?
     var onImagePicked: ((UIImage, String) -> Void)?
-    var onFilePicked: ((AIChatFileAttachment) -> Void)?
+    var onFilePicked: ((AIChatFileAttachment, FileMetadata) -> Void)?
     var onFileValidationFailed: ((String, FileMetadata) -> Void)?
     var fileMetadataValidationMessage: ((FileMetadata) -> String?)?
+
+    nonisolated static func recoverFileAttachment(from metadata: FileMetadata) -> AIChatFileAttachment? {
+        fileAttachment(from: metadata)
+    }
 
     func makeAttachmentMenu(
         presenterProvider: @escaping () -> UIViewController?,
@@ -263,7 +267,7 @@ extension UnifiedToggleInputAttachmentPresenter: UIDocumentPickerDelegate {
                 return
             }
 
-            onFilePicked?(fileAttachment)
+            onFilePicked?(fileAttachment, metadata)
         }
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentPresenter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentPresenter.swift
@@ -36,7 +36,7 @@ final class UnifiedToggleInputAttachmentPresenter: NSObject {
     var onExpandIfNeeded: (() -> Void)?
     var onImagePicked: ((UIImage, String) -> Void)?
     var onFilePicked: ((AIChatFileAttachment) -> Void)?
-    var onFileValidationFailed: ((String, FileMetadata?) -> Void)?
+    var onFileValidationFailed: ((String, FileMetadata) -> Void)?
     var fileMetadataValidationMessage: ((FileMetadata) -> String?)?
 
     func makeAttachmentMenu(

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentPresenter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentPresenter.swift
@@ -36,7 +36,7 @@ final class UnifiedToggleInputAttachmentPresenter: NSObject {
     var onExpandIfNeeded: (() -> Void)?
     var onImagePicked: ((UIImage, String) -> Void)?
     var onFilePicked: ((AIChatFileAttachment) -> Void)?
-    var onFileValidationFailed: ((String) -> Void)?
+    var onFileValidationFailed: ((String, FileMetadata?) -> Void)?
     var fileMetadataValidationMessage: ((FileMetadata) -> String?)?
 
     func makeAttachmentMenu(
@@ -241,12 +241,12 @@ extension UnifiedToggleInputAttachmentPresenter: UIDocumentPickerDelegate {
                 Self.fileMetadata(from: url)
             }.value
             guard let metadata else {
-                onFileValidationFailed?(UserText.aiChatAttachmentFileUnreadable)
+                onFileValidationFailed?(UserText.aiChatAttachmentFileUnreadable, nil)
                 return
             }
 
             if let validationMessage = fileMetadataValidationMessage?(metadata) {
-                onFileValidationFailed?(validationMessage)
+                onFileValidationFailed?(validationMessage, metadata)
                 return
             }
 
@@ -254,7 +254,7 @@ extension UnifiedToggleInputAttachmentPresenter: UIDocumentPickerDelegate {
                 Self.fileAttachment(from: metadata)
             }.value
             guard let fileAttachment else {
-                onFileValidationFailed?(UserText.aiChatAttachmentFileUnreadable)
+                onFileValidationFailed?(UserText.aiChatAttachmentFileUnreadable, metadata)
                 return
             }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentPresenter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentPresenter.swift
@@ -150,6 +150,11 @@ private extension UnifiedToggleInputAttachmentPresenter {
         }
     }
 
+    nonisolated static func fallbackFileMetadata(from url: URL) -> FileMetadata {
+        let mimeType = UTType(filenameExtension: url.pathExtension)?.preferredMIMEType ?? "application/octet-stream"
+        return FileMetadata(fileName: url.lastPathComponent, mimeType: mimeType, fileSizeBytes: nil, url: url)
+    }
+
     nonisolated static func fileAttachment(from metadata: FileMetadata) -> AIChatFileAttachment? {
         let hasScopedAccess = metadata.url.startAccessingSecurityScopedResource()
         defer {
@@ -241,7 +246,7 @@ extension UnifiedToggleInputAttachmentPresenter: UIDocumentPickerDelegate {
                 Self.fileMetadata(from: url)
             }.value
             guard let metadata else {
-                onFileValidationFailed?(UserText.aiChatAttachmentFileUnreadable, nil)
+                onFileValidationFailed?(UserText.aiChatAttachmentFileUnreadable, Self.fallbackFileMetadata(from: url))
                 return
             }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentPresenter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentPresenter.swift
@@ -160,6 +160,8 @@ private extension UnifiedToggleInputAttachmentPresenter {
     }
 
     nonisolated static func fileAttachment(from metadata: FileMetadata, id: UUID = UUID()) -> AIChatFileAttachment? {
+        guard !Task.isCancelled else { return nil }
+
         let hasScopedAccess = metadata.url.startAccessingSecurityScopedResource()
         defer {
             if hasScopedAccess {
@@ -169,6 +171,8 @@ private extension UnifiedToggleInputAttachmentPresenter {
 
         do {
             let data = try Data(contentsOf: metadata.url)
+            guard !Task.isCancelled else { return nil }
+
             let pdfInspection = Self.inspectPDF(data: data, mimeType: metadata.mimeType)
 
             return AIChatFileAttachment(

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentThumbnailView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentThumbnailView.swift
@@ -25,26 +25,38 @@ import UIKit
 final class UnifiedToggleInputAttachmentThumbnailView: UIView {
 
     enum Constants {
-        static let thumbnailSize: CGFloat = 50
-        static let cornerRadius: CGFloat = 12
-        static let borderWidth: CGFloat = 2
-        static let removeButtonSize: CGFloat = 20
-        static let removeButtonInset: CGFloat = 4
-        static let removeButtonOverflow: CGFloat = 8
-        static let totalSize: CGFloat = thumbnailSize + removeButtonOverflow
+        static let chipHeight: CGFloat = 44
+        static let imageChipWidth: CGFloat = 82
+        static let fileChipWidth: CGFloat = 196
+        static let chipCornerRadius: CGFloat = 18
+        static let thumbnailSize: CGFloat = 32
+        static let thumbnailCornerRadius: CGFloat = 6
+        static let documentIconSize: CGFloat = 32
+        static let removeButtonSize: CGFloat = 32
+        static let horizontalPadding: CGFloat = 10
+        static let iconTextSpacing: CGFloat = 8
+        static let textRemoveSpacing: CGFloat = 6
+        static let borderWidth: CGFloat = 1
     }
 
     let attachmentId: UUID
     var onRemove: ((UUID) -> Void)?
     private let attachment: UnifiedToggleInputAttachment
 
+    private let chipView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.clipsToBounds = true
+        view.layer.cornerRadius = Constants.chipCornerRadius
+        view.layer.borderWidth = Constants.borderWidth
+        return view
+    }()
+
     private let imageView: UIImageView = {
         let iv = UIImageView()
         iv.contentMode = .scaleAspectFill
         iv.clipsToBounds = true
-        iv.layer.cornerRadius = Constants.cornerRadius
-        iv.layer.borderWidth = Constants.borderWidth
-        iv.layer.borderColor = UIColor(designSystemColor: .lines).cgColor
+        iv.layer.cornerRadius = Constants.thumbnailCornerRadius
         iv.translatesAutoresizingMaskIntoConstraints = false
         return iv
     }()
@@ -57,25 +69,20 @@ final class UnifiedToggleInputAttachmentThumbnailView: UIView {
         return imageView
     }()
 
-    private let fileExtensionLabel: UILabel = {
+    private let fileNameLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.daxCaptionBold()
+        label.font = UIFont.daxSubheadSemibold()
         label.adjustsFontForContentSizeCategory = true
-        label.textAlignment = .center
         label.textColor = UIColor(designSystemColor: .textPrimary)
+        label.lineBreakMode = .byTruncatingMiddle
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
 
     private lazy var removeButton: UIButton = {
         let button = UIButton(type: .system)
-        let config = UIImage.SymbolConfiguration(pointSize: 8, weight: .bold)
-        button.setImage(UIImage(systemName: "xmark", withConfiguration: config), for: .normal)
-        button.tintColor = UIColor(designSystemColor: .iconsSecondary)
-        button.backgroundColor = UIColor(designSystemColor: .panel)
-        button.layer.cornerRadius = Constants.removeButtonSize / 2
-        button.layer.borderWidth = 1
-        button.layer.borderColor = UIColor(designSystemColor: .lines).cgColor
+        button.setImage(DesignSystemImages.Glyphs.Size16.close, for: .normal)
+        button.tintColor = UIColor(designSystemColor: .textPrimary)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(removeTapped), for: .touchUpInside)
         return button
@@ -95,49 +102,70 @@ final class UnifiedToggleInputAttachmentThumbnailView: UIView {
     }
 
     override var intrinsicContentSize: CGSize {
-        CGSize(width: Constants.totalSize, height: Constants.totalSize)
+        let width = attachment.isImage ? Constants.imageChipWidth : Constants.fileChipWidth
+        return CGSize(width: width, height: Constants.chipHeight)
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
-            imageView.layer.borderColor = UIColor(designSystemColor: .lines).cgColor
-            removeButton.layer.borderColor = UIColor(designSystemColor: .lines).cgColor
+            applyAppearance()
         }
     }
 }
 
 private extension UnifiedToggleInputAttachmentThumbnailView {
 
+    var borderColor: UIColor {
+        attachment.isInvalid
+            ? UIColor(designSystemColor: .destructivePrimary).withAlphaComponent(traitCollection.userInterfaceStyle == .dark ? 0.60 : 0.34)
+            : UIColor(designSystemColor: .lines)
+    }
+
+    var chipBackgroundColor: UIColor {
+        attachment.isInvalid
+            ? UIColor(designSystemColor: .destructivePrimary).withAlphaComponent(traitCollection.userInterfaceStyle == .dark ? 0.24 : 0.18)
+            : UIColor(designSystemColor: .controlsFillPrimary)
+    }
+
     func setupUI() {
         translatesAutoresizingMaskIntoConstraints = false
-        addSubview(imageView)
-        addSubview(fileIconView)
-        addSubview(fileExtensionLabel)
-        addSubview(removeButton)
+        addSubview(chipView)
+        chipView.addSubview(imageView)
+        chipView.addSubview(fileIconView)
+        chipView.addSubview(fileNameLabel)
+        chipView.addSubview(removeButton)
+
+        fileNameLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        removeButton.setContentCompressionResistancePriority(.required, for: .horizontal)
 
         NSLayoutConstraint.activate([
-            imageView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            imageView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            chipView.topAnchor.constraint(equalTo: topAnchor),
+            chipView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            chipView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            chipView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            imageView.leadingAnchor.constraint(equalTo: chipView.leadingAnchor, constant: Constants.horizontalPadding),
+            imageView.centerYAnchor.constraint(equalTo: chipView.centerYAnchor),
             imageView.widthAnchor.constraint(equalToConstant: Constants.thumbnailSize),
             imageView.heightAnchor.constraint(equalToConstant: Constants.thumbnailSize),
 
-            fileIconView.centerXAnchor.constraint(equalTo: imageView.centerXAnchor),
-            fileIconView.centerYAnchor.constraint(equalTo: imageView.centerYAnchor, constant: -6),
-            fileIconView.widthAnchor.constraint(equalToConstant: 24),
-            fileIconView.heightAnchor.constraint(equalToConstant: 24),
+            fileIconView.leadingAnchor.constraint(equalTo: chipView.leadingAnchor, constant: Constants.horizontalPadding),
+            fileIconView.centerYAnchor.constraint(equalTo: chipView.centerYAnchor),
+            fileIconView.widthAnchor.constraint(equalToConstant: Constants.documentIconSize),
+            fileIconView.heightAnchor.constraint(equalToConstant: Constants.documentIconSize),
 
-            fileExtensionLabel.leadingAnchor.constraint(equalTo: imageView.leadingAnchor, constant: 4),
-            fileExtensionLabel.trailingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: -4),
-            fileExtensionLabel.bottomAnchor.constraint(equalTo: imageView.bottomAnchor, constant: -6),
+            fileNameLabel.leadingAnchor.constraint(equalTo: fileIconView.trailingAnchor, constant: Constants.iconTextSpacing),
+            fileNameLabel.trailingAnchor.constraint(equalTo: removeButton.leadingAnchor, constant: -Constants.textRemoveSpacing),
+            fileNameLabel.centerYAnchor.constraint(equalTo: chipView.centerYAnchor),
 
             removeButton.widthAnchor.constraint(equalToConstant: Constants.removeButtonSize),
             removeButton.heightAnchor.constraint(equalToConstant: Constants.removeButtonSize),
-            removeButton.centerXAnchor.constraint(equalTo: imageView.trailingAnchor, constant: -Constants.removeButtonInset),
-            removeButton.centerYAnchor.constraint(equalTo: imageView.topAnchor, constant: Constants.removeButtonInset),
+            removeButton.trailingAnchor.constraint(equalTo: chipView.trailingAnchor, constant: -Constants.horizontalPadding),
+            removeButton.centerYAnchor.constraint(equalTo: chipView.centerYAnchor),
 
-            widthAnchor.constraint(equalToConstant: Constants.totalSize),
-            heightAnchor.constraint(equalToConstant: Constants.totalSize),
+            widthAnchor.constraint(equalToConstant: intrinsicContentSize.width),
+            heightAnchor.constraint(equalToConstant: Constants.chipHeight),
         ])
     }
 
@@ -145,21 +173,35 @@ private extension UnifiedToggleInputAttachmentThumbnailView {
         switch attachment {
         case .image(let imageAttachment):
             imageView.image = imageAttachment.image
-            imageView.backgroundColor = .clear
             imageView.isHidden = false
             fileIconView.isHidden = true
-            fileExtensionLabel.isHidden = true
+            fileNameLabel.isHidden = true
             accessibilityLabel = imageAttachment.fileName
         case .file(let fileAttachment):
-            imageView.image = nil
-            imageView.backgroundColor = UIColor(designSystemColor: .surface)
-            imageView.isHidden = false
-            fileIconView.image = DesignSystemImages.Glyphs.Size24.folder.withRenderingMode(.alwaysTemplate)
-            fileExtensionLabel.text = attachment.fileExtensionDisplayName
-            fileIconView.isHidden = false
-            fileExtensionLabel.isHidden = false
-            accessibilityLabel = fileAttachment.fileName
+            configureFile(fileName: fileAttachment.fileName, validationMessage: nil)
+        case .invalidFile(let fileAttachment):
+            configureFile(fileName: fileAttachment.fileName, validationMessage: fileAttachment.validationMessage)
         }
+        applyAppearance()
+    }
+
+    func configureFile(fileName: String, validationMessage: String?) {
+        imageView.image = nil
+        imageView.isHidden = true
+        fileIconView.image = DesignSystemImages.Color.Size24.document
+        fileIconView.tintColor = nil
+        fileNameLabel.text = fileName
+        fileIconView.isHidden = false
+        fileNameLabel.isHidden = false
+        accessibilityLabel = fileName
+        accessibilityValue = validationMessage
+    }
+
+    func applyAppearance() {
+        chipView.backgroundColor = chipBackgroundColor
+        chipView.layer.borderColor = borderColor.cgColor
+        fileNameLabel.textColor = UIColor(designSystemColor: .textPrimary)
+        removeButton.tintColor = UIColor(designSystemColor: .textPrimary)
     }
 
     @objc func removeTapped() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentsStripView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentsStripView.swift
@@ -62,6 +62,7 @@ final class UnifiedToggleInputAttachmentsStripView: UIView {
     }
 
     func addAttachment(_ attachment: UnifiedToggleInputAttachment) {
+        let shouldAutoScroll = shouldAutoScrollAfterAddingAttachment()
         attachments.append(attachment)
         let thumbnail = UnifiedToggleInputAttachmentThumbnailView(attachment: attachment)
         thumbnail.onRemove = { [weak self] id in
@@ -69,7 +70,9 @@ final class UnifiedToggleInputAttachmentsStripView: UIView {
         }
         stackView.addArrangedSubview(thumbnail)
         onAttachmentsChanged?()
-        scheduleScrollToTrailingEdge()
+        if shouldAutoScroll {
+            scheduleScrollToTrailingEdge()
+        }
     }
 
     func removeAttachment(id: UUID) {
@@ -119,6 +122,12 @@ final class UnifiedToggleInputAttachmentsStripView: UIView {
         layoutIfNeeded()
         let maximumOffset = max(scrollView.contentSize.width - scrollView.bounds.width, 0)
         scrollView.setContentOffset(CGPoint(x: maximumOffset, y: 0), animated: false)
+    }
+
+    private func shouldAutoScrollAfterAddingAttachment() -> Bool {
+        guard !scrollView.isTracking, !scrollView.isDragging, !scrollView.isDecelerating else { return false }
+        let maximumOffset = max(scrollView.contentSize.width - scrollView.bounds.width, 0)
+        return maximumOffset == 0 || scrollView.contentOffset.x >= maximumOffset - 1
     }
 
     private func scheduleScrollToTrailingEdge() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentsStripView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentsStripView.swift
@@ -68,8 +68,8 @@ final class UnifiedToggleInputAttachmentsStripView: UIView {
             self?.removeAttachment(id: id)
         }
         stackView.addArrangedSubview(thumbnail)
-        scrollToTrailingEdge()
         onAttachmentsChanged?()
+        scheduleScrollToTrailingEdge()
     }
 
     func removeAttachment(id: UUID) {
@@ -119,5 +119,14 @@ final class UnifiedToggleInputAttachmentsStripView: UIView {
         layoutIfNeeded()
         let maximumOffset = max(scrollView.contentSize.width - scrollView.bounds.width, 0)
         scrollView.setContentOffset(CGPoint(x: maximumOffset, y: 0), animated: false)
+    }
+
+    private func scheduleScrollToTrailingEdge() {
+        setNeedsLayout()
+        DispatchQueue.main.async { [weak self] in
+            self?.superview?.layoutIfNeeded()
+            self?.layoutIfNeeded()
+            self?.scrollToTrailingEdge()
+        }
     }
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentsStripView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentsStripView.swift
@@ -26,18 +26,27 @@ final class UnifiedToggleInputAttachmentsStripView: UIView {
         static let spacing: CGFloat = 4
         static let horizontalPadding: CGFloat = 12
         static let topPadding: CGFloat = 8
-        static let stripHeight: CGFloat = topPadding + UnifiedToggleInputAttachmentThumbnailView.Constants.totalSize
+        static let stripHeight: CGFloat = topPadding + UnifiedToggleInputAttachmentThumbnailView.Constants.chipHeight
     }
 
     private(set) var attachments: [UnifiedToggleInputAttachment] = []
     var onAttachmentRemoved: ((UUID) -> Void)?
     var onAttachmentsChanged: (() -> Void)?
 
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.alwaysBounceHorizontal = true
+        scrollView.clipsToBounds = true
+        return scrollView
+    }()
+
     private let stackView: UIStackView = {
         let stack = UIStackView()
         stack.axis = .horizontal
         stack.spacing = Constants.spacing
-        stack.alignment = .bottom
+        stack.alignment = .center
         stack.translatesAutoresizingMaskIntoConstraints = false
         return stack
     }()
@@ -59,6 +68,7 @@ final class UnifiedToggleInputAttachmentsStripView: UIView {
             self?.removeAttachment(id: id)
         }
         stackView.addArrangedSubview(thumbnail)
+        scrollToTrailingEdge()
         onAttachmentsChanged?()
     }
 
@@ -86,14 +96,28 @@ final class UnifiedToggleInputAttachmentsStripView: UIView {
     private func setupUI() {
         translatesAutoresizingMaskIntoConstraints = false
         clipsToBounds = false
-        addSubview(stackView)
-        let bottomConstraint = stackView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        addSubview(scrollView)
+        scrollView.addSubview(stackView)
+        let bottomConstraint = scrollView.bottomAnchor.constraint(equalTo: bottomAnchor)
         bottomConstraint.priority = .defaultHigh
         NSLayoutConstraint.activate([
-            stackView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.topPadding),
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.horizontalPadding),
-            stackView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -Constants.horizontalPadding),
+            scrollView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.topPadding),
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.heightAnchor.constraint(equalToConstant: UnifiedToggleInputAttachmentThumbnailView.Constants.chipHeight),
             bottomConstraint,
+
+            stackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            stackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor, constant: Constants.horizontalPadding),
+            stackView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor, constant: -Constants.horizontalPadding),
+            stackView.heightAnchor.constraint(equalTo: scrollView.frameLayoutGuide.heightAnchor),
         ])
+    }
+
+    private func scrollToTrailingEdge() {
+        layoutIfNeeded()
+        let maximumOffset = max(scrollView.contentSize.width - scrollView.bounds.width, 0)
+        scrollView.setContentOffset(CGPoint(x: maximumOffset, y: 0), animated: false)
     }
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentsStripView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentsStripView.swift
@@ -64,15 +64,23 @@ final class UnifiedToggleInputAttachmentsStripView: UIView {
     func addAttachment(_ attachment: UnifiedToggleInputAttachment) {
         let shouldAutoScroll = shouldAutoScrollAfterAddingAttachment()
         attachments.append(attachment)
-        let thumbnail = UnifiedToggleInputAttachmentThumbnailView(attachment: attachment)
-        thumbnail.onRemove = { [weak self] id in
-            self?.removeAttachment(id: id)
-        }
-        stackView.addArrangedSubview(thumbnail)
+        stackView.addArrangedSubview(makeThumbnail(for: attachment))
         onAttachmentsChanged?()
         if shouldAutoScroll {
             scheduleScrollToTrailingEdge()
         }
+    }
+
+    func replaceAttachment(id: UUID, with attachment: UnifiedToggleInputAttachment) {
+        guard let index = attachments.firstIndex(where: { $0.id == id }) else { return }
+        attachments[index] = attachment
+        let thumbnailViews = stackView.arrangedSubviews.compactMap { $0 as? UnifiedToggleInputAttachmentThumbnailView }
+        guard let view = thumbnailViews.first(where: { $0.attachmentId == id }),
+              let arrangedIndex = stackView.arrangedSubviews.firstIndex(of: view) else { return }
+        stackView.removeArrangedSubview(view)
+        view.removeFromSuperview()
+        stackView.insertArrangedSubview(makeThumbnail(for: attachment), at: arrangedIndex)
+        onAttachmentsChanged?()
     }
 
     func removeAttachment(id: UUID) {
@@ -116,6 +124,14 @@ final class UnifiedToggleInputAttachmentsStripView: UIView {
             stackView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor, constant: -Constants.horizontalPadding),
             stackView.heightAnchor.constraint(equalTo: scrollView.frameLayoutGuide.heightAnchor),
         ])
+    }
+
+    private func makeThumbnail(for attachment: UnifiedToggleInputAttachment) -> UnifiedToggleInputAttachmentThumbnailView {
+        let thumbnail = UnifiedToggleInputAttachmentThumbnailView(attachment: attachment)
+        thumbnail.onRemove = { [weak self] id in
+            self?.removeAttachment(id: id)
+        }
+        return thumbnail
     }
 
     private func scrollToTrailingEdge() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1096,8 +1096,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
                     mimeType: fileAttachment.mimeType,
                     fileSizeBytes: fileAttachment.fileSizeBytes,
                     validationMessage: validationMessage,
-                    sourceURL: sourceURL,
-                    recoverableFileAttachment: fileAttachment
+                    sourceURL: sourceURL
                 )
             ))
             presentAttachmentValidationError(validationMessage)
@@ -1360,10 +1359,6 @@ private extension UnifiedToggleInputCoordinator {
             return replaceInvalidAttachment(attachment, validationMessage: validationMessage)
         }
 
-        if let fileAttachment = attachment.recoverableFileAttachment {
-            return applyRecoveredFileAttachment(fileAttachment, for: attachment)
-        }
-
         guard attachment.sourceURL != nil else {
             return replaceInvalidAttachment(attachment, validationMessage: UserText.aiChatAttachmentFileUnreadable)
         }
@@ -1446,8 +1441,7 @@ private extension UnifiedToggleInputCoordinator {
                 mimeType: attachment.mimeType,
                 fileSizeBytes: attachment.fileSizeBytes,
                 validationMessage: validationMessage,
-                sourceURL: attachment.sourceURL,
-                recoverableFileAttachment: attachment.recoverableFileAttachment
+                sourceURL: attachment.sourceURL
             )
         )
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -205,6 +205,11 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         textChangeSubject.eraseToAnyPublisher()
     }
 
+    private let floatingSubmitStateSubject = CurrentValueSubject<UnifiedToggleInputFloatingSubmitState, Never>(.empty)
+    var floatingSubmitStatePublisher: AnyPublisher<UnifiedToggleInputFloatingSubmitState, Never> {
+        floatingSubmitStateSubject.eraseToAnyPublisher()
+    }
+
     private let modeChangeSubject = PassthroughSubject<TextEntryMode, Never>()
     var modeChangePublisher: AnyPublisher<TextEntryMode, Never> {
         modeChangeSubject.eraseToAnyPublisher()
@@ -339,7 +344,10 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
 
     func applyState(_ state: TabInputState) {
         isApplyingState = true
-        defer { isApplyingState = false }
+        defer {
+            isApplyingState = false
+            updateFloatingSubmitState()
+        }
         Logger.unifiedInputState.debug("applyState for tab [\(self.currentTabUID ?? "nil")]: \(state.summary)")
 
         setText(state.text)
@@ -478,6 +486,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         resetToolsSelection()
         clearAttachments()
         setText("")
+        updateFloatingSubmitState()
 
         let renderState = computeRenderState()
         viewController.apply(renderState.viewConfig, animated: false)
@@ -552,6 +561,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         // Text clear is deferred to dismiss completion — avoids placeholder flash mid-collapse.
         resetToolsSelection()
         clearAttachments()
+        updateFloatingSubmitState()
 
         if resetView {
             let renderState = computeRenderState()
@@ -574,6 +584,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             viewController.apply(computeRenderState().viewConfig, animated: false)
             refreshToolsPresentation()
             modeChangeSubject.send(.search)
+            updateFloatingSubmitState()
         }
     }
 
@@ -594,6 +605,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         textState = text.isEmpty ? .empty : .userTyped
         viewController.text = text
         persistDraftToStore()
+        updateFloatingSubmitState()
     }
 
     // MARK: - Input Management
@@ -630,6 +642,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             syncAttachmentValidationErrorForCurrentMode()
         }
         recordUserChoiceToStore()
+        updateFloatingSubmitState()
     }
 
     func updateAIVoiceChatAvailability(_ enabled: Bool) {
@@ -653,6 +666,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             refreshToolsPresentation()
         }
         updateToolbarAIVoiceChat()
+        updateFloatingSubmitState()
     }
 
     func updateOmnibarInputVisibility(_ isInputVisible: Bool) {
@@ -1210,6 +1224,7 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
         textChangeSubject.send(text)
         persistDraftToStore()
         clearAttachmentValidationErrorIfPossible()
+        updateFloatingSubmitState()
     }
 
     func unifiedToggleInputVC(_ vc: UnifiedToggleInputViewController, didChangeMode mode: TextEntryMode) {
@@ -1231,6 +1246,7 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
     func unifiedToggleInputVCDidChangeAttachments(_ vc: UnifiedToggleInputViewController) {
         attachmentsChangeSubject.send()
         updateImageButtonEnabledState()
+        updateFloatingSubmitState()
     }
 
     func unifiedToggleInputVCDidChangeHeight(_ vc: UnifiedToggleInputViewController) {
@@ -1245,6 +1261,25 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
 
     func unifiedToggleInputVCDidTapAIChatShortcut(_ vc: UnifiedToggleInputViewController) {
         delegate?.unifiedToggleInputDidRequestAIChat()
+    }
+}
+
+extension UnifiedToggleInputCoordinator {
+
+    func submitCurrentInputFromFloatingSubmit() {
+        let state = makeFloatingSubmitState()
+        guard state.canSubmit else {
+            if state.hasInvalidAttachment {
+                syncAttachmentValidationErrorForCurrentMode()
+            }
+            return
+        }
+
+        if currentText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            viewController.handler.submitAIChatAttachmentOnlyPrompt()
+        } else {
+            viewController.handler.submitText(currentText)
+        }
     }
 }
 
@@ -1347,6 +1382,20 @@ private extension UnifiedToggleInputCoordinator {
     func clearAttachmentValidationErrorIfPossible() {
         guard viewController.currentAttachments.contains(where: \.isInvalid) == false else { return }
         viewController.clearAttachmentValidationError()
+    }
+
+    func makeFloatingSubmitState() -> UnifiedToggleInputFloatingSubmitState {
+        let isAIChatMode = inputMode == .aiChat
+        let attachments = viewController.currentAttachments
+        return UnifiedToggleInputFloatingSubmitState(
+            hasText: !currentText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            hasValidAttachment: isAIChatMode && attachments.contains { !$0.isInvalid },
+            hasInvalidAttachment: isAIChatMode && attachments.contains(where: \.isInvalid)
+        )
+    }
+
+    func updateFloatingSubmitState() {
+        floatingSubmitStateSubject.send(makeFloatingSubmitState())
     }
 
     // MARK: Session State

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -640,8 +640,8 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         applyToolbarPresentation()
         if didModeChange {
             syncAttachmentValidationErrorForCurrentMode()
+            recordUserChoiceToStore()
         }
-        recordUserChoiceToStore()
         updateFloatingSubmitState()
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -155,6 +155,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     private(set) var isInputVisibleForKeyboard: Bool = true
     private var isAwaitingTopOmnibarKeyboardPresentation = false
     private var topOmnibarKeyboardPresentationFallback: DispatchWorkItem?
+    private var invalidAttachmentRecoveryTasks: [UUID: Task<Void, Never>] = [:]
 
     private(set) var currentText: String = ""
     var hasActiveChat: Bool { boundUserScript != nil }
@@ -353,6 +354,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         setText(state.text)
         syncInputModeFromExternalSource(state.toggleMode)
 
+        cancelInvalidAttachmentRecoveryTasks()
         viewController.removeAllAttachments()
         for attachment in state.attachments {
             viewController.addAttachment(attachment)
@@ -1109,6 +1111,8 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     }
 
     func removeAttachment(id: UUID) {
+        invalidAttachmentRecoveryTasks[id]?.cancel()
+        invalidAttachmentRecoveryTasks[id] = nil
         viewController.removeAttachment(id: id)
         persistDraftToStore()
         syncAttachmentValidationErrorForCurrentMode()
@@ -1121,6 +1125,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             updateAttachButtonPresentation()
             return
         }
+        cancelInvalidAttachmentRecoveryTasks()
         viewController.removeAllAttachments()
         viewController.clearAttachmentValidationError()
         persistDraftToStore()
@@ -1335,47 +1340,96 @@ private extension UnifiedToggleInputCoordinator {
 
         for attachment in viewController.currentAttachments {
             guard case .invalidFile(let invalidAttachment) = attachment else { continue }
-
-            if let metadataValidationMessage = attachmentPolicy.fileMetadataValidationMessage(
-                mimeType: invalidAttachment.mimeType,
-                fileSizeBytes: invalidAttachment.fileSizeBytes > 0 ? invalidAttachment.fileSizeBytes : nil
-            ) {
-                guard metadataValidationMessage != invalidAttachment.validationMessage else { continue }
-                viewController.replaceAttachment(
-                    id: attachment.id,
-                    with: invalidFileAttachment(from: invalidAttachment, validationMessage: metadataValidationMessage)
-                )
-                didChange = true
-                continue
-            }
-
-            guard let fileAttachment = recoverableFileAttachment(for: invalidAttachment) else {
-                let validationMessage = UserText.aiChatAttachmentFileUnreadable
-                guard validationMessage != invalidAttachment.validationMessage else { continue }
-                viewController.replaceAttachment(
-                    id: attachment.id,
-                    with: invalidFileAttachment(from: invalidAttachment, validationMessage: validationMessage)
-                )
-                didChange = true
-                continue
-            }
-
-            if let validationMessage = attachmentPolicy.fileValidationMessage(for: fileAttachment) {
-                guard validationMessage != invalidAttachment.validationMessage else { continue }
-                viewController.replaceAttachment(
-                    id: attachment.id,
-                    with: invalidFileAttachment(from: invalidAttachment, validationMessage: validationMessage)
-                )
-            } else {
-                viewController.replaceAttachment(id: attachment.id, with: .file(fileAttachment))
-            }
-            didChange = true
+            didChange = revalidateInvalidAttachment(invalidAttachment) || didChange
         }
 
         guard didChange else { return }
+        finishAttachmentRevalidation()
+    }
+
+    @discardableResult
+    func revalidateInvalidAttachment(_ attachment: UnifiedToggleInputInvalidFileAttachment) -> Bool {
+        if let validationMessage = metadataValidationMessage(for: attachment) {
+            invalidAttachmentRecoveryTasks[attachment.id]?.cancel()
+            invalidAttachmentRecoveryTasks[attachment.id] = nil
+            return replaceInvalidAttachment(attachment, validationMessage: validationMessage)
+        }
+
+        if let fileAttachment = attachment.recoverableFileAttachment {
+            return applyRecoveredFileAttachment(fileAttachment, for: attachment)
+        }
+
+        guard attachment.sourceURL != nil else {
+            return replaceInvalidAttachment(attachment, validationMessage: UserText.aiChatAttachmentFileUnreadable)
+        }
+
+        recoverInvalidAttachmentFromSourceURL(attachment)
+        return false
+    }
+
+    func recoverInvalidAttachmentFromSourceURL(_ attachment: UnifiedToggleInputInvalidFileAttachment) {
+        guard invalidAttachmentRecoveryTasks[attachment.id] == nil,
+              let metadata = fileMetadata(for: attachment) else { return }
+
+        let attachmentID = attachment.id
+        invalidAttachmentRecoveryTasks[attachmentID] = Task { [weak self] in
+            let fileAttachment = await Task.detached(priority: .userInitiated) {
+                UnifiedToggleInputAttachmentPresenter.recoverFileAttachment(from: metadata, id: attachmentID)
+            }.value
+            guard !Task.isCancelled else { return }
+            await self?.completeInvalidAttachmentRecovery(id: attachmentID, fileAttachment: fileAttachment)
+        }
+    }
+
+    func completeInvalidAttachmentRecovery(id: UUID, fileAttachment: AIChatFileAttachment?) {
+        invalidAttachmentRecoveryTasks[id] = nil
+        guard let attachment = viewController.currentAttachments.first(where: { $0.id == id }),
+              case .invalidFile(let invalidAttachment) = attachment else { return }
+
+        let didChange: Bool
+        if let validationMessage = metadataValidationMessage(for: invalidAttachment) {
+            didChange = replaceInvalidAttachment(invalidAttachment, validationMessage: validationMessage)
+        } else if let fileAttachment {
+            didChange = applyRecoveredFileAttachment(fileAttachment, for: invalidAttachment)
+        } else {
+            didChange = replaceInvalidAttachment(invalidAttachment, validationMessage: UserText.aiChatAttachmentFileUnreadable)
+        }
+
+        guard didChange else { return }
+        finishAttachmentRevalidation()
+    }
+
+    @discardableResult
+    func applyRecoveredFileAttachment(
+        _ fileAttachment: AIChatFileAttachment,
+        for attachment: UnifiedToggleInputInvalidFileAttachment
+    ) -> Bool {
+        if let validationMessage = attachmentPolicy.fileValidationMessage(for: fileAttachment) {
+            return replaceInvalidAttachment(attachment, validationMessage: validationMessage)
+        }
+
+        viewController.replaceAttachment(id: attachment.id, with: .file(fileAttachment))
+        return true
+    }
+
+    @discardableResult
+    func replaceInvalidAttachment(
+        _ attachment: UnifiedToggleInputInvalidFileAttachment,
+        validationMessage: String
+    ) -> Bool {
+        guard validationMessage != attachment.validationMessage else { return false }
+        viewController.replaceAttachment(
+            id: attachment.id,
+            with: invalidFileAttachment(from: attachment, validationMessage: validationMessage)
+        )
+        return true
+    }
+
+    func finishAttachmentRevalidation() {
         persistDraftToStore()
         updateAttachButtonPresentation()
         updateFloatingSubmitState()
+        syncAttachmentValidationErrorForCurrentMode()
     }
 
     func invalidFileAttachment(
@@ -1395,19 +1449,26 @@ private extension UnifiedToggleInputCoordinator {
         )
     }
 
-    func recoverableFileAttachment(for attachment: UnifiedToggleInputInvalidFileAttachment) -> AIChatFileAttachment? {
-        if let fileAttachment = attachment.recoverableFileAttachment {
-            return fileAttachment
-        }
+    func metadataValidationMessage(for attachment: UnifiedToggleInputInvalidFileAttachment) -> String? {
+        attachmentPolicy.fileMetadataValidationMessage(
+            mimeType: attachment.mimeType,
+            fileSizeBytes: attachment.fileSizeBytes > 0 ? attachment.fileSizeBytes : nil
+        )
+    }
 
+    func fileMetadata(for attachment: UnifiedToggleInputInvalidFileAttachment) -> UnifiedToggleInputAttachmentPresenter.FileMetadata? {
         guard let sourceURL = attachment.sourceURL else { return nil }
-        let metadata = UnifiedToggleInputAttachmentPresenter.FileMetadata(
+        return UnifiedToggleInputAttachmentPresenter.FileMetadata(
             fileName: attachment.fileName,
             mimeType: attachment.mimeType,
             fileSizeBytes: attachment.fileSizeBytes > 0 ? attachment.fileSizeBytes : nil,
             url: sourceURL
         )
-        return UnifiedToggleInputAttachmentPresenter.recoverFileAttachment(from: metadata)
+    }
+
+    func cancelInvalidAttachmentRecoveryTasks() {
+        invalidAttachmentRecoveryTasks.values.forEach { $0.cancel() }
+        invalidAttachmentRecoveryTasks.removeAll()
     }
 
     func removeUnsupportedAttachmentsForSelectedModel() {
@@ -1416,6 +1477,8 @@ private extension UnifiedToggleInputCoordinator {
             attachmentPolicy.isAttachmentSupported(attachment) == false
         }
         unsupportedAttachments.forEach { attachment in
+            invalidAttachmentRecoveryTasks[attachment.id]?.cancel()
+            invalidAttachmentRecoveryTasks[attachment.id] = nil
             viewController.removeAttachment(id: attachment.id)
         }
         revalidateInvalidAttachmentsForSelectedModel()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1168,6 +1168,10 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
         showExpanded(inputMode: inputMode)
     }
 
+    func unifiedToggleInputVCDidRequestSubmitCurrentInput(_ vc: UnifiedToggleInputViewController) {
+        submitCurrentInputFromCoordinator()
+    }
+
     func unifiedToggleInputVC(_ vc: UnifiedToggleInputViewController, didSubmitText text: String, mode: TextEntryMode) {
         commitCurrentToggleState()
 
@@ -1182,17 +1186,7 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
             delegate?.unifiedToggleInputDidSubmitQuery(text)
             didSubmitQuery.send(text)
         case .aiChat:
-            if let validationMessage = attachmentPolicy.imageSubmissionValidationMessage() {
-                presentAttachmentValidationError(validationMessage)
-                return
-            }
-
-            if let validationMessage = attachmentPolicy.fileSubmissionValidationMessage() {
-                presentAttachmentValidationError(validationMessage)
-                return
-            }
-
-            if let validationMessage = attachmentPolicy.promptValidationMessage(for: text) {
+            if let validationMessage = attachmentSubmissionValidationMessage(for: text, mode: mode) {
                 presentAttachmentValidationError(validationMessage)
                 return
             }
@@ -1277,6 +1271,10 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
 extension UnifiedToggleInputCoordinator {
 
     func submitCurrentInputFromFloatingSubmit() {
+        submitCurrentInputFromCoordinator()
+    }
+
+    func submitCurrentInputFromCoordinator() {
         let state = makeFloatingSubmitState()
         guard state.canSubmit else {
             if state.hasInvalidAttachment {
@@ -1285,7 +1283,12 @@ extension UnifiedToggleInputCoordinator {
             return
         }
 
-        if currentText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        if let validationMessage = attachmentSubmissionValidationMessage(for: currentText, mode: inputMode) {
+            presentAttachmentValidationError(validationMessage)
+            return
+        }
+
+        if currentText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, inputMode == .aiChat {
             viewController.handler.submitAIChatAttachmentOnlyPrompt()
         } else {
             viewController.handler.submitText(currentText)
@@ -1506,6 +1509,20 @@ private extension UnifiedToggleInputCoordinator {
 
     func presentAttachmentValidationError(_ message: String) {
         viewController.showAttachmentValidationError(message)
+    }
+
+    func attachmentSubmissionValidationMessage(for text: String, mode: TextEntryMode) -> String? {
+        guard mode == .aiChat else { return nil }
+
+        if let validationMessage = attachmentPolicy.imageSubmissionValidationMessage() {
+            return validationMessage
+        }
+
+        if let validationMessage = attachmentPolicy.fileSubmissionValidationMessage() {
+            return validationMessage
+        }
+
+        return attachmentPolicy.promptValidationMessage(for: text)
     }
 
     func syncAttachmentValidationError() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -260,8 +260,8 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         attachmentPresenter.onImagePicked = { [weak self] image, fileName in
             self?.addImageAttachment(image: image, fileName: fileName)
         }
-        attachmentPresenter.onFilePicked = { [weak self] attachment in
-            self?.addFileAttachment(attachment)
+        attachmentPresenter.onFilePicked = { [weak self] attachment, metadata in
+            self?.addFileAttachment(attachment, sourceURL: metadata.url)
         }
         attachmentPresenter.onFileValidationFailed = { [weak self] message, metadata in
             self?.addInvalidFileAttachment(metadata: metadata, validationMessage: message)
@@ -1083,14 +1083,17 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         updateAttachButtonPresentation()
     }
 
-    func addFileAttachment(_ fileAttachment: AIChatFileAttachment) {
+    func addFileAttachment(_ fileAttachment: AIChatFileAttachment, sourceURL: URL? = nil) {
         if let validationMessage = attachmentPolicy.fileValidationMessage(for: fileAttachment) {
             viewController.addAttachment(.invalidFile(
                 UnifiedToggleInputInvalidFileAttachment(
+                    id: fileAttachment.id,
                     fileName: fileAttachment.fileName,
                     mimeType: fileAttachment.mimeType,
                     fileSizeBytes: fileAttachment.fileSizeBytes,
-                    validationMessage: validationMessage
+                    validationMessage: validationMessage,
+                    sourceURL: sourceURL,
+                    recoverableFileAttachment: fileAttachment
                 )
             ))
             presentAttachmentValidationError(validationMessage)
@@ -1318,12 +1321,93 @@ private extension UnifiedToggleInputCoordinator {
                 fileName: metadata.fileName,
                 mimeType: metadata.mimeType,
                 fileSizeBytes: metadata.fileSizeBytes ?? 0,
-                validationMessage: validationMessage
+                validationMessage: validationMessage,
+                sourceURL: metadata.url
             )
         ))
         persistDraftToStore()
         updateAttachButtonPresentation()
         presentAttachmentValidationError(validationMessage)
+    }
+
+    func revalidateInvalidAttachmentsForSelectedModel() {
+        var didChange = false
+
+        for attachment in viewController.currentAttachments {
+            guard case .invalidFile(let invalidAttachment) = attachment else { continue }
+
+            if let metadataValidationMessage = attachmentPolicy.fileMetadataValidationMessage(
+                mimeType: invalidAttachment.mimeType,
+                fileSizeBytes: invalidAttachment.fileSizeBytes > 0 ? invalidAttachment.fileSizeBytes : nil
+            ) {
+                guard metadataValidationMessage != invalidAttachment.validationMessage else { continue }
+                viewController.replaceAttachment(
+                    id: attachment.id,
+                    with: invalidFileAttachment(from: invalidAttachment, validationMessage: metadataValidationMessage)
+                )
+                didChange = true
+                continue
+            }
+
+            guard let fileAttachment = recoverableFileAttachment(for: invalidAttachment) else {
+                let validationMessage = UserText.aiChatAttachmentFileUnreadable
+                guard validationMessage != invalidAttachment.validationMessage else { continue }
+                viewController.replaceAttachment(
+                    id: attachment.id,
+                    with: invalidFileAttachment(from: invalidAttachment, validationMessage: validationMessage)
+                )
+                didChange = true
+                continue
+            }
+
+            if let validationMessage = attachmentPolicy.fileValidationMessage(for: fileAttachment) {
+                guard validationMessage != invalidAttachment.validationMessage else { continue }
+                viewController.replaceAttachment(
+                    id: attachment.id,
+                    with: invalidFileAttachment(from: invalidAttachment, validationMessage: validationMessage)
+                )
+            } else {
+                viewController.replaceAttachment(id: attachment.id, with: .file(fileAttachment))
+            }
+            didChange = true
+        }
+
+        guard didChange else { return }
+        persistDraftToStore()
+        updateAttachButtonPresentation()
+        updateFloatingSubmitState()
+    }
+
+    func invalidFileAttachment(
+        from attachment: UnifiedToggleInputInvalidFileAttachment,
+        validationMessage: String
+    ) -> UnifiedToggleInputAttachment {
+        .invalidFile(
+            UnifiedToggleInputInvalidFileAttachment(
+                id: attachment.id,
+                fileName: attachment.fileName,
+                mimeType: attachment.mimeType,
+                fileSizeBytes: attachment.fileSizeBytes,
+                validationMessage: validationMessage,
+                sourceURL: attachment.sourceURL,
+                recoverableFileAttachment: attachment.recoverableFileAttachment
+            )
+        )
+    }
+
+    func recoverableFileAttachment(for attachment: UnifiedToggleInputInvalidFileAttachment) -> AIChatFileAttachment? {
+        if let fileAttachment = attachment.recoverableFileAttachment {
+            return fileAttachment
+        }
+
+        guard let sourceURL = attachment.sourceURL else { return nil }
+        let metadata = UnifiedToggleInputAttachmentPresenter.FileMetadata(
+            fileName: attachment.fileName,
+            mimeType: attachment.mimeType,
+            fileSizeBytes: attachment.fileSizeBytes > 0 ? attachment.fileSizeBytes : nil,
+            url: sourceURL
+        )
+        return UnifiedToggleInputAttachmentPresenter.recoverFileAttachment(from: metadata)
     }
 
     func removeUnsupportedAttachmentsForSelectedModel() {
@@ -1334,6 +1418,7 @@ private extension UnifiedToggleInputCoordinator {
         unsupportedAttachments.forEach { attachment in
             viewController.removeAttachment(id: attachment.id)
         }
+        revalidateInvalidAttachmentsForSelectedModel()
         syncAttachmentValidationErrorForCurrentMode()
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -258,8 +258,8 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         attachmentPresenter.onFilePicked = { [weak self] attachment in
             self?.addFileAttachment(attachment)
         }
-        attachmentPresenter.onFileValidationFailed = { [weak self] message in
-            self?.presentAttachmentValidationError(message)
+        attachmentPresenter.onFileValidationFailed = { [weak self] message, metadata in
+            self?.addInvalidFileAttachment(metadata: metadata, validationMessage: message)
         }
         attachmentPresenter.fileMetadataValidationMessage = { [weak self] metadata in
             self?.attachmentPolicy.fileMetadataValidationMessage(mimeType: metadata.mimeType, fileSizeBytes: metadata.fileSizeBytes)
@@ -347,8 +347,9 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
 
         viewController.removeAllAttachments()
         for attachment in state.attachments {
-            viewController.addAttachment(.image(attachment))
+            viewController.addAttachment(attachment)
         }
+        syncAttachmentValidationErrorForCurrentMode()
 
         // Always sync the live model store from per-tab state — including nil values —
         // so the previous tab's selections don't leak through preferences. With the
@@ -374,7 +375,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         TabInputState(
             text: currentText,
             toggleMode: inputMode,
-            attachments: currentImageAttachmentsForTabState,
+            attachments: viewController.currentAttachments,
             selectedModelID: modelStore.persistedModelId,
             selectedReasoningMode: modelStore.selectedReasoningMode,
             selectedTool: toolsController.selectedTool
@@ -470,11 +471,13 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         isAwaitingTopOmnibarKeyboardPresentation = false
         displayState = .hidden
         isInputVisibleForKeyboard = true
-        resetToolsSelection()
         // The live state is no longer authoritative for the previous tab; clearing
         // currentTabUID prevents the next activateForTab from snapshotting the
         // (now tool-cleared) live state back over the previous tab's stored entry.
         currentTabUID = nil
+        resetToolsSelection()
+        clearAttachments()
+        setText("")
 
         let renderState = computeRenderState()
         viewController.apply(renderState.viewConfig, animated: false)
@@ -623,8 +626,8 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         }
 
         applyToolbarPresentation()
-        if didModeChange, effectiveMode == .search {
-            clearAttachments()
+        if didModeChange {
+            syncAttachmentValidationErrorForCurrentMode()
         }
         recordUserChoiceToStore()
     }
@@ -1062,26 +1065,49 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         let attachment = UnifiedToggleInputAttachment.image(AIChatImageAttachment(image: image, fileName: fileName))
         viewController.addAttachment(attachment)
         persistDraftToStore()
+        clearAttachmentValidationErrorIfPossible()
+        updateAttachButtonPresentation()
     }
 
     func addFileAttachment(_ fileAttachment: AIChatFileAttachment) {
         if let validationMessage = attachmentPolicy.fileValidationMessage(for: fileAttachment) {
+            viewController.addAttachment(.invalidFile(
+                UnifiedToggleInputInvalidFileAttachment(
+                    fileName: fileAttachment.fileName,
+                    mimeType: fileAttachment.mimeType,
+                    fileSizeBytes: fileAttachment.fileSizeBytes,
+                    validationMessage: validationMessage
+                )
+            ))
             presentAttachmentValidationError(validationMessage)
+            persistDraftToStore()
+            updateAttachButtonPresentation()
             return
         }
 
         viewController.addAttachment(.file(fileAttachment))
+        persistDraftToStore()
+        clearAttachmentValidationErrorIfPossible()
+        updateAttachButtonPresentation()
     }
 
     func removeAttachment(id: UUID) {
         viewController.removeAttachment(id: id)
         persistDraftToStore()
+        syncAttachmentValidationErrorForCurrentMode()
+        updateAttachButtonPresentation()
     }
 
     func clearAttachments() {
-        guard !viewController.currentAttachments.isEmpty else { return }
+        guard !viewController.currentAttachments.isEmpty else {
+            viewController.clearAttachmentValidationError()
+            updateAttachButtonPresentation()
+            return
+        }
         viewController.removeAllAttachments()
+        viewController.clearAttachmentValidationError()
         persistDraftToStore()
+        updateAttachButtonPresentation()
     }
 
     func updateImageButtonVisibility() {
@@ -1120,10 +1146,10 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
 
     func unifiedToggleInputVC(_ vc: UnifiedToggleInputViewController, didSubmitText text: String, mode: TextEntryMode) {
         commitCurrentToggleState()
-        clearStoreEntryAfterSubmission()
 
         switch mode {
         case .search:
+            clearStoreEntryAfterSubmission()
             if case .aiTab = displayState {
                 hide()
             } else if isOmnibarSession {
@@ -1157,6 +1183,7 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
             let configuration = promptSubmissionConfiguration
 
             resetToolsSelection()
+            clearStoreEntryAfterSubmission()
             clearAttachments()
             hasSubmittedPrompt = true
             updateModelChipVisibility()
@@ -1182,6 +1209,7 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
         textState = text.isEmpty ? .empty : .userTyped
         textChangeSubject.send(text)
         persistDraftToStore()
+        clearAttachmentValidationErrorIfPossible()
     }
 
     func unifiedToggleInputVC(_ vc: UnifiedToggleInputViewController, didChangeMode mode: TextEntryMode) {
@@ -1224,13 +1252,6 @@ private extension UnifiedToggleInputCoordinator {
 
     // MARK: Attachments
 
-    var currentImageAttachmentsForTabState: [AIChatImageAttachment] {
-        viewController.currentAttachments.compactMap { attachment in
-            guard case .image(let imageAttachment) = attachment else { return nil }
-            return imageAttachment
-        }
-    }
-
     var canPresentFilePicker: Bool {
         attachmentPolicy.canAttachFiles && !allowedFileUTTypes.isEmpty
     }
@@ -1253,6 +1274,25 @@ private extension UnifiedToggleInputCoordinator {
         UTType(mimeType: mimeType)
     }
 
+    func addInvalidFileAttachment(
+        metadata: UnifiedToggleInputAttachmentPresenter.FileMetadata?,
+        validationMessage: String
+    ) {
+        if let metadata {
+            viewController.addAttachment(.invalidFile(
+                UnifiedToggleInputInvalidFileAttachment(
+                    fileName: metadata.fileName,
+                    mimeType: metadata.mimeType,
+                    fileSizeBytes: metadata.fileSizeBytes ?? 0,
+                    validationMessage: validationMessage
+                )
+            ))
+            persistDraftToStore()
+            updateAttachButtonPresentation()
+        }
+        presentAttachmentValidationError(validationMessage)
+    }
+
     func removeUnsupportedAttachmentsForSelectedModel() {
         guard selectedModel != nil else { return }
         let unsupportedAttachments = viewController.currentAttachments.filter { attachment in
@@ -1261,6 +1301,7 @@ private extension UnifiedToggleInputCoordinator {
         unsupportedAttachments.forEach { attachment in
             viewController.removeAttachment(id: attachment.id)
         }
+        syncAttachmentValidationErrorForCurrentMode()
     }
 
     func makeAttachmentMenu() -> UIMenu? {
@@ -1283,7 +1324,29 @@ private extension UnifiedToggleInputCoordinator {
     }
 
     func presentAttachmentValidationError(_ message: String) {
-        ActionMessageView.present(message: message, presentationLocation: .top)
+        viewController.showAttachmentValidationError(message)
+    }
+
+    func syncAttachmentValidationError() {
+        if let validationMessage = viewController.currentAttachments.compactMap(\.validationMessage).first {
+            viewController.showAttachmentValidationError(validationMessage)
+        } else {
+            viewController.clearAttachmentValidationError()
+        }
+    }
+
+    func syncAttachmentValidationErrorForCurrentMode() {
+        guard inputMode == .aiChat else {
+            viewController.clearAttachmentValidationError()
+            return
+        }
+
+        syncAttachmentValidationError()
+    }
+
+    func clearAttachmentValidationErrorIfPossible() {
+        guard viewController.currentAttachments.contains(where: \.isInvalid) == false else { return }
+        viewController.clearAttachmentValidationError()
     }
 
     // MARK: Session State

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1273,6 +1273,10 @@ extension UnifiedToggleInputCoordinator {
         submitCurrentInputFromCoordinator()
     }
 
+}
+
+private extension UnifiedToggleInputCoordinator {
+
     func submitCurrentInputFromCoordinator() {
         let state = makeFloatingSubmitState()
         guard state.canSubmit else {
@@ -1293,9 +1297,6 @@ extension UnifiedToggleInputCoordinator {
             viewController.handler.submitText(currentText)
         }
     }
-}
-
-private extension UnifiedToggleInputCoordinator {
 
     // MARK: Attachments
 
@@ -1360,7 +1361,7 @@ private extension UnifiedToggleInputCoordinator {
         }
 
         guard attachment.sourceURL != nil else {
-            return replaceInvalidAttachment(attachment, validationMessage: UserText.aiChatAttachmentFileUnreadable)
+            return false
         }
 
         recoverInvalidAttachmentFromSourceURL(attachment)
@@ -1542,13 +1543,10 @@ private extension UnifiedToggleInputCoordinator {
     }
 
     func makeFloatingSubmitState() -> UnifiedToggleInputFloatingSubmitState {
-        let isAIChatMode = inputMode == .aiChat
-        let attachments = viewController.currentAttachments
-        return UnifiedToggleInputFloatingSubmitState(
-            hasText: !currentText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-            hasValidAttachment: isAIChatMode && attachments.contains { !$0.isInvalid },
-            hasInvalidAttachment: isAIChatMode && attachments.contains(where: \.isInvalid)
-        )
+        UnifiedToggleInputFloatingSubmitState(
+            text: currentText,
+            mode: inputMode,
+            attachments: viewController.currentAttachments)
     }
 
     func updateFloatingSubmitState() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -459,6 +459,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             setText(prefilledText)
             textState = .prefilledSelected
         }
+        updateFloatingSubmitState()
 
         intentSubject.send(.showExpanded)
         DispatchQueue.main.async { [weak self] in
@@ -528,6 +529,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         } else {
             shouldSelectAllText = false
         }
+        updateFloatingSubmitState()
 
         let expandedHeight = editingHeight()
 
@@ -1372,10 +1374,8 @@ private extension UnifiedToggleInputCoordinator {
               let metadata = fileMetadata(for: attachment) else { return }
 
         let attachmentID = attachment.id
-        invalidAttachmentRecoveryTasks[attachmentID] = Task { [weak self] in
-            let fileAttachment = await Task.detached(priority: .userInitiated) {
-                UnifiedToggleInputAttachmentPresenter.recoverFileAttachment(from: metadata, id: attachmentID)
-            }.value
+        invalidAttachmentRecoveryTasks[attachmentID] = Task.detached(priority: .userInitiated) { [weak self] in
+            let fileAttachment = UnifiedToggleInputAttachmentPresenter.recoverFileAttachment(from: metadata, id: attachmentID)
             guard !Task.isCancelled else { return }
             await self?.completeInvalidAttachmentRecovery(id: attachmentID, fileAttachment: fileAttachment)
         }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1310,21 +1310,19 @@ private extension UnifiedToggleInputCoordinator {
     }
 
     func addInvalidFileAttachment(
-        metadata: UnifiedToggleInputAttachmentPresenter.FileMetadata?,
+        metadata: UnifiedToggleInputAttachmentPresenter.FileMetadata,
         validationMessage: String
     ) {
-        if let metadata {
-            viewController.addAttachment(.invalidFile(
-                UnifiedToggleInputInvalidFileAttachment(
-                    fileName: metadata.fileName,
-                    mimeType: metadata.mimeType,
-                    fileSizeBytes: metadata.fileSizeBytes ?? 0,
-                    validationMessage: validationMessage
-                )
-            ))
-            persistDraftToStore()
-            updateAttachButtonPresentation()
-        }
+        viewController.addAttachment(.invalidFile(
+            UnifiedToggleInputInvalidFileAttachment(
+                fileName: metadata.fileName,
+                mimeType: metadata.mimeType,
+                fileSizeBytes: metadata.fileSizeBytes ?? 0,
+                validationMessage: validationMessage
+            )
+        ))
+        persistDraftToStore()
+        updateAttachButtonPresentation()
         presentAttachmentValidationError(validationMessage)
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -588,6 +588,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             viewController.apply(computeRenderState().viewConfig, animated: false)
             refreshToolsPresentation()
             modeChangeSubject.send(.search)
+            syncAttachmentValidationErrorForCurrentMode()
             updateFloatingSubmitState()
         }
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputFileEncoder.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputFileEncoder.swift
@@ -23,7 +23,7 @@ enum UnifiedToggleInputFileEncoder {
 
     static func encode(_ attachments: [UnifiedToggleInputAttachment]) -> [AIChatNativePrompt.NativePromptFile]? {
         let files = attachments.compactMap { attachment -> AIChatNativePrompt.NativePromptFile? in
-            guard case .file(let fileAttachment) = attachment else { return nil }
+            guard let fileAttachment = attachment.fileAttachment else { return nil }
             return AIChatNativePrompt.NativePromptFile(
                 data: fileAttachment.data.base64EncodedString(),
                 fileName: fileAttachment.fileName,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputFloatingSubmitViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputFloatingSubmitViewController.swift
@@ -27,6 +27,26 @@ protocol UnifiedToggleInputFloatingSubmitDelegate: AnyObject {
     func floatingSubmitDidTapVoice()
 }
 
+struct UnifiedToggleInputFloatingSubmitState: Equatable {
+    let hasText: Bool
+    let hasValidAttachment: Bool
+    let hasInvalidAttachment: Bool
+
+    static let empty = UnifiedToggleInputFloatingSubmitState(
+        hasText: false,
+        hasValidAttachment: false,
+        hasInvalidAttachment: false
+    )
+
+    var canSubmit: Bool {
+        !hasInvalidAttachment && (hasText || hasValidAttachment)
+    }
+
+    var canRequestVoice: Bool {
+        !hasInvalidAttachment && !hasText && !hasValidAttachment
+    }
+}
+
 final class UnifiedToggleInputFloatingSubmitViewController: UIViewController {
 
     weak var delegate: UnifiedToggleInputFloatingSubmitDelegate?
@@ -42,7 +62,11 @@ final class UnifiedToggleInputFloatingSubmitViewController: UIViewController {
         didSet { updateIcon() }
     }
 
-    private var hasText = false
+    var isSubmitButtonEnabled: Bool {
+        button.isEnabled
+    }
+
+    private var submitState = UnifiedToggleInputFloatingSubmitState.empty
     private var isFireTab = false
     private var cancellables = Set<AnyCancellable>()
 
@@ -70,21 +94,24 @@ final class UnifiedToggleInputFloatingSubmitViewController: UIViewController {
         updateIcon()
     }
 
-    func subscribe(to textPublisher: AnyPublisher<String, Never>) {
-        textPublisher
-            .map { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+    func subscribe(to submitStatePublisher: AnyPublisher<UnifiedToggleInputFloatingSubmitState, Never>) {
+        submitStatePublisher
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] hasText in
-                self?.hasText = hasText
-                self?.updateIcon()
+            .sink { [weak self] state in
+                self?.updateState(state)
             }
             .store(in: &cancellables)
     }
 
+    func updateState(_ state: UnifiedToggleInputFloatingSubmitState) {
+        submitState = state
+        updateIcon()
+    }
+
     private func updateIcon() {
-        let showVoice = !hasText && isAIVoiceChatEnabled
-        let isActive = hasText || showVoice
+        let showVoice = submitState.canRequestVoice && isAIVoiceChatEnabled
+        let isActive = submitState.canSubmit || showVoice
         let icon = showVoice ? DesignSystemImages.Glyphs.Size24.voice : DesignSystemImages.Glyphs.Size24.arrowUp
         button.setImage(icon, for: .normal)
         button.isEnabled = isActive
@@ -98,9 +125,9 @@ final class UnifiedToggleInputFloatingSubmitViewController: UIViewController {
     }
 
     @objc private func buttonTapped() {
-        if hasText {
+        if submitState.canSubmit {
             delegate?.floatingSubmitDidTapSubmit()
-        } else if isAIVoiceChatEnabled {
+        } else if submitState.canRequestVoice && isAIVoiceChatEnabled {
             delegate?.floatingSubmitDidTapVoice()
         }
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputFloatingSubmitViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputFloatingSubmitViewController.swift
@@ -38,6 +38,19 @@ struct UnifiedToggleInputFloatingSubmitState: Equatable {
         hasInvalidAttachment: false
     )
 
+    init(hasText: Bool, hasValidAttachment: Bool, hasInvalidAttachment: Bool) {
+        self.hasText = hasText
+        self.hasValidAttachment = hasValidAttachment
+        self.hasInvalidAttachment = hasInvalidAttachment
+    }
+
+    init(text: String, mode: TextEntryMode, attachments: [UnifiedToggleInputAttachment]) {
+        let isAIChatMode = mode == .aiChat
+        hasText = !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        hasValidAttachment = isAIChatMode && attachments.contains { !$0.isInvalid }
+        hasInvalidAttachment = isAIChatMode && attachments.contains(where: \.isInvalid)
+    }
+
     var canSubmit: Bool {
         !hasInvalidAttachment && (hasText || hasValidAttachment)
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
@@ -182,6 +182,10 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
         textSubmissionSubject.send((text: trimmed, mode: currentToggleState))
     }
 
+    func submitAIChatAttachmentOnlyPrompt() {
+        textSubmissionSubject.send((text: "", mode: .aiChat))
+    }
+
     func setToggleState(_ state: TextEntryMode) {
         guard currentToggleState != state else { return }
         currentToggleState = state

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -244,6 +244,10 @@ final class UnifiedToggleInputView: UIView {
         attachmentsStrip.addAttachment(attachment)
     }
 
+    func replaceAttachment(id: UUID, with attachment: UnifiedToggleInputAttachment) {
+        attachmentsStrip.replaceAttachment(id: id, with: attachment)
+    }
+
     func removeAttachment(id: UUID) {
         attachmentsStrip.removeAttachment(id: id)
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -758,12 +758,11 @@ final class UnifiedToggleInputView: UIView {
     }
 
     private func updateSubmitButtonAvailability() {
-        let isAIChatMode = handler.currentToggleState == .aiChat
-        let hasSubmittableText = !handler.currentText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        let hasValidAttachment = attachmentsStrip.attachments.contains { !$0.isInvalid }
-        let hasInvalidAttachment = isAIChatMode && attachmentsStrip.attachments.contains(where: \.isInvalid)
-        let hasSubmittableAttachment = isAIChatMode && hasValidAttachment
-        toolsToolbar.isSubmitEnabled = !hasInvalidAttachment && (hasSubmittableText || hasSubmittableAttachment)
+        let state = UnifiedToggleInputFloatingSubmitState(
+            text: handler.currentText,
+            mode: handler.currentToggleState,
+            attachments: attachmentsStrip.attachments)
+        toolsToolbar.isSubmitEnabled = state.canSubmit
     }
 
     private func submitCurrentInput() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -29,6 +29,7 @@ import UIKit
 /// Delegate protocol for handling interactions with the unified toggle input composite view.
 protocol UnifiedToggleInputViewDelegate: AnyObject {
     func unifiedToggleInputViewDidTapWhileCollapsed(_ view: UnifiedToggleInputView)
+    func unifiedToggleInputViewDidRequestSubmitCurrentInput(_ view: UnifiedToggleInputView)
     func unifiedToggleInputViewDidSubmitText(_ view: UnifiedToggleInputView, text: String, mode: TextEntryMode)
     func unifiedToggleInputViewDidChangeText(_ view: UnifiedToggleInputView, text: String)
     func unifiedToggleInputViewDidChangeMode(_ view: UnifiedToggleInputView, mode: TextEntryMode)
@@ -766,17 +767,7 @@ final class UnifiedToggleInputView: UIView {
     }
 
     private func submitCurrentInput() {
-        let isAIChatMode = handler.currentToggleState == .aiChat
-        let trimmedText = handler.currentText.trimmingCharacters(in: .whitespacesAndNewlines)
-        let hasValidAttachment = attachmentsStrip.attachments.contains { !$0.isInvalid }
-        let hasInvalidAttachment = isAIChatMode && attachmentsStrip.attachments.contains(where: \.isInvalid)
-        guard !hasInvalidAttachment else { return }
-
-        if trimmedText.isEmpty, isAIChatMode, hasValidAttachment {
-            handler.submitAIChatAttachmentOnlyPrompt()
-        } else {
-            handler.submitText(handler.currentText)
-        }
+        delegate?.unifiedToggleInputViewDidRequestSubmitCurrentInput(self)
     }
 }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -236,6 +236,10 @@ final class UnifiedToggleInputView: UIView {
         attachmentsStrip.attachments
     }
 
+    var isToolbarSubmitEnabled: Bool {
+        toolsToolbar.isSubmitEnabled
+    }
+
     func addAttachment(_ attachment: UnifiedToggleInputAttachment) {
         attachmentsStrip.addAttachment(attachment)
     }
@@ -749,20 +753,22 @@ final class UnifiedToggleInputView: UIView {
     }
 
     private func updateSubmitButtonAvailability() {
+        let isAIChatMode = handler.currentToggleState == .aiChat
         let hasSubmittableText = !handler.currentText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let hasValidAttachment = attachmentsStrip.attachments.contains { !$0.isInvalid }
-        let hasInvalidAttachment = attachmentsStrip.attachments.contains(where: \.isInvalid)
-        let hasSubmittableAttachment = handler.currentToggleState == .aiChat && hasValidAttachment
+        let hasInvalidAttachment = isAIChatMode && attachmentsStrip.attachments.contains(where: \.isInvalid)
+        let hasSubmittableAttachment = isAIChatMode && hasValidAttachment
         toolsToolbar.isSubmitEnabled = !hasInvalidAttachment && (hasSubmittableText || hasSubmittableAttachment)
     }
 
     private func submitCurrentInput() {
+        let isAIChatMode = handler.currentToggleState == .aiChat
         let trimmedText = handler.currentText.trimmingCharacters(in: .whitespacesAndNewlines)
         let hasValidAttachment = attachmentsStrip.attachments.contains { !$0.isInvalid }
-        let hasInvalidAttachment = attachmentsStrip.attachments.contains(where: \.isInvalid)
+        let hasInvalidAttachment = isAIChatMode && attachmentsStrip.attachments.contains(where: \.isInvalid)
         guard !hasInvalidAttachment else { return }
 
-        if trimmedText.isEmpty, handler.currentToggleState == .aiChat, hasValidAttachment {
+        if trimmedText.isEmpty, isAIChatMode, hasValidAttachment {
             handler.submitAIChatAttachmentOnlyPrompt()
         } else {
             handler.submitText(handler.currentText)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -747,6 +747,27 @@ final class UnifiedToggleInputView: UIView {
         attachmentsStripHeightConstraint.constant = showStrip ? UnifiedToggleInputAttachmentsStripView.Constants.stripHeight : 0
         attachmentsStrip.alpha = showStrip ? 1 : 0
     }
+
+    private func updateSubmitButtonAvailability() {
+        let hasSubmittableText = !handler.currentText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let hasValidAttachment = attachmentsStrip.attachments.contains { !$0.isInvalid }
+        let hasInvalidAttachment = attachmentsStrip.attachments.contains(where: \.isInvalid)
+        let hasSubmittableAttachment = handler.currentToggleState == .aiChat && hasValidAttachment
+        toolsToolbar.isSubmitEnabled = !hasInvalidAttachment && (hasSubmittableText || hasSubmittableAttachment)
+    }
+
+    private func submitCurrentInput() {
+        let trimmedText = handler.currentText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let hasValidAttachment = attachmentsStrip.attachments.contains { !$0.isInvalid }
+        let hasInvalidAttachment = attachmentsStrip.attachments.contains(where: \.isInvalid)
+        guard !hasInvalidAttachment else { return }
+
+        if trimmedText.isEmpty, handler.currentToggleState == .aiChat, hasValidAttachment {
+            handler.submitAIChatAttachmentOnlyPrompt()
+        } else {
+            handler.submitText(handler.currentText)
+        }
+    }
 }
 
 // MARK: - Inline Dismiss
@@ -872,6 +893,7 @@ private extension UnifiedToggleInputView {
         attachmentsStrip.onAttachmentsChanged = { [weak self] in
             guard let self else { return }
             updateAttachmentsStripLayout()
+            updateSubmitButtonAvailability()
             layoutIfNeeded()
             onNeedsHierarchyLayout?()
             onAttachmentsLayoutDidChange?()
@@ -886,7 +908,7 @@ private extension UnifiedToggleInputView {
         toolsToolbar.alpha = 0
         toolsToolbar.onSubmitTapped = { [weak self] in
             guard let self else { return }
-            handler.submitText(handler.currentText)
+            submitCurrentInput()
         }
         toolsToolbar.onStopGeneratingTapped = { [weak self] in
             self?.handler.stopGeneratingButtonTapped()
@@ -983,8 +1005,7 @@ private extension UnifiedToggleInputView {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] text in
                 guard let self else { return }
-                let hasSubmittableText = !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                toolsToolbar.isSubmitEnabled = hasSubmittableText
+                updateSubmitButtonAvailability()
                 delegate?.unifiedToggleInputViewDidChangeText(self, text: text)
             }
             .store(in: &cancellables)
@@ -995,6 +1016,7 @@ private extension UnifiedToggleInputView {
                 guard let self else { return }
                 toggleView.setMode(mode, animated: true)
                 updateToolbarVisibility(for: mode, animated: true)
+                updateSubmitButtonAvailability()
             }
             .store(in: &cancellables)
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
@@ -28,6 +28,7 @@ import UIKit
 /// The view controller translates raw view events into these higher-level callbacks.
 protocol UnifiedToggleInputViewControllerDelegate: AnyObject {
     func unifiedToggleInputVCDidTapWhileCollapsed(_ vc: UnifiedToggleInputViewController)
+    func unifiedToggleInputVCDidRequestSubmitCurrentInput(_ vc: UnifiedToggleInputViewController)
     func unifiedToggleInputVC(_ vc: UnifiedToggleInputViewController, didSubmitText text: String, mode: TextEntryMode)
     func unifiedToggleInputVC(_ vc: UnifiedToggleInputViewController, didChangeText text: String)
     func unifiedToggleInputVC(_ vc: UnifiedToggleInputViewController, didChangeMode mode: TextEntryMode)
@@ -377,6 +378,10 @@ extension UnifiedToggleInputViewController: UnifiedToggleInputViewDelegate {
 
     func unifiedToggleInputViewDidTapWhileCollapsed(_ view: UnifiedToggleInputView) {
         delegate?.unifiedToggleInputVCDidTapWhileCollapsed(self)
+    }
+
+    func unifiedToggleInputViewDidRequestSubmitCurrentInput(_ view: UnifiedToggleInputView) {
+        delegate?.unifiedToggleInputVCDidRequestSubmitCurrentInput(self)
     }
 
     func unifiedToggleInputViewDidSubmitText(_ view: UnifiedToggleInputView, text: String, mode: TextEntryMode) {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
@@ -18,6 +18,8 @@
 //
 
 import AIChat
+import DesignResourcesKit
+import DesignResourcesKitIcons
 import UIKit
 
 // MARK: - Delegate Protocol
@@ -48,13 +50,15 @@ final class UnifiedToggleInputViewController: UIViewController {
 
     weak var delegate: UnifiedToggleInputViewControllerDelegate?
 
-    private var inputBarView: UnifiedToggleInputView {
-        // swiftlint:disable:next force_cast
-        view as! UnifiedToggleInputView
-    }
-
     let isToggleEnabled: Bool
     let handler: UnifiedToggleInputHandler
+    private lazy var inputBarView = UnifiedToggleInputView(handler: handler, isToggleEnabled: isToggleEnabled)
+    private(set) var attachmentValidationMessage: String?
+
+    private var containerView: UnifiedToggleInputContainerView? {
+        guard isViewLoaded else { return nil }
+        return view as? UnifiedToggleInputContainerView
+    }
 
     // MARK: - Public API
 
@@ -98,7 +102,10 @@ final class UnifiedToggleInputViewController: UIViewController {
 
     var cardPosition: UnifiedToggleInputCardPosition {
         get { inputBarView.cardPosition }
-        set { inputBarView.cardPosition = newValue }
+        set {
+            inputBarView.cardPosition = newValue
+            containerView?.cardPosition = newValue
+        }
     }
 
     var usesOmnibarMargins: Bool {
@@ -190,19 +197,37 @@ final class UnifiedToggleInputViewController: UIViewController {
     }
 
     var currentAttachments: [UnifiedToggleInputAttachment] {
-        inputBarView.currentAttachments
+        loadViewIfNeeded()
+        return inputBarView.currentAttachments
     }
 
     func addAttachment(_ attachment: UnifiedToggleInputAttachment) {
+        loadViewIfNeeded()
         inputBarView.addAttachment(attachment)
     }
 
     func removeAttachment(id: UUID) {
+        loadViewIfNeeded()
         inputBarView.removeAttachment(id: id)
     }
 
     func removeAllAttachments() {
+        loadViewIfNeeded()
         inputBarView.removeAllAttachments()
+    }
+
+    func showAttachmentValidationError(_ message: String) {
+        attachmentValidationMessage = message
+        loadViewIfNeeded()
+        containerView?.showAttachmentValidationError(message)
+        notifyHeightDidChange()
+    }
+
+    func clearAttachmentValidationError() {
+        guard attachmentValidationMessage != nil else { return }
+        attachmentValidationMessage = nil
+        containerView?.clearAttachmentValidationError()
+        notifyHeightDidChange()
     }
 
     func apply(_ config: UTIViewConfig, animated: Bool) {
@@ -305,12 +330,11 @@ final class UnifiedToggleInputViewController: UIViewController {
     // MARK: - Lifecycle
 
     override func loadView() {
-        let barView = UnifiedToggleInputView(handler: handler, isToggleEnabled: isToggleEnabled)
+        let barView = inputBarView
         barView.delegate = self
         barView.onNeedsHierarchyLayout = { [weak self] in
             guard let self else { return }
-            self.view.window?.layoutIfNeeded()
-            self.delegate?.unifiedToggleInputVCDidChangeHeight(self)
+            self.notifyHeightDidChange()
         }
         barView.onAttachmentRemoved = { [weak self] id in
             guard let self else { return }
@@ -328,7 +352,17 @@ final class UnifiedToggleInputViewController: UIViewController {
             guard let self else { return }
             delegate?.unifiedToggleInputVCDidTapAIChatShortcut(self)
         }
-        view = barView
+        let containerView = UnifiedToggleInputContainerView(inputView: barView)
+        containerView.cardPosition = barView.cardPosition
+        if let attachmentValidationMessage {
+            containerView.showAttachmentValidationError(attachmentValidationMessage)
+        }
+        view = containerView
+    }
+
+    private func notifyHeightDidChange() {
+        view.window?.layoutIfNeeded()
+        delegate?.unifiedToggleInputVCDidChangeHeight(self)
     }
 }
 
@@ -358,5 +392,213 @@ extension UnifiedToggleInputViewController: UnifiedToggleInputViewDelegate {
 
     func unifiedToggleInputViewDidClearSelectedTool(_ view: UnifiedToggleInputView) {
         delegate?.unifiedToggleInputVCDidClearSelectedTool(self)
+    }
+}
+
+private final class UnifiedToggleInputContainerView: UIView {
+
+    private enum Metrics {
+        static let bannerHeight: CGFloat = 48
+        static let bannerSpacing: CGFloat = 8
+        static let topBannerHorizontalMargin: CGFloat = 16
+        static let bottomBannerHorizontalMargin: CGFloat = 12
+    }
+
+    var cardPosition: UnifiedToggleInputCardPosition = .bottom {
+        didSet {
+            guard cardPosition != oldValue else { return }
+            applyBannerPlacement()
+        }
+    }
+
+    private let unifiedInputView: UnifiedToggleInputView
+    private let errorBannerView = UnifiedToggleInputAttachmentErrorBannerView()
+
+    private var isBannerVisible = false
+    private var bannerHeightConstraint: NSLayoutConstraint!
+    private var inputTopToContainerConstraint: NSLayoutConstraint!
+    private var inputBottomToContainerConstraint: NSLayoutConstraint!
+    private var bannerTopToContainerConstraint: NSLayoutConstraint!
+    private var bannerBottomToContainerConstraint: NSLayoutConstraint!
+    private var bannerTopToInputConstraint: NSLayoutConstraint!
+    private var bannerBottomToInputConstraint: NSLayoutConstraint!
+    private var bannerLeadingConstraint: NSLayoutConstraint!
+    private var bannerTrailingConstraint: NSLayoutConstraint!
+
+    init(inputView: UnifiedToggleInputView) {
+        self.unifiedInputView = inputView
+        super.init(frame: .zero)
+        setupUI()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func showAttachmentValidationError(_ message: String) {
+        errorBannerView.message = message
+        isBannerVisible = true
+        errorBannerView.isHidden = false
+        applyBannerPlacement()
+    }
+
+    func clearAttachmentValidationError() {
+        isBannerVisible = false
+        applyBannerPlacement()
+        errorBannerView.isHidden = true
+    }
+}
+
+private extension UnifiedToggleInputContainerView {
+
+    func setupUI() {
+        backgroundColor = .clear
+        addSubview(unifiedInputView)
+        addSubview(errorBannerView)
+        unifiedInputView.translatesAutoresizingMaskIntoConstraints = false
+        errorBannerView.translatesAutoresizingMaskIntoConstraints = false
+        errorBannerView.isHidden = true
+
+        bannerHeightConstraint = errorBannerView.heightAnchor.constraint(equalToConstant: 0)
+        inputTopToContainerConstraint = unifiedInputView.topAnchor.constraint(equalTo: topAnchor)
+        inputBottomToContainerConstraint = unifiedInputView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        bannerTopToContainerConstraint = errorBannerView.topAnchor.constraint(equalTo: topAnchor)
+        bannerBottomToContainerConstraint = errorBannerView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        bannerTopToInputConstraint = errorBannerView.topAnchor.constraint(equalTo: unifiedInputView.bottomAnchor, constant: Metrics.bannerSpacing)
+        bannerBottomToInputConstraint = errorBannerView.bottomAnchor.constraint(equalTo: unifiedInputView.topAnchor, constant: -Metrics.bannerSpacing)
+        bannerLeadingConstraint = errorBannerView.leadingAnchor.constraint(equalTo: leadingAnchor)
+        bannerTrailingConstraint = errorBannerView.trailingAnchor.constraint(equalTo: trailingAnchor)
+
+        NSLayoutConstraint.activate([
+            unifiedInputView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            unifiedInputView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            bannerLeadingConstraint,
+            bannerTrailingConstraint,
+            bannerHeightConstraint,
+        ])
+
+        applyBannerPlacement()
+    }
+
+    func applyBannerPlacement() {
+        NSLayoutConstraint.deactivate([
+            inputTopToContainerConstraint,
+            inputBottomToContainerConstraint,
+            bannerTopToContainerConstraint,
+            bannerBottomToContainerConstraint,
+            bannerTopToInputConstraint,
+            bannerBottomToInputConstraint,
+        ])
+
+        bannerHeightConstraint.constant = isBannerVisible ? Metrics.bannerHeight : 0
+        let horizontalMargin = cardPosition == .top ? Metrics.topBannerHorizontalMargin : Metrics.bottomBannerHorizontalMargin
+        bannerLeadingConstraint.constant = horizontalMargin
+        bannerTrailingConstraint.constant = -horizontalMargin
+
+        if !isBannerVisible {
+            NSLayoutConstraint.activate([
+                inputTopToContainerConstraint,
+                inputBottomToContainerConstraint,
+                bannerTopToContainerConstraint,
+            ])
+            return
+        }
+
+        switch cardPosition {
+        case .top:
+            NSLayoutConstraint.activate([
+                inputTopToContainerConstraint,
+                bannerTopToInputConstraint,
+                bannerBottomToContainerConstraint,
+            ])
+        case .bottom:
+            NSLayoutConstraint.activate([
+                bannerTopToContainerConstraint,
+                bannerBottomToInputConstraint,
+                inputBottomToContainerConstraint,
+            ])
+        }
+    }
+}
+
+private final class UnifiedToggleInputAttachmentErrorBannerView: UIView {
+
+    var message: String? {
+        get { messageLabel.text }
+        set { messageLabel.text = newValue }
+    }
+
+    private let iconView: UIImageView = {
+        let imageView = UIImageView(image: DesignSystemImages.Glyphs.Size24.alertRecolorable)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+
+    private let messageLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.daxCaption1()
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 2
+        label.textColor = UIColor(designSystemColor: .textPrimary)
+        return label
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            applyColors()
+        }
+    }
+}
+
+private extension UnifiedToggleInputAttachmentErrorBannerView {
+
+    enum Metrics {
+        static let cornerRadius: CGFloat = 24
+        static let horizontalPadding: CGFloat = 18
+        static let iconSize: CGFloat = 24
+        static let iconTextSpacing: CGFloat = 12
+    }
+
+    func setupUI() {
+        layer.cornerRadius = Metrics.cornerRadius
+        layer.cornerCurve = .continuous
+        clipsToBounds = true
+        accessibilityTraits = .staticText
+
+        addSubview(iconView)
+        addSubview(messageLabel)
+
+        NSLayoutConstraint.activate([
+            iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Metrics.horizontalPadding),
+            iconView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            iconView.widthAnchor.constraint(equalToConstant: Metrics.iconSize),
+            iconView.heightAnchor.constraint(equalToConstant: Metrics.iconSize),
+
+            messageLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: Metrics.iconTextSpacing),
+            messageLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Metrics.horizontalPadding),
+            messageLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+
+        applyColors()
+    }
+
+    func applyColors() {
+        backgroundColor = UIColor(singleUseColor: .unifiedToggleInputAttachmentErrorBannerBackground)
+        iconView.tintColor = UIColor(singleUseColor: .unifiedToggleInputAttachmentErrorIcon)
+        messageLabel.textColor = UIColor(singleUseColor: .unifiedToggleInputAttachmentErrorText)
     }
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
@@ -206,6 +206,11 @@ final class UnifiedToggleInputViewController: UIViewController {
         inputBarView.addAttachment(attachment)
     }
 
+    func replaceAttachment(id: UUID, with attachment: UnifiedToggleInputAttachment) {
+        loadViewIfNeeded()
+        inputBarView.replaceAttachment(id: id, with: attachment)
+    }
+
     func removeAttachment(id: UUID) {
         loadViewIfNeeded()
         inputBarView.removeAttachment(id: id)

--- a/iOS/DuckDuckGo/bg.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/bg.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Направете снимка";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Можете да прикачите само %d файла на разговор.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "Не можем да прочетем прикачените файлове, защото поне един от тях е криптиран.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "Прикачените файлове надвишават общия лимит за размер от %d MB.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "Този файл е прекалено голям. Максималният размер на файла е %d MB.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "Един от прикачените файлове има повече страници, отколкото поддържаме. Качете файлове с максимум %d страници.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "Не можем да прочетем един от прикачените файлове. Проверете дали не е повреден и опитайте отново.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Можете да прикачите само %d изображения на разговор.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Можете да прикачите само %d изображения едновременно.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Прикачване на файл";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Прикачване на снимка";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "Това съобщение е твърде дълго, за да бъде изпратено с прикачени файлове.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Прикачените файлове са временно недостъпни. Моля, опитайте отново по-късно.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Този тип файл не се поддържа.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Този тип файл не се поддържа, прикачете %1$@ или %2$@.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Този тип файл не се поддържа, прикачете %@.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "За аналитични задачи";
 

--- a/iOS/DuckDuckGo/cs.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/cs.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Pořídit fotku";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Počet souborů, které můžeš v jedné konverzaci přiložit: %d";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "Nemůžeme přečíst přiložené soubory, protože minimálně jeden z nich je zašifrovaný.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "Přiložené soubory překračují limit celkové velikosti %d MB.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "Tento soubor je moc velký. Maximální velikost souboru je %d MB.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "Jeden z přiložených souborů má více stránek, než kolik podporujeme. Maximální počet stránek v souboru: %d.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "Jeden z přiložených souborů jsme nemohli přečíst. Zkontroluj, jestli není poškozený, a zkus to znovu.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Počet obrázků, které můžeš přiložit v jedné konverzaci: %d.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Maximum obrázků, které jde přiložit najednou: %d.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Přiložit soubor";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Přiložit fotku";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "Tahle zpráva je moc dlouhá na to, aby se dala poslat s přílohami.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Přílohy jsou dočasně nedostupné. Zkus to znovu později.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Tento typ souboru není podporován.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Tento typ souboru nepodporujeme. Podporované přílohy: %1$@ nebo %2$@.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Tento typ souboru nepodporujeme. Podporované přílohy: %@.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "Pro analytické úlohy";
 

--- a/iOS/DuckDuckGo/da.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/da.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Tag et billede";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Du kan kun vedhæfte %d filer pr. samtale.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "Vi kan ikke læse de vedhæftede filer, fordi mindst én af dem er krypteret.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "De vedhæftede filer overstiger grænsen for den samlede størrelse på %d MB.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "Denne fil er for stor. Den maksimale filstørrelse er %d MB.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "En af de vedhæftede filer har flere sider, end vi understøtter. Upload filer med højst %d sider.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "Vi kan ikke læse en af de vedhæftede filer. Kontroller, at den ikke er beskadiget, og prøv igen.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Du kan kun vedhæfte %d billeder pr. samtale.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Du kan kun vedhæfte %d billeder ad gangen.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Vedhæft fil";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Vedhæft foto";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "Beskeden er for lang til at blive sendt med vedhæftede filer.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Vedhæftede filer er midlertidigt utilgængelige. Prøv igen senere.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Denne filtype understøttes ikke.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Denne filtype understøttes ikke. Vedhæft en %1$@- eller %2$@-fil.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Denne filtype understøttes ikke. Vedhæft en %@-fil.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "Til analytiske opgaver";
 

--- a/iOS/DuckDuckGo/de.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/de.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Foto machen";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Du kannst nur %d Dateien pro Gespräch anhängen.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "Wir können die angehängten Dateien nicht lesen, weil mindestens eine davon verschlüsselt ist.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "Die angehängten Dateien überschreiten die Größenbegrenzung von %d MB.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "Diese Datei ist zu groß. Die maximale Dateigröße beträgt %d MB.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "Eine der beigefügten Dateien enthält mehr Seiten, als wir unterstützen. Bitte lade Dateien mit %d Seiten oder weniger hoch.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "Wir können eine der angehängten Dateien nicht lesen. Bitte überprüfe, ob die Datei beschädigt ist, und versuche es erneut.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Du kannst nur %d Bilder pro Gespräch anhängen.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Du kannst jeweils nur %d Bilder anhängen.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Datei anhängen";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Foto anhängen";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "Diese Nachricht ist zu lang, um sie mit Anhängen zu versenden.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Anhänge sind vorübergehend nicht verfügbar. Bitte versuche es zu einem späteren Zeitpunkt erneut.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Dieser Dateityp wird nicht unterstützt";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Dieser Dateityp wird nicht unterstützt. Bitte hänge eine %1$@- oder %2$@-Datei an.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Dieser Dateityp wird nicht unterstützt. Bitte %@ anhängen.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "Für analytische Aufgaben";
 

--- a/iOS/DuckDuckGo/el.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/el.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Τραβήξτε μια φωτογραφία";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Μπορείτε να επισυνάψετε μόνο %d αρχεία ανά συνομιλία.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "Δεν μπορούμε να διαβάσουμε τα επισυναπτόμενα αρχεία επειδή τουλάχιστον ένα από αυτά είναι κρυπτογραφημένο.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "Τα συνημμένα αρχεία υπερβαίνουν το συνολικό όριο μεγέθους των %d MB.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %d MB.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "Ένα από τα συνημμένα αρχεία έχει περισσότερες σελίδες από όσες υποστηρίζουμε. Μεταφορτώστε αρχεία με %d σελίδες ή λιγότερες.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "Δεν μπορούμε να διαβάσουμε ένα από τα συνημμένα αρχεία. Έλεγξε ότι δεν είναι κατεστραμμένο και προσπαθήστε ξανά.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Μπορείτε να επισυνάψετε μόνο %d εικόνες ανά συνομιλία.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Μπορείτε να επισυνάψετε μόνο %d εικόνες κάθε φορά.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Επισύναψη αρχείου";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Επισύναψη φωτογραφίας";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "Αυτό το μήνυμα είναι πολύ μεγάλο για να σταλεί με συνημμένα.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Τα συνημμένα δεν είναι προσωρινά διαθέσιμα. Προσπαθήστε πάλι αργότερα.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Αυτός ο τύπος αρχείου δεν υποστηρίζεται.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Αυτός ο τύπος αρχείου δεν υποστηρίζεται, επισύναψε %1$@ ή %2$@.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Αυτός ο τύπος αρχείου δεν υποστηρίζεται, επισυνάψτε %@.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "Για εργασίες ανάλυσης";
 

--- a/iOS/DuckDuckGo/es.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/es.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Hacer una foto";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Solo puedes adjuntar %d archivos por conversación.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "No podemos leer los archivos adjuntos porque al menos uno de ellos está encriptado.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "Los archivos adjuntos superan el límite total de tamaño de %d MB.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "Este archivo es demasiado grande. El tamaño máximo del archivo es de %d MB.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "Uno de los archivos adjuntos tiene más páginas de las que admitimos. Carga archivos con %d páginas o menos.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "No podemos leer uno de los archivos adjuntos. Compruebe que no esté dañado e inténtelo de nuevo.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Solo puedes adjuntar %d imágenes por conversación.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Solo puedes adjuntar %d imágenes a la vez.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Adjuntar archivo";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Adjuntar foto";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "Ese mensaje es demasiado largo para enviar con archivos adjuntos.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Los archivos adjuntos no están disponibles temporalmente. Inténtelo de nuevo más tarde.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Este tipo de archivo no es compatible.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Este tipo de archivo no es compatible, adjunte un %1$@ o %2$@.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Este tipo de archivo no es compatible, adjunte un %@.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "Para tareas de análisis";
 

--- a/iOS/DuckDuckGo/et.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/et.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Tee foto";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Saad vestluse kohta lisada ainult %d faili.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "Me ei saa lisatud faile lugeda, sest vähemalt üks neist on krüptitud.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "Lisatud failid ületavad %d MB suuruse kogumahu piirangut.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "See fail on liiga suur. Maksimaalne faili suurus on %d MB.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "Ühel lisatud failidest on rohkem lehekülgi, kui me toetame. Palun laadi üles failid, millel on %d lehekülge või vähem.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "Me ei saa ühte lisatud failidest lugeda. Palun kontrolli, et see poleks rikutud, ja proovi uuesti.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Saad vestlusele lisada ainult %d pilti.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Saad korraga lisada ainult %d pilti.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Lisa fail";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Lisa foto";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "See sõnum on manustega saatmiseks liiga pikk.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Manused pole ajutiselt saadaval. Proovi hiljem uuesti.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Seda failitüüpi ei toetata.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Seda failitüüpi ei toetata, palun lisa %1$@ või %2$@.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Seda failitüüpi ei toetata, palun lisa %@.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "Analüütiliste ülesannete jaoks";
 

--- a/iOS/DuckDuckGo/fi.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fi.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Ota kuva";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Voit liittää vain %d tiedostoa keskustelua kohden.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "Emme voi lukea liitettyjä tiedostoja, koska ainakin yksi niistä on salattu.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "Liitetyt tiedostot ylittävät %d Mt:n kokonaisrajan.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "Tämä tiedosto on liian suuri. Tiedoston suurin sallittu koko on %d Mt.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "Yhdessä liitetiedostossa on enemmän sivuja kuin järjestelmämme tukee. Lataa tiedostoja, joissa on enintään %d sivua.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "Emme voi lukea yhtä liitetyistä tiedostoista. Tarkista, ettei se ole vioittunut, ja yritä uudelleen.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Voit liittää vain %d kuvaa keskustelua kohden.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Voit liittää vain %d kuvaa kerrallaan.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Liitä tiedosto";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Liitä kuva";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "Viesti on liian pitkä lähetettäväksi liitteiden kanssa.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Liitteet eivät ole tilapäisesti käytettävissä. Yritä myöhemmin uudelleen.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Tätä tiedostotyyppiä ei tueta.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Tätä tiedostotyyppiä ei tueta, liitä %1$@ tai %2$@.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Tätä tiedostotyyppiä ei tueta, liitä %@.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "Analyyttisiä tehtäviä varten";
 

--- a/iOS/DuckDuckGo/fr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fr.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Prends une photo";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Vous ne pouvez joindre que %d fichiers par conversation.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "Nous ne pouvons pas ouvrir les fichiers joints, car au moins l’un d’entre eux est chiffré.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "Les fichiers joints dépassent la limite totale de taille de %d Mo.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "Ce fichier est trop volumineux. La taille maximale du fichier est de %d Mo.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "L’un des fichiers joints comporte plus de pages que la prise en charge disponible. Veuillez télécharger des fichiers avec %d pages ou moins.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "Nous ne pouvons pas lire l'un des fichiers joints. Veuillez vérifier qu’il n’est pas corrompu et réessayer.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Vous ne pouvez joindre que %d images par conversation.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Vous ne pouvez joindre que %d images à la fois.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Joindre un fichier";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Joindre une photo";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "Ce message est trop long pour être envoyé avec des pièces jointes.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Les pièces jointes sont temporairement indisponibles. Veuillez réessayer plus tard.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Ce type de fichier n'est pas pris en charge.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Ce type de fichier n'est pas pris en charge. Veuillez joindre un %1$@ ou un %2$@.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Ce type de fichier n’est pas pris en charge. Veuillez joindre un %@.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "Pour les tâches analytiques";
 

--- a/iOS/DuckDuckGo/hr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hr.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Snimi fotografiju";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Možeš priložiti samo %d datoteke/a po razgovoru.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "Ne možemo pročitati priložene datoteke jer je barem jedna od njih šifrirana.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "Priložene datoteke prelaze ukupno ograničenje veličine od %d MB.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "Ova je datoteka prevelika. Maksimalna veličina datoteke je %d MB.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "Jedna od priloženih datoteka ima više stranica nego što podržavamo. Prenesite datoteke s najviše %d stranica.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "Ne možemo pročitati jednu od priloženih datoteka. Provjeri je li datoteka oštećena i pokušaj ponovno.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Možeš priložiti samo %d slike/a po razgovoru.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Možeš priložiti samo %d slike/a odjednom.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Priloži datoteku";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Priloži fotografiju";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "Ta je poruka predugačka za slanje s prilozima.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Prilozi su privremeno nedostupni. Pokušaj ponovno nešto kasnije.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Ova vrsta datoteke nije podržana.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Ova vrsta datoteke nije podržana; priloži %1$@ ili %2$@.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Ova vrsta datoteke nije podržana, priloži %@.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "Za analitičke zadatke";
 

--- a/iOS/DuckDuckGo/hu.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hu.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Fénykép készítése";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Beszélgetésenként csak %d fájlt csatolhatsz.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "Nem tudjuk olvasni a csatolt fájlokat, mert legalább az egyik titkosítva van.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "A csatolt fájlok összmérete meghaladja a maximálisan megengedett %d MB-ot.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "A fájl túl nagy. Maximális fájlméret: %d MB.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "Az egyik csatolt fájlnak az általunk támogatottnál több oldala van. Legfeljebb %d oldalas fájlokat tölts fel.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "Nem tudjuk olvasni az egyik csatolt fájlt. Ellenőrizd, hogy nem sérült-e, és próbálkozz újra.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Beszélgetésenként csak %d képet csatolhatsz.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Egyszerre csak %d képet csatolhatsz.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Fájl csatolása";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Fénykép csatolása";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "Az üzenet túl hosszú a mellékletekkel együtt való küldéshez.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "A mellékletek átmenetileg nem érhetők el. Próbálkozz újra később.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "A fájltípus nem támogatott.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "A fájltípus nem támogatott, csatolj %1$@ vagy %2$@ fájlt.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "A fájltípus nem támogatott, csatolj %@ fájlt.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "Elemezési feladatokhoz";
 

--- a/iOS/DuckDuckGo/it.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/it.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Scatta una foto";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Puoi allegare solo %d file per conversazione.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "Non possiamo leggere i file allegati perché almeno uno di essi è crittografato.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "I file allegati superano il limite totale di dimensione di %d MB.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "Questo file è troppo grande. La dimensione massima del file è %d MB.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "Uno dei file allegati ha più pagine di quante ne supportiamo. Carica file con %d pagine o meno.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "Non riusciamo a leggere uno dei file allegati. Verifica che non sia danneggiato e riprova.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Puoi allegare solo %d immagini per conversazione.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Puoi allegare solo %d immagini alla volta.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Allega file";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Allega una foto";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "Il messaggio è troppo lungo per essere inviato con allegati.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Gli allegati non sono al momento disponibili. Riprova in seguito.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Questo tipo di file non è supportato.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Questo tipo di file non è supportato, allega un %1$@ o %2$@.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Questo tipo di file non è supportato, allega un %@.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "Per attività analitiche";
 

--- a/iOS/DuckDuckGo/ja.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ja.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "写真を撮影";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "ファイルは会話ごとに点しか添付できません。";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "添付ファイルのうち少なくとも1つが暗号化されているため、内容を読み取ることができません。";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "添付ファイルは%dMBの総サイズ制限を超えています。";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "このファイルは大きすぎます。最大ファイルサイズは%dMBです。";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "添付ファイルの1点が対応ページ数を超えています。%dページ以下のファイルをアップロードしてください。";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "添付されたファイルの1つを読み取れません。破損していないか確認してから、もう一度お試しください。";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "画像は会話ごとに%d点しか添付できません。";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "一度に添付できる画像は枚までです。";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "ファイルを添付する";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "写真を添付";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "そのメッセージは長すぎて添付ファイル付きで送信できません。";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "添付ファイルは一時的に利用できません。時間を置いてもう一度お試しください。";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "このファイル形式はサポートされていません。";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "このファイル形式はサポートされていません。%1$@または%2$@を添付してください。";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "このファイル形式はサポートされていません。%@を添付してください。";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "分析タスク用";
 

--- a/iOS/DuckDuckGo/lt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lt.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Fotografuoti";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Vienu metu galima pridėti tik %d failų.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "Negalime perskaityti pridėtų failų, nes bent vienas iš jų yra užšifruotas.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "Bendras pridėtų failų dydis viršija %d MB ribą.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "Šis failas yra per didelis. Didžiausias failo dydis – %d MB.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "Viename iš pridėtų failų yra daugiau puslapių, nei mes palaikome. Įkelkite failus, kuriuose yra iki %d puslapių.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "Negalime nuskaityti vieno iš pridėtų failų. Patikrinkite, ar jis nepažeistas, ir bandyk dar kartą.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Vienam pokalbiui galima pridėti tik %d paveikslėlių.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Vienu metu galima pridėti iki %d paveikslėlių.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Pridėti failą";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Pridėti nuotrauką";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "Šis pranešimas yra per ilgas, kad būtų galima siųsti su priedais.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Priedai laikinai nepasiekiami. Bandykite dar kartą vėliau.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Šis failo tipas nepalaikomas.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Šis failo tipas nepalaikomas. Pridėkite %1$@ arba %2$@.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Šis failo tipas nepalaikomas. Pridėkite %@.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "Analitinėms užduotims";
 

--- a/iOS/DuckDuckGo/lv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lv.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Uzņemt fotoattēlu";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Tu vari katrai sarunai pievienot tikai %d failus.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "Mēs nevaram nolasīt pievienotos failus, jo vismaz viens no tiem ir šifrēts.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "Pievienoto failu kopējais lieluma ierobežojums pārsniedz %d MB.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "Šis fails ir pārāk liels. Maksimālais faila lielums ir %d MB.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "Vienam no pievienotajiem failiem ir vairāk lappušu, nekā mēs atbalstām. Lūdzu, augšupielādē failus ar %d lapām vai mazāk.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "Mēs nevaram nolasīt vienu no pievienotajiem failiem. Lūdzu, pārbaudi, vai tas nav bojāts, un mēģini vēlreiz.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Tu vari katrā sarunā pievienot tikai %d attēlus.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Tu vari vienlaikus pievienot tikai %d attēlus.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Pievienot failu";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Pievienot fotoattēlu";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "Šis ziņojums ir pārāk garš, lai to nosūtītu ar pielikumiem.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Pielikumi īslaicīgi nav pieejami. Lūdzu, vēlāk mēģini vēlreiz.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Šis faila tips netiek atbalstīts.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Šis faila tips netiek atbalstīts, lūdzu, pievieno %1$@ vai %2$@.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Šis faila tips netiek atbalstīts, lūdzu, pievieno %@.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "Analītiskiem uzdevumiem";
 

--- a/iOS/DuckDuckGo/nb.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nb.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Ta et bilde";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Du kan bare legge ved %d filer per samtale.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "Vi kan ikke lese de vedlagte filene, da minst én av dem er kryptert.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "De vedlagte filene overskrider den totale størrelsesgrensen på %d MB.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "Filen er for stor. Maksimal filstørrelse er %d MB.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "En av de vedlagte filene har flere sider enn vi støtter. Last opp filer med maksimalt %d sider.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "En av de vedlagte filene kan ikke leses. Kontroller at den ikke er ødelagt, og prøv igjen.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Du kan bare legge ved %d bilder per samtale.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Du kan bare legge ved %d bilder av gangen.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Legg ved fil";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Legg ved bilde";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "Den meldingen er for lang til å sendes med vedlegg.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Vedlegg er midlertidig utilgjengelige. Prøv igjen senere.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Denne filtypen støttes ikke.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Denne filtypen støttes ikke. Legg heller ved en %1$@ eller %2$@.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Denne filtypen støttes ikke. Legg heller ved en %@.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "Til analytiske oppgaver";
 

--- a/iOS/DuckDuckGo/nl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nl.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Maak een foto";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Je kunt per gesprek maximaal %d bestanden bijvoegen.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "We kunnen de bijgevoegde bestanden niet lezen omdat minstens één ervan versleuteld is.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "De bijgevoegde bestanden overschrijden de totale groottelimiet van %d MB.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "Dit bestand is te groot. De maximale bestandsgrootte is %d MB.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "Een van de bijgevoegde bestanden bevat meer pagina's dan we ondersteunen. Upload bestanden met %d pagina's of minder.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "We kunnen een van de bijgevoegde bestanden niet lezen. Controleer of het bestand niet beschadigd is en probeer het opnieuw.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Je kunt slechts %d afbeeldingen per gesprek bijvoegen.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Je kunt slechts %d afbeeldingen tegelijk bijvoegen.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Bestand bijvoegen";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Foto bijvoegen";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "Dat bericht is te lang om met bijlagen te versturen.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Bijlagen zijn tijdelijk niet beschikbaar. Probeer het later opnieuw.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Dit bestandstype wordt niet ondersteund.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Dit bestandstype wordt niet ondersteund, voeg een %1$@ of %2$@ bij.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Dit bestandstype wordt niet ondersteund. Voeg een %@ toe.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "Voor analytische taken";
 

--- a/iOS/DuckDuckGo/pl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pl.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Zrób zdjęcie";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Możesz dołączyć tylko %d plików na każdą rozmowę.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "Nie możemy odczytać załączonych plików, ponieważ przynajmniej jeden z nich jest zaszyfrowany.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "Załączone pliki przekraczają całkowity limit rozmiaru MB.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "Ten plik jest za duży. Maksymalny rozmiar pliku to %d MB.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "Jeden z załączonych plików ma więcej stron niż obsługujemy. Proszę przesłać pliki z %d stronami lub mniej.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "Nie możemy odczytać jednego z załączonych plików. Sprawdź, czy nie jest uszkodzony i spróbuj ponownie.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Możesz dołączyć tylko %d zdjęć na każdą rozmowę.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Możesz dołączyć maksymalnie %d obrazów na raz.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Dołącz plik";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Dołącz zdjęcie";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "Ta wiadomość jest zbyt długa, by wysłać ją z załącznikami.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Załączniki są tymczasowo niedostępne. Spróbuj ponownie później.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Ten typ pliku nie jest obsługiwany.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Ten typ pliku nie jest obsługiwany, załącz %1$@ lub %2$@.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Ten typ pliku nie jest obsługiwany, załącz %@.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "Do zadań analitycznych";
 

--- a/iOS/DuckDuckGo/pt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pt.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Tira uma fotografia";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Só podes anexar %d ficheiros por conversa.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "Não conseguimos ler os ficheiros anexos porque pelo menos um deles está encriptado.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "Os ficheiros anexados excedem o limite total de tamanho de %d MB.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é de %d MB.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "Um dos ficheiros anexados tem mais páginas do que suportamos. Carrega ficheiros com %d páginas ou menos.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "Não foi possível ler um dos ficheiros anexados. Verifica se não está corrompido e tenta novamente.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Só podes anexar %d imagens por conversa.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Só podes anexar %d imagens de cada vez.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Anexar ficheiro";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Anexar foto";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "Esta mensagem é demasiado longa para enviar com anexos.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Os anexos estão temporariamente indisponíveis. Tenta novamente mais tarde.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Este tipo de ficheiro não é compatível.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Este tipo de ficheiro não é compatível. Anexa um %1$@ ou um %2$@.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Este tipo de ficheiro não é compatível. Anexa um %@.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "Para tarefas analíticas";
 

--- a/iOS/DuckDuckGo/ro.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ro.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Fă o fotografie";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Poți atașa doar %d fișiere per conversație.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "Nu putem citi fișierele atașate deoarece cel puțin unul dintre ele este criptat.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "Fișierele atașate depășesc limita totală de %d MB.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "Fișierul acesta este prea mare. Dimensiunea maximă a fișierului este de %d MB.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "Unul dintre fișierele atașate are mai multe pagini decât acceptăm. Încarcă fișiere cu %d pagini sau mai puține.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "Nu putem citi unul dintre fișierele pe care le-ai atașat. Verifică dacă nu este deteriorat și încearcă din nou.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Poți atașa doar %d imagini per conversație.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Poți atașa doar %d imagini odată.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Atașează fișierul";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Atașează o fotografie";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "Acel mesaj este prea lung pentru a fi trimis cu atașări.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Atașările nu sunt disponibile temporar. Încearcă din nou mai târziu.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Acest tip de fișier nu este acceptat.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Acest tip de fișier nu este acceptat, atașează un %1$@ sau un %2$@.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Acest tip de fișier nu este acceptat, atașează un %@.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "Pentru sarcini analitice";
 

--- a/iOS/DuckDuckGo/ru.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ru.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Сделать фото";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Число файлов, прикрепляемых к одной беседе, ограничено: максимум %d.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "Невозможно считать прикрепленные файлы: по крайней мере один из них зашифрован.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "Размер файлов превышает лимит в %d МБ.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "Файл слишком большой. Максимальный размер — %d МБ.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "Один из прикрепленных файлов содержит больше страниц, чем поддерживает наш сервис. Не загружайте файлы объемом более %d стр.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "Не удалось прочитать один из прикрепленных файлов. Проверьте, не поврежден ли файл, и повторите попытку.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Число изображений, прикрепляемых к одной беседе, ограничено: максимум %d.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Число изображений, прикрепляемых за один раз, ограничено: максимум %d.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Прикрепить файл";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Прикрепить фото";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "Это сообщение слишком длинное для отправки с вложениями.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Вложения временно недоступны. Повторите попытку позже.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Формат не поддерживается.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Формат не поддерживается. Прикрепите файл в %1$@ или %2$@.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Формат не поддерживается. Прикрепите файл в %@.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "Для аналитических задач";
 

--- a/iOS/DuckDuckGo/sk.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sk.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Urobiť fotografiu";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Do jednej konverzácie môžeš pripojiť iba %d súborov.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "Priložené súbory nemôžeme prečítať, pretože aspoň jeden z nich je zašifrovaný.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "Pripojené súbory presahujú celkovú maximálnu veľkosť %d MB.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "Tento súbor je príliš veľký. Maximálna veľkosť súboru je %d MB.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "Jeden z priložených súborov má viac strán ako podporujeme. Nahraj súbory s maximálne %d stranami.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "Jeden z priložených súborov sa nám nepodarilo prečítať. Skontroluj, či nie je poškodený, a skús to znova.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Do jednej konverzácie môžeš pripojiť iba %d obrázkov.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Naraz môžeš priložiť iba %d obrázkov.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Pripojiť súbor";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Pripojiť fotografiu";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "Táto správa je príliš dlhá na odoslanie s prílohami.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Prílohy sú dočasne nedostupné. Skús to znova neskôr.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Tento typ súboru nie je podporovaný.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Tento typ súboru nie je podporovaný. Prilož súbor %1$@ alebo %2$@.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Tento typ súboru nie je podporovaný. Prilož %@.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "Pre analytické úlohy";
 

--- a/iOS/DuckDuckGo/sl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sl.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Posnemite fotografijo";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "V enem pogovoru lahko priložite največ toliko datotek: %d.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "Priloženih datotek ne moremo prebrati, ker je vsaj ena od njih šifrirana.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "Priložene datoteke presegajo skupno omejitev velikosti %d MB.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "Ta datoteka je prevelika. Največja velikost datoteke je %d MB.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "Ena od priloženih datotek ima več strani, kot jih podpiramo. Naložite datoteke z največ toliko stranmi: %d.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "Ene od priloženih datotek ne moremo prebrati. Preverite, ali je poškodovana, in poskusite znova.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "V enem pogovoru lahko priložite največ toliko slik: %d.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Naenkrat lahko priložite samo toliko slik: %d.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Priloži datoteko";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Priloži fotografijo";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "To sporočilo je predolgo za pošiljanje s prilogami.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Priloge trenutno niso na voljo. Poskusite znova pozneje.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Ta vrsta datoteke ni podprta.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Ta vrsta datoteke ni podprta, priložite datoteko %1$@ ali %2$@.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Ta vrsta datoteke ni podprta, priložite %@.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "Za analitične naloge";
 

--- a/iOS/DuckDuckGo/sv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sv.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Ta ett foto";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Du kan bara bifoga %d filer per konversation.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "Vi kan inte läsa de bifogade filerna eftersom minst en av dem är krypterad.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "De bifogade filerna överskrider den totala storleksgränsen på %d MB.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "Filen är för stor. Den maximala filstorleken är %d MB.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "En av de bifogade filerna har fler sidor än vad som stöds. Ladda upp filer med %d sidor eller färre.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "Vi kan inte läsa en av de bifogade filerna. Kontrollera att den inte är skadad och försök igen.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Du kan bara bifoga %d bilder per konversation.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Du kan bara bifoga %d bilder åt gången.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Bifoga fil";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Bifoga foto";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "Meddelandet är för långt för att skickas med bilagor.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Bilagor är tillfälligt inte tillgängliga. Försök igen senare.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Filtypen stöds inte.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Den här filtypen stöds inte. Bifoga en %1$@ eller %2$@.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Filtypen stöds inte – bifoga en %@.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "För analytiska uppgifter";
 

--- a/iOS/DuckDuckGo/tr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/tr.lproj/Localizable.strings
@@ -212,51 +212,6 @@
 /* Action sheet option to take a photo using the device camera for attaching to an AI chat message */
 "aichat.attachment.option.take.photo" = "Fotoğraf Çek";
 
-/* Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files. */
-"aichat.attachment.file.count.limit" = "Konuşma başına en fazla %d dosya ekleyebilirsiniz.";
-
-/* Error message displayed when one or more attached files are encrypted and cannot be read */
-"aichat.attachment.file.encrypted" = "En az birinin şifrelenmiş olması nedeniyle ekli dosyaları okuyamıyoruz.";
-
-/* Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Parameter is the backend-provided combined size limit in megabytes. */
-"aichat.attachment.file.exceeds.conversation.limit" = "Ekli dosyalar, toplam boyut sınırını (%d MB) aşıyor.";
-
-/* Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes. */
-"aichat.attachment.file.too.large" = "Bu dosya çok büyük. Maksimum dosya boyutu %d MB'dir.";
-
-/* Error message displayed when one attached file has more pages than supported. Parameter is the backend-provided maximum supported page count. */
-"aichat.attachment.file.too.many.pages" = "Ekli dosyalardan biri, desteklediğimizden daha fazla sayfa içeriyor. Lütfen %d veya daha az sayfa içeren dosyalar yükleyin.";
-
-/* Error message displayed when one or more attached files cannot be read */
-"aichat.attachment.file.unreadable" = "Ekli dosyalardan birini okuyamıyoruz. Lütfen bozuk olmadığını kontrol edin ve tekrar deneyin.";
-
-/* Error message displayed when the user has attached more images than are allowed in a conversation. Parameter is the backend-provided maximum number of images. */
-"aichat.attachment.image.count.limit" = "Konuşma başına en fazla %d görsel ekleyebilirsiniz.";
-
-/* Error message displayed when the user has attached more images than are allowed in one message. Parameter is the backend-provided maximum number of images per message. */
-"aichat.attachment.image.turn.limit" = "Bir defada yalnızca %d görsel ekleyebilirsiniz.";
-
-/* Top-level attachment menu option to attach a file to an AI chat message */
-"aichat.attachment.option.attach.file" = "Dosya Ekle";
-
-/* Top-level attachment menu option to attach a photo to an AI chat message */
-"aichat.attachment.option.attach.photo" = "Fotoğraf Ekle";
-
-/* Alert message shown when an AI chat message exceeds the allowed length while attachments are included */
-"aichat.attachment.prompt.too.long" = "Bu mesaj, eklerle birlikte gönderilemeyecek kadar uzun.";
-
-/* Generic fallback error message displayed when attachments cannot be validated because the backend-provided attachment limits are unavailable */
-"aichat.attachment.unavailable" = "Ekler geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin.";
-
-/* Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types */
-"aichat.attachment.unsupported.file.type" = "Bu dosya türü desteklenmiyor.";
-
-/* Error message for unsupported file type when multiple types are accepted. First parameter is a comma-separated list of all accepted types except the last. Second parameter is the last accepted type. Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF. */
-"aichat.attachment.unsupported.file.type.multiple" = "Bu dosya türü desteklenmiyor. Lütfen bir %1$@ veya %2$@ ekleyin.";
-
-/* Error message displayed when the user tries to upload an unsupported file type and we know which type is accepted. Parameter is a single accepted type. E.g. This file type is not supported, please attach a PDF. */
-"aichat.attachment.unsupported.file.type.single" = "Bu dosya türü desteklenmiyor, lütfen bir %@ ekleyin.";
-
 /* Subtitle for the extended reasoning mode in the Duck.ai reasoning picker */
 "aichat.reasoning.extended.subtitle" = "Analitik görevler için";
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIAttachmentPolicyTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIAttachmentPolicyTests.swift
@@ -308,6 +308,15 @@ final class UTIAttachmentPolicyTests: XCTestCase {
         XCTAssertEqual(policy.fileSubmissionValidationMessage(), UserText.aiChatAttachmentUnsupportedFileType(acceptedFileTypes: ["PNG", "JPG", "PDF"]))
     }
 
+    func test_fileSubmissionValidation_usesFallbackNameForUnknownAcceptedType() {
+        let policy = makePolicy(
+            pendingAttachments: [makeFileAttachment(mimeType: "text/plain")],
+            model: makeModel(supportedFileTypes: ["text/csv"])
+        )
+
+        XCTAssertEqual(policy.fileSubmissionValidationMessage(), UserText.aiChatAttachmentUnsupportedFileType(acceptedFileType: "CSV"))
+    }
+
     func test_fileSubmissionValidation_rejectsUnsupportedPendingFileWithSingleAcceptedType() {
         let policy = makePolicy(
             pendingAttachments: [makeFileAttachment(mimeType: "text/plain")]

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIAttachmentPolicyTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIAttachmentPolicyTests.swift
@@ -114,6 +114,20 @@ final class UTIAttachmentPolicyTests: XCTestCase {
         XCTAssertEqual(policy.fileValidationMessage(for: file), UserText.aiChatAttachmentUnsupportedFileType(acceptedFileType: "PDF"))
     }
 
+    func test_fileValidation_rejectsUnsupportedMimeTypeWithMultipleAcceptedTypes() {
+        let policy = makePolicy(model: makeModel(supportedFileTypes: ["image/png", "image/jpeg", "application/pdf"]))
+        let file = makeFile(mimeType: "text/plain", pageCount: nil)
+
+        XCTAssertEqual(policy.fileValidationMessage(for: file), UserText.aiChatAttachmentUnsupportedFileType(acceptedFileTypes: ["PNG", "JPG", "PDF"]))
+    }
+
+    func test_fileValidation_whenModelDoesNotSupportFiles_returnsGenericUnsupportedMessage() {
+        let policy = makePolicy(model: makeModel(supportedFileTypes: []))
+        let file = makeFile(mimeType: "text/plain", pageCount: nil)
+
+        XCTAssertEqual(policy.fileValidationMessage(for: file), UserText.aiChatAttachmentUnsupportedFileType)
+    }
+
     func test_fileValidation_rejectsFileAboveMaxFileSize() {
         let policy = makePolicy(attachmentLimits: makeLimits(maxFileSizeMB: 5))
         let file = makeFile(size: 5_242_881)
@@ -136,6 +150,33 @@ final class UTIAttachmentPolicyTests: XCTestCase {
         XCTAssertEqual(
             policy.fileMetadataValidationMessage(mimeType: "application/pdf", fileSizeBytes: 100),
             UserText.aiChatAttachmentUnavailable
+        )
+    }
+
+    func test_fileMetadataValidation_rejectsUnsupportedMimeTypeWithSingleAcceptedType() {
+        let policy = makePolicy()
+
+        XCTAssertEqual(
+            policy.fileMetadataValidationMessage(mimeType: "text/plain", fileSizeBytes: 100),
+            UserText.aiChatAttachmentUnsupportedFileType(acceptedFileType: "PDF")
+        )
+    }
+
+    func test_fileMetadataValidation_rejectsUnsupportedMimeTypeWithMultipleAcceptedTypes() {
+        let policy = makePolicy(model: makeModel(supportedFileTypes: ["image/png", "image/jpeg", "application/pdf"]))
+
+        XCTAssertEqual(
+            policy.fileMetadataValidationMessage(mimeType: "text/plain", fileSizeBytes: 100),
+            UserText.aiChatAttachmentUnsupportedFileType(acceptedFileTypes: ["PNG", "JPG", "PDF"])
+        )
+    }
+
+    func test_fileMetadataValidation_whenModelDoesNotSupportFiles_returnsGenericUnsupportedMessage() {
+        let policy = makePolicy(model: makeModel(supportedFileTypes: []))
+
+        XCTAssertEqual(
+            policy.fileMetadataValidationMessage(mimeType: "text/plain", fileSizeBytes: 100),
+            UserText.aiChatAttachmentUnsupportedFileType
         )
     }
 
@@ -249,6 +290,96 @@ final class UTIAttachmentPolicyTests: XCTestCase {
         XCTAssertEqual(policy.fileSubmissionValidationMessage(), UserText.aiChatAttachmentUnavailable)
     }
 
+    func test_fileSubmissionValidation_rejectsUnsupportedPendingFileWithMultipleAcceptedTypes() {
+        let policy = makePolicy(
+            pendingAttachments: [makeFileAttachment(mimeType: "text/plain")],
+            model: makeModel(supportedFileTypes: ["image/png", "image/jpeg", "application/pdf"])
+        )
+
+        XCTAssertEqual(policy.fileSubmissionValidationMessage(), UserText.aiChatAttachmentUnsupportedFileType(acceptedFileTypes: ["PNG", "JPG", "PDF"]))
+    }
+
+    func test_fileSubmissionValidation_rejectsUnsupportedPendingFileWithSingleAcceptedType() {
+        let policy = makePolicy(
+            pendingAttachments: [makeFileAttachment(mimeType: "text/plain")]
+        )
+
+        XCTAssertEqual(policy.fileSubmissionValidationMessage(), UserText.aiChatAttachmentUnsupportedFileType(acceptedFileType: "PDF"))
+    }
+
+    func test_fileSubmissionValidation_whenModelDoesNotSupportFiles_returnsGenericUnsupportedMessage() {
+        let policy = makePolicy(
+            pendingAttachments: [makeFileAttachment()],
+            model: makeModel(supportedFileTypes: [])
+        )
+
+        XCTAssertEqual(policy.fileSubmissionValidationMessage(), UserText.aiChatAttachmentUnsupportedFileType)
+    }
+
+    func test_fileSubmissionValidation_rejectsInvalidFileAttachmentWithStoredMessage() {
+        let validationMessage = UserText.aiChatAttachmentFileTooManyPages(maxPagesPerFile: 15)
+        let policy = makePolicy(
+            pendingAttachments: [
+                .invalidFile(
+                    UnifiedToggleInputInvalidFileAttachment(
+                        fileName: "too-many-pages.pdf",
+                        mimeType: "application/pdf",
+                        fileSizeBytes: 1_000,
+                        validationMessage: validationMessage
+                    )
+                )
+            ]
+        )
+
+        XCTAssertEqual(policy.fileSubmissionValidationMessage(), validationMessage)
+    }
+
+    func test_fileSubmissionValidation_rejectsFileAboveMaxFileSize() {
+        let policy = makePolicy(
+            attachmentLimits: makeLimits(maxFileSizeMB: 5),
+            pendingAttachments: [makeFileAttachment(size: 5_242_881)]
+        )
+
+        XCTAssertEqual(policy.fileSubmissionValidationMessage(), UserText.aiChatAttachmentFileTooLarge(maxFileSizeMB: 5))
+    }
+
+    func test_fileSubmissionValidation_rejectsFilesAboveTotalSize() {
+        let policy = makePolicy(
+            attachmentLimits: makeLimits(maxTotalFileSizeBytes: 5_242_880),
+            attachmentUsage: AIChatAttachmentUsage(imagesUsed: 0, filesUsed: 0, fileSizeBytesUsed: 5_242_400),
+            pendingAttachments: [makeFileAttachment(size: 600)]
+        )
+
+        XCTAssertEqual(policy.fileSubmissionValidationMessage(), UserText.aiChatAttachmentFilesExceedTotalSizeLimit(maxTotalFileSizeMB: 5))
+    }
+
+    func test_fileSubmissionValidation_rejectsPdfAboveMaxPages() {
+        let policy = makePolicy(
+            attachmentLimits: makeLimits(maxPagesPerFile: 15),
+            pendingAttachments: [makeFileAttachment(pageCount: 16)]
+        )
+
+        XCTAssertEqual(policy.fileSubmissionValidationMessage(), UserText.aiChatAttachmentFileTooManyPages(maxPagesPerFile: 15))
+    }
+
+    func test_fileSubmissionValidation_rejectsUnreadablePdfWhenPageLimitApplies() {
+        let policy = makePolicy(
+            attachmentLimits: makeLimits(maxPagesPerFile: 15),
+            pendingAttachments: [makeFileAttachment(pageCount: nil)]
+        )
+
+        XCTAssertEqual(policy.fileSubmissionValidationMessage(), UserText.aiChatAttachmentFileUnreadable)
+    }
+
+    func test_fileSubmissionValidation_rejectsEncryptedPdfWhenPageLimitApplies() {
+        let policy = makePolicy(
+            attachmentLimits: makeLimits(maxPagesPerFile: 15),
+            pendingAttachments: [makeFileAttachment(pageCount: nil, isEncrypted: true)]
+        )
+
+        XCTAssertEqual(policy.fileSubmissionValidationMessage(), UserText.aiChatAttachmentFileEncrypted)
+    }
+
     func test_imageSubmissionValidation_rejectsImagesWhenUsageChangesBeforeSubmit() {
         let policy = makePolicy(
             attachmentLimits: makeLimits(maxImagesPerConversation: 5),
@@ -333,7 +464,8 @@ final class UTIAttachmentPolicyTests: XCTestCase {
     private func makeFileAttachment(
         size: Int = 1_000,
         mimeType: String = "application/pdf",
-        pageCount: Int? = 1
+        pageCount: Int? = 1,
+        isEncrypted: Bool = false
     ) -> UnifiedToggleInputAttachment {
         .file(
             AIChatFileAttachment(
@@ -341,7 +473,8 @@ final class UTIAttachmentPolicyTests: XCTestCase {
                 fileName: "test.pdf",
                 mimeType: mimeType,
                 fileSizeBytes: size,
-                pageCount: pageCount
+                pageCount: pageCount,
+                isEncrypted: isEncrypted
             )
         )
     }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIAttachmentPolicyTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIAttachmentPolicyTests.swift
@@ -107,6 +107,15 @@ final class UTIAttachmentPolicyTests: XCTestCase {
         XCTAssertTrue(policy.canAttachFiles)
     }
 
+    func test_canAttachFiles_ignoresInvalidFileAttachmentsForCapacity() {
+        let policy = makePolicy(
+            attachmentLimits: makeLimits(maxFilesPerConversation: 1, maxTotalFileSizeBytes: 1_000),
+            pendingAttachments: [makeInvalidFileAttachment(size: 2_000)]
+        )
+
+        XCTAssertTrue(policy.canAttachFiles)
+    }
+
     func test_fileValidation_rejectsUnsupportedMimeType() {
         let policy = makePolicy()
         let file = makeFile(mimeType: "text/plain", pageCount: nil)
@@ -498,5 +507,20 @@ final class UTIAttachmentPolicyTests: XCTestCase {
     private func makeImage() -> UnifiedToggleInputAttachment {
         let image = UIGraphicsImageRenderer(size: CGSize(width: 1, height: 1)).image { _ in }
         return .image(AIChatImageAttachment(image: image, fileName: "image.png"))
+    }
+
+    private func makeInvalidFileAttachment(
+        size: Int = 1_000,
+        mimeType: String = "application/pdf",
+        validationMessage: String = UserText.aiChatAttachmentFileTooManyPages(maxPagesPerFile: 15)
+    ) -> UnifiedToggleInputAttachment {
+        .invalidFile(
+            UnifiedToggleInputInvalidFileAttachment(
+                fileName: "invalid.pdf",
+                mimeType: mimeType,
+                fileSizeBytes: size,
+                validationMessage: validationMessage
+            )
+        )
     }
 }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift
@@ -323,6 +323,27 @@ final class UnifiedToggleInputCoordinatorAttachmentLimitsTests: XCTestCase {
         XCTAssertEqual(sut.viewController.currentAttachments.count, 1)
     }
 
+    func testWhenModelChangeMakesInvalidFileValidThenAttachmentIsPromoted() {
+        let prefs = StubAIChatPreferences()
+        prefs.selectedModelId = "unsupported-file-model"
+        let sut = makeCoordinator(preferences: prefs)
+        sut.modelStore.models = [
+            makeModel(id: "unsupported-file-model", supportsImageUpload: true, supportedFileTypes: []),
+            makeModel(id: "file-model", supportsImageUpload: true, supportedFileTypes: ["application/pdf"])
+        ]
+        sut.updateInputMode(.aiChat, animated: false)
+        sut.addFileAttachment(makeFileAttachment(fileName: "a.pdf"))
+        XCTAssertTrue(sut.viewController.currentAttachments.first?.isInvalid ?? false)
+        XCTAssertNotNil(sut.viewController.attachmentValidationMessage)
+
+        sut.updateSelectedModel("file-model")
+
+        XCTAssertEqual(sut.viewController.currentAttachments.count, 1)
+        XCTAssertFalse(sut.viewController.currentAttachments.first?.isInvalid ?? true)
+        XCTAssertEqual(sut.viewController.currentAttachments.first?.fileAttachment?.fileName, "a.pdf")
+        XCTAssertNil(sut.viewController.attachmentValidationMessage)
+    }
+
     func testWhenFloatingSubmitHasInvalidAttachmentThenPromptDoesNotSubmit() {
         let prefs = StubAIChatPreferences()
         prefs.selectedModelId = "mixed-model"

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift
@@ -351,12 +351,12 @@ final class UnifiedToggleInputCoordinatorAttachmentLimitsTests: XCTestCase {
         let sut = makeCoordinator(preferences: prefs)
         sut.modelStore.models = [
             makeModel(id: "unsupported-file-model", supportsImageUpload: true, supportedFileTypes: []),
-            makeModel(id: "file-model", supportsImageUpload: true, supportedFileTypes: ["text/plain"])
+            makeModel(id: "file-model", supportsImageUpload: true, supportedFileTypes: ["application/pdf"])
         ]
         let delegate = SpyUnifiedToggleInputDelegate()
         sut.delegate = delegate
-        let fileData = Data("hello".utf8)
-        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent("attachment-\(UUID().uuidString).txt")
+        let fileData = makePDFData()
+        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent("attachment-\(UUID().uuidString).pdf")
         try fileData.write(to: fileURL)
         addTeardownBlock {
             try? FileManager.default.removeItem(at: fileURL)
@@ -365,8 +365,8 @@ final class UnifiedToggleInputCoordinatorAttachmentLimitsTests: XCTestCase {
         sut.addFileAttachment(
             AIChatFileAttachment(
                 data: fileData,
-                fileName: "a.txt",
-                mimeType: "text/plain",
+                fileName: "a.pdf",
+                mimeType: "application/pdf",
                 fileSizeBytes: fileData.count
             ),
             sourceURL: fileURL
@@ -381,7 +381,7 @@ final class UnifiedToggleInputCoordinatorAttachmentLimitsTests: XCTestCase {
         }
         XCTAssertEqual(sut.viewController.currentAttachments.count, 1)
         XCTAssertFalse(sut.viewController.currentAttachments.first?.isInvalid ?? true)
-        XCTAssertEqual(sut.viewController.currentAttachments.first?.fileAttachment?.fileName, "a.txt")
+        XCTAssertEqual(sut.viewController.currentAttachments.first?.fileAttachment?.fileName, "a.pdf")
         XCTAssertEqual(sut.viewController.currentAttachments.first?.fileAttachment?.data, fileData)
         XCTAssertNil(sut.viewController.attachmentValidationMessage)
 
@@ -389,46 +389,35 @@ final class UnifiedToggleInputCoordinatorAttachmentLimitsTests: XCTestCase {
 
         XCTAssertEqual(delegate.submittedPrompt, "use the file")
         XCTAssertEqual(delegate.submittedFiles?.count, 1)
-        XCTAssertEqual(delegate.submittedFiles?.first?.fileName, "a.txt")
-        XCTAssertEqual(delegate.submittedFiles?.first?.mimeType, "text/plain")
+        XCTAssertEqual(delegate.submittedFiles?.first?.fileName, "a.pdf")
+        XCTAssertEqual(delegate.submittedFiles?.first?.mimeType, "application/pdf")
     }
 
-    func testWhenModelChangeMakesMetadataOnlyInvalidFileValidThenAttachmentIsPromoted() throws {
+    func testWhenModelChangeMakesInvalidFileValidButSourceIsMissingThenExistingErrorIsPreserved() {
         let prefs = StubAIChatPreferences()
         prefs.selectedModelId = "unsupported-file-model"
         let sut = makeCoordinator(preferences: prefs)
         sut.modelStore.models = [
             makeModel(id: "unsupported-file-model", supportsImageUpload: true, supportedFileTypes: []),
-            makeModel(id: "text-model", supportsImageUpload: true, supportedFileTypes: ["text/plain"])
+            makeModel(id: "file-model", supportsImageUpload: true, supportedFileTypes: ["application/pdf"])
         ]
-        let fileData = Data("hello".utf8)
-        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent("attachment-\(UUID().uuidString).txt")
-        try fileData.write(to: fileURL)
-        addTeardownBlock {
-            try? FileManager.default.removeItem(at: fileURL)
-        }
         let validationMessage = UserText.aiChatAttachmentUnsupportedFileType
         sut.viewController.addAttachment(.invalidFile(
             UnifiedToggleInputInvalidFileAttachment(
-                fileName: "a.txt",
-                mimeType: "text/plain",
-                fileSizeBytes: fileData.count,
+                fileName: "a.pdf",
+                mimeType: "application/pdf",
+                fileSizeBytes: 1_000,
                 validationMessage: validationMessage,
-                sourceURL: fileURL
+                sourceURL: nil
             )
         ))
         sut.viewController.showAttachmentValidationError(validationMessage)
 
-        sut.updateSelectedModel("text-model")
+        sut.updateSelectedModel("file-model")
 
-        waitUntil("metadata-only invalid file is promoted") {
-            sut.viewController.currentAttachments.first?.fileAttachment != nil
-        }
         XCTAssertEqual(sut.viewController.currentAttachments.count, 1)
-        XCTAssertFalse(sut.viewController.currentAttachments.first?.isInvalid ?? true)
-        XCTAssertEqual(sut.viewController.currentAttachments.first?.fileAttachment?.fileName, "a.txt")
-        XCTAssertEqual(sut.viewController.currentAttachments.first?.fileAttachment?.data, fileData)
-        XCTAssertNil(sut.viewController.attachmentValidationMessage)
+        XCTAssertTrue(sut.viewController.currentAttachments.first?.isInvalid ?? false)
+        XCTAssertEqual(sut.viewController.attachmentValidationMessage, validationMessage)
     }
 
     func testWhenFloatingSubmitHasInvalidAttachmentThenPromptDoesNotSubmit() {
@@ -661,6 +650,14 @@ final class UnifiedToggleInputCoordinatorAttachmentLimitsTests: XCTestCase {
             fileSizeBytes: data.count,
             pageCount: pageCount
         )
+    }
+
+    private func makePDFData() -> Data {
+        let renderer = UIGraphicsPDFRenderer(bounds: CGRect(x: 0, y: 0, width: 100, height: 100))
+        return renderer.pdfData { context in
+            context.beginPage()
+            "test".draw(at: CGPoint(x: 20, y: 20), withAttributes: nil)
+        }
     }
 
     private func viewContainsLabelText(_ text: String, in view: UIView) -> Bool {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift
@@ -345,25 +345,52 @@ final class UnifiedToggleInputCoordinatorAttachmentLimitsTests: XCTestCase {
         XCTAssertEqual(sut.viewController.currentAttachments.count, 1)
     }
 
-    func testWhenModelChangeMakesInvalidFileValidThenAttachmentIsPromoted() {
+    func testWhenModelChangeMakesInvalidFileValidThenAttachmentIsPromoted() throws {
         let prefs = StubAIChatPreferences()
         prefs.selectedModelId = "unsupported-file-model"
         let sut = makeCoordinator(preferences: prefs)
         sut.modelStore.models = [
             makeModel(id: "unsupported-file-model", supportsImageUpload: true, supportedFileTypes: []),
-            makeModel(id: "file-model", supportsImageUpload: true, supportedFileTypes: ["application/pdf"])
+            makeModel(id: "file-model", supportsImageUpload: true, supportedFileTypes: ["text/plain"])
         ]
+        let delegate = SpyUnifiedToggleInputDelegate()
+        sut.delegate = delegate
+        let fileData = Data("hello".utf8)
+        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent("attachment-\(UUID().uuidString).txt")
+        try fileData.write(to: fileURL)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: fileURL)
+        }
         sut.updateInputMode(.aiChat, animated: false)
-        sut.addFileAttachment(makeFileAttachment(fileName: "a.pdf"))
+        sut.addFileAttachment(
+            AIChatFileAttachment(
+                data: fileData,
+                fileName: "a.txt",
+                mimeType: "text/plain",
+                fileSizeBytes: fileData.count
+            ),
+            sourceURL: fileURL
+        )
         XCTAssertTrue(sut.viewController.currentAttachments.first?.isInvalid ?? false)
         XCTAssertNotNil(sut.viewController.attachmentValidationMessage)
 
         sut.updateSelectedModel("file-model")
 
+        waitUntil("invalid file is promoted after source recovery") {
+            sut.viewController.currentAttachments.first?.fileAttachment != nil
+        }
         XCTAssertEqual(sut.viewController.currentAttachments.count, 1)
         XCTAssertFalse(sut.viewController.currentAttachments.first?.isInvalid ?? true)
-        XCTAssertEqual(sut.viewController.currentAttachments.first?.fileAttachment?.fileName, "a.pdf")
+        XCTAssertEqual(sut.viewController.currentAttachments.first?.fileAttachment?.fileName, "a.txt")
+        XCTAssertEqual(sut.viewController.currentAttachments.first?.fileAttachment?.data, fileData)
         XCTAssertNil(sut.viewController.attachmentValidationMessage)
+
+        sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "use the file", mode: .aiChat)
+
+        XCTAssertEqual(delegate.submittedPrompt, "use the file")
+        XCTAssertEqual(delegate.submittedFiles?.count, 1)
+        XCTAssertEqual(delegate.submittedFiles?.first?.fileName, "a.txt")
+        XCTAssertEqual(delegate.submittedFiles?.first?.mimeType, "text/plain")
     }
 
     func testWhenModelChangeMakesMetadataOnlyInvalidFileValidThenAttachmentIsPromoted() throws {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift
@@ -344,6 +344,44 @@ final class UnifiedToggleInputCoordinatorAttachmentLimitsTests: XCTestCase {
         XCTAssertNil(sut.viewController.attachmentValidationMessage)
     }
 
+    func testWhenModelChangeMakesMetadataOnlyInvalidFileValidThenAttachmentIsPromoted() throws {
+        let prefs = StubAIChatPreferences()
+        prefs.selectedModelId = "unsupported-file-model"
+        let sut = makeCoordinator(preferences: prefs)
+        sut.modelStore.models = [
+            makeModel(id: "unsupported-file-model", supportsImageUpload: true, supportedFileTypes: []),
+            makeModel(id: "text-model", supportsImageUpload: true, supportedFileTypes: ["text/plain"])
+        ]
+        let fileData = Data("hello".utf8)
+        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent("attachment-\(UUID().uuidString).txt")
+        try fileData.write(to: fileURL)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: fileURL)
+        }
+        let validationMessage = UserText.aiChatAttachmentUnsupportedFileType
+        sut.viewController.addAttachment(.invalidFile(
+            UnifiedToggleInputInvalidFileAttachment(
+                fileName: "a.txt",
+                mimeType: "text/plain",
+                fileSizeBytes: fileData.count,
+                validationMessage: validationMessage,
+                sourceURL: fileURL
+            )
+        ))
+        sut.viewController.showAttachmentValidationError(validationMessage)
+
+        sut.updateSelectedModel("text-model")
+
+        waitUntil("metadata-only invalid file is promoted") {
+            sut.viewController.currentAttachments.first?.fileAttachment != nil
+        }
+        XCTAssertEqual(sut.viewController.currentAttachments.count, 1)
+        XCTAssertFalse(sut.viewController.currentAttachments.first?.isInvalid ?? true)
+        XCTAssertEqual(sut.viewController.currentAttachments.first?.fileAttachment?.fileName, "a.txt")
+        XCTAssertEqual(sut.viewController.currentAttachments.first?.fileAttachment?.data, fileData)
+        XCTAssertNil(sut.viewController.attachmentValidationMessage)
+    }
+
     func testWhenFloatingSubmitHasInvalidAttachmentThenPromptDoesNotSubmit() {
         let prefs = StubAIChatPreferences()
         prefs.selectedModelId = "mixed-model"
@@ -594,6 +632,27 @@ final class UnifiedToggleInputCoordinatorAttachmentLimitsTests: XCTestCase {
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 1)
+    }
+
+    private func waitUntil(_ description: String, timeout: TimeInterval = 2, condition: @escaping () -> Bool) {
+        if condition() {
+            return
+        }
+
+        let expectation = expectation(description: description)
+
+        func poll() {
+            if condition() {
+                expectation.fulfill()
+            } else {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                    poll()
+                }
+            }
+        }
+
+        poll()
+        wait(for: [expectation], timeout: timeout)
     }
 }
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift
@@ -275,6 +275,22 @@ final class UnifiedToggleInputCoordinatorAttachmentLimitsTests: XCTestCase {
         XCTAssertEqual(delegate.submittedFiles?.count, 1)
     }
 
+    func testWhenFloatingSubmitHasFileAttachmentWithoutTextThenFileIsSubmitted() {
+        let prefs = StubAIChatPreferences()
+        prefs.selectedModelId = "mixed-model"
+        let sut = makeCoordinator(preferences: prefs)
+        sut.modelStore.models = [makeModel(id: "mixed-model", supportsImageUpload: true, supportedFileTypes: ["application/pdf"])]
+        let delegate = SpyUnifiedToggleInputDelegate()
+        sut.delegate = delegate
+        sut.addFileAttachment(makeFileAttachment(fileName: "a.pdf"))
+
+        sut.submitCurrentInputFromFloatingSubmit()
+        flushMainQueue()
+
+        XCTAssertEqual(delegate.submittedPrompt, "")
+        XCTAssertEqual(delegate.submittedFiles?.count, 1)
+    }
+
     func testWhenFileValidationFailsThenInvalidAttachmentIsAdded() {
         let prefs = StubAIChatPreferences()
         prefs.selectedModelId = "mixed-model"
@@ -305,6 +321,25 @@ final class UnifiedToggleInputCoordinatorAttachmentLimitsTests: XCTestCase {
         XCTAssertNil(delegate.submittedPrompt)
         XCTAssertNil(delegate.submittedFiles)
         XCTAssertEqual(sut.viewController.currentAttachments.count, 1)
+    }
+
+    func testWhenFloatingSubmitHasInvalidAttachmentThenPromptDoesNotSubmit() {
+        let prefs = StubAIChatPreferences()
+        prefs.selectedModelId = "mixed-model"
+        let sut = makeCoordinator(preferences: prefs)
+        sut.modelStore.models = [makeModel(id: "mixed-model", supportsImageUpload: true, supportedFileTypes: ["application/pdf"])]
+        let delegate = SpyUnifiedToggleInputDelegate()
+        sut.delegate = delegate
+        sut.addFileAttachment(makeFileAttachment(fileName: "too-many-pages.pdf", pageCount: 9))
+
+        sut.submitCurrentInputFromFloatingSubmit()
+
+        XCTAssertNil(delegate.submittedPrompt)
+        XCTAssertNil(delegate.submittedFiles)
+        XCTAssertEqual(
+            sut.viewController.attachmentValidationMessage,
+            UserText.aiChatAttachmentFileTooManyPages(maxPagesPerFile: 8)
+        )
     }
 
     func testWhenSwitchingToSearchThenBackToDuckAIAttachmentsArePreserved() {
@@ -530,6 +565,14 @@ final class UnifiedToggleInputCoordinatorAttachmentLimitsTests: XCTestCase {
 
     private func attachmentMenuTitles(for coordinator: UnifiedToggleInputCoordinator) -> [String] {
         coordinator.viewController.attachmentMenu?.children.map(\.title) ?? []
+    }
+
+    private func flushMainQueue() {
+        let expectation = expectation(description: "main queue flushed")
+        DispatchQueue.main.async {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
     }
 }
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift
@@ -19,6 +19,7 @@
 
 import AIChat
 import Combine
+import UIKit
 import XCTest
 @testable import DuckDuckGo
 
@@ -259,6 +260,166 @@ final class UnifiedToggleInputCoordinatorAttachmentLimitsTests: XCTestCase {
         XCTAssertEqual(delegate.submittedFiles?.count, 3)
     }
 
+    func testWhenSubmittingFileAttachmentWithoutTextThenFileIsSubmitted() {
+        let prefs = StubAIChatPreferences()
+        prefs.selectedModelId = "mixed-model"
+        let sut = makeCoordinator(preferences: prefs)
+        sut.modelStore.models = [makeModel(id: "mixed-model", supportsImageUpload: true, supportedFileTypes: ["application/pdf"])]
+        let delegate = SpyUnifiedToggleInputDelegate()
+        sut.delegate = delegate
+        sut.addFileAttachment(makeFileAttachment(fileName: "a.pdf"))
+
+        sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "", mode: .aiChat)
+
+        XCTAssertEqual(delegate.submittedPrompt, "")
+        XCTAssertEqual(delegate.submittedFiles?.count, 1)
+    }
+
+    func testWhenFileValidationFailsThenInvalidAttachmentIsAdded() {
+        let prefs = StubAIChatPreferences()
+        prefs.selectedModelId = "mixed-model"
+        let sut = makeCoordinator(preferences: prefs)
+        sut.modelStore.models = [makeModel(id: "mixed-model", supportsImageUpload: true, supportedFileTypes: ["application/pdf"])]
+
+        sut.addFileAttachment(makeFileAttachment(fileName: "too-many-pages.pdf", pageCount: 9))
+
+        XCTAssertEqual(sut.viewController.currentAttachments.count, 1)
+        XCTAssertTrue(sut.viewController.currentAttachments.first?.isInvalid ?? false)
+        XCTAssertEqual(
+            sut.viewController.currentAttachments.first?.validationMessage,
+            UserText.aiChatAttachmentFileTooManyPages(maxPagesPerFile: 8)
+        )
+    }
+
+    func testWhenInvalidFileAttachmentIsPresentThenPromptDoesNotSubmit() {
+        let prefs = StubAIChatPreferences()
+        prefs.selectedModelId = "mixed-model"
+        let sut = makeCoordinator(preferences: prefs)
+        sut.modelStore.models = [makeModel(id: "mixed-model", supportsImageUpload: true, supportedFileTypes: ["application/pdf"])]
+        let delegate = SpyUnifiedToggleInputDelegate()
+        sut.delegate = delegate
+        sut.addFileAttachment(makeFileAttachment(fileName: "too-many-pages.pdf", pageCount: 9))
+
+        sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "hello", mode: .aiChat)
+
+        XCTAssertNil(delegate.submittedPrompt)
+        XCTAssertNil(delegate.submittedFiles)
+        XCTAssertEqual(sut.viewController.currentAttachments.count, 1)
+    }
+
+    func testWhenSwitchingToSearchThenBackToDuckAIAttachmentsArePreserved() {
+        let prefs = StubAIChatPreferences()
+        prefs.selectedModelId = "mixed-model"
+        let sut = makeCoordinator(preferences: prefs)
+        sut.modelStore.models = [makeModel(id: "mixed-model", supportsImageUpload: true, supportedFileTypes: ["application/pdf"])]
+        sut.activateFromOmnibar(inputMode: .aiChat)
+        sut.addFileAttachment(makeFileAttachment(fileName: "a.pdf"))
+
+        sut.updateInputMode(.search, animated: false)
+
+        XCTAssertEqual(sut.viewController.currentAttachments.count, 1)
+
+        sut.updateInputMode(.aiChat, animated: false)
+
+        XCTAssertEqual(sut.viewController.currentAttachments.count, 1)
+        XCTAssertEqual(sut.viewController.currentAttachments.first?.fileName, "a.pdf")
+    }
+
+    func testWhenSwitchingInvalidAttachmentToSearchThenBackToDuckAIErrorReturns() {
+        let prefs = StubAIChatPreferences()
+        prefs.selectedModelId = "mixed-model"
+        let sut = makeCoordinator(preferences: prefs)
+        sut.modelStore.models = [makeModel(id: "mixed-model", supportsImageUpload: true, supportedFileTypes: ["application/pdf"])]
+        sut.activateFromOmnibar(inputMode: .aiChat)
+        sut.addFileAttachment(makeFileAttachment(fileName: "too-many-pages.pdf", pageCount: 9))
+        let expectedMessage = UserText.aiChatAttachmentFileTooManyPages(maxPagesPerFile: 8)
+        XCTAssertEqual(sut.viewController.attachmentValidationMessage, expectedMessage)
+
+        sut.updateInputMode(.search, animated: false)
+
+        XCTAssertEqual(sut.viewController.currentAttachments.count, 1)
+        XCTAssertNil(sut.viewController.attachmentValidationMessage)
+
+        sut.updateInputMode(.aiChat, animated: false)
+
+        XCTAssertEqual(sut.viewController.currentAttachments.count, 1)
+        XCTAssertEqual(sut.viewController.attachmentValidationMessage, expectedMessage)
+    }
+
+    func testAttachmentErrorBannerDisplaysAllAttachmentErrorCopy() {
+        let sut = makeCoordinator()
+        let messages = [
+            UserText.aiChatAttachmentFileCountLimit(maxFilesPerConversation: 3),
+            UserText.aiChatAttachmentFileEncrypted,
+            UserText.aiChatAttachmentFilesExceedTotalSizeLimit(maxTotalFileSizeMB: 5),
+            UserText.aiChatAttachmentFileTooLarge(maxFileSizeMB: 5),
+            UserText.aiChatAttachmentFileTooManyPages(maxPagesPerFile: 15),
+            UserText.aiChatAttachmentFileUnreadable,
+            UserText.aiChatAttachmentImageCountLimit(maxImagesPerConversation: 5),
+            UserText.aiChatAttachmentImageTurnLimit(maxImagesPerTurn: 3),
+            UserText.aiChatAttachmentPromptTooLong,
+            UserText.aiChatAttachmentUnavailable,
+            UserText.aiChatAttachmentUnsupportedFileType,
+            UserText.aiChatAttachmentUnsupportedFileType(acceptedFileType: "PDF"),
+            UserText.aiChatAttachmentUnsupportedFileType(acceptedFileTypes: ["PNG", "JPG", "PDF"]),
+        ]
+
+        for message in messages {
+            sut.viewController.showAttachmentValidationError(message)
+
+            XCTAssertEqual(sut.viewController.attachmentValidationMessage, message)
+            XCTAssertTrue(viewContainsLabelText(message, in: sut.viewController.view), message)
+        }
+    }
+
+    func testWhenSubmittingSearchAfterAddingAttachmentThenAttachmentsAreCleared() {
+        let prefs = StubAIChatPreferences()
+        prefs.selectedModelId = "mixed-model"
+        let sut = makeCoordinator(preferences: prefs)
+        sut.modelStore.models = [makeModel(id: "mixed-model", supportsImageUpload: true, supportedFileTypes: ["application/pdf"])]
+        sut.activateFromOmnibar(inputMode: .aiChat)
+        sut.addFileAttachment(makeFileAttachment(fileName: "a.pdf"))
+        sut.updateInputMode(.search, animated: false)
+
+        sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "example", mode: .search)
+
+        XCTAssertEqual(sut.viewController.currentAttachments.count, 0)
+        XCTAssertNil(sut.viewController.attachmentValidationMessage)
+    }
+
+    func testWhenSubmittingSearchFromDuckAITabAfterAddingAttachmentThenLiveInputIsCleared() {
+        let prefs = StubAIChatPreferences()
+        prefs.selectedModelId = "mixed-model"
+        let sut = makeCoordinator(preferences: prefs)
+        sut.modelStore.models = [makeModel(id: "mixed-model", supportsImageUpload: true, supportedFileTypes: ["application/pdf"])]
+        sut.showExpanded(inputMode: .aiChat)
+        sut.addFileAttachment(makeFileAttachment(fileName: "a.pdf"))
+        sut.setText("example")
+        sut.updateInputMode(.search, animated: false)
+
+        sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "example", mode: .search)
+
+        XCTAssertEqual(sut.viewController.currentAttachments.count, 0)
+        XCTAssertNil(sut.viewController.attachmentValidationMessage)
+        XCTAssertEqual(sut.viewController.text, "")
+    }
+
+    func testWhenExternalQuerySubmissionFromDuckAITabAfterAddingAttachmentThenLiveInputIsCleared() {
+        let prefs = StubAIChatPreferences()
+        prefs.selectedModelId = "mixed-model"
+        let sut = makeCoordinator(preferences: prefs)
+        sut.modelStore.models = [makeModel(id: "mixed-model", supportsImageUpload: true, supportedFileTypes: ["application/pdf"])]
+        sut.showExpanded(inputMode: .aiChat)
+        sut.addFileAttachment(makeFileAttachment(fileName: "a.pdf"))
+        sut.setText("example")
+
+        sut.handleExternalSubmission(.query)
+
+        XCTAssertEqual(sut.viewController.currentAttachments.count, 0)
+        XCTAssertNil(sut.viewController.attachmentValidationMessage)
+        XCTAssertEqual(sut.viewController.text, "")
+    }
+
     func testWhenGeneratingThenImageButtonIsDisabled() {
         let prefs = StubAIChatPreferences()
         prefs.selectedModelId = "image-model"
@@ -348,15 +509,23 @@ final class UnifiedToggleInputCoordinatorAttachmentLimitsTests: XCTestCase {
         )
     }
 
-    private func makeFileAttachment(fileName: String = "test.pdf") -> AIChatFileAttachment {
+    private func makeFileAttachment(fileName: String = "test.pdf", pageCount: Int? = 1) -> AIChatFileAttachment {
         let data = Data(repeating: 0, count: 1_000)
         return AIChatFileAttachment(
             data: data,
             fileName: fileName,
             mimeType: "application/pdf",
             fileSizeBytes: data.count,
-            pageCount: 1
+            pageCount: pageCount
         )
+    }
+
+    private func viewContainsLabelText(_ text: String, in view: UIView) -> Bool {
+        if let label = view as? UILabel, label.text == text {
+            return true
+        }
+
+        return view.subviews.contains { viewContainsLabelText(text, in: $0) }
     }
 
     private func attachmentMenuTitles(for coordinator: UnifiedToggleInputCoordinator) -> [String] {
@@ -366,10 +535,12 @@ final class UnifiedToggleInputCoordinatorAttachmentLimitsTests: XCTestCase {
 
 @MainActor
 private final class SpyUnifiedToggleInputDelegate: UnifiedToggleInputDelegate {
+    var submittedPrompt: String?
     var submittedImages: [AIChatNativePrompt.NativePromptImage]?
     var submittedFiles: [AIChatNativePrompt.NativePromptFile]?
 
     func unifiedToggleInputDidSubmitPrompt(_ prompt: String, modelId: String?, tools: [AIChatRAGTool]?, reasoningEffort: AIChatReasoningEffort?, images: [AIChatNativePrompt.NativePromptImage]?, files: [AIChatNativePrompt.NativePromptFile]?) {
+        submittedPrompt = prompt
         submittedImages = images
         submittedFiles = files
     }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift
@@ -291,6 +291,28 @@ final class UnifiedToggleInputCoordinatorAttachmentLimitsTests: XCTestCase {
         XCTAssertEqual(delegate.submittedFiles?.count, 1)
     }
 
+    func testWhenToolbarAttachmentOnlySubmitWouldExceedFileLimitThenPromptDoesNotSubmit() {
+        let prefs = StubAIChatPreferences()
+        prefs.selectedModelId = "mixed-model"
+        let sut = makeCoordinator(preferences: prefs)
+        sut.modelStore.models = [makeModel(id: "mixed-model", supportsImageUpload: true, supportedFileTypes: ["application/pdf"])]
+        let delegate = SpyUnifiedToggleInputDelegate()
+        sut.delegate = delegate
+        sut.updateInputMode(.aiChat, animated: false)
+        sut.addFileAttachment(makeFileAttachment(fileName: "a.pdf"))
+        sut.attachmentUsage = AIChatAttachmentUsage(imagesUsed: 0, filesUsed: 3, fileSizeBytesUsed: 0)
+
+        sut.unifiedToggleInputVCDidRequestSubmitCurrentInput(sut.viewController)
+
+        XCTAssertNil(delegate.submittedPrompt)
+        XCTAssertNil(delegate.submittedFiles)
+        XCTAssertEqual(
+            sut.viewController.attachmentValidationMessage,
+            UserText.aiChatAttachmentFileCountLimit(maxFilesPerConversation: 3)
+        )
+        XCTAssertEqual(sut.viewController.currentAttachments.count, 1)
+    }
+
     func testWhenFileValidationFailsThenInvalidAttachmentIsAdded() {
         let prefs = StubAIChatPreferences()
         prefs.selectedModelId = "mixed-model"

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -2044,6 +2044,26 @@ final class UnifiedToggleInputCoordinatorPerTabStateTests: XCTestCase {
                        "Dismiss-time clearText must preserve the per-tab stored draft.")
     }
 
+    func test_hide_doesNotWipeStoreEntryForCurrentTab() {
+        let store = FakeInputStateStore()
+        let sut = makeSUT(stateStore: store)
+        sut.modelStore.models = [makeModel(id: "file-model", access: true, supportedFileTypes: ["application/pdf"])]
+        sut.modelStore.attachmentLimits = makeLimits()
+        sut.activateForTab("tab-A")
+        sut.unifiedToggleInputVC(sut.viewController, didChangeText: "draft to keep")
+        sut.addFileAttachment(makeFileAttachment())
+        XCTAssertEqual(store.states["tab-A"]?.text, "draft to keep")
+        XCTAssertEqual(store.states["tab-A"]?.attachments.count, 1)
+
+        sut.hide()
+
+        XCTAssertEqual(store.states["tab-A"]?.text, "draft to keep",
+                       "hide() must preserve the previous tab's stored draft.")
+        XCTAssertEqual(store.states["tab-A"]?.attachments.count, 1)
+        XCTAssertEqual(sut.viewController.text, "")
+        XCTAssertEqual(sut.viewController.currentAttachments.count, 0)
+    }
+
     // Regression: applyState must always sync the live model store from per-tab
     // state, even when state values are nil. Otherwise the previous tab's reasoning
     // mode (or model id) leaks through preferences, and the next snapshot writes
@@ -2096,7 +2116,7 @@ final class UnifiedToggleInputCoordinatorPerTabStateTests: XCTestCase {
     // activateForTab; applyState must clear them before any user can see them.
     func test_activateForTab_newTabDoesNotInheritPreviousTabAttachments() {
         let store = FakeInputStateStore()
-        let attachment = AIChatImageAttachment(image: UIImage(), fileName: "x.jpg")
+        let attachment = UnifiedToggleInputAttachment.image(AIChatImageAttachment(image: UIImage(), fileName: "x.jpg"))
         store.states["tab-1"] = TabInputState(attachments: [attachment])
         let sut = makeSUT(stateStore: store)
 
@@ -2107,6 +2127,18 @@ final class UnifiedToggleInputCoordinatorPerTabStateTests: XCTestCase {
         sut.activateForTab("tab-2")
         XCTAssertEqual(sut.viewController.currentAttachments.count, 0,
                        "tab-2 must start with no attachments; the previous tab's strip contents must be cleared.")
+    }
+
+    func test_activateForTab_restoresFileAttachmentDraft() {
+        let store = FakeInputStateStore()
+        let attachment = UnifiedToggleInputAttachment.file(makeFileAttachment())
+        store.states["tab-1"] = TabInputState(attachments: [attachment])
+        let sut = makeSUT(stateStore: store)
+
+        sut.activateForTab("tab-1")
+
+        XCTAssertEqual(sut.viewController.currentAttachments.count, 1)
+        XCTAssertTrue(sut.viewController.currentAttachments.first?.isFile ?? false)
     }
 
     // Regression: submitting a search/prompt empties the live input. The store entry
@@ -2139,6 +2171,55 @@ final class UnifiedToggleInputCoordinatorPerTabStateTests: XCTestCase {
         sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "ask claude something", mode: .aiChat)
         XCTAssertEqual(store.states["tab-A"]?.text ?? "", "")
         XCTAssertEqual(store.states["tab-A"]?.attachments.count, 0)
+    }
+
+    func test_addFileAttachment_persistsToStore() {
+        let store = FakeInputStateStore()
+        let sut = makeSUT(stateStore: store)
+        sut.modelStore.models = [makeModel(id: "file-model", access: true, supportedFileTypes: ["application/pdf"])]
+        sut.modelStore.attachmentLimits = makeLimits()
+        sut.activateForTab("tab-A")
+
+        sut.addFileAttachment(makeFileAttachment())
+
+        XCTAssertEqual(store.states["tab-A"]?.attachments.count, 1)
+        XCTAssertTrue(store.states["tab-A"]?.attachments.first?.isFile ?? false)
+    }
+
+    func test_activateForTab_restoresInvalidFileAttachmentDraft() {
+        let store = FakeInputStateStore()
+        let sut = makeSUT(stateStore: store)
+        sut.modelStore.models = [makeModel(id: "file-model", access: true, supportedFileTypes: ["application/pdf"])]
+        sut.modelStore.attachmentLimits = makeLimits()
+        sut.activateForTab("tab-A")
+        sut.updateInputMode(.aiChat, animated: false)
+
+        sut.addFileAttachment(makeFileAttachment(pageCount: 9))
+        XCTAssertTrue(store.states["tab-A"]?.attachments.first?.isInvalid ?? false)
+
+        sut.activateForTab("tab-B")
+        sut.activateForTab("tab-A")
+
+        XCTAssertEqual(sut.viewController.currentAttachments.count, 1)
+        XCTAssertTrue(sut.viewController.currentAttachments.first?.isInvalid ?? false)
+        XCTAssertEqual(sut.viewController.attachmentValidationMessage, UserText.aiChatAttachmentFileTooManyPages(maxPagesPerFile: 8))
+    }
+
+    func test_submitPrompt_whenValidationFails_preservesStoreTextAndAttachments() {
+        let store = FakeInputStateStore()
+        let sut = makeSUT(stateStore: store)
+        sut.modelStore.models = [makeModel(id: "file-model", access: true, supportedFileTypes: ["application/pdf"])]
+        sut.modelStore.attachmentLimits = makeLimits()
+        sut.activateForTab("tab-A")
+        sut.addFileAttachment(makeFileAttachment())
+        let text = String(repeating: "a", count: 4_501)
+        sut.setText(text)
+
+        sut.unifiedToggleInputVC(sut.viewController, didSubmitText: text, mode: .aiChat)
+
+        XCTAssertEqual(store.states["tab-A"]?.text, text)
+        XCTAssertEqual(store.states["tab-A"]?.attachments.count, 1)
+        XCTAssertTrue(store.states["tab-A"]?.attachments.first?.isFile ?? false)
     }
 
     // Regression: user keystrokes flow through unifiedToggleInputVC(_:didChangeText:),
@@ -2198,6 +2279,19 @@ final class UnifiedToggleInputCoordinatorPerTabStateTests: XCTestCase {
         let baseline = store.lastUsed
 
         sut.addImageAttachment(image: UIImage(), fileName: "x.jpg")
+
+        XCTAssertEqual(store.lastUsed, baseline)
+    }
+
+    func test_addFileAttachment_doesNotMutateLastUsed() {
+        let store = FakeInputStateStore()
+        let sut = makeSUT(stateStore: store)
+        sut.modelStore.models = [makeModel(id: "file-model", access: true, supportedFileTypes: ["application/pdf"])]
+        sut.modelStore.attachmentLimits = makeLimits()
+        sut.activateForTab("tab-A")
+        let baseline = store.lastUsed
+
+        sut.addFileAttachment(makeFileAttachment())
 
         XCTAssertEqual(store.lastUsed, baseline)
     }
@@ -2456,6 +2550,17 @@ final class UnifiedToggleInputCoordinatorPerTabStateTests: XCTestCase {
 
     // MARK: - Helpers
 
+    private func makeModel(id: String, access: Bool, supportedFileTypes: [String] = []) -> AIChatModel {
+        AIChatModel(
+            id: id,
+            name: id,
+            provider: .unknown,
+            supportsImageUpload: false,
+            supportedFileTypes: supportedFileTypes,
+            entityHasAccess: access
+        )
+    }
+
     private func makeModelWithTools(
         id: String,
         supportsImageUpload: Bool = false,
@@ -2468,6 +2573,17 @@ final class UnifiedToggleInputCoordinatorPerTabStateTests: XCTestCase {
             supportsImageUpload: supportsImageUpload,
             supportedTools: supportedTools,
             entityHasAccess: true
+        )
+    }
+
+    private func makeFileAttachment(fileName: String = "test.pdf", pageCount: Int? = 1) -> AIChatFileAttachment {
+        let data = Data(repeating: 0, count: 1_000)
+        return AIChatFileAttachment(
+            data: data,
+            fileName: fileName,
+            mimeType: "application/pdf",
+            fileSizeBytes: data.count,
+            pageCount: pageCount
         )
     }
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -663,6 +663,24 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         XCTAssertEqual(sut.inputMode, .search)
     }
 
+    func test_updateToggleEnabled_false_clearsAttachmentErrorBannerWhenOmnibar() {
+        let validationMessage = UserText.aiChatAttachmentFileTooManyPages(maxPagesPerFile: 8)
+        sut.activateFromOmnibar(inputMode: .aiChat)
+        sut.viewController.addAttachment(.invalidFile(UnifiedToggleInputInvalidFileAttachment(
+            fileName: "too-many-pages.pdf",
+            mimeType: "application/pdf",
+            fileSizeBytes: 1_000,
+            validationMessage: validationMessage
+        )))
+        sut.viewController.showAttachmentValidationError(validationMessage)
+        XCTAssertEqual(sut.viewController.attachmentValidationMessage, validationMessage)
+
+        sut.updateToggleEnabled(false)
+
+        XCTAssertEqual(sut.inputMode, .search)
+        XCTAssertNil(sut.viewController.attachmentValidationMessage)
+    }
+
     func test_updateToggleEnabled_noChangeIsNoOp() {
         let exp = expectation(description: "no mode change emitted")
         exp.isInverted = true

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputHandlerTests.swift
@@ -243,6 +243,22 @@ final class UnifiedToggleInputHandlerTests: XCTestCase {
         XCTAssertFalse(fired)
     }
 
+    func test_submitAIChatAttachmentOnlyPrompt_firesEmptyAIChatSubmission() {
+        let expectation = expectation(description: "empty AI chat submission fires")
+        sut.setToggleState(.search)
+
+        sut.textSubmissionPublisher
+            .sink { submission in
+                XCTAssertEqual(submission.text, "")
+                XCTAssertEqual(submission.mode, .aiChat)
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        sut.submitAIChatAttachmentOnlyPrompt()
+        waitForExpectations(timeout: 1)
+    }
+
     func test_submitText_usesCurrentToggleMode() {
         let expectation = expectation(description: "mode in submission matches toggle")
         sut.setToggleState(.search)

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -62,6 +62,30 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         XCTAssertEqual(scrollView.contentOffset.x, expectedOffset, accuracy: 1)
     }
 
+    func test_attachmentStripDoesNotAutoScrollWhenUserHasScrolledAwayFromTrailingEdge() throws {
+        let sut = UnifiedToggleInputAttachmentsStripView()
+        sut.frame = CGRect(
+            x: 0,
+            y: 0,
+            width: 160,
+            height: UnifiedToggleInputAttachmentsStripView.Constants.stripHeight
+        )
+
+        (0..<6).forEach { index in
+            sut.addAttachment(makeInvalidFileAttachment(fileName: "attachment-\(index)-long-name.pdf"))
+        }
+        flushMainQueue()
+        sut.layoutIfNeeded()
+        let scrollView = try XCTUnwrap(firstDescendant(of: UIScrollView.self, in: sut))
+        XCTAssertGreaterThan(scrollView.contentSize.width - scrollView.bounds.width, 0)
+
+        scrollView.setContentOffset(.zero, animated: false)
+        sut.addAttachment(makeInvalidFileAttachment(fileName: "attachment-new-long-name.pdf"))
+        flushMainQueue()
+
+        XCTAssertEqual(scrollView.contentOffset.x, 0, accuracy: 1)
+    }
+
     @MainActor
     func test_documentPickerFailureIncludesFallbackMetadataForInvalidChip() async {
         let sut = UnifiedToggleInputAttachmentPresenter()

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -82,6 +82,38 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         await fulfillment(of: [expectation], timeout: 1)
     }
 
+    func test_floatingSubmitEnablesAndSubmitsAttachmentOnlyState() throws {
+        let sut = UnifiedToggleInputFloatingSubmitViewController()
+        let delegate = SpyFloatingSubmitDelegate()
+        sut.delegate = delegate
+        sut.loadViewIfNeeded()
+
+        sut.updateState(UnifiedToggleInputFloatingSubmitState(
+            hasText: false,
+            hasValidAttachment: true,
+            hasInvalidAttachment: false
+        ))
+
+        XCTAssertTrue(sut.isSubmitButtonEnabled)
+        try XCTUnwrap(firstDescendant(of: UIButton.self, in: sut.view)).sendActions(for: .touchUpInside)
+        XCTAssertEqual(delegate.submitTapCount, 1)
+        XCTAssertEqual(delegate.voiceTapCount, 0)
+    }
+
+    func test_floatingSubmitDisablesWhenInvalidAttachmentIsPresent() {
+        let sut = UnifiedToggleInputFloatingSubmitViewController()
+        sut.isAIVoiceChatEnabled = true
+        sut.loadViewIfNeeded()
+
+        sut.updateState(UnifiedToggleInputFloatingSubmitState(
+            hasText: true,
+            hasValidAttachment: false,
+            hasInvalidAttachment: true
+        ))
+
+        XCTAssertFalse(sut.isSubmitButtonEnabled)
+    }
+
     private func flushMainQueue() {
         let expectation = expectation(description: "main queue flushed")
         DispatchQueue.main.async {
@@ -116,5 +148,18 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         }
 
         return nil
+    }
+}
+
+private final class SpyFloatingSubmitDelegate: UnifiedToggleInputFloatingSubmitDelegate {
+    var submitTapCount = 0
+    var voiceTapCount = 0
+
+    func floatingSubmitDidTapSubmit() {
+        submitTapCount += 1
+    }
+
+    func floatingSubmitDidTapVoice() {
+        voiceTapCount += 1
     }
 }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -1,0 +1,58 @@
+//
+//  UnifiedToggleInputViewTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo
+
+final class UnifiedToggleInputViewTests: XCTestCase {
+
+    func test_searchModeTextSubmitStaysEnabledWhenInvalidDuckAIAttachmentIsHidden() {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        let sut = UnifiedToggleInputView(handler: handler)
+
+        sut.applyCardLayout(.expanded(showsToggle: true, showsToolbar: true), animated: false)
+        sut.addAttachment(makeInvalidFileAttachment())
+        sut.text = "search query"
+        sut.setInputMode(.search, animated: false)
+        flushMainQueue()
+
+        XCTAssertTrue(sut.isToolbarSubmitEnabled)
+    }
+
+    private func flushMainQueue() {
+        let expectation = expectation(description: "main queue flushed")
+        DispatchQueue.main.async {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+    }
+
+    private func makeInvalidFileAttachment(
+        validationMessage: String = UserText.aiChatAttachmentFileTooManyPages(maxPagesPerFile: 15)
+    ) -> UnifiedToggleInputAttachment {
+        .invalidFile(
+            UnifiedToggleInputInvalidFileAttachment(
+                fileName: "invalid.pdf",
+                mimeType: "application/pdf",
+                fileSizeBytes: 1_000,
+                validationMessage: validationMessage
+            )
+        )
+    }
+}

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -17,6 +17,7 @@
 //  limitations under the License.
 //
 
+import AIChat
 import XCTest
 import UIKit
 import UniformTypeIdentifiers
@@ -35,6 +36,18 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         flushMainQueue()
 
         XCTAssertTrue(sut.isToolbarSubmitEnabled)
+    }
+
+    func test_searchModeAttachmentOnlySubmitStaysDisabledWhenDuckAIAttachmentIsHidden() {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        let sut = UnifiedToggleInputView(handler: handler)
+
+        sut.applyCardLayout(.expanded(showsToggle: true, showsToolbar: true), animated: false)
+        sut.addAttachment(makeFileAttachment())
+        sut.setInputMode(.search, animated: false)
+        flushMainQueue()
+
+        XCTAssertFalse(sut.isToolbarSubmitEnabled)
     }
 
     func test_attachmentStripScrollsToTrailingEdgeAfterAttachmentLayoutChange() throws {
@@ -156,6 +169,18 @@ final class UnifiedToggleInputViewTests: XCTestCase {
                 mimeType: "application/pdf",
                 fileSizeBytes: 1_000,
                 validationMessage: validationMessage
+            )
+        )
+    }
+
+    private func makeFileAttachment(fileName: String = "valid.pdf") -> UnifiedToggleInputAttachment {
+        .file(
+            AIChatFileAttachment(
+                data: Data(repeating: 0, count: 1_000),
+                fileName: fileName,
+                mimeType: "application/pdf",
+                fileSizeBytes: 1_000,
+                pageCount: 1
             )
         )
     }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -70,9 +70,9 @@ final class UnifiedToggleInputViewTests: XCTestCase {
 
         sut.onFileValidationFailed = { message, metadata in
             XCTAssertEqual(message, UserText.aiChatAttachmentFileUnreadable)
-            XCTAssertEqual(metadata?.fileName, "missing-unreadable.pdf")
-            XCTAssertEqual(metadata?.mimeType, "application/pdf")
-            XCTAssertNil(metadata?.fileSizeBytes)
+            XCTAssertEqual(metadata.fileName, "missing-unreadable.pdf")
+            XCTAssertEqual(metadata.mimeType, "application/pdf")
+            XCTAssertNil(metadata.fileSizeBytes)
             expectation.fulfill()
         }
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -18,6 +18,8 @@
 //
 
 import XCTest
+import UIKit
+import UniformTypeIdentifiers
 @testable import DuckDuckGo
 
 final class UnifiedToggleInputViewTests: XCTestCase {
@@ -35,6 +37,51 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         XCTAssertTrue(sut.isToolbarSubmitEnabled)
     }
 
+    func test_attachmentStripScrollsToTrailingEdgeAfterAttachmentLayoutChange() throws {
+        let sut = UnifiedToggleInputAttachmentsStripView()
+        sut.frame = .zero
+        sut.onAttachmentsChanged = {
+            sut.frame = CGRect(
+                x: 0,
+                y: 0,
+                width: 160,
+                height: UnifiedToggleInputAttachmentsStripView.Constants.stripHeight
+            )
+        }
+
+        (0..<6).forEach { index in
+            sut.addAttachment(makeInvalidFileAttachment(fileName: "attachment-\(index)-long-name.pdf"))
+        }
+        flushMainQueue()
+        sut.layoutIfNeeded()
+
+        let scrollView = try XCTUnwrap(firstDescendant(of: UIScrollView.self, in: sut))
+        let expectedOffset = max(scrollView.contentSize.width - scrollView.bounds.width, 0)
+
+        XCTAssertGreaterThan(expectedOffset, 0)
+        XCTAssertEqual(scrollView.contentOffset.x, expectedOffset, accuracy: 1)
+    }
+
+    @MainActor
+    func test_documentPickerFailureIncludesFallbackMetadataForInvalidChip() async {
+        let sut = UnifiedToggleInputAttachmentPresenter()
+        let expectation = expectation(description: "file validation failed")
+        let missingURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("missing-unreadable.pdf")
+
+        sut.onFileValidationFailed = { message, metadata in
+            XCTAssertEqual(message, UserText.aiChatAttachmentFileUnreadable)
+            XCTAssertEqual(metadata?.fileName, "missing-unreadable.pdf")
+            XCTAssertEqual(metadata?.mimeType, "application/pdf")
+            XCTAssertNil(metadata?.fileSizeBytes)
+            expectation.fulfill()
+        }
+
+        let controller = UIDocumentPickerViewController(forOpeningContentTypes: [.pdf])
+        sut.documentPicker(controller, didPickDocumentsAt: [missingURL])
+
+        await fulfillment(of: [expectation], timeout: 1)
+    }
+
     private func flushMainQueue() {
         let expectation = expectation(description: "main queue flushed")
         DispatchQueue.main.async {
@@ -44,15 +91,30 @@ final class UnifiedToggleInputViewTests: XCTestCase {
     }
 
     private func makeInvalidFileAttachment(
+        fileName: String = "invalid.pdf",
         validationMessage: String = UserText.aiChatAttachmentFileTooManyPages(maxPagesPerFile: 15)
     ) -> UnifiedToggleInputAttachment {
         .invalidFile(
             UnifiedToggleInputInvalidFileAttachment(
-                fileName: "invalid.pdf",
+                fileName: fileName,
                 mimeType: "application/pdf",
                 fileSizeBytes: 1_000,
                 validationMessage: validationMessage
             )
         )
+    }
+
+    private func firstDescendant<T: UIView>(of type: T.Type, in view: UIView) -> T? {
+        if let match = view as? T {
+            return match
+        }
+
+        for subview in view.subviews {
+            if let match = firstDescendant(of: type, in: subview) {
+                return match
+            }
+        }
+
+        return nil
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214489484949107

### Description
Updates the Duck.ai Unified Toggle Input attachment experience after the document-attachment baseline: invalid files now remain visible as removable error chips, attachment errors render in-context, attachment drafts persist across the relevant UTI flows, and attachment-only submissions go through the normal handler path.

High-level changes:
- Attachment errors now use the new in-context banner UI.
- Invalid files stay visible as red removable chips and block Duck.ai submission until removed.
- Attachment chips now sit in a horizontally scrollable row for mixed image and file sets.

### Testing Steps

#### Testing Prerequisites
- Feature flag: enable `unifiedToggleInput`
- Enable Duck.ai and the Search + Duck.ai input setting. For the toggle-disabled case, temporarily switch the setting to Search Only.
- Use PR #4659 as the baseline for attachment-limit behavior. If you already ran those tests, do not repeat every limit permutation; run the reduced UI-focused paths below.
- Run one Free/no-subscription path and one paid path. Internal accounts should follow Pro values.

Reference limits from PR #4659:

| Tier | Images per turn | Images per conversation | Files per conversation | Max file size | Max total file size | PDF page limit |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Free | 3 | 5 | 3 | 5 MB | 5,242,880 bytes | 15 |
| Plus | 3 | 10 | 5 | 25 MB | 26,214,400 bytes | 35 |
| Pro/internal | 3 | 10 | 5 | 25 MB | 26,214,400 bytes | 50 |

Test-file setup prompt for an agent:

```text
Create or reuse the Duck.ai attachment fixture bundle from PR #4659. Put the files in one local folder.

If the PR #4659 bundle is not already available, generate these files:
- 01-valid-small.pdf: valid 1-page PDF, under 1 MB.
- 02-valid-free-max-pages-15.pdf: valid 15-page PDF, under 5 MB.
- 03-over-free-page-limit-16.pdf: valid 16-page PDF, under 5 MB.
- 04-over-pro-page-limit-51.pdf: valid 51-page PDF, under 5 MB.
- 05-over-free-size-5mb.pdf: valid 1-page PDF, at least 5,242,881 bytes and under 25 MB.
- 06-over-paid-size-25mb.pdf: valid 1-page PDF, at least 26,214,401 bytes.
- 07-unsupported-text-file.txt: plain text file.
- 08-paid-pro-valid-plus-over-pages-36.pdf: valid 36-page PDF, under 5 MB.
- 09-valid-small-2.pdf through 13-valid-small-6.pdf: valid 1-page PDFs, under 1 MB, for file-count testing.
- 14-corrupt.pdf: invalid/corrupt PDF bytes.
- 15-encrypted.pdf: encrypted/password-protected PDF.
- image-one.png through image-four.png: valid small PNG images.
- README.txt: summarize which files should be valid/invalid for Free, Plus, and Pro/internal.

Create a zip archive containing the folder.
```

Simulator download: from the folder that contains `DuckAI Attachment Test Files.zip`, run `python3 -m http.server 8765`. In another terminal, run `ipconfig getifaddr en0` to get the Mac IP address; if that returns nothing, try `ipconfig getifaddr en1`. Open `http://<mac-ip>:8765/` in Simulator Safari. Download the zip, open Safari Downloads, tap the zip to open it in Files, then tap Uncompress. In the document picker, use Browse > Downloads > DuckAI Attachment Test Files.

#### Manual Tests

These paths intentionally combine coverage. The goal is to validate the new invalid-chip/banner UI and preservation behavior while spot-checking that the PR #4659 tier limits still behave correctly.

**Designs to validate against - https://www.figma.com/design/QUTLfN2oPR6ivG1Jwsw3Mg/%F0%9F%93%B1-Phase-4--Full-Screen-Integration--iOS-?node-id=12920-60911&m=dev**

##### 1. Free/no-subscription: top omnibar UI, mixed row, and Free-limit
1. Sign out or use a Free/no-subscription account. Set the omnibar to the top position and start from a regular web/search tab.
2. Open Unified Toggle Input, switch to Duck.ai, and select a file-capable model.
3. Attach `01-valid-small.pdf` and any image. Verify the updated document and image chips are visible together.
4. Add attachments up to 3 images and 3 PDFs. Verify the row scrolls horizontally, and every chip can be reached and removed.
5. Verify After the limit is reached for images and PDFs (i.e., three each), the attachments button is grayed. 

##### 2. Free/no-subscription: bottom omnibar UI and Search toggle
1. Keep the Free/no-subscription account and set the omnibar to the bottom position.
2. Start from a regular web/search tab, open Unified Toggle Input, switch to Duck.ai, and attach `03-over-free-page-limit-16.pdf`.
3. Verify the invalid banner appears above the UTI, and the invalid chip UI is shown
4. Toggle to Search. Verify the attachment chip and banner hide, Search text submission remains enabled, and a normal Search query can submit.
5. Repeat without submitting Search, toggle back to Duck.ai, and verify the invalid attachment is preserved until removed.

##### 3. Paid Plus/Pro/internal: full Duck.ai tab paid limits and submit cleanup

1. Sign in with a Plus or Pro/internal account, open a full Duck.ai tab, expand Unified Toggle Input, and select a paid file-capable model such as GPT-5.2.
2. Attach `05-over-free-size-5mb.pdf`. Verify it is accepted on the paid tier.
3. Attach `06-over-paid-size-25mb.pdf`. Verify it shows the new red removable chip plus 25 MB banner and blocks Duck.ai submission until removed.
4. Attach 5 valid PDFs using `01-valid-small.pdf`, `02-valid-free-max-pages-15.pdf`, and `09-valid-small-2.pdf` through `11-valid-small-4.pdf`; then try a sixth valid PDF. Verify the file-count limit is enforced and photo/image actions still behave as allowed.
5. If testing Plus, attach `08-paid-pro-valid-plus-over-pages-36.pdf` and verify it is rejected. If testing Pro/internal, verify that file is accepted and `04-over-pro-page-limit-51.pdf` is rejected.
6. Attach one valid PDF plus at least one image, submit attachment-only, then submit text plus attachments. Verify submissions go through and the live text/attachment row clears after submission.

##### 4. Remaining UI/error-copy smoke: unreadable, encrypted, and toggle-disabled

1. In any Duck.ai-enabled UTI surface, attach `14-corrupt.pdf` and `15-encrypted.pdf` one at a time.
2. Verify each shows the matching unreadable/encrypted copy in the in-context banner, appears as a removable invalid chip, blocks Duck.ai submission, and clears after removal.

### Impact and Risks

Medium risk in Unified Toggle Input attachment state management. This touches invalid file rendering, error placement, draft persistence, submit gating, and mixed attachment flows across web-origin UTI and full Duck.ai tabs.

### Quality Considerations

Unit coverage was added around attachment validation policy, invalid-file persistence/restoration, attachment-only submission routing, search-mode submit gating, and post-submit cleanup. Manual validation should focus on Figma parity and the reduced tier/layout matrix above.

### Notes to Reviewer

- This PR changes presentation and state handling for errors; the underlying attachment limits should match PR #4659.
- The old PR #4659 dev-testing URL/tag setup is intentionally not included here. This follow-up only requires the feature flag plus the normal account/tier setup.
- Invalid file chips are intentionally persisted with the Duck.ai draft until the user removes them or submits a path that clears live input state.
- Search mode should not be blocked by invalid Duck.ai attachments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added visible invalid file attachment chips with error styling, clear messaging, and removal support.
  - Introduced attachment-only AI chat submissions and scrollable attachment rows.
  - Added in-context attachment error banners across unified input containers.

- **Bug Fixes**
  - Preserved Duck.ai attachments across Search/Duck.ai toggles and cleared them correctly after submissions.
  - Prevented invalid Duck.ai attachments from blocking Search-mode submissions.
  - Excluded invalid file chips from valid file capacity and size calculations.

- **Tests**
  - Added coverage for invalid attachment persistence, restoration, validation gating, attachment-only submission routing, and cleanup flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Unified Toggle Input state, submission routing, and attachment validation/persistence across modes, which can affect chat/search submission behavior and draft retention.
> 
> **Overview**
> Refines Duck.ai Unified Toggle Input attachment UX by keeping invalid file picks as *removable error chips*, persisting attachment drafts across relevant UTI flows, and adding attachment-only prompt submission.
> 
> Moves attachment errors from transient messages to an **in-context validation banner** (with new design-system colors) and tightens submit gating via a shared `UnifiedToggleInputFloatingSubmitState` so floating/toolbar submits consistently block on invalid attachments.
> 
> Updates attachment presentation to a horizontally scrollable chip row, enhances file-type display/validation (including better MIME→extension naming), adds invalid-attachment recovery/revalidation when model support changes, and wires a new `UnifiedToggleInputViewTests.swift` into the test target/project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 065e45ef02464b67296454600fe00487d4a67cb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->