### PR TITLE
Fix idle-return NTP layout when Escape Hatch targets a Duck.ai tab

### DIFF
--- a/iOS/DuckDuckGo/MainViewCoordinator.swift
+++ b/iOS/DuckDuckGo/MainViewCoordinator.swift
@@ -228,6 +228,11 @@ class MainViewCoordinator {
 
         navigationBarContainer.bringSubviewToFront(unifiedToggleInputContainer)
 
+        if addressBarPosition == .top {
+            setNavBarContainerBottomToToolbar()
+            setAddressBarBottomActive(false)
+            setAddressBarTopActive(true)
+        }
         constraints.navigationBarContainerHeight.constant = expandedHeight
         superview.layoutIfNeeded()
     }

--- a/iOS/DuckDuckGo/MainViewCoordinator.swift
+++ b/iOS/DuckDuckGo/MainViewCoordinator.swift
@@ -229,8 +229,8 @@ class MainViewCoordinator {
         navigationBarContainer.bringSubviewToFront(unifiedToggleInputContainer)
 
         if addressBarPosition == .top {
-            setNavBarContainerBottomToToolbar()
             setAddressBarBottomActive(false)
+            setNavBarContainerBottomToToolbar(active: false)
             setAddressBarTopActive(true)
         }
         constraints.navigationBarContainerHeight.constant = expandedHeight
@@ -492,14 +492,14 @@ class MainViewCoordinator {
         constraints.contentContainerBottomToSafeArea.isActive = mode == .safeArea
     }
 
-    private func setNavBarContainerBottomToToolbar() {
+    private func setNavBarContainerBottomToToolbar(active: Bool = true) {
         constraints.navigationBarContainerBottom.isActive = false
         constraints.navigationBarContainerBottomSafeAreaFloor?.isActive = false
         constraints.navigationBarContainerBottomSafeAreaFloor = nil
         constraints.navigationBarContainerBottom = navigationBarContainer.bottomAnchor
             .constraint(equalTo: toolbar.topAnchor)
         constraints.navigationBarContainerBottom.constant = 0
-        constraints.navigationBarContainerBottom.isActive = true
+        constraints.navigationBarContainerBottom.isActive = active
         isNavBarContainerBottomKeyboardBased = false
     }
 

--- a/iOS/DuckDuckGo/NewTabPageView.swift
+++ b/iOS/DuckDuckGo/NewTabPageView.swift
@@ -162,6 +162,7 @@ private extension NewTabPageView {
 
     private var shouldShowLogoInEmptyState: Bool {
         guard messagesModel.homeMessageViewModels.isEmpty && !messagesModel.isFirePromotionVisible else { return false }
+        if viewModel.escapeHatch?.tabType == .aiChat { return false }
         if viewModel.escapeHatch != nil && isLandscapeOrientation { return false }
         if viewModel.escapeHatch != nil && isFocussedState { return false }
         return true

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -669,7 +669,8 @@ final class UnifiedInputContentContainerViewController: UIViewController {
             hasFavorites: suggestionTrayManager?.hasFavorites ?? false,
             hasRemoteMessages: suggestionTrayManager?.hasRemoteMessages ?? false
         )
-        let isHomeDaxVisible = daxLogoManager.shouldShowHomeDax(homeDaxInputs)
+        let isSearchMode = switchBarHandler.currentToggleState == .search
+        let isHomeDaxVisible = isSearchMode && daxLogoManager.shouldShowHomeDax(homeDaxInputs)
         let isAIDaxVisible = !hasContent && !isShowingDuckAISuggestions && !isDuckAISuggestionsPending
 
         daxLogoManager.updateVisibility(isHomeDaxVisible: isHomeDaxVisible, isAIDaxVisible: isAIDaxVisible)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214640741766083?focus=true
Tech Design URL:
CC:

### Description
**Root cause:**
- When returning from background to a Duck.ai chat tab, the app attaches an NTP-after-idle whose Escape Hatch points back to that Duck.ai tab. The previous AI-tab path activated the bottom address-bar constraints. `MainViewCoordinator.showUnifiedToggleInputOmnibar` didn't reset them, so the unified input stayed anchored to the bottom even when the user's address bar setting is **Top**. 
- Two independent visual layers stacked the home logo on top of Duck.ai content: the UTI `DaxLogoManager` computed `isHomeDaxVisible=true` regardless of the toggle, and `NewTabPageView` rendered the classic DuckDuckGo logo for any escape hatch type.

**Changes**
- `MainViewCoordinator.showUnifiedToggleInputOmnibar`: when `addressBarPosition == .top`, reset to top anchor (top active, bottom inactive, bottom-to-toolbar) before laying out.
- `UnifiedInputContentContainerViewController.updateDaxVisibility`: gate `isHomeDaxVisible` on `currentToggleState == .search` ([Duck.ai](http://duck.ai/)'s empty state is already handled by `isAIDaxVisible`).
- `NewTabPageView.shouldShowLogoInEmptyState`: hide the classic NTP logo when `viewModel.escapeHatch?.tabType == .aiChat`.


### Testing Steps
### Steps to reproduce the bug
1. Set address bar position to top
2. Tap on address bar to go into focus mode, switch to [Duck.ai](http://duck.ai/) 
3. Open a [Duck.ai](http://duck.ai/) chat -> that’s important part! This bug is not reproducible on other websites (see root cause)
4. Background the app long enough to trigger NTP-after-idle, then foreground.
5. Verify the NTP-after-idle screen.
   1. Before: UI was corrupted
   2. After: UI is rendered properly

| #   | Address bar        | Toggle  | Content state | Setup notes                                  | Pass criteria                                                |
|-----|--------------------|---------|---------------|----------------------------------------------|--------------------------------------------------------------|
| 1   | Top                | Search  | Empty         | No favorites                                 | Hatch below the input renders correctly                      |
| 2   | Top                | Search  | Favorites     | At least one favorite saved                  | Hatch below the input renders correctly. Favorites grid renders below the hatch, no logo overlap. |
| 3   | Top                | [Duck.ai](http://duck.ai/) | Empty         | No recent [Duck.ai](http://duck.ai/) chats                      | Hatch below the input renders correctly.                     |
| 4   | Top                | [Duck.ai](http://duck.ai/) | Recent Chats  | At least one recent [Duck.ai](http://duck.ai/) chat in history  | Hatch below the input renders correctly. <br>Recent Chats list visible below the hatch. |
| 5   | Bottom             | Search  | Empty         | As 1, address bar at bottom                  | Hatch renders at top of the screen, native input at the bottom |
| 6   | Bottom             | Search  | Favorites     | At least one favorite saved                  | Hatch renders at top of the screen, native input at the bottom. Favs rendered below hatch |
| 7   | Bottom             | [Duck.ai](http://duck.ai/) | Empty         | As 3, address bar at bottom                  | Hatch renders at top of the screen, native input at the bottom |
| 8   | Bottom             | [Duck.ai](http://duck.ai/) | Recent Chats  | As 4, address bar at bottom                  | Hatch renders at top of the screen, native input at the bottom. <br>Recent Chats list visible below the hatch. |
| 9   | Landscape (iPhone) | Search  | Empty         | Rotate device to landscape after idle return | Hatch renders correctly. NTP logo hidden (existing landscape behavior). |
| 10  | Landscape (iPhone) | Search  | Favorites     | As 9 with favorites set up                   | Hatch renders correctly. Favs grid as well. NTP logo hidden (existing landscape behavior). |
| 11  | Landscape (iPhone) | [Duck.ai](http://duck.ai/) | Empty         | As 9 with [Duck.ai](http://duck.ai/) mode                       | Hatch renders correctly                                      |
| 12  | Landscape (iPhone) | [Duck.ai](http://duck.ai/) | Recent Chats  | As 11 with chat history                      | Hatch renders at top of the screen.<br>Recent Chats list visible below the hatch. |

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
4. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
**Impact level: Low.** The change is bug-fix only, no data path or privacy surface is touched.

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
- **Constraints reset in `showUnifiedToggleInputOmnibar`:** scoped to `addressBarPosition == .top`, no-op for bottom-bar users (their constraints were already correct from the AI tab path). Mirrors the address-bar setting and uses the same internal helpers (`setNavBarContainerBottomToToolbar`, `setAddressBar*Active`) already exercised by `moveAddressBarToPosition`.
- **HomeDax gated on Search:** Search-mode behavior is identical; [Duck.ai](http://duck.ai/) mode previously could show the home Dax incorrectly while [Duck.ai](http://duck.ai/) content was visible. The [Duck.ai](http://duck.ai/) empty state is still covered by the existing `isAIDaxVisible` slot, so no regression to [Duck.ai](http://duck.ai/)'s empty UX.
- **Classic NTP logo guard:** narrowly conditioned on `escapeHatch?.tabType == .aiChat`. No effect on the standard empty NTP (no escape hatch), favorites NTP, or escape hatches targeting regular/fire web tabs (logo still appears there as before).

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->
- **Edge cases:** verified across the 12-row manual matrix (top / bottom / landscape × Search / [Duck.ai](http://duck.ai/) × empty / populated)
- **Performance:** no new work paths; only constraint flips at existing transition points already exercised by the omnibar editing flow.
- **Privacy/security:** none — UI-layer only.
- **Monitoring:** no new pixels needed; fix is a deterministic layout/visibility guard.
- **Documentation:** none — no public API, feature flag, or user-facing behavior surface changes.

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes: adjusts Auto Layout constraint activation and logo visibility conditions, with no data, privacy, or auth impact. Main risk is unintended layout regressions across top/bottom address bar modes during omnibar transitions.
> 
> **Overview**
> Fixes an idle-return layout corruption when an NTP escape hatch points to a Duck.ai chat tab while the user’s address bar is set to **Top**.
> 
> `MainViewCoordinator.showUnifiedToggleInputOmnibar` now explicitly reactivates top-bar constraints (and deactivates bottom/toolbar anchoring) before layout, and `setNavBarContainerBottomToToolbar` can be installed without activating its constraint.
> 
> Prevents duplicate/incorrect logos on Duck.ai-targeted NTPs by hiding the classic NTP logo for `.aiChat` escape hatches and by only showing the Home Dax logo in `UnifiedInputContentContainerViewController.updateDaxVisibility` when the current toggle mode is `.search`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5339b06db9d4c149a5369433b033d18479d1232. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->