### PR TITLE
[iOS][Custom Product Page] Add Pixel to measure how many users coming from Duck.ai CPP are presented with Duck.ai chat

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -252,6 +252,9 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
 
     /// https://app.asana.com/1/137249556945/project/715106103902962/task/1212810377867736
     case filterAddressBarUpdates
+
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214797978179697?focus=true
+    case customProductPageDuckAiChat
 }
 
 public enum TabManagerSubfeature: String, PrivacySubfeature {

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -394,6 +394,9 @@ public enum FeatureFlag: String {
     /// Failsafe feature flag. Filters intermediate redirect URLs from the address bar.
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213972422695959
     case filterAddressBarUpdates
+
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214797978179697?focus=true
+    case customProductPageDuckAiChat
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
@@ -689,6 +692,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(.subfeature(AIChatSubfeature.nativeDataAccess)))
         case .filterAddressBarUpdates:
             Config(defaultValue: .enabled, source: .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.filterAddressBarUpdates)))
+        case .customProductPageDuckAiChat:
+            Config(defaultValue: .enabled, source: .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.customProductPageDuckAiChat)), supportsLocalOverriding: true)
         }
     }
 

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1859,6 +1859,9 @@ extension Pixel {
         case linkLongPressNewTab
         case linkLongPressBackgroundTab
         case linkLongPressFireTab
+
+        // MARK: - Custom Product Page
+        case customProductPageDuckAIOpenedAIChat
     }
 
 }
@@ -3644,6 +3647,8 @@ extension Pixel.Event {
         case .linkLongPressBackgroundTab: return "m_link-long-press_background-tab"
         case .linkLongPressFireTab: return "m_link-long-press_fire-tab"
 
+        // MARK: - Custom Product Page
+        case .customProductPageDuckAIOpenedAIChat: return "m_custom-product-page_duck-ai_opened-ai-chat"
         }
     }
 }

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1594,6 +1594,11 @@
 		9FBE93BC2EB040F5003E74FB /* ShareAction+UIActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FBE93BB2EB040F5003E74FB /* ShareAction+UIActivity.swift */; };
 		9FC555D12E2F4AFC00763BEC /* default-browser-tutorial.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 9FC555CF2E2F4AFC00763BEC /* default-browser-tutorial.mp4 */; };
 		9FC555D32E2F4B4100763BEC /* DefaultBrowserPiPTutorialURLProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FC555D22E2F4B4100763BEC /* DefaultBrowserPiPTutorialURLProvider.swift */; };
+		9FCCC09F2FB59F16001F2670 /* DuckAIDestinationHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCCC09E2FB59F16001F2670 /* DuckAIDestinationHandlerTests.swift */; };
+		9FCCC0A12FB59FF3001F2670 /* MockAIChatDeepLinkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCCC0A02FB59FEC001F2670 /* MockAIChatDeepLinkHandler.swift */; };
+		9FCCC0A22FB59FF3001F2670 /* MockAIChatDeepLinkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCCC0A02FB59FEC001F2670 /* MockAIChatDeepLinkHandler.swift */; };
+		9FCCC0A32FB59FF3001F2670 /* MockAIChatDeepLinkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCCC0A02FB59FEC001F2670 /* MockAIChatDeepLinkHandler.swift */; };
+		9FCCC0A42FB59FF3001F2670 /* MockAIChatDeepLinkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCCC0A02FB59FEC001F2670 /* MockAIChatDeepLinkHandler.swift */; };
 		9FCFCD802C6AF56D006EB7A0 /* LaunchOptionsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCFCD7F2C6AF56D006EB7A0 /* LaunchOptionsHandlerTests.swift */; };
 		9FCFCD812C6B020D006EB7A0 /* LaunchOptionsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCFCD7D2C6AF52A006EB7A0 /* LaunchOptionsHandler.swift */; };
 		9FCFCD852C75C91A006EB7A0 /* ProgressBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCFCD842C75C91A006EB7A0 /* ProgressBarView.swift */; };
