### PR TITLE
[macOS] Suppresses the first-time quit survey when termination wasn't initiated by the user

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -151,6 +151,10 @@ public enum MacOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/inbox/1203972458584425/item/1212200919350194/story/1212483080081687
     case firstTimeQuitSurvey
 
+    /// Suppresses the first-time quit survey when termination wasn't initiated by the user
+    /// (Sparkle update relaunch, or system logout/restart/shutdown).
+    case firstTimeQuitSurveySkipNonUserQuit
+
     /// Web Notifications API polyfill - allows websites to show notifications via native macOS Notification Center
     /// https://app.asana.com/1/137249556945/project/414235014887631/task/1211395954816928?focus=true
     case webNotifications

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -1728,6 +1728,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 installDate: AppDelegate.firstLaunchDate,
                 persistor: persistor,
                 reinstallUserDetection: DefaultReinstallUserDetection(keyValueStore: keyValueStore),
+                isAppRelaunchingForUpdate: { [weak self] in
+                    self?.stateRestorationManager?.isRelaunchingAutomatically ?? false
+                },
+                isSystemQuitting: {
+                    NSAppleEventManager.shared().isQuittingForSystemEvent
+                },
+                resetRelaunchFlagOnCancel: { [weak self] in
+                    guard let stateRestorationManager = self?.stateRestorationManager,
+                          stateRestorationManager.isRelaunchingAutomatically else { return }
+                    stateRestorationManager.resetRelaunchFlag()
+                },
                 showQuitSurvey: { [weak self] in
                     guard let self else { return }
                     let presenter = QuitSurveyPresenter(windowControllersManager: self.windowControllersManager, persistor: persistor, featureFlagger: self.featureFlagger, historyCoordinating: self.historyCoordinator, faviconManaging: self.faviconManager)

--- a/macOS/DuckDuckGo/QuitSurvey/QuitSurveyDecider.swift
+++ b/macOS/DuckDuckGo/QuitSurvey/QuitSurveyDecider.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import Carbon.OpenScripting
 import Common
 import FeatureFlags
 import Foundation
@@ -38,10 +39,12 @@ protocol QuitSurveyDeciding {
 ///
 /// The quit survey is shown when ALL of the following conditions are met:
 /// 1. The feature flag is enabled
-/// 2. No other quit dialogs will be shown (auto-clear warning or active downloads)
-/// 3. User is within 0-3 days of first launch (new user)
-/// 4. This is the user's first quit
-/// 5. User is not reinstalling (reinstalling users are not considered new users)
+/// 2. The app is not relaunching to install an update
+/// 3. The system is not logging out, restarting, or shutting down
+/// 4. No other quit dialogs will be shown (auto-clear warning or active downloads)
+/// 5. User is within 0-3 days of first launch (new user)
+/// 6. This is the user's first quit
+/// 7. User is not reinstalling (reinstalling users are not considered new users)
 @MainActor
 final class QuitSurveyDecider: QuitSurveyDeciding {
 
@@ -58,6 +61,8 @@ final class QuitSurveyDecider: QuitSurveyDeciding {
     private let installDate: Date
     private var persistor: QuitSurveyPersistor
     private let reinstallUserDetection: ReinstallingUserDetecting
+    private let isAppRelaunchingForUpdate: @MainActor () -> Bool
+    private let isSystemQuitting: @MainActor () -> Bool
     private let dateProvider: () -> Date
 
     // MARK: - Initialization
@@ -69,6 +74,8 @@ final class QuitSurveyDecider: QuitSurveyDeciding {
         installDate: Date,
         persistor: QuitSurveyPersistor,
         reinstallUserDetection: ReinstallingUserDetecting,
+        isAppRelaunchingForUpdate: @escaping @MainActor () -> Bool = { false },
+        isSystemQuitting: @escaping @MainActor () -> Bool = { false },
         dateProvider: @escaping () -> Date = { Date() }
     ) {
         self.featureFlagger = featureFlagger
@@ -77,6 +84,8 @@ final class QuitSurveyDecider: QuitSurveyDeciding {
         self.installDate = installDate
         self.persistor = persistor
         self.reinstallUserDetection = reinstallUserDetection
+        self.isAppRelaunchingForUpdate = isAppRelaunchingForUpdate
+        self.isSystemQuitting = isSystemQuitting
         self.dateProvider = dateProvider
     }
 
@@ -89,24 +98,30 @@ final class QuitSurveyDecider: QuitSurveyDeciding {
         // Condition 1: Feature flag is enabled
         guard featureFlagger.isFeatureOn(.firstTimeQuitSurvey) else { return false }
 
+        // Conditions 2 & 3: Skip when termination wasn't initiated by the user explicitly
+        // quitting the app — a Sparkle update relaunch or a system logout/restart/shutdown.
+        if featureFlagger.isFeatureOn(.firstTimeQuitSurveySkipNonUserQuit) {
+            guard !isAppRelaunchingForUpdate(), !isSystemQuitting() else { return false }
+        }
+
         // Only for debugging purposes when the debug flag is turned on in the Debug menu.
         // Only works for internal users.
         if persistor.alwaysShowQuitSurvey {
             return true
         }
 
-        // Condition 2: No other quit dialogs will be shown
+        // Condition 4: No other quit dialogs will be shown
         let willShowAutoClearDialog = dataClearingPreferences.isAutoClearEnabled && dataClearingPreferences.isWarnBeforeClearingEnabled
         let willShowDownloadsDialog = downloadManager.downloads.contains { $0.state.isDownloading }
         let noOtherDialogsWillShow = !willShowAutoClearDialog && !willShowDownloadsDialog
 
-        // Condition 3: User is within 0-3 days of install
+        // Condition 5: User is within 0-3 days of install
         let isNewUser = isWithinNewUserThreshold
 
-        // Condition 4: First quit
+        // Condition 6: First quit
         let isFirstQuit = !persistor.hasQuitAppBefore
 
-        // Condition 5: User is not reinstalling (reinstalling users are not considered new users)
+        // Condition 7: User is not reinstalling (reinstalling users are not considered new users)
         let isNotReinstallingUser = !reinstallUserDetection.isReinstallingUser
 
         return noOtherDialogsWillShow
@@ -136,6 +151,15 @@ struct QuitSurveyAppTerminationDecider {
     let installDate: Date?
     let persistor: QuitSurveyPersistor
     let reinstallUserDetection: ReinstallingUserDetecting
+    /// `true` when Sparkle is relaunching the app to install an update.
+    let isAppRelaunchingForUpdate: @MainActor () -> Bool
+    /// `true` when the termination is part of a system logout, restart, or shutdown
+    /// (e.g., the user is restarting macOS for an OS update).
+    let isSystemQuitting: @MainActor () -> Bool
+    /// Resets the persisted "relaunching for update" flag — invoked when the
+    /// termination chain is cancelled, so a stale flag doesn't suppress the survey
+    /// on a later legitimate quit in the same session.
+    let resetRelaunchFlagOnCancel: @MainActor () -> Void
     let showQuitSurvey: @MainActor () async -> Void
 }
 
@@ -149,7 +173,9 @@ extension QuitSurveyAppTerminationDecider: ApplicationTerminationDecider {
             downloadManager: downloadManager,
             installDate: installDate ?? Date.distantPast,
             persistor: persistor,
-            reinstallUserDetection: reinstallUserDetection
+            reinstallUserDetection: reinstallUserDetection,
+            isAppRelaunchingForUpdate: isAppRelaunchingForUpdate,
+            isSystemQuitting: isSystemQuitting
         )
 
         guard decider.shouldShowQuitSurvey else {
@@ -164,6 +190,17 @@ extension QuitSurveyAppTerminationDecider: ApplicationTerminationDecider {
             // Survey completed - user chose to quit
             return .next
         })
+    }
+
+    func deciderSequenceCompleted(shouldProceed: Bool) {
+        // Reset the persisted relaunch flag when termination is cancelled.
+        // Why: this decider is at index 0 in the chain, so it's always notified —
+        // even when a later decider (e.g., active downloads) cancels termination
+        // before AutoClearHandler (which has its own reset) is reached. Without
+        // this, the persisted flag would survive the cancel and silently suppress
+        // the survey on the next legitimate quit in the same session.
+        guard !shouldProceed else { return }
+        resetRelaunchFlagOnCancel()
     }
 }
 
@@ -288,4 +325,33 @@ final class QuitSurveyUserDefaultsPersistor: QuitSurveyPersistor {
         }
     }
 
+}
+
+// MARK: - System Quit Detection
+
+extension NSAppleEventManager {
+    /// `true` when the current Apple Event indicates the app is terminating because
+    /// the system is logging out, restarting, or shutting down — for example, when
+    /// the user is restarting macOS to install an OS update.
+    ///
+    /// Only meaningful when called from inside `applicationShouldTerminate(_:)`
+    /// (i.e. while AppKit is dispatching the `kAEQuitApplication` Apple Event).
+    /// Outside that context `currentAppleEvent` is `nil` and this returns `false`.
+    var isQuittingForSystemEvent: Bool {
+        guard let descriptor = currentAppleEvent?.attributeDescriptor(forKeyword: AEKeyword(kAEQuitReason)) else {
+            return false
+        }
+        switch descriptor.enumCodeValue {
+        case kAEQuitAll,
+             kAELogOut,
+             kAEReallyLogOut,
+             kAEShowRestartDialog,
+             kAERestart,
+             kAEShowShutdownDialog,
+             kAEShutDown:
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -218,6 +218,10 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1204006570077678/task/1212242893241885?focus=true
     case firstTimeQuitSurvey
 
+    /// Suppresses the first-time quit survey when termination wasn't initiated by the user
+    /// (Sparkle update relaunch, or system logout/restart/shutdown).
+    case firstTimeQuitSurveySkipNonUserQuit
+
     /// Prioritize results where the domain matches the search query when searching passwords & autofill
     case autofillPasswordSearchPrioritizeDomain
 
@@ -530,6 +534,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.webNotifications)), category: .webNotifications)
         case .firstTimeQuitSurvey:
             Config(defaultValue: .enabled, source: .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.firstTimeQuitSurvey)))
