### PR TITLE
[macOS] Web Push PoC: dispatch real PushEvents to real SWs without APNs

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -627,6 +627,11 @@
 		3706FB51293F65D500E42796 /* NSScreenExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B3E0DC2657E9CF0040E0A2 /* NSScreenExtension.swift */; };
 		3706FB52293F65D500E42796 /* NSBezierPathExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65E6B9F26D9F10600095F96 /* NSBezierPathExtension.swift */; };
 		3706FB53293F65D500E42796 /* WebsiteDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6820E325502F19005ED0D5 /* WebsiteDataStore.swift */; };
+		6D2FB66C4B96C1E77927765C /* WebPushSubscriptionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1019A0208E29F013E275F2A5 /* WebPushSubscriptionStore.swift */; };
+		CD202D587ABAAEA0D7ABE038 /* WebPushJSShim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D2E9548AE8E6FFF74F61596 /* WebPushJSShim.swift */; };
+		E72F76CE6E7104AE675A3F20 /* WebPushDebugHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA5975F9CCA27B22AA7F2D9 /* WebPushDebugHelper.swift */; };
+		D6E6EB5C3722533C11C0877E /* WebPushNotificationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0B49D25BF62CC009536723F /* WebPushNotificationDelegate.swift */; };
+		EB2BB98CC122B57B0D761E4A /* WebPushSPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B6D3FD1EF72C070EFF7122 /* WebPushSPI.swift */; };
 		3706FB55293F65D500E42796 /* ContextMenuSubfeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85D438B5256E7C9E00F3BAF8 /* ContextMenuSubfeature.swift */; };
 		3706FB56293F65D500E42796 /* NSSavePanelExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B693954726F04BEA0015B914 /* NSSavePanelExtension.swift */; };
 		3706FB57293F65D500E42796 /* AppPrivacyConfigurationDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9826B0A12747DFEB0092F683 /* AppPrivacyConfigurationDataProvider.swift */; };
@@ -2923,6 +2928,11 @@
 		AA652CCE25DD9071009059CC /* BookmarkListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA652CCD25DD9071009059CC /* BookmarkListTests.swift */; };
 		AA652CD325DDA6E9009059CC /* LocalBookmarkManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA652CD225DDA6E9009059CC /* LocalBookmarkManagerTests.swift */; };
 		AA6820E425502F19005ED0D5 /* WebsiteDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6820E325502F19005ED0D5 /* WebsiteDataStore.swift */; };
+		7B1E351E204620CBA15B393C /* WebPushSubscriptionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1019A0208E29F013E275F2A5 /* WebPushSubscriptionStore.swift */; };
+		C405073750BBDF3F3E36A025 /* WebPushJSShim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D2E9548AE8E6FFF74F61596 /* WebPushJSShim.swift */; };
+		F7AFB62E66FEA2FAA04526DF /* WebPushDebugHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA5975F9CCA27B22AA7F2D9 /* WebPushDebugHelper.swift */; };
+		282E93274D2224DFD1255247 /* WebPushNotificationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0B49D25BF62CC009536723F /* WebPushNotificationDelegate.swift */; };
+		1838D454FA13617F99A67417 /* WebPushSPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B6D3FD1EF72C070EFF7122 /* WebPushSPI.swift */; };
 		AA6820EB25503D6A005ED0D5 /* Fire.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6820EA25503D6A005ED0D5 /* Fire.swift */; };
 		AA6820F125503DA9005ED0D5 /* FireViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6820F025503DA9005ED0D5 /* FireViewModel.swift */; };
 		AA693E5E2696E5B90007BB78 /* CrashReports.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA693E5D2696E5B90007BB78 /* CrashReports.storyboard */; };
@@ -6001,6 +6011,11 @@
 		AA652CD225DDA6E9009059CC /* LocalBookmarkManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalBookmarkManagerTests.swift; sourceTree = "<group>"; };
 		AA652CDA25DDAB32009059CC /* BookmarkStoreMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkStoreMock.swift; sourceTree = "<group>"; };
 		AA6820E325502F19005ED0D5 /* WebsiteDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebsiteDataStore.swift; sourceTree = "<group>"; };
+		1019A0208E29F013E275F2A5 /* WebPushSubscriptionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPushSubscriptionStore.swift; sourceTree = "<group>"; };
+		2D2E9548AE8E6FFF74F61596 /* WebPushJSShim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPushJSShim.swift; sourceTree = "<group>"; };
+		1FA5975F9CCA27B22AA7F2D9 /* WebPushDebugHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPushDebugHelper.swift; sourceTree = "<group>"; };
+		E0B49D25BF62CC009536723F /* WebPushNotificationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPushNotificationDelegate.swift; sourceTree = "<group>"; };
+		73B6D3FD1EF72C070EFF7122 /* WebPushSPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPushSPI.swift; sourceTree = "<group>"; };
 		AA6820EA25503D6A005ED0D5 /* Fire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fire.swift; sourceTree = "<group>"; };
 		AA6820F025503DA9005ED0D5 /* FireViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireViewModel.swift; sourceTree = "<group>"; };
 		AA693E5D2696E5B90007BB78 /* CrashReports.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CrashReports.storyboard; sourceTree = "<group>"; };
@@ -10464,6 +10479,11 @@
 			isa = PBXGroup;
 			children = (
 				AA6820E325502F19005ED0D5 /* WebsiteDataStore.swift */,
+				1019A0208E29F013E275F2A5 /* WebPushSubscriptionStore.swift */,
+				2D2E9548AE8E6FFF74F61596 /* WebPushJSShim.swift */,
+				1FA5975F9CCA27B22AA7F2D9 /* WebPushDebugHelper.swift */,
+				E0B49D25BF62CC009536723F /* WebPushNotificationDelegate.swift */,
+				73B6D3FD1EF72C070EFF7122 /* WebPushSPI.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -15099,6 +15119,11 @@
 				EEC4A66A2B2C87D300F7C0AA /* VPNLocationView.swift in Sources */,
 				3706FB52293F65D500E42796 /* NSBezierPathExtension.swift in Sources */,
 				3706FB53293F65D500E42796 /* WebsiteDataStore.swift in Sources */,
+				6D2FB66C4B96C1E77927765C /* WebPushSubscriptionStore.swift in Sources */,
+				CD202D587ABAAEA0D7ABE038 /* WebPushJSShim.swift in Sources */,
+				E72F76CE6E7104AE675A3F20 /* WebPushDebugHelper.swift in Sources */,
+				D6E6EB5C3722533C11C0877E /* WebPushNotificationDelegate.swift in Sources */,
+				EB2BB98CC122B57B0D761E4A /* WebPushSPI.swift in Sources */,
 				3706FB55293F65D500E42796 /* ContextMenuSubfeature.swift in Sources */,
 				3706FB56293F65D500E42796 /* NSSavePanelExtension.swift in Sources */,
 				B6B5F5802B024105008DB58A /* DataImportSummaryView.swift in Sources */,
