### PR TITLE
[macOS] Clarify internal and external promo types and default values

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -3905,6 +3905,8 @@
 		CBECDB852CDA813C005B8B87 /* BrokenSitePromptLimiterStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBECDB832CDA8137005B8B87 /* BrokenSitePromptLimiterStore.swift */; };
 		CC00A0902E1D52A700750ED3 /* FirefoxPreferencesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00A08F2E1D52A700750ED3 /* FirefoxPreferencesTests.swift */; };
 		CC00A0912E1D52A700750ED3 /* FirefoxPreferencesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00A08F2E1D52A700750ED3 /* FirefoxPreferencesTests.swift */; };
+		CC0816472FAC9FE9000F8217 /* PromoDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0816462FAC9FE5000F8217 /* PromoDelegate.swift */; };
+		CC0816482FAC9FE9000F8217 /* PromoDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0816462FAC9FE5000F8217 /* PromoDelegate.swift */; };
 		CC0942FD2E16AF9C00E67336 /* FavoritesImportProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0942FC2E16AF6000E67336 /* FavoritesImportProcessor.swift */; };
 		CC0942FE2E16AF9C00E67336 /* FavoritesImportProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0942FC2E16AF6000E67336 /* FavoritesImportProcessor.swift */; };
 		CC0943002E16B6F000E67336 /* FavoritesImportProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0942FF2E16B6F000E67336 /* FavoritesImportProcessorTests.swift */; };
@@ -6632,6 +6634,7 @@
 		CBDD5DE229A67F2700832877 /* MockConfigurationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockConfigurationStore.swift; sourceTree = "<group>"; };
 		CBECDB832CDA8137005B8B87 /* BrokenSitePromptLimiterStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrokenSitePromptLimiterStore.swift; sourceTree = "<group>"; };
 		CC00A08F2E1D52A700750ED3 /* FirefoxPreferencesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirefoxPreferencesTests.swift; sourceTree = "<group>"; };
+		CC0816462FAC9FE5000F8217 /* PromoDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoDelegate.swift; sourceTree = "<group>"; };
 		CC0942FC2E16AF6000E67336 /* FavoritesImportProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesImportProcessor.swift; sourceTree = "<group>"; };
 		CC0942FF2E16B6F000E67336 /* FavoritesImportProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesImportProcessorTests.swift; sourceTree = "<group>"; };
 		CC0DD90E2E5DD74600277E46 /* AppStateRestorationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateRestorationManagerTests.swift; sourceTree = "<group>"; };
@@ -12730,6 +12733,7 @@
 			isa = PBXGroup;
 			children = (
 				A1B2C3D42E5F600300000003 /* Promo.swift */,
+				CC0816462FAC9FE5000F8217 /* PromoDelegate.swift */,
 				CC82ABC12F52100D00AD9807 /* PromoContext.swift */,
 				CC82ABB52F5206BE00AD9807 /* PromoHistoryProviding.swift */,
 				A1B2C3D42E5F600200000002 /* PromoHistoryRecord.swift */,
