### PR TITLE
[iOS] Remove autoplayBlocking feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -230,9 +230,6 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213336304802675
     case showNTPAfterIdleReturn
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213557229772465?focus=true
-    case autoplayBlocking
-
     case crashReportOptInStatusResetting
 
     case fireproofingETLDPlus1

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -362,9 +362,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213965646075290
     case fireButtonRefinements
 
-    /// https://app.asana.com/1/137249556945/project/1202500774821704/task/1212559012504218
-    case autoplayBlocking
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213617478454569?focus=true
     case simplifiedSyncSetupExperiment
 
@@ -667,8 +664,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.fireMode)))
         case .fireButtonRefinements:
             Config(defaultValue: .enabled, source: .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.fireButtonRefinements)))
-        case .autoplayBlocking:
-            Config(defaultValue: .enabled, source: .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.autoplayBlocking)))
         case .simplifiedSyncSetupExperiment:
             Config(source: .remoteReleasable(.subfeature(SyncSubfeature.simplifiedSyncSetupExperiment)), cohortType: SimplifiedSyncSetupExperimentCohort.self)
         case .aiChatOmnibarDefaultPosition:

--- a/iOS/DuckDuckGo/SettingsGeneralView.swift
+++ b/iOS/DuckDuckGo/SettingsGeneralView.swift
@@ -144,13 +144,10 @@ struct SettingsGeneralView: View {
             }
 
             // Media
-            if viewModel.featureFlagger.isFeatureOn(.autoplayBlocking) {
-                Section(header: Text(UserText.settingsMediaSection)) {
-                    NavigationLink(destination: SettingsAutoplayView().environmentObject(viewModel)) {
-                        SettingsCellView(label: UserText.settingsAutoplayLabel,
-                                         accessory: .rightDetail(viewModel.state.autoplayBlockingMode.description))
-                    }
-                    .listRowBackground(Color(designSystemColor: .surface)) // This is needed because of the combination of ConditionalContent + NavigationLink wrappers. This line should be removed when cleaning up the feature flag.
+            Section(header: Text(UserText.settingsMediaSection)) {
+                NavigationLink(destination: SettingsAutoplayView().environmentObject(viewModel)) {
+                    SettingsCellView(label: UserText.settingsAutoplayLabel,
+                                     accessory: .rightDetail(viewModel.state.autoplayBlockingMode.description))
                 }
             }
 

--- a/iOS/DuckDuckGo/TabManager.swift
+++ b/iOS/DuckDuckGo/TabManager.swift
@@ -296,9 +296,7 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
                                  inheritedAttribution: AdClickAttributionLogic.State?,
                                  interactionState: Data?) -> TabViewController {
         let configuration = WKWebViewConfiguration.persistent(fireMode: tab.fireTab)
-        if featureFlagger.isFeatureOn(.autoplayBlocking) {
-            configuration.mediaTypesRequiringUserActionForPlayback = autoplaySettings.currentAutoplayBlockingMode.mediaTypesRequiringUserAction
-        }
+        configuration.mediaTypesRequiringUserActionForPlayback = autoplaySettings.currentAutoplayBlockingMode.mediaTypesRequiringUserAction
 
         if #available(iOS 18.4, *), let webExtensionManager = webExtensionManager {
             configuration.webExtensionController = webExtensionManager.controller

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -1599,7 +1599,7 @@ class TabViewController: UIViewController {
                                                                      userRefreshCount: refreshCountSinceLoad,
                                                                      breakageReportingSubfeature: breakageReportingSubfeature,
                                                                      isForceDarkModeEnabled: darkReaderFeatureSettings.isForceDarkModeEnabled,
-                                                                     autoplayBlockingMode: featureFlagger.isFeatureOn(.autoplayBlocking) ? autoplaySettings.currentAutoplayBlockingMode.rawValue : nil,
+                                                                     autoplayBlockingMode: autoplaySettings.currentAutoplayBlockingMode.rawValue,
                                                                      isAfterSuppressedXSafariRedirect: safariRedirectHandler.isAfterSuppressedXSafariRedirect(for: currentURL),
                                                                      loadedWebExtensions: loadedWebExtensions,
                                                                      adBlockingExtensionScriptletsVersion: adBlockingScriptletsVersion)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1213557229772465?focus=true
Tech Design URL:
CC: @dus7 @brindy 

### Description

Autoplay blocking is fully rolled out, so this PR removes the `autoplayBlocking` FeatureFlag case and the matching `iOSBrowserConfigSubfeature` case. Media settings visibility, `WKWebViewConfiguration.mediaTypesRequiringUserActionForPlayback` wiring, and the breakage-report `autoplayBlockingMode` parameter are now wired up unconditionally. The breakage-report parameter is kept for telemetry continuity.

Also drops the orphaned `autoplayBlocking` node from the embedded `iOS/Core/ios-config.json` fallback.

### Testing Steps
1. Open `Settings → General`. The `Media` section with the `Autoplay` row should be present (no longer gated).
2. Open `Autoplay `settings, switch between modes, confirm the right-detail label on the `General` row updates and persists across launches.
3. Run the automated test on https://privacy-test-pages.site/features/autoplay.html and check that it matches the result matrix at the bottom of the page.
4. Report a broken site and confirm the `autoplayBlockingMode` parameter is still included in the report payload.

### Impact and Risks
Low. The flag was already at full rollout and the gated branch was the only real-world path.

#### What could go wrong?
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup that removes a fully rolled-out feature flag and its remote-config wiring; behavior should remain unchanged aside from dropping local override/config support for the flag.
> 
> **Overview**
> Removes the `autoplayBlocking` rollout flag from both the shared privacy-config subfeature enum (`iOSBrowserConfigSubfeature`) and the app-level `FeatureFlag` enum.
> 
> Deletes the corresponding `FeatureFlag` configuration mapping to remote privacy config, so autoplay blocking is no longer controlled via feature-flag evaluation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bf5619e154c235ad929bf1bd95d3a6ac01ca173. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->