### PR TITLE
[iOS][Tailored Onboarding] Implement Duck.ai tailored steps copy and UI elements changes

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1372,6 +1372,7 @@
 		9F0B19B72EA5E74F001FA867 /* ModalPromptCoordinationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0B19B62EA5E740001FA867 /* ModalPromptCoordinationManager.swift */; };
 		9F104B942F4EA27200FD6139 /* RebrandedScrollableOnboardingBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F104B932F4EA26600FD6139 /* RebrandedScrollableOnboardingBackground.swift */; };
 		9F12A0BD2FB1677D00F80554 /* RebrandedOnboardingView+AIComparisonContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F12A0BC2FB1676F00F80554 /* RebrandedOnboardingView+AIComparisonContent.swift */; };
+		9F12A0C12FB187FD00F80554 /* OnboardingRichTextMessageRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F12A0C02FB187F400F80554 /* OnboardingRichTextMessageRenderer.swift */; };
 		9F16230B2CA0F0190093C4FC /* DebouncerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F16230A2CA0F0190093C4FC /* DebouncerTests.swift */; };
 		9F1798572CD2443F0073018B /* AddToDockPromoViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F1798562CD2443F0073018B /* AddToDockPromoViewModelTests.swift */; };
 		9F219FE92F74DFA700006156 /* OnboardingDuckAISuggestionsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F219FE82F74DFA700006156 /* OnboardingDuckAISuggestionsProvider.swift */; };
