### PR TITLE
[iOS] Fix SIGTRAP crash from concurrent mutation during TabsModel archiving

### DIFF
--- a/iOS/Core/Link.swift
+++ b/iOS/Core/Link.swift
@@ -19,7 +19,7 @@
 
 import Foundation
 
-public class Link: NSObject, NSCoding {
+public class Link: NSObject, NSCoding, NSCopying {
 
     struct Constants {
         static let ddgSuffix = " at DuckDuckGo"
@@ -65,6 +65,10 @@ public class Link: NSObject, NSCoding {
         coder.encode(title, forKey: NSCodingKeys.title)
         coder.encode(url, forKey: NSCodingKeys.url)
         coder.encode(localFileURL, forKey: NSCodingKeys.localPath)
+    }
+
+    public func copy(with zone: NSZone? = nil) -> Any {
+        Link(title: title, url: url, localPath: localFileURL)
     }
 
     public override func isEqual(_ other: Any?) -> Bool {

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Terminating.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Terminating.swift
@@ -157,7 +157,6 @@ struct Terminating: TerminatingHandling {
             pixel = switch error {
             case .appSupportDirAccess: .tabsStoreSupportDirAccessError
             case .storeInit: .tabsStoreInitError
-            case .copying: .tabsStoreSaveError
             }
             mode = .immediately(debugMessage: "TabsModelPersistence init failed: \(error)")
         }

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Terminating.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Terminating.swift
@@ -157,6 +157,7 @@ struct Terminating: TerminatingHandling {
             pixel = switch error {
             case .appSupportDirAccess: .tabsStoreSupportDirAccessError
             case .storeInit: .tabsStoreInitError
+            case .copying: .tabsStoreSaveError
             }
             mode = .immediately(debugMessage: "TabsModelPersistence init failed: \(error)")
         }

--- a/iOS/DuckDuckGo/BulkGeneratorView.swift
+++ b/iOS/DuckDuckGo/BulkGeneratorView.swift
@@ -136,6 +136,7 @@ struct BulkTabFactory: BulkGeneratorView.Factory {
         return
     }
     
+    @MainActor
     func finished() {
         _ = tabManager.save()
     }

--- a/iOS/DuckDuckGo/Tab.swift
+++ b/iOS/DuckDuckGo/Tab.swift
@@ -32,7 +32,7 @@ protocol TabObserver: AnyObject {
     
 }
 
-public class Tab: NSObject, NSCoding, NSCopying {
+public class Tab: NSObject, NSCoding {
 
     struct WeaklyHeldTabObserver {
         weak var observer: TabObserver?
@@ -236,7 +236,8 @@ public class Tab: NSObject, NSCoding, NSCopying {
         // Note: type is not encoded as it's now a computed property based on the link URL
     }
 
-    public func copy(with zone: NSZone? = nil) -> Any {
+    /// Returns a frozen deep copy containing only the fields that are persisted via NSCoding.
+    func archivalSnapshot() -> Tab {
         Tab(uid: uid,
             link: link?.copy() as? Link,
             viewed: viewed,

--- a/iOS/DuckDuckGo/Tab.swift
+++ b/iOS/DuckDuckGo/Tab.swift
@@ -32,7 +32,7 @@ protocol TabObserver: AnyObject {
     
 }
 
-public class Tab: NSObject, NSCoding {
+public class Tab: NSObject, NSCoding, NSCopying {
 
     struct WeaklyHeldTabObserver {
         weak var observer: TabObserver?
@@ -234,6 +234,19 @@ public class Tab: NSObject, NSCoding {
         coder.encode(unifiedInputState.selectedTool?.rawValue, forKey: NSCodingKeys.selectedTool)
         // Note: isExternalLaunch and shouldSuppressTrackerAnimationOnFirstLoad are not encoded as they are transient flags
         // Note: type is not encoded as it's now a computed property based on the link URL
+    }
+
+    public func copy(with zone: NSZone? = nil) -> Any {
+        Tab(uid: uid,
+            link: link?.copy() as? Link,
+            viewed: viewed,
+            desktop: isDesktop,
+            lastViewedDate: lastViewedDate,
+            daxEasterEggLogoURL: daxEasterEggLogoURL,
+            contextualChatURL: contextualChatURL,
+            supportsTabHistory: supportsTabHistory,
+            fireTab: fireTab,
+            unifiedInputState: unifiedInputState)
     }
 
     public override func isEqual(_ other: Any?) -> Bool {

--- a/iOS/DuckDuckGo/TabManager.swift
+++ b/iOS/DuckDuckGo/TabManager.swift
@@ -475,6 +475,7 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
         return controller
     }
 
+    @MainActor
     func addHomeTab(in tabsModel: TabsModelManaging? = nil) {
         let model = tabsModel ?? currentTabsModel
         let tab = Tab(fireTab: model.shouldCreateFireTabs, unifiedInputState: UnifiedInputTabState(preferredTextEntryMode: resolvedTextEntryMode()))
@@ -626,6 +627,7 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
         }
     }
 
+    @MainActor
     func save() -> Result<Void, Error> {
         return tabsModelProvider.save()
     }

--- a/iOS/DuckDuckGo/TabsModel.swift
+++ b/iOS/DuckDuckGo/TabsModel.swift
@@ -119,7 +119,10 @@ public class TabsModel: NSObject, NSCoding, NSCopying, TabsModelManaging {
 
     public func copy(with zone: NSZone? = nil) -> Any {
         let tabsCopy = tabs.compactMap { $0.copy() as? Tab }
-        return TabsModel(tabs: tabsCopy, currentIndex: _currentIndex, desktop: false, mode: mode)
+        return TabsModel(tabs: tabsCopy,
+                         currentIndex: _currentIndex,
+                         desktop: UIDevice.current.userInterfaceIdiom == .pad,
+                         mode: mode)
     }
 
     var currentTab: Tab? {

--- a/iOS/DuckDuckGo/TabsModel.swift
+++ b/iOS/DuckDuckGo/TabsModel.swift
@@ -21,7 +21,7 @@ import Foundation
 import Core
 import Combine
 
-public class TabsModel: NSObject, NSCoding, TabsModelManaging {
+public class TabsModel: NSObject, NSCoding, NSCopying, TabsModelManaging {
 
     private struct NSCodingKeys {
         static let legacyIndex = "currentIndex"
@@ -115,6 +115,11 @@ public class TabsModel: NSObject, NSCoding, TabsModelManaging {
         coder.encode(tabs, forKey: NSCodingKeys.tabs)
         coder.encode(_currentIndex, forKey: NSCodingKeys.currentIndex)
         coder.encode(mode.rawValue, forKey: NSCodingKeys.mode)
+    }
+
+    public func copy(with zone: NSZone? = nil) -> Any {
+        let tabsCopy = tabs.compactMap { $0.copy() as? Tab }
+        return TabsModel(tabs: tabsCopy, currentIndex: _currentIndex, desktop: false, mode: mode)
     }
 
     var currentTab: Tab? {

--- a/iOS/DuckDuckGo/TabsModel.swift
+++ b/iOS/DuckDuckGo/TabsModel.swift
@@ -21,7 +21,7 @@ import Foundation
 import Core
 import Combine
 
-public class TabsModel: NSObject, NSCoding, NSCopying, TabsModelManaging {
+public class TabsModel: NSObject, NSCoding, TabsModelManaging {
 
     private struct NSCodingKeys {
         static let legacyIndex = "currentIndex"
@@ -117,12 +117,10 @@ public class TabsModel: NSObject, NSCoding, NSCopying, TabsModelManaging {
         coder.encode(mode.rawValue, forKey: NSCodingKeys.mode)
     }
 
-    public func copy(with zone: NSZone? = nil) -> Any {
-        let tabsCopy = tabs.compactMap { $0.copy() as? Tab }
-        return TabsModel(tabs: tabsCopy,
-                         currentIndex: _currentIndex,
-                         desktop: UIDevice.current.userInterfaceIdiom == .pad,
-                         mode: mode)
+    /// Returns a frozen deep copy of the model suitable for archiving without concurrent-mutation risk.
+    func archivalSnapshot() -> TabsModel {
+        let tabsCopy = tabs.map { $0.archivalSnapshot() }
+        return TabsModel(tabs: tabsCopy, currentIndex: _currentIndex, desktop: false, mode: mode)
     }
 
     var currentTab: Tab? {

--- a/iOS/DuckDuckGo/TabsModel.swift
+++ b/iOS/DuckDuckGo/TabsModel.swift
@@ -120,7 +120,10 @@ public class TabsModel: NSObject, NSCoding, TabsModelManaging {
     /// Returns a frozen deep copy of the model suitable for archiving without concurrent-mutation risk.
     func archivalSnapshot() -> TabsModel {
         let tabsCopy = tabs.map { $0.archivalSnapshot() }
-        return TabsModel(tabs: tabsCopy, currentIndex: _currentIndex, desktop: false, mode: mode)
+        return TabsModel(tabs: tabsCopy,
+                         currentIndex: _currentIndex,
+                         desktop: UIDevice.current.userInterfaceIdiom == .pad,
+                         mode: mode)
     }
 
     var currentTab: Tab? {

--- a/iOS/DuckDuckGo/TabsModelPersistence.swift
+++ b/iOS/DuckDuckGo/TabsModelPersistence.swift
@@ -37,6 +37,7 @@ protocol TabsModelPersisting {
 enum TabsPersistenceError: Error {
     case appSupportDirAccess
     case storeInit
+    case copying
 }
 
 class TabsModelPersistence: TabsModelPersisting {
@@ -141,7 +142,12 @@ class TabsModelPersistence: TabsModelPersisting {
 
     public func save(model: TabsModel, for key: TabsModelStorageKey) -> Result<Void, Error> {
         do {
-            let data = try NSKeyedArchiver.archivedData(withRootObject: model, requiringSecureCoding: false)
+            // Deep-copy to freeze mutable state before archiving
+            guard let snapshot = model.copy() as? TabsModel else {
+                assertionFailure("Copying TabsModel failed")
+                return .failure(TabsPersistenceError.copying)
+            }
+            let data = try NSKeyedArchiver.archivedData(withRootObject: snapshot, requiringSecureCoding: false)
             try store(for: key).set(data, forKey: Constants.storageKey)
             return .success(())
         } catch {

--- a/iOS/DuckDuckGo/TabsModelPersistence.swift
+++ b/iOS/DuckDuckGo/TabsModelPersistence.swift
@@ -37,7 +37,6 @@ protocol TabsModelPersisting {
 enum TabsPersistenceError: Error {
     case appSupportDirAccess
     case storeInit
-    case copying
 }
 
 class TabsModelPersistence: TabsModelPersisting {
@@ -143,10 +142,7 @@ class TabsModelPersistence: TabsModelPersisting {
     public func save(model: TabsModel, for key: TabsModelStorageKey) -> Result<Void, Error> {
         do {
             // Deep-copy to freeze mutable state before archiving
-            guard let snapshot = model.copy() as? TabsModel else {
-                assertionFailure("Copying TabsModel failed")
-                return .failure(TabsPersistenceError.copying)
-            }
+            let snapshot = model.archivalSnapshot()
             let data = try NSKeyedArchiver.archivedData(withRootObject: snapshot, requiringSecureCoding: false)
             try store(for: key).set(data, forKey: Constants.storageKey)
             return .success(())

--- a/iOS/DuckDuckGoTests/TabsModelTests.swift
+++ b/iOS/DuckDuckGoTests/TabsModelTests.swift
@@ -354,4 +354,67 @@ class TabsModelTests: XCTestCase {
         XCTAssertNil(model.currentIndex)
     }
 
+    // MARK: - NSCopying
+
+    func testWhenTabSnapshotTakenThenAllPersistedFieldsArePreserved() {
+        let link = Link(title: "Example", url: URL(string: "https://example.com")!, localPath: URL(string: "file:///tmp/local")!)
+        let date = Date(timeIntervalSince1970: 1_000_000)
+        let unifiedState = UnifiedInputTabState(preferredTextEntryMode: .aiChat,
+                                                selectedModelID: "gpt-4",
+                                                selectedReasoningMode: nil,
+                                                selectedTool: nil)
+        let tab = Tab(uid: "test-uid",
+                      link: link,
+                      viewed: true,
+                      desktop: true,
+                      lastViewedDate: date,
+                      daxEasterEggLogoURL: "https://logo.example.com",
+                      contextualChatURL: "https://chat.example.com",
+                      supportsTabHistory: true,
+                      fireTab: false,
+                      unifiedInputState: unifiedState)
+
+        let snapshot = tab.archivalSnapshot()
+
+        XCTAssertFalse(snapshot === tab)
+        XCTAssertEqual(snapshot.uid, "test-uid")
+        XCTAssertEqual(snapshot.link?.title, "Example")
+        XCTAssertEqual(snapshot.link?.url, URL(string: "https://example.com")!)
+        XCTAssertEqual(snapshot.link?.localFileURL, URL(string: "file:///tmp/local")!)
+        XCTAssertFalse(snapshot.link === tab.link)
+        XCTAssertEqual(snapshot.viewed, true)
+        XCTAssertEqual(snapshot.isDesktop, true)
+        XCTAssertEqual(snapshot.lastViewedDate, date)
+        XCTAssertEqual(snapshot.daxEasterEggLogoURL, "https://logo.example.com")
+        XCTAssertEqual(snapshot.contextualChatURL, "https://chat.example.com")
+        XCTAssertEqual(snapshot.supportsTabHistory, true)
+        XCTAssertEqual(snapshot.fireTab, false)
+        XCTAssertEqual(snapshot.unifiedInputState, unifiedState)
+    }
+
+    func testWhenModelSnapshotTakenThenMutatingSourceDoesNotAffectSnapshot() {
+        let link1 = Link(title: "Page 1", url: URL(string: "https://one.example.com")!)
+        let link2 = Link(title: "Page 2", url: URL(string: "https://two.example.com")!)
+        let tab1 = Tab(link: link1, fireTab: false)
+        let tab2 = Tab(link: link2, fireTab: false)
+        let model = TabsModel(tabs: [tab1, tab2], currentIndex: 1, desktop: false)
+
+        let snapshot = model.archivalSnapshot()
+
+        XCTAssertEqual(snapshot.count, 2)
+        XCTAssertEqual(snapshot.currentIndex, 1)
+        XCTAssertEqual(snapshot.tabs[0].link?.url, URL(string: "https://one.example.com")!)
+        XCTAssertEqual(snapshot.tabs[1].link?.url, URL(string: "https://two.example.com")!)
+
+        // Mutate the source model
+        tab1.link = Link(title: "Mutated", url: URL(string: "https://mutated.example.com")!)
+        model.remove(tab: tab2)
+
+        // Snapshot must be unaffected
+        XCTAssertEqual(snapshot.count, 2)
+        XCTAssertEqual(snapshot.tabs[0].link?.url, URL(string: "https://one.example.com")!)
+        XCTAssertEqual(snapshot.tabs[0].link?.title, "Page 1")
+        XCTAssertEqual(snapshot.tabs[1].link?.url, URL(string: "https://two.example.com")!)
+    }
+
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211767540372501/task/1214486604108348

### Description

- Fix SIGTRAP crash in `Link.encode` caused by concurrent mutation of `TabsModel` during `NSKeyedArchiver` serialization
- Add `NSCopying` conformance to `Link`, `Tab`, and `TabsModel` to enable deep-copying the object graph before archiving
- `TabsModelPersistence.save` now archives a frozen snapshot instead of the live mutable model
- Add `@MainActor` to `TabManager.addHomeTab` and `TabManager.save()` to ensure mutations and saves run on the same thread

### Testing Steps

1. Open the app and create several tabs (mix of home tabs and web pages)
2. Rapidly tap "+" to add new tabs while the tab switcher animation is running
3. Switch between tabs quickly while new tabs are being created
4. Verify no crashes occur during rapid tab creation and switching
5. Close and reopen the app — verify all tabs are restored correctly
6. Repeat steps 2-5 with Fire Mode enabled

### Impact and Risks

**Impact Level: Low**

This is a targeted fix for a crash with minimal behavioral change — the only difference is that archiving now operates on a snapshot copy rather than the live object graph. Tab persistence behavior is otherwise unchanged.

#### What could go wrong?

- The deep copy adds a small memory/CPU overhead per save. Given the typical tab count (<100 tabs with lightweight properties), this should be negligible.
- If a `Tab` property is added in the future but not included in `copy(with:)`, it could be silently dropped during persistence. Mitigated by the copy using the main `init`, so any new required parameter will produce a compile error if not provided.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tab persistence to archive deep-copied snapshots and adds MainActor annotations around save/mutations; risk is moderate because it touches tab storage/threading and could affect what state is persisted.
> 
> **Overview**
> Fixes a SIGTRAP during tab persistence by **archiving frozen snapshots** of the `TabsModel` object graph instead of serializing live, mutable instances.
> 
> Adds `NSCopying` support for `Link` and introduces `archivalSnapshot()` deep-copy helpers on `Tab` and `TabsModel`, then updates `TabsModelPersistence.save` to archive the snapshot. Also tightens threading by marking `TabManager.save`, `TabManager.addHomeTab`, and bulk-generation `finished()` as `@MainActor`, and adds tests to verify snapshot correctness and isolation from subsequent mutations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35ce628a9366fe471f82b90a724b234cef279e58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->