### PR TITLE
[macOS] Lazy-load favicon images to reduce memory by ~316 MB

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -2120,6 +2120,8 @@
 		7B1522B22DE9CCA900887371 /* MockFeatureGatekeeper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1522B02DE9CCA500887371 /* MockFeatureGatekeeper.swift */; };
 		7B1522B92DE9D19600887371 /* MockLoginItemsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1522B82DE9D19200887371 /* MockLoginItemsManager.swift */; };
 		7B1522BA2DE9D19600887371 /* MockLoginItemsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1522B82DE9D19200887371 /* MockLoginItemsManager.swift */; };
+		7B15FB6B2FACF8BF00019A26 /* FaviconMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B15FB6A2FACF8BF00019A26 /* FaviconMetadata.swift */; };
+		7B15FB6C2FACF8BF00019A26 /* FaviconMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B15FB6A2FACF8BF00019A26 /* FaviconMetadata.swift */; };
 		7B17AA872F757C350087A9ED /* UnloadedTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B17AA862F757C350087A9ED /* UnloadedTab.swift */; };
 		7B17AA882F757C350087A9ED /* UnloadedTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B17AA862F757C350087A9ED /* UnloadedTab.swift */; };
 		7B17AA8A2F757C3B0087A9ED /* AnyTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B17AA892F757C3B0087A9ED /* AnyTab.swift */; };
@@ -5589,6 +5591,7 @@
 		7B1522AD2DE9CBE300887371 /* VPNAppEventsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNAppEventsHandlerTests.swift; sourceTree = "<group>"; };
 		7B1522B02DE9CCA500887371 /* MockFeatureGatekeeper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFeatureGatekeeper.swift; sourceTree = "<group>"; };
 		7B1522B82DE9D19200887371 /* MockLoginItemsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLoginItemsManager.swift; sourceTree = "<group>"; };
+		7B15FB6A2FACF8BF00019A26 /* FaviconMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaviconMetadata.swift; sourceTree = "<group>"; };
 		7B17AA862F757C350087A9ED /* UnloadedTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnloadedTab.swift; sourceTree = "<group>"; };
 		7B17AA892F757C3B0087A9ED /* AnyTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyTab.swift; sourceTree = "<group>"; };
 		7B17AA8C2F757C480087A9ED /* UnloadedTabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnloadedTabViewModel.swift; sourceTree = "<group>"; };
@@ -10834,6 +10837,7 @@
 				AA5FA696275F90C400DCE9C9 /* FaviconImageCache.swift */,
 				AA512D1324D99D9800230283 /* FaviconManager.swift */,
 				37F09AD22DDE433000643A1B /* FaviconManagerMock.swift */,
+				7B15FB6A2FACF8BF00019A26 /* FaviconMetadata.swift */,
 				AA222CB82760F74E00321475 /* FaviconReferenceCache.swift */,
 				AAEF6BC7276A081C0024DCF4 /* FaviconSelector.swift */,
 				AA6197C3276B314D008396F0 /* FaviconUrlReference.swift */,
@@ -15083,6 +15087,7 @@
 				3706FB2C293F65D500E42796 /* UserDefaultsWrapper.swift in Sources */,
 				BB53CF3F2E26CEED007F0B42 /* RequestNewFeatureFormView.swift in Sources */,
 				BB8E05722EE0D2B9006CD2E6 /* HomePageSubscriptionCardPersistor.swift in Sources */,
+				7B15FB6B2FACF8BF00019A26 /* FaviconMetadata.swift in Sources */,
 				3706FB2D293F65D500E42796 /* PasswordManagementPopover.swift in Sources */,
 				C1935A152C88F958001AD72D /* SyncPromoView.swift in Sources */,
 				1D955E273EB784CB1672BB43 /* AdBlockingDebugMenu.swift in Sources */,
@@ -17334,6 +17339,7 @@
 				319FCFF32CC81D54004F9288 /* AIChatRemoteSettings.swift in Sources */,
 				84F950B92F150E3D00863D32 /* PrivacyStatsAppTerminationDecider.swift in Sources */,
 				84CE00172DAE41F100852AA2 /* ResizablePreviewView.swift in Sources */,
+				7B15FB6C2FACF8BF00019A26 /* FaviconMetadata.swift in Sources */,
 				4B379C2427BDE1B0008A968E /* FlatButton.swift in Sources */,
 				B6FA8941269C425400588ECD /* PrivacyDashboardPopover.swift in Sources */,
 				1D5C232A2F150A680055046E /* AIChatSuggestionsView.swift in Sources */,

--- a/macOS/DuckDuckGo/Favicons/Model/FaviconImageCache.swift
+++ b/macOS/DuckDuckGo/Favicons/Model/FaviconImageCache.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import AppKit
 import Foundation
 import Combine
 import Common
@@ -56,10 +57,22 @@ protocol FaviconImageCaching {
 
 final class FaviconImageCache: FaviconImageCaching {
 
+    private static let imageCacheTotalCostLimit = 32 * 1024 * 1024
+
     private let storing: FaviconStoring
 
     @MainActor
-    private var entries = [URL: Favicon]()
+    private var entries = [URL: FaviconMetadata]()
+
+    // Bounded image cache. Cost is approximated as RGBA size-units in points
+    // (so retina images undercount by ~4×); NSCache only requires the cost to
+    // be proportional, not byte-accurate, and computing real PNG bytes would
+    // mean re-encoding on every insert.
+    private let imageCache: NSCache<NSURL, NSImage> = {
+        let cache = NSCache<NSURL, NSImage>()
+        cache.totalCostLimit = imageCacheTotalCostLimit
+        return cache
+    }()
 
     init(faviconStoring: FaviconStoring) {
         storing = faviconStoring
@@ -69,18 +82,18 @@ final class FaviconImageCache: FaviconImageCaching {
     private(set) var loaded = false
 
     func load() async throws {
-        let favicons: [Favicon]
+        let metadata: [FaviconMetadata]
         do {
-            favicons = try await storing.loadFavicons()
-            Logger.favicons.debug("Favicons loaded successfully")
+            metadata = try await storing.loadFaviconMetadata()
+            Logger.favicons.debug("Favicon metadata loaded successfully (\(metadata.count) entries)")
         } catch {
-            Logger.favicons.error("Loading of favicons failed: \(error.localizedDescription)")
+            Logger.favicons.error("Loading of favicon metadata failed: \(error.localizedDescription)")
             throw error
         }
 
         await MainActor.run {
-            for favicon in favicons {
-                entries[favicon.url] = favicon
+            for entry in metadata {
+                entries[entry.url] = entry
             }
             loaded = true
         }
@@ -91,17 +104,19 @@ final class FaviconImageCache: FaviconImageCaching {
             return
         }
 
-        // Remove existing favicon with the same URL
-        let oldFavicons = favicons.compactMap { entries[$0.url] }
+        // Capture the metadata of any existing entries with the same URL so the
+        // store can drop the prior rows after the new ones are saved.
+        let oldMetadata = favicons.compactMap { entries[$0.url] }
 
-        // Save the new ones
+        // Update metadata entries and image cache for the new favicons.
         for favicon in favicons {
-            entries[favicon.url] = favicon
+            entries[favicon.url] = FaviconMetadata(favicon: favicon)
+            cacheImage(favicon.image, for: favicon.url)
         }
 
         Task {
             do {
-                await self.removeFaviconsFromStore(oldFavicons)
+                await self.removeFaviconsFromStore(oldMetadata)
                 try await self.storing.save(favicons)
                 Logger.favicons.debug("Favicon saved successfully. URL: \(favicons.map(\.url.absoluteString).description)")
                 await MainActor.run {
@@ -114,26 +129,43 @@ final class FaviconImageCache: FaviconImageCaching {
     }
 
     func get(faviconUrl: URL) -> Favicon? {
-        guard loaded else { return nil }
+        guard loaded, let metadata = entries[faviconUrl] else { return nil }
 
-        return entries[faviconUrl]
+        // Hot path: image already in NSCache.
+        let key = faviconUrl as NSURL
+        if let cached = imageCache.object(forKey: key) {
+            return Favicon(metadata: metadata, image: cached)
+        }
+
+        // Cold path: synchronous single-row fetch from the store. Per
+        // FaviconStore.loadImage, this is a `performAndWait` against the
+        // private-queue context — typically ~1 ms; under simultaneous write
+        // load it can briefly stall main. Documented trade-off.
+        let image: NSImage?
+        do {
+            image = try storing.loadImage(for: metadata.identifier)
+        } catch {
+            Logger.favicons.error("Loading favicon image failed for \(metadata.url.absoluteString): \(error.localizedDescription)")
+            image = nil
+        }
+        cacheImage(image, for: faviconUrl)
+        return Favicon(metadata: metadata, image: image)
     }
 
     func getFavicons(with urls: some Sequence<URL>) -> [Favicon]? {
         guard loaded else { return nil }
-
-        return urls.compactMap { faviconUrl in entries[faviconUrl] }
+        return urls.compactMap { get(faviconUrl: $0) }
     }
 
     // MARK: - Clean
 
     func cleanOld(except fireproofDomains: FireproofDomains, bookmarkManager: BookmarkManager) async {
         let bookmarkedHosts = bookmarkManager.allHosts()
-        await removeFavicons { favicon in
-            guard let host = favicon.documentUrl.host else {
+        await removeFavicons { metadata in
+            guard let host = metadata.documentUrl.host else {
                 return false
             }
-            return favicon.dateCreated < Date.monthAgo &&
+            return metadata.dateCreated < Date.monthAgo &&
                 !fireproofDomains.isFireproof(fireproofDomain: host) &&
                 !bookmarkedHosts.contains(host)
         }
@@ -143,8 +175,8 @@ final class FaviconImageCache: FaviconImageCaching {
 
     func burn(except fireproofDomains: FireproofDomains, bookmarkManager: BookmarkManager, savedLogins: Set<String>) async -> Result<Void, Error> {
         let bookmarkedHosts = bookmarkManager.allHosts()
-        return await removeFavicons { favicon in
-            guard let host = favicon.documentUrl.host else {
+        return await removeFavicons { metadata in
+            guard let host = metadata.documentUrl.host else {
                 return false
             }
             return !(fireproofDomains.isFireproof(fireproofDomain: host) ||
@@ -160,8 +192,8 @@ final class FaviconImageCache: FaviconImageCaching {
                      exceptHistoryDomains history: Set<String>,
                      tld: TLD) async -> Result<Void, Error> {
         let bookmarkedHosts = bookmarkManager.allHosts()
-        return await removeFavicons { favicon in
-            guard let host = favicon.documentUrl.host, let baseDomain = tld.eTLDplus1(host) else { return false }
+        return await removeFavicons { metadata in
+            guard let host = metadata.documentUrl.host, let baseDomain = tld.eTLDplus1(host) else { return false }
             return baseDomains.contains(baseDomain)
                 && !bookmarkedHosts.contains(host)
                 && !logins.contains(host)
@@ -172,16 +204,22 @@ final class FaviconImageCache: FaviconImageCaching {
     // MARK: - Private
 
     @MainActor
-    private func removeFavicons(filter isRemoved: (Favicon) -> Bool) async -> Result<Void, Error> {
-        let faviconsToRemove = entries.values.filter(isRemoved)
-        faviconsToRemove.forEach { entries[$0.url] = nil }
-
-        return await removeFaviconsFromStore(faviconsToRemove)
+    private func removeFavicons(filter isRemoved: (FaviconMetadata) -> Bool) async -> Result<Void, Error> {
+        let toRemove = entries.values.filter(isRemoved)
+        for metadata in toRemove {
+            entries[metadata.url] = nil
+            imageCache.removeObject(forKey: metadata.url as NSURL)
+        }
+        return await removeFaviconsFromStore(Array(toRemove))
     }
 
-    private func removeFaviconsFromStore(_ favicons: [Favicon]) async -> Result<Void, Error> {
-        guard !favicons.isEmpty else { return .success(()) }
+    private func removeFaviconsFromStore(_ metadatas: [FaviconMetadata]) async -> Result<Void, Error> {
+        guard !metadatas.isEmpty else { return .success(()) }
 
+        // FaviconStoring.removeFavicons takes [Favicon] and only reads
+        // `identifier` from each (see FaviconStore.removeFavicons). Wrap the
+        // metadata in nil-image Favicons just for the delete call.
+        let favicons = metadatas.map { $0.asFaviconWithoutImage() }
         do {
             try await storing.removeFavicons(favicons)
             Logger.favicons.debug("Favicons removed successfully.")
@@ -191,4 +229,48 @@ final class FaviconImageCache: FaviconImageCaching {
             return .failure(error)
         }
     }
+
+    @MainActor
+    private func cacheImage(_ image: NSImage?, for url: URL) {
+        guard let image else { return }
+        let cost = Int(image.size.width * image.size.height * 4)
+        imageCache.setObject(image, forKey: url as NSURL, cost: cost)
+    }
+
+}
+
+// MARK: - Favicon ↔ FaviconMetadata bridges
+
+private extension Favicon {
+
+    init(metadata: FaviconMetadata, image: NSImage?) {
+        self.init(identifier: metadata.identifier,
+                  url: metadata.url,
+                  image: image,
+                  relation: metadata.relation,
+                  documentUrl: metadata.documentUrl,
+                  dateCreated: metadata.dateCreated)
+    }
+
+}
+
+private extension FaviconMetadata {
+
+    init(favicon: Favicon) {
+        self.init(identifier: favicon.identifier,
+                  url: favicon.url,
+                  documentUrl: favicon.documentUrl,
+                  dateCreated: favicon.dateCreated,
+                  relation: favicon.relation)
+    }
+
+    func asFaviconWithoutImage() -> Favicon {
+        Favicon(identifier: identifier,
+                url: url,
+                image: nil,
+                relation: relation,
+                documentUrl: documentUrl,
+                dateCreated: dateCreated)
+    }
+
 }

--- a/macOS/DuckDuckGo/Favicons/Model/FaviconMetadata.swift
+++ b/macOS/DuckDuckGo/Favicons/Model/FaviconMetadata.swift
@@ -1,0 +1,29 @@
+//
+//  FaviconMetadata.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+struct FaviconMetadata: Sendable, Equatable {
+
+    let identifier: UUID
+    let url: URL
+    let documentUrl: URL
+    let dateCreated: Date
+    let relation: Favicon.Relation
+
+}

--- a/macOS/DuckDuckGo/Favicons/Services/FaviconNullStore.swift
+++ b/macOS/DuckDuckGo/Favicons/Services/FaviconNullStore.swift
@@ -16,13 +16,18 @@
 //  limitations under the License.
 //
 
-import Foundation
+import AppKit
 import Combine
+import Foundation
 
 final class FaviconNullStore: FaviconStoring {
 
-    func loadFavicons() async throws -> [Favicon] {
+    func loadFaviconMetadata() async throws -> [FaviconMetadata] {
         return []
+    }
+
+    func loadImage(for identifier: UUID) throws -> NSImage? {
+        return nil
     }
 
     func save(_ favicons: [Favicon]) async throws {

--- a/macOS/DuckDuckGo/Favicons/Services/FaviconStore.swift
+++ b/macOS/DuckDuckGo/Favicons/Services/FaviconStore.swift
@@ -26,7 +26,8 @@ import os.log
 
 protocol FaviconStoring {
 
-    func loadFavicons() async throws -> [Favicon]
+    func loadFaviconMetadata() async throws -> [FaviconMetadata]
+    func loadImage(for identifier: UUID) throws -> NSImage?
     func save(_ favicons: [Favicon]) async throws
     func removeFavicons(_ favicons: [Favicon]) async throws
 
@@ -55,23 +56,46 @@ final class FaviconStore: FaviconStoring {
         self.context = context
     }
 
-    func loadFavicons() async throws -> [Favicon] {
+    func loadFaviconMetadata() async throws -> [FaviconMetadata] {
         try await withCheckedThrowingContinuation { [context] continuation in
             context.perform {
                 let fetchRequest = FaviconManagedObject.fetchRequest() as NSFetchRequest<FaviconManagedObject>
                 fetchRequest.sortDescriptors = [NSSortDescriptor(key: #keyPath(FaviconManagedObject.dateCreated), ascending: true)]
-                fetchRequest.returnsObjectsAsFaults = false
+                // returnsObjectsAsFaults stays at the default (true). The image
+                // blob (`imageEncrypted`) is never accessed during the metadata
+                // mapping below, so CoreData never realizes it from SQLite —
+                // this is what avoids the ~310 MB launch-time spike.
                 do {
                     let faviconMOs = try context.fetch(fetchRequest)
-                    Logger.favicons.debug("\(faviconMOs.count) favicons loaded")
-                    let favicons = faviconMOs.compactMap { Favicon(faviconMO: $0) }
+                    Logger.favicons.debug("\(faviconMOs.count) favicon metadata entries loaded")
+                    let metadata = faviconMOs.compactMap { FaviconMetadata(faviconMO: $0) }
 
-                    continuation.resume(returning: favicons)
+                    continuation.resume(returning: metadata)
                 } catch {
                     continuation.resume(throwing: error)
                 }
             }
         }
+    }
+
+    func loadImage(for identifier: UUID) throws -> NSImage? {
+        var image: NSImage?
+        var caughtError: Error?
+        context.performAndWait {
+            let fetchRequest = FaviconManagedObject.fetchRequest() as NSFetchRequest<FaviconManagedObject>
+            fetchRequest.predicate = NSPredicate(format: "%K == %@", #keyPath(FaviconManagedObject.identifier), identifier as NSUUID)
+            fetchRequest.fetchLimit = 1
+            do {
+                let result = try context.fetch(fetchRequest)
+                image = result.first?.imageEncrypted as? NSImage
+            } catch {
+                caughtError = error
+            }
+        }
+        if let caughtError {
+            throw caughtError
+        }
+        return image
     }
 
     func removeFavicons(_ favicons: [Favicon]) async throws {
@@ -221,7 +245,7 @@ final class FaviconStore: FaviconStoring {
 
 }
 
-fileprivate extension Favicon {
+fileprivate extension FaviconMetadata {
 
     init?(faviconMO: FaviconManagedObject) {
         guard let identifier = faviconMO.identifier,
@@ -230,13 +254,11 @@ fileprivate extension Favicon {
               let dateCreated = faviconMO.dateCreated,
               let relation = Favicon.Relation(rawValue: Int(faviconMO.relation)) else {
             PixelKit.fire(DebugEvent(GeneralPixel.faviconDecryptionFailedUnique), frequency: .legacyDaily)
-            assertionFailure("Favicon: Failed to init Favicon from FaviconManagedObject")
+            assertionFailure("FaviconMetadata: Failed to init from FaviconManagedObject")
             return nil
         }
 
-        let image = faviconMO.imageEncrypted as? NSImage
-
-        self.init(identifier: identifier, url: url, image: image, relation: relation, documentUrl: documentUrl, dateCreated: dateCreated)
+        self.init(identifier: identifier, url: url, documentUrl: documentUrl, dateCreated: dateCreated, relation: relation)
     }
 
 }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/FaviconsTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/FaviconsTabExtension.swift
@@ -64,6 +64,24 @@ final class FaviconsTabExtension {
             self?.content = content
         }
         .store(in: &cancellables)
+
+        // Re-resolve cached favicon once the favicon cache finishes loading.
+        // Tab.swift triggers `loadCachedFavicon` when the URL is set (e.g. for
+        // pinned tabs during state restoration), but at that moment the cache
+        // may not be loaded yet — `loadCachedFavicon` early-returns on
+        // `isCacheLoaded == false`. Without this subscription pinned tabs
+        // would render with the LetterView placeholder until something else
+        // re-triggered favicon resolution.
+        self.faviconManagement.faviconsLoadedPublisher
+            .removeDuplicates()
+            .filter { $0 }
+            .sink { [weak self] _ in
+                Task { @MainActor in
+                    guard let self, self.content != nil else { return }
+                    self.loadCachedFavicon(isBurner: false)
+                }
+            }
+            .store(in: &cancellables)
     }
 
     @MainActor

--- a/macOS/UnitTests/Favicons/FaviconStoringMock.swift
+++ b/macOS/UnitTests/Favicons/FaviconStoringMock.swift
@@ -16,15 +16,20 @@
 //  limitations under the License.
 //
 
+import AppKit
+import Combine
 import Foundation
 import XCTest
-import Combine
 @testable import DuckDuckGo_Privacy_Browser
 
 final class FaviconStoringMock: FaviconStoring {
 
-    func loadFavicons() async throws -> [Favicon] {
+    func loadFaviconMetadata() async throws -> [FaviconMetadata] {
         []
+    }
+
+    func loadImage(for identifier: UUID) throws -> NSImage? {
+        nil
     }
 
     func save(_ favicons: [Favicon]) async throws {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214612370091414?focus=true

### Description

The macOS browser was holding every saved favicon's bitmap in memory for the lifetime of the process — roughly 310 MB of resident memory traceable to the favicon load path. This change keeps lightweight favicon metadata in memory and lazy-loads images on demand, dropping steady-state footprint by about 48% with no behavioural regression for the UIs that show favicons before their pages have loaded.

### Testing Steps

1. Quit and relaunch the app with at least a few pinned tabs and some history.
2. Pinned tabs should show their favicons (not letter placeholders) on first paint after launch.
3. Open the History menu and the Bookmarks Bar — favicons should appear immediately for previously-visited sites.
4. Open a new tab — favorite tiles should show favicons for sites you've visited before.
5. Burn the session via the Fire button — confirm favicons are cleared.

### Impact and Risks

#### What could go wrong?

The main risk is favicons not appearing for users where we expect them to. The most likely failure mode is a cold-start race where pinned tabs render before the metadata cache loads, addressed by re-resolving once the cache is ready. Manage Bookmarks scrolled over a very long list may pay a brief synchronous I/O cost on first reveal as the image cache warms; subsequent scrolls are smooth.

### Quality Considerations

Memory was measured with footprint and vmmap before and after. Steady-state footprint dropped from 655 MB to 339 MB; large allocations dropped from 432 MB to 129 MB. Existing favicon-related unit tests pass. Targeted unit tests for the new metadata-fetch and cache-miss flow are a follow-up.

### Notes to Reviewer

The cache-miss path is synchronous on the main thread to keep the diff contained and avoid rippling consumer-side changes. If anyone reports stutters during burn or heavy bookmark imports we can switch to an async-with-placeholder pattern without changing the public surface.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)