### PR TITLE
Disable onboardingRebranding feature flag for UI tests

### DIFF
--- a/macOS/UITests/OnboardingUITests.swift
+++ b/macOS/UITests/OnboardingUITests.swift
@@ -28,13 +28,9 @@ final class OnboardingUITests: UITestCase {
         continueAfterFailure = false
         try resetApplicationData()
 
-        // The rebranded onboarding flow (gated by the `onboardingRebranding` feature flag, enabled by
-        // default since #4795) ships different copy and a different step ordering, so the assertions
-        // in this file no longer match. Force the flag off until the tests are rewritten for v4.
-        app = XCUIApplication.setUp(
-            environment: ["UITEST_MODE_ONBOARDING": "1"],
-            featureFlags: ["onboardingRebranding": false]
-        )
+        app = XCUIApplication.setUp(environment: [
+            "UITEST_MODE_ONBOARDING": "1"
+        ])
         app.enforceSingleWindow()
 
         welcomeWindow = app.windows["Welcome"]
@@ -54,7 +50,7 @@ final class OnboardingUITests: UITestCase {
         // Get Started
         XCTAssertTrue(welcomeWindow.webViews["Welcome"].staticTexts["Ready for a faster browser that keeps you protected?"].waitForExistence(timeout: UITests.Timeouts.elementExistence))
 
-        let getStartedButton = welcomeWindow.webViews["Welcome"].buttons["Let’s Do It!"]
+        let getStartedButton = welcomeWindow.webViews["Welcome"].buttons["Let’s do it!"]
         XCTAssertTrue(getStartedButton.waitForExistence(timeout: UITests.Timeouts.elementExistence))
         // Use coordinate tap to avoid overlay/hittability quirks
         let centerCoordinate = getStartedButton.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.1))

--- a/macOS/UITests/OnboardingUITests.swift
+++ b/macOS/UITests/OnboardingUITests.swift
@@ -28,9 +28,13 @@ final class OnboardingUITests: UITestCase {
         continueAfterFailure = false
         try resetApplicationData()
 
-        app = XCUIApplication.setUp(environment: [
-            "UITEST_MODE_ONBOARDING": "1"
-        ])
+        // The rebranded onboarding flow (gated by the `onboardingRebranding` feature flag, enabled by
+        // default since #4795) ships different copy and a different step ordering, so the assertions
+        // in this file no longer match. Force the flag off until the tests are rewritten for v4.
+        app = XCUIApplication.setUp(
+            environment: ["UITEST_MODE_ONBOARDING": "1"],
+            featureFlags: ["onboardingRebranding": false]
+        )
         app.enforceSingleWindow()
 
         welcomeWindow = app.windows["Welcome"]


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1214816707188281?focus=true
Tech Design URL:
CC:

### Description

This PR disables the `onboardingRebranding` feature flag for UI tests, as the updated rebranding was causing them to fail. We will need to re-write the tests to match the rebrand, but for now this will get things passing again.

### Testing Steps

1. Check CI is happy!

### Impact and Risks

None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a UI test string selector to match updated onboarding copy, with no production code changes.
> 
> **Overview**
> Updates the macOS onboarding UI test to look for the Get Started button label `Let’s do it!` (lowercase “do”) instead of `Let’s Do It!`, aligning the test with current onboarding text to prevent false failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8542e5f130f95a42e2d7d085fcc23ec15d46c7c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->