### PR TITLE
Fix model picker and tools visibility on Duck.ai

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIModelStore.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIModelStore.swift
@@ -86,6 +86,10 @@ final class UTIModelStore {
         return models.first(where: { $0.id == persistedModelId })?.supportsTool(tool) ?? false
     }
 
+    var selectedModelSupportsAnyTool: Bool {
+        selectedModelSupports(tool: .imageGeneration) || selectedModelSupports(tool: .webSearch)
+    }
+
     private var firstAccessibleModelId: String? {
         models.first(where: { $0.entityHasAccess })?.id
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIModelStore.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIModelStore.swift
@@ -86,10 +86,6 @@ final class UTIModelStore {
         return models.first(where: { $0.id == persistedModelId })?.supportsTool(tool) ?? false
     }
 
-    var selectedModelSupportsAnyTool: Bool {
-        selectedModelSupports(tool: .imageGeneration) || selectedModelSupports(tool: .webSearch)
-    }
-
     private var firstAccessibleModelId: String? {
         models.first(where: { $0.entityHasAccess })?.id
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIToolsController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIToolsController.swift
@@ -68,7 +68,8 @@ final class UTIToolsController {
         displayState: UnifiedToggleInputDisplayState,
         modelStore: UTIModelStore
     ) -> Presentation {
-        guard canShowTools(displayState: displayState) else {
+        guard canShowTools(displayState: displayState),
+              modelStore.selectedModelSupportsAnyTool else {
             return .hidden
         }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIToolsController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIToolsController.swift
@@ -68,16 +68,21 @@ final class UTIToolsController {
         displayState: UnifiedToggleInputDisplayState,
         modelStore: UTIModelStore
     ) -> Presentation {
+        let toolsMenu = buildToolsMenu(modelStore: modelStore)
         guard canShowTools(displayState: displayState),
-              modelStore.selectedModelSupportsAnyTool else {
+              selectedModelSupportsAnyTool(modelStore: modelStore, toolsMenu: toolsMenu) else {
             return .hidden
         }
 
         return Presentation(
             isToolsButtonHidden: false,
             selectedTool: selectedTool,
-            toolsMenu: buildToolsMenu(modelStore: modelStore)
+            toolsMenu: toolsMenu
         )
+    }
+
+    private func selectedModelSupportsAnyTool(modelStore: UTIModelStore, toolsMenu: UTIToolsMenu) -> Bool {
+        toolsMenu.items.contains { modelStore.selectedModelSupports(tool: $0.tool) }
     }
 }
 
@@ -114,6 +119,15 @@ struct UTIToolsMenu {
         }
 
         var identifier: Identifier {
+            switch self {
+            case .webSearch:
+                return .webSearch
+            case .imageGeneration:
+                return .imageGeneration
+            }
+        }
+
+        var tool: AIChatRAGTool {
             switch self {
             case .webSearch:
                 return .webSearch

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1686,9 +1686,8 @@ private extension UnifiedToggleInputCoordinator {
             return
         }
         isNewChatPending = false
-        let shouldHide = hasExistingChat || hasSubmittedPrompt
-        guard hasSubmittedPrompt != shouldHide else { return }
-        hasSubmittedPrompt = shouldHide
+        guard hasSubmittedPrompt != hasExistingChat else { return }
+        hasSubmittedPrompt = hasExistingChat
         updateModelChipVisibility()
         syncHasSubmittedPromptToHandler()
     }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -952,17 +952,23 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
 
     // MARK: - Web Search Tools
 
-    func test_toolsButton_visibleOnAITab() {
+    func test_toolsButton_visibleOnAITabWhenModelSupportsTools() {
+        mockPreferences.selectedModelId = "gpt-5"
+        sut.modelStore.models = [makeModel(id: "gpt-5", access: true, supportedTools: [.webSearch])]
+
         sut.showExpanded()
 
         XCTAssertFalse(sut.viewController.isToolsButtonHidden)
     }
 
-    func test_toolsButton_visibleInOmnibarWhenModelDoesNotSupportWebSearch() {
+    func test_toolsButton_hiddenWhenModelDoesNotSupportAnyTool() {
+        mockPreferences.selectedModelId = "mistral"
+        sut.modelStore.models = [makeModel(id: "mistral", access: true, supportedTools: [])]
+
         sut.activateFromOmnibar(inputMode: .aiChat)
         sut.updateInputMode(.aiChat, animated: false)
 
-        XCTAssertFalse(sut.viewController.isToolsButtonHidden)
+        XCTAssertTrue(sut.viewController.isToolsButtonHidden)
     }
 
     func test_toolsButton_visibleInOmnibarAIChatWhenModelSupportsWebSearch() {
@@ -976,6 +982,9 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
     }
 
     func test_toolsButton_staysUnhiddenAcrossSwitchToSearchMode_soItFadesWithTheToolbar() {
+        mockPreferences.selectedModelId = "gpt-5"
+        sut.modelStore.models = [makeModel(id: "gpt-5", access: true, supportedTools: [.webSearch])]
+
         sut.showExpanded()
         XCTAssertFalse(sut.viewController.isToolsButtonHidden)
 
@@ -986,7 +995,7 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
 
     func test_toolsMenu_disablesWebSearchActionWhenModelDoesNotSupportIt() {
         mockPreferences.selectedModelId = "gpt-5"
-        sut.modelStore.models = [makeModel(id: "gpt-5", access: true)]
+        sut.modelStore.models = [makeModel(id: "gpt-5", access: true, supportedTools: [.imageGeneration])]
 
         sut.showExpanded()
 
@@ -1080,6 +1089,9 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
     // MARK: - Image Generation Tool
 
     func test_toolsMenu_containsImageGenerationAction() {
+        mockPreferences.selectedModelId = "gpt-5"
+        sut.modelStore.models = [makeModel(id: "gpt-5", access: true, supportedTools: [.imageGeneration])]
+
         sut.showExpanded()
 
         let actionTitles = toolsMenuActions().map(\.title)
@@ -1089,7 +1101,7 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
 
     func test_toolsMenu_disablesImageGenerationActionWhenModelDoesNotSupportIt() {
         mockPreferences.selectedModelId = "gpt-5"
-        sut.modelStore.models = [makeModel(id: "gpt-5", access: true, supportedTools: [])]
+        sut.modelStore.models = [makeModel(id: "gpt-5", access: true, supportedTools: [.webSearch])]
 
         sut.showExpanded()
 
@@ -1590,11 +1602,11 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         XCTAssertTrue(sut.viewController.handler.hasSubmittedPrompt)
     }
 
-    func test_handlerHasSubmittedPrompt_syncedAfterBindWithNewChat() {
+    func test_handlerHasSubmittedPrompt_resetAfterBindWithNewChat() {
         sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "hello", mode: .aiChat)
         let userScript = makeTestUserScript()
         sut.bindToTab(userScript, hasExistingChat: false)
-        XCTAssertTrue(sut.viewController.handler.hasSubmittedPrompt)
+        XCTAssertFalse(sut.viewController.handler.hasSubmittedPrompt)
     }
 
     func test_handlerHasSubmittedPrompt_syncedAfterUnbind() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211767540372501/task/1214790938454653

### Description

- Fix model picker not reappearing when starting a new chat from the duck.ai web "New Chat" menu. `syncChipVisibility` now derives `hasSubmittedPrompt` directly from the URL's `chatID` presence, so navigating to a new chat (no `chatID`) correctly resets the flag and shows the model picker.
- Hide the tools button entirely when the selected model does not support any of the tools presented in the menu (e.g., Mistral). Previously the button appeared but all menu items were disabled, which felt broken. `UTIToolsController` now checks whether the model supports at least one menu tool before showing the button.

### Testing Steps

1. Go to duck.ai on iOS
2. Start a new chat (e.g., type "Tardigrade facts" and submit)
3. Verify the model picker disappears (correct — ongoing chat)
4. Tap the top-right menu in the duck.ai web page
5. Tap "New Chat"
6. Verify the model picker reappears
7. Switch to a model that doesn't support tools (e.g., Mistral)
8. Verify the tools button is hidden in the toolbar
9. Switch to a model that supports tools (e.g., GPT-4o)
10. Verify the tools button reappears

### Impact and Risks

**Impact Level: Low**

Both fixes are scoped to the Duck.ai unified toggle input on iOS only. The model picker fix changes when `hasSubmittedPrompt` resets, which is a UI-only flag. The tools button fix adds a visibility guard based on existing model capability data. No data, networking, or privacy implications.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state changes limited to Duck.ai’s unified toggle input; main risk is minor regressions in toolbar visibility/selection state when switching chats or models.
> 
> **Overview**
> Fixes Duck.ai unified toggle input session state so `hasSubmittedPrompt` is derived directly from whether an existing chat is present, ensuring the model picker/chip reappears when navigating to a fresh chat.
> 
> Updates `UTIToolsController` to hide the Tools button entirely when the currently selected model supports *none* of the tools in the menu (instead of showing a button with all-disabled actions), and adjusts tests to cover the new visibility and prompt-sync behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a53dcf3d18fdd0f5912f8022d6af594180d514bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->