### PR TITLE
Fix Duck Player Settings deep link and update Maestro flows

### DIFF
--- a/.maestro/duckplayer_classic/shared/close_settings.yaml
+++ b/.maestro/duckplayer_classic/shared/close_settings.yaml
@@ -1,7 +1,10 @@
 appId: com.duckduckgo.mobile.ios
 ---
 # Close Settings - need to go back twice on iPad
-- tapOn: 
+# Duck Player is now nested under Ad Blocking — step back one level first.
+- tapOn:
+    text: "Ad Blocking"
+- tapOn:
     text: "Settings"
-- tapOn: 
+- tapOn:
     text: "Done"

--- a/.maestro/duckplayer_classic/shared/close_settings.yaml
+++ b/.maestro/duckplayer_classic/shared/close_settings.yaml
@@ -1,9 +1,9 @@
 appId: com.duckduckgo.mobile.ios
 ---
 # Close Settings - need to go back twice on iPad
-# Duck Player is now nested under Ad Blocking — step back one level first.
+# Duck Player is now nested under YouTube Ad Blocking — step back one level first.
 - tapOn:
-    text: "Ad Blocking"
+    text: "YouTube Ad Blocking"
 - tapOn:
     text: "Settings"
 - tapOn:

--- a/.maestro/duckplayer_classic/shared/open_settings.yaml
+++ b/.maestro/duckplayer_classic/shared/open_settings.yaml
@@ -7,17 +7,29 @@ appId: com.duckduckgo.mobile.ios
 - waitForAnimationToEnd:
     timeout: 1000
     
-- tapOn: Settings    
+- tapOn: Settings
+
+- waitForAnimationToEnd
+
+# Duck Player now lives inside the Ad Blocking screen (under Privacy Protections).
+- scrollUntilVisible:
+    element:
+      text: "Ad Blocking"
+    direction: DOWN
+    centerElement: true
+
+- tapOn:
+    text: "Ad Blocking"
 
 - waitForAnimationToEnd
 
 - scrollUntilVisible:
-    element: 
+    element:
       text: "Duck Player"
     direction: DOWN
     centerElement: true
-    
-- tapOn: 
+
+- tapOn:
     text: "Duck Player"
-    
+
 - waitForAnimationToEnd

--- a/.maestro/duckplayer_classic/shared/open_settings.yaml
+++ b/.maestro/duckplayer_classic/shared/open_settings.yaml
@@ -11,15 +11,15 @@ appId: com.duckduckgo.mobile.ios
 
 - waitForAnimationToEnd
 
-# Duck Player now lives inside the Ad Blocking screen (under Privacy Protections).
+# Duck Player now lives inside the YouTube Ad Blocking screen (under Privacy Protections).
 - scrollUntilVisible:
     element:
-      text: "Ad Blocking"
+      text: "YouTube Ad Blocking"
     direction: DOWN
     centerElement: true
 
 - tapOn:
-    text: "Ad Blocking"
+    text: "YouTube Ad Blocking"
 
 - waitForAnimationToEnd
 

--- a/.maestro/duckplayer_native/shared/close_settings.yaml
+++ b/.maestro/duckplayer_native/shared/close_settings.yaml
@@ -5,6 +5,11 @@ appId: com.duckduckgo.mobile.ios
 - runFlow:
     file: constants.yaml
 
+# Duck Player is now nested under Ad Blocking — step back one level first.
+- tapOn: ${output.adBlockingLabel}
+
+- waitForAnimationToEnd
+
 - tapOn: ${output.settingsLabel}
 
 - waitForAnimationToEnd

--- a/.maestro/duckplayer_native/shared/close_settings.yaml
+++ b/.maestro/duckplayer_native/shared/close_settings.yaml
@@ -5,7 +5,7 @@ appId: com.duckduckgo.mobile.ios
 - runFlow:
     file: constants.yaml
 
-# Duck Player is now nested under Ad Blocking — step back one level first.
+# Duck Player is now nested under YouTube Ad Blocking — step back one level first.
 - tapOn: ${output.adBlockingLabel}
 
 - waitForAnimationToEnd

