### PR TITLE
iOS: Bug - unified toggle overlaps contextual onboarding

### DIFF
--- a/iOS/DuckDuckGo/BrowserChromeManager.swift
+++ b/iOS/DuckDuckGo/BrowserChromeManager.swift
@@ -24,6 +24,7 @@ protocol BrowserChromeDelegate: AnyObject {
     func setBarsHidden(_ hidden: Bool, animated: Bool, customAnimationDuration: CGFloat?)
     func setNavigationBarHidden(_ hidden: Bool)
     func setRefreshControlEnabled(_ isEnabled: Bool)
+    func setUnifiedInputContentOverlaySuppressed(_ suppressed: Bool)
     
     func setBarsVisibility(_ percent: CGFloat, animated: Bool, animationDuration: CGFloat?)
     

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2009,6 +2009,7 @@ class MainViewController: UIViewController {
 
     private func resetUnifiedToggleInputForTabTransition(to tab: TabViewController) {
         guard let coordinator = unifiedToggleInputCoordinator else { return }
+        coordinator.setContentOverlaySuppressed(false)
         coordinator.deactivateToOmnibar()
         if !tab.isAITab {
             coordinator.hide()

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3355,6 +3355,12 @@ extension MainViewController: BrowserChromeDelegate {
         viewCoordinator.omniBar
     }
 
+    func setUnifiedInputContentOverlaySuppressed(_ suppressed: Bool) {
+        guard let coordinator = unifiedToggleInputCoordinator else { return }
+        coordinator.setContentOverlaySuppressed(suppressed)
+        updateUnifiedInputContentVisibility(for: coordinator)
+    }
+
     private func hideKeyboard() {
         dismissOmniBar()
         _ = findInPageView?.resignFirstResponder()

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -279,6 +279,7 @@ class MainViewController: UIViewController {
     let customConfigurationURLProvider: CustomConfigurationURLProviding
     let experimentalAIChatManager: ExperimentalAIChatManager
     let daxDialogsManager: DaxDialogsManaging
+    let onboardingSearchExperienceSettingsResolver: OnboardingSearchExperienceSettingsResolver
     let dbpIOSPublicInterface: DBPIOSInterface.PublicInterface?
     let freemiumPIREligibilityChecker: FreemiumPIREligibilityChecking
     let freemiumPIRDebugSettings: FreemiumPIRDebugSettings
@@ -417,6 +418,7 @@ class MainViewController: UIViewController {
         customConfigurationURLProvider: CustomConfigurationURLProviding,
         systemSettingsPiPTutorialManager: SystemSettingsPiPTutorialManaging,
         daxDialogsManager: DaxDialogsManaging,
+        onboardingSearchExperienceSettingsResolver: OnboardingSearchExperienceSettingsResolver? = nil,
         daxEasterEggPresenter: DaxEasterEggPresenting? = nil,
         daxEasterEggLogoStore: DaxEasterEggLogoStoring = DaxEasterEggLogoStore(),
         dbpIOSPublicInterface: DBPIOSInterface.PublicInterface?,
@@ -493,6 +495,10 @@ class MainViewController: UIViewController {
         self.customConfigurationURLProvider = customConfigurationURLProvider
         self.systemSettingsPiPTutorialManager = systemSettingsPiPTutorialManager
         self.daxDialogsManager = daxDialogsManager
+        self.onboardingSearchExperienceSettingsResolver = onboardingSearchExperienceSettingsResolver ?? OnboardingSearchExperienceSettingsResolver(
+            onboardingProvider: OnboardingSearchExperience(),
+            daxDialogsStatusProvider: daxDialogsManager
+        )
         self.daxEasterEggLogoStore = daxEasterEggLogoStore
         self.daxEasterEggPresenter = daxEasterEggPresenter ?? DaxEasterEggPresenter(logoStore: daxEasterEggLogoStore, featureFlagger: featureFlagger)
         self.dbpIOSPublicInterface = dbpIOSPublicInterface

--- a/iOS/DuckDuckGo/NewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPageViewController.swift
@@ -272,6 +272,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
 
     func dismiss() {
         notifyDuckAICompletionDismissedIfNeeded()
+        chromeDelegate?.setUnifiedInputContentOverlaySuppressed(false)
         delegate = nil
         chromeDelegate = nil
         removeFromParent()
@@ -386,9 +387,13 @@ extension NewTabPageViewController {
     }
 
     func showNextDaxDialogNew(dialogProvider: NewTabDialogSpecProvider, factory: any NewTabDaxDialogProviding) {
-        dismissHostingController(didFinishNTPOnboarding: false)
+        dismissHostingController(didFinishNTPOnboarding: false, updateUnifiedInputContentOverlaySuppression: false)
 
-        guard let spec = dialogProvider.nextHomeScreenMessageNew() else { return }
+        guard let spec = dialogProvider.nextHomeScreenMessageNew() else {
+            chromeDelegate?.setUnifiedInputContentOverlaySuppressed(false)
+            return
+        }
+        chromeDelegate?.setUnifiedInputContentOverlaySuppressed(true)
 
         let onDismiss: (_ activateSearch: Bool) -> Void = { [weak self] activateSearch in
             guard let self else { return }
@@ -446,11 +451,14 @@ extension NewTabPageViewController {
         newTabPageViewModel.startOnboarding()
     }
 
-    private func dismissHostingController(didFinishNTPOnboarding: Bool) {
+    private func dismissHostingController(didFinishNTPOnboarding: Bool, updateUnifiedInputContentOverlaySuppression: Bool = true) {
         let didDismissDuckAICompletionDialog = isShowingDuckAICompletionDialog
         hostingController?.willMove(toParent: nil)
         hostingController?.view.removeFromSuperview()
         hostingController?.removeFromParent()
+        if updateUnifiedInputContentOverlaySuppression {
+            chromeDelegate?.setUnifiedInputContentOverlaySuppressed(false)
+        }
         isShowingDuckAICompletionDialog = false
         if didDismissDuckAICompletionDialog {
             delegate?.newTabPageDidDismissDuckAIExperimentCompletion(self)

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -1208,13 +1208,23 @@ class TabViewController: UIViewController {
 
     func dismissContextualDaxFireDialog() {
         guard contextualOnboardingLogic.isShowingFireDialog else { return }
-        contextualOnboardingPresenter.dismissContextualOnboardingIfNeeded(from: self)
+        dismissContextualOnboardingIfNeeded()
     }
 
     func presentExperimentContextualDaxFireDialog() {
         contextualOnboardingLogic.setLastShownDialog(type: .fire(.duckAIOnboarding))
         let fireSpec = DaxDialogs.BrowsingSpec.fireDuckAIOnboarding
-        contextualOnboardingPresenter.presentContextualOnboarding(for: fireSpec, in: self)
+        presentContextualOnboarding(for: fireSpec)
+    }
+
+    private func presentContextualOnboarding(for spec: DaxDialogs.BrowsingSpec) {
+        chromeDelegate?.setUnifiedInputContentOverlaySuppressed(true)
+        contextualOnboardingPresenter.presentContextualOnboarding(for: spec, in: self)
+    }
+
+    private func dismissContextualOnboardingIfNeeded() {
+        contextualOnboardingPresenter.dismissContextualOnboardingIfNeeded(from: self)
+        chromeDelegate?.setUnifiedInputContentOverlaySuppressed(false)
     }
 
     private func shouldHandleUpdate(_ previousURL: URL?, _ newURL: URL?) -> Bool {
@@ -1447,7 +1457,7 @@ class TabViewController: UIViewController {
     private var didGoBackForward: Bool = false {
         didSet {
             if didGoBackForward {
-                contextualOnboardingPresenter.dismissContextualOnboardingIfNeeded(from: self)
+                dismissContextualOnboardingIfNeeded()
             }
         }
     }
@@ -2080,7 +2090,7 @@ extension TabViewController: WKNavigationDelegate {
         guard let spec = daxDialogsManager.nextBrowsingMessageIfShouldShow(for: privacyInfo) else {
 
             // Dismiss Contextual onboarding if there's no message to show.
-            contextualOnboardingPresenter.dismissContextualOnboardingIfNeeded(from: self)
+            dismissContextualOnboardingIfNeeded()
             // Dismiss privacy dashbooard pulse animation when no browsing dialog to show.
             delegate?.tabDidRequestPrivacyDashboardButtonPulse(tab: self, animated: false)
 
@@ -2109,7 +2119,7 @@ extension TabViewController: WKNavigationDelegate {
             self.chromeDelegate?.setBarsHidden(false, animated: true, customAnimationDuration: nil)
 
             // Present the contextual onboarding
-            contextualOnboardingPresenter.presentContextualOnboarding(for: spec, in: self)
+            presentContextualOnboarding(for: spec)
 
             if spec == DaxDialogs.BrowsingSpec.withoutTrackers {
                 self.woShownRecently = true
@@ -4186,7 +4196,7 @@ extension TabViewController: ContextualOnboardingEventDelegate {
         // Reset last visited onboarding site and last dax dialog shown.
         contextualOnboardingLogic.setDaxDialogDismiss()
 
-        contextualOnboardingPresenter.dismissContextualOnboardingIfNeeded(from: self)
+        dismissContextualOnboardingIfNeeded()
     }
 
 }

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -161,10 +161,15 @@ final class MainCoordinator {
         let websiteDataManager = Self.makeWebsiteDataManager(fireproofing: fireproofing)
         interactionStateSource = TabInteractionStateDiskSource()
         self.launchSourceManager = launchSourceManager
+        let onboardingSearchExperienceProvider = OnboardingSearchExperience()
         onboardingSearchExperienceSelectionHandler = OnboardingSearchExperienceSelectionHandler(
             daxDialogs: daxDialogs,
             aiChatSettings: aiChatSettings,
-            onboardingSearchExperienceProvider: OnboardingSearchExperience()
+            onboardingSearchExperienceProvider: onboardingSearchExperienceProvider
+        )
+        let onboardingSearchExperienceSettingsResolver = OnboardingSearchExperienceSettingsResolver(
+            onboardingProvider: onboardingSearchExperienceProvider,
+            daxDialogsStatusProvider: daxDialogs
         )
         self.privacyStats = PrivacyStats(databaseProvider: PrivacyStatsDatabase())
         let toggleModeStorage: ToggleModeStoring = ToggleModeStorage()
@@ -270,6 +275,7 @@ final class MainCoordinator {
                                         customConfigurationURLProvider: customConfigurationURLProvider,
                                         systemSettingsPiPTutorialManager: systemSettingsPiPTutorialManager,
                                         daxDialogsManager: daxDialogsManager,
+                                        onboardingSearchExperienceSettingsResolver: onboardingSearchExperienceSettingsResolver,
                                         dbpIOSPublicInterface: dbpIOSPublicInterface,
                                         freemiumPIREligibilityChecker: freemiumPIREligibilityChecker,
                                         freemiumPIRDebugSettings: freemiumPIRDebugSettings,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -55,9 +55,10 @@ extension MainViewController {
         stateStore.observeTabsModel(tabManager.fireModeTabsModel)
         self.unifiedInputStateStore = stateStore
 
+        let initialToggleEnabled = isAIChatSearchInputToggleEnabledForCurrentOnboardingState()
         let coordinator = UnifiedToggleInputCoordinator(
             host: .omnibar,
-            isToggleEnabled: aiChatSettings.isAIChatSearchInputUserSettingsEnabled,
+            isToggleEnabled: initialToggleEnabled,
             isFireTab: isCurrentTabFireTab(),
             duckAiNativeStorageHandler: duckAiNativeStorageHandler,
             preferences: aiChatPreferences,
@@ -228,6 +229,13 @@ extension MainViewController {
 }
 
 private extension MainViewController {
+
+    /// While Dax Dialogs are still in progress, the onboarding Search vs Search & Duck.ai choice
+    /// is not applied to AIChatSettings yet. Use that pending choice for UTI presentation so
+    /// Search-only hides the toggle, while Search & Duck.ai keeps it visible.
+    func isAIChatSearchInputToggleEnabledForCurrentOnboardingState() -> Bool {
+        onboardingSearchExperienceSettingsResolver.deferredValue ?? aiChatSettings.isAIChatSearchInputUserSettingsEnabled
+    }
 
     enum UnifiedToggleInputRefreshAction {
         case unbindInactiveNonAITab
@@ -402,7 +410,7 @@ private extension MainViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self, let coordinator = self.unifiedToggleInputCoordinator else { return }
-                let enabled = self.aiChatSettings.isAIChatSearchInputUserSettingsEnabled
+                let enabled = self.isAIChatSearchInputToggleEnabledForCurrentOnboardingState()
                 coordinator.updateToggleEnabled(enabled)
                 coordinator.contentViewController.isSwipeEnabled = enabled
                 coordinator.updateAIChatShortcutAvailability(self.aiChatAddressBarExperience.shouldShowDuckAIAddressBarButton)
@@ -756,6 +764,9 @@ extension MainViewController: UnifiedToggleInputOmnibarActivating {
         }
         let position: UnifiedToggleInputCardPosition = appSettings.currentAddressBarPosition == .bottom ? .bottom : .top
         let inputMode = tabManager.currentTabsModel.currentTab?.unifiedInputState.preferredTextEntryMode ?? .search
+        let isToggleEnabled = isAIChatSearchInputToggleEnabledForCurrentOnboardingState()
+        coordinator.updateToggleEnabled(isToggleEnabled)
+        coordinator.contentViewController.isSwipeEnabled = isToggleEnabled
         coordinator.activateFromOmnibar(prefilledText: currentText, inputMode: inputMode, cardPosition: position)
         return .intercept
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -287,6 +287,16 @@ private extension MainViewController {
                 self.updateUnifiedInputContentVisibility(for: coordinator)
             }
             .store(in: &unifiedToggleInputCancellables)
+
+        // Refresh Dax overlay visibility while onboarding as omnibar text changes.
+        coordinator.textChangePublisher
+            .sink { [weak self] _ in
+                guard let self, let coordinator = self.unifiedToggleInputCoordinator,
+                      !self.daxDialogsManager.hasSeenOnboarding,
+                      coordinator.isOmnibarSession else { return }
+                self.updateUnifiedInputContentVisibility(for: coordinator)
+            }
+            .store(in: &unifiedToggleInputCancellables)
     }
 
     func handleModeChange(_ mode: TextEntryMode) {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -232,6 +232,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     private var isAwaitingTopOmnibarKeyboardPresentation = false
     private var topOmnibarKeyboardPresentationFallback: DispatchWorkItem?
     private var invalidAttachmentRecoveryTasks: [UUID: Task<Void, Never>] = [:]
+    private var isContentOverlaySuppressed = false
 
     private(set) var currentText: String = ""
     var hasActiveChat: Bool { boundUserScript != nil }
@@ -975,6 +976,10 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         contentViewController.setInputMode(mode, animated: animated)
     }
 
+    func setContentOverlaySuppressed(_ suppressed: Bool) {
+        isContentOverlaySuppressed = suppressed
+    }
+
     // MARK: - Render State
 
     func computeRenderState() -> UTIRenderState {
@@ -1024,10 +1029,12 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         let isFloatingSubmitVisible = displayState == .omnibar(.active)
             && cardPosition == .top
             && inputMode == .aiChat
+        let shouldSuppressContentOverlay = isOmnibarSession && isContentOverlaySuppressed && textState != .userTyped
+        let effectiveContentVisible = isContentVisible && !shouldSuppressContentOverlay
 
         return UTIRenderState(
             isInputVisible: isInputVisible,
-            isContentVisible: isContentVisible,
+            isContentVisible: effectiveContentVisible,
             cardLayout: cardLayout(forIsExpanded: isExpanded),
             cardPosition: cardPosition,
             usesOmnibarMargins: cardPosition == .top && isOmnibarSession,

--- a/iOS/DuckDuckGoTests/BarsAnimatorTests.swift
+++ b/iOS/DuckDuckGoTests/BarsAnimatorTests.swift
@@ -209,6 +209,10 @@ private class BrowserChromeDelegateMock: BrowserChromeDelegate {
         receivedMessages.append(.setRefreshControlEnabled(isEnabled))
     }
 
+    func setUnifiedInputContentOverlaySuppressed(_ suppressed: Bool) {
+        // no-op
+    }
+
     var canHideBars: Bool = false
 
     var isToolbarHidden: Bool = false

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -384,6 +384,44 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         XCTAssertTrue(sut.viewController.isInputExpanded)
     }
 
+    func test_computeRenderState_whenContentOverlayNotSuppressed_keepsContentVisibleForPrefilledText() {
+        sut.activateFromOmnibar(prefilledText: "example.com")
+
+        XCTAssertTrue(sut.computeRenderState().isContentVisible)
+        XCTAssertEqual(sut.textState, .prefilledSelected)
+    }
+
+    func test_setContentOverlaySuppressed_whenOmnibarActive_hidesContentButKeepsInputVisible() {
+        sut.activateFromOmnibar()
+
+        sut.setContentOverlaySuppressed(true)
+
+        let renderState = sut.computeRenderState()
+        XCTAssertTrue(renderState.isInputVisible)
+        XCTAssertFalse(renderState.isContentVisible)
+        XCTAssertTrue(sut.isOmnibarSession)
+    }
+
+    func test_setContentOverlaySuppressed_whenOmnibarActiveWithPrefilledText_hidesContentButKeepsInputVisible() {
+        sut.activateFromOmnibar(prefilledText: "example.com")
+
+        sut.setContentOverlaySuppressed(true)
+
+        let renderState = sut.computeRenderState()
+        XCTAssertTrue(renderState.isInputVisible)
+        XCTAssertFalse(renderState.isContentVisible)
+        XCTAssertEqual(sut.textState, .prefilledSelected)
+    }
+
+    func test_setContentOverlaySuppressed_whenOmnibarActiveAndTextEntered_keepsContentVisible() {
+        sut.activateFromOmnibar()
+        sut.setContentOverlaySuppressed(true)
+
+        sut.unifiedToggleInputVC(sut.viewController, didChangeText: "duck")
+
+        XCTAssertTrue(sut.computeRenderState().isContentVisible)
+    }
+
     func test_activateFromOmnibar_bottomPosition_leavesBarInCollapsedStartPose() {
         sut.activateFromOmnibar(cardPosition: .bottom)
         // Bottom pre-stages to collapsed; the show animation expands it.

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/DuckPlayerMocks.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/DuckPlayerMocks.swift
@@ -605,6 +605,10 @@ final class DuckPlayerBrowserChromeDelegateMock: BrowserChromeDelegate {
         receivedMessages.append(.setRefreshControlEnabled(isEnabled))
     }
 
+    func setUnifiedInputContentOverlaySuppressed(_ suppressed: Bool) {
+        // no-op
+    }
+
     var canHideBars: Bool = false
 
     var isToolbarHidden: Bool = false


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214547796928329?focus=true
Tech Design URL:
CC:

### Description
Fixes Dax Dialog presentation while `unifiedToggleInput` is enabled.
Root cause: Dax Dialogs are hosted by NTP/contextual onboarding, while for unifiedToggleInput we have a separate content overlay for suggestions. When new native input is activated from the omnibar, that overlay could stay visible over Dax Dialogs.

Fix:
- Add a chrome delegate hook to suppress UTI content overlay while Dax Dialogs are visible.
- Apply suppression from both NTP Dax Dialogs and contextual Dax Dialogs.
- Keep suggestions available once the user starts typing, while keeping Dax visible for empty/prefilled omnibar text.
- Add coordinator tests for suppressed, prefilled, and user-typed render states (covering changes in `computeRenderState` method)

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
Firstly, open `iOS Browser` scheme and in `Arguments Passed On Launch` section add
`-ff.unifiedToggleInput true`. Then enable this checkbox to enable this ff.

Run this test two times. One with selecting Search only on step 5/5. Then, by selecting Search & Duck.ai 

1. Go through and complete linear onboarding. 
2. After finishing linear onboarding, verify each Dax Dialog is visible with the focused omnibar
3. Type in the omnibar and verify suggestions appear.
4. Tap clear and verify the Dax Dialog becomes visible again.
5. Continue through all Dax Dialogs.

[screenshot dax dialog 1](https://github.com/user-attachments/assets/a782b1ab-0c2c-4dbc-ae25-a927ee255e9f)

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low. This changes UTI overlay visibility only during Dax onboarding.

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
UTI suggestions could be hidden or shown at the wrong time during onboarding. The fix is guarded to onboarding and omnibar sessions, and coordinator tests cover the render-state behavior.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->
No privacy or storage impact. The change only affects local UI presentation state.


### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts overlay visibility during onboarding dialogs; main risk is regressions where UTI suggestions or dialogs are shown/hidden at the wrong times.
> 
> **Overview**
> Prevents `unifiedToggleInput`’s suggestion/content overlay from covering Dax onboarding dialogs by adding a new `BrowserChromeDelegate.setUnifiedInputContentOverlaySuppressed(_:)` hook and wiring it through `MainViewController`.
> 
> Applies suppression while New Tab Page and contextual Dax dialogs are presented, and clears it on dismissal/tab transitions. Updates `UnifiedToggleInputCoordinator.computeRenderState()` to hide the overlay only for non-user-typed states (empty/prefilled), keeping suggestions visible once the user starts typing.
> 
> Also aligns initial toggle-enabled state with the in-progress onboarding Search vs Search+Duck.ai selection via `OnboardingSearchExperienceSettingsResolver`, and adds coordinator unit tests covering suppressed/prefilled/user-typed render states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61dd249204741203e43d50a527dbfabb2da55fff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->