### PR TITLE
[macOS] Skip tab suspension pixel when there are no tabs to inspect

### DIFF
--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabSuspensionService.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabSuspensionService.swift
@@ -133,11 +133,13 @@ final class TabSuspensionService {
         Logger.tabSuspension.info("Critical memory pressure event received, starting tab suspension")
 
         let cutoffDate = dateProvider().addingTimeInterval(-minimumInactiveInterval)
+        var didInspectAnyTab = false
         var suspendedCount = 0
         var reclaimedBytes: UInt64 = 0
 
         for viewModel in windowControllersManager.allTabCollectionViewModels where !viewModel.isBurner {
             for (index, tab) in viewModel.tabCollection.tabs.enumerated() where !tab.isSuspended {
+                didInspectAnyTab = true
                 if tab.lastSelectedAt == nil || tab.lastSelectedAt! < cutoffDate {
                     let webProcessMemory: UInt64 = {
                         guard case let .loaded(loadedTab) = tab,
@@ -154,6 +156,11 @@ final class TabSuspensionService {
                     }
                 }
             }
+        }
+
+        guard didInspectAnyTab else {
+            Logger.tabSuspension.info("No tabs to inspect for suspension")
+            return
         }
 
         guard suspendedCount > 0 else {

--- a/macOS/UnitTests/TabBar/ViewModel/TabSuspensionServiceTests.swift
+++ b/macOS/UnitTests/TabBar/ViewModel/TabSuspensionServiceTests.swift
@@ -237,6 +237,28 @@ final class TabSuspensionServiceTests: XCTestCase {
         XCTAssertEqual(call?.frequency, .dailyAndCount)
     }
 
+    func testWhenNoWindowsOpen_ThenPixelIsNotFired() {
+        featureFlagger.enabledFeatureFlags = [.tabSuspension]
+        sut = makeSUT(tabCollectionViewModels: [])
+
+        postMemoryPressure()
+
+        XCTAssertTrue(mockPixelFiring.fireCalls.isEmpty)
+    }
+
+    func testWhenOnlyBurnerWindowsOpen_ThenPixelIsNotFired() {
+        featureFlagger.enabledFeatureFlags = [.tabSuspension]
+        let burnerMode = BurnerMode(isBurner: true)
+        let tab = Tab(content: .url(.duckDuckGo, credential: nil, source: .link), extensionsBuilder: tabExtensionsBuilder, featureFlagger: featureFlagger, burnerMode: burnerMode, lastSelectedAt: now.addingTimeInterval(-20 * 60))
+        let tabCollection = TabCollection(tabs: [tab])
+        let vm = TabCollectionViewModel(tabCollection: tabCollection, pinnedTabsManagerProvider: PinnedTabsManagerProvidingMock(), burnerMode: burnerMode)
+        sut = makeSUT(tabCollectionViewModels: [vm])
+
+        postMemoryPressure()
+
+        XCTAssertTrue(mockPixelFiring.fireCalls.isEmpty)
+    }
+
     func testWhenFeatureFlagDisabled_ThenPixelIsNotFired() {
         featureFlagger.enabledFeatureFlags = []
         let tab = Tab(content: .url(.duckDuckGo, credential: nil, source: .link), extensionsBuilder: tabExtensionsBuilder, featureFlagger: featureFlagger, lastSelectedAt: now.addingTimeInterval(-20 * 60))


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214688752138156?focus=true

### Description

When a critical memory pressure event arrives but the user has no app windows open (or only burner windows), we currently still fire the `m_mac_tab_suspension` pixel with zero counts. That happens often — users frequently close all app windows but keep the app running — and the pixel can't carry any useful signal in that state.

This PR skips the pixel when no non-burner, non-already-suspended tabs are inspected. The zero-count pixel still fires when tabs exist but none qualify for suspension (so we keep visibility into "memory pressure fired but nothing was eligible").

### Testing Steps

1. Run the app and filter logs by m_mac_tab_suspension
2. Close all windows
3. Go to Main Menu -> Debug -> Memory Usage Reporting -> Simulate Memory Pressure (Critical)
4. Verify that the pixel wasn't sent.
5. Open a window and repeat step 3 - verify that the pixel was sent.

### Impact and Risks

Low — pixel volume change only; no behavioral effect on tab suspension itself.

#### What could go wrong?

We lose the signal "memory pressure fired while app had no windows." That's intentional: the pixel can't drive any action in that case, and the noise was crowding out signal from sessions where suspension actually matters.

### Notes to Reviewer

The early-return is gated on a `didInspectAnyTab` bool set inside the inner loop, so it correctly skips the pixel whether the cause is zero windows, only burner windows, or only already-suspended tabs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only gate pixel emission on whether any non-burner, non-suspended tabs were iterated during memory-pressure handling; tab suspension behavior is otherwise unchanged.
> 
> **Overview**
> **Stops emitting noisy tab-suspension telemetry when there’s nothing to evaluate.** On critical memory pressure, `TabSuspensionService` now tracks whether any eligible tabs were *inspected* and early-returns (with a log) if there are none (e.g., no windows, only burner windows, or all tabs already suspended).
> 
> The existing behavior of firing the `m_mac_tab_suspension` pixel with zero counts is preserved when tabs exist but none meet the inactivity cutoff. Unit tests add coverage for the “no windows” and “only burner windows” cases to ensure the pixel is not fired.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1422b1c5982c796977d5a137df4641f27f2cc290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->