### PR TITLE
Fix invalid closure assignment for autocomplete tap-ahead

### DIFF
--- a/iOS/DuckDuckGo/AutocompleteView.swift
+++ b/iOS/DuckDuckGo/AutocompleteView.swift
@@ -179,9 +179,9 @@ private struct SuggestionView: View {
                 SuggestionListItem(icon: Image(uiImage: DesignSystemImages.Glyphs.Size24.findSearchSmall),
                                    title: phrase,
                                    query: query,
-                                   indicator: tapAheadImage) {
-                    autocompleteModel.onTapAhead(model)
-                }.accessibilityIdentifier("Autocomplete.Suggestions.ListItem.SearchPhrase-\(phrase)")
+                                   indicator: tapAheadImage,
+                                   onTapIndicator: { autocompleteModel.onTapAhead(model) })
+                .accessibilityIdentifier("Autocomplete.Suggestions.ListItem.SearchPhrase-\(phrase)")
 
             case .website(let url):
                 SuggestionListItem(icon: Image(uiImage: DesignSystemImages.Glyphs.Size24.globe),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1214593765736830?focus=true
Tech Design URL:
CC:

### Description

The tap-ahead suggestion row in `AutocompleteView` was passing the tap handler as a trailing closure on `SuggestionListItem`. That trailing closure does not bind to the `onTapIndicator` parameter, so tapping the tap-ahead indicator did nothing.

This change passes the closure explicitly via the `onTapIndicator:` argument so the indicator tap correctly invokes `autocompleteModel.onTapAhead(model)`.

### Testing Steps

1. Tap the address bar and type a partial query that produces a suggestion with a tap-ahead arrow indicator (for example `wiki`).
2. Tap the tap-ahead arrow on a suggestion row, verify the omnibar text is updated with the tapped suggestion and the suggestion list refreshes.
3. Verify that tapping the body of the suggestion row still triggers the normal selection (search/navigation) behaviour.
4. Type in recently visited site
5. Verify if history item is deleted when taping an x button.

### Impact and Risks

Low. One-line wiring fix in a single SwiftUI view, no behaviour change beyond restoring the intended tap-ahead action.

#### What could go wrong?

--

### Quality Considerations

N/A

### Notes to Reviewer

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> SwiftUI change is a small wiring fix, but resetting `CURRENT_PROJECT_VERSION` to `0` could impact build/versioning and release tooling if unintended.
> 
> **Overview**
> Fixes autocomplete “tap-ahead” so tapping the indicator arrow now correctly triggers `onTapIndicator` (calling `autocompleteModel.onTapAhead(model)`) instead of being passed as a mis-bound trailing closure.
> 
> Bumps the iOS marketing version to `7.218.1` (and updates Settings bundle display) and resets `CURRENT_PROJECT_VERSION` to `0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab065a9b030664eee4302324728bd090009c3e0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->