### PR TITLE
Fix fire mode breaking contextual sheet expand

### DIFF
--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -74,6 +74,7 @@ final class AIChatContextualSheetCoordinator {
     private let featureDiscovery: FeatureDiscovery
     private let featureFlagger: FeatureFlagger
     private let duckAiNativeStorageHandler: DuckAiNativeStorageHandling?
+    private let duckAiFireModeStorageHandler: DuckAiNativeStorageHandling?
     private let debugSettings: AIChatDebugSettingsHandling
     private let isFireTab: Bool
 
@@ -121,6 +122,7 @@ final class AIChatContextualSheetCoordinator {
          tabURLPublishers: AIChatTabURLPublishers,
          isFireTab: Bool = false,
          duckAiNativeStorageHandler: DuckAiNativeStorageHandling? = nil,
+         duckAiFireModeStorageHandler: DuckAiNativeStorageHandling? = nil,
          debugSettings: AIChatDebugSettingsHandling = AIChatDebugSettings(),
          pixelHandler: AIChatContextualModePixelFiring = AIChatContextualModePixelHandler()) {
         self.voiceSearchHelper = voiceSearchHelper
@@ -133,6 +135,7 @@ final class AIChatContextualSheetCoordinator {
         self.tabURLPublishers = tabURLPublishers
         self.isFireTab = isFireTab
         self.duckAiNativeStorageHandler = duckAiNativeStorageHandler
+        self.duckAiFireModeStorageHandler = duckAiFireModeStorageHandler
         self.debugSettings = debugSettings
         self.pixelHandler = pixelHandler
         self.sessionState = AIChatContextualChatSessionState(
@@ -287,6 +290,7 @@ private extension AIChatContextualSheetCoordinator {
             featureDiscovery: featureDiscovery,
             featureFlagger: featureFlagger,
             isFireTab: isFireTab,
+            duckAiFireModeStorageHandler: duckAiFireModeStorageHandler,
             downloadHandler: downloadHandler,
             getPageContext: { [weak self] reason in
                 guard let self else { return nil }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
@@ -48,6 +48,7 @@ final class AIChatContextualWebViewController: UIViewController {
     private let featureDiscovery: FeatureDiscovery
     private let featureFlagger: FeatureFlagger
     private let isFireTab: Bool
+    private let duckAiFireModeStorageHandler: DuckAiNativeStorageHandling?
     private var downloadHandler: DownloadHandling
     private let pixelHandler: AIChatContextualModePixelFiring
     private let debugSettings: AIChatDebugSettingsHandling
@@ -128,6 +129,7 @@ final class AIChatContextualWebViewController: UIViewController {
          featureDiscovery: FeatureDiscovery,
          featureFlagger: FeatureFlagger,
          isFireTab: Bool = false,
+         duckAiFireModeStorageHandler: DuckAiNativeStorageHandling? = nil,
          downloadHandler: DownloadHandling,
          getPageContext: ((PageContextRequestReason) -> AIChatPageContextData?)?,
          pixelHandler: AIChatContextualModePixelFiring,
@@ -140,6 +142,7 @@ final class AIChatContextualWebViewController: UIViewController {
         self.featureDiscovery = featureDiscovery
         self.featureFlagger = featureFlagger
         self.isFireTab = isFireTab
+        self.duckAiFireModeStorageHandler = duckAiFireModeStorageHandler
         self.downloadHandler = downloadHandler
         self.pixelHandler = pixelHandler
         self.debugSettings = debugSettings
@@ -374,6 +377,11 @@ extension AIChatContextualWebViewController: UserContentControllerDelegate {
         }
 
         userScripts.aiChatUserScript.setFireModeProvider { [weak self] in self?.isFireTab ?? false }
+        userScripts.duckAiNativeStorageUserScript?.fireModeStorageProvider = { [weak self] in
+            guard let self else { return .notFireMode }
+            return .resolve(isFireMode: self.isFireTab,
+                            handler: self.duckAiFireModeStorageHandler)
+        }
         aiChatContentHandler.setup(with: userScripts.aiChatUserScript, webView: webView, displayMode: .contextual)
         userScripts.aiChatUserScript.setContextualModePixelHandler(pixelHandler)
         utiHost?.bindToUserScript(userScripts.aiChatUserScript)

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -588,7 +588,8 @@ class TabViewController: UIViewController {
             pageContextHandler: pageContextHandler,
             tabURLPublishers: AIChatTabURLPublishers(originating: urlPublisher, didFinish: didFinishURLPublisher),
             isFireTab: tabModel.fireTab,
-            duckAiNativeStorageHandler: duckAiNativeStorageHandler
+            duckAiNativeStorageHandler: duckAiNativeStorageHandler,
+            duckAiFireModeStorageHandler: duckAiFireModeStorageHandler
         )
         coordinator.delegate = self
         return coordinator


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211767540372501/task/1214615564401389?focus=true

### Description

- The contextual sheet's `AIChatContextualWebViewController` was missing the `fireModeStorageProvider` setup on `duckAiNativeStorageUserScript`, causing native chat storage in fire mode to write to the normal (non-fire) disk store instead of the fire-mode-isolated store
- When expanding the contextual sheet to a full duck.ai tab in fire mode, the new tab could not find the chat data (stored in the wrong partition), resulting in an empty duck.ai page and the chat not appearing in history
- Threaded `duckAiFireModeStorageHandler` from `TabViewController` through `AIChatContextualSheetCoordinator` to `AIChatContextualWebViewController`, matching the pattern already used by `TabViewController` and `AIChatViewControllerManager`

### Testing Steps

1. Enable Fire mode
2. Open a fire tab and navigate to a content-heavy page (e.g. bbc.com)
3. Open the duck.ai contextual sheet and summarize the page
4. Wait for the summary to complete
5. Tap the expand button on the contextual sheet
6. Verify that duck.ai opens in a new tab with the chat summary conversation preserved
7. Verify the chat appears in duck.ai chat history
8. Switch to normal mode and verify the fire-mode chat does not appear in normal-mode chat history (no cross-mode leakage)
9. Repeat steps 2-7 in normal (non-fire) mode to confirm no regression

### Impact and Risks

**Impact Level: Low**

Bug fix scoped to the contextual sheet in fire mode only. All new parameters have `nil` defaults, so existing callsites and tests are unaffected. The change mirrors the exact pattern already used by `TabViewController` and `AIChatViewControllerManager`.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bug fix that threads an additional optional dependency and updates user-script configuration to ensure fire-mode chat data is stored in the correct isolated partition.
> 
> **Overview**
> Fixes fire-mode contextual sheet expansion losing chat history by **wiring fire-mode native storage into the contextual webview**.
> 
> This threads a new optional `duckAiFireModeStorageHandler` from `TabViewController` through `AIChatContextualSheetCoordinator` into `AIChatContextualWebViewController`, and sets `duckAiNativeStorageUserScript.fireModeStorageProvider` so storage reads/writes resolve to the fire-mode handler when `isFireTab` is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c428d6c7ecfb5dfef6277111199a0362f1706c55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->