### PR TITLE
Fix post-idle session UNKNOWN race condition, default old users to NTP, and bucket durations

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PixelKitTestingUtilities/WideEventMock.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKitTestingUtilities/WideEventMock.swift
@@ -26,6 +26,7 @@ public final class WideEventMock: WideEventManaging {
     public var updates: [WideEventData] = []
     public var completions: [(WideEventData, WideEventStatus)] = []
     public var discarded: [WideEventData] = []
+    private var completedIDs: Set<String> = []
 
     public var onStart: ((WideEventData) -> Void)?
     public var onUpdate: ((WideEventData) -> Void)?
@@ -56,25 +57,28 @@ public final class WideEventMock: WideEventManaging {
 
     public func completeFlow<T: WideEventData>(_ data: T, status: WideEventStatus, onComplete: @escaping PixelKit.CompletionBlock) {
         completions.append((data, status))
+        completedIDs.insert(data.globalData.id)
         self.onComplete?(data, status)
         onComplete(true, nil)
     }
 
     public func completeFlow<T: WideEventData>(_ data: T, status: WideEventStatus) async throws -> Bool {
         completions.append((data, status))
+        completedIDs.insert(data.globalData.id)
         onComplete?(data, status)
         return true
     }
 
     public func discardFlow<T: WideEventData>(_ data: T) {
         discarded.append(data)
+        completedIDs.insert(data.globalData.id)
     }
 
     public func getFlowData<T: WideEventData>(_ type: T.Type, globalID: String) -> T? {
-        return started.first { ($0 as? T)?.globalData.id == globalID } as? T
+        return started.first { ($0 as? T)?.globalData.id == globalID && !completedIDs.contains($0.globalData.id) } as? T
     }
 
     public func getAllFlowData<T: WideEventData>(_ type: T.Type) -> [T] {
-        return started.compactMap { $0 as? T }
+        return started.compactMap { $0 as? T }.filter { !completedIDs.contains($0.globalData.id) }
     }
 }

--- a/iOS/DuckDuckGo/AppLifecycle/AfterInactivityEffectiveOptionResolver.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AfterInactivityEffectiveOptionResolver.swift
@@ -37,19 +37,19 @@ final class AfterInactivityEffectiveOptionResolver: AfterInactivityEffectiveOpti
         self.isPad = isPad
     }
 
-    /// Returns the effective option and, when it is .newTab for a new user with no stored value,
-    /// persists that choice and clears `idleReturnNewUser`.
-    /// iPad always defaults to `.lastUsedTab` when no preference is stored.
+    /// Returns the user's explicit preference when stored, otherwise defaults to
+    /// `.newTab` on iPhone (both new and existing users) or `.lastUsedTab` on iPad.
+    /// Users who manually selected "Last Used Tab" in Settings keep that choice.
     func resolveEffectiveOption() -> AfterInactivityOption {
         if let raw = try? storage.afterInactivityOption,
            let option = AfterInactivityOption(rawValue: raw) {
             return option
-        } else if !isPad, (try? storage.idleReturnNewUser) == true {
+        } else if isPad {
+            return .lastUsedTab
+        } else {
             try? storage.set(AfterInactivityOption.newTab.rawValue, for: \AfterInactivitySettingKeys.afterInactivityOption)
             try? storage.set(false, for: \AfterInactivitySettingKeys.idleReturnNewUser)
             return .newTab
-        } else {
-            return .lastUsedTab
         }
     }
 }

--- a/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionInstrumentation.swift
@@ -70,6 +70,12 @@ final class DefaultPostIdleSessionInstrumentation: PostIdleSessionInstrumentatio
             sessionCancelledByBackground()
         }
 
+        // Complete any orphaned flows left in storage from a previous app lifecycle
+        // (e.g., the app was killed before the session could complete). This runs
+        // synchronously before the new flow is created, avoiding a race with
+        // WideEventService.resume() which would otherwise complete new flows as UNKNOWN.
+        completeOrphanedFlows()
+
         let data = PostIdleSessionWideEventData(surface: surface, startedAt: dateProvider())
         activeSessionID = data.globalData.id
         pageEngagedSent = false
@@ -130,6 +136,15 @@ final class DefaultPostIdleSessionInstrumentation: PostIdleSessionInstrumentatio
     }
 
     // MARK: - Helpers
