### PR TITLE
[iOS] Show "Off" label on Sync & Backup settings row when disabled

### DIFF
--- a/iOS/DuckDuckGo/SettingsMainSettingsView.swift
+++ b/iOS/DuckDuckGo/SettingsMainSettingsView.swift
@@ -118,7 +118,7 @@ struct SettingsMainSettingsView: View {
         }
 
         @ViewBuilder func buildSyncEntry(viewModel: SettingsViewModel) -> AnyView {
-            let statusIndicator = viewModel.syncStatus == .on ? StatusIndicatorView(status: viewModel.syncStatus, isDotHidden: true) : nil
+            let statusIndicator = StatusIndicatorView(status: viewModel.syncStatus, isDotHidden: true)
             let label = viewModel.state.sync.title
             AnyView(SettingsCellView(label: label,
                              image: Image(uiImage: DesignSystemImages.Color.Size24.sync),

--- a/iOS/DuckDuckGo/SettingsMainSettingsView.swift
+++ b/iOS/DuckDuckGo/SettingsMainSettingsView.swift
@@ -118,7 +118,7 @@ struct SettingsMainSettingsView: View {
         }
 
         @ViewBuilder func buildSyncEntry(viewModel: SettingsViewModel) -> AnyView {
-            let statusIndicator = StatusIndicatorView(status: viewModel.syncStatus, isDotHidden: true)
+            let statusIndicator = StatusIndicatorView(status: viewModel.syncStatus)
             let label = viewModel.state.sync.title
             AnyView(SettingsCellView(label: label,
                              image: Image(uiImage: DesignSystemImages.Color.Size24.sync),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214200115953388/task/1211707305668306?focus=true
Tech Design URL:
CC:

### Description
The Sync & Backup row only rendered the "On" status indicator when sync was enabled, leaving no trailing label when it was off. Always pass the `StatusIndicatorView` so users see "Off" when sync is disabled, matching the rest of the Settings screen.

### Testing Steps
1. With sync **disabled** (Settings → Sync & Backup → ensure sync is off), return to the main Settings screen and confirm the Sync & Backup row shows an "Off" label on the trailing edge — matching rows like Email Protection.
2. Enable sync, return to Settings, and confirm the row now shows "On".
3. Toggle sync off again and confirm the label updates back to "Off" without needing to re-open Settings.

### Impact and Risks
Low — visual-only change to a single Settings row; no behavior, data, or privacy impact.

#### What could go wrong?
Minimal: `syncStatus` only ever returns `.on` or `.off` and `StatusIndicator.text` is defined for every case, so the indicator can't render an unexpected label. The only plausible regression is a layout / spacing issue on the Sync row when "Off" is now shown.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change to the Settings list row; main regression risk is minor layout/spacing changes in the Sync entry.
> 
> **Overview**
> Updates the main Settings screen’s **Sync & Backup** row to always render a `StatusIndicatorView` (instead of only when Sync is on), so the trailing status label shows *Off* when Sync is disabled and *On* when enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dcd8af8cfad581422c40dac62dc9ef6f692cf20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->