### PR TITLE
[macOS] Fix selection being dismissed when swiching from duck.ai to search

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -1295,7 +1295,21 @@ extension AddressBarViewController: AddressBarButtonsViewControllerDelegate {
 
             updateMode()
             addressBarTextField.makeMeFirstResponder()
-            addressBarTextField.moveCursorToEnd()
+            /// Mirror of the capture in the `if isAIChatMode` branch: restore the selection that
+            /// Duck.ai's `textViewDidChangeSelection` persisted, so toggling back doesn't drop the
+            /// user's highlight. UTF-16 bounds check matches `focusTextViewRestoringCursorPosition`.
+            if let saved = sharedTextState?.selectionRange,
+               let editor = addressBarTextField.currentEditor() {
+                let utf16Length = (editor.string as NSString).length
+                if saved.location <= utf16Length {
+                    let clampedLength = min(saved.length, max(0, utf16Length - saved.location))
+                    editor.selectedRange = NSRange(location: saved.location, length: clampedLength)
+                } else {
+                    addressBarTextField.moveCursorToEnd()
+                }
+            } else {
+                addressBarTextField.moveCursorToEnd()
+            }
 
             /// Force layout update after becoming first responder to update in case the window was resized
             layoutTextFields(withMinX: addressBarButtonsViewController.buttonsWidth)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1214797210892699?focus=true
Tech Design URL:
CC:

### Description
Fix a bug where the selection state would disappear when switching from AI mode to search in the omnibar.

### Testing Steps
1. Open the browser, make sure the Duck.ai toggle is on in the ominbar 
2. Type some text, select the text, switch between modes
3. The selection shouldn’t be lost

### Impact and Risks
Low

#### What could go wrong?
Nothing specific.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state change limited to restoring a saved selection range when toggling modes; primary risk is minor cursor/selection edge cases if saved ranges are out of bounds.
> 
> **Overview**
> Fixes a macOS omnibar bug where highlighted text selection was lost when toggling from Duck.ai back to normal search.
> 
> When switching to search mode, the address bar now restores the previously persisted `selectionRange` from shared tab state (with UTF-16 bounds clamping) instead of always moving the cursor to the end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09195ed912c5e08f2bf0c9d7ce7f6e544d05a438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->