--- a/.maestro/duckplayer_native/shared/constants.yaml
+++ b/.maestro/duckplayer_native/shared/constants.yaml
@@ -11,6 +11,7 @@ appId: com.duckduckgo.mobile.ios
 - evalScript: "${output.chevronUpId = 'chevron.up'}"
 - evalScript: "${output.duckPlayerSettingsId = 'DuckPlayerOpenSettings'}"
 - evalScript: "${output.duckPlayerLabel = 'Duck Player'}"
+- evalScript: "${output.adBlockingLabel = 'Ad Blocking'}"
 - evalScript: "${output.settingsLabel = 'Settings'}"
 - evalScript: "${output.doneLabel = 'Done'}"
 - evalScript: "${output.browsingMenuLabel = 'Browsing Menu'}"

--- a/.maestro/duckplayer_native/shared/constants.yaml
+++ b/.maestro/duckplayer_native/shared/constants.yaml
@@ -11,7 +11,7 @@ appId: com.duckduckgo.mobile.ios
 - evalScript: "${output.chevronUpId = 'chevron.up'}"
 - evalScript: "${output.duckPlayerSettingsId = 'DuckPlayerOpenSettings'}"
 - evalScript: "${output.duckPlayerLabel = 'Duck Player'}"
-- evalScript: "${output.adBlockingLabel = 'Ad Blocking'}"
+- evalScript: "${output.adBlockingLabel = 'YouTube Ad Blocking'}"
 - evalScript: "${output.settingsLabel = 'Settings'}"
 - evalScript: "${output.doneLabel = 'Done'}"
 - evalScript: "${output.browsingMenuLabel = 'Browsing Menu'}"

--- a/.maestro/duckplayer_native/shared/open_settings.yaml
+++ b/.maestro/duckplayer_native/shared/open_settings.yaml
@@ -11,11 +11,21 @@ appId: com.duckduckgo.mobile.ios
 
 - tapOn: ${output.settingsLabel}
 
+# Duck Player now lives inside the Ad Blocking screen (under Privacy Protections).
+- scrollUntilVisible:
+    centerElement: true
+    element: ${output.adBlockingLabel}
+    direction: DOWN
+
+- tapOn: ${output.adBlockingLabel}
+
+- waitForAnimationToEnd
+
 - scrollUntilVisible:
     centerElement: true
     element: ${output.duckPlayerLabel}
     direction: DOWN
-    
+
 - tapOn: ${output.duckPlayerLabel}
 
 - waitForAnimationToEnd

--- a/.maestro/duckplayer_native/shared/open_settings.yaml
+++ b/.maestro/duckplayer_native/shared/open_settings.yaml
@@ -11,7 +11,7 @@ appId: com.duckduckgo.mobile.ios
 
 - tapOn: ${output.settingsLabel}
 
-# Duck Player now lives inside the Ad Blocking screen (under Privacy Protections).
+# Duck Player now lives inside the YouTube Ad Blocking screen (under Privacy Protections).
 - scrollUntilVisible:
     centerElement: true
     element: ${output.adBlockingLabel}

