### PR TITLE
Add RMF navigation action for Settings > General

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Model/RemoteMessageModel.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Model/RemoteMessageModel.swift
@@ -282,6 +282,7 @@ public extension RemoteMessageModelType.ListItem {
 public enum NavigationTarget: String, Codable, Equatable {
     case duckAISettings = "duckai.settings"
     case settings
+    case settingsGeneral = "settings.general"
     case feedback
     case sync
     case importPasswords = "import.passwords"

--- a/iOS/DuckDuckGo/MainViewController+Segues.swift
+++ b/iOS/DuckDuckGo/MainViewController+Segues.swift
@@ -37,6 +37,12 @@ extension MainViewController {
         }, deepLinkTarget: .appearance)
     }
 
+    func segueToGeneralSettings() {
+        launchSettings(completion: {
+            $0.triggerDeepLinkNavigation(to: .general)
+        }, deepLinkTarget: .general)
+    }
+
     func segueToCustomizeAddressBarSettings() {
         launchSettings(completion: {
             $0.triggerDeepLinkNavigation(to: .customizeAddressBarButton)

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -5817,6 +5817,15 @@ extension MainViewController: MessageNavigationDelegate {
         }
     }
 
+    func segueToSettingsGeneral(presentationStyle: PresentationContext.Style) {
+        switch presentationStyle {
+        case .dismissModalsAndPresentFromRoot:
+            segueToGeneralSettings()
+        case .withinCurrentContext:
+            assertionFailure("Not implemented yet.")
+        }
+    }
+
     func segueToFeedback(presentationStyle: PresentationContext.Style) {
         switch presentationStyle {
         case .dismissModalsAndPresentFromRoot:

--- a/iOS/DuckDuckGo/MessageNavigator.swift
+++ b/iOS/DuckDuckGo/MessageNavigator.swift
@@ -31,6 +31,7 @@ protocol MessageNavigationDelegate: AnyObject {
 
     func segueToSettingsAIChat(openedFromSERPSettingsButton: Bool, presentationStyle: PresentationContext.Style)
     func segueToSettings(presentationStyle: PresentationContext.Style)
+    func segueToSettingsGeneral(presentationStyle: PresentationContext.Style)
     func segueToSettingsAppearance(presentationStyle: PresentationContext.Style)
     func segueToFeedback(presentationStyle: PresentationContext.Style)
     func segueToSettingsSync(with source: String?, pairingInfo: PairingInfo?, presentationStyle: PresentationContext.Style)
@@ -54,6 +55,8 @@ class DefaultMessageNavigator: MessageNavigator {
                                             presentationStyle: presentationStyle)
         case .settings:
             delegate?.segueToSettings(presentationStyle: presentationStyle)
+        case .settingsGeneral:
+            delegate?.segueToSettingsGeneral(presentationStyle: presentationStyle)
         case .feedback:
             delegate?.segueToFeedback(presentationStyle: presentationStyle)
         case .sync:

--- a/iOS/DuckDuckGo/SettingsRootView.swift
+++ b/iOS/DuckDuckGo/SettingsRootView.swift
@@ -255,6 +255,8 @@ struct SettingsRootView: View {
             PrivateSearchView().environmentObject(viewModel)
         case .appearance, .customizeAddressBarButton, .customizeToolbarButton:
             SettingsAppearanceView().environmentObject(viewModel)
+        case .general:
+            SettingsGeneralView().environmentObject(viewModel)
         case .subscriptionSettings:
             if let configuration = subscriptionSettingsConfiguration() {
                 let model = SubscriptionSettingsViewModel(userScriptsDependencies: viewModel.userScriptsDependencies)

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -1462,6 +1462,7 @@ extension SettingsViewModel {
         case customizeToolbarButton
         case customizeAddressBarButton
         case appearance
+        case general
         // Add other cases as needed
 
         var id: String {
@@ -1479,6 +1480,7 @@ extension SettingsViewModel {
             case .customizeToolbarButton: return "customizeToolbarButton"
             case .customizeAddressBarButton: return "customizeAddressButton"
             case .appearance: return "appearance"
+            case .general: return "general"
             // Ensure all cases are covered
             }
         }
@@ -1487,7 +1489,7 @@ extension SettingsViewModel {
         // Default to .sheet, specify .push where needed
         var type: DeepLinkType {
             switch self {
-            case .netP, .dbp, .itr, .subscriptionFlow, .subscriptionPlanChangeFlow, .restoreFlow, .duckPlayer, .aiChat, .privateSearch, .subscriptionSettings, .customizeToolbarButton, .customizeAddressBarButton, .appearance:
+            case .netP, .dbp, .itr, .subscriptionFlow, .subscriptionPlanChangeFlow, .restoreFlow, .duckPlayer, .aiChat, .privateSearch, .subscriptionSettings, .customizeToolbarButton, .customizeAddressBarButton, .appearance, .general:
                 return .navigationLink
             }
         }

--- a/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
+++ b/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
@@ -312,6 +312,10 @@ extension NewTabPageMessagesModelTests: MessageNavigationDelegate {
         segueToSettingsCallCount += 1
     }
 
+    func segueToSettingsGeneral(presentationStyle: PresentationContext.Style) {
+        segueToSettingsCallCount += 1
+    }
+
     func segueToFeedback(presentationStyle: PresentationContext.Style) {
         segueToFeedbackCallCount += 1
     }

--- a/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
+++ b/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
@@ -31,6 +31,7 @@ final class NewTabPageMessagesModelTests: XCTestCase {
 
     private var segueToAIChatSettingsCallCount = 0
     private var segueToSettingsCallCount = 0
+    private var segueToSettingsGeneralCallCount = 0
     private var segueToFeedbackCallCount = 0
     private var segueToSyncSettingsCallCount = 0
     private var segueToSettingsAppearanceCallCount = 0
@@ -41,6 +42,7 @@ final class NewTabPageMessagesModelTests: XCTestCase {
         notificationCenter = NotificationCenter()
         segueToAIChatSettingsCallCount = 0
         segueToSettingsCallCount = 0
+        segueToSettingsGeneralCallCount = 0
         segueToFeedbackCallCount = 0
         segueToSyncSettingsCallCount = 0
         segueToSettingsAppearanceCallCount = 0
@@ -144,6 +146,7 @@ final class NewTabPageMessagesModelTests: XCTestCase {
 
         func assertSegueCount(_ count: Int) {
             XCTAssertEqual(segueToSettingsCallCount, count)
+            XCTAssertEqual(segueToSettingsGeneralCallCount, count)
             XCTAssertEqual(segueToAIChatSettingsCallCount, count)
             XCTAssertEqual(segueToFeedbackCallCount, count)
             XCTAssertEqual(segueToSettingsAppearanceCallCount, count)
@@ -156,6 +159,9 @@ final class NewTabPageMessagesModelTests: XCTestCase {
         // Individual states
         DefaultMessageNavigator(delegate: self).navigateTo(.settings, presentationStyle: .dismissModalsAndPresentFromRoot)
         XCTAssertEqual(segueToSettingsCallCount, 1)
+
+        DefaultMessageNavigator(delegate: self).navigateTo(.settingsGeneral, presentationStyle: .dismissModalsAndPresentFromRoot)
+        XCTAssertEqual(segueToSettingsGeneralCallCount, 1)
 
         DefaultMessageNavigator(delegate: self).navigateTo(.duckAISettings, presentationStyle: .dismissModalsAndPresentFromRoot)
         XCTAssertEqual(segueToAIChatSettingsCallCount, 1)
@@ -313,7 +319,7 @@ extension NewTabPageMessagesModelTests: MessageNavigationDelegate {
     }
 
     func segueToSettingsGeneral(presentationStyle: PresentationContext.Style) {
-        segueToSettingsCallCount += 1
+        segueToSettingsGeneralCallCount += 1
     }
 
     func segueToFeedback(presentationStyle: PresentationContext.Style) {

--- a/iOS/IntegrationTests/RemoteMessaging/RemoteMessagingActionHandlerIntegrationTests.swift
+++ b/iOS/IntegrationTests/RemoteMessaging/RemoteMessagingActionHandlerIntegrationTests.swift
@@ -29,6 +29,7 @@ struct RemoteMessagingActionHandlerIntegrationTests {
         "Check Navigation Target Asks Delegate To Perform Segue",
         arguments: [
             (.appearance, \MockMessageNavigationDelegate.didCallSegueToSettingsAppearance),
+            (.settingsGeneral, \MockMessageNavigationDelegate.didCallSegueToSettingsGeneral),
             (.sync, \MockMessageNavigationDelegate.didCallSegueToSettingsSync),
             (.settings, \MockMessageNavigationDelegate.didCallSegueToSettings),
             (.duckAISettings, \MockMessageNavigationDelegate.didCallSegueToAIChatSettings),
@@ -53,7 +54,7 @@ struct RemoteMessagingActionHandlerIntegrationTests {
     @Test(
         "Check Navigation Passes Presentation Style To Delegate",
         arguments:
-            [.sync, .settings, .duckAISettings, .feedback, .importPasswords] as [NavigationTarget],
+            [.sync, .settings, .settingsGeneral, .duckAISettings, .feedback, .importPasswords] as [NavigationTarget],
             [.dismissModalsAndPresentFromRoot, .withinCurrentContext] as [PresentationContext.Style]
     )
     func navigationActionPassesPresentationStyleToDelegate(navigationTarget: NavigationTarget, presentationStyle: PresentationContext.Style) async throws {

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/NewTabPage/MockMessageNavigationDelegate.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/NewTabPage/MockMessageNavigationDelegate.swift
@@ -24,6 +24,7 @@ class MockMessageNavigationDelegate: MessageNavigationDelegate {
     private(set) var didCallSegueToAIChatSettings: Bool = false
     private(set) var capturedAIChatOpenedFromSERPSettingsButton: Bool?
     private(set) var didCallSegueToSettings: Bool = false
+    private(set) var didCallSegueToSettingsGeneral: Bool = false
     private(set) var didCallSegueToSettingsAppearance: Bool = false
     private(set) var didCallSegueToFeedback: Bool = false
     private(set) var didCallSegueToSettingsSync: Bool = false
@@ -43,6 +44,11 @@ class MockMessageNavigationDelegate: MessageNavigationDelegate {
 
     func segueToSettings(presentationStyle: PresentationContext.Style) {
         didCallSegueToSettings = true
+        capturedPresentationStyle = presentationStyle
+    }
+
+    func segueToSettingsGeneral(presentationStyle: PresentationContext.Style) {
+        didCallSegueToSettingsGeneral = true
         capturedPresentationStyle = presentationStyle
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1214707096849934
Tech Design URL: N/A
CC: N/A

### Description
- Add `settingsGeneral` (`"settings.general"`) navigation target to the Remote Messaging Framework, allowing RMF messages to deep-link users to the Settings > General screen on tap

### Testing Steps
1. Build and run the app as an internal user
2. Configure a test RMF endpoint with the payload at https://pastebin.com/raw/aqe2yccZ
3. Trigger the RMF message on the New Tab Page
4. Tap the "Open General" primary action button
5. Verify that Settings opens modally and navigates to the General subsection
6. Verify the back button navigates back to the main Settings list

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- Low risk: adds a new enum case to `NavigationTarget` which is decoded from raw value; unknown values are already handled gracefully by the mapper (returns nil and message is skipped)

### Quality Considerations
- Follows existing pattern used by `.appearance`, `.sync`, and other navigation targets
- No new UI or privacy implications -- reuses existing `SettingsGeneralView`
- Integration test coverage added for the new navigation target

### Notes to Reviewer
- The raw value `"settings.general"` is what the backend RMF config will use to trigger this action

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new `NavigationTarget` case and wires it through existing settings deep-link navigation, with unit/integration test coverage to catch routing regressions.
> 
> **Overview**
> Adds a new RMF `NavigationTarget` (`settings.general`) and routes it through `DefaultMessageNavigator` to a new `segueToSettingsGeneral` delegate method.
> 
> Implements the iOS segue by launching Settings modally and deep-linking to a new `SettingsViewModel.SettingsDeepLinkSection.general`, which is mapped in `SettingsRootView` to `SettingsGeneralView`.
> 
> Updates unit and integration tests/mocks to cover the new navigation target and ensure presentation style is forwarded correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 667542bf6c1924b37a0d69542d42a02039d131c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->