### PR TITLE
[iOS] Pin Maestro tests to simplifiedSyncSetupExperiment's control variant

### DIFF
--- a/.maestro/shared/sync_setup.yaml
+++ b/.maestro/shared/sync_setup.yaml
@@ -1,0 +1,21 @@
+# sync_setup.yaml
+# Shared setup for the sync_tests suite.
+#
+# Forces simplifiedSyncSetupExperiment into the `control` cohort so the
+# Maestro flows continue to find the legacy "Sync and Back Up This Device"
+# entry point. Remove the override once the experiment is fully rolled out
+# and the flows are migrated to the simplified UI.
+appId: com.duckduckgo.mobile.ios
+
+---
+
+- launchApp:
+    appId: "com.duckduckgo.mobile.ios"
+    clearState: true
+    clearKeychain: true
+    arguments:
+        isOnboardingCompleted: ${ONBOARDING_COMPLETED}
+        currentAppVariant: ${APP_VARIANT}
+        isRunningUITests: true
+        ff.browsingMenuSheetEnabledByDefault: "true"
+        "experiment.simplifiedSyncSetupExperiment": "control"

--- a/.maestro/sync_tests/01_create_account.yaml
+++ b/.maestro/sync_tests/01_create_account.yaml
@@ -6,9 +6,9 @@ name: 01_create_account
 
 ---
 
-# Set up 
-- runFlow: 
-    file: ../shared/setup.yaml
+# Set up
+- runFlow:
+    file: ../shared/sync_setup.yaml
 
 # Set Internal User
 - tapOn: Browsing menu

--- a/.maestro/sync_tests/02_login_account.yaml
+++ b/.maestro/sync_tests/02_login_account.yaml
@@ -6,9 +6,9 @@ name: 02_login_account
 
 ---
 
-# Set up 
-- runFlow: 
-    file: ../shared/setup.yaml
+# Set up
+- runFlow:
+    file: ../shared/sync_setup.yaml
 
 #  Copy Recovery Code
 - tapOn: Browsing menu

--- a/.maestro/sync_tests/03_recover_account.yaml
+++ b/.maestro/sync_tests/03_recover_account.yaml
@@ -6,9 +6,9 @@ name: 03_recover_account
 
 ---
 
-# Set up 
-- runFlow: 
-    file: ../shared/setup.yaml
+# Set up
+- runFlow:
+    file: ../shared/sync_setup.yaml
 
 # Set Internal User
 - tapOn: "Browsing menu"

--- a/.maestro/sync_tests/04_sync_data_setup.yaml
+++ b/.maestro/sync_tests/04_sync_data_setup.yaml
@@ -6,9 +6,9 @@ name: 04_sync_data_setup
 
 ---
 
-# Set up 
-- runFlow: 
-    file: ../shared/setup.yaml
+# Set up
+- runFlow:
+    file: ../shared/sync_setup.yaml
 
 # Add local favorite and bookmark
 - runFlow:

--- a/.maestro/sync_tests/05_sync_data_check.yaml
+++ b/.maestro/sync_tests/05_sync_data_check.yaml
@@ -10,8 +10,8 @@ name: 05_sync_data_check
 #            The test is split in two different flow to accomodate 
 #            for Maestro CI max execution time. 
 
-- runFlow: 
-    file: ../shared/setup.yaml
+- runFlow:
+    file: ../shared/sync_setup.yaml
     
 #  Copy Recovery Code
 - tapOn: Browsing menu

--- a/.maestro/sync_tests/06_delete_account.yaml
+++ b/.maestro/sync_tests/06_delete_account.yaml
@@ -5,9 +5,9 @@ tags:
 name: 06_delete_account
 ---
 
-# Set up 
-- runFlow: 
-    file: ../shared/setup.yaml
+# Set up
+- runFlow:
+    file: ../shared/sync_setup.yaml
 
 # Set Internal User
 - tapOn: Browsing menu


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1214795286249345?focus=true
Tech Design URL:
CC:

### Description
e2e tests were failing as the test runner was getting enrolled in the treatment variant for the new simplifiedSyncSetup experiment. This PR pins the tests to the control variant.

### Testing Steps

1. Check the code looks okay, check CI is happy.
2. I kicked off a run of the tests here, so we can also check that’s looking good: https://github.com/duckduckgo/apple-browsers/actions/runs/25870882497

### Impact and Risks

None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only YAML changes that add a launch argument and adjust sync test setup flows, with no production code impact.
> 
> **Overview**
> Adds a new shared Maestro flow, `shared/sync_setup.yaml`, which launches the app with an explicit `experiment.simplifiedSyncSetupExperiment: control` override to keep the legacy sync entry point available during experiment rollout.
> 
> Updates all `sync_tests/*` flows to use this new sync-specific setup instead of the generic `shared/setup.yaml`, stabilizing the sync suite against UI changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63d1abd12f0c7febcdeaaca90836128d8bc49550. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->