+
+    private func completeOrphanedFlows() {
+        for orphan in wideEvent.getAllFlowData(PostIdleSessionWideEventData.self) {
+            wideEvent.completeFlow(
+                orphan,
+                status: .unknown(reason: PostIdleSessionWideEventData.appTerminatedReason),
+                onComplete: { _, _ in })
+        }
+    }
 
     private func updateActiveSession(_ mutate: (inout PostIdleSessionWideEventData) -> Void) {
         guard let globalID = activeSessionID else { return }

--- a/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionWideEventData.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionWideEventData.swift
@@ -83,15 +83,12 @@ final class PostIdleSessionWideEventData: WideEventData {
         self.globalData = globalData
     }
 
-    /// Any pending flow on relaunch is by definition orphaned: the normal
-    /// background path completes flows as CANCELLED, and a successful
-    /// terminal action removes them. So if we still see one at app launch
-    /// the app died mid-session — complete immediately as UNKNOWN.
+    /// Orphaned flows are cleaned up by `sessionStarted()` which runs
+    /// synchronously before creating a new flow. This avoids a race with
+    /// `WideEventService.resume()` where the cleanup task would complete
+    /// a freshly created flow as UNKNOWN before any user interaction.
     func completionDecision(for trigger: WideEventCompletionTrigger) async -> WideEventCompletionDecision {
-        switch trigger {
-        case .appLaunch:
-            return .complete(.unknown(reason: Self.appTerminatedReason))
-        }
+        .keepPending
     }
 
     static let appTerminatedReason = "app_terminated"
@@ -99,12 +96,18 @@ final class PostIdleSessionWideEventData: WideEventData {
 
 extension PostIdleSessionWideEventData {
 
+    static let durationBucket: DurationBucket = .bucketed { ms in
+        let thresholds = [0, 1000, 5000, 10_000, 30_000, 60_000, 300_000, 600_000]
+        return thresholds.last(where: { $0 <= ms }) ?? 0
+    }
+
     func jsonParameters() -> [String: Encodable] {
-        Dictionary(compacting: [
+        let bucket = Self.durationBucket
+        return Dictionary(compacting: [
             (WideEventParameter.PostIdleSessionFeature.surface, surface.rawValue),
             (WideEventParameter.Feature.statusReason, statusReason?.rawValue),
-            (WideEventParameter.PostIdleSessionFeature.sessionDurationMs, sessionInterval.durationMilliseconds),
-            (WideEventParameter.PostIdleSessionFeature.timeToFirstInteractionMs, firstInteractionInterval.durationMilliseconds),
+            (WideEventParameter.PostIdleSessionFeature.sessionDurationMsBucketed, sessionInterval.stringValue(bucket)),
+            (WideEventParameter.PostIdleSessionFeature.timeToFirstInteractionMsBucketed, firstInteractionInterval.stringValue(bucket)),
             (WideEventParameter.PostIdleSessionFeature.pageEngaged, pageEngaged),
             (WideEventParameter.PostIdleSessionFeature.toggleUsed, toggleUsed),
             (WideEventParameter.PostIdleSessionFeature.backPressed, backPressed),
@@ -116,8 +119,8 @@ extension WideEventParameter {
 
     enum PostIdleSessionFeature {
         static let surface = "feature.data.ext.surface"
-        static let sessionDurationMs = "feature.data.ext.session_duration_ms"
-        static let timeToFirstInteractionMs = "feature.data.ext.time_to_first_interaction_ms"
+        static let sessionDurationMsBucketed = "feature.data.ext.session_duration_ms_bucketed"
+        static let timeToFirstInteractionMsBucketed = "feature.data.ext.time_to_first_interaction_ms_bucketed"
         static let pageEngaged = "feature.data.ext.page_engaged"
         static let toggleUsed = "feature.data.ext.toggle_used"
         static let backPressed = "feature.data.ext.back_pressed"

--- a/iOS/DuckDuckGoTests/AfterInactivityEffectiveOptionResolverTests.swift
+++ b/iOS/DuckDuckGoTests/AfterInactivityEffectiveOptionResolverTests.swift
@@ -68,21 +68,31 @@ struct AfterInactivityEffectiveOptionResolverTests {
         #expect(resolver.resolveEffectiveOption() == .lastUsedTab)
     }
 
-    @Test("When no stored value and idleReturnNewUser is false then returns Last Used Tab")
-    func whenReturningUserThenReturnsLastUsedTab() throws {
+    @Test("When no stored value and idleReturnNewUser is false on iPhone then returns New Tab")
+    func whenReturningUserOnPhoneThenReturnsNewTab() throws {
         let (_, storage) = try makeStorage()
         try storage.set(false, for: \AfterInactivitySettingKeys.idleReturnNewUser)
 
         let resolver = AfterInactivityEffectiveOptionResolver(storage: storage, isPad: false)
 
-        #expect(resolver.resolveEffectiveOption() == .lastUsedTab)
+        #expect(resolver.resolveEffectiveOption() == .newTab)
     }
 
-    @Test("When no stored value and idleReturnNewUser not set then returns Last Used Tab")
-    func whenNoStoredValueAndNewUserNotSetThenReturnsLastUsedTab() throws {
+    @Test("When no stored value and idleReturnNewUser not set on iPhone then returns New Tab")
+    func whenNoStoredValueAndNewUserNotSetOnPhoneThenReturnsNewTab() throws {
         let (_, storage) = try makeStorage()
 
         let resolver = AfterInactivityEffectiveOptionResolver(storage: storage, isPad: false)
+
+        #expect(resolver.resolveEffectiveOption() == .newTab)
+    }
+
+    @Test("When no stored value and idleReturnNewUser is false on iPad then returns Last Used Tab")
+    func whenReturningUserOnPadThenReturnsLastUsedTab() throws {
+        let (_, storage) = try makeStorage()
+        try storage.set(false, for: \AfterInactivitySettingKeys.idleReturnNewUser)
+
+        let resolver = AfterInactivityEffectiveOptionResolver(storage: storage, isPad: true)
 
         #expect(resolver.resolveEffectiveOption() == .lastUsedTab)
     }

--- a/iOS/DuckDuckGoTests/PostIdleSessionInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/PostIdleSessionInstrumentationTests.swift
@@ -268,4 +268,71 @@ struct PostIdleSessionInstrumentationTests {
         sut.sessionCancelledByBackground()
         #expect(wideEvent.completions.count == 1)
     }
+
+    // MARK: - Orphan cleanup
+
+    @available(iOS 16, *)
+    @Test("sessionStarted completes orphaned flows as UNKNOWN with app_terminated", .timeLimit(.minutes(1)))
+    func sessionStartedCompletesOrphansAsAppTerminated() {
+        let (sut, wideEvent, _) = makeSUT()
+        let orphan = PostIdleSessionWideEventData(surface: .ntp)
+        wideEvent.startFlow(orphan)
+
+        sut.sessionStarted(surface: .ntp)
+
+        let orphanCompletion = wideEvent.completions.first {
+            ($0.0 as? PostIdleSessionWideEventData)?.globalData.id == orphan.globalData.id
+        }
+        guard let orphanCompletion else {
+            Issue.record("Expected the orphan to be completed")
+            return
+        }
+        if case .unknown(let reason) = orphanCompletion.1 {
+            #expect(reason == PostIdleSessionWideEventData.appTerminatedReason)
+        } else {
+            Issue.record("Expected .unknown status, got \(orphanCompletion.1)")
+        }
+    }
+
+    @available(iOS 16, *)
+    @Test("Orphan cleanup happens before the new flow is started", .timeLimit(.minutes(1)))
+    func orphanCleanupHappensBeforeNewFlowStarts() {
+        let (sut, wideEvent, _) = makeSUT()
+        let orphan = PostIdleSessionWideEventData(surface: .ntp)
+        wideEvent.startFlow(orphan)
+
+        sut.sessionStarted(surface: .lut)
+
+        #expect(wideEvent.started.count == 2)
+        #expect((wideEvent.started[1] as? PostIdleSessionWideEventData)?.surface == .lut)
+        let orphanCompleted = wideEvent.completions.contains {
+            ($0.0 as? PostIdleSessionWideEventData)?.globalData.id == orphan.globalData.id
+        }
+        #expect(orphanCompleted)
+    }
+
+    @available(iOS 16, *)
+    @Test("Multiple orphans are all completed", .timeLimit(.minutes(1)))
+    func multipleOrphansAllCompleted() {
+        let (sut, wideEvent, _) = makeSUT()
+        let firstOrphan = PostIdleSessionWideEventData(surface: .ntp)
+        let secondOrphan = PostIdleSessionWideEventData(surface: .lut)
+        wideEvent.startFlow(firstOrphan)
+        wideEvent.startFlow(secondOrphan)
+
+        sut.sessionStarted(surface: .ntp)
+
+        let unknownCompletions = wideEvent.completions.filter {
+            if case .unknown = $0.1 { return true } else { return false }
+        }
+        #expect(unknownCompletions.count == 2)
+    }
+
+    @available(iOS 16, *)
+    @Test("sessionStarted with no orphans does not produce spurious completions", .timeLimit(.minutes(1)))
+    func sessionStartedWithoutOrphansProducesNoCompletions() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.sessionStarted(surface: .ntp)
+        #expect(wideEvent.completions.isEmpty)
+    }
 }

--- a/iOS/DuckDuckGoTests/PostIdleSessionWideEventDataTests.swift
+++ b/iOS/DuckDuckGoTests/PostIdleSessionWideEventDataTests.swift
@@ -46,8 +46,8 @@ struct PostIdleSessionWideEventDataTests {
 
         #expect(params["feature.data.ext.surface"] as? String == "ntp")
         #expect(params["feature.data.ext.status_reason"] == nil)
-        #expect(params["feature.data.ext.session_duration_ms"] == nil)
-        #expect(params["feature.data.ext.time_to_first_interaction_ms"] == nil)
+        #expect(params["feature.data.ext.session_duration_ms_bucketed"] == nil)
+        #expect(params["feature.data.ext.time_to_first_interaction_ms_bucketed"] == nil)
         #expect(params["feature.data.ext.page_engaged"] as? Bool == false)
         #expect(params["feature.data.ext.toggle_used"] as? Bool == false)
         #expect(params["feature.data.ext.back_pressed"] as? Bool == false)
@@ -124,25 +124,49 @@ struct PostIdleSessionWideEventDataTests {
     // MARK: - Durations
 
     @available(iOS 16, *)
-    @Test("Session duration is computed in ms when sessionInterval is closed", .timeLimit(.minutes(1)))
-    func sessionDurationIsComputedInMs() {
+    @Test("Session duration is bucketed when sessionInterval is closed", .timeLimit(.minutes(1)))
+    func sessionDurationIsBucketed() {
         let start = Date()
         let data = PostIdleSessionWideEventData(surface: .ntp, startedAt: start)
-        data.sessionInterval.end = start.addingTimeInterval(2.5) // 2500ms
+        data.sessionInterval.end = start.addingTimeInterval(2.5) // 2500ms → bucket "1000"
 
         let params = data.jsonParameters()
-        #expect(params["feature.data.ext.session_duration_ms"] as? Int == 2500)
+        #expect(params["feature.data.ext.session_duration_ms_bucketed"] as? String == "1000")
     }
 
     @available(iOS 16, *)
-    @Test("First interaction duration is computed in ms when interval is closed", .timeLimit(.minutes(1)))
-    func firstInteractionDurationIsComputedInMs() {
+    @Test("First interaction duration is bucketed when interval is closed", .timeLimit(.minutes(1)))
+    func firstInteractionDurationIsBucketed() {
         let start = Date()
         let data = PostIdleSessionWideEventData(surface: .ntp, startedAt: start)
-        data.firstInteractionInterval.end = start.addingTimeInterval(0.5) // 500ms (exactly representable in float)
+        data.firstInteractionInterval.end = start.addingTimeInterval(0.5) // 500ms → bucket "0"
 
         let params = data.jsonParameters()
-        #expect(params["feature.data.ext.time_to_first_interaction_ms"] as? Int == 500)
+        #expect(params["feature.data.ext.time_to_first_interaction_ms_bucketed"] as? String == "0")
+    }
+
+    @available(iOS 16, *)
+    @Test("Duration bucketing selects correct threshold", .timeLimit(.minutes(1)))
+    func durationBucketingSelectsCorrectThreshold() {
+        let start = Date()
+
+        func bucketFor(seconds: TimeInterval) -> String? {
+            let data = PostIdleSessionWideEventData(surface: .ntp, startedAt: start)
+            data.sessionInterval.end = start.addingTimeInterval(seconds)
+            return data.jsonParameters()["feature.data.ext.session_duration_ms_bucketed"] as? String
+        }
+
+        #expect(bucketFor(seconds: 0) == "0")
+        #expect(bucketFor(seconds: 0.999) == "0")
+        #expect(bucketFor(seconds: 1.0) == "1000")
+        #expect(bucketFor(seconds: 4.999) == "1000")
+        #expect(bucketFor(seconds: 5.0) == "5000")
+        #expect(bucketFor(seconds: 10.0) == "10000")
+        #expect(bucketFor(seconds: 30.0) == "30000")
+        #expect(bucketFor(seconds: 60.0) == "60000")
+        #expect(bucketFor(seconds: 300.0) == "300000")
+        #expect(bucketFor(seconds: 600.0) == "600000")
+        #expect(bucketFor(seconds: 9999.0) == "600000")
     }
 
     @available(iOS 16, *)
@@ -157,29 +181,28 @@ struct PostIdleSessionWideEventDataTests {
     // MARK: - Completion decision
 
     @available(iOS 16, *)
-    @Test("App launch trigger always completes as UNKNOWN with app_terminated reason", .timeLimit(.minutes(1)))
-    func appLaunchAlwaysCompletesAsUnknownAppTerminated() async {
+    @Test("App launch trigger returns keepPending so sessionStarted handles orphan cleanup", .timeLimit(.minutes(1)))
+    func appLaunchReturnsKeepPending() async {
         let data = PostIdleSessionWideEventData(surface: .ntp)
         let decision = await data.completionDecision(for: .appLaunch)
 
-        if case .complete(.unknown(let reason)) = decision {
-            #expect(reason == PostIdleSessionWideEventData.appTerminatedReason)
-            #expect(reason == "app_terminated")
+        if case .keepPending = decision {
+            // expected
         } else {
-            Issue.record("Expected .complete(.unknown(reason:)), got \(decision)")
+            Issue.record("Expected .keepPending, got \(decision)")
         }
     }
 
     @available(iOS 16, *)
-    @Test("App launch trigger completes orphan with all surface variants", .timeLimit(.minutes(1)))
-    func appLaunchCompletesAllSurfaceVariants() async {
+    @Test("App launch trigger returns keepPending for all surface variants", .timeLimit(.minutes(1)))
+    func appLaunchReturnsKeepPendingForAllSurfaces() async {
         for surface in PostIdleSessionWideEventData.Surface.allCases {
             let data = PostIdleSessionWideEventData(surface: surface)
             let decision = await data.completionDecision(for: .appLaunch)
-            if case .complete = decision {
+            if case .keepPending = decision {
                 // ok
             } else {
-                Issue.record("Expected .complete for surface \(surface), got \(decision)")
+                Issue.record("Expected .keepPending for surface \(surface), got \(decision)")
             }
         }
     }

--- a/iOS/PixelDefinitions/pixels/definitions/post_idle_session_wide_event.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/post_idle_session_wide_event.json5
@@ -61,14 +61,16 @@
                 ]
             },
             {
-                "key": "feature.data.ext.session_duration_ms",
-                "type": "integer",
-                "description": "Duration from surface shown to session end (in ms)."
+                "key": "feature.data.ext.session_duration_ms_bucketed",
+                "type": "string",
+                "description": "Duration from surface shown to session end, bucketed (lower end of bucket, in ms)",
+                "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
             },
             {
-                "key": "feature.data.ext.time_to_first_interaction_ms",
-                "type": "integer",
-                "description": "Duration from surface shown to first user interaction or terminal action (in ms)."
+                "key": "feature.data.ext.time_to_first_interaction_ms_bucketed",
+                "type": "string",
+                "description": "Duration from surface shown to first user interaction or terminal action, bucketed (lower end of bucket, in ms)",
+                "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
             },
             {
                 "key": "feature.data.ext.page_engaged",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214578665494291
Tech Design URL: N/A
CC: N/A

### Description

- Fix race condition causing ~70% of post-idle session wide events to complete as UNKNOWN: `sessionStarted()` now synchronously cleans orphaned flows before creating a new one, and `completionDecision(for:)` returns `.keepPending` so the async resume path cannot race with new flow creation
- Default old iPhone users (with no stored preference) to New Tab Page after idle, matching new user behavior. Users who explicitly chose "Last Used Tab" in Settings keep that preference. iPad continues to default to Last Used Tab
- Bucket session duration and time-to-first-interaction to match Android's schema (privacy requirement): values are now bucketed strings (`0`, `1000`, `5000`, `10000`, `30000`, `60000`, `300000`, `600000` ms) instead of raw integers

### Testing Steps

**Setup (run once after installing the app):**

```bash
# Find your app container (use the correct bundle ID for your build)
# Alpha: com.duckduckgo.mobile.ios.alpha
# Debug: com.duckduckgo.mobile.ios
BUNDLE_ID="com.duckduckgo.mobile.ios.alpha"
CONTAINER=$(xcrun simctl get_app_container booted $BUNDLE_ID data)
PLIST="$CONTAINER/Library/Application Support/AppKeyValueStore.plist"

# Set idle threshold to 5 seconds for quick testing
xcrun simctl spawn booted defaults write $BUNDLE_ID idle-threshold-override -float 5
```

**Scenario 1: Old user with no stored preference (should see NTP)**

```bash
xcrun simctl terminate booted $BUNDLE_ID
plutil -remove idle-return-after-inactivity-option "$PLIST" 2>/dev/null
plutil -replace idle-return-new-user -bool false "$PLIST"
xcrun simctl launch booted $BUNDLE_ID
```

1. Background the app for 5+ seconds, then reopen
2. Verify NTP is shown after idle
3. Go to Settings > General > Show on App Launch — verify "New Tab Page" is selected

**Scenario 2: User who explicitly chose Last Used Tab (should see LUT)**

```bash
xcrun simctl terminate booted $BUNDLE_ID
plutil -replace idle-return-after-inactivity-option -string "lastUsedTab" "$PLIST"
xcrun simctl launch booted $BUNDLE_ID
```

1. Background the app for 5+ seconds, then reopen
2. Verify Last Used Tab is shown after idle
3. Go to Settings > General > Show on App Launch — verify "Last Used Tab" is selected

**Scenario 3: New user (should see NTP)**

```bash
xcrun simctl terminate booted $BUNDLE_ID
plutil -remove idle-return-after-inactivity-option "$PLIST" 2>/dev/null
plutil -replace idle-return-new-user -bool true "$PLIST"
xcrun simctl launch booted $BUNDLE_ID
```

1. Background the app for 5+ seconds, then reopen
2. Verify NTP is shown after idle

Scenario 4: Race condition fix (no UNKNOWN accumulation)

Kill the app mid-session (force quit while on NTP/LUT after idle)
Relaunch the app
Trigger another idle session
Verify the orphaned session completes as UNKNOWN with app_terminated reason and the new session starts cleanly (no double-completion)
Smoke test we get the wide pixels as expected

### Impact and Risks
**Impact Level: Medium**

#### What could go wrong?
- Old users who were accustomed to seeing their last tab after idle will now see NTP (intentional behavior change, users can switch back in Settings)
- Duration values in existing dashboards will shift from exact ms to bucketed values (dashboard update planned separately to COALESCE both keys)

### Quality Considerations
- Race condition fix is defensive: orphan cleanup runs synchronously before new flow creation
- Bucketing thresholds match Android exactly for cross-platform consistency
- All boundary cases tested (0ms, 999ms, 1000ms, etc.)
- iPad behavior unchanged (always defaults to Last Used Tab)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to changes in post-idle wide-event completion timing (orphan cleanup and completion decisions) and a behavior change in default after-idle tab selection on iPhone; could affect analytics and user-facing defaults.
> 
> **Overview**
> **Post-idle session wide-event reliability:** `sessionStarted()` now synchronously completes any orphaned `PostIdleSessionWideEventData` flows as `.unknown(reason: "app_terminated")` *before* starting a new flow, and `completionDecision(for:)` no longer completes on `.appLaunch` (returns `.keepPending`) to avoid resume-time races that were producing UNKNOWN completions.
> 
> **After-inactivity default change:** When no preference is stored, iPhone now defaults to `.newTab` (and persists it) regardless of `idleReturnNewUser`, while iPad continues to default to `.lastUsedTab`; tests updated/expanded accordingly.
> 
> **Privacy/metrics schema update:** Post-idle session duration and time-to-first-interaction parameters switch from raw millisecond integers to **bucketed string** values (new `*_ms_bucketed` keys), with matching PixelDefinitions updates and new boundary-condition tests.
> 
> **Test utilities:** `WideEventMock` now tracks completed/discarded IDs so `getFlowData`/`getAllFlowData` exclude finished flows, supporting the new orphan-cleanup tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ced6eba7b557635c5e9cb725f733a5dec597703. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->