### PR TITLE
Toggle feature flag for onboarding rebranding

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -186,6 +186,9 @@ public enum MacOSBrowserConfigSubfeature: String, PrivacySubfeature {
     case addToDockAppStore
 
     case screenTimeCleaning
+
+    /// https://app.asana.com/1/137249556945/project/1211264967278501/task/1211806114021633?focus=true
+    case onboardingRebranding
 }
 
 public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -407,7 +407,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .contextualOnboarding:
             Config(defaultValue: .enabled, source: .remoteReleasable(.subfeature(ContextualOnboardingSubfeature.featureEnabled)), supportsLocalOverriding: false)
         case .onboardingRebranding:
-            Config(source: .disabled)
+            Config(defaultValue: .enabled, source: .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.onboardingRebranding)))
         case .unknownUsernameCategorization:
             Config(source: .remoteReleasable(.subfeature(AutofillSubfeature.unknownUsernameCategorization)), supportsLocalOverriding: false)
         case .credentialsImportPromotionForExistingUsers:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211264967278501/task/1214643189402576?focus=true
Tech Design URL:
CC:

### Description

This PR simply enables the feature flag for the macOS contextual onboarding design updates.

### Testing Steps

1. Build and run the Mac browser
2. From the debug menu, check the `onboardingRebranding` feature flag is enabled
3. You could also use Debug > Reset Data > Reset Contextual Onboarding / Reset Onboarding and verify that you see the new styles in onboarding.

### Impact and Risks

Low: Minor visual changes, small bug fixes, improvement to existing features

Low, as long as we’re happy shipping the new style.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds a new privacy-config subfeature key and switches the macOS `onboardingRebranding` feature flag to be enabled and remotely configurable; behavior changes are limited to gated onboarding UI.
> 
> **Overview**
> **Enables the macOS onboarding rebranding feature flag.** The `onboardingRebranding` flag now defaults to *enabled* and is backed by a remote-releasable privacy-config subfeature (`MacOSBrowserConfigSubfeature.onboardingRebranding`) instead of being hard-disabled.
> 
> Adds the corresponding `onboardingRebranding` subfeature case to `PrivacyConfig`’s `MacOSBrowserConfigSubfeature` enum so it can be controlled via configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 177f99e8d7199b31b275212803f1b924f2b0993c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->