### PR TITLE
Remove flaky Dax logo cache test

### DIFF
--- a/iOS/DuckDuckGoTests/DaxEasterEggLogos/DaxEasterEggLogoCacheTests.swift
+++ b/iOS/DuckDuckGoTests/DaxEasterEggLogos/DaxEasterEggLogoCacheTests.swift
@@ -140,30 +140,4 @@ final class DaxEasterEggLogoCacheTests: XCTestCase {
         // This is implementation-specific behavior
     }
     
-    // MARK: - Thread Safety Test
-    
-    func testConcurrentSameQuery_handledCorrectly() {
-        let sameQuery = "shared-query"
-        let operationCount = 3
-        let dispatchGroup = DispatchGroup()
-        let queue = DispatchQueue(label: "test-same-query", attributes: .concurrent)
-        
-        // When - Multiple threads access the same query
-        for i in 0..<operationCount {
-            dispatchGroup.enter()
-            queue.async {
-                self.cache.storeLogo("logo-from-thread-\(i)", for: sameQuery)
-                _ = self.cache.getLogo(for: sameQuery)
-                dispatchGroup.leave()
-            }
-        }
-        
-        let waitResult = dispatchGroup.wait(timeout: .now() + 10.0)
-        XCTAssertEqual(waitResult, .success, "Concurrent same query operations did not complete in time")
-        
-        // Verify the query exists and has some value
-        let finalValue = cache.getLogo(for: sameQuery)
-        XCTAssertNotNil(finalValue)
-        XCTAssertTrue(finalValue!.hasPrefix("logo-from-thread-"))
-    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205237866452338/task/1214729126817949?focus=true

### Description

Removes the flaky `DaxEasterEggLogoCacheTests.testConcurrentSameQuery_handledCorrectly` test. The test only asserted that a small set of concurrent GCD operations completed before a timeout, while the remaining cache tests continue covering store/get, overwrite, normalization, and size-limit behavior.

### Testing Steps
1. CI is green.

### Impact and Risks
Low.

#### What could go wrong?
A cache threading regression could be missed by this removed smoke test, but the removed test did not assert a deterministic cache contract and has been flaky on CI.

### Quality Considerations
No production code changes.

### Notes to Reviewer
Removed because the test primarily validated that the queued operations completed rather than product behavior.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only removes a non-deterministic concurrency smoke test and does not change production code. The main risk is reduced coverage for potential thread-safety regressions in `DaxEasterEggLogoCache`.
> 
> **Overview**
> Removes the flaky `DaxEasterEggLogoCacheTests.testConcurrentSameQuery_handledCorrectly` concurrency test that relied on GCD timing/timeout behavior.
> 
> All other cache tests (store/get, overwrite, query normalization, and size-limit clearing) remain unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ef826350cd8df3dd8b38fb619925409c8b59b3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->