### PR TITLE
[iOS][Tailored Onboarding] Add Duck.ai steps to Onboarding Manager

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1366,6 +1366,7 @@
 		9F0B19B42EA5E4FA001FA867 /* DefaultBrowserModalPromptProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0B19AF2EA5E4FA001FA867 /* DefaultBrowserModalPromptProvider.swift */; };
 		9F0B19B72EA5E74F001FA867 /* ModalPromptCoordinationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0B19B62EA5E740001FA867 /* ModalPromptCoordinationManager.swift */; };
 		9F104B942F4EA27200FD6139 /* RebrandedScrollableOnboardingBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F104B932F4EA26600FD6139 /* RebrandedScrollableOnboardingBackground.swift */; };
+		9F12A0BD2FB1677D00F80554 /* RebrandedOnboardingView+AIComparisonContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F12A0BC2FB1676F00F80554 /* RebrandedOnboardingView+AIComparisonContent.swift */; };
 		9F16230B2CA0F0190093C4FC /* DebouncerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F16230A2CA0F0190093C4FC /* DebouncerTests.swift */; };
 		9F1798572CD2443F0073018B /* AddToDockPromoViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F1798562CD2443F0073018B /* AddToDockPromoViewModelTests.swift */; };
 		9F219FE92F74DFA700006156 /* OnboardingDuckAISuggestionsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F219FE82F74DFA700006156 /* OnboardingDuckAISuggestionsProvider.swift */; };
@@ -4047,6 +4048,7 @@
 		9F0B19AF2EA5E4FA001FA867 /* DefaultBrowserModalPromptProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserModalPromptProvider.swift; sourceTree = "<group>"; };
 		9F0B19B62EA5E740001FA867 /* ModalPromptCoordinationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationManager.swift; sourceTree = "<group>"; };
 		9F104B932F4EA26600FD6139 /* RebrandedScrollableOnboardingBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RebrandedScrollableOnboardingBackground.swift; sourceTree = "<group>"; };
+		9F12A0BC2FB1676F00F80554 /* RebrandedOnboardingView+AIComparisonContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RebrandedOnboardingView+AIComparisonContent.swift"; sourceTree = "<group>"; };
 		9F16230A2CA0F0190093C4FC /* DebouncerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebouncerTests.swift; sourceTree = "<group>"; };
 		9F1798562CD2443F0073018B /* AddToDockPromoViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddToDockPromoViewModelTests.swift; sourceTree = "<group>"; };
 		9F219FE82F74DFA700006156 /* OnboardingDuckAISuggestionsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingDuckAISuggestionsProvider.swift; sourceTree = "<group>"; };
@@ -7999,6 +8001,7 @@
 				4D434F523CEFF1B86C75ECC6 /* RebrandedOnboardingView+AddToDockContent.swift */,
 				EDB06E4C5FAE7E6BC7CDC6CC /* RebrandedOnboardingView+AppIconPickerContent.swift */,
 				8693FFCAC02CE4A85D0BD62C /* RebrandedOnboardingView+BrowsersComparisonContent.swift */,
+				9F12A0BC2FB1676F00F80554 /* RebrandedOnboardingView+AIComparisonContent.swift */,
 				9785D25DF2EA27126C8A33B8 /* RebrandedOnboardingView+IntroDialogContent.swift */,
 				DD503EBD506182525F5E8107 /* RebrandedOnboardingView+Landing.swift */,
 				9FADFC5F2F62384C00CA16F7 /* RebrandedOnboardingView+RestorePromptDialogContent.swift */,
@@ -13182,6 +13185,7 @@
 				C12726F22A5FF8CB00215B02 /* EmailSignupPromptViewController.swift in Sources */,
 				CBF259B92D499D0B00AC63E4 /* MainCoordinator.swift in Sources */,
 				9FCFCD852C75C91A006EB7A0 /* ProgressBarView.swift in Sources */,
