### PR TITLE
Rename drk-add-icon skill to ddg-drk-add-icon

### DIFF
--- a/.claude/skills/ddg-drk-add-icon/SKILL.md
+++ b/.claude/skills/ddg-drk-add-icon/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: drk-add-icon
-description: Invoke ONLY when the user explicitly runs /drk-add-icon or names this skill by name (e.g. "use drk-add-icon to add these SVGs"). Do NOT auto-invoke from symptom/intent matching — the skill mutates the apple-browsers asset catalog and Swift files and creates a git commit, so it must be user-initiated. If the user asks about adding icons or Swift package assets without naming this skill, answer directly instead. Inputs are a list of local paths and/or HTTP URLs (one entry per icon); category (Glyph/Color/Recolorable) and size are derived from each filename. Handles imageset/symbolset creation, Contents.json variants, and the camelCase accessor in the matching DesignSystemImages+*.swift file, in a single batch commit.
+name: ddg-drk-add-icon
+description: Invoke ONLY when the user explicitly runs /ddg-drk-add-icon or names this skill by name (e.g. "use ddg-drk-add-icon to add these SVGs"). Do NOT auto-invoke from symptom/intent matching — the skill mutates the apple-browsers asset catalog and Swift files and creates a git commit, so it must be user-initiated. If the user asks about adding icons or Swift package assets without naming this skill, answer directly instead. Inputs are a list of local paths and/or HTTP URLs (one entry per icon); category (Glyph/Color/Recolorable) and size are derived from each filename. Handles imageset/symbolset creation, Contents.json variants, and the camelCase accessor in the matching DesignSystemImages+*.swift file, in a single batch commit.
 ---
 
-# drk-add-icon
+# ddg-drk-add-icon
 
 ## Overview
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1214777370255435

### Description

Renames the Claude Code skill added in #4858 from `drk-add-icon` to `ddg-drk-add-icon` so it shares the `ddg-` prefix used by every other repo skill (`ddg-sentry-report`, `ddg-diagnose-ci-failure`, `ddg-apple-feedback-review`).

Three places change:
- Directory: `.claude/skills/drk-add-icon/` → `.claude/skills/ddg-drk-add-icon/`
- Frontmatter `name:` value
- `# Heading` and the trigger references inside the skill's `description:` (so the skill correctly responds to `/ddg-drk-add-icon` instead of `/drk-add-icon`)

No other behavior changes.

### Testing Steps

1. From a fresh Claude Code session in this repo, run `/ddg-drk-add-icon <some-svg-path>` and confirm the skill loads (no "skill not found" / loads the same SKILL.md contents as before).
2. Confirm `/drk-add-icon` no longer matches a repo skill.

### Impact and Risks

None — repo tooling only. Renames a developer-only skill file; no product code, no shipping binaries, no CI changes.

#### What could go wrong?

- Anyone with muscle memory for `/drk-add-icon` will need to update to `/ddg-drk-add-icon`. Limited blast radius — I'm the only documented user of this skill so far.

### Quality Considerations

None beyond the trigger-name update. The skill body is unchanged.

### Notes to Reviewer

N/A.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 176fa60913beb000237ba5268518303c802b6979. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->