### PR TITLE
[VPN] Fix flaky leak check test

### DIFF
--- a/SharedPackages/VPN/Tests/VPNTests/LeakCheck/VPNLeakCheckServiceTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/LeakCheck/VPNLeakCheckServiceTests.swift
@@ -783,6 +783,9 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         let http = MockLeakCheckHTTPClient(ipv4: "1.2.3.4", ipv6Error: URLError(.cannotFindHost))
         let stun = MockLeakCheckSTUNClient(ipv4: "1.2.3.4", ipv6Error: URLError(.cannotFindHost))
         let wideEvent = MockWideEventManager()
+        let rekeyCompleted = expectation(description: "rekey leak check completes after debounce")
+        wideEvent.onCompleteFlow = { rekeyCompleted.fulfill() }
+
         let config = LeakCheckConfiguration(
             host: "leakcheck.netp.duckduckgo.com",
             httpPort: 80, httpsPort: 443, stunPort: 3478,
@@ -801,11 +804,10 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         )
 
         await service.scheduleCheck(trigger: .rekey)
-        try? await Task.sleep(nanoseconds: 100_000_000)
         await service.runCheck(trigger: .periodic)
-        XCTAssertEqual(wideEvent.startedFlows.count, 0, "periodic timer should not sample during a path-change debounce")
+        XCTAssertEqual(wideEvent.startedFlows.count, 0, "periodic should be skipped while a path-change check is pending")
 
-        try? await Task.sleep(nanoseconds: 300_000_000)
+        await fulfillment(of: [rekeyCompleted], timeout: 5.0)
         XCTAssertEqual(wideEvent.startedFlows.count, 1)
         XCTAssertEqual(wideEvent.lastCompletedData?.trigger, .rekey)
     }
@@ -1112,6 +1114,7 @@ final class MockWideEventManager: WideEventManaging, @unchecked Sendable {
     var lastCompletedData: VPNIPLeakCheckWideEventData?
     var lastCompletedStatus: WideEventStatus?
     var discardedCount = 0
+    var onCompleteFlow: (() -> Void)?
 
     func startFlow<T: WideEventData>(_ data: T) {
         startedFlows.append(data)
@@ -1123,6 +1126,7 @@ final class MockWideEventManager: WideEventManaging, @unchecked Sendable {
             lastCompletedData = data
             lastCompletedStatus = status
         }
+        onCompleteFlow?()
         onComplete(true, nil)
     }
     func completeFlow<T: WideEventData>(_ data: T, status: WideEventStatus) async throws -> Bool {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1214821250965653?focus=true
Tech Design URL:
CC:

### Description

This PR fixes a flaky test, which was previously highly dependent on precise timing. Now we don't depend on sleep calls, and instead wait for events to happen before proceeding.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that CI is green

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that replace timing-based sleeps with an explicit completion signal, reducing CI flakiness with minimal production risk.
> 
> **Overview**
> Makes `testRunCheck_periodicSkipsWhilePathChangeCheckIsPending` deterministic by replacing fixed `Task.sleep` timing with an `XCTestExpectation` that is fulfilled when the mocked `WideEventManaging.completeFlow` fires.
> 
> Adds an `onCompleteFlow` callback to `MockWideEventManager` to signal flow completion, and updates the assertion message to clarify that periodic checks are skipped while a path-change (rekey) check is pending.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82bd95041cd60843a187ad79f05056a99db1bf04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->