### PR TITLE
[iOS/macOS][Dependencies] Bump Lottie to 4.6.0

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dbb93c25e598640d19a385d52148151178fe8b2dc6b19622d0a2ab66a37d94e4",
+  "originHash" : "744d696216a65cd197e2adef74467ca37e00788f90a46258090a3c81a88b1259",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/airbnb/lottie-spm.git",
       "state" : {
-        "revision" : "04f2fd18cc9404a0a0917265a449002674f24ec9",
-        "version" : "4.5.2"
+        "revision" : "69faaefa7721fba9e434a52c16adf4329c9084db",
+        "version" : "4.6.0"
       }
     },
     {

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -17632,7 +17632,7 @@
 			repositoryURL = "https://github.com/airbnb/lottie-spm.git";
 			requirement = {
 				kind = exactVersion;
-				version = 4.5.2;
+				version = 4.6.0;
 			};
 		};
 		9FADFC482F5FC56400CA16F7 /* XCRemoteSwiftPackageReference "native-apps-ducksans" */ = {

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -20065,7 +20065,7 @@
 			repositoryURL = "https://github.com/airbnb/lottie-spm.git";
 			requirement = {
 				kind = exactVersion;
-				version = 4.5.2;
+				version = 4.6.0;
 			};
 		};
 		B65CD8C92B316DF100A595BB /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {

--- a/macOS/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
         .library(name: "VPNNotifications", targets: ["VPNNotifications"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/airbnb/lottie-spm", exact: "4.5.2"),
+        .package(url: "https://github.com/airbnb/lottie-spm", exact: "4.6.0"),
         .package(path: "../../../SharedPackages/BrowserServicesKit"),
         .package(path: "../AppInfoRetriever"),
         .package(path: "../AppLauncher"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1212706550114243?focus=true
Tech Design URL:
CC:

### Description

This PR bumps Lottie from 4.5.2 to 4.6.0. [Lottie 4.6.0 changelog](https://github.com/airbnb/lottie-spm/releases/tag/4.6.0)

### Testing Steps
1. Smoke test Lottie animations on iOS
2. Smoke test Lottie animations on macOS
3. Smoke test Lottie animations on VPN

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump; main risk is potential runtime/visual regressions in Lottie-based animations across iOS, macOS, and VPN UI.
> 
> **Overview**
> Bumps the `lottie-spm` Swift Package dependency from **4.5.2** to **4.6.0** across the workspace.
> 
> Updates the pinned package resolution (`Package.resolved`) and aligns both iOS and macOS Xcode project Swift Package references, plus the `NetworkProtectionMac` local package dependency, to use `lottie-spm` **4.6.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59207a3fc84d8fee1fc8145cb1bf1e1206c7bfa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->