@@ -4055,6 +4056,7 @@
 		9F0B19B62EA5E740001FA867 /* ModalPromptCoordinationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationManager.swift; sourceTree = "<group>"; };
 		9F104B932F4EA26600FD6139 /* RebrandedScrollableOnboardingBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RebrandedScrollableOnboardingBackground.swift; sourceTree = "<group>"; };
 		9F12A0BC2FB1676F00F80554 /* RebrandedOnboardingView+AIComparisonContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RebrandedOnboardingView+AIComparisonContent.swift"; sourceTree = "<group>"; };
+		9F12A0C02FB187F400F80554 /* OnboardingRichTextMessageRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingRichTextMessageRenderer.swift; sourceTree = "<group>"; };
 		9F16230A2CA0F0190093C4FC /* DebouncerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebouncerTests.swift; sourceTree = "<group>"; };
 		9F1798562CD2443F0073018B /* AddToDockPromoViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddToDockPromoViewModelTests.swift; sourceTree = "<group>"; };
 		9F219FE82F74DFA700006156 /* OnboardingDuckAISuggestionsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingDuckAISuggestionsProvider.swift; sourceTree = "<group>"; };
@@ -8773,6 +8775,7 @@
 		9FF7E9802C22A19800902BE5 /* OnboardingFlow */ = {
 			isa = PBXGroup;
 			children = (
+				9F12A0C02FB187F400F80554 /* OnboardingRichTextMessageRenderer.swift */,
 				9FD8A2F12F99B982005772BC /* CustomProductPage+Onboarding.swift */,
 				9F8E0F2B2CCA617C001EA7C5 /* VideoPlayer */,
 				9F96F73D2C914C3D009E45D5 /* Background */,
@@ -12414,6 +12417,7 @@
 				85F996CE2E54ADC0006B4641 /* OpenAIChatFromAddressBarHandling.swift in Sources */,
 				1E8AD1C727BE9B2900ABA377 /* DownloadsListDataSource.swift in Sources */,
 				85B7CD8D2DCA3308000C7B7B /* MessageNavigator.swift in Sources */,
+				9F12A0C12FB187FD00F80554 /* OnboardingRichTextMessageRenderer.swift in Sources */,
 				97D99E622F741FE900EE34E7 /* AIVoiceChatIntent.swift in Sources */,
 				9FF362DA2F3DC6A200824B30 /* RebrandedContextualOnboardingDialogs+SubscriptionPromo.swift in Sources */,
 				8569E1702D52C9A4004A3CB7 /* TabSwitcherBarsStateHandler.swift in Sources */,

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroContentProvider.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroContentProvider.swift
@@ -91,10 +91,20 @@ struct OnboardingIntroStepContent: Equatable {
 extension OnboardingIntroContentProvider {
 
     var introStepContent: OnboardingIntroStepContent {
+        let introMessage = switch flowType {
+        case .default: UserText.Onboarding.Rebranding.Intro.message
+        case .duckAI: UserText.Onboarding.DuckAICPP.Intro.message
+        }
+
+        let (skipMessage, skipPrimaryCTA) = switch flowType {
+        case .default: (UserText.Onboarding.Skip.message, UserText.Onboarding.Skip.confirmSkipOnboardingCTA)
+        case .duckAI: (UserText.Onboarding.DuckAICPP.Skip.message, UserText.Onboarding.DuckAICPP.Skip.confirmSkipOnboardingCTA)
+        }
+
         let skipOnboardingContent = OnboardingIntroStepContent.SkipFlowStepContent(
             title: UserText.Onboarding.Skip.title,
-            message: UserText.Onboarding.Skip.message,
-            primaryCTA: UserText.Onboarding.Skip.confirmSkipOnboardingCTA,
+            message: skipMessage,
+            primaryCTA: skipPrimaryCTA,
             secondaryCTA: UserText.Onboarding.Skip.resumeOnboardingCTA
         )
 
@@ -107,7 +117,7 @@ extension OnboardingIntroContentProvider {
 
         return OnboardingIntroStepContent(
             title: UserText.Onboarding.Rebranding.Intro.title,
-            message: UserText.Onboarding.Rebranding.Intro.message,
+            message: introMessage,
             primaryCTA: UserText.Onboarding.Intro.continueCTA,
             secondaryCTA: UserText.Onboarding.Intro.skipCTA,
             restorePromptStepContent: restoreOnboardingContent,

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroContentProvider.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroContentProvider.swift
@@ -139,8 +139,13 @@ struct OnboardingBrowserComparisonContent: Equatable {
 extension OnboardingIntroContentProvider {
 
     var browserComparisonContent: OnboardingBrowserComparisonContent {
-        OnboardingBrowserComparisonContent(
-            title: UserText.Onboarding.BrowsersComparison.title,
+        let title = switch flowType {
+        case .default: UserText.Onboarding.BrowsersComparison.title
+        case .duckAI: UserText.Onboarding.DuckAICPP.BrowserComparison.title
+        }
+
+        return OnboardingBrowserComparisonContent(
+            title: title,
             features: RebrandedBrowsersComparisonModel.defaultFeatures,
             primaryCTA: UserText.Onboarding.BrowsersComparison.cta,
             secondaryCTA: UserText.onboardingSkip

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroContentProvider.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroContentProvider.swift
@@ -299,13 +299,13 @@ struct OnboardingDuckAIQueryContent: Equatable {
     let searchPlaceholder: String
     let aiPlaceholder: String
 
-    let shouldToggleBeVisible: Bool
+    let isToggleVisible: Bool
 }
 
 extension OnboardingIntroContentProvider {
 
     var duckAIQueryContent: OnboardingDuckAIQueryContent {
-        let (title, shouldToggleBeVisible) = switch flowType {
+        let (title, isToggleVisible) = switch flowType {
         case .default:
             (UserText.Onboarding.DuckAIQueryExperiment.title, true)
         case .duckAI:
@@ -316,7 +316,7 @@ extension OnboardingIntroContentProvider {
             title: title,
             searchPlaceholder: UserText.Onboarding.DuckAIQueryExperiment.searchPlaceholder,
             aiPlaceholder: UserText.Onboarding.DuckAIQueryExperiment.aiPlaceholder,
-            shouldToggleBeVisible: shouldToggleBeVisible
+            isToggleVisible: isToggleVisible
         )
     }
 

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroContentProvider.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroContentProvider.swift
@@ -190,6 +190,11 @@ struct OnboardingAddToDockContent: Equatable {
 extension OnboardingIntroContentProvider {
 
     var addToDockContent: OnboardingAddToDockContent {
+        let promoMessage = switch flowType {
+        case .default: UserText.AddToDockOnboarding.Promo.introMessage
+        case .duckAI: UserText.Onboarding.DuckAICPP.AddToDock.Promo.message
+        }
+
         let tutorial = OnboardingAddToDockContent.TutorialStepContent(
             title: UserText.AddToDockOnboarding.Tutorial.title,
             message: UserText.AddToDockOnboarding.Tutorial.message,
@@ -198,7 +203,7 @@ extension OnboardingIntroContentProvider {
 
         return OnboardingAddToDockContent(
             title: UserText.AddToDockOnboarding.Promo.title,
-            message: UserText.AddToDockOnboarding.Promo.introMessage,
+            message: promoMessage,
             primaryCTA: UserText.AddToDockOnboarding.Buttons.tutorial,
             secondaryCTA: UserText.AddToDockOnboarding.Buttons.skip,
             tutorialStepContent: tutorial

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroContentProvider.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroContentProvider.swift
@@ -32,7 +32,7 @@ protocol OnboardingIntroContentProviding {
     var appIconColorContent: OnboardingAppIconColorContent { get }
     var addressBarPositionContent: OnboardingAddressBarPositionContent { get }
     var searchExperienceContent: OnboardingSearchExperienceContent { get }
-    var duckAIQueryExperimentContent: OnboardingDuckAIQueryExperimentContent { get }
+    var duckAIQueryContent: OnboardingDuckAIQueryContent { get }
 }
 
 struct OnboardingIntroContentProvider: OnboardingIntroContentProviding {
@@ -284,19 +284,29 @@ extension OnboardingIntroContentProvider {
 
 // MARK: - Content Provider + Duck.ai Query Experiment (Ready to get started?)
 
-struct OnboardingDuckAIQueryExperimentContent: Equatable {
+struct OnboardingDuckAIQueryContent: Equatable {
     let title: String
     let searchPlaceholder: String
     let aiPlaceholder: String
+
+    let shouldToggleBeVisible: Bool
 }
 
 extension OnboardingIntroContentProvider {
 
-    var duckAIQueryExperimentContent: OnboardingDuckAIQueryExperimentContent {
-        OnboardingDuckAIQueryExperimentContent(
-            title: UserText.Onboarding.DuckAIQueryExperiment.title,
+    var duckAIQueryContent: OnboardingDuckAIQueryContent {
+        let (title, shouldToggleBeVisible) = switch flowType {
+        case .default:
+            (UserText.Onboarding.DuckAIQueryExperiment.title, true)
+        case .duckAI:
+            (UserText.Onboarding.DuckAICPP.DuckAIQuery.title, false)
+        }
+
+        return OnboardingDuckAIQueryContent(
+            title: title,
             searchPlaceholder: UserText.Onboarding.DuckAIQueryExperiment.searchPlaceholder,
-            aiPlaceholder: UserText.Onboarding.DuckAIQueryExperiment.aiPlaceholder
+            aiPlaceholder: UserText.Onboarding.DuckAIQueryExperiment.aiPlaceholder,
+            shouldToggleBeVisible: shouldToggleBeVisible
         )
     }
 

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
@@ -346,7 +346,7 @@ private extension OnboardingIntroViewModel {
         case .searchExperienceSelection:
             OnboardingView.ViewState.onboarding(.init(type: .chooseSearchExperienceDialog(content: contentProvider.searchExperienceContent), step: stepInfo()))
         case .duckAIQuerySelection:
-            OnboardingView.ViewState.onboarding(.init(type: .duckAIQueryExperimentDialog(content: contentProvider.duckAIQueryExperimentContent, defaultMode: onboardingManager.currentOnboardingFlow == .duckAI ? .duckAI : duckAIQueryExperimentDefaultMode), step: stepInfo()))
+            OnboardingView.ViewState.onboarding(.init(type: .duckAIQueryExperimentDialog(content: contentProvider.duckAIQueryContent, defaultMode: onboardingManager.currentOnboardingFlow == .duckAI ? .duckAI : duckAIQueryExperimentDefaultMode), step: stepInfo()))
         }
 
         state = viewState

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingView+DuckAIExperimentSearchContent.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingView+DuckAIExperimentSearchContent.swift
@@ -128,7 +128,7 @@ extension OnboardingView {
                 title: UserText.Onboarding.DuckAIQueryExperiment.title,
                 searchPlaceholder: UserText.Onboarding.DuckAIQueryExperiment.searchPlaceholder,
                 aiPlaceholder: UserText.Onboarding.DuckAIQueryExperiment.aiPlaceholder,
-                shouldToggleBeVisible: true
+                isToggleVisible: true
             ),
             defaultMode: DuckAIQueryExperimentMode,
             visualStyle: VisualStyle = .legacy,
@@ -184,7 +184,7 @@ extension OnboardingView {
                     .fixedSize(horizontal: false, vertical: true)
 
                 Group {
-                    if content.shouldToggleBeVisible {
+                    if content.isToggleVisible {
                         // Search / Duck.ai segmented control.
                         ImageSegmentedPickerView(viewModel: pickerViewModel)
                             .frame(width: Metrics.pickerWidth, height: Metrics.pickerHeight)
@@ -214,7 +214,7 @@ extension OnboardingView {
                     }
 
                     // If toggle is not visible set a different padding to avoid text area to be too close to the title
-                    let queryFieldTopPadding = content.shouldToggleBeVisible ? Metrics.queryFieldTopPadding : nil
+                    let queryFieldTopPadding = content.isToggleVisible ? Metrics.queryFieldTopPadding : nil
 
                     // Query field + trailing action icon.
                     queryField

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingView+DuckAIExperimentSearchContent.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingView+DuckAIExperimentSearchContent.swift
@@ -83,7 +83,7 @@ extension OnboardingView {
         // MARK: Dependencies
         @Environment(\.onboardingTheme) private var onboardingTheme
         @Environment(\.accessibilityReduceMotion) private var reduceMotion
-        private let content: OnboardingDuckAIQueryExperimentContent
+        private let content: OnboardingDuckAIQueryContent
         private let onModeConfirmed: (DuckAIQueryExperimentMode) -> Void
         private let openAIChatAction: (String?, Bool) -> Void
         private let openSearchAction: (String) -> Void
@@ -124,10 +124,11 @@ extension OnboardingView {
         ]
 
         init(
-            content: OnboardingDuckAIQueryExperimentContent = .init(
+            content: OnboardingDuckAIQueryContent = .init(
                 title: UserText.Onboarding.DuckAIQueryExperiment.title,
                 searchPlaceholder: UserText.Onboarding.DuckAIQueryExperiment.searchPlaceholder,
-                aiPlaceholder: UserText.Onboarding.DuckAIQueryExperiment.aiPlaceholder
+                aiPlaceholder: UserText.Onboarding.DuckAIQueryExperiment.aiPlaceholder,
+                shouldToggleBeVisible: true
             ),
             defaultMode: DuckAIQueryExperimentMode,
             visualStyle: VisualStyle = .legacy,
@@ -183,36 +184,41 @@ extension OnboardingView {
                     .fixedSize(horizontal: false, vertical: true)
 
                 Group {
-                    // Search / Duck.ai segmented control.
-                    ImageSegmentedPickerView(viewModel: pickerViewModel)
-                        .frame(width: Metrics.pickerWidth, height: Metrics.pickerHeight)
-                        .padding(.vertical, Metrics.pickerVerticalPadding)
-                        .frame(width: Metrics.pickerWidth, height: Metrics.pickerContainerHeight)
+                    if content.shouldToggleBeVisible {
+                        // Search / Duck.ai segmented control.
+                        ImageSegmentedPickerView(viewModel: pickerViewModel)
+                            .frame(width: Metrics.pickerWidth, height: Metrics.pickerHeight)
+                            .padding(.vertical, Metrics.pickerVerticalPadding)
+                            .frame(width: Metrics.pickerWidth, height: Metrics.pickerContainerHeight)
                         // Drive content mode (Search vs Duck.ai) from user picker selection.
-                        .onChange(of: pickerViewModel.selectedItem) { [reduceMotion] selectedItem in
-                            let newMode: DuckAIQueryExperimentMode = selectedItem == Self.pickerItems[1] ? .duckAI : .search
-                            if reduceMotion {
-                                selectedMode = newMode
-                            } else {
-                                SwiftUI.withAnimation(.easeInOut(duration: Metrics.pickerSelectionAnimationDuration)) {
+                            .onChange(of: pickerViewModel.selectedItem) { [reduceMotion] selectedItem in
+                                let newMode: DuckAIQueryExperimentMode = selectedItem == Self.pickerItems[1] ? .duckAI : .search
+                                if reduceMotion {
                                     selectedMode = newMode
+                                } else {
+                                    SwiftUI.withAnimation(.easeInOut(duration: Metrics.pickerSelectionAnimationDuration)) {
+                                        selectedMode = newMode
+                                    }
                                 }
                             }
-                        }
                         // Keep picker model + visual progress in sync for programmatic/default mode changes.
-                        .onChange(of: selectedMode) { selection in
-                            let pickerItem = selection == .duckAI ? Self.pickerItems[1] : Self.pickerItems[0]
-                            if pickerViewModel.selectedItem != pickerItem {
-                                pickerViewModel.selectItem(pickerItem)
+                            .onChange(of: selectedMode) { selection in
+                                let pickerItem = selection == .duckAI ? Self.pickerItems[1] : Self.pickerItems[0]
+                                if pickerViewModel.selectedItem != pickerItem {
+                                    pickerViewModel.selectItem(pickerItem)
+                                }
+                                pickerViewModel.updateScrollProgress(selection == .duckAI ? 1 : 0)
                             }
-                            pickerViewModel.updateScrollProgress(selection == .duckAI ? 1 : 0)
-                        }
-                        .padding(.top, titleToPickerTopPadding)
-                        .padding(.bottom, Metrics.pickerBottomPadding)
+                            .padding(.top, titleToPickerTopPadding)
+                            .padding(.bottom, Metrics.pickerBottomPadding)
+                    }
+
+                    // If toggle is not visible set a different padding to avoid text area to be too close to the title
+                    let queryFieldTopPadding = content.shouldToggleBeVisible ? Metrics.queryFieldTopPadding : nil
 
                     // Query field + trailing action icon.
                     queryField
-                        .padding(.top, Metrics.queryFieldTopPadding)
+                        .padding(.top, queryFieldTopPadding)
                         .padding(.bottom, Metrics.queryFieldBottomPadding)
                 }
                 .opacity(showInteractiveControls ? 1 : 0)

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingView.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingView.swift
@@ -353,7 +353,7 @@ extension OnboardingView.ViewState.Intro {
         case chooseAppIconDialog(content: OnboardingAppIconColorContent)
         case chooseAddressBarPositionDialog(content: OnboardingAddressBarPositionContent)
         case chooseSearchExperienceDialog(content: OnboardingSearchExperienceContent)
-        case duckAIQueryExperimentDialog(content: OnboardingDuckAIQueryExperimentContent, defaultMode: DuckAIQueryExperimentMode)
+        case duckAIQueryExperimentDialog(content: OnboardingDuckAIQueryContent, defaultMode: DuckAIQueryExperimentMode)
     }
 
     struct StepInfo: Equatable {

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView+SkipOnboardingContent.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView+SkipOnboardingContent.swift
@@ -60,7 +60,7 @@ extension OnboardingRebranding.OnboardingView {
                     actionsSpacing: onboardingTheme.linearOnboardingMetrics.actionsSpacing
                 ),
                 message: AnyView(
-                    styledMessage()
+                    Text(attributedStringWithAttachments: OnboardingRichTextMessageRenderer.render(content.message))
                         .foregroundColor(onboardingTheme.colorPalette.textPrimary)
                         .multilineTextAlignment(.center)
                         .font(onboardingTheme.typography.body)
@@ -93,15 +93,6 @@ extension OnboardingRebranding.OnboardingView {
                 }
             )
             .onBubbleVisibilityChanged(isVisible: $isVisible, shouldStartTyping: $shouldStartTyping, showContent: $showContent)
-        }
-
-        /// Composes the skip message with bold "Fire Button". Uses `Text` concatenation so the
-        /// bold weight inherits from the outer `.font(...)`.
-        private func styledMessage() -> Text {
-            let highlight = Self.fireButtonCopy
-            let parts = content.message.components(separatedBy: highlight)
-            guard parts.count == 2 else { return Text(content.message) }
-            return Text(parts[0]) + Text(highlight).bold() + Text(parts[1])
         }
     }
 }

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView+SkipOnboardingContent.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView+SkipOnboardingContent.swift
@@ -25,7 +25,6 @@ extension OnboardingRebranding.OnboardingView {
 
     /// Figma: https://www.figma.com/design/YPE94Xkcrk2uqiF2l4VmSv/Onboarding--2026-?node-id=12191-44303
     struct SkipOnboardingContent: View {
-        private static let fireButtonCopy = "Fire Button"
         @Environment(\.onboardingTheme) private var onboardingTheme
         @Environment(\.accessibilityReduceMotion) private var reduceMotion
 

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView.swift
@@ -657,7 +657,7 @@ extension OnboardingRebranding {
         }
 
         /// Hide → action → show sequence prevents cross-fading between steps.
-        private func experimentSearchExperienceSelectionView(content: OnboardingDuckAIQueryExperimentContent, defaultMode: DuckAIQueryExperimentMode) -> some View {
+        private func experimentSearchExperienceSelectionView(content: OnboardingDuckAIQueryContent, defaultMode: DuckAIQueryExperimentMode) -> some View {
             LegacyOnboardingView.DuckAIExperimentSearchContent(
                 content: content,
                 defaultMode: defaultMode,

--- a/iOS/DuckDuckGo/OnboardingFlow/OnboardingRichTextMessageRenderer.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/OnboardingRichTextMessageRenderer.swift
@@ -1,0 +1,51 @@
+//
+//  OnboardingRichTextMessageRenderer.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import DesignResourcesKitIcons
+import Core
+
+enum OnboardingRichTextMessageRenderer {
+
+    private static let fireButtonCopy = "Fire Button"
+
+    static func render(_ message: String) -> NSAttributedString {
+        let mutable = NSMutableAttributedString(attributedString: applyChatIconReplacement(to: message))
+        applyFireButtonBold(to: mutable)
+        return mutable
+    }
+
+    private static func applyChatIconReplacement(to message: String) -> NSAttributedString {
+        message.attributedString(
+            withPlaceholder: UserText.Onboarding.ContextualOnboarding.onboardingChatIconToken,
+            replacedByImage: DesignSystemImages.Glyphs.Size16.aiChatOnboarding,
+            verticalOffset: -2
+        ) ?? NSAttributedString(string: message)
+    }
+
+    private static func applyFireButtonBold(to attributed: NSMutableAttributedString) {
+        let nsRange = (attributed.string as NSString).range(of: fireButtonCopy)
+        guard nsRange.location != NSNotFound else { return }
+
+        var fragment = AttributedString(attributed.attributedSubstring(from: nsRange))
+        fragment.inlinePresentationIntent = .stronglyEmphasized
+        attributed.replaceCharacters(in: nsRange, with: NSAttributedString(fragment))
+    }
+
+}

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -2479,6 +2479,14 @@ public struct UserText {
                     )
                 }
             }
+
+            public enum BrowserComparison {
+                public static let title = NotLocalizedString(
+                    "onboarding.duckai.browser.title",
+                    value: "Want to make DuckDuckGo your default browser?",
+                    comment: "The title of the dialog to show the privacy features that DuckDuckGo offers"
+                )
+            }
         }
 
         enum ContextualOnboarding {

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -2461,6 +2461,14 @@ public struct UserText {
 
                 public static let confirmSkipOnboardingCTA = NotLocalizedString("onboarding.duckai.skip.cta.confirm", value: "Start AI Chat", comment: "The title of the button to skip the onboarding and start browsing.")
             }
+
+            public enum DuckAIQuery {
+                public static let title = NotLocalizedString(
+                    "onboarding.duckai.duckAIQuery.title",
+                    value: "Now, try a private AI chat!",
+                    comment: "Title for the onboarding Duck.ai query screen."
+                )
+            }
         }
 
         enum ContextualOnboarding {

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -2451,6 +2451,18 @@ public struct UserText {
             )
         }
 
+        enum DuckAICPP {
+            public enum Intro {
+                public static let message = NotLocalizedString("onboarding.duckai.intro.message", value: "Ready to chat privately with ChatGPT, Claude, and other AIs for free, in a browser that actively protects you?", comment: "The message of the onboarding intro dialog popup")
+            }
+
+            public enum Skip {
+                public static let message = NotLocalizedString("onboarding.duckai.skip.message", value: "Remember: you can use Duck.ai from anywhere you see the chat icon [[chat_icon]]", comment: "The message of the onboarding skip dialog popup")
+
+                public static let confirmSkipOnboardingCTA = NotLocalizedString("onboarding.duckai.skip.cta.confirm", value: "Start AI Chat", comment: "The title of the button to skip the onboarding and start browsing.")
+            }
+        }
+
         enum ContextualOnboarding {
 
             enum Rebranding {

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -2469,6 +2469,16 @@ public struct UserText {
                     comment: "Title for the onboarding Duck.ai query screen."
                 )
             }
+
+            public enum AddToDock {
+                public enum Promo {
+                    static let message = NotLocalizedString(
+                        "onboarding.duckai.addToDock.promo.message",
+                        value: "I'll nest in easy reach for all your daily AI chats and browsing.",
+                        comment: "The message of the onboarding dialog popup that promotes adding the DDG browser icon to the dock."
+                    )
+                }
+            }
         }
 
         enum ContextualOnboarding {

--- a/iOS/DuckDuckGoTests/OnboardingIntroContentProviderTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroContentProviderTests.swift
@@ -88,10 +88,13 @@ struct OnboardingIntroContentProviderTests {
         }
 
         @Test(
-            "Check intro message is correct",
-            arguments: [.default, .duckAI] as [OnboardingFlowType]
+            "Check intro message is correct per flow",
+            arguments: zip(
+                [OnboardingFlowType.default, .duckAI],
+                [UserText.Onboarding.Rebranding.Intro.message, UserText.Onboarding.DuckAICPP.Intro.message]
+            )
         )
-        func checkIntroMessage(flow: OnboardingFlowType) {
+        func checkIntroMessage(flow: OnboardingFlowType, expectedMessage: String) {
             // GIVEN
             let sut = OnboardingIntroContentProvider(flowType: flow, featureFlagger: MockFeatureFlagger())
 
@@ -99,7 +102,7 @@ struct OnboardingIntroContentProviderTests {
             let result = sut.introStepContent
 
             // THEN
-            #expect(result.message == UserText.Onboarding.Rebranding.Intro.message)
+            #expect(result.message == expectedMessage)
         }
 
         @Test(
@@ -216,10 +219,13 @@ struct OnboardingIntroContentProviderTests {
             }
 
             @Test(
-                "Check skip flow message is correct",
-                arguments: [.default, .duckAI] as [OnboardingFlowType]
+                "Check skip flow message is correct per flow",
+                arguments: zip(
+                    [OnboardingFlowType.default, .duckAI],
+                    [UserText.Onboarding.Skip.message, UserText.Onboarding.DuckAICPP.Skip.message]
+                )
             )
-            func checkSkipFlowMessage(flow: OnboardingFlowType) {
+            func checkSkipFlowMessage(flow: OnboardingFlowType, expectedMessage: String) {
                 // GIVEN
                 let sut = OnboardingIntroContentProvider(flowType: flow, featureFlagger: MockFeatureFlagger())
 
@@ -227,14 +233,17 @@ struct OnboardingIntroContentProviderTests {
                 let result = sut.introStepContent.skipFlowStepContent
 
                 // THEN
-                #expect(result.message == UserText.Onboarding.Skip.message)
+                #expect(result.message == expectedMessage)
             }
 
             @Test(
-                "Check skip flow primary CTA is start browsing",
-                arguments: [.default, .duckAI] as [OnboardingFlowType]
+                "Check skip flow primary CTA is correct per flow",
+                arguments: zip(
+                    [OnboardingFlowType.default, .duckAI],
+                    [UserText.Onboarding.Skip.confirmSkipOnboardingCTA, UserText.Onboarding.DuckAICPP.Skip.confirmSkipOnboardingCTA]
+                )
             )
-            func checkSkipFlowPrimaryCTA(flow: OnboardingFlowType) {
+            func checkSkipFlowPrimaryCTA(flow: OnboardingFlowType, expectedPrimaryCTA: String) {
                 // GIVEN
                 let sut = OnboardingIntroContentProvider(flowType: flow, featureFlagger: MockFeatureFlagger())
 
@@ -242,7 +251,31 @@ struct OnboardingIntroContentProviderTests {
                 let result = sut.introStepContent.skipFlowStepContent
 
                 // THEN
-                #expect(result.primaryCTA == UserText.Onboarding.Skip.confirmSkipOnboardingCTA)
+                #expect(result.primaryCTA == expectedPrimaryCTA)
+            }
+
+            @Test("Check Duck.ai skip flow message contains the chat icon token")
+            func duckAISkipFlowMessageContainsChatIconToken() {
+                // GIVEN
+                let sut = OnboardingIntroContentProvider(flowType: .duckAI, featureFlagger: MockFeatureFlagger())
+
+                // WHEN
+                let result = sut.introStepContent.skipFlowStepContent
+
+                // THEN
+                #expect(result.message.contains(UserText.Onboarding.ContextualOnboarding.onboardingChatIconToken))
+            }
+
+            @Test("Check default skip flow message does not contain the chat icon token")
+            func defaultSkipFlowMessageDoesNotContainChatIconToken() {
+                // GIVEN
+                let sut = OnboardingIntroContentProvider(flowType: .default, featureFlagger: MockFeatureFlagger())
+
+                // WHEN
+                let result = sut.introStepContent.skipFlowStepContent
+
+                // THEN
+                #expect(!result.message.contains(UserText.Onboarding.ContextualOnboarding.onboardingChatIconToken))
             }
 
             @Test(

--- a/iOS/DuckDuckGoTests/OnboardingIntroContentProviderTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroContentProviderTests.swift
@@ -381,10 +381,13 @@ struct OnboardingIntroContentProviderTests {
         }
 
         @Test(
-            "Check add to dock message is correct",
-            arguments: [.default, .duckAI] as [OnboardingFlowType]
+            "Check add to dock message is correct per flow",
+            arguments: zip(
+                [OnboardingFlowType.default, .duckAI],
+                [UserText.AddToDockOnboarding.Promo.introMessage, UserText.Onboarding.DuckAICPP.AddToDock.Promo.message]
+            )
         )
-        func checkAddToDockMessage(flow: OnboardingFlowType) {
+        func checkAddToDockMessage(flow: OnboardingFlowType, expectedMessage: String) {
             // GIVEN
             let sut = OnboardingIntroContentProvider(flowType: flow, featureFlagger: MockFeatureFlagger())
 
@@ -392,7 +395,7 @@ struct OnboardingIntroContentProviderTests {
             let result = sut.addToDockContent
 
             // THEN
-            #expect(result.message == UserText.AddToDockOnboarding.Promo.introMessage)
+            #expect(result.message == expectedMessage)
         }
 
         @Test(

--- a/iOS/DuckDuckGoTests/OnboardingIntroContentProviderTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroContentProviderTests.swift
@@ -301,10 +301,13 @@ struct OnboardingIntroContentProviderTests {
     struct BrowserComparisonContent {
 
         @Test(
-            "Check browser comparison title is correct",
-            arguments: [.default, .duckAI] as [OnboardingFlowType]
+            "Check browser comparison title is correct per flow",
+            arguments: zip(
+                [OnboardingFlowType.default, .duckAI],
+                [UserText.Onboarding.BrowsersComparison.title, UserText.Onboarding.DuckAICPP.BrowserComparison.title]
+            )
         )
-        func checkBrowserComparisonTitle(flow: OnboardingFlowType) {
+        func checkBrowserComparisonTitle(flow: OnboardingFlowType, expectedTitle: String) {
             // GIVEN
             let sut = OnboardingIntroContentProvider(flowType: flow, featureFlagger: MockFeatureFlagger())
 
@@ -312,7 +315,7 @@ struct OnboardingIntroContentProviderTests {
             let result = sut.browserComparisonContent
 
             // THEN
-            #expect(result.title == UserText.Onboarding.BrowsersComparison.title)
+            #expect(result.title == expectedTitle)
         }
 
         @Test(

--- a/iOS/DuckDuckGoTests/OnboardingIntroContentProviderTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroContentProviderTests.swift
@@ -697,52 +697,73 @@ struct OnboardingIntroContentProviderTests {
 
     }
 
-    @Suite("Duck.ai Query Experiment Content")
-    struct DuckAIQueryExperimentContent {
+    @Suite("Duck.ai Query Content")
+    struct DuckAIQueryContent {
 
         @Test(
-            "Check duck.ai query experiment title is correct",
-            arguments: [.default, .duckAI] as [OnboardingFlowType]
+            "Check duck.ai query title is correct per flow",
+            arguments: zip(
+                [OnboardingFlowType.default, .duckAI],
+                [UserText.Onboarding.DuckAIQueryExperiment.title, UserText.Onboarding.DuckAICPP.DuckAIQuery.title]
+            )
         )
-        func checkDuckAIQueryExperimentTitle(flow: OnboardingFlowType) {
+        func checkDuckAIQueryTitle(flow: OnboardingFlowType, expectedTitle: String) {
             // GIVEN
             let sut = OnboardingIntroContentProvider(flowType: flow, featureFlagger: MockFeatureFlagger())
 
             // WHEN
-            let result = sut.duckAIQueryExperimentContent
+            let result = sut.duckAIQueryContent
 
             // THEN
-            #expect(result.title == UserText.Onboarding.DuckAIQueryExperiment.title)
+            #expect(result.title == expectedTitle)
         }
 
         @Test(
-            "Check duck.ai query experiment search placeholder is correct",
+            "Check duck.ai query search placeholder is correct",
             arguments: [.default, .duckAI] as [OnboardingFlowType]
         )
-        func checkDuckAIQueryExperimentSearchPlaceholder(flow: OnboardingFlowType) {
+        func checkDuckAIQuerySearchPlaceholder(flow: OnboardingFlowType) {
             // GIVEN
             let sut = OnboardingIntroContentProvider(flowType: flow, featureFlagger: MockFeatureFlagger())
 
             // WHEN
-            let result = sut.duckAIQueryExperimentContent
+            let result = sut.duckAIQueryContent
 
             // THEN
             #expect(result.searchPlaceholder == UserText.Onboarding.DuckAIQueryExperiment.searchPlaceholder)
         }
 
         @Test(
-            "Check duck.ai query experiment AI placeholder is correct",
+            "Check duck.ai query AI placeholder is correct",
             arguments: [.default, .duckAI] as [OnboardingFlowType]
         )
-        func checkDuckAIQueryExperimentAIPlaceholder(flow: OnboardingFlowType) {
+        func checkDuckAIQueryAIPlaceholder(flow: OnboardingFlowType) {
             // GIVEN
             let sut = OnboardingIntroContentProvider(flowType: flow, featureFlagger: MockFeatureFlagger())
 
             // WHEN
-            let result = sut.duckAIQueryExperimentContent
+            let result = sut.duckAIQueryContent
 
             // THEN
             #expect(result.aiPlaceholder == UserText.Onboarding.DuckAIQueryExperiment.aiPlaceholder)
+        }
+
+        @Test(
+            "Check toggle visibility is correct per flow",
+            arguments: zip(
+                [OnboardingFlowType.default, .duckAI],
+                [true, false]
+            )
+        )
+        func checkShouldToggleBeVisible(flow: OnboardingFlowType, expectedVisibility: Bool) {
+            // GIVEN
+            let sut = OnboardingIntroContentProvider(flowType: flow, featureFlagger: MockFeatureFlagger())
+
+            // WHEN
+            let result = sut.duckAIQueryContent
+
+            // THEN
+            #expect(result.shouldToggleBeVisible == expectedVisibility)
         }
 
     }

--- a/iOS/DuckDuckGoTests/OnboardingIntroContentProviderTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroContentProviderTests.swift
@@ -761,7 +761,7 @@ struct OnboardingIntroContentProviderTests {
                 [true, false]
             )
         )
-        func checkShouldToggleBeVisible(flow: OnboardingFlowType, expectedVisibility: Bool) {
+        func checkIsToggleVisible(flow: OnboardingFlowType, expectedVisibility: Bool) {
             // GIVEN
             let sut = OnboardingIntroContentProvider(flowType: flow, featureFlagger: MockFeatureFlagger())
 
@@ -769,7 +769,7 @@ struct OnboardingIntroContentProviderTests {
             let result = sut.duckAIQueryContent
 
             // THEN
-            #expect(result.shouldToggleBeVisible == expectedVisibility)
+            #expect(result.isToggleVisible == expectedVisibility)
         }
 
     }

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/MockOnboardingIntroContentProvider.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/MockOnboardingIntroContentProvider.swift
@@ -127,6 +127,6 @@ extension OnboardingDuckAIQueryContent {
         title: "Duck.ai Query Title",
         searchPlaceholder: "Search Placeholder",
         aiPlaceholder: "AI Placeholder",
-        shouldToggleBeVisible: true
+        isToggleVisible: true
     )
 }

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/MockOnboardingIntroContentProvider.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/MockOnboardingIntroContentProvider.swift
@@ -29,7 +29,7 @@ class MockOnboardingIntroContentProvider: OnboardingIntroContentProviding {
     var appIconColorContent: OnboardingAppIconColorContent = .mock
     var addressBarPositionContent: OnboardingAddressBarPositionContent = .mock
     var searchExperienceContent: OnboardingSearchExperienceContent = .mock
-    var duckAIQueryExperimentContent: OnboardingDuckAIQueryExperimentContent = .mock
+    var duckAIQueryContent: OnboardingDuckAIQueryContent = .mock
 }
 
 // MARK: - Helpers
@@ -122,10 +122,11 @@ extension OnboardingSearchExperienceContent {
     )
 }
 
-extension OnboardingDuckAIQueryExperimentContent {
-    static let mock = OnboardingDuckAIQueryExperimentContent(
-        title: "Duck.ai Query Experiment Title",
+extension OnboardingDuckAIQueryContent {
+    static let mock = OnboardingDuckAIQueryContent(
+        title: "Duck.ai Query Title",
         searchPlaceholder: "Search Placeholder",
-        aiPlaceholder: "AI Placeholder"
+        aiPlaceholder: "AI Placeholder",
+        shouldToggleBeVisible: true
     )
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214068803741443
Tech Design URL:
CC:

### Description

Wires the Duck.ai tailored copy into the content provider and adds the rendering support the new copy needs. Default-flow strings are unchanged.

### Testing Steps
1. In FeatureFlag.swift set Config(source: .remoteReleasable(.feature(.iOSBrowserConfig)), supportsLocalOverriding: true) for .onboardingDuckAIFlow
2. In AppStoreCustomProductPageEvaluator add 'let url = URL(string: "ddgCPP://duckAI”)` at line 33 to simulate launching the app from Duck.ai CPP.
3. Fresh install the app and  step through onboarding and verify that screens shows the Duck.ai-specific copy:                                                                                                                             
     - Intro: "Ready to chat privately with ChatGPT, Claude…”
     - Skip dialog:  Duck.ai-specific message. Primary CTA reads "Start AI Chat”. 
     - Browser comparison: Duck.ai-specific title.                                                                                                              
     - Add to Dock promo: Duck.ai-specific message.
     - Duck.ai Query screen: Duck.ai-specific title; the search/Duck.ai segmented picker is hidden.
  
 [Figma Mockup](https://www.figma.com/design/5QvJbyUBbeonblsjViDIkf/Mobile-Onboarding-AI-First?node-id=173-50969&p=f&m=dev) for Copy
  
### Impact and Risks
**Low**:  copy-only changes Default flow has no behavioural change; Duck.ai flow is still gated by the (currently off) `onboardingDuckAIFlow` feature flag inherited from the parent branch.

#### What could go wrong?
- Strings for Duck.ai flow leaked to standard flow. Mitigated by writing automation tests.

### Quality Considerations
- `OnboardingIntroContentProviderTests` updated for every per-flow field, plus new tests:
    - Skip dialog message contains the chat-icon token in the Duck.ai flow and doesn't in the default flow.                                                     
    - `shouldToggleBeVisible` is `true` in default flow, `false` in Duck.ai flow.                                                                               

### Notes to Reviewer
- NotLocalizedStrings have been used to avoid creating translations beforehand.
- AIComparison view will be provided in a subsequent PR.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are mostly string selection/rendering and a conditional UI toggle in onboarding, with updated tests to prevent copy leaking across flows.
> 
> **Overview**
> Implements **Duck.ai-tailored linear onboarding copy** by branching `OnboardingIntroContentProvider` strings (intro, skip dialog/CTA, browser comparison title, add-to-dock message, Duck.ai query title) on `OnboardingFlowType`.
> 
> Updates the Duck.ai query step model from `OnboardingDuckAIQueryExperimentContent` to `OnboardingDuckAIQueryContent` and adds `isToggleVisible` to **hide the Search/Duck.ai segmented control** for the Duck.ai flow.
> 
> Adds `OnboardingRichTextMessageRenderer` to render onboarding messages with **inline chat-icon token replacement** and **bold “Fire Button”** styling, and wires it into the rebranded skip dialog. Updates mocks and `OnboardingIntroContentProviderTests` for per-flow expectations and new coverage (chat icon token presence + toggle visibility).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04be80ca2c75c507be3e9e31d803075092a224b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->