### PR TITLE
[iOS][Onboarding] Fix NTP Contextual Onboarding dialog sequence

### DIFF
--- a/iOS/DuckDuckGo/NewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPageViewController.swift
@@ -55,6 +55,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
     private let appWidthObserver: AppWidthObserver
 
     private let internalUserCommands: URLBasedDebugCommands
+    private let tutorialSettings: TutorialSettings
 
     var onViewDidAppear: (() -> Void)?
 
@@ -76,7 +77,8 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
          subscriptionManager: any SubscriptionManager,
          internalUserCommands: URLBasedDebugCommands,
          narrowLayoutInLandscape: Bool = false,
-         appWidthObserver: AppWidthObserver = .shared) {
+         appWidthObserver: AppWidthObserver = .shared,
+         tutorialSettings: TutorialSettings = DefaultTutorialSettings()) {
 
         self.associatedTab = tab
         self.newTabDialogFactory = newTabDialogFactory
@@ -84,6 +86,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
         self.appSettings = appSettings
         self.appWidthObserver = appWidthObserver
         self.internalUserCommands = internalUserCommands
+        self.tutorialSettings = tutorialSettings
 
         newTabPageViewModel = NewTabPageViewModel(fireTab: tab.fireTab)
         favoritesModel = FavoritesViewModel(isFocussedState: isFocussedState,
@@ -285,7 +288,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
 
     private func presentNextDaxDialog() {
         // If linear onboarding is not completed do not attempt to present any Dax dialog.
-        guard DefaultTutorialSettings().hasSeenOnboarding else { return }
+        guard tutorialSettings.hasSeenOnboarding else { return }
         // Present Dax dialog if needed.
         showNextDaxDialogNew(dialogProvider: daxDialogsManager, factory: newTabDialogFactory)
     }

--- a/iOS/DuckDuckGo/NewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPageViewController.swift
@@ -284,6 +284,9 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
     // MARK: - Onboarding
 
     private func presentNextDaxDialog() {
+        // If linear onboarding is not completed do not attempt to present any Dax dialog.
+        guard DefaultTutorialSettings().hasSeenOnboarding else { return }
+        // Present Dax dialog if needed.
         showNextDaxDialogNew(dialogProvider: daxDialogsManager, factory: newTabDialogFactory)
     }
 

--- a/iOS/SharedStateTests/NewTabPageControllerDaxDialogTests.swift
+++ b/iOS/SharedStateTests/NewTabPageControllerDaxDialogTests.swift
@@ -45,7 +45,6 @@ final class NewTabPageControllerDaxDialogTests: XCTestCase {
     var hvc: NewTabPageViewController!
 
     override func setUpWithError() throws {
-        let db = CoreDataDatabase.bookmarksMock
         variantManager = CapturingVariantManager()
         dialogFactory = CapturingNewTabDaxDialogProvider()
         specProvider = MockNewTabDialogSpecProvider()
@@ -65,7 +64,8 @@ final class NewTabPageControllerDaxDialogTests: XCTestCase {
             appSettings: AppSettingsMock(),
             faviconsCache: Favicons(),
             subscriptionManager: SubscriptionManagerMock(),
-            internalUserCommands: MockURLBasedDebugCommands()
+            internalUserCommands: MockURLBasedDebugCommands(),
+            tutorialSettings: MockTutorialSettings(hasSeenOnboarding: true),
         )
 
         let window = UIWindow(frame: UIScreen.main.bounds)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1214629859848714?focus=true
Tech Design URL:
CC:

### Description

This PR fixes an issue where “Try A Search!” was not showing anymore after completing the linear onboarding after merging the [tailored onboarding foundation PR](https://github.com/duckduckgo/apple-browsers/pull/4604). 

Before that PR in `NewTabPageViewController.viewDidAppear`

```
// If there's no tab switcher then this will be true, if there is a tabswitcher then only allow the
// stuff below to happen if it's being dismissed
guard presentedViewController?.isBeingDismissed ?? true else {
  return
}
```
the function would return, not it would not.

The PR moved onboarding presentation from a synchronous call in `MainViewController.viewDidAppear` to an async call in UIIInteractionManager, so `NewTabPageViewController.viewDidAppear` now runs before onboarding is presented. `presentedViewController` is `nil`, the `guard's nil?.isBeingDismissed ?? true` evaluates to `true`, and the early-return no longer fires.

Fix the Issue by ensuring that linear onboarding is completed before attempting to present a contextual dax dialog.
 
### Testing Steps
1. Comment out fix and run onboarding and ensure that “Try A Search!” on NTP is not shown
2. Uncomment fix and run onboarding and ensure that “Try A Search” on NTP is shown
3. General onboarding smoke test.

### Impact and Risks
Low: Small bug fix

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to new tab onboarding dialog presentation gated by `hasSeenOnboarding`, plus test updates. Main risk is a regression in when/if contextual Dax dialogs appear for edge onboarding states.
> 
> **Overview**
> Fixes the NTP contextual onboarding sequence by **blocking `presentNextDaxDialog()` until linear onboarding is complete** (`tutorialSettings.hasSeenOnboarding`).
> 
> `NewTabPageViewController` now accepts/injects `TutorialSettings` (defaulting to `DefaultTutorialSettings`), and the Dax dialog unit test is updated to pass a `MockTutorialSettings` to cover the new gating behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f39fe1745eb953559313878290771a0922c73ef9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->