### PR TITLE
[macOS] Pass versioned DMG URL to create-variants workflow

### DIFF
--- a/.github/workflows/macos_create_variants.yml
+++ b/.github/workflows/macos_create_variants.yml
@@ -6,8 +6,18 @@ defaults:
 
 on:
   workflow_dispatch:
+    inputs:
+      dmg-url:
+        description: "DMG URL to download (overrides RELEASE_DMG_URL variable when set)"
+        required: false
+        type: string
 
   workflow_call:
+    inputs:
+      dmg-url:
+        description: "DMG URL to download (overrides RELEASE_DMG_URL variable when set)"
+        required: false
+        type: string
     secrets:
       ASANA_ACCESS_TOKEN:
         required: true
@@ -63,8 +73,10 @@ jobs:
             macOS/scripts
 
       - name: Download release app
+        env:
+          DMG_URL: ${{ inputs.dmg-url != '' && inputs.dmg-url || vars.RELEASE_DMG_URL }}
         run: |
-          curl -fLSs "${{ vars.RELEASE_DMG_URL }}" --output duckduckgo.dmg
+          curl -fLSs "${DMG_URL}" --output duckduckgo.dmg
 
       - name: Upload DMG artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/macos_publish_dmg_release.yml
+++ b/.github/workflows/macos_publish_dmg_release.yml
@@ -113,6 +113,9 @@ jobs:
     # by the stop_workflow flag.
     if: always() && !cancelled() && needs.stop-workflow-if-needed.outputs.stop_workflow != 'true'
 
+    outputs:
+      dmg-url: ${{ steps.set-common-env.outputs.dmg-url }}
+
     runs-on: macos-26-xlarge
     timeout-minutes: 10
 
@@ -334,13 +337,16 @@ jobs:
           echo "tasks=$tasks" >> $GITHUB_OUTPUT
 
       - name: Set common environment variables
+        id: set-common-env
         if: always()
         env:
           DMG_NAME: ${{ steps.fetch-dmg.outputs.dmg-name }}
         run: |
+          DMG_URL="${{ vars.DMG_URL_ROOT }}${DMG_NAME}"
           echo "APPCAST_PATCH_NAME=${{ steps.appcast.outputs.appcast-patch-name }}" >> $GITHUB_ENV
           echo "DMG_NAME=${DMG_NAME}" >> $GITHUB_ENV
-          echo "DMG_URL=${{ vars.DMG_URL_ROOT }}${DMG_NAME}" >> $GITHUB_ENV
+          echo "DMG_URL=${DMG_URL}" >> $GITHUB_ENV
+          echo "dmg-url=${DMG_URL}" >> $GITHUB_OUTPUT
           echo "RELEASE_BUCKET_NAME=${{ vars.RELEASE_BUCKET_NAME }}" >> $GITHUB_ENV
           echo "RELEASE_BUCKET_PREFIX=${{ vars.RELEASE_BUCKET_PREFIX }}" >> $GITHUB_ENV
           echo "RELEASE_TASK_ID=${{ steps.task-id.outputs.asana_task_id }}" >> $GITHUB_ENV
@@ -463,4 +469,6 @@ jobs:
     if: github.event.inputs.release-type != null && github.event.inputs.release-type != 'internal'
 
     uses: ./.github/workflows/macos_create_variants.yml
+    with:
+      dmg-url: ${{ needs.publish-to-sparkle.outputs.dmg-url }}
     secrets: inherit


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1214833463039831

### Description

The `Create DMG variants` job in the public release workflow was downloading the DMG from the `funnel_home_website/duckduckgo.dmg` CDN path right after `Publish a release to Sparkle` finished uploading it. Because that path is fronted by a 1-2 minute CDN cache, the variants job often picked up the **previous** release's DMG instead of the one that had just been published — which is why duckduckgo.com/mac most recently served 1.188 even though 1.189 was the published release.

This PR fixes the race by feeding the versioned DMG URL directly into the variants workflow:

- `macos_create_variants.yml` gains an optional `dmg-url` input on both `workflow_dispatch` and `workflow_call`. The `Download release app` step uses it when set, falling back to `vars.RELEASE_DMG_URL` so manual dispatches keep working.
- `macos_publish_dmg_release.yml` exposes `DMG_URL` (already built in the `Set common environment variables` step as `${{ vars.DMG_URL_ROOT }}${DMG_NAME}`) as a job output on `publish-to-sparkle`, then passes it to the `create-variants` reusable workflow via `with: dmg-url:`.

### Testing Steps

We'll test it on Monday 😇 

### Impact and Risks

Low. Workflow-only change that affects the public/hotfix release path. The only behavioral change is that variants are now built from the just-published versioned DMG instead of the cached `duckduckgo.dmg` alias, which is the intended behavior. Internal releases don't run the variants job and are unaffected.

#### What could go wrong?

- If `Set common environment variables` doesn't run, the `dmg-url` job output would be empty and `create-variants` would receive an empty string — the `Download release app` step's expression (`inputs.dmg-url != '' && inputs.dmg-url || vars.RELEASE_DMG_URL`) falls back to the existing variable, so the worst-case behavior is the pre-PR behavior.
- `create-variants` depends on `publish-to-sparkle` succeeding, so the output should always be populated when variants actually run.
- Backwards compatible for direct `workflow_dispatch`: the new input is optional and defaults to the previous CDN URL.

### Quality Considerations

- No other callers of `macos_create_variants.yml` exist in the repo (verified via grep), so there are no other workflow integrations to update.
- The `DMG_URL` value is built from the same template (`vars.DMG_URL_ROOT` + versioned DMG name) that the publish step uses when uploading, so the URL is guaranteed to match the just-uploaded artifact.
- No new permissions, no new secrets.

### Notes to Reviewer

The `${DMG_URL}` value being passed already exists in the publish job — this PR only exposes it as a job output so the downstream reusable workflow can consume it. The fallback expression intentionally treats an empty string the same as "not provided" so workflow re-runs that skipped the env step don't break.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public/hotfix macOS release pipeline by wiring a computed DMG URL between workflows; misconfigured outputs/inputs could cause variants to be built from the fallback URL or fail to download the DMG.
> 
> **Overview**
> Fixes a race in the macOS public/hotfix release workflow by **passing the freshly published, versioned DMG URL** into the variants build instead of relying on the cached `vars.RELEASE_DMG_URL` alias.
> 
> `macos_create_variants.yml` now accepts an optional `dmg-url` input (for both `workflow_dispatch` and `workflow_call`) and downloads from it when provided, while `macos_publish_dmg_release.yml` exposes the computed `DMG_URL` as a `publish-to-sparkle` job output and forwards it to the `create-variants` reusable workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeb9ae4b14318c1449b94e4a2281d55a4c6f65b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->