### PR TITLE
iOS: Move Duck.ai native storage out of app group container

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -519,6 +519,11 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// surfaces a "System microphone disabled" warning when the OS has denied access, and
     /// presents the Permission Center popover when the FE reports `getUserMedia` failure.
     case nativeVoicePermissionFlow
+
+    /// Enables moving the AI Chat native-storage container from the shared App
+    /// Group into the app's Application Support directory on iOS. Off keeps the
+    /// legacy App Group path.
+    case nativeStoragePathMigration
 }
 
 public enum HtmlNewTabPageSubfeature: String, Equatable, PrivacySubfeature {

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -394,6 +394,9 @@ public enum FeatureFlag: String {
 
     case aiChatNativeStorage
 
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215106459483563?focus=true
+    case duckAINativeStoragePathMigration
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214025222413375
     case aiChatNativeDataAccess
 
@@ -706,6 +709,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.minimalChromeInLandscape))
         case .aiChatNativeStorage:
             Config(source: .remoteReleasable(AIChatSubfeature.nativeStorage))
+        case .duckAINativeStoragePathMigration:
+            Config(source: .remoteReleasable(AIChatSubfeature.nativeStoragePathMigration))
         case .aiChatNativeDataAccess:
             Config(source: .remoteReleasable(AIChatSubfeature.nativeDataAccess))
         case .omniBarLongPressMenu:

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -710,7 +710,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .aiChatNativeStorage:
             Config(source: .remoteReleasable(AIChatSubfeature.nativeStorage))
         case .duckAINativeStoragePathMigration:
-            Config(source: .remoteReleasable(AIChatSubfeature.nativeStoragePathMigration))
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.nativeStoragePathMigration))
         case .aiChatNativeDataAccess:
             Config(source: .remoteReleasable(AIChatSubfeature.nativeDataAccess))
         case .omniBarLongPressMenu:

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1595,6 +1595,7 @@ extension Pixel {
         case duckAiNativeStorageContainerMigrationSuccess(label: String)
         case duckAiNativeStorageContainerMigrationAttemptFailed(label: String)
         case duckAiNativeStorageContainerMigrationGaveUp(label: String)
+        case duckAiNativeStorageContainerMigrationProtectionFailed(label: String)
 
         case duckAiNativeStorageInitSuccess
         case duckAiNativeStorageInitError
@@ -3359,6 +3360,7 @@ extension Pixel.Event {
         case .duckAiNativeStorageContainerMigrationSuccess(let label): return "m_duck-ai_native-storage_container-migration_success_\(label)"
         case .duckAiNativeStorageContainerMigrationAttemptFailed(let label): return "m_duck-ai_native-storage_container-migration_attempt-failed_\(label)"
         case .duckAiNativeStorageContainerMigrationGaveUp(let label): return "m_duck-ai_native-storage_container-migration_gave-up_\(label)"
+        case .duckAiNativeStorageContainerMigrationProtectionFailed(let label): return "m_duck-ai_native-storage_container-migration_protection-failed_\(label)"
 
         case .duckAiNativeStorageInitSuccess: return "m_duck-ai_native-storage_init_success"
         case .duckAiNativeStorageInitError: return "m_duck-ai_native-storage_init_error"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1591,7 +1591,6 @@ extension Pixel {
         case duckAiNativeStorageMigrationDoneBlankCount
 
         case duckAiNativeStorageContainerMigrationNotNeeded(label: String)
-        case duckAiNativeStorageContainerMigrationOrphanRemoved(label: String)
         case duckAiNativeStorageContainerMigrationSuccess(label: String)
         case duckAiNativeStorageContainerMigrationAttemptFailed(label: String)
         case duckAiNativeStorageContainerMigrationGaveUp(label: String)
@@ -3359,7 +3358,6 @@ extension Pixel.Event {
         case .duckAiNativeStorageMigrationDoneBlankCount: return "m_duck-ai_native-storage_migration_done_blank_count"
 
         case .duckAiNativeStorageContainerMigrationNotNeeded(let label): return "m_duck-ai_native-storage_container-migration_not-needed_\(label)"
-        case .duckAiNativeStorageContainerMigrationOrphanRemoved(let label): return "m_duck-ai_native-storage_container-migration_orphan-removed_\(label)"
         case .duckAiNativeStorageContainerMigrationSuccess(let label): return "m_duck-ai_native-storage_container-migration_success_\(label)"
         case .duckAiNativeStorageContainerMigrationAttemptFailed(let label): return "m_duck-ai_native-storage_container-migration_attempt-failed_\(label)"
         case .duckAiNativeStorageContainerMigrationGaveUp(let label): return "m_duck-ai_native-storage_container-migration_gave-up_\(label)"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1598,6 +1598,7 @@ extension Pixel {
         case duckAiNativeStorageContainerMigrationDestinationConflict(label: String)
         case duckAiNativeStorageContainerMigrationExcludeFromBackupFailed(label: String)
         case duckAiNativeStorageContainerMigrationProtectedDataUnavailable(label: String)
+        case duckAiNativeStorageContainerMigrationKeyValueStoreReadFailed(label: String)
 
         case duckAiNativeStorageInitSuccess
         case duckAiNativeStorageInitError
@@ -3365,6 +3366,7 @@ extension Pixel.Event {
         case .duckAiNativeStorageContainerMigrationDestinationConflict(let label): return "m_duck-ai_native-storage_container-migration_destination-conflict_\(label)"
         case .duckAiNativeStorageContainerMigrationExcludeFromBackupFailed(let label): return "m_duck-ai_native-storage_container-migration_exclude-from-backup-failed_\(label)"
         case .duckAiNativeStorageContainerMigrationProtectedDataUnavailable(let label): return "m_duck-ai_native-storage_container-migration_protected-data-unavailable_\(label)"
+        case .duckAiNativeStorageContainerMigrationKeyValueStoreReadFailed(let label): return "m_duck-ai_native-storage_container-migration_key-value-store-read-failed_\(label)"
 
         case .duckAiNativeStorageInitSuccess: return "m_duck-ai_native-storage_init_success"
         case .duckAiNativeStorageInitError: return "m_duck-ai_native-storage_init_error"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1596,6 +1596,9 @@ extension Pixel {
         case duckAiNativeStorageContainerMigrationAttemptFailed(label: String)
         case duckAiNativeStorageContainerMigrationGaveUp(label: String)
         case duckAiNativeStorageContainerMigrationProtectionFailed(label: String)
+        case duckAiNativeStorageContainerMigrationDestinationConflict(label: String)
+        case duckAiNativeStorageContainerMigrationExcludeFromBackupFailed(label: String)
+        case duckAiNativeStorageContainerMigrationProtectedDataUnavailable(label: String)
 
         case duckAiNativeStorageInitSuccess
         case duckAiNativeStorageInitError
@@ -3361,6 +3364,9 @@ extension Pixel.Event {
         case .duckAiNativeStorageContainerMigrationAttemptFailed(let label): return "m_duck-ai_native-storage_container-migration_attempt-failed_\(label)"
         case .duckAiNativeStorageContainerMigrationGaveUp(let label): return "m_duck-ai_native-storage_container-migration_gave-up_\(label)"
         case .duckAiNativeStorageContainerMigrationProtectionFailed(let label): return "m_duck-ai_native-storage_container-migration_protection-failed_\(label)"
+        case .duckAiNativeStorageContainerMigrationDestinationConflict(let label): return "m_duck-ai_native-storage_container-migration_destination-conflict_\(label)"
+        case .duckAiNativeStorageContainerMigrationExcludeFromBackupFailed(let label): return "m_duck-ai_native-storage_container-migration_exclude-from-backup-failed_\(label)"
+        case .duckAiNativeStorageContainerMigrationProtectedDataUnavailable(let label): return "m_duck-ai_native-storage_container-migration_protected-data-unavailable_\(label)"
 
         case .duckAiNativeStorageInitSuccess: return "m_duck-ai_native-storage_init_success"
         case .duckAiNativeStorageInitError: return "m_duck-ai_native-storage_init_error"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1590,6 +1590,12 @@ extension Pixel {
         case duckAiNativeStorageMigrationDoneCount(key: String)
         case duckAiNativeStorageMigrationDoneBlankCount
 
+        case duckAiNativeStorageContainerMigrationNotNeeded(label: String)
+        case duckAiNativeStorageContainerMigrationOrphanRemoved(label: String)
+        case duckAiNativeStorageContainerMigrationSuccess(label: String)
+        case duckAiNativeStorageContainerMigrationAttemptFailed(label: String)
+        case duckAiNativeStorageContainerMigrationGaveUp(label: String)
+
         case duckAiNativeStorageInitSuccess
         case duckAiNativeStorageInitError
         case duckAiNativeStorageMigrationStarted
@@ -3347,6 +3353,12 @@ extension Pixel.Event {
         case .duckAiNativeStorageMigrationDoneUnique(let key): return "m_duck-ai_native-storage_migration_done_\(key)_unique"
         case .duckAiNativeStorageMigrationDoneCount(let key): return "m_duck-ai_native-storage_migration_done_\(key)_count"
         case .duckAiNativeStorageMigrationDoneBlankCount: return "m_duck-ai_native-storage_migration_done_blank_count"
+
+        case .duckAiNativeStorageContainerMigrationNotNeeded(let label): return "m_duck-ai_native-storage_container-migration_not-needed_\(label)"
+        case .duckAiNativeStorageContainerMigrationOrphanRemoved(let label): return "m_duck-ai_native-storage_container-migration_orphan-removed_\(label)"
+        case .duckAiNativeStorageContainerMigrationSuccess(let label): return "m_duck-ai_native-storage_container-migration_success_\(label)"
+        case .duckAiNativeStorageContainerMigrationAttemptFailed(let label): return "m_duck-ai_native-storage_container-migration_attempt-failed_\(label)"
+        case .duckAiNativeStorageContainerMigrationGaveUp(let label): return "m_duck-ai_native-storage_container-migration_gave-up_\(label)"
 
         case .duckAiNativeStorageInitSuccess: return "m_duck-ai_native-storage_init_success"
         case .duckAiNativeStorageInitError: return "m_duck-ai_native-storage_init_error"

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -148,7 +148,9 @@
 		312BF6F12E6B4A2500411CF9 /* NewAddressBarPickerDisplayValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312BF6F02E6B4A2500411CF9 /* NewAddressBarPickerDisplayValidatorTests.swift */; };
 		312E5746283BB04A00C18FA0 /* AutofillEmptySearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312E5745283BB04A00C18FA0 /* AutofillEmptySearchView.swift */; };
 		312F786A2F28C32D006903C7 /* AIChatHistoryManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312F78692F28C32D006903C7 /* AIChatHistoryManagerTests.swift */; };
+		3132928308A0000000C3A276 /* DuckAiNativeStorageContainerMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3132928208A0000000C3A276 /* DuckAiNativeStorageContainerMigrationTests.swift */; };
 		3132927F2F9FE38000C3A276 /* FireModeNativeStorageController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3132927E2F9FE38000C3A276 /* FireModeNativeStorageController.swift */; };
+		3132928108A0000000C3A276 /* DuckAiNativeStorageContainerMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3132928008A0000000C3A276 /* DuckAiNativeStorageContainerMigration.swift */; };
 		3132FA2627A0784600DD7A12 /* FilePreviewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3132FA2527A0784600DD7A12 /* FilePreviewHelper.swift */; };
 		3132FA2827A0788400DD7A12 /* PassKitPreviewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3132FA2727A0788400DD7A12 /* PassKitPreviewHelper.swift */; };
 		3132FA2A27A0788F00DD7A12 /* QuickLookPreviewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3132FA2927A0788F00DD7A12 /* QuickLookPreviewHelper.swift */; };
@@ -2770,7 +2772,9 @@
 		312BF6F02E6B4A2500411CF9 /* NewAddressBarPickerDisplayValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewAddressBarPickerDisplayValidatorTests.swift; sourceTree = "<group>"; };
 		312E5745283BB04A00C18FA0 /* AutofillEmptySearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillEmptySearchView.swift; sourceTree = "<group>"; };
 		312F78692F28C32D006903C7 /* AIChatHistoryManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatHistoryManagerTests.swift; sourceTree = "<group>"; };
+		3132928208A0000000C3A276 /* DuckAiNativeStorageContainerMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAiNativeStorageContainerMigrationTests.swift; sourceTree = "<group>"; };
 		3132927E2F9FE38000C3A276 /* FireModeNativeStorageController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireModeNativeStorageController.swift; sourceTree = "<group>"; };
+		3132928008A0000000C3A276 /* DuckAiNativeStorageContainerMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAiNativeStorageContainerMigration.swift; sourceTree = "<group>"; };
 		3132FA2527A0784600DD7A12 /* FilePreviewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewHelper.swift; sourceTree = "<group>"; };
 		3132FA2727A0788400DD7A12 /* PassKitPreviewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassKitPreviewHelper.swift; sourceTree = "<group>"; };
 		3132FA2927A0788F00DD7A12 /* QuickLookPreviewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLookPreviewHelper.swift; sourceTree = "<group>"; };
@@ -5804,6 +5808,7 @@
 				C14414782EB11A100057F921 /* AIChatFullModeFeatureTests.swift */,
 				C14414822EB11A100057F921 /* AIChatIPadTabFeatureTests.swift */,
 				312F78692F28C32D006903C7 /* AIChatHistoryManagerTests.swift */,
+				3132928208A0000000C3A276 /* DuckAiNativeStorageContainerMigrationTests.swift */,
 				C12B671F2EC0BDD9003B80DD /* AIChatContentHandlerTests.swift */,
 				C16670E32EE7301300C6105C /* SubscriptionAIChatStateHandlerTests.swift */,
 				C13EBC502EE9CD2F00CE5A4B /* AIChatContextualModeFeatureTests.swift */,
@@ -5829,6 +5834,7 @@
 				85F996CD2E54ADB9006B4641 /* OpenAIChatFromAddressBarHandling.swift */,
 				852E766C2E4638AB00BA92F1 /* AIChatSettingsMigration.swift */,
 				3132927E2F9FE38000C3A276 /* FireModeNativeStorageController.swift */,
+				3132928008A0000000C3A276 /* DuckAiNativeStorageContainerMigration.swift */,
 				31FD991A2DCE6AAB00AAC9C7 /* ExperimentalAIChatManager.swift */,
 				9770D4A82F6AFD3F0029361F /* DuckAIVoiceShortcutFeature.swift */,
 				9770D4AD2F7B000100293610 /* VoiceSessionStateManager.swift */,
@@ -12383,6 +12389,7 @@
 				9FE7CD632E14D90E006691AB /* DefaultBrowserPromptKeyValueFilesStorePixelHandlers.swift in Sources */,
 				B623C1C42862CD670043013E /* WKDownloadSession.swift in Sources */,
 				3132927F2F9FE38000C3A276 /* FireModeNativeStorageController.swift in Sources */,
+				3132928108A0000000C3A276 /* DuckAiNativeStorageContainerMigration.swift in Sources */,
 				1E8AD1D927C4FEC100ABA377 /* DownloadsListSectioningHelper.swift in Sources */,
 				6526CA712D70E0BB0048819E /* DuckPlayerViewUtils.swift in Sources */,
 				D60170BD2BA34CE8001911B5 /* Subscription.swift in Sources */,
@@ -13949,6 +13956,7 @@
 				CBCCF96828885DEE006F4A71 /* AppPrivacyConfigurationTests.swift in Sources */,
 				F0A200012F31000100BAD001 /* NewBadgeVisibilityManagerTests.swift in Sources */,
 				312F786A2F28C32D006903C7 /* AIChatHistoryManagerTests.swift in Sources */,
+				3132928308A0000000C3A276 /* DuckAiNativeStorageContainerMigrationTests.swift in Sources */,
 				6F40D15E2C34436500BF22F0 /* HomePageDisplayDailyPixelBucketTests.swift in Sources */,
 				310742AB2848E6FD0012660B /* BackForwardMenuHistoryItemURLSanitizerTests.swift in Sources */,
 				C1935A222C89CA9F001AD72D /* AutofillSurveyManagerTests.swift in Sources */,

--- a/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
+++ b/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
@@ -23,77 +23,6 @@ import Persistence
 import UIKit
 import os.log
 
-/// Identifies the container being migrated. Raw value is suffixed onto pixel names.
-enum DuckAiNativeStorageContainerMigrationLabel: String {
-    case `default`
-    case fireMode = "fire-mode"
-}
-
-/// Outcomes for the container relocation. Distinct from the JS→native chat-data
-/// migration pixels (`duckAiNativeStorageMigration*`).
-enum DuckAiNativeStorageContainerMigrationEvent {
-    case notNeeded(label: DuckAiNativeStorageContainerMigrationLabel)
-    case success(label: DuckAiNativeStorageContainerMigrationLabel)
-    case attemptFailed(label: DuckAiNativeStorageContainerMigrationLabel, error: Error)
-    case gaveUp(label: DuckAiNativeStorageContainerMigrationLabel, error: Error?)
-    /// Move succeeded but `applyDefaultFileProtection` failed — the DB kept its
-    /// inherited `NSFileProtectionComplete` class (the 0xdead10cc condition).
-    case protectionFailed(label: DuckAiNativeStorageContainerMigrationLabel, error: Error)
-    /// Destination has data but the migrated flag isn't set — could be a partial
-    /// move or a DB created while the App Group entitlement was unavailable. The
-    /// destination is claimed going forward and the source is preserved.
-    case destinationConflict(label: DuckAiNativeStorageContainerMigrationLabel)
-    /// `isExcludedFromBackup` or the destination directory creation failed.
-    /// The encrypted DB may end up in iCloud backups.
-    case excludeFromBackupFailed(label: DuckAiNativeStorageContainerMigrationLabel, error: Error)
-    /// Deferred because protected data is unavailable (pre-first-unlock
-    /// background launch). No state is modified.
-    case protectedDataUnavailable(label: DuckAiNativeStorageContainerMigrationLabel)
-}
-
-enum DuckAiNativeStorageContainerMigrationOutcome {
-    case proceed
-    case skip
-}
-
-protocol DuckAiNativeStorageContainerMigrationPixelFiring {
-    func fire(_ event: DuckAiNativeStorageContainerMigrationEvent)
-}
-
-struct NullDuckAiNativeStorageContainerMigrationPixelFiring: DuckAiNativeStorageContainerMigrationPixelFiring {
-    func fire(_ event: DuckAiNativeStorageContainerMigrationEvent) {}
-}
-
-struct DuckAiNativeStorageContainerMigrationPixelAdapter: DuckAiNativeStorageContainerMigrationPixelFiring {
-    func fire(_ event: DuckAiNativeStorageContainerMigrationEvent) {
-        switch event {
-        case .notNeeded(let label):
-            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationNotNeeded(label: label.rawValue))
-        case .success(let label):
-            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationSuccess(label: label.rawValue))
-        case .attemptFailed(let label, let error):
-            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationAttemptFailed(label: label.rawValue), error: error)
-        case .gaveUp(let label, let error):
-            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationGaveUp(label: label.rawValue), error: error)
-        case .protectionFailed(let label, let error):
-            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationProtectionFailed(label: label.rawValue), error: error)
-        case .destinationConflict(let label):
-            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationDestinationConflict(label: label.rawValue))
-        case .excludeFromBackupFailed(let label, let error):
-            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationExcludeFromBackupFailed(label: label.rawValue), error: error)
-        case .protectedDataUnavailable(let label):
-            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationProtectedDataUnavailable(label: label.rawValue))
-        }
-    }
-}
-
-/// Runs the one-time move of a Duck.ai container from the shared App Group into
-/// the app's Application Support directory.
-protocol DuckAiNativeStorageContainerMigrating {
-    @discardableResult
-    func run() -> DuckAiNativeStorageContainerMigrationOutcome
-}
-
 /// One-time move of a Duck.ai container from the shared App Group into the
 /// app's Application Support directory.
 ///
@@ -103,16 +32,7 @@ protocol DuckAiNativeStorageContainerMigrating {
 /// `NSFileProtectionCompleteUntilFirstUserAuthentication`, which stays readable
 /// after first unlock.
 ///
-/// State (in `keyValueStore`):
-/// - `<migrationKey>.migrated` (Bool) — set when we own the destination going
-///   forward (success / notNeeded / destinationConflict). Once set, `run()`
-///   is a no-op apart from `ensureProtection`.
-/// - `<migrationKey>.attempts` (Int) — failed move attempts. Cleared when
-///   `migrated` is set. Left at the cap on `.gaveUp` so the next launch
-///   detects the exhausted budget and resets for a fresh retry.
-/// - `<migrationKey>.protectionAttempts` (Int) — retry budget for
-///   `applyDefaultFileProtection`. `maxAttempts` is the "done" sentinel
-///   (set by success or by exhausting retries).
+/// Persistent state is owned by `MigrationStateStore`.
 struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrating {
 
     static let defaultMaxAttempts = 3
@@ -122,13 +42,13 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
 
     let oldURL: URL
     let newURL: URL
-    let migrationKey: String
     let label: DuckAiNativeStorageContainerMigrationLabel
-    let keyValueStore: ThrowingKeyValueStoring
     let fileManager: FileManager
     let pixelFiring: DuckAiNativeStorageContainerMigrationPixelFiring
     let isProtectedDataAvailable: () -> Bool
     let maxAttempts: Int
+
+    private let stateStore: MigrationStateStore
 
     init(oldURL: URL,
          newURL: URL,
@@ -141,43 +61,54 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
          maxAttempts: Int = DuckAiNativeStorageContainerMigration.defaultMaxAttempts) {
         self.oldURL = oldURL
         self.newURL = newURL
-        self.migrationKey = migrationKey
         self.label = label
-        self.keyValueStore = keyValueStore
         self.fileManager = fileManager
         self.pixelFiring = pixelFiring
         self.isProtectedDataAvailable = isProtectedDataAvailable
         // 0 / negative would give up on the first failure.
         self.maxAttempts = max(1, maxAttempts)
+        self.stateStore = MigrationStateStore(keyValueStore: keyValueStore, migrationKey: migrationKey)
     }
 
     // MARK: - Entry point
 
     @discardableResult
     func run() -> DuckAiNativeStorageContainerMigrationOutcome {
-        // Background launches before first unlock can't read
-        // `NSFileProtectionComplete` source bytes. Defer rather than burn
-        // retries on a transient condition.
         guard isProtectedDataAvailable() else {
             Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] protected data unavailable; deferring")
             pixelFiring.fire(.protectedDataUnavailable(label: label))
             return .skip
         }
 
-        resetExhaustedAttemptsIfNeeded()
+        do {
+            return try performMigration()
+        } catch let kvError as MigrationStateStore.ReadError {
+            Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] key-value store read failed; deferring: \(kvError.underlying.localizedDescription, privacy: .public)")
+            pixelFiring.fire(.keyValueStoreReadFailed(label: label, error: kvError.underlying))
+            return .skip
+        } catch {
+            assertionFailure("Unexpected throw from performMigration: \(error)")
+            Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] unexpected migration error; deferring: \(error.localizedDescription, privacy: .public)")
+            return .skip
+        }
+    }
 
-        if isMigrated {
-            ensureProtection()
+    private func performMigration() throws -> DuckAiNativeStorageContainerMigrationOutcome {
+        var state = try stateStore.load()
+        resetExhaustedAttemptsIfNeeded(&state)
+
+        if state.isMigrated {
+            ensureProtection(priorAttempts: state.protectionAttempts)
             return .proceed
         }
 
-        Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] starting (prior attempts: \(attempts)); old=\(oldURL.path, privacy: .public) new=\(newURL.path, privacy: .public)")
+        Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] starting (prior attempts: \(state.attempts)); old=\(oldURL.path, privacy: .public) new=\(newURL.path, privacy: .public)")
 
         guard fileManager.fileExists(atPath: oldURL.path) else {
             Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] no old directory; marking done")
-            markMigrated()
+            stateStore.markMigrated()
             pixelFiring.fire(.notNeeded(label: label))
-            ensureProtection()
+            ensureProtection(priorAttempts: state.protectionAttempts)
             return .proceed
         }
 
@@ -188,16 +119,16 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
             // `excludeFromBackup` on a skipped launch — remove and proceed.
             if destinationHasData {
                 Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] destination has data without migrated flag; claiming new and preserving old for recovery")
-                markMigrated()
+                stateStore.markMigrated()
                 pixelFiring.fire(.destinationConflict(label: label))
-                ensureProtection()
+                ensureProtection(priorAttempts: state.protectionAttempts)
                 return .proceed
             }
             Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] empty destination directory present; removing to clear path for move")
             do {
                 try fileManager.removeItem(at: newURL)
             } catch {
-                return handleMoveFailure(error, operation: .removingEmptyDestination)
+                return handleMoveFailure(error, operation: .removingEmptyDestination, priorAttempts: state.attempts)
             }
         }
 
@@ -206,12 +137,12 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
                                             withIntermediateDirectories: true)
             try fileManager.moveItem(at: oldURL, to: newURL)
             Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] moved successfully")
-            markMigrated()
+            stateStore.markMigrated()
             pixelFiring.fire(.success(label: label))
-            ensureProtection()
+            ensureProtection(priorAttempts: state.protectionAttempts)
             return .proceed
         } catch {
-            return handleMoveFailure(error, operation: .move)
+            return handleMoveFailure(error, operation: .move, priorAttempts: state.attempts)
         }
     }
 
@@ -284,24 +215,6 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
         return firstError
     }
 
-    // MARK: - State (computed)
-
-    private var migratedKey: String { migrationKey + ".migrated" }
-    private var attemptsKey: String { migrationKey + ".attempts" }
-    private var protectionAttemptsKey: String { migrationKey + ".protectionAttempts" }
-
-    private var isMigrated: Bool {
-        (try? keyValueStore.object(forKey: migratedKey) as? Bool) ?? false
-    }
-
-    private var attempts: Int {
-        (try? keyValueStore.object(forKey: attemptsKey) as? Int) ?? 0
-    }
-
-    private var protectionAttempts: Int {
-        (try? keyValueStore.object(forKey: protectionAttemptsKey) as? Int) ?? 0
-    }
-
     /// Fire-mode stores DBs in `<UUID>/chats.db` subdirectories rather than at
     /// the root, so any non-empty `newURL` implies data that must not be wiped.
     private var destinationHasData: Bool {
@@ -311,47 +224,34 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
         return !children.isEmpty
     }
 
-    // MARK: - State (mutation)
-
-    private func markMigrated() {
-        try? keyValueStore.set(true, forKey: migratedKey)
-        try? keyValueStore.removeObject(forKey: attemptsKey)
-    }
-
-    private func setAttempts(_ value: Int) {
-        try? keyValueStore.set(value, forKey: attemptsKey)
-    }
-
-    private func setProtectionAttempts(_ value: Int) {
-        try? keyValueStore.set(value, forKey: protectionAttemptsKey)
-    }
-
-    private func resetExhaustedAttemptsIfNeeded() {
-        guard !isMigrated, attempts >= maxAttempts else { return }
+    private func resetExhaustedAttemptsIfNeeded(_ state: inout MigrationStateStore.State) {
+        guard !state.isMigrated, state.attempts >= maxAttempts else { return }
         Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] prior launch exhausted retry budget; resetting attempts")
-        try? keyValueStore.removeObject(forKey: attemptsKey)
-        try? keyValueStore.removeObject(forKey: protectionAttemptsKey)
+        stateStore.resetCounters()
+        state.attempts = 0
+        state.protectionAttempts = 0
     }
 
-    private func ensureProtection() {
-        let priorAttempts = protectionAttempts
+    private func ensureProtection(priorAttempts: Int) {
         guard priorAttempts < maxAttempts else { return }
         guard fileManager.fileExists(atPath: newURL.path) else {
             // Nothing at the destination yet — no protection to enforce.
-            setProtectionAttempts(maxAttempts)
+            stateStore.setProtectionAttempts(maxAttempts)
             return
         }
         if let error = Self.applyDefaultFileProtection(at: newURL, fileManager: fileManager) {
-            setProtectionAttempts(priorAttempts + 1)
+            stateStore.setProtectionAttempts(priorAttempts + 1)
             pixelFiring.fire(.protectionFailed(label: label, error: error))
         } else {
-            setProtectionAttempts(maxAttempts)
+            stateStore.setProtectionAttempts(maxAttempts)
         }
     }
 
-    private func handleMoveFailure(_ error: Error, operation: FailingOperation) -> DuckAiNativeStorageContainerMigrationOutcome {
-        let attempt = attempts + 1
-        setAttempts(attempt)
+    private func handleMoveFailure(_ error: Error,
+                                   operation: FailingOperation,
+                                   priorAttempts: Int) -> DuckAiNativeStorageContainerMigrationOutcome {
+        let attempt = priorAttempts + 1
+        stateStore.setAttempts(attempt)
         if attempt >= maxAttempts {
             Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] \(operation.rawValue, privacy: .public) failed (attempt \(attempt)/\(maxAttempts)); giving up: \(error.localizedDescription, privacy: .public)")
             pixelFiring.fire(.gaveUp(label: label, error: error))
@@ -365,5 +265,129 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
     private enum FailingOperation: String {
         case move
         case removingEmptyDestination
+    }
+}
+
+/// Identifies the container being migrated. Raw value is suffixed onto pixel names.
+enum DuckAiNativeStorageContainerMigrationLabel: String {
+    case `default`
+    case fireMode = "fire-mode"
+}
+
+/// Outcomes for the container relocation. Distinct from the JS→native chat-data
+/// migration pixels (`duckAiNativeStorageMigration*`).
+enum DuckAiNativeStorageContainerMigrationEvent {
+    case notNeeded(label: DuckAiNativeStorageContainerMigrationLabel)
+    case success(label: DuckAiNativeStorageContainerMigrationLabel)
+    case attemptFailed(label: DuckAiNativeStorageContainerMigrationLabel, error: Error)
+    case gaveUp(label: DuckAiNativeStorageContainerMigrationLabel, error: Error?)
+    case protectionFailed(label: DuckAiNativeStorageContainerMigrationLabel, error: Error)
+    case destinationConflict(label: DuckAiNativeStorageContainerMigrationLabel)
+    case excludeFromBackupFailed(label: DuckAiNativeStorageContainerMigrationLabel, error: Error)
+    case protectedDataUnavailable(label: DuckAiNativeStorageContainerMigrationLabel)
+    case keyValueStoreReadFailed(label: DuckAiNativeStorageContainerMigrationLabel, error: Error)
+}
+
+enum DuckAiNativeStorageContainerMigrationOutcome {
+    case proceed
+    case skip
+}
+
+protocol DuckAiNativeStorageContainerMigrationPixelFiring {
+    func fire(_ event: DuckAiNativeStorageContainerMigrationEvent)
+}
+
+struct NullDuckAiNativeStorageContainerMigrationPixelFiring: DuckAiNativeStorageContainerMigrationPixelFiring {
+    func fire(_ event: DuckAiNativeStorageContainerMigrationEvent) {}
+}
+
+struct DuckAiNativeStorageContainerMigrationPixelAdapter: DuckAiNativeStorageContainerMigrationPixelFiring {
+    func fire(_ event: DuckAiNativeStorageContainerMigrationEvent) {
+        switch event {
+        case .notNeeded(let label):
+            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationNotNeeded(label: label.rawValue))
+        case .success(let label):
+            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationSuccess(label: label.rawValue))
+        case .attemptFailed(let label, let error):
+            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationAttemptFailed(label: label.rawValue), error: error)
+        case .gaveUp(let label, let error):
+            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationGaveUp(label: label.rawValue), error: error)
+        case .protectionFailed(let label, let error):
+            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationProtectionFailed(label: label.rawValue), error: error)
+        case .destinationConflict(let label):
+            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationDestinationConflict(label: label.rawValue))
+        case .excludeFromBackupFailed(let label, let error):
+            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationExcludeFromBackupFailed(label: label.rawValue), error: error)
+        case .protectedDataUnavailable(let label):
+            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationProtectedDataUnavailable(label: label.rawValue))
+        case .keyValueStoreReadFailed(let label, let error):
+            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationKeyValueStoreReadFailed(label: label.rawValue), error: error)
+        }
+    }
+}
+
+/// Runs the one-time move of a Duck.ai container from the shared App Group into
+/// the app's Application Support directory.
+protocol DuckAiNativeStorageContainerMigrating {
+    @discardableResult
+    func run() -> DuckAiNativeStorageContainerMigrationOutcome
+}
+
+private struct MigrationStateStore {
+
+    struct State {
+        let isMigrated: Bool
+        var attempts: Int
+        var protectionAttempts: Int
+    }
+
+    /// Tags errors that originate from a kv-store read so the migration's
+    /// catch can distinguish them from any other propagating throw.
+    struct ReadError: Error {
+        let underlying: Error
+    }
+
+    private let keyValueStore: ThrowingKeyValueStoring
+    private let migratedKey: String
+    private let attemptsKey: String
+    private let protectionAttemptsKey: String
+
+    init(keyValueStore: ThrowingKeyValueStoring, migrationKey: String) {
+        self.keyValueStore = keyValueStore
+        self.migratedKey = migrationKey + ".migrated"
+        self.attemptsKey = migrationKey + ".attempts"
+        self.protectionAttemptsKey = migrationKey + ".protectionAttempts"
+    }
+
+    func load() throws -> State {
+        do {
+            return State(
+                isMigrated: try keyValueStore.object(forKey: migratedKey) as? Bool ?? false,
+                attempts: try keyValueStore.object(forKey: attemptsKey) as? Int ?? 0,
+                protectionAttempts: try keyValueStore.object(forKey: protectionAttemptsKey) as? Int ?? 0
+            )
+        } catch {
+            throw ReadError(underlying: error)
+        }
+    }
+
+    func markMigrated() {
+        try? keyValueStore.set(true, forKey: migratedKey)
+        try? keyValueStore.removeObject(forKey: attemptsKey)
+    }
+
+    func setAttempts(_ value: Int) {
+        try? keyValueStore.set(value, forKey: attemptsKey)
+    }
+
+    func setProtectionAttempts(_ value: Int) {
+        try? keyValueStore.set(value, forKey: protectionAttemptsKey)
+    }
+
+    /// Clears `attempts` and `protectionAttempts`. Used when the prior launch
+    /// exhausted the retry budget so this launch starts with a fresh budget.
+    func resetCounters() {
+        try? keyValueStore.removeObject(forKey: attemptsKey)
+        try? keyValueStore.removeObject(forKey: protectionAttemptsKey)
     }
 }

