### PR TITLE
iOS: Update release notes for 7.220.0

### DIFF
--- a/iOS/fastlane/metadata/default/release_notes.txt
+++ b/iOS/fastlane/metadata/default/release_notes.txt
@@ -1,1 +1,3 @@
-• As usual, we've included some bug fixes and improvements.
+• Start searching faster — we now give you a fresh tab when you open the app and an easy way to get back to your last used tab, with a link right below the address bar.
+• You can always customize the browser to show your last used tab when returning instead, and set an inactivity timer to delay your opening screen of choice. Go to Settings > General to customize.
+• This update also includes other bug fixes and improvements.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/38424471409662/task/1214682766520832?focus=true
Tech Design URL: N/A
CC:

### Description

Updates the iOS App Store release notes for 7.220.0 with the new tab opening behavior copy.

Note: PR targets `main` because the script that promotes the build and updates store metadata runs from `main`.

### Testing Steps

1. Open `iOS/fastlane/metadata/default/release_notes.txt`.
2. Verify the contents match the approved copy for 7.220.0.

### Impact and Risks

Low — metadata-only change to App Store release notes copy.

#### What could go wrong?

Typo or formatting issue in the copy. Mitigated by review of the diff.

### Quality Considerations

N/A — copy-only update with no code or runtime impact.

### Notes to Reviewer

Please verify the copy matches the approved version in the linked Asana task.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change; the main risk is typos or formatting issues in the App Store release notes.
> 
> **Overview**
> Updates `iOS/fastlane/metadata/default/release_notes.txt` with new App Store release notes describing the *fresh tab on app open*, a quick link back to the last-used tab, and Settings options for restoring the last tab and configuring an inactivity timer, plus a generic bug-fixes line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fa7bd0d39b9e65e1e20ded318258dab9ea65d81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->