### PR TITLE
iOS: UTI Duck.ai shortcut carries typed text

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4092,6 +4092,10 @@ extension MainViewController: OmniBarDelegate {
     }
 
     func onAIChatPressed() {
+        onAIChatPressed(prefilledText: nil)
+    }
+
+    func onAIChatPressed(prefilledText: String?) {
         ViewHighlighter.hideAll()
         hideSuggestionTray()
 
@@ -4099,7 +4103,7 @@ extension MainViewController: OmniBarDelegate {
             omniBar.endEditing()
             currentTab.presentContextualAIChatSheet(from: self)
         } else {
-            openAIChatFromAddressBar()
+            openAIChatFromAddressBar(prefilledText: prefilledText)
         }
     }
 
@@ -4119,10 +4123,17 @@ extension MainViewController: OmniBarDelegate {
         currentTab?.onShareAction(forLink: link, fromView: targetView)
     }
 
-    private func openAIChatFromAddressBar() {
+    private func openAIChatFromAddressBar(prefilledText: String?) {
 
-        let isEditing = omniBar.isTextFieldEditing
-        let textFieldValue = omniBar.text
+        let isEditing: Bool
+        let textFieldValue: String?
+        if let prefilledText {
+            isEditing = true
+            textFieldValue = prefilledText
+        } else {
+            isEditing = omniBar.isTextFieldEditing
+            textFieldValue = omniBar.text
+        }
         omniBar.endEditing()
 
         OpenAIChatFromAddressBarHandling().determineOpeningStrategy(

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -776,8 +776,11 @@ extension MainViewController: UnifiedToggleInputDelegate {
         onDuckAIVoiceModeRequested()
     }
 
-    func unifiedToggleInputDidRequestAIChat() {
-        onAIChatPressed()
+    func unifiedToggleInputDidRequestAIChat(prefilledText: String) {
+        let trimmed = prefilledText.trimmingWhitespace()
+        unifiedToggleInputCoordinator?.clearText()
+        unifiedToggleInputCoordinator?.handleExternalSubmission(.prompt)
+        onAIChatPressed(prefilledText: trimmed.isEmpty ? nil : trimmed)
     }
 
     func unifiedToggleInputDidChangeHeight() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1374,7 +1374,7 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
     }
 
     func unifiedToggleInputVCDidTapAIChatShortcut(_ vc: UnifiedToggleInputViewController) {
-        delegate?.unifiedToggleInputDidRequestAIChat()
+        delegate?.unifiedToggleInputDidRequestAIChat(prefilledText: viewController.handler.currentText)
     }
 
     func unifiedToggleInputVCDidTapFire(_ vc: UnifiedToggleInputViewController) {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputDelegate.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputDelegate.swift
@@ -25,7 +25,7 @@ protocol UnifiedToggleInputDelegate: AnyObject {
     func unifiedToggleInputDidSubmitQuery(_ query: String)
     func unifiedToggleInputDidRequestVoiceSearch()
     func unifiedToggleInputDidRequestAIVoiceChat()
-    func unifiedToggleInputDidRequestAIChat()
+    func unifiedToggleInputDidRequestAIChat(prefilledText: String)
     func unifiedToggleInputDidChangeHeight()
     func unifiedToggleInputDidCommitMode(_ mode: TextEntryMode)
     func unifiedToggleInputDidRequestFire()

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift
@@ -716,7 +716,7 @@ private final class SpyUnifiedToggleInputDelegate: UnifiedToggleInputDelegate {
     func unifiedToggleInputDidSubmitQuery(_ query: String) {}
     func unifiedToggleInputDidRequestVoiceSearch() {}
     func unifiedToggleInputDidRequestAIVoiceChat() {}
-    func unifiedToggleInputDidRequestAIChat() {}
+    func unifiedToggleInputDidRequestAIChat(prefilledText: String) {}
     func unifiedToggleInputDidChangeHeight() {}
     func unifiedToggleInputDidCommitMode(_ mode: TextEntryMode) {}
     func unifiedToggleInputDidRequestFire() {}

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -1733,6 +1733,15 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         sut.unifiedToggleInputVCDidTapAIChatShortcut(sut.viewController)
 
         XCTAssertEqual(mockDelegate.didRequestAIChatCount, 1)
+        XCTAssertEqual(mockDelegate.didRequestAIChatPrefilledText, "")
+    }
+
+    func test_unifiedToggleInputVCDidTapAIChatShortcut_forwardsCurrentText() {
+        sut.viewController.handler.updateCurrentText("hello")
+
+        sut.unifiedToggleInputVCDidTapAIChatShortcut(sut.viewController)
+
+        XCTAssertEqual(mockDelegate.didRequestAIChatPrefilledText, "hello")
     }
 
     // MARK: - Helpers
@@ -1918,7 +1927,11 @@ private final class MockUnifiedToggleInputDelegate: UnifiedToggleInputDelegate {
     func unifiedToggleInputDidSubmitQuery(_ query: String) { submittedQuery = query }
     func unifiedToggleInputDidRequestVoiceSearch() { didRequestVoiceSearchCount += 1 }
     func unifiedToggleInputDidRequestAIVoiceChat() { didRequestAIVoiceChatCount += 1 }
-    func unifiedToggleInputDidRequestAIChat() { didRequestAIChatCount += 1 }
+    var didRequestAIChatPrefilledText: String?
+    func unifiedToggleInputDidRequestAIChat(prefilledText: String) {
+        didRequestAIChatCount += 1
+        didRequestAIChatPrefilledText = prefilledText
+    }
     func unifiedToggleInputDidChangeHeight() {}
     func unifiedToggleInputDidCommitMode(_ mode: TextEntryMode) {
         committedMode = mode

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputReasoningTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputReasoningTests.swift
@@ -268,7 +268,7 @@ private final class MockUnifiedToggleInputReasoningDelegate: UnifiedToggleInputD
     func unifiedToggleInputDidSubmitQuery(_ query: String) {}
     func unifiedToggleInputDidRequestVoiceSearch() {}
     func unifiedToggleInputDidRequestAIVoiceChat() {}
-    func unifiedToggleInputDidRequestAIChat() {}
+    func unifiedToggleInputDidRequestAIChat(prefilledText: String) {}
     func unifiedToggleInputDidChangeHeight() {}
     func unifiedToggleInputDidCommitMode(_ mode: TextEntryMode) {}
     func unifiedToggleInputDidRequestFire() {}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214747293677682

### Description

When `unifiedToggleInputFeature` is on, tapping the Duck.ai shortcut from UTI opened Duck.ai blank — UTI owns the input but the legacy handler still reads `omniBar.text` / `isTextFieldEditing`, both stale at that point. Legacy (flag-off) behaviour carries the typed text and auto-submits.

Fix: plumb UTI's `currentText` through `unifiedToggleInputDidRequestAIChat(prefilledText:)` and route via a new `onAIChatPressed(prefilledText:)` overload. Contextual-sheet path (content page + `contextualDuckAIMode` available) still wins and discards the text — matches production.

### Testing Steps

1. Enable `unifiedToggleInputFeature` (Settings → Internal → Debug, or feature flag tooling).
2. On the **NTP**, tap the omnibar, type `tell me about tokamaks`, tap the Duck.ai shortcut in the UTI buttons cluster. **Expect:** Duck.ai opens with the prompt auto-submitted.
3. On a content page (e.g. wikipedia.org), tap the omnibar, replace the URL with `hello`, tap the Duck.ai shortcut. **Expect:** the contextual Duck.ai sheet opens **without** the text (matches flag-off / production).
4. Repeat step 2 with empty input → Duck.ai opens blank. Whitespace-only input → same.
5. Disable `unifiedToggleInputFeature`, type in the omnibar, tap the legacy Duck.ai shortcut — confirm behaviour is unchanged from before.

### Impact and Risks

**Low.** Behavioural change is confined to the UTI Duck.ai shortcut handler. Legacy (flag-off) path is untouched — `openAIChatFromAddressBar()` still reads `omniBar.text` when called without `prefilledText`. Contextual-sheet routing is unchanged; the new param only adds a fallback text source on the non-contextual branch.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to the Unified Toggle Input AI chat shortcut flow and a small signature change; main behavior remains unchanged when no prefilled text is provided and contextual-sheet routing is preserved.
> 
> **Overview**
> Fixes the UTI Duck.ai shortcut so it carries the user’s currently typed text into Duck.ai (and auto-sends it) instead of opening a blank chat.
> 
> This plumbs `currentText` through a new `unifiedToggleInputDidRequestAIChat(prefilledText:)` delegate method into a new `onAIChatPressed(prefilledText:)`/`openAIChatFromAddressBar(prefilledText:)` path, trimming whitespace and treating empty input as `nil`, with tests updated to assert the forwarded text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e6f8ec99192e20c6d708fbfb05001c3c60a0263. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->