### PR TITLE
macOS 13.7.8 favicon crash workaround (part 2)

### DIFF
--- a/macOS/DuckDuckGo/Common/View/SwiftUI/LoginFaviconView.swift
+++ b/macOS/DuckDuckGo/Common/View/SwiftUI/LoginFaviconView.swift
@@ -24,18 +24,9 @@ struct LoginFaviconView: View {
     let domain: String
     let generatedIconLetters: String
     let faviconManagement: FaviconManagement = NSApp.delegateTyped.faviconManager
-    let osVersion: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion
 
     private var displayableFaviconImage: NSImage? {
-        // Workaround for favicon rendering crashes on Ventura 13.7.8 and newer 13.x patches.
-        switch (osVersion.majorVersion, osVersion.minorVersion, osVersion.patchVersion) {
-        case let (13, minor, _) where minor > 7:
-            return nil
-        case let (13, 7, patch) where patch >= 8:
-            return nil
-        default:
-            return faviconManagement.getCachedFavicon(for: domain, sizeCategory: .small)?.image
-        }
+        faviconManagement.getCachedFaviconSafeForRendering(for: domain, sizeCategory: .small)?.image
     }
 
     var body: some View {

--- a/macOS/DuckDuckGo/Favicons/Model/FaviconManager.swift
+++ b/macOS/DuckDuckGo/Favicons/Model/FaviconManager.swift
@@ -92,6 +92,15 @@ extension FaviconManagement {
     }
 
     @MainActor
+    func getCachedFaviconSafeForRendering(for host: String, sizeCategory: Favicon.SizeCategory) -> Favicon? {
+        guard shouldRenderFavicon else {
+            return nil
+        }
+
+        return getCachedFavicon(for: host, sizeCategory: sizeCategory)
+    }
+
+    @MainActor
     func getCachedFavicon(forUrlOrAnySubdomain documentUrl: URL, sizeCategory: Favicon.SizeCategory, fallBackToSmaller: Bool) -> Favicon? {
         if let favicon = getCachedFavicon(for: documentUrl, sizeCategory: sizeCategory, fallBackToSmaller: fallBackToSmaller) {
             return favicon
@@ -102,6 +111,21 @@ extension FaviconManagement {
         }
 
         return nil
+    }
+
+    @MainActor
+    private var shouldRenderFavicon: Bool {
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+
+        // Workaround for favicon rendering crashes on Ventura 13.7.8 and newer 13.x patches.
+        switch (osVersion.majorVersion, osVersion.minorVersion, osVersion.patchVersion) {
+        case let (13, minor, _) where minor > 7:
+            return false
+        case let (13, 7, patch) where patch >= 8:
+            return false
+        default:
+            return true
+        }
     }
 }
 

--- a/macOS/DuckDuckGo/SecureVault/View/SaveCredentialsViewController.swift
+++ b/macOS/DuckDuckGo/SecureVault/View/SaveCredentialsViewController.swift
@@ -451,7 +451,7 @@ final class SaveCredentialsViewController: NSViewController {
             faviconImage.image = .web
             return
         }
-        faviconImage.image = faviconManagement.getCachedFavicon(for: domain, sizeCategory: .small)?.image ?? .web
+        faviconImage.image = faviconManagement.getCachedFaviconSafeForRendering(for: domain, sizeCategory: .small)?.image ?? .web
     }
 
     private func updatePasswordFieldVisibility(visible: Bool) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1214808478057181?focus=true
Tech Design URL:
CC:

### Description
Follow on from https://github.com/duckduckgo/apple-browsers/pull/4560 to use LetterIconView instead of any cached favicons when saving new passwords on macOS 13.7.8 due to NSImage crash reports

### Testing Steps

1. Trigger the Save Password popover on a site with a known cached favicon.
2. Confirm the popover shows the favicon
3. Open Password Management and verify the saved entry is present and the passwords list favicons display correctly
4. Temporarily force fallback mode in macOS/DuckDuckGo/Favicons/Model/FaviconManager.swift (for example, make shouldRenderFavicon return false).
5. Relaunch and re-trigger the Save Password popover; confirm it shows fallback icon.
6. Verify Password Management list favicon show letter fallback.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

<!-- CURSOR_SUMMARY -->
--

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that centralizes an OS-version crash workaround; main risk is missing favicons (falling back to letter/web icons) on affected macOS versions.
> 
> **Overview**
> Prevents favicon-related `NSImage` rendering crashes on macOS Ventura 13.7.8+ by centralizing the OS-version gating in `FaviconManagement.getCachedFaviconSafeForRendering`.
> 
> Updates login and save-credentials UI (`LoginFaviconView`, `SaveCredentialsViewController`) to use the new safe accessor, falling back to letter/web icons when favicons should not be rendered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d79bb12bddf49ab6f8f6b77146a6cd80356262f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->