### PR TITLE
[macOS] Button height changes on first time quit survey

### DIFF
--- a/macOS/DuckDuckGo/QuitSurvey/QuitSurveyView.swift
+++ b/macOS/DuckDuckGo/QuitSurvey/QuitSurveyView.swift
@@ -166,7 +166,7 @@ private struct QuitSurveyInitialView: View {
             Text(UserText.quitSurveyCloseAndQuit)
                 .frame(maxWidth: .infinity)
         }
-        .buttonStyle(DefaultActionButtonStyle(enabled: true))
+        .buttonStyle(DefaultActionButtonStyle(enabled: true, topPadding: 8, bottomPadding: 8))
         .padding([.leading, .trailing], 24)
         .padding(.bottom, 16)
     }
@@ -314,7 +314,7 @@ private struct QuitSurveyPositiveView: View {
                 Text(UserText.quitSurveyQuitNow)
                     .frame(maxWidth: .infinity)
             }
-            .buttonStyle(DefaultActionButtonStyle(enabled: true))
+            .buttonStyle(DefaultActionButtonStyle(enabled: true, topPadding: 8, bottomPadding: 8))
             .padding([.leading, .trailing], 24)
             .padding(.bottom, 16)
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1213807924439992?focus=true
Tech Design URL:
CC:

### Description
Fix button height of the first time quit survey

### Testing Steps
1. Open the browser
2. Go to Debug -> UI Triggers -> Always show First Time Quit Survey
3. Quit the app, check the height of the button in the first dialog is like the image attached, tap on thumbs up and check the same.

<img width="405" height="164" alt="Screenshot 2026-05-13 at 5 03 02 PM" src="https://github.com/user-attachments/assets/1de7cc8e-ead2-428c-9b05-3ffb4838af55" />
<img width="398" height="245" alt="Screenshot 2026-05-13 at 5 02 53 PM" src="https://github.com/user-attachments/assets/ec3fa807-3cea-480f-8434-d9dbb2795e4b" />

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing specific.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only tweak that adjusts padding in `DefaultActionButtonStyle` usage; no logic, data, or control-flow changes.
> 
> **Overview**
> Adjusts the primary action buttons in the first-time quit survey (`Close and Quit` and `Quit Now`) to pass explicit `topPadding`/`bottomPadding` into `DefaultActionButtonStyle`, normalizing button height across the initial and positive-response dialogs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea1efbc3cd226e99aebf5586b8a13549775d120a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->