--- a/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
+++ b/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
@@ -40,6 +40,18 @@ enum DuckAiNativeStorageContainerMigrationEvent {
     case gaveUp(label: DuckAiNativeStorageContainerMigrationLabel, error: Error?)
 }
 
+/// Result of a `migrateIfNeeded` call. Callers MUST honor `.skip` by not creating
+/// or opening the destination directory — doing so would make the next launch
+/// treat the un-migrated old data as an orphan and delete it.
+enum DuckAiNativeStorageContainerMigrationOutcome {
+    /// Migration is complete (or unnecessary, or gave up after the retry cap).
+    /// Caller may create/open the destination.
+    case proceed
+    /// A move attempt failed and the retry cap is not yet exhausted. Caller MUST
+    /// NOT touch the destination this launch; migration will retry next launch.
+    case skip
+}
+
 protocol DuckAiNativeStorageContainerMigrationPixelFiring {
     func fire(_ event: DuckAiNativeStorageContainerMigrationEvent)
 }
@@ -98,15 +110,47 @@ enum DuckAiNativeStorageContainerMigration {
         }
     }
 
+    /// Recursively applies `completeUntilFirstUserAuthentication` protection to `url`
+    /// and every existing child. Files moved from an App Group container retain
+    /// their `NSFileProtectionComplete` attribute on the same volume, so without
+    /// this step a locked device can still trip 0xdead10cc on SQLite reads. Setting
+    /// the directory itself also fixes the default class new sidecars inherit.
+    static func applyDefaultFileProtection(at url: URL, fileManager: FileManager = .default) {
+        let attributes: [FileAttributeKey: Any] = [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
+
+        func apply(to path: String) {
+            do {
+                try fileManager.setAttributes(attributes, ofItemAtPath: path)
+            } catch {
+                Self.logger.error("[NativeStorage] failed to set file protection on \(path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
+        }
+
+        apply(to: url.path)
+
+        guard let enumerator = fileManager.enumerator(at: url,
+                                                     includingPropertiesForKeys: nil,
+                                                     options: [],
+                                                     errorHandler: nil) else { return }
+        for case let childURL as URL in enumerator {
+            apply(to: childURL.path)
+        }
+    }
+
     /// Moves `oldURL` to `newURL`, retrying on failure across launches.
     ///
     /// Persistence in `userDefaults`:
     /// - `migrationKey + ".done"` (Bool) — set when the migration reaches a terminal
     ///   state (success, no-op, orphan-cleaned, or `maxAttempts` exhausted).
-    /// - `migrationKey + ".attempts"` (Int) — number of failed move attempts so far.
-    ///   Cleared on success.
+    /// - `migrationKey + ".attempts"` (Int) — number of failed attempts so far
+    ///   (move or orphan-removal). Cleared on success.
     ///
     /// `label` distinguishes the default vs. fire-mode container in logs and pixels.
+    ///
+    /// Returns `.skip` when a move attempt fails and retries remain — the caller
+    /// MUST NOT create or open `newURL` in that case, otherwise the next launch
+    /// will treat the still-present old data as an orphan and delete it.
+    @discardableResult
     static func migrateIfNeeded(from oldURL: URL,
                                 to newURL: URL,
                                 migrationKey: String,
@@ -114,13 +158,13 @@ enum DuckAiNativeStorageContainerMigration {
                                 userDefaults: UserDefaults = .standard,
                                 fileManager: FileManager = .default,
                                 pixelFiring: DuckAiNativeStorageContainerMigrationPixelFiring = NullDuckAiNativeStorageContainerMigrationPixelFiring(),
-                                maxAttempts: Int = defaultMaxAttempts) {
+                                maxAttempts: Int = defaultMaxAttempts) -> DuckAiNativeStorageContainerMigrationOutcome {
         let doneKey = migrationKey + ".done"
         let attemptsKey = migrationKey + ".attempts"
 
         guard !userDefaults.bool(forKey: doneKey) else {
             Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] skipping: already done")
-            return
+            return .proceed
         }
 
         let priorAttempts = userDefaults.integer(forKey: attemptsKey)
@@ -131,7 +175,7 @@ enum DuckAiNativeStorageContainerMigration {
             userDefaults.set(true, forKey: doneKey)
             userDefaults.removeObject(forKey: attemptsKey)
             pixelFiring.fire(.notNeeded(label: label))
-            return
+            return .proceed
         }
 
         if fileManager.fileExists(atPath: newURL.path) {
@@ -139,24 +183,38 @@ enum DuckAiNativeStorageContainerMigration {
             do {
                 try fileManager.removeItem(at: oldURL)
                 Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] orphan removed")
+                userDefaults.set(true, forKey: doneKey)
+                userDefaults.removeObject(forKey: attemptsKey)
+                pixelFiring.fire(.orphanRemoved(label: label))
+                return .proceed
             } catch {
-                Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] orphan removal failed: \(error.localizedDescription, privacy: .public)")
+                // newURL is intact and usable, but the old container still holds
+                // sensitive data. Don't claim success — keep retrying deletion
+                // across launches until it works or we hit the attempt cap.
+                let attempt = priorAttempts + 1
+                userDefaults.set(attempt, forKey: attemptsKey)
+                if attempt >= maxAttempts {
+                    Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] orphan removal failed (attempt \(attempt)/\(maxAttempts)); giving up — old data may remain in app group: \(error.localizedDescription, privacy: .public)")
+                    userDefaults.set(true, forKey: doneKey)
+                    pixelFiring.fire(.gaveUp(label: label, error: error))
+                } else {
+                    Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] orphan removal failed (attempt \(attempt)/\(maxAttempts)); will retry next launch: \(error.localizedDescription, privacy: .public)")
+                    pixelFiring.fire(.attemptFailed(label: label, error: error))
+                }
+                return .proceed
             }
-            // New data is intact regardless of orphan removal outcome — mark done.
-            userDefaults.set(true, forKey: doneKey)
-            userDefaults.removeObject(forKey: attemptsKey)
-            pixelFiring.fire(.orphanRemoved(label: label))
-            return
         }
 
         do {
             try fileManager.createDirectory(at: newURL.deletingLastPathComponent(),
                                             withIntermediateDirectories: true)
             try fileManager.moveItem(at: oldURL, to: newURL)
+            applyDefaultFileProtection(at: newURL, fileManager: fileManager)
             Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] moved successfully")
             userDefaults.set(true, forKey: doneKey)
             userDefaults.removeObject(forKey: attemptsKey)
             pixelFiring.fire(.success(label: label))
+            return .proceed
         } catch {
             let attempt = priorAttempts + 1
             userDefaults.set(attempt, forKey: attemptsKey)
@@ -164,9 +222,11 @@ enum DuckAiNativeStorageContainerMigration {
                 Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] move failed (attempt \(attempt)/\(maxAttempts)); giving up: \(error.localizedDescription, privacy: .public)")
                 userDefaults.set(true, forKey: doneKey)
                 pixelFiring.fire(.gaveUp(label: label, error: error))
+                return .proceed
             } else {
                 Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] move failed (attempt \(attempt)/\(maxAttempts)); will retry next launch: \(error.localizedDescription, privacy: .public)")
                 pixelFiring.fire(.attemptFailed(label: label, error: error))
+                return .skip
             }
         }
     }

--- a/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
+++ b/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
@@ -36,6 +36,7 @@ import os.log
 struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrating {
 
     static let defaultMaxAttempts = 3
+    typealias ProtectionDispatcher = (@escaping () -> Void) -> Void
 
     private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "DuckDuckGo",
                                        category: "DuckAiNativeStorageContainerMigration")
@@ -49,6 +50,7 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
     let maxAttempts: Int
 
     private let stateStore: MigrationStateStore
+    private let protectionDispatcher: ProtectionDispatcher
 
     init(oldURL: URL,
          newURL: URL,
@@ -58,7 +60,10 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
          fileManager: FileManager = .default,
          pixelFiring: DuckAiNativeStorageContainerMigrationPixelFiring = NullDuckAiNativeStorageContainerMigrationPixelFiring(),
          isProtectedDataAvailable: @escaping () -> Bool = { DuckAiNativeStorageContainerMigration.defaultIsProtectedDataAvailable() },
-         maxAttempts: Int = DuckAiNativeStorageContainerMigration.defaultMaxAttempts) {
+         maxAttempts: Int = DuckAiNativeStorageContainerMigration.defaultMaxAttempts,
+         protectionDispatcher: @escaping ProtectionDispatcher = { work in
+             DispatchQueue.global(qos: .utility).async(execute: work)
+         }) {
         self.oldURL = oldURL
         self.newURL = newURL
         self.label = label
@@ -68,6 +73,7 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
         // 0 / negative would give up on the first failure.
         self.maxAttempts = max(1, maxAttempts)
         self.stateStore = MigrationStateStore(keyValueStore: keyValueStore, migrationKey: migrationKey)
+        self.protectionDispatcher = protectionDispatcher
     }
 
     // MARK: - Entry point
@@ -239,11 +245,14 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
             stateStore.setProtectionAttempts(maxAttempts)
             return
         }
-        if let error = Self.applyDefaultFileProtection(at: newURL, fileManager: fileManager) {
-            stateStore.setProtectionAttempts(priorAttempts + 1)
-            pixelFiring.fire(.protectionFailed(label: label, error: error))
-        } else {
-            stateStore.setProtectionAttempts(maxAttempts)
+
+        protectionDispatcher {
+            if let error = Self.applyDefaultFileProtection(at: newURL, fileManager: fileManager) {
+                stateStore.setProtectionAttempts(priorAttempts + 1)
+                pixelFiring.fire(.protectionFailed(label: label, error: error))
+            } else {
+                stateStore.setProtectionAttempts(maxAttempts)
+            }
         }
     }
 

--- a/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
+++ b/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
@@ -1,0 +1,78 @@
+//
+//  DuckAiNativeStorageContainerMigration.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import os.log
+
+/// One-time directory move from the shared app-group container into the app's
+/// Application Support directory.
+///
+/// Files in App Group containers default to `NSFileProtectionComplete`, which
+/// makes the SQLCipher DB and files folder inaccessible whenever the device
+/// locks while the app is still alive — yielding 0xdead10cc terminations on
+/// the next SQLite read (notably the background auto-clear path). Files in
+/// the app sandbox default to `NSFileProtectionCompleteUntilFirstUserAuthentication`,
+/// which stays available after first unlock.
+enum DuckAiNativeStorageContainerMigration {
+
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "DuckDuckGo",
+                                       category: "DuckAiNativeStorageContainerMigration")
+
+    /// Moves `oldURL` to `newURL` once. The `migrationDoneKey` flag is set after
+    /// the first attempt regardless of outcome (success, no-op, or failure) so
+    /// subsequent launches do not retry.
+    static func migrateIfNeeded(from oldURL: URL,
+                                to newURL: URL,
+                                migrationDoneKey: String,
+                                userDefaults: UserDefaults = .standard,
+                                fileManager: FileManager = .default) {
+        guard !userDefaults.bool(forKey: migrationDoneKey) else {
+            Self.logger.info("[NativeStorage] [\(migrationDoneKey, privacy: .public)] skipping: flag already set")
+            return
+        }
+        defer { userDefaults.set(true, forKey: migrationDoneKey) }
+
+        Self.logger.info("[NativeStorage] [\(migrationDoneKey, privacy: .public)] starting; old=\(oldURL.path, privacy: .public) new=\(newURL.path, privacy: .public)")
+
+        guard fileManager.fileExists(atPath: oldURL.path) else {
+            Self.logger.info("[NativeStorage] [\(migrationDoneKey, privacy: .public)] no old directory at \(oldURL.path, privacy: .public); marking done")
+            return
+        }
+
+        if fileManager.fileExists(atPath: newURL.path) {
+            Self.logger.info("[NativeStorage] [\(migrationDoneKey, privacy: .public)] new location already exists; removing orphan old at \(oldURL.path, privacy: .public)")
+            do {
+                try fileManager.removeItem(at: oldURL)
+                Self.logger.info("[NativeStorage] [\(migrationDoneKey, privacy: .public)] orphan removed")
+            } catch {
+                Self.logger.error("[NativeStorage] [\(migrationDoneKey, privacy: .public)] orphan removal failed: \(error.localizedDescription, privacy: .public)")
+            }
+            return
+        }
+
+        do {
+            try fileManager.createDirectory(at: newURL.deletingLastPathComponent(),
+                                            withIntermediateDirectories: true)
+            try fileManager.moveItem(at: oldURL, to: newURL)
+            Self.logger.info("[NativeStorage] [\(migrationDoneKey, privacy: .public)] moved \(oldURL.path, privacy: .public) → \(newURL.path, privacy: .public)")
+        } catch {
+            Self.logger.error("[NativeStorage] [\(migrationDoneKey, privacy: .public)] move failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
+++ b/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
@@ -17,8 +17,53 @@
 //  limitations under the License.
 //
 
+import Core
 import Foundation
 import os.log
+
+/// Identifies which Duck.ai native-storage container is being migrated. The raw
+/// value is suffixed onto the pixel name (see `PixelEvent.swift`).
+enum DuckAiNativeStorageContainerMigrationLabel: String {
+    case `default`
+    case fireMode = "fire-mode"
+}
+
+/// Outcome events for `DuckAiNativeStorageContainerMigration`. Distinct from the
+/// JS→native chat-data migration pixels (`duckAiNativeStorageMigration*`) — these
+/// track the iOS-only relocation of the on-disk store from the app group container
+/// into Application Support.
+enum DuckAiNativeStorageContainerMigrationEvent {
+    case notNeeded(label: DuckAiNativeStorageContainerMigrationLabel)
+    case orphanRemoved(label: DuckAiNativeStorageContainerMigrationLabel)
+    case success(label: DuckAiNativeStorageContainerMigrationLabel)
+    case attemptFailed(label: DuckAiNativeStorageContainerMigrationLabel, error: Error)
+    case gaveUp(label: DuckAiNativeStorageContainerMigrationLabel, error: Error?)
+}
+
+protocol DuckAiNativeStorageContainerMigrationPixelFiring {
+    func fire(_ event: DuckAiNativeStorageContainerMigrationEvent)
+}
+
+struct NullDuckAiNativeStorageContainerMigrationPixelFiring: DuckAiNativeStorageContainerMigrationPixelFiring {
+    func fire(_ event: DuckAiNativeStorageContainerMigrationEvent) {}
+}
+
+struct DuckAiNativeStorageContainerMigrationPixelAdapter: DuckAiNativeStorageContainerMigrationPixelFiring {
+    func fire(_ event: DuckAiNativeStorageContainerMigrationEvent) {
+        switch event {
+        case .notNeeded(let label):
+            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationNotNeeded(label: label.rawValue))
+        case .orphanRemoved(let label):
+            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationOrphanRemoved(label: label.rawValue))
+        case .success(let label):
+            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationSuccess(label: label.rawValue))
+        case .attemptFailed(let label, let error):
+            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationAttemptFailed(label: label.rawValue), error: error)
+        case .gaveUp(let label, let error):
+            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationGaveUp(label: label.rawValue), error: error)
+        }
+    }
+}
 
 /// One-time directory move from the shared app-group container into the app's
 /// Application Support directory.
@@ -29,40 +74,78 @@ import os.log
 /// the next SQLite read (notably the background auto-clear path). Files in
 /// the app sandbox default to `NSFileProtectionCompleteUntilFirstUserAuthentication`,
 /// which stays available after first unlock.
+///
+/// The helper retries the move up to `maxAttempts` times across launches; after that
+/// it marks the migration done and stops, accepting data loss rather than crashing
+/// in a retry loop.
 enum DuckAiNativeStorageContainerMigration {
+
+    static let defaultMaxAttempts = 3
 
     private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "DuckDuckGo",
                                        category: "DuckAiNativeStorageContainerMigration")
 
-    /// Moves `oldURL` to `newURL` once. The `migrationDoneKey` flag is set after
-    /// the first attempt regardless of outcome (success, no-op, or failure) so
-    /// subsequent launches do not retry.
+    /// Ensures the directory at `url` exists and is excluded from iCloud
+    static func excludeFromBackup(_ url: URL) {
+        do {
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+            var url = url
+            var resourceValues = URLResourceValues()
+            resourceValues.isExcludedFromBackup = true
+            try url.setResourceValues(resourceValues)
+        } catch {
+            Self.logger.error("[NativeStorage] failed to exclude \(url.lastPathComponent, privacy: .public) from backup: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Moves `oldURL` to `newURL`, retrying on failure across launches.
+    ///
+    /// Persistence in `userDefaults`:
+    /// - `migrationKey + ".done"` (Bool) — set when the migration reaches a terminal
+    ///   state (success, no-op, orphan-cleaned, or `maxAttempts` exhausted).
+    /// - `migrationKey + ".attempts"` (Int) — number of failed move attempts so far.
+    ///   Cleared on success.
+    ///
+    /// `label` distinguishes the default vs. fire-mode container in logs and pixels.
     static func migrateIfNeeded(from oldURL: URL,
                                 to newURL: URL,
-                                migrationDoneKey: String,
+                                migrationKey: String,
+                                label: DuckAiNativeStorageContainerMigrationLabel,
                                 userDefaults: UserDefaults = .standard,
-                                fileManager: FileManager = .default) {
-        guard !userDefaults.bool(forKey: migrationDoneKey) else {
-            Self.logger.info("[NativeStorage] [\(migrationDoneKey, privacy: .public)] skipping: flag already set")
+                                fileManager: FileManager = .default,
+                                pixelFiring: DuckAiNativeStorageContainerMigrationPixelFiring = NullDuckAiNativeStorageContainerMigrationPixelFiring(),
+                                maxAttempts: Int = defaultMaxAttempts) {
+        let doneKey = migrationKey + ".done"
+        let attemptsKey = migrationKey + ".attempts"
+
+        guard !userDefaults.bool(forKey: doneKey) else {
+            Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] skipping: already done")
             return
         }
-        defer { userDefaults.set(true, forKey: migrationDoneKey) }
 
-        Self.logger.info("[NativeStorage] [\(migrationDoneKey, privacy: .public)] starting; old=\(oldURL.path, privacy: .public) new=\(newURL.path, privacy: .public)")
+        let priorAttempts = userDefaults.integer(forKey: attemptsKey)
+        Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] starting (prior attempts: \(priorAttempts)); old=\(oldURL.path, privacy: .public) new=\(newURL.path, privacy: .public)")
 
         guard fileManager.fileExists(atPath: oldURL.path) else {
-            Self.logger.info("[NativeStorage] [\(migrationDoneKey, privacy: .public)] no old directory at \(oldURL.path, privacy: .public); marking done")
+            Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] no old directory; marking done")
+            userDefaults.set(true, forKey: doneKey)
+            userDefaults.removeObject(forKey: attemptsKey)
+            pixelFiring.fire(.notNeeded(label: label))
             return
         }
 
         if fileManager.fileExists(atPath: newURL.path) {
-            Self.logger.info("[NativeStorage] [\(migrationDoneKey, privacy: .public)] new location already exists; removing orphan old at \(oldURL.path, privacy: .public)")
+            Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] new location already exists; removing orphan old")
             do {
                 try fileManager.removeItem(at: oldURL)
-                Self.logger.info("[NativeStorage] [\(migrationDoneKey, privacy: .public)] orphan removed")
+                Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] orphan removed")
             } catch {
-                Self.logger.error("[NativeStorage] [\(migrationDoneKey, privacy: .public)] orphan removal failed: \(error.localizedDescription, privacy: .public)")
+                Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] orphan removal failed: \(error.localizedDescription, privacy: .public)")
             }
+            // New data is intact regardless of orphan removal outcome — mark done.
+            userDefaults.set(true, forKey: doneKey)
+            userDefaults.removeObject(forKey: attemptsKey)
+            pixelFiring.fire(.orphanRemoved(label: label))
             return
         }
 
@@ -70,9 +153,21 @@ enum DuckAiNativeStorageContainerMigration {
             try fileManager.createDirectory(at: newURL.deletingLastPathComponent(),
                                             withIntermediateDirectories: true)
             try fileManager.moveItem(at: oldURL, to: newURL)
-            Self.logger.info("[NativeStorage] [\(migrationDoneKey, privacy: .public)] moved \(oldURL.path, privacy: .public) → \(newURL.path, privacy: .public)")
+            Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] moved successfully")
+            userDefaults.set(true, forKey: doneKey)
+            userDefaults.removeObject(forKey: attemptsKey)
+            pixelFiring.fire(.success(label: label))
         } catch {
-            Self.logger.error("[NativeStorage] [\(migrationDoneKey, privacy: .public)] move failed: \(error.localizedDescription, privacy: .public)")
+            let attempt = priorAttempts + 1
+            userDefaults.set(attempt, forKey: attemptsKey)
+            if attempt >= maxAttempts {
+                Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] move failed (attempt \(attempt)/\(maxAttempts)); giving up: \(error.localizedDescription, privacy: .public)")
+                userDefaults.set(true, forKey: doneKey)
+                pixelFiring.fire(.gaveUp(label: label, error: error))
+            } else {
+                Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] move failed (attempt \(attempt)/\(maxAttempts)); will retry next launch: \(error.localizedDescription, privacy: .public)")
+                pixelFiring.fire(.attemptFailed(label: label, error: error))
+            }
         }
     }
 }

--- a/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
+++ b/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
@@ -19,6 +19,7 @@
 
 import Core
 import Foundation
+import Persistence
 import UIKit
 import os.log
 
@@ -38,8 +39,8 @@ enum DuckAiNativeStorageContainerMigrationEvent {
     /// Move succeeded but `applyDefaultFileProtection` failed — the DB kept its
     /// inherited `NSFileProtectionComplete` class (the 0xdead10cc condition).
     case protectionFailed(label: DuckAiNativeStorageContainerMigrationLabel, error: Error)
-    /// Destination has a `chats.db` but no marker — could be a partial move or
-    /// a DB created while the App Group entitlement was unavailable. The
+    /// Destination has data but the migrated flag isn't set — could be a partial
+    /// move or a DB created while the App Group entitlement was unavailable. The
     /// destination is claimed going forward and the source is preserved.
     case destinationConflict(label: DuckAiNativeStorageContainerMigrationLabel)
     /// `isExcludedFromBackup` or the destination directory creation failed.
@@ -88,7 +89,18 @@ struct DuckAiNativeStorageContainerMigrationPixelAdapter: DuckAiNativeStorageCon
     }
 }
 
-/// One-time move of the Duck.ai container from the shared App Group into the
+/// Runs the one-time move of a Duck.ai container from the shared App Group into
+/// the app's Application Support directory.
+///
+/// Letting callers fake the outcome means production code can stay tightly
+/// coupled to the concrete `DuckAiNativeStorageContainerMigration` while tests
+/// can substitute a mock that returns canned outcomes.
+protocol DuckAiNativeStorageContainerMigrating {
+    @discardableResult
+    func run() -> DuckAiNativeStorageContainerMigrationOutcome
+}
+
+/// One-time move of a Duck.ai container from the shared App Group into the
 /// app's Application Support directory.
 ///
 /// App Group files default to `NSFileProtectionComplete`, which makes the DB
@@ -97,20 +109,123 @@ struct DuckAiNativeStorageContainerMigrationPixelAdapter: DuckAiNativeStorageCon
 /// `NSFileProtectionCompleteUntilFirstUserAuthentication`, which stays readable
 /// after first unlock.
 ///
-/// Completion is signalled by a marker file at
-/// `<Application Support>/.<migrationKey>.migrated`. The marker is excluded
-/// from iCloud backup so a cross-device restore re-runs the migration against
-/// the restored App Group data.
-///
-/// Retries the move up to `maxAttempts` times across launches. On `.gaveUp` the
-/// source is preserved (not deleted) so the user can recover on a later launch
-/// when conditions improve (e.g. disk pressure clears).
-enum DuckAiNativeStorageContainerMigration {
+/// State (in `keyValueStore`):
+/// - `<migrationKey>.migrated` (Bool) — set when we own the destination going
+///   forward (success / notNeeded / destinationConflict). Once set, `run()`
+///   is a no-op apart from `ensureProtection`.
+/// - `<migrationKey>.attempts` (Int) — failed move attempts. Cleared when
+///   `migrated` is set. Left at the cap on `.gaveUp` so the next launch
+///   detects the exhausted budget and resets for a fresh retry.
+/// - `<migrationKey>.protectionAttempts` (Int) — retry budget for
+///   `applyDefaultFileProtection`. `maxAttempts` is the "done" sentinel
+///   (set by success or by exhausting retries).
+struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrating {
 
     static let defaultMaxAttempts = 3
 
     private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "DuckDuckGo",
                                        category: "DuckAiNativeStorageContainerMigration")
+
+    let oldURL: URL
+    let newURL: URL
+    let migrationKey: String
+    let label: DuckAiNativeStorageContainerMigrationLabel
+    let keyValueStore: ThrowingKeyValueStoring
+    let fileManager: FileManager
+    let pixelFiring: DuckAiNativeStorageContainerMigrationPixelFiring
+    let isProtectedDataAvailable: () -> Bool
+    let maxAttempts: Int
+
+    init(oldURL: URL,
+         newURL: URL,
+         migrationKey: String,
+         label: DuckAiNativeStorageContainerMigrationLabel,
+         keyValueStore: ThrowingKeyValueStoring,
+         fileManager: FileManager = .default,
+         pixelFiring: DuckAiNativeStorageContainerMigrationPixelFiring = NullDuckAiNativeStorageContainerMigrationPixelFiring(),
+         isProtectedDataAvailable: @escaping () -> Bool = { DuckAiNativeStorageContainerMigration.defaultIsProtectedDataAvailable() },
+         maxAttempts: Int = DuckAiNativeStorageContainerMigration.defaultMaxAttempts) {
+        self.oldURL = oldURL
+        self.newURL = newURL
+        self.migrationKey = migrationKey
+        self.label = label
+        self.keyValueStore = keyValueStore
+        self.fileManager = fileManager
+        self.pixelFiring = pixelFiring
+        self.isProtectedDataAvailable = isProtectedDataAvailable
+        // 0 / negative would give up on the first failure.
+        self.maxAttempts = max(1, maxAttempts)
+    }
+
+    // MARK: - Entry point
+
+    @discardableResult
+    func run() -> DuckAiNativeStorageContainerMigrationOutcome {
+        // Background launches before first unlock can't read
+        // `NSFileProtectionComplete` source bytes. Defer rather than burn
+        // retries on a transient condition.
+        guard isProtectedDataAvailable() else {
+            Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] protected data unavailable; deferring")
+            pixelFiring.fire(.protectedDataUnavailable(label: label))
+            return .skip
+        }
+
+        resetExhaustedAttemptsIfNeeded()
+
+        if isMigrated {
+            // Migration is final on this device. Leave `oldURL` alone — when
+            // `migrated` was set via `destinationConflict`, the source may hold
+            // the only complete copy. Worst case is unused bytes in the App
+            // Group until app uninstall.
+            ensureProtection()
+            return .proceed
+        }
+
+        Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] starting (prior attempts: \(attempts)); old=\(oldURL.path, privacy: .public) new=\(newURL.path, privacy: .public)")
+
+        guard fileManager.fileExists(atPath: oldURL.path) else {
+            Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] no old directory; marking done")
+            markMigrated()
+            pixelFiring.fire(.notNeeded(label: label))
+            ensureProtection()
+            return .proceed
+        }
+
+        if fileManager.fileExists(atPath: newURL.path) {
+            // Destination exists without `migrated`. If data is present, treat
+            // it as a possibly-partial copy: claim the destination but keep the
+            // source for recovery. If empty, it's scaffolding from a prior
+            // `excludeFromBackup` on a skipped launch — remove and proceed.
+            if destinationHasData {
+                Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] destination has data without migrated flag; claiming new and preserving old for recovery")
+                markMigrated()
+                pixelFiring.fire(.destinationConflict(label: label))
+                ensureProtection()
+                return .proceed
+            }
+            Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] empty destination directory present; removing to clear path for move")
+            do {
+                try fileManager.removeItem(at: newURL)
+            } catch {
+                return handleMoveFailure(error, operation: .removingEmptyDestination)
+            }
+        }
+
+        do {
+            try fileManager.createDirectory(at: newURL.deletingLastPathComponent(),
+                                            withIntermediateDirectories: true)
+            try fileManager.moveItem(at: oldURL, to: newURL)
+            Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] moved successfully")
+            markMigrated()
+            pixelFiring.fire(.success(label: label))
+            ensureProtection()
+            return .proceed
+        } catch {
+            return handleMoveFailure(error, operation: .move)
+        }
+    }
+
+    // MARK: - Static helpers
 
     /// Default `isProtectedDataAvailable` source; safe to call from the
     /// main-thread launch path used by both callers in this codebase.
@@ -181,216 +296,103 @@ enum DuckAiNativeStorageContainerMigration {
         return firstError
     }
 
