### PR TITLE
iOS: Snapshot unifiedToggleInput flag at launch

### DIFF
--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -73,6 +73,7 @@ final class AIChatContextualSheetCoordinator {
     private let contentBlockingAssetsPublisher: AnyPublisher<ContentBlockingUpdating.NewContent, Never>
     private let featureDiscovery: FeatureDiscovery
     private let featureFlagger: FeatureFlagger
+    private let unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding
     private let duckAiNativeStorageHandler: DuckAiNativeStorageHandling?
     private let duckAiFireModeStorageHandler: DuckAiNativeStorageHandling?
     private let debugSettings: AIChatDebugSettingsHandling
@@ -118,6 +119,7 @@ final class AIChatContextualSheetCoordinator {
          contentBlockingAssetsPublisher: AnyPublisher<ContentBlockingUpdating.NewContent, Never>,
          featureDiscovery: FeatureDiscovery,
          featureFlagger: FeatureFlagger,
+         unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature(),
          pageContextHandler: AIChatPageContextHandling,
          tabURLPublishers: AIChatTabURLPublishers,
          isFireTab: Bool = false,
@@ -131,6 +133,7 @@ final class AIChatContextualSheetCoordinator {
         self.contentBlockingAssetsPublisher = contentBlockingAssetsPublisher
         self.featureDiscovery = featureDiscovery
         self.featureFlagger = featureFlagger
+        self.unifiedToggleInputFeature = unifiedToggleInputFeature
         self.pageContextHandler = pageContextHandler
         self.tabURLPublishers = tabURLPublishers
         self.isFireTab = isFireTab
@@ -188,7 +191,7 @@ final class AIChatContextualSheetCoordinator {
     func notifyPageChanged() async {
         guard hasActiveSheet else { return }
         // Native UTI handles nav via the chip view-model's `originatingURLPublisher` subscription.
-        if featureFlagger.isFeatureOn(.unifiedToggleInput) { return }
+        if unifiedToggleInputFeature.isFeatureFlagEnabled { return }
         sessionState.notifyPageChanged()
 
         if sessionState.shouldAutoCollectContext {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
@@ -47,6 +47,7 @@ final class AIChatContextualWebViewController: UIViewController {
     private let contentBlockingAssetsPublisher: AnyPublisher<ContentBlockingUpdating.NewContent, Never>
     private let featureDiscovery: FeatureDiscovery
     private let featureFlagger: FeatureFlagger
+    private let unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding
     private let isFireTab: Bool
     private let duckAiFireModeStorageHandler: DuckAiNativeStorageHandling?
     private var downloadHandler: DownloadHandling
@@ -128,6 +129,7 @@ final class AIChatContextualWebViewController: UIViewController {
          contentBlockingAssetsPublisher: AnyPublisher<ContentBlockingUpdating.NewContent, Never>,
          featureDiscovery: FeatureDiscovery,
          featureFlagger: FeatureFlagger,
+         unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature(),
          isFireTab: Bool = false,
          duckAiFireModeStorageHandler: DuckAiNativeStorageHandling? = nil,
          downloadHandler: DownloadHandling,
@@ -141,6 +143,7 @@ final class AIChatContextualWebViewController: UIViewController {
         self.contentBlockingAssetsPublisher = contentBlockingAssetsPublisher
         self.featureDiscovery = featureDiscovery
         self.featureFlagger = featureFlagger
+        self.unifiedToggleInputFeature = unifiedToggleInputFeature
         self.isFireTab = isFireTab
         self.duckAiFireModeStorageHandler = duckAiFireModeStorageHandler
         self.downloadHandler = downloadHandler
@@ -297,7 +300,7 @@ final class AIChatContextualWebViewController: UIViewController {
     }
 
     private var isUTIEnabled: Bool {
-        featureFlagger.isFeatureOn(.unifiedToggleInput) && utiHostInstaller != nil
+        unifiedToggleInputFeature.isFeatureFlagEnabled && utiHostInstaller != nil
     }
 
     private func setupDownloadHandler() {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
@@ -107,7 +107,6 @@ final class SwitchBarHandler: SwitchBarHandling {
     private let aiChatSettings: AIChatSettingsProvider
     private let funnelState: SwitchBarFunnelProviding
     private var sessionStateMetrics: SessionStateMetricsProviding
-    private let featureFlagger: FeatureFlagger
     private let unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding
     private let voiceShortcutFeature: DuckAIVoiceShortcutFeatureProviding
 
@@ -207,7 +206,6 @@ final class SwitchBarHandler: SwitchBarHandling {
          initialToggleState: TextEntryMode? = nil,
          funnelState: SwitchBarFunnelProviding = SwitchBarFunnel(storage: UserDefaults.standard),
          sessionStateMetrics: SessionStateMetricsProviding,
-         featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
          unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature(),
          devicePlatform: DevicePlatformProviding.Type = DevicePlatform.self,
          voiceShortcutFeature: DuckAIVoiceShortcutFeatureProviding = DuckAIVoiceShortcutFeature(),
@@ -217,7 +215,6 @@ final class SwitchBarHandler: SwitchBarHandling {
         self.toggleModeStorage = toggleModeStorage
         self.funnelState = funnelState
         self.sessionStateMetrics = sessionStateMetrics
-        self.featureFlagger = featureFlagger
         self.unifiedToggleInputFeature = unifiedToggleInputFeature
         self.devicePlatform = devicePlatform
         self.voiceShortcutFeature = voiceShortcutFeature

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
@@ -108,6 +108,7 @@ final class SwitchBarHandler: SwitchBarHandling {
     private let funnelState: SwitchBarFunnelProviding
     private var sessionStateMetrics: SessionStateMetricsProviding
     private let featureFlagger: FeatureFlagger
+    private let unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding
     private let voiceShortcutFeature: DuckAIVoiceShortcutFeatureProviding
 
     // MARK: - Published Properties
@@ -138,14 +139,14 @@ final class SwitchBarHandler: SwitchBarHandling {
     }
 
     var isUsingFadeOutAnimation: Bool {
-        guard featureFlagger.isFeatureOn(.unifiedToggleInput) else {
+        guard unifiedToggleInputFeature.isFeatureFlagEnabled else {
             return devicePlatform.isIphone
         }
         return false
     }
 
     var shouldDisableAutocorrectOnEmpty: Bool {
-        featureFlagger.isFeatureOn(.unifiedToggleInput) || devicePlatform.isIphone
+        unifiedToggleInputFeature.isFeatureFlagEnabled || devicePlatform.isIphone
     }
 
     var isVoiceSearchEnabled: Bool {
@@ -207,6 +208,7 @@ final class SwitchBarHandler: SwitchBarHandling {
          funnelState: SwitchBarFunnelProviding = SwitchBarFunnel(storage: UserDefaults.standard),
          sessionStateMetrics: SessionStateMetricsProviding,
          featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
+         unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature(),
          devicePlatform: DevicePlatformProviding.Type = DevicePlatform.self,
          voiceShortcutFeature: DuckAIVoiceShortcutFeatureProviding = DuckAIVoiceShortcutFeature(),
          isFireTab: Bool) {
@@ -216,6 +218,7 @@ final class SwitchBarHandler: SwitchBarHandling {
         self.funnelState = funnelState
         self.sessionStateMetrics = sessionStateMetrics
         self.featureFlagger = featureFlagger
+        self.unifiedToggleInputFeature = unifiedToggleInputFeature
         self.devicePlatform = devicePlatform
         self.voiceShortcutFeature = voiceShortcutFeature
         self.isFireTab = isFireTab

--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -121,6 +121,7 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
     private let experimentalAIChatManager: ExperimentalAIChatManager
     private let syncHandler: AIChatSyncHandling
     private let featureFlagger: FeatureFlagger
+    private let unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding
     private var syncStatusChangedHandler: ((AIChatSyncHandler.SyncStatus) -> Void)?
     private var cancellables = Set<AnyCancellable>()
     private let migrationStore = AIChatMigrationStore()
@@ -148,6 +149,7 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
          promptHandler: any AIChatConsumableDataHandling = AIChatPromptHandler.shared,
          aichatFullModeFeature: AIChatFullModeFeatureProviding = AIChatFullModeFeature(),
          aichatContextualModeFeature: AIChatContextualModeFeatureProviding = AIChatContextualModeFeature(),
+         unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature(),
          isNativeStorageBridgeAvailable: Bool = false) {
         self.experimentalAIChatManager = experimentalAIChatManager
         self.syncHandler = syncHandler
@@ -156,6 +158,7 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
         self.promptHandler = promptHandler
         self.aichatFullModeFeature = aichatFullModeFeature
         self.aichatContextualModeFeature = aichatContextualModeFeature
+        self.unifiedToggleInputFeature = unifiedToggleInputFeature
         self.isNativeStorageBridgeAvailable = isNativeStorageBridgeAvailable
         setUpSyncStatusObserver()
     }
@@ -256,7 +259,7 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
             supportsContextualMode = aichatContextualModeFeature.isAvailable || defaults.supportsAIChatContextualMode
         }
 
-        let supportsNativeChatInput = (supportsFullMode || supportsContextualMode) && featureFlagger.isFeatureOn(.unifiedToggleInput)
+        let supportsNativeChatInput = (supportsFullMode || supportsContextualMode) && unifiedToggleInputFeature.isFeatureFlagEnabled
         let supportsNativePrompt = supportsNativeChatInput || defaults.supportsNativePrompt
         let fireMode = isFireModeProvider?() ?? false
 

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -147,7 +147,7 @@ class TabViewController: UIViewController {
 
     private(set) var webView: WKWebView!
     private lazy var appRatingPrompt: AppRatingPrompt = AppRatingPrompt(featureFlagger: self.featureFlagger)
-    private lazy var unifiedToggleInputFeature = UnifiedToggleInputFeature(featureFlagger: featureFlagger)
+    private lazy var unifiedToggleInputFeature = UnifiedToggleInputFeature()
     public weak var privacyDashboard: PrivacyDashboardViewController?
     
     private var storageCache: StorageCache = AppDependencyProvider.shared.storageCache

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -140,6 +140,7 @@ final class MainCoordinator {
         self.voiceSessionStateManager = VoiceSessionStateManager()
         self.voiceShortcutFeature = DuckAIVoiceShortcutFeature(featureFlagger: featureFlagger)
         FireModeCapability.resolve(using: featureFlagger)
+        UnifiedToggleInputFeature.resolve(using: featureFlagger)
         let fireModeCapability = FireModeCapability.create()
         let fireModePromotionsCoordinator = FireModePromotionsCoordinator(fireModeCapability: fireModeCapability)
         let homePageConfiguration = HomePageConfiguration(variantManager: AppDependencyProvider.shared.variantManager,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputFeature.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputFeature.swift
@@ -18,26 +18,38 @@
 //
 
 import Foundation
-import PrivacyConfig
 import Common
-import UIKit
+import Core
+import PrivacyConfig
 
 protocol UnifiedToggleInputFeatureProviding {
     var isAvailable: Bool { get }
+    var isFeatureFlagEnabled: Bool { get }
 }
 
 struct UnifiedToggleInputFeature: UnifiedToggleInputFeatureProviding {
 
-    private let featureFlagger: any FeatureFlagger
+    static let isFeatureFlagEnabledKey = "com.duckduckgo.unifiedToggleInput.session.enabled"
+
+    /// Evaluate the feature flag once and persist the result for the session.
+    /// Must be called early in the app launch sequence, before any consumer
+    /// reads `isAvailable`, so that every component sees the same value.
+    static func resolve(using featureFlagger: FeatureFlagger) {
+        let enabled = featureFlagger.isFeatureOn(.unifiedToggleInput)
+        UserDefaults.app.set(enabled, forKey: isFeatureFlagEnabledKey)
+    }
+
     private let devicePlatform: DevicePlatformProviding.Type
 
-    init(featureFlagger: any FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
-         devicePlatform: DevicePlatformProviding.Type = DevicePlatform.self) {
-        self.featureFlagger = featureFlagger
+    init(devicePlatform: DevicePlatformProviding.Type = DevicePlatform.self) {
         self.devicePlatform = devicePlatform
     }
 
+    var isFeatureFlagEnabled: Bool {
+        UserDefaults.app.bool(forKey: Self.isFeatureFlagEnabledKey)
+    }
+
     var isAvailable: Bool {
-        featureFlagger.isFeatureOn(.unifiedToggleInput) && devicePlatform.isIphone
+        isFeatureFlagEnabled && devicePlatform.isIphone
     }
 }

--- a/iOS/DuckDuckGoTests/SwitchBar/SwitchBarHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/SwitchBar/SwitchBarHandlerTests.swift
@@ -37,7 +37,6 @@ final class SwitchBarHandlerTests: XCTestCase {
     private var sut: SwitchBarHandler!
     private var mockVoiceSearchHelper: MockVoiceSearchHelper!
     private var mockStorage: MockKeyValueStore!
-    private var mockFeatureFlagger: MockFeatureFlagger!
     private var cancellables: Set<AnyCancellable>!
 
     override func setUp() {
@@ -45,7 +44,6 @@ final class SwitchBarHandlerTests: XCTestCase {
         MockDevicePlatform.isIphone = true
         mockVoiceSearchHelper = MockVoiceSearchHelper()
         mockStorage = MockKeyValueStore()
-        mockFeatureFlagger = MockFeatureFlagger(enabledFeatureFlags: [])
         cancellables = Set<AnyCancellable>()
         createSUT()
     }
@@ -55,16 +53,14 @@ final class SwitchBarHandlerTests: XCTestCase {
         sut = nil
         mockVoiceSearchHelper = nil
         mockStorage = nil
-        mockFeatureFlagger = nil
         super.tearDown()
     }
 
-    private func createSUT(devicePlatform: DevicePlatformProviding.Type = MockDevicePlatform.self, featureFlagger: FeatureFlagger? = nil) {
+    private func createSUT(devicePlatform: DevicePlatformProviding.Type = MockDevicePlatform.self) {
         sut = SwitchBarHandler(
             voiceSearchHelper: mockVoiceSearchHelper,
             aiChatSettings: MockAIChatSettingsProvider(),
             sessionStateMetrics: SessionStateMetrics(storage: mockStorage),
-            featureFlagger: featureFlagger ?? mockFeatureFlagger,
             devicePlatform: devicePlatform,
             isFireTab: false
         )

--- a/iOS/DuckDuckGoTests/ToggleMode/DefaultTogglePositionTests.swift
+++ b/iOS/DuckDuckGoTests/ToggleMode/DefaultTogglePositionTests.swift
@@ -171,7 +171,6 @@ final class SwitchBarHandlerDefaultModeTests: XCTestCase {
             aiChatSettings: settings,
             toggleModeStorage: toggleModeStorage,
             sessionStateMetrics: SessionStateMetrics(storage: MockKeyValueStore()),
-            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: []),
             isFireTab: false
         )
     }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputFeatureTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputFeatureTests.swift
@@ -65,20 +65,32 @@ final class UnifiedToggleInputFeatureTests: XCTestCase {
 
     // MARK: - Snapshot semantics
 
-    /// Flipping the feature flag mid-session must NOT change the captured value — the UI
-    /// architecture is bound at launch and changing it mid-session leaves the old toggle UI
-    /// in a half-wired state.
-    func test_isFeatureFlagEnabled_doesNotReflectFlaggerChangesAfterResolve() {
-        UnifiedToggleInputFeature.resolve(using: MockFeatureFlagger(enabledFeatureFlags: [.unifiedToggleInput]))
-        let captured = UnifiedToggleInputFeature(devicePlatform: MockDevicePlatform.self)
+    /// Mid-session flag flips (e.g. debug-menu toggle, remote-config update) must NOT
+    /// change the captured value. The resolve writes the launch-time value into UserDefaults,
+    /// and readers must never re-consult the live flagger — even if the same flagger object
+    /// that was passed to resolve subsequently reports a different value. This is the whole
+    /// point of the snapshot: a re-evaluating implementation would let the live flagger drag
+    /// `isFeatureFlagEnabled` along with it and would fail this test.
+    func test_isFeatureFlagEnabled_ignoresLiveFlaggerMutationAfterResolve() {
+        let flagger = MockFeatureFlagger(enabledFeatureFlags: [.unifiedToggleInput])
+        UnifiedToggleInputFeature.resolve(using: flagger)
+        let feature = UnifiedToggleInputFeature(devicePlatform: MockDevicePlatform.self)
+        XCTAssertTrue(feature.isFeatureFlagEnabled, "Precondition: snapshot is ON after resolve")
 
-        // Simulate "the flag was turned off remotely / via debug menu" by re-resolving with a flagger
-        // that reports the flag as off. The captured instance must still report the launch value.
-        let originalCapturedValue = captured.isFeatureFlagEnabled
+        // Simulate "the user toggled the flag off in the debug menu" by mutating the same
+        // flagger that was passed to resolve. A re-evaluating implementation would observe
+        // this and flip; the snapshot must not.
+        flagger.enabledFeatureFlags = []
+        XCTAssertFalse(flagger.isFeatureOn(.unifiedToggleInput),
+                       "Sanity: the live flagger now reports the flag as off")
+        XCTAssertTrue(feature.isFeatureFlagEnabled,
+                      "Snapshot must ignore the post-resolve mutation on the same instance")
+        XCTAssertTrue(UnifiedToggleInputFeature(devicePlatform: MockDevicePlatform.self).isFeatureFlagEnabled,
+                      "A fresh instance must read the same snapshot, not the mutated live flagger")
 
-        // No re-resolve here; the live flagger value flipped, but consumers must keep the
-        // snapshot. (Re-resolving would be a fresh app launch — not what we're modelling.)
-        XCTAssertEqual(captured.isFeatureFlagEnabled, originalCapturedValue)
-        XCTAssertTrue(captured.isFeatureFlagEnabled)
+        // Only an explicit re-resolve (i.e. the next app launch) flips the snapshot.
+        UnifiedToggleInputFeature.resolve(using: flagger)
+        XCTAssertFalse(feature.isFeatureFlagEnabled,
+                       "After re-resolving the snapshot must flip — otherwise resolve isn't doing its job")
     }
 }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputFeatureTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputFeatureTests.swift
@@ -29,15 +29,20 @@ final class UnifiedToggleInputFeatureTests: XCTestCase {
         static var isIphone: Bool = false
     }
 
+    // MARK: - Setup
+
+    override func tearDown() {
+        UserDefaults.app.removeObject(forKey: UnifiedToggleInputFeature.isFeatureFlagEnabledKey)
+        super.tearDown()
+    }
+
     // MARK: - Helpers
 
     private func makeFeature(flagEnabled: Bool, isIphone: Bool) -> UnifiedToggleInputFeature {
         MockDevicePlatform.isIphone = isIphone
         let flags: [FeatureFlag] = flagEnabled ? [.unifiedToggleInput] : []
-        return UnifiedToggleInputFeature(
-            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: flags),
-            devicePlatform: MockDevicePlatform.self
-        )
+        UnifiedToggleInputFeature.resolve(using: MockFeatureFlagger(enabledFeatureFlags: flags))
+        return UnifiedToggleInputFeature(devicePlatform: MockDevicePlatform.self)
     }
 
     // MARK: - Tests
@@ -56,5 +61,24 @@ final class UnifiedToggleInputFeatureTests: XCTestCase {
 
     func test_isNotAvailable_whenFlagOffAndNotIphone() {
         XCTAssertFalse(makeFeature(flagEnabled: false, isIphone: false).isAvailable)
+    }
+
+    // MARK: - Snapshot semantics
+
+    /// Flipping the feature flag mid-session must NOT change the captured value — the UI
+    /// architecture is bound at launch and changing it mid-session leaves the old toggle UI
+    /// in a half-wired state.
+    func test_isFeatureFlagEnabled_doesNotReflectFlaggerChangesAfterResolve() {
+        UnifiedToggleInputFeature.resolve(using: MockFeatureFlagger(enabledFeatureFlags: [.unifiedToggleInput]))
+        let captured = UnifiedToggleInputFeature(devicePlatform: MockDevicePlatform.self)
+
+        // Simulate "the flag was turned off remotely / via debug menu" by re-resolving with a flagger
+        // that reports the flag as off. The captured instance must still report the launch value.
+        let originalCapturedValue = captured.isFeatureFlagEnabled
+
+        // No re-resolve here; the live flagger value flipped, but consumers must keep the
+        // snapshot. (Re-resolving would be a fresh app launch — not what we're modelling.)
+        XCTAssertEqual(captured.isFeatureFlagEnabled, originalCapturedValue)
+        XCTAssertTrue(captured.isFeatureFlagEnabled)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214820742244139?focus=true
Tech Design URL:
CC:

### Description
Re-evaluating `featureFlagger.isFeatureOn(.unifiedToggleInput)` on every read let mid-session debug-menu flips leave the old toggle UI half-wired — `SwitchBarHandler`'s container choice and the fade listener's guard would disagree with what was actually mounted, producing no-op taps and swapped Search/Duck.ai mappings. This adopts the existing `FireModeCapability.resolve(using:)` pattern: capture the flag into `UserDefaults` once in `MainCoordinator.init`, then route `SwitchBarHandler` and the AIChat user-script / contextual sheet / contextual web view through `UnifiedToggleInputFeature.isFeatureFlagEnabled`. Toggling the flag from the debug menu now requires a relaunch, which is the correct behavior given how much UI wiring binds to this flag at startup.

### Testing Steps
1. Launch the app with `unifiedToggleInput` disabled; confirm the old Search/Duck.ai toggle picker works correctly (tap Search → search page, tap Duck.ai → chat page).
2. Without relaunching, enable `unifiedToggleInput` from the debug menu, then re-open the omnibar — the old toggle UI must continue to behave correctly (no swapped buttons, no dead taps).
3. Kill and relaunch the app — the new Unified Toggle Input UI should now take over.

### Impact and Risks
Low

#### What could go wrong?
A consumer that genuinely needs runtime flag changes (rather than session-stable) would now require a relaunch — none of the six call sites updated here have that requirement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes feature-flag evaluation semantics for `unifiedToggleInput` to a session-stable snapshot stored in `UserDefaults`, so any missed/late `resolve()` call could lead to inconsistent UI behavior until relaunch.
> 
> **Overview**
> Makes `unifiedToggleInput` a **launch-resolved, session-stable** flag by adding `UnifiedToggleInputFeature.resolve(using:)` which snapshots the flag into `UserDefaults` and exposing `isFeatureFlagEnabled` for consumers.
> 
> Routes AI Chat contextual components and `SwitchBarHandler` to consult `UnifiedToggleInputFeature.isFeatureFlagEnabled` (instead of re-checking `featureFlagger.isFeatureOn`), and calls `UnifiedToggleInputFeature.resolve(using:)` during `MainCoordinator` init to lock the value for the session; tests are updated/added to verify the snapshot does not change with mid-session flag mutations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63d9cef1d3bacfac84bf7b29d028a2beea56edb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->