### PR TITLE
Fix broken nightly e2e tests (Fire Mode tip blocking tab switcher)

### DIFF
--- a/iOS/DuckDuckGo/TabCountBadge.swift
+++ b/iOS/DuckDuckGo/TabCountBadge.swift
@@ -60,6 +60,8 @@ struct TabCountBadge: View {
             }
         }
         .frame(width: Metrics.iconSize, height: Metrics.iconSize)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(UserText.numberOfTabs(model.count))
     }
     
     private func textFont(_ isShowingSymbol: Bool) -> Font {

--- a/iOS/DuckDuckGo/TabSwitcherViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController.swift
@@ -268,6 +268,7 @@ class TabSwitcherViewController: UIViewController {
 
     func showFireTabsTipIfNeeded() {
         guard #available(iOS 17.0, *) else { return }
+        guard !LaunchOptionsHandler().isAutomationSession else { return }
         guard fireModeCapability.isFireModeEnabled else { return }
         guard selectedBrowsingMode != .fire else { return }
         guard let sourceView = segmentedPickerHostingController?.view else { return }

--- a/iOS/DuckDuckGo/TabSwitcherViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController.swift
@@ -269,8 +269,7 @@ class TabSwitcherViewController: UIViewController {
     func showFireTabsTipIfNeeded() {
         guard #available(iOS 17.0, *) else { return }
         guard !LaunchOptionsHandler().isAutomationSession else { return }
-        guard fireModeCapability.isFireModeEnabled else { return }
-        guard selectedBrowsingMode != .fire else { return }
+        guard fireModeCapability.isFireModeEnabled, selectedBrowsingMode != .fire else { return }
         guard let sourceView = segmentedPickerHostingController?.view else { return }
 
         fireTabsTipTask?.cancel()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214689304260153?focus=true

### Description

- Suppress the Fire Tabs TipKit popover during automation sessions (`isRunningUITests`) to prevent it from blocking UI elements in the tab switcher, which was causing Maestro e2e test failures.
- Add an accessibility label to `TabCountBadge` so the tab count (e.g., "2 Private Tabs") is discoverable by Maestro regardless of whether fire mode is enabled (fire mode hides the text title in favor of the segmented picker badge).

### Testing Steps

Ensure E2E tests pass on CI.
Run triggered [here](https://github.com/duckduckgo/apple-browsers/actions/runs/25698575035).

### Impact and Risks

**Impact Level: Low**

Test-only behavioral change (suppressing a TipKit tip during automation) and an accessibility label addition. No user-facing behavior is affected.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to suppressing a TipKit popover during automation sessions and adding an accessibility label, with minimal impact on user-facing behavior.
> 
> **Overview**
> Prevents the `FireTabsTip` TipKit popover from showing during automation sessions (`LaunchOptionsHandler().isAutomationSession`) so it can’t block the tab switcher UI in E2E runs.
> 
> Improves testability/accessibility by making `TabCountBadge` expose the tab count via an explicit accessibility element/label (`UserText.numberOfTabs(model.count)`), independent of whether the count text is visually shown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88a6ade24a55e5fad9b099f1e8c5221a7aa02dd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->