@@ -4202,6 +4207,8 @@
 		9FC555CD2E2F4AFC00763BEC /* nl */ = {isa = PBXFileReference; lastKnownFileType = file; name = nl; path = "nl.lproj/default-browser-tutorial.mp4"; sourceTree = "<group>"; };
 		9FC555CE2E2F4AFC00763BEC /* pt */ = {isa = PBXFileReference; lastKnownFileType = file; name = pt; path = "pt.lproj/default-browser-tutorial.mp4"; sourceTree = "<group>"; };
 		9FC555D22E2F4B4100763BEC /* DefaultBrowserPiPTutorialURLProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserPiPTutorialURLProvider.swift; sourceTree = "<group>"; };
+		9FCCC09E2FB59F16001F2670 /* DuckAIDestinationHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAIDestinationHandlerTests.swift; sourceTree = "<group>"; };
+		9FCCC0A02FB59FEC001F2670 /* MockAIChatDeepLinkHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAIChatDeepLinkHandler.swift; sourceTree = "<group>"; };
 		9FCFCD7D2C6AF52A006EB7A0 /* LaunchOptionsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LaunchOptionsHandler.swift; path = ../DuckDuckGo/LaunchOptionsHandler.swift; sourceTree = "<group>"; };
 		9FCFCD7F2C6AF56D006EB7A0 /* LaunchOptionsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchOptionsHandlerTests.swift; sourceTree = "<group>"; };
 		9FCFCD842C75C91A006EB7A0 /* ProgressBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBarView.swift; sourceTree = "<group>"; };
@@ -8186,6 +8193,7 @@
 			children = (
 				9F3038ED2F99C2460007310C /* CustomProductPageEvaluatorTests.swift */,
 				9F3038EF2F99C2550007310C /* CustomProductPageDeepLinkHandlerTests.swift */,
+				9FCCC09E2FB59F16001F2670 /* DuckAIDestinationHandlerTests.swift */,
 			);
 			path = CustomProductPage;
 			sourceTree = "<group>";
@@ -8313,6 +8321,7 @@
 		9F6454252F99CB6800D5FB71 /* CustomProductPage */ = {
 			isa = PBXGroup;
 			children = (
+				9FCCC0A02FB59FEC001F2670 /* MockAIChatDeepLinkHandler.swift */,
 				9F6454302F99D04C00D5FB71 /* MockAppStoreCustomProductPagePresenter.swift */,
 				9F64542B2F99CB8600D5FB71 /* MockCustomProductPageDestinationHandler.swift */,
 				9F6454262F99CB7600D5FB71 /* MockCustomProductPageEvaluator.swift */,
@@ -13530,6 +13539,7 @@
 				CB3B4D542D648C44006DAD63 /* AuthenticationServiceTests.swift in Sources */,
 				8565A34D1FC8DFE400239327 /* LaunchTabNotificationTests.swift in Sources */,
 				BB1D99D92EB9F3710050D8CF /* MockWinBackOfferPresenter.swift in Sources */,
+				9FCCC09F2FB59F16001F2670 /* DuckAIDestinationHandlerTests.swift in Sources */,
 				9FA0AF1A2EB4855000713387 /* MockRemoteMessagingPixelReporter.swift in Sources */,
 				9F6454272F99CB8200D5FB71 /* MockCustomProductPageEvaluator.swift in Sources */,
 				4B62C4BA25B930DD008912C6 /* AppConfigurationFetchTests.swift in Sources */,
@@ -13568,6 +13578,7 @@
 				98E564BD2DE8F34E00E6E75F /* TimeTraveller.swift in Sources */,
 				98E564BE2DE8F34E00E6E75F /* MaliciousSiteProtectionMocks.swift in Sources */,
 				8341D807212D5E8D000514C2 /* HashExtensionTest.swift in Sources */,
+				9FCCC0A22FB59FF3001F2670 /* MockAIChatDeepLinkHandler.swift in Sources */,
 				C1D21E2F293A599C006E5A05 /* AutofillLoginSessionTests.swift in Sources */,
 				85D2187924BF6B8B004373D2 /* FaviconSourcesProviderTests.swift in Sources */,
 				9F1798572CD2443F0073018B /* AddToDockPromoViewModelTests.swift in Sources */,
@@ -13916,6 +13927,7 @@
 				986CD53D2DE8FA1400AFA98A /* ConfigurationMocks.swift in Sources */,
 				98E564202DE8B32D00E6E75F /* MockOmniBar.swift in Sources */,
 				98E564212DE8B32D00E6E75F /* MockUsageSegmentation.swift in Sources */,
+				9FCCC0A12FB59FF3001F2670 /* MockAIChatDeepLinkHandler.swift in Sources */,
 				986CD54C2DE9139400AFA98A /* HomePageMessagesConfigurationMock.swift in Sources */,
 				80C947FF2F53E819002EDB79 /* Tab+ConvenienceInitializer.swift in Sources */,
 				9F387E0E2EA9A30B006861F8 /* MockNewAddressBarPickerStorage.swift in Sources */,
@@ -14104,6 +14116,7 @@
 				98E563E02DE8B32D00E6E75F /* OnboardingPixelReporterMock.swift in Sources */,
 				9FAB4B792E98C98300D8298A /* MockRemoteMessagingActionHandler.swift in Sources */,
 				9F434CAF2EE933D5009027AE /* MockWhatsNewMessageRepository.swift in Sources */,
+				9FCCC0A32FB59FF3001F2670 /* MockAIChatDeepLinkHandler.swift in Sources */,
 				98E563E12DE8B32D00E6E75F /* ContextualOnboardingPresenterMock.swift in Sources */,
 				98E564A52DE8EDE200E6E75F /* CapturingAlertPresenter.swift in Sources */,
 				98E564352DE8B64300E6E75F /* HistoryMocks.swift in Sources */,
@@ -14231,6 +14244,7 @@
 				98E564A12DE8EDCE00E6E75F /* CapturingSyncPausedStateManager.swift in Sources */,
 				98E564702DE8DDDC00E6E75F /* HistoryMocks.swift in Sources */,
 				BBFF22F02F3469160055A710 /* MockFreeTrialConversionInstrumentationService.swift in Sources */,
+				9FCCC0A42FB59FF3001F2670 /* MockAIChatDeepLinkHandler.swift in Sources */,
 				36F2CA5B2E60589600C7039D /* MockUNUserNotificationCenter.swift in Sources */,
 				9F387DED2EA895DD006861F8 /* MockModalPromptPresenter.swift in Sources */,
 				98E564712DE8DDDC00E6E75F /* MockFaviconStore.swift in Sources */,

--- a/iOS/DuckDuckGo/CustomProductPage/CustomProductPageDeepLinkHandler+DuckAI.swift
+++ b/iOS/DuckDuckGo/CustomProductPage/CustomProductPageDeepLinkHandler+DuckAI.swift
@@ -20,6 +20,7 @@
 import Foundation
 import AIChat
 import Core
+import PrivacyConfig
 
 protocol AIChatDeepLinkHandling {
     func handleDeepLink(_ url: URL, on presenter: AIChatDeepLinkPresenting, voiceMode: Bool)
@@ -37,16 +38,21 @@ extension AIChatDeepLinkHandler: AIChatDeepLinkHandling {}
 struct DuckAIDestinationHandler: CustomProductPageDestinationHandling {
     private let aiChatDeepLinkHandler: AIChatDeepLinkHandling
     private let pixelFiring: DailyPixelFiring.Type
+    private let featureFlagger: FeatureFlagger
 
     init(
         aiChatDeepLinkHandler: AIChatDeepLinkHandling = AIChatDeepLinkHandler(),
-        pixelFiring: DailyPixelFiring.Type = DailyPixel.self
+        pixelFiring: DailyPixelFiring.Type = DailyPixel.self,
+        featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger
     ) {
         self.aiChatDeepLinkHandler = aiChatDeepLinkHandler
         self.pixelFiring = pixelFiring
+        self.featureFlagger = featureFlagger
     }
 
     func handle(url: URL, on presenter: AppStoreCustomProductPagePresenter) {
+        guard featureFlagger.isFeatureOn(.customProductPageDuckAiChat) else { return }
+        
         pixelFiring.fireDailyAndCount(.customProductPageDuckAIOpenedAIChat, error: nil, withAdditionalParameters: [:])
         aiChatDeepLinkHandler.handleDeepLink(url, on: presenter)
     }

--- a/iOS/DuckDuckGo/CustomProductPage/CustomProductPageDeepLinkHandler+DuckAI.swift
+++ b/iOS/DuckDuckGo/CustomProductPage/CustomProductPageDeepLinkHandler+DuckAI.swift
@@ -19,6 +19,7 @@
 
 import Foundation
 import AIChat
+import Core
 
 protocol AIChatDeepLinkHandling {
     func handleDeepLink(_ url: URL, on presenter: AIChatDeepLinkPresenting, voiceMode: Bool)
@@ -35,12 +36,18 @@ extension AIChatDeepLinkHandler: AIChatDeepLinkHandling {}
 /// Wrapper for AI Chat deep link handler
 struct DuckAIDestinationHandler: CustomProductPageDestinationHandling {
     private let aiChatDeepLinkHandler: AIChatDeepLinkHandling
+    private let pixelFiring: DailyPixelFiring.Type
 
-    init(aiChatDeepLinkHandler: AIChatDeepLinkHandling = AIChatDeepLinkHandler()) {
+    init(
+        aiChatDeepLinkHandler: AIChatDeepLinkHandling = AIChatDeepLinkHandler(),
+        pixelFiring: DailyPixelFiring.Type = DailyPixel.self
+    ) {
         self.aiChatDeepLinkHandler = aiChatDeepLinkHandler
+        self.pixelFiring = pixelFiring
     }
 
     func handle(url: URL, on presenter: AppStoreCustomProductPagePresenter) {
+        pixelFiring.fireDailyAndCount(.customProductPageDuckAIOpenedAIChat, error: nil, withAdditionalParameters: [:])
         aiChatDeepLinkHandler.handleDeepLink(url, on: presenter)
     }
 }

--- a/iOS/DuckDuckGo/CustomProductPage/CustomProductPageDeepLinkHandler.swift
+++ b/iOS/DuckDuckGo/CustomProductPage/CustomProductPageDeepLinkHandler.swift
@@ -40,10 +40,11 @@ struct AppStoreCustomProductPageDeepLinkHandler {
 
     init(
         handlers: [AppStoreCustomProductPage: CustomProductPageDestinationHandling] = [.duckAI: DuckAIDestinationHandler()],
-        customProductPageEvaluator: AppStoreCustomProductPageEvaluating = AppStoreCustomProductPageEvaluator()) {
-            self.handlers = handlers
-            self.customProductPageEvaluator = customProductPageEvaluator
-        }
+        customProductPageEvaluator: AppStoreCustomProductPageEvaluating = AppStoreCustomProductPageEvaluator())
+    {
+        self.handlers = handlers
+        self.customProductPageEvaluator = customProductPageEvaluator
+    }
 
     /// Handles a Custom Product Page deep link by routing to the appropriate feature.
     /// - Parameters:

--- a/iOS/DuckDuckGoTests/CustomProductPage/DuckAIDestinationHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/CustomProductPage/DuckAIDestinationHandlerTests.swift
@@ -1,0 +1,104 @@
+//
+//  DuckAIDestinationHandlerTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Testing
+import AIChat
+import Core
+@testable import DuckDuckGo
+
+@MainActor
+@Suite("Custom Product Page - Duck AI Destination Handler")
+struct DuckAIDestinationHandlerTests {
+    let mockAIChatDeepLinkHandler: MockAIChatDeepLinkHandler
+    let mockPresenter: MockAppStoreCustomProductPagePresenter
+    let mockFeatureFlagger: MockFeatureFlagger
+    let sut: DuckAIDestinationHandler
+
+    init() {
+        PixelFiringMock.tearDown()
+        mockAIChatDeepLinkHandler = MockAIChatDeepLinkHandler()
+        mockPresenter = MockAppStoreCustomProductPagePresenter()
+        mockFeatureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.customProductPageDuckAiChat])
+        sut = DuckAIDestinationHandler(
+            aiChatDeepLinkHandler: mockAIChatDeepLinkHandler,
+            pixelFiring: PixelFiringMock.self,
+            featureFlagger: mockFeatureFlagger
+        )
+    }
+
+    // MARK: - Feature Flag Enabled
+
+    @Test("Forwards URL and presenter to the AI Chat deep link handler when feature flag is enabled")
+    func forwardsURLAndPresenterToAIChatDeepLinkHandler() throws {
+        // GIVEN
+        let url = try #require(URL(string: "ddgCPP://duckAI"))
+
+        // WHEN
+        sut.handle(url: url, on: mockPresenter)
+
+        // THEN
+        #expect(mockAIChatDeepLinkHandler.didHandleDeepLinkCalled)
+        #expect(mockAIChatDeepLinkHandler.capturedURL == url)
+        #expect(mockAIChatDeepLinkHandler.capturedPresenter === mockPresenter)
+        #expect(mockAIChatDeepLinkHandler.capturedVoiceMode == false)
+    }
+
+    @Test("Fires the opened AI Chat daily pixel when feature flag is enabled")
+    func firesOpenedAIChatDailyPixel() throws {
+        // GIVEN
+        let url = try #require(URL(string: "ddgCPP://duckAI"))
+
+        // WHEN
+        sut.handle(url: url, on: mockPresenter)
+
+        // THEN
+        #expect(PixelFiringMock.lastDailyPixelInfo?.pixelName == Pixel.Event.customProductPageDuckAIOpenedAIChat.name)
+        #expect(PixelFiringMock.lastDailyPixelInfo?.params?.isEmpty == true)
+        #expect(PixelFiringMock.lastDailyPixelInfo?.error == nil)
+    }
+
+    // MARK: - Feature Flag Disabled
+
+    @Test("Does not forward to the AI Chat deep link handler when feature flag is disabled")
+    func doesNotForwardWhenFeatureFlagDisabled() throws {
+        // GIVEN
+        mockFeatureFlagger.enabledFeatureFlags = []
+        let url = try #require(URL(string: "ddgCPP://duckAI"))
+
+        // WHEN
+        sut.handle(url: url, on: mockPresenter)
+
+        // THEN
+        #expect(!mockAIChatDeepLinkHandler.didHandleDeepLinkCalled)
+    }
+
+    @Test("Does not fire the pixel when feature flag is disabled")
+    func doesNotFirePixelWhenFeatureFlagDisabled() throws {
+        // GIVEN
+        mockFeatureFlagger.enabledFeatureFlags = []
+        let url = try #require(URL(string: "ddgCPP://duckAI"))
+
+        // WHEN
+        sut.handle(url: url, on: mockPresenter)
+
+        // THEN
+        #expect(PixelFiringMock.lastDailyPixelInfo == nil)
+    }
+}

--- a/iOS/PixelDefinitions/pixels/definitions/cpp_duck-ai.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/cpp_duck-ai.json5
@@ -1,0 +1,9 @@
+{
+    "m_custom-product-page_duck-ai_opened-ai-chat": {
+        "description": "Fired when the user opens AI Chat from the custom product page",
+        "owners": ["alessandroboron"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    }
+}

--- a/iOS/SharedTestUtils/Mocks/CustomProductPage/MockAIChatDeepLinkHandler.swift
+++ b/iOS/SharedTestUtils/Mocks/CustomProductPage/MockAIChatDeepLinkHandler.swift
@@ -1,0 +1,35 @@
+//
+//  MockAIChatDeepLinkHandler.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+@testable import DuckDuckGo
+
+final class MockAIChatDeepLinkHandler: AIChatDeepLinkHandling {
+    private(set) var didHandleDeepLinkCalled = false
+    private(set) var capturedURL: URL?
+    private(set) var capturedPresenter: AIChatDeepLinkPresenting?
+    private(set) var capturedVoiceMode: Bool?
+
+    func handleDeepLink(_ url: URL, on presenter: AIChatDeepLinkPresenting, voiceMode: Bool) {
+        didHandleDeepLinkCalled = true
+        capturedURL = url
+        capturedPresenter = presenter
+        capturedVoiceMode = voiceMode
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214518492561419
Tech Design URL:
CC:

### Description

Users who open the app via Custom Product Page who already completed the onboarding flow will be prompted with Duck.ai web page. This PR adds:
- Instrumentation to measure how many users coming from Duck.ai CPP are presented with Duck.ai chat.
- Add a feature flag as safety net to disable opening AI chat if something goes wrong. 

### Testing Steps
1. In Notes app, create a new note with `ddgCPP://duckAI URL`.
2. Edit iOS Browser Alpha Scheme -> Run -> Info -> Launch and select “Wait for the executable to be launched” (if Xcode has issues attaching the debugger you can always lunch the app without the debugger attached.)
3. Ensure app is installed and onboarding has been completed.
4. Terminate the app.
5. Open Notes and tap on `ddgCPP://duckAI`
6. Expected: App opens, Duck.ai web page is shown and pixel "m_custom-product-page_duck-ai_opened-ai-chat” fires.

If debugger cannot be attached when setting “Wait for the executable to be launched”. Install the app open Console.app and check that `m.custom-product-page.duck-ai.opened-ai-chat.count` is fired


### Impact and Risks
Low: Added a pixel for instrumentation and a feature flag as a safety net.

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Low Risk**
> Low risk: adds a new feature flag and a daily-count pixel around an existing custom product page deep-link flow, with unit tests covering enabled/disabled behavior.
> 
> **Overview**
> Adds a new `customProductPageDuckAiChat` remote-config subfeature/feature-flag (default **enabled**, locally overridable) to gate the Duck.ai Custom Product Page deep-link destination.
> 
> When handling `ddgCPP://duckAI`, `DuckAIDestinationHandler` now **early-exits if the flag is off** and otherwise fires a new daily-count pixel `m_custom-product-page_duck-ai_opened-ai-chat` before forwarding to the AI Chat deep-link handler.
> 
> Includes the pixel definition JSON plus new unit tests and mocks wired into the Xcode project to verify forwarding/pixel firing only when the flag is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfb19a64c754a568af1df5771c4725c635451b36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>