### PR TITLE
[macOS] Feedback: Show product chooser again

### DIFF
--- a/macOS/DuckDuckGo/Feedback/Resources/internal-feedback-autofiller.js
+++ b/macOS/DuckDuckGo/Feedback/Resources/internal-feedback-autofiller.js
@@ -89,6 +89,22 @@ function hideFormQuestion(labelText) {
     }
 }
 
+function rehideFieldsWhenReturningToNativeApps() {
+    var wasNativeApps = true;
+    const observer = new MutationObserver(() => {
+        const selected = document.querySelector('[aria-label^="Which product area or team does this feedback relate to?"]');
+        if (!selected) return;
+        const isNativeApps = selected.textContent.trim().includes('Native Apps');
+        if (isNativeApps && !wasNativeApps) {
+            fillOutFormAfterNativeAppsSelected();
+        }
+        wasNativeApps = isNativeApps;
+    });
+    observer.observe(document.body, { childList: true, subtree: true, characterData: true });
+}
+
+var quickModeUIInjected = false;
+
 function addEmailFieldPadding() {
     var emailLabel = Array.from(document.querySelectorAll('label'))
         .find(function(l) {
@@ -104,7 +120,6 @@ function addEmailFieldPadding() {
 
 function hideIrrelevantFields() {
     const fieldsToHide = [
-        'Which product area or team',
         'Which platform?',
         'Which macOS version',
         'Which version of the DuckDuckGo',
@@ -116,11 +131,15 @@ function hideIrrelevantFields() {
     ];
     fieldsToHide.forEach(hideFormQuestion);
 
+    if (quickModeUIInjected) return;
+    quickModeUIInjected = true;
+
     addEmailFieldPadding();
     moveSubmitButtonUnderDescription();
     injectDiagnosticsSection();
     injectScreenshotSection();
     hookSubmitForDiagnostics();
+    rehideFieldsWhenReturningToNativeApps();
 
     var hider = document.getElementById('ddg-form-hider');
     if (hider) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211850802118632/task/1214780725465406
Tech Design URL:
CC:

### Description

The quick feedback popup hid the "Which product area or team" dropdown and locked all submissions to "Native Apps & Extensions", causing feedback for other products (e.g. Duck.ai) to silently land in the Native Apps inbox.

The dropdown is now visible above the description field, still defaulted to "Native Apps & Extensions". Switching to another product area shows that area's standard fields. Switching back re-fills and re-hides the Native Apps fields.

### Testing Steps

1. Open the quick feedback popup.
2. Confirm "Which product area or team" is visible at the top, defaulted to "Native Apps & Extensions". Description / diagnostics / screenshot section / submit button look the same as before. Platform / macOS version / app version are hidden.
3. Switch the dropdown to "Duck.ai" — Duck.ai's fields should appear.
4. Switch back to "Native Apps & Extensions" — the platform fields should hide again (no lingering visibility).
5. Submit one feedback for Native Apps and one for Duck.ai; confirm each lands in the correct Asana team.

### Impact and Risks

Low. Internal-only feature; the JS only runs on the internal feedback Asana form for internal users. Worst case: the dropdown logic misbehaves and feedback still routes to Native Apps as before.

#### What could go wrong?

- Asana changes its form's DOM structure or rerender behavior when switching product areas, breaking the re-fill-on-return logic. Mitigation: re-fill uses the existing `waitForElement` + `setInputAfterLabel` helpers that already tolerate Asana's async rendering.
- The MutationObserver runs continuously over `document.body`. Acceptable for an internal-only form that's only open briefly.

### Notes to Reviewer

The Windows browser has the equivalent change in a parallel PR (`InternalFeedbackFormFiller.js`). Both files were kept in sync.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk internal-only JS change, but it relies on Asana form DOM mutations and adds a `MutationObserver` that could misfire if the form structure/rerendering changes.
> 
> **Overview**
> **Fixes misrouted feedback in the macOS internal quick feedback form** by no longer hiding the "Which product area or team" dropdown, allowing users to switch to non–Native Apps product areas.
> 
> Adds a `MutationObserver` to detect when the selection returns to *Native Apps & Extensions* and re-run `fillOutFormAfterNativeAppsSelected()` so the Native Apps platform/version fields get re-hidden consistently after toggling.
> 
> Guards one-time quick-mode UI setup with `quickModeUIInjected` so the injected UI/handlers aren’t re-added on subsequent hide passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0498709b7ba3ca54c733310d067b72053833fd45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->