-    /// Moves `oldURL` to `newURL`, retrying across launches.
-    ///
-    /// State:
-    /// - Marker file at `<newURL parent>/.<migrationKey>.migrated` —
-    ///   authoritative completion signal. Excluded from iCloud backup so a
-    ///   cross-device restore re-runs the migration against restored App
-    ///   Group data.
-    /// - `<migrationKey>.done` (Bool) — legacy flag for pre-marker users.
-    ///   Without a marker it is trusted only when `oldURL` is gone.
-    /// - `<migrationKey>.attempts` (Int) — failed move attempts. Cleared on
-    ///   any terminal outcome.
-    /// - `<migrationKey>.protectionApplied` / `.protectionAttempts` —
-    ///   separate retry budget for `applyDefaultFileProtection`.
-    ///
-    /// `label` segments logs and pixels by container (default vs. fire-mode).
-    ///
-    /// Returns `.skip` on retryable failure or when protected data is
-    /// unavailable. See `DuckAiNativeStorageContainerMigrationOutcome.skip`
-    /// for the caller contract.
-    @discardableResult
-    static func migrateIfNeeded(from oldURL: URL,
-                                to newURL: URL,
-                                migrationKey: String,
-                                label: DuckAiNativeStorageContainerMigrationLabel,
-                                userDefaults: UserDefaults = .standard,
-                                fileManager: FileManager = .default,
-                                pixelFiring: DuckAiNativeStorageContainerMigrationPixelFiring = NullDuckAiNativeStorageContainerMigrationPixelFiring(),
-                                isProtectedDataAvailable: () -> Bool = { defaultIsProtectedDataAvailable() },
-                                maxAttempts: Int = defaultMaxAttempts) -> DuckAiNativeStorageContainerMigrationOutcome {
-        // 0 / negative would give up on the first failure.
-        let maxAttempts = max(1, maxAttempts)
+    // MARK: - State (computed)
 
-        let doneKey = migrationKey + ".done"
-        let attemptsKey = migrationKey + ".attempts"
-        let protectionAppliedKey = migrationKey + ".protectionApplied"
-        let protectionAttemptsKey = migrationKey + ".protectionAttempts"
-        let markerURL = newURL.deletingLastPathComponent()
-            .appendingPathComponent(".\(migrationKey).migrated")
+    private var migratedKey: String { migrationKey + ".migrated" }
+    private var attemptsKey: String { migrationKey + ".attempts" }
+    private var protectionAttemptsKey: String { migrationKey + ".protectionAttempts" }
 
-        func writeMarker() {
-            do {
-                try fileManager.createDirectory(at: markerURL.deletingLastPathComponent(),
-                                                withIntermediateDirectories: true)
-                try Data().write(to: markerURL, options: .atomic)
-                var url = markerURL
-                var resourceValues = URLResourceValues()
-                resourceValues.isExcludedFromBackup = true
-                try url.setResourceValues(resourceValues)
-            } catch {
-                Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] failed to write marker at \(markerURL.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
-            }
+    private var isMigrated: Bool {
+        (try? keyValueStore.object(forKey: migratedKey) as? Bool) ?? false
+    }
+
+    private var attempts: Int {
+        (try? keyValueStore.object(forKey: attemptsKey) as? Int) ?? 0
+    }
+
+    private var protectionAttempts: Int {
+        (try? keyValueStore.object(forKey: protectionAttemptsKey) as? Int) ?? 0
+    }
+
+    /// Fire-mode stores DBs in `<UUID>/chats.db` subdirectories rather than at
+    /// the root, so any non-empty `newURL` implies data that must not be wiped.
+    private var destinationHasData: Bool {
+        guard let children = try? fileManager.contentsOfDirectory(atPath: newURL.path) else {
+            return false
         }
+        return !children.isEmpty
+    }
 
-        func markerExists() -> Bool {
-            fileManager.fileExists(atPath: markerURL.path)
+    // MARK: - State (mutation)
+
+    private func markMigrated() {
+        try? keyValueStore.set(true, forKey: migratedKey)
+        try? keyValueStore.removeObject(forKey: attemptsKey)
+    }
+
+    private func setAttempts(_ value: Int) {
+        try? keyValueStore.set(value, forKey: attemptsKey)
+    }
+
+    private func setProtectionAttempts(_ value: Int) {
+        try? keyValueStore.set(value, forKey: protectionAttemptsKey)
+    }
+
+    /// A prior launch hit the retry cap and returned `.gaveUp` (attempts left
+    /// at the cap, not marked migrated). Clear the budget so this launch can
+    /// re-attempt with a fresh budget when conditions have improved. Protection
+    /// retries are also reset — the prior gaveUp marked protection "done"
+    /// against an absent destination; once we successfully move, protection
+    /// has to actually run.
+    private func resetExhaustedAttemptsIfNeeded() {
+        guard !isMigrated, attempts >= maxAttempts else { return }
+        Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] prior launch exhausted retry budget; resetting attempts")
+        try? keyValueStore.removeObject(forKey: attemptsKey)
+        try? keyValueStore.removeObject(forKey: protectionAttemptsKey)
+    }
+
+    /// `protectionAttempts == maxAttempts` is the "done" sentinel — set either
+    /// by a successful apply or by exhausting the retry budget. Below the cap
+    /// we try again and fire `.protectionFailed` on each failure (including
+    /// the one that hits the cap).
+    private func ensureProtection() {
+        let priorAttempts = protectionAttempts
+        guard priorAttempts < maxAttempts else { return }
+        guard fileManager.fileExists(atPath: newURL.path) else {
+            // Nothing at the destination yet — no protection to enforce.
+            setProtectionAttempts(maxAttempts)
+            return
         }
-
-        // Fire-mode stores DBs in `<UUID>/chats.db` subdirectories rather than at
-        // the root, so any non-empty `newURL` implies data that must not be wiped.
-        func destinationHasData() -> Bool {
-            guard let children = try? fileManager.contentsOfDirectory(atPath: newURL.path) else {
-                return false
-            }
-            return !children.isEmpty
+        if let error = Self.applyDefaultFileProtection(at: newURL, fileManager: fileManager) {
+            setProtectionAttempts(priorAttempts + 1)
+            pixelFiring.fire(.protectionFailed(label: label, error: error))
+        } else {
+            setProtectionAttempts(maxAttempts)
         }
+    }
 
-        // `doneKey=true` without a marker means a pre-marker build, an iCloud
-        // restore (App Group came back, Application Support didn't), or a
-        // prior `.gaveUp` (source preserved). Trust the flag only when
-        // `oldURL` is gone — the unambiguous "migration ran" signal. Otherwise
-        // clear the state and fall through; the standard flow handles whichever
-        // configuration we actually find.
-        func reconcileLegacyDoneFlag() {
-            guard userDefaults.bool(forKey: doneKey), !markerExists() else { return }
-            if !fileManager.fileExists(atPath: oldURL.path) {
-                Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] writing marker for pre-marker completed migration")
-                writeMarker()
-            } else {
-                Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] done flag set without marker and oldURL still exists; resetting state to re-evaluate migration")
-                userDefaults.removeObject(forKey: doneKey)
-                userDefaults.removeObject(forKey: attemptsKey)
-                userDefaults.removeObject(forKey: protectionAppliedKey)
-                userDefaults.removeObject(forKey: protectionAttemptsKey)
-            }
-        }
-
-        func ensureProtection() {
-            guard !userDefaults.bool(forKey: protectionAppliedKey) else { return }
-            guard fileManager.fileExists(atPath: newURL.path) else {
-                // Nothing at the destination yet — no protection to enforce.
-                userDefaults.set(true, forKey: protectionAppliedKey)
-                userDefaults.removeObject(forKey: protectionAttemptsKey)
-                return
-            }
-            if let error = applyDefaultFileProtection(at: newURL, fileManager: fileManager) {
-                let attempt = userDefaults.integer(forKey: protectionAttemptsKey) + 1
-                userDefaults.set(attempt, forKey: protectionAttemptsKey)
-                if attempt <= maxAttempts {
-                    pixelFiring.fire(.protectionFailed(label: label, error: error))
-                }
-                if attempt >= maxAttempts {
-                    // Cap reached: stop retrying to avoid pixel spam. The user
-                    // is left with the original protection class.
-                    userDefaults.set(true, forKey: protectionAppliedKey)
-                    userDefaults.removeObject(forKey: protectionAttemptsKey)
-                }
-            } else {
-                userDefaults.set(true, forKey: protectionAppliedKey)
-                userDefaults.removeObject(forKey: protectionAttemptsKey)
-            }
-        }
-
-        // Background launches before first unlock can't read
-        // `NSFileProtectionComplete` source bytes. Defer rather than burn
-        // retries on a transient condition.
-        guard isProtectedDataAvailable() else {
-            Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] protected data unavailable; deferring")
-            pixelFiring.fire(.protectedDataUnavailable(label: label))
-            return .skip
-        }
-
-        reconcileLegacyDoneFlag()
-
-        if markerExists() {
-            // Migration is final on this device. Leave `oldURL` alone — when
-            // the marker was written via `destinationConflict`, the source may
-            // hold the only complete copy. Worst case is unused bytes in the
-            // App Group until app uninstall.
+    private func handleMoveFailure(_ error: Error, operation: FailingOperation) -> DuckAiNativeStorageContainerMigrationOutcome {
+        let attempt = attempts + 1
+        setAttempts(attempt)
+        if attempt >= maxAttempts {
+            Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] \(operation.rawValue, privacy: .public) failed (attempt \(attempt)/\(maxAttempts)); giving up: \(error.localizedDescription, privacy: .public)")
+            // attempts left at the cap — next launch resets the budget so
+            // transient failures get another full retry when conditions
+            // improve. Source is preserved either way (no sweep).
+            pixelFiring.fire(.gaveUp(label: label, error: error))
             ensureProtection()
             return .proceed
         }
+        Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] \(operation.rawValue, privacy: .public) failed (attempt \(attempt)/\(maxAttempts)); will retry next launch: \(error.localizedDescription, privacy: .public)")
+        pixelFiring.fire(.attemptFailed(label: label, error: error))
+        return .skip
+    }
 
-        let priorAttempts = userDefaults.integer(forKey: attemptsKey)
-        Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] starting (prior attempts: \(priorAttempts)); old=\(oldURL.path, privacy: .public) new=\(newURL.path, privacy: .public)")
-
-        guard fileManager.fileExists(atPath: oldURL.path) else {
-            Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] no old directory; marking done")
-            userDefaults.set(true, forKey: doneKey)
-            userDefaults.removeObject(forKey: attemptsKey)
-            writeMarker()
-            pixelFiring.fire(.notNeeded(label: label))
-            ensureProtection()
-            return .proceed
-        }
-
-        if fileManager.fileExists(atPath: newURL.path) {
-            // Destination exists without a marker. If `chats.db` is present,
-            // treat it as a possibly-partial copy: claim the destination but
-            // keep the source for recovery. If empty, it's scaffolding from a
-            // prior `excludeFromBackup` on a skipped launch — remove and proceed.
-            if destinationHasData() {
-                Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] destination has data without marker; claiming new and preserving old for recovery")
-                userDefaults.set(true, forKey: doneKey)
-                userDefaults.removeObject(forKey: attemptsKey)
-                writeMarker()
-                pixelFiring.fire(.destinationConflict(label: label))
-                ensureProtection()
-                return .proceed
-            } else {
-                Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] empty destination directory present; removing to clear path for move")
-                do {
-                    try fileManager.removeItem(at: newURL)
-                } catch {
-                    let attempt = priorAttempts + 1
-                    userDefaults.set(attempt, forKey: attemptsKey)
-                    if attempt >= maxAttempts {
-                        Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] failed to remove empty destination at cap; giving up: \(error.localizedDescription, privacy: .public)")
-                        userDefaults.set(true, forKey: doneKey)
-                        // No marker: the legacy transition resets state on the
-                        // next launch so the move can be re-attempted.
-                        pixelFiring.fire(.gaveUp(label: label, error: error))
-                        ensureProtection()
-                        return .proceed
-                    } else {
-                        Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] failed to remove empty destination; will retry: \(error.localizedDescription, privacy: .public)")
-                        pixelFiring.fire(.attemptFailed(label: label, error: error))
-                        return .skip
-                    }
-                }
-            }
-        }
-
-        do {
-            try fileManager.createDirectory(at: newURL.deletingLastPathComponent(),
-                                            withIntermediateDirectories: true)
-            try fileManager.moveItem(at: oldURL, to: newURL)
-            Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] moved successfully")
-            userDefaults.set(true, forKey: doneKey)
-            userDefaults.removeObject(forKey: attemptsKey)
-            writeMarker()
-            pixelFiring.fire(.success(label: label))
-            ensureProtection()
-            return .proceed
-        } catch {
-            let attempt = priorAttempts + 1
-            userDefaults.set(attempt, forKey: attemptsKey)
-            if attempt >= maxAttempts {
-                Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] move failed (attempt \(attempt)/\(maxAttempts)); giving up: \(error.localizedDescription, privacy: .public)")
-                userDefaults.set(true, forKey: doneKey)
-                // Source preserved (no sweep) and no marker — the legacy
-                // transition resets state on the next launch, giving transient
-                // failures another full retry budget when conditions improve.
-                pixelFiring.fire(.gaveUp(label: label, error: error))
-                ensureProtection()
-                return .proceed
-            } else {
-                Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] move failed (attempt \(attempt)/\(maxAttempts)); will retry next launch: \(error.localizedDescription, privacy: .public)")
-                pixelFiring.fire(.attemptFailed(label: label, error: error))
-                return .skip
-            }
-        }
+    /// Identifies which filesystem step failed; tagged onto the retry / give-up
+    /// log lines so `moveItem` and the `removeItem(emptyDestination)` precursor
+    /// stay distinguishable.
+    private enum FailingOperation: String {
+        case move
+        case removingEmptyDestination
     }
 }

--- a/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
+++ b/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
@@ -247,6 +247,26 @@ enum DuckAiNativeStorageContainerMigration {
             return !children.isEmpty
         }
 
+        // `doneKey=true` without a marker means a pre-marker build, an iCloud
+        // restore (App Group came back, Application Support didn't), or a
+        // prior `.gaveUp` (source preserved). Trust the flag only when
+        // `oldURL` is gone — the unambiguous "migration ran" signal. Otherwise
+        // clear the state and fall through; the standard flow handles whichever
+        // configuration we actually find.
+        func reconcileLegacyDoneFlag() {
+            guard userDefaults.bool(forKey: doneKey), !markerExists() else { return }
+            if !fileManager.fileExists(atPath: oldURL.path) {
+                Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] writing marker for pre-marker completed migration")
+                writeMarker()
+            } else {
+                Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] done flag set without marker and oldURL still exists; resetting state to re-evaluate migration")
+                userDefaults.removeObject(forKey: doneKey)
+                userDefaults.removeObject(forKey: attemptsKey)
+                userDefaults.removeObject(forKey: protectionAppliedKey)
+                userDefaults.removeObject(forKey: protectionAttemptsKey)
+            }
+        }
+
         func ensureProtection() {
             guard !userDefaults.bool(forKey: protectionAppliedKey) else { return }
             guard fileManager.fileExists(atPath: newURL.path) else {
@@ -282,25 +302,7 @@ enum DuckAiNativeStorageContainerMigration {
             return .skip
         }
 
-        // `doneKey=true` without a marker means a pre-marker build, an iCloud
-        // restore (App Group came back, Application Support didn't), or a
-        // prior `.gaveUp` (source preserved). Trust the flag only when
-        // `oldURL` is gone — the unambiguous "migration ran" signal. Otherwise
-        // clear the state and fall through; the standard flow handles whichever
-        // configuration we actually find.
-        if userDefaults.bool(forKey: doneKey) && !markerExists() {
-            let oldExists = fileManager.fileExists(atPath: oldURL.path)
-            if !oldExists {
-                Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] writing marker for pre-marker completed migration")
-                writeMarker()
-            } else {
-                Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] done flag set without marker and oldURL still exists; resetting state to re-evaluate migration")
-                userDefaults.removeObject(forKey: doneKey)
-                userDefaults.removeObject(forKey: attemptsKey)
-                userDefaults.removeObject(forKey: protectionAppliedKey)
-                userDefaults.removeObject(forKey: protectionAttemptsKey)
-            }
-        }
+        reconcileLegacyDoneFlag()
 
         if markerExists() {
             // Migration is final on this device. Leave `oldURL` alone — when

--- a/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
+++ b/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
@@ -355,8 +355,7 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
         if attempt >= maxAttempts {
             Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] \(operation.rawValue, privacy: .public) failed (attempt \(attempt)/\(maxAttempts)); giving up: \(error.localizedDescription, privacy: .public)")
             pixelFiring.fire(.gaveUp(label: label, error: error))
-            ensureProtection()
-            return .proceed
+            return .skip
         }
         Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] \(operation.rawValue, privacy: .public) failed (attempt \(attempt)/\(maxAttempts)); will retry next launch: \(error.localizedDescription, privacy: .public)")
         pixelFiring.fire(.attemptFailed(label: label, error: error))

--- a/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
+++ b/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
@@ -19,42 +19,42 @@
 
 import Core
 import Foundation
+import UIKit
 import os.log
 
-/// Identifies which Duck.ai native-storage container is being migrated. The raw
-/// value is suffixed onto the pixel name (see `PixelEvent.swift`).
+/// Identifies the container being migrated. Raw value is suffixed onto pixel names.
 enum DuckAiNativeStorageContainerMigrationLabel: String {
     case `default`
     case fireMode = "fire-mode"
 }
 
-/// Outcome events for `DuckAiNativeStorageContainerMigration`. Distinct from the
-/// JS→native chat-data migration pixels (`duckAiNativeStorageMigration*`) — these
-/// track the iOS-only relocation of the on-disk store from the app group container
-/// into Application Support.
+/// Outcomes for the container relocation. Distinct from the JS→native chat-data
+/// migration pixels (`duckAiNativeStorageMigration*`).
 enum DuckAiNativeStorageContainerMigrationEvent {
     case notNeeded(label: DuckAiNativeStorageContainerMigrationLabel)
     case orphanRemoved(label: DuckAiNativeStorageContainerMigrationLabel)
     case success(label: DuckAiNativeStorageContainerMigrationLabel)
     case attemptFailed(label: DuckAiNativeStorageContainerMigrationLabel, error: Error)
     case gaveUp(label: DuckAiNativeStorageContainerMigrationLabel, error: Error?)
-    /// Fired alongside `.success` when the move itself worked but at least one
-    /// `setAttributes` call in `applyDefaultFileProtection` failed — the DB ends
-    /// up at the new path with the original `NSFileProtectionComplete` class
-    /// still applied, which is the 0xdead10cc condition this migration exists
-    /// to prevent. Surfaces silently otherwise.
+    /// Move succeeded but `applyDefaultFileProtection` failed — the DB kept its
+    /// inherited `NSFileProtectionComplete` class (the 0xdead10cc condition).
     case protectionFailed(label: DuckAiNativeStorageContainerMigrationLabel, error: Error)
+    /// Destination has a `chats.db` but no marker — could be a partial move or
+    /// a DB created while the App Group entitlement was unavailable. The
+    /// destination is claimed going forward and the source is preserved.
+    case destinationConflict(label: DuckAiNativeStorageContainerMigrationLabel)
+    /// `isExcludedFromBackup` or the destination directory creation failed.
+    /// The encrypted DB may end up in iCloud backups.
+    case excludeFromBackupFailed(label: DuckAiNativeStorageContainerMigrationLabel, error: Error)
+    /// Deferred because protected data is unavailable (pre-first-unlock
+    /// background launch). No state is modified.
+    case protectedDataUnavailable(label: DuckAiNativeStorageContainerMigrationLabel)
 }
 
-/// Result of a `migrateIfNeeded` call. Callers MUST honor `.skip` by not creating
-/// or opening the destination directory — doing so would make the next launch
-/// treat the un-migrated old data as an orphan and delete it.
 enum DuckAiNativeStorageContainerMigrationOutcome {
-    /// Migration is complete (or unnecessary, or gave up after the retry cap).
-    /// Caller may create/open the destination.
     case proceed
-    /// A move attempt failed and the retry cap is not yet exhausted. Caller MUST
-    /// NOT touch the destination this launch; migration will retry next launch.
+    /// Caller MUST NOT create or open the destination — doing so makes the next
+    /// launch see the source as an orphan and delete it.
     case skip
 }
 
@@ -81,53 +81,78 @@ struct DuckAiNativeStorageContainerMigrationPixelAdapter: DuckAiNativeStorageCon
             Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationGaveUp(label: label.rawValue), error: error)
         case .protectionFailed(let label, let error):
             Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationProtectionFailed(label: label.rawValue), error: error)
+        case .destinationConflict(let label):
+            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationDestinationConflict(label: label.rawValue))
+        case .excludeFromBackupFailed(let label, let error):
+            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationExcludeFromBackupFailed(label: label.rawValue), error: error)
+        case .protectedDataUnavailable(let label):
+            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationProtectedDataUnavailable(label: label.rawValue))
         }
     }
 }
 
-/// One-time directory move from the shared app-group container into the app's
-/// Application Support directory.
+/// One-time move of the Duck.ai container from the shared App Group into the
+/// app's Application Support directory.
 ///
-/// Files in App Group containers default to `NSFileProtectionComplete`, which
-/// makes the SQLCipher DB and files folder inaccessible whenever the device
-/// locks while the app is still alive — yielding 0xdead10cc terminations on
-/// the next SQLite read (notably the background auto-clear path). Files in
-/// the app sandbox default to `NSFileProtectionCompleteUntilFirstUserAuthentication`,
-/// which stays available after first unlock.
+/// App Group files default to `NSFileProtectionComplete`, which makes the DB
+/// inaccessible whenever the device locks while the app is alive (0xdead10cc
+/// on the next SQLite read). The app sandbox defaults to
+/// `NSFileProtectionCompleteUntilFirstUserAuthentication`, which stays readable
+/// after first unlock.
 ///
-/// The helper retries the move up to `maxAttempts` times across launches; after that
-/// it marks the migration done and stops, accepting data loss rather than crashing
-/// in a retry loop.
+/// Completion is signalled by a marker file at
+/// `<Application Support>/.<migrationKey>.migrated`. The marker is excluded
+/// from iCloud backup so a cross-device restore re-runs the migration against
+/// the restored App Group data.
+///
+/// Retries the move up to `maxAttempts` times across launches. On `.gaveUp` the
+/// source is preserved (not deleted) so the user can recover on a later launch
+/// when conditions improve (e.g. disk pressure clears).
 enum DuckAiNativeStorageContainerMigration {
 
     static let defaultMaxAttempts = 3
 
+    /// Existence sentinel for "destination holds migrated data", used by the
+    /// legacy transition for pre-marker users. Contents are not inspected.
+    private static let databaseFilename = "chats.db"
+
     private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "DuckDuckGo",
                                        category: "DuckAiNativeStorageContainerMigration")
 
-    /// Ensures the directory at `url` exists and is excluded from iCloud
-    static func excludeFromBackup(_ url: URL) {
+    /// Default `isProtectedDataAvailable` source; safe to call from the
+    /// main-thread launch path used by both callers in this codebase.
+    static func defaultIsProtectedDataAvailable() -> Bool {
+        UIApplication.shared.isProtectedDataAvailable
+    }
+
+    /// Creates `url` if needed and marks it `isExcludedFromBackup`. Fires
+    /// `.excludeFromBackupFailed` on failure — silent inclusion of the
+    /// encrypted DB in iCloud backups is what this guards against.
+    static func excludeFromBackup(_ url: URL,
+                                  label: DuckAiNativeStorageContainerMigrationLabel,
+                                  pixelFiring: DuckAiNativeStorageContainerMigrationPixelFiring = NullDuckAiNativeStorageContainerMigrationPixelFiring(),
+                                  fileManager: FileManager = .default) {
         do {
-            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+            try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
             var url = url
             var resourceValues = URLResourceValues()
             resourceValues.isExcludedFromBackup = true
             try url.setResourceValues(resourceValues)
         } catch {
-            Self.logger.error("[NativeStorage] failed to exclude \(url.lastPathComponent, privacy: .public) from backup: \(error.localizedDescription, privacy: .public)")
+            Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] failed to exclude \(url.lastPathComponent, privacy: .public) from backup: \(error.localizedDescription, privacy: .public)")
+            pixelFiring.fire(.excludeFromBackupFailed(label: label, error: error))
         }
     }
 
-    /// Recursively applies `completeUntilFirstUserAuthentication` protection to `url`
-    /// and every existing child. Files moved from an App Group container retain
-    /// their `NSFileProtectionComplete` attribute on the same volume, so without
-    /// this step a locked device can still trip 0xdead10cc on SQLite reads. Setting
-    /// the directory itself also fixes the default class new sidecars inherit.
+    /// Recursively applies `completeUntilFirstUserAuthentication` to `url` and
+    /// every child. Files moved from App Group keep their inherited
+    /// `NSFileProtectionComplete` attribute, so without this the locked-device
+    /// crash this migration exists to fix still happens. Setting it on the
+    /// directory also fixes the default class new sidecars inherit.
     ///
-    /// Returns the first `setAttributes` error encountered, or `nil` if every
-    /// path succeeded. Callers can surface this to detect a silent regression
-    /// where the move worked but the destination DB kept its original protection
-    /// class.
+    /// Returns the first error encountered, or `nil` on full success. A `nil`
+    /// enumerator is reported as an error so the caller retries — otherwise
+    /// we'd silently mark protection applied while children kept the wrong class.
     @discardableResult
     static func applyDefaultFileProtection(at url: URL, fileManager: FileManager = .default) -> Error? {
         let attributes: [FileAttributeKey: Any] = [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
@@ -144,41 +169,44 @@ enum DuckAiNativeStorageContainerMigration {
 
         apply(to: url.path)
 
-        guard let enumerator = fileManager.enumerator(at: url,
-                                                     includingPropertiesForKeys: nil,
-                                                     options: [],
-                                                     errorHandler: nil) else { return firstError }
+        let enumerator = fileManager.enumerator(at: url,
+                                                includingPropertiesForKeys: nil,
+                                                options: [],
+                                                errorHandler: { childURL, error in
+            Self.logger.error("[NativeStorage] enumerator error at \(childURL.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            if firstError == nil { firstError = error }
+            return true
+        })
+        guard let enumerator else {
+            return firstError ?? NSError(domain: "DuckAiNativeStorageContainerMigration",
+                                          code: -1,
+                                          userInfo: [NSLocalizedDescriptionKey: "Could not enumerate \(url.path)"])
+        }
         for case let childURL as URL in enumerator {
             apply(to: childURL.path)
         }
         return firstError
     }
 
-    /// Moves `oldURL` to `newURL`, retrying on failure across launches.
+    /// Moves `oldURL` to `newURL`, retrying across launches.
     ///
-    /// Persistence in `userDefaults`:
-    /// - `migrationKey + ".done"` (Bool) — set when the migration's *data* state is
-    ///   settled (success, no-op, orphan-cleaned, or `maxAttempts` exhausted).
-    /// - `migrationKey + ".attempts"` (Int) — number of failed attempts so far
-    ///   (move or orphan-removal). Cleared on success.
-    /// - `migrationKey + ".protectionApplied"` (Bool) — set when file protection
-    ///   at `newURL` is confirmed correct, or there's no data at `newURL` needing
-    ///   protection, or the retry cap has been reached.
-    /// - `migrationKey + ".protectionAttempts"` (Int) — number of failed
-    ///   `applyDefaultFileProtection` retries. Cleared on success.
+    /// State:
+    /// - Marker file at `<newURL parent>/.<migrationKey>.migrated` —
+    ///   authoritative completion signal. Excluded from iCloud backup so a
+    ///   cross-device restore re-runs the migration against restored App
+    ///   Group data.
+    /// - `<migrationKey>.done` (Bool) — legacy flag for pre-marker users.
+    ///   Without a marker it is trusted only when `oldURL` is gone.
+    /// - `<migrationKey>.attempts` (Int) — failed move attempts. Cleared on
+    ///   any terminal outcome.
+    /// - `<migrationKey>.protectionApplied` / `.protectionAttempts` —
+    ///   separate retry budget for `applyDefaultFileProtection`.
     ///
-    /// `done` and `protectionApplied` are tracked independently: a successful
-    /// move that fails to re-apply file protection sets `done=true` but leaves
-    /// `protectionApplied=false`, so each subsequent launch retries protection
-    /// until success or the cap. Otherwise the destination DB would keep its
-    /// original `NSFileProtectionComplete` class permanently — the 0xdead10cc
-    /// condition this migration exists to fix.
+    /// `label` segments logs and pixels by container (default vs. fire-mode).
     ///
-    /// `label` distinguishes the default vs. fire-mode container in logs and pixels.
-    ///
-    /// Returns `.skip` when a move attempt fails and retries remain — the caller
-    /// MUST NOT create or open `newURL` in that case, otherwise the next launch
-    /// will treat the still-present old data as an orphan and delete it.
+    /// Returns `.skip` on retryable failure or when protected data is
+    /// unavailable. See `DuckAiNativeStorageContainerMigrationOutcome.skip`
+    /// for the caller contract.
     @discardableResult
     static func migrateIfNeeded(from oldURL: URL,
                                 to newURL: URL,
@@ -187,11 +215,35 @@ enum DuckAiNativeStorageContainerMigration {
                                 userDefaults: UserDefaults = .standard,
                                 fileManager: FileManager = .default,
                                 pixelFiring: DuckAiNativeStorageContainerMigrationPixelFiring = NullDuckAiNativeStorageContainerMigrationPixelFiring(),
+                                isProtectedDataAvailable: () -> Bool = { defaultIsProtectedDataAvailable() },
                                 maxAttempts: Int = defaultMaxAttempts) -> DuckAiNativeStorageContainerMigrationOutcome {
+        // 0 / negative would give up on the first failure.
+        let maxAttempts = max(1, maxAttempts)
+
         let doneKey = migrationKey + ".done"
         let attemptsKey = migrationKey + ".attempts"
         let protectionAppliedKey = migrationKey + ".protectionApplied"
         let protectionAttemptsKey = migrationKey + ".protectionAttempts"
+        let markerURL = newURL.deletingLastPathComponent()
+            .appendingPathComponent(".\(migrationKey).migrated")
+
+        func writeMarker() {
+            do {
+                try fileManager.createDirectory(at: markerURL.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+                try Data().write(to: markerURL, options: .atomic)
+            } catch {
+                Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] failed to write marker at \(markerURL.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
+        }
+
+        func markerExists() -> Bool {
+            fileManager.fileExists(atPath: markerURL.path)
+        }
+
+        func destinationHasData() -> Bool {
+            fileManager.fileExists(atPath: newURL.appendingPathComponent(Self.databaseFilename).path)
+        }
 
         func ensureProtection() {
             guard !userDefaults.bool(forKey: protectionAppliedKey) else { return }
@@ -208,10 +260,10 @@ enum DuckAiNativeStorageContainerMigration {
                     pixelFiring.fire(.protectionFailed(label: label, error: error))
                 }
                 if attempt >= maxAttempts {
-                    // Stop retrying. We've fired the pixel `maxAttempts` times;
-                    // the user is left with the original protection class, but
-                    // continued churn would only spam telemetry.
+                    // Cap reached: stop retrying to avoid pixel spam. The user
+                    // is left with the original protection class.
                     userDefaults.set(true, forKey: protectionAppliedKey)
+                    userDefaults.removeObject(forKey: protectionAttemptsKey)
                 }
             } else {
                 userDefaults.set(true, forKey: protectionAppliedKey)
@@ -219,8 +271,40 @@ enum DuckAiNativeStorageContainerMigration {
             }
         }
 
-        if userDefaults.bool(forKey: doneKey) {
-            Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] skipping: already done")
+        // Background launches before first unlock can't read
+        // `NSFileProtectionComplete` source bytes. Defer rather than burn
+        // retries on a transient condition.
+        guard isProtectedDataAvailable() else {
+            Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] protected data unavailable; deferring")
+            pixelFiring.fire(.protectedDataUnavailable(label: label))
+            return .skip
+        }
+
+        // `doneKey=true` without a marker means a pre-marker build, an iCloud
+        // restore (App Group came back, Application Support didn't), or a
+        // prior `.gaveUp` (source preserved). Trust the flag only when
+        // `oldURL` is gone — the unambiguous "migration ran" signal. Otherwise
+        // clear the state and fall through; the standard flow handles whichever
+        // configuration we actually find.
+        if userDefaults.bool(forKey: doneKey) && !markerExists() {
+            let oldExists = fileManager.fileExists(atPath: oldURL.path)
+            if !oldExists {
+                Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] writing marker for pre-marker completed migration")
+                writeMarker()
+            } else {
+                Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] done flag set without marker and oldURL still exists; resetting state to re-evaluate migration")
+                userDefaults.removeObject(forKey: doneKey)
+                userDefaults.removeObject(forKey: attemptsKey)
+                userDefaults.removeObject(forKey: protectionAppliedKey)
+                userDefaults.removeObject(forKey: protectionAttemptsKey)
+            }
+        }
+
+        if markerExists() {
+            // Migration is final on this device. Leave `oldURL` alone — when
+            // the marker was written via `destinationConflict`, the source may
+            // hold the only complete copy. Worst case is unused bytes in the
+            // App Group until app uninstall.
             ensureProtection()
             return .proceed
         }
@@ -232,37 +316,46 @@ enum DuckAiNativeStorageContainerMigration {
             Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] no old directory; marking done")
             userDefaults.set(true, forKey: doneKey)
             userDefaults.removeObject(forKey: attemptsKey)
+            writeMarker()
             pixelFiring.fire(.notNeeded(label: label))
             ensureProtection()
             return .proceed
         }
 
         if fileManager.fileExists(atPath: newURL.path) {
-            Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] new location already exists; removing orphan old")
-            do {
-                try fileManager.removeItem(at: oldURL)
-                Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] orphan removed")
+            // Destination exists without a marker. If `chats.db` is present,
+            // treat it as a possibly-partial copy: claim the destination but
+            // keep the source for recovery. If empty, it's scaffolding from a
+            // prior `excludeFromBackup` on a skipped launch — remove and proceed.
+            if destinationHasData() {
+                Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] destination has data without marker; claiming new and preserving old for recovery")
                 userDefaults.set(true, forKey: doneKey)
                 userDefaults.removeObject(forKey: attemptsKey)
-                pixelFiring.fire(.orphanRemoved(label: label))
+                writeMarker()
+                pixelFiring.fire(.destinationConflict(label: label))
                 ensureProtection()
                 return .proceed
-            } catch {
-                // newURL is intact and usable, but the old container still holds
-                // sensitive data. Don't claim success — keep retrying deletion
-                // across launches until it works or we hit the attempt cap.
-                let attempt = priorAttempts + 1
-                userDefaults.set(attempt, forKey: attemptsKey)
-                if attempt >= maxAttempts {
-                    Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] orphan removal failed (attempt \(attempt)/\(maxAttempts)); giving up — old data may remain in app group: \(error.localizedDescription, privacy: .public)")
-                    userDefaults.set(true, forKey: doneKey)
-                    pixelFiring.fire(.gaveUp(label: label, error: error))
-                } else {
-                    Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] orphan removal failed (attempt \(attempt)/\(maxAttempts)); will retry next launch: \(error.localizedDescription, privacy: .public)")
-                    pixelFiring.fire(.attemptFailed(label: label, error: error))
+            } else {
+                Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] empty destination directory present; removing to clear path for move")
+                do {
+                    try fileManager.removeItem(at: newURL)
+                } catch {
+                    let attempt = priorAttempts + 1
+                    userDefaults.set(attempt, forKey: attemptsKey)
+                    if attempt >= maxAttempts {
+                        Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] failed to remove empty destination at cap; giving up: \(error.localizedDescription, privacy: .public)")
+                        userDefaults.set(true, forKey: doneKey)
+                        // No marker: the legacy transition resets state on the
+                        // next launch so the move can be re-attempted.
+                        pixelFiring.fire(.gaveUp(label: label, error: error))
+                        ensureProtection()
+                        return .proceed
+                    } else {
+                        Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] failed to remove empty destination; will retry: \(error.localizedDescription, privacy: .public)")
+                        pixelFiring.fire(.attemptFailed(label: label, error: error))
+                        return .skip
+                    }
                 }
