### PR TITLE
[macOS] Use Tab in internal feedback popup for autofill and shared Asana session

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -2695,6 +2695,8 @@
 		98A95D88299A2DF900B9B81A /* BookmarkMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A95D87299A2DF900B9B81A /* BookmarkMigrationTests.swift */; };
 		98EB5D1027516A4800681FE6 /* AppPrivacyConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98EB5D0F27516A4800681FE6 /* AppPrivacyConfigurationTests.swift */; };
 		9BF66A3171D59EB4B55171ED /* AutoplayPolicyTabExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FEBFD485D01E6666551201 /* AutoplayPolicyTabExtensionTests.swift */; };
+		FB37FB37FB37FB37FB37FB38 /* InternalFeedbackFormTabExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB37FB37FB37FB37FB37FB37 /* InternalFeedbackFormTabExtensionTests.swift */; };
+		FB37FB37FB37FB37FB37FB39 /* InternalFeedbackFormTabExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB37FB37FB37FB37FB37FB37 /* InternalFeedbackFormTabExtensionTests.swift */; };
 		9D84E42C2CD4E66F0046CD8B /* Common in Frameworks */ = {isa = PBXBuildFile; productRef = 9D84E4072CD4E66F0046CD8B /* Common */; };
 		9D84E42D2CD4E66F0046CD8B /* PixelKitTestingUtilities in Frameworks */ = {isa = PBXBuildFile; productRef = 9D84E4042CD4E66F0046CD8B /* PixelKitTestingUtilities */; };
 		9D84E42E2CD4E66F0046CD8B /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 9D84E4022CD4E66F0046CD8B /* SnapshotTesting */; };
@@ -5480,6 +5482,7 @@
 		4BF4EA4F27C71F26004E57C4 /* PasswordManagementListSectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasswordManagementListSectionTests.swift; sourceTree = "<group>"; };
 		4BF6961F28BEEE8B00D402D4 /* LocalPinningManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalPinningManagerTests.swift; sourceTree = "<group>"; };
 		51FEBFD485D01E6666551201 /* AutoplayPolicyTabExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoplayPolicyTabExtensionTests.swift; sourceTree = "<group>"; };
+		FB37FB37FB37FB37FB37FB37 /* InternalFeedbackFormTabExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalFeedbackFormTabExtensionTests.swift; sourceTree = "<group>"; };
 		5601FECC29B7973D00068905 /* TabBarViewItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarViewItemTests.swift; sourceTree = "<group>"; };
 		5603D90529B7B746007F9F01 /* MockTabViewItemDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabViewItemDelegate.swift; sourceTree = "<group>"; };
 		560419432DD49BB600818414 /* PreferencesThreatProtectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesThreatProtectionView.swift; sourceTree = "<group>"; };
@@ -12139,6 +12142,7 @@
 				6590DB542DB7D59F007D6046 /* DuckPlayerTabExtensionTests.swift */,
 				56BA1E7C2BAB290E001CF69F /* ErrorPageTabExtensionTests.swift */,
 				1D1C36E529FB019C001FA40C /* HistoryTabExtensionTests.swift */,
+				FB37FB37FB37FB37FB37FB37 /* InternalFeedbackFormTabExtensionTests.swift */,
 				84C1007D2ECC75350083AB11 /* MockWKNavigationAction.swift */,
 				84C1007A2ECC6F3C0083AB11 /* PopupHandlingTabExtensionTests.swift */,
 				B626A7632992506A00053070 /* SerpHeadersNavigationResponderTests.swift */,
@@ -16416,6 +16420,7 @@
 				37598EFA2D5A278400720EAF /* ArrayExtensionTests.swift in Sources */,
 				84C1007C2ECC6F3C0083AB11 /* PopupHandlingTabExtensionTests.swift in Sources */,
 				BB5555E7950EDE4C3EE58AD9 /* AutoplayPolicyTabExtensionTests.swift in Sources */,
+				FB37FB37FB37FB37FB37FB38 /* InternalFeedbackFormTabExtensionTests.swift in Sources */,
 				3706FE77293F661700E42796 /* PreferencesSidebarModelTests.swift in Sources */,
 				5650E3742D3FDC8900D41ECF /* PageRefreshMonitorExtensionTests.swift in Sources */,
 				B51A90DB2F044C3E00FB9C0C /* ScriptStyleProviderTests.swift in Sources */,
@@ -18645,6 +18650,7 @@
 				56A054162C1C37B0007D8FAB /* CapturingOnboardingNavigation.swift in Sources */,
 				84C1007B2ECC6F3C0083AB11 /* PopupHandlingTabExtensionTests.swift in Sources */,
 				9BF66A3171D59EB4B55171ED /* AutoplayPolicyTabExtensionTests.swift in Sources */,
+				FB37FB37FB37FB37FB37FB39 /* InternalFeedbackFormTabExtensionTests.swift in Sources */,
 				1DE28D5F2EEADBCF00C07F15 /* SystemPermissionManagerMock.swift in Sources */,
 				CD3301302C89B602009AA127 /* ErrorPageHTMLFactoryTests.swift in Sources */,
 				4B2975992828285900187C4E /* FirefoxKeyReaderTests.swift in Sources */,

