### PR TITLE
Fix dataNotInDatabase when opting out in PIR debugging tool

### DIFF
--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/Debug/DataBrokerRunCustomJSONViewModel.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/Debug/DataBrokerRunCustomJSONViewModel.swift
@@ -391,7 +391,7 @@ final class DataBrokerRunCustomJSONViewModel: ObservableObject {
         let dataBroker: DataBroker
         if let data = jsonString.data(using: .utf8),
            let decoded = try? JSONDecoder().decode(DataBroker.self, from: data) {
-            dataBroker = decoded
+            dataBroker = decoded.with(id: DebugHelper.stableId(for: decoded))
         } else {
             dataBroker = scanResult.dataBroker
         }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214793341452819?focus=true
Tech Design URL:
CC:

### Description

Fixes dataNotInDatabase error stopping PIR debugging tool from opting out

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Smoke test PIR debugging tools
2.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized to the macOS PIR debugging opt-out flow and only adjusts how the `DataBroker` id is set when using edited JSON. Main risk is unintended id mismatch affecting debug opt-out behavior, not production user flows.
> 
> **Overview**
> Fixes the PIR macOS debugging tool’s opt-out path to assign a stable id to `DataBroker` instances re-decoded from the custom JSON editor (via `decoded.with(id: DebugHelper.stableId(for: decoded))`).
> 
> This keeps the broker identity consistent with scan/DB expectations during opt-out and avoids `dataNotInDatabase` errors when the broker JSON is edited without re-scanning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3e673887f35f41c40f1ba7419ea48616fc745bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->