### PR TITLE
[macOS] Switch Internal Feedback Toolbar Icon to Monochrome

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -1840,11 +1840,9 @@ final class NavigationBarViewController: NSViewController {
                 .targetting(self)
                 .withImage(theme.iconsProvider.navigationToolbarIconsProvider.downloadsButtonImage)
         case .feedback:
-            let icon = (DesignSystemImages.Color.Size16.feedback.copy() as? NSImage) ?? DesignSystemImages.Color.Size16.feedback
-            icon.isTemplate = false
             return NSMenuItem(title: UserText.feedbackShortcutTooltip, action: #selector(quickFeedbackButtonClicked), keyEquivalent: "")
                 .targetting(self)
-                .withImage(icon)
+                .withImage(DesignSystemImages.Glyphs.Size16.feedback)
         case .share:
             return NSMenuItem(title: UserText.shareMenuItem, action: #selector(overflowMenuRequestedSharePopover), keyEquivalent: "")
                 .targetting(self)
@@ -2054,9 +2052,7 @@ extension NavigationBarViewController: NSMenuDelegate {
         button.target = self
         button.action = #selector(quickFeedbackButtonClicked)
 
-        let icon = (DesignSystemImages.Color.Size16.feedback.copy() as? NSImage) ?? DesignSystemImages.Color.Size16.feedback
-        icon.isTemplate = false
-        button.image = icon
+        button.image = DesignSystemImages.Glyphs.Size16.feedback
         button.mouseOverColor = theme.colorsProvider.buttonMouseOverColor
         button.setCornerRadius(theme.toolbarButtonsCornerRadius)
 

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -1080,8 +1080,8 @@ final class NavigationBarViewController: NSViewController {
         let allButtons: [MouseOverButton] = [
             goBackButton, goForwardButton, refreshOrStopButton, homeButton,
             downloadsButton, shareButton, passwordManagementButton, bookmarkListButton, optionsButton,
-            networkProtectionButton
-        ]
+            networkProtectionButton, feedbackButton
+        ].compactMap { $0 }
 
         let colorsProvider = theme.colorsProvider
 

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -2053,6 +2053,9 @@ extension NavigationBarViewController: NSMenuDelegate {
         button.action = #selector(quickFeedbackButtonClicked)
 
         button.image = DesignSystemImages.Glyphs.Size16.feedback
+        let iconsColor = theme.colorsProvider.iconsColor
+        button.contentTintColor = iconsColor
+        button.normalTintColor = iconsColor
         button.mouseOverColor = theme.colorsProvider.buttonMouseOverColor
         button.setCornerRadius(theme.toolbarButtonsCornerRadius)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211850802118632/task/1214650827378922
Tech Design URL:
CC:

### Description

The Internal Feedback toolbar shortcut (internal users only) was rendering as a multi-color yellow chat-bubble icon that stood out against the monochrome toolbar.

This PR swaps `DesignSystemImages.Color.Size16.feedback` for `DesignSystemImages.Glyphs.Size16.feedback` at the two call sites in `NavigationBarViewController.swift` (the overflow-menu `.feedback` case and `addQuickFeedbackButton`) and drops the `.copy()` + `isTemplate = false` workaround. The glyph asset is a template image, so AppKit now tints it automatically per the active appearance, matching every other toolbar button. The same asset is already used by More Options > Send Feedback.

### Testing Steps

1. As an internal user, confirm the toolbar feedback button now renders monochrome and matches the tint of neighboring buttons.
2. Toggle Light/Dark appearance and open a fire window. Confirm the icon adapts correctly.
3. Click the button to confirm the feedback popup still opens.

### Impact and Risks

**Low.** Internal-only, purely visual, no logic or signatures changed.

#### What could go wrong?

Worst case is an incorrect tint for the feedback button on an appearance we haven't tested. The asset is already in production use in the More Options menu across all appearances, so this is unlikely. No data, privacy, or non-internal-user impact.

### Quality Considerations

- Removing `.copy()` and `isTemplate = false` is a strict simplification; performance is unaffected.
- No new pixels, storage, or network calls; no privacy or security impact.

### Notes to Reviewer

- The colored asset lives in `DesignResourcesKitIcons` (shared with iOS, which still uses `Color.Size24.feedback`). Retiring the colored feedback family entirely is a cross-platform decision and out of scope here.
- Optional follow-up: route this button's image through `theme.iconsProvider.navigationToolbarIconsProvider` like every other toolbar button. Scope-expanding, deferred.
- No automated tests added (pure visual swap with no observable behavior to assert on); existing feedback-related tests were audited and are unaffected.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, UI-only change limited to the internal-only feedback button/icon and its tinting behavior; no navigation or feedback action logic is modified.
> 
> **Overview**
> Switches the internal quick feedback icon (toolbar button and overflow menu item) from `DesignSystemImages.Color.Size16.feedback` to the template `DesignSystemImages.Glyphs.Size16.feedback` so it renders monochrome and tints with the active theme.
> 
> Updates tint handling by including `feedbackButton` in `setupNavigationButtonColors()` and explicitly setting the feedback button’s `contentTintColor`/`normalTintColor`, removing the prior `.copy()`/`isTemplate = false` workaround.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b02c090b3e88c26f27f60119107e35940d45e451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->