### PR TITLE
Fix Duck.ai header gap between icon and title on paid plan

### DIFF
--- a/iOS/DuckDuckGo/AIChat/AIChatTabChatHeaderView.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatTabChatHeaderView.swift
@@ -131,7 +131,6 @@ final class AIChatTabChatHeaderView: UIView {
             font: .daxHeadline(),
             color: UIColor(designSystemColor: .textPrimary)
         )
-        label.textAlignment = .center
         label.adjustsFontForContentSizeCategory = true
         return label
     }()
@@ -209,9 +208,10 @@ final class AIChatTabChatHeaderView: UIView {
             freeTitleStack.bottomAnchor.constraint(equalTo: titleContainer.bottomAnchor),
 
             paidTitleStack.topAnchor.constraint(equalTo: titleContainer.topAnchor),
-            paidTitleStack.leadingAnchor.constraint(equalTo: titleContainer.leadingAnchor),
-            paidTitleStack.trailingAnchor.constraint(equalTo: titleContainer.trailingAnchor),
             paidTitleStack.bottomAnchor.constraint(equalTo: titleContainer.bottomAnchor),
+            paidTitleStack.centerXAnchor.constraint(equalTo: titleContainer.centerXAnchor),
+            paidTitleStack.leadingAnchor.constraint(greaterThanOrEqualTo: titleContainer.leadingAnchor),
+            paidTitleStack.trailingAnchor.constraint(lessThanOrEqualTo: titleContainer.trailingAnchor),
 
             upgradeArrow.widthAnchor.constraint(equalToConstant: Constants.upgradeArrowSize),
             upgradeArrow.heightAnchor.constraint(equalToConstant: Constants.upgradeArrowSize),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214005521302324?focus=true
Tech Design URL:
CC:

### Description
On the paid plan, the Duck.ai chat header showed a large gap between the leading icon and the "Duck.ai" title. The paid title stack was pinned to the title container's edges (which is sized by the wider hidden free-plan stack) and used `.fill` distribution, so the centered title label stretched and the text floated away from the icon. Centering the paid title stack as a group and removing the no-longer-needed `textAlignment = .center` makes the icon and title hug each other.

### Testing Steps
1. With an active Duck.ai paid subscription, open the Duck.ai tab and confirm the header shows the icon immediately followed by "Duck.ai" with no large gap.
2. Sign out / switch to the free state and confirm the "Free Plan • Upgrade ↑" header layout is unchanged.
3. Toggle between free and paid states (or rotate / change Dynamic Type) and verify both layouts stay correctly centered in the header.

### Impact and Risks
Low — purely cosmetic constraint change in the AI chat header.

#### What could go wrong?
A constraint regression could leave the title misaligned at large Dynamic Type sizes if the paid stack's intrinsic width exceeds the container's available space.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, cosmetic Auto Layout adjustment limited to the Duck.ai chat header; potential issues are limited to layout truncation/misalignment at extreme Dynamic Type sizes.
> 
> **Overview**
> Fixes the paid Duck.ai chat header layout by **centering `paidTitleStack` as a group** (using `centerX` plus `>=`/`<=` edge constraints) instead of pinning it to the title container’s edges, preventing the icon/title from being spaced apart.
> 
> Removes the now-unnecessary `paidTitleLabel.textAlignment = .center` to avoid label-driven stretching in the stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a217cb5697636b3d1990c8fa788333f85ff5ac7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->