-                ensureProtection()
-                return .proceed
             }
         }
 
@@ -273,6 +366,7 @@ enum DuckAiNativeStorageContainerMigration {
             Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] moved successfully")
             userDefaults.set(true, forKey: doneKey)
             userDefaults.removeObject(forKey: attemptsKey)
+            writeMarker()
             pixelFiring.fire(.success(label: label))
             ensureProtection()
             return .proceed
@@ -281,13 +375,10 @@ enum DuckAiNativeStorageContainerMigration {
             userDefaults.set(attempt, forKey: attemptsKey)
             if attempt >= maxAttempts {
                 Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] move failed (attempt \(attempt)/\(maxAttempts)); giving up: \(error.localizedDescription, privacy: .public)")
-                // Best-effort sweep: once we give up, we'll never look at the
-                // old container again, so the sensitive chat content would sit
-                // in the app-group container indefinitely under NSFileProtectionComplete.
-                // Take one last shot at removing it — it may well succeed even
-                // when moveItem couldn't (different syscall, no destination required).
-                try? fileManager.removeItem(at: oldURL)
                 userDefaults.set(true, forKey: doneKey)
+                // Source preserved (no sweep) and no marker — the legacy
+                // transition resets state on the next launch, giving transient
+                // failures another full retry budget when conditions improve.
                 pixelFiring.fire(.gaveUp(label: label, error: error))
                 ensureProtection()
                 return .proceed

--- a/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
+++ b/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
@@ -53,8 +53,6 @@ enum DuckAiNativeStorageContainerMigrationEvent {
 
 enum DuckAiNativeStorageContainerMigrationOutcome {
     case proceed
-    /// Caller MUST NOT create or open the destination — doing so makes the next
-    /// launch see the source as an orphan and delete it.
     case skip
 }
 
@@ -91,10 +89,6 @@ struct DuckAiNativeStorageContainerMigrationPixelAdapter: DuckAiNativeStorageCon
 
 /// Runs the one-time move of a Duck.ai container from the shared App Group into
 /// the app's Application Support directory.
-///
-/// Letting callers fake the outcome means production code can stay tightly
-/// coupled to the concrete `DuckAiNativeStorageContainerMigration` while tests
-/// can substitute a mock that returns canned outcomes.
 protocol DuckAiNativeStorageContainerMigrating {
     @discardableResult
     func run() -> DuckAiNativeStorageContainerMigrationOutcome
@@ -173,10 +167,6 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
         resetExhaustedAttemptsIfNeeded()
 
         if isMigrated {
-            // Migration is final on this device. Leave `oldURL` alone — when
-            // `migrated` was set via `destinationConflict`, the source may hold
-            // the only complete copy. Worst case is unused bytes in the App
-            // Group until app uninstall.
             ensureProtection()
             return .proceed
         }
@@ -227,8 +217,6 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
 
     // MARK: - Static helpers
 
-    /// Default `isProtectedDataAvailable` source; safe to call from the
-    /// main-thread launch path used by both callers in this codebase.
     static func defaultIsProtectedDataAvailable() -> Bool {
         UIApplication.shared.isProtectedDataAvailable
     }
@@ -338,12 +326,6 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
         try? keyValueStore.set(value, forKey: protectionAttemptsKey)
     }
 
-    /// A prior launch hit the retry cap and returned `.gaveUp` (attempts left
-    /// at the cap, not marked migrated). Clear the budget so this launch can
-    /// re-attempt with a fresh budget when conditions have improved. Protection
-    /// retries are also reset — the prior gaveUp marked protection "done"
-    /// against an absent destination; once we successfully move, protection
-    /// has to actually run.
     private func resetExhaustedAttemptsIfNeeded() {
         guard !isMigrated, attempts >= maxAttempts else { return }
         Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] prior launch exhausted retry budget; resetting attempts")
@@ -351,10 +333,6 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
         try? keyValueStore.removeObject(forKey: protectionAttemptsKey)
     }
 
-    /// `protectionAttempts == maxAttempts` is the "done" sentinel — set either
-    /// by a successful apply or by exhausting the retry budget. Below the cap
-    /// we try again and fire `.protectionFailed` on each failure (including
-    /// the one that hits the cap).
     private func ensureProtection() {
         let priorAttempts = protectionAttempts
         guard priorAttempts < maxAttempts else { return }
@@ -376,9 +354,6 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
         setAttempts(attempt)
         if attempt >= maxAttempts {
             Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] \(operation.rawValue, privacy: .public) failed (attempt \(attempt)/\(maxAttempts)); giving up: \(error.localizedDescription, privacy: .public)")
-            // attempts left at the cap — next launch resets the budget so
-            // transient failures get another full retry when conditions
-            // improve. Source is preserved either way (no sweep).
             pixelFiring.fire(.gaveUp(label: label, error: error))
             ensureProtection()
             return .proceed
@@ -388,9 +363,6 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
         return .skip
     }
 
-    /// Identifies which filesystem step failed; tagged onto the retry / give-up
-    /// log lines so `moveItem` and the `removeItem(emptyDestination)` precursor
-    /// stay distinguishable.
     private enum FailingOperation: String {
         case move
         case removingEmptyDestination

--- a/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
+++ b/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
@@ -38,6 +38,12 @@ enum DuckAiNativeStorageContainerMigrationEvent {
     case success(label: DuckAiNativeStorageContainerMigrationLabel)
     case attemptFailed(label: DuckAiNativeStorageContainerMigrationLabel, error: Error)
     case gaveUp(label: DuckAiNativeStorageContainerMigrationLabel, error: Error?)
+    /// Fired alongside `.success` when the move itself worked but at least one
+    /// `setAttributes` call in `applyDefaultFileProtection` failed — the DB ends
+    /// up at the new path with the original `NSFileProtectionComplete` class
+    /// still applied, which is the 0xdead10cc condition this migration exists
+    /// to prevent. Surfaces silently otherwise.
+    case protectionFailed(label: DuckAiNativeStorageContainerMigrationLabel, error: Error)
 }
 
 /// Result of a `migrateIfNeeded` call. Callers MUST honor `.skip` by not creating
@@ -73,6 +79,8 @@ struct DuckAiNativeStorageContainerMigrationPixelAdapter: DuckAiNativeStorageCon
             Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationAttemptFailed(label: label.rawValue), error: error)
         case .gaveUp(let label, let error):
             Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationGaveUp(label: label.rawValue), error: error)
+        case .protectionFailed(let label, let error):
+            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationProtectionFailed(label: label.rawValue), error: error)
         }
     }
 }
@@ -115,14 +123,22 @@ enum DuckAiNativeStorageContainerMigration {
     /// their `NSFileProtectionComplete` attribute on the same volume, so without
     /// this step a locked device can still trip 0xdead10cc on SQLite reads. Setting
     /// the directory itself also fixes the default class new sidecars inherit.
-    static func applyDefaultFileProtection(at url: URL, fileManager: FileManager = .default) {
+    ///
+    /// Returns the first `setAttributes` error encountered, or `nil` if every
+    /// path succeeded. Callers can surface this to detect a silent regression
+    /// where the move worked but the destination DB kept its original protection
+    /// class.
+    @discardableResult
+    static func applyDefaultFileProtection(at url: URL, fileManager: FileManager = .default) -> Error? {
         let attributes: [FileAttributeKey: Any] = [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
+        var firstError: Error?
 
         func apply(to path: String) {
             do {
                 try fileManager.setAttributes(attributes, ofItemAtPath: path)
             } catch {
                 Self.logger.error("[NativeStorage] failed to set file protection on \(path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                if firstError == nil { firstError = error }
             }
         }
 
@@ -131,10 +147,11 @@ enum DuckAiNativeStorageContainerMigration {
         guard let enumerator = fileManager.enumerator(at: url,
                                                      includingPropertiesForKeys: nil,
                                                      options: [],
-                                                     errorHandler: nil) else { return }
+                                                     errorHandler: nil) else { return firstError }
         for case let childURL as URL in enumerator {
             apply(to: childURL.path)
         }
+        return firstError
     }
 
     /// Moves `oldURL` to `newURL`, retrying on failure across launches.
@@ -209,11 +226,14 @@ enum DuckAiNativeStorageContainerMigration {
             try fileManager.createDirectory(at: newURL.deletingLastPathComponent(),
                                             withIntermediateDirectories: true)
             try fileManager.moveItem(at: oldURL, to: newURL)
-            applyDefaultFileProtection(at: newURL, fileManager: fileManager)
+            let protectionError = applyDefaultFileProtection(at: newURL, fileManager: fileManager)
             Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] moved successfully")
             userDefaults.set(true, forKey: doneKey)
             userDefaults.removeObject(forKey: attemptsKey)
             pixelFiring.fire(.success(label: label))
+            if let protectionError {
+                pixelFiring.fire(.protectionFailed(label: label, error: protectionError))
+            }
             return .proceed
         } catch {
             let attempt = priorAttempts + 1

--- a/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
+++ b/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
@@ -32,7 +32,6 @@ enum DuckAiNativeStorageContainerMigrationLabel: String {
 /// migration pixels (`duckAiNativeStorageMigration*`).
 enum DuckAiNativeStorageContainerMigrationEvent {
     case notNeeded(label: DuckAiNativeStorageContainerMigrationLabel)
-    case orphanRemoved(label: DuckAiNativeStorageContainerMigrationLabel)
     case success(label: DuckAiNativeStorageContainerMigrationLabel)
     case attemptFailed(label: DuckAiNativeStorageContainerMigrationLabel, error: Error)
     case gaveUp(label: DuckAiNativeStorageContainerMigrationLabel, error: Error?)
@@ -71,8 +70,6 @@ struct DuckAiNativeStorageContainerMigrationPixelAdapter: DuckAiNativeStorageCon
         switch event {
         case .notNeeded(let label):
             Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationNotNeeded(label: label.rawValue))
-        case .orphanRemoved(let label):
-            Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationOrphanRemoved(label: label.rawValue))
         case .success(let label):
             Pixel.fire(pixel: .duckAiNativeStorageContainerMigrationSuccess(label: label.rawValue))
         case .attemptFailed(let label, let error):
@@ -111,10 +108,6 @@ struct DuckAiNativeStorageContainerMigrationPixelAdapter: DuckAiNativeStorageCon
 enum DuckAiNativeStorageContainerMigration {
 
     static let defaultMaxAttempts = 3
-
-    /// Existence sentinel for "destination holds migrated data", used by the
-    /// legacy transition for pre-marker users. Contents are not inspected.
-    private static let databaseFilename = "chats.db"
 
     private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "DuckDuckGo",
                                        category: "DuckAiNativeStorageContainerMigration")
@@ -232,6 +225,10 @@ enum DuckAiNativeStorageContainerMigration {
                 try fileManager.createDirectory(at: markerURL.deletingLastPathComponent(),
                                                 withIntermediateDirectories: true)
                 try Data().write(to: markerURL, options: .atomic)
+                var url = markerURL
+                var resourceValues = URLResourceValues()
+                resourceValues.isExcludedFromBackup = true
+                try url.setResourceValues(resourceValues)
             } catch {
                 Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] failed to write marker at \(markerURL.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
@@ -241,8 +238,13 @@ enum DuckAiNativeStorageContainerMigration {
             fileManager.fileExists(atPath: markerURL.path)
         }
 
+        // Fire-mode stores DBs in `<UUID>/chats.db` subdirectories rather than at
+        // the root, so any non-empty `newURL` implies data that must not be wiped.
         func destinationHasData() -> Bool {
-            fileManager.fileExists(atPath: newURL.appendingPathComponent(Self.databaseFilename).path)
+            guard let children = try? fileManager.contentsOfDirectory(atPath: newURL.path) else {
+                return false
+            }
+            return !children.isEmpty
         }
 
         func ensureProtection() {

--- a/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
+++ b/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
@@ -240,6 +240,12 @@ enum DuckAiNativeStorageContainerMigration {
             userDefaults.set(attempt, forKey: attemptsKey)
             if attempt >= maxAttempts {
                 Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] move failed (attempt \(attempt)/\(maxAttempts)); giving up: \(error.localizedDescription, privacy: .public)")
+                // Best-effort sweep: once we give up, we'll never look at the
+                // old container again, so the sensitive chat content would sit
+                // in the app-group container indefinitely under NSFileProtectionComplete.
+                // Take one last shot at removing it — it may well succeed even
+                // when moveItem couldn't (different syscall, no destination required).
+                try? fileManager.removeItem(at: oldURL)
                 userDefaults.set(true, forKey: doneKey)
                 pixelFiring.fire(.gaveUp(label: label, error: error))
                 return .proceed

--- a/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
+++ b/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
@@ -157,10 +157,22 @@ enum DuckAiNativeStorageContainerMigration {
     /// Moves `oldURL` to `newURL`, retrying on failure across launches.
     ///
     /// Persistence in `userDefaults`:
-    /// - `migrationKey + ".done"` (Bool) — set when the migration reaches a terminal
-    ///   state (success, no-op, orphan-cleaned, or `maxAttempts` exhausted).
+    /// - `migrationKey + ".done"` (Bool) — set when the migration's *data* state is
+    ///   settled (success, no-op, orphan-cleaned, or `maxAttempts` exhausted).
     /// - `migrationKey + ".attempts"` (Int) — number of failed attempts so far
     ///   (move or orphan-removal). Cleared on success.
+    /// - `migrationKey + ".protectionApplied"` (Bool) — set when file protection
+    ///   at `newURL` is confirmed correct, or there's no data at `newURL` needing
+    ///   protection, or the retry cap has been reached.
+    /// - `migrationKey + ".protectionAttempts"` (Int) — number of failed
+    ///   `applyDefaultFileProtection` retries. Cleared on success.
+    ///
+    /// `done` and `protectionApplied` are tracked independently: a successful
+    /// move that fails to re-apply file protection sets `done=true` but leaves
+    /// `protectionApplied=false`, so each subsequent launch retries protection
+    /// until success or the cap. Otherwise the destination DB would keep its
+    /// original `NSFileProtectionComplete` class permanently — the 0xdead10cc
+    /// condition this migration exists to fix.
     ///
     /// `label` distinguishes the default vs. fire-mode container in logs and pixels.
     ///
@@ -178,9 +190,38 @@ enum DuckAiNativeStorageContainerMigration {
                                 maxAttempts: Int = defaultMaxAttempts) -> DuckAiNativeStorageContainerMigrationOutcome {
         let doneKey = migrationKey + ".done"
         let attemptsKey = migrationKey + ".attempts"
+        let protectionAppliedKey = migrationKey + ".protectionApplied"
+        let protectionAttemptsKey = migrationKey + ".protectionAttempts"
 
-        guard !userDefaults.bool(forKey: doneKey) else {
+        func ensureProtection() {
+            guard !userDefaults.bool(forKey: protectionAppliedKey) else { return }
+            guard fileManager.fileExists(atPath: newURL.path) else {
+                // Nothing at the destination yet — no protection to enforce.
+                userDefaults.set(true, forKey: protectionAppliedKey)
+                userDefaults.removeObject(forKey: protectionAttemptsKey)
+                return
+            }
+            if let error = applyDefaultFileProtection(at: newURL, fileManager: fileManager) {
+                let attempt = userDefaults.integer(forKey: protectionAttemptsKey) + 1
+                userDefaults.set(attempt, forKey: protectionAttemptsKey)
+                if attempt <= maxAttempts {
+                    pixelFiring.fire(.protectionFailed(label: label, error: error))
+                }
+                if attempt >= maxAttempts {
+                    // Stop retrying. We've fired the pixel `maxAttempts` times;
+                    // the user is left with the original protection class, but
+                    // continued churn would only spam telemetry.
+                    userDefaults.set(true, forKey: protectionAppliedKey)
+                }
+            } else {
+                userDefaults.set(true, forKey: protectionAppliedKey)
+                userDefaults.removeObject(forKey: protectionAttemptsKey)
+            }
+        }
+
+        if userDefaults.bool(forKey: doneKey) {
             Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] skipping: already done")
+            ensureProtection()
             return .proceed
         }
 
@@ -192,6 +233,7 @@ enum DuckAiNativeStorageContainerMigration {
             userDefaults.set(true, forKey: doneKey)
             userDefaults.removeObject(forKey: attemptsKey)
             pixelFiring.fire(.notNeeded(label: label))
+            ensureProtection()
             return .proceed
         }
 
@@ -203,6 +245,7 @@ enum DuckAiNativeStorageContainerMigration {
                 userDefaults.set(true, forKey: doneKey)
                 userDefaults.removeObject(forKey: attemptsKey)
                 pixelFiring.fire(.orphanRemoved(label: label))
+                ensureProtection()
                 return .proceed
             } catch {
                 // newURL is intact and usable, but the old container still holds
@@ -218,6 +261,7 @@ enum DuckAiNativeStorageContainerMigration {
                     Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] orphan removal failed (attempt \(attempt)/\(maxAttempts)); will retry next launch: \(error.localizedDescription, privacy: .public)")
                     pixelFiring.fire(.attemptFailed(label: label, error: error))
                 }
+                ensureProtection()
                 return .proceed
             }
         }
@@ -226,14 +270,11 @@ enum DuckAiNativeStorageContainerMigration {
             try fileManager.createDirectory(at: newURL.deletingLastPathComponent(),
                                             withIntermediateDirectories: true)
             try fileManager.moveItem(at: oldURL, to: newURL)
-            let protectionError = applyDefaultFileProtection(at: newURL, fileManager: fileManager)
             Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] moved successfully")
             userDefaults.set(true, forKey: doneKey)
             userDefaults.removeObject(forKey: attemptsKey)
             pixelFiring.fire(.success(label: label))
-            if let protectionError {
-                pixelFiring.fire(.protectionFailed(label: label, error: protectionError))
-            }
+            ensureProtection()
             return .proceed
         } catch {
             let attempt = priorAttempts + 1
@@ -248,6 +289,7 @@ enum DuckAiNativeStorageContainerMigration {
                 try? fileManager.removeItem(at: oldURL)
                 userDefaults.set(true, forKey: doneKey)
                 pixelFiring.fire(.gaveUp(label: label, error: error))
+                ensureProtection()
                 return .proceed
             } else {
                 Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] move failed (attempt \(attempt)/\(maxAttempts)); will retry next launch: \(error.localizedDescription, privacy: .public)")

--- a/iOS/DuckDuckGo/AIChat/FireModeNativeStorageController.swift
+++ b/iOS/DuckDuckGo/AIChat/FireModeNativeStorageController.swift
@@ -78,13 +78,19 @@ final class FireModeNativeStorageController: DuckAiNativeStorageHandling {
         let baseDirectoryURL = appSupportURL.appendingPathComponent(Constants.fireModeDirectoryName)
 
         if let groupContainer = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appConfigurationGroupName) {
-            DuckAiNativeStorageContainerMigration.migrateIfNeeded(
+            let outcome = DuckAiNativeStorageContainerMigration.migrateIfNeeded(
                 from: groupContainer.appendingPathComponent(Constants.fireModeDirectoryName),
                 to: baseDirectoryURL,
                 migrationKey: "com.duckduckgo.duckai.nativeStorage.fireModeMigratedFromAppGroup",
                 label: .fireMode,
                 pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter()
             )
+            // A failed move retries next launch. If we create/open the destination
+            // now, the retry would see it as already-migrated and treat the old
+            // data as an orphan to delete.
+            if outcome == .skip {
+                return nil
+            }
         }
 
         DuckAiNativeStorageContainerMigration.excludeFromBackup(baseDirectoryURL)

--- a/iOS/DuckDuckGo/AIChat/FireModeNativeStorageController.swift
+++ b/iOS/DuckDuckGo/AIChat/FireModeNativeStorageController.swift
@@ -93,7 +93,9 @@ final class FireModeNativeStorageController: DuckAiNativeStorageHandling {
             }
         }
 
-        DuckAiNativeStorageContainerMigration.excludeFromBackup(baseDirectoryURL)
+        DuckAiNativeStorageContainerMigration.excludeFromBackup(baseDirectoryURL,
+                                                                label: .fireMode,
+                                                                pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter())
 
         self.baseDirectoryURL = baseDirectoryURL
         self.dataStoreIDManager = dataStoreIDManager

--- a/iOS/DuckDuckGo/AIChat/FireModeNativeStorageController.swift
+++ b/iOS/DuckDuckGo/AIChat/FireModeNativeStorageController.swift
@@ -27,10 +27,14 @@ import PrivacyConfig
 /// Owns the iOS fire-mode Duck.ai native storage handler and rotates it on burn.
 ///
 /// The underlying disk-backed handler lives at
-/// `<group>/DuckAiNativeStorage-fireMode/<UUID>/`, where `<UUID>` is
+/// `<Application Support>/DuckAiNativeStorage-fireMode/<UUID>/`, where `<UUID>` is
 /// `DataStoreIDManager.currentFireModeID` — matching the WebKit fire-mode data
 /// store identity. On burn we invalidate the current ID, swap in a fresh handler at
 /// the new ID's directory, and asynchronously delete the old directory on disk.
+///
+/// On first launch after upgrading from a build that stored fire-mode data in the
+/// shared app-group container, the existing directory is moved into Application
+/// Support; see `DuckAiNativeStorageContainerMigration`.
 ///
 /// Conforms to `DuckAiNativeStorageHandling` so consumers don't need to know about
 /// rotation; only `FireExecutor` calls `syncWithCurrentFireModeID()` directly on the concrete type.
@@ -60,7 +64,7 @@ final class FireModeNativeStorageController: DuckAiNativeStorageHandling {
     private let pixelFiring: DuckAiNativeStoragePixelFiring
     private let keyStoreAccessGroup: String
 
-    /// Returns `nil` if `aiChatNativeStorage` is off, the app group container is missing,
+    /// Returns `nil` if `aiChatNativeStorage` is off, Application Support is unavailable,
     /// or the underlying store can't be opened.
     init?(featureFlagger: FeatureFlagger,
           dataStoreIDManager: DataStoreIDManaging = DataStoreIDManager.shared,
@@ -68,10 +72,20 @@ final class FireModeNativeStorageController: DuckAiNativeStorageHandling {
           appConfigurationGroupName: String,
           pixelFiring: DuckAiNativeStoragePixelFiring = DuckAiNativeStoragePixelAdapter()) {
         guard featureFlagger.isFeatureOn(.aiChatNativeStorage),
-              let groupContainer = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appConfigurationGroupName) else {
+              let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
             return nil
         }
-        self.baseDirectoryURL = groupContainer.appendingPathComponent(Constants.fireModeDirectoryName)
+        let baseDirectoryURL = appSupportURL.appendingPathComponent(Constants.fireModeDirectoryName)
+
+        if let groupContainer = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appConfigurationGroupName) {
+            DuckAiNativeStorageContainerMigration.migrateIfNeeded(
+                from: groupContainer.appendingPathComponent(Constants.fireModeDirectoryName),
+                to: baseDirectoryURL,
+                migrationDoneKey: "com.duckduckgo.duckai.nativeStorage.fireModeMigratedFromAppGroup"
+            )
+        }
+
+        self.baseDirectoryURL = baseDirectoryURL
         self.dataStoreIDManager = dataStoreIDManager
         self.consentSeedSource = consentSeedSource
         self.pixelFiring = pixelFiring
@@ -130,6 +144,10 @@ final class FireModeNativeStorageController: DuckAiNativeStorageHandling {
                                     keyStoreAccessGroup: String,
                                     pixelFiring: DuckAiNativeStoragePixelFiring) -> DuckAiNativeStorageHandling? {
         let containerURL = baseDirectoryURL.appendingPathComponent(id.uuidString)
+        let dbURL = containerURL.appendingPathComponent("chats.db")
+        if !FileManager.default.fileExists(atPath: dbURL.path) {
+            Logger.aiChat.info("[NativeStorage] fire-mode DB does not exist yet for id \(id), will be created at: \(dbURL.path)")
+        }
         do {
             return try DuckAiNativeStorageHandler(
                 .disk(path: containerURL,

--- a/iOS/DuckDuckGo/AIChat/FireModeNativeStorageController.swift
+++ b/iOS/DuckDuckGo/AIChat/FireModeNativeStorageController.swift
@@ -64,38 +64,45 @@ final class FireModeNativeStorageController: DuckAiNativeStorageHandling {
     private let pixelFiring: DuckAiNativeStoragePixelFiring
     private let keyStoreAccessGroup: String
 
-    /// Returns `nil` if `aiChatNativeStorage` is off, Application Support is unavailable,
-    /// or the underlying store can't be opened.
+    /// Returns `nil` if `aiChatNativeStorage` is off, the required container is
+    /// unavailable, or the underlying store can't be opened.
     init?(featureFlagger: FeatureFlagger,
           dataStoreIDManager: DataStoreIDManaging = DataStoreIDManager.shared,
           consentSeedSource: DuckAiNativeStorageHandling?,
           appConfigurationGroupName: String,
           pixelFiring: DuckAiNativeStoragePixelFiring = DuckAiNativeStoragePixelAdapter()) {
-        guard featureFlagger.isFeatureOn(.aiChatNativeStorage),
-              let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
-            return nil
-        }
-        let baseDirectoryURL = appSupportURL.appendingPathComponent(Constants.fireModeDirectoryName)
+        guard featureFlagger.isFeatureOn(.aiChatNativeStorage) else { return nil }
 
-        if let groupContainer = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appConfigurationGroupName) {
-            let outcome = DuckAiNativeStorageContainerMigration.migrateIfNeeded(
-                from: groupContainer.appendingPathComponent(Constants.fireModeDirectoryName),
-                to: baseDirectoryURL,
-                migrationKey: "com.duckduckgo.duckai.nativeStorage.fireModeMigratedFromAppGroup",
-                label: .fireMode,
-                pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter()
-            )
-            // A failed move retries next launch. If we create/open the destination
-            // now, the retry would see it as already-migrated and treat the old
-            // data as an orphan to delete.
-            if outcome == .skip {
+        let baseDirectoryURL: URL
+        if featureFlagger.isFeatureOn(.duckAINativeStoragePathMigration) {
+            guard let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
                 return nil
             }
-        }
+            baseDirectoryURL = appSupportURL.appendingPathComponent(Constants.fireModeDirectoryName)
 
-        DuckAiNativeStorageContainerMigration.excludeFromBackup(baseDirectoryURL,
-                                                                label: .fireMode,
-                                                                pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter())
+            if let groupContainer = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appConfigurationGroupName) {
+                let outcome = DuckAiNativeStorageContainerMigration.migrateIfNeeded(
+                    from: groupContainer.appendingPathComponent(Constants.fireModeDirectoryName),
+                    to: baseDirectoryURL,
+                    migrationKey: "com.duckduckgo.duckai.nativeStorage.fireModeMigratedFromAppGroup",
+                    label: .fireMode,
+                    pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter()
+                )
+                if outcome == .skip {
+                    return nil
+                }
+            }
+
+            DuckAiNativeStorageContainerMigration.excludeFromBackup(baseDirectoryURL,
+                                                                    label: .fireMode,
+                                                                    pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter())
+        } else {
+            // Path migration disabled: keep the legacy App Group container.
+            guard let groupContainer = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appConfigurationGroupName) else {
+                return nil
+            }
+            baseDirectoryURL = groupContainer.appendingPathComponent(Constants.fireModeDirectoryName)
+        }
 
         self.baseDirectoryURL = baseDirectoryURL
         self.dataStoreIDManager = dataStoreIDManager

--- a/iOS/DuckDuckGo/AIChat/FireModeNativeStorageController.swift
+++ b/iOS/DuckDuckGo/AIChat/FireModeNativeStorageController.swift
@@ -81,9 +81,13 @@ final class FireModeNativeStorageController: DuckAiNativeStorageHandling {
             DuckAiNativeStorageContainerMigration.migrateIfNeeded(
                 from: groupContainer.appendingPathComponent(Constants.fireModeDirectoryName),
                 to: baseDirectoryURL,
-                migrationDoneKey: "com.duckduckgo.duckai.nativeStorage.fireModeMigratedFromAppGroup"
+                migrationKey: "com.duckduckgo.duckai.nativeStorage.fireModeMigratedFromAppGroup",
+                label: .fireMode,
+                pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter()
             )
         }
+
+        DuckAiNativeStorageContainerMigration.excludeFromBackup(baseDirectoryURL)
 
         self.baseDirectoryURL = baseDirectoryURL
         self.dataStoreIDManager = dataStoreIDManager

--- a/iOS/DuckDuckGo/AIChat/FireModeNativeStorageController.swift
+++ b/iOS/DuckDuckGo/AIChat/FireModeNativeStorageController.swift
@@ -23,6 +23,7 @@ import Core
 import DuckAiDataStore
 import Foundation
 import os.log
+import Persistence
 import PrivacyConfig
 /// Owns the iOS fire-mode Duck.ai native storage handler and rotates it on burn.
 ///
@@ -70,6 +71,7 @@ final class FireModeNativeStorageController: DuckAiNativeStorageHandling {
           dataStoreIDManager: DataStoreIDManaging = DataStoreIDManager.shared,
           consentSeedSource: DuckAiNativeStorageHandling?,
           appConfigurationGroupName: String,
+          keyValueStore: ThrowingKeyValueStoring,
           pixelFiring: DuckAiNativeStoragePixelFiring = DuckAiNativeStoragePixelAdapter()) {
         guard featureFlagger.isFeatureOn(.aiChatNativeStorage) else { return nil }
 
@@ -81,13 +83,14 @@ final class FireModeNativeStorageController: DuckAiNativeStorageHandling {
             baseDirectoryURL = appSupportURL.appendingPathComponent(Constants.fireModeDirectoryName)
 
             if let groupContainer = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appConfigurationGroupName) {
-                let outcome = DuckAiNativeStorageContainerMigration.migrateIfNeeded(
-                    from: groupContainer.appendingPathComponent(Constants.fireModeDirectoryName),
-                    to: baseDirectoryURL,
+                let outcome = DuckAiNativeStorageContainerMigration(
+                    oldURL: groupContainer.appendingPathComponent(Constants.fireModeDirectoryName),
+                    newURL: baseDirectoryURL,
                     migrationKey: "com.duckduckgo.duckai.nativeStorage.fireModeMigratedFromAppGroup",
                     label: .fireMode,
+                    keyValueStore: keyValueStore,
                     pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter()
-                )
+                ).run()
                 if outcome == .skip {
                     return nil
                 }

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -374,10 +374,24 @@ struct Launching: LaunchingHandling {
 
     private static func makeNativeStorageHandler(featureFlagger: FeatureFlagger) -> DuckAiNativeStorageHandling? {
         guard featureFlagger.isFeatureOn(.aiChatNativeStorage),
-              let groupContainer = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: Global.appConfigurationGroupName) else {
+              let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
             return nil
         }
-        let containerURL = groupContainer.appendingPathComponent(DuckAiNativeStorageHandler.defaultDirectoryName)
+        let containerURL = appSupportURL.appendingPathComponent(DuckAiNativeStorageHandler.defaultDirectoryName)
+
+        if let groupContainer = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: Global.appConfigurationGroupName) {
+            DuckAiNativeStorageContainerMigration.migrateIfNeeded(
+                from: groupContainer.appendingPathComponent(DuckAiNativeStorageHandler.defaultDirectoryName),
+                to: containerURL,
+                migrationDoneKey: "com.duckduckgo.duckai.nativeStorage.defaultMigratedFromAppGroup"
+            )
+        }
+
+        let dbURL = containerURL.appendingPathComponent("chats.db")
+        if !FileManager.default.fileExists(atPath: dbURL.path) {
+            Logger.aiChat.info("[NativeStorage] DB does not exist yet, will be created at: \(dbURL.path)")
+        }
+
         do {
             return try DuckAiNativeStorageHandler(
                 .disk(path: containerURL,

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -128,11 +128,15 @@ struct Launching: LaunchingHandling {
             }
         )
 
-        let duckAiNativeStorageHandler = Self.makeNativeStorageHandler(featureFlagger: featureFlagger)
+        let duckAiNativeStorageHandler = Self.makeNativeStorageHandler(
+            featureFlagger: featureFlagger,
+            keyValueStore: appKeyValueFileStoreService.keyValueFilesStore
+        )
         let fireModeStorageController = FireModeNativeStorageController(
             featureFlagger: featureFlagger,
             consentSeedSource: duckAiNativeStorageHandler,
-            appConfigurationGroupName: Global.appConfigurationGroupName
+            appConfigurationGroupName: Global.appConfigurationGroupName,
+            keyValueStore: appKeyValueFileStoreService.keyValueFilesStore
         )
 
         let contentBlockingService = ContentBlockingService(appSettings: appSettings,
@@ -372,7 +376,8 @@ struct Launching: LaunchingHandling {
         // For a broader overview: https://app.asana.com/0/1202500774821704/1209445353536490/f
     }
 
-    private static func makeNativeStorageHandler(featureFlagger: FeatureFlagger) -> DuckAiNativeStorageHandling? {
+    private static func makeNativeStorageHandler(featureFlagger: FeatureFlagger,
+                                                 keyValueStore: ThrowingKeyValueStoring) -> DuckAiNativeStorageHandling? {
         guard featureFlagger.isFeatureOn(.aiChatNativeStorage) else { return nil }
 
         let containerURL: URL
@@ -383,13 +388,14 @@ struct Launching: LaunchingHandling {
             containerURL = appSupportURL.appendingPathComponent(DuckAiNativeStorageHandler.defaultDirectoryName)
 
             if let groupContainer = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: Global.appConfigurationGroupName) {
-                let outcome = DuckAiNativeStorageContainerMigration.migrateIfNeeded(
-                    from: groupContainer.appendingPathComponent(DuckAiNativeStorageHandler.defaultDirectoryName),
-                    to: containerURL,
+                let outcome = DuckAiNativeStorageContainerMigration(
+                    oldURL: groupContainer.appendingPathComponent(DuckAiNativeStorageHandler.defaultDirectoryName),
+                    newURL: containerURL,
                     migrationKey: "com.duckduckgo.duckai.nativeStorage.defaultMigratedFromAppGroup",
                     label: .default,
+                    keyValueStore: keyValueStore,
                     pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter()
-                )
+                ).run()
                 if outcome == .skip {
                     return nil
                 }

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -395,7 +395,9 @@ struct Launching: LaunchingHandling {
             }
         }
 
-        DuckAiNativeStorageContainerMigration.excludeFromBackup(containerURL)
+        DuckAiNativeStorageContainerMigration.excludeFromBackup(containerURL,
+                                                                label: .default,
+                                                                pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter())
 
         let dbURL = containerURL.appendingPathComponent("chats.db")
         if !FileManager.default.fileExists(atPath: dbURL.path) {

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -380,13 +380,19 @@ struct Launching: LaunchingHandling {
         let containerURL = appSupportURL.appendingPathComponent(DuckAiNativeStorageHandler.defaultDirectoryName)
 
         if let groupContainer = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: Global.appConfigurationGroupName) {
-            DuckAiNativeStorageContainerMigration.migrateIfNeeded(
+            let outcome = DuckAiNativeStorageContainerMigration.migrateIfNeeded(
                 from: groupContainer.appendingPathComponent(DuckAiNativeStorageHandler.defaultDirectoryName),
                 to: containerURL,
                 migrationKey: "com.duckduckgo.duckai.nativeStorage.defaultMigratedFromAppGroup",
                 label: .default,
                 pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter()
             )
+            // A failed move retries next launch. If we create/open the destination
+            // now, the retry would see it as already-migrated and treat the old
+            // data as an orphan to delete.
+            if outcome == .skip {
+                return nil
+            }
         }
 
         DuckAiNativeStorageContainerMigration.excludeFromBackup(containerURL)

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -383,9 +383,13 @@ struct Launching: LaunchingHandling {
             DuckAiNativeStorageContainerMigration.migrateIfNeeded(
                 from: groupContainer.appendingPathComponent(DuckAiNativeStorageHandler.defaultDirectoryName),
                 to: containerURL,
-                migrationDoneKey: "com.duckduckgo.duckai.nativeStorage.defaultMigratedFromAppGroup"
+                migrationKey: "com.duckduckgo.duckai.nativeStorage.defaultMigratedFromAppGroup",
+                label: .default,
+                pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter()
             )
         }
+
+        DuckAiNativeStorageContainerMigration.excludeFromBackup(containerURL)
 
         let dbURL = containerURL.appendingPathComponent("chats.db")
         if !FileManager.default.fileExists(atPath: dbURL.path) {

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -373,31 +373,38 @@ struct Launching: LaunchingHandling {
     }
 
     private static func makeNativeStorageHandler(featureFlagger: FeatureFlagger) -> DuckAiNativeStorageHandling? {
-        guard featureFlagger.isFeatureOn(.aiChatNativeStorage),
-              let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
-            return nil
-        }
-        let containerURL = appSupportURL.appendingPathComponent(DuckAiNativeStorageHandler.defaultDirectoryName)
+        guard featureFlagger.isFeatureOn(.aiChatNativeStorage) else { return nil }
 
-        if let groupContainer = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: Global.appConfigurationGroupName) {
-            let outcome = DuckAiNativeStorageContainerMigration.migrateIfNeeded(
-                from: groupContainer.appendingPathComponent(DuckAiNativeStorageHandler.defaultDirectoryName),
-                to: containerURL,
-                migrationKey: "com.duckduckgo.duckai.nativeStorage.defaultMigratedFromAppGroup",
-                label: .default,
-                pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter()
-            )
-            // A failed move retries next launch. If we create/open the destination
-            // now, the retry would see it as already-migrated and treat the old
-            // data as an orphan to delete.
-            if outcome == .skip {
+        let containerURL: URL
+        if featureFlagger.isFeatureOn(.duckAINativeStoragePathMigration) {
+            guard let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
                 return nil
             }
-        }
+            containerURL = appSupportURL.appendingPathComponent(DuckAiNativeStorageHandler.defaultDirectoryName)
 
-        DuckAiNativeStorageContainerMigration.excludeFromBackup(containerURL,
-                                                                label: .default,
-                                                                pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter())
+            if let groupContainer = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: Global.appConfigurationGroupName) {
+                let outcome = DuckAiNativeStorageContainerMigration.migrateIfNeeded(
+                    from: groupContainer.appendingPathComponent(DuckAiNativeStorageHandler.defaultDirectoryName),
+                    to: containerURL,
+                    migrationKey: "com.duckduckgo.duckai.nativeStorage.defaultMigratedFromAppGroup",
+                    label: .default,
+                    pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter()
+                )
+                if outcome == .skip {
+                    return nil
+                }
+            }
+
+            DuckAiNativeStorageContainerMigration.excludeFromBackup(containerURL,
+                                                                    label: .default,
+                                                                    pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter())
+        } else {
+            // Path migration disabled: keep the legacy App Group container.
+            guard let groupContainer = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: Global.appConfigurationGroupName) else {
+                return nil
+            }
+            containerURL = groupContainer.appendingPathComponent(DuckAiNativeStorageHandler.defaultDirectoryName)
+        }
 
         let dbURL = containerURL.appendingPathComponent("chats.db")
         if !FileManager.default.fileExists(atPath: dbURL.path) {

--- a/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
@@ -17,42 +17,35 @@
 //  limitations under the License.
 //
 
+import Persistence
+import PersistenceTestingUtils
 import XCTest
 @testable import DuckDuckGo
 
 final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
 
     private var sandbox: URL!
-    private var userDefaults: UserDefaults!
+    private var keyValueStore: MockKeyValueStore!
     private var pixelSpy: SpyContainerMigrationPixelFiring!
     private let migrationKey = "test.migration"
     private let label: DuckAiNativeStorageContainerMigrationLabel = .default
-    private let suiteName = "DuckAiNativeStorageContainerMigrationTests"
 
-    private var doneKey: String { migrationKey + ".done" }
+    private var migratedKey: String { migrationKey + ".migrated" }
     private var attemptsKey: String { migrationKey + ".attempts" }
-    private var protectionAppliedKey: String { migrationKey + ".protectionApplied" }
     private var protectionAttemptsKey: String { migrationKey + ".protectionAttempts" }
-
-    private func markerURL(forNew newURL: URL) -> URL {
-        newURL.deletingLastPathComponent()
-            .appendingPathComponent(".\(migrationKey).migrated")
-    }
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         sandbox = FileManager.default.temporaryDirectory
             .appendingPathComponent("DuckAiNativeStorageContainerMigrationTests-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: sandbox, withIntermediateDirectories: true)
-        UserDefaults().removePersistentDomain(forName: suiteName)
-        userDefaults = UserDefaults(suiteName: suiteName)
+        keyValueStore = MockKeyValueStore()
         pixelSpy = SpyContainerMigrationPixelFiring()
     }
 
     override func tearDownWithError() throws {
         try? FileManager.default.removeItem(at: sandbox)
-        userDefaults.removePersistentDomain(forName: suiteName)
-        userDefaults = nil
+        keyValueStore = nil
         sandbox = nil
         pixelSpy = nil
         try super.tearDownWithError()
@@ -60,14 +53,13 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
 
     // MARK: - Happy paths
 
-    func testWhenOldDirectoryDoesNotExistThenMarkerIsWrittenAndNotNeededPixelFires() {
+    func testWhenOldDirectoryDoesNotExistThenMigratedFlagIsSetAndNotNeededPixelFires() {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
 
         migrate(from: oldURL, to: newURL)
 
-        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
-        XCTAssertTrue(FileManager.default.fileExists(atPath: markerURL(forNew: newURL).path))
+        XCTAssertTrue(keyValueStore.bool(forKey: migratedKey))
         XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path))
         XCTAssertEqual(pixelSpy.firedEventNames, ["notNeeded"])
     }
@@ -81,22 +73,18 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
 
         migrate(from: oldURL, to: newURL)
 
-        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
-        XCTAssertTrue(FileManager.default.fileExists(atPath: markerURL(forNew: newURL).path))
+        XCTAssertTrue(keyValueStore.bool(forKey: migratedKey))
         XCTAssertFalse(FileManager.default.fileExists(atPath: oldURL.path))
         XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("chats".utf8))
         XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("files.bin")), Data("files".utf8))
         XCTAssertEqual(pixelSpy.firedEventNames, ["success"])
     }
 
-    func testWhenMarkerExistsAndOldDoesNotExistThenMigrationIsNoOp() throws {
+    func testWhenMigratedAndOldDoesNotExistThenMigrationIsNoOp() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
-        // Simulate completed migration: marker present, oldURL absent.
-        try FileManager.default.createDirectory(at: markerURL(forNew: newURL).deletingLastPathComponent(),
-                                                withIntermediateDirectories: true)
-        try Data().write(to: markerURL(forNew: newURL))
-        userDefaults.set(true, forKey: doneKey)
+        // Simulate completed migration: migrated flag set, oldURL absent.
+        try? keyValueStore.set(true, forKey: migratedKey)
 
         migrate(from: oldURL, to: newURL)
 
@@ -117,9 +105,9 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
 
         migrate(from: oldURL, to: newURL)
 
-        // Marker exists → second call is a pure no-op.
+        // Migrated flag set → second call is a pure no-op.
         // We do NOT delete the re-created oldURL: it could be the only complete
-        // copy of pre-upgrade data when the marker was written via the
+        // copy of pre-upgrade data when the migrated flag was set via the
         // destination-conflict path, so we preserve it for recovery.
         XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("first".utf8))
         XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path),
@@ -139,8 +127,7 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
 
         migrate(from: oldURL, to: newURL)
 
-        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
-        XCTAssertTrue(FileManager.default.fileExists(atPath: markerURL(forNew: newURL).path))
+        XCTAssertTrue(keyValueStore.bool(forKey: migratedKey))
         XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("keep-me".utf8))
         // Source must be preserved so the user's pre-upgrade data is recoverable.
         XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path),
@@ -158,7 +145,6 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
 
         migrate(from: oldURL, to: newURL)
 
-        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
         XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("chats".utf8))
         XCTAssertFalse(FileManager.default.fileExists(atPath: oldURL.path))
         XCTAssertEqual(pixelSpy.firedEventNames, ["success"])
@@ -166,7 +152,7 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
 
     // MARK: - Retry behavior (move failure)
 
-    func testWhenMoveFailsThenAttemptIsRecordedAndDoneFlagNotSetAndOutcomeIsSkip() throws {
+    func testWhenMoveFailsThenAttemptIsRecordedAndOutcomeIsSkip() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
         try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
@@ -175,9 +161,8 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
 
         XCTAssertEqual(outcome, .skip)
         XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path))
-        XCTAssertFalse(userDefaults.bool(forKey: doneKey))
-        XCTAssertFalse(FileManager.default.fileExists(atPath: markerURL(forNew: newURL).path))
-        XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 1)
+        XCTAssertFalse(keyValueStore.bool(forKey: migratedKey))
+        XCTAssertEqual(keyValueStore.integer(forKey: attemptsKey), 1)
         XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed"])
     }
 
@@ -193,17 +178,15 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         }
 
         XCTAssertEqual(outcomes, [.skip, .skip, .proceed])
-        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
-        XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 3)
+        XCTAssertEqual(keyValueStore.integer(forKey: attemptsKey), 3,
+                       "attempts must stay at the cap so the next launch detects the exhausted budget")
         XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "attemptFailed", "gaveUp"])
         // Source data must NOT be deleted — accepting data loss in exchange for
         // privacy hygiene is the wrong trade-off for chat history.
         XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path),
                       "give-up sweep must not delete source data")
-        // No marker yet — a future launch can re-try via the legacy transition
-        // if conditions improve.
-        XCTAssertFalse(FileManager.default.fileExists(atPath: markerURL(forNew: newURL).path),
-                       "marker must NOT be written on give-up so retries can resume when conditions improve")
+        XCTAssertFalse(keyValueStore.bool(forKey: migratedKey),
+                       "migrated flag must NOT be set on give-up so retries can resume when conditions improve")
     }
 
     func testWhenGaveUpAndNextLaunchSucceedsThenMigrationCompletes() throws {
@@ -217,12 +200,12 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         }
 
         // Disk pressure clears / locked storage unlocks / FS error transient
-        // resolves. Next launch with a working FileManager should succeed via
-        // the legacy doneKey transition.
+        // resolves. Next launch sees attempts at the cap with no migrated
+        // flag and resets the retry budget before re-attempting the move.
         let recoveryOutcome = migrate(from: oldURL, to: newURL, maxAttempts: 3)
 
         XCTAssertEqual(recoveryOutcome, .proceed)
-        XCTAssertTrue(FileManager.default.fileExists(atPath: markerURL(forNew: newURL).path))
+        XCTAssertTrue(keyValueStore.bool(forKey: migratedKey))
         XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("user-data".utf8))
         XCTAssertFalse(FileManager.default.fileExists(atPath: oldURL.path))
         XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "attemptFailed", "gaveUp", "success"])
