### PR TITLE
Fix: Merge Glitch

### DIFF
--- a/iOS/DuckDuckGo/SettingsYouTubeAdBlockingView.swift
+++ b/iOS/DuckDuckGo/SettingsYouTubeAdBlockingView.swift
@@ -113,30 +113,6 @@ struct SettingsYouTubeAdBlockingView: View {
         base.append(link)
         return base
     }
-
-    private static let learnMoreURL = URL(string: "ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/detecting-ad-blocking-interference-anonymously")
-
-    private var footerAttributedString: AttributedString {
-        var base = AttributedString(UserText.youTubeAdBlockingToggleFooter)
-        base.append(AttributedString(" "))
-        var link = AttributedString(UserText.youTubeAdBlockingLearnMoreButton)
-        link.foregroundColor = Color(designSystemColor: .accent)
-        link.link = Self.learnMoreURL
-        base.append(link)
-        return base
-    }
-
-    private static let learnMoreURL = URL(string: "ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/detecting-ad-blocking-interference-anonymously")
-
-    private var footerAttributedString: AttributedString {
-        var base = AttributedString(UserText.youTubeAdBlockingToggleFooter)
-        base.append(AttributedString(" "))
-        var link = AttributedString(UserText.youTubeAdBlockingLearnMoreButton)
-        link.foregroundColor = Color(designSystemColor: .accent)
-        link.link = Self.learnMoreURL
-        base.append(link)
-        return base
-    }
 }
 
 private struct ContingencyMessageView: View {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205237866452338/task/1214784262353754?focus=true
Tech Design URL:
CC:

### Description
This PR fixes a merge glitch, that resulted in URL triplication

### Testing Steps
- [ ] Verify the CI is green please!

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing really!

### Quality Considerations
None

### Notes to Reviewer
Thank you!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup: removes accidentally duplicated Swift properties caused by a merge glitch, with no behavioral change beyond ensuring a single source of the footer link text/URL.
> 
> **Overview**
> Fixes a bad merge in `SettingsYouTubeAdBlockingView.swift` that had duplicated `learnMoreURL` and `footerAttributedString` definitions.
> 
> The view now has a single, canonical footer attributed string and learn-more link, avoiding triplicated declarations in the settings screen code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e5c87909a96219373d61cb4723fafe5bcf9c7b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->