### PR TITLE
fix crash creating VPN app shortcut item without checking API

### DIFF
--- a/iOS/DuckDuckGo/AppServices/VPNService.swift
+++ b/iOS/DuckDuckGo/AppServices/VPNService.swift
@@ -113,7 +113,7 @@ final class VPNService: NSObject {
         // No-op
     }
 
-    /// Checks if the shortcut item should be shown by asking if a subscription is present, and if so, is the  network protection feature included - avoiding calls to the API.
+    /// Checks if the shortcut item should be shown by asking if a subscription is present, and if so, is the network protection feature included - avoiding calls to the API.
     @MainActor
     func shortcutItem() async -> UIApplicationShortcutItem? {
         guard subscriptionManager.isSubscriptionPresent(),

--- a/iOS/DuckDuckGo/AppServices/VPNService.swift
+++ b/iOS/DuckDuckGo/AppServices/VPNService.swift
@@ -113,9 +113,10 @@ final class VPNService: NSObject {
         // No-op
     }
 
+    /// Checks if the shortcut item should be shown by asking if a subscription is present, and if so, is the  network protection feature included - avoiding calls to the API.
     @MainActor
     func shortcutItem() async -> UIApplicationShortcutItem? {
-        guard await vpnFeatureVisibility.shouldShowVPNShortcut(),
+        guard subscriptionManager.isSubscriptionPresent(),
            let canShowVPNInUI = try? await subscriptionManager.isFeatureIncludedInSubscription(.networkProtection),
            canShowVPNInUI else {
             return nil


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1214128779898080?focus=true
Tech Design URL:
CC: @federicocappelli 

### Description
Fixes crash by avoiding touch the API while determining if to show VPN shortcut item

### Testing Steps
1. With no subscription, check app shortcut menu - no VPN item
2. Add subscription, check app shortcut menu - should show Open VPN item. Check it opens as expected.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Could break VPN opening from app shortcut menu.

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes a single UI shortcut gating check to use local subscription presence before awaiting feature inclusion; potential impact is only whether the VPN shortcut appears.
> 
> **Overview**
> Updates `VPNService.shortcutItem()` to **stop using** `vpnFeatureVisibility.shouldShowVPNShortcut()` and instead **gate the VPN quick action** on `subscriptionManager.isSubscriptionPresent()` plus `isFeatureIncludedInSubscription(.networkProtection)`, avoiding API-dependent checks when building the home screen shortcut item.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b0f6ad4b2537a8a73f10c710bbbf89ea628a719. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->