+        case .firstTimeQuitSurveySkipNonUserQuit:
+            Config(defaultValue: .enabled, source: .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.firstTimeQuitSurveySkipNonUserQuit)))
         case .autofillPasswordSearchPrioritizeDomain:
             Config(defaultValue: .enabled, source: .remoteReleasable(.subfeature(AutofillSubfeature.autofillPasswordSearchPrioritizeDomain)))
         case .autofillPasswordsStatusBar:

--- a/macOS/UnitTests/QuitSurvey/QuitSurveyDeciderTests.swift
+++ b/macOS/UnitTests/QuitSurvey/QuitSurveyDeciderTests.swift
@@ -63,7 +63,7 @@ final class QuitSurveyDeciderTests: XCTestCase {
     override func setUp() {
         super.setUp()
         featureFlagger = MockFeatureFlagger()
-        featureFlagger.enabledFeatureFlags = [.firstTimeQuitSurvey]
+        featureFlagger.enabledFeatureFlags = [.firstTimeQuitSurvey, .firstTimeQuitSurveySkipNonUserQuit]
 
         dataClearingPersistor = MockFireButtonPreferencesPersistor()
         dataClearingPreferences = DataClearingPreferences(persistor: dataClearingPersistor)
@@ -89,7 +89,10 @@ final class QuitSurveyDeciderTests: XCTestCase {
         super.tearDown()
     }
 
-    private func createDecider() {
+    private func createDecider(
+        isAppRelaunchingForUpdate: @escaping () -> Bool = { false },
+        isSystemQuitting: @escaping () -> Bool = { false }
+    ) {
         decider = QuitSurveyDecider(
             featureFlagger: featureFlagger,
             dataClearingPreferences: dataClearingPreferences,
@@ -97,6 +100,8 @@ final class QuitSurveyDeciderTests: XCTestCase {
             installDate: installDate,
             persistor: persistor,
             reinstallUserDetection: reinstallUserDetection,
+            isAppRelaunchingForUpdate: isAppRelaunchingForUpdate,
+            isSystemQuitting: isSystemQuitting,
             dateProvider: { [unowned self] in self.currentDate }
         )
     }
@@ -272,6 +277,107 @@ final class QuitSurveyDeciderTests: XCTestCase {
         createDecider()
 
         XCTAssertFalse(decider.shouldShowQuitSurvey)
+    }
+
+    // MARK: - Update Relaunch / System Quit Bypass Tests
+
+    func testWhenAppIsRelaunchingForUpdateThenShouldNotShowSurvey() {
+        createDecider(isAppRelaunchingForUpdate: { true })
+
+        XCTAssertFalse(decider.shouldShowQuitSurvey)
+    }
+
+    func testWhenSystemIsQuittingThenShouldNotShowSurvey() {
+        createDecider(isSystemQuitting: { true })
+
+        XCTAssertFalse(decider.shouldShowQuitSurvey)
+    }
+
+    func testWhenSkipNonUserQuitFlagIsOffThenUpdateRelaunchDoesNotBypassSurvey() {
+        featureFlagger.enabledFeatureFlags = [.firstTimeQuitSurvey]
+        createDecider(isAppRelaunchingForUpdate: { true })
+
+        XCTAssertTrue(decider.shouldShowQuitSurvey)
+    }
+
+    func testWhenSkipNonUserQuitFlagIsOffThenSystemQuitDoesNotBypassSurvey() {
+        featureFlagger.enabledFeatureFlags = [.firstTimeQuitSurvey]
+        createDecider(isSystemQuitting: { true })
+
+        XCTAssertTrue(decider.shouldShowQuitSurvey)
+    }
+}
+
+// MARK: - QuitSurveyAppTerminationDecider Tests
+
+@MainActor
+final class QuitSurveyAppTerminationDeciderTests: XCTestCase {
+
+    private var featureFlagger: MockFeatureFlagger!
+    private var dataClearingPreferences: DataClearingPreferences!
+    private var dataClearingPersistor: MockFireButtonPreferencesPersistor!
+    private var downloadManager: FileDownloadManagerMock!
+    private var persistor: MockQuitSurveyPersistor!
+    private var reinstallUserDetection: MockReinstallingUserDetecting!
+
+    override func setUp() {
+        super.setUp()
+        featureFlagger = MockFeatureFlagger()
+        featureFlagger.enabledFeatureFlags = [.firstTimeQuitSurvey]
+        dataClearingPersistor = MockFireButtonPreferencesPersistor()
+        dataClearingPreferences = DataClearingPreferences(persistor: dataClearingPersistor)
+        downloadManager = FileDownloadManagerMock()
+        persistor = MockQuitSurveyPersistor()
+        reinstallUserDetection = MockReinstallingUserDetecting()
+    }
+
+    override func tearDown() {
+        featureFlagger = nil
+        dataClearingPreferences = nil
+        dataClearingPersistor = nil
+        downloadManager = nil
+        persistor = nil
+        reinstallUserDetection = nil
+        super.tearDown()
+    }
+
+    private func makeDecider(
+        resetRelaunchFlagOnCancel: @escaping @MainActor () -> Void
+    ) -> QuitSurveyAppTerminationDecider {
+        QuitSurveyAppTerminationDecider(
+            featureFlagger: featureFlagger,
+            dataClearingPreferences: dataClearingPreferences,
+            downloadManager: downloadManager,
+            installDate: Date(),
+            persistor: persistor,
+            reinstallUserDetection: reinstallUserDetection,
+            isAppRelaunchingForUpdate: { false },
+            isSystemQuitting: { false },
+            resetRelaunchFlagOnCancel: resetRelaunchFlagOnCancel,
+            showQuitSurvey: {}
+        )
+    }
+
+    // MARK: - resetRelaunchFlagOnCancel
+
+    func testWhenTerminationIsCancelledThenResetRelaunchFlagOnCancelIsCalled() {
+        var resetCalled = false
+        let decider = makeDecider(resetRelaunchFlagOnCancel: { resetCalled = true })
+
+        decider.deciderSequenceCompleted(shouldProceed: false)
+
+        XCTAssertTrue(resetCalled,
+                      "Cancellation must reset the persisted relaunch flag so a stale flag doesn't suppress the survey on a later legit quit")
+    }
+
+    func testWhenTerminationProceedsThenResetRelaunchFlagOnCancelIsNotCalled() {
+        var resetCalled = false
+        let decider = makeDecider(resetRelaunchFlagOnCancel: { resetCalled = true })
+
+        decider.deciderSequenceCompleted(shouldProceed: true)
+
+        XCTAssertFalse(resetCalled,
+                       "On a successful termination the flag must survive across the process boundary so applicationDidFinishLaunching can use it for tab restoration")
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1213985848142870?focus=true
Tech Design URL:
CC:

### Description

Suppresses the first-time quit survey when termination wasn't initiated by the user explicitly quitting the app — specifically:

- **Sparkle update relaunch** — when the app is restarting itself to install an update, detected via `StateRestorationManager.isRelaunchingAutomatically`.
- **System logout / restart / shutdown** — detected by inspecting the `kAEQuitReason` attribute on the current Apple Event (`kAELogOut`, `kAEReallyLogOut`, `kAEShowRestartDialog`, `kAERestart`, `kAEShowShutdownDialog`, `kAEShutDown`, `kAEQuitAll`).

In both cases the user didn't choose to quit, so prompting them with "why are you quitting?" is wrong and pollutes the survey data.

Wired through two new closures on `QuitSurveyDecider` / `QuitSurveyAppTerminationDecider` (`isAppRelaunchingForUpdate`, `isSystemQuitting`), plus a `resetRelaunchFlagOnCancel` callback used to clear the persisted Sparkle relaunch flag when the termination chain is cancelled by a later decider — without it, a stale flag could silently suppress the survey on the next legitimate quit in the same session.

Gated behind a new macOS feature flag `firstTimeQuitSurveySkipNonUserQuit` (remote-releasable, default `.enabled`), so the bypass can be remotely disabled if it misbehaves.

### Testing Steps

> Prereq: be a "new user" (install date within 0–3 days) on a build where `firstTimeQuitSurvey` is enabled. Easiest path: run the `clean-app.sh debug` inside the macOS folder.

1. **Baseline — user-initiated quit**: with the feature flag on, ⌘Q the app as a new user → first-time quit survey appears. (sanity check)
2. **System restart bypass**: with the app running, choose Apple menu → Restart… → confirm. The app should terminate without showing the survey. (Equivalent: Log Out / Shut Down.)
3. **Update relaunch bypass**: trigger a Sparkle update install (or simulate via the updater debug menu so the app relaunches itself) → survey should NOT appear.
4. **Feature flag off**: disable `firstTimeQuitSurveySkipNonUserQuit` via the internal feature-flag debug menu (or set it to disabled in privacy config), then repeat step 2 or 3 → survey SHOULD appear (proves the gating works).
5. **Cancelled-termination reset**: with an active download running and Sparkle in the middle of an update relaunch, the downloads dialog should appear → click Cancel. Then quit normally with no download. Survey should still appear on this second quit (proves `resetRelaunchFlagOnCancel` clears the stale relaunch flag).

### Impact and Risks

**Low.** This only changes whether a survey dialog is shown in two non-user-initiated termination paths. Worst case if the detection misfires:

- **False negative** (we wrongly think it's a non-user quit): a legitimate first-time quitter doesn't see the survey — we lose one data point, no user-facing harm.
- **False positive** (we wrongly think it's a user quit): survey shows during shutdown/restart — user sees a brief dialog they can ignore as the system tears down. Same behavior as before this PR.

No data loss, no privacy regression (no new data collected), no change to core browsing or quit behavior.

#### What could go wrong?

- **Apple Event reason detection misses an edge case** — e.g., a future macOS adds a new system-quit reason we don't enum-match. **Mitigation**: falls back to the existing behavior (survey shows); also the feature flag lets us disable the bypass entirely.
- **Sparkle `isRelaunchingAutomatically` not set in time** — if Sparkle's relaunch path doesn't set the flag before `applicationShouldTerminate` runs, the bypass won't trigger. **Mitigation**: this is the same flag tab-restoration already relies on, so any regression there would surface in restoration tests too.
- **Stale relaunch flag suppressing a later quit** — the cancellation-reset closure is explicitly there to prevent this. The `QuitSurveyAppTerminationDecider` sits at index 0 of the decider chain, so its `deciderSequenceCompleted` always fires even when a later decider cancels; this is tested.
- **Carbon `OpenScripting` deprecation** — `kAEQuitReason`, `kAELogOut`, etc. live in Carbon, which Apple has long signalled they'd like to deprecate. **Mitigation**: still fully supported in current macOS SDKs; if removed in a future SDK, the build break is loud and obvious.

### Quality Considerations

- **Edge cases**: cancelled termination chains (handled), repeated quits in the same session (handled by the reset), feature flag off (handled by gating).
- **Performance**: zero hot-path impact — the new checks only run inside `applicationShouldTerminate`.
- **Monitoring**: none added. The existing first-time-quit-survey pixels naturally measure the change — if the bypass misfires we'll see survey-shown counts move on macOS-restart days; if the bypass works, we'll see fewer surveys per install (the desired effect).
- **Privacy/security**: no new data collected. Apple Event inspection is local and synchronous.

### Notes to Reviewer

- The `isQuittingForSystemEvent` extension on `NSAppleEventManager` is only meaningful inside `applicationShouldTerminate(_:)` (when AppKit is dispatching the `kAEQuitApplication` Apple Event). I noted this in the doc comment.
- Step 5 (cancelled-termination reset) is the subtlest scenario — please pay attention to the `deciderSequenceCompleted` reset and the unit tests for it.
- The feature flag is wired remote-releasable with `defaultValue: .enabled`. If you'd prefer `.internalOnly` for staged rollout, easy switch in `FeatureFlag.swift`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the conditions for showing the first-time quit survey during app termination, gated behind a new feature flag, with added unit coverage; no browsing, security, or data-handling logic is modified.
> 
> **Overview**
> Prevents the **first-time quit survey** from showing when the app is terminating due to a *non-user-initiated quit* (Sparkle update relaunch or system logout/restart/shutdown), gated behind a new `firstTimeQuitSurveySkipNonUserQuit` flag (remote-releasable, default enabled).
> 
> Wires new termination-context signals into `QuitSurveyDecider`/`QuitSurveyAppTerminationDecider` from `AppDelegate`, adds AppleEvent-based system-quit detection via `NSAppleEventManager.isQuittingForSystemEvent`, and resets the update-relaunch flag when the termination decider chain is cancelled to avoid suppressing a later legitimate quit.
> 
> Updates privacy/feature flag enums to include the new flag and adds unit tests covering the bypass and cancellation-reset behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2430e85587c017e39088bb913f2935978351060f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->