@@ -17323,6 +17348,11 @@
 				EDC4D50F2F23C414001BCE10 /* SecureVaultModels+CreditCardSummary.swift in Sources */,
 				BB4AA66F2E96F7160008CC12 /* WinBackOfferFeatureFlagger.swift in Sources */,
 				AA6820E425502F19005ED0D5 /* WebsiteDataStore.swift in Sources */,
+				7B1E351E204620CBA15B393C /* WebPushSubscriptionStore.swift in Sources */,
+				C405073750BBDF3F3E36A025 /* WebPushJSShim.swift in Sources */,
+				F7AFB62E66FEA2FAA04526DF /* WebPushDebugHelper.swift in Sources */,
+				282E93274D2224DFD1255247 /* WebPushNotificationDelegate.swift in Sources */,
+				1838D454FA13617F99A67417 /* WebPushSPI.swift in Sources */,
 				ED4470152EB2676A003DC918 /* HangReportingFeatureMonitor.swift in Sources */,
 				E274EFF92E1E8DFF00373C41 /* NewTabPageOmnibarActionsHandler.swift in Sources */,
 				B6F9BDDC2B45B7EE00677B33 /* WebsiteInfo.swift in Sources */,

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -2350,6 +2350,17 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         if let tabUUID = userInfo[WebNotificationsHandler.UserInfoKey.tabUUID] as? String,
            let notificationId = userInfo[WebNotificationsHandler.UserInfoKey.notificationId] as? String {
             await webNotificationClickHandler.handleClick(tabUUID: tabUUID, notificationId: notificationId)
+            return
+        }
+
+        // Web Push PoC: route a click on a SW-initiated notification to the
+        // scope's tab (focusing it if open, opening a new one otherwise).
+        if #available(macOS 13.3, *),
+           let scopeString = userInfo[WebPushNotificationDelegate.scopeURLUserInfoKey] as? String,
+           let scopeURL = URL(string: scopeString) {
+            await MainActor.run {
+                windowControllersManager.showTab(with: .contentFromURL(scopeURL, source: .appOpenUrl))
+            }
         }
     }
 

--- a/macOS/DuckDuckGo/Common/Extensions/WKWebViewConfigurationExtensions.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/WKWebViewConfigurationExtensions.swift
@@ -76,6 +76,32 @@ extension WKWebViewConfiguration {
 
         self.userContentController = userContentController
         self.processPool.geolocationProvider = GeolocationProvider(processPool: self.processPool)
+
+        // Web Push PoC: install a delegate on the data store so SW-side
+        // `registration.showNotification()` calls are routed through
+        // `UNUserNotificationCenter`. Only relevant when paired with a
+        // synthetic push fired from the Debug menu.
+        if #available(macOS 13.3, *) {
+            self.websiteDataStore.ddg_setPushDelegate(WebPushNotificationDelegate.shared)
+        }
+
+        // Web Push PoC: enable WebKit's PushManager surface so our JS shim has
+        // something to monkey-patch (`PushManager` is off-by-default in this
+        // build, so `typeof PushManager === 'undefined'` and the shim no-ops).
+        if #available(macOS 13.0, *) {
+            unsafeBitCast(preferences, to: _DDGWKPreferencesSPI.self).setPushAPIEnabled(true)
+        }
+
+        // Web Push PoC: monkey-patch `PushManager.prototype` so subscribe()
+        // returns a synthetic PushSubscription instead of routing to APNs.
+        userContentController.addUserScript(WebPushJSShim.userScript())
+
+        // Web Push PoC: bridge the JS shim's subscribe/unsubscribe/isSubscribed
+        // events into an in-memory native subscription store. With-reply variant
+        // so getSubscription() can rehydrate after page reload.
+        userContentController.addScriptMessageHandler(WebPushBridge.shared,
+                                                      contentWorld: .page,
+                                                      name: WebPushBridge.messageHandlerName)
     }
 
 }

--- a/macOS/DuckDuckGo/Menus/MainMenu.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenu.swift
@@ -888,6 +888,14 @@ final class MainMenu: NSMenu {
             }
             NSMenuItem(title: "Content Scope Experiments")
                 .submenu(ContentScopeExperimentsMenu())
