### PR TITLE
iOS: Unified Input Restore private voice search

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/CircularButton.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/CircularButton.swift
@@ -134,6 +134,11 @@ final class CircularButton: UIButton {
                   pressedBackground: pressedBackground)
     }
 
+    func applyAIVoiceChatStyle() {
+        setColors(foreground: UIColor(designSystemColor: .textPrimary),
+                  background: UIColor(singleUseColor: .unifiedToggleInputStopButtonBackground))
+    }
+
     override func layoutSubviews() {
         super.layoutSubviews()
 

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarButtonsView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarButtonsView.swift
@@ -107,6 +107,12 @@ enum SwitchBarButtonState {
 }
 
 class SwitchBarButtonsView: UIView {
+    enum VoiceButtonStyle {
+        case microphone
+        case aiVoiceAccent
+        case aiVoicePlain
+    }
+
     private enum Constants {
         static let buttonSize: CGFloat = 44
         static let separatorWidth: CGFloat = 1
@@ -123,9 +129,9 @@ class SwitchBarButtonsView: UIView {
         }
     }
 
-    var isAIVoiceChatEnabled: Bool = false {
+    var voiceButtonStyle: VoiceButtonStyle = .microphone {
         didSet {
-            updateAIVoiceChatButtonAppearance()
+            updateVoiceButtonAppearance()
         }
     }
 
@@ -273,18 +279,26 @@ class SwitchBarButtonsView: UIView {
         searchGoToButton.isHidden = !buttonState.showsSearchGoToButton
     }
 
-    private func updateAIVoiceChatButtonAppearance() {
-        if isAIVoiceChatEnabled {
+    private func updateVoiceButtonAppearance() {
+        switch voiceButtonStyle {
+        case .microphone:
+            voiceButton.setImage(DesignSystemImages.Glyphs.Size24.microphone)
+            voiceButton.backgroundColor = .clear
+            voiceButton.tintColor = nil
+            voiceButton.layer.cornerRadius = 0
+            voiceButton.clipsToBounds = false
+        case .aiVoiceAccent:
             voiceButton.setImage(DesignSystemImages.Glyphs.Size24.voice)
             voiceButton.backgroundColor = UIColor(designSystemColor: .accent)
             voiceButton.tintColor = UIColor(designSystemColor: .accentContentPrimary)
             voiceButton.layer.cornerRadius = Constants.buttonSize / 2
             voiceButton.clipsToBounds = true
-        } else {
-            voiceButton.setImage(DesignSystemImages.Glyphs.Size24.microphone)
+        case .aiVoicePlain:
+            voiceButton.setImage(DesignSystemImages.Glyphs.Size24.voice)
             voiceButton.backgroundColor = .clear
-            voiceButton.tintColor = nil
+            voiceButton.tintColor = UIColor(designSystemColor: .textPrimary)
             voiceButton.layer.cornerRadius = 0
+            voiceButton.clipsToBounds = false
         }
     }
 }

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -25,6 +25,12 @@ import Core
 
 class SwitchBarTextEntryView: UIView {
 
+    enum VoiceButtonAppearance {
+        case automatic
+        case microphone
+        case aiVoicePlain
+    }
+
     private enum Constants {
         static let maxHeight: CGFloat = 120
         static let maxHeightWhenUsingFadeOutAnimation: CGFloat = 132
@@ -49,6 +55,12 @@ class SwitchBarTextEntryView: UIView {
     }
 
     private let handler: SwitchBarHandling
+    var voiceButtonAppearance: VoiceButtonAppearance {
+        didSet {
+            guard voiceButtonAppearance != oldValue else { return }
+            updateButtonState()
+        }
+    }
 
     private let textView = SwitchBarTextView()
     private let placeholderLabel = UILabel()
@@ -135,8 +147,9 @@ class SwitchBarTextEntryView: UIView {
     }
 
     // MARK: - Initialization
-    init(handler: SwitchBarHandling) {
+    init(handler: SwitchBarHandling, voiceButtonAppearance: VoiceButtonAppearance = .automatic) {
         self.handler = handler
+        self.voiceButtonAppearance = voiceButtonAppearance
         super.init(frame: .zero)
 
         setupView()
@@ -315,7 +328,7 @@ class SwitchBarTextEntryView: UIView {
 
     private func updateButtonState() {
         let newButtonState = handler.buttonState
-        buttonsView.isAIVoiceChatEnabled = handler.isAIVoiceChatEnabled && handler.currentToggleState == .aiChat
+        updateVoiceButtonStyle()
 
         if newButtonState != currentButtonState {
             // Snapshot crossfade so icons fade in/out without UIStackView's `isHidden` jank.
@@ -328,6 +341,18 @@ class SwitchBarTextEntryView: UIView {
                     self.layoutIfNeeded()
                 }
             }
+        }
+    }
+
+    private func updateVoiceButtonStyle() {
+        let showsAIVoiceChatButton = handler.isAIVoiceChatEnabled && handler.currentToggleState == .aiChat
+        switch voiceButtonAppearance {
+        case .automatic:
+            buttonsView.voiceButtonStyle = showsAIVoiceChatButton ? .aiVoiceAccent : .microphone
+        case .microphone:
+            buttonsView.voiceButtonStyle = .microphone
+        case .aiVoicePlain:
+            buttonsView.voiceButtonStyle = showsAIVoiceChatButton ? .aiVoicePlain : .microphone
         }
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -648,11 +648,11 @@ extension MainViewController: UnifiedToggleInputDelegate {
 
     func unifiedToggleInputDidRequestVoiceSearch() {
         let mode = unifiedToggleInputCoordinator?.inputMode ?? .search
-        if mode == .aiChat && voiceShortcutFeature.isAvailable {
-            onDuckAIVoiceModeRequested()
-        } else {
-            handleVoiceSearchOpenRequest(preferredTarget: mode == .aiChat ? .AIChat : .SERP)
-        }
+        handleVoiceSearchOpenRequest(preferredTarget: mode == .aiChat ? .AIChat : .SERP)
+    }
+
+    func unifiedToggleInputDidRequestAIVoiceChat() {
+        onDuckAIVoiceModeRequested()
     }
 
     func unifiedToggleInputDidRequestAIChat() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -271,6 +271,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         subscribeToStopGeneratingTap()
         subscribeToCustomizeResponsesTap()
         subscribeToVoiceSearchTap()
+        subscribeToAIVoiceChatTap()
         subscribeToAttachmentUsageChanges()
         viewController.isToolsButtonHidden = true
 
@@ -1401,7 +1402,24 @@ private extension UnifiedToggleInputCoordinator {
     func subscribeToVoiceSearchTap() {
         viewController.handler.microphoneButtonTappedPublisher
             .sink { [weak self] in
-                self?.delegate?.unifiedToggleInputDidRequestVoiceSearch()
+                guard let self else { return }
+                let isCollapsedAIVoiceChatButton = viewController.handler.isAIVoiceChatEnabled
+                    && viewController.inputMode == .aiChat
+                    && !viewController.isInputExpanded
+                if isCollapsedAIVoiceChatButton {
+                    delegate?.unifiedToggleInputDidRequestAIVoiceChat()
+                } else {
+                    guard viewController.handler.isVoiceSearchEnabled else { return }
+                    delegate?.unifiedToggleInputDidRequestVoiceSearch()
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    func subscribeToAIVoiceChatTap() {
+        viewController.handler.aiVoiceChatButtonTappedPublisher
+            .sink { [weak self] in
+                self?.delegate?.unifiedToggleInputDidRequestAIVoiceChat()
             }
             .store(in: &cancellables)
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputDelegate.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputDelegate.swift
@@ -24,6 +24,7 @@ protocol UnifiedToggleInputDelegate: AnyObject {
     func unifiedToggleInputDidSubmitPrompt(_ prompt: String, modelId: String?, tools: [AIChatRAGTool]?, reasoningEffort: AIChatReasoningEffort?, images: [AIChatNativePrompt.NativePromptImage]?, files: [AIChatNativePrompt.NativePromptFile]?)
     func unifiedToggleInputDidSubmitQuery(_ query: String)
     func unifiedToggleInputDidRequestVoiceSearch()
+    func unifiedToggleInputDidRequestAIVoiceChat()
     func unifiedToggleInputDidRequestAIChat()
     func unifiedToggleInputDidChangeHeight()
     func unifiedToggleInputDidCommitMode(_ mode: TextEntryMode)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputFloatingSubmitViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputFloatingSubmitViewController.swift
@@ -88,9 +88,13 @@ final class UnifiedToggleInputFloatingSubmitViewController: UIViewController {
         let icon = showVoice ? DesignSystemImages.Glyphs.Size24.voice : DesignSystemImages.Glyphs.Size24.arrowUp
         button.setImage(icon, for: .normal)
         button.isEnabled = isActive
-        button.applySubmitStyle(isActive: isActive,
-                                isFireTab: isFireTab,
-                                activeForeground: UIColor(designSystemColor: .accentContentPrimary))
+        if showVoice {
+            button.applyAIVoiceChatStyle()
+        } else {
+            button.applySubmitStyle(isActive: isActive,
+                                    isFireTab: isFireTab,
+                                    activeForeground: UIColor(designSystemColor: .accentContentPrimary))
+        }
     }
 
     @objc private func buttonTapped() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
@@ -128,6 +128,11 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
         microphoneButtonTappedSubject.eraseToAnyPublisher()
     }
 
+    private let aiVoiceChatButtonTappedSubject = PassthroughSubject<Void, Never>()
+    var aiVoiceChatButtonTappedPublisher: AnyPublisher<Void, Never> {
+        aiVoiceChatButtonTappedSubject.eraseToAnyPublisher()
+    }
+
     private let clearButtonTappedSubject = PassthroughSubject<Void, Never>()
     var clearButtonTappedPublisher: AnyPublisher<Void, Never> {
         clearButtonTappedSubject.eraseToAnyPublisher()
@@ -189,6 +194,10 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
         microphoneButtonTappedSubject.send()
     }
 
+    func aiVoiceChatButtonTapped() {
+        aiVoiceChatButtonTappedSubject.send()
+    }
+
     func markUserInteraction() {
         guard !hasUserInteractedWithText else { return }
         hasUserInteractedWithText = true
@@ -215,7 +224,8 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
     // MARK: - Private
 
     private func updateButtonState() {
-        let voiceAvailable = !hidesVoiceButton && isVoiceSearchEnabled && !(isAIVoiceChatEnabled && currentToggleState == .aiChat)
+        let aiVoiceChatAvailable = !isExpanded && isAIVoiceChatEnabled && currentToggleState == .aiChat
+        let voiceAvailable = !hidesVoiceButton && (isVoiceSearchEnabled || aiVoiceChatAvailable)
         let nextButtonState: SwitchBarButtonState
 
         if isGenerating && !isExpanded && currentToggleState == .aiChat && !isToggleEnabled {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
@@ -418,7 +418,11 @@ private extension UnifiedToggleInputToolbarView {
         submitButton.setImage(icon, for: .normal)
         let isActive = isSubmitEnabled || showVoice
         submitButton.isEnabled = isActive
-        submitButton.applySubmitStyle(isActive: isActive, isFireTab: isFireTab, activeForeground: .white)
+        if showVoice {
+            submitButton.applyAIVoiceChatStyle()
+        } else {
+            submitButton.applySubmitStyle(isActive: isActive, isFireTab: isFireTab, activeForeground: .white)
+        }
     }
 
     func updateGeneratingVisibility() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -349,7 +349,7 @@ final class UnifiedToggleInputView: UIView {
     init(handler: UnifiedToggleInputHandler, isToggleEnabled: Bool = true) {
         self.handler = handler
         self.isToggleEnabled = isToggleEnabled
-        self.textEntryView = SwitchBarTextEntryView(handler: handler)
+        self.textEntryView = SwitchBarTextEntryView(handler: handler, voiceButtonAppearance: .aiVoicePlain)
         super.init(frame: .zero)
         setupUI()
         setupSubscriptions()
@@ -481,11 +481,12 @@ final class UnifiedToggleInputView: UIView {
     }
 
     func applyCardLayout(_ layout: UnifiedToggleInputCardLayout, animated: Bool, updateShadow: Bool = true) {
-        guard layout != currentLayout else { return }
-        currentLayout = layout
         let expanded = layout.isExpanded
         isExpanded = expanded
         handler.isExpanded = expanded
+        textEntryView.voiceButtonAppearance = expanded ? .microphone : .aiVoicePlain
+        guard layout != currentLayout else { return }
+        currentLayout = layout
 
         let showsToggle = layout.showsToggle
         let showToolbar = layout.showsToolbar
@@ -891,7 +892,7 @@ private extension UnifiedToggleInputView {
             self?.handler.stopGeneratingButtonTapped()
         }
         toolsToolbar.onVoiceTapped = { [weak self] in
-            self?.handler.microphoneButtonTapped()
+            self?.handler.aiVoiceChatButtonTapped()
         }
         toolsToolbar.onSelectedToolClearTapped = { [weak self] in
             guard let self else { return }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift
@@ -375,6 +375,7 @@ private final class SpyUnifiedToggleInputDelegate: UnifiedToggleInputDelegate {
     }
     func unifiedToggleInputDidSubmitQuery(_ query: String) {}
     func unifiedToggleInputDidRequestVoiceSearch() {}
+    func unifiedToggleInputDidRequestAIVoiceChat() {}
     func unifiedToggleInputDidRequestAIChat() {}
     func unifiedToggleInputDidChangeHeight() {}
     func unifiedToggleInputDidCommitMode(_ mode: TextEntryMode) {}

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -353,6 +353,40 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         XCTAssertFalse(sut.viewController.isToolbarSubmitHidden)
     }
 
+    func test_activateFromSearchTopPosition_withVoiceSearchDisabledAndAIVoiceEnabled_hidesInlineVoiceButton() {
+        sut.updateVoiceSearchAvailability(false)
+        sut.updateAIVoiceChatAvailability(true)
+
+        sut.activateFromOmnibar(inputMode: .search, cardPosition: .top)
+
+        XCTAssertEqual(sut.viewController.handler.buttonState, .noButtons)
+    }
+
+    func test_activateFromSearchBottomPosition_withVoiceSearchDisabledAndAIVoiceEnabled_hidesInlineVoiceButton() {
+        sut.updateVoiceSearchAvailability(false)
+        sut.updateAIVoiceChatAvailability(true)
+
+        sut.activateFromOmnibar(inputMode: .search, cardPosition: .bottom)
+
+        XCTAssertEqual(sut.viewController.handler.buttonState, .noButtons)
+    }
+
+    func test_activateFromSearchTopPosition_withVoiceSearchEnabled_showsInlineVoiceButton() {
+        sut.updateVoiceSearchAvailability(true)
+
+        sut.activateFromOmnibar(inputMode: .search, cardPosition: .top)
+
+        XCTAssertEqual(sut.viewController.handler.buttonState, .voiceOnly)
+    }
+
+    func test_activateFromSearchBottomPosition_withVoiceSearchEnabled_showsInlineVoiceButton() {
+        sut.updateVoiceSearchAvailability(true)
+
+        sut.activateFromOmnibar(inputMode: .search, cardPosition: .bottom)
+
+        XCTAssertEqual(sut.viewController.handler.buttonState, .voiceOnly)
+    }
+
     func test_activateFromOmnibar_setsExpandedTrue() {
         sut.activateFromOmnibar()
         XCTAssertTrue(sut.viewController.isInputExpanded)
@@ -1394,6 +1428,63 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         XCTAssertEqual(mockDelegate.committedMode, .aiChat)
     }
 
+    func test_inlineVoiceSearchTap_requestsVoiceSearch() {
+        sut.updateVoiceSearchAvailability(true)
+
+        sut.viewController.handler.microphoneButtonTapped()
+
+        XCTAssertEqual(mockDelegate.didRequestVoiceSearchCount, 1)
+        XCTAssertEqual(mockDelegate.didRequestAIVoiceChatCount, 0)
+    }
+
+    func test_collapsedAIVoiceChatButtonTap_requestsAIVoiceChat() {
+        sut.updateAIVoiceChatAvailability(true)
+        sut.showCollapsed()
+
+        sut.viewController.handler.microphoneButtonTapped()
+
+        XCTAssertEqual(mockDelegate.didRequestAIVoiceChatCount, 1)
+        XCTAssertEqual(mockDelegate.didRequestVoiceSearchCount, 0)
+    }
+
+    func test_initialCollapsedAIVoiceChatButton_usesPlainWaveformStyle() {
+        sut.updateAIVoiceChatAvailability(true)
+        sut.showCollapsed()
+
+        let voiceButton = findButton(accessibilityIdentifier: "Browser.OmniBar.Button.VoiceSearch", in: sut.viewController.view)
+
+        XCTAssertEqual(voiceButton?.backgroundColor, .clear)
+        XCTAssertEqual(voiceButton?.layer.cornerRadius, 0)
+    }
+
+    func test_expandedAIChatInlineVoiceSearchTap_requestsVoiceSearch() {
+        sut.updateVoiceSearchAvailability(true)
+        sut.updateAIVoiceChatAvailability(true)
+        sut.showExpanded(inputMode: .aiChat)
+
+        sut.viewController.handler.microphoneButtonTapped()
+
+        XCTAssertEqual(mockDelegate.didRequestVoiceSearchCount, 1)
+        XCTAssertEqual(mockDelegate.didRequestAIVoiceChatCount, 0)
+    }
+
+    func test_expandedAIChatInlineVoiceSearchTap_whenVoiceSearchDisabled_ignoresStaleTap() {
+        sut.updateVoiceSearchAvailability(false)
+        sut.updateAIVoiceChatAvailability(true)
+        sut.showExpanded(inputMode: .aiChat)
+
+        sut.viewController.handler.microphoneButtonTapped()
+
+        XCTAssertEqual(mockDelegate.didRequestVoiceSearchCount, 0)
+        XCTAssertEqual(mockDelegate.didRequestAIVoiceChatCount, 0)
+    }
+
+    func test_aiVoiceChatTap_requestsAIVoiceChat() {
+        sut.viewController.handler.aiVoiceChatButtonTapped()
+        XCTAssertEqual(mockDelegate.didRequestAIVoiceChatCount, 1)
+        XCTAssertEqual(mockDelegate.didRequestVoiceSearchCount, 0)
+    }
+
     // MARK: - Toolbar Voice Chat State Sync
 
     func test_showCollapsed_whenAIVoiceChatEnabled_setsToolbarVoiceChatActive() {
@@ -1459,6 +1550,18 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
 
     private func toolsMenuActions() -> [UIAction] {
         (sut.viewController.toolsMenu?.children ?? []).compactMap { $0 as? UIAction }
+    }
+
+    private func findButton(accessibilityIdentifier: String, in view: UIView) -> UIButton? {
+        for subview in view.subviews {
+            if let button = subview as? UIButton, button.accessibilityIdentifier == accessibilityIdentifier {
+                return button
+            }
+            if let button = findButton(accessibilityIdentifier: accessibilityIdentifier, in: subview) {
+                return button
+            }
+        }
+        return nil
     }
 }
 
@@ -1588,6 +1691,8 @@ private final class MockUnifiedToggleInputDelegate: UnifiedToggleInputDelegate {
     var submittedFiles: [AIChatNativePrompt.NativePromptFile]?
     var submittedQuery: String?
     var committedMode: TextEntryMode?
+    var didRequestVoiceSearchCount = 0
+    var didRequestAIVoiceChatCount = 0
     var didRequestAIChatCount = 0
 
     func unifiedToggleInputDidSubmitPrompt(_ prompt: String, modelId: String?, tools: [AIChatRAGTool]?, reasoningEffort: AIChatReasoningEffort?, images: [AIChatNativePrompt.NativePromptImage]?, files: [AIChatNativePrompt.NativePromptFile]?) {
@@ -1599,7 +1704,8 @@ private final class MockUnifiedToggleInputDelegate: UnifiedToggleInputDelegate {
         submittedFiles = files
     }
     func unifiedToggleInputDidSubmitQuery(_ query: String) { submittedQuery = query }
-    func unifiedToggleInputDidRequestVoiceSearch() {}
+    func unifiedToggleInputDidRequestVoiceSearch() { didRequestVoiceSearchCount += 1 }
+    func unifiedToggleInputDidRequestAIVoiceChat() { didRequestAIVoiceChatCount += 1 }
     func unifiedToggleInputDidRequestAIChat() { didRequestAIChatCount += 1 }
     func unifiedToggleInputDidChangeHeight() {}
     func unifiedToggleInputDidCommitMode(_ mode: TextEntryMode) {
@@ -2160,6 +2266,7 @@ final class UnifiedToggleInputCoordinatorPerTabStateTests: XCTestCase {
             supportedReasoningEffort: supportedReasoningEffort
         )
     }
+
 }
 
 private final class MockAIChatPreferencesForPerTab: AIChatPreferencesPersisting {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputHandlerTests.swift
@@ -245,6 +245,48 @@ final class UnifiedToggleInputHandlerTests: XCTestCase {
         XCTAssertEqual(sut.buttonState, .clearOnly)
     }
 
+    func test_setAIVoiceChatEnabled_aiChatModeWithEmptyText_keepsInlineVoiceSearchButton() {
+        sut.isVoiceSearchEnabled = true
+        sut.isAIVoiceChatEnabled = true
+        sut.isExpanded = true
+        sut.setToggleState(.aiChat)
+
+        XCTAssertEqual(sut.buttonState, .voiceOnly)
+    }
+
+    func test_setAIVoiceChatEnabled_collapsedAIChatWithVoiceSearchDisabled_showsVoiceButton() {
+        sut.isAIVoiceChatEnabled = true
+        sut.setToggleState(.aiChat)
+
+        XCTAssertEqual(sut.buttonState, .voiceOnly)
+    }
+
+    func test_setAIVoiceChatEnabled_expandedAIChatWithVoiceSearchDisabled_hidesVoiceButton() {
+        sut.isAIVoiceChatEnabled = true
+        sut.isExpanded = true
+        sut.setToggleState(.aiChat)
+
+        XCTAssertEqual(sut.buttonState, .noButtons)
+    }
+
+    func test_setAIVoiceChatEnabled_aiChatModeWithText_keepsClearButton() {
+        sut.isVoiceSearchEnabled = true
+        sut.isAIVoiceChatEnabled = true
+        sut.setToggleState(.aiChat)
+        sut.updateCurrentText("hello")
+
+        XCTAssertEqual(sut.buttonState, .clearOnly)
+    }
+
+    func test_hidesVoiceButton_aiChatModeWithAIVoiceChatEnabled_hidesInlineVoiceSearchButton() {
+        sut.isVoiceSearchEnabled = true
+        sut.isAIVoiceChatEnabled = true
+        sut.setToggleState(.aiChat)
+        sut.hidesVoiceButton = true
+
+        XCTAssertEqual(sut.buttonState, .noButtons)
+    }
+
     // MARK: - microphoneButtonTapped
 
     func test_microphoneButtonTapped_firesPublisher() {
@@ -254,6 +296,16 @@ final class UnifiedToggleInputHandlerTests: XCTestCase {
             .store(in: &cancellables)
 
         sut.microphoneButtonTapped()
+        waitForExpectations(timeout: 1)
+    }
+
+    func test_aiVoiceChatButtonTapped_firesPublisher() {
+        let expectation = expectation(description: "aiVoiceChatButtonTappedPublisher fires")
+        sut.aiVoiceChatButtonTappedPublisher
+            .sink { expectation.fulfill() }
+            .store(in: &cancellables)
+
+        sut.aiVoiceChatButtonTapped()
         waitForExpectations(timeout: 1)
     }
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputReasoningTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputReasoningTests.swift
@@ -267,6 +267,7 @@ private final class MockUnifiedToggleInputReasoningDelegate: UnifiedToggleInputD
 
     func unifiedToggleInputDidSubmitQuery(_ query: String) {}
     func unifiedToggleInputDidRequestVoiceSearch() {}
+    func unifiedToggleInputDidRequestAIVoiceChat() {}
     func unifiedToggleInputDidRequestAIChat() {}
     func unifiedToggleInputDidChangeHeight() {}
     func unifiedToggleInputDidCommitMode(_ mode: TextEntryMode) {}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1214488294482411
Tech Design URL: N/A
CC:

### Description

Restores the Unified Toggle Input voice affordances so empty expanded inputs show the Private Voice Search microphone, collapsed Duck.ai shows the plain waveform for Duck.ai voice mode, and typed input still swaps to the clear button.

Splits Private Voice Search routing from Duck.ai voice mode routing, updates the expanded waveform styling to the neutral stop-button background, and locks the first-render collapsed Duck.ai waveform style with regression coverage.

### Testing Prerequisites
- Enable the `unifiedToggleInput` feature flag.d.
- For microphone visibility, enable **Private Voice Search** from Settings > General or Settings > Accessibility.
- For Duck.ai target-picker coverage only, enable **Voice Search** from Settings > Duck.ai > Browser Shortcuts.

### Testing Steps

#### Test Private Voice Search in Search Mode - Top Address Bar
1. Set the address bar to the top position.
2. Expand the unified input while it is in Search mode and has no text.
3. Verify the trailing microphone is visible.
4. Type text and verify the clear button replaces the microphone.
5. Clear the text, tap the microphone, speak a search query, and verify search results load for the spoken query.

#### Test Private Voice Search in Duck.ai Mode Coming From Search - Top Address Bar
1. Set the address bar to the top position.
2. Expand the unified input in Search mode, then switch the toggle to Duck.ai.
3. Verify the expanded empty unified input in Duck.ai mode shows the trailing microphone.
4. Type text and verify the clear button replaces the microphone.
5. Clear the text, tap the microphone, speak a Duck.ai prompt, and verify the prompt is submitted to Duck.ai.

#### Test Private Voice Search in Search Mode - Bottom Address Bar
1. Set the address bar to the bottom position.
2. Expand the unified input while it is in Search mode and has no text.
3. Tap the microphone, speak a search query, and verify search results load for the spoken query.

#### Test Private Voice Search in Duck.ai Mode Coming From Search - Bottom Address Bar
1. Set the address bar to the bottom position.
2. Expand the unified input in Search mode, then switch the toggle to Duck.ai.
3. Tap the microphone, speak a Duck.ai prompt, and verify the prompt is submitted to Duck.ai.

#### Test Duck.ai Voice Mode Still Works on a Duck.ai Tab
1. Open a Duck.ai tab with the unified input collapsed.
2. Verify the trailing waveform is visible with no filled circle behind it.
3. Tap the waveform, speak a prompt, and verify Duck.ai voice mode starts and handles the spoken prompt.
4. Expand the input and verify the Private Voice Search microphone is separate from the Duck.ai voice-mode waveform.

#### Test User Settings
1. Turn off **Private Voice Search** from Settings > Accessibility and verify the expanded unified input microphone is hidden in Search mode and Duck.ai mode.
2. Turn on **Private Voice Search** from Settings > Accessibility and verify the expanded unified input microphone is visible in Search mode and Duck.ai mode.
3. With **Private Voice Search** still on, turn off **Voice Search** from Settings > AI Features > Manage Duck.ai Shortcuts.
4. Open Private Voice Search from the unified input in Search mode and verify the Duck.ai target option is not offered.
5. Turn **Voice Search** back on from Settings > AI Features > Manage Duck.ai Shortcuts.
6. Open Private Voice Search from the unified input in Search mode, verify the Duck.ai target option is offered, select it, speak a Duck.ai prompt, and verify the prompt is submitted to Duck.ai.

### Impact and Risks

Medium. This changes voice affordance visibility and tap routing inside Unified Toggle Input.

#### What could go wrong?

- The expanded microphone could be shown when Private Voice Search is disabled.
- The collapsed Duck.ai waveform could use the wrong filled style on first render.
- Taps could route to Duck.ai voice mode when they should open Private Voice Search, or vice versa.

These paths are covered by focused Unified Toggle Input unit tests and light/dark simulator validation screenshots.

### Quality Considerations

- Added unit coverage for expanded vs collapsed voice button state, top and bottom search-origin entry, stale disabled voice-search taps, and first-render collapsed Duck.ai styling.
- Verified focused Unified Toggle Input tests pass.
- Validated collapsed Duck.ai light and dark screenshots against the supplied visual references.

### Notes to Reviewer

Please focus on the split between Private Voice Search microphone behavior and Duck.ai voice mode waveform behavior. The legacy switchbar text-entry default remains unchanged outside Unified Toggle Input.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
