### PR TITLE
[iOS] Remove stale Waitlist package reference from project file

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -2877,7 +2877,6 @@
 		37E615742A5F533E00ACD63D /* SyncCredentialsAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncCredentialsAdapter.swift; sourceTree = "<group>"; };
 		37FCAABB2992F592000E420A /* MultilineScrollableTextFix.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineScrollableTextFix.swift; sourceTree = "<group>"; };
 		37FCAABF29930E26000E420A /* FailedAssertionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailedAssertionView.swift; sourceTree = "<group>"; };
-		37FCAACB2993149A000E420A /* Waitlist */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Waitlist; sourceTree = "<group>"; };
 		37FD780E2A29E28B00B36DB1 /* SyncErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncErrorHandler.swift; sourceTree = "<group>"; };
 		392856D96DBE03E4E18EFCF8 /* RebrandedOnboardingAddressBarPositionPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RebrandedOnboardingAddressBarPositionPicker.swift; sourceTree = "<group>"; };
 		40D67C082BD4927358D771DB /* RebrandedAppIconPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RebrandedAppIconPicker.swift; sourceTree = "<group>"; };
@@ -6100,7 +6099,6 @@
 				31D49A3C2DC294E500262F26 /* UIComponents */,
 				7BB9F8E82DFC1DDA00741690 /* VPN */,
 				7B10FF282D11AA0D00F36BF2 /* VPNiOS */,
-				37FCAACB2993149A000E420A /* Waitlist */,
 				1EC8B18B2F29147000F18679 /* WebExtensions */,
 			);
 			path = LocalPackages;


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1214828715304402?focus=true

## Description

A previous PR renamed the iOS Waitlist local package folder from `Waitlist` to `Waitlist-iOS`, but the Xcode project still listed a `PBXFileReference` pointing at the old `LocalPackages/Waitlist` path inside the `LocalPackages` group. Opening the project surfaced "Couldn't load project at: .../iOS/LocalPackages/Waitlist/.swiftpm/xcode" because Xcode tried to resolve a Swift package at a folder that no longer exists. This removes the orphan reference and its group entry.

## Testing Steps

- Clean build of the iOS app from this branch — should complete without the "Couldn't load project at" log.

## Impact and Risks

Trivial. The orphan reference had no associated build phase, target dependency, or scheme, so removing it can only fix the load error.

#### What could go wrong?

NA

## Quality Considerations

NA

## Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk project-file cleanup that only removes an orphan `LocalPackages/Waitlist` reference; no app code or build phases are modified.
> 
> **Overview**
> Removes the stale `Waitlist` local Swift package `PBXFileReference` and its entry in the `LocalPackages` group from `DuckDuckGo-iOS.xcodeproj`.
> 
> This prevents Xcode from attempting to resolve a non-existent `LocalPackages/Waitlist` folder when opening the project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e34882bfb476fe3a67deaa8e27e93c8cd3e1c213. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->