+            NSMenuItem(title: "Web Push") {
+                NSMenuItem(title: "Set up Web Push testing environment…",
+                           action: #selector(AppDelegate.debugSetupWebPushTestingEnvironment))
+                NSMenuItem(title: "Fire Test Push (localhost:8765)",
+                           action: #selector(AppDelegate.debugFireTestWebPush))
+                NSMenuItem(title: "Fire Test Push at Current Tab Origin",
+                           action: #selector(AppDelegate.debugFireTestWebPushAtCurrentTab))
+            }
             NSMenuItem(title: "Reset Data") {
                 NSMenuItem(title: "Reset Default Grammar Checks", action: #selector(AppDelegate.resetDefaultGrammarChecks))
                 NSMenuItem(title: "Reset Autofill Data", action: #selector(AppDelegate.resetSecureVaultData)).withAccessibilityIdentifier("MainMenu.resetSecureVaultData")

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -527,6 +527,25 @@ extension AppDelegate {
             modifiedSince: .distantPast) { }
     }
 
+    @objc func debugSetupWebPushTestingEnvironment(_ sender: Any?) {
+        if #available(macOS 13.0, *) {
+            WebPushDebugHelper.setupWebPushTestingEnvironment()
+        }
+    }
+
+    @objc func debugFireTestWebPush(_ sender: Any?) {
+        if #available(macOS 13.0, *) {
+            WebPushDebugHelper.fireTestPushMessage()
+        }
+    }
+
+    @MainActor
+    @objc func debugFireTestWebPushAtCurrentTab(_ sender: Any?) {
+        if #available(macOS 13.3, *) {
+            WebPushDebugHelper.fireTestPushAtActiveTabOrigin()
+        }
+    }
+
     @MainActor
     @objc func skipOnboarding(_ sender: Any?) {
         UserDefaults.standard.set(true, forKey: UserDefaultsWrapper<Bool>.Key.onboardingFinished.rawValue)

--- a/macOS/DuckDuckGo/Tab/Services/WebPushDebugHelper.swift
+++ b/macOS/DuckDuckGo/Tab/Services/WebPushDebugHelper.swift
@@ -1,0 +1,434 @@
+//
+//  WebPushDebugHelper.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppKit
+import Foundation
+import OSLog
+import WebKit
+
+private let log = Logger(subsystem: "com.duckduckgo.macos.browser", category: "WebPush")
+
+/// Debug helper for the Web Push PoC. Writes a folder of test artefacts to
+/// `~/Desktop/ddg-web-push-testing/` (HTML, SW JS, Python HTTP server, README)
+/// and provides a one-shot "fire a synthetic push" action that bypasses
+/// WebKit's webpushd / APNs entirely.
+///
+/// Mirrors the pattern used by `SparkleDebugHelper`.
+@available(macOS 13.0, *)
+enum WebPushDebugHelper {
+
+    private static let testOrigin = URL(string: "http://localhost:8765/")!
+    private static let folderName = "ddg-web-push-testing"
+
+    // MARK: - Public actions
+
+    /// Writes the test environment to `~/Desktop/ddg-web-push-testing/` and
+    /// opens the generated README.
+    static func setupWebPushTestingEnvironment() {
+        let fileManager = FileManager.default
+        let folder = fileManager
+            .homeDirectoryForCurrentUser
+            .appendingPathComponent("Desktop")
+            .appendingPathComponent(folderName)
+
+        do {
+            try fileManager.createDirectory(at: folder, withIntermediateDirectories: true)
+
+            let files: [(String, String)] = [
+                ("index.html", Resources.indexHTML),
+                ("sw.js", Resources.serviceWorkerJS),
+                ("serve_push.py", Resources.serverScript),
+                ("README.md", Resources.readme)
+            ]
+            for (name, contents) in files {
+                try contents.write(to: folder.appendingPathComponent(name), atomically: true, encoding: .utf8)
+            }
+
+            // Allow `./serve_push.py` to be executed directly.
+            try? fileManager.setAttributes(
+                [.posixPermissions: NSNumber(value: 0o755)],
+                ofItemAtPath: folder.appendingPathComponent("serve_push.py").path
+            )
+
+            NSWorkspace.shared.open(folder.appendingPathComponent("README.md"))
+        } catch {
+            log.error("WebPushDebugHelper setup failed: \(error.localizedDescription, privacy: .public)")
+            let alert = NSAlert()
+            alert.messageText = "Failed to set up Web Push testing environment"
+            alert.informativeText = error.localizedDescription
+            alert.alertStyle = .warning
+            alert.runModal()
+        }
+    }
+
+    /// Fires a synthetic push at the active tab's origin. Used to verify the
+    /// receive path on real sites (Slack, GitHub, etc.) that subscribed via
+    /// the JS shim. Grants notification permission to that origin so WebKit's
+    /// gate in `NetworkProcessProxy::processPushMessage` accepts the dispatch.
+    @MainActor
+    static func fireTestPushAtActiveTabOrigin() {
+        guard let url = Application.appDelegate.windowControllersManager.lastKeyMainWindowController?
+                .mainViewController.tabCollectionViewModel.selectedTabViewModel?.tab.url,
+              let scheme = url.scheme,
+              let host = url.host else {
+            let alert = NSAlert()
+            alert.messageText = "No active tab"
+            alert.informativeText = "Open a real site (e.g. https://app.slack.com/) in the foreground tab first."
+            alert.runModal()
+            return
+        }
+
+        var components = URLComponents()
+        components.scheme = scheme
+        components.host = host
+        components.port = url.port
+        components.path = "/"
+        guard let scopeURL = components.url else { return }
+
+        // The permission check in WebKit keys by SecurityOriginData.toString(),
+        // i.e. scheme://host[:port] with no trailing slash.
+        var origin = "\(scheme)://\(host)"
+        if let port = url.port { origin += ":\(port)" }
+
+        if #available(macOS 13.3, *) {
+            WebPushNotificationDelegate.shared.grantPermission(forOrigin: origin)
+        }
+
+        guard WebPushSubscriptionStore.shared.isSubscribed(origin: origin) else {
+            let alert = NSAlert()
+            alert.messageText = "No active subscription"
+            alert.informativeText = "The page at \(origin) hasn't called pushManager.subscribe() yet, or it called unsubscribe(). Subscribe first, then fire."
+            alert.alertStyle = .warning
+            alert.runModal()
+            return
+        }
+
+        Task {
+            let timestamp = Date.now.formatted(date: .omitted, time: .standard)
+            let payload = "Synthetic push at \(timestamp)"
+            let wasProcessed = await WKWebsiteDataStore.default().ddg_processPushMessage(
+                registrationURL: scopeURL,
+                pushData: Data(payload.utf8)
+            )
+
+            guard !wasProcessed else { return }
+            await MainActor.run {
+                let alert = NSAlert()
+                alert.messageText = "Push not delivered"
+                alert.informativeText = """
+                    WebKit returned false for \(scopeURL.absoluteString).
+                    Most likely no Service Worker is registered for that scope yet — open the site, wait for its SW to register (\(host) may take a few seconds after first load), then try again.
+                    """
+                alert.alertStyle = .warning
+                alert.runModal()
+            }
+        }
+    }
+
+    /// Fires a synthetic push at whatever Service Worker is registered for
+    /// `testOrigin` in the default data store. Shows an alert with the result.
+    static func fireTestPushMessage() {
+        let testOriginString = "http://localhost:8765"
+        guard WebPushSubscriptionStore.shared.isSubscribed(origin: testOriginString) else {
+            let alert = NSAlert()
+            alert.messageText = "No active subscription"
+            alert.informativeText = "Open \(testOrigin.absoluteString) and click Subscribe before firing."
+            alert.alertStyle = .warning
+            alert.runModal()
+            return
+        }
+
+        Task {
+            let timestamp = Date.now.formatted(date: .omitted, time: .standard)
+            let payload = "Hello from DuckDuckGo at \(timestamp)"
+            let wasProcessed = await WKWebsiteDataStore.default().ddg_processPushMessage(
+                registrationURL: testOrigin,
+                pushData: Data(payload.utf8)
+            )
+
+            guard !wasProcessed else { return }
+            await MainActor.run {
+                let alert = NSAlert()
+                alert.messageText = "Push not delivered"
+                alert.informativeText = """
+                    WebKit returned false. Most likely no Service Worker is registered for \(testOrigin.absoluteString).
+                    Make sure the local server is running and that you've loaded the page in this browser.
+                    """
+                alert.alertStyle = .warning
+                alert.runModal()
+            }
+        }
+    }
+
+    // MARK: - Artefact resources
+
+    private enum Resources {
+
+        static let indexHTML = """
+        <!doctype html>
+        <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <title>DDG Web Push PoC</title>
+            <style>
+              body { font: 16px -apple-system, sans-serif; padding: 2em; max-width: 50em; }
+              code, pre { background: #f3f3f3; padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.9em; }
+              pre { padding: 0.6em 1em; white-space: pre-wrap; word-break: break-all; }
+              .status { padding: 0.5em 1em; border-radius: 6px; margin: 1em 0; }
+              .pending { background: #fff7e6; border: 1px solid #f0c36d; }
+              .ready   { background: #e6ffed; border: 1px solid #6dcd86; }
+              .error   { background: #ffeaea; border: 1px solid #d96565; }
+              button { padding: 0.5em 1em; margin-right: 0.5em; font-size: inherit; }
+              h2 { margin-top: 1.6em; font-size: 1.1em; }
+            </style>
+          </head>
+          <body>
+            <h1>DDG Web Push PoC</h1>
+
+            <h2>1. Service Worker</h2>
+            <div id="swStatus" class="status pending">Registering Service Worker…</div>
+
+            <h2>2. Push subscription</h2>
+            <div id="subStatus" class="status pending">Waiting for SW…</div>
+            <button id="subscribeBtn" disabled>Subscribe</button>
+            <button id="getSubBtn" disabled>Get current subscription</button>
+            <button id="unsubBtn" disabled>Unsubscribe</button>
+            <pre id="subDump"></pre>
+
+            <h2>3. Trigger the push</h2>
+            <p>From the menu bar, choose <em>Debug → Web Push → Fire Test Push (localhost:8765)</em>. Your macOS notification should appear with the synthetic payload.</p>
+
+            <script>
+              const swStatus  = document.getElementById('swStatus');
+              const subStatus = document.getElementById('subStatus');
+              const subDump   = document.getElementById('subDump');
+              const subscribeBtn = document.getElementById('subscribeBtn');
+              const getSubBtn    = document.getElementById('getSubBtn');
+              const unsubBtn     = document.getElementById('unsubBtn');
+
+              function setStatus(el, text, cls) { el.textContent = text; el.className = 'status ' + cls; }
+              function dumpSubscription(sub) {
+                if (!sub) { subDump.textContent = '(none)'; return; }
+                subDump.textContent = JSON.stringify(sub.toJSON ? sub.toJSON() : sub, null, 2);
+              }
+
+              // Dummy VAPID public key (65-byte uncompressed P-256, 0x04 prefix
+              // followed by zeros). Format is what the API accepts; for the PoC
+              // the value itself doesn't matter — our shim doesn't look at it.
+              const dummyVapid = (() => {
+                const buf = new Uint8Array(65);
+                buf[0] = 0x04;
+                return buf;
+              })();
+
+              async function refreshExistingSubscription(reg) {
+                try {
+                  const existing = await reg.pushManager.getSubscription();
+                  dumpSubscription(existing);
+                  if (existing) {
+                    setStatus(subStatus, 'Already subscribed (cached in this page).', 'ready');
+                    unsubBtn.disabled = false;
+                  } else {
+                    setStatus(subStatus, 'Not subscribed yet — click Subscribe.', 'pending');
+                    unsubBtn.disabled = true;
+                  }
+                } catch (err) {
+                  setStatus(subStatus, 'getSubscription failed: ' + err.message, 'error');
+                }
+              }
+
+              if (!('serviceWorker' in navigator)) {
+                setStatus(swStatus, 'Service Workers not supported.', 'error');
+              } else {
+                navigator.serviceWorker.register('/sw.js', { scope: '/' })
+                  .then(async reg => {
+                    console.log('SW registered, scope:', reg.scope);
+                    await navigator.serviceWorker.ready;
+                    setStatus(swStatus, 'Service Worker ready.', 'ready');
+
+                    if (!('PushManager' in window)) {
+                      setStatus(subStatus, "'PushManager' not in window — JS shim didn't run.", 'error');
+                      return;
+                    }
+                    subscribeBtn.disabled = false;
+                    getSubBtn.disabled = false;
+
+                    subscribeBtn.addEventListener('click', async () => {
+                      try {
+                        const sub = await reg.pushManager.subscribe({
+                          userVisibleOnly: true,
+                          applicationServerKey: dummyVapid
+                        });
+                        dumpSubscription(sub);
+                        setStatus(subStatus, 'Subscribed.', 'ready');
+                        unsubBtn.disabled = false;
+                      } catch (err) {
+                        setStatus(subStatus, 'subscribe failed: ' + err.message, 'error');
+                      }
+                    });
+
+                    getSubBtn.addEventListener('click', () => refreshExistingSubscription(reg));
+
+                    unsubBtn.addEventListener('click', async () => {
+                      const existing = await reg.pushManager.getSubscription();
+                      if (existing && await existing.unsubscribe()) {
+                        dumpSubscription(null);
+                        setStatus(subStatus, 'Unsubscribed.', 'pending');
+                        unsubBtn.disabled = true;
+                      }
+                    });
+
+                    refreshExistingSubscription(reg);
+                  })
+                  .catch(err => {
+                    console.error('SW registration failed:', err);
+                    setStatus(swStatus, 'SW registration failed: ' + err.message, 'error');
+                  });
+              }
+            </script>
+          </body>
+        </html>
+        """
+
+        static let serviceWorkerJS = """
+        // DDG Web Push PoC Service Worker.
+
+        console.log('🟣 [sw] script evaluated, scope:', self.registration && self.registration.scope);
+
+        self.addEventListener('install', event => {
+          console.log('🟣 [sw] install');
+          event.waitUntil(self.skipWaiting());
+        });
+
+        self.addEventListener('activate', event => {
+          console.log('🟣 [sw] activate');
+          event.waitUntil(self.clients.claim());
+        });
+
+        self.addEventListener('push', event => {
+          const text = event.data ? event.data.text() : '(no payload)';
+          console.log('🟣 [sw] push event received:', text);
+          event.waitUntil(
+            self.registration.showNotification('DDG Push PoC', {
+              body: text,
+              tag: 'ddg-poc'
+            }).then(
+              () => console.log('🟣 [sw] showNotification resolved'),
+              err => console.log('🟣 [sw] showNotification REJECTED:', err)
+            )
+          );
+        });
+
+        self.addEventListener('pushsubscriptionchange', event => {
+          console.log('🟣 [sw] pushsubscriptionchange');
+        });
+        """
+
+        static let serverScript = #"""
+        #!/usr/bin/env python3
+        """Tiny HTTP server for the DDG Web Push PoC.
+
+        Service Workers can register over plain HTTP on `localhost`, so there's
+        no TLS / cert setup required. Run from this directory:
+
+            python3 serve_push.py
+        """
+
+        import http.server
+        import socketserver
+
+        PORT = 8765
+
+
+        class Handler(http.server.SimpleHTTPRequestHandler):
+            def end_headers(self):
+                # No caching while iterating on the test page / SW.
+                self.send_header('Cache-Control', 'no-store, max-age=0')
+                self.send_header('Service-Worker-Allowed', '/')
+                super().end_headers()
+
+            def log_message(self, fmt, *args):
+                # Keep the console quiet — uncomment for verbose logging.
+                pass
+
+
+        if __name__ == '__main__':
+            with socketserver.TCPServer(('127.0.0.1', PORT), Handler) as httpd:
+                print(f'Serving DDG Web Push PoC at http://localhost:{PORT}/')
+                print('Open this URL in DuckDuckGo, then trigger Debug → Web Push → Fire Test Push.')
+                print('Ctrl+C to stop.')
+                try:
+                    httpd.serve_forever()
+                except KeyboardInterrupt:
+                    print('\nServer stopped.')
+        """#
+
+        static let readme = """
+        # Web Push PoC
+
+        This folder lets you verify that the DuckDuckGo macOS browser can deliver
+        a synthetic Web Push event to a real Service Worker — without going
+        through Apple's APNs / webpushd.
+
+        ## Steps
+
+        1. **Start the local server.** In Terminal:
+
+               cd ~/Desktop/ddg-web-push-testing
+               python3 serve_push.py
+
+           Leave the Terminal window open.
+
+        2. **Open the page in DuckDuckGo.** Navigate to:
+
+               http://localhost:8765/
+
+           Wait for the status banner to turn green ("Service Worker ready").
+
+        3. **Fire a test push.** In the DuckDuckGo menu bar:
+
+               Debug → Web Push → Fire Test Push
+
+           A macOS notification should appear titled "DDG Push PoC". On first
+           run you'll get a system notification-permission prompt — accept it
+           and trigger the push again.
+
+        ## What's happening
+
+        - `sw.js` is a real Service Worker registered against `http://localhost:8765/`.
+        - The debug menu item calls `WKWebsiteDataStore._processPushMessage:`, a
+          private WebKit SPI, with a synthesised payload scoped to the same URL.
+        - WebKit dispatches a real `PushEvent` at the SW; the handler calls
+          `self.registration.showNotification(...)`.
+        - The browser receives that call via the `_WKWebsiteDataStoreDelegate`
+          hook and forwards it to `UNUserNotificationCenter` — what you see as
+          the system notification.
+
+        ## Troubleshooting
+
+        - **"Push not delivered" alert.** The SW isn't registered for this
+          origin. Reload the page, wait for the green banner, and try again.
+        - **No notification appears, but "Push delivered" alert showed up.**
+          Check System Settings → Notifications → DuckDuckGo. The first run
+          should have prompted; if you dismissed the prompt, re-enable
+          notifications manually.
+        - **SW won't register.** Make sure you opened `http://localhost:8765/`
+          (not `127.0.0.1` — secure-context status is keyed on the host name).
+        """
+    }
+}

--- a/macOS/DuckDuckGo/Tab/Services/WebPushJSShim.swift
+++ b/macOS/DuckDuckGo/Tab/Services/WebPushJSShim.swift
@@ -1,0 +1,192 @@
+//
+//  WebPushJSShim.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import WebKit
+
+/// Monkey-patches `PushManager.prototype` so that `pushManager.subscribe(...)`
+/// returns a synthesised `PushSubscription` instead of routing through
+/// WebKit's native PushManager → webpushd → APNs path.
+///
+/// PoC only. The site sees a `PushSubscription`-shaped object with a fake
+/// endpoint; it dutifully posts `{endpoint, keys}` to its backend, but the
+/// backend can't reach the fake endpoint. To verify the receive path, fire a
+/// synthetic push at the site's origin via Debug → Web Push → Fire Test Push
+/// at Current Tab Origin.
+enum WebPushJSShim {
+
+    static func userScript() -> WKUserScript {
+        WKUserScript(source: source, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+    }
+
+    private static let source = #"""
+    (function() {
+        const LOG_PREFIX = '🟣 [shim]';
+
+        function base64UrlEncode(buf) {
+            const bytes = new Uint8Array(buf);
+            let str = '';
+            for (let i = 0; i < bytes.length; i++) {
+                str += String.fromCharCode(bytes[i]);
+            }
+            return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+        }
+
+        function randomBytes(len) {
+            const buf = new Uint8Array(len);
+            crypto.getRandomValues(buf);
+            return buf;
+        }
+
+        // RFC 8291 expects a 65-byte uncompressed P-256 public key (0x04 prefix)
+        // for p256dh and 16 random bytes for auth. We don't actually do ECDH —
+        // the keys here are decorative; receive path goes via _processPushMessage:.
+        let stashed = null;
+        function makeSubscription(opts) {
+            const id = (crypto.randomUUID && crypto.randomUUID()) || (Date.now() + '-' + Math.random());
+            const p256dh = randomBytes(65); p256dh[0] = 0x04;
+            const auth   = randomBytes(16);
+
+            return {
+                endpoint: 'https://ddg-webpush-poc.invalid/' + id,
+                expirationTime: null,
+                options: opts || { userVisibleOnly: true, applicationServerKey: null },
+                getKey(name) {
+                    if (name === 'p256dh') return p256dh.buffer;
+                    if (name === 'auth')   return auth.buffer;
+                    return null;
+                },
+                toJSON() {
+                    return {
+                        endpoint: this.endpoint,
+                        expirationTime: this.expirationTime,
+                        keys: {
+                            p256dh: base64UrlEncode(p256dh.buffer),
+                            auth:   base64UrlEncode(auth.buffer)
+                        }
+                    };
+                },
+                unsubscribe() {
+                    console.log(LOG_PREFIX, 'unsubscribe()');
+                    notifyNative('unsubscribe');
+                    stashed = null;
+                    return Promise.resolve(true);
+                }
+            };
+        }
+
+        // (1) Ensure a PushManager constructor exists on `window` so feature
+        // detection (`'PushManager' in window`) passes even if WebKit's native
+        // class isn't exposed.
+        if (typeof window.PushManager === 'undefined') {
+            window.PushManager = function PushManager() {};
+            console.log(LOG_PREFIX, 'PushManager synthesised (native was missing)');
+        }
+
+        async function callNative(action) {
+            const bridge = window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.ddgWebPushBridge;
+            if (!bridge) {
+                console.log(LOG_PREFIX, 'callNative SKIPPED (no bridge):', action);
+                return null;
+            }
+            try {
+                const result = await bridge.postMessage({ action });
+                console.log(LOG_PREFIX, 'callNative →', action, '=', result);
+                return result;
+            } catch (e) {
+                console.log(LOG_PREFIX, 'callNative ERROR:', action, e);
+                return null;
+            }
+        }
+
+        function notifyNative(action) {
+            // Fire-and-forget shorthand for actions whose result we don't use.
+            callNative(action);
+        }
+
+        // (2) Override the prototype methods so any PushManager instance
+        // (native or synthesised, registration-bound) uses our subscribe path.
+        const proto = window.PushManager.prototype;
+        proto.subscribe = function(opts) {
+            console.log(LOG_PREFIX, 'PushManager.subscribe', opts);
+            stashed = makeSubscription(opts);
+            notifyNative('subscribe');
+            return Promise.resolve(stashed);
+        };
+        proto.getSubscription = async function() {
+            if (stashed) {
+                console.log(LOG_PREFIX, 'PushManager.getSubscription → cached');
+                return stashed;
+            }
+            // Native may know about a subscription from before this page load.
+            // Rehydrate a synthetic one — new keys (PoC), but page UI is correct.
+            const knownToNative = await callNative('isSubscribed');
+            console.log(LOG_PREFIX, 'PushManager.getSubscription → native says:', knownToNative);
+            if (knownToNative) {
+                stashed = makeSubscription({ userVisibleOnly: true, applicationServerKey: null });
+            }
+            return stashed || null;
+        };
+        proto.permissionState = function(_opts) {
+            return Promise.resolve('granted');
+        };
+
+        // (3) Make sure `registration.pushManager` returns something useful even
+        // if WebKit didn't define the property. Patch the SW registration
+        // prototype's pushManager getter so it lazily creates an instance.
+        if (typeof ServiceWorkerRegistration !== 'undefined') {
+            const swrProto = ServiceWorkerRegistration.prototype;
+            const desc = Object.getOwnPropertyDescriptor(swrProto, 'pushManager');
+            if (!desc || !desc.get) {
+                Object.defineProperty(swrProto, 'pushManager', {
+                    configurable: true,
+                    enumerable: true,
+                    get() {
+                        if (!this._ddgPushManager) {
+                            this._ddgPushManager = Object.create(window.PushManager.prototype);
+                        }
+                        return this._ddgPushManager;
+                    }
+                });
+                console.log(LOG_PREFIX, 'ServiceWorkerRegistration.pushManager getter synthesised');
+            }
+        }
+
+        // (4) Shim navigator.permissions.query for push/notifications so sites
+        // that gate subscribe() behind a Permissions-API precondition pass.
+        if (navigator.permissions && typeof navigator.permissions.query === 'function') {
+            const originalQuery = navigator.permissions.query.bind(navigator.permissions);
+            navigator.permissions.query = function(descriptor) {
+                if (descriptor && (descriptor.name === 'push' || descriptor.name === 'notifications')) {
+                    return Promise.resolve({
+                        state: 'granted',
+                        status: 'granted',
+                        onchange: null,
+                        addEventListener() {},
+                        removeEventListener() {},
+                        dispatchEvent() { return false; }
+                    });
+                }
+                return originalQuery(descriptor);
+            };
+        }
+
+        console.log(LOG_PREFIX, 'PushManager shimmed');
+    })();
+    """#
+}

--- a/macOS/DuckDuckGo/Tab/Services/WebPushNotificationDelegate.swift
+++ b/macOS/DuckDuckGo/Tab/Services/WebPushNotificationDelegate.swift
@@ -1,0 +1,104 @@
+//
+//  WebPushNotificationDelegate.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import OSLog
+import UserNotifications
+import WebKit
+
+private let log = Logger(subsystem: "com.duckduckgo.macos.browser", category: "WebPush")
+
+/// Receives SW-side `registration.showNotification(...)` callbacks from WebKit
+/// and posts them via `UNUserNotificationCenter`. Installed as the `_delegate`
+/// of `WKWebsiteDataStore` (see `WKWebsiteDataStore.ddg_setPushDelegate`).
+///
+/// PoC only — the production version would reuse `WebNotificationsHandler`'s
+/// permission gating, icon fetching and pixel reporting.
+@available(macOS 13.3, *)
+final class WebPushNotificationDelegate: NSObject, _DDGWebsiteDataStoreDelegate {
+
+    /// App-process-lifetime singleton — the data store's `_delegate` property
+    /// is `weak`, so we keep a strong reference here.
+    static let shared = WebPushNotificationDelegate()
+
+    /// Key under which we stash the SW scope URL in the `UNNotificationRequest`'s
+    /// `userInfo`, so `AppDelegate`'s `UNUserNotificationCenterDelegate` can
+    /// route the click back to the right tab.
+    static let scopeURLUserInfoKey = "ddg.webPush.scopeURL"
+
+    private override init() {}
+
+    /// Origins that should be treated as having notification permission granted.
+    /// PoC: starts with the local test page and accepts ad-hoc additions from
+    /// the debug menu. Production would wire this to `PermissionManager`.
+    private var grantedOrigins: Set<String> = ["http://localhost:8765"]
+    private let lock = NSLock()
+
+    func grantPermission(forOrigin origin: String) {
+        lock.lock(); defer { lock.unlock() }
+        grantedOrigins.insert(origin)
+    }
+
+    // Explicit selector — Swift's auto-derived `notificationPermissionsFor:`
+    // doesn't match what WebKit actually invokes.
+    @objc(notificationPermissionsForWebsiteDataStore:)
+    func notificationPermissions(for dataStore: WKWebsiteDataStore) -> [String: NSNumber] {
+        lock.lock(); defer { lock.unlock() }
+        let dict = Dictionary(uniqueKeysWithValues: grantedOrigins.map { ($0, NSNumber(value: true)) })
+        log.info("🟣 [native] notificationPermissionsForWebsiteDataStore: → \(dict.keys.joined(separator: ","), privacy: .public)")
+        return dict
+    }
+
+    func websiteDataStore(_ dataStore: WKWebsiteDataStore, showNotification notificationData: NSObject) {
+        // `_WKNotificationData` fields are read via KVC. Fallback to
+        // `dictionaryRepresentation` if any direct access fails.
+        let title = (notificationData.value(forKey: "title") as? String) ?? "Notification"
+        let body = (notificationData.value(forKey: "body") as? String) ?? ""
+        let tag = notificationData.value(forKey: "tag") as? String
+        let scopeURL = notificationData.value(forKey: "serviceWorkerRegistrationURL") as? URL
+        let identifierRaw = notificationData.value(forKey: "identifier") as? String
+        let identifier = (identifierRaw?.isEmpty == false) ? identifierRaw! : UUID().uuidString
+
+        log.debug("WebPushNotificationDelegate: showNotification title=\(title, privacy: .public) scope=\(scopeURL?.absoluteString ?? "-", privacy: .public)")
+
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = .default
+        if let tag, !tag.isEmpty {
+            content.threadIdentifier = tag
+        }
+        if let scopeURL {
+            content.userInfo = [Self.scopeURLUserInfoKey: scopeURL.absoluteString]
+        }
+
+        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: nil)
+        Task { @MainActor in
+            let center = UNUserNotificationCenter.current()
+            let status = await center.notificationSettings().authorizationStatus
+            if status == .notDetermined {
+                _ = try? await center.requestAuthorization(options: [.alert, .sound])
+            }
+            do {
+                try await center.add(request)
+            } catch {
+                log.error("WebPushNotificationDelegate failed to post: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+}

--- a/macOS/DuckDuckGo/Tab/Services/WebPushSPI.swift
+++ b/macOS/DuckDuckGo/Tab/Services/WebPushSPI.swift
@@ -1,0 +1,150 @@
+//
+//  WebPushSPI.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import OSLog
+import WebKit
+
+// MARK: - Private WebKit SPI bridges
+//
+// These protocols mirror methods declared in WebKit's private headers
+// (WKWebsiteDataStorePrivate.h, _WKWebsiteDataStoreDelegate.h).
+// We can call into them from Swift via an `as AnyObject as!` cast — Obj-C
+// method dispatch is selector-based at runtime, so the cast only succeeds if
+// the underlying object responds to the selector. PoC only.
+
+/// Mirrors `-[WKWebsiteDataStore _processPushMessage:completionHandler:]` from
+/// `WKWebsiteDataStorePrivate.h` (macOS 13.0+).
+@objc protocol _DDGWebPushDataStoreSPI {
+    @objc(_processPushMessage:completionHandler:)
+    func processPushMessage(_ message: [AnyHashable: Any], completionHandler: @escaping (Bool) -> Void)
+}
+
+/// Mirrors `-[WKPreferences _setPushAPIEnabled:]` from `WKPreferencesPrivate.h`.
+/// In our build, the Push API is off by default — `PushManager` doesn't appear
+/// on `window`, so the JS shim has nothing to monkey-patch. Enabling this
+/// makes `PushManager` exist so our prototype-overrides take effect.
+@objc protocol _DDGWKPreferencesSPI {
+    @objc(_setPushAPIEnabled:)
+    func setPushAPIEnabled(_ enabled: Bool)
+}
+
+/// Class-method SPI for accessing the SW-side notification manager singleton.
+@objc protocol _DDGSWNotificationManagerSPI {
+    @objc(_sharedServiceWorkerNotificationManager)
+    static func sharedServiceWorkerNotificationManager() -> OpaquePointer
+}
+
+// WebKit C API (declared via @_silgen_name so we don't need a bridging header).
+// Symbols exported by the WebKit framework binary.
+
+@_silgen_name("WKStringCreateWithUTF8CString")
+private func WKStringCreateWithUTF8CString(_ cString: UnsafePointer<CChar>) -> OpaquePointer
+
+@_silgen_name("WKSecurityOriginCreate")
+private func WKSecurityOriginCreate(_ protocol_: OpaquePointer, _ host: OpaquePointer, _ port: Int32) -> OpaquePointer
+
+@_silgen_name("WKNotificationManagerProviderDidUpdateNotificationPolicy")
+private func WKNotificationManagerProviderDidUpdateNotificationPolicy(_ manager: OpaquePointer, _ origin: OpaquePointer, _ allowed: Bool)
+
+@_silgen_name("WKRelease")
+private func WKRelease(_ ref: OpaquePointer)
+
+/// Grants the SW-side notification permission for the given origin so that
+/// `self.registration.showNotification(...)` calls inside a `push` handler
+/// pass WebKit's `WebNotificationManager::policyForOrigin` check.
+enum WebPushNotificationPermission {
+    private static let log = Logger(subsystem: "com.duckduckgo.macos.browser", category: "WebPush")
+
+    static func grant(scheme: String, host: String, port: Int) {
+        let classSPI: _DDGSWNotificationManagerSPI.Type =
+            unsafeBitCast(WKWebsiteDataStore.self, to: _DDGSWNotificationManagerSPI.Type.self)
+        let manager = classSPI.sharedServiceWorkerNotificationManager()
+
+        let schemeRef = scheme.withCString(WKStringCreateWithUTF8CString)
+        let hostRef = host.withCString(WKStringCreateWithUTF8CString)
+        let originRef = WKSecurityOriginCreate(schemeRef, hostRef, Int32(port))
+
+        WKNotificationManagerProviderDidUpdateNotificationPolicy(manager, originRef, true)
+        log.info("🟣 [native] granted SW notif permission for \(scheme, privacy: .public)://\(host, privacy: .public):\(port, privacy: .public)")
+
+        WKRelease(originRef)
+        WKRelease(hostRef)
+        WKRelease(schemeRef)
+    }
+}
+
+/// Mirrors `<_WKWebsiteDataStoreDelegate>` methods we need from
+/// `_WKWebsiteDataStoreDelegate.h`. Called by WebKit when a Service Worker
+/// invokes `self.registration.showNotification(...)` and when the network
+/// process needs to know which origins have notification permission.
+///
+/// The `notificationData` parameter is a `_WKNotificationData` instance; we
+/// read its fields via KVC (see `WebPushNotificationDelegate`).
+@objc protocol _DDGWebsiteDataStoreDelegate {
+    @objc(websiteDataStore:showNotification:)
+    optional func websiteDataStore(_ dataStore: WKWebsiteDataStore, showNotification notificationData: NSObject)
+
+    @objc(notificationPermissionsForWebsiteDataStore:)
+    optional func notificationPermissions(for dataStore: WKWebsiteDataStore) -> [String: NSNumber]
+}
+
+// MARK: - WKWebsiteDataStore convenience
+
+extension WKWebsiteDataStore {
+
+    /// Dispatches a synthetic Web Push at the Service Worker registered for
+    /// `registrationURL`. Routes through WebKit's regular push pipeline but
+    /// bypasses webpushd / APNs entirely. PoC only.
+    ///
+    /// Dictionary schema mirrors what WebKit's own `_getPendingPushMessage`
+    /// produces (see `WebPushMessage::toDictionary()` in
+    /// `Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm`).
+    @available(macOS 13.0, *)
+    @discardableResult
+    func ddg_processPushMessage(registrationURL: URL, pushData: Data?, partition: String? = nil) async -> Bool {
+        let resolvedPartition = partition ?? (value(forKey: "_webPushPartition") as? String) ?? ""
+        let dictionary: [AnyHashable: Any] = [
+            "WebKitPushRegistrationURL": registrationURL,
+            "WebKitPushData": pushData ?? NSNull(),
+            "WebKitPushPartition": resolvedPartition,
+            "WebKitNotificationPayload": NSNull()
+        ]
+        let webPushLog = Logger(subsystem: "com.duckduckgo.macos.browser", category: "WebPush")
+        webPushLog.info("🟣 [native] _processPushMessage: scope=\(registrationURL.absoluteString, privacy: .public) partition=\"\(resolvedPartition, privacy: .public)\" bytes=\(pushData?.count ?? 0, privacy: .public)")
+        let wasProcessed: Bool = await withCheckedContinuation { continuation in
+            // `as!` would check formal protocol conformance, which the
+            // private SPI doesn't declare. `unsafeBitCast` bypasses that —
+            // dispatch is by ObjC selector at runtime, so this is safe as
+            // long as the underlying object responds to the selector.
+            let spi = unsafeBitCast(self, to: _DDGWebPushDataStoreSPI.self)
+            spi.processPushMessage(dictionary) { processed in
+                continuation.resume(returning: processed)
+            }
+        }
+        webPushLog.info("🟣 [native] _processPushMessage: returned \(wasProcessed, privacy: .public)")
+        return wasProcessed
+    }
+
+    /// Sets WebKit's `_delegate` on the data store so the embedder receives
+    /// SW-side `registration.showNotification()` callbacks. The property is
+    /// `weak`, so the caller must keep the delegate alive.
+    func ddg_setPushDelegate(_ delegate: NSObject?) {
+        setValue(delegate, forKey: "_delegate")
+    }
+}

--- a/macOS/DuckDuckGo/Tab/Services/WebPushSubscriptionStore.swift
+++ b/macOS/DuckDuckGo/Tab/Services/WebPushSubscriptionStore.swift
@@ -1,0 +1,100 @@
+//
+//  WebPushSubscriptionStore.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import OSLog
+import WebKit
+
+private let log = Logger(subsystem: "com.duckduckgo.macos.browser", category: "WebPush")
+
+/// In-memory subscription registry. Owned by us — WebKit is out of the loop
+/// once the JS shim short-circuits `pushManager.subscribe()`. Production would
+/// persist this and key delivery on a real channel ID from the DDG autopush
+/// backend instead of just origin.
+final class WebPushSubscriptionStore: NSObject {
+
+    static let shared = WebPushSubscriptionStore()
+
+    private var subscribed: Set<String> = []
+    private let lock = NSLock()
+
+    func recordSubscribe(origin: String) {
+        lock.lock(); defer { lock.unlock() }
+        subscribed.insert(origin)
+        log.debug("WebPushSubscriptionStore: + \(origin, privacy: .public)")
+    }
+
+    func recordUnsubscribe(origin: String) {
+        lock.lock(); defer { lock.unlock() }
+        subscribed.remove(origin)
+        log.debug("WebPushSubscriptionStore: - \(origin, privacy: .public)")
+    }
+
+    func isSubscribed(origin: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return subscribed.contains(origin)
+    }
+}
+
+/// Message handler the JS shim posts to on subscribe/unsubscribe/isSubscribed.
+/// Uses the frame's `securityOrigin` (not page-supplied data) so the page
+/// can't lie about which origin it's subscribing for. With-reply variant so
+/// `getSubscription()` can ask "is this origin known to native?" and rehydrate
+/// a synthetic subscription after page reload.
+final class WebPushBridge: NSObject, WKScriptMessageHandlerWithReply {
+
+    static let shared = WebPushBridge()
+    static let messageHandlerName = "ddgWebPushBridge"
+
+    func userContentController(_ userContentController: WKUserContentController,
+                               didReceive message: WKScriptMessage,
+                               replyHandler: @escaping (Any?, String?) -> Void) {
+        guard let body = message.body as? [String: Any],
+              let action = body["action"] as? String else {
+            replyHandler(nil, "invalid message")
+            return
+        }
+
+        let frame = message.frameInfo.securityOrigin
+        var origin = "\(frame.protocol)://\(frame.host)"
+        if frame.port != 0 {
+            origin += ":\(frame.port)"
+        }
+
+        switch action {
+        case "subscribe":
+            WebPushSubscriptionStore.shared.recordSubscribe(origin: origin)
+            // Also grant SW-side notification permission so the worker's
+            // `registration.showNotification(...)` call inside its `push`
+            // handler isn't rejected by WebKit's `policyForOrigin` check.
+            // Pass frame.port as-is — WKSecurityOriginCreate treats 0 as
+            // "default port for scheme", matching what `SecurityOriginData::fromURL`
+            // produces for URLs without an explicit port.
+            WebPushNotificationPermission.grant(scheme: frame.protocol, host: frame.host, port: Int(frame.port))
+            replyHandler(true, nil)
+        case "unsubscribe":
+            WebPushSubscriptionStore.shared.recordUnsubscribe(origin: origin)
+            replyHandler(true, nil)
+        case "isSubscribed":
+            replyHandler(WebPushSubscriptionStore.shared.isSubscribed(origin: origin), nil)
+        default:
+            replyHandler(nil, "unknown action: \(action)")
+        }
+    }
+}
+


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214828715304408?focus=true

### Description

Proof-of-concept that the browser can dispatch real `push` events into real Service Workers using WebKit's private `_processPushMessage:` SPI, without going through Apple's `webpushd` daemon or APNs. Goal is to validate the SPI path end-to-end before deciding whether to build a real Web Push stack on top of it.

All new entry points are behind the existing Debug menu under a "Web Push" submenu; nothing ships to users.

### Testing Steps

Run a local Web Push test page (e.g. `python3 -m http.server 8765` serving a page that registers a Service Worker with a `push` handler) and:
1. Debug → Web Push → "Set up Web Push testing environment…"
2. Open the test page in a tab and let the SW register.
3. Debug → Web Push → "Fire Test Push at Current Tab Origin" — confirm the SW's `push` handler runs and shows a notification.
4. "Fire Test Push (localhost:8765)" exercises the same path against a fixed origin.

### Impact and Risks

None for end users — code paths are only reachable from the internal Debug menu and gated behind `macOS 13.0+` / `13.3+` availability checks. Uses WebKit private SPI, so any production follow-up needs a separate review for App Store / API-stability implications.

#### What could go wrong?

SPI behavior could change across WebKit versions; this PoC is meant to surface that risk early rather than ship.

### Quality Considerations

PoC scope: no unit tests, no pixel instrumentation, no feature flag. Manual verification via the Debug menu only.

### Notes to Reviewer

Reviewing for soundness of the approach rather than production readiness. The interesting files are `WebPushSPI.swift` (private SPI bindings) and `WebPushDebugHelper.swift` (the dispatch path).

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
