### PR TITLE
iOS: Localize NTP-after-idle settings strings + escape hatch tab switcher pixel

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1442,6 +1442,7 @@ extension Pixel {
         case ntpAfterIdleAppBackgroundedUserInitiated
         case ntpAfterIdleTabSwitcherSelectedAfterIdle
         case ntpAfterIdleTabSwitcherSelectedUserInitiated
+        case ntpAfterIdleEscapeHatchTabSwitcherTappedAfterIdle
         case ntpAfterIdleSettingChangedToNewTab
         case ntpAfterIdleSettingChangedToLastUsedTab
 
@@ -3153,6 +3154,7 @@ extension Pixel.Event {
         case .ntpAfterIdleAppBackgroundedUserInitiated: return "m_ntp_after_idle_app_backgrounded_from_ntp_user_initiated"
         case .ntpAfterIdleTabSwitcherSelectedAfterIdle: return "m_ntp_after_idle_tab_switcher_selected_from_ntp_after_idle"
         case .ntpAfterIdleTabSwitcherSelectedUserInitiated: return "m_ntp_after_idle_tab_switcher_selected_from_ntp_user_initiated"
+        case .ntpAfterIdleEscapeHatchTabSwitcherTappedAfterIdle: return "m_ntp_after_idle_escape_hatch_tab_switcher_tapped_after_idle"
         case .ntpAfterIdleSettingChangedToNewTab: return "m_ntp_after_idle_setting_changed_to_new_tab"
         case .ntpAfterIdleSettingChangedToLastUsedTab: return "m_ntp_after_idle_setting_changed_to_last_used_tab"
 

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1445,6 +1445,7 @@ extension Pixel {
         case ntpAfterIdleEscapeHatchTabSwitcherTappedAfterIdle
         case ntpAfterIdleSettingChangedToNewTab
         case ntpAfterIdleSettingChangedToLastUsedTab
+        case ntpAfterIdleSettingIdleIntervalChanged
 
         // MARK: DuckPlayer
 
@@ -3157,6 +3158,7 @@ extension Pixel.Event {
         case .ntpAfterIdleEscapeHatchTabSwitcherTappedAfterIdle: return "m_ntp_after_idle_escape_hatch_tab_switcher_tapped_after_idle"
         case .ntpAfterIdleSettingChangedToNewTab: return "m_ntp_after_idle_setting_changed_to_new_tab"
         case .ntpAfterIdleSettingChangedToLastUsedTab: return "m_ntp_after_idle_setting_changed_to_last_used_tab"
+        case .ntpAfterIdleSettingIdleIntervalChanged: return "m_ntp_after_idle_setting_idle_interval_changed"
 
         // MARK: DuckPlayer
         case .duckPlayerSettingsOpen: return "m_settings_duckplayer_open"

--- a/iOS/DuckDuckGo/AppLifecycle/NTPAfterIdleInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/NTPAfterIdleInstrumentation.swift
@@ -46,6 +46,10 @@ protocol NTPAfterIdleInstrumentation: AnyObject {
 
     /// The user opened the tab switcher while on the NTP.
     func tabSwitcherSelectedFromNTP(afterIdle: Bool)
+
+    /// The user tapped the tab switcher pill next to the escape hatch card.
+    /// (The escape hatch is only shown after idle return, so no user-initiated variant is needed.)
+    func escapeHatchTabSwitcherTapped()
 }
 
 final class DefaultNTPAfterIdleInstrumentation: NTPAfterIdleInstrumentation {
@@ -92,5 +96,10 @@ final class DefaultNTPAfterIdleInstrumentation: NTPAfterIdleInstrumentation {
     func tabSwitcherSelectedFromNTP(afterIdle: Bool) {
         guard eligibilityManager.isEligibleForNTPAfterIdle() else { return }
         firePixel(afterIdle ? .ntpAfterIdleTabSwitcherSelectedAfterIdle : .ntpAfterIdleTabSwitcherSelectedUserInitiated)
+    }
+
+    func escapeHatchTabSwitcherTapped() {
+        guard eligibilityManager.isEligibleForNTPAfterIdle() else { return }
+        firePixel(.ntpAfterIdleEscapeHatchTabSwitcherTappedAfterIdle)
     }
 }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4509,6 +4509,7 @@ extension MainViewController: NewTabPageControllerDelegate {
     }
 
     func newTabPageDidRequestTabSwitcher(_ controller: NewTabPageViewController) {
+        ntpAfterIdleInstrumentation.escapeHatchTabSwitcherTapped()
         requestTabSwitcher()
     }
 

--- a/iOS/DuckDuckGo/SettingsGeneralView.swift
+++ b/iOS/DuckDuckGo/SettingsGeneralView.swift
@@ -34,7 +34,7 @@ enum AfterInactivityOption: String, CaseIterable, CustomStringConvertible {
 }
 
 enum AfterInactivityIdleInterval: Int, CaseIterable, CustomStringConvertible {
-    case always = 0
+    case none = 0
     case oneMinute = 60
     case fiveMinutes = 300
     case tenMinutes = 600
@@ -48,7 +48,7 @@ enum AfterInactivityIdleInterval: Int, CaseIterable, CustomStringConvertible {
 
     var description: String {
         switch self {
-        case .always: return UserText.settingsAfterInactivityIdleIntervalAlways
+        case .none: return UserText.settingsAfterInactivityIdleIntervalNone
         case .oneMinute: return UserText.settingsAfterInactivityIdleIntervalMinuteSingular
         case .fiveMinutes: return String(format: UserText.settingsAfterInactivityIdleIntervalMinutesFormat, 5)
         case .tenMinutes: return String(format: UserText.settingsAfterInactivityIdleIntervalMinutesFormat, 10)

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -417,6 +417,10 @@ final class SettingsViewModel: ObservableObject {
             set: { newValue in
                 self.afterInactivityIdleInterval = newValue
                 try? self.afterInactivityStorage.set(newValue.seconds, for: \AfterInactivitySettingKeys.idleReturnIntervalSeconds)
+                DailyPixel.fireDailyAndCount(
+                    pixel: .ntpAfterIdleSettingIdleIntervalChanged,
+                    withAdditionalParameters: ["idle_interval_seconds": String(newValue.seconds)]
+                )
             }
         )
     }

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -391,8 +391,8 @@ final class SettingsViewModel: ObservableObject {
     }
 
     var afterInactivityFooterText: String {
-        if afterInactivityOption == .lastUsedTab || afterInactivityIdleInterval == .always {
-            return UserText.settingsAfterInactivityFooterAlways
+        if afterInactivityOption == .lastUsedTab || afterInactivityIdleInterval == .none {
+            return UserText.settingsAfterInactivityFooterNone
         }
         return String(format: UserText.settingsAfterInactivityFooterFormat, idleTimeInterval)
     }

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -1609,9 +1609,9 @@ public struct UserText {
     public static let settingsAfterInactivityIdleIntervalMinutesFormat = NSLocalizedString("settings.afterInactivity.idle.interval.minutes", value: "%d minutes", comment: "Idle interval in minutes for settings footer (plural)")
     public static let settingsAfterInactivityIdleIntervalHourSingular = NSLocalizedString("settings.afterInactivity.idle.interval.hour", value: "1 hour", comment: "Idle interval 1 hour for settings footer")
     public static let settingsAfterInactivityIdleIntervalHoursFormat = NSLocalizedString("settings.afterInactivity.idle.interval.hours", value: "%d hours", comment: "Idle interval in hours for settings footer (plural)")
-    public static let settingsAfterInactivityIntervalLabel = NotLocalizedString("settings.afterInactivity.interval.label", value: "Inactivity Timer", comment: "Settings picker label for the inactivity duration before showing New Tab")
-    public static let settingsAfterInactivityIdleIntervalAlways = NotLocalizedString("settings.afterInactivity.idle.interval.always", value: "None", comment: "Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold)")
-    public static let settingsAfterInactivityFooterAlways = NotLocalizedString("settings.afterInactivity.footer.always", value: "Choose what you see when you return to DuckDuckGo.", comment: "Section footer when the user has selected to always show the New Tab Page on return")
+    public static let settingsAfterInactivityIntervalLabel = NSLocalizedString("settings.afterInactivity.interval.label", value: "Inactivity Timer", comment: "Settings picker label for the inactivity duration before showing New Tab")
+    public static let settingsAfterInactivityIdleIntervalNone = NSLocalizedString("settings.afterInactivity.idle.interval.none", value: "None", comment: "Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold)")
+    public static let settingsAfterInactivityFooterNone = NSLocalizedString("settings.afterInactivity.footer.none", value: "Choose what you see when you return to DuckDuckGo.", comment: "Section footer when no inactivity timer is set or the Last Used Tab option is selected")
 
     // Escape Hatch (Return to Tab Card)
     public static let escapeHatchReturnToLabel = NSLocalizedString("escapeHatch.returnTo.label", value: "Return to…", comment: "Label shown on the escape hatch card above the tab title")

--- a/iOS/DuckDuckGo/bg.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/bg.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Показване в адресната лента";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Изберете какво да виждате, когато се върнете след %@ неактивност.";
+"settings.afterInactivity.footer.format" = "Изберете какво да виждате, когато се върнете в DuckDuckGo след %@ неактивност.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Изберете какво да виждате, когато се върнете в DuckDuckGo.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Таймер за неактивност";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "След неактивност";
+"settings.afterInactivity.label" = "Начален екран при отваряне";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Последно използван раздел";

--- a/iOS/DuckDuckGo/bg.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/bg.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Изберете какво да виждате, когато се върнете след %@ неактивност.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Изберете какво да виждате, когато се върнете в DuckDuckGo.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 час";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d минути";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Няма";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 секунда";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d секунди";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Таймер за неактивност";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "След неактивност";

--- a/iOS/DuckDuckGo/cs.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/cs.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Zobrazit v adresním řádku";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Vyber, co uvidíš, když se vrátíš po %@ neaktivity.";
+"settings.afterInactivity.footer.format" = "Vyber, co uvidíš po návratu na DuckDuckGo po %@ neaktivity.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Vyber, co uvidíš po návratu na DuckDuckGo.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Časovač neaktivity";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "Po nečinnosti";
+"settings.afterInactivity.label" = "Úvodní obrazovka";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Naposledy použitá karta";

--- a/iOS/DuckDuckGo/cs.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/cs.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Vyber, co uvidíš, když se vrátíš po %@ neaktivity.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Vyber, co uvidíš po návratu na DuckDuckGo.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 hodina";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d minut(y)";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Žádný";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 sekunda";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d sekund(y)";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Časovač neaktivity";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "Po nečinnosti";

--- a/iOS/DuckDuckGo/da.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/da.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Vis i adresselinjen";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Vælg, hvad du ser, når du vender tilbage efter inaktivitet i %@.";
+"settings.afterInactivity.footer.format" = "Vælg, hvad du ser, når du vender tilbage til DuckDuckGo efter %@ inaktivitet.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Vælg, hvad du ser, når du vender tilbage til DuckDuckGo.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Timer for inaktivitet";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "Efter inaktivitet";
+"settings.afterInactivity.label" = "Åbningsskærm";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Sidst brugte fane";

--- a/iOS/DuckDuckGo/da.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/da.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Vælg, hvad du ser, når du vender tilbage efter inaktivitet i %@.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Vælg, hvad du ser, når du vender tilbage til DuckDuckGo.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 time";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d minutter";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Ingen";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 sekund";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d sekunder";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Timer for inaktivitet";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "Efter inaktivitet";

--- a/iOS/DuckDuckGo/de.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/de.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "In der Adresszeile anzeigen";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Wähle aus, was dir angezeigt werden soll, wenn du nach %@ Minuten Inaktivität zu DuckDuckGo zurückkehrst.";
+"settings.afterInactivity.footer.format" = "Wähle aus, was dir angezeigt werden soll, wenn du nach %@ Inaktivität zu DuckDuckGo zurückkehrst.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Wähle aus, was dir angezeigt werden soll, wenn du zu DuckDuckGo zurückkehrst.";

--- a/iOS/DuckDuckGo/de.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/de.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "In der Adresszeile anzeigen";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Wähle aus, was dir nach %@ Inaktivität angezeigt werden soll.";
+"settings.afterInactivity.footer.format" = "Wähle aus, was dir angezeigt werden soll, wenn du nach %@ Minuten Inaktivität zu DuckDuckGo zurückkehrst.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Wähle aus, was dir angezeigt werden soll, wenn du zu DuckDuckGo zurückkehrst.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Inaktivitätstimer";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "Nach Inaktivität";
+"settings.afterInactivity.label" = "Eröffnungsbildschirm";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Zuletzt verwendeter Tab";

--- a/iOS/DuckDuckGo/de.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/de.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Wähle aus, was dir nach %@ Inaktivität angezeigt werden soll.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Wähle aus, was dir angezeigt werden soll, wenn du zu DuckDuckGo zurückkehrst.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 Stunde";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d Minuten";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Gar nichts";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 Sekunde";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d Sekunden";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Inaktivitätstimer";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "Nach Inaktivität";

--- a/iOS/DuckDuckGo/el.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/el.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Εμφάνιση στη Γραμμή διευθύνσεων";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Επιλέξτε τι θα βλέπετε όταν επιστρέφετε μετά από %@ αδράνειας.";
+"settings.afterInactivity.footer.format" = "Επιλέξτε τι θα βλέπετε όταν επιστρέψετε στο DuckDuckGo μετά από %@ αδράνειας.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Επιλέξτε τι θα βλέπετε όταν επιστρέψετε στο DuckDuckGo.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Χρονόμετρο αδράνειας";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "Μετά από αδράνεια";
+"settings.afterInactivity.label" = "Οθόνη έναρξης";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Τελευταία καρτέλα που χρησιμοποιήθηκε";

--- a/iOS/DuckDuckGo/el.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/el.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Επιλέξτε τι θα βλέπετε όταν επιστρέφετε μετά από %@ αδράνειας.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Επιλέξτε τι θα βλέπετε όταν επιστρέψετε στο DuckDuckGo.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 ώρα";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d λεπτά";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Κανένα";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 δευτερόλεπτο";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d δευτερόλεπτα";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Χρονόμετρο αδράνειας";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "Μετά από αδράνεια";

--- a/iOS/DuckDuckGo/en.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/en.lproj/Localizable.strings
@@ -3271,6 +3271,9 @@ Take back control of your personal information with the browser designed for dat
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Choose what you see when you return to DuckDuckGo after %@ of inactivity.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Choose what you see when you return to DuckDuckGo.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 hour";
 
@@ -3283,11 +3286,17 @@ Take back control of your personal information with the browser designed for dat
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d minutes";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "None";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 second";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d seconds";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Inactivity Timer";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "Opening Screen";

--- a/iOS/DuckDuckGo/es.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/es.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Elige lo que ves cuando vuelves después de %@ de inactividad.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Elige qué quieres ver cuando vuelvas a DuckDuckGo.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 hora";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d minutos";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Nada";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 segundo";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d segundos";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Temporizador de inactividad";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "Después de inactividad";

--- a/iOS/DuckDuckGo/es.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/es.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Mostrar en la barra de direcciones";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Elige lo que ves cuando vuelves después de %@ de inactividad.";
+"settings.afterInactivity.footer.format" = "Elige lo que verás cuando regreses a DuckDuckGo después de %@ de inactividad.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Elige qué quieres ver cuando vuelvas a DuckDuckGo.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Temporizador de inactividad";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "Después de inactividad";
+"settings.afterInactivity.label" = "Pantalla de apertura";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Última pestaña utilizada";

--- a/iOS/DuckDuckGo/et.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/et.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Vali, mida näed, kui naased pärast %@ tegevusetuse perioodi möödumist.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Vali, mida näed DuckDuckGo-sse naastes.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 tund";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d minutit";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Puudub";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 sekund";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d sekundit";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Tegevusetuse taimer";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "Pärast tegevusetust";

--- a/iOS/DuckDuckGo/et.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/et.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Näita aadressiribal";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Vali, mida näed, kui naased pärast %@ tegevusetuse perioodi möödumist.";
+"settings.afterInactivity.footer.format" = "Vali, mida näed, kui naased DuckDuckGo-sse pärast %@ tegevusetuse perioodi.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Vali, mida näed DuckDuckGo-sse naastes.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Tegevusetuse taimer";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "Pärast tegevusetust";
+"settings.afterInactivity.label" = "Avakuva";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Viimati kasutatud vahekaart";

--- a/iOS/DuckDuckGo/fi.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fi.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Valitse, mitä näet, kun palaat %@ käyttämättömyyden jälkeen.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Valitse, mitä näet, kun palaat DuckDuckGoon.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 tunti";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d minuuttia";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Ei mitään";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 sekunti";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d sekuntia";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Passiivisuusajastin";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "Toimettomuuden jälkeen";

--- a/iOS/DuckDuckGo/fi.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fi.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Näytä osoitekentässä";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Valitse, mitä näet, kun palaat %@ käyttämättömyyden jälkeen.";
+"settings.afterInactivity.footer.format" = "Valitse, mitä näet, kun palaat DuckDuckGoon %@ passiivisuuden jälkeen.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Valitse, mitä näet, kun palaat DuckDuckGoon.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Passiivisuusajastin";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "Toimettomuuden jälkeen";
+"settings.afterInactivity.label" = "Aloitusnäyttö";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Viimeksi käytetty välilehti";

--- a/iOS/DuckDuckGo/fr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fr.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Choisissez ce que vous voyez lorsque vous revenez après %@ d’inactivité.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Choisissez ce que vous voyez en revenant sur DuckDuckGo.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 heure";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d minutes";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Aucun";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 seconde";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d secondes";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Minuteur d'inactivité";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "Après l'inactivité";

--- a/iOS/DuckDuckGo/fr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fr.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Afficher dans la barre d'adresse";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Choisissez ce que vous voyez lorsque vous revenez après %@ d’inactivité.";
+"settings.afterInactivity.footer.format" = "Choisissez ce que vous voyez lorsque vous revenez sur DuckDuckGo après %@ d’inactivité.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Choisissez ce que vous voyez en revenant sur DuckDuckGo.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Minuteur d'inactivité";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "Après l'inactivité";
+"settings.afterInactivity.label" = "Écran d'ouverture";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Dernier onglet utilisé";

--- a/iOS/DuckDuckGo/hr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hr.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Odaberi što ćeš vidjeti kada se vratiš nakon %@ neaktivnosti.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Odaberi što ćeš vidjeti kada se vratiš na DuckDuckGo.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 sat";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d minute/a";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Nijedno";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 sekundu";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d sekunde/i";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Mjerač vremena neaktivnosti";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "Nakon neaktivnosti";

--- a/iOS/DuckDuckGo/hr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hr.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Prikaži u adresnoj traci";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Odaberi što ćeš vidjeti kada se vratiš nakon %@ neaktivnosti.";
+"settings.afterInactivity.footer.format" = "Odaberi što ćeš vidjeti kada se vratiš na DuckDuckGo nakon %@ neaktivnosti.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Odaberi što ćeš vidjeti kada se vratiš na DuckDuckGo.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Mjerač vremena neaktivnosti";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "Nakon neaktivnosti";
+"settings.afterInactivity.label" = "Početni zaslon";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Posljednja korištena kartica";

--- a/iOS/DuckDuckGo/hu.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hu.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Válaszd ki, mit jelenjen meg, ha %@ inaktivitás után visszatérsz.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Válaszd ki, mi jelenjen meg, amikor visszatérsz a DuckDuckGóba.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 óra";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d perc";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Nincs";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 másodperc";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d másodperc";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Tétlenségi időzítő";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "Inaktivitás után";

--- a/iOS/DuckDuckGo/hu.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hu.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Megjelenítés a címsorban";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Válaszd ki, mit jelenjen meg, ha %@ inaktivitás után visszatérsz.";
+"settings.afterInactivity.footer.format" = "Válaszd ki, mi jelenjen meg, amikor %@ tétlenség után visszatérsz a DuckDuckGóba.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Válaszd ki, mi jelenjen meg, amikor visszatérsz a DuckDuckGóba.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Tétlenségi időzítő";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "Inaktivitás után";
+"settings.afterInactivity.label" = "Nyitóképernyő";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Utoljára használt lap";

--- a/iOS/DuckDuckGo/it.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/it.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Mostra nella barra degli indirizzi";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Scegli cosa vedi quando torni dopo %@ di inattività.";
+"settings.afterInactivity.footer.format" = "Scegli cosa visualizzare al tuo ritorno su DuckDuckGo dopo %@ di inattività.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Scegli cosa visualizzare al tuo ritorno su DuckDuckGo.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Timer di inattività";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "Dopo l'inattività";
+"settings.afterInactivity.label" = "Schermata di apertura";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Ultima scheda usata";

--- a/iOS/DuckDuckGo/it.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/it.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Scegli cosa vedi quando torni dopo %@ di inattività.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Scegli cosa visualizzare al tuo ritorno su DuckDuckGo.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 ora";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d minuti";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Niente";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 secondo";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d secondi";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Timer di inattività";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "Dopo l'inattività";

--- a/iOS/DuckDuckGo/ja.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ja.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "操作がない状態が%@続いた後、戻ってきたときに表示する内容を選択してください。";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "DuckDuckGoに戻ったときに表示する内容を選択してください。";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1時間";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d 分";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "なし";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1秒";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d 秒";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "非アクティブタイマー";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "操作がない状態が続いた後";

--- a/iOS/DuckDuckGo/ja.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ja.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "アドレスバーに表示";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "操作がない状態が%@続いた後、戻ってきたときに表示する内容を選択してください。";
+"settings.afterInactivity.footer.format" = "操作がない状態が%@続いた後、DuckDuckGoに戻ってきたときに表示する内容を選択してください。";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "DuckDuckGoに戻ったときに表示する内容を選択してください。";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "非アクティブタイマー";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "操作がない状態が続いた後";
+"settings.afterInactivity.label" = "オープニングスクリーン";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "最後に使用したタブ";

--- a/iOS/DuckDuckGo/lt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lt.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Rodyti adreso juostoje";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Pasirinkite, ką matysite grįžę po %@ neaktyvumo.";
+"settings.afterInactivity.footer.format" = "Pasirinkite, ką matysite grįžę į „DuckDuckGo“ po %@ neaktyvumo.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Pasirinkite, ką matysite grįžę į „DuckDuckGo“.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Neaktyvumo laikmatis";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "Po neaktyvumo";
+"settings.afterInactivity.label" = "Atidarymo ekranas";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Paskutinį kartą naudotas skirtukas";

--- a/iOS/DuckDuckGo/lt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lt.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Pasirinkite, ką matysite grįžę po %@ neaktyvumo.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Pasirinkite, ką matysite grįžę į „DuckDuckGo“.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 val.";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d min.";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Nėra";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 sek.";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d sek.";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Neaktyvumo laikmatis";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "Po neaktyvumo";

--- a/iOS/DuckDuckGo/lv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lv.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Rādīt adreses joslā";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Izvēlies, ko redzēt, atgriežoties pēc %@ neaktivitātes perioda.";
+"settings.afterInactivity.footer.format" = "Izvēlies, ko redzēt, atgriežoties DuckDuckGo pēc %@ neaktivitātes perioda.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Izvēlies, ko redzēt, atgriežoties DuckDuckGo.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Neaktivitātes taimeris";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "Pēc neaktivitātes perioda";
+"settings.afterInactivity.label" = "Ekrāna atvēršana";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Pēdējā lietotā cilne";

--- a/iOS/DuckDuckGo/lv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lv.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Izvēlies, ko redzēt, atgriežoties pēc %@ neaktivitātes perioda.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Izvēlies, ko redzēt, atgriežoties DuckDuckGo.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 stunda";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d minūtes";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Nav";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 sekunde";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d sekundes";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Neaktivitātes taimeris";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "Pēc neaktivitātes perioda";

--- a/iOS/DuckDuckGo/nb.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nb.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Velg hva du vil se, når du kommer tilbake etter %@ med inaktivitet.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Velg hva du vil se, når du kommer tilbake til DuckDuckGo.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 time";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d minutter";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Ingen";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 sekund";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d sekunder";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Inaktivitetstidtaker";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "Etter inaktivitet";

--- a/iOS/DuckDuckGo/nb.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nb.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Vis i adressefeltet";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Velg hva du vil se, når du kommer tilbake etter %@ med inaktivitet.";
+"settings.afterInactivity.footer.format" = "Velg hva du vil se, når du kommer tilbake til DuckDuckGo etter %@ med inaktivitet.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Velg hva du vil se, når du kommer tilbake til DuckDuckGo.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Inaktivitetstidtaker";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "Etter inaktivitet";
+"settings.afterInactivity.label" = "Gjenopptaksskjerm";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Sist brukte fane";

--- a/iOS/DuckDuckGo/nl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nl.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Kies wat je ziet als je terugkeert na %@ inactiviteit.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Kies wat je wilt zien als je terugkeert naar DuckDuckGo.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 uur";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d minuten";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Geen";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 seconde";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d seconden";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Inactiviteitstimer";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "Na inactiviteit";

--- a/iOS/DuckDuckGo/nl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nl.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "In adresbalk weergeven";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Kies wat je ziet als je terugkeert na %@ inactiviteit.";
+"settings.afterInactivity.footer.format" = "Kies wat je wilt zien als je terugkeert naar DuckDuckGo na %@ inactiviteit.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Kies wat je wilt zien als je terugkeert naar DuckDuckGo.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Inactiviteitstimer";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "Na inactiviteit";
+"settings.afterInactivity.label" = "Openingsscherm";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Laatst gebruikte tabblad";

--- a/iOS/DuckDuckGo/pl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pl.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Pokaż na pasku adresu";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Wybierz, co zobaczysz, gdy wrócisz po %@ braku aktywności.";
+"settings.afterInactivity.footer.format" = "Wybierz, co zobaczysz po powrocie do DuckDuckGo po %@ braku aktywności.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Wybierz, co zobaczysz po powrocie do DuckDuckGo.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Timer bezczynności";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "Po braku aktywności";
+"settings.afterInactivity.label" = "Ekran startowy";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Ostatnio używana karta";

--- a/iOS/DuckDuckGo/pl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pl.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Wybierz, co zobaczysz, gdy wrócisz po %@ braku aktywności.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Wybierz, co zobaczysz po powrocie do DuckDuckGo.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 godzina";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d min";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Brak";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 s";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d s";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Timer bezczynności";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "Po braku aktywności";

--- a/iOS/DuckDuckGo/pt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pt.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Mostrar na barra de endereço";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Escolhe o que vês quando voltares após %@ de inatividade.";
+"settings.afterInactivity.footer.format" = "Escolhe o que vês quando voltas ao DuckDuckGo após %@ de inatividade.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Escolhe o que vês quando voltares ao DuckDuckGo.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Temporizador de inatividade";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "Após Inatividade";
+"settings.afterInactivity.label" = "Ecrã de abertura";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Último separador utilizado";

--- a/iOS/DuckDuckGo/pt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pt.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Escolhe o que vês quando voltares após %@ de inatividade.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Escolhe o que vês quando voltares ao DuckDuckGo.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 hora";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d minutos";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Nenhum";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 segundo";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d segundos";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Temporizador de inatividade";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "Após Inatividade";

--- a/iOS/DuckDuckGo/ro.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ro.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Alege ce vezi când revii după %@ de inactivitate.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Alege ce vezi când revii la DuckDuckGo.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 oră";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d minute";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Niciuna";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 secundă";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d secunde";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Cronometru de inactivitate";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "După inactivitate";

--- a/iOS/DuckDuckGo/ro.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ro.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Afișează în bara de adrese";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Alege ce vezi când revii după %@ de inactivitate.";
+"settings.afterInactivity.footer.format" = "Alege ce vezi când revii la DuckDuckGo după %@ de inactivitate.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Alege ce vezi când revii la DuckDuckGo.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Cronometru de inactivitate";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "După inactivitate";
+"settings.afterInactivity.label" = "Ecran de deschidere";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Ultima filă utilizată";

--- a/iOS/DuckDuckGo/ru.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ru.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Выберите, что вы увидите, когда вернетесь после %@ бездействия.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Выберите, что будет отображаться при возвращении в DuckDuckGo.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 ч.";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d минут";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Каждый раз";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 секунда";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d секунд";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Таймер бездействия";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "После бездействия";

--- a/iOS/DuckDuckGo/ru.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ru.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Показывать в адресной строке";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Выберите, что вы увидите, когда вернетесь после %@ бездействия.";
+"settings.afterInactivity.footer.format" = "Выберите, что будет отображаться в DuckDuckGo после %@ бездействия.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Выберите, что будет отображаться при возвращении в DuckDuckGo.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Таймер бездействия";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "После бездействия";
+"settings.afterInactivity.label" = "Начальный экран";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Последняя использованная вкладка";

--- a/iOS/DuckDuckGo/sk.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sk.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Vyber, čo sa zobrazí po návrate po %@ nečinnosti.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Vyber si, čo uvidíš po návrate na DuckDuckGo.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 hod.";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d min.";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Žiadne";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 sek.";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d sek.";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Časovač nečinnosti";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "Po nečinnosti";

--- a/iOS/DuckDuckGo/sk.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sk.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Zobraziť v adresnom riadku";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Vyber, čo sa zobrazí po návrate po %@ nečinnosti.";
+"settings.afterInactivity.footer.format" = "Vyber si, čo sa zobrazí po návrate do DuckDuckGo po %@ minútach nečinnosti.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Vyber si, čo uvidíš po návrate na DuckDuckGo.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Časovač nečinnosti";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "Po nečinnosti";
+"settings.afterInactivity.label" = "Uvítacia obrazovka";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Naposledy použitá karta";

--- a/iOS/DuckDuckGo/sk.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sk.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Zobraziť v adresnom riadku";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Vyber si, čo sa zobrazí po návrate do DuckDuckGo po %@ minútach nečinnosti.";
+"settings.afterInactivity.footer.format" = "Vyber si, čo sa zobrazí po návrate do DuckDuckGo po %@ nečinnosti.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Vyber si, čo uvidíš po návrate na DuckDuckGo.";

--- a/iOS/DuckDuckGo/sl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sl.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Prikaži v naslovni vrstici";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Izberite, kaj naj bo prikazano ob vrnitvi po %@ neaktivnosti.";
+"settings.afterInactivity.footer.format" = "Izberite, kaj želite videti, ko se po %@ neaktivnosti vrnete na DuckDuckGo.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Izberite, kaj bo prikazano, ko se vrnete na DuckDuckGo.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Časovnik neaktivnosti";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "Po neaktivnosti";
+"settings.afterInactivity.label" = "Začetni zaslon";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Nazadnje uporabljeni zavihek";

--- a/iOS/DuckDuckGo/sl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sl.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Izberite, kaj naj bo prikazano ob vrnitvi po %@ neaktivnosti.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Izberite, kaj bo prikazano, ko se vrnete na DuckDuckGo.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 uri";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d minutah";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Brez";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 sekundi";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d sekundah";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Časovnik neaktivnosti";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "Po neaktivnosti";

--- a/iOS/DuckDuckGo/sv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sv.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Visa i adressfältet";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "Välj vad du ser när du återgår efter %@ av inaktivitet.";
+"settings.afterInactivity.footer.format" = "Välj vad du ser när du återgår till DuckDuckGo efter %@ av inaktivitet.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "Välj vad du ser när du återgår till DuckDuckGo.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Inaktivitetstimer";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "Efter inaktivitet";
+"settings.afterInactivity.label" = "Öppningsskärm";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Senast använda flik";

--- a/iOS/DuckDuckGo/sv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sv.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "Välj vad du ser när du återgår efter %@ av inaktivitet.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "Välj vad du ser när du återgår till DuckDuckGo.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 timme";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d minuter";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Ingen";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 sekund";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d sekunder";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Inaktivitetstimer";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "Efter inaktivitet";

--- a/iOS/DuckDuckGo/tr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/tr.lproj/Localizable.strings
@@ -3506,6 +3506,9 @@
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
 "settings.afterInactivity.footer.format" = "%@ boyunca işlem yapılmadığında ne göreceğinizi seçin.";
 
+/* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
+"settings.afterInactivity.footer.none" = "DuckDuckGo'ya döndüğünüzde ne göreceğinizi seçin.";
+
 /* Idle interval 1 hour for settings footer */
 "settings.afterInactivity.idle.interval.hour" = "1 saat";
 
@@ -3518,11 +3521,17 @@
 /* Idle interval in minutes for settings footer (plural) */
 "settings.afterInactivity.idle.interval.minutes" = "%d dakika";
 
+/* Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold) */
+"settings.afterInactivity.idle.interval.none" = "Yok";
+
 /* Idle interval 1 second for settings footer */
 "settings.afterInactivity.idle.interval.second" = "1 saniye";
 
 /* Idle interval in seconds for settings footer (plural) */
 "settings.afterInactivity.idle.interval.seconds" = "%d saniye";
+
+/* Settings picker label for the inactivity duration before showing New Tab */
+"settings.afterInactivity.interval.label" = "Hareketsizlik Zamanlayıcısı";
 
 /* Settings picker label for what to show when returning after inactivity */
 "settings.afterInactivity.label" = "Hareketsizlik Sonrası";

--- a/iOS/DuckDuckGo/tr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/tr.lproj/Localizable.strings
@@ -3504,7 +3504,7 @@
 "settings.address.trackers.animation" = "Adres Çubuğunda Göster";
 
 /* Section footer; %@ is the idle interval (e.g. 5 minutes) */
-"settings.afterInactivity.footer.format" = "%@ boyunca işlem yapılmadığında ne göreceğinizi seçin.";
+"settings.afterInactivity.footer.format" = "%@ hareketsizlikten sonra DuckDuckGo'ya döndüğünüzde ne göreceğinizi seçin.";
 
 /* Section footer when no inactivity timer is set or the Last Used Tab option is selected */
 "settings.afterInactivity.footer.none" = "DuckDuckGo'ya döndüğünüzde ne göreceğinizi seçin.";
@@ -3534,7 +3534,7 @@
 "settings.afterInactivity.interval.label" = "Hareketsizlik Zamanlayıcısı";
 
 /* Settings picker label for what to show when returning after inactivity */
-"settings.afterInactivity.label" = "Hareketsizlik Sonrası";
+"settings.afterInactivity.label" = "Açılış Ekranı";
 
 /* Option: show last used tab when returning after inactivity */
 "settings.afterInactivity.option.lastUsedTab" = "Son Kullanılan Sekme";

--- a/iOS/DuckDuckGoTests/IdleReturnThresholdResolverTests.swift
+++ b/iOS/DuckDuckGoTests/IdleReturnThresholdResolverTests.swift
@@ -64,10 +64,10 @@ struct IdleReturnThresholdResolverTests {
     }
 
     @available(iOS 16, *)
-    @Test("When user has selected Always (0) then resolver returns 0", .timeLimit(.minutes(1)))
-    func userStoredAlwaysReturnsZero() throws {
+    @Test("When user has selected None (0) then resolver returns 0", .timeLimit(.minutes(1)))
+    func userStoredNoneReturnsZero() throws {
         let (_, userStorage) = try makeUserStorage()
-        try userStorage.set(AfterInactivityIdleInterval.always.seconds,
+        try userStorage.set(AfterInactivityIdleInterval.none.seconds,
                             for: \AfterInactivitySettingKeys.idleReturnIntervalSeconds)
 
         let resolver = IdleReturnThresholdResolver(

--- a/iOS/DuckDuckGoTests/NTPAfterIdleInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/NTPAfterIdleInstrumentationTests.swift
@@ -89,6 +89,14 @@ struct NTPAfterIdleInstrumentationTests {
         #expect(collector.firedPixelNames.isEmpty)
     }
 
+    @available(iOS 16, *)
+    @Test("When not eligible then escapeHatchTabSwitcherTapped fires no pixel", .timeLimit(.minutes(1)))
+    func whenNotEligibleThenEscapeHatchTabSwitcherTappedFiresNothing() {
+        let (sut, collector) = makeSUT(eligible: false)
+        sut.escapeHatchTabSwitcherTapped()
+        #expect(collector.firedPixelNames.isEmpty)
+    }
+
     @Test("When not eligible then tabSwitcherSelectedFromNTP fires no pixel")
     func whenNotEligibleThenTabSwitcherFiresNothing() {
         let (sut, collector) = makeSUT(eligible: false)
@@ -207,6 +215,16 @@ struct NTPAfterIdleInstrumentationTests {
         let (sut, collector) = makeSUT()
         sut.tabSwitcherSelectedFromNTP(afterIdle: false)
         #expect(collector.firedPixelNames == [Pixel.Event.ntpAfterIdleTabSwitcherSelectedUserInitiated.name])
+    }
+
+    // MARK: - escapeHatchTabSwitcherTapped
+
+    @available(iOS 16, *)
+    @Test("When escape hatch tab switcher tapped then fires the after_idle pixel", .timeLimit(.minutes(1)))
+    func whenEscapeHatchTabSwitcherTappedThenFiresCorrectPixel() {
+        let (sut, collector) = makeSUT()
+        sut.escapeHatchTabSwitcherTapped()
+        #expect(collector.firedPixelNames == [Pixel.Event.ntpAfterIdleEscapeHatchTabSwitcherTappedAfterIdle.name])
     }
 
     // MARK: - Multiple calls accumulate

--- a/iOS/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
@@ -98,6 +98,13 @@
         "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
+    "m_ntp_after_idle_escape_hatch_tab_switcher_tapped_after_idle": {
+        "description": "Fires when the user taps the tab switcher pill next to the escape hatch card. The escape hatch is only shown after idle return.",
+        "owners": ["SabrinaTardio"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
     "m_ntp_after_idle_setting_changed_to_new_tab": {
         "description": "Fires when the user changes the after-inactivity setting to New Tab.",
         "owners": ["SabrinaTardio"],

--- a/iOS/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
@@ -118,5 +118,12 @@
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_setting_idle_interval_changed": {
+        "description": "Fires when the user changes the inactivity-timer interval. The selected interval is reported via the idle_interval_seconds parameter.",
+        "owners": ["SabrinaTardio"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion", "idle_interval_seconds"]
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
@@ -124,6 +124,14 @@
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion", "idle_interval_seconds"]
+        "parameters": [
+            "appVersion",
+            {
+                "key": "idle_interval_seconds",
+                "type": "string",
+                "description": "Selected inactivity-timer threshold in seconds. 0 means None (NTP is shown every time the user returns).",
+                "enum": ["0", "60", "300", "600", "1800", "3600", "43200"]
+            }
+        ]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214767972426470
CC: @miasma13 

### Description

Release-branch version of #4787, cherry-picked on top of `release/ios/7.220.0` so the localization + pixel can ship in 7.220.0.

1. **Localize the three new copy strings** that were previously gated behind `NotLocalizedString`:
   - `settings.afterInactivity.interval.label` — picker label *Inactivity Timer*
   - `settings.afterInactivity.idle.interval.none` — option *None*
   - `settings.afterInactivity.footer.none` — footer *Choose what you see when you return to DuckDuckGo.*

   Switched to `NSLocalizedString` and added matching entries to `en.lproj/Localizable.strings`. Translations for the 25 supported locales are included.

2. **Add a pixel for the escape hatch tab switcher pill** (`m_ntp_after_idle_escape_hatch_tab_switcher_tapped_after_idle`). The escape hatch is only shown after idle return, so a single after-idle pixel is sufficient. Wired through `NTPAfterIdleInstrumentation.escapeHatchTabSwitcherTapped()` and fired from `MainViewController.newTabPageDidRequestTabSwitcher(_:)`. Pixel definition added under `PixelDefinitions/pixels/definitions/ntp_after_idle.json5`.

### Testing Steps
1. Build and run with the `showNTPAfterIdleReturn` subfeature enabled.
2. Open Settings → General → confirm the *Opening Screen* / *Inactivity Timer* / *None* / footer copy renders correctly.
3. Trigger the escape hatch (background the app past the idle threshold, foreground it on a tab with content). Tap the round tab-switcher pill next to the *Return to…* card. Confirm `m_ntp_after_idle_escape_hatch_tab_switcher_tapped_after_idle` fires.

### Impact and Risks
Low. Localization change is purely additive (no behavioral effect). The new pixel is in the existing daily-and-count instrumentation pipeline. One cherry-pick conflict was resolved in `MainViewController.newTabPageDidRequestTabSwitcher(_:)` to preserve the release branch's `requestTabSwitcher()` call alongside the new instrumentation line.

### Notes to Reviewer
Mirrors #4787 (`main`-targeted). Targets release branch instead so it ships in 7.220.0.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to UI string localization and additional analytics pixels/parameters with small, well-scoped wiring in settings and NTP instrumentation.
> 
> **Overview**
> Adds a new NTP-after-idle analytics event for tapping the escape hatch’s adjacent tab-switcher pill, wiring it through `NTPAfterIdleInstrumentation.escapeHatchTabSwitcherTapped()` and firing it from `MainViewController.newTabPageDidRequestTabSwitcher(_:)`, with a matching definition in `ntp_after_idle.json5`.
> 
> Updates the after-inactivity settings to use fully localized strings (including a renamed idle-interval enum case `always` → `none`) and adds a new pixel `m_ntp_after_idle_setting_idle_interval_changed` that reports the selected `idle_interval_seconds` when the inactivity timer value changes; includes updated tests and translations across supported locales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eba4a68555b298e8c8eaa6e775a33419615a3969. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->