### PR TITLE
Fix HTML named entities in ddg-sentry-report skill output

### DIFF
--- a/.claude/skills/ddg-sentry-report/SKILL.md
+++ b/.claude/skills/ddg-sentry-report/SKILL.md
@@ -298,6 +298,7 @@ Do **not** add the DRI as a follower of any per-issue tracking task created in s
 - **Subtask name format:** `Sentry summary - <platform> <version> - <YYYY-MM-DD>` (e.g. `Sentry summary - macOS 1.186 - 2026-04-30`).
 - **`asana_get_task` requires `opt_fields="tags,tags.name"`** — the data-protection hook rejects queries without it (`RETRY REQUIRED` error).
 - **Asana `html_notes` must be wrapped in `<body>...</body>`.** Use `<a href="...">` for plain links (not @-mentions). `<strong>`, `<em>`, `<code>`, `<hr>` supported. See the `asana-rich-text` skill for full syntax.
+- **Use literal Unicode characters, never HTML named entities.** `html_notes` is XML — Asana decodes only the five XML built-ins (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&apos;`). Any other named entity (`&bull;`, `&mdash;`, `&ndash;`, `&hellip;`, `&middot;`, `&nbsp;`, `&copy;`, `&trade;`, …) renders as its literal source text (e.g. `&bull;` shows as the eight characters `&bull;`, not `•`). Type the character itself: `•` `—` `–` `…` `·` (regular space) `©` `™`. The templates already use literal characters; preserve them through substitution and never "HTML-escape" typographic punctuation before passing the string to `asana_create_task` / `asana_update_task`. Numeric character references (`&#8226;`) have the same problem — use the literal character.
 - **Resolve parent task GID from URL:** numeric segment after `/task/` (e.g. `.../task/1214175611004136` → `1214175611004136`).
 
 ## Common mistakes
@@ -339,6 +340,7 @@ Top-bite rows. See [`references/common-mistakes-extended.md`](references/common-
 | Mistake | Fix |
 |---|---|
 | Overstating coverage in the report's headlines or "Recommended next step" | Anchor every finding to `<TIME_RANGE>`: "No new regressions in the last 24h", not "Zero new regressions in {version}". Never write "ship it / proceed with confidence / release looks healthy" — those are sign-off statements, not summaries. |
+| Emitting HTML named entities (`&bull;`, `&mdash;`, `&ndash;`, `&hellip;`, `&middot;`, `&nbsp;`) or numeric character references (`&#8226;`) into `html_notes` | Asana's `html_notes` is XML — it decodes only `&amp;`, `&lt;`, `&gt;`, `&quot;`, `&apos;`. Everything else renders literally (`&bull;` becomes the eight characters `&bull;`, not `•`). The templates store the bullet/em-dash as literal Unicode — copy them through verbatim; do not "escape" typographic punctuation when substituting values. |
 
 ## Examples
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1214808436903591?focus=true
CC:

### Description

A recent Sentry summary subtask produced by the `ddg-sentry-report` skill contained literal HTML named entities (`&bull;`, etc.) instead of the bullet characters. Asana's `html_notes` is XML — it decodes only the five XML built-in entities (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&apos;`). Anything else (`&bull;`, `&mdash;`, `&ndash;`, `&hellip;`, `&middot;`, `&nbsp;`, numeric refs like `&#8226;`) renders as its raw source text.

The skill's templates already store typographic punctuation as literal Unicode; the bug was at substitution time, where the LLM was "HTML-escaping" those characters before passing the string to `asana_create_task`. This PR adds an explicit rule against that.

Changes (one file, +2 lines):

- **Quick reference** — new bullet next to the existing `html_notes` rule. Names the five built-in entities Asana decodes, lists the typographic characters to type literally (`•` `—` `–` `…` `·` `©` `™`), and explicitly forbids "HTML-escaping" typographic punctuation during substitution. Calls out numeric character references too.
- **Common mistakes → Reporting tone** — paired wrong/right row so the rule shows up in the scannable mistakes table, not just the prose.

### Testing Steps
1. The next `/ddg-sentry-report` run should write `•` as the literal U+2022 character in the rendered Asana task body, not `&bull;`. Verify by opening the new subtask in Asana.

### Impact and Risks

None — documentation-only change to a skill file. No code paths, no user-visible product surface.

#### What could go wrong?

If the rule is interpreted too broadly and someone strips the five XML built-in entities (`&amp;` `&lt;` `&gt;` `&quot;` `&apos;`), the body becomes invalid XML and Asana returns 400. The new bullet calls those out by name as the exceptions to keep.

### Notes to Reviewer

Skill-only change in `.claude/skills/ddg-sentry-report/SKILL.md`. No effect on app code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change in a skill markdown file with no runtime logic modifications; risk is limited to misinterpretation of which XML entities are allowed.
> 
> **Overview**
> Updates the `ddg-sentry-report` skill documentation to explicitly forbid emitting HTML named entities or numeric character references into Asana `html_notes`, since Asana only decodes the five XML built-in entities and otherwise renders entity text literally.
> 
> Adds this guidance to both the **Quick reference** section and the **Common mistakes → Reporting tone** table to prevent “HTML-escaping” typographic punctuation during template substitution before calling `asana_create_task`/`asana_update_task`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60f97c652966e428a9924f267af2448e6b85e562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->