--- a/macOS/DuckDuckGo/Feedback/QuickFeedback/QuickFeedbackService.swift
+++ b/macOS/DuckDuckGo/Feedback/QuickFeedback/QuickFeedbackService.swift
@@ -31,6 +31,7 @@ final class QuickFeedbackService: NSObject {
     private var cancellables = Set<AnyCancellable>()
 
     private var contentOverlayPopover: ContentOverlayPopover?
+    private var overlayClampObserver: NSObjectProtocol?
 
     /// Suffix match (not substring) so only Asana-owned cookies are cleared on sign-out.
     private static let asanaDomainSuffix = "asana.com"
@@ -97,7 +98,6 @@ final class QuickFeedbackService: NSObject {
             self?.signOut()
         }
         controller.window?.delegate = self
-        controller.setSignOutVisible(true)
         windowController = controller
 
         tab.autofill?.setDelegate(self)
@@ -137,12 +137,14 @@ final class QuickFeedbackService: NSObject {
     // MARK: - Popup lifecycle
 
     private func hidePopup() {
+        stopClampingAutofillOverlay()
         contentOverlayPopover?.viewController.closeContentOverlayPopover()
         windowController?.window?.orderOut(nil)
         screenshotData = nil
     }
 
     private func forceClosePopup() {
+        stopClampingAutofillOverlay()
         contentOverlayPopover?.viewController.closeContentOverlayPopover()
         contentOverlayPopover = nil
         windowController?.window?.orderOut(nil)
@@ -182,7 +184,6 @@ final class QuickFeedbackService: NSObject {
             dataStore.removeData(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), for: asanaRecords) {
                 Task { @MainActor [weak self] in
                     self?.currentTab?.webView.load(URLRequest(url: .internalFeedbackForm))
-                    self?.windowController?.setSignOutVisible(true)
                 }
             }
         }
@@ -232,12 +233,20 @@ extension QuickFeedbackService: TabDelegate {
 
     func tabWillStartNavigation(_ tab: Tab, isUserInitiated: Bool) {}
     func tabDidStartNavigation(_ tab: Tab) {}
-    func tabPageDOMLoaded(_ tab: Tab) {}
+
+    /// Bar visibility follows the rendered page: visible only when the form URL is loaded
+    /// (i.e. user is signed in). Hidden on the login screen and during transient navigations.
+    func tabPageDOMLoaded(_ tab: Tab) {
+        let isOnFeedbackForm = tab.webView.url.map(InternalFeedbackFormTabExtension.isInternalFeedbackURL) ?? false
+        windowController?.setSignOutVisible(isOnFeedbackForm)
+    }
+
     func closeTab(_ tab: Tab) {
         forceClosePopup()
     }
 
     func websiteAutofillUserScriptCloseOverlay(_ websiteAutofillUserScript: WebsiteAutofillUserScript?) {
+        stopClampingAutofillOverlay()
         overlayPopoverCreatingIfNeeded()?.websiteAutofillUserScriptCloseOverlay(websiteAutofillUserScript)
     }
 
@@ -245,12 +254,61 @@ extension QuickFeedbackService: TabDelegate {
                                    willDisplayOverlayAtClick: CGPoint?,
                                    serializedInputContext: String,
                                    inputPosition: CGRect) {
-        overlayPopoverCreatingIfNeeded()?.websiteAutofillUserScript(
+        let popover = overlayPopoverCreatingIfNeeded()
+        popover?.websiteAutofillUserScript(
             websiteAutofillUserScript,
             willDisplayOverlayAtClick: willDisplayOverlayAtClick,
             serializedInputContext: serializedInputContext,
             inputPosition: inputPosition
         )
+        startClampingAutofillOverlay()
+    }
+}
+
+// MARK: - Autofill overlay clamping
+//
+// `ContentOverlayPopover` positions itself relative to the focused input and is sized to fit
+// its content -- in a regular browser window the host is large enough that this never spills
+// out. The feedback popup is only 600×700, so tall overlays (e.g. the "Import passwords"
+// prompt) can extend outside the panel. We clamp the overlay's screen frame to the panel and
+// re-clamp on every resize so async content loads stay contained.
+
+private extension QuickFeedbackService {
+
+    func startClampingAutofillOverlay() {
+        guard let overlayWindow = contentOverlayPopover?.windowController.window else { return }
+        stopClampingAutofillOverlay()
+        overlayClampObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResizeNotification,
+            object: overlayWindow,
+            queue: .main
+        ) { [weak self] _ in
+            self?.clampAutofillOverlayToPanel()
+        }
+        Task { @MainActor [weak self] in
+            self?.clampAutofillOverlayToPanel()
+        }
+    }
+
+    func stopClampingAutofillOverlay() {
+        if let observer = overlayClampObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        overlayClampObserver = nil
+    }
+
+    func clampAutofillOverlayToPanel() {
+        guard let overlayWindow = contentOverlayPopover?.windowController.window,
+              let panelFrame = windowController?.window?.frame else {
+            return
+        }
+        let overlayFrame = overlayWindow.frame
+        let clampedX = min(max(overlayFrame.minX, panelFrame.minX), max(panelFrame.minX, panelFrame.maxX - overlayFrame.width))
+        let clampedY = min(max(overlayFrame.minY, panelFrame.minY), max(panelFrame.minY, panelFrame.maxY - overlayFrame.height))
+        let clamped = NSRect(x: clampedX, y: clampedY, width: overlayFrame.width, height: overlayFrame.height)
+        if clamped != overlayFrame {
+            overlayWindow.setFrame(clamped, display: true)
+        }
     }
 }
 

--- a/macOS/DuckDuckGo/Feedback/QuickFeedback/QuickFeedbackService.swift
+++ b/macOS/DuckDuckGo/Feedback/QuickFeedback/QuickFeedbackService.swift
@@ -31,7 +31,8 @@ final class QuickFeedbackService: NSObject {
     private var cancellables = Set<AnyCancellable>()
 
     private var contentOverlayPopover: ContentOverlayPopover?
-    private var overlayClampObserver: NSObjectProtocol?
+    private var overlayAnchorObserver: NSObjectProtocol?
+    private var lastAutofillInputPosition: CGRect?
 
     /// Suffix match (not substring) so only Asana-owned cookies are cleared on sign-out.
     private static let asanaDomainSuffix = "asana.com"
@@ -137,14 +138,14 @@ final class QuickFeedbackService: NSObject {
     // MARK: - Popup lifecycle
 
     private func hidePopup() {
-        stopClampingAutofillOverlay()
+        stopAnchoringAutofillOverlay()
         contentOverlayPopover?.viewController.closeContentOverlayPopover()
         windowController?.window?.orderOut(nil)
         screenshotData = nil
     }
 
     private func forceClosePopup() {
-        stopClampingAutofillOverlay()
+        stopAnchoringAutofillOverlay()
         contentOverlayPopover?.viewController.closeContentOverlayPopover()
         contentOverlayPopover = nil
         windowController?.window?.orderOut(nil)
@@ -246,7 +247,7 @@ extension QuickFeedbackService: TabDelegate {
     }
 
     func websiteAutofillUserScriptCloseOverlay(_ websiteAutofillUserScript: WebsiteAutofillUserScript?) {
-        stopClampingAutofillOverlay()
+        stopAnchoringAutofillOverlay()
         overlayPopoverCreatingIfNeeded()?.websiteAutofillUserScriptCloseOverlay(websiteAutofillUserScript)
     }
 
@@ -261,54 +262,71 @@ extension QuickFeedbackService: TabDelegate {
             serializedInputContext: serializedInputContext,
             inputPosition: inputPosition
         )
-        startClampingAutofillOverlay()
+        lastAutofillInputPosition = inputPosition
+        startAnchoringAutofillOverlay()
     }
 }
 
-// MARK: - Autofill overlay clamping
+// MARK: - Autofill overlay anchoring
 //
-// `ContentOverlayPopover` positions itself relative to the focused input and is sized to fit
-// its content -- in a regular browser window the host is large enough that this never spills
-// out. The feedback popup is only 600×700, so tall overlays (e.g. the "Import passwords"
-// prompt) can extend outside the panel. We clamp the overlay's screen frame to the panel and
-// re-clamp on every resize so async content loads stay contained.
+// `ContentOverlayPopover`'s positioning math is tuned for a full browser window and doesn't
+// reliably land inside our 600×700 panel (tall prompts like "Import passwords" end up off
+// the panel). We override its placement by re-anchoring the overlay's top-left to the input
+// field's bottom-left using AppKit view conversion, and re-anchor on resize so async content
+// loads stay anchored. Horizontal position is clamped so the overlay can't poke past the
+// panel's right edge.
 
 private extension QuickFeedbackService {
 
-    func startClampingAutofillOverlay() {
+    func startAnchoringAutofillOverlay() {
         guard let overlayWindow = contentOverlayPopover?.windowController.window else { return }
-        stopClampingAutofillOverlay()
-        overlayClampObserver = NotificationCenter.default.addObserver(
+        stopAnchoringAutofillOverlay()
+        overlayAnchorObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.didResizeNotification,
             object: overlayWindow,
             queue: .main
         ) { [weak self] _ in
-            self?.clampAutofillOverlayToPanel()
+            self?.anchorAutofillOverlayBelowInput()
         }
         Task { @MainActor [weak self] in
-            self?.clampAutofillOverlayToPanel()
+            self?.anchorAutofillOverlayBelowInput()
         }
     }
 
-    func stopClampingAutofillOverlay() {
-        if let observer = overlayClampObserver {
+    func stopAnchoringAutofillOverlay() {
+        if let observer = overlayAnchorObserver {
             NotificationCenter.default.removeObserver(observer)
         }
-        overlayClampObserver = nil
+        overlayAnchorObserver = nil
+        lastAutofillInputPosition = nil
     }
 
-    func clampAutofillOverlayToPanel() {
+    func anchorAutofillOverlayBelowInput() {
         guard let overlayWindow = contentOverlayPopover?.windowController.window,
+              let inputPosition = lastAutofillInputPosition,
+              let webView = currentTab?.webView,
+              let webViewWindow = webView.window,
               let panelFrame = windowController?.window?.frame else {
             return
         }
-        let overlayFrame = overlayWindow.frame
-        let clampedX = min(max(overlayFrame.minX, panelFrame.minX), max(panelFrame.minX, panelFrame.maxX - overlayFrame.width))
-        let clampedY = min(max(overlayFrame.minY, panelFrame.minY), max(panelFrame.minY, panelFrame.maxY - overlayFrame.height))
-        let clamped = NSRect(x: clampedX, y: clampedY, width: overlayFrame.width, height: overlayFrame.height)
-        if clamped != overlayFrame {
-            overlayWindow.setFrame(clamped, display: true)
-        }
+        // JS reports `inputPosition` in top-left-origin viewport coordinates. Flip to AppKit
+        // local coords (bottom-left origin) before letting AppKit handle the rest of the
+        // transform up to screen space.
+        let inputRectInWebView: NSRect = webView.isFlipped
+            ? inputPosition
+            : NSRect(x: inputPosition.minX,
+                     y: webView.bounds.height - inputPosition.maxY,
+                     width: inputPosition.width,
+                     height: inputPosition.height)
+        let inputRectInWindow = webView.convert(inputRectInWebView, to: nil)
+        let inputRectInScreen = webViewWindow.convertToScreen(inputRectInWindow)
+
+        // Overlay's top-left lands at the input's bottom-left so the overlay sits directly
+        // beneath the field.
+        let overlayWidth = overlayWindow.frame.width
+        let anchorX = min(max(inputRectInScreen.minX, panelFrame.minX),
+                          max(panelFrame.minX, panelFrame.maxX - overlayWidth))
+        overlayWindow.setFrameTopLeftPoint(NSPoint(x: anchorX, y: inputRectInScreen.minY))
     }
 }
 

--- a/macOS/DuckDuckGo/Feedback/QuickFeedback/QuickFeedbackService.swift
+++ b/macOS/DuckDuckGo/Feedback/QuickFeedback/QuickFeedbackService.swift
@@ -31,8 +31,6 @@ final class QuickFeedbackService: NSObject {
     private var cancellables = Set<AnyCancellable>()
 
     private var contentOverlayPopover: ContentOverlayPopover?
-    private var overlayAnchorObserver: NSObjectProtocol?
-    private var lastAutofillInputPosition: CGRect?
 
     /// Suffix match (not substring) so only Asana-owned cookies are cleared on sign-out.
     private static let asanaDomainSuffix = "asana.com"
@@ -138,14 +136,12 @@ final class QuickFeedbackService: NSObject {
     // MARK: - Popup lifecycle
 
     private func hidePopup() {
-        stopAnchoringAutofillOverlay()
         contentOverlayPopover?.viewController.closeContentOverlayPopover()
         windowController?.window?.orderOut(nil)
         screenshotData = nil
     }
 
     private func forceClosePopup() {
-        stopAnchoringAutofillOverlay()
         contentOverlayPopover?.viewController.closeContentOverlayPopover()
         contentOverlayPopover = nil
         windowController?.window?.orderOut(nil)
@@ -247,7 +243,6 @@ extension QuickFeedbackService: TabDelegate {
     }
 
     func websiteAutofillUserScriptCloseOverlay(_ websiteAutofillUserScript: WebsiteAutofillUserScript?) {
-        stopAnchoringAutofillOverlay()
         overlayPopoverCreatingIfNeeded()?.websiteAutofillUserScriptCloseOverlay(websiteAutofillUserScript)
     }
 
@@ -255,78 +250,12 @@ extension QuickFeedbackService: TabDelegate {
                                    willDisplayOverlayAtClick: CGPoint?,
                                    serializedInputContext: String,
                                    inputPosition: CGRect) {
-        let popover = overlayPopoverCreatingIfNeeded()
-        popover?.websiteAutofillUserScript(
+        overlayPopoverCreatingIfNeeded()?.websiteAutofillUserScript(
             websiteAutofillUserScript,
             willDisplayOverlayAtClick: willDisplayOverlayAtClick,
             serializedInputContext: serializedInputContext,
             inputPosition: inputPosition
         )
-        lastAutofillInputPosition = inputPosition
-        startAnchoringAutofillOverlay()
-    }
-}
-
-// MARK: - Autofill overlay anchoring
-//
-// `ContentOverlayPopover`'s positioning math is tuned for a full browser window and doesn't
-// reliably land inside our 600×700 panel (tall prompts like "Import passwords" end up off
-// the panel). We override its placement by re-anchoring the overlay's top-left to the input
-// field's bottom-left using AppKit view conversion, and re-anchor on resize so async content
-// loads stay anchored. Horizontal position is clamped so the overlay can't poke past the
-// panel's right edge.
-
-private extension QuickFeedbackService {
-
-    func startAnchoringAutofillOverlay() {
-        guard let overlayWindow = contentOverlayPopover?.windowController.window else { return }
-        stopAnchoringAutofillOverlay()
-        overlayAnchorObserver = NotificationCenter.default.addObserver(
-            forName: NSWindow.didResizeNotification,
-            object: overlayWindow,
-            queue: .main
-        ) { [weak self] _ in
-            self?.anchorAutofillOverlayBelowInput()
-        }
-        Task { @MainActor [weak self] in
-            self?.anchorAutofillOverlayBelowInput()
-        }
-    }
-
-    func stopAnchoringAutofillOverlay() {
-        if let observer = overlayAnchorObserver {
-            NotificationCenter.default.removeObserver(observer)
-        }
-        overlayAnchorObserver = nil
-        lastAutofillInputPosition = nil
-    }
-
-    func anchorAutofillOverlayBelowInput() {
-        guard let overlayWindow = contentOverlayPopover?.windowController.window,
-              let inputPosition = lastAutofillInputPosition,
-              let webView = currentTab?.webView,
-              let webViewWindow = webView.window,
-              let panelFrame = windowController?.window?.frame else {
-            return
-        }
-        // JS reports `inputPosition` in top-left-origin viewport coordinates. Flip to AppKit
-        // local coords (bottom-left origin) before letting AppKit handle the rest of the
-        // transform up to screen space.
-        let inputRectInWebView: NSRect = webView.isFlipped
-            ? inputPosition
-            : NSRect(x: inputPosition.minX,
-                     y: webView.bounds.height - inputPosition.maxY,
-                     width: inputPosition.width,
-                     height: inputPosition.height)
-        let inputRectInWindow = webView.convert(inputRectInWebView, to: nil)
-        let inputRectInScreen = webViewWindow.convertToScreen(inputRectInWindow)
-
-        // Overlay's top-left lands at the input's bottom-left so the overlay sits directly
-        // beneath the field.
-        let overlayWidth = overlayWindow.frame.width
-        let anchorX = min(max(inputRectInScreen.minX, panelFrame.minX),
-                          max(panelFrame.minX, panelFrame.maxX - overlayWidth))
-        overlayWindow.setFrameTopLeftPoint(NSPoint(x: anchorX, y: inputRectInScreen.minY))
     }
 }
 

--- a/macOS/DuckDuckGo/Feedback/QuickFeedback/QuickFeedbackService.swift
+++ b/macOS/DuckDuckGo/Feedback/QuickFeedback/QuickFeedbackService.swift
@@ -112,8 +112,8 @@ final class QuickFeedbackService: NSObject {
         // before document-start fires on the first navigation.
         let tab = Tab(
             content: .none,
-            burnerMode: .regular,
-            shouldLoadInBackground: false
+            shouldLoadInBackground: false,
+            burnerMode: .regular
         )
         tab.setDelegate(self)
         tab.webView.configuration.userContentController.addUserScript(
@@ -157,10 +157,10 @@ final class QuickFeedbackService: NSObject {
         if let existing = contentOverlayPopover {
             return existing
         }
-        guard let anchorView = windowController?.webViewContainer else {
+        guard let anchorView = windowController?.webViewContainer,
+              let appDelegate = Application.appDelegate else {
             return nil
         }
-        let appDelegate = Application.appDelegate
         let popover = ContentOverlayPopover(
             currentTabView: anchorView,
             privacyConfigurationManager: appDelegate.privacyFeatures.contentBlocking.privacyConfigurationManager,

--- a/macOS/DuckDuckGo/Feedback/QuickFeedback/QuickFeedbackService.swift
+++ b/macOS/DuckDuckGo/Feedback/QuickFeedback/QuickFeedbackService.swift
@@ -223,8 +223,12 @@ extension QuickFeedbackService: TabDelegate {
             WindowsManager.openPopUpWindow(with: childTab, origin: origin, contentSize: contentSize)
         case .window(active: let active, _):
             WindowsManager.openNewWindow(with: childTab, showWindow: active)
-        case .tab:
-            WindowsManager.openNewWindow(with: childTab, showWindow: true)
+        case .tab(selected: let selected, _, _):
+            if let parentWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController {
+                parentWindowController.mainViewController.tabCollectionViewModel.insertOrAppend(tab: childTab, selected: selected)
+            } else {
+                WindowsManager.openNewWindow(with: childTab, showWindow: true)
+            }
         }
     }
 

--- a/macOS/DuckDuckGo/Feedback/QuickFeedback/QuickFeedbackService.swift
+++ b/macOS/DuckDuckGo/Feedback/QuickFeedback/QuickFeedbackService.swift
@@ -17,27 +17,27 @@
 //
 
 import AppKit
+import BrowserServicesKit
 import Combine
-import Common
-import os.log
 import WebKit
 
 @MainActor
 final class QuickFeedbackService: NSObject {
 
     private var windowController: QuickFeedbackWindowController?
+    private var currentTab: Tab?
     private var screenshotData: Data?
     private let diagnosticsCollector: QuickFeedbackDiagnosticsCollector
-    private let appVersion: AppVersion
-
-    private let dataStore: WKWebsiteDataStore
     private var cancellables = Set<AnyCancellable>()
 
-    private static let asanaFormHost = "form.asana.com"
-    private static let asanaCookieDomain = "asana.com"
-    private static let feedbackStoreIdentifier = UUID(uuidString: "D1A2B3C4-E5F6-7890-ABCD-EF1234567890")!
+    private var contentOverlayPopover: ContentOverlayPopover?
 
-    private static let earlyInjectionScript = """
+    /// `hasSuffix` (not `contains`) so unrelated domains like `casanaresort.com` aren't purged.
+    private static let asanaDomainSuffix = "asana.com"
+
+    /// Hides the form section until the autofiller's `hideIrrelevantFields` runs (8s fallback)
+    /// and suppresses `beforeunload` prompts that would block the panel closing.
+    private static let popupModeEarlyInjectionScript = """
     (function() {
         var s = document.createElement('style');
         s.id = 'ddg-form-hider';
@@ -64,20 +64,9 @@ final class QuickFeedbackService: NSObject {
 
     init(
         diagnosticsCollector: QuickFeedbackDiagnosticsCollector,
-        appVersion: AppVersion = AppVersion(),
         firePublisher: AnyPublisher<Fire.BurningData?, Never>
     ) {
         self.diagnosticsCollector = diagnosticsCollector
-        self.appVersion = appVersion
-        // macOS 14+ uses an isolated persistent store so Fire doesn't clear
-        // the Asana session. On older macOS (no forIdentifier API), we fall
-        // back to .default() where Fire will clear cookies. Acceptable since
-        // internal users on macOS < 14 are extremely rare.
-        if #available(macOS 14.0, *) {
-            self.dataStore = WKWebsiteDataStore(forIdentifier: Self.feedbackStoreIdentifier)
-        } else {
-            self.dataStore = .default()
-        }
 
         super.init()
 
@@ -93,92 +82,109 @@ final class QuickFeedbackService: NSObject {
     func openFeedbackPopup(from window: NSWindow? = nil) {
         captureScreenshot(from: window)
 
-        if let existing = windowController {
+        if let existing = windowController, let tab = currentTab {
             existing.window?.makeKeyAndOrderFront(nil)
-            navigateToForm()
+            tab.internalFeedbackForm?.popupContext = makePopupContext()
+            tab.webView.load(URLRequest(url: .internalFeedbackForm))
             return
         }
 
-        let controller = createWindowController()
-        windowController = controller
+        let tab = makeFeedbackTab()
+        currentTab = tab
 
-        controller.window?.makeKeyAndOrderFront(nil)
-
-        Task {
-            await copyAsanaCookiesFromDefaultStore()
-            navigateToForm()
-        }
-    }
-
-    private func createWindowController() -> QuickFeedbackWindowController {
-        let config = WKWebViewConfiguration()
-        config.websiteDataStore = dataStore
-        config.processPool = WKProcessPool()
-
-        let userScript = WKUserScript(
-            source: Self.earlyInjectionScript,
-            injectionTime: .atDocumentStart,
-            forMainFrameOnly: true
-        )
-        config.userContentController.addUserScript(userScript)
-        let controller = QuickFeedbackWindowController(webViewConfiguration: config)
-        controller.webView.navigationDelegate = self
-        controller.window?.delegate = self
+        let controller = QuickFeedbackWindowController(tab: tab)
         controller.onSignOutRequested = { [weak self] in
             self?.signOut()
         }
+        controller.window?.delegate = self
+        controller.setSignOutVisible(true)
+        windowController = controller
 
-        return controller
+        tab.autofill?.setDelegate(self)
+
+        controller.window?.makeKeyAndOrderFront(nil)
     }
 
-    private func navigateToForm() {
-        guard let webView = windowController?.webView else { return }
-        let request = URLRequest(url: .internalFeedbackForm)
-        webView.load(request)
+    // MARK: - Tab construction
+
+    private func makeFeedbackTab() -> Tab {
+        // `.none` then explicit `load`: ensures the early-injection script is registered
+        // before document-start fires on the first navigation.
+        let tab = Tab(
+            content: .none,
+            burnerMode: .regular,
+            shouldLoadInBackground: false
+        )
+        tab.setDelegate(self)
+        tab.webView.configuration.userContentController.addUserScript(
+            WKUserScript(source: Self.popupModeEarlyInjectionScript,
+                         injectionTime: .atDocumentStart,
+                         forMainFrameOnly: true)
+        )
+        tab.internalFeedbackForm?.popupContext = makePopupContext()
+        tab.webView.load(URLRequest(url: .internalFeedbackForm))
+        return tab
     }
+
+    private func makePopupContext() -> InternalFeedbackFormPopupContext {
+        InternalFeedbackFormPopupContext(
+            quickMode: true,
+            diagnostics: diagnosticsCollector.collectDiagnostics(),
+            screenshotData: screenshotData
+        )
+    }
+
+    // MARK: - Popup lifecycle
 
     private func hidePopup() {
+        contentOverlayPopover?.viewController.closeContentOverlayPopover()
         windowController?.window?.orderOut(nil)
         screenshotData = nil
     }
 
     private func forceClosePopup() {
+        contentOverlayPopover?.viewController.closeContentOverlayPopover()
+        contentOverlayPopover = nil
         windowController?.window?.orderOut(nil)
         windowController = nil
+        currentTab = nil
         screenshotData = nil
+    }
+
+    // MARK: - Autofill overlay
+
+    private func overlayPopoverCreatingIfNeeded() -> ContentOverlayPopover? {
+        if let existing = contentOverlayPopover {
+            return existing
+        }
+        guard let anchorView = windowController?.webViewContainer else {
+            return nil
+        }
+        let appDelegate = Application.appDelegate
+        let popover = ContentOverlayPopover(
+            currentTabView: anchorView,
+            privacyConfigurationManager: appDelegate.privacyFeatures.contentBlocking.privacyConfigurationManager,
+            webTrackingProtectionPreferences: appDelegate.webTrackingProtectionPreferences,
+            featureFlagger: appDelegate.featureFlagger,
+            tld: appDelegate.tld,
+            pinningManager: appDelegate.pinningManager
+        )
+        contentOverlayPopover = popover
+        return popover
     }
 
     private func signOut() {
         windowController?.setSignOutVisible(false)
 
-        if dataStore === WKWebsiteDataStore.default() {
-            dataStore.fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes()) { [weak self] records in
-                let asanaRecords = records.filter { $0.displayName.contains("asana") }
-                self?.dataStore.removeData(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), for: asanaRecords) {
-                    Task { @MainActor [weak self] in
-                        self?.navigateToForm()
-                    }
-                }
-            }
-        } else {
-            dataStore.removeData(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), modifiedSince: .distantPast) { [weak self] in
+        let dataStore = WKWebsiteDataStore.default()
+        dataStore.fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes()) { records in
+            let asanaRecords = records.filter { $0.displayName.hasSuffix(Self.asanaDomainSuffix) }
+            dataStore.removeData(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), for: asanaRecords) {
                 Task { @MainActor [weak self] in
-                    self?.navigateToForm()
+                    self?.currentTab?.webView.load(URLRequest(url: .internalFeedbackForm))
+                    self?.windowController?.setSignOutVisible(true)
                 }
             }
-        }
-    }
-
-    // MARK: - Cookie Sync
-
-    private func copyAsanaCookiesFromDefaultStore() async {
-        guard dataStore !== WKWebsiteDataStore.default() else { return }
-
-        let defaultCookies = await WKWebsiteDataStore.default().httpCookieStore.allCookies()
-        let asanaCookies = defaultCookies.filter { $0.domain.hasSuffix(Self.asanaCookieDomain) }
-
-        for cookie in asanaCookies {
-            await dataStore.httpCookieStore.setCookie(cookie)
         }
     }
 
@@ -204,71 +210,47 @@ final class QuickFeedbackService: NSObject {
         let bitmapRep = NSBitmapImageRep(cgImage: cgImage)
         screenshotData = bitmapRep.representation(using: .png, properties: [:])
     }
-
-    // MARK: - JS Injection
-
-    private func injectQuickModeScript() {
-        guard let webView = windowController?.webView else { return }
-
-        guard let url = Bundle.main.url(forResource: "internal-feedback-autofiller", withExtension: "js"),
-              let template = try? String(contentsOf: url, encoding: .utf8) else {
-            Logger.general.error("Failed to load internal-feedback-autofiller.js from bundle")
-            return
-        }
-
-        let bootstrapScript = template
-            .replacingOccurrences(of: "%QUICK_MODE%", with: "null")
-            .replacingOccurrences(of: "%DIAGNOSTICS%", with: "")
-            .replacingOccurrences(of: "%SCREENSHOT_BASE64%", with: "")
-            .replacingOccurrences(of: "%OS_VERSION%", with: "")
-            .replacingOccurrences(of: "%APP_VERSION%", with: "")
-
-        let appVersionModel = AppVersionModel(appVersion: appVersion)
-
-        let payload: [String: Any] = [
-            "osVersion": appVersion.osVersionMajorMinorPatch,
-            "appVersion": "\(appVersionModel.versionLabelShort) (\(appVersionModel.distributionLabel))",
-            "quickMode": true,
-            "diagnostics": diagnosticsCollector.collectDiagnostics(),
-            "screenshotBase64": screenshotData?.base64EncodedString() ?? "",
-        ]
-
-        guard let jsonData = try? JSONSerialization.data(withJSONObject: payload),
-              let json = String(data: jsonData, encoding: .utf8) else {
-            Logger.general.error("Failed to serialize quick feedback payload")
-            return
-        }
-
-        webView.evaluateJavaScript(bootstrapScript) { [weak self] _, error in
-            if let error {
-                Logger.general.error("Quick feedback JS bootstrap failed: \(error.localizedDescription)")
-                return
-            }
-            self?.windowController?.webView.evaluateJavaScript("window.__ddgQuickFeedbackAutofill(\(json))") { _, error in
-                if let error {
-                    Logger.general.error("Quick feedback autofill failed: \(error.localizedDescription)")
-                }
-            }
-        }
-    }
 }
 
-// MARK: - WKNavigationDelegate
+// MARK: - TabDelegate
 
-extension QuickFeedbackService: WKNavigationDelegate {
+extension QuickFeedbackService: TabDelegate {
 
-    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        guard let url = webView.url else { return }
+    var isInPopUpWindow: Bool { true }
 
-        let isAsanaForm = url.host == Self.asanaFormHost
-
-        if !isAsanaForm {
-            windowController?.setSignOutVisible(false)
-            return
+    func tab(_ tab: Tab, createdChild childTab: Tab, of kind: NewWindowPolicy) {
+        // Asana help links and similar new-window navigations open in a regular browser window.
+        switch kind {
+        case .popup(origin: let origin, size: let contentSize):
+            WindowsManager.openPopUpWindow(with: childTab, origin: origin, contentSize: contentSize)
+        case .window(active: let active, _):
+            WindowsManager.openNewWindow(with: childTab, showWindow: active)
+        case .tab:
+            WindowsManager.openNewWindow(with: childTab, showWindow: true)
         }
+    }
 
-        windowController?.setSignOutVisible(true)
-        injectQuickModeScript()
+    func tabWillStartNavigation(_ tab: Tab, isUserInitiated: Bool) {}
+    func tabDidStartNavigation(_ tab: Tab) {}
+    func tabPageDOMLoaded(_ tab: Tab) {}
+    func closeTab(_ tab: Tab) {
+        forceClosePopup()
+    }
+
+    func websiteAutofillUserScriptCloseOverlay(_ websiteAutofillUserScript: WebsiteAutofillUserScript?) {
+        overlayPopoverCreatingIfNeeded()?.websiteAutofillUserScriptCloseOverlay(websiteAutofillUserScript)
+    }
+
+    func websiteAutofillUserScript(_ websiteAutofillUserScript: WebsiteAutofillUserScript,
+                                   willDisplayOverlayAtClick: CGPoint?,
+                                   serializedInputContext: String,
+                                   inputPosition: CGRect) {
+        overlayPopoverCreatingIfNeeded()?.websiteAutofillUserScript(
+            websiteAutofillUserScript,
+            willDisplayOverlayAtClick: willDisplayOverlayAtClick,
+            serializedInputContext: serializedInputContext,
+            inputPosition: inputPosition
+        )
     }
 }
 

--- a/macOS/DuckDuckGo/Feedback/QuickFeedback/QuickFeedbackService.swift
+++ b/macOS/DuckDuckGo/Feedback/QuickFeedback/QuickFeedbackService.swift
@@ -32,7 +32,7 @@ final class QuickFeedbackService: NSObject {
 
     private var contentOverlayPopover: ContentOverlayPopover?
 
-    /// `hasSuffix` (not `contains`) so unrelated domains like `casanaresort.com` aren't purged.
+    /// Suffix match (not substring) so only Asana-owned cookies are cleared on sign-out.
     private static let asanaDomainSuffix = "asana.com"
 
     /// Hides the form section until the autofiller's `hideIrrelevantFields` runs (8s fallback)

--- a/macOS/DuckDuckGo/Feedback/QuickFeedback/QuickFeedbackWindowController.swift
+++ b/macOS/DuckDuckGo/Feedback/QuickFeedback/QuickFeedbackWindowController.swift
@@ -22,14 +22,19 @@ import WebKit
 @MainActor
 final class QuickFeedbackWindowController: NSWindowController {
 
-    let webView: WKWebView
+    private let tab: Tab
     private let signOutBar = NSView()
     private let signOutButton = NSButton()
     private var signOutBarHeightConstraint: NSLayoutConstraint!
 
+    /// Exposed so the autofill overlay anchors to this panel rather than the main browser window.
+    private(set) var webViewContainer: NSView!
+
     var onSignOutRequested: (() -> Void)?
 
-    init(webViewConfiguration: WKWebViewConfiguration) {
+    init(tab: Tab) {
+        self.tab = tab
+
         let panel = NSPanel(
             contentRect: NSRect(x: 0, y: 0, width: 600, height: 700),
             styleMask: [.titled, .closable, .resizable, .utilityWindow],
@@ -41,9 +46,6 @@ final class QuickFeedbackWindowController: NSWindowController {
         panel.isReleasedWhenClosed = false
         panel.minSize = NSSize(width: 450, height: 500)
         panel.center()
-
-        webView = WKWebView(frame: .zero, configuration: webViewConfiguration)
-        webView.translatesAutoresizingMaskIntoConstraints = false
 
         super.init(window: panel)
 
@@ -83,8 +85,12 @@ final class QuickFeedbackWindowController: NSWindowController {
         signOutBar.addSubview(signOutButton)
         signOutBar.addSubview(separator)
 
+        let webViewContainer = WebViewContainerView(tab: tab, webView: tab.webView, frame: .zero)
+        webViewContainer.translatesAutoresizingMaskIntoConstraints = false
+        self.webViewContainer = webViewContainer
+
         contentView.addSubview(signOutBar)
-        contentView.addSubview(webView)
+        contentView.addSubview(webViewContainer)
 
         panel.contentView = contentView
 
@@ -103,10 +109,10 @@ final class QuickFeedbackWindowController: NSWindowController {
             separator.trailingAnchor.constraint(equalTo: signOutBar.trailingAnchor),
             separator.bottomAnchor.constraint(equalTo: signOutBar.bottomAnchor),
 
-            webView.topAnchor.constraint(equalTo: signOutBar.bottomAnchor),
-            webView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            webView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            webView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            webViewContainer.topAnchor.constraint(equalTo: signOutBar.bottomAnchor),
+            webViewContainer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            webViewContainer.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            webViewContainer.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
         ])
     }
 

--- a/macOS/DuckDuckGo/Feedback/Resources/internal-feedback-autofiller.js
+++ b/macOS/DuckDuckGo/Feedback/Resources/internal-feedback-autofiller.js
@@ -422,19 +422,6 @@ function handleNativeAppsDropdown() {
     observer.observe(document.body, { childList: true, subtree: true, characterData: true });
 }
 
-window.__ddgQuickFeedbackAutofill = function(data) {
-    quickMode = data.quickMode;
-    diagnosticsText = data.diagnostics || '';
-    screenshotBase64 = data.screenshotBase64 || '';
-    osVersion = data.osVersion || '';
-    appVersion = data.appVersion || '';
-    waitForElement('h1', 'Internal Product Feedback Form')
-        .then(function() { handleNativeAppsDropdown(); })
-        .catch(function() { console.error('Internal Product Feedback Form is not loaded after 5s'); });
-};
-
-if (quickMode !== null) {
-    waitForElement('h1', 'Internal Product Feedback Form')
-        .then(_ => handleNativeAppsDropdown())
-        .catch(_ => console.error('Internal Product Feedback Form is not loaded after 5s'));
-}
+waitForElement('h1', 'Internal Product Feedback Form')
+    .then(_ => handleNativeAppsDropdown())
+    .catch(_ => console.error('Internal Product Feedback Form is not loaded after 5s'));

--- a/macOS/DuckDuckGo/Feedback/Resources/internal-feedback-autofiller.js
+++ b/macOS/DuckDuckGo/Feedback/Resources/internal-feedback-autofiller.js
@@ -1,8 +1,8 @@
 var quickMode = %QUICK_MODE%;
-var diagnosticsText = '%DIAGNOSTICS%';
-var screenshotBase64 = '%SCREENSHOT_BASE64%';
-var osVersion = '%OS_VERSION%';
-var appVersion = '%APP_VERSION%';
+var diagnosticsText = %DIAGNOSTICS%;
+var screenshotBase64 = %SCREENSHOT_BASE64%;
+var osVersion = %OS_VERSION%;
+var appVersion = %APP_VERSION%;
 
 function openDropdown(label) {
     const dropdown = document.querySelector(`[aria-label^="${label}"]`);
@@ -228,7 +228,7 @@ function injectDiagnosticsSection() {
     details.appendChild(summary);
 
     var pre = document.createElement('pre');
-    pre.textContent = diagnosticsText.replace(/\\n/g, '\n');
+    pre.textContent = diagnosticsText;
     pre.style.cssText = 'font-size: 11px; background: #f5f5f5; padding: 10px; border-radius: 4px; margin: 6px 0 0; overflow-x: auto; white-space: pre-wrap; word-break: break-word; max-height: 200px; overflow-y: auto;';
     details.appendChild(pre);
 
@@ -365,10 +365,9 @@ function hookSubmitForDiagnostics() {
 
         var diagsCb = document.getElementById('ddg-include-diagnostics');
         if (diagsCb && diagsCb.checked && diagnosticsText) {
-            var decodedDiags = diagnosticsText.replace(/\\n/g, '\n');
             var combined = userText
-                ? userText + '\n\n' + decodedDiags
-                : decodedDiags;
+                ? userText + '\n\n' + diagnosticsText
+                : diagnosticsText;
 
             var setter = Object.getOwnPropertyDescriptor(
                 window.HTMLTextAreaElement.prototype, 'value'

--- a/macOS/DuckDuckGo/Tab/TabExtensions/InternalFeedbackFormTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/InternalFeedbackFormTabExtension.swift
@@ -25,6 +25,14 @@ import WebKit
 import PixelKit
 import PrivacyConfig
 
+/// When set on a tab, switches the autofiller into popup mode (quick mode + screenshot +
+/// diagnostics) and forces a rebuild on each navigation so reopening picks up a fresh screenshot.
+struct InternalFeedbackFormPopupContext {
+    let quickMode: Bool
+    let diagnostics: String
+    let screenshotData: Data?
+}
+
 /**
  * This is a wrapper class for a hardcoded script evaluated on the Internal Feedback Form page.
  *
@@ -42,7 +50,7 @@ final class InternalFeedbackFormUserScript: NSObject, UserScript {
 
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {}
 
-    init(quickMode: Bool = false, diagnostics: String = "") {
+    init(quickMode: Bool = false, diagnostics: String = "", screenshotBase64: String = "") {
         let appVersionModel = AppVersionModel()
 
         do {
@@ -51,7 +59,7 @@ final class InternalFeedbackFormUserScript: NSObject, UserScript {
                 "%APP_VERSION%": "\(appVersionModel.versionLabelShort) (\(appVersionModel.distributionLabel))",
                 "%QUICK_MODE%": quickMode ? "true" : "false",
                 "%DIAGNOSTICS%": diagnostics,
-                "%SCREENSHOT_BASE64%": "",
+                "%SCREENSHOT_BASE64%": screenshotBase64,
             ])
             super.init()
         } catch {
@@ -71,25 +79,46 @@ fileprivate extension URLComponents {
 /// This tab extension auto-fills Internal Feedback Form with OS version and app version values.
 ///
 /// It's only active for internal users and only performs an action on the Internal Feedback Form page.
-///
 final class InternalFeedbackFormTabExtension {
 
+    /// Injected so tests don't need `internal-feedback-autofiller.js` in the test bundle.
+    typealias ScriptSourceBuilder = (_ quickMode: Bool, _ diagnostics: String, _ screenshotBase64: String) -> String
+
+    static let defaultScriptSourceBuilder: ScriptSourceBuilder = { quickMode, diagnostics, screenshotBase64 in
+        InternalFeedbackFormUserScript(
+            quickMode: quickMode,
+            diagnostics: diagnostics,
+            screenshotBase64: screenshotBase64
+        ).source
+    }
+
     private let internalUserDecider: InternalUserDecider
+    private let scriptSourceBuilder: ScriptSourceBuilder
     private weak var webView: WKWebView?
     private var cancellables = Set<AnyCancellable>()
     /// Non-internal users don't need this script, hence lazy load only for them.
-    private lazy var scriptSource: String = InternalFeedbackFormUserScript().source
+    private lazy var defaultScriptSource: String = scriptSourceBuilder(false, "", "")
+
+    var popupContext: InternalFeedbackFormPopupContext?
 
     init(
         webViewPublisher: some Publisher<WKWebView, Never>,
-        internalUserDecider: InternalUserDecider
+        internalUserDecider: InternalUserDecider,
+        scriptSourceBuilder: @escaping ScriptSourceBuilder = defaultScriptSourceBuilder
     ) {
         self.internalUserDecider = internalUserDecider
+        self.scriptSourceBuilder = scriptSourceBuilder
 
         webViewPublisher.sink { [weak self] webView in
             self?.webView = webView
         }
         .store(in: &cancellables)
+    }
+
+    func scriptSourceForCurrentNavigation() -> String {
+        guard let popupContext else { return defaultScriptSource }
+        let base64 = popupContext.screenshotData?.base64EncodedString() ?? ""
+        return scriptSourceBuilder(popupContext.quickMode, popupContext.diagnostics, base64)
     }
 }
 
@@ -99,11 +128,11 @@ extension InternalFeedbackFormTabExtension: NavigationResponder {
         guard internalUserDecider.isInternalUser, let webView, navigation.navigationAction.isForMainFrame, isInternalFeedbackURL(navigation.url) else {
             return
         }
-        webView.evaluateJavaScript(scriptSource)
+        webView.evaluateJavaScript(scriptSourceForCurrentNavigation())
     }
 
     /// The URL needs to be matched against the form URL, but there may be additional
-    /// query items in the webView URL that shouldn't be affecting the logic.
+    /// query items in the webView URL that shouldn't be affecting the logic.
     /// So we're comparing the host, path and that webView URL query items are superset
     /// of the reference URL query items.
     private func isInternalFeedbackURL(_ url: URL) -> Bool {
@@ -117,6 +146,7 @@ extension InternalFeedbackFormTabExtension: NavigationResponder {
 }
 
 protocol InternalFeedbackFormTabExtensionProtocol: AnyObject, NavigationResponder {
+    var popupContext: InternalFeedbackFormPopupContext? { get set }
 }
 
 extension InternalFeedbackFormTabExtension: InternalFeedbackFormTabExtensionProtocol, TabExtension {

--- a/macOS/DuckDuckGo/Tab/TabExtensions/InternalFeedbackFormTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/InternalFeedbackFormTabExtension.swift
@@ -138,7 +138,7 @@ final class InternalFeedbackFormTabExtension {
 extension InternalFeedbackFormTabExtension: NavigationResponder {
 
     func navigationDidFinish(_ navigation: Navigation) {
-        guard internalUserDecider.isInternalUser, let webView, navigation.navigationAction.isForMainFrame, isInternalFeedbackURL(navigation.url) else {
+        guard internalUserDecider.isInternalUser, let webView, navigation.navigationAction.isForMainFrame, Self.isInternalFeedbackURL(navigation.url) else {
             return
         }
         webView.evaluateJavaScript(scriptSourceForCurrentNavigation())
@@ -148,7 +148,7 @@ extension InternalFeedbackFormTabExtension: NavigationResponder {
     /// query items in the webView URL that shouldn't be affecting the logic.
     /// So we're comparing the host, path and that webView URL query items are superset
     /// of the reference URL query items.
-    private func isInternalFeedbackURL(_ url: URL) -> Bool {
+    static func isInternalFeedbackURL(_ url: URL) -> Bool {
         guard let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
             return false
         }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/InternalFeedbackFormTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/InternalFeedbackFormTabExtension.swift
@@ -74,7 +74,6 @@ final class InternalFeedbackFormUserScript: NSObject, UserScript {
     /// into the autofiller script. Diagnostics in particular contain newlines and may contain
     /// apostrophes, both of which would otherwise terminate a hand-quoted literal early.
     /// Mirrors `DuckAiNativeStorageBootstrapUserScript.jsStringLiteral`.
-    /// `internal` (not `private`) so unit tests can verify the JS-literal contract directly.
     static func jsStringLiteral(_ value: String) -> String {
         guard let data = try? JSONSerialization.data(withJSONObject: [value]),
               let array = String(data: data, encoding: .utf8) else {

--- a/macOS/DuckDuckGo/Tab/TabExtensions/InternalFeedbackFormTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/InternalFeedbackFormTabExtension.swift
@@ -55,11 +55,11 @@ final class InternalFeedbackFormUserScript: NSObject, UserScript {
 
         do {
             source = try Self.loadJS("internal-feedback-autofiller", from: .main, withReplacements: [
-                "%OS_VERSION%": ProcessInfo.processInfo.operatingSystemVersion.description,
-                "%APP_VERSION%": "\(appVersionModel.versionLabelShort) (\(appVersionModel.distributionLabel))",
+                "%OS_VERSION%": Self.jsStringLiteral(ProcessInfo.processInfo.operatingSystemVersion.description),
+                "%APP_VERSION%": Self.jsStringLiteral("\(appVersionModel.versionLabelShort) (\(appVersionModel.distributionLabel))"),
                 "%QUICK_MODE%": quickMode ? "true" : "false",
-                "%DIAGNOSTICS%": diagnostics,
-                "%SCREENSHOT_BASE64%": screenshotBase64,
+                "%DIAGNOSTICS%": Self.jsStringLiteral(diagnostics),
+                "%SCREENSHOT_BASE64%": Self.jsStringLiteral(screenshotBase64),
             ])
             super.init()
         } catch {
@@ -68,6 +68,18 @@ final class InternalFeedbackFormUserScript: NSObject, UserScript {
             }
             fatalError("Failed to load JS for InternalFeedbackFormUserScript: \(error)")
         }
+    }
+
+    /// Produces a JS string literal (including surrounding quotes) for safe inline substitution
+    /// into the autofiller script. Diagnostics in particular contain newlines and may contain
+    /// apostrophes, both of which would otherwise terminate a hand-quoted literal early.
+    private static func jsStringLiteral(_ value: String) -> String {
+        guard let data = try? JSONSerialization.data(withJSONObject: [value]),
+              let json = String(data: data, encoding: .utf8),
+              json.count >= 2 else {
+            return "\"\""
+        }
+        return String(json.dropFirst().dropLast())
     }
 }
 

--- a/macOS/DuckDuckGo/Tab/TabExtensions/InternalFeedbackFormTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/InternalFeedbackFormTabExtension.swift
@@ -73,13 +73,15 @@ final class InternalFeedbackFormUserScript: NSObject, UserScript {
     /// Produces a JS string literal (including surrounding quotes) for safe inline substitution
     /// into the autofiller script. Diagnostics in particular contain newlines and may contain
     /// apostrophes, both of which would otherwise terminate a hand-quoted literal early.
-    private static func jsStringLiteral(_ value: String) -> String {
+    /// Mirrors `DuckAiNativeStorageBootstrapUserScript.jsStringLiteral`.
+    /// `internal` (not `private`) so unit tests can verify the JS-literal contract directly.
+    static func jsStringLiteral(_ value: String) -> String {
         guard let data = try? JSONSerialization.data(withJSONObject: [value]),
-              let json = String(data: data, encoding: .utf8),
-              json.count >= 2 else {
+              let array = String(data: data, encoding: .utf8) else {
             return "\"\""
         }
-        return String(json.dropFirst().dropLast())
+        // Strip the surrounding `[` `]` to get the quoted-and-escaped string.
+        return String(array.dropFirst().dropLast())
     }
 }
 

--- a/macOS/UnitTests/TabExtensionsTests/InternalFeedbackFormTabExtensionTests.swift
+++ b/macOS/UnitTests/TabExtensionsTests/InternalFeedbackFormTabExtensionTests.swift
@@ -178,7 +178,7 @@ final class InternalFeedbackFormTabExtensionTests: XCTestCase {
         Line 5 with </script> closer and Unicode 🦆
         """
 
-        let literal = InternalFeedbackFormTabExtension.jsStringLiteral(adversarial)
+        let literal = InternalFeedbackFormUserScript.jsStringLiteral(adversarial)
 
         let context = try XCTUnwrap(JSContext())
         var exception: JSValue?
@@ -191,7 +191,7 @@ final class InternalFeedbackFormTabExtensionTests: XCTestCase {
     }
 
     func testJSStringLiteralProducesEmptyStringLiteralForEmptyInput() throws {
-        let literal = InternalFeedbackFormTabExtension.jsStringLiteral("")
+        let literal = InternalFeedbackFormUserScript.jsStringLiteral("")
 
         let context = try XCTUnwrap(JSContext())
         let result = context.evaluateScript("(\(literal))")

--- a/macOS/UnitTests/TabExtensionsTests/InternalFeedbackFormTabExtensionTests.swift
+++ b/macOS/UnitTests/TabExtensionsTests/InternalFeedbackFormTabExtensionTests.swift
@@ -17,6 +17,7 @@
 //
 
 import Combine
+import JavaScriptCore
 import PrivacyConfig
 import WebKit
 import XCTest
@@ -161,6 +162,41 @@ final class InternalFeedbackFormTabExtensionTests: XCTestCase {
 
         XCTAssertEqual(afterClear, "SCRIPT|quick=false|diag=|shot=")
         XCTAssertEqual(builderInvocations.count, 2, "Clearing popup context should revert to the cached default without rebuilding")
+    }
+
+    // MARK: - JS literal escaping (regression: diagnostics with newlines/quotes/separators)
+
+    /// Diagnostics include arbitrary user/system text — newlines, apostrophes, backslashes, and
+    /// even U+2028/U+2029 (which terminate JS string literals). The helper must produce a literal
+    /// that parses as valid JavaScript and round-trips back to the original string.
+    func testJSStringLiteralProducesValidJSLiteralForAdversarialInput() throws {
+        let adversarial = """
+        Line 1 with 'apostrophe' and "quote"
+        Line 2 with backslash \\ and literal \\n sequence
+        Line 3 with U+2028 line sep:\u{2028}and U+2029 para sep:\u{2029}end
+        Line 4 with carriage return\rand tab\tand null \0 byte
+        Line 5 with </script> closer and Unicode 🦆
+        """
+
+        let literal = InternalFeedbackFormTabExtension.jsStringLiteral(adversarial)
+
+        let context = try XCTUnwrap(JSContext())
+        var exception: JSValue?
+        context.exceptionHandler = { _, value in exception = value }
+
+        let result = context.evaluateScript("(\(literal))")
+
+        XCTAssertNil(exception, "jsStringLiteral output must parse as JavaScript. Error: \(exception?.toString() ?? "")")
+        XCTAssertEqual(result?.toString(), adversarial, "JS literal must round-trip back to the original string")
+    }
+
+    func testJSStringLiteralProducesEmptyStringLiteralForEmptyInput() throws {
+        let literal = InternalFeedbackFormTabExtension.jsStringLiteral("")
+
+        let context = try XCTUnwrap(JSContext())
+        let result = context.evaluateScript("(\(literal))")
+
+        XCTAssertEqual(result?.toString(), "")
     }
 
     // MARK: - Protocol exposure

--- a/macOS/UnitTests/TabExtensionsTests/InternalFeedbackFormTabExtensionTests.swift
+++ b/macOS/UnitTests/TabExtensionsTests/InternalFeedbackFormTabExtensionTests.swift
@@ -1,0 +1,181 @@
+//
+//  InternalFeedbackFormTabExtensionTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import PrivacyConfig
+import WebKit
+import XCTest
+
+@testable import DuckDuckGo_Privacy_Browser
+
+@MainActor
+final class InternalFeedbackFormTabExtensionTests: XCTestCase {
+
+    private var webViewSubject: PassthroughSubject<WKWebView, Never>!
+    private var internalUserDecider: MockInternalUserDecider!
+    private var builderInvocations: [(quickMode: Bool, diagnostics: String, screenshotBase64: String)]!
+
+    override func setUp() {
+        super.setUp()
+        webViewSubject = PassthroughSubject<WKWebView, Never>()
+        internalUserDecider = MockInternalUserDecider(isInternalUser: true)
+        builderInvocations = []
+    }
+
+    override func tearDown() {
+        webViewSubject = nil
+        internalUserDecider = nil
+        builderInvocations = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Returns a tagged script string so tests can assert which inputs the builder was called with.
+    private func recordingBuilder() -> InternalFeedbackFormTabExtension.ScriptSourceBuilder {
+        return { [weak self] quickMode, diagnostics, screenshotBase64 in
+            self?.builderInvocations.append((quickMode, diagnostics, screenshotBase64))
+            return "SCRIPT|quick=\(quickMode)|diag=\(diagnostics)|shot=\(screenshotBase64)"
+        }
+    }
+
+    private func makeExtension(
+        builder: InternalFeedbackFormTabExtension.ScriptSourceBuilder? = nil
+    ) -> InternalFeedbackFormTabExtension {
+        InternalFeedbackFormTabExtension(
+            webViewPublisher: webViewSubject,
+            internalUserDecider: internalUserDecider,
+            scriptSourceBuilder: builder ?? recordingBuilder()
+        )
+    }
+
+    // MARK: - Default (no popup context)
+
+    func testWhenPopupContextIsNilThenScriptSourceUsesDefaultBuilderArguments() {
+        let ext = makeExtension()
+
+        let source = ext.scriptSourceForCurrentNavigation()
+
+        XCTAssertEqual(source, "SCRIPT|quick=false|diag=|shot=")
+        XCTAssertEqual(builderInvocations.count, 1)
+        XCTAssertEqual(builderInvocations[0].quickMode, false)
+        XCTAssertEqual(builderInvocations[0].diagnostics, "")
+        XCTAssertEqual(builderInvocations[0].screenshotBase64, "")
+    }
+
+    func testWhenPopupContextIsNilThenDefaultScriptSourceIsCachedAcrossCalls() {
+        let ext = makeExtension()
+
+        _ = ext.scriptSourceForCurrentNavigation()
+        _ = ext.scriptSourceForCurrentNavigation()
+        _ = ext.scriptSourceForCurrentNavigation()
+
+        XCTAssertEqual(builderInvocations.count, 1, "Default script source should be built once and cached")
+    }
+
+    // MARK: - Popup context
+
+    func testWhenPopupContextIsSetThenScriptSourceReflectsContextValues() {
+        let ext = makeExtension()
+        ext.popupContext = InternalFeedbackFormPopupContext(
+            quickMode: true,
+            diagnostics: "diag-payload",
+            screenshotData: Data([0xDE, 0xAD, 0xBE, 0xEF])
+        )
+
+        let source = ext.scriptSourceForCurrentNavigation()
+
+        XCTAssertEqual(source, "SCRIPT|quick=true|diag=diag-payload|shot=3q2+7w==")
+    }
+
+    func testWhenPopupContextScreenshotIsNilThenScreenshotBase64IsEmpty() {
+        let ext = makeExtension()
+        ext.popupContext = InternalFeedbackFormPopupContext(
+            quickMode: true,
+            diagnostics: "no-shot",
+            screenshotData: nil
+        )
+
+        _ = ext.scriptSourceForCurrentNavigation()
+
+        XCTAssertEqual(builderInvocations.count, 1)
+        XCTAssertEqual(builderInvocations[0].screenshotBase64, "", "Nil screenshot should map to empty string, not the literal \"nil\"")
+    }
+
+    func testWhenPopupContextChangesBetweenCallsThenScriptIsRebuiltWithLatestValues() {
+        let ext = makeExtension()
+
+        ext.popupContext = InternalFeedbackFormPopupContext(quickMode: true, diagnostics: "first", screenshotData: nil)
+        let firstSource = ext.scriptSourceForCurrentNavigation()
+
+        ext.popupContext = InternalFeedbackFormPopupContext(quickMode: true, diagnostics: "second", screenshotData: Data([0x01, 0x02]))
+        let secondSource = ext.scriptSourceForCurrentNavigation()
+
+        XCTAssertNotEqual(firstSource, secondSource, "A changed popup context must produce a freshly built script")
+        XCTAssertEqual(builderInvocations.count, 2)
+        XCTAssertEqual(builderInvocations[0].diagnostics, "first")
+        XCTAssertEqual(builderInvocations[1].diagnostics, "second")
+        XCTAssertEqual(builderInvocations[1].screenshotBase64, "AQI=")
+    }
+
+    func testWhenSamePopupContextIsUsedTwiceThenScriptIsStillRebuiltEachCall() {
+        let ext = makeExtension()
+        ext.popupContext = InternalFeedbackFormPopupContext(quickMode: true, diagnostics: "same", screenshotData: nil)
+
+        _ = ext.scriptSourceForCurrentNavigation()
+        _ = ext.scriptSourceForCurrentNavigation()
+
+        XCTAssertEqual(builderInvocations.count, 2, "Popup mode must rebuild the script per call so reopening picks up a fresh screenshot")
+    }
+
+    // MARK: - Reverting to default
+
+    func testWhenPopupContextIsSetThenClearedThenSubsequentCallReturnsCachedDefault() {
+        let ext = makeExtension()
+
+        // Prime the cached default first so the call count is deterministic.
+        _ = ext.scriptSourceForCurrentNavigation()
+        XCTAssertEqual(builderInvocations.count, 1)
+
+        ext.popupContext = InternalFeedbackFormPopupContext(quickMode: true, diagnostics: "popup", screenshotData: nil)
+        _ = ext.scriptSourceForCurrentNavigation()
+        XCTAssertEqual(builderInvocations.count, 2)
+
+        ext.popupContext = nil
+        let afterClear = ext.scriptSourceForCurrentNavigation()
+
+        XCTAssertEqual(afterClear, "SCRIPT|quick=false|diag=|shot=")
+        XCTAssertEqual(builderInvocations.count, 2, "Clearing popup context should revert to the cached default without rebuilding")
+    }
+
+    // MARK: - Protocol exposure
+
+    func testProtocolExposesReadWritePopupContext() {
+        let ext = makeExtension()
+        let asProtocol: any InternalFeedbackFormTabExtensionProtocol = ext
+
+        XCTAssertNil(asProtocol.popupContext)
+
+        let context = InternalFeedbackFormPopupContext(quickMode: true, diagnostics: "via-protocol", screenshotData: nil)
+        asProtocol.popupContext = context
+
+        XCTAssertEqual(asProtocol.popupContext?.quickMode, true)
+        XCTAssertEqual(asProtocol.popupContext?.diagnostics, "via-protocol")
+        XCTAssertNil(asProtocol.popupContext?.screenshotData)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211850802118632/task/1214581201461619
Tech Design URL:
CC: @ayoy @jotaemepereira @Bunn 

### Description

The internal feedback popup used a bespoke `WKWebView` with an isolated `WKWebsiteDataStore`, which forced internal users to sign back into Asana every time they opened the form, and it had no autofill overlay wired up so the DDG password manager couldn't help.

This PR replaces the bespoke web view with a `Tab` from the regular browser pipeline. The tab brings `AutofillTabExtension`, content scripts, and tracking protection, and uses the default `WKWebsiteDataStore` so cookies and credentials are shared with the main browser. The autofill credential picker is wired through `ContentOverlayPopover`, anchored to the popup panel.

Also fixes https://app.asana.com/1/137249556945/project/1211850802118632/task/1214561178722641.

In addition, the autofiller script's placeholder substitution was unsafe: diagnostics text was injected into single-quoted JS string literals by hand, so any newline or apostrophe terminated the literal early and broke the script. Placeholders are now JSON-escaped through a small `jsStringLiteral` helper (mirroring `DuckAiNativeStorageBootstrapUserScript.jsStringLiteral`), and the JS template uses raw placeholders without surrounding quotes.

Other changes:
- `InternalFeedbackFormTabExtension` gains a per-tab `popupContext` (quick mode, diagnostics, screenshot). When set, the script is rebuilt on each navigation so reopening the popup picks up a fresh screenshot. Non-popup tabs keep the existing lazy-cached default-script behavior.
- Sign-out cookie filter tightened from `displayName.contains("asana")` → `displayName.hasSuffix("asana.com")` so unrelated domains aren't caught by the purge.
- Adds a `ScriptSourceBuilder` DI seam on the tab extension so tests don't need the JS resource in the test bundle.
- All injected JS placeholders (diagnostics, OS version, app version, screenshot base64) now go through the `jsStringLiteral` JSON-escape helper instead of being hand-quoted in the template.

### Testing Steps

1. Sign into `app.asana.com` in a regular tab; verify credentials are saved in DDG password manager.
2. Quit and relaunch the browser.
3. Click the debug toolbar feedback button → popup opens directly to the form, **already signed in** (no login screen). _Validates shared session._
4. Sign out (popup top bar) → form reloads to login screen.
5. Click into the email field → DDG password manager overlay appears anchored to the popup panel, suggesting the saved credential. _Validates autofill wiring._
6. Close the popup (X), reopen → screenshot reflects the current main-window state. _Validates per-open script rebuild._
7. With the popup open, click Fire → popup auto-closes.
8. Open the popup with multi-line diagnostics containing apostrophes (e.g. real device state) → diagnostics section renders, and submitting appends them to the description without breaking the script. _Validates safe JS-literal escaping._

### Impact and Risks

**Low** — internal-only feature behind the debug feedback toolbar button. No production user surface affected.

#### What could go wrong?

- Default `WKWebsiteDataStore` means signing out of Asana from the popup also clears Asana cookies in the main browser. This is intentional (sessions are shared), but worth confirming behavior matches expectations.
- The popup tab and overlay popover are retained across `hidePopup()` (X button) and only released on Fire / `closeTab(_:)`. Bounded by one tab + one overlay per app session for users who opened the popup once. Acceptable for an internal tool.
- `ContentOverlayPopover` anchors as a child window of an `NSPanel` (level `.floating`). Standard Cocoa child-window behavior, but verify the overlay sits correctly relative to the panel during manual testing.

### Quality Considerations

- **Privacy:** No new pixels, logs, or network calls. Sign-out filter narrowed (less collateral cookie clearing).
- **Performance:** No startup-chain impact. Per-tab cost adds one closure reference. Popup-mode script rebuild on each navigation runs only when a user opens the internal popup; JS template is cached by `JSFileCache` after first load. Non-popup tabs keep the existing lazy-cached behavior.
- **Tests:** 10 new unit tests in `InternalFeedbackFormTabExtensionTests` covering popup-context flow, default caching, screenshot base64 substitution, rebuild-on-change semantics, and two regression tests that round-trip diagnostics through `JSContext` to verify the JS-literal contract holds for adversarial input (newlines, quotes, U+2028/U+2029, backslashes, emoji). Autofill UX, shared session, and sign-out cookie behavior are not unit-testable (WebKit + UI dependencies) — covered by the manual steps above.

### Notes to Reviewer

- `InternalFeedbackFormUserScript.jsStringLiteral(_:)` is `internal` (not `private`) so the regression tests can call it directly.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the internal feedback popup to use the main `Tab` pipeline (default `WKWebsiteDataStore`, navigation, and autofill overlay), which could affect session/cookie behavior and popup lifecycle despite being internal-only.
> 
> **Overview**
> The internal feedback popup is refactored to embed a real browser `Tab` (via `WebViewContainerView`) instead of a bespoke `WKWebView`, enabling shared Asana session cookies and wiring the autofill credential overlay through `ContentOverlayPopover` anchored to the popup panel.
> 
> The internal feedback autofill path is reworked to support a per-tab `popupContext` (quick mode, diagnostics, screenshot) that rebuilds the injected script per navigation in popup mode, while keeping a cached default for normal tabs.
> 
> The autofiller template and Swift replacement logic are hardened by JSON-escaping all injected placeholders (diagnostics/versions/screenshot) via `jsStringLiteral`, removing the previous fragile hand-quoted JS literals; sign-out now clears only Asana-owned records using a domain-suffix match. New unit tests cover popup-context rebuilding/caching and JS-literal escaping regressions, and the Xcode project is updated to include them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c4602074115f61f287bd2107f53104d60cb439f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->