@@ -236,15 +219,13 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
 
         let firstOutcome = migrate(from: oldURL, to: newURL, fileManager: FailingMoveFileManager(), maxAttempts: 3)
         XCTAssertEqual(firstOutcome, .skip)
-        XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 1)
-        XCTAssertFalse(userDefaults.bool(forKey: doneKey))
+        XCTAssertEqual(keyValueStore.integer(forKey: attemptsKey), 1)
 
         let secondOutcome = migrate(from: oldURL, to: newURL, maxAttempts: 3)
 
         XCTAssertEqual(secondOutcome, .proceed)
-        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
-        XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 0)
-        XCTAssertTrue(FileManager.default.fileExists(atPath: markerURL(forNew: newURL).path))
+        XCTAssertEqual(keyValueStore.integer(forKey: attemptsKey), 0)
+        XCTAssertTrue(keyValueStore.bool(forKey: migratedKey))
         XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "success"])
     }
 
@@ -259,8 +240,7 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         let outcome = migrate(from: oldURL, to: newURL, isProtectedDataAvailable: { false })
 
         XCTAssertEqual(outcome, .skip)
-        XCTAssertFalse(userDefaults.bool(forKey: doneKey))
-        XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 0,
+        XCTAssertEqual(keyValueStore.integer(forKey: attemptsKey), 0,
                        "retry counter must not be burned by a locked-device launch")
         XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path))
@@ -275,80 +255,62 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
 
         let lockedOutcome = migrate(from: oldURL, to: newURL, isProtectedDataAvailable: { false })
         XCTAssertEqual(lockedOutcome, .skip)
-        XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 0)
+        XCTAssertEqual(keyValueStore.integer(forKey: attemptsKey), 0)
 
         let unlockedOutcome = migrate(from: oldURL, to: newURL, isProtectedDataAvailable: { true })
 
         XCTAssertEqual(unlockedOutcome, .proceed)
-        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
+        XCTAssertTrue(keyValueStore.bool(forKey: migratedKey))
         XCTAssertEqual(pixelSpy.firedEventNames, ["protectedDataUnavailable", "success"])
     }
 
-    // MARK: - Legacy doneKey transition (iCloud restore + pre-marker upgrades)
+    // MARK: - Exhausted retry budget reset
 
-    func testWhenLegacyDoneFlagSetAndDestinationHasDataThenMarkerIsWrittenAndCallIsNoOp() throws {
+    func testWhenAttemptsAreAtCapWithoutMigratedFlagThenBudgetResetsAndMigrationRuns() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
-        // Simulate a user who completed migration on a pre-marker build:
-        // doneKey set, oldURL absent, newURL contains chats.db, no marker yet.
-        try FileManager.default.createDirectory(at: newURL, withIntermediateDirectories: true)
-        try Data("migrated".utf8).write(to: newURL.appendingPathComponent("chats.db"))
-        userDefaults.set(true, forKey: doneKey)
-
-        migrate(from: oldURL, to: newURL)
-
-        XCTAssertTrue(FileManager.default.fileExists(atPath: markerURL(forNew: newURL).path),
-                      "marker should be written on first launch under the new code")
-        XCTAssertTrue(pixelSpy.firedEventNames.isEmpty,
-                      "no migration events should fire for a no-op transition")
-    }
-
-    func testWhenLegacyDoneFlagSetButDestinationEmptyAndSourceHasDataThenStateResetsAndMigrationRuns() throws {
-        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
-        let newURL = sandbox.appendingPathComponent("new/DuckAi")
-        // Simulate iCloud restore: doneKey survived backup, App Group oldURL
-        // was restored, but Application Support newURL was excluded from backup
-        // so the destination is empty. The migration must re-run.
         try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
-        try Data("restored".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
-        userDefaults.set(true, forKey: doneKey)
+        try Data("user".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+        // Simulate the post-gaveUp state: attempts pegged at the cap, no migrated flag.
+        try? keyValueStore.set(3, forKey: attemptsKey)
+        try? keyValueStore.set(3, forKey: protectionAttemptsKey)
 
-        migrate(from: oldURL, to: newURL)
+        migrate(from: oldURL, to: newURL, maxAttempts: 3)
 
-        XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("restored".utf8))
-        XCTAssertFalse(FileManager.default.fileExists(atPath: oldURL.path))
-        XCTAssertTrue(FileManager.default.fileExists(atPath: markerURL(forNew: newURL).path))
+        XCTAssertTrue(keyValueStore.bool(forKey: migratedKey))
+        XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("user".utf8))
+        XCTAssertEqual(keyValueStore.integer(forKey: attemptsKey), 0)
         XCTAssertEqual(pixelSpy.firedEventNames, ["success"])
     }
 
-    func testWhenLegacyDoneFlagSetAndNeitherSourceNorDestinationHasDataThenMarkerIsWritten() throws {
+    func testWhenAttemptsAreAtCapWithMigratedFlagThenBudgetIsNotReset() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
-        userDefaults.set(true, forKey: doneKey)
+        try? keyValueStore.set(true, forKey: migratedKey)
+        try? keyValueStore.set(3, forKey: attemptsKey)
 
-        migrate(from: oldURL, to: newURL)
+        migrate(from: oldURL, to: newURL, maxAttempts: 3)
 
-        XCTAssertTrue(FileManager.default.fileExists(atPath: markerURL(forNew: newURL).path))
+        XCTAssertEqual(keyValueStore.integer(forKey: attemptsKey), 3,
+                       "migrated state must not touch the retry counter")
         XCTAssertTrue(pixelSpy.firedEventNames.isEmpty)
     }
 
-    // MARK: - Marker-present steady state
+    // MARK: - Migrated-flag steady state
 
-    func testWhenMarkerExistsAndOldStillExistsThenMigrationIsNoOpAndOldIsPreserved() throws {
+    func testWhenMigratedAndOldStillExistsThenMigrationIsNoOpAndOldIsPreserved() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
-        try FileManager.default.createDirectory(at: markerURL(forNew: newURL).deletingLastPathComponent(),
-                                                withIntermediateDirectories: true)
-        try Data().write(to: markerURL(forNew: newURL))
+        try? keyValueStore.set(true, forKey: migratedKey)
         try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
         try Data("preserved".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
 
         migrate(from: oldURL, to: newURL)
 
-        // Marker-present state must NOT delete oldURL. After the destination
+        // Migrated state must NOT delete oldURL. After the destination
         // conflict path runs, oldURL can be the only complete copy.
         XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path),
-                      "oldURL data must be preserved once marker exists")
+                      "oldURL data must be preserved once migrated flag is set")
         XCTAssertTrue(pixelSpy.firedEventNames.isEmpty)
     }
 
@@ -357,22 +319,20 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
         try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
         try Data("complete".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
-        // Simulate the post-gaveUp + partial-copy state without writing a marker:
+        // Simulate the post-gaveUp + partial-copy state without setting migrated:
         // newURL has a partial chats.db, oldURL still has the complete copy,
-        // doneKey was set when migration gave up. No marker.
+        // attempts left at the cap when migration gave up.
         try FileManager.default.createDirectory(at: newURL, withIntermediateDirectories: true)
         try Data("partial".utf8).write(to: newURL.appendingPathComponent("chats.db"))
-        userDefaults.set(true, forKey: doneKey)
-        userDefaults.set(3, forKey: attemptsKey)
+        try? keyValueStore.set(3, forKey: attemptsKey)
 
         migrate(from: oldURL, to: newURL)
 
-        // Legacy transition sees `oldExists` and resets state. The standard
-        // flow then takes the destinationConflict path, writes the marker,
-        // and preserves both sides so the complete oldURL data remains
-        // recoverable.
+        // Exhausted-budget reset clears attempts. The standard flow then takes
+        // the destinationConflict path, sets the migrated flag, and preserves
+        // both sides so the complete oldURL data remains recoverable.
         XCTAssertEqual(pixelSpy.firedEventNames, ["destinationConflict"])
-        XCTAssertTrue(FileManager.default.fileExists(atPath: markerURL(forNew: newURL).path))
+        XCTAssertTrue(keyValueStore.bool(forKey: migratedKey))
         XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path),
                       "post-gaveUp source must survive — newURL might be a partial copy")
         XCTAssertEqual(try Data(contentsOf: oldURL.appendingPathComponent("chats.db")), Data("complete".utf8))
@@ -389,28 +349,28 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         let outcome = migrate(from: oldURL, to: newURL, fileManager: FailingSetAttributesFileManager(), maxAttempts: 3)
 
         XCTAssertEqual(outcome, .proceed)
-        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
+        XCTAssertTrue(keyValueStore.bool(forKey: migratedKey))
         XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("chats".utf8))
         XCTAssertEqual(pixelSpy.firedEventNames, ["success", "protectionFailed"])
         XCTAssertEqual((pixelSpy.lastProtectionFailedError as NSError?)?.domain, FailingSetAttributesFileManager.errorDomain)
         XCTAssertEqual((pixelSpy.lastProtectionFailedError as NSError?)?.code, FailingSetAttributesFileManager.errorCode)
-        XCTAssertFalse(userDefaults.bool(forKey: protectionAppliedKey))
-        XCTAssertEqual(userDefaults.integer(forKey: protectionAttemptsKey), 1)
+        XCTAssertEqual(keyValueStore.integer(forKey: protectionAttemptsKey), 1,
+                       "protection retry counter must reflect the single failed attempt")
     }
 
-    func testWhenProtectionFailsThenRetriedOnSubsequentLaunchAndSucceedsThenProtectionAppliedIsSet() throws {
+    func testWhenProtectionFailsThenRetriedOnSubsequentLaunchAndSucceedsThenProtectionIsDone() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
         try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
         try Data("chats".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
 
         migrate(from: oldURL, to: newURL, fileManager: FailingSetAttributesFileManager(), maxAttempts: 3)
-        XCTAssertFalse(userDefaults.bool(forKey: protectionAppliedKey))
+        XCTAssertEqual(keyValueStore.integer(forKey: protectionAttemptsKey), 1)
 
         migrate(from: oldURL, to: newURL, maxAttempts: 3)
 
-        XCTAssertTrue(userDefaults.bool(forKey: protectionAppliedKey))
-        XCTAssertEqual(userDefaults.integer(forKey: protectionAttemptsKey), 0)
+        XCTAssertEqual(keyValueStore.integer(forKey: protectionAttemptsKey), 3,
+                       "successful apply must set the counter to the done sentinel (maxAttempts)")
         XCTAssertEqual(pixelSpy.firedEventNames, ["success", "protectionFailed"])
     }
 
@@ -423,22 +383,21 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         for _ in 0..<3 {
             migrate(from: oldURL, to: newURL, fileManager: FailingSetAttributesFileManager(), maxAttempts: 3)
         }
-        XCTAssertTrue(userDefaults.bool(forKey: protectionAppliedKey))
-        XCTAssertEqual(userDefaults.integer(forKey: protectionAttemptsKey), 0,
-                       "protectionAttempts should be cleared when the cap marks applied=true")
+        XCTAssertEqual(keyValueStore.integer(forKey: protectionAttemptsKey), 3,
+                       "counter sits at the done sentinel once the cap is reached")
         XCTAssertEqual(pixelSpy.firedEventNames, ["success", "protectionFailed", "protectionFailed", "protectionFailed"])
 
         migrate(from: oldURL, to: newURL, fileManager: FailingSetAttributesFileManager(), maxAttempts: 3)
         XCTAssertEqual(pixelSpy.firedEventNames, ["success", "protectionFailed", "protectionFailed", "protectionFailed"])
     }
 
-    func testWhenMigrationIsNotNeededThenProtectionAppliedIsSetWithoutEnumeratingFiles() throws {
+    func testWhenMigrationIsNotNeededThenProtectionIsMarkedDoneWithoutEnumeratingFiles() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
 
         migrate(from: oldURL, to: newURL)
 
-        XCTAssertTrue(userDefaults.bool(forKey: protectionAppliedKey))
+        XCTAssertEqual(keyValueStore.integer(forKey: protectionAttemptsKey), DuckAiNativeStorageContainerMigration.defaultMaxAttempts)
         XCTAssertEqual(pixelSpy.firedEventNames, ["notNeeded"])
     }
 
@@ -507,7 +466,8 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         let outcome = migrate(from: oldURL, to: newURL, fileManager: FailingMoveFileManager(), maxAttempts: 0)
 
         XCTAssertEqual(outcome, .proceed, "maxAttempts clamped to 1 triggers gaveUp on the first failure")
-        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
+        XCTAssertEqual(keyValueStore.integer(forKey: attemptsKey), 1,
+                       "attempts must be left at the clamped cap so the next launch resets the budget")
         XCTAssertEqual(pixelSpy.firedEventNames, ["gaveUp"])
         // Even at maxAttempts=0 (clamped), source must be preserved.
         XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path),
@@ -550,7 +510,7 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         XCTAssertFalse(handlerCreated, "handler creation must be skipped after a failed move")
         XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path))
-        XCTAssertFalse(userDefaults.bool(forKey: doneKey))
+        XCTAssertFalse(keyValueStore.bool(forKey: migratedKey))
         XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed"])
     }
 
@@ -605,7 +565,7 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         XCTAssertFalse(handlerCreated)
         XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path),
                        "locked-device launch must not create destination — otherwise next launch sees it as orphan")
-        XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 0,
+        XCTAssertEqual(keyValueStore.integer(forKey: attemptsKey), 0,
                        "locked-device launch must not consume the retry budget")
     }
 
@@ -615,19 +575,19 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
     private func migrate(from oldURL: URL,
                          to newURL: URL,
                          fileManager: FileManager = .default,
-                         isProtectedDataAvailable: () -> Bool = { true },
+                         isProtectedDataAvailable: @escaping () -> Bool = { true },
                          maxAttempts: Int = DuckAiNativeStorageContainerMigration.defaultMaxAttempts) -> DuckAiNativeStorageContainerMigrationOutcome {
-        DuckAiNativeStorageContainerMigration.migrateIfNeeded(
-            from: oldURL,
-            to: newURL,
+        DuckAiNativeStorageContainerMigration(
+            oldURL: oldURL,
+            newURL: newURL,
             migrationKey: migrationKey,
             label: label,
-            userDefaults: userDefaults,
+            keyValueStore: keyValueStore,
             fileManager: fileManager,
             pixelFiring: pixelSpy,
             isProtectedDataAvailable: isProtectedDataAvailable,
             maxAttempts: maxAttempts
-        )
+        ).run()
     }
 
     /// Mirrors the caller pattern in `Launching.makeNativeStorageHandler` and
@@ -707,4 +667,9 @@ private final class FailingCreateDirectoryFileManager: FileManager {
                                   attributes: [FileAttributeKey: Any]? = nil) throws {
         throw NSError(domain: "DuckAiNativeStorageContainerMigrationTests.createDirectory", code: -4)
     }
+}
+
+private extension MockKeyValueStore {
+    func integer(forKey key: String) -> Int { object(forKey: key) as? Int ?? 0 }
+    func bool(forKey key: String) -> Bool { object(forKey: key) as? Bool ?? false }
 }

--- a/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
@@ -256,6 +256,47 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "orphanRemoved"])
     }
 