@@ -14679,6 +14683,7 @@
 			files = (
 				A1B2C3D42E5F601100000001 /* PromoType.swift in Sources */,
 				A1B2C3D42E5F601200000002 /* PromoHistoryRecord.swift in Sources */,
+				CC0816472FAC9FE9000F8217 /* PromoDelegate.swift in Sources */,
 				A1B2C3D42E5F601300000003 /* Promo.swift in Sources */,
 				A1B2C3D42E5F601500000005 /* PromoHistoryStoring.swift in Sources */,
 				A1B2C3D42E5F601600000007 /* PromoService.swift in Sources */,
@@ -16931,6 +16936,7 @@
 			files = (
 				CC3967ED2F461D6700AE83F2 /* PromoType.swift in Sources */,
 				CC3967EE2F461D6B00AE83F2 /* PromoHistoryRecord.swift in Sources */,
+				CC0816482FAC9FE9000F8217 /* PromoDelegate.swift in Sources */,
 				CC3967EF2F461D7000AE83F2 /* Promo.swift in Sources */,
 				CC3967F12F461D7B00AE83F2 /* PromoHistoryStoring.swift in Sources */,
 				CC3967F22F461D8000AE83F2 /* PromoService.swift in Sources */,

--- a/macOS/DuckDuckGo/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromoDelegate.swift
+++ b/macOS/DuckDuckGo/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromoDelegate.swift
@@ -20,7 +20,7 @@ import Combine
 import Foundation
 
 /// PromoDelegate for default browser/dock prompts. One delegate per promo kind (popover, banner, inactive modal).
-final class DefaultBrowserAndDockPromoDelegate: PromoDelegate {
+final class DefaultBrowserAndDockPromoDelegate: InternalPromoDelegate {
 
     private let type: DefaultBrowserAndDockPromptPresentationType
     private let coordinator: DefaultBrowserAndDockPrompt

--- a/macOS/DuckDuckGo/NewTabPage/Features/NewTabPageFreemiumDBPBannerProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/NewTabPageFreemiumDBPBannerProvider.swift
@@ -75,7 +75,7 @@ extension NewTabPageDataModel.FreemiumPIRBannerMessage {
     }
 }
 
-final class FreemiumDBPPromoDelegate: PromoDelegate {
+final class FreemiumDBPPromoDelegate: InternalPromoDelegate {
 
     private let coordinator: FreemiumDBPPromotionViewCoordinator
     private let historyProvider: PromoHistoryProviding?

--- a/macOS/DuckDuckGo/Promotions/PromoDebugMenu.swift
+++ b/macOS/DuckDuckGo/Promotions/PromoDebugMenu.swift
@@ -107,7 +107,7 @@ final class PromoDebugMenu: NSMenu {
             parentItem.setAccessibilityIdentifier(AccessibilityIdentifiers.PromoQueue.promoMenuItem(promo.id))
 
             let submenu = NSMenu()
-            if promo.delegate is PromoDelegate {
+            if promo.delegate is InternalPromoDelegate {
                 let forceShowItem = NSMenuItem(title: "Force Show", action: #selector(forceShowPromo(_:)), keyEquivalent: "")
                 forceShowItem.representedObject = promo.id
                 forceShowItem.target = self

--- a/macOS/DuckDuckGo/Promotions/PromoService.swift
+++ b/macOS/DuckDuckGo/Promotions/PromoService.swift
@@ -25,7 +25,7 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
     /// Tracks state for a promo that is currently being shown.
     private struct ActiveShowSession {
         let promoId: String
-        let delegate: any PromoDelegate
+        let delegate: any InternalPromoDelegate
         let promoType: PromoType
 
         /// First-write-wins flag. Once true, ignore further results from show(), timeout, or eligibility.
@@ -100,7 +100,7 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
 
     /// Attaches a delegate to a promo by ID. Call when the delegate object is ready.
     /// If all delegates are ready and start() was already called, completes registration immediately.
-    func setDelegate(for promoId: String, delegate: any AnyPromoDelegate) {
+    func setDelegate(for promoId: String, delegate: any PromoDelegate) {
         stateQueue.async { [weak self] in
             guard let self else { return }
             guard let index = promos.firstIndex(where: { $0.id == promoId }) else {
@@ -184,7 +184,7 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
                 Logger.general.warning("PromoService: forceShow unknown promo ID \(promoId)")
                 return
             }
-            guard let delegate = promo.delegate as? PromoDelegate else {
+            guard let delegate = promo.delegate as? InternalPromoDelegate else {
                 Logger.general.warning("PromoService: forceShow - external promos control their own visibility")
                 return
             }
@@ -385,7 +385,7 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
         processBufferedTriggersIfReady()
     }
 
-    private func subscribeToExternalDelegateIfNeeded(promoId: String, delegate: (any AnyPromoDelegate)?) {
+    private func subscribeToExternalDelegateIfNeeded(promoId: String, delegate: (any PromoDelegate)?) {
         dispatchPrecondition(condition: .onQueue(stateQueue))
         guard let externalDelegate = delegate as? ExternalPromoDelegate else { return }
         guard externalSubscriptions[promoId] == nil else { return }
@@ -424,7 +424,7 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
         for promoID in visiblePromos {
             guard activeSessions[promoID] != nil,
                   let promo = promos.first(where: { $0.id == promoID }),
-                  promo.delegate is PromoDelegate else { continue }
+                  promo.delegate is InternalPromoDelegate else { continue }
             if !checkRules(for: promo) {
                 recordResultAndCleanup(promoId: promoID, result: .noChange)
             }
@@ -452,7 +452,7 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
         guard !externalActivationSuppression.isSet else { return }
 
         for promo in promos {
-            guard let delegate = promo.delegate as? PromoDelegate else { continue }
+            guard let delegate = promo.delegate as? InternalPromoDelegate else { continue }
             let record = historyStore.record(for: promo.id)
 
             guard let lastShown = record.lastShown else { continue }
@@ -475,12 +475,12 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
 
         let matchingPromos = promos.filter { $0.triggers.contains(where: triggers.contains) }
         for promo in matchingPromos {
-            (promo.delegate as? PromoDelegate)?.refreshEligibility()
+            (promo.delegate as? InternalPromoDelegate)?.refreshEligibility()
         }
 
         for promo in matchingPromos {
             guard activeSessions[promo.id] == nil,
-                  let delegate = promo.delegate as? PromoDelegate,
+                  let delegate = promo.delegate as? InternalPromoDelegate,
                   checkRules(for: promo) else { continue }
 
             let record = historyStore.record(for: promo.id)
@@ -536,7 +536,7 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
 
     // MARK: - Show / Session Management
 
-    private func performShow(promo: Promo, delegate: PromoDelegate, record: PromoHistoryRecord, isRestore: Bool = false) {
+    private func performShow(promo: Promo, delegate: InternalPromoDelegate, record: PromoHistoryRecord, isRestore: Bool = false) {
         dispatchPrecondition(condition: .onQueue(stateQueue))
         let promoId = promo.id
         var recordToUse = record

--- a/macOS/DuckDuckGo/Promotions/PromoTypes/Promo.swift
+++ b/macOS/DuckDuckGo/Promotions/PromoTypes/Promo.swift
@@ -55,6 +55,9 @@ struct Promo {
     /// Delegate should be set by feature module when their dependencies are ready.
     var delegate: (any AnyPromoDelegate)?
 
+    /// Init for an internal promo. Use this for most promos.
+    ///
+    /// Internal promo visibility is managed by `PromoService` based on triggers and eligibility.
     init(id: String,
          triggers: Set<PromoTrigger>,
          initiated: PromoInitiated,
@@ -63,7 +66,7 @@ struct Promo {
          coexistingPromoIDs: Set<String> = [],
          respectsGlobalCooldown: Bool = true,
          setsGlobalCooldown: Bool = true,
-         delegate: (any AnyPromoDelegate)? = nil) {
+         delegate: PromoDelegate? = nil) {
         self.id = id
         self.triggers = triggers
         self.initiated = initiated
@@ -71,6 +74,29 @@ struct Promo {
         self.context = context
         self.coexistingPromoIDs = coexistingPromoIDs
         self.respectsGlobalCooldown = respectsGlobalCooldown
+        self.setsGlobalCooldown = setsGlobalCooldown
+        self.delegate = delegate
+    }
+
+    /// Init for an external promo, whose visibility is controlled outside PromoService.
+    ///
+    /// Use when another system (e.g. Remote Messaging Framework) decides when to show or hide the promo.
+    /// `PromoService` observes the promo's visibility and uses it to manage internal promos.
+    /// Use sparingly; most promos should conform to `PromoDelegate` instead.
+    init(id: String,
+         initiated: PromoInitiated,
+         promoType: PromoType,
+         context: PromoContext,
+         coexistingPromoIDs: Set<String> = [],
+         setsGlobalCooldown: Bool = true,
+         delegate: ExternalPromoDelegate? = nil) {
+        self.id = id
+        self.triggers = [] // External promos show themselves without PromoService triggers
+        self.initiated = initiated
+        self.promoType = promoType
+        self.context = context
+        self.coexistingPromoIDs = coexistingPromoIDs
+        self.respectsGlobalCooldown = false // External promos define when they will show; they don't respect PromoService cooldowns
         self.setsGlobalCooldown = setsGlobalCooldown
         self.delegate = delegate
     }
@@ -83,7 +109,7 @@ struct Promo {
 /// system (e.g. Remote Messaging Framework); PromoService only observes their visibility.
 protocol AnyPromoDelegate: AnyObject { }
 
-/// Delegate for promos that PromoService controls. Use this for most promos.
+/// Delegate for promos that PromoService controls.
 ///
 /// PromoService evaluates triggers, checks eligibility, and calls `show()` / `hide()` to manage
 /// visibility. The delegate provides eligibility state and implements the UI for showing and hiding.
@@ -119,10 +145,8 @@ extension PromoDelegate {
 
 /// Delegate for promos whose visibility is controlled outside PromoService.
 ///
-/// Use when another system (e.g. Remote Messaging Framework) decides when to show or hide the promo.
 /// PromoService subscribes to `isVisiblePublisher` to observe visibility, record history, and apply
-/// global cooldowns—it never calls `show()` or `hide()`. Use sparingly; most promos should conform
-/// to `PromoDelegate` instead.
+/// global cooldowns—it never calls `show()` or `hide()`.
 protocol ExternalPromoDelegate: AnyPromoDelegate {
     /// Current visibility state. Use isVisiblePublisher to observe changes.
     var isVisible: Bool { get }

--- a/macOS/DuckDuckGo/Promotions/PromoTypes/Promo.swift
+++ b/macOS/DuckDuckGo/Promotions/PromoTypes/Promo.swift
@@ -20,44 +20,57 @@ import Combine
 import Foundation
 
 /// Static metadata for a promo. Priority is defined by array order when passed to PromoService.
-struct Promo {
+protocol Promo {
     /// Unique identifier
-    let id: String
+    var id: String { get }
 
     /// Which trigger(s) this promo responds to
-    let triggers: Set<PromoTrigger>
+    var triggers: Set<PromoTrigger> { get }
 
     /// How this promo was initiated and its cooldown
-    let initiated: PromoInitiated
+    var initiated: PromoInitiated { get }
 
     /// Display metadata (severity, timeout)
-    let promoType: PromoType
+    var promoType: PromoType { get }
 
     /// Where this promo appears
-    let context: PromoContext
+    var context: PromoContext { get }
 
     /// IDs of promos that can be visible simultaneously with this one.
     /// Promos can appear together when all visible promos that would conflict
     /// are in this set and this promo is in all of theirs (mutual coexistence).
     /// This should be used only in very rare cases that are pre-validated (e.g. with a PFR).
     /// Default: empty (no coexistence exceptions).
-    let coexistingPromoIDs: Set<String>
+    var coexistingPromoIDs: Set<String> { get }
 
     /// When false, this promo can show even if the global cooldown for its PromoInitiated type hasn't elapsed.
     /// Default: true.
-    let respectsGlobalCooldown: Bool
+    var respectsGlobalCooldown: Bool { get }
 
     /// When false, dismissing this promo does not count toward the global cooldown for its PromoInitiated type.
     /// Default: true.
-    let setsGlobalCooldown: Bool
+    var setsGlobalCooldown: Bool { get }
 
     /// Provides dynamic promo behavior (eligibility, show, hide).
     /// Delegate should be set by feature module when their dependencies are ready.
+    var delegate: (any AnyPromoDelegate)? { get set }
+}
+
+/// Static metadata for an internal promo. Use this for most promos.
+///
+/// Internal promo visibility is managed by `PromoService` based on triggers and eligibility.
+struct InternalPromo: Promo {
+    let id: String
+    let triggers: Set<PromoTrigger>
+    let initiated: PromoInitiated
+    let promoType: PromoType
+    let context: PromoContext
+    let coexistingPromoIDs: Set<String>
+    let respectsGlobalCooldown: Bool
+    let setsGlobalCooldown: Bool
+
     var delegate: (any AnyPromoDelegate)?
 
-    /// Init for an internal promo. Use this for most promos.
-    ///
-    /// Internal promo visibility is managed by `PromoService` based on triggers and eligibility.
     init(id: String,
          triggers: Set<PromoTrigger>,
          initiated: PromoInitiated,
@@ -77,12 +90,29 @@ struct Promo {
         self.setsGlobalCooldown = setsGlobalCooldown
         self.delegate = delegate
     }
+}
 
-    /// Init for an external promo, whose visibility is controlled outside PromoService.
-    ///
-    /// Use when another system (e.g. Remote Messaging Framework) decides when to show or hide the promo.
-    /// `PromoService` observes the promo's visibility and uses it to manage internal promos.
-    /// Use sparingly; most promos should conform to `PromoDelegate` instead.
+/// Static metadata for an external promo, whose visibility is controlled outside PromoService.
+///
+/// Use when another system (e.g. Remote Messaging Framework) decides when to show or hide the promo.
+/// `PromoService` observes the promo's visibility and uses it to manage internal promos.
+/// Use sparingly; most promos should use `InternalPromo` instead.
+struct ExternalPromo: Promo {
+    let id: String
+    let initiated: PromoInitiated
+    let promoType: PromoType
+    let context: PromoContext
+    let coexistingPromoIDs: Set<String>
+    let setsGlobalCooldown: Bool
+
+    /// External promos show themselves without PromoService triggers
+    let triggers: Set<PromoTrigger> = []
+
+    /// External promos control when they will show; they don't respect PromoService cooldowns
+    let respectsGlobalCooldown: Bool = false
+
+    var delegate: (any AnyPromoDelegate)?
+
     init(id: String,
          initiated: PromoInitiated,
          promoType: PromoType,
@@ -91,12 +121,10 @@ struct Promo {
          setsGlobalCooldown: Bool = true,
          delegate: ExternalPromoDelegate? = nil) {
         self.id = id
-        self.triggers = [] // External promos show themselves without PromoService triggers
         self.initiated = initiated
         self.promoType = promoType
         self.context = context
         self.coexistingPromoIDs = coexistingPromoIDs
-        self.respectsGlobalCooldown = false // External promos define when they will show; they don't respect PromoService cooldowns
         self.setsGlobalCooldown = setsGlobalCooldown
         self.delegate = delegate
     }

--- a/macOS/DuckDuckGo/Promotions/PromoTypes/Promo.swift
+++ b/macOS/DuckDuckGo/Promotions/PromoTypes/Promo.swift
@@ -53,7 +53,7 @@ protocol Promo {
 
     /// Provides dynamic promo behavior (eligibility, show, hide).
     /// Delegate should be set by feature module when their dependencies are ready.
-    var delegate: (any AnyPromoDelegate)? { get set }
+    var delegate: (any PromoDelegate)? { get set }
 }
 
 /// Static metadata for an internal promo. Use this for most promos.
@@ -69,7 +69,7 @@ struct InternalPromo: Promo {
     let respectsGlobalCooldown: Bool
     let setsGlobalCooldown: Bool
 
-    var delegate: (any AnyPromoDelegate)?
+    var delegate: (any PromoDelegate)?
 
     init(id: String,
          triggers: Set<PromoTrigger>,
@@ -79,7 +79,7 @@ struct InternalPromo: Promo {
          coexistingPromoIDs: Set<String> = [],
          respectsGlobalCooldown: Bool = true,
          setsGlobalCooldown: Bool = true,
-         delegate: PromoDelegate? = nil) {
+         delegate: InternalPromoDelegate? = nil) {
         self.id = id
         self.triggers = triggers
         self.initiated = initiated
@@ -111,7 +111,7 @@ struct ExternalPromo: Promo {
     /// External promos control when they will show; they don't respect PromoService cooldowns
     let respectsGlobalCooldown: Bool = false
 
-    var delegate: (any AnyPromoDelegate)?
+    var delegate: (any PromoDelegate)?
 
     init(id: String,
          initiated: PromoInitiated,
@@ -128,61 +128,4 @@ struct ExternalPromo: Promo {
         self.setsGlobalCooldown = setsGlobalCooldown
         self.delegate = delegate
     }
-}
-
-/// Base protocol for all promo delegates. Used as the type-erased delegate type on `Promo`.
-///
-/// Conform to `PromoDelegate` for promos that PromoService controls (show, hide, eligibility).
-/// Conform to `ExternalPromoDelegate` for promos whose visibility is controlled by an external
-/// system (e.g. Remote Messaging Framework); PromoService only observes their visibility.
-protocol AnyPromoDelegate: AnyObject { }
-
-/// Delegate for promos that PromoService controls.
-///
-/// PromoService evaluates triggers, checks eligibility, and calls `show()` / `hide()` to manage
-/// visibility. The delegate provides eligibility state and implements the UI for showing and hiding.
-/// Conformances are set on `Promo` structs when feature modules are ready.
-protocol PromoDelegate: AnyPromoDelegate {
-    /// Current eligibility state. Use isEligiblePublisher to observe changes.
-    var isEligible: Bool { get }
-
-    /// Publisher indicating whether this promo is currently eligible.
-    /// Must emit a current value immediately on subscription (use CurrentValueSubject).
-    var isEligiblePublisher: AnyPublisher<Bool, Never> { get }
-
-    /// Called by PromoService before reading `isEligible` to give the delegate
-    /// a chance to recompute its eligibility state. Default: no-op.
-    func refreshEligibility()
-
-    /// Shows the promo. Returns when user interacts, promo retracts, or hide() is called.
-    /// Receives the promo's own history for result decisions (e.g. varying cooldown by timesDismissed).
-    /// Use `force` to force show the promo (for debug menu).
-    @MainActor
-    func show(history: PromoHistoryRecord, force: Bool) async -> PromoResult
-
-    /// Hides the promo. Must be idempotent.
-    /// PromoService calls hide() after recording any result, so a delegate that has
-    /// already hidden its own UI will receive a second hide() that should be a no-op.
-    @MainActor
-    func hide()
-}
-
-extension PromoDelegate {
-    func refreshEligibility() { }
-}
-
-/// Delegate for promos whose visibility is controlled outside PromoService.
-///
-/// PromoService subscribes to `isVisiblePublisher` to observe visibility, record history, and apply
-/// global cooldowns—it never calls `show()` or `hide()`.
-protocol ExternalPromoDelegate: AnyPromoDelegate {
-    /// Current visibility state. Use isVisiblePublisher to observe changes.
-    var isVisible: Bool { get }
-
-    /// Publisher indicating whether this promo is currently visible.
-    /// Must emit a current value immediately on subscription (use CurrentValueSubject).
-    var isVisiblePublisher: AnyPublisher<Bool, Never> { get }
-
-    /// Result to apply when the external promo is hidden.
-    var resultWhenHidden: PromoResult { get }
 }

--- a/macOS/DuckDuckGo/Promotions/PromoTypes/Promo.swift
+++ b/macOS/DuckDuckGo/Promotions/PromoTypes/Promo.swift
@@ -37,14 +37,16 @@ protocol Promo {
     var context: PromoContext { get }
 
     /// IDs of promos that can be visible simultaneously with this one.
+    ///
     /// Promos can appear together when all visible promos that would conflict
     /// are in this set and this promo is in all of theirs (mutual coexistence).
     /// This should be used only in very rare cases that are pre-validated (e.g. with a PFR).
+    /// External promos can always coexist with each other, but must use this property to coexist with internal promos.
     /// Default: empty (no coexistence exceptions).
     var coexistingPromoIDs: Set<String> { get }
 
     /// When false, this promo can show even if the global cooldown for its PromoInitiated type hasn't elapsed.
-    /// Default: true.
+    /// Default: true for internal promos; false for external promos.
     var respectsGlobalCooldown: Bool { get }
 
     /// When false, dismissing this promo does not count toward the global cooldown for its PromoInitiated type.

--- a/macOS/DuckDuckGo/Promotions/PromoTypes/PromoDelegate.swift
+++ b/macOS/DuckDuckGo/Promotions/PromoTypes/PromoDelegate.swift
@@ -1,0 +1,76 @@
+//
+//  PromoDelegate.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+
+/// Base protocol for all promo delegates. Used as the type-erased delegate type on `Promo`.
+///
+/// Conform to `InternalPromoDelegate` for promos that PromoService controls (show, hide, eligibility).
+/// Conform to `ExternalPromoDelegate` for promos whose visibility is controlled by an external
+/// system (e.g. Remote Messaging Framework); PromoService only observes their visibility.
+protocol PromoDelegate: AnyObject { }
+
+/// Delegate for promos that PromoService controls.
+///
+/// PromoService evaluates triggers, checks eligibility, and calls `show()` / `hide()` to manage
+/// visibility. The delegate provides eligibility state and implements the UI for showing and hiding.
+/// Conformances are set on `Promo` structs when feature modules are ready.
+protocol InternalPromoDelegate: PromoDelegate {
+    /// Current eligibility state. Use isEligiblePublisher to observe changes.
+    var isEligible: Bool { get }
+
+    /// Publisher indicating whether this promo is currently eligible.
+    /// Must emit a current value immediately on subscription (use CurrentValueSubject).
+    var isEligiblePublisher: AnyPublisher<Bool, Never> { get }
+
+    /// Called by PromoService before reading `isEligible` to give the delegate
+    /// a chance to recompute its eligibility state. Default: no-op.
+    func refreshEligibility()
+
+    /// Shows the promo. Returns when user interacts, promo retracts, or hide() is called.
+    /// Receives the promo's own history for result decisions (e.g. varying cooldown by timesDismissed).
+    /// Use `force` to force show the promo (for debug menu).
+    @MainActor
+    func show(history: PromoHistoryRecord, force: Bool) async -> PromoResult
+
+    /// Hides the promo. Must be idempotent.
+    /// PromoService calls hide() after recording any result, so a delegate that has
+    /// already hidden its own UI will receive a second hide() that should be a no-op.
+    @MainActor
+    func hide()
+}
+
+extension InternalPromoDelegate {
+    func refreshEligibility() { }
+}
+
+/// Delegate for promos whose visibility is controlled outside PromoService.
+///
+/// PromoService subscribes to `isVisiblePublisher` to observe visibility, record history, and apply
+/// global cooldowns—it never calls `show()` or `hide()`.
+protocol ExternalPromoDelegate: PromoDelegate {
+    /// Current visibility state. Use isVisiblePublisher to observe changes.
+    var isVisible: Bool { get }
+
+    /// Publisher indicating whether this promo is currently visible.
+    /// Must emit a current value immediately on subscription (use CurrentValueSubject).
+    var isVisiblePublisher: AnyPublisher<Bool, Never> { get }
+
+    /// Result to apply when the external promo is hidden.
+    var resultWhenHidden: PromoResult { get }
+}

--- a/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+DefaultBrowserAndDock.swift
+++ b/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+DefaultBrowserAndDock.swift
@@ -23,7 +23,7 @@ extension PromoServiceFactory {
     @MainActor
     static func defaultBrowserAndDockInactiveModal(service: DefaultBrowserAndDockPromptService) -> Promo {
         let delegate = DefaultBrowserAndDockPromoDelegate(type: .inactive, service: service)
-        return Promo(
+        return InternalPromo(
             id: "default-browser-and-dock-inactive-modal",
             triggers: [.windowBecameKey, .appLaunched],
             initiated: .app,
@@ -36,7 +36,7 @@ extension PromoServiceFactory {
     @MainActor
     static func defaultBrowserAndDockPopover(service: DefaultBrowserAndDockPromptService) -> Promo {
         let delegate = DefaultBrowserAndDockPromoDelegate(type: .active(.popover), service: service)
-        return Promo(
+        return InternalPromo(
             id: "default-browser-and-dock-popover",
             triggers: [.windowBecameKey, .appLaunched],
             initiated: .app,
@@ -49,7 +49,7 @@ extension PromoServiceFactory {
     @MainActor
     static func defaultBrowserAndDockBanner(service: DefaultBrowserAndDockPromptService) -> Promo {
         let delegate = DefaultBrowserAndDockPromoDelegate(type: .active(.banner), service: service)
-        return Promo(
+        return InternalPromo(
             id: "default-browser-and-dock-banner",
             triggers: [.windowBecameKey, .appLaunched],
             initiated: .app,

--- a/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+FreemiumDBP.swift
+++ b/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+FreemiumDBP.swift
@@ -27,7 +27,6 @@ extension PromoServiceFactory {
         initiated: .app,
         promoType: PromoType(.remoteMessage, customTimeoutInterval: .days(7), customTimeoutResult: .ignored(cooldown: .days(28))),
         context: .newTabPage,
-        coexistingPromoIDs: [],
         delegate: nil
     )
 }

--- a/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+FreemiumDBP.swift
+++ b/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+FreemiumDBP.swift
@@ -21,7 +21,7 @@ import Foundation
 extension PromoServiceFactory {
 
     /// Freemium DBP banner promo. Delegate is set when NTP is built.
-    static let freemiumDBP = Promo(
+    static let freemiumDBP = InternalPromo(
         id: "freemium-dbp-ntp-banner",
         triggers: [.newTabPageAppeared],
         initiated: .app,

--- a/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+NextSteps.swift
+++ b/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+NextSteps.swift
@@ -26,8 +26,6 @@ extension PromoServiceFactory {
         initiated: .app,
         promoType: PromoType(.nextSteps),
         context: .newTabPage,
-        coexistingPromoIDs: [],
-        setsGlobalCooldown: true,
         delegate: nil
     )
 }

--- a/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+NextSteps.swift
+++ b/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+NextSteps.swift
@@ -23,12 +23,10 @@ extension PromoServiceFactory {
     /// Next Steps promo (nextStepsList and nextSteps widgets). Delegate is set when NTP is built.
     static let nextSteps = Promo(
         id: "next-steps-cards",
-        triggers: [], // External promo (Next Steps cards) so no internal triggers
         initiated: .app,
         promoType: PromoType(.nextSteps),
         context: .newTabPage,
-        coexistingPromoIDs: [], // Coexistence between external promos is handled externally
-        respectsGlobalCooldown: false,
+        coexistingPromoIDs: [],
         setsGlobalCooldown: true,
         delegate: nil
     )

--- a/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+NextSteps.swift
+++ b/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+NextSteps.swift
@@ -21,7 +21,7 @@ import Foundation
 extension PromoServiceFactory {
 
     /// Next Steps promo (nextStepsList and nextSteps widgets). Delegate is set when NTP is built.
-    static let nextSteps = Promo(
+    static let nextSteps = ExternalPromo(
         id: "next-steps-cards",
         initiated: .app,
         promoType: PromoType(.nextSteps),

--- a/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+RemoteMessage.swift
+++ b/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+RemoteMessage.swift
@@ -29,8 +29,6 @@ extension PromoServiceFactory {
             initiated: .app,
             promoType: PromoType(.remoteMessage),
             context: .newTabPage,
-            coexistingPromoIDs: [], // No coexistence with internal promos; coexistence between external promos is handled externally
-            setsGlobalCooldown: true,
             delegate: delegate
         )
     }
@@ -43,8 +41,6 @@ extension PromoServiceFactory {
             initiated: .app,
             promoType: PromoType(.remoteMessage),
             context: .global,
-            coexistingPromoIDs: [], // No coexistence with internal promos; coexistence between external promos is handled externally
-            setsGlobalCooldown: true,
             delegate: delegate
         )
     }

--- a/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+RemoteMessage.swift
+++ b/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+RemoteMessage.swift
@@ -24,7 +24,7 @@ extension PromoServiceFactory {
     @MainActor
     static func remoteMessageNewTabPage(model: ActiveRemoteMessageModel) -> Promo {
         let delegate = RemoteMessagePromoDelegate(activeRemoteMessageModel: model, surface: .newTabPage)
-        return Promo(
+        return ExternalPromo(
             id: "remote-message-ntp",
             initiated: .app,
             promoType: PromoType(.remoteMessage),
@@ -38,7 +38,7 @@ extension PromoServiceFactory {
     @MainActor
     static func remoteMessageTabBar(model: ActiveRemoteMessageModel) -> Promo {
         let delegate = RemoteMessagePromoDelegate(activeRemoteMessageModel: model, surface: .tabBar)
-        return Promo(
+        return ExternalPromo(
             id: "remote-message-tabbar",
             initiated: .app,
             promoType: PromoType(.remoteMessage),

--- a/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+RemoteMessage.swift
+++ b/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+RemoteMessage.swift
@@ -26,12 +26,10 @@ extension PromoServiceFactory {
         let delegate = RemoteMessagePromoDelegate(activeRemoteMessageModel: model, surface: .newTabPage)
         return Promo(
             id: "remote-message-ntp",
-            triggers: [], // External promo (RemoteMessage) so no internal triggers
             initiated: .app,
             promoType: PromoType(.remoteMessage),
             context: .newTabPage,
-            coexistingPromoIDs: [], // Coexistence between external promos is handled externally
-            respectsGlobalCooldown: false,
+            coexistingPromoIDs: [], // No coexistence with internal promos; coexistence between external promos is handled externally
             setsGlobalCooldown: true,
             delegate: delegate
         )
@@ -42,12 +40,10 @@ extension PromoServiceFactory {
         let delegate = RemoteMessagePromoDelegate(activeRemoteMessageModel: model, surface: .tabBar)
         return Promo(
             id: "remote-message-tabbar",
-            triggers: [], // External promo (RemoteMessage) so no internal triggers
             initiated: .app,
             promoType: PromoType(.remoteMessage),
             context: .global,
-            coexistingPromoIDs: [], // Coexistence between external promos is handled externally
-            respectsGlobalCooldown: false,
+            coexistingPromoIDs: [], // No coexistence with internal promos; coexistence between external promos is handled externally
             setsGlobalCooldown: true,
             delegate: delegate
         )

--- a/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+SessionRestore.swift
+++ b/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+SessionRestore.swift
@@ -24,12 +24,10 @@ extension PromoServiceFactory {
         let delegate = SessionRestorePromoDelegate(coordinator: coordinator)
         return Promo(
             id: "session-restore",
-            triggers: [], // External promo; visibility driven by coordinator
             initiated: .app,
             promoType: PromoType(.semiModal),
             context: .global,
-            coexistingPromoIDs: [], // Coexistence between external promos is handled externally
-            respectsGlobalCooldown: false,
+            coexistingPromoIDs: [],
             setsGlobalCooldown: false,
             delegate: delegate
         )

--- a/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+SessionRestore.swift
+++ b/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+SessionRestore.swift
@@ -22,7 +22,7 @@ extension PromoServiceFactory {
 
     static func sessionRestore(coordinator: SessionRestorePromptCoordinating) -> Promo {
         let delegate = SessionRestorePromoDelegate(coordinator: coordinator)
-        return Promo(
+        return ExternalPromo(
             id: "session-restore",
             initiated: .app,
             promoType: PromoType(.semiModal),

--- a/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+SessionRestore.swift
+++ b/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+SessionRestore.swift
@@ -27,7 +27,6 @@ extension PromoServiceFactory {
             initiated: .app,
             promoType: PromoType(.semiModal),
             context: .global,
-            coexistingPromoIDs: [],
             setsGlobalCooldown: false,
             delegate: delegate
         )

--- a/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+SubscriptionPromo.swift
+++ b/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+SubscriptionPromo.swift
@@ -21,7 +21,7 @@ import Foundation
 extension PromoServiceFactory {
 
     static func subscriptionPromo(delegate: FireWindowSubscriptionPromoDelegate) -> Promo {
-        Promo(
+        ExternalPromo(
             id: "subscription-promo-fire-window",
             initiated: .app,
             promoType: PromoType(.banner),

--- a/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+SubscriptionPromo.swift
+++ b/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+SubscriptionPromo.swift
@@ -23,11 +23,9 @@ extension PromoServiceFactory {
     static func subscriptionPromo(delegate: FireWindowSubscriptionPromoDelegate) -> Promo {
         Promo(
             id: "subscription-promo-fire-window",
-            triggers: [], // External promo — visibility is driven by SubscriptionPromoViewModel
             initiated: .app,
             promoType: PromoType(.banner),
             context: .fireWindow,
-            respectsGlobalCooldown: false, // ViewModel handles its own display rules
             setsGlobalCooldown: false,
             delegate: delegate
         )

--- a/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+Test.swift
+++ b/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+Test.swift
@@ -42,7 +42,7 @@ extension PromoServiceFactory {
 
 /// Test promo delegate that shows an NSAlert with metadata, history, and result buttons.
 /// Used to exercise promo persistence across app restarts.
-final class TestPromoDelegate: PromoDelegate {
+final class TestPromoDelegate: InternalPromoDelegate {
     private let promo: Promo
     private var alert: NSAlert?
     private let isEligibleSubject = CurrentValueSubject<Bool, Never>(true)

--- a/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+Test.swift
+++ b/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+Test.swift
@@ -26,10 +26,10 @@ extension PromoServiceFactory {
     static var testPromos: [Promo] = {
         guard includeTestPromos else { return [] }
 
-        var testPromoA = Promo(id: "test-promo-a", triggers: [.testTriggered], initiated: .user, promoType: PromoType(.appModal), context: .newTabPage)
-        var testPromoB = Promo(id: "test-promo-b", triggers: [.testTriggered], initiated: .user, promoType: PromoType(.appModal), context: .webPage)
-        var testPromoC = Promo(id: "test-promo-c", triggers: [.testTriggered], initiated: .app, promoType: PromoType(.appModal), context: .global)
-        var testPromoD = Promo(id: "test-promo-d", triggers: [.testTriggered], initiated: .app, promoType: PromoType(.appModal, customTimeoutInterval: .seconds(3), customTimeoutResult: .ignored()), context: .global)
+        var testPromoA = InternalPromo(id: "test-promo-a", triggers: [.testTriggered], initiated: .user, promoType: PromoType(.appModal), context: .newTabPage)
+        var testPromoB = InternalPromo(id: "test-promo-b", triggers: [.testTriggered], initiated: .user, promoType: PromoType(.appModal), context: .webPage)
+        var testPromoC = InternalPromo(id: "test-promo-c", triggers: [.testTriggered], initiated: .app, promoType: PromoType(.appModal), context: .global)
+        var testPromoD = InternalPromo(id: "test-promo-d", triggers: [.testTriggered], initiated: .app, promoType: PromoType(.appModal, customTimeoutInterval: .seconds(3), customTimeoutResult: .ignored()), context: .global)
 
         testPromoA.delegate = TestPromoDelegate(for: testPromoA)
         testPromoB.delegate = TestPromoDelegate(for: testPromoB)

--- a/macOS/UnitTests/Promotions/Mocks/MockPromoDelegate.swift
+++ b/macOS/UnitTests/Promotions/Mocks/MockPromoDelegate.swift
@@ -20,7 +20,7 @@ import Combine
 import Foundation
 @testable import DuckDuckGo_Privacy_Browser
 
-final class MockPromoDelegate: PromoDelegate {
+final class MockPromoDelegate: InternalPromoDelegate {
 
     let isEligibleSubject: CurrentValueSubject<Bool, Never>
     var isEligible: Bool {

--- a/macOS/UnitTests/Promotions/PromoTestHelpers.swift
+++ b/macOS/UnitTests/Promotions/PromoTestHelpers.swift
@@ -31,9 +31,9 @@ enum PromoTestHelpers {
         coexistingPromoIDs: Set<String> = [],
         respectsGlobalCooldown: Bool = true,
         setsGlobalCooldown: Bool = true,
-        delegate: (any AnyPromoDelegate)? = nil
+        delegate: InternalPromoDelegate? = nil
     ) -> Promo {
-        Promo(
+        InternalPromo(
             id: id,
             triggers: triggers,
             initiated: initiated,
@@ -41,6 +41,26 @@ enum PromoTestHelpers {
             context: context,
             coexistingPromoIDs: coexistingPromoIDs,
             respectsGlobalCooldown: respectsGlobalCooldown,
+            setsGlobalCooldown: setsGlobalCooldown,
+            delegate: delegate
+        )
+    }
+
+    static func makePromo(
+        id: String = "test-promo",
+        initiated: PromoInitiated = .app,
+        promoType: PromoType = PromoType(.banner),
+        context: PromoContext = .global,
+        coexistingPromoIDs: Set<String> = [],
+        setsGlobalCooldown: Bool = true,
+        delegate: ExternalPromoDelegate
+    ) -> Promo {
+        ExternalPromo(
+            id: id,
+            initiated: initiated,
+            promoType: promoType,
+            context: context,
+            coexistingPromoIDs: coexistingPromoIDs,
             setsGlobalCooldown: setsGlobalCooldown,
             delegate: delegate
         )


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214605639506217?focus=true
Tech Design URL:
CC:

### Description

Currently, there is some potential for confusion around internal vs. external promos:

- Some of the `Promo` properties are irrelevant for external promos (`triggers`, `respectsGlobalCooldown`)
- The naming doesn't make it clear whether a given promo is internal or external; it entirely depends on the selected `delegate` type.

This defines internal and external promos explicitly as different types, with constants for promo properties that are unchanging for external promos. This will reduce potential confusion and simplify the process for adding new promos.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Confirm tests pass.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Medium: Could disrupt specific features or user flows

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
* Wrong promo type for existing promos
   * Risk: With the renamed promo types, all promos in the promo queue (previously `Promo` type) were given explicit `InternalPromo` and `ExternalPromo` types; this affects how the promo is treated by the queue.
   * Mitigations: All promos have a delegate with an explicit internal/external type, and no changes were made to the delegates set for each promo aside from directly renaming PromoDelegate to InternalPromoDelegate for internal promos. A promo/delegate mismatch would cause a compiler error.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors core promo-queue types and delegate plumbing; misclassification or default-value changes could alter when promos appear, cooldown behavior, or debug force-show behavior.
> 
> **Overview**
> Clarifies promo-queue modeling by replacing the old `Promo` struct + type-erased `AnyPromoDelegate` with a `Promo` protocol and two concrete types: `InternalPromo` (trigger/eligibility managed by `PromoService`) and `ExternalPromo` (visibility controlled externally, with fixed defaults like no triggers and no global cooldown respect).
> 
> Introduces explicit delegate protocols (`InternalPromoDelegate` vs `ExternalPromoDelegate`) in a new `PromoDelegate.swift`, updates `PromoService`/`PromoDebugMenu` to only `show`/`hide`/force-show internal delegates, and migrates all promo factories and tests to the correct promo type and delegate protocol.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7fc698f40768b468165208ca5bf4a5b5fa2afce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->