### PR TITLE
[iOS] Fix focussed-state UI scaling on cold-launch idle return

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -579,6 +579,17 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
 
     private func scheduleAnimation(_ animation: @escaping () -> Void, completion: ((UIViewAnimatingPosition) -> Void)? = nil) {
 
+        // If the view hasn't entered the window yet (e.g. initial Combine
+        // emissions during viewDidLoad's setupSubscriptions), running this
+        // through a spring animator captures unsettled bounds and visibly
+        // animates to the final layout when the view finally appears. Run the
+        // work synchronously in that case so layout settles before first paint.
+        guard view.window != nil else {
+            UIView.performWithoutAnimation { animation() }
+            completion?(.end)
+            return
+        }
+
         if contentAnimator?.state == .stopped {
             contentAnimator = nil
         }

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -579,11 +579,7 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
 
     private func scheduleAnimation(_ animation: @escaping () -> Void, completion: ((UIViewAnimatingPosition) -> Void)? = nil) {
 
-        // If the view hasn't entered the window yet (e.g. initial Combine
-        // emissions during viewDidLoad's setupSubscriptions), running this
-        // through a spring animator captures unsettled bounds and visibly
-        // animates to the final layout when the view finally appears. Run the
-        // work synchronously in that case so layout settles before first paint.
+        // Skip animation when off-window to prevent spring from capturing unsettled bounds.
         guard view.window != nil else {
             UIView.performWithoutAnimation { animation() }
             completion?(.end)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1210379416433601/task/1214457828903077?focus=true

### Description

Fixes the focussed-state UI scaling in from the top-left of the screen on cold-launch idle return.

`scheduleAnimation` runs a 0.4s spring around `view.layoutIfNeeded()` for runtime animations. It also unintentionally fires at `viewDidLoad` because `currentTextPublisher` is `@Published` (emits its current value to new subscribers on subscribe) — the spring captures the view's off-window unsettled bounds and the in-progress tail becomes visible when the view enters the window.

Fix: skip the animator when `view.window == nil`. On-screen animations are unchanged.

### Testing Steps
1. Build with the focussed-state-on-NTP feature enabled and the idle-return-NTP threshold debug-overridden to a short value (e.g. 30s) via the debug menu.
2. Launch the app, browse to any tab, leave the app for longer than the threshold, then force-kill the app.
3. Cold-launch the app from the home-screen icon.
4. Verify the focussed-state UI appears smoothly without scaling from the top-left corner of the screen.
5. Confirm typing into the focussed search field, opening suggestions, and switching modes all still animate normally (no regression to runtime animations).

### Impact and Risks

**Severity: Low** — narrow visual fix, no behavior change once the view is on screen. The guard only takes effect when the view isn't on a window yet (i.e. during initial Combine emissions inside `viewDidLoad`), where animation isn't observable anyway.

#### What could go wrong?

- The runtime animation paths (typing / height changes / suggestion appearance / action-bar transitions) are unchanged; if any caller of `scheduleAnimation` were ever invoked while the view is off-window and *expected* the animation to play once visible, behavior would now be a synchronous snap. This is the buggy behavior we're fixing — not a regression.
- The completion handler is invoked synchronously with `.end` when the guard fires, which is correct semantically (the work is done) and matches what callers receive when an animator runs to completion.

### Quality Considerations

- The bug was intermittent and got progressively worse as launch-flow work was added (auth, data clear, idle-return decision, etc.) — slower launches widened the window during which CA's animation was still running when the view became visible. This fix removes the underlying race rather than masking it with timing tweaks.
- No new external dependencies, no behavior change once the view is on screen, no performance regression.

### Notes to Reviewer

- This is the minimal fix. A separate local branch (`sabrina/cold-launch-cover-polish`) has cosmetic polish (a launch-screen cover that extends across the foreground transition to also hide the brief previous-tab restore frame). We can iterate on that separately if desired — it's not required to fix the scaling bug.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: animations are skipped only while the view is not yet in a window, reducing chance of layout/scale glitches without altering on-screen animation behavior.
> 
> **Overview**
> Prevents `OmniBarEditingStateViewController.scheduleAnimation` from running the spring `UIViewPropertyAnimator` while the view is off-window (e.g., during initial Combine emissions on cold launch), applying layout changes without animation and completing immediately instead.
> 
> On-screen behavior is unchanged; once `view.window` is non-nil the existing 0.4s spring animation path is used as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 807b77c3e62468a13ef20e05acec33d446028eca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->