### PR TITLE
iOS: Revert release notes for 7.220.0

### DIFF
--- a/iOS/fastlane/metadata/default/release_notes.txt
+++ b/iOS/fastlane/metadata/default/release_notes.txt
@@ -1,3 +1,1 @@
-• Start searching faster — we now give you a fresh tab when you open the app and an easy way to get back to your last used tab, with a link right below the address bar.
-• You can always customize the browser to show your last used tab when returning instead, and set an inactivity timer to delay your opening screen of choice. Go to Settings > General to customize.
-• This update also includes other bug fixes and improvements.
+• As usual, we've included some bug fixes and improvements.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214843452937462?focus=true
Tech Design URL: N/A
CC:

### Description

Reverts [#4895](https://github.com/duckduckgo/apple-browsers/pull/4895), restoring `iOS/fastlane/metadata/default/release_notes.txt` to the previous generic bug-fixes copy.

Note: PR targets `main` because the promote script that updates store metadata runs from `main`.

### Testing Steps

1. Open `iOS/fastlane/metadata/default/release_notes.txt`.
2. Verify the file contains only the single bug-fixes line and matches the pre-#4895 state.

### Impact and Risks

Low — metadata-only change to App Store release notes copy.

#### What could go wrong?

Wrong copy ships in App Store metadata. Mitigated by review of the diff.

### Quality Considerations

N/A — copy-only update with no code or runtime impact.

### Notes to Reviewer

This is a pure revert of #4895.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change; the main risk is shipping incorrect release note text to the App Store.
> 
> **Overview**
> Reverts `iOS/fastlane/metadata/default/release_notes.txt` by removing the detailed tab/search release notes and restoring the single generic “bug fixes and improvements” line for the App Store metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff297606a12e4ba9eec33f6b1bf0c31dd99003c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->