### PR TITLE
iOS: Smooth UTI collapse animation with long text

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -458,10 +458,6 @@ class SwitchBarTextEntryView: UIView {
             heightConstraint?.constant = currentMinHeight
             textView.isScrollEnabled = true
             textView.showsVerticalScrollIndicator = true
-            // Match the omnibar's single-line truncated presentation so that on collapse the
-            // UTI text reads like the omnibar text it's handing off to, instead of staying
-            // wrapped across multiple lines as the height shrinks.
-            textView.textContainer.lineBreakMode = .byTruncatingTail
             return
         }
 

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -458,6 +458,10 @@ class SwitchBarTextEntryView: UIView {
             heightConstraint?.constant = currentMinHeight
             textView.isScrollEnabled = true
             textView.showsVerticalScrollIndicator = true
+            // Match the omnibar's single-line truncated presentation so that on collapse the
+            // UTI text reads like the omnibar text it's handing off to, instead of staying
+            // wrapped across multiple lines as the height shrinks.
+            textView.textContainer.lineBreakMode = .byTruncatingTail
             return
         }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -791,6 +791,7 @@ private extension MainViewController {
         let omnibarPlaceholderColor = currentOmnibarPlaceholderColor()
         let utiPlaceholderColor = coordinator.viewController.defaultPlaceholderColor
         let duration = Constants.omnibarTransitionDuration(isBottom: coordinator.cardPosition.isBottom)
+        let shouldCrossfadeOmnibar = !viewCoordinator.isNavigationChromeHidden
         UIView.animate(
             withDuration: duration,
             delay: 0,
@@ -800,6 +801,10 @@ private extension MainViewController {
                 coordinator.viewController.applyOmnibarEditingDismissPose()
                 self.viewCoordinator.animateUnifiedToggleInputOmnibarDismissLayout()
                 self.viewCoordinator.unifiedInputContentContainer.alpha = 0
+                if shouldCrossfadeOmnibar {
+                    self.viewCoordinator.navigationBarCollectionView.alpha = 1
+                    self.viewCoordinator.unifiedToggleInputContainer.alpha = 0
+                }
                 if let omnibarPlaceholderWindowX {
                     coordinator.viewController.alignPlaceholderHorizontally(toWindowX: omnibarPlaceholderWindowX)
                 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -803,6 +803,7 @@ final class UnifiedToggleInputView: UIView {
         toolbarBottomConstraint.constant = 0
         toolbarHeightConstraint.constant = 0
         toolsToolbar.alpha = 0
+        textEntryView.isExpandable = false
     }
 
     func setInactiveCardAppearance(_ inactive: Bool) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1214816363232572?focus=true
Tech Design URL:
CC:

### Description
With the UnifiedToggleInput feature flag on, collapsing the address bar with a lot of text broke the animation — the bar stayed at its expanded height and snapped away at completion. This fix resets the inner text view's height when the toggle hides (top + toggle-on path), truncates rather than wraps the text once it's no longer expandable, and crossfades the omnibar in instead of snapping it at completion. Result: the UTI smoothly shrinks and the text appears to morph into the omnibar text.

### Testing Steps
1. Enable the UnifiedToggleInput feature flag, top address bar, toggle ON.
2. Tap the address bar, paste a long URL or type enough to wrap to multiple lines, then tap the inline dismiss (X) — confirm the bar shrinks smoothly to omnibar height with no jump.
3. Repeat with short text and on bottom address bar / toggle OFF to confirm no regressions.

### Impact and Risks
Low

#### What could go wrong?
The crossfade adds momentary alpha overlap between the UTI bar and omnibar — if their fonts/positions drift out of alignment, a brief double-text could be visible mid-dismiss.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only animation tweaks; main risk is visual overlap during the new omnibar/UTI crossfade if layouts diverge.
> 
> **Overview**
> Fixes the Unified Toggle Input (UTI) → omnibar collapse animation when the text view had grown to multiple lines.
> 
> During dismiss, the UI now *crossfades* between the UTI container and the navigation/omnibar (when navigation chrome is visible) instead of snapping at completion, and `applyToggleHideChanges()` now disables `textEntryView.isExpandable` to force the inner text view back to a single-line/truncated height before the collapse animation runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a53e05793793def017bc535266fe5bb610c7cb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->