+				9F12A0BD2FB1677D00F80554 /* RebrandedOnboardingView+AIComparisonContent.swift in Sources */,
 				9FA09DAC2EA7400200E26F3F /* PromptCooldownStorePixelReporter.swift in Sources */,
 				6F3537A42C4AC140009F8717 /* NewTabPageDaxLogoView.swift in Sources */,
 				314C92B827C3DD660042EC96 /* QuickLookPreviewView.swift in Sources */,

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -59,7 +59,7 @@ struct StartupOnboardingDecision {
          resumeStepStore: (any KeyedStoring<OnboardingStoringKeys>)? = nil) {
         let resumeStepStore: any KeyedStoring<OnboardingStoringKeys> = if let resumeStepStore { resumeStepStore } else { UserDefaults.app.keyedStoring() }
         switch resumeStepStore.resumeStep {
-        case .browserComparison, .addToDockPromo, .appIconSelection,
+        case .browserComparison, .aiComparison, .addToDockPromo, .appIconSelection,
              .addressBarPositionSelection, .searchExperienceSelection,
              .duckAIQuerySelection:
             shouldShowOnboarding = true

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroContentProvider.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroContentProvider.swift
@@ -27,6 +27,7 @@ protocol OnboardingIntroContentProviding {
     var landingContent: OnboardingLandingContent { get }
     var introStepContent: OnboardingIntroStepContent { get }
     var browserComparisonContent: OnboardingBrowserComparisonContent { get }
+    var aiComparisonContent: OnboardingAIComparisonContent { get }
     var addToDockContent: OnboardingAddToDockContent { get }
     var appIconColorContent: OnboardingAppIconColorContent { get }
     var addressBarPositionContent: OnboardingAddressBarPositionContent { get }
@@ -133,6 +134,28 @@ extension OnboardingIntroContentProvider {
             features: RebrandedBrowsersComparisonModel.defaultFeatures,
             primaryCTA: UserText.Onboarding.BrowsersComparison.cta,
             secondaryCTA: UserText.onboardingSkip
+        )
+    }
+
+}
+
+// MARK: - Content Provider + AI Comparison (AI Protections activated!)
+
+struct OnboardingAIComparisonContent: Equatable {
+    let title: String
+    let subHeader: String
+    let features: [RebrandedBrowsersComparisonModel.Feature]
+    let primaryCTA: String
+}
+
+extension OnboardingIntroContentProvider {
+
+    var aiComparisonContent: OnboardingAIComparisonContent {
+        OnboardingAIComparisonContent(
+            title: UserText.Onboarding.BrowsersComparison.title,
+            subHeader: "",
+            features: [],
+            primaryCTA: UserText.Onboarding.BrowsersComparison.cta,
         )
     }
 

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
@@ -486,6 +486,10 @@ private extension OnboardingIntroViewModel {
         guard isReturningUser else {
             return .default
         }
+        // Restore-data prompt is suppressed in the Duck.ai tailored flow.
+        guard onboardingManager.currentOnboardingFlow != .duckAI else {
+            return .skipTutorial
+        }
         return restorePromptHandler.isEligibleForRestorePrompt() ? .restoreData : .skipTutorial
     }
 

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
@@ -406,6 +406,8 @@ private extension OnboardingIntroViewModel {
 
         case .browserComparison where introSteps.contains(.browserComparison):
             currentIntroStep = .browserComparison
+        case .aiComparison where introSteps.contains(.aiComparison):
+            currentIntroStep = .aiComparison
         case .addToDockPromo where introSteps.contains(.addToDockPromo):
             currentIntroStep = .addToDockPromo
         case .appIconSelection where introSteps.contains(.appIconSelection):

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
@@ -394,7 +394,12 @@ private extension OnboardingIntroViewModel {
 
         switch resumeStep {
         case .duckAIQuerySelection:
-            guard featureFlagger.isFeatureOn(.onboardingDuckAIQueryExperiment) else {
+            // The step is reachable either as an experimental insertion in the default flow,
+            // or as a standard step in the Duck.ai tailored flow — the two flags are independent.
+            guard
+                featureFlagger.isFeatureOn(.onboardingDuckAIQueryExperiment) ||
+                    onboardingManager.currentOnboardingFlow == .duckAI
+            else {
                 OnboardingResumeCheckpointStore.clearAll(in: onboardingResumeStepStore)
                 return
             }

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
@@ -224,6 +224,10 @@ final class OnboardingIntroViewModel: ObservableObject {
         makeNextViewState()
     }
 
+    func aiComparisonAction() {
+        makeNextViewState()
+    }
+
     func addToDockContinueAction(isShowingAddToDockTutorial: Bool) {
         makeNextViewState()
 
@@ -331,6 +335,8 @@ private extension OnboardingIntroViewModel {
             OnboardingView.ViewState.onboarding(.init(type: .startOnboardingDialog(content: contentProvider.introStepContent, type: introDialogType(isReturningUser: isReturningUser)), step: .hidden))
         case .browserComparison:
             OnboardingView.ViewState.onboarding(.init(type: .browsersComparisonDialog(content: contentProvider.browserComparisonContent), step: stepInfo()))
+        case .aiComparison:
+            OnboardingView.ViewState.onboarding(.init(type: .aiComparisonDialog(content: contentProvider.aiComparisonContent), step: stepInfo()))
         case .addToDockPromo:
             OnboardingView.ViewState.onboarding(.init(type: .addToDockPromoDialog(content: contentProvider.addToDockContent), step: stepInfo()))
         case .appIconSelection:
@@ -340,7 +346,7 @@ private extension OnboardingIntroViewModel {
         case .searchExperienceSelection:
             OnboardingView.ViewState.onboarding(.init(type: .chooseSearchExperienceDialog(content: contentProvider.searchExperienceContent), step: stepInfo()))
         case .duckAIQuerySelection:
-            OnboardingView.ViewState.onboarding(.init(type: .duckAIQueryExperimentDialog(content: contentProvider.duckAIQueryExperimentContent, defaultMode: duckAIQueryExperimentDefaultMode), step: stepInfo()))
+            OnboardingView.ViewState.onboarding(.init(type: .duckAIQueryExperimentDialog(content: contentProvider.duckAIQueryExperimentContent, defaultMode: onboardingManager.currentOnboardingFlow == .duckAI ? .duckAI : duckAIQueryExperimentDefaultMode), step: stepInfo()))
         }
 
         state = viewState
@@ -433,6 +439,8 @@ private extension OnboardingIntroViewModel {
             measureAutoRestorePromptImpressionIfNeeded(dialogType: dialogType)
         case .browsersComparisonDialog:
             pixelReporter.measureBrowserComparisonImpression()
+        case .aiComparisonDialog:
+            break
         case .addToDockPromoDialog:
             pixelReporter.measureAddToDockPromoImpression()
         case .chooseAppIconDialog:
@@ -467,7 +475,8 @@ private extension OnboardingIntroViewModel {
     }
 
     func resolveDuckAIQueryExperimentCohortID() -> FeatureFlag.DuckAIQueryExperimentCohort? {
-        guard featureFlagger.isFeatureOn(.onboardingDuckAIQueryExperiment) else { return nil }
+        // Do not enroll users experiencing Duck.ai tailored flow in the experiment
+        guard onboardingManager.currentOnboardingFlow == .default && featureFlagger.isFeatureOn(.onboardingDuckAIQueryExperiment) else { return nil }
         return featureFlagger.resolveCohort(for: FeatureFlag.onboardingDuckAIQueryExperiment) as? FeatureFlag.DuckAIQueryExperimentCohort
     }
 

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingView.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingView.swift
@@ -89,6 +89,8 @@ struct OnboardingView: View {
                                 introView(dialogType: dialogType)
                             case .browsersComparisonDialog:
                                 browsersComparisonView
+                            case .aiComparisonDialog:
+                                browsersComparisonView
                             case .addToDockPromoDialog:
                                 addToDockPromoView
                             case .chooseAppIconDialog:
@@ -346,6 +348,7 @@ extension OnboardingView.ViewState.Intro {
     enum IntroType: Equatable {
         case startOnboardingDialog(content: OnboardingIntroStepContent, type: IntroDialogType)
         case browsersComparisonDialog(content: OnboardingBrowserComparisonContent)
+        case aiComparisonDialog(content: OnboardingAIComparisonContent)
         case addToDockPromoDialog(content: OnboardingAddToDockContent)
         case chooseAppIconDialog(content: OnboardingAppIconColorContent)
         case chooseAddressBarPositionDialog(content: OnboardingAddressBarPositionContent)

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView+AIComparisonContent.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView+AIComparisonContent.swift
@@ -1,0 +1,67 @@
+//
+//  RebrandedOnboardingView+AIComparisonContent.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+import DuckUI
+import Onboarding
+
+extension OnboardingRebranding.OnboardingView {
+
+    struct AIComparisonContent: View {
+        @Environment(\.onboardingTheme) private var onboardingTheme
+
+        @Binding var showContent: Bool
+        private let content: OnboardingAIComparisonContent
+        private let continueAction: () -> Void
+
+        init(
+            content: OnboardingAIComparisonContent,
+            showContent: Binding<Bool>,
+            continueAction: @escaping () -> Void,
+        ) {
+            self.content = content
+            self._showContent = showContent
+            self.continueAction = continueAction
+        }
+
+        var body: some View {
+            VStack(spacing: onboardingTheme.linearOnboardingMetrics.contentInnerSpacing) {
+                Text(content.title)
+                    .foregroundColor(onboardingTheme.colorPalette.textPrimary)
+                    .font(onboardingTheme.typography.title)
+                    .multilineTextAlignment(.center)
+
+                VStack(spacing: onboardingTheme.linearOnboardingMetrics.contentInnerSpacing) {
+                    RoundedRectangle(cornerRadius: 12)
+                        .foregroundStyle(Color.blue)
+                        .frame(height: 300)
+
+                    VStack(spacing: onboardingTheme.linearOnboardingMetrics.buttonSpacing) {
+                        Button(action: continueAction) {
+                            Text(content.primaryCTA)
+                        }
+                        .buttonStyle(onboardingTheme.primaryButtonStyle.style)
+                    }
+                }
+            }
+        }
+
+    }
+
+}

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView.swift
@@ -408,6 +408,14 @@ extension OnboardingRebranding {
             )
         }
 
+        private func aiComparisonView(content: OnboardingAIComparisonContent) -> some View {
+            AIComparisonContent(
+                content: content,
+                showContent: $showBubbleContent,
+                continueAction: model.aiComparisonAction
+            )
+        }
+
         private func bubbleBackedDialogView(
             state: ViewState.Intro,
             configuration: BubbleBackedDialogConfiguration
@@ -475,6 +483,8 @@ extension OnboardingRebranding {
                 introView(content: content, dialogType: dialogType)
             case let .browsersComparisonDialog(content):
                 browsersComparisonView(content: content)
+            case let .aiComparisonDialog(content):
+                aiComparisonView(content: content)
             case let .addToDockPromoDialog(content):
                 addToDockPromoView(content: content)
             case let .chooseAppIconDialog(content):
@@ -500,14 +510,7 @@ extension OnboardingRebranding {
                     isVisible: model.introState.showIntroViewContent,
                     showsStepCounter: false
                 )
-            case .chooseAppIconDialog:
-                return BubbleBackedDialogConfiguration(
-                    tailOffset: tailLeadingOffset,
-                    tailDirection: .trailing,
-                    isVisible: true,
-                    showsStepCounter: true
-                )
-            case .browsersComparisonDialog:
+            case .browsersComparisonDialog, .aiComparisonDialog:
                 return BubbleBackedDialogConfiguration(
                     tailOffset: tailTrailingOffset,
                     tailDirection: .leading,
@@ -518,6 +521,13 @@ extension OnboardingRebranding {
                 return BubbleBackedDialogConfiguration(
                     tailOffset: tailLeadingOffset,
                     tailDirection: .leading,
+                    isVisible: true,
+                    showsStepCounter: true
+                )
+            case .chooseAppIconDialog:
+                return BubbleBackedDialogConfiguration(
+                    tailOffset: tailLeadingOffset,
+                    tailDirection: .trailing,
                     isVisible: true,
                     showsStepCounter: true
                 )
@@ -633,7 +643,7 @@ extension OnboardingRebranding {
             // `lockedIntroBubbleHeight` (not the live value) keeps Dax stable across intro
             // bubble content swaps.
             case .startOnboardingDialog: return IntroDialogContent.daxAnimation(forBubbleHeight: lockedIntroBubbleHeight)
-            case .browsersComparisonDialog: return BrowsersComparisonContent.daxAnimation
+            case .browsersComparisonDialog, .aiComparisonDialog: return BrowsersComparisonContent.daxAnimation
             case .addToDockPromoDialog: return AddToDockPromoContent.daxAnimation
             case .chooseAppIconDialog: return AppIconPickerContent.daxAnimation
             case .chooseAddressBarPositionDialog: return nil // Dax-Floating is embedded in ScrollableOnboardingBackground

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView.swift
@@ -412,7 +412,11 @@ extension OnboardingRebranding {
             AIComparisonContent(
                 content: content,
                 showContent: $showBubbleContent,
-                continueAction: model.aiComparisonAction
+                continueAction: {
+                    animateContentTransition {
+                        model.aiComparisonAction()
+                    }
+                }
             )
         }
 

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedScrollableOnboardingBackground.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedScrollableOnboardingBackground.swift
@@ -218,7 +218,7 @@ private extension OnboardingView.ViewState.Intro.IntroType {
         switch self {
         case .startOnboardingDialog:
             return OnboardingRebrandingImages.Linear.introBackground
-        case .browsersComparisonDialog:
+        case .browsersComparisonDialog, .aiComparisonDialog:
             return OnboardingRebrandingImages.Linear.browsersComparisonBackground
         case .addToDockPromoDialog:
             return OnboardingRebrandingImages.Linear.addToDockBackground
@@ -241,7 +241,7 @@ private extension OnboardingView.ViewState.Intro.IntroType {
         switch self {
         case .startOnboardingDialog:
             return 404
-        case .browsersComparisonDialog:
+        case .browsersComparisonDialog, .aiComparisonDialog:
             return 216
         case .addToDockPromoDialog:
             return 286
@@ -271,7 +271,7 @@ private extension OnboardingView.ViewState.Intro.IntroType {
         switch self {
         case .startOnboardingDialog:
             return 320
-        case .browsersComparisonDialog:
+        case .browsersComparisonDialog, .aiComparisonDialog:
             return 380
         case .addToDockPromoDialog:
             return 194

--- a/iOS/DuckDuckGo/OnboardingFlow/Manager/OnboardingManager.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/Manager/OnboardingManager.swift
@@ -228,6 +228,9 @@ extension OnboardingManager: OnboardingFlowManaging {
         case .duckAI where !featureFlagger.isFeatureOn(.onboardingDuckAIFlow):
             Logger.onboarding.debug("Duck.ai onboarding feature disabled. Reverting to default onboarding")
             resolvedFlow = .default
+        case .duckAI where !isIphone:
+            Logger.onboarding.debug("Duck.ai onboarding not available for iPad. Reverting to default onboarding")
+            resolvedFlow = .default
         default:
             resolvedFlow = evaluatedOnboarding.flow
         }

--- a/iOS/DuckDuckGo/OnboardingFlow/Manager/OnboardingManager.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/Manager/OnboardingManager.swift
@@ -63,6 +63,7 @@ final class OnboardingManager {
     private let isIphone: Bool
     private let tutorialSettings: TutorialSettings
     private let sharedPixelsStorage: any KeyedStoring<OnboardingSharedPixelsKeys>
+    private let onboardingResumeStepStore: any KeyedStoring<OnboardingStoringKeys>
 
     private let iPhoneFlow: [OnboardingIntroStep] = [
         .browserComparison,
@@ -97,7 +98,8 @@ final class OnboardingManager {
         isIphone: Bool = UIDevice.current.userInterfaceIdiom == .phone,
         onboardingFlowEvaluator: OnboardingFlowEvaluating = AppStoreCustomProductPageEvaluator(),
         tutorialSettings: TutorialSettings = DefaultTutorialSettings(),
-        sharedPixelsStorage: (any KeyedStoring<OnboardingSharedPixelsKeys>)? = nil
+        sharedPixelsStorage: (any KeyedStoring<OnboardingSharedPixelsKeys>)? = nil,
+        onboardingResumeStepStore: (any KeyedStoring<OnboardingStoringKeys>)? = nil
     ) {
         self.appDefaults = appDefaults
         self.featureFlagger = featureFlagger
@@ -106,6 +108,7 @@ final class OnboardingManager {
         self.onboardingFlowEvaluator = onboardingFlowEvaluator
         self.tutorialSettings = tutorialSettings
         self.sharedPixelsStorage = if let sharedPixelsStorage { sharedPixelsStorage } else { UserDefaults.app.keyedStoring() }
+        self.onboardingResumeStepStore = if let onboardingResumeStepStore { onboardingResumeStepStore } else { UserDefaults.app.keyedStoring() }
     }
 }
 
@@ -234,6 +237,11 @@ extension OnboardingManager: OnboardingFlowManaging {
         default:
             resolvedFlow = evaluatedOnboarding.flow
         }
+
+        // Clear any stale resume checkpoint persisted before the flow was configured
+        // (e.g. by a previous build that didn't set onboardingFlowType), so we don't
+        // resume into a step that appears at a different point of the flow causing the user to skip important steps.
+        OnboardingResumeCheckpointStore.clearAll(in: onboardingResumeStepStore)
 
         tutorialSettings.onboardingFlowType = resolvedFlow
         persistOnboardingPixelContext(flow: resolvedFlow, source: evaluatedOnboarding.source)

--- a/iOS/DuckDuckGo/OnboardingFlow/Manager/OnboardingManager.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/Manager/OnboardingManager.swift
@@ -132,6 +132,7 @@ extension OnboardingManager: OnboardingNewUserProviderDebugging {
 enum OnboardingIntroStep: Equatable {
     case introDialog(isReturningUser: Bool)
     case browserComparison
+    case aiComparison
     case appIconSelection
     case addToDockPromo
     case addressBarPositionSelection
@@ -250,15 +251,18 @@ private extension OnboardingManager {
         let introStep = OnboardingIntroStep.introDialog(isReturningUser: !isNewUser)
         switch tutorialSettings.onboardingFlowType {
         case .none, .default:
-            return [introStep] + steps(isIphone: isIphone)
+            return [introStep] + defaultFlowSteps(isIphone: isIphone)
         case .duckAI:
-            // Temporarily return steps for default flow
-            return [introStep] + steps(isIphone: isIphone)
+            return [introStep] + duckAITailoredFlowSteps()
         }
     }
 
-    func steps(isIphone: Bool) -> [OnboardingIntroStep] {
+    func defaultFlowSteps(isIphone: Bool) -> [OnboardingIntroStep] {
         isIphone ? iPhoneFlow : iPadFlow
+    }
+
+    func duckAITailoredFlowSteps() -> [OnboardingIntroStep] {
+        [.aiComparison, .duckAIQuerySelection, .addToDockPromo, .browserComparison, .addressBarPositionSelection]
     }
 
 }

--- a/iOS/DuckDuckGo/OnboardingFlow/Manager/OnboardingManager.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/Manager/OnboardingManager.swift
@@ -146,6 +146,7 @@ extension OnboardingIntroStep {
         switch self {
         case .introDialog: return nil
         case .browserComparison: return .browserComparison
+        case .aiComparison: return .aiComparison
         case .addToDockPromo: return .addToDockPromo
         case .appIconSelection: return .appIconSelection
         case .addressBarPositionSelection: return .addressBarPositionSelection
@@ -158,6 +159,7 @@ extension OnboardingIntroStep {
 /// Persisted checkpoint allowing the onboarding flow to resume after an app relaunch.
 enum OnboardingResumeStep: String {
     case browserComparison
+    case aiComparison
     case addToDockPromo
     case appIconSelection
     case addressBarPositionSelection

--- a/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
@@ -1317,6 +1317,47 @@ extension OnboardingIntroViewModelTests {
         XCTAssertNil(resumeStepRawValue(in: store))
     }
 
+    func testWhenResumeStepIsDuckAIQuerySelection_AndIsDefaultFlow_AndExperimentFlagIsOn_ThenOnAppearShowsDuckAIQuery() {
+        let store = MockKeyValueStore()
+        setResumeStep(.duckAIQuerySelection, in: store)
+        onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedIPhoneSteps(isReturningUser: false)
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.onboardingDuckAIQueryExperiment])
+        featureFlagger.cohortToReturn = FeatureFlag.DuckAIQueryExperimentCohort.treatmentA
+        let sut = makeSUT(featureFlagger: featureFlagger, resumeStepStore: store)
+        sut.onAppear()
+        if case .duckAIQueryExperimentDialog = sut.state.intro?.type {
+            // OK
+        } else {
+            XCTFail("Expected duckAIQueryExperimentDialog, got \(String(describing: sut.state.intro?.type))")
+        }
+    }
+
+    func testWhenResumeStepIsDuckAIQuerySelection_AndIsDuckAIFlow_AndExperimentFlagIsOff_ThenOnAppearShowsDuckAIQuery() {
+        // Regression: the Duck.ai tailored flow includes .duckAIQuerySelection as a standard step,
+        // so a resume on that step must succeed even when the (independent) experiment flag is off.
+        let store = MockKeyValueStore()
+        setResumeStep(.duckAIQuerySelection, in: store)
+        onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedDuckAISteps(isReturningUser: false)
+        onboardingManagerMock.currentOnboardingFlow = .duckAI
+        let sut = makeSUT(featureFlagger: MockFeatureFlagger(), resumeStepStore: store)
+        sut.onAppear()
+        if case .duckAIQueryExperimentDialog = sut.state.intro?.type {
+            // OK
+        } else {
+            XCTFail("Expected duckAIQueryExperimentDialog, got \(String(describing: sut.state.intro?.type))")
+        }
+        XCTAssertEqual(resumeStepRawValue(in: store), OnboardingResumeStep.duckAIQuerySelection.rawValue)
+    }
+
+    func testWhenResumeStepIsDuckAIQuerySelection_AndIsDefaultFlow_AndExperimentFlagIsOff_ThenStoreIsCleared() {
+        let store = MockKeyValueStore()
+        setResumeStep(.duckAIQuerySelection, in: store)
+        onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedIPhoneSteps(isReturningUser: false)
+        onboardingManagerMock.currentOnboardingFlow = .default
+        _ = makeSUT(featureFlagger: MockFeatureFlagger(), resumeStepStore: store)
+        XCTAssertNil(resumeStepRawValue(in: store))
+    }
+
 }
 
 extension OnboardingIntroViewModelTests {

--- a/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
@@ -184,6 +184,24 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         XCTAssertEqual(sut.state, .onboarding(.init(type: .startOnboardingDialog(content: .mock, type: .restoreData), step: .hidden)))
     }
 
+    func testWhenReturningUserAndRestorePromptEligibilityIsTrue_AndIsDuckAIFlow_ThenDoesNotShowRestorePrompt() {
+        // GIVEN
+        let restorePromptHandlerMock = MockRestorePromptHandler()
+        restorePromptHandlerMock.isEligibleForRestorePromptValue = true
+        onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedDuckAISteps(isReturningUser: true)
+        onboardingManagerMock.currentOnboardingFlow = .duckAI
+        let sut = makeSUT(
+            currentOnboardingStep: .introDialog(isReturningUser: true),
+            restorePromptHandler: restorePromptHandlerMock
+        )
+
+        // WHEN
+        sut.onAppear()
+
+        // THEN - restore prompt is suppressed in the Duck.ai tailored flow even when the user is eligible
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .startOnboardingDialog(content: .mock, type: .skipTutorial), step: .hidden)))
+    }
+
     func testWhenReturningUserAndRestorePromptEligibilityIsFalseThenDoesNotShowRestorePrompt() {
         // GIVEN
         let restorePromptHandlerMock = MockRestorePromptHandler()

--- a/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
@@ -518,7 +518,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         // GIVEN
         onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedDuckAISteps(isReturningUser: false)
         onboardingManagerMock.currentOnboardingFlow = .duckAI
-        let sut = makeSUT(currentOnboardingStep: .duckAIQueryExperimentSelection)
+        let sut = makeSUT(currentOnboardingStep: .duckAIQuerySelection)
 
         // WHEN
         sut.selectDuckAIQueryExperimentAction(selection: .duckAI)

--- a/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
@@ -1189,6 +1189,15 @@ extension OnboardingIntroViewModelTests {
         XCTAssertEqual(resumeStepRawValue(in: store), OnboardingResumeStep.browserComparison.rawValue)
     }
 
+    func testWhenAdvancingToAIComparisonThenResumeStepIsPersisted() {
+        let store = MockKeyValueStore()
+        onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedDuckAISteps(isReturningUser: false)
+        let sut = makeSUT(resumeStepStore: store)
+        sut.onAppear()
+        sut.startOnboardingAction()
+        XCTAssertEqual(resumeStepRawValue(in: store), OnboardingResumeStep.aiComparison.rawValue)
+    }
+
     func testWhenAdvancingToAddToDockPromoThenResumeStepIsPersisted() {
         let store = MockKeyValueStore()
         onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedIPhoneSteps(isReturningUser: false)
@@ -1234,6 +1243,15 @@ extension OnboardingIntroViewModelTests {
         let sut = makeSUT(resumeStepStore: store)
         sut.onAppear()
         XCTAssertEqual(sut.state.intro?.type, .browsersComparisonDialog(content: .mock))
+    }
+
+    func testWhenResumeStepIsAIComparisonThenOnAppearShowsAIComparison() {
+        let store = MockKeyValueStore()
+        setResumeStep(.aiComparison, in: store)
+        onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedDuckAISteps(isReturningUser: false)
+        let sut = makeSUT(resumeStepStore: store)
+        sut.onAppear()
+        XCTAssertEqual(sut.state.intro?.type, .aiComparisonDialog(content: .mock))
     }
 
     func testWhenResumeStepIsAddToDockPromoThenOnAppearShowsAddToDock() {

--- a/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
@@ -485,6 +485,122 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         XCTAssertTrue(didCallOnCompletingOnboardingIntro)
     }
 
+    // MARK: Duck.ai Flow
+
+    func testWhenStartOnboardingActionIsCalled_AndIsDuckAIFlow_ThenViewStateChangesToAIComparisonDialogAndProgressIs1Of5() {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedDuckAISteps(isReturningUser: false)
+        onboardingManagerMock.currentOnboardingFlow = .duckAI
+        let sut = makeSUT()
+        XCTAssertEqual(sut.state, .landing(.mock))
+
+        // WHEN
+        sut.startOnboardingAction()
+
+        // THEN
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .aiComparisonDialog(content: .mock), step: .init(currentStep: 1, totalSteps: 5))))
+    }
+
+    func testWhenAIComparisonActionIsCalled_AndIsDuckAIFlow_ThenViewStateChangesToDuckAIQueryExperimentDialogAndProgressIs2Of5() {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedDuckAISteps(isReturningUser: false)
+        onboardingManagerMock.currentOnboardingFlow = .duckAI
+        let sut = makeSUT(currentOnboardingStep: .aiComparison)
+
+        // WHEN
+        sut.aiComparisonAction()
+
+        // THEN
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .duckAIQueryExperimentDialog(content: .mock, defaultMode: .duckAI), step: .init(currentStep: 2, totalSteps: 5))))
+    }
+
+    func testWhenSelectDuckAIQueryExperimentActionIsCalled_AndIsDuckAIFlow_ThenViewStateChangesToAddToDockPromoDialogAndProgressIs3Of5() {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedDuckAISteps(isReturningUser: false)
+        onboardingManagerMock.currentOnboardingFlow = .duckAI
+        let sut = makeSUT(currentOnboardingStep: .duckAIQueryExperimentSelection)
+
+        // WHEN
+        sut.selectDuckAIQueryExperimentAction(selection: .duckAI)
+
+        // THEN
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .addToDockPromoDialog(content: .mock), step: .init(currentStep: 3, totalSteps: 5))))
+    }
+
+    func testWhenAddToDockContinueActionIsCalled_AndIsDuckAIFlow_ThenViewStateChangesToBrowsersComparisonDialogAndProgressIs4Of5() {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedDuckAISteps(isReturningUser: false)
+        onboardingManagerMock.currentOnboardingFlow = .duckAI
+        let sut = makeSUT(currentOnboardingStep: .addToDockPromo)
+
+        // WHEN
+        sut.addToDockContinueAction(isShowingAddToDockTutorial: false)
+
+        // THEN
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog(content: .mock), step: .init(currentStep: 4, totalSteps: 5))))
+    }
+
+    func testWhenSetDefaultBrowserActionIsCalled_AndIsDuckAIFlow_ThenViewStateChangesToChooseAddressBarPositionDialogAndProgressIs5Of5() {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedDuckAISteps(isReturningUser: false)
+        onboardingManagerMock.currentOnboardingFlow = .duckAI
+        let sut = makeSUT(currentOnboardingStep: .browserComparison)
+
+        // WHEN
+        sut.setDefaultBrowserAction()
+
+        // THEN
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .chooseAddressBarPositionDialog(content: .mock), step: .init(currentStep: 5, totalSteps: 5))))
+    }
+
+    func testWhenCancelSetDefaultBrowserActionIsCalled_AndIsDuckAIFlow_ThenViewStateChangesToChooseAddressBarPositionDialogAndProgressIs5Of5() {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedDuckAISteps(isReturningUser: false)
+        onboardingManagerMock.currentOnboardingFlow = .duckAI
+        let sut = makeSUT(currentOnboardingStep: .browserComparison)
+
+        // WHEN
+        sut.cancelSetDefaultBrowserAction()
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallMeasureSetDefaultBrowserSkipped)
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .chooseAddressBarPositionDialog(content: .mock), step: .init(currentStep: 5, totalSteps: 5))))
+    }
+
+    func testWhenSelectAddressBarPositionActionIsCalled_AndIsDuckAIFlow_ThenOnCompletingOnboardingIntroIsCalled() {
+        // GIVEN
+        var didCallOnCompletingOnboardingIntro = false
+        onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedDuckAISteps(isReturningUser: false)
+        onboardingManagerMock.currentOnboardingFlow = .duckAI
+        let sut = makeSUT(currentOnboardingStep: .addressBarPositionSelection)
+        sut.onCompletingOnboardingIntro = {
+            didCallOnCompletingOnboardingIntro = true
+        }
+        XCTAssertFalse(didCallOnCompletingOnboardingIntro)
+
+        // WHEN
+        sut.selectAddressBarPositionAction()
+
+        // THEN
+        XCTAssertTrue(didCallOnCompletingOnboardingIntro)
+    }
+
+    func testWhenIsDuckAIFlow_AndReachingDuckAIQueryExperimentDialog_ThenUserIsNotEnrolledInExperiment() {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedDuckAISteps(isReturningUser: false)
+        onboardingManagerMock.currentOnboardingFlow = .duckAI
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.onboardingDuckAIQueryExperiment])
+        featureFlagger.cohortToReturn = FeatureFlag.DuckAIQueryExperimentCohort.treatmentA
+        let sut = makeSUT(currentOnboardingStep: .aiComparison, featureFlagger: featureFlagger)
+        XCTAssertFalse(featureFlagger.didCallResolveCohort)
+
+        // WHEN
+        sut.aiComparisonAction()
+
+        // THEN
+        XCTAssertFalse(featureFlagger.didCallResolveCohort)
+    }
+
     // MARK: - Pixels
 
     func testWhenOnAppearIsCalledThenPixelReporterMeasureOnboardingIntroImpression() {

--- a/iOS/DuckDuckGoTests/OnboardingManagerTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingManagerTests.swift
@@ -441,7 +441,7 @@ struct OnboardingStepsForConfiguredFlow {
             isIphone: true,
             tutorialSettings: tutorialSettings
         )
-        let expectedSteps: [OnboardingIntroStep] = OnboardingStepsHelper.expectedIPhoneSteps(isReturningUser: isReturningUser)
+        let expectedSteps: [OnboardingIntroStep] = OnboardingStepsHelper.expectedDuckAISteps(isReturningUser: isReturningUser)
 
         // WHEN
         let result = sut.onboardingSteps

--- a/iOS/DuckDuckGoTests/OnboardingManagerTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingManagerTests.swift
@@ -382,6 +382,53 @@ struct OnboardingFlowConfiguration {
         #expect(sharedPixelStorage.onboardingFlow == .default)
     }
 
+    @Test("Check stale resume checkpoint is cleared when configuring the flow for the first time")
+    func clearsStaleResumeCheckpointWhenConfiguringFlowFirstTime() {
+        // GIVEN - resume step persisted by a prior build that never set onboardingFlowType
+        let sharedPixelStorage = makePixelStore()
+        let resumeStore: any KeyedStoring<OnboardingStoringKeys> = InMemoryKeyValueStore().keyedStoring()
+        resumeStore.resumeStep = .appIconSelection
+        let tutorialSettings = MockTutorialSettings(hasSeenOnboarding: false)
+        let sut = OnboardingManager(
+            appDefaults: AppSettingsMock(),
+            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.onboardingDuckAIFlow]),
+            tutorialSettings: tutorialSettings,
+            sharedPixelsStorage: sharedPixelStorage,
+            onboardingResumeStepStore: resumeStore
+        )
+        #expect(tutorialSettings.onboardingFlowType == nil)
+        #expect(resumeStore.resumeStep == .appIconSelection)
+
+        // WHEN
+        sut.configureOnboardingFlow(from: URL(string: "ddgCPP://duckAI"))
+
+        // THEN - resume checkpoint is wiped so we don't restore into a step that may not exist in the resolved flow
+        #expect(resumeStore.resumeStep == nil)
+    }
+
+    @Test("Check resume checkpoint is preserved when flow is already configured")
+    func preservesResumeCheckpointWhenFlowAlreadyConfigured() {
+        // GIVEN
+        let sharedPixelStorage = makePixelStore()
+        let resumeStore: any KeyedStoring<OnboardingStoringKeys> = InMemoryKeyValueStore().keyedStoring()
+        resumeStore.resumeStep = .appIconSelection
+        let tutorialSettings = MockTutorialSettings(hasSeenOnboarding: false)
+        tutorialSettings.onboardingFlowType = .default
+        let sut = OnboardingManager(
+            appDefaults: AppSettingsMock(),
+            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.onboardingDuckAIFlow]),
+            tutorialSettings: tutorialSettings,
+            sharedPixelsStorage: sharedPixelStorage,
+            onboardingResumeStepStore: resumeStore
+        )
+
+        // WHEN
+        sut.configureOnboardingFlow(from: URL(string: "ddgCPP://duckAI"))
+
+        // THEN - flow was already set, no reconfiguration, no clear
+        #expect(resumeStore.resumeStep == .appIconSelection)
+    }
+
     private func makePixelStore(source: OnboardingPixelParameter.Source? = nil,
                                 flow: OnboardingPixelParameter.Flow? = nil) -> any KeyedStoring<OnboardingSharedPixelsKeys> {
         let mockStore = InMemoryKeyValueStore()

--- a/iOS/DuckDuckGoTests/OnboardingManagerTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingManagerTests.swift
@@ -313,6 +313,30 @@ struct OnboardingFlowConfiguration {
         #expect(sharedPixelStorage.onboardingFlow == .default)
     }
 
+    @Test("Check Duck.ai flow falls back to default on iPad")
+    func fallsBackToDefaultWhenDeviceIsIPad() {
+        // GIVEN
+        let sharedPixelStorage = makePixelStore()
+        let tutorialSettings = MockTutorialSettings(hasSeenOnboarding: false)
+        let sut = OnboardingManager(
+            appDefaults: AppSettingsMock(),
+            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.onboardingDuckAIFlow]),
+            isIphone: false,
+            tutorialSettings: tutorialSettings,
+            sharedPixelsStorage: sharedPixelStorage
+        )
+        #expect(tutorialSettings.onboardingFlowType == nil)
+        let url = URL(string: "ddgCPP://duckAI")
+
+        // WHEN
+        sut.configureOnboardingFlow(from: url)
+
+        // THEN - Should fall back to .default since Duck.ai onboarding is iPhone-only
+        #expect(tutorialSettings.onboardingFlowType == .default)
+        #expect(sharedPixelStorage.onboardingSource == .duckAICustomProductPage)
+        #expect(sharedPixelStorage.onboardingFlow == .default)
+    }
+
     @Test("Check Duck.ai flow is configured when feature flag is enabled")
     func configuresDuckAIFlowWhenFeatureFlagEnabled() {
         // GIVEN

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/MockOnboardingIntroContentProvider.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/MockOnboardingIntroContentProvider.swift
@@ -24,6 +24,7 @@ class MockOnboardingIntroContentProvider: OnboardingIntroContentProviding {
     var landingContent: OnboardingLandingContent = .mock
     var introStepContent: OnboardingIntroStepContent = .mock
     var browserComparisonContent: OnboardingBrowserComparisonContent = .mock
+    var aiComparisonContent: OnboardingAIComparisonContent = .mock
     var addToDockContent: OnboardingAddToDockContent = .mock
     var appIconColorContent: OnboardingAppIconColorContent = .mock
     var addressBarPositionContent: OnboardingAddressBarPositionContent = .mock
@@ -69,6 +70,15 @@ extension OnboardingBrowserComparisonContent {
         ],
         primaryCTA: "Browser Comparison Primary",
         secondaryCTA: "Browser Comparison Secondary"
+    )
+}
+
+extension OnboardingAIComparisonContent {
+    static let mock = OnboardingAIComparisonContent(
+        title: "AI Comparison Title",
+        subHeader: "AI Comparison SubHeader",
+        features: [],
+        primaryCTA: "AI Comparison Primary"
     )
 }
 

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/OnboardingStepsHelper.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/OnboardingStepsHelper.swift
@@ -42,4 +42,15 @@ struct OnboardingStepsHelper {
     static func expectedIPadStepsWithSearchExperience(isReturningUser: Bool) -> [OnboardingIntroStep] {
         expectedIPadSteps(isReturningUser: isReturningUser) + [.searchExperienceSelection]
     }
+
+    static func expectedDuckAISteps(isReturningUser: Bool) -> [OnboardingIntroStep] {
+        [
+            .introDialog(isReturningUser: isReturningUser),
+            .aiComparison,
+            .duckAIQueryExperimentSelection,
+            .addToDockPromo,
+            .browserComparison,
+            .addressBarPositionSelection
+        ]
+    }
 }

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/OnboardingStepsHelper.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/OnboardingStepsHelper.swift
@@ -47,7 +47,7 @@ struct OnboardingStepsHelper {
         [
             .introDialog(isReturningUser: isReturningUser),
             .aiComparison,
-            .duckAIQueryExperimentSelection,
+            .duckAIQuerySelection,
             .addToDockPromo,
             .browserComparison,
             .addressBarPositionSelection


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214080667430307
Tech Design URL:
CC:

### Description

Adds the Duck.ai tailored onboarding flow steps to the Onboarding manager for users who install and open the app from Duck.ai Custom Product Page:
- Intro -> AI Comparison -> Duck.ai Query -> Add to Dock -> Browsers Comparison -> Address Bar Position

**Key changes:**
  - New `.aiComparison` step in `OnboardingIntroStep` (and matching `OnboardingResumeStep` case) so the dialog is resumable on relaunch.
  - `OnboardingManager.duckAITailoredFlowSteps()` returns the new step list; the previous placeholder that routed Duck.ai to the default flow is removed.       
  - `OnboardingIntroViewModel.aiComparisonAction()` advances to the next step; new `.aiComparisonDialog` view state plumbed through `OnboardingView` /  `RebrandedOnboardingView`.                                                                                                      
  - New `RebrandedOnboardingView+AIComparisonContent.swift` placeholder view (uses the browsers-comparison background and bubble configuration; final visual pass will come in subsequent PR).                                                                                                                                             
  - Duck.ai flow users are excluded from the Duck.ai Query Experiment: `resolveDuckAIQueryExperimentCohortID()` short-circuits to nil, and the query-dialog default mode is forced to `.duckAI` in that flow.
  - iPad users will default to default onboarding. 
  - OnboardingIntroViewModel.introDialogType now suppresses the restore-data prompt when the current flow is Duck.ai, even for returning users who would otherwise be eligible.        

### Testing Steps

**Fresh Install Scenario**
1. In FeatureFlag.swift set `Config(source: .remoteReleasable(.feature(.iOSBrowserConfig)), supportsLocalOverriding: true)` for `.onboardingDuckAIFlow`
2. In `AppStoreCustomProductPageEvaluator` add 'let url = URL(string: "ddgCPP://duckAI”)` at line 33 to simulate launching the app from Duck.ai CPP.
3.Launch the app and verify the flow is: intro → AI Comparison → Duck.ai Query → Add to Dock → Browsers Comparison → Address Bar Position → main app. (Do not worry if Duck.ai query doesn’t transition to contextual and if they show at the end of the linear onboarding)
4. Repeat the test case on iPad and verify that the onboarding flow is the default one and not Duck.ai.                     

**Resume AI comparison Scenario**
1. Fresh install the app.
2. Mid-Duck.ai flow, force-quit the app on the AI Comparison screen and relaunch. Confirm the flow resumes on AI Comparison rather than restarting.
3. Mid-Duck.ai flow on the Duck.ai Query screen, verify the default toggle is `.duckAI`.

**Returning Users who previously synced data**
1. Go to ‘Settings' -> 'Sync & Backup’ -> ’Sync with another device’ and setup sync.
2. Delete the app.
3. In FeatureFlag.swift set `Config(source: .remoteReleasable(.feature(.iOSBrowserConfig)), supportsLocalOverriding: true)` for `.onboardingDuckAIFlow`
4. In `AppStoreCustomProductPageEvaluator` add 'let url = URL(string: "ddgCPP://duckAI”)` at line 33 to simulate launching the app from Duck.ai CPP.
5. Fresh install the app and verify that onboarding first dialog does not mention restoring data.

**Default Onboarding Scenario**
1. Remove  'let url = URL(string: "ddgCPP://duckAI”)` added in step 2 of **Fresh Install Scenario**.
4. Fresh install the app and verify that the the flow is the default one and not Duck.ai.             

### Impact and Risks
**Low** in current production state because `onboardingDuckAIFlow` is off, no user actually enters the new flow.
**Medium** once the flag is enabled it could impact onboarding flow.

#### What could go wrong?
 - **Stale resume step crossing flows**: if a user has a persisted `OnboardingResumeStep` and then `onboardingFlowType` is configured for the first time (e.g. via the Duck.ai CPP link), the resumed step may not exist in the newly-configured flow or appear at different point in time. Mitigation: `configureOnboardingFlow` clears the resume store when `onboardingFlowType` transitions from `nil` to configured. The view model also defensively checks `introSteps.contains(step)` before resuming, so the worst case is "no resume".                                                                                                              

### Quality Considerations
 - `OnboardingIntroViewModelTests` now covers the full Duck.ai flow transitions end-to-end (AI Comparison advance, query → add-to-dock, add-to-dock → browsers comparison, browsers comparison → address bar, address bar → completion) plus a no-enrollment test that asserts `featureFlagger.resolveCohort` is never called in the Duck.ai flow and the default mode is `.duckAI`.
 - `OnboardingManagerTests` adds: iPad-fallback test for Duck.ai, resume-store clear test on first-time configuration, and a test that the resume step is preserved when the flow is already configured.  

### Notes to Reviewer
- The `RebrandedOnboardingView+AIComparisonContent.swift` view is intentionally minimal; the real layout will land in a follow-up PR with the final copy and assets.     

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the linear onboarding step sequence and resume behavior, including a new Duck.ai-specific flow path and checkpoint clearing, which could affect onboarding progression and experiment gating when the flag is enabled.
> 
> **Overview**
> Adds a Duck.ai *tailored onboarding flow* (triggered via CPP) and wires it through the linear onboarding state machine: introduces a new resumable `.aiComparison` step/dialog, adds placeholder UI in `RebrandedOnboardingView+AIComparisonContent.swift`, and updates backgrounds/bubble config to support the new dialog.
> 
> Tightens flow correctness: Duck.ai flow is iPhone-only (iPad falls back to default), suppresses restore-data prompts for Duck.ai flow, forces Duck.ai as the default mode on the query selection screen in that flow, and prevents Duck.ai-flow users from being enrolled in the Duck.ai query experiment.
> 
> Improves resume safety by persisting the new resume step and clearing stale resume checkpoints when initially configuring the onboarding flow to avoid resuming into mismatched steps; updates tests to cover Duck.ai flow transitions, resume behavior, and experiment exclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7af58fd124a72d819ab2ed932b93d3beefb507c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->