### PR TITLE
macOS: Revert DuckPlayerTests changes (release/macos/1.190.0)

### DIFF
--- a/macOS/UITests/DuckPlayerTests.swift
+++ b/macOS/UITests/DuckPlayerTests.swift
@@ -71,41 +71,23 @@ class DuckPlayerTests: UITestCase {
         let scrollView = app.scrollViews.element(boundBy: 0)
         scrollView.swipeUp()
 
-        // When `adBlockingExtension` is enabled the standalone Duck Player
-        // sidebar entry is replaced by YouTube Ad Blocking, which embeds the
-        // Duck Player controls in its pane.
-        let youTubeAdBlockingButton = app.buttons["PreferencesSidebar.youTubeAdBlockingButton"]
-        youTubeAdBlockingButton.click()
-    }
-
-    private func setDuckPlayerEnableToggle(on: Bool) {
-        let toggle = app.checkBoxes["DuckPlayer.enableToggle"]
-        XCTAssertTrue(toggle.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        if (toggle.value as? Bool) != on {
-            toggle.click()
-        }
-    }
-
-    private func setDuckPlayerAlwaysOpenToggle(on: Bool) {
-        let toggle = app.checkBoxes["DuckPlayer.alwaysOpenToggle"]
-        XCTAssertTrue(toggle.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        if (toggle.value as? Bool) != on {
-            toggle.click()
-        }
+        let duckPlayerButton = app.buttons["PreferencesSidebar.duckplayerButton"]
+        duckPlayerButton.click()
     }
 
     private func selectAlwaysOpenInDuckPlayer() {
-        setDuckPlayerEnableToggle(on: true)
-        setDuckPlayerAlwaysOpenToggle(on: true)
+        let alwaysOpenRadioButton = app.radioButtons["DuckPlayerMode.enabled"]
+        alwaysOpenRadioButton.click()
     }
 
     private func selectNeverOpenInDuckPlayer() {
-        setDuckPlayerEnableToggle(on: false)
+        let alwaysOpenRadioButton = app.radioButtons["DuckPlayerMode.disabled"]
+        alwaysOpenRadioButton.click()
     }
 
     private func selectAskOpenInDuckPlayer() {
-        setDuckPlayerEnableToggle(on: true)
-        setDuckPlayerAlwaysOpenToggle(on: false)
+        let alwaysOpenRadioButton = app.radioButtons["DuckPlayerMode.alwaysAsk"]
+        alwaysOpenRadioButton.click()
     }
 
     private func verifyDuckPlayerLoads() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214803984223224

### Description

Release backport of #4878 onto `release/macos/1.190.0`. Reverts the `DuckPlayerTests` helpers introduced by the #4847 backport (squashed backport of #4671, YouTube Ad Blocking analytics opt-in) so they match the `adBlockingExtension: false` flag added to `setUpWithError` by the release fix in #4734. Those two changes landed on the release branch without being reconciled: setUp force-disables `adBlockingExtension`, but the helpers query elements (`PreferencesSidebar.youTubeAdBlockingButton`, `DuckPlayer.enableToggle`, `DuckPlayer.alwaysOpenToggle`) that only exist when the flag is on. This restores the original sidebar button + `DuckPlayerMode.*` radio buttons so the tests run against the standalone Duck Player preferences UI again.

### Testing Steps

1. Check out this branch.
2. Run the `macOS UI Tests CI` scheme, scoped to `UI Tests/DuckPlayerTests` (or trigger the `macOS - UI Tests` GitHub Actions workflow on this branch).
3. Confirm the `DuckPlayerTests` cases pass on macOS 15 and macOS 26 runners.

### Impact and Risks

**Low.** Test-only change, no product code touched. Restores helpers to a state that already shipped on `main` until #4671 landed, against a setUp configuration (`adBlockingExtension: false`) that exercises the same standalone Duck Player UI as before. Worst case is the tests still fail for an unrelated reason, in which case CI surfaces it.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