--- a/iOS/DuckDuckGo/SettingsYouTubeAdBlockingView.swift
+++ b/iOS/DuckDuckGo/SettingsYouTubeAdBlockingView.swift
@@ -28,6 +28,8 @@ struct SettingsYouTubeAdBlockingView: View {
     /// This property ensures that the associated action is only triggered once per viewing session, preventing redundant executions.
     @State private var hasFiredSettingsDisplayedPixel = false
 
+    @State private var showDuckPlayer = false
+
     @EnvironmentObject var viewModel: SettingsViewModel
     var body: some View {
         List {
@@ -75,7 +77,10 @@ struct SettingsYouTubeAdBlockingView: View {
             }
 
             Section(footer: Text(UserText.duckPlayerEnableFooter)) {
-                NavigationLink(destination: SettingsDuckPlayerView().environmentObject(viewModel)) {
+                NavigationLink(
+                    destination: SettingsDuckPlayerView().environmentObject(viewModel),
+                    isActive: $showDuckPlayer
+                ) {
                     SettingsCellView(label: UserText.duckPlayerFeatureName)
                 }
                 .listRowBackground(Color(designSystemColor: .surface))
@@ -88,6 +93,14 @@ struct SettingsYouTubeAdBlockingView: View {
         .onAppear {
             DailyPixel.fireDailyAndCount(pixel: .webExtensionAdBlockingSettingsOpen,
                                          pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes)
+        }
+        .onFirstAppear {
+            if viewModel.deepLinkTarget == .duckPlayer,
+               !viewModel.shouldDisplayDuckPlayerContingencyMessage {
+                DispatchQueue.main.async {
+                    showDuckPlayer = true
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1214599506614434?focus=true

### Description

Fixes the Duck Player settings deep link and updates the Duck Player Maestro flows for the new YouTube Ad Blocking settings hierarchy.

- **Deep link fix:** Tapping "Open Settings" inside the Duck Player UI was landing the user on the YouTube Ad Blocking screen instead of Duck Player settings. `SettingsYouTubeAdBlockingView` now reads `viewModel.deepLinkTarget` on first appear and programmatically pushes `SettingsDuckPlayerView` on top, restoring the natural back stack (Settings → YouTube Ad Blocking → Duck Player). Mirrors the existing precedent in `SettingsAppearanceView` for `.customizeAddressBarButton` / `.customizeToolbarButton`.
- **Maestro flow fixes:** `duckplayer_native` and `duckplayer_classic` shared `open_settings.yaml` / `close_settings.yaml` now navigate through the YouTube Ad Blocking screen to reach Duck Player and back out correctly.

### Testing Steps

1. **Deep link**: open YouTube in the iOS app, play a video that triggers Duck Player, dismiss it once or twice (or use the gear/settings button inside Duck Player). When the "Open Settings" toast / button is tapped, you should land directly on the **Duck Player** settings screen (not the YouTube Ad Blocking screen). Tapping back should go YouTube Ad Blocking → Settings → Done.
2. **Manual navigation still works**: Settings → Privacy Protections → YouTube Ad Blocking → Duck Player loads the Duck Player screen normally.
3. **Maestro — native**: run `.maestro/run_ui_tests.sh .maestro/duckplayer_native` and confirm all flows pass. Pay special attention to `02_serp_off_organic.yaml` (uses `open_settings`/`close_settings`) and `10_youtube_open_settings.yaml` (asserts `SettingsDuckPlayerHero` immediately after the in-Duck-Player settings tap).
4. **Maestro — classic**: run `.maestro/run_ui_tests.sh .maestro/duckplayer_classic` and confirm all flows pass.

### Impact and Risks

Low. The deep-link change is scoped to `SettingsYouTubeAdBlockingView` and mirrors an existing precedent (`SettingsAppearanceView`). The Maestro changes are test-only — they don't ship to users.

Worst case for the deep link: the YouTube Ad Blocking screen flickers briefly before Duck Player is pushed on top. `viewModel.deepLinkTarget` is cleared after consumption (`SettingsViewModel.swift:1482`), so subsequent natural navigation through the Settings hierarchy won't accidentally auto-push the Duck Player screen.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches iOS settings navigation by programmatically pushing `SettingsDuckPlayerView` based on `deepLinkTarget`, which can affect routing/back-stack behavior. Maestro changes are test-only but could mask regressions if selectors/text change again.
> 
> **Overview**
> Fixes the Duck Player “Open Settings” deep link now that Duck Player settings live under **YouTube Ad Blocking**: `SettingsYouTubeAdBlockingView` adds an `isActive`-driven `NavigationLink` and, on first appearance, auto-navigates into `SettingsDuckPlayerView` when `viewModel.deepLinkTarget == .duckPlayer` (and no contingency message is shown).
> 
> Updates Duck Player Maestro UI-test flows (classic + native) to navigate through the new hierarchy: scroll/tap into **YouTube Ad Blocking** before selecting **Duck Player**, and back out by stepping up to **YouTube Ad Blocking** then **Settings** then **Done**; native flows add a shared `adBlockingLabel` constant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e58a890290b8b5fc42e56212e21319d150d9514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->