+    // MARK: - File protection failure surfacing
+
+    func testWhenMoveSucceedsButSetAttributesFailsThenSuccessAndProtectionFailedBothFire() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("chats".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+
+        let outcome = migrate(from: oldURL, to: newURL, fileManager: FailingSetAttributesFileManager(), maxAttempts: 3)
+
+        // The move itself succeeded so we proceed and mark done — data is at newURL.
+        XCTAssertEqual(outcome, .proceed)
+        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
+        XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("chats".utf8))
+        // But protection failed, so both pixels fire — `.success` then `.protectionFailed`.
+        XCTAssertEqual(pixelSpy.firedEventNames, ["success", "protectionFailed"])
+        XCTAssertEqual((pixelSpy.lastProtectionFailedError as NSError?)?.domain, FailingSetAttributesFileManager.errorDomain)
+        XCTAssertEqual((pixelSpy.lastProtectionFailedError as NSError?)?.code, FailingSetAttributesFileManager.errorCode)
+    }
+
+    func testWhenApplyDefaultFileProtectionSucceedsForAllPathsThenReturnsNil() throws {
+        let url = sandbox.appendingPathComponent("DuckAi")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        try Data("chats".utf8).write(to: url.appendingPathComponent("chats.db"))
+
+        let error = DuckAiNativeStorageContainerMigration.applyDefaultFileProtection(at: url)
+
+        XCTAssertNil(error)
+    }
+
+    func testWhenApplyDefaultFileProtectionFailsThenReturnsFirstError() throws {
+        let url = sandbox.appendingPathComponent("DuckAi")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        try Data("chats".utf8).write(to: url.appendingPathComponent("chats.db"))
+
+        let error = DuckAiNativeStorageContainerMigration.applyDefaultFileProtection(at: url, fileManager: FailingSetAttributesFileManager())
+
+        XCTAssertEqual((error as NSError?)?.domain, FailingSetAttributesFileManager.errorDomain)
+        XCTAssertEqual((error as NSError?)?.code, FailingSetAttributesFileManager.errorCode)
+    }
+
     // MARK: - Caller-contract regression (Issue 4)
 
     /// Models the launch-time factory: if migration says `.skip`, do not call
@@ -353,6 +394,7 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
 
 private final class SpyContainerMigrationPixelFiring: DuckAiNativeStorageContainerMigrationPixelFiring {
     private(set) var firedEventNames: [String] = []
+    private(set) var lastProtectionFailedError: Error?
 
     func fire(_ event: DuckAiNativeStorageContainerMigrationEvent) {
         switch event {
@@ -361,6 +403,9 @@ private final class SpyContainerMigrationPixelFiring: DuckAiNativeStorageContain
         case .success: firedEventNames.append("success")
         case .attemptFailed: firedEventNames.append("attemptFailed")
         case .gaveUp: firedEventNames.append("gaveUp")
+        case .protectionFailed(_, let error):
+            firedEventNames.append("protectionFailed")
+            lastProtectionFailedError = error
         }
     }
 }
@@ -374,5 +419,16 @@ private final class FailingMoveFileManager: FileManager {
 private final class FailingRemoveFileManager: FileManager {
     override func removeItem(at URL: URL) throws {
         throw NSError(domain: "DuckAiNativeStorageContainerMigrationTests", code: -2)
+    }
+}
+
+/// Lets `moveItem` and directory creation succeed but rejects `setAttributes`
+/// so `applyDefaultFileProtection` records a failure on every path.
+private final class FailingSetAttributesFileManager: FileManager {
+    static let errorDomain = "DuckAiNativeStorageContainerMigrationTests.setAttributes"
+    static let errorCode = -3
+
+    override func setAttributes(_ attributes: [FileAttributeKey: Any], ofItemAtPath path: String) throws {
+        throw NSError(domain: Self.errorDomain, code: Self.errorCode)
     }
 }

--- a/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
@@ -505,19 +505,6 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         XCTAssertEqual((error as NSError?)?.code, FailingSetAttributesOnChildFileManager.errorCode)
     }
 
-    func testWhenApplyDefaultFileProtectionEnumeratorErrorHandlerFiresThenReturnsThatError() throws {
-        let url = sandbox.appendingPathComponent("DuckAi")
-        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
-        try Data("chats".utf8).write(to: url.appendingPathComponent("chats.db"))
-
-        let fileManager = FailingEnumeratorChildFileManager()
-        let error = DuckAiNativeStorageContainerMigration.applyDefaultFileProtection(at: url, fileManager: fileManager)
-
-        XCTAssertEqual((error as NSError?)?.domain, FailingEnumeratorChildFileManager.errorDomain,
-                       "errorHandler invocation must surface as the returned error")
-        XCTAssertEqual((error as NSError?)?.code, FailingEnumeratorChildFileManager.errorCode)
-    }
-
     func testWhenApplyDefaultFileProtectionEnumeratorReturnsNilThenReturnsError() throws {
         let url = sandbox.appendingPathComponent("nonexistent-directory")
         // No directory created; default FileManager.enumerator(at:) returns nil
@@ -864,29 +851,6 @@ private final class FailingSetAttributesFileManager: FileManager {
 
     override func setAttributes(_ attributes: [FileAttributeKey: Any], ofItemAtPath path: String) throws {
         throw NSError(domain: Self.errorDomain, code: Self.errorCode)
-    }
-}
-
-/// Synthesizes one `errorHandler` invocation on `enumerator(at:)` before
-/// returning the real enumerator — exercises the closure at the call site of
-/// `applyDefaultFileProtection`, distinct from the per-child setAttributes
-/// failure path. `setAttributes` is not overridden so root and any real
-/// children succeed normally.
-private final class FailingEnumeratorChildFileManager: FileManager {
-    static let errorDomain = "DuckAiNativeStorageContainerMigrationTests.enumeratorChild"
-    static let errorCode = -6
-
-    override func enumerator(at url: URL,
-                             includingPropertiesForKeys keys: [URLResourceKey]?,
-                             options mask: FileManager.DirectoryEnumerationOptions = [],
-                             errorHandler handler: ((URL, Error) -> Bool)? = nil) -> FileManager.DirectoryEnumerator? {
-        let inaccessibleChild = url.appendingPathComponent("inaccessible-child")
-        let syntheticError = NSError(domain: Self.errorDomain, code: Self.errorCode)
-        _ = handler?(inaccessibleChild, syntheticError)
-        return super.enumerator(at: url,
-                                includingPropertiesForKeys: keys,
-                                options: mask,
-                                errorHandler: handler)
     }
 }
 

--- a/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
@@ -320,6 +320,33 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         XCTAssertTrue(pixelSpy.firedEventNames.isEmpty)
     }
 
+    /// Fire-mode stores DBs in `<UUID>/chats.db` subdirectories rather than at
+    /// the destination root, so a regression in `destinationHasData` that only
+    /// looked for `chats.db` at the root would silently mis-classify a populated
+    /// fire-mode container as empty scaffolding and `removeItem` it before the
+    /// next move attempt.
+    func testWhenFireModeDestinationHasUUIDSubdirectoryThenDestinationConflictFires() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi-fireMode")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi-fireMode")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("complete".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+        // Stage fire-mode shape at the destination: <UUID>/chats.db, no
+        // chats.db at the root.
+        let uuidSubdir = newURL.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: uuidSubdir, withIntermediateDirectories: true)
+        try Data("foreign".utf8).write(to: uuidSubdir.appendingPathComponent("chats.db"))
+
+        migrate(from: oldURL, to: newURL, label: .fireMode)
+
+        XCTAssertEqual(pixelSpy.firedEventNames, ["destinationConflict"],
+                       "destinationHasData must detect <UUID>/chats.db, not only chats.db at the root")
+        XCTAssertTrue(keyValueStore.bool(forKey: migratedKey))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path),
+                      "oldURL must survive — the foreign fire-mode destination may not be a complete copy")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: uuidSubdir.appendingPathComponent("chats.db").path),
+                      "foreign fire-mode contents must not be wiped")
+    }
+
     func testWhenForeignDataIsPresentAtDestinationWithoutMigratedFlagThenDestinationConflictFires() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
@@ -427,6 +454,19 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
 
         XCTAssertEqual((error as NSError?)?.domain, FailingSetAttributesFileManager.errorDomain)
         XCTAssertEqual((error as NSError?)?.code, FailingSetAttributesFileManager.errorCode)
+    }
+
+    func testWhenApplyDefaultFileProtectionRootSucceedsButChildFailsThenReturnsChildError() throws {
+        let url = sandbox.appendingPathComponent("DuckAi")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        try Data("chats".utf8).write(to: url.appendingPathComponent("chats.db"))
+
+        let fileManager = FailingSetAttributesOnChildFileManager(rootPath: url.path)
+        let error = DuckAiNativeStorageContainerMigration.applyDefaultFileProtection(at: url, fileManager: fileManager)
+
+        XCTAssertEqual((error as NSError?)?.domain, FailingSetAttributesOnChildFileManager.errorDomain,
+                       "child-only failure must surface as a non-nil error")
+        XCTAssertEqual((error as NSError?)?.code, FailingSetAttributesOnChildFileManager.errorCode)
     }
 
     func testWhenApplyDefaultFileProtectionEnumeratorReturnsNilThenReturnsError() throws {
@@ -551,6 +591,51 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "success"])
     }
 
+    func testGivenThreeFailedMoveLaunchesWhenFourthLaunchSucceedsThenNoDestinationConflict() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("user-chats".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+
+        for _ in 0..<3 {
+            let launch = runFactory(
+                oldURL: oldURL,
+                newURL: newURL,
+                fileManager: FailingMoveFileManager(),
+                createHandler: {
+                    XCTFail("createHandler must never run when the migration short-circuits on .skip")
+                }
+            )
+            XCTAssertNil(launch, "factory must short-circuit on .skip for every failing launch")
+            XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path),
+                           "destination must stay absent across all failing launches — its presence is the orphan precondition")
+        }
+        XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "attemptFailed", "gaveUp"])
+        XCTAssertEqual(keyValueStore.integer(forKey: attemptsKey), 3)
+        XCTAssertFalse(keyValueStore.bool(forKey: migratedKey))
+
+        var recoveryHandlerCreated = false
+        let recovery = runFactory(
+            oldURL: oldURL,
+            newURL: newURL,
+            fileManager: .default,
+            createHandler: {
+                recoveryHandlerCreated = true
+                DuckAiNativeStorageContainerMigration.excludeFromBackup(newURL,
+                                                                        label: .default,
+                                                                        pixelFiring: self.pixelSpy)
+            }
+        )
+
+        XCTAssertNotNil(recovery)
+        XCTAssertTrue(recoveryHandlerCreated)
+        XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "attemptFailed", "gaveUp", "success"],
+                       "recovery must take the normal success path — destinationConflict would prove the orphan bug regressed")
+        XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("user-chats".utf8))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: oldURL.path),
+                       "successful recovery moves oldURL, so it is consumed normally")
+    }
+
     func testGivenProtectedDataUnavailableWhenFactoryRunsThenDestinationStaysAbsent() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
@@ -581,6 +666,7 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
     @discardableResult
     private func migrate(from oldURL: URL,
                          to newURL: URL,
+                         label: DuckAiNativeStorageContainerMigrationLabel? = nil,
                          fileManager: FileManager = .default,
                          isProtectedDataAvailable: @escaping () -> Bool = { true },
                          maxAttempts: Int = DuckAiNativeStorageContainerMigration.defaultMaxAttempts) -> DuckAiNativeStorageContainerMigrationOutcome {
@@ -588,7 +674,7 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
             oldURL: oldURL,
             newURL: newURL,
             migrationKey: migrationKey,
-            label: label,
+            label: label ?? self.label,
             keyValueStore: keyValueStore,
             fileManager: fileManager,
             pixelFiring: pixelSpy,
@@ -662,6 +748,25 @@ private final class FailingSetAttributesFileManager: FileManager {
     static let errorCode = -3
 
     override func setAttributes(_ attributes: [FileAttributeKey: Any], ofItemAtPath path: String) throws {
+        throw NSError(domain: Self.errorDomain, code: Self.errorCode)
+    }
+}
+
+/// Succeeds on `setAttributes` for the root path and rejects it for every
+/// descendant — exercises the child-only branch of `applyDefaultFileProtection`.
+private final class FailingSetAttributesOnChildFileManager: FileManager {
+    static let errorDomain = "DuckAiNativeStorageContainerMigrationTests.setAttributesOnChild"
+    static let errorCode = -5
+
+    private let rootPath: String
+
+    init(rootPath: String) {
+        self.rootPath = rootPath
+        super.init()
+    }
+
+    override func setAttributes(_ attributes: [FileAttributeKey: Any], ofItemAtPath path: String) throws {
+        if path == rootPath { return }
         throw NSError(domain: Self.errorDomain, code: Self.errorCode)
     }
 }

--- a/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
@@ -130,29 +130,33 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
 
     // MARK: - Retry behavior
 
-    func testWhenMoveFailsThenAttemptIsRecordedAndDoneFlagNotSet() throws {
+    func testWhenMoveFailsThenAttemptIsRecordedAndDoneFlagNotSetAndOutcomeIsSkip() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
         try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
         let failingFM = FailingMoveFileManager()
 
-        migrate(from: oldURL, to: newURL, fileManager: failingFM, maxAttempts: 3)
+        let outcome = migrate(from: oldURL, to: newURL, fileManager: failingFM, maxAttempts: 3)
 
+        XCTAssertEqual(outcome, .skip)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path))
         XCTAssertFalse(userDefaults.bool(forKey: doneKey))
         XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 1)
         XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed"])
     }
 
-    func testWhenMoveFailsRepeatedlyThenGivesUpAtMaxAttempts() throws {
+    func testWhenMoveFailsRepeatedlyThenGivesUpAtMaxAttemptsAndOutcomeIsProceed() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
         try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
         let failingFM = FailingMoveFileManager()
 
+        var outcomes: [DuckAiNativeStorageContainerMigrationOutcome] = []
         for _ in 0..<3 {
-            migrate(from: oldURL, to: newURL, fileManager: failingFM, maxAttempts: 3)
+            outcomes.append(migrate(from: oldURL, to: newURL, fileManager: failingFM, maxAttempts: 3))
         }
 
+        XCTAssertEqual(outcomes, [.skip, .skip, .proceed])
         XCTAssertTrue(userDefaults.bool(forKey: doneKey))
         XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 3)
         XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "attemptFailed", "gaveUp"])
@@ -164,12 +168,14 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
         try Data("data".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
 
-        migrate(from: oldURL, to: newURL, fileManager: FailingMoveFileManager(), maxAttempts: 3)
+        let firstOutcome = migrate(from: oldURL, to: newURL, fileManager: FailingMoveFileManager(), maxAttempts: 3)
+        XCTAssertEqual(firstOutcome, .skip)
         XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 1)
         XCTAssertFalse(userDefaults.bool(forKey: doneKey))
 
-        migrate(from: oldURL, to: newURL, maxAttempts: 3)
+        let secondOutcome = migrate(from: oldURL, to: newURL, maxAttempts: 3)
 
+        XCTAssertEqual(secondOutcome, .proceed)
         XCTAssertTrue(userDefaults.bool(forKey: doneKey))
         XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 0)
         XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "success"])
@@ -186,19 +192,134 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         XCTAssertTrue(userDefaults.bool(forKey: doneKey))
 
         // Even with a non-failing FM and old data still present, we don't retry.
-        migrate(from: oldURL, to: newURL, maxAttempts: 3)
+        let outcome = migrate(from: oldURL, to: newURL, maxAttempts: 3)
 
+        XCTAssertEqual(outcome, .proceed)
         XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path))
         XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "attemptFailed", "gaveUp"])
     }
 
+    // MARK: - Orphan removal retry behavior
+
+    func testWhenOrphanRemovalFailsThenDoneFlagNotSetAndAttemptFailedFires() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: newURL, withIntermediateDirectories: true)
+        try Data("old".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+        try Data("keep-me".utf8).write(to: newURL.appendingPathComponent("chats.db"))
+
+        let outcome = migrate(from: oldURL, to: newURL, fileManager: FailingRemoveFileManager(), maxAttempts: 3)
+
+        // newURL is still usable so we proceed, but old data remains and we'll retry.
+        XCTAssertEqual(outcome, .proceed)
+        XCTAssertFalse(userDefaults.bool(forKey: doneKey))
+        XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 1)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.path))
+        XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed"])
+    }
+
+    func testWhenOrphanRemovalFailsRepeatedlyThenGivesUpAtMaxAttempts() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: newURL, withIntermediateDirectories: true)
+
+        for _ in 0..<3 {
+            migrate(from: oldURL, to: newURL, fileManager: FailingRemoveFileManager(), maxAttempts: 3)
+        }
+
+        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
+        XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 3)
+        XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "attemptFailed", "gaveUp"])
+        // The gaveUp event indicates abandoned data — orphanRemoved should NOT have fired.
+        XCTAssertFalse(pixelSpy.firedEventNames.contains("orphanRemoved"))
+    }
+
+    func testWhenOrphanRemovalFailsThenSucceedsThenAttemptsAreClearedAndOrphanRemovedFires() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: newURL, withIntermediateDirectories: true)
+
+        migrate(from: oldURL, to: newURL, fileManager: FailingRemoveFileManager(), maxAttempts: 3)
+        XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 1)
+        XCTAssertFalse(userDefaults.bool(forKey: doneKey))
+
+        let outcome = migrate(from: oldURL, to: newURL, maxAttempts: 3)
+
+        XCTAssertEqual(outcome, .proceed)
+        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
+        XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 0)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: oldURL.path))
+        XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "orphanRemoved"])
+    }
+
+    // MARK: - Caller-contract regression (Issue 4)
+
+    /// Models the launch-time factory: if migration says `.skip`, do not call
+    /// `excludeFromBackup` and do not construct a handler at `newURL`.
+    func testGivenFailedMoveWhenFactoryRunsThenDestinationStaysAbsentAndHandlerIsNotCreated() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("user-chats".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+
+        var handlerCreated = false
+        let result = runFactory(
+            oldURL: oldURL,
+            newURL: newURL,
+            fileManager: FailingMoveFileManager(),
+            createHandler: {
+                handlerCreated = true
+                DuckAiNativeStorageContainerMigration.excludeFromBackup(newURL)
+            }
+        )
+
+        XCTAssertNil(result, "factory must short-circuit when migration returns .skip")
+        XCTAssertFalse(handlerCreated, "handler creation must be skipped after a failed move")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path), "destination must remain absent so next-launch retry can move the data")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path), "user data must remain at the old location")
+        XCTAssertFalse(userDefaults.bool(forKey: doneKey))
+        XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed"])
+    }
+
+    func testGivenFailedMoveOnFirstLaunchWhenSecondLaunchSucceedsThenHandlerIsCreatedWithMigratedData() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("user-chats".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+
+        let firstLaunch = runFactory(oldURL: oldURL, newURL: newURL, fileManager: FailingMoveFileManager(), createHandler: {})
+        XCTAssertNil(firstLaunch)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path))
+
+        var secondLaunchHandlerCreated = false
+        let secondLaunch = runFactory(
+            oldURL: oldURL,
+            newURL: newURL,
+            fileManager: .default,
+            createHandler: {
+                secondLaunchHandlerCreated = true
+                DuckAiNativeStorageContainerMigration.excludeFromBackup(newURL)
+            }
+        )
+
+        XCTAssertNotNil(secondLaunch)
+        XCTAssertTrue(secondLaunchHandlerCreated)
+        XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("user-chats".utf8))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: oldURL.path))
+        XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "success"])
+    }
+
     // MARK: - Helpers
 
+    @discardableResult
     private func migrate(from oldURL: URL,
                          to newURL: URL,
                          fileManager: FileManager = .default,
-                         maxAttempts: Int = DuckAiNativeStorageContainerMigration.defaultMaxAttempts) {
+                         maxAttempts: Int = DuckAiNativeStorageContainerMigration.defaultMaxAttempts) -> DuckAiNativeStorageContainerMigrationOutcome {
         DuckAiNativeStorageContainerMigration.migrateIfNeeded(
             from: oldURL,
             to: newURL,
@@ -209,6 +330,22 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
             pixelFiring: pixelSpy,
             maxAttempts: maxAttempts
         )
+    }
+
+    /// Mirrors the caller pattern in `Launching.makeNativeStorageHandler` and
+    /// `FireModeNativeStorageController.init`: bail out on `.skip`, otherwise
+    /// create the destination and open a handler. Returns a non-nil sentinel
+    /// when a handler would have been created.
+    private func runFactory(oldURL: URL,
+                            newURL: URL,
+                            fileManager: FileManager,
+                            createHandler: () -> Void) -> AnyObject? {
+        let outcome = migrate(from: oldURL, to: newURL, fileManager: fileManager)
+        if outcome == .skip {
+            return nil
+        }
+        createHandler()
+        return NSObject()
     }
 }
 
@@ -231,5 +368,11 @@ private final class SpyContainerMigrationPixelFiring: DuckAiNativeStorageContain
 private final class FailingMoveFileManager: FileManager {
     override func moveItem(at srcURL: URL, to dstURL: URL) throws {
         throw NSError(domain: "DuckAiNativeStorageContainerMigrationTests", code: -1)
+    }
+}
+
+private final class FailingRemoveFileManager: FileManager {
+    override func removeItem(at URL: URL) throws {
+        throw NSError(domain: "DuckAiNativeStorageContainerMigrationTests", code: -2)
     }
 }

--- a/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
@@ -31,6 +31,8 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
 
     private var doneKey: String { migrationKey + ".done" }
     private var attemptsKey: String { migrationKey + ".attempts" }
+    private var protectionAppliedKey: String { migrationKey + ".protectionApplied" }
+    private var protectionAttemptsKey: String { migrationKey + ".protectionAttempts" }
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -304,6 +306,58 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         XCTAssertEqual(pixelSpy.firedEventNames, ["success", "protectionFailed"])
         XCTAssertEqual((pixelSpy.lastProtectionFailedError as NSError?)?.domain, FailingSetAttributesFileManager.errorDomain)
         XCTAssertEqual((pixelSpy.lastProtectionFailedError as NSError?)?.code, FailingSetAttributesFileManager.errorCode)
+        // Protection state must remain pending so the next launch retries it.
+        XCTAssertFalse(userDefaults.bool(forKey: protectionAppliedKey))
+        XCTAssertEqual(userDefaults.integer(forKey: protectionAttemptsKey), 1)
+    }
+
+    func testWhenProtectionFailsThenRetriedOnSubsequentLaunchAndSucceedsThenProtectionAppliedIsSet() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("chats".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+
+        // First launch: move succeeds, protection silently fails.
+        migrate(from: oldURL, to: newURL, fileManager: FailingSetAttributesFileManager(), maxAttempts: 3)
+        XCTAssertFalse(userDefaults.bool(forKey: protectionAppliedKey))
+
+        // Second launch (transient failure resolved): protection should retry and succeed.
+        migrate(from: oldURL, to: newURL, maxAttempts: 3)
+
+        XCTAssertTrue(userDefaults.bool(forKey: protectionAppliedKey))
+        XCTAssertEqual(userDefaults.integer(forKey: protectionAttemptsKey), 0)
+        XCTAssertEqual(pixelSpy.firedEventNames, ["success", "protectionFailed"])
+    }
+
+    func testWhenProtectionFailsRepeatedlyThenGivesUpAtMaxAttemptsAndStopsFiringPixel() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("chats".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+
+        // Three failing launches: pixel fires each time, last one caps and marks applied.
+        for _ in 0..<3 {
+            migrate(from: oldURL, to: newURL, fileManager: FailingSetAttributesFileManager(), maxAttempts: 3)
+        }
+        XCTAssertTrue(userDefaults.bool(forKey: protectionAppliedKey))
+        XCTAssertEqual(userDefaults.integer(forKey: protectionAttemptsKey), 3)
+        XCTAssertEqual(pixelSpy.firedEventNames, ["success", "protectionFailed", "protectionFailed", "protectionFailed"])
+
+        // Fourth launch must NOT fire another pixel even though the file system
+        // would still reject setAttributes — we've given up on this regression.
+        migrate(from: oldURL, to: newURL, fileManager: FailingSetAttributesFileManager(), maxAttempts: 3)
+        XCTAssertEqual(pixelSpy.firedEventNames, ["success", "protectionFailed", "protectionFailed", "protectionFailed"])
+    }
+
+    func testWhenMigrationIsNotNeededThenProtectionAppliedIsSetWithoutEnumeratingFiles() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+
+        migrate(from: oldURL, to: newURL)
+
+        // No data to protect → mark applied so we don't retry unnecessarily.
+        XCTAssertTrue(userDefaults.bool(forKey: protectionAppliedKey))
+        XCTAssertEqual(pixelSpy.firedEventNames, ["notNeeded"])
     }
 
     func testWhenApplyDefaultFileProtectionSucceedsForAllPathsThenReturnsNil() throws {

--- a/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
@@ -469,6 +469,19 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         XCTAssertEqual((error as NSError?)?.code, FailingSetAttributesOnChildFileManager.errorCode)
     }
 
+    func testWhenApplyDefaultFileProtectionEnumeratorErrorHandlerFiresThenReturnsThatError() throws {
+        let url = sandbox.appendingPathComponent("DuckAi")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        try Data("chats".utf8).write(to: url.appendingPathComponent("chats.db"))
+
+        let fileManager = FailingEnumeratorChildFileManager()
+        let error = DuckAiNativeStorageContainerMigration.applyDefaultFileProtection(at: url, fileManager: fileManager)
+
+        XCTAssertEqual((error as NSError?)?.domain, FailingEnumeratorChildFileManager.errorDomain,
+                       "errorHandler invocation must surface as the returned error")
+        XCTAssertEqual((error as NSError?)?.code, FailingEnumeratorChildFileManager.errorCode)
+    }
+
     func testWhenApplyDefaultFileProtectionEnumeratorReturnsNilThenReturnsError() throws {
         let url = sandbox.appendingPathComponent("nonexistent-directory")
         // No directory created; default FileManager.enumerator(at:) returns nil
@@ -749,6 +762,29 @@ private final class FailingSetAttributesFileManager: FileManager {
 
     override func setAttributes(_ attributes: [FileAttributeKey: Any], ofItemAtPath path: String) throws {
         throw NSError(domain: Self.errorDomain, code: Self.errorCode)
+    }
+}
+
+/// Synthesizes one `errorHandler` invocation on `enumerator(at:)` before
+/// returning the real enumerator — exercises the closure at the call site of
+/// `applyDefaultFileProtection`, distinct from the per-child setAttributes
+/// failure path. `setAttributes` is not overridden so root and any real
+/// children succeed normally.
+private final class FailingEnumeratorChildFileManager: FileManager {
+    static let errorDomain = "DuckAiNativeStorageContainerMigrationTests.enumeratorChild"
+    static let errorCode = -6
+
+    override func enumerator(at url: URL,
+                             includingPropertiesForKeys keys: [URLResourceKey]?,
+                             options mask: FileManager.DirectoryEnumerationOptions = [],
+                             errorHandler handler: ((URL, Error) -> Bool)? = nil) -> FileManager.DirectoryEnumerator? {
+        let inaccessibleChild = url.appendingPathComponent("inaccessible-child")
+        let syntheticError = NSError(domain: Self.errorDomain, code: Self.errorCode)
+        _ = handler?(inaccessibleChild, syntheticError)
+        return super.enumerator(at: url,
+                                includingPropertiesForKeys: keys,
+                                options: mask,
+                                errorHandler: handler)
     }
 }
 

--- a/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
@@ -1,0 +1,146 @@
+//
+//  DuckAiNativeStorageContainerMigrationTests.swift
+//  DuckDuckGoTests
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo
+
+final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
+
+    private var sandbox: URL!
+    private var userDefaults: UserDefaults!
+    private let migrationKey = "test.migrationDone"
+    private let suiteName = "DuckAiNativeStorageContainerMigrationTests"
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sandbox = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DuckAiNativeStorageContainerMigrationTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: sandbox, withIntermediateDirectories: true)
+        UserDefaults().removePersistentDomain(forName: suiteName)
+        userDefaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: sandbox)
+        userDefaults.removePersistentDomain(forName: suiteName)
+        userDefaults = nil
+        sandbox = nil
+        try super.tearDownWithError()
+    }
+
+    func testWhenOldDirectoryDoesNotExistThenFlagIsSetAndNothingMoves() {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+
+        DuckAiNativeStorageContainerMigration.migrateIfNeeded(
+            from: oldURL,
+            to: newURL,
+            migrationDoneKey: migrationKey,
+            userDefaults: userDefaults
+        )
+
+        XCTAssertTrue(userDefaults.bool(forKey: migrationKey))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path))
+    }
+
+    func testWhenOldDirectoryExistsAndNewDoesNotThenContentsAreMovedAndFlagIsSet() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("chats".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+        try Data("files".utf8).write(to: oldURL.appendingPathComponent("files.bin"))
+
+        DuckAiNativeStorageContainerMigration.migrateIfNeeded(
+            from: oldURL,
+            to: newURL,
+            migrationDoneKey: migrationKey,
+            userDefaults: userDefaults
+        )
+
+        XCTAssertTrue(userDefaults.bool(forKey: migrationKey))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: oldURL.path))
+        XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("chats".utf8))
+        XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("files.bin")), Data("files".utf8))
+    }
+
+    func testWhenBothOldAndNewExistThenOldIsRemovedAndNewIsPreserved() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: newURL, withIntermediateDirectories: true)
+        try Data("old".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+        try Data("keep-me".utf8).write(to: newURL.appendingPathComponent("chats.db"))
+
+        DuckAiNativeStorageContainerMigration.migrateIfNeeded(
+            from: oldURL,
+            to: newURL,
+            migrationDoneKey: migrationKey,
+            userDefaults: userDefaults
+        )
+
+        XCTAssertTrue(userDefaults.bool(forKey: migrationKey))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: oldURL.path))
+        XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("keep-me".utf8))
+    }
+
+    func testWhenFlagAlreadySetThenNoMigrationHappensEvenIfOldExists() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("untouched".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+        userDefaults.set(true, forKey: migrationKey)
+
+        DuckAiNativeStorageContainerMigration.migrateIfNeeded(
+            from: oldURL,
+            to: newURL,
+            migrationDoneKey: migrationKey,
+            userDefaults: userDefaults
+        )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path))
+    }
+
+    func testWhenMigrationRunsTwiceThenSecondCallIsNoOp() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("first".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+
+        DuckAiNativeStorageContainerMigration.migrateIfNeeded(
+            from: oldURL,
+            to: newURL,
+            migrationDoneKey: migrationKey,
+            userDefaults: userDefaults
+        )
+
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("reappeared".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+
+        DuckAiNativeStorageContainerMigration.migrateIfNeeded(
+            from: oldURL,
+            to: newURL,
+            migrationDoneKey: migrationKey,
+            userDefaults: userDefaults
+        )
+
+        XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("first".utf8))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path))
+    }
+}

--- a/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
@@ -273,7 +273,8 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
             label: label,
             keyValueStore: failingStore,
             pixelFiring: pixelSpy,
-            isProtectedDataAvailable: { true }
+            isProtectedDataAvailable: { true },
+            protectionDispatcher: { $0() }
         ).run()
 
         XCTAssertEqual(outcome, .skip)
@@ -528,6 +529,45 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         XCTAssertNotNil(error, "nil enumerator must not be treated as success")
     }
 
+    // MARK: - Protection dispatch
+
+    /// Pins the contract that `ensureProtection`'s recursive setAttributes
+    /// walk is deferred off the launch thread. The synchronous return path
+    /// must complete before the protection work runs — otherwise a large
+    /// `files/` tree could push past the iOS launch watchdog.
+    func testWhenMoveSucceedsThenProtectionWorkIsDispatched() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("chats".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+
+        var capturedWork: (() -> Void)?
+        let outcome = DuckAiNativeStorageContainerMigration(
+            oldURL: oldURL,
+            newURL: newURL,
+            migrationKey: migrationKey,
+            label: label,
+            keyValueStore: keyValueStore,
+            pixelFiring: pixelSpy,
+            isProtectedDataAvailable: { true },
+            protectionDispatcher: { capturedWork = $0 }
+        ).run()
+
+        XCTAssertEqual(outcome, .proceed)
+        XCTAssertEqual(pixelSpy.firedEventNames, ["success"],
+                       "success fires synchronously; protection pixel only fires after the dispatched work runs")
+        XCTAssertNotNil(capturedWork,
+                        "protection work must be dispatched, not executed inline on the launch thread")
+        XCTAssertEqual(keyValueStore.integer(forKey: protectionAttemptsKey), 0,
+                       "protection counter must not be touched until the dispatched work runs")
+
+        capturedWork?()
+
+        XCTAssertEqual(keyValueStore.integer(forKey: protectionAttemptsKey),
+                       DuckAiNativeStorageContainerMigration.defaultMaxAttempts,
+                       "after the dispatched work completes, the counter is set to the done sentinel")
+    }
+
     // MARK: - excludeFromBackup pixel
 
     func testWhenExcludeFromBackupSucceedsThenNoPixelFires() {
@@ -717,7 +757,8 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
                          label: DuckAiNativeStorageContainerMigrationLabel? = nil,
                          fileManager: FileManager = .default,
                          isProtectedDataAvailable: @escaping () -> Bool = { true },
-                         maxAttempts: Int = DuckAiNativeStorageContainerMigration.defaultMaxAttempts) -> DuckAiNativeStorageContainerMigrationOutcome {
+                         maxAttempts: Int = DuckAiNativeStorageContainerMigration.defaultMaxAttempts,
+                         protectionDispatcher: @escaping DuckAiNativeStorageContainerMigration.ProtectionDispatcher = { $0() }) -> DuckAiNativeStorageContainerMigrationOutcome {
         DuckAiNativeStorageContainerMigration(
             oldURL: oldURL,
             newURL: newURL,
@@ -727,7 +768,8 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
             fileManager: fileManager,
             pixelFiring: pixelSpy,
             isProtectedDataAvailable: isProtectedDataAvailable,
-            maxAttempts: maxAttempts
+            maxAttempts: maxAttempts,
+            protectionDispatcher: protectionDispatcher
         ).run()
     }
 

--- a/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
@@ -661,7 +661,6 @@ private final class SpyContainerMigrationPixelFiring: DuckAiNativeStorageContain
     func fire(_ event: DuckAiNativeStorageContainerMigrationEvent) {
         switch event {
         case .notNeeded: firedEventNames.append("notNeeded")
-        case .orphanRemoved: firedEventNames.append("orphanRemoved")
         case .success: firedEventNames.append("success")
         case .attemptFailed: firedEventNames.append("attemptFailed")
         case .gaveUp: firedEventNames.append("gaveUp")

--- a/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
@@ -191,12 +191,42 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         }
         XCTAssertTrue(userDefaults.bool(forKey: doneKey))
 
-        // Even with a non-failing FM and old data still present, we don't retry.
+        // Sanity: the doneKey gates further calls regardless of file state.
         let outcome = migrate(from: oldURL, to: newURL, maxAttempts: 3)
 
         XCTAssertEqual(outcome, .proceed)
-        XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path))
+        XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "attemptFailed", "gaveUp"])
+    }
+
+    func testWhenGivingUpOnMoveFailureThenBestEffortSweepRemovesOldData() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("sensitive".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+
+        for _ in 0..<3 {
+            migrate(from: oldURL, to: newURL, fileManager: FailingMoveFileManager(), maxAttempts: 3)
+        }
+
+        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
+        XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "attemptFailed", "gaveUp"])
+        // The sweep should have removed the abandoned old container so sensitive
+        // content doesn't linger in the app group under NSFileProtectionComplete.
+        XCTAssertFalse(FileManager.default.fileExists(atPath: oldURL.path))
+    }
+
+    func testWhenGivingUpAndSweepAlsoFailsThenStillMarksDoneAndFiresGaveUp() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+
+        for _ in 0..<3 {
+            migrate(from: oldURL, to: newURL, fileManager: FailingMoveAndRemoveFileManager(), maxAttempts: 3)
+        }
+
+        // Sweep failure must not undo the gave-up state — otherwise we'd retry forever.
+        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
         XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "attemptFailed", "gaveUp"])
     }
 
@@ -417,6 +447,15 @@ private final class FailingMoveFileManager: FileManager {
 }
 
 private final class FailingRemoveFileManager: FileManager {
+    override func removeItem(at URL: URL) throws {
+        throw NSError(domain: "DuckAiNativeStorageContainerMigrationTests", code: -2)
+    }
+}
+
+private final class FailingMoveAndRemoveFileManager: FileManager {
+    override func moveItem(at srcURL: URL, to dstURL: URL) throws {
+        throw NSError(domain: "DuckAiNativeStorageContainerMigrationTests", code: -1)
+    }
     override func removeItem(at URL: URL) throws {
         throw NSError(domain: "DuckAiNativeStorageContainerMigrationTests", code: -2)
     }

--- a/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
@@ -177,7 +177,7 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
             outcomes.append(migrate(from: oldURL, to: newURL, fileManager: FailingMoveFileManager(), maxAttempts: 3))
         }
 
-        XCTAssertEqual(outcomes, [.skip, .skip, .proceed])
+        XCTAssertEqual(outcomes, [.skip, .skip, .skip])
         XCTAssertEqual(keyValueStore.integer(forKey: attemptsKey), 3,
                        "attempts must stay at the cap so the next launch detects the exhausted budget")
         XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "attemptFailed", "gaveUp"])
@@ -187,6 +187,12 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
                       "give-up sweep must not delete source data")
         XCTAssertFalse(keyValueStore.bool(forKey: migratedKey),
                        "migrated flag must NOT be set on give-up so retries can resume when conditions improve")
+        // Returning .skip on give-up is what keeps the caller from creating an
+        // empty destination DB — without that, the next launch's
+        // destinationConflict path would claim the empty destination and
+        // permanently orphan the user's pre-upgrade data at oldURL.
+        XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path),
+                       "give-up must leave destination untouched so the caller short-circuits")
     }
 
     func testWhenGaveUpAndNextLaunchSucceedsThenMigrationCompletes() throws {
@@ -314,27 +320,28 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         XCTAssertTrue(pixelSpy.firedEventNames.isEmpty)
     }
 
-    func testWhenGaveUpLeftPartialDestinationAndNextLaunchRunsThenDestinationConflictFires() throws {
+    func testWhenForeignDataIsPresentAtDestinationWithoutMigratedFlagThenDestinationConflictFires() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
         try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
         try Data("complete".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
-        // Simulate the post-gaveUp + partial-copy state without setting migrated:
-        // newURL has a partial chats.db, oldURL still has the complete copy,
-        // attempts left at the cap when migration gave up.
+        // The migration's own give-up path returns .skip and never leaves
+        // anything at newURL, so this state is only reachable when some external
+        // source (sibling process, OS-level sync, manual data drop) populates
+        // the destination before our migration runs. Stage that here: foreign
+        // chats.db at newURL, complete copy still at oldURL.
         try FileManager.default.createDirectory(at: newURL, withIntermediateDirectories: true)
-        try Data("partial".utf8).write(to: newURL.appendingPathComponent("chats.db"))
-        try? keyValueStore.set(3, forKey: attemptsKey)
+        try Data("foreign".utf8).write(to: newURL.appendingPathComponent("chats.db"))
 
         migrate(from: oldURL, to: newURL)
 
-        // Exhausted-budget reset clears attempts. The standard flow then takes
-        // the destinationConflict path, sets the migrated flag, and preserves
-        // both sides so the complete oldURL data remains recoverable.
+        // The standard flow takes the destinationConflict path, claims newURL
+        // going forward, and preserves oldURL so the user's pre-upgrade data
+        // remains on disk.
         XCTAssertEqual(pixelSpy.firedEventNames, ["destinationConflict"])
         XCTAssertTrue(keyValueStore.bool(forKey: migratedKey))
         XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path),
-                      "post-gaveUp source must survive — newURL might be a partial copy")
+                      "oldURL must survive — the foreign destination may not be a complete copy")
         XCTAssertEqual(try Data(contentsOf: oldURL.appendingPathComponent("chats.db")), Data("complete".utf8))
     }
 
@@ -465,7 +472,7 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
 
         let outcome = migrate(from: oldURL, to: newURL, fileManager: FailingMoveFileManager(), maxAttempts: 0)
 
-        XCTAssertEqual(outcome, .proceed, "maxAttempts clamped to 1 triggers gaveUp on the first failure")
+        XCTAssertEqual(outcome, .skip, "maxAttempts clamped to 1 triggers gaveUp on the first failure")
         XCTAssertEqual(keyValueStore.integer(forKey: attemptsKey), 1,
                        "attempts must be left at the clamped cap so the next launch resets the budget")
         XCTAssertEqual(pixelSpy.firedEventNames, ["gaveUp"])
@@ -481,7 +488,7 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
 
         let outcome = migrate(from: oldURL, to: newURL, fileManager: FailingMoveFileManager(), maxAttempts: -5)
 
-        XCTAssertEqual(outcome, .proceed)
+        XCTAssertEqual(outcome, .skip)
         XCTAssertEqual(pixelSpy.firedEventNames, ["gaveUp"])
     }
 

--- a/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
@@ -597,7 +597,7 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
     private func runFactory(oldURL: URL,
                             newURL: URL,
                             fileManager: FileManager,
-                            isProtectedDataAvailable: () -> Bool = { true },
+                            isProtectedDataAvailable: @escaping () -> Bool = { true },
                             createHandler: () -> Void) -> AnyObject? {
         let outcome = migrate(from: oldURL,
                               to: newURL,

--- a/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
@@ -34,6 +34,11 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
     private var protectionAppliedKey: String { migrationKey + ".protectionApplied" }
     private var protectionAttemptsKey: String { migrationKey + ".protectionAttempts" }
 
+    private func markerURL(forNew newURL: URL) -> URL {
+        newURL.deletingLastPathComponent()
+            .appendingPathComponent(".\(migrationKey).migrated")
+    }
+
     override func setUpWithError() throws {
         try super.setUpWithError()
         sandbox = FileManager.default.temporaryDirectory
@@ -55,13 +60,14 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
 
     // MARK: - Happy paths
 
-    func testWhenOldDirectoryDoesNotExistThenFlagIsSetAndNotNeededPixelFires() {
+    func testWhenOldDirectoryDoesNotExistThenMarkerIsWrittenAndNotNeededPixelFires() {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
 
         migrate(from: oldURL, to: newURL)
 
         XCTAssertTrue(userDefaults.bool(forKey: doneKey))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: markerURL(forNew: newURL).path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path))
         XCTAssertEqual(pixelSpy.firedEventNames, ["notNeeded"])
     }
@@ -76,13 +82,54 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         migrate(from: oldURL, to: newURL)
 
         XCTAssertTrue(userDefaults.bool(forKey: doneKey))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: markerURL(forNew: newURL).path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: oldURL.path))
         XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("chats".utf8))
         XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("files.bin")), Data("files".utf8))
         XCTAssertEqual(pixelSpy.firedEventNames, ["success"])
     }
 
-    func testWhenBothOldAndNewExistThenOldIsRemovedAndOrphanRemovedPixelFires() throws {
+    func testWhenMarkerExistsAndOldDoesNotExistThenMigrationIsNoOp() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        // Simulate completed migration: marker present, oldURL absent.
+        try FileManager.default.createDirectory(at: markerURL(forNew: newURL).deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        try Data().write(to: markerURL(forNew: newURL))
+        userDefaults.set(true, forKey: doneKey)
+
+        migrate(from: oldURL, to: newURL)
+
+        XCTAssertTrue(pixelSpy.firedEventNames.isEmpty)
+    }
+
+    func testWhenMigrationSucceedsThenSecondCallIsNoOpAndPreservesAnyReappearedOldURL() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("first".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+
+        migrate(from: oldURL, to: newURL)
+
+        // Re-create oldURL contents to verify the second call ignores them.
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("reappeared".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+
+        migrate(from: oldURL, to: newURL)
+
+        // Marker exists → second call is a pure no-op.
+        // We do NOT delete the re-created oldURL: it could be the only complete
+        // copy of pre-upgrade data when the marker was written via the
+        // destination-conflict path, so we preserve it for recovery.
+        XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("first".utf8))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path),
+                      "reappeared oldURL data must be preserved — we can't prove it's redundant")
+        XCTAssertEqual(pixelSpy.firedEventNames, ["success"])
+    }
+
+    // MARK: - Destination conflict (replaces blind orphan-removal)
+
+    func testWhenBothOldAndNewExistWithDataThenDestinationConflictFiresAndOldIsPreserved() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
         try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
@@ -93,75 +140,92 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         migrate(from: oldURL, to: newURL)
 
         XCTAssertTrue(userDefaults.bool(forKey: doneKey))
-        XCTAssertFalse(FileManager.default.fileExists(atPath: oldURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: markerURL(forNew: newURL).path))
         XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("keep-me".utf8))
-        XCTAssertEqual(pixelSpy.firedEventNames, ["orphanRemoved"])
+        // Source must be preserved so the user's pre-upgrade data is recoverable.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path),
+                      "source data must be preserved for recovery when destination already has data")
+        XCTAssertEqual(pixelSpy.firedEventNames, ["destinationConflict"])
     }
 
-    func testWhenDoneFlagAlreadySetThenNoMigrationHappensAndNoPixelFires() throws {
+    func testWhenDestinationDirectoryIsEmptyThenItIsRemovedAndMoveSucceeds() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
         try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
-        try Data("untouched".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
-        userDefaults.set(true, forKey: doneKey)
+        try Data("chats".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+        // Empty newURL — e.g. scaffolding created by a prior excludeFromBackup call.
+        try FileManager.default.createDirectory(at: newURL, withIntermediateDirectories: true)
 
         migrate(from: oldURL, to: newURL)
 
-        XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path))
-        XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path))
-        XCTAssertTrue(pixelSpy.firedEventNames.isEmpty)
-    }
-
-    func testWhenMigrationSucceedsThenSecondCallIsNoOp() throws {
-        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
-        let newURL = sandbox.appendingPathComponent("new/DuckAi")
-        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
-        try Data("first".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
-
-        migrate(from: oldURL, to: newURL)
-
-        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
-        try Data("reappeared".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
-
-        migrate(from: oldURL, to: newURL)
-
-        XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("first".utf8))
-        XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path))
+        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
+        XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("chats".utf8))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: oldURL.path))
         XCTAssertEqual(pixelSpy.firedEventNames, ["success"])
     }
 
-    // MARK: - Retry behavior
+    // MARK: - Retry behavior (move failure)
 
     func testWhenMoveFailsThenAttemptIsRecordedAndDoneFlagNotSetAndOutcomeIsSkip() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
         try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
-        let failingFM = FailingMoveFileManager()
 
-        let outcome = migrate(from: oldURL, to: newURL, fileManager: failingFM, maxAttempts: 3)
+        let outcome = migrate(from: oldURL, to: newURL, fileManager: FailingMoveFileManager(), maxAttempts: 3)
 
         XCTAssertEqual(outcome, .skip)
         XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path))
         XCTAssertFalse(userDefaults.bool(forKey: doneKey))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: markerURL(forNew: newURL).path))
         XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 1)
         XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed"])
     }
 
-    func testWhenMoveFailsRepeatedlyThenGivesUpAtMaxAttemptsAndOutcomeIsProceed() throws {
+    func testWhenMoveFailsRepeatedlyThenGivesUpAtMaxAttemptsWithoutSweepingSource() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
         try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
-        let failingFM = FailingMoveFileManager()
+        try Data("sensitive".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
 
         var outcomes: [DuckAiNativeStorageContainerMigrationOutcome] = []
         for _ in 0..<3 {
-            outcomes.append(migrate(from: oldURL, to: newURL, fileManager: failingFM, maxAttempts: 3))
+            outcomes.append(migrate(from: oldURL, to: newURL, fileManager: FailingMoveFileManager(), maxAttempts: 3))
         }
 
         XCTAssertEqual(outcomes, [.skip, .skip, .proceed])
         XCTAssertTrue(userDefaults.bool(forKey: doneKey))
         XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 3)
         XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "attemptFailed", "gaveUp"])
+        // Source data must NOT be deleted — accepting data loss in exchange for
+        // privacy hygiene is the wrong trade-off for chat history.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path),
+                      "give-up sweep must not delete source data")
+        // No marker yet — a future launch can re-try via the legacy transition
+        // if conditions improve.
+        XCTAssertFalse(FileManager.default.fileExists(atPath: markerURL(forNew: newURL).path),
+                       "marker must NOT be written on give-up so retries can resume when conditions improve")
+    }
+
+    func testWhenGaveUpAndNextLaunchSucceedsThenMigrationCompletes() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("user-data".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+
+        for _ in 0..<3 {
+            migrate(from: oldURL, to: newURL, fileManager: FailingMoveFileManager(), maxAttempts: 3)
+        }
+
+        // Disk pressure clears / locked storage unlocks / FS error transient
+        // resolves. Next launch with a working FileManager should succeed via
+        // the legacy doneKey transition.
+        let recoveryOutcome = migrate(from: oldURL, to: newURL, maxAttempts: 3)
+
+        XCTAssertEqual(recoveryOutcome, .proceed)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: markerURL(forNew: newURL).path))
+        XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("user-data".utf8))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: oldURL.path))
+        XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "attemptFailed", "gaveUp", "success"])
     }
 
     func testWhenMoveFailsThenSucceedsThenAttemptsAreClearedAndSuccessPixelFires() throws {
@@ -180,112 +244,138 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         XCTAssertEqual(secondOutcome, .proceed)
         XCTAssertTrue(userDefaults.bool(forKey: doneKey))
         XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 0)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: markerURL(forNew: newURL).path))
         XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "success"])
     }
 
-    func testWhenGaveUpThenSubsequentCallsAreSkipped() throws {
+    // MARK: - Protected data gate
+
+    func testWhenProtectedDataIsUnavailableThenOutcomeIsSkipAndStateUnchanged() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
         try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("user".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
 
-        for _ in 0..<3 {
-            migrate(from: oldURL, to: newURL, fileManager: FailingMoveFileManager(), maxAttempts: 3)
-        }
-        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
+        let outcome = migrate(from: oldURL, to: newURL, isProtectedDataAvailable: { false })
 
-        // Sanity: the doneKey gates further calls regardless of file state.
-        let outcome = migrate(from: oldURL, to: newURL, maxAttempts: 3)
-
-        XCTAssertEqual(outcome, .proceed)
+        XCTAssertEqual(outcome, .skip)
+        XCTAssertFalse(userDefaults.bool(forKey: doneKey))
+        XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 0,
+                       "retry counter must not be burned by a locked-device launch")
         XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path))
-        XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "attemptFailed", "gaveUp"])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path))
+        XCTAssertEqual(pixelSpy.firedEventNames, ["protectedDataUnavailable"])
     }
 
-    func testWhenGivingUpOnMoveFailureThenBestEffortSweepRemovesOldData() throws {
+    func testWhenProtectedDataReturnsToAvailableThenMigrationCompletes() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
         try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
-        try Data("sensitive".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+        try Data("user".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
 
-        for _ in 0..<3 {
-            migrate(from: oldURL, to: newURL, fileManager: FailingMoveFileManager(), maxAttempts: 3)
-        }
-
-        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
-        XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "attemptFailed", "gaveUp"])
-        // The sweep should have removed the abandoned old container so sensitive
-        // content doesn't linger in the app group under NSFileProtectionComplete.
-        XCTAssertFalse(FileManager.default.fileExists(atPath: oldURL.path))
-    }
-
-    func testWhenGivingUpAndSweepAlsoFailsThenStillMarksDoneAndFiresGaveUp() throws {
-        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
-        let newURL = sandbox.appendingPathComponent("new/DuckAi")
-        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
-
-        for _ in 0..<3 {
-            migrate(from: oldURL, to: newURL, fileManager: FailingMoveAndRemoveFileManager(), maxAttempts: 3)
-        }
-
-        // Sweep failure must not undo the gave-up state — otherwise we'd retry forever.
-        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
-        XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "attemptFailed", "gaveUp"])
-    }
-
-    // MARK: - Orphan removal retry behavior
-
-    func testWhenOrphanRemovalFailsThenDoneFlagNotSetAndAttemptFailedFires() throws {
-        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
-        let newURL = sandbox.appendingPathComponent("new/DuckAi")
-        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: newURL, withIntermediateDirectories: true)
-        try Data("old".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
-        try Data("keep-me".utf8).write(to: newURL.appendingPathComponent("chats.db"))
-
-        let outcome = migrate(from: oldURL, to: newURL, fileManager: FailingRemoveFileManager(), maxAttempts: 3)
-
-        // newURL is still usable so we proceed, but old data remains and we'll retry.
-        XCTAssertEqual(outcome, .proceed)
-        XCTAssertFalse(userDefaults.bool(forKey: doneKey))
-        XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 1)
-        XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.path))
-        XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed"])
-    }
-
-    func testWhenOrphanRemovalFailsRepeatedlyThenGivesUpAtMaxAttempts() throws {
-        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
-        let newURL = sandbox.appendingPathComponent("new/DuckAi")
-        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: newURL, withIntermediateDirectories: true)
-
-        for _ in 0..<3 {
-            migrate(from: oldURL, to: newURL, fileManager: FailingRemoveFileManager(), maxAttempts: 3)
-        }
-
-        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
-        XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 3)
-        XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "attemptFailed", "gaveUp"])
-        // The gaveUp event indicates abandoned data — orphanRemoved should NOT have fired.
-        XCTAssertFalse(pixelSpy.firedEventNames.contains("orphanRemoved"))
-    }
-
-    func testWhenOrphanRemovalFailsThenSucceedsThenAttemptsAreClearedAndOrphanRemovedFires() throws {
-        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
-        let newURL = sandbox.appendingPathComponent("new/DuckAi")
-        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: newURL, withIntermediateDirectories: true)
-
-        migrate(from: oldURL, to: newURL, fileManager: FailingRemoveFileManager(), maxAttempts: 3)
-        XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 1)
-        XCTAssertFalse(userDefaults.bool(forKey: doneKey))
-
-        let outcome = migrate(from: oldURL, to: newURL, maxAttempts: 3)
-
-        XCTAssertEqual(outcome, .proceed)
-        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
+        let lockedOutcome = migrate(from: oldURL, to: newURL, isProtectedDataAvailable: { false })
+        XCTAssertEqual(lockedOutcome, .skip)
         XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 0)
+
+        let unlockedOutcome = migrate(from: oldURL, to: newURL, isProtectedDataAvailable: { true })
+
+        XCTAssertEqual(unlockedOutcome, .proceed)
+        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
+        XCTAssertEqual(pixelSpy.firedEventNames, ["protectedDataUnavailable", "success"])
+    }
+
+    // MARK: - Legacy doneKey transition (iCloud restore + pre-marker upgrades)
+
+    func testWhenLegacyDoneFlagSetAndDestinationHasDataThenMarkerIsWrittenAndCallIsNoOp() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        // Simulate a user who completed migration on a pre-marker build:
+        // doneKey set, oldURL absent, newURL contains chats.db, no marker yet.
+        try FileManager.default.createDirectory(at: newURL, withIntermediateDirectories: true)
+        try Data("migrated".utf8).write(to: newURL.appendingPathComponent("chats.db"))
+        userDefaults.set(true, forKey: doneKey)
+
+        migrate(from: oldURL, to: newURL)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: markerURL(forNew: newURL).path),
+                      "marker should be written on first launch under the new code")
+        XCTAssertTrue(pixelSpy.firedEventNames.isEmpty,
+                      "no migration events should fire for a no-op transition")
+    }
+
+    func testWhenLegacyDoneFlagSetButDestinationEmptyAndSourceHasDataThenStateResetsAndMigrationRuns() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        // Simulate iCloud restore: doneKey survived backup, App Group oldURL
+        // was restored, but Application Support newURL was excluded from backup
+        // so the destination is empty. The migration must re-run.
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("restored".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+        userDefaults.set(true, forKey: doneKey)
+
+        migrate(from: oldURL, to: newURL)
+
+        XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("restored".utf8))
         XCTAssertFalse(FileManager.default.fileExists(atPath: oldURL.path))
-        XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "orphanRemoved"])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: markerURL(forNew: newURL).path))
+        XCTAssertEqual(pixelSpy.firedEventNames, ["success"])
+    }
+
+    func testWhenLegacyDoneFlagSetAndNeitherSourceNorDestinationHasDataThenMarkerIsWritten() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        userDefaults.set(true, forKey: doneKey)
+
+        migrate(from: oldURL, to: newURL)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: markerURL(forNew: newURL).path))
+        XCTAssertTrue(pixelSpy.firedEventNames.isEmpty)
+    }
+
+    // MARK: - Marker-present steady state
+
+    func testWhenMarkerExistsAndOldStillExistsThenMigrationIsNoOpAndOldIsPreserved() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: markerURL(forNew: newURL).deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        try Data().write(to: markerURL(forNew: newURL))
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("preserved".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+
+        migrate(from: oldURL, to: newURL)
+
+        // Marker-present state must NOT delete oldURL. After the destination
+        // conflict path runs, oldURL can be the only complete copy.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path),
+                      "oldURL data must be preserved once marker exists")
+        XCTAssertTrue(pixelSpy.firedEventNames.isEmpty)
+    }
+
+    func testWhenGaveUpLeftPartialDestinationAndNextLaunchRunsThenDestinationConflictFires() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("complete".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+        // Simulate the post-gaveUp + partial-copy state without writing a marker:
+        // newURL has a partial chats.db, oldURL still has the complete copy,
+        // doneKey was set when migration gave up. No marker.
+        try FileManager.default.createDirectory(at: newURL, withIntermediateDirectories: true)
+        try Data("partial".utf8).write(to: newURL.appendingPathComponent("chats.db"))
+        userDefaults.set(true, forKey: doneKey)
+        userDefaults.set(3, forKey: attemptsKey)
+
+        migrate(from: oldURL, to: newURL)
+
+        // Legacy transition sees `oldExists` and resets state. The standard
+        // flow then takes the destinationConflict path, writes the marker,
+        // and preserves both sides so the complete oldURL data remains
+        // recoverable.
+        XCTAssertEqual(pixelSpy.firedEventNames, ["destinationConflict"])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: markerURL(forNew: newURL).path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path),
+                      "post-gaveUp source must survive — newURL might be a partial copy")
+        XCTAssertEqual(try Data(contentsOf: oldURL.appendingPathComponent("chats.db")), Data("complete".utf8))
     }
 
     // MARK: - File protection failure surfacing
@@ -298,15 +388,12 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
 
         let outcome = migrate(from: oldURL, to: newURL, fileManager: FailingSetAttributesFileManager(), maxAttempts: 3)
 
-        // The move itself succeeded so we proceed and mark done — data is at newURL.
         XCTAssertEqual(outcome, .proceed)
         XCTAssertTrue(userDefaults.bool(forKey: doneKey))
         XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("chats".utf8))
-        // But protection failed, so both pixels fire — `.success` then `.protectionFailed`.
         XCTAssertEqual(pixelSpy.firedEventNames, ["success", "protectionFailed"])
         XCTAssertEqual((pixelSpy.lastProtectionFailedError as NSError?)?.domain, FailingSetAttributesFileManager.errorDomain)
         XCTAssertEqual((pixelSpy.lastProtectionFailedError as NSError?)?.code, FailingSetAttributesFileManager.errorCode)
-        // Protection state must remain pending so the next launch retries it.
         XCTAssertFalse(userDefaults.bool(forKey: protectionAppliedKey))
         XCTAssertEqual(userDefaults.integer(forKey: protectionAttemptsKey), 1)
     }
@@ -317,11 +404,9 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
         try Data("chats".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
 
-        // First launch: move succeeds, protection silently fails.
         migrate(from: oldURL, to: newURL, fileManager: FailingSetAttributesFileManager(), maxAttempts: 3)
         XCTAssertFalse(userDefaults.bool(forKey: protectionAppliedKey))
 
-        // Second launch (transient failure resolved): protection should retry and succeed.
         migrate(from: oldURL, to: newURL, maxAttempts: 3)
 
         XCTAssertTrue(userDefaults.bool(forKey: protectionAppliedKey))
@@ -335,16 +420,14 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
         try Data("chats".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
 
-        // Three failing launches: pixel fires each time, last one caps and marks applied.
         for _ in 0..<3 {
             migrate(from: oldURL, to: newURL, fileManager: FailingSetAttributesFileManager(), maxAttempts: 3)
         }
         XCTAssertTrue(userDefaults.bool(forKey: protectionAppliedKey))
-        XCTAssertEqual(userDefaults.integer(forKey: protectionAttemptsKey), 3)
+        XCTAssertEqual(userDefaults.integer(forKey: protectionAttemptsKey), 0,
+                       "protectionAttempts should be cleared when the cap marks applied=true")
         XCTAssertEqual(pixelSpy.firedEventNames, ["success", "protectionFailed", "protectionFailed", "protectionFailed"])
 
-        // Fourth launch must NOT fire another pixel even though the file system
-        // would still reject setAttributes — we've given up on this regression.
         migrate(from: oldURL, to: newURL, fileManager: FailingSetAttributesFileManager(), maxAttempts: 3)
         XCTAssertEqual(pixelSpy.firedEventNames, ["success", "protectionFailed", "protectionFailed", "protectionFailed"])
     }
@@ -355,7 +438,6 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
 
         migrate(from: oldURL, to: newURL)
 
-        // No data to protect → mark applied so we don't retry unnecessarily.
         XCTAssertTrue(userDefaults.bool(forKey: protectionAppliedKey))
         XCTAssertEqual(pixelSpy.firedEventNames, ["notNeeded"])
     }
@@ -381,10 +463,70 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         XCTAssertEqual((error as NSError?)?.code, FailingSetAttributesFileManager.errorCode)
     }
 
-    // MARK: - Caller-contract regression (Issue 4)
+    func testWhenApplyDefaultFileProtectionEnumeratorReturnsNilThenReturnsError() throws {
+        let url = sandbox.appendingPathComponent("nonexistent-directory")
+        // No directory created; default FileManager.enumerator(at:) returns nil
+        // because the path can't be opened. setAttributes on the root will also
+        // fail, so we should get a non-nil error rather than a false success.
 
-    /// Models the launch-time factory: if migration says `.skip`, do not call
-    /// `excludeFromBackup` and do not construct a handler at `newURL`.
+        let error = DuckAiNativeStorageContainerMigration.applyDefaultFileProtection(at: url)
+
+        XCTAssertNotNil(error, "nil enumerator must not be treated as success")
+    }
+
+    // MARK: - excludeFromBackup pixel
+
+    func testWhenExcludeFromBackupSucceedsThenNoPixelFires() {
+        let url = sandbox.appendingPathComponent("DuckAi")
+
+        DuckAiNativeStorageContainerMigration.excludeFromBackup(url, label: .default, pixelFiring: pixelSpy)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+        XCTAssertTrue(pixelSpy.firedEventNames.isEmpty)
+    }
+
+    func testWhenExcludeFromBackupFailsThenPixelFires() {
+        let url = sandbox.appendingPathComponent("DuckAi")
+
+        DuckAiNativeStorageContainerMigration.excludeFromBackup(url,
+                                                                label: .default,
+                                                                pixelFiring: pixelSpy,
+                                                                fileManager: FailingCreateDirectoryFileManager())
+
+        XCTAssertEqual(pixelSpy.firedEventNames, ["excludeFromBackupFailed"])
+    }
+
+    // MARK: - maxAttempts clamp
+
+    func testWhenMaxAttemptsIsZeroThenClampedToOneAndGivesUpOnFirstFailure() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("user".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+
+        let outcome = migrate(from: oldURL, to: newURL, fileManager: FailingMoveFileManager(), maxAttempts: 0)
+
+        XCTAssertEqual(outcome, .proceed, "maxAttempts clamped to 1 triggers gaveUp on the first failure")
+        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
+        XCTAssertEqual(pixelSpy.firedEventNames, ["gaveUp"])
+        // Even at maxAttempts=0 (clamped), source must be preserved.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path),
+                      "source data must be preserved even at the clamped lower bound")
+    }
+
+    func testWhenMaxAttemptsIsNegativeThenClampedToOne() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+
+        let outcome = migrate(from: oldURL, to: newURL, fileManager: FailingMoveFileManager(), maxAttempts: -5)
+
+        XCTAssertEqual(outcome, .proceed)
+        XCTAssertEqual(pixelSpy.firedEventNames, ["gaveUp"])
+    }
+
+    // MARK: - Caller-contract regression (factory pattern)
+
     func testGivenFailedMoveWhenFactoryRunsThenDestinationStaysAbsentAndHandlerIsNotCreated() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
@@ -398,14 +540,16 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
             fileManager: FailingMoveFileManager(),
             createHandler: {
                 handlerCreated = true
-                DuckAiNativeStorageContainerMigration.excludeFromBackup(newURL)
+                DuckAiNativeStorageContainerMigration.excludeFromBackup(newURL,
+                                                                        label: .default,
+                                                                        pixelFiring: self.pixelSpy)
             }
         )
 
         XCTAssertNil(result, "factory must short-circuit when migration returns .skip")
         XCTAssertFalse(handlerCreated, "handler creation must be skipped after a failed move")
-        XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path), "destination must remain absent so next-launch retry can move the data")
-        XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path), "user data must remain at the old location")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path))
         XCTAssertFalse(userDefaults.bool(forKey: doneKey))
         XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed"])
     }
@@ -427,7 +571,9 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
             fileManager: .default,
             createHandler: {
                 secondLaunchHandlerCreated = true
-                DuckAiNativeStorageContainerMigration.excludeFromBackup(newURL)
+                DuckAiNativeStorageContainerMigration.excludeFromBackup(newURL,
+                                                                        label: .default,
+                                                                        pixelFiring: self.pixelSpy)
             }
         )
 
@@ -438,12 +584,38 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "success"])
     }
 
+    func testGivenProtectedDataUnavailableWhenFactoryRunsThenDestinationStaysAbsent() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("user-chats".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+
+        var handlerCreated = false
+        let result = runFactory(
+            oldURL: oldURL,
+            newURL: newURL,
+            fileManager: .default,
+            isProtectedDataAvailable: { false },
+            createHandler: {
+                handlerCreated = true
+            }
+        )
+
+        XCTAssertNil(result, "locked-device launch must not construct a handler")
+        XCTAssertFalse(handlerCreated)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path),
+                       "locked-device launch must not create destination — otherwise next launch sees it as orphan")
+        XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 0,
+                       "locked-device launch must not consume the retry budget")
+    }
+
     // MARK: - Helpers
 
     @discardableResult
     private func migrate(from oldURL: URL,
                          to newURL: URL,
                          fileManager: FileManager = .default,
+                         isProtectedDataAvailable: () -> Bool = { true },
                          maxAttempts: Int = DuckAiNativeStorageContainerMigration.defaultMaxAttempts) -> DuckAiNativeStorageContainerMigrationOutcome {
         DuckAiNativeStorageContainerMigration.migrateIfNeeded(
             from: oldURL,
@@ -453,6 +625,7 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
             userDefaults: userDefaults,
             fileManager: fileManager,
             pixelFiring: pixelSpy,
+            isProtectedDataAvailable: isProtectedDataAvailable,
             maxAttempts: maxAttempts
         )
     }
@@ -464,8 +637,12 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
     private func runFactory(oldURL: URL,
                             newURL: URL,
                             fileManager: FileManager,
+                            isProtectedDataAvailable: () -> Bool = { true },
                             createHandler: () -> Void) -> AnyObject? {
-        let outcome = migrate(from: oldURL, to: newURL, fileManager: fileManager)
+        let outcome = migrate(from: oldURL,
+                              to: newURL,
+                              fileManager: fileManager,
+                              isProtectedDataAvailable: isProtectedDataAvailable)
         if outcome == .skip {
             return nil
         }
@@ -479,6 +656,7 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
 private final class SpyContainerMigrationPixelFiring: DuckAiNativeStorageContainerMigrationPixelFiring {
     private(set) var firedEventNames: [String] = []
     private(set) var lastProtectionFailedError: Error?
+    private(set) var lastExcludeFromBackupError: Error?
 
     func fire(_ event: DuckAiNativeStorageContainerMigrationEvent) {
         switch event {
@@ -490,6 +668,11 @@ private final class SpyContainerMigrationPixelFiring: DuckAiNativeStorageContain
         case .protectionFailed(_, let error):
             firedEventNames.append("protectionFailed")
             lastProtectionFailedError = error
+        case .destinationConflict: firedEventNames.append("destinationConflict")
+        case .excludeFromBackupFailed(_, let error):
+            firedEventNames.append("excludeFromBackupFailed")
+            lastExcludeFromBackupError = error
+        case .protectedDataUnavailable: firedEventNames.append("protectedDataUnavailable")
         }
     }
 }
@@ -506,15 +689,6 @@ private final class FailingRemoveFileManager: FileManager {
     }
 }
 
-private final class FailingMoveAndRemoveFileManager: FileManager {
-    override func moveItem(at srcURL: URL, to dstURL: URL) throws {
-        throw NSError(domain: "DuckAiNativeStorageContainerMigrationTests", code: -1)
-    }
-    override func removeItem(at URL: URL) throws {
-        throw NSError(domain: "DuckAiNativeStorageContainerMigrationTests", code: -2)
-    }
-}
-
 /// Lets `moveItem` and directory creation succeed but rejects `setAttributes`
 /// so `applyDefaultFileProtection` records a failure on every path.
 private final class FailingSetAttributesFileManager: FileManager {
@@ -523,5 +697,15 @@ private final class FailingSetAttributesFileManager: FileManager {
 
     override func setAttributes(_ attributes: [FileAttributeKey: Any], ofItemAtPath path: String) throws {
         throw NSError(domain: Self.errorDomain, code: Self.errorCode)
+    }
+}
+
+/// Rejects `createDirectory(at:withIntermediateDirectories:)` so
+/// `excludeFromBackup` surfaces the failure via pixel.
+private final class FailingCreateDirectoryFileManager: FileManager {
+    override func createDirectory(at url: URL,
+                                  withIntermediateDirectories createIntermediates: Bool,
+                                  attributes: [FileAttributeKey: Any]? = nil) throws {
+        throw NSError(domain: "DuckAiNativeStorageContainerMigrationTests.createDirectory", code: -4)
     }
 }

--- a/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
@@ -24,8 +24,13 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
 
     private var sandbox: URL!
     private var userDefaults: UserDefaults!
-    private let migrationKey = "test.migrationDone"
+    private var pixelSpy: SpyContainerMigrationPixelFiring!
+    private let migrationKey = "test.migration"
+    private let label: DuckAiNativeStorageContainerMigrationLabel = .default
     private let suiteName = "DuckAiNativeStorageContainerMigrationTests"
+
+    private var doneKey: String { migrationKey + ".done" }
+    private var attemptsKey: String { migrationKey + ".attempts" }
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -34,6 +39,7 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         try FileManager.default.createDirectory(at: sandbox, withIntermediateDirectories: true)
         UserDefaults().removePersistentDomain(forName: suiteName)
         userDefaults = UserDefaults(suiteName: suiteName)
+        pixelSpy = SpyContainerMigrationPixelFiring()
     }
 
     override func tearDownWithError() throws {
@@ -41,45 +47,40 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         userDefaults.removePersistentDomain(forName: suiteName)
         userDefaults = nil
         sandbox = nil
+        pixelSpy = nil
         try super.tearDownWithError()
     }
 
-    func testWhenOldDirectoryDoesNotExistThenFlagIsSetAndNothingMoves() {
+    // MARK: - Happy paths
+
+    func testWhenOldDirectoryDoesNotExistThenFlagIsSetAndNotNeededPixelFires() {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
 
-        DuckAiNativeStorageContainerMigration.migrateIfNeeded(
-            from: oldURL,
-            to: newURL,
-            migrationDoneKey: migrationKey,
-            userDefaults: userDefaults
-        )
+        migrate(from: oldURL, to: newURL)
 
-        XCTAssertTrue(userDefaults.bool(forKey: migrationKey))
+        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
         XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path))
+        XCTAssertEqual(pixelSpy.firedEventNames, ["notNeeded"])
     }
 
-    func testWhenOldDirectoryExistsAndNewDoesNotThenContentsAreMovedAndFlagIsSet() throws {
+    func testWhenOldDirectoryExistsAndNewDoesNotThenContentsAreMovedAndSuccessPixelFires() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
         try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
         try Data("chats".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
         try Data("files".utf8).write(to: oldURL.appendingPathComponent("files.bin"))
 
-        DuckAiNativeStorageContainerMigration.migrateIfNeeded(
-            from: oldURL,
-            to: newURL,
-            migrationDoneKey: migrationKey,
-            userDefaults: userDefaults
-        )
+        migrate(from: oldURL, to: newURL)
 
-        XCTAssertTrue(userDefaults.bool(forKey: migrationKey))
+        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
         XCTAssertFalse(FileManager.default.fileExists(atPath: oldURL.path))
         XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("chats".utf8))
         XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("files.bin")), Data("files".utf8))
+        XCTAssertEqual(pixelSpy.firedEventNames, ["success"])
     }
 
-    func testWhenBothOldAndNewExistThenOldIsRemovedAndNewIsPreserved() throws {
+    func testWhenBothOldAndNewExistThenOldIsRemovedAndOrphanRemovedPixelFires() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
         try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
@@ -87,60 +88,148 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         try Data("old".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
         try Data("keep-me".utf8).write(to: newURL.appendingPathComponent("chats.db"))
 
-        DuckAiNativeStorageContainerMigration.migrateIfNeeded(
-            from: oldURL,
-            to: newURL,
-            migrationDoneKey: migrationKey,
-            userDefaults: userDefaults
-        )
+        migrate(from: oldURL, to: newURL)
 
-        XCTAssertTrue(userDefaults.bool(forKey: migrationKey))
+        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
         XCTAssertFalse(FileManager.default.fileExists(atPath: oldURL.path))
         XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("keep-me".utf8))
+        XCTAssertEqual(pixelSpy.firedEventNames, ["orphanRemoved"])
     }
 
-    func testWhenFlagAlreadySetThenNoMigrationHappensEvenIfOldExists() throws {
+    func testWhenDoneFlagAlreadySetThenNoMigrationHappensAndNoPixelFires() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
         try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
         try Data("untouched".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
-        userDefaults.set(true, forKey: migrationKey)
+        userDefaults.set(true, forKey: doneKey)
 
-        DuckAiNativeStorageContainerMigration.migrateIfNeeded(
-            from: oldURL,
-            to: newURL,
-            migrationDoneKey: migrationKey,
-            userDefaults: userDefaults
-        )
+        migrate(from: oldURL, to: newURL)
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path))
+        XCTAssertTrue(pixelSpy.firedEventNames.isEmpty)
     }
 
-    func testWhenMigrationRunsTwiceThenSecondCallIsNoOp() throws {
+    func testWhenMigrationSucceedsThenSecondCallIsNoOp() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
         try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
         try Data("first".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
 
-        DuckAiNativeStorageContainerMigration.migrateIfNeeded(
-            from: oldURL,
-            to: newURL,
-            migrationDoneKey: migrationKey,
-            userDefaults: userDefaults
-        )
+        migrate(from: oldURL, to: newURL)
 
         try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
         try Data("reappeared".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
 
-        DuckAiNativeStorageContainerMigration.migrateIfNeeded(
-            from: oldURL,
-            to: newURL,
-            migrationDoneKey: migrationKey,
-            userDefaults: userDefaults
-        )
+        migrate(from: oldURL, to: newURL)
 
         XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("first".utf8))
         XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path))
+        XCTAssertEqual(pixelSpy.firedEventNames, ["success"])
+    }
+
+    // MARK: - Retry behavior
+
+    func testWhenMoveFailsThenAttemptIsRecordedAndDoneFlagNotSet() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        let failingFM = FailingMoveFileManager()
+
+        migrate(from: oldURL, to: newURL, fileManager: failingFM, maxAttempts: 3)
+
+        XCTAssertFalse(userDefaults.bool(forKey: doneKey))
+        XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 1)
+        XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed"])
+    }
+
+    func testWhenMoveFailsRepeatedlyThenGivesUpAtMaxAttempts() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        let failingFM = FailingMoveFileManager()
+
+        for _ in 0..<3 {
+            migrate(from: oldURL, to: newURL, fileManager: failingFM, maxAttempts: 3)
+        }
+
+        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
+        XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 3)
+        XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "attemptFailed", "gaveUp"])
+    }
+
+    func testWhenMoveFailsThenSucceedsThenAttemptsAreClearedAndSuccessPixelFires() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("data".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+
+        migrate(from: oldURL, to: newURL, fileManager: FailingMoveFileManager(), maxAttempts: 3)
+        XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 1)
+        XCTAssertFalse(userDefaults.bool(forKey: doneKey))
+
+        migrate(from: oldURL, to: newURL, maxAttempts: 3)
+
+        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
+        XCTAssertEqual(userDefaults.integer(forKey: attemptsKey), 0)
+        XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "success"])
+    }
+
+    func testWhenGaveUpThenSubsequentCallsAreSkipped() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+
+        for _ in 0..<3 {
+            migrate(from: oldURL, to: newURL, fileManager: FailingMoveFileManager(), maxAttempts: 3)
+        }
+        XCTAssertTrue(userDefaults.bool(forKey: doneKey))
+
+        // Even with a non-failing FM and old data still present, we don't retry.
+        migrate(from: oldURL, to: newURL, maxAttempts: 3)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path))
+        XCTAssertEqual(pixelSpy.firedEventNames, ["attemptFailed", "attemptFailed", "gaveUp"])
+    }
+
+    // MARK: - Helpers
+
+    private func migrate(from oldURL: URL,
+                         to newURL: URL,
+                         fileManager: FileManager = .default,
+                         maxAttempts: Int = DuckAiNativeStorageContainerMigration.defaultMaxAttempts) {
+        DuckAiNativeStorageContainerMigration.migrateIfNeeded(
+            from: oldURL,
+            to: newURL,
+            migrationKey: migrationKey,
+            label: label,
+            userDefaults: userDefaults,
+            fileManager: fileManager,
+            pixelFiring: pixelSpy,
+            maxAttempts: maxAttempts
+        )
+    }
+}
+
+// MARK: - Test doubles
+
+private final class SpyContainerMigrationPixelFiring: DuckAiNativeStorageContainerMigrationPixelFiring {
+    private(set) var firedEventNames: [String] = []
+
+    func fire(_ event: DuckAiNativeStorageContainerMigrationEvent) {
+        switch event {
+        case .notNeeded: firedEventNames.append("notNeeded")
+        case .orphanRemoved: firedEventNames.append("orphanRemoved")
+        case .success: firedEventNames.append("success")
+        case .attemptFailed: firedEventNames.append("attemptFailed")
+        case .gaveUp: firedEventNames.append("gaveUp")
+        }
+    }
+}
+
+private final class FailingMoveFileManager: FileManager {
+    override func moveItem(at srcURL: URL, to dstURL: URL) throws {
+        throw NSError(domain: "DuckAiNativeStorageContainerMigrationTests", code: -1)
     }
 }

--- a/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
@@ -253,6 +253,41 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         XCTAssertEqual(pixelSpy.firedEventNames, ["protectedDataUnavailable"])
     }
 
+    /// Without the up-front kv-store sanity check, the `try?` computed
+    /// properties below silently fall back to defaults and the migration
+    /// proceeds — likely landing in `notNeeded` (when oldURL is absent) or
+    /// `destinationConflict` (once the destination has data). Deferring on
+    /// unhealthy reads keeps the source on disk and gives the next launch a
+    /// chance to recover with a healthy store.
+    func testWhenKeyValueStoreReadFailsThenMigrationDefersWithoutMutatingState() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("user".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+        let failingStore = FailingReadKeyValueStore()
+
+        let outcome = DuckAiNativeStorageContainerMigration(
+            oldURL: oldURL,
+            newURL: newURL,
+            migrationKey: migrationKey,
+            label: label,
+            keyValueStore: failingStore,
+            pixelFiring: pixelSpy,
+            isProtectedDataAvailable: { true }
+        ).run()
+
+        XCTAssertEqual(outcome, .skip)
+        XCTAssertEqual(pixelSpy.firedEventNames, ["keyValueStoreReadFailed"])
+        XCTAssertEqual((pixelSpy.lastKeyValueStoreReadError as NSError?)?.domain, FailingReadKeyValueStore.errorDomain)
+        XCTAssertEqual((pixelSpy.lastKeyValueStoreReadError as NSError?)?.code, FailingReadKeyValueStore.errorCode)
+        XCTAssertTrue(failingStore.writeCalls.isEmpty,
+                      "unhealthy store must not be written to — no attempts counter increments, no migrated flag set")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: newURL.path),
+                       "destination must not be touched on a kv-store failure")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: oldURL.appendingPathComponent("chats.db").path),
+                      "source must be preserved on a kv-store failure")
+    }
+
     func testWhenProtectedDataReturnsToAvailableThenMigrationCompletes() throws {
         let oldURL = sandbox.appendingPathComponent("old/DuckAi")
         let newURL = sandbox.appendingPathComponent("new/DuckAi")
@@ -723,6 +758,7 @@ private final class SpyContainerMigrationPixelFiring: DuckAiNativeStorageContain
     private(set) var firedEventNames: [String] = []
     private(set) var lastProtectionFailedError: Error?
     private(set) var lastExcludeFromBackupError: Error?
+    private(set) var lastKeyValueStoreReadError: Error?
 
     func fire(_ event: DuckAiNativeStorageContainerMigrationEvent) {
         switch event {
@@ -738,7 +774,31 @@ private final class SpyContainerMigrationPixelFiring: DuckAiNativeStorageContain
             firedEventNames.append("excludeFromBackupFailed")
             lastExcludeFromBackupError = error
         case .protectedDataUnavailable: firedEventNames.append("protectedDataUnavailable")
+        case .keyValueStoreReadFailed(_, let error):
+            firedEventNames.append("keyValueStoreReadFailed")
+            lastKeyValueStoreReadError = error
         }
+    }
+}
+
+/// Throws on every `object(forKey:)` read, accepts writes. Mirrors a
+/// genuinely-broken store at the boundary the migration uses.
+private final class FailingReadKeyValueStore: ThrowingKeyValueStoring {
+    static let errorDomain = "DuckAiNativeStorageContainerMigrationTests.kvStoreRead"
+    static let errorCode = -7
+
+    private(set) var writeCalls: [(key: String, value: Any?)] = []
+
+    func object(forKey defaultName: String) throws -> Any? {
+        throw NSError(domain: Self.errorDomain, code: Self.errorCode)
+    }
+
+    func set(_ value: Any?, forKey defaultName: String) throws {
+        writeCalls.append((defaultName, value))
+    }
+
+    func removeObject(forKey defaultName: String) throws {
+        writeCalls.append((defaultName, nil))
     }
 }
 

--- a/iOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
@@ -171,6 +171,48 @@
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion", "errorDomain", "errorCode"]
     },
+    "m_duck-ai_native-storage_container-migration_destination-conflict_default": {
+        "description": "Fires when the default Duck.ai destination directory already contains a chats.db at migration time but no migration marker is present — could indicate a partial moveItem copy that crashed, or a previous launch that created data while the App Group entitlement was unavailable; the new location is claimed going forward and the old App Group container is preserved so the user's pre-upgrade data remains recoverable",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_duck-ai_native-storage_container-migration_destination-conflict_fire-mode": {
+        "description": "Fires when the fire-mode Duck.ai destination directory already contains a chats.db at migration time but no migration marker is present — could indicate a partial moveItem copy that crashed, or a previous launch that created data while the App Group entitlement was unavailable; the new location is claimed going forward and the old App Group container is preserved so the user's pre-upgrade data remains recoverable",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_duck-ai_native-storage_container-migration_exclude-from-backup-failed_default": {
+        "description": "Fires when setting isExcludedFromBackup or creating the default container directory under Application Support failed — the database may end up in iCloud backups",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "errorDomain", "errorCode"]
+    },
+    "m_duck-ai_native-storage_container-migration_exclude-from-backup-failed_fire-mode": {
+        "description": "Fires when setting isExcludedFromBackup or creating the fire-mode container directory under Application Support failed — the database may end up in iCloud backups",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "errorDomain", "errorCode"]
+    },
+    "m_duck-ai_native-storage_container-migration_protected-data-unavailable_default": {
+        "description": "Fires when the default-container migration is deferred because UIApplication.isProtectedDataAvailable was false (pre-first-unlock background launch); no state is modified so the migration retries on a later launch",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_duck-ai_native-storage_container-migration_protected-data-unavailable_fire-mode": {
+        "description": "Fires when the fire-mode container migration is deferred because UIApplication.isProtectedDataAvailable was false (pre-first-unlock background launch); no state is modified so the migration retries on a later launch",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
     "m_duck-ai_native-storage_settings-put_error": {
         "description": "Fires when putEntry (Settings) fails",
         "owners": ["Bunn"],

--- a/iOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
@@ -101,20 +101,6 @@
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
-    "m_duck-ai_native-storage_container-migration_orphan-removed_default": {
-        "description": "Fires once when the new default container already had data so the orphaned app-group default copy was deleted",
-        "owners": ["Bunn"],
-        "triggers": ["other"],
-        "suffixes": ["platform", "form_factor"],
-        "parameters": ["appVersion"]
-    },
-    "m_duck-ai_native-storage_container-migration_orphan-removed_fire-mode": {
-        "description": "Fires once when the new fire-mode container already had data so the orphaned app-group fire-mode copy was deleted",
-        "owners": ["Bunn"],
-        "triggers": ["other"],
-        "suffixes": ["platform", "form_factor"],
-        "parameters": ["appVersion"]
-    },
     "m_duck-ai_native-storage_container-migration_success_default": {
         "description": "Fires once when the default Duck.ai container was successfully moved from the app-group container into Application Support",
         "owners": ["Bunn"],

--- a/iOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
@@ -87,6 +87,76 @@
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion", "errorDomain", "errorCode"]
     },
+    "m_duck-ai_native-storage_container-migration_not-needed_default": {
+        "description": "Fires once when no app-group default container directory exists on launch (fresh install or already migrated previously)",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_duck-ai_native-storage_container-migration_not-needed_fire-mode": {
+        "description": "Fires once when no app-group fire-mode container directory exists on launch (fresh install or already migrated previously)",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_duck-ai_native-storage_container-migration_orphan-removed_default": {
+        "description": "Fires once when the new default container already had data so the orphaned app-group default copy was deleted",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_duck-ai_native-storage_container-migration_orphan-removed_fire-mode": {
+        "description": "Fires once when the new fire-mode container already had data so the orphaned app-group fire-mode copy was deleted",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_duck-ai_native-storage_container-migration_success_default": {
+        "description": "Fires once when the default Duck.ai container was successfully moved from the app-group container into Application Support",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_duck-ai_native-storage_container-migration_success_fire-mode": {
+        "description": "Fires once when the fire-mode Duck.ai container was successfully moved from the app-group container into Application Support",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_duck-ai_native-storage_container-migration_attempt-failed_default": {
+        "description": "Fires when a default-container move attempt fails and will be retried on a subsequent launch (up to 3 attempts total)",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "errorDomain", "errorCode"]
+    },
+    "m_duck-ai_native-storage_container-migration_attempt-failed_fire-mode": {
+        "description": "Fires when a fire-mode container move attempt fails and will be retried on a subsequent launch (up to 3 attempts total)",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "errorDomain", "errorCode"]
+    },
+    "m_duck-ai_native-storage_container-migration_gave-up_default": {
+        "description": "Fires once after the default-container move has failed the maximum number of attempts; migration will not be retried and old data is abandoned",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "errorDomain", "errorCode"]
+    },
+    "m_duck-ai_native-storage_container-migration_gave-up_fire-mode": {
+        "description": "Fires once after the fire-mode container move has failed the maximum number of attempts; migration will not be retried and old data is abandoned",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "errorDomain", "errorCode"]
+    },
     "m_duck-ai_native-storage_settings-put_error": {
         "description": "Fires when putEntry (Settings) fails",
         "owners": ["Bunn"],

--- a/iOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
@@ -199,6 +199,20 @@
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
+    "m_duck-ai_native-storage_container-migration_key-value-store-read-failed_default": {
+        "description": "Fires when a sanity-check read against the key-value store at the top of the default-container migration throws — indicates the store itself is unhealthy. The migration is deferred without consuming the retry budget or mutating disk so a healthy launch can resume normally",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
+    },
+    "m_duck-ai_native-storage_container-migration_key-value-store-read-failed_fire-mode": {
+        "description": "Fires when a sanity-check read against the key-value store at the top of the fire-mode container migration throws — indicates the store itself is unhealthy. The migration is deferred without consuming the retry budget or mutating disk so a healthy launch can resume normally",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
+    },
     "m_duck-ai_native-storage_settings-put_error": {
         "description": "Fires when putEntry (Settings) fails",
         "owners": ["Bunn"],

--- a/iOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
@@ -157,6 +157,20 @@
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion", "errorDomain", "errorCode"]
     },
+    "m_duck-ai_native-storage_container-migration_protection-failed_default": {
+        "description": "Fires alongside container-migration_success_default when at least one setAttributes call failed while applying NSFileProtectionCompleteUntilFirstUserAuthentication after the default container move — destination data may have retained the original NSFileProtectionComplete class",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "errorDomain", "errorCode"]
+    },
+    "m_duck-ai_native-storage_container-migration_protection-failed_fire-mode": {
+        "description": "Fires alongside container-migration_success_fire-mode when at least one setAttributes call failed while applying NSFileProtectionCompleteUntilFirstUserAuthentication after the fire-mode container move — destination data may have retained the original NSFileProtectionComplete class",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "errorDomain", "errorCode"]
+    },
     "m_duck-ai_native-storage_settings-put_error": {
         "description": "Fires when putEntry (Settings) fails",
         "owners": ["Bunn"],

--- a/iOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
@@ -120,52 +120,52 @@
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
-        "parameters": ["appVersion", "errorDomain", "errorCode"]
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_duck-ai_native-storage_container-migration_attempt-failed_fire-mode": {
         "description": "Fires when a fire-mode container move attempt fails and will be retried on a subsequent launch (up to 3 attempts total)",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
-        "parameters": ["appVersion", "errorDomain", "errorCode"]
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_duck-ai_native-storage_container-migration_gave-up_default": {
-        "description": "Fires once after the default-container move has failed the maximum number of attempts; migration will not be retried and old data is abandoned",
+        "description": "Fires once after the default-container move has failed the maximum number of attempts in a single launch. The migration is retried on subsequent launches with a fresh attempt budget; the user's pre-migration container at the old App Group path is preserved on disk in the meantime",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
-        "parameters": ["appVersion", "errorDomain", "errorCode"]
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_duck-ai_native-storage_container-migration_gave-up_fire-mode": {
-        "description": "Fires once after the fire-mode container move has failed the maximum number of attempts; migration will not be retried and old data is abandoned",
+        "description": "Fires once after the fire-mode container move has failed the maximum number of attempts in a single launch. The migration is retried on subsequent launches with a fresh attempt budget; the user's pre-migration container at the old App Group path is preserved on disk in the meantime",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
-        "parameters": ["appVersion", "errorDomain", "errorCode"]
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_duck-ai_native-storage_container-migration_protection-failed_default": {
         "description": "Fires alongside container-migration_success_default when at least one setAttributes call failed while applying NSFileProtectionCompleteUntilFirstUserAuthentication after the default container move — destination data may have retained the original NSFileProtectionComplete class",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
-        "parameters": ["appVersion", "errorDomain", "errorCode"]
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_duck-ai_native-storage_container-migration_protection-failed_fire-mode": {
         "description": "Fires alongside container-migration_success_fire-mode when at least one setAttributes call failed while applying NSFileProtectionCompleteUntilFirstUserAuthentication after the fire-mode container move — destination data may have retained the original NSFileProtectionComplete class",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
-        "parameters": ["appVersion", "errorDomain", "errorCode"]
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_duck-ai_native-storage_container-migration_destination-conflict_default": {
-        "description": "Fires when the default Duck.ai destination directory already contains a chats.db at migration time but no migration marker is present — could indicate a partial moveItem copy that crashed, or a previous launch that created data while the App Group entitlement was unavailable; the new location is claimed going forward and the old App Group container is preserved so the user's pre-upgrade data remains recoverable",
+        "description": "Fires when the default Duck.ai destination directory already contains data at migration time but no migration flag is set in the key-value store — likely an external source (sibling process, OS-level sync) or a previous launch that created data while the App Group entitlement was unavailable. The new location is claimed going forward and the old App Group container is preserved on disk but not surfaced to the user",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "m_duck-ai_native-storage_container-migration_destination-conflict_fire-mode": {
-        "description": "Fires when the fire-mode Duck.ai destination directory already contains a chats.db at migration time but no migration marker is present — could indicate a partial moveItem copy that crashed, or a previous launch that created data while the App Group entitlement was unavailable; the new location is claimed going forward and the old App Group container is preserved so the user's pre-upgrade data remains recoverable",
+        "description": "Fires when the fire-mode Duck.ai destination directory already contains data at migration time but no migration flag is set in the key-value store — likely an external source (sibling process, OS-level sync) or a previous launch that created data while the App Group entitlement was unavailable. The new location is claimed going forward and the old App Group container is preserved on disk but not surfaced to the user",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
@@ -176,14 +176,14 @@
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
-        "parameters": ["appVersion", "errorDomain", "errorCode"]
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_duck-ai_native-storage_container-migration_exclude-from-backup-failed_fire-mode": {
         "description": "Fires when setting isExcludedFromBackup or creating the fire-mode container directory under Application Support failed — the database may end up in iCloud backups",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
-        "parameters": ["appVersion", "errorDomain", "errorCode"]
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_duck-ai_native-storage_container-migration_protected-data-unavailable_default": {
         "description": "Fires when the default-container migration is deferred because UIApplication.isProtectedDataAvailable was false (pre-first-unlock background launch); no state is modified so the migration retries on a later launch",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1214837562649183?focus=true
Tech Design URL:
CC:

### Description
The Duck.ai SQLCipher DB lives in the shared app-group container, whose default `NSFileProtectionComplete` makes it inaccessible while the device is locked — producing 0xdead10cc kills on the background auto-clear path. This PR relocates the default and fire-mode containers to `Library/Application Support/`, migrating existing user data once with up-to-3 retries across launches, and marks both directories as excluded from iCloud / Finder backups. New container-migration pixels (`default` / `fire-mode`) report success, no-data, orphan-cleaned, attempt-failed, and gave-up outcomes.

### Testing Steps
Feature gated behind FF: duckAINativeStoragePathMigration

1. Install a build with the old (app-group) storage, send a few Duck.ai messages, then upgrade to this build and confirm chat history is still present after launch.
2. Reboot the device, lock it, and trigger the auto-clear path to verify no 0xdead10cc termination.
3. Delete the app, install a clean version, check if duck.ai storage is creating the folder in the correct path and data is being saved there (There are logs printing the path, and for validating data you can check on the AI Chat storage debugger. Debug -> AI Chat -> Start Server)

### Impact and Risks
High

#### What could go wrong?
Migration fails for a user with non-trivial chat data and the give-up path discards their history after 3 attempts; pixels will surface the rate if it happens.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> One-time filesystem migration of encrypted chat DBs at launch can block native storage or strand history if move/conflict handling fails; mitigated by preserving source data on give-up and deferring when protected data or KV reads are unavailable.
> 
> **Overview**
> Adds a **remote-gated** (`duckAINativeStoragePathMigration` / `nativeStoragePathMigration`, internal-only default) path that relocates Duck.ai **default** and **fire-mode** native SQLCipher containers from the shared **App Group** to **`Library/Application Support`**, with the legacy App Group layout unchanged when the flag is off.
> 
> Introduces **`DuckAiNativeStorageContainerMigration`**: one-time directory move with KV-backed state, protected-data deferral, up to three move retries per launch (budget resets across launches), destination-conflict handling that preserves the old copy, async recursive **`NSFileProtectionCompleteUntilFirstUserAuthentication`**, and **`isExcludedFromBackup`**. **`Launching.makeNativeStorageHandler`** and **`FireModeNativeStorageController`** run migration before opening storage and return **`nil`** on **`.skip`** so an empty DB is not created mid-failure.
> 
> Adds labeled **container-migration** pixels (default / fire-mode) and extensive unit tests for retry, recovery, and launch short-circuit behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c56643b11c40a0cdf1539b9f3637ee0f53995010. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->