### PR TITLE
[Freemium PIR] Ship Review fixes

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL.swift
@@ -185,6 +185,21 @@ extension SubscriptionURL {
     }
 }
 
+public enum SubscriptionPurchaseFlowPath: String, CaseIterable {
+    case purchase = "/subscriptions"
+    case plans = "/subscriptions/plans"
+    case pro = "/pro"
+    case proPlans = "/pro/plans"
+
+    public static func contains(_ path: String) -> Bool {
+        allCases.contains { $0.rawValue == path }
+    }
+
+    public static func isPlansPath(_ path: String) -> Bool {
+        path == plans.rawValue || path == proPlans.rawValue
+    }
+}
+
 extension SubscriptionURL {
     public enum FeaturePage {
         public static let winback = "winback"

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
@@ -127,6 +127,21 @@ final class SubscriptionURLTests: XCTestCase {
         XCTAssertEqual(url, expectedURL)
     }
 
+    func testSubscriptionPurchaseFlowPathContainsPath() throws {
+        XCTAssertTrue(SubscriptionPurchaseFlowPath.contains("/subscriptions"))
+        XCTAssertTrue(SubscriptionPurchaseFlowPath.contains("/subscriptions/plans"))
+        XCTAssertTrue(SubscriptionPurchaseFlowPath.contains("/pro"))
+        XCTAssertTrue(SubscriptionPurchaseFlowPath.contains("/pro/plans"))
+        XCTAssertFalse(SubscriptionPurchaseFlowPath.contains("/subscriptions/manage"))
+    }
+
+    func testSubscriptionPurchaseFlowPathIdentifiesPlansPaths() throws {
+        XCTAssertTrue(SubscriptionPurchaseFlowPath.isPlansPath("/subscriptions/plans"))
+        XCTAssertTrue(SubscriptionPurchaseFlowPath.isPlansPath("/pro/plans"))
+        XCTAssertFalse(SubscriptionPurchaseFlowPath.isPlansPath("/subscriptions"))
+        XCTAssertFalse(SubscriptionPurchaseFlowPath.isPlansPath("/pro"))
+    }
+
     func testCustomBaseSubscriptionURLForPlansURL() throws {
         // Given
         let customBaseURL = URL(string: "https://dax.duck.co/subscriptions")!

--- a/iOS/DuckDuckGo/AppServices/DBPService.swift
+++ b/iOS/DuckDuckGo/AppServices/DBPService.swift
@@ -24,6 +24,7 @@ import Common
 import BrowserServicesKit
 import PixelKit
 import Networking
+import Subscription
 
 final class DBPService: NSObject {
     private let dbpIOSManager: DataBrokerProtectionIOSManager?
@@ -81,7 +82,7 @@ final class DBPService: NSObject {
                 subscriptionManager: dbpSubscriptionManager,
                 quickLinkOpenURLHandler: { url in
                     if let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-                       components.path == "/subscriptions" || components.path == "/subscriptions/plans" {
+                       SubscriptionPurchaseFlowPath.contains(components.path) {
                         let urlInterceptor = TabURLInterceptorDefault(featureFlagger: appDependencies.featureFlagger) {
                             appDependencies.subscriptionManager.isSubscriptionPurchaseEligible
                         }

--- a/iOS/DuckDuckGo/AppServices/DBPService.swift
+++ b/iOS/DuckDuckGo/AppServices/DBPService.swift
@@ -80,6 +80,15 @@ final class DBPService: NSObject {
                 wideEvent: appDependencies.wideEvent,
                 subscriptionManager: dbpSubscriptionManager,
                 quickLinkOpenURLHandler: { url in
+                    if let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+                       components.path == "/subscriptions" || components.path == "/subscriptions/plans" {
+                        let urlInterceptor = TabURLInterceptorDefault(featureFlagger: appDependencies.featureFlagger) {
+                            appDependencies.subscriptionManager.isSubscriptionPurchaseEligible
+                        }
+
+                        guard urlInterceptor.allowsNavigatingTo(url: url) else { return }
+                    }
+
                     guard let quickLinkURL = URL(string: AppDeepLinkSchemes.quickLink.appending(url.absoluteString)) else { return }
                     UIApplication.shared.open(quickLinkURL)
                 },

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2906,7 +2906,7 @@ class MainViewController: UIViewController {
                 } else {
                     deepLinkTarget = .subscriptionFlow()
                 }
-                self?.launchSettings(deepLinkTarget: deepLinkTarget)
+                self?.launchSettingsForSubscriptionInterception(deepLinkTarget)
 
             }
             .store(in: &urlInterceptorCancellables)
@@ -2932,6 +2932,13 @@ class MainViewController: UIViewController {
                 }
             }
             .store(in: &urlInterceptorCancellables)
+    }
+
+    private func launchSettingsForSubscriptionInterception(_ deepLinkTarget: SettingsViewModel.SettingsDeepLinkSection) {
+        // If Settings is already presented, launchSettings reuses its view model; trigger the deep link explicitly.
+        launchSettings(completion: {
+            $0.triggerDeepLinkNavigation(to: deepLinkTarget)
+        }, deepLinkTarget: deepLinkTarget)
     }
 
     private func subscribeToSettingsDeeplinkNotifications() {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2898,7 +2898,7 @@ class MainViewController: UIViewController {
             .sink { [weak self] notification in
                 let deepLinkTarget: SettingsViewModel.SettingsDeepLinkSection
                 if let redirectURLComponents = notification.userInfo?[TabURLInterceptorParameter.interceptedURLComponents] as? URLComponents {
-                    if redirectURLComponents.path == "/subscriptions/plans" || redirectURLComponents.path == "/pro/plans" {
+                    if SubscriptionPurchaseFlowPath.isPlansPath(redirectURLComponents.path) {
                         deepLinkTarget = .subscriptionPlanChangeFlow(redirectURLComponents: redirectURLComponents)
                     } else {
                         deepLinkTarget = .subscriptionFlow(redirectURLComponents: redirectURLComponents)

--- a/iOS/DuckDuckGo/TabURLInterceptor.swift
+++ b/iOS/DuckDuckGo/TabURLInterceptor.swift
@@ -56,12 +56,9 @@ final class TabURLInterceptorDefault: TabURLInterceptor {
         self.aichatIPadTabFeature = aichatIPadTabFeature ?? AIChatIPadTabFeature(featureFlagger: featureFlagger)
     }
 
-    static let interceptedURLs: [InterceptedURLInfo] = [
-        InterceptedURLInfo(id: .subscription, path: "/pro"),
-        InterceptedURLInfo(id: .subscription, path: "/pro/plans"),
-        InterceptedURLInfo(id: .subscription, path: "/subscriptions"),
-        InterceptedURLInfo(id: .subscription, path: "/subscriptions/plans")
-    ]
+    static let interceptedURLs: [InterceptedURLInfo] = SubscriptionPurchaseFlowPath.allCases.map {
+        InterceptedURLInfo(id: .subscription, path: $0.rawValue)
+    }
     
     func allowsNavigatingTo(url: URL) -> Bool {
         if url.isDuckAIURL && !aichatFullModeFeature.isAvailable && !aichatIPadTabFeature.isAvailable {

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -1666,7 +1666,7 @@ public struct UserText {
 
     public static let settingsPProVPNTitle = NSLocalizedString("settings.subscription.VPN.title", value: "VPN", comment: "VPN cell title for privacy pro")
     public static let settingsPProDBPTitle = NSLocalizedString("settings.subscription.DBP.title", value: "Personal Information Removal", comment: "Data Broker protection cell title for privacy pro")
-    public static let settingsPProOtherProtectionsSection = NotLocalizedString("settings.subscription.otherProtections.section", value: "Other protections", comment: "Freemium PIR section title for eligible users")
+    public static let settingsPProOtherProtectionsSection = NotLocalizedString("settings.subscription.otherProtections.section", value: "Other Protections", comment: "Freemium PIR section title for eligible users")
     public static let settingsPProFreemiumDBPSubtitle = NotLocalizedString("settings.subscription.DBP.freemium.subtitle", value: "Find your personal info on sites that sell it.", comment: "Freemium PIR subtitle for eligible users")
     public static let settingsPProFreemiumDBPFreeScanCTA = NotLocalizedString("settings.subscription.DBP.freemium.freeScan", value: "Free Scan", comment: "Freemium PIR CTA for eligible users")
     public static let settingsSubscriptionAiChatTitle = NSLocalizedString("settings.subscription.AIChat.title", value: "Duck.ai", comment: "Paid AIChat protection cell title for subscription")

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/UINative/DataBrokerProtectionViewController.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/UINative/DataBrokerProtectionViewController.swift
@@ -27,6 +27,7 @@ import Combine
 import DataBrokerProtectionCore
 import os.log
 import PrivacyConfig
+import Subscription
 
 final public class DataBrokerProtectionViewController: UIViewController {
 
@@ -197,7 +198,7 @@ final public class DataBrokerProtectionViewController: UIViewController {
             return false
         }
 
-        return url.path == "/subscriptions" || url.path == "/subscriptions/plans"
+        return SubscriptionPurchaseFlowPath.contains(url.path)
     }
 }
 

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/UINative/DataBrokerProtectionViewController.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/UINative/DataBrokerProtectionViewController.swift
@@ -189,6 +189,16 @@ final public class DataBrokerProtectionViewController: UIViewController {
             await webUIViewModel.sendBackgroundAppRefreshDidChange(into: webView)
         }
     }
+
+    private func shouldOpenExternally(_ url: URL) -> Bool {
+        guard let selectedURL = URL(string: webUISettings.selectedURL),
+              let selectedHost = selectedURL.host,
+              url.host?.caseInsensitiveCompare(selectedHost) == .orderedSame else {
+            return false
+        }
+
+        return url.path == "/subscriptions" || url.path == "/subscriptions/plans"
+    }
 }
 
 extension DataBrokerProtectionViewController: DBPUIViewModelOpenFeedbackFormDelegate {
@@ -230,6 +240,17 @@ extension DataBrokerProtectionViewController: WKNavigationDelegate {
         }
 
         return .allow
+    }
+
+    public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction) async -> WKNavigationActionPolicy {
+        guard navigationAction.targetFrame?.isMainFrame == true,
+              let url = navigationAction.request.url,
+              shouldOpenExternally(url) else {
+            return .allow
+        }
+
+        openURLHandler(url)
+        return .cancel
     }
 
     public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214738378921896?focus=true
Tech Design URL:
CC:

### Description

This PR contains the following changes:
* https://app.asana.com/1/137249556945/task/1214686539788966: Applies title casing to Settings menu section title
* https://app.asana.com/1/137249556945/task/1214738378921896: Makes sure subscription CTA in the PIR flow redirects users to purchase flow.

### Testing Steps
1. Build and run the iOS app with the freemium PIR settings entry point enabled.
2. Open Settings > Subscription.
3. Confirm the Personal Information Removal entry appears under "Other Protections".
4. Open the freemium Personal Information Removal flow.
5. Tap the "Discover DuckDuckGo" CTA.
6. Confirm the DuckDuckGo Subscription flow opens.

### Impact and Risks

Low: Behind feature flag and not planned to ship soon.

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted navigation and shared path constants behind freemium PIR; no auth, billing, or data-model changes.
> 
> **Overview**
> Introduces shared **`SubscriptionPurchaseFlowPath`** so subscription purchase URLs (`/subscriptions`, `/pro`, plans variants) are defined once and reused for tab interception, plans deep links, and PIR web handling.
> 
> **Freemium PIR → subscription:** The PIR web view now cancels in-web navigation to those paths on the same host and routes them through **`openURLHandler`**. **`DBPService`** runs subscription URLs through **`TabURLInterceptor`** (eligibility) before opening the quick-link deep link so CTAs like “Discover DuckDuckGo” reach the in-app purchase flow.
> 
> **Settings deep link fix:** Subscription URL interception uses **`launchSettingsForSubscriptionInterception`**, which always calls **`triggerDeepLinkNavigation`** so subscription/plan flows still open when Settings is already on screen.
> 
> Minor copy: Settings section title **“Other Protections”** (title case).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b422351aff3e3ad76e32dd85a6e3f751917c9a53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->