### PR TITLE
macOS: Clear stale Duck.ai page context on remove and navigation

### DIFF
--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -118,8 +118,11 @@ final class PageContextTabExtension {
                 self.content = tabContent
                 // Reset user-removed suppression when navigating to a new URL so
                 // auto-collect resumes on the next page, regardless of feature flag state.
+                // Also drop the previous page's cached context so a stale snapshot
+                // can't be re-pushed to the sidebar before the new page is collected.
                 if case .url = tabContent {
                     self.userRemovedContext = false
+                    self.cachedPageContext = nil
                 }
                 self.handleNavigationForMultipleContexts(from: previousContent, to: tabContent)
                 self.sendNonAttachableContextIfNeeded()
@@ -220,7 +223,13 @@ final class PageContextTabExtension {
         session.pageContextRemovedPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
-                self?.userRemovedContext = true
+                guard let self else { return }
+                self.userRemovedContext = true
+                self.cachedPageContext = nil
+                // Also clear the stored pageContext inside messageHandling. Otherwise a
+                // subsequent FE `getAIChatPageContext(reason: userAction)` would return
+                // the stale snapshot and skip requesting a fresh collect.
+                self.aiChatSessionStore.sessions[self.tabID]?.chatViewController?.setPageContext(nil)
             }
             .store(in: &sidebarCancellables)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1214638317790753
Tech Design URL:
CC:

### Description

The Duck.ai page-context chip displayed the previous page's title after the user removed the chip and then re-attached on a new URL. Repro: visit a.com → Attach page content (chip shows a.com) → Remove → navigate to b.com → Attach → chip still shows a.com.

Root cause: `AIChatTabExtension.submitAIChatPageContext` stores the page context inside `AIChatMessageHandler.pageContextHandler` (in addition to pushing it to the FE) so the sidebar can read it via `getAIChatPageContext` on first load. That stored copy was never cleared on user removal. So when the user clicked Attach on b.com, the FE called `getAIChatPageContext(reason: "userAction")`, native returned the still‑stored a.com snapshot, and because `pageContext != nil` the `pageContextRequestedSubject.send()` branch was skipped — no fresh collect happened and the FE rendered the stale chip.

Fix in `PageContextTabExtension`:
- On `pageContextRemovedPublisher`: nil the local `cachedPageContext` and push `setPageContext(nil)` through the chat view controller so `messageHandling.pageContextHandler` is reset (nil → `pageContextHandler.reset()`).
- On URL change in the `contentPublisher` sink: nil the local `cachedPageContext` so a stale snapshot can't be re-pushed by the sidebar-reappear path or the multi-contexts `.keepExistingContext` branch.

### Testing Steps
1. Open the Duck.ai sidebar with the **Automatically send page content** AI Features setting **off**.
2. Visit `https://www.nytimes.com/` → click **Attach page content** → confirm chip shows the nytimes title.
3. Remove the chip.
4. Navigate to a different URL → click **Attach page content** again → chip should show the *new* page's title (not nytimes).
5. Repeat with the same setting **on**: navigate between pages and confirm the chip auto-updates to each new page; no flicker or stale value.
6. Reload the same URL while a chip is attached → chip should still show the same page (reload preserves attachment thanks to `removeDuplicates()`).
7. Open the sidebar fresh on a tab whose previous page had a chip attached, then was removed → chip stays gone; clicking Attach collects the current page.

### Impact and Risks

Low. The change touches one file (`PageContextTabExtension`), adds ~10 lines, and the two `cachedPageContext = nil` resets are immediately followed by either a fresh collect (auto-collect) or an explicit nil push to the FE (user remove). Same-URL reloads are filtered by the existing `removeDuplicates()` on the content publisher so cache is preserved across reloads.

#### What could go wrong?

- **Auto-collect mode regression?** Verified manually — every navigation goes through `handle` with the new page's URL and pushes the correct context to the FE. The brief nil window in the `contentPublisher` sink does not leak to the FE because we only nil the *local* cache there.
- **Sidebar (re)appears between navigation and fresh collect?** With nil cache the existing `sendNonAttachableContextIfNeeded()` early-returns on URL pages, so the FE simply receives the next fresh collect — no worse than a fresh tab.
- **Same-URL reload would clear the chip?** `removeDuplicates()` on `contentPublisher` filters duplicate `.url(same_url)` emissions before the sink runs, so reloads preserve attachment.

### Quality Considerations

- No new dependencies, no new files.
- Existing macOS unit tests under `macOS/UnitTests/AIChat/` continue to pass; none of them assert the previous "cache survives navigation" behavior.

### Notes to Reviewer

The key insight is the dual storage in `AIChatTabExtension.submitAIChatPageContext` (AIChatTabExtension.swift:226-228): each call both pushes to the FE *and* stores in `messageHandling.pageContextHandler`, where the data is only ever cleared by `consumeData()` (i.e. when the FE explicitly asks). On user removal the local cache was being cleared (implicitly via `userRemovedContext`) but the stored copy was not, so `getAIChatPageContext` could keep returning the stale snapshot.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized changes to page-context caching/clearing that primarily affect sidebar attachment state; main risk is a regression in when context is available during navigation/removal.
> 
> **Overview**
> Prevents the Duck.ai sidebar from reusing *stale* page-context snapshots after navigation or after the user removes the page-context chip.
> 
> On URL changes, `PageContextTabExtension` now clears `cachedPageContext` (and resets `userRemovedContext`) so an old snapshot can’t be re-sent before a fresh collect. On user removal, it also clears both the local cache and the sidebar’s stored context via `chatViewController.setPageContext(nil)` to ensure subsequent “Attach page content” triggers a new collection instead of returning the previous page’s data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbf2b6b936b7e52e7bc03a7b7fe6b6f208823c67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->