### PR TITLE
Fix crash when back/forward item has a nil URL during commit

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Navigation/Extensions/WKBackForwardListItemExtension.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Navigation/Extensions/WKBackForwardListItemExtension.swift
@@ -24,12 +24,12 @@ public extension WKBackForwardListItem {
     /// Safe Optional `url: URL` getter:
     /// `WKBackForwardListItem.url` is imported as non-optional, but WebKit's
     /// implementation can return nil for null or invalid underlying URLs,
-    /// trapping Swift's unconditional `NSURL` → `URL` bridge. Reading via KVC
-    /// keeps the value optional so the conditional `as? URL` cast safely
-    /// returns nil instead of crashing.
+    /// trapping Swift's unconditional `NSURL` → `URL` bridge. Reading via the
+    /// getter selector keeps the value optional so the conditional `as? URL`
+    /// cast safely returns nil instead of crashing.
     /// See: https://app.asana.com/1/137249556945/project/1201037661562251/task/1214602405943382
     var safeURL: URL? {
-        (self as NSObject).value(forKey: #keyPath(WKBackForwardListItem.url)) as? URL
+        self.perform(#selector(getter: WKBackForwardListItem.url))?.takeUnretainedValue() as? URL
     }
 
 }

--- a/SharedPackages/BrowserServicesKit/Sources/Navigation/Extensions/WKBackForwardListItemExtension.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Navigation/Extensions/WKBackForwardListItemExtension.swift
@@ -1,0 +1,35 @@
+//
+//  WKBackForwardListItemExtension.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import WebKit
+
+public extension WKBackForwardListItem {
+
+    /// Safe Optional `url: URL` getter:
+    /// `WKBackForwardListItem.url` is imported as non-optional, but WebKit's
+    /// implementation can return nil for null or invalid underlying URLs,
+    /// trapping Swift's unconditional `NSURL` → `URL` bridge. Reading via KVC
+    /// keeps the value optional so the conditional `as? URL` cast safely
+    /// returns nil instead of crashing.
+    /// See: https://app.asana.com/1/137249556945/project/1201037661562251/task/1214602405943382
+    var safeURL: URL? {
+        (self as NSObject).value(forKey: #keyPath(WKBackForwardListItem.url)) as? URL
+    }
+
+}

--- a/SharedPackages/BrowserServicesKit/Sources/Navigation/NavigationType.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Navigation/NavigationType.swift
@@ -174,7 +174,7 @@ public struct HistoryItemIdentity: Hashable {
     public init(backForwardListItem: WKBackForwardListItem) {
         self.identifier = ObjectIdentifier(backForwardListItem)
         self.title = backForwardListItem.title
-        self.url = backForwardListItem.url
+        self.url = backForwardListItem.safeURL
     }
 
     public static func == (lhs: HistoryItemIdentity, rhs: HistoryItemIdentity) -> Bool {

--- a/macOS/DuckDuckGo/Common/Extensions/WKBackForwardListItemExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/WKBackForwardListItemExtension.swift
@@ -32,9 +32,15 @@ extension WKBackForwardListItem {
         }
     }
 
-    // `url` is imported as non-optional but WebKit's implementation returns nil
-    // for null/invalid underlying URLs, trapping the unconditional NSURL→URL bridge.
-    // Read via KVC to keep the optional and use a conditional bridge.
+    /// Crash-safe alternative to `url`.
+    ///
+    /// `WKBackForwardListItem.url` is imported as non-optional, but WebKit's
+    /// implementation returns nil for null or invalid underlying URLs, which
+    /// traps Swift's unconditional `NSURL` → `URL` bridge. Reading via KVC
+    /// keeps the value optional so the conditional `as? URL` cast safely
+    /// returns nil instead of crashing.
+    ///
+    /// See: https://app.asana.com/1/137249556945/project/1201037661562251/task/1214602405943382
     var safeURL: URL? {
         (self as NSObject).value(forKey: "URL") as? URL
     }

--- a/macOS/DuckDuckGo/Common/Extensions/WKBackForwardListItemExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/WKBackForwardListItemExtension.swift
@@ -32,4 +32,11 @@ extension WKBackForwardListItem {
         }
     }
 
+    // `url` is imported as non-optional but WebKit's implementation returns nil
+    // for null/invalid underlying URLs, trapping the unconditional NSURL→URL bridge.
+    // Read via KVC to keep the optional and use a conditional bridge.
+    var safeURL: URL? {
+        (self as NSObject).value(forKey: "URL") as? URL
+    }
+
 }

--- a/macOS/DuckDuckGo/Common/Extensions/WKBackForwardListItemExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/WKBackForwardListItemExtension.swift
@@ -42,7 +42,7 @@ extension WKBackForwardListItem {
     ///
     /// See: https://app.asana.com/1/137249556945/project/1201037661562251/task/1214602405943382
     var safeURL: URL? {
-        (self as NSObject).value(forKey: "URL") as? URL
+        (self as NSObject).value(forKey: #keyPath(WKBackForwardListItem.url)) as? URL
     }
 
 }

--- a/macOS/DuckDuckGo/Common/Extensions/WKBackForwardListItemExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/WKBackForwardListItemExtension.swift
@@ -32,17 +32,4 @@ extension WKBackForwardListItem {
         }
     }
 
-    /// Crash-safe alternative to `url`.
-    ///
-    /// `WKBackForwardListItem.url` is imported as non-optional, but WebKit's
-    /// implementation returns nil for null or invalid underlying URLs, which
-    /// traps Swift's unconditional `NSURL` → `URL` bridge. Reading via KVC
-    /// keeps the value optional so the conditional `as? URL` cast safely
-    /// returns nil instead of crashing.
-    ///
-    /// See: https://app.asana.com/1/137249556945/project/1201037661562251/task/1214602405943382
-    var safeURL: URL? {
-        (self as NSObject).value(forKey: #keyPath(WKBackForwardListItem.url)) as? URL
-    }
-
 }

--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -689,7 +689,8 @@ protocol TabDelegate: ContentOverlayUserScriptDelegate {
         self.title = webView.title?.trimmingWhitespace()
 
         if let wkBackForwardListItem = webView.backForwardList.currentItem,
-           content.urlForWebView == wkBackForwardListItem.url,
+           let itemURL = wkBackForwardListItem.safeURL,
+           content.urlForWebView == itemURL,
            !webView.isLoading,
            title?.isEmpty == false {
             wkBackForwardListItem.tabTitle = title


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1214602405943382?focus=true

### Description

Tentative fix for a rare crash that surfaces when WebKit delivers a page title change during a navigation commit.

The change is purely a defensive nil-guard on a path that previously trapped on `nil`, so functional behavior is unchanged in the happy case.

### Working theory
We noticed in WebKit sources that back/forward item can briefly expose a `nil` URL — despite advertising the property as non-optional (I've checked the WebKit sources and there are a few instances where this happens).

This PR routes the property through an optional path so the transient `nil` is tolerated instead of trapping; if the theory holds, the crash signature should drop.

### Testing Steps

We have no reproduction steps, so we just need to make sure this doesn't introduce issues.

Smoke-test browsing: open and close tabs, navigate forward/back, and confirm tab titles still update correctly.

To verify the new path actually runs, set a breakpoint inside the `if let itemURL = wkBackForwardListItem.safeURL` block in `Tab.updateTitle()` and step through normal browsing — you should hit the block regularly with a non-nil `itemURL`, confirming the KVC-based read returns the expected URL on the happy path.

### Impact and Risks

Low. The change only adds a nil-guard on an existing path; in the no-nil case the behavior is identical.

#### What could go wrong?

If the back/forward URL is nil in some non-pathological case the contract didn't anticipate, the tab title would simply not be persisted onto that back/forward item for that update — minor UX at worst, no crash.

### Quality Considerations

Privacy/security: none. Performance: one extra KVC read per title-change observation, negligible. Monitoring: existing crash reporting will surface a drop in this signature; no new instrumentation added.

### Notes to Reviewer

The justification for reading the URL via KVC instead of trusting the imported non-optional type is documented inline. WebKit's URL bridge explicitly returns nil for invalid or null underlying URLs despite the header's nonnull annotation, so the trap is on Apple's side of the contract — not ours to fix upstream.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk defensive change: replaces direct reads of `WKBackForwardListItem.url` with an optional `safeURL` to avoid a rare nil-bridging crash; behavior is unchanged when the URL is valid.
> 
> **Overview**
> Prevents a rare WebKit nil-bridge crash by adding `WKBackForwardListItem.safeURL` (an optional selector-based URL read) and routing history/title logic through it.
> 
> `HistoryItemIdentity` and macOS `Tab.updateTitle()` now guard on `safeURL` before comparing/persisting titles, so transiently invalid back/forward items no longer trap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01b279e752b292f7cdcca1c6d395582eec11ff17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->