### PR TITLE
iOS: Voice mode opens in new tab; X button closes Duck.ai tab

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatUserScriptMessages.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatUserScriptMessages.swift
@@ -50,6 +50,7 @@ public enum AIChatUserScriptMessages: String, CaseIterable {
 
     case voiceSessionStarted
     case voiceSessionEnded
+    case voiceSessionUserEnded
 
     // Sync
     case getSyncStatus

--- a/iOS/DuckDuckGo/AIChat/AIChatContentHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatContentHandler.swift
@@ -58,6 +58,9 @@ protocol AIChatContentHandlingDelegate: AnyObject {
     /// Called when the content handler receives a request to close the AIChat interface.
     func aiChatContentHandlerDidReceiveCloseChatRequest(_ handler: AIChatContentHandling)
 
+    /// Called when the user explicitly ends a voice session via the X button — the host should close the originating tab.
+    func aiChatContentHandlerDidReceiveVoiceSessionUserEndedRequest(_ handler: AIChatContentHandling)
+
     /// Called when the content handler receives a request to open Sync settings.
     func aiChatContentHandlerDidReceiveOpenSyncSettingsRequest(_ handler: AIChatContentHandling)
 
@@ -113,6 +116,7 @@ extension AIChatContentHandling {
 
 extension AIChatContentHandlingDelegate {
     func aiChatContentHandlerDidReceivePageContextRequest(_ handler: AIChatContentHandling) {}
+    func aiChatContentHandlerDidReceiveVoiceSessionUserEndedRequest(_ handler: AIChatContentHandling) {}
 }
 
 final class AIChatContentHandler: AIChatContentHandling {
@@ -260,6 +264,8 @@ extension AIChatContentHandler: AIChatUserScriptDelegate {
             delegate?.aiChatContentHandlerDidReceiveOpenSettingsRequest(self)
         case .closeAIChat:
             delegate?.aiChatContentHandlerDidReceiveCloseChatRequest(self)
+        case .voiceSessionUserEnded:
+            delegate?.aiChatContentHandlerDidReceiveVoiceSessionUserEndedRequest(self)
         case .sendToSyncSettings, .sendToSetupSync:
             delegate?.aiChatContentHandlerDidReceiveOpenSyncSettingsRequest(self)
         default:

--- a/iOS/DuckDuckGo/FindInPageView.swift
+++ b/iOS/DuckDuckGo/FindInPageView.swift
@@ -90,6 +90,11 @@ class FindInPageView: UIView {
     }
 
     @IBAction func done() {
+        // Idempotent — `closeFindInPage` defensively calls this on every WKWebView navigation
+        // (see TabViewController's decidePolicyFor handler), but the delegate's `done` side-effect
+        // un-hides the bottom navigation bar. Bail if the view is not actually visible so we
+        // don't leak that un-hide into states that need the bar hidden (e.g. Duck.ai voice mode).
+        guard !isHidden else { return }
         isHidden = true
         findInPage?.done()
         delegate?.done(findInPageView: self)

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3313,14 +3313,16 @@ class MainViewController: UIViewController {
 
         guard let currentTab else { return }
 
-        if fromDeepLink, currentTab.tabModel.link != nil {
+        if currentTab.tabModel.link != nil {
             let voiceURL = currentTab.aiChatContentHandler.buildVoiceModeURL()
             loadUrlInNewTab(voiceURL, inheritedAttribution: nil)
-            // Collapse the input that was auto-expanded for the restored tab.
-            // This cancels any pending async activateInput because showCollapsed
-            // sets displayState to .collapsed, failing the guard in showExpanded's
-            // async block.
-            unifiedToggleInputCoordinator?.showCollapsed()
+            if fromDeepLink {
+                // Collapse the input that was auto-expanded for the restored tab.
+                // This cancels any pending async activateInput because showCollapsed
+                // sets displayState to .collapsed, failing the guard in showExpanded's
+                // async block.
+                unifiedToggleInputCoordinator?.showCollapsed()
+            }
             return
         }
 
@@ -5862,12 +5864,20 @@ extension MainViewController: AIChatContentHandlingDelegate {
 
     func aiChatContentHandlerDidReceiveCloseChatRequest(_ handler:
                                                         AIChatContentHandling) {
-        guard let tab = self.currentTab?.tabModel else { return }
-        self.closeTab(tab)
+        closeCurrentTab()
+    }
+
+    func aiChatContentHandlerDidReceiveVoiceSessionUserEndedRequest(_ handler: AIChatContentHandling) {
+        closeCurrentTab()
     }
 
     func aiChatContentHandlerDidReceivePromptSubmission(_ handler: AIChatContentHandling) {
         // No action needed for full mode - notification handles metrics
+    }
+
+    private func closeCurrentTab() {
+        guard let tab = currentTab?.tabModel else { return }
+        closeTab(tab)
     }
 
 }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3313,7 +3313,10 @@ class MainViewController: UIViewController {
 
         guard let currentTab else { return }
 
-        if currentTab.tabModel.link != nil {
+        let hasContent = currentTab.tabModel.link != nil
+        let openInNewTab = hasContent && (unifiedToggleInputFeature.isAvailable || fromDeepLink)
+
+        if openInNewTab {
             let voiceURL = currentTab.aiChatContentHandler.buildVoiceModeURL()
             loadUrlInNewTab(voiceURL, inheritedAttribution: nil)
             if fromDeepLink {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3313,6 +3313,10 @@ class MainViewController: UIViewController {
 
         guard let currentTab else { return }
 
+        // Voice mode has no on-screen keyboard, so dismiss whatever input is focused before
+        // loading — applies to both the current-tab and new-tab branches below.
+        unifiedToggleInputCoordinator?.dismissOmnibarKeyboard()
+
         let hasContent = currentTab.tabModel.link != nil
         let openInNewTab = hasContent && (unifiedToggleInputFeature.isAvailable || fromDeepLink)
 
@@ -3329,7 +3333,6 @@ class MainViewController: UIViewController {
             return
         }
 
-        unifiedToggleInputCoordinator?.dismissOmnibarKeyboard()
         prepareTabForRequest {
             currentTab.loadVoiceMode()
         }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1045,7 +1045,7 @@ class MainViewController: UIViewController {
         guard unifiedToggleInputFeature.isAvailable,
               currentTab?.isAITab == true,
               let coordinator = unifiedToggleInputCoordinator,
-              coordinator.shouldCollapseOnKeyboardDismiss,
+              coordinator.isAITabExpanded,
               currentTab?.aiChatContextualSheetCoordinator.isSheetPresented != true else { return }
         // With a hardware keyboard connected, iOS fires keyboardWillHide even though the
         // text field is still the first responder. Treat that as "still editing" and skip
@@ -3313,8 +3313,7 @@ class MainViewController: UIViewController {
 
         guard let currentTab else { return }
 
-        // Voice mode has no on-screen keyboard, so dismiss whatever input is focused before
-        // loading — applies to both the current-tab and new-tab branches below.
+        // Voice mode has no on-screen input; dismiss the keyboard before either branch loads.
         unifiedToggleInputCoordinator?.dismissOmnibarKeyboard()
 
         let hasContent = currentTab.tabModel.link != nil

--- a/iOS/DuckDuckGo/MainViewCoordinator.swift
+++ b/iOS/DuckDuckGo/MainViewCoordinator.swift
@@ -48,6 +48,7 @@ class MainViewCoordinator {
     var aiChatTabChatHeaderContainer: UIView!
     var unifiedToggleInputContainer: UIView!
     var aiTabCollapsedTopSeparator: UIView!
+    private var aiTabCollapsedTopSeparatorLogicallyVisible = false
     var unifiedInputContentContainer: UIView!
 
     /// Owned so a subsequent show can cancel an in-flight dismiss and skip the stale completion.
@@ -275,6 +276,15 @@ class MainViewCoordinator {
     }
 
     func setAITabCollapsedTopSeparatorVisible(_ visible: Bool) {
+        aiTabCollapsedTopSeparatorLogicallyVisible = visible
+        applyAITabCollapsedTopSeparatorVisibility()
+    }
+
+    /// Enforces the invariant: the separator can only be visible above a visible chrome. The
+    /// separator is anchored to the safe area, not to `navigationBarContainer`, so hiding the
+    /// chrome doesn't hide the separator transitively — we have to re-apply on either change.
+    private func applyAITabCollapsedTopSeparatorVisibility() {
+        let visible = aiTabCollapsedTopSeparatorLogicallyVisible && !navigationBarContainer.isHidden
         guard aiTabCollapsedTopSeparator.isHidden == visible else { return }
         aiTabCollapsedTopSeparator.isHidden = !visible
         if visible {
@@ -379,6 +389,7 @@ class MainViewCoordinator {
     func setAITabBottomChromeHidden(_ hidden: Bool) {
         guard navigationBarContainer.isHidden != hidden else { return }
         navigationBarContainer.isHidden = hidden
+        applyAITabCollapsedTopSeparatorVisibility()
         if hidden {
             setContentContainerBottomAnchorMode(.safeArea)
         } else if isNavigationChromeHidden {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -542,6 +542,11 @@ private extension MainViewController {
         if tabURL?.isDuckAIVoiceMode == true || tab.isVoiceModeRequested {
             coordinator.aiChatInputBoxVisibility = .hidden
         }
+        // AI tabs never show the wrapping web-view border. Apply before the early-return so
+        // a freshly-bound AI tab opened from another AI tab (which routes through
+        // `preserveCurrentPresentation`) still gets its `UIView`-default visible borders hidden.
+        tab.borderView.isTopVisible = false
+        tab.borderView.isBottomVisible = false
         reconcileToolbarVisibilityForCurrentTab()
         reconcileAIChromeForCurrentTab()
 
@@ -565,8 +570,6 @@ private extension MainViewController {
 
         updateUnifiedInputContentVisibility(for: coordinator)
         refreshAIChatTabChatHeaderSubscriptionState()
-        tab.borderView.isTopVisible = false
-        tab.borderView.isBottomVisible = false
         return true
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -533,8 +533,15 @@ private extension MainViewController {
         coordinator: UnifiedToggleInputCoordinator,
         behavior: AITabRefreshBehavior
     ) -> Bool {
-        let hasExistingChat = (tab.url ?? tab.link?.url)?.duckAIChatID != nil
+        let tabURL = tab.url ?? tab.link?.url
+        let hasExistingChat = tabURL?.duckAIChatID != nil
         bindAITabIfPossible(tab: tab, coordinator: coordinator, hasExistingChat: hasExistingChat)
+        // Assert input-hidden synchronously for voice-mode tabs so the bottom chrome doesn't
+        // flash visible during the FE's "Connecting…" window. The FE's `hideChatInput` is
+        // idempotent over this. Persisted per tab in `TabInputState`.
+        if tabURL?.isDuckAIVoiceMode == true || tab.isVoiceModeRequested {
+            coordinator.aiChatInputBoxVisibility = .hidden
+        }
         reconcileToolbarVisibilityForCurrentTab()
         reconcileAIChromeForCurrentTab()
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -542,9 +542,8 @@ private extension MainViewController {
         if tabURL?.isDuckAIVoiceMode == true || tab.isVoiceModeRequested {
             coordinator.aiChatInputBoxVisibility = .hidden
         }
-        // AI tabs never show the wrapping web-view border. Apply before the early-return so
-        // a freshly-bound AI tab opened from another AI tab (which routes through
-        // `preserveCurrentPresentation`) still gets its `UIView`-default visible borders hidden.
+        // Before the early-return so AI→AI tab transitions (`preserveCurrentPresentation`) also
+        // override the `UIView`-default-visible borders on a freshly-bound tab.
         tab.borderView.isTopVisible = false
         tab.borderView.isBottomVisible = false
         reconcileToolbarVisibilityForCurrentTab()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -279,10 +279,6 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         displayState != .hidden
     }
 
-    var shouldCollapseOnKeyboardDismiss: Bool {
-        displayState == .aiTab(.expanded)
-    }
-
     private var isOmnibarNewAIChatPrompt: Bool {
         isOmnibarSession && inputMode == .aiChat && !hasSubmittedPrompt
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -280,7 +280,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     }
 
     var shouldCollapseOnKeyboardDismiss: Bool {
-        displayState == .aiTab(.expanded) && inputMode == .aiChat
+        displayState == .aiTab(.expanded)
     }
 
     private var isOmnibarNewAIChatPrompt: Bool {

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContentHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContentHandlerTests.swift
@@ -476,6 +476,37 @@ final class AIChatContentHandlerTests: XCTestCase {
         XCTAssertEqual(mockDelegate.didReceivePageContextRequestCallCount, 0)
     }
 
+    func testDidReceiveVoiceSessionUserEndedNotifiesDelegate() throws {
+        // Given
+        let mockUserScript = MockAIChatUserScript()
+        let mockWebView = WKWebView()
+        handler.setup(with: mockUserScript, webView: mockWebView, displayMode: .fullTab)
+        let mockDelegate = MockAIChatContentHandlingDelegate()
+        handler.delegate = mockDelegate
+
+        // When
+        handler.aiChatUserScript(makeTestUserScript(), didReceiveMessage: .voiceSessionUserEnded)
+
+        // Then
+        XCTAssertEqual(mockDelegate.didReceiveVoiceSessionUserEndedRequestCallCount, 1)
+        XCTAssertEqual(mockDelegate.didReceiveCloseChatRequestCallCount, 0)
+    }
+
+    func testDidReceiveVoiceSessionEndedDoesNotNotifyVoiceSessionUserEndedDelegate() throws {
+        // Given
+        let mockUserScript = MockAIChatUserScript()
+        let mockWebView = WKWebView()
+        handler.setup(with: mockUserScript, webView: mockWebView, displayMode: .fullTab)
+        let mockDelegate = MockAIChatContentHandlingDelegate()
+        handler.delegate = mockDelegate
+
+        // When
+        handler.aiChatUserScript(makeTestUserScript(), didReceiveMessage: .voiceSessionEnded)
+
+        // Then
+        XCTAssertEqual(mockDelegate.didReceiveVoiceSessionUserEndedRequestCallCount, 0)
+    }
+
     // MARK: - fireAIChatTelemetry
 
     func testFireAIChatTelemetryCallsProductSurfaceTelemetry() throws {

--- a/iOS/SharedTestUtils/Mocks/AIChat/MockAIChatContentHandlingDelegate.swift
+++ b/iOS/SharedTestUtils/Mocks/AIChat/MockAIChatContentHandlingDelegate.swift
@@ -23,6 +23,7 @@ import Foundation
 public final class MockAIChatContentHandlingDelegate: AIChatContentHandlingDelegate {
     public var didReceiveOpenSettingsRequestCallCount = 0
     public var didReceiveCloseChatRequestCallCount = 0
+    public var didReceiveVoiceSessionUserEndedRequestCallCount = 0
     public var didReceiveOpenSyncSettingsRequestCallCount = 0
     public var didReceivePromptSubmissionCallCount = 0
     public var didReceivePageContextRequestCallCount = 0
@@ -35,6 +36,10 @@ public final class MockAIChatContentHandlingDelegate: AIChatContentHandlingDeleg
 
     public func aiChatContentHandlerDidReceiveCloseChatRequest(_ handler: AIChatContentHandling) {
         didReceiveCloseChatRequestCallCount += 1
+    }
+
+    public func aiChatContentHandlerDidReceiveVoiceSessionUserEndedRequest(_ handler: AIChatContentHandling) {
+        didReceiveVoiceSessionUserEndedRequestCallCount += 1
     }
 
     public func aiChatContentHandlerDidReceiveOpenSyncSettingsRequest(_ handler: AIChatContentHandling) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214810245123542

### Description

Two voice-mode behavior changes on Duck.ai:

1. **Close tab on X tap.** Listen for the new `voiceSessionUserEnded` FE message (added by Moon in [duckduckgo/ddg#45732](https://dub.duckduckgo.com/duckduckgo/ddg/pull/45732)) and close the originating tab. We can't reuse `voiceSessionEnded` because it also fires on idle timeout / network drop — closing the tab in those cases would be hostile. macOS ignores the new message. No iOS flag added — the FE only sends this message when `supportsNativeChatInput` is reported true (which already requires `unifiedToggleInput`), so the path is transitively gated.

2. **Open voice mode in a new tab when current tab has content** (gated by `unifiedToggleInput`). Previously, tapping a voice entry point on a website replaced the page; now voice opens in a new tab. Empty/NTP tabs are still reused. Deeplink path is preserved with its prior new-tab behavior regardless of the flag.

### Testing Steps

**Setup:** Enable the `unifiedToggleInput` feature flag in Settings → Debug → Feature Flags. In Settings → Debug → AI Chat, set the custom AI chat URL to `https://euw-serp-dev-testing20.duck.ai` (the FE dev instance for the new `voiceSessionUserEnded` message).

**Close tab on X tap:**
1. Open a new Duck.ai tab, enter voice mode, tap the X (close) button → the tab closes.
2. Open a new Duck.ai tab, enter voice mode, let it idle out (don't tap X) → the tab stays open.

**Voice mode opens in new tab (with `unifiedToggleInput` ON):**
3. On the NTP, tap the voice button (toolbar / address bar / NTP shortcut) → voice loads in the current tab.
4. On any website (e.g. duckduckgo.com), tap the voice button → a new Duck.ai voice tab opens; the website tab stays as it was.
5. On an existing Duck.ai chat tab, tap the voice button → a new Duck.ai voice tab opens; the prior chat is preserved.
6. Deeplink into voice mode (when current tab has content) → still opens in a new tab.

**With `unifiedToggleInput` OFF (sanity):**
7. On a website, tap the voice button → voice loads **in the current tab** (legacy behavior).
8. Deeplink with content in current tab → still opens in new tab (unchanged).

### Impact and Risks

**Low.** Both changes are scoped to Duck.ai voice mode entry/exit and feature-gated by the existing `aichatFullModeFeature` / `aichatIPadTabFeature` flags that already wrap voice-in-tab behavior.

- Close-tab path uses the same delegate chain already proven by `closeAIChat`; macOS is untouched.
- The new-tab behavior is an existing branch in `openAIChatVoiceModeInTab` that we extended from deeplink-only to all entry points, gated by `unifiedToggleInput`. Worst case is a user gets a second Duck.ai voice tab when they didn't want one — easily dismissable.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Duck.ai voice-mode tab lifecycle and UI-chrome behavior, which can affect navigation state and visibility of browser controls. Risk is moderate due to new branching around tab creation/closure and coordination with UTI/keyboard visibility.
> 
> **Overview**
> Duck.ai voice mode now **opens in a new tab when the current tab already has content**, while still reusing empty/NTP tabs; keyboard dismissal/collapse behavior is updated to align with the new voice entry flow.
> 
> Adds a new JS bridge message `voiceSessionUserEnded` and delegate callback so tapping the voice-mode X button closes the current Duck.ai tab, without treating generic `voiceSessionEnded` events (timeouts/network drops) as a close signal.
> 
> Includes a couple of UI guardrails for voice mode: `FindInPageView.done()` is made idempotent when hidden to avoid unintentionally revealing bottom chrome, and the AI-tab collapsed separator visibility is re-applied when bottom chrome is hidden to prevent stray separators. Tests and mocks are updated to cover the new voice-session message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5abac8f8d904b56e6200949aa4532a7c840129a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->