### PR TITLE
iOS: nudge dax logo down to clear toolbar under unified input

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -675,7 +675,9 @@ final class UnifiedInputContentContainerViewController: UIViewController {
 
         daxLogoManager.updateVisibility(isHomeDaxVisible: isHomeDaxVisible, isAIDaxVisible: isAIDaxVisible)
         let escapeHatchOffset: CGFloat = (escapeHatchModel != nil && !switchBarHandler.isFireTab) ? Metrics.escapeHatchLogoOffset : 0
-        daxLogoManager.setEscapeHatchBaseOffset(escapeHatchOffset)
+        // The toolbar is still in the hierarchy under the unified input, so the keyboard-relative
+        // centering sits visually too high — shift the dax down by this constant to compensate.
+        daxLogoManager.setEscapeHatchBaseOffset(escapeHatchOffset + Metrics.toolbarCompensationOffset)
         updateSectionTitle()
     }
 
@@ -686,6 +688,7 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         static let escapeHatchLogoOffset: CGFloat = 120
         // Pulls the suggestion tray (NTP/Favorites) upward in UTI top bar to tighten gap between UTI input and hatch.
         static let escapeHatchTopBarTrayPullUp: CGFloat = -10
+        static let toolbarCompensationOffset: CGFloat = 80
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214005520745151?focus=true
Tech Design URL:
CC:

### Description
With the `unifiedToggleInput` feature on, the toolbar still sits in the view hierarchy under the unified input, so the dax logo's keyboard-relative centering rendered too high. This adds a fixed downward offset to the existing dax centering math so the logo settles where it's meant to.

### Testing Steps
1. Enable the `unifiedToggleInput` feature flag.
2. Tap the omnibar on a tab to bring up the unified input + keyboard.
3. Confirm the dax logo sits at the intended vertical position (not overlapping the input bar and clear of the toolbar zone).

### Impact and Risks
Low — single constant adjustment scoped to the unified-input content container; no other dax users (NTP, omnibar editing) are touched.

#### What could go wrong?
The fixed 80pt offset could feel wrong on smaller iPhone screens if the keyboard area is unusually short.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only adjustment: adds a fixed vertical offset to Dax logo positioning in the unified input container, with the main risk being suboptimal placement on some device/keyboard sizes.
> 
> **Overview**
> Adjusts unified-input Dax logo positioning by adding a fixed `toolbarCompensationOffset` (80pt) to the existing escape-hatch-based centering math, so the logo renders lower when the toolbar remains beneath the unified input.
> 
> This change is isolated to `UnifiedInputContentContainerViewController.updateDaxVisibility()` and only affects the unified toggle input layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da235236c3929c1e14ba933c7431d09a050cf3fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->