### PR TITLE
iOS: Wire native storage into contextual UTI host

### DIFF
--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -336,7 +336,8 @@ private extension AIChatContextualSheetCoordinator {
     }
 
     var duckAiLastUsedModelProvider: DuckAiLastUsedModelProviding? {
-        duckAiNativeStorageHandler.map {
+        let storageHandler = isFireTab ? duckAiFireModeStorageHandler : duckAiNativeStorageHandler
+        return storageHandler.map {
             DuckAiLastUsedModelProvider(storage: $0, pixelFiring: DuckAiNativeStoragePixelAdapter())
         }
     }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -314,7 +314,8 @@ private extension AIChatContextualSheetCoordinator {
                     hasActiveChat: { [weak self] in self?.sessionState.hasActiveChat ?? false },
                     isAutoAttachEnabled: { [weak self] in self?.sessionState.shouldAutoCollectContext ?? false },
                     pageContextHandler: self.pageContextHandler,
-                    isFireTab: self.isFireTab
+                    isFireTab: self.isFireTab,
+                    lastUsedModelProvider: self.duckAiLastUsedModelProvider
                 )
                 host.install(in: contextualChatViewController)
                 return host
@@ -332,6 +333,12 @@ private extension AIChatContextualSheetCoordinator {
             return (context, .pendingSubmit)
         }
         return (nil, .delivered)
+    }
+
+    var duckAiLastUsedModelProvider: DuckAiLastUsedModelProviding? {
+        duckAiNativeStorageHandler.map {
+            DuckAiLastUsedModelProvider(storage: $0, pixelFiring: DuckAiNativeStoragePixelAdapter())
+        }
     }
     
     /// Starts the session timer after the sheet is dismissed.

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -46,7 +46,8 @@ final class AIChatContextualUTIHost {
         hasActiveChat: @escaping () -> Bool,
         isAutoAttachEnabled: @escaping () -> Bool,
         pageContextHandler: AIChatPageContextHandling,
-        isFireTab: Bool
+        isFireTab: Bool,
+        lastUsedModelProvider: DuckAiLastUsedModelProviding? = nil
     ) {
         self.pageContextHandler = pageContextHandler
         self.isAutoAttachEnabled = isAutoAttachEnabled
@@ -54,7 +55,8 @@ final class AIChatContextualUTIHost {
         self.coordinator = UnifiedToggleInputCoordinator(
             host: .contextualChat,
             isToggleEnabled: false,
-            isFireTab: isFireTab
+            isFireTab: isFireTab,
+            lastUsedModelProvider: lastUsedModelProvider
         )
         self.chipViewModel = UnifiedToggleInputPageContextChipViewModel(
             originatingURLPublisher: originatingURLPublisher,
@@ -167,13 +169,21 @@ final class AIChatContextualUTIHost {
     func bindToUserScript(_ userScript: AIChatUserScript) {
         Logger.contextualUTI.info("Binding coordinator to AIChatUserScript")
         isBoundToUserScript = true
-        coordinator.bindToTab(userScript)
+        let chatID = userScript.webView?.url?.duckAIChatID
+        coordinator.bindToTab(userScript, hasExistingChat: hasActiveChat() || chatID != nil)
+        if let chatID {
+            coordinator.restoreLastUsedModel(forChatID: chatID)
+        }
         userScript.attachedPageContextProvider = { [weak self] in
             self?.chipViewModel.attachedContext?.contextData
         }
         userScript.onPromptSubmitted = { [weak self] in
             self?.chipViewModel.markPromptSubmitted()
         }
+    }
+
+    func observeChatUpdates(_ publisher: AnyPublisher<String, Never>) {
+        coordinator.observeChatUpdates(publisher)
     }
 
     func markPromptSubmitted() {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -69,8 +69,15 @@ final class AIChatContextualUTIHost {
         chipViewModel.onRemoveActionRequested = { [weak self] in
             self?.handleChipRemoveRequest()
         }
+        coordinator.delegate = self
 
         Logger.contextualUTI.debug("UTIHost init — carryOver=\(initialAttachedContext != nil, privacy: .public) auto=\(isAutoAttachEnabled(), privacy: .public)")
+
+        coordinator.intentPublisher
+            .sink { [weak self] _ in
+                self?.applyCurrentRenderState()
+            }
+            .store(in: &cancellables)
 
         // Out-of-band context (BEFORECHAT manual attach, FE-driven flows) reaches the chip
         // here; pick a delivery state from session timing — pre-chat = silent, active-chat =
@@ -197,8 +204,38 @@ final class AIChatContextualUTIHost {
             contextualChatViewController.anchorWebViewBottom(to: coordinator.viewController.view.topAnchor)
             coordinator.viewController.didMove(toParent: contextualChatViewController)
             coordinator.showExpanded()
+            applyCurrentRenderState()
             contextualChatViewController.view.layoutIfNeeded()
         }
         Logger.contextualUTI.info("Installed at bottom of contextual chat")
     }
+
+    private func applyCurrentRenderState() {
+        coordinator.viewController.apply(coordinator.computeRenderState().viewConfig, animated: false)
+        contextualChatViewController?.view.layoutIfNeeded()
+    }
+}
+
+extension AIChatContextualUTIHost: UnifiedToggleInputDelegate {
+
+    func unifiedToggleInputDidSubmitPrompt(_ prompt: String,
+                                           modelId: String?,
+                                           tools: [AIChatRAGTool]?,
+                                           reasoningEffort: AIChatReasoningEffort?,
+                                           images: [AIChatNativePrompt.NativePromptImage]?,
+                                           files: [AIChatNativePrompt.NativePromptFile]?) {
+        contextualChatViewController?.submitPrompt(prompt, pageContext: chipViewModel.attachedContext?.contextData)
+    }
+
+    func unifiedToggleInputDidChangeHeight() {
+        contextualChatViewController?.view.layoutIfNeeded()
+    }
+
+    func unifiedToggleInputDidSubmitQuery(_ query: String) {}
+    func unifiedToggleInputDidRequestVoiceSearch() {}
+    func unifiedToggleInputDidRequestAIVoiceChat() {}
+    func unifiedToggleInputDidRequestAIChat(prefilledText: String) {}
+    func unifiedToggleInputDidCommitMode(_ mode: TextEntryMode) {}
+    func unifiedToggleInputDidRequestFire() {}
+    func unifiedToggleInputDidRequestDuckAIVoiceMode() {}
 }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -227,16 +227,6 @@ final class AIChatContextualUTIHost {
 }
 
 extension AIChatContextualUTIHost: UnifiedToggleInputDelegate {
-
-    func unifiedToggleInputDidSubmitPrompt(_ prompt: String,
-                                           modelId: String?,
-                                           tools: [AIChatRAGTool]?,
-                                           reasoningEffort: AIChatReasoningEffort?,
-                                           images: [AIChatNativePrompt.NativePromptImage]?,
-                                           files: [AIChatNativePrompt.NativePromptFile]?) {
-        contextualChatViewController?.submitPrompt(prompt, pageContext: chipViewModel.attachedContext?.contextData)
-    }
-
     func unifiedToggleInputDidChangeHeight() {
         contextualChatViewController?.view.layoutIfNeeded()
     }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -71,7 +71,6 @@ final class AIChatContextualUTIHost {
         chipViewModel.onRemoveActionRequested = { [weak self] in
             self?.handleChipRemoveRequest()
         }
-        coordinator.delegate = self
 
         Logger.contextualUTI.debug("UTIHost init — carryOver=\(initialAttachedContext != nil, privacy: .public) auto=\(isAutoAttachEnabled(), privacy: .public)")
 
@@ -224,18 +223,4 @@ final class AIChatContextualUTIHost {
         coordinator.viewController.apply(coordinator.computeRenderState().viewConfig, animated: false)
         contextualChatViewController?.view.layoutIfNeeded()
     }
-}
-
-extension AIChatContextualUTIHost: UnifiedToggleInputDelegate {
-    func unifiedToggleInputDidChangeHeight() {
-        contextualChatViewController?.view.layoutIfNeeded()
-    }
-
-    func unifiedToggleInputDidSubmitQuery(_ query: String) {}
-    func unifiedToggleInputDidRequestVoiceSearch() {}
-    func unifiedToggleInputDidRequestAIVoiceChat() {}
-    func unifiedToggleInputDidRequestAIChat(prefilledText: String) {}
-    func unifiedToggleInputDidCommitMode(_ mode: TextEntryMode) {}
-    func unifiedToggleInputDidRequestFire() {}
-    func unifiedToggleInputDidRequestDuckAIVoiceMode() {}
 }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
@@ -385,6 +385,9 @@ extension AIChatContextualWebViewController: UserContentControllerDelegate {
         aiChatContentHandler.setup(with: userScripts.aiChatUserScript, webView: webView, displayMode: .contextual)
         userScripts.aiChatUserScript.setContextualModePixelHandler(pixelHandler)
         utiHost?.bindToUserScript(userScripts.aiChatUserScript)
+        if let chatUpdatesPublisher = userScripts.duckAiNativeStorageUserScript?.chatUpdatesPublisher {
+            utiHost?.observeChatUpdates(chatUpdatesPublisher)
+        }
 
         isContentHandlerReady = true
         submitPendingIfReady()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputDelegate.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputDelegate.swift
@@ -31,8 +31,3 @@ protocol UnifiedToggleInputDelegate: AnyObject {
     func unifiedToggleInputDidRequestFire()
     func unifiedToggleInputDidRequestDuckAIVoiceMode()
 }
-
-extension UnifiedToggleInputDelegate {
-    /// Optional: only fires when no `AIChatUserScript` is bound (omnibar "open new chat" path).
-    func unifiedToggleInputDidSubmitPrompt(_ prompt: String, modelId: String?, tools: [AIChatRAGTool]?, reasoningEffort: AIChatReasoningEffort?, images: [AIChatNativePrompt.NativePromptImage]?, files: [AIChatNativePrompt.NativePromptFile]?) {}
-}

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputDelegate.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputDelegate.swift
@@ -31,3 +31,8 @@ protocol UnifiedToggleInputDelegate: AnyObject {
     func unifiedToggleInputDidRequestFire()
     func unifiedToggleInputDidRequestDuckAIVoiceMode()
 }
+
+extension UnifiedToggleInputDelegate {
+    /// Optional: only fires when no `AIChatUserScript` is bound (omnibar "open new chat" path).
+    func unifiedToggleInputDidSubmitPrompt(_ prompt: String, modelId: String?, tools: [AIChatRAGTool]?, reasoningEffort: AIChatReasoningEffort?, images: [AIChatNativePrompt.NativePromptImage]?, files: [AIChatNativePrompt.NativePromptFile]?) {}
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214820742244148?focus=true
Tech Design URL:
CC:

### Description
Fixes UTI in context mode toolbar buttons

### Testing Steps
1. Open a page and trigger the contextual chat (UTI bar appears).
2. Submit a prompt, change the model from the FE, then reopen the contextual chat on the same page — verify the UTI reflects the last-used model.
3. Open the contextual chat on a brand-new page and confirm the follow-up placeholder/state still behaves correctly.

### Impact and Risks
Medium — touches the contextual chat init path and adds a second publisher subscription wired off the native-storage user script.

#### What could go wrong?
A `userContentController` re-install could subscribe to the chat-updates publisher twice, doubling chat-update side effects.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the contextual chat/UTI initialization and adds new Combine subscriptions for model/state updates, which could cause missed/duplicate updates or subtle UI state desyncs on reinits.
> 
> **Overview**
> **Contextual chat’s native UTI now participates in Duck.ai native storage.** The sheet coordinator builds and injects a `DuckAiLastUsedModelProvider` (fire-mode aware) into `AIChatContextualUTIHost`/`UnifiedToggleInputCoordinator` so the contextual surface can persist and reuse the last-selected model.
> 
> The UTI host now treats a URL with a `duckAIChatID` as an existing chat, restores the last-used model for that chat on bind, and forwards the native-storage user script’s `chatUpdatesPublisher` so FE-driven model changes are reflected in the UTI. It also refreshes the UTI view config on coordinator intent changes and immediately after installation to keep render state in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59bc94db72639daba0b8a2c1a879f92442fbdc27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->