### PR TITLE
RMF update

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "85cc5632cc315ba2b693145a2f7d6db53697285b9b92d72eff40322e3621706f",
+  "originHash" : "763f4d4129992a65e8ff72f27075ab54dd8343029a227c9774e2ae697be8fbd3",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "4d35a8c3e8e613bc4f5217c9ff3238e6857e1ad7",
-        "version" : "14.7.0"
+        "revision" : "c3d43a3f971d8c21ba3624e0e1c2ee2598ddfd1c",
+        "version" : "14.9.0"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Package.resolved
+++ b/SharedPackages/BrowserServicesKit/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "d3e17cb6e45b15420637d9d689c45bff81df1a4a",
-        "version" : "14.8.0"
+        "revision" : "c3d43a3f971d8c21ba3624e0e1c2ee2598ddfd1c",
+        "version" : "14.9.0"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
         .package(url: "https://github.com/1024jp/GzipSwift.git", exact: "6.0.1"),
         .package(url: "https://github.com/vapor/jwt-kit.git", exact: "4.13.5"),
         .package(url: "https://github.com/pointfreeco/swift-clocks.git", exact: "1.0.6"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts.git", exact: "14.8.0"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts.git", exact: "14.9.0"),
         .package(path: "../URLPredictor"),
     ],
     targets: [

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
@@ -398,6 +398,8 @@ struct JsonToRemoteMessageModelMapper {
             return .subscription
         case .veryCriticalUpdate:
             return .veryCriticalUpdate
+        case .youtubeNew:
+            return .youtubeNew
         case .none:
             return .announce
         }

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Model/JsonRemoteMessagingConfig.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Model/JsonRemoteMessagingConfig.swift
@@ -176,6 +176,7 @@ public enum RemoteMessageResponse {
         case pir = "PIR"
         case subscription = "Subscription"
         case veryCriticalUpdate = "VeryCriticalUpdate"
+        case youtubeNew = "YoutubeNew"
     }
 
     public enum StatusError: Error {

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Model/RemoteMessageModel.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Model/RemoteMessageModel.swift
@@ -349,5 +349,5 @@ public enum RemotePlaceholder: String, Codable, CaseIterable {
     case veryCriticalUpdate = "RemoteMessageVeryCriticalUpdate"
     case newTabOptions = "RemoteMessageNewTabOptions"
     case splitBarMobile = "RemoteMessageSplitBarMobile"
-    case youtubeNew = "RemoteMessageYoutubeNew"
+    case youtubeNew = "RemoteMessageYoutubeNew" // macOS only
 }

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Model/RemoteMessageModel.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Model/RemoteMessageModel.swift
@@ -349,4 +349,5 @@ public enum RemotePlaceholder: String, Codable, CaseIterable {
     case veryCriticalUpdate = "RemoteMessageVeryCriticalUpdate"
     case newTabOptions = "RemoteMessageNewTabOptions"
     case splitBarMobile = "RemoteMessageSplitBarMobile"
+    case youtubeNew = "RemoteMessageYoutubeNew"
 }

--- a/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Mappers/JsonToRemoteMessageModelMapperCardsListTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Mappers/JsonToRemoteMessageModelMapperCardsListTests.swift
@@ -355,6 +355,7 @@ struct JsonToRemoteMessageModelMapperCardsListTests {
             ("KeyImport", .keyImport),
             ("NewTabOptions", .newTabOptions),
             ("SplitBarMobile", .splitBarMobile),
+            ("YoutubeNew", .youtubeNew),
             ("PIR", .pir),
             ("Subscription", .subscription),
             (nil, nil)

--- a/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Mappers/JsonToRemoteMessageModelMapperPlaceholdersTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Mappers/JsonToRemoteMessageModelMapperPlaceholdersTests.swift
@@ -44,6 +44,7 @@ struct JsonToRemoteMessageModelMapperPlaceholdersTests {
         (.pir, .pir),
         (.subscription, .subscription),
         (.veryCriticalUpdate, .veryCriticalUpdate),
+        (.youtubeNew, .youtubeNew),
     ]
 
     @Test("Check Placeholder Mapping Coverage")

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2626ddc952d79dc2c03fc93c06d9c463bfc6d88db1b4234221a04dfbc91662f0",
+  "originHash" : "2aaa4f39c3c51a17308f416431b1b1c96f9f9c7473d7df671a02503794332cf4",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "4d35a8c3e8e613bc4f5217c9ff3238e6857e1ad7",
-        "version" : "14.7.0"
+        "revision" : "c3d43a3f971d8c21ba3624e0e1c2ee2598ddfd1c",
+        "version" : "14.9.0"
       }
     },
     {

--- a/iOS/DuckDuckGo/ConfigurationURLDebugViewController.swift
+++ b/iOS/DuckDuckGo/ConfigurationURLDebugViewController.swift
@@ -58,6 +58,15 @@ final class ConfigurationURLDebugViewController: UITableViewController {
         }
     }
 
+    override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        switch Sections(rawValue: section) {
+        case .customURLs:
+            return "Note: Release builds require an RMF config URL that returns ETag headers."
+        case nil:
+            return nil
+        }
+    }
+
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let item = configurationItems[indexPath.row]
         guard let cell = tableView.dequeueReusableCell(withIdentifier: ConfigurationURLTableViewCell.reuseIdentifier) as? ConfigurationURLTableViewCell else {

--- a/iOS/DuckDuckGo/HomeMessageViewModelBuilder.swift
+++ b/iOS/DuckDuckGo/HomeMessageViewModelBuilder.swift
@@ -101,7 +101,10 @@ extension RemoteAction {
             return .default
 
         case .dismiss:
-            return .cancel
+            if isSecondaryAction {
+                return .cancel
+            }
+            return .default
         }
     }
 

--- a/iOS/DuckDuckGo/HomeMessageViewModelBuilder.swift
+++ b/iOS/DuckDuckGo/HomeMessageViewModelBuilder.swift
@@ -94,13 +94,7 @@ extension RemoteAction {
         case .share(let value, let title):
             return .share(value: value, title: title)
 
-        case .appStore, .url, .urlInContext, .survey, .navigation:
-            if isSecondaryAction {
-                return .cancel
-            }
-            return .default
-
-        case .dismiss:
+        case .appStore, .url, .urlInContext, .survey, .navigation, .dismiss:
             if isSecondaryAction {
                 return .cancel
             }

--- a/iOS/DuckDuckGo/RemoteMessagingDebugViewController.swift
+++ b/iOS/DuckDuckGo/RemoteMessagingDebugViewController.swift
@@ -62,6 +62,8 @@ struct RemoteMessagingDebugRootView: View {
                 Button("Refresh Config", action: model.refreshConfig)
             } header: {
                 Text("Configuration")
+            } footer: {
+                Text("Set custom RMF config URLs in the Configuration URLs debug screen.")
             }
 
             Section {

--- a/iOS/DuckDuckGoTests/HomeMessageViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/HomeMessageViewModelTests.swift
@@ -219,4 +219,36 @@ struct HomeMessageViewModelTests {
         #expect(mockActionHandler.capturedPresentationContext?.presentationStyle == .dismissModalsAndPresentFromRoot)
         #expect(mockActionHandler.capturedPresentationContext?.presenter != nil)
     }
+
+    @Test("Check Dismiss Action In Primary Slot Uses Default Button Style")
+    func dismissActionInPrimarySlotUsesDefaultButtonStyle() {
+        // GIVEN
+        let style = RemoteAction.dismiss.actionStyle()
+
+        // THEN
+        #expect(isDefaultStyle(style))
+    }
+
+    @Test("Check Dismiss Action In Secondary Slot Uses Cancel Button Style")
+    func dismissActionInSecondarySlotUsesCancelButtonStyle() {
+        // GIVEN
+        let style = RemoteAction.dismiss.actionStyle(isSecondaryAction: true)
+
+        // THEN
+        #expect(isCancelStyle(style))
+    }
+
+    private func isDefaultStyle(_ style: HomeMessageButtonViewModel.ActionStyle) -> Bool {
+        if case .default = style {
+            return true
+        }
+        return false
+    }
+
+    private func isCancelStyle(_ style: HomeMessageButtonViewModel.ActionStyle) -> Bool {
+        if case .cancel = style {
+            return true
+        }
+        return false
+    }
 }

--- a/iOS/DuckDuckGoTests/HomeMessageViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/HomeMessageViewModelTests.swift
@@ -220,7 +220,8 @@ struct HomeMessageViewModelTests {
         #expect(mockActionHandler.capturedPresentationContext?.presenter != nil)
     }
 
-    @Test("Check Dismiss Action In Primary Slot Uses Default Button Style")
+    @available(iOS 16, *)
+    @Test("Check Dismiss Action In Primary Slot Uses Default Button Style", .timeLimit(.minutes(1)))
     func dismissActionInPrimarySlotUsesDefaultButtonStyle() {
         // GIVEN
         let style = RemoteAction.dismiss.actionStyle()
@@ -229,7 +230,8 @@ struct HomeMessageViewModelTests {
         #expect(isDefaultStyle(style))
     }
 
-    @Test("Check Dismiss Action In Secondary Slot Uses Cancel Button Style")
+    @available(iOS 16, *)
+    @Test("Check Dismiss Action In Secondary Slot Uses Cancel Button Style", .timeLimit(.minutes(1)))
     func dismissActionInSecondarySlotUsesCancelButtonStyle() {
         // GIVEN
         let style = RemoteAction.dismiss.actionStyle(isSecondaryAction: true)

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/RMF/NewTabPageDataModel+RMF.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/RMF/NewTabPageDataModel+RMF.swift
@@ -124,6 +124,7 @@ extension NewTabPageDataModel {
         case radarCheckPurple = "RadarCheckPurple"
         case subscriptionIcon = "Subscription"
         case veryCriticalUpdate = "VeryCriticalUpdate"
+        case youtubeNew = "YoutubeNew"
 
         init(_ placeholder: RemotePlaceholder) {
             switch placeholder {
@@ -149,6 +150,8 @@ extension NewTabPageDataModel {
                 self = .subscriptionIcon
             case .veryCriticalUpdate:
                 self = .veryCriticalUpdate
+            case .youtubeNew:
+                self = .youtubeNew
             default:
                 self = .ddgAnnounce
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214636049052935?focus=true
Tech Design URL:
CC:

### Description

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1.
2.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly dependency/version bumps and additive enum cases, but it touches remote-messaging placeholder/type mapping used to render messages across iOS/macOS; mismatched placeholder values could cause messages to fall back or be dropped.
> 
> **Overview**
> Updates SwiftPM dependencies to `content-scope-scripts` `14.9.0` across the workspace, iOS project, and `BrowserServicesKit`.
> 
> Extends RMF/Remote Messaging placeholder support by adding `YoutubeNew` (`.youtubeNew`) to the JSON config model, mapper, domain enum, macOS New Tab Page RMF icon mapping, and associated unit tests.
> 
> Tweaks iOS RMF tooling: adds guidance footers in the debug screens, and changes `RemoteAction.dismiss` button styling so it behaves like other actions (default when primary, cancel when secondary), with new tests to lock this in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77d3b9286234de7bb3070c782f07ea466973d8bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->