### PR TITLE
macOS: Revert DuckPlayerTests changes from  #4671

### DIFF
--- a/macOS/UITests/DuckPlayerTests.swift
+++ b/macOS/UITests/DuckPlayerTests.swift
@@ -71,41 +71,23 @@ class DuckPlayerTests: UITestCase {
         let scrollView = app.scrollViews.element(boundBy: 0)
         scrollView.swipeUp()
 
-        // When `adBlockingExtension` is enabled the standalone Duck Player
-        // sidebar entry is replaced by YouTube Ad Blocking, which embeds the
-        // Duck Player controls in its pane.
-        let youTubeAdBlockingButton = app.buttons["PreferencesSidebar.youTubeAdBlockingButton"]
-        youTubeAdBlockingButton.click()
-    }
-
-    private func setDuckPlayerEnableToggle(on: Bool) {
-        let toggle = app.checkBoxes["DuckPlayer.enableToggle"]
-        XCTAssertTrue(toggle.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        if (toggle.value as? Bool) != on {
-            toggle.click()
-        }
-    }
-
-    private func setDuckPlayerAlwaysOpenToggle(on: Bool) {
-        let toggle = app.checkBoxes["DuckPlayer.alwaysOpenToggle"]
-        XCTAssertTrue(toggle.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        if (toggle.value as? Bool) != on {
-            toggle.click()
-        }
+        let duckPlayerButton = app.buttons["PreferencesSidebar.duckplayerButton"]
+        duckPlayerButton.click()
     }
 
     private func selectAlwaysOpenInDuckPlayer() {
-        setDuckPlayerEnableToggle(on: true)
-        setDuckPlayerAlwaysOpenToggle(on: true)
+        let alwaysOpenRadioButton = app.radioButtons["DuckPlayerMode.enabled"]
+        alwaysOpenRadioButton.click()
     }
 
     private func selectNeverOpenInDuckPlayer() {
-        setDuckPlayerEnableToggle(on: false)
+        let alwaysOpenRadioButton = app.radioButtons["DuckPlayerMode.disabled"]
+        alwaysOpenRadioButton.click()
     }
 
     private func selectAskOpenInDuckPlayer() {
-        setDuckPlayerEnableToggle(on: true)
-        setDuckPlayerAlwaysOpenToggle(on: false)
+        let alwaysOpenRadioButton = app.radioButtons["DuckPlayerMode.alwaysAsk"]
+        alwaysOpenRadioButton.click()
     }
 
     private func verifyDuckPlayerLoads() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212951208799468/task/1214803984223222?focus=true

### Description

Reverts the `DuckPlayerTests` helpers introduced in #4671 (YouTube Ad Blocking analytics opt-in) so they match the `adBlockingExtension: false` flag added to `setUpWithError` by the release fix in #4734. Those two PRs landed without being reconciled: setUp force-disables `adBlockingExtension`, but the helpers query elements (`PreferencesSidebar.youTubeAdBlockingButton`, `DuckPlayer.enableToggle`, `DuckPlayer.alwaysOpenToggle`) that only exist when the flag is on. This restores the original sidebar button + `DuckPlayerMode.*` radio buttons so the tests run against the standalone Duck Player preferences UI again.

### Testing Steps

1. Check out this branch.
2. Run the `macOS UI Tests CI` scheme, scoped to `UI Tests/DuckPlayerTests` (or trigger the `macOS - UI Tests` GitHub Actions workflow on this branch).
3. Confirm the `DuckPlayerTests` cases pass on macOS 15 and macOS 26 runners.

### Impact and Risks

**Low.** Test-only change, no product code touched. Restores helpers to a state that already shipped on `main` until #4671 landed, against a setUp configuration (`adBlockingExtension: false`) that exercises the same standalone Duck Player UI as before. Worst case is the tests still fail for an unrelated reason, in which case CI surfaces it.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this is a test-only change that only updates UI element selectors/helpers; the main risk is continued UITest flakiness if the preferences UI identifiers change again.
> 
> **Overview**
> Reverts `DuckPlayerTests` helper logic to open the Duck Player preferences via `PreferencesSidebar.duckplayerButton` and set mode using `DuckPlayerMode.enabled/disabled/alwaysAsk` radio buttons.
> 
> Removes the newer helpers that navigated through the YouTube Ad Blocking preferences pane and toggled `DuckPlayer.enableToggle`/`DuckPlayer.alwaysOpenToggle`, aligning the tests with `adBlockingExtension: false` setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdc6c33d3284abdf6301fd53c5d0cf25b2722c4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->