### PR TITLE
Add channel parameter to warn_before_quit pixels

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/warn_before_quit_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/warn_before_quit_pixels.json5
@@ -28,13 +28,13 @@
         "owners": ["mallexxx"],
         "triggers": ["other"],
         "suffixes": ["count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_settings_warn-before-quit_disabled": {
         "description": "Fired when the user disables 'Show confirmation before quitting with ⌘Q' setting in preferences",
         "owners": ["mallexxx"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211850802118632/task/1214681333135874
Tech Design URL:
CC: 

### Description

Add `"channel"` to the `parameters` array of two macOS pixel definitions in `warn_before_quit_pixels.json5` so live pixel validation stops flagging `channel` as an unexpected property:

- `m_mac_warn-before-quit_dont-show-again` — flagged in the 5/10 validation report.
- `m_mac_settings_warn-before-quit_disabled` — not flagged yet, but emits the same parameter and would surface in a future report; updating it here to avoid a follow-up PR.

The remaining three pixels in this file (`shown`, `quit`, `cancelled`) were already updated in #4648 and are not changed.

This is the same definitions-only pattern as #4648: the `channel` parameter is already sent on the wire by PixelKit (matching the existing entry in `params_dictionary.json5`); this PR just documents it so automated validation accepts it.

### Testing Steps

1. Confirm the PixelDefinitions validation passes in CI.

### Impact and Risks

**None** — definitions-only change. No Swift code is modified. No change to what is sent on the wire.

#### What could go wrong?

N/A

### Quality Considerations

N/A

### Notes to Reviewer

Identical pattern to #4648; only two lines change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk definitions-only change that just updates pixel metadata; no runtime or data-handling logic is modified.
> 
> **Overview**
> Updates `warn_before_quit_pixels.json5` to include the `channel` parameter for `m_mac_warn-before-quit_dont-show-again` and `m_mac_settings_warn-before-quit_disabled`, aligning these definitions with the parameters being emitted and avoiding validation failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40b47bf55af615879fbe621e1c99b3afe4f7ba3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->