### PR TITLE
Revert Duck Player Settings deep link fix (#4765)

### DIFF
--- a/.maestro/duckplayer_classic/shared/close_settings.yaml
+++ b/.maestro/duckplayer_classic/shared/close_settings.yaml
@@ -1,10 +1,7 @@
 appId: com.duckduckgo.mobile.ios
 ---
 # Close Settings - need to go back twice on iPad
-# Duck Player is now nested under YouTube Ad Blocking — step back one level first.
-- tapOn:
-    text: "YouTube Ad Blocking"
-- tapOn:
+- tapOn: 
     text: "Settings"
-- tapOn:
+- tapOn: 
     text: "Done"

--- a/.maestro/duckplayer_classic/shared/open_settings.yaml
+++ b/.maestro/duckplayer_classic/shared/open_settings.yaml
@@ -7,29 +7,17 @@ appId: com.duckduckgo.mobile.ios
 - waitForAnimationToEnd:
     timeout: 1000
     
-- tapOn: Settings
-
-- waitForAnimationToEnd
-
-# Duck Player now lives inside the YouTube Ad Blocking screen (under Privacy Protections).
-- scrollUntilVisible:
-    element:
-      text: "YouTube Ad Blocking"
-    direction: DOWN
-    centerElement: true
-
-- tapOn:
-    text: "YouTube Ad Blocking"
+- tapOn: Settings    
 
 - waitForAnimationToEnd
 
 - scrollUntilVisible:
-    element:
+    element: 
       text: "Duck Player"
     direction: DOWN
     centerElement: true
-
-- tapOn:
+    
+- tapOn: 
     text: "Duck Player"
-
+    
 - waitForAnimationToEnd

--- a/.maestro/duckplayer_native/shared/close_settings.yaml
+++ b/.maestro/duckplayer_native/shared/close_settings.yaml
@@ -5,11 +5,6 @@ appId: com.duckduckgo.mobile.ios
 - runFlow:
     file: constants.yaml
 
-# Duck Player is now nested under YouTube Ad Blocking — step back one level first.
-- tapOn: ${output.adBlockingLabel}
-
-- waitForAnimationToEnd
-
 - tapOn: ${output.settingsLabel}
 
 - waitForAnimationToEnd

--- a/.maestro/duckplayer_native/shared/constants.yaml
+++ b/.maestro/duckplayer_native/shared/constants.yaml
@@ -11,7 +11,6 @@ appId: com.duckduckgo.mobile.ios
 - evalScript: "${output.chevronUpId = 'chevron.up'}"
 - evalScript: "${output.duckPlayerSettingsId = 'DuckPlayerOpenSettings'}"
 - evalScript: "${output.duckPlayerLabel = 'Duck Player'}"
-- evalScript: "${output.adBlockingLabel = 'YouTube Ad Blocking'}"
 - evalScript: "${output.settingsLabel = 'Settings'}"
 - evalScript: "${output.doneLabel = 'Done'}"
 - evalScript: "${output.browsingMenuLabel = 'Browsing Menu'}"

--- a/.maestro/duckplayer_native/shared/open_settings.yaml
+++ b/.maestro/duckplayer_native/shared/open_settings.yaml
@@ -11,21 +11,11 @@ appId: com.duckduckgo.mobile.ios
 
 - tapOn: ${output.settingsLabel}
 
-# Duck Player now lives inside the YouTube Ad Blocking screen (under Privacy Protections).
-- scrollUntilVisible:
-    centerElement: true
-    element: ${output.adBlockingLabel}
-    direction: DOWN
-
-- tapOn: ${output.adBlockingLabel}
-
-- waitForAnimationToEnd
-
 - scrollUntilVisible:
     centerElement: true
     element: ${output.duckPlayerLabel}
     direction: DOWN
-
+    
 - tapOn: ${output.duckPlayerLabel}
 
 - waitForAnimationToEnd

--- a/iOS/DuckDuckGo/SettingsYouTubeAdBlockingView.swift
+++ b/iOS/DuckDuckGo/SettingsYouTubeAdBlockingView.swift
@@ -28,8 +28,6 @@ struct SettingsYouTubeAdBlockingView: View {
     /// This property ensures that the associated action is only triggered once per viewing session, preventing redundant executions.
     @State private var hasFiredSettingsDisplayedPixel = false
 
-    @State private var showDuckPlayer = false
-
     @EnvironmentObject var viewModel: SettingsViewModel
     var body: some View {
         List {
@@ -77,10 +75,7 @@ struct SettingsYouTubeAdBlockingView: View {
             }
 
             Section(footer: Text(UserText.duckPlayerEnableFooter)) {
-                NavigationLink(
-                    destination: SettingsDuckPlayerView().environmentObject(viewModel),
-                    isActive: $showDuckPlayer
-                ) {
+                NavigationLink(destination: SettingsDuckPlayerView().environmentObject(viewModel)) {
                     SettingsCellView(label: UserText.duckPlayerFeatureName)
                 }
                 .listRowBackground(Color(designSystemColor: .surface))
@@ -93,14 +88,6 @@ struct SettingsYouTubeAdBlockingView: View {
         .onAppear {
             DailyPixel.fireDailyAndCount(pixel: .webExtensionAdBlockingSettingsOpen,
                                          pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes)
-        }
-        .onFirstAppear {
-            if viewModel.deepLinkTarget == .duckPlayer,
-               !viewModel.shouldDisplayDuckPlayerContingencyMessage {
-                DispatchQueue.main.async {
-                    showDuckPlayer = true
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1214683438819740?focus=true

### Description

PR #4765 fixed a Duck Player Settings deep-link issue and updated the Duck Player Maestro flows (`open_settings.yaml` / `close_settings.yaml` in both `duckplayer_classic` and `duckplayer_native`) to navigate through a new "YouTube Ad Blocking" screen on the path to Duck Player settings.

That work turned out to be unnecessary: the new "YouTube Ad Blocking" entry point was showing because of a gating bug that exposed the web-extensions UI on builds where it should have been hidden. That gating bug has since been fixed, so the Settings hierarchy on the iOS versions we target — including iOS 18.2, which is what Maestro currently runs against — no longer has the intermediate "YouTube Ad Blocking" screen, and the deep-link workaround in `SettingsYouTubeAdBlockingView` is no longer reachable in practice.

This PR reverts #4765 in full:
- `SettingsYouTubeAdBlockingView`: drops the `showDuckPlayer` state and the `onFirstAppear` deep-link push.
- Maestro flows: `open_settings.yaml` / `close_settings.yaml` (classic + native) no longer step through "YouTube Ad Blocking"; `output.adBlockingLabel` is removed from the native `constants.yaml`.

### Testing Steps

1. Confirm the web-extensions gating is in place on your build — there should be no "YouTube Ad Blocking" entry under Settings → Privacy Protections.
2. Open Settings → Privacy Protections → Duck Player. Verify it loads the Duck Player settings screen directly (no intermediate "YouTube Ad Blocking" hop).
3. Tap back / Done. Verify the navigation returns through Settings → Done normally.
4. Run `.maestro/run_ui_tests.sh .maestro/duckplayer_native` and confirm all flows pass on the pinned iOS 18.2 simulator.
5. Run `.maestro/run_ui_tests.sh .maestro/duckplayer_classic` and confirm all flows pass on the iPad simulator.

### Impact and Risks

Low. This is a pure revert of #4765. The Duck Player code path returns to its pre-#4765 form, which was the shipping behavior for the entire iOS 18.2-era release window. The only scenario where this regresses anything is if the web-extensions gating bug ever resurfaces and the "YouTube Ad Blocking" intermediate screen reappears — at which point the Duck Player Maestro flows would fail and we'd revisit. The Swift change is scoped to `SettingsYouTubeAdBlockingView` and removes a single deep-link push.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk revert that removes an unused deep-link navigation workaround and updates UI test flows to match the current Settings hierarchy; main risk is tests/navigation would break again if the intermediate "YouTube Ad Blocking" screen reappears.
> 
> **Overview**
> Removes the Duck Player deep-link auto-navigation workaround from `SettingsYouTubeAdBlockingView` by dropping the `showDuckPlayer`/`onFirstAppear`-driven `NavigationLink` activation.
> 
> Updates Duck Player Maestro flows (classic + native) to navigate directly to `Duck Player` without stepping through `YouTube Ad Blocking`, and deletes the native `output.adBlockingLabel` constant accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f73d0842d4f70216e4aeb95e99a5c74b09122de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->