### PR TITLE
[Free Trial Conversion] Default macOS feature flag to enabled

### DIFF
--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -545,7 +545,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .crashCollectionLimitCallStackTreeDepth:
             Config(defaultValue: .enabled, source: .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.crashCollectionLimitCallStackTreeDepth)), supportsLocalOverriding: false)
         case .freeTrialConversionWideEvent:
-            Config(source: .remoteReleasable(.subfeature(PrivacyProSubfeature.freeTrialConversionWideEvent)))
+            Config(defaultValue: .enabled, source: .remoteReleasable(.subfeature(PrivacyProSubfeature.freeTrialConversionWideEvent)))
         case .supportsSyncChatsDeletion:
             Config(source: .remoteReleasable(.subfeature(AIChatSubfeature.supportsSyncChatsDeletion)))
         case .aiChatMultiplePageContexts:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207260194172075/task/1214604885062520
Tech Design URL:
CC:

### Description

A previous [PR](https://github.com/duckduckgo/apple-browsers/pull/4158) migrated the `PrivacyProSubfeature.freeTrialConversionWideEvent` feature flag with the incorrect default value, which resulted in the related pixels not firing. This PR restores 'enabled' as its default value.

### Testing Steps
N/A

### Impact and Risks

N/A

#### What could go wrong?
N/A


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk single-line change to a feature flag default; main impact is enabling related instrumentation/pixels when remote config is absent or fails.
> 
> **Overview**
> Restores `FeatureFlag.freeTrialConversionWideEvent` to default to **enabled** (while still being remotely releasable), so free-trial conversion wide-event instrumentation isn’t inadvertently off by default on macOS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f36a47fbee0d75f56d07ecf2adc3770bcd7026d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->