### PR TITLE
[iOS] Update Fire Mode colors in UTI

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
@@ -67,11 +67,7 @@ final class UnifiedToggleInputToolbarView: UIView {
 
     func refreshFireMode(fireMode: Bool) {
         isFireTab = fireMode
-        // Apply fire-mode dark trait to content children only; submit keeps OS trait so `.fireModeAccent` tracks the OS.
-        let style: UIUserInterfaceStyle = fireMode ? .dark : .unspecified
-        [toolsButton, imageButton, modelChipButton, selectedToolChipView, stopButton].forEach {
-            $0.overrideUserInterfaceStyle = style
-        }
+        overrideUserInterfaceStyle = fireMode ? .dark : .unspecified
         updateSubmitButtonAppearance()
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -468,14 +468,19 @@ final class UnifiedToggleInputView: UIView {
         expandedShadowView.backgroundColor = background
         // cardView keeps the OS trait so `fireModeCardBackground` picks its light variant in light OS; content subviews force `.dark` so their dynamic colors resolve against the dark surface.
         let style: UIUserInterfaceStyle = isFireTab ? .dark : .unspecified
-        // Future direct content subviews inherit fire-mode appearance by default; only the card background and shadow keep the OS trait.
+        // Future direct content subviews inherit fire-mode appearance by default; card chrome and collapsed flanking accessories keep the OS trait.
         fireModeContentSubviews.forEach {
             $0.overrideUserInterfaceStyle = style
         }
     }
 
     private var fireModeContentSubviews: [UIView] {
-        subviews.filter { $0 !== cardView && $0 !== expandedShadowView }
+        subviews.filter {
+            $0 !== cardView &&
+            $0 !== expandedShadowView &&
+            $0 !== aiTabCollapsedFireButton &&
+            $0 !== aiTabCollapsedVoiceButton
+        }
     }
 
     // MARK: - First Responder

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -468,10 +468,14 @@ final class UnifiedToggleInputView: UIView {
         expandedShadowView.backgroundColor = background
         // cardView keeps the OS trait so `fireModeCardBackground` picks its light variant in light OS; content subviews force `.dark` so their dynamic colors resolve against the dark surface.
         let style: UIUserInterfaceStyle = isFireTab ? .dark : .unspecified
-        // `toolsToolbar` manages its own subtree's trait so the accent submit button keeps OS trait.
-        [toggleView, textEntryView, attachmentsStrip, inlineDismissButton].forEach {
+        // Future direct content subviews inherit fire-mode appearance by default; only the card background and shadow keep the OS trait.
+        fireModeContentSubviews.forEach {
             $0.overrideUserInterfaceStyle = style
         }
+    }
+
+    private var fireModeContentSubviews: [UIView] {
+        subviews.filter { $0 !== cardView && $0 !== expandedShadowView }
     }
 
     // MARK: - First Responder


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214748594691481

### Description

- Fixes Fire Tab color resolution in Unified Toggle Input by forcing the toolbar subtree to use the dark trait in Fire Mode.
- Applies Fire Mode trait handling dynamically to Unified Toggle Input content subviews, so future controls inherit the correct Fire Mode colors by default.
- Keeps the card background and shadow on the OS trait so the light-mode Fire Tab card surface remains unchanged.

### Testing Steps

1. Enable the Unified Toggle Input and Fire Mode feature flags.
2. Launch iOS in light mode.
3. Open a Fire tab and switch the Unified Toggle Input to Duck.ai.
4. Verify the Duck.ai Send button uses the Fire Mode Mandarin accent from the dark trait.
5. Verify the Fast/Reasoning icon uses the primary icon color on the dark Fire Tab input surface.
6. Verify the Fire Tab card background still matches the light-mode spec.
7. Switch iOS to dark mode and verify the Fire Tab Duck.ai input still looks correct.

### Impact and Risks

**Impact Level: Low**

This is a small visual bug fix scoped to Unified Toggle Input in Fire Mode. The main risk is that forcing the dark trait more broadly on UTI content could affect another nested control's dynamic colors, but the card background and shadow are explicitly kept on the OS trait to preserve the light-mode Fire Tab surface.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change that adjusts `overrideUserInterfaceStyle` propagation for Fire Mode; main risk is unintended color/trait effects on newly added subviews within the UTI hierarchy.
> 
> **Overview**
> Fixes Fire Mode color resolution in Unified Toggle Input by **forcing the entire `UnifiedToggleInputToolbarView` subtree** to use the `.dark` trait when in a Fire tab, instead of selectively overriding individual buttons.
> 
> Updates Fire Mode handling in `UnifiedToggleInputView` to **apply the Fire Mode trait to all direct content subviews dynamically** (excluding `cardView` and `expandedShadowView`), so new controls inherit the correct Fire Mode colors without needing to be manually added to a list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1e4a7f5d18e62dfbd9246ca2271824adfb70967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->