### PR TITLE
Align escape hatch with recent Figma. Fix issue on iPhone Pro Max

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/DuckAISuggestionsCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/DuckAISuggestionsCoordinator.swift
@@ -40,6 +40,7 @@ final class DuckAISuggestionsCoordinator {
     private let urlLoader: DuckAIURLSuggestionsLoader
     private let chatViewModel: AIChatSuggestionsViewModel
     private let queryProvider: () -> String
+    private let layoutConfiguration: DuckAISuggestionsViewController.LayoutConfiguration
 
     private var viewController: DuckAISuggestionsViewController?
     private var cancellables = Set<AnyCancellable>()
@@ -64,11 +65,13 @@ final class DuckAISuggestionsCoordinator {
     init(chatManager: AIChatHistoryManager,
          urlLoader: DuckAIURLSuggestionsLoader,
          chatViewModel: AIChatSuggestionsViewModel,
-         queryProvider: @escaping () -> String) {
+         queryProvider: @escaping () -> String,
+         layoutConfiguration: DuckAISuggestionsViewController.LayoutConfiguration = .standard) {
         self.chatManager = chatManager
         self.urlLoader = urlLoader
         self.chatViewModel = chatViewModel
         self.queryProvider = queryProvider
+        self.layoutConfiguration = layoutConfiguration
     }
 
     func start<P: Publisher>(in containerView: UIView,
@@ -95,7 +98,8 @@ final class DuckAISuggestionsCoordinator {
         let vc = DuckAISuggestionsViewController(
             chatViewModel: chatViewModel,
             urlLoader: urlLoader,
-            queryProvider: queryProvider
+            queryProvider: queryProvider,
+            layoutConfiguration: layoutConfiguration
         )
         vc.delegate = self
 

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/DuckAISuggestionsViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/DuckAISuggestionsViewController.swift
@@ -60,6 +60,24 @@ final class DuckAISuggestionsViewController: UIViewController {
         static let recentChatsHeaderBottomPadding: CGFloat = 24
     }
 
+    struct LayoutConfiguration {
+        let tableHorizontalInset: CGFloat
+        let escapeHatchHorizontalInset: CGFloat
+        let escapeHatchMaxWidth: CGFloat?
+
+        static let standard = LayoutConfiguration(
+            tableHorizontalInset: 0,
+            escapeHatchHorizontalInset: Constants.horizontalInset,
+            escapeHatchMaxWidth: HomeMessageCollectionViewCell.maximumWidth
+        )
+
+        static let unifiedToggleInput = LayoutConfiguration(
+            tableHorizontalInset: 10,
+            escapeHatchHorizontalInset: Constants.horizontalInset,
+            escapeHatchMaxWidth: nil
+        )
+    }
+
     /// Suppresses the "Recent Chats" section header per the unified-input redesign.
     /// Flip to `true` to restore the header; rendering logic below is preserved.
     private static let areSectionHeadersEnabled = false
@@ -69,6 +87,7 @@ final class DuckAISuggestionsViewController: UIViewController {
     private let chatViewModel: AIChatSuggestionsViewModel
     private let urlLoader: DuckAIURLSuggestionsLoader
     private let queryProvider: () -> String
+    private let layoutConfiguration: LayoutConfiguration
 
     /// Absorbs the gap between the two fetcher debounces so a single reload renders both. Coupled to
     /// `AIChatHistoryManager.Constants.debounceMilliseconds` (150ms) and `DuckAIURLSuggestionsLoader.debounceMilliseconds` (100ms).
@@ -117,10 +136,12 @@ final class DuckAISuggestionsViewController: UIViewController {
 
     init(chatViewModel: AIChatSuggestionsViewModel,
          urlLoader: DuckAIURLSuggestionsLoader,
-         queryProvider: @escaping () -> String) {
+         queryProvider: @escaping () -> String,
+         layoutConfiguration: LayoutConfiguration = .standard) {
         self.chatViewModel = chatViewModel
         self.urlLoader = urlLoader
         self.queryProvider = queryProvider
+        self.layoutConfiguration = layoutConfiguration
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -133,8 +154,8 @@ final class DuckAISuggestionsViewController: UIViewController {
         view.addSubview(tableView)
         NSLayoutConstraint.activate([
             tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: layoutConfiguration.tableHorizontalInset),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -layoutConfiguration.tableHorizontalInset),
             tableView.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor)
         ])
 
@@ -269,22 +290,45 @@ final class DuckAISuggestionsViewController: UIViewController {
 
             hosting.view.translatesAutoresizingMaskIntoConstraints = false
             container.addSubview(hosting.view)
-            let maxWidth = HomeMessageCollectionViewCell.maximumWidth
-            let preferredWidth = hosting.view.widthAnchor.constraint(equalToConstant: maxWidth)
-            preferredWidth.priority = .defaultHigh
-            let minimumLeading = hosting.view.leadingAnchor.constraint(greaterThanOrEqualTo: container.leadingAnchor, constant: Constants.horizontalInset)
-            minimumLeading.priority = .required - 1
-            let minimumTrailing = hosting.view.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -Constants.horizontalInset)
-            minimumTrailing.priority = .required - 1
-            NSLayoutConstraint.activate([
-                hosting.view.centerXAnchor.constraint(equalTo: container.centerXAnchor),
-                hosting.view.widthAnchor.constraint(lessThanOrEqualToConstant: maxWidth),
-                preferredWidth,
-                minimumLeading,
-                minimumTrailing,
+            var constraints = [
                 hosting.view.topAnchor.constraint(equalTo: container.topAnchor, constant: Constants.escapeHatchTopPadding),
                 hosting.view.heightAnchor.constraint(equalToConstant: Constants.escapeHatchCardHeight)
-            ])
+            ]
+
+            if let maxWidth = layoutConfiguration.escapeHatchMaxWidth {
+                let preferredWidth = hosting.view.widthAnchor.constraint(equalToConstant: maxWidth)
+                preferredWidth.priority = .defaultHigh
+                let minimumLeading = hosting.view.leadingAnchor.constraint(
+                    greaterThanOrEqualTo: container.leadingAnchor,
+                    constant: layoutConfiguration.escapeHatchHorizontalInset
+                )
+                minimumLeading.priority = .required - 1
+                let minimumTrailing = hosting.view.trailingAnchor.constraint(
+                    lessThanOrEqualTo: container.trailingAnchor,
+                    constant: -layoutConfiguration.escapeHatchHorizontalInset
+                )
+                minimumTrailing.priority = .required - 1
+                constraints.append(contentsOf: [
+                    hosting.view.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+                    hosting.view.widthAnchor.constraint(lessThanOrEqualToConstant: maxWidth),
+                    preferredWidth,
+                    minimumLeading,
+                    minimumTrailing
+                ])
+            } else {
+                constraints.append(contentsOf: [
+                    hosting.view.leadingAnchor.constraint(
+                        equalTo: container.leadingAnchor,
+                        constant: layoutConfiguration.escapeHatchHorizontalInset
+                    ),
+                    hosting.view.trailingAnchor.constraint(
+                        equalTo: container.trailingAnchor,
+                        constant: -layoutConfiguration.escapeHatchHorizontalInset
+                    )
+                ])
+            }
+
+            NSLayoutConstraint.activate(constraints)
             container.layoutIfNeeded()
             tableView.tableHeaderView = container
         }

--- a/iOS/DuckDuckGo/NewTabPageView.swift
+++ b/iOS/DuckDuckGo/NewTabPageView.swift
@@ -33,10 +33,12 @@ struct NewTabPageView: View {
     let isFocussedState: Bool
     let narrowLayoutInLandscape: Bool
     let dismissKeyboardOnScroll: Bool
+    let layoutConfiguration: NewTabPageLayoutConfiguration
 
     init(isFocussedState: Bool = false,
          narrowLayoutInLandscape: Bool = false,
          dismissKeyboardOnScroll: Bool = true,
+         layoutConfiguration: NewTabPageLayoutConfiguration = .standard,
          viewModel: NewTabPageViewModel,
          messagesModel: NewTabPageMessagesModel,
          favoritesViewModel: FavoritesViewModel) {
@@ -46,6 +48,7 @@ struct NewTabPageView: View {
         self.favoritesViewModel = favoritesViewModel
         self.narrowLayoutInLandscape = narrowLayoutInLandscape
         self.dismissKeyboardOnScroll = dismissKeyboardOnScroll
+        self.layoutConfiguration = layoutConfiguration
 
         self.messagesModel.load()
     }
@@ -78,6 +81,16 @@ struct NewTabPageView: View {
             emptyStateView
         }
     }
+}
+
+struct NewTabPageLayoutConfiguration {
+    let expandsEscapeHatchToAvailableWidth: Bool
+    let escapeHatchHorizontalPadding: CGFloat
+
+    static let standard = NewTabPageLayoutConfiguration(expandsEscapeHatchToAvailableWidth: false,
+                                                        escapeHatchHorizontalPadding: Metrics.updatedNonGridSectionHorizontalPadding)
+    static let unifiedToggleInput = NewTabPageLayoutConfiguration(expandsEscapeHatchToAvailableWidth: true,
+                                                                  escapeHatchHorizontalPadding: 0)
 }
 
 private extension NewTabPageView {
@@ -168,10 +181,12 @@ private extension NewTabPageView {
         return true
     }
 
-    /// On iPad regular size class, widen the hatch to match the favorites grid container.
-    /// iPhone (including Plus/Max in landscape, where horizontal size class is regular) keeps
-    /// the original `messageMaximumWidth` because the favorites grid stays compact (4 cols).
+    /// The unified toggle input design lets the hatch fill the same content span as favorites.
+    /// Legacy NTP keeps its existing max widths so the flag-off UI remains unchanged.
     private var escapeHatchMaxWidth: CGFloat {
+        if layoutConfiguration.expandsEscapeHatchToAvailableWidth {
+            return .infinity
+        }
         if UIDevice.current.userInterfaceIdiom == .pad && horizontalSizeClass == .regular {
             return Metrics.escapeHatchMaximumWidthPad
         }
@@ -189,7 +204,7 @@ private extension NewTabPageView {
             )
             .frame(maxWidth: escapeHatchMaxWidth)
             .padding(.top, Metrics.nonGridSectionTopPadding)
-            .padding(.horizontal, Metrics.updatedNonGridSectionHorizontalPadding)
+            .padding(.horizontal, layoutConfiguration.escapeHatchHorizontalPadding)
         }
     }
 

--- a/iOS/DuckDuckGo/NewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPageViewController.swift
@@ -78,6 +78,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
          subscriptionManager: any SubscriptionManager,
          internalUserCommands: URLBasedDebugCommands,
          narrowLayoutInLandscape: Bool = false,
+         unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature(),
          appWidthObserver: AppWidthObserver = .shared,
          tutorialSettings: TutorialSettings = DefaultTutorialSettings()) {
 
@@ -105,6 +106,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
         super.init(rootView: NewTabPageView(isFocussedState: isFocussedState,
                                             narrowLayoutInLandscape: narrowLayoutInLandscape,
                                             dismissKeyboardOnScroll: dismissKeyboardOnScroll,
+                                            layoutConfiguration: unifiedToggleInputFeature.isAvailable ? .unifiedToggleInput : .standard,
                                             viewModel: self.newTabPageViewModel,
                                             messagesModel: self.messagesModel,
                                             favoritesViewModel: self.favoritesModel))

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -505,7 +505,8 @@ final class UnifiedInputContentContainerViewController: UIViewController {
             chatManager: chatManager,
             urlLoader: urlLoader,
             chatViewModel: chatViewModel,
-            queryProvider: { [weak self] in self?.switchBarHandler.currentText ?? "" }
+            queryProvider: { [weak self] in self?.switchBarHandler.currentText ?? "" },
+            layoutConfiguration: .unifiedToggleInput
         )
         coordinator.delegate = self
         coordinator.onContentChanged = { [weak self] in

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/DuckAISuggestionsViewControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/DuckAISuggestionsViewControllerTests.swift
@@ -32,20 +32,23 @@ final class DuckAISuggestionsViewControllerTests: XCTestCase {
         let urlLoader: DuckAIURLSuggestionsLoader
     }
 
-    private func makeHarness(query: String = "") -> Harness {
+    private func makeHarness(query: String = "",
+                             layoutConfiguration: DuckAISuggestionsViewController.LayoutConfiguration = .standard) -> Harness {
         let viewModel = AIChatSuggestionsViewModel()
         let loader = DuckAIURLSuggestionsLoader(dataSource: EmptySuggestionLoadingDataSource())
         let vc = DuckAISuggestionsViewController(
             chatViewModel: viewModel,
             urlLoader: loader,
-            queryProvider: { query }
+            queryProvider: { query },
+            layoutConfiguration: layoutConfiguration
         )
         vc.loadViewIfNeeded()
         return Harness(viewController: vc, chatViewModel: viewModel, urlLoader: loader)
     }
 
-    private func makeViewController(query: String = "") -> DuckAISuggestionsViewController {
-        makeHarness(query: query).viewController
+    private func makeViewController(query: String = "",
+                                    layoutConfiguration: DuckAISuggestionsViewController.LayoutConfiguration = .standard) -> DuckAISuggestionsViewController {
+        makeHarness(query: query, layoutConfiguration: layoutConfiguration).viewController
     }
 
     private func makeChat(id: String) -> AIChatSuggestion {
@@ -69,6 +72,39 @@ final class DuckAISuggestionsViewControllerTests: XCTestCase {
         XCTAssertNotNil(table.tableHeaderView)
         XCTAssertGreaterThan(table.tableHeaderView?.bounds.height ?? 0, 0)
         XCTAssertEqual(vc.children.count, 1, "hatch hosting controller should be added as a child view controller")
+    }
+
+    func test_defaultLayout_preservesFullWidthTableView() throws {
+        let vc = makeViewController()
+        vc.view.frame = CGRect(x: 0, y: 0, width: 430, height: 800)
+        vc.view.layoutIfNeeded()
+
+        let table = try tableView(in: vc)
+
+        XCTAssertEqual(table.frame.minX, 0, accuracy: 0.5)
+        XCTAssertEqual(vc.view.bounds.width - table.frame.maxX, 0, accuracy: 0.5)
+    }
+
+    func test_unifiedToggleInputLayout_matchesRecentChatsHorizontalInset() throws {
+        let vc = makeViewController(layoutConfiguration: .unifiedToggleInput)
+        vc.view.frame = CGRect(x: 0, y: 0, width: 430, height: 800)
+        vc.view.layoutIfNeeded()
+
+        let table = try tableView(in: vc)
+        vc.setEscapeHatch(.testFixture, openTabCount: 0, onTapped: {}, onTabSwitcherTapped: {})
+        vc.view.layoutIfNeeded()
+
+        let header = try XCTUnwrap(table.tableHeaderView)
+        let hatchView = try XCTUnwrap(header.subviews.first)
+        let hatchFrame = hatchView.convert(hatchView.bounds, to: vc.view)
+        let expectedTableInset: CGFloat = 10
+        let expectedHatchInset: CGFloat = 26
+
+        XCTAssertEqual(table.frame.minX, expectedTableInset, accuracy: 0.5)
+        XCTAssertEqual(vc.view.bounds.width - table.frame.maxX, expectedTableInset, accuracy: 0.5)
+        XCTAssertEqual(header.bounds.width, table.bounds.width, accuracy: 0.5)
+        XCTAssertEqual(hatchFrame.minX, expectedHatchInset, accuracy: 0.5)
+        XCTAssertEqual(vc.view.bounds.width - hatchFrame.maxX, expectedHatchInset, accuracy: 0.5)
     }
 
     func test_setEscapeHatch_withNil_removesTableHeaderView() throws {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214342153921883?focus=true
Tech Design URL:
CC:

### Description
- Align Escape Hatch width with favorites/recent chats in unified toggle input layouts.
- Fix issue on iPhone Pro Max, where hatch was too narrow
- Preserve uti off layout via explicit layout configurations.
- Add regression coverage for [Duck.ai](http://duck.ai/) suggestions default and UTI widths.
- [Latest Figma](https://www.figma.com/design/2srEASSUWzaioxnaZkZvbM/New-Tab-Page-with-Duck.ai-Entry-Point---Escape-Hatch--Mobile-?node-id=2614-22867&t=J90zIhIF0jRch39F-4)

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Have at least one favorite, ideally four
2. Enable `unifiedToggleInput` on iPhone and verify Escape Hatch aligns with Favorites on NTP.
3. Open [Duck.ai](http://duck.ai/) suggestions with recent chats and verify Escape Hatch aligns with the list.
4. Disable `unifiedToggleInput` and verify the legacy UI remains unchanged.

### Screenshots
* Click to expand given section

<details>
<summary>iPhone, UTI off</summary>

| Search | Duck |
|--------|--------|
| <img width="603" height="1311" alt="IMG_0359" src="https://github.com/user-attachments/assets/53141388-3520-4aa9-8625-455c347de1c6" /> | <img width="603" height="1311" alt="IMG_0360" src="https://github.com/user-attachments/assets/161ca323-c463-43af-8750-11c90ee3c545" /> | 

</details>

<details>
<summary>iPhone, UTI on</summary>

| Search | Duck |
|--------|--------|
| <img width="603" height="1311" alt="IMG_0361" src="https://github.com/user-attachments/assets/b172858d-f00f-4b7c-9d8c-89d434d487b2" /> | <img width="603" height="1311" alt="IMG_0362" src="https://github.com/user-attachments/assets/c8d2fddf-70e1-4404-ba76-1468cfd06e67" /> | 

</details>

<details>
<summary>iPhone Pro Max</summary>

| Search | Duck |
|--------|--------|
| <img width="1320" height="2868" alt="1 pro-max-search" src="https://github.com/user-attachments/assets/58b45750-845e-47cd-b0ce-7f72add77d91" /> | <img width="1320" height="2868" alt="2 pro-max-duck" src="https://github.com/user-attachments/assets/cc478d82-f551-4706-ae04-d28f4a20e779" /> | 

</details>

<details>
<summary>iPad (no changes)</summary>

| Portrait | Landscape  |
|--------|--------|
| <img width="2360" height="1640" alt="iPad - landscape" src="https://github.com/user-attachments/assets/c7ae7c3b-a9d9-49d8-95c0-c718a85d50f8" /> | <img width="1640" height="2360" alt="iPad - portrait" src="https://github.com/user-attachments/assets/0fd8e19e-e674-4919-810a-d7bb8cca250e" /> | 

</details>

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
**Impact Level: Low**

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
Visual misalignment in Escape Hatch or Duck.ai suggestions widths.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->
- No privacy, storage, or networking impact.
- Layout changes are gated through explicit configurations.

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual/layout-only changes gated by new layout configuration flags; primary risk is regressions in constraints/insets on specific device sizes.
> 
> **Overview**
> Aligns the Escape Hatch width/padding with the unified toggle input (UTI) layout while preserving the legacy (UTI-off) appearance via explicit `LayoutConfiguration`/`NewTabPageLayoutConfiguration` switches.
> 
> Updates `DuckAISuggestionsViewController`/`DuckAISuggestionsCoordinator` to support configurable table/header insets and optional max-width behavior, wires UTI to use the new config, and adds regression tests covering default vs UTI sizing/insets for Duck.ai suggestions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 922117b582aab28aac9711d6d7d526e71c667dde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->