### PR TITLE
iOS: UTI Newline Bugs & Placeholder Regression

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
@@ -56,6 +56,7 @@ protocol SwitchBarHandling: AnyObject {
 
     var isUsingExpandedBottomBarHeight: Bool { get }
     var isUsingFadeOutAnimation: Bool { get }
+    var usesExpandedAIChatTextEntryLayout: Bool { get }
     var shouldDisableAutocorrectOnEmpty: Bool { get }
 
     /// Suppresses the in-pill voice button — used when an external flank already provides one.
@@ -94,6 +95,7 @@ protocol SwitchBarHandling: AnyObject {
 extension SwitchBarHandling {
     func saveToggleState() {}
     func stopGeneratingButtonTapped() {}
+    var usesExpandedAIChatTextEntryLayout: Bool { false }
     var submitsAIChatOnKeyboardReturn: Bool { true }
     var submitsAIChatOnKeyboardReturnPublisher: AnyPublisher<Bool, Never> { Just(true).eraseToAnyPublisher() }
 }

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -84,6 +84,10 @@ class SwitchBarTextEntryView: UIView {
     }
 
     private var currentMinHeight: CGFloat {
+        if isExpandable && currentMode == .aiChat && handler.isTopBarPosition {
+            return Constants.minHeightAIChat
+        }
+
         guard handler.isUsingFadeOutAnimation else {
             return Constants.minHeight
         }
@@ -107,10 +111,16 @@ class SwitchBarTextEntryView: UIView {
         handler.isUsingExpandedBottomBarHeight
     }
 
+    private var usesTopAlignedPlaceholder: Bool {
+        isExpandable && currentMode == .aiChat
+    }
+
     private var cancellables = Set<AnyCancellable>()
 
     private var heightConstraint: NSLayoutConstraint?
     private var buttonsTrailingConstraint: NSLayoutConstraint?
+    private var placeholderTopConstraint: NSLayoutConstraint?
+    private var placeholderCenterYConstraint: NSLayoutConstraint?
 
     private var wasTextEmptyForAutocorrection: Bool = true
 
@@ -131,8 +141,14 @@ class SwitchBarTextEntryView: UIView {
 
     var isExpandable: Bool = false {
         didSet {
+            updatePlaceholderVerticalAlignment()
             updateTextViewHeight()
         }
+    }
+
+    func refreshLayoutForBarPositionChange() {
+        updatePlaceholderVerticalAlignment()
+        updateTextViewHeight()
     }
 
     /// A visible trailing button (e.g. stop-generating) forces `.natural` regardless of this
@@ -272,6 +288,11 @@ class SwitchBarTextEntryView: UIView {
 
         buttonsTrailingConstraint = buttonsView.trailingAnchor.constraint(equalTo: trailingAnchor)
         buttonsTrailingConstraint?.isActive = true
+        let placeholderTopConstraint = placeholderLabel.topAnchor.constraint(equalTo: textView.topAnchor, constant: Constants.placeholderTopOffset)
+        let placeholderCenterYConstraint = placeholderLabel.centerYAnchor.constraint(equalTo: textView.centerYAnchor)
+        self.placeholderTopConstraint = placeholderTopConstraint
+        self.placeholderCenterYConstraint = placeholderCenterYConstraint
+        placeholderTopConstraint.isActive = false
 
         NSLayoutConstraint.activate([
             textView.topAnchor.constraint(equalTo: topAnchor),
@@ -279,7 +300,7 @@ class SwitchBarTextEntryView: UIView {
             textView.bottomAnchor.constraint(equalTo: bottomAnchor),
             textView.trailingAnchor.constraint(equalTo: trailingAnchor),
 
-            placeholderLabel.centerYAnchor.constraint(equalTo: textView.centerYAnchor),
+            placeholderCenterYConstraint,
             placeholderLabel.leadingAnchor.constraint(equalTo: textView.leadingAnchor, constant: Constants.placeholderHorizontalOffset),
             // Trail to the buttons so a visible stop / search-go-to / voice button truncates the
             // placeholder. When `.noButtons`, buttonsView has zero width so this is a no-op.
@@ -345,6 +366,7 @@ class SwitchBarTextEntryView: UIView {
             }
         }
         updateKeyboardConfiguration()
+        updatePlaceholderVerticalAlignment()
         updatePlaceholderVisibility()
         updateButtonState()
         updateTextViewHeight()
@@ -401,6 +423,18 @@ class SwitchBarTextEntryView: UIView {
 
     private func updatePlaceholderAlignment() {
         placeholderLabel.textAlignment = currentButtonState.showsAnyButton ? .natural : placeholderTextAlignment
+    }
+
+    private func updatePlaceholderVerticalAlignment() {
+        guard placeholderTopConstraint?.isActive != usesTopAlignedPlaceholder else { return }
+
+        if usesTopAlignedPlaceholder {
+            placeholderCenterYConstraint?.isActive = false
+            placeholderTopConstraint?.isActive = true
+        } else {
+            placeholderTopConstraint?.isActive = false
+            placeholderCenterYConstraint?.isActive = true
+        }
     }
 
     private func updateVoiceButtonStyle() {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -33,6 +33,29 @@ class SwitchBarTextEntryView: UIView {
         case hidden
     }
 
+    private enum TextEntryPose: Equatable {
+        case compact
+        case tallTopAlignedAIChat
+
+        var minHeight: CGFloat {
+            switch self {
+            case .compact:
+                return Constants.minHeight
+            case .tallTopAlignedAIChat:
+                return Constants.minHeightAIChat
+            }
+        }
+
+        var usesTopAlignedPlaceholder: Bool {
+            switch self {
+            case .compact:
+                return false
+            case .tallTopAlignedAIChat:
+                return true
+            }
+        }
+    }
+
     private enum Constants {
         static let maxHeight: CGFloat = 120
         static let maxHeightWhenUsingFadeOutAnimation: CGFloat = 132
@@ -83,9 +106,17 @@ class SwitchBarTextEntryView: UIView {
         handler.currentToggleState
     }
 
+    private var currentPose: TextEntryPose {
+        if isExpandable && currentMode == .aiChat && handler.isTopBarPosition && handler.usesExpandedAIChatTextEntryLayout {
+            return .tallTopAlignedAIChat
+        }
+
+        return .compact
+    }
+
     private var currentMinHeight: CGFloat {
-        if isExpandable && currentMode == .aiChat && handler.isTopBarPosition {
-            return Constants.minHeightAIChat
+        if currentPose == .tallTopAlignedAIChat {
+            return currentPose.minHeight
         }
 
         guard handler.isUsingFadeOutAnimation else {
@@ -112,7 +143,7 @@ class SwitchBarTextEntryView: UIView {
     }
 
     private var usesTopAlignedPlaceholder: Bool {
-        isExpandable && currentMode == .aiChat
+        currentPose.usesTopAlignedPlaceholder
     }
 
     private var cancellables = Set<AnyCancellable>()
@@ -141,12 +172,11 @@ class SwitchBarTextEntryView: UIView {
 
     var isExpandable: Bool = false {
         didSet {
-            updatePlaceholderVerticalAlignment()
-            updateTextViewHeight()
+            updatePoseForCurrentState()
         }
     }
 
-    func refreshLayoutForBarPositionChange() {
+    func updatePoseForCurrentState() {
         updatePlaceholderVerticalAlignment()
         updateTextViewHeight()
     }
@@ -366,10 +396,9 @@ class SwitchBarTextEntryView: UIView {
             }
         }
         updateKeyboardConfiguration()
-        updatePlaceholderVerticalAlignment()
+        updatePoseForCurrentState()
         updatePlaceholderVisibility()
         updateButtonState()
-        updateTextViewHeight()
     }
 
     private func updateKeyboardConfiguration() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
@@ -27,7 +27,7 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
 
     // MARK: - SwitchBarHandling — Fixed Values
 
-    var isTopBarPosition: Bool = false
+    private(set) var isTopBarPosition: Bool = false
     let isUsingExpandedBottomBarHeight: Bool = false
     /// The fadeOutOnToggle experiment applies only to the OmniBar editing state, not here.
     let isUsingFadeOutAnimation: Bool = false
@@ -226,7 +226,11 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
         customizeResponsesButtonTappedSubject.send()
     }
 
-    func updateBarPosition(isTop: Bool) {}
+    func updateBarPosition(isTop: Bool) {
+        guard isTopBarPosition != isTop else { return }
+        isTopBarPosition = isTop
+        updateButtonState()
+    }
 
     // MARK: - Private
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
@@ -29,6 +29,7 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
 
     private(set) var isTopBarPosition: Bool = false
     let isUsingExpandedBottomBarHeight: Bool = false
+    let usesExpandedAIChatTextEntryLayout: Bool = true
     /// The fadeOutOnToggle experiment applies only to the OmniBar editing state, not here.
     let isUsingFadeOutAnimation: Bool = false
     let shouldDisableAutocorrectOnEmpty: Bool = true

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -254,7 +254,10 @@ final class UnifiedToggleInputView: UIView {
 
     var handlerIsTopBarPosition: Bool {
         get { handler.isTopBarPosition }
-        set { handler.isTopBarPosition = newValue }
+        set {
+            handler.updateBarPosition(isTop: newValue)
+            textEntryView.refreshLayoutForBarPositionChange()
+        }
     }
 
     // MARK: - Attachment Callbacks
@@ -1343,7 +1346,6 @@ private extension UnifiedToggleInputView {
             .store(in: &cancellables)
 
         textEntryView.textHeightChangeSubject
-            .receive(on: DispatchQueue.main)
             .sink { [weak self] in
                 self?.onNeedsHierarchyLayout?()
             }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -255,8 +255,9 @@ final class UnifiedToggleInputView: UIView {
     var handlerIsTopBarPosition: Bool {
         get { handler.isTopBarPosition }
         set {
+            guard handler.isTopBarPosition != newValue else { return }
             handler.updateBarPosition(isTop: newValue)
-            textEntryView.refreshLayoutForBarPositionChange()
+            textEntryView.updatePoseForCurrentState()
         }
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
@@ -380,7 +380,6 @@ final class UnifiedToggleInputViewController: UIViewController {
     }
 
     private func notifyHeightDidChange() {
-        view.window?.layoutIfNeeded()
         delegate?.unifiedToggleInputVCDidChangeHeight(self)
     }
 }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputHandlerTests.swift
@@ -62,6 +62,7 @@ final class UnifiedToggleInputHandlerTests: XCTestCase {
         XCTAssertFalse(sut.isTopBarPosition)
         XCTAssertFalse(sut.isUsingExpandedBottomBarHeight)
         XCTAssertFalse(sut.isCurrentTextValidURL)
+        XCTAssertTrue(sut.usesExpandedAIChatTextEntryLayout)
     }
 
     // MARK: - Fire Tab
@@ -400,9 +401,11 @@ final class UnifiedToggleInputHandlerTests: XCTestCase {
 
     // MARK: - updateBarPosition
 
-    func test_updateBarPosition_doesNotChangeConstants() {
-        sut.updateBarPosition(isTop: true)
+    func test_updateBarPosition_updatesTopBarPosition() {
         XCTAssertFalse(sut.isTopBarPosition)
+
+        sut.updateBarPosition(isTop: true)
+        XCTAssertTrue(sut.isTopBarPosition)
 
         sut.updateBarPosition(isTop: false)
         XCTAssertFalse(sut.isTopBarPosition)

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -241,12 +241,161 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         XCTAssertEqual(handler.currentText, "he\nllo")
     }
 
+    func test_topAIChatTextEntryDoesNotGrowOnFirstFloatingReturnNewline() {
+        let expectedTopAIChatMinimumHeight: CGFloat = 68
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.updateBarPosition(isTop: true)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut)
+        sut.setQueryText("hello")
+        let initialHeight = applyFittingHeight(to: sut)
+
+        sut.insertNewlineAtCursor()
+        let heightAfterFirstNewline = applyFittingHeight(to: sut)
+
+        XCTAssertEqual(initialHeight, expectedTopAIChatMinimumHeight, accuracy: 1)
+        XCTAssertEqual(heightAfterFirstNewline, initialHeight, accuracy: 1)
+    }
+
+    func test_topAIChatPlaceholderAlignsWithTextContainerTopInset() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.updateBarPosition(isTop: true)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut)
+        applyFittingHeight(to: sut)
+
+        let textView = try XCTUnwrap(firstDescendant(of: UITextView.self, in: sut))
+        let placeholderLabel = try XCTUnwrap(firstDescendant(of: UILabel.self, in: sut))
+        let expectedPlaceholderMinY = textView.convert(CGPoint(x: 0, y: textView.textContainerInset.top), to: sut).y
+
+        XCTAssertFalse(placeholderLabel.isHidden)
+        XCTAssertEqual(placeholderLabel.frame.minY, expectedPlaceholderMinY, accuracy: 1)
+    }
+
+    func test_collapsedAIChatPlaceholderStaysVerticallyCenteredInPill() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        prepareForFitting(sut, height: 48)
+        applyFittingHeight(to: sut, height: 48)
+
+        let textView = try XCTUnwrap(firstDescendant(of: UITextView.self, in: sut))
+        let placeholderLabel = try XCTUnwrap(firstDescendant(of: UILabel.self, in: sut))
+
+        XCTAssertFalse(placeholderLabel.isHidden)
+        XCTAssertEqual(placeholderLabel.center.y, textView.center.y, accuracy: 1)
+    }
+
+    func test_expandedSearchPlaceholderStaysVerticallyCenteredInPill() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.setToggleState(.search)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut, height: 48)
+        applyFittingHeight(to: sut, height: 48)
+
+        let textView = try XCTUnwrap(firstDescendant(of: UITextView.self, in: sut))
+        let placeholderLabel = try XCTUnwrap(firstDescendant(of: UILabel.self, in: sut))
+
+        XCTAssertFalse(placeholderLabel.isHidden)
+        XCTAssertEqual(placeholderLabel.center.y, textView.center.y, accuracy: 1)
+    }
+
+    func test_expandedPlaceholderAlignmentUpdatesWhenToggleSwitchesMode() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.updateBarPosition(isTop: true)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut)
+        applyFittingHeight(to: sut)
+
+        let textView = try XCTUnwrap(firstDescendant(of: UITextView.self, in: sut))
+        let placeholderLabel = try XCTUnwrap(firstDescendant(of: UILabel.self, in: sut))
+        let expectedPlaceholderMinY = textView.convert(CGPoint(x: 0, y: textView.textContainerInset.top), to: sut).y
+
+        XCTAssertEqual(placeholderLabel.frame.minY, expectedPlaceholderMinY, accuracy: 1)
+
+        handler.setToggleState(.search)
+        flushMainQueue()
+        applyFittingHeight(to: sut)
+
+        XCTAssertEqual(placeholderLabel.center.y, textView.center.y, accuracy: 1)
+
+        handler.setToggleState(.aiChat)
+        flushMainQueue()
+        applyFittingHeight(to: sut)
+
+        XCTAssertEqual(placeholderLabel.frame.minY, expectedPlaceholderMinY, accuracy: 1)
+    }
+
+    func test_clearButtonStaysPinnedToTopLineWhenTextEntryExpands() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.updateBarPosition(isTop: true)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut)
+        sut.setQueryText("hello")
+        let initialHeight = applyFittingHeight(to: sut)
+        let clearButton = try XCTUnwrap(findButton(accessibilityLabel: "Clear text", in: sut))
+        let initialClearButtonMinY = clearButton.convert(clearButton.bounds, to: sut).minY
+
+        sut.insertNewlineAtCursor()
+        sut.insertNewlineAtCursor()
+        let expandedHeight = applyFittingHeight(to: sut)
+        let expandedClearButtonMinY = clearButton.convert(clearButton.bounds, to: sut).minY
+
+        XCTAssertGreaterThan(expandedHeight, initialHeight)
+        XCTAssertEqual(expandedClearButtonMinY, initialClearButtonMinY, accuracy: 1)
+    }
+
+    func test_topAIChatToggleDoesNotCompressWhenFloatingReturnExpandsTextEntry() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        let sut = UnifiedToggleInputView(handler: handler)
+        sut.handlerIsTopBarPosition = true
+        sut.applyCardLayout(.expanded(showsToggle: true, showsToolbar: true), animated: false)
+        prepareForFitting(sut, width: 402, height: 192)
+        applyFittingHeight(to: sut, width: 402)
+        sut.onNeedsHierarchyLayout = { [weak sut] in
+            guard let sut else { return }
+            self.applyFittingHeight(to: sut, width: 402)
+        }
+        sut.text = "hello"
+        applyFittingHeight(to: sut, width: 402)
+        let duckAIButton = try XCTUnwrap(findButton(accessibilityIdentifier: "AddressBar.Button.DuckAI", in: sut))
+
+        sut.insertNewlineAtCursor()
+        sut.insertNewlineAtCursor()
+        sut.layoutIfNeeded()
+
+        XCTAssertEqual(duckAIButton.frame.height, 36, accuracy: 1)
+    }
+
     private func flushMainQueue() {
         let expectation = expectation(description: "main queue flushed")
         DispatchQueue.main.async {
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 1)
+    }
+
+    private func prepareForFitting(_ view: UIView, width: CGFloat = 320, height: CGFloat = 68) {
+        view.frame = CGRect(x: 0, y: 0, width: width, height: height)
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+    }
+
+    @discardableResult
+    private func applyFittingHeight(to view: UIView, width: CGFloat = 320, height proposedHeight: CGFloat = UIView.layoutFittingCompressedSize.height) -> CGFloat {
+        let height = view.systemLayoutSizeFitting(
+            CGSize(width: width, height: proposedHeight),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        ).height
+        view.frame = CGRect(x: 0, y: 0, width: width, height: height)
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+        return height
     }
 
     private func makeInvalidFileAttachment(
@@ -290,12 +439,20 @@ final class UnifiedToggleInputViewTests: XCTestCase {
     }
 
     private func findButton(accessibilityLabel: String, in view: UIView) -> UIButton? {
-        if let button = view as? UIButton, button.accessibilityLabel == accessibilityLabel {
+        findButton(in: view) { $0.accessibilityLabel == accessibilityLabel }
+    }
+
+    private func findButton(accessibilityIdentifier: String, in view: UIView) -> UIButton? {
+        findButton(in: view) { $0.accessibilityIdentifier == accessibilityIdentifier }
+    }
+
+    private func findButton(in view: UIView, where matches: (UIButton) -> Bool) -> UIButton? {
+        if let button = view as? UIButton, matches(button) {
             return button
         }
 
         for subview in view.subviews {
-            if let button = findButton(accessibilityLabel: accessibilityLabel, in: subview) {
+            if let button = findButton(in: subview, where: matches) {
                 return button
             }
         }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -18,6 +18,7 @@
 //
 
 import AIChat
+import Combine
 import DesignResourcesKitIcons
 import XCTest
 import UIKit
@@ -302,6 +303,55 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         XCTAssertEqual(placeholderLabel.center.y, textView.center.y, accuracy: 1)
     }
 
+    func test_bottomAIChatPlaceholderStaysVerticallyCenteredInPill() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.updateBarPosition(isTop: false)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut, height: 48)
+        applyFittingHeight(to: sut, height: 48)
+
+        let textView = try XCTUnwrap(firstDescendant(of: UITextView.self, in: sut))
+        let placeholderLabel = try XCTUnwrap(firstDescendant(of: UILabel.self, in: sut))
+
+        XCTAssertFalse(placeholderLabel.isHidden)
+        XCTAssertEqual(placeholderLabel.center.y, textView.center.y, accuracy: 1)
+    }
+
+    func test_legacyNonFadeOutTopAIChatTextEntryStaysCompactWhenExpandable() throws {
+        let handler = LegacyTextEntryMockHandler(
+            currentToggleState: .aiChat,
+            isTopBarPosition: true,
+            isUsingFadeOutAnimation: false
+        )
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut, height: 44)
+        let height = applyFittingHeight(to: sut, height: 44)
+
+        let textView = try XCTUnwrap(firstDescendant(of: UITextView.self, in: sut))
+        let placeholderLabel = try XCTUnwrap(firstDescendant(of: UILabel.self, in: sut))
+
+        XCTAssertEqual(height, 44, accuracy: 1)
+        XCTAssertFalse(placeholderLabel.isHidden)
+        XCTAssertEqual(placeholderLabel.center.y, textView.center.y, accuracy: 1)
+    }
+
+    func test_barPositionChangeRefreshesExpandedAIChatPose() {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.updateBarPosition(isTop: false)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut, height: 44)
+
+        XCTAssertEqual(applyFittingHeight(to: sut, height: 44), 44, accuracy: 1)
+
+        handler.updateBarPosition(isTop: true)
+        sut.updatePoseForCurrentState()
+
+        XCTAssertEqual(applyFittingHeight(to: sut), 68, accuracy: 1)
+    }
+
     func test_expandedPlaceholderAlignmentUpdatesWhenToggleSwitchesMode() throws {
         let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
         handler.updateBarPosition(isTop: true)
@@ -369,6 +419,24 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         sut.layoutIfNeeded()
 
         XCTAssertEqual(duckAIButton.frame.height, 36, accuracy: 1)
+    }
+
+    func test_topAIChatHierarchyLayoutCallbackFiresSynchronouslyWhenNewlineExpandsTextEntry() {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        let sut = UnifiedToggleInputView(handler: handler)
+        sut.handlerIsTopBarPosition = true
+        sut.applyCardLayout(.expanded(showsToggle: true, showsToolbar: true), animated: false)
+        prepareForFitting(sut, width: 402, height: 192)
+        applyFittingHeight(to: sut, width: 402)
+        sut.text = "hello"
+        applyFittingHeight(to: sut, width: 402)
+
+        var callbacks = 0
+        sut.onNeedsHierarchyLayout = { callbacks += 1 }
+        sut.insertNewlineAtCursor()
+        sut.insertNewlineAtCursor()
+
+        XCTAssertGreaterThan(callbacks, 0)
     }
 
     private func flushMainQueue() {
@@ -466,5 +534,62 @@ private final class SpyFloatingReturnKeyDelegate: UnifiedToggleInputFloatingRetu
 
     func floatingReturnKeyDidTap() {
         returnKeyTapCount += 1
+    }
+}
+
+private final class LegacyTextEntryMockHandler: SwitchBarHandling {
+    var currentText: String = ""
+    var currentToggleState: TextEntryMode
+    var isVoiceSearchEnabled: Bool = false
+    var isAIVoiceChatEnabled: Bool = false
+    var hasUserInteractedWithText: Bool = false
+    var isCurrentTextValidURL: Bool = false
+    var buttonState: SwitchBarButtonState = .noButtons
+    var isTopBarPosition: Bool
+    var isToggleEnabled: Bool = true
+    var isFireTab: Bool = false
+    var isUsingExpandedBottomBarHeight: Bool = false
+    var isUsingFadeOutAnimation: Bool
+    var shouldDisableAutocorrectOnEmpty: Bool = false
+    var hidesVoiceButton: Bool = false
+    var hasSubmittedPrompt: Bool = false
+    var modeParameters: [String: String] = [:]
+
+    var hasSubmittedPromptPublisher: AnyPublisher<Bool, Never> { Just(false).eraseToAnyPublisher() }
+    var currentTextPublisher: AnyPublisher<String, Never> { Empty().eraseToAnyPublisher() }
+    var toggleStatePublisher: AnyPublisher<TextEntryMode, Never> { Empty().eraseToAnyPublisher() }
+    var textSubmissionPublisher: AnyPublisher<(text: String, mode: TextEntryMode), Never> { Empty().eraseToAnyPublisher() }
+    var microphoneButtonTappedPublisher: AnyPublisher<Void, Never> { Empty().eraseToAnyPublisher() }
+    var clearButtonTappedPublisher: AnyPublisher<Void, Never> { Empty().eraseToAnyPublisher() }
+    var hasUserInteractedWithTextPublisher: AnyPublisher<Bool, Never> { Empty().eraseToAnyPublisher() }
+    var isCurrentTextValidURLPublisher: AnyPublisher<Bool, Never> { Empty().eraseToAnyPublisher() }
+    var currentButtonStatePublisher: AnyPublisher<SwitchBarButtonState, Never> { Empty().eraseToAnyPublisher() }
+
+    init(currentToggleState: TextEntryMode, isTopBarPosition: Bool, isUsingFadeOutAnimation: Bool) {
+        self.currentToggleState = currentToggleState
+        self.isTopBarPosition = isTopBarPosition
+        self.isUsingFadeOutAnimation = isUsingFadeOutAnimation
+    }
+
+    func updateCurrentText(_ text: String) {
+        currentText = text
+    }
+
+    func submitText(_ text: String) {}
+
+    func setToggleState(_ state: TextEntryMode) {
+        currentToggleState = state
+    }
+
+    func clearText() {}
+
+    func microphoneButtonTapped() {}
+
+    func markUserInteraction() {}
+
+    func clearButtonTapped() {}
+
+    func updateBarPosition(isTop: Bool) {
+        isTopBarPosition = isTop
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1214812457808116
Tech Design URL: N/A
CC:

### Description

Fixes Unified Toggle Input layout jumps when the floating return key inserts newlines in top-position Duck.ai. The text-entry height notification now reaches the parent synchronously, the extra full-window layout pass is removed, and Duck.ai placeholder/clear-button alignment stays pinned while Search-mode placeholder alignment remains unchanged.

### Testing Steps

#### Top address bar Duck.ai newline expansion
   - Set Address Bar Position to Top.
   - Open the Unified Toggle Input from Search, switch to Duck.ai, type text, then use the floating return key to insert two newlines.
   - Expected: the text entry grows only when needed, the Search/Duck.ai toggle does not jump/compress/bounce, and the inline clear button stays pinned beside the first line instead of moving down with the growing text.

#### Unified Toggle Input Duck.ai placeholder alignment
   - Enable Unified Toggle Input.
   - Open the Unified Toggle Input, switch to Duck.ai, and focus the empty input in top and bottom address bar positions.
   - Expected: the Duck.ai placeholder text aligns with the cursor/caret, stays pinned there while the input is focused, and does not sit below it.

#### Duck.ai tab follow-up pill placeholder alignment
   - Enable Unified Toggle Input and open a Duck.ai tab/chat so the bottom follow-up pill is visible.
   - Focus the empty follow-up input.
   - Expected: the `Ask a follow-up question...` placeholder aligns with the cursor/caret in the bottom pill, stays pinned there while the input is focused, and does not sit below it.

#### Legacy toggle placeholder alignment
   - Disable Unified Toggle Input and open the old Search/Duck.ai toggle.
   - Switch to Duck.ai and focus the input.
   - Expected: the Duck.ai placeholder text aligns with the caret/text top inset, stays pinned there while the input is focused, and does not sit below the cursor.

### Impact and Risks

Low. This is limited to Unified Toggle Input layout timing and placeholder positioning.

#### What could go wrong?

Height-change timing now runs synchronously for text-entry height updates, so regressions would show up as parent/child layout timing issues during UTI expansion. Placeholder alignment now switches constraints based on expanded Duck.ai state, so regressions would show up as misaligned placeholder text when toggling modes or bar positions. The added tests cover those cases, and the simulator visual pass covered the newline and mode-switch flows.

### Quality Considerations

No privacy or data handling changes. The focused tests cover top Duck.ai min-height behavior, placeholder alignment, mode-switch alignment refresh, clear-button positioning, and toggle compression during newline expansion.

### Notes to Reviewer

The two timing changes are intentional: removing the queued delivery from `textHeightChangeSubject` prevents a transient stale parent-height layout, and removing the window-wide `layoutIfNeeded()` avoids forcing a layout pass with the new text height inside the old container height.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes text-entry sizing/constraint logic and layout-notification timing for the Unified Toggle Input, which could cause visual regressions in expansion/collapse and bar-position transitions.
> 
> **Overview**
> Fixes Unified Toggle Input layout jumps when inserting newlines in top-position Duck.ai by introducing a new expanded *top AI chat* text-entry pose (min height + top-aligned placeholder) gated by `usesExpandedAIChatTextEntryLayout`.
> 
> Makes bar-position changes update `UnifiedToggleInputHandler.isTopBarPosition` via `updateBarPosition` and refreshes the text-entry pose, and delivers `textHeightChangeSubject` callbacks synchronously (removing the main-queue hop and a window-wide `layoutIfNeeded()` call) to avoid transient stale parent layouts.
> 
> Adds/updates unit tests covering top AI chat min-height behavior on first newline, placeholder vertical alignment across modes/positions, clear-button pinning during expansion, and preventing toggle compression during newline-driven growth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5306ce42bca38eea12a68b7bbb4c13945002a0a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->