### PR TITLE
iOS: Fix omnibar address bar not activating keyboard on first tap

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextView.swift
@@ -34,22 +34,19 @@ final class SwitchBarTextView: UITextView {
         onTouchesBeganHandler?()
     }
 
-    /// Block first-responder when any ancestor is hidden — covers iOS's modal-dismiss FR
-    /// restoration path which otherwise wakes the textView up while its host UTI is still
-    /// hidden, firing `textViewDidBeginEditing` on a surface the user isn't interacting with.
+    /// Block FR when any ancestor is hidden — covers iOS's modal-dismiss FR restoration path.
     override func becomeFirstResponder() -> Bool {
-        guard isPartOfVisibleHierarchy else { return false }
+        guard !hasHiddenAncestor else { return false }
         return super.becomeFirstResponder()
     }
 
-    private var isPartOfVisibleHierarchy: Bool {
-        guard window != nil else { return false }
+    private var hasHiddenAncestor: Bool {
         var view: UIView? = self
         while let current = view {
-            if current.isHidden { return false }
+            if current.isHidden { return true }
             view = current.superview
         }
-        return true
+        return false
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1214741014878180

### Description

PR #4792's `SwitchBarTextView.becomeFirstResponder` guard rejected first-responder activation whenever `window == nil`. That broke the legitimate user-initiated tap on the non-UTI omnibar's address bar: at `OmniBarEditingStateViewController.viewWillAppear`, the custom presenting transition hasn't yet added `toVC.view` to its container, so `window` is nil and the guard returned false. Result: keyboard never came up — user had to tap a second time once the view settled.

Dropped the `window != nil` sub-check. The `isHidden` ancestor walk alone is the actual discriminator for the original modal-dismiss FR-restoration scenario PR #4792 was protecting against — `unifiedInputContentContainer.isHidden = true` is set on non-AI tabs (`MainViewCoordinator.swift:352`, called from `MainViewController+UnifiedToggleInput.swift:601`), so the walk still catches that path.

### Testing Steps

1. Make sure `unifiedToggleInputFeature` is **disabled** (Debug menu → Features).
2. Tap the address bar in the top toolbar. Keyboard should appear immediately, cursor in the field. (Pre-fix: required a second tap.)
3. **Regression check** — enable `unifiedToggleInputFeature`. Open a Duck.ai tab, expand the UTI (textView first responder, keyboard up).
4. Open the tab switcher and switch to a non-AI tab. The bottom browser toolbar must stay visible — no spurious keyboard popup. This is the scenario PR #4792 was protecting against; the `isHidden` ancestor walk still catches it.

### Impact and Risks

Low. Five-line change to a single private method. Removes a guard sub-condition that was producing a false negative; the remaining sub-condition (ancestor `isHidden` walk) is the actual discriminator for the bug PR #4792 was fixing. Only behaviour change is on the `window == nil && no ancestor hidden` path, which now activates FR — matches pre-#4792 behaviour, and UIKit defers keyboard activation until the view enters its window anyway.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to first-responder gating logic; behavior only changes for views not yet in a `window`, and still blocks activation when any ancestor is `isHidden`.
> 
> **Overview**
> Fixes an omnibar focus regression by loosening `SwitchBarTextView.becomeFirstResponder()` gating: it no longer rejects activation just because `window == nil`, and instead blocks only when the text view has a hidden ancestor.
> 
> This preserves the prior safeguard against iOS restoring first-responder to a hidden hierarchy while allowing legitimate first-tap keyboard activation during custom transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d43f11124a4fa9f17ba7ea17cdba573ea0dd521b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->