### PR TITLE
Fix unified input field URL highlight on omnibar tap

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -566,6 +566,10 @@ class SwitchBarTextEntryView: UIView {
     }
 
     func selectAllText() {
+        if !hasBeenInteractedWith {
+            hasBeenInteractedWith = true
+            updateTextViewHeight()
+        }
         textView.selectAll(nil)
         canExpandOnSelectionChange = true
     }

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -157,9 +157,10 @@ final class DefaultOmniBarViewController: OmniBarViewController {
     }
 
     private func extractCurrentTextForEditing(_ textField: UITextField) -> String? {
-        guard let text = textField.text, !text.isEmpty else { return nil }
-        if let url = URL(string: text), url.host != nil {
-            return url.absoluteString
+        guard let text = textField.text?.trimmingWhitespace(), !text.isEmpty else { return nil }
+        if URL(trimmedAddressBarString: text, useUnifiedLogic: isUsingUnifiedPredictor) != nil,
+           let url = omniDelegate?.didRequestCurrentURL() {
+            return AddressDisplayHelper.addressForDisplay(url: url, showsFullURL: true).string
         }
         return text
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -505,9 +505,13 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         applyToolbarPresentation()
         fetchModels()
 
+        let shouldSelectAllText: Bool
         if let text = prefilledText, !text.isEmpty {
             setText(text)
             textState = .prefilledSelected
+            shouldSelectAllText = true
+        } else {
+            shouldSelectAllText = false
         }
 
         let expandedHeight = editingHeight()
@@ -524,8 +528,11 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         DispatchQueue.main.async { [weak self] in
             guard let self, case .omnibar(.active) = displayState else { return }
             viewController.activateInput()
-            if textState == .prefilledSelected {
-                viewController.selectAllText()
+            if shouldSelectAllText {
+                DispatchQueue.main.async { [weak self] in
+                    guard let self, case .omnibar(.active) = displayState else { return }
+                    viewController.selectAllText()
+                }
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1213984293008244?focus=true
Tech Design URL:
CC:

### Description
Tapping the address bar with the unified input field now prefills the full URL (instead of the short display form) and selects all of it so the user can immediately type a replacement query. The omnibar activation flow no longer relies on `textState`, which was being clobbered by the published-text subscription before selection could fire. `selectAllText()` also marks the text entry as interacted so a URL prefill no longer renders single-line-truncated with "..." on first activation.

### Testing Steps
1. Enable the `unifiedToggleInput` feature flag and navigate to a deep URL such as https://www.reddit.com/r/duckduckgo/comments/1t5et47/duck_tales_episode_28_using_data_science_to/
2. Tap the address bar; verify the full URL is shown (not the host-only `reddit.com`) and is fully selected/highlighted.
3. Repeat on a SERP/typed query to confirm non-URL text still appears unchanged and is selected.

### Impact and Risks
Low — the change is scoped to omnibar-tap activation of the unified input field.

#### What could go wrong?
A regression in the SwitchBar editing path could occur if the `selectAllText()` change interacts unexpectedly with the existing transition that toggles `isExpandable`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-behavior change limited to omnibar activation and text selection/highlighting, with minimal surface area outside the unified input flow.
> 
> **Overview**
> Fixes unified input activation from the omnibar to **prefill and highlight the full URL** (instead of the shortened display string) when the current text is URL-like, while leaving non-URL text unchanged.
> 
> Makes selection more reliable by **decoupling select-all from `textState` timing** (using an explicit `shouldSelectAllText` and an extra async hop) and by having `selectAllText()` mark the field as interacted so the prefilled URL expands correctly instead of rendering truncated on first activation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2daeeab5f2153e594f998f190effded2f2f23101. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->