### PR TITLE
Fixes breaking unit test

### DIFF
--- a/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
@@ -138,14 +138,14 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         let restorePromptHandlerMock = MockRestorePromptHandler()
         onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedIPhoneSteps(isReturningUser: true)
         let sut = makeSUT(
-            currentOnboardingStep: .addressBarPositionSelection,
+            currentOnboardingStep: .searchExperienceSelection,
             restorePromptHandler: restorePromptHandlerMock
         )
         sut.restoreSyncAccountAction()
         XCTAssertFalse(contextualDaxDialogs.didCallDisableDaxDialogs)
 
         // WHEN
-        sut.selectAddressBarPositionAction()
+        sut.selectSearchExperienceAction()
 
         // THEN
         XCTAssertTrue(contextualDaxDialogs.didCallDisableDaxDialogs)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1214623285127234
Tech Design URL:
CC:

### Description
Unfortunate timing, the new Unit Test introduced via #4752 stopped working with the changeset from #4604.

In this PR we're adjusting the Test logic to accommodate.

### Testing Steps
- [ ] Verify the CI is green!

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing really

### Quality Considerations
None

### Notes to Reviewer
Thank you!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates only a unit test to match a changed onboarding step/action sequence; no production code paths are modified.
> 
> **Overview**
> Fixes a broken `OnboardingIntroViewModelTests` case by updating the “restore action + onboarding completes” test to complete onboarding via the new final step (`.searchExperienceSelection` with `selectSearchExperienceAction()`) instead of the previous address bar selection step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3867f7dd44c92d875a304a0b525798bb6316722. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->