### PR TITLE
Ignore .xcodebuildmcp/config.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ buildServer.json
 /macOS/LocalPackages/PerformanceTest/Sources/PerformanceTest/SafariTestRunner/src/constants/metricsScript.js
 content-scope-scripts/
 privacy-configuration/
+.xcodebuildmcp/config.yaml


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214137467353555/task/1214624691371335?focus=true
Tech Design URL:
CC:

### Description
The file holds per-machine values (simulator UDID, scheme override, debug flag) that shouldn't be shared across the team.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `.gitignore` to prevent committing a machine-specific config file; no runtime or build logic changes.
> 
> **Overview**
> Adds `.xcodebuildmcp/config.yaml` to `.gitignore` so per-developer Xcode build MCP settings (e.g., local simulator/scheme overrides) are not committed to the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c387b757ae0a3511d676d03df839b87373f12b3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->