### PR TITLE
[iOS] Update skipped onboarding origin to funnel_modal_ios__skippedonboardingupsell

### DIFF
--- a/iOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
+++ b/iOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
@@ -25,7 +25,7 @@ enum SubscriptionFunnelOrigin: String {
     case onboarding = "funnel_onboarding_ios"
 
     /// User entered the funnel via the skipped-onboarding promo modal.
-    case skippedOnboarding = "funnel_skippedonboarding_ios"
+    case skippedOnboarding = "funnel_modal_ios__skippedonboardingupsell"
 
     /// User entered the funnel via the App Settings screen.
     case appSettings = "funnel_appsettings_ios"

--- a/iOS/PixelDefinitions/pixels/definitions/subscription.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/subscription.json5
@@ -372,7 +372,7 @@
                 "description": "Purchase funnel entry point",
                 "enum": [
                     "funnel_onboarding_ios",
-                    "funnel_skippedonboarding_ios",
+                    "funnel_modal_ios__skippedonboardingupsell",
                     "funnel_appsettings_ios",
                     "funnel_appmenu_ios",
                     "funnel_applaunch_ios_winback",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214735361273604
Tech Design URL:
CC:

### Description

Renames the existing origin

- **From:** `funnel_skippedonboarding_ios`
- **To:** `funnel_modal_ios__skippedonboardingupsell`

### Testing Steps

Green CI, as there is no behavior change

### Impact and Risks

N/A

#### What could go wrong?

N/A

### Notes to Reviewer

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is an analytics attribution rename (string enum value) with no behavioral logic changes, but it may affect reporting/attribution continuity if downstream dashboards still expect the old origin value.
> 
> **Overview**
> Updates the *subscription funnel origin identifier* for the skipped-onboarding promo from `funnel_skippedonboarding_ios` to `funnel_modal_ios__skippedonboardingupsell`.
> 
> This changes the `SubscriptionFunnelOrigin.skippedOnboarding` raw value and updates the allowed `origin` enum values for the `m_subscribe` pixel definition to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9da8ba15f66a53564c75a406197de21624c69b75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->