### PR TITLE
[iOS, macOS] Refresh card suffix on incoming Sync card number update

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/SecureVault/AutofillSecureVault.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/SecureVault/AutofillSecureVault.swift
@@ -639,6 +639,9 @@ public class DefaultAutofillSecureVault<T: AutofillDatabaseProvider>: AutofillSe
             return
         }
 
+        if let cardNumber = String(data: creditCard.cardNumberData, encoding: .utf8) {
+            creditCard.cardSuffix = SecureVaultModels.CreditCard.suffix(from: cardNumber)
+        }
         creditCard.cardNumberData = try l2Encrypt(data: creditCard.cardNumberData, using: l2Key)
 
         var syncableCreditCardToStore = syncableCreditCard

--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
@@ -227,7 +227,7 @@ public struct SecureVaultModels {
             return type.displayCardType
         }
 
-        static func suffix(from cardNumber: String) -> String {
+        public static func suffix(from cardNumber: String) -> String {
             let trimmedCardNumber = cardNumber.trimmingCharacters(in: .whitespacesAndNewlines)
             return String(trimmedCardNumber.suffix(4))
         }

--- a/SharedPackages/BrowserServicesKit/Sources/SyncDataProviders/CreditCards/CreditCardsProvider.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/SyncDataProviders/CreditCards/CreditCardsProvider.swift
@@ -22,12 +22,21 @@ import Combine
 import Common
 import DDGSync
 import GRDB
+import Persistence
 import SecureStorage
 import os.log
 
 public struct CreditCardsInput {
     public var modifiedCreditCards: [SecureVaultModels.CreditCard]
     public var deletedCreditCards: [SecureVaultModels.CreditCard]
+}
+
+private enum CreditCardsProviderSettingsKeyNames: String, StorageKeyDescribing {
+    case staleCardSuffixRefreshCompleted = "sync-credit-cards-stale-card-suffix-refresh-completed"
+}
+
+private struct CreditCardsProviderSettings: StoringKeys {
+    let staleCardSuffixRefreshCompleted = StorageKey<Bool>(CreditCardsProviderSettingsKeyNames.staleCardSuffixRefreshCompleted)
 }
 
 public final class CreditCardsProvider: DataProvider, FeatureToggleableProvider {
@@ -52,6 +61,7 @@ public final class CreditCardsProvider: DataProvider, FeatureToggleableProvider 
     public init(
         secureVaultFactory: AutofillVaultFactory = AutofillSecureVaultFactory,
         secureVaultErrorReporter: SecureVaultReporting,
+        keyValueStore: ThrowingKeyValueStoring,
         metadataStore: SyncMetadataStore,
         metricsEvents: EventMapping<MetricsEvent>? = nil,
         syncDidUpdateData: @escaping () -> Void,
@@ -59,6 +69,7 @@ public final class CreditCardsProvider: DataProvider, FeatureToggleableProvider 
     ) throws {
         self.secureVaultFactory = secureVaultFactory
         self.secureVaultErrorReporter = secureVaultErrorReporter
+        self.settings = keyValueStore.throwingKeyedStoring()
         self.metricsEvents = metricsEvents
         super.init(feature: .init(name: "credit_cards"), metadataStore: metadataStore, syncDidUpdateData: syncDidUpdateData)
         self.syncDidFinish = { [weak self] in
@@ -225,6 +236,8 @@ public final class CreditCardsProvider: DataProvider, FeatureToggleableProvider 
             throw saveError
         }
 
+        try? refreshCardSuffixesIfNeeded(secureVault: secureVault)
+
         if let serverTimestamp {
             updateSyncTimestamps(server: serverTimestamp, local: clientTimestamp)
             syncDidUpdateData()
@@ -266,6 +279,52 @@ public final class CreditCardsProvider: DataProvider, FeatureToggleableProvider 
         return idsOfItemsToClearModifiedAt
     }
 
+    private func refreshCardSuffixesIfNeeded(secureVault: any AutofillSecureVault) throws {
+        guard try settings.value(for: \.staleCardSuffixRefreshCompleted) != true else {
+            return
+        }
+
+        let encryptionKey = try secureVault.getEncryptionKey()
+        try secureVault.inDatabaseTransaction { database in
+            try self.refreshStaleCardSuffixes(in: database, secureVault: secureVault, using: encryptionKey)
+        }
+        try? settings.set(true, for: \.staleCardSuffixRefreshCompleted)
+    }
+
+    private func refreshStaleCardSuffixes(
+        in database: Database,
+        secureVault: any AutofillSecureVault,
+        using encryptionKey: Data
+    ) throws {
+        let syncableCreditCards = try SecureVaultModels.SyncableCreditCard.query.fetchAll(database)
+
+        for syncableCreditCard in syncableCreditCards {
+            guard let creditCard = syncableCreditCard.creditCard,
+                  let creditCardId = creditCard.id else {
+                continue
+            }
+
+            let decryptedCardNumberData = try secureVault.decrypt(creditCard.cardNumberData, using: encryptionKey)
+            guard let decryptedCardNumber = String(data: decryptedCardNumberData, encoding: .utf8) else {
+                continue
+            }
+
+            let refreshedCardSuffix = SecureVaultModels.SyncableCreditCard.cardSuffix(from: decryptedCardNumber)
+            if refreshedCardSuffix == creditCard.cardSuffix {
+                continue
+            }
+
+            try database.execute(
+                sql: """
+                UPDATE \(SecureVaultModels.CreditCard.databaseTableName)
+                SET \(SecureVaultModels.CreditCard.Columns.cardSuffix.name) = ?
+                WHERE \(SecureVaultModels.CreditCard.Columns.id.name) = ?
+                """,
+                arguments: [refreshedCardSuffix, creditCardId]
+            )
+        }
+    }
+
     private func clearModifiedAt(uuids: Set<String>, clientTimestamp: Date, in database: Database) throws {
 
         let request = SecureVaultModels.SyncableCreditCardsRecord
@@ -285,6 +344,7 @@ public final class CreditCardsProvider: DataProvider, FeatureToggleableProvider 
 
     private let secureVaultFactory: AutofillVaultFactory
     private let secureVaultErrorReporter: SecureVaultReporting
+    private let settings: any ThrowingKeyedStoring<CreditCardsProviderSettings>
     private let metricsEvents: EventMapping<MetricsEvent>?
 
     enum Const {

--- a/SharedPackages/BrowserServicesKit/Sources/SyncDataProviders/CreditCards/CreditCardsProvider.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/SyncDataProviders/CreditCards/CreditCardsProvider.swift
@@ -304,12 +304,18 @@ public final class CreditCardsProvider: DataProvider, FeatureToggleableProvider 
                 continue
             }
 
-            let decryptedCardNumberData = try secureVault.decrypt(creditCard.cardNumberData, using: encryptionKey)
-            guard let decryptedCardNumber = String(data: decryptedCardNumberData, encoding: .utf8) else {
+            let refreshedCardSuffix: String
+            do {
+                let decryptedCardNumberData = try secureVault.decrypt(creditCard.cardNumberData, using: encryptionKey)
+                guard let decryptedCardNumber = String(data: decryptedCardNumberData, encoding: .utf8) else {
+                    continue
+                }
+
+                refreshedCardSuffix = SecureVaultModels.CreditCard.suffix(from: decryptedCardNumber)
+            } catch {
                 continue
             }
 
-            let refreshedCardSuffix = SecureVaultModels.SyncableCreditCard.cardSuffix(from: decryptedCardNumber)
             if refreshedCardSuffix == creditCard.cardSuffix {
                 continue
             }

--- a/SharedPackages/BrowserServicesKit/Sources/SyncDataProviders/CreditCards/internal/CreditCardsResponseHandler.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/SyncDataProviders/CreditCards/internal/CreditCardsResponseHandler.swift
@@ -315,6 +315,7 @@ extension SecureVaultModels.SyncableCreditCard {
             creditCard?.cardholderName = cardholderName
             if let cardNumber, let cardNumberData = cardNumber.data(using: .utf8) {
                 creditCard?.cardNumberData = cardNumberData
+                creditCard?.cardSuffix = Self.cardSuffix(from: cardNumber)
             }
             creditCard?.cardSecurityCode = cardSecurityCode
             creditCard?.expirationMonth = expirationMonthInt
@@ -342,5 +343,10 @@ extension SecureVaultModels.SyncableCreditCard {
             return (nil, nil)
         }
         return (monthInt, yearInt)
+    }
+
+    static func cardSuffix(from cardNumber: String) -> String {
+        let trimmedCardNumber = cardNumber.trimmingCharacters(in: .whitespacesAndNewlines)
+        return String(trimmedCardNumber.suffix(4))
     }
 }

--- a/SharedPackages/BrowserServicesKit/Sources/SyncDataProviders/CreditCards/internal/CreditCardsResponseHandler.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/SyncDataProviders/CreditCards/internal/CreditCardsResponseHandler.swift
@@ -315,7 +315,7 @@ extension SecureVaultModels.SyncableCreditCard {
             creditCard?.cardholderName = cardholderName
             if let cardNumber, let cardNumberData = cardNumber.data(using: .utf8) {
                 creditCard?.cardNumberData = cardNumberData
-                creditCard?.cardSuffix = Self.cardSuffix(from: cardNumber)
+                creditCard?.cardSuffix = SecureVaultModels.CreditCard.suffix(from: cardNumber)
             }
             creditCard?.cardSecurityCode = cardSecurityCode
             creditCard?.expirationMonth = expirationMonthInt
@@ -343,10 +343,5 @@ extension SecureVaultModels.SyncableCreditCard {
             return (nil, nil)
         }
         return (monthInt, yearInt)
-    }
-
-    static func cardSuffix(from cardNumber: String) -> String {
-        let trimmedCardNumber = cardNumber.trimmingCharacters(in: .whitespacesAndNewlines)
-        return String(trimmedCardNumber.suffix(4))
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/SyncDataProvidersTests/CreditCards/CreditCardsRegularSyncResponseHandlerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SyncDataProvidersTests/CreditCards/CreditCardsRegularSyncResponseHandlerTests.swift
@@ -152,6 +152,27 @@ final class CreditCardsRegularSyncResponseHandlerTests: CreditCardsProviderTests
         XCTAssertEqual(keyValueStore.underlyingDict.count, 1)
     }
 
+    func testWhenOneCardDecryptFailsDuringStaleSuffixRefreshThenOtherCardsStillRefresh() async throws {
+        try reinitializeVaultUsingBitFlipCryptoProvider()
+        let decryptionFailureMarker = Data([0xAA, 0xBB, 0xCC, 0xDD])
+        TestBitFlipCryptoProvider.decryptionFailureMarker = decryptionFailureMarker
+        defer { TestBitFlipCryptoProvider.decryptionFailureMarker = nil }
+
+        try secureVault.inDatabaseTransaction { database in
+            try self.secureVault.storeSyncableCreditCard("1", cardNumber: "4111111111111111", in: database)
+            try self.secureVault.storeSyncableCreditCard("2", cardNumber: "5555555555554444", in: database)
+        }
+        try setStaleStoredCardSuffix("0000", forUUID: "1")
+        try setStaleStoredCardSuffix("0000", forUUID: "2")
+        try setStoredEncryptedCardNumberData(decryptionFailureMarker, forUUID: "1")
+
+        try await handleSyncResponse(received: [])
+
+        XCTAssertEqual(try storedCardSuffix(forUUID: "1"), "0000")
+        XCTAssertEqual(try storedCardSuffix(forUUID: "2"), "4444")
+        XCTAssertEqual(keyValueStore.underlyingDict.count, 1)
+    }
+
     func testWhenIncomingSyncUpdatesCardNumberThenSuffixUpdatesWithoutBackfill() async throws {
         try secureVault.inDatabaseTransaction { database in
             try self.secureVault.storeSyncableCreditCard("1", cardNumber: "4111111111111111", in: database)
@@ -185,6 +206,21 @@ final class CreditCardsRegularSyncResponseHandlerTests: CreditCardsProviderTests
             }
 
             creditCard.cardSuffix = suffix
+            try creditCard.update(database)
+        }
+    }
+
+    private func setStoredEncryptedCardNumberData(_ cardNumberData: Data, forUUID uuid: String) throws {
+        try secureVault.inDatabaseTransaction { database in
+            guard let syncableCreditCard = try SecureVaultModels.SyncableCreditCard.query
+                .filter(SecureVaultModels.SyncableCreditCardsRecord.Columns.uuid == uuid)
+                .fetchOne(database),
+                var creditCard = syncableCreditCard.creditCard else {
+                XCTFail("Expected syncable credit card to exist for uuid \(uuid)")
+                return
+            }
+
+            creditCard.cardNumberData = cardNumberData
             try creditCard.update(database)
         }
     }

--- a/SharedPackages/BrowserServicesKit/Tests/SyncDataProvidersTests/CreditCards/CreditCardsRegularSyncResponseHandlerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SyncDataProvidersTests/CreditCards/CreditCardsRegularSyncResponseHandlerTests.swift
@@ -120,4 +120,72 @@ final class CreditCardsRegularSyncResponseHandlerTests: CreditCardsProviderTests
         XCTAssertTrue(syncableCreditCards.map(\.metadata.lastModified).allSatisfy { $0 == nil })
         crypter.throwsException(exceptionString: nil)
     }
+
+    func testWhenCardSuffixIsStaleThenSyncRefreshesItOnlyOnce() async throws {
+        try secureVault.inDatabaseTransaction { database in
+            try self.secureVault.storeSyncableCreditCard("1", cardNumber: "4111111111111111", in: database)
+        }
+        try setStaleStoredCardSuffix("0000", forUUID: "1")
+
+        try await handleSyncResponse(received: [])
+        XCTAssertEqual(try storedCardSuffix(forUUID: "1"), "1111")
+
+        try setStaleStoredCardSuffix("2222", forUUID: "1")
+        try await handleSyncResponse(received: [])
+        XCTAssertEqual(try storedCardSuffix(forUUID: "1"), "2222")
+    }
+
+    func testWhenRefreshGateWriteFailsThenSyncSucceedsAndRefreshIsRetried() async throws {
+        try secureVault.inDatabaseTransaction { database in
+            try self.secureVault.storeSyncableCreditCard("1", cardNumber: "4111111111111111", in: database)
+        }
+        try setStaleStoredCardSuffix("0000", forUUID: "1")
+        keyValueStore.shouldThrowOnSet = true
+
+        try await handleSyncResponse(received: [])
+        XCTAssertEqual(try storedCardSuffix(forUUID: "1"), "1111")
+        XCTAssertTrue(keyValueStore.underlyingDict.isEmpty)
+
+        keyValueStore.shouldThrowOnSet = false
+        try await handleSyncResponse(received: [])
+        XCTAssertEqual(try storedCardSuffix(forUUID: "1"), "1111")
+        XCTAssertEqual(keyValueStore.underlyingDict.count, 1)
+    }
+
+    func testWhenIncomingSyncUpdatesCardNumberThenSuffixUpdatesWithoutBackfill() async throws {
+        try secureVault.inDatabaseTransaction { database in
+            try self.secureVault.storeSyncableCreditCard("1", cardNumber: "4111111111111111", in: database)
+        }
+
+        // Complete the one-time refresh upfront so this assertion validates the forward update path.
+        try await handleSyncResponse(received: [])
+
+        let received: [Syncable] = [
+            .creditCard(uuid: "1", cardNumber: "5555555555554444")
+        ]
+        try await handleSyncResponse(received: received)
+
+        XCTAssertEqual(try storedCardSuffix(forUUID: "1"), "4444")
+    }
+
+    private func storedCardSuffix(forUUID uuid: String) throws -> String? {
+        try fetchAllSyncableCreditCards()
+            .first(where: { $0.metadata.uuid == uuid })?
+            .creditCard?.cardSuffix
+    }
+
+    private func setStaleStoredCardSuffix(_ suffix: String, forUUID uuid: String) throws {
+        try secureVault.inDatabaseTransaction { database in
+            guard let syncableCreditCard = try SecureVaultModels.SyncableCreditCard.query
+                .filter(SecureVaultModels.SyncableCreditCardsRecord.Columns.uuid == uuid)
+                .fetchOne(database),
+                var creditCard = syncableCreditCard.creditCard else {
+                XCTFail("Expected syncable credit card to exist for uuid \(uuid)")
+                return
+            }
+
+            creditCard.cardSuffix = suffix
+            try creditCard.update(database)
+        }
+    }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/SyncDataProvidersTests/CreditCards/helpers/CreditCardsProviderTestsBase.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SyncDataProvidersTests/CreditCards/helpers/CreditCardsProviderTestsBase.swift
@@ -215,6 +215,9 @@ extension AutofillSecureVault {
 // Implements an "encryption" that simply bit-flips every byte so encrypting twice is observable.
 final class TestBitFlipCryptoProvider: SecureStorageCryptoProvider {
 
+    /// Optional marker used by tests to simulate decrypt failures for selected ciphertext blobs.
+    static var decryptionFailureMarker: Data?
+
     var hashingSalt: Data?
 
     var passwordSalt: Data { Data() }
@@ -231,6 +234,10 @@ final class TestBitFlipCryptoProvider: SecureStorageCryptoProvider {
     }
 
     func decrypt(_ data: Data, withKey key: Data) throws -> Data {
+        if let decryptionFailureMarker = Self.decryptionFailureMarker,
+           data.starts(with: decryptionFailureMarker) {
+            throw SecureStorageError.invalidPassword
+        }
         Data(data.map { ~$0 })
     }
 

--- a/SharedPackages/BrowserServicesKit/Tests/SyncDataProvidersTests/CreditCards/helpers/CreditCardsProviderTestsBase.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SyncDataProvidersTests/CreditCards/helpers/CreditCardsProviderTestsBase.swift
@@ -22,6 +22,7 @@ import DDGSync
 import Foundation
 import GRDB
 import Persistence
+import PersistenceTestingUtils
 import SecureStorage
 import SecureStorageTestsUtils
 @testable import BrowserServicesKit
@@ -38,6 +39,7 @@ internal class CreditCardsProviderTestsBase: XCTestCase {
 
     var crypter = CryptingMock()
     var provider: CreditCardsProvider!
+    var keyValueStore: MockKeyValueFileStore!
 
     var secureVaultFactory: AutofillVaultFactory!
     var secureVault: (any AutofillSecureVault)!
@@ -79,10 +81,12 @@ internal class CreditCardsProviderTestsBase: XCTestCase {
         try makeSecureVault()
 
         setUpSyncMetadataDatabase()
+        keyValueStore = MockKeyValueFileStore()
 
         provider = try CreditCardsProvider(
             secureVaultFactory: secureVaultFactory,
             secureVaultErrorReporter: MockSecureVaultErrorReporter(),
+            keyValueStore: keyValueStore,
             metadataStore: LocalSyncMetadataStore(database: metadataDatabase),
             syncDidUpdateData: {},
             syncDidFinish: { _ in }
@@ -95,6 +99,7 @@ internal class CreditCardsProviderTestsBase: XCTestCase {
         try? metadataDatabase.tearDown(deleteStores: true)
         metadataDatabase = nil
         try? FileManager.default.removeItem(at: metadataDatabaseLocation)
+        keyValueStore = nil
 
         try super.tearDownWithError()
     }
@@ -147,6 +152,7 @@ internal class CreditCardsProviderTestsBase: XCTestCase {
         provider = try CreditCardsProvider(
             secureVaultFactory: secureVaultFactory,
             secureVaultErrorReporter: MockSecureVaultErrorReporter(),
+            keyValueStore: keyValueStore,
             metadataStore: LocalSyncMetadataStore(database: metadataDatabase),
             syncDidUpdateData: {},
             syncDidFinish: { _ in }

--- a/iOS/DuckDuckGo/Adapters/SyncCreditCardsAdapter.swift
+++ b/iOS/DuckDuckGo/Adapters/SyncCreditCardsAdapter.swift
@@ -64,6 +64,7 @@ public final class SyncCreditCardsAdapter {
     public func setUpProviderIfNeeded(
         secureVaultFactory: AutofillVaultFactory,
         metadataStore: SyncMetadataStore,
+        keyValueStore: ThrowingKeyValueStoring,
         metricsEventsHandler: EventMapping<MetricsEvent>? = nil,
         privacyConfigurationManager: PrivacyConfigurationManaging
     ) {
@@ -75,6 +76,7 @@ public final class SyncCreditCardsAdapter {
             let provider = try CreditCardsProvider(
                 secureVaultFactory: secureVaultFactory,
                 secureVaultErrorReporter: secureVaultErrorReporter,
+                keyValueStore: keyValueStore,
                 metadataStore: metadataStore,
                 metricsEvents: metricsEventsHandler,
                 syncDidUpdateData: { [weak self] in

--- a/iOS/DuckDuckGo/AppServices/SyncService.swift
+++ b/iOS/DuckDuckGo/AppServices/SyncService.swift
@@ -69,6 +69,7 @@ final class SyncService {
             privacyConfigurationManager: privacyConfigurationManager,
             bookmarksDatabase: bookmarksDatabase,
             secureVaultErrorReporter: SecureVaultReporter(),
+            keyValueStore: keyValueStore,
             settingHandlers: [FavoritesDisplayModeSyncHandler()],
             favoritesDisplayModeStorage: FavoritesDisplayModeStorage(),
             syncErrorHandler: syncErrorHandler,

--- a/iOS/DuckDuckGo/SyncDataProviders.swift
+++ b/iOS/DuckDuckGo/SyncDataProviders.swift
@@ -57,6 +57,7 @@ public class SyncDataProviders: DataProvidersSource {
             creditCardsAdapter?.setUpProviderIfNeeded(
                 secureVaultFactory: secureVaultFactory,
                 metadataStore: syncMetadata,
+                keyValueStore: keyValueStore,
                 metricsEventsHandler: metricsEventsHandler,
                 privacyConfigurationManager: privacyConfigurationManager
             )
@@ -128,6 +129,7 @@ public class SyncDataProviders: DataProvidersSource {
         bookmarksDatabase: CoreDataDatabase,
         secureVaultFactory: AutofillVaultFactory = AutofillSecureVaultFactory,
         secureVaultErrorReporter: SecureVaultReporting,
+        keyValueStore: ThrowingKeyValueStoring,
         settingHandlers: [SettingSyncHandler],
         favoritesDisplayModeStorage: FavoritesDisplayModeStoring,
         syncErrorHandler: SyncErrorHandling,
@@ -139,6 +141,7 @@ public class SyncDataProviders: DataProvidersSource {
         self.bookmarksDatabase = bookmarksDatabase
         self.secureVaultFactory = secureVaultFactory
         self.secureVaultErrorReporter = secureVaultErrorReporter
+        self.keyValueStore = keyValueStore
         self.featureFlagger = featureFlagger
 
         bookmarksAdapter = SyncBookmarksAdapter(database: bookmarksDatabase,
@@ -193,4 +196,5 @@ public class SyncDataProviders: DataProvidersSource {
     private let bookmarksDatabase: CoreDataDatabase
     private let secureVaultFactory: AutofillVaultFactory
     private let secureVaultErrorReporter: SecureVaultReporting
+    private let keyValueStore: ThrowingKeyValueStoring
 }

--- a/iOS/DuckDuckGoTests/AutofillSettingsViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/AutofillSettingsViewModelTests.swift
@@ -23,6 +23,7 @@ import BrowserServicesKit
 import Bookmarks
 import DDGSync
 import Persistence
+import PersistenceTestingUtils
 @testable import Core
 import Common
 @testable import BrowserServicesKitTestsUtils
@@ -54,6 +55,7 @@ final class AutofillSettingsViewModelTests: XCTestCase {
             bookmarksDatabase: db,
             secureVaultFactory: AutofillSecureVaultFactory,
             secureVaultErrorReporter: SecureVaultReporter(),
+            keyValueStore: MockThrowingKeyValueStore(),
             settingHandlers: [],
             favoritesDisplayModeStorage: MockFavoritesDisplayModeStoring(),
             syncErrorHandler: SyncErrorHandler(),

--- a/iOS/DuckDuckGoTests/OnboardingNavigationDelegateTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingNavigationDelegateTests.swift
@@ -47,6 +47,7 @@ final class OnboardingNavigationDelegateTests: XCTestCase {
             bookmarksDatabase: db,
             secureVaultFactory: AutofillSecureVaultFactory,
             secureVaultErrorReporter: SecureVaultReporter(),
+            keyValueStore: MockThrowingKeyValueStore(),
             settingHandlers: [],
             favoritesDisplayModeStorage: MockFavoritesDisplayModeStoring(),
             syncErrorHandler: SyncErrorHandler(),

--- a/iOS/DuckDuckGoTests/SyncCreditCardsAdapterTests.swift
+++ b/iOS/DuckDuckGoTests/SyncCreditCardsAdapterTests.swift
@@ -24,6 +24,7 @@ import DDGSync
 import SecureStorage
 import Core
 import Common
+import PersistenceTestingUtils
 @testable import DuckDuckGo
 
 final class SyncCreditCardsAdapterTests: XCTestCase {
@@ -31,6 +32,7 @@ final class SyncCreditCardsAdapterTests: XCTestCase {
     var errorHandler: CapturingAdapterErrorHandler!
     var adapter: SyncCreditCardsAdapter!
     let metadataStore = MockMetadataStore()
+    var keyValueStore: MockThrowingKeyValueStore!
     var cancellables: Set<AnyCancellable>!
 
     override func setUpWithError() throws {
@@ -40,12 +42,14 @@ final class SyncCreditCardsAdapterTests: XCTestCase {
             secureVaultErrorReporter: MockSecureVaultReporting(),
             syncErrorHandler: errorHandler
         )
+        keyValueStore = MockThrowingKeyValueStore()
         cancellables = []
     }
 
     override func tearDownWithError() throws {
         errorHandler = nil
         adapter = nil
+        keyValueStore = nil
         cancellables = nil
     }
 
@@ -53,7 +57,9 @@ final class SyncCreditCardsAdapterTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Sync did fail")
         let expectedError = NSError(domain: "some error", code: 400)
         adapter.setUpProviderIfNeeded(secureVaultFactory: AutofillSecureVaultFactory,
-                                      metadataStore: metadataStore, privacyConfigurationManager: MockPrivacyConfigurationManager())
+                                      metadataStore: metadataStore,
+                                      keyValueStore: keyValueStore,
+                                      privacyConfigurationManager: MockPrivacyConfigurationManager())
         adapter.provider!.syncErrorPublisher
             .sink { _ in
                 expectation.fulfill()
@@ -71,6 +77,7 @@ final class SyncCreditCardsAdapterTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Sync Did Update")
         adapter.setUpProviderIfNeeded(secureVaultFactory: AutofillSecureVaultFactory,
                                       metadataStore: metadataStore,
+                                      keyValueStore: keyValueStore,
                                       privacyConfigurationManager: MockPrivacyConfigurationManager())
 
         Task {

--- a/iOS/SharedStateTests/OnboardingDaxFavouritesTests.swift
+++ b/iOS/SharedStateTests/OnboardingDaxFavouritesTests.swift
@@ -64,6 +64,7 @@ private final class MockIdleReturnEligibilityManagerForMainVC: IdleReturnEligibi
             bookmarksDatabase: db,
             secureVaultFactory: AutofillSecureVaultFactory,
             secureVaultErrorReporter: SecureVaultReporter(),
+            keyValueStore: keyValueStore,
             settingHandlers: [],
             favoritesDisplayModeStorage: MockFavoritesDisplayModeStoring(),
             syncErrorHandler: SyncErrorHandler(),

--- a/iOS/SharedStateTests/OnboardingNavigationDelegateTests.swift
+++ b/iOS/SharedStateTests/OnboardingNavigationDelegateTests.swift
@@ -53,6 +53,7 @@ final class OnboardingNavigationDelegateTests: XCTestCase {
             bookmarksDatabase: db,
             secureVaultFactory: AutofillSecureVaultFactory,
             secureVaultErrorReporter: SecureVaultReporter(),
+            keyValueStore: keyValueStore,
             settingHandlers: [],
             favoritesDisplayModeStorage: MockFavoritesDisplayModeStoring(),
             syncErrorHandler: SyncErrorHandler(),

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -2065,6 +2065,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             bookmarksDatabase: bookmarkDatabase.db,
             bookmarkManager: bookmarkManager,
             appearancePreferences: appearancePreferences,
+            keyValueStore: keyValueStore,
             syncErrorHandler: syncErrorHandler
         )
         let syncService = DDGSync(

--- a/macOS/DuckDuckGo/Sync/SyncCreditCardsAdapter.swift
+++ b/macOS/DuckDuckGo/Sync/SyncCreditCardsAdapter.swift
@@ -57,6 +57,7 @@ final class SyncCreditCardsAdapter {
     func setUpProviderIfNeeded(
         secureVaultFactory: AutofillVaultFactory,
         metadataStore: SyncMetadataStore,
+        keyValueStore: ThrowingKeyValueStoring,
         metricsEventsHandler: EventMapping<MetricsEvent>? = nil,
         privacyConfigurationManager: PrivacyConfigurationManaging = Application.appDelegate.privacyFeatures.contentBlocking.privacyConfigurationManager
     ) {
@@ -68,6 +69,7 @@ final class SyncCreditCardsAdapter {
             let provider = try CreditCardsProvider(
                 secureVaultFactory: secureVaultFactory,
                 secureVaultErrorReporter: SecureVaultReporter.shared,
+                keyValueStore: keyValueStore,
                 metadataStore: metadataStore,
                 metricsEvents: metricsEventsHandler,
                 syncDidUpdateData: { [weak self] in

--- a/macOS/DuckDuckGo/Sync/SyncDataProviders.swift
+++ b/macOS/DuckDuckGo/Sync/SyncDataProviders.swift
@@ -60,6 +60,7 @@ final class SyncDataProvidersSource: DataProvidersSource {
             creditCardsAdapter?.setUpProviderIfNeeded(
                 secureVaultFactory: secureVaultFactory,
                 metadataStore: syncMetadata,
+                keyValueStore: keyValueStore,
                 metricsEventsHandler: metricsEventsHandler
             )
         }
@@ -159,12 +160,14 @@ final class SyncDataProvidersSource: DataProvidersSource {
         bookmarkManager: BookmarkManager,
         secureVaultFactory: AutofillVaultFactory = AutofillSecureVaultFactory,
         appearancePreferences: AppearancePreferences,
+        keyValueStore: ThrowingKeyValueStoring,
         syncErrorHandler: SyncErrorHandler,
         featureFlagger: FeatureFlagger = Application.appDelegate.featureFlagger
     ) {
         self.bookmarksDatabase = bookmarksDatabase
         self.secureVaultFactory = secureVaultFactory
         self.appearancePreferences = appearancePreferences
+        self.keyValueStore = keyValueStore
         self.syncErrorHandler = syncErrorHandler
         self.featureFlagger = featureFlagger
         bookmarksAdapter = SyncBookmarksAdapter(database: bookmarksDatabase, bookmarkManager: bookmarkManager, appearancePreferences: appearancePreferences, syncErrorHandler: syncErrorHandler)
@@ -215,4 +218,5 @@ final class SyncDataProvidersSource: DataProvidersSource {
     private let bookmarksDatabase: CoreDataDatabase
     private let secureVaultFactory: AutofillVaultFactory
     private let appearancePreferences: AppearancePreferences
+    private let keyValueStore: ThrowingKeyValueStoring
 }

--- a/macOS/UnitTests/Sync/SyncCreditCardsAdapterTests.swift
+++ b/macOS/UnitTests/Sync/SyncCreditCardsAdapterTests.swift
@@ -20,6 +20,7 @@ import XCTest
 import BrowserServicesKit
 import Combine
 import DDGSync
+import PersistenceTestingUtils
 @testable import DuckDuckGo_Privacy_Browser
 
 final class SyncCreditCardsAdapterTests: XCTestCase {
@@ -27,11 +28,13 @@ final class SyncCreditCardsAdapterTests: XCTestCase {
     var errorHandler: CapturingAdapterErrorHandler!
     var adapter: SyncCreditCardsAdapter!
     var metadataStore: MockMetadataStore! = .init()
+    var keyValueStore: MockThrowingKeyValueStore!
     var cancellables: Set<AnyCancellable>!
 
     override func setUpWithError() throws {
         errorHandler = CapturingAdapterErrorHandler()
         adapter = SyncCreditCardsAdapter(syncErrorHandler: errorHandler)
+        keyValueStore = MockThrowingKeyValueStore()
         cancellables = []
     }
 
@@ -40,12 +43,15 @@ final class SyncCreditCardsAdapterTests: XCTestCase {
         adapter = nil
         cancellables = nil
         metadataStore = nil
+        keyValueStore = nil
     }
 
     func testWhenSyncErrorPublished_ThenErrorHandlerHandleCreditCardErrorCalled() async {
         let expectation = XCTestExpectation(description: "Sync did fail")
         let expectedError = NSError(domain: "some error", code: 400)
-        adapter.setUpProviderIfNeeded(secureVaultFactory: AutofillSecureVaultFactory, metadataStore: metadataStore)
+        adapter.setUpProviderIfNeeded(secureVaultFactory: AutofillSecureVaultFactory,
+                                      metadataStore: metadataStore,
+                                      keyValueStore: keyValueStore)
         adapter.provider!.syncErrorPublisher
             .sink { error in
                 expectation.fulfill()
@@ -61,7 +67,9 @@ final class SyncCreditCardsAdapterTests: XCTestCase {
 
     func testWhenSyncErrorPublished_ThenErrorHandlerSyncCreditCardsSuccededCalled() async {
         let expectation = XCTestExpectation(description: "Sync Did Update")
-        adapter.setUpProviderIfNeeded(secureVaultFactory: AutofillSecureVaultFactory, metadataStore: metadataStore)
+        adapter.setUpProviderIfNeeded(secureVaultFactory: AutofillSecureVaultFactory,
+                                      metadataStore: metadataStore,
+                                      keyValueStore: keyValueStore)
 
         Task {
             adapter.provider?.syncDidUpdateData()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201462886803403/task/1214548114411709?focus=true
Tech Design URL:
CC:

### Description
This PR fixes credit-card sync suffix consistency by running a one-time update of any stale stored suffixes and by always recalculating suffix when card numbers are updated.

### Testing Steps
_Test card numbers can be found [here](https://docs.stripe.com/testing)_

#### Set up card with stale suffix:
1. Start on main with iOS and macOS signed into the same Sync account.
2. Create/sync a credit card ending in e.g. `1111` so it exists on both platforms.
3. On macOS, update the card number to one with new last-4 digits.
4. On iOS, go to the Credit Cards screen and confirm the suffix is still stale `1111` (although the full card number is updated when you view the full card number in the details screen)

#### Confirm stale suffixes are updated as a one-off clean-up:
- Switch both builds to this branch, launch iOS, go back to the Credit Cards screen, and verify suffix updated correctly.

#### Confirm suffix are now updated with each Sync card number update
- Update card number on iOS to new last-4, verify macOS updates with the new suffix.
- Update card number on macOS to a new last-4, verify iOS updates with the new suffix.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Medium Risk**
> Touches credit-card sync storage and performs a one-time backfill that decrypts card data and updates the vault database; issues here could impact card display data or sync correctness.
> 
> **Overview**
> Ensures `cardSuffix` stays in sync with `cardNumber` for credit cards coming from Sync by recalculating the suffix whenever a synced card number is stored/updated.
> 
> Adds a **one-time post-sync backfill** in `CreditCardsProvider` that decrypts existing stored card numbers, updates any stale `cardSuffix` values directly in the database, and gates the migration via a persisted key-value flag (plumbed through iOS/macOS adapters and tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09bb80f3ad1531f298b0559570650b217a6c3c55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>