### PR TITLE
iOS: Duck.ai back arrow opens focused omnibar instead of tab switcher

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2286,7 +2286,7 @@ class MainViewController: UIViewController {
     func dismissOmniBar() {
         hideSuggestionTray()
         viewCoordinator.omniBar.endEditing()
-        unifiedToggleInputCoordinator?.deactivateToOmnibar()
+        deactivateUnifiedToggleInputOmnibarSession()
         refreshOmniBar()
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -76,7 +76,7 @@ extension MainViewController {
         coordinator.updateAIChatShortcutAvailability(aiChatAddressBarExperience.shouldShowDuckAIAddressBarButton)
         coordinator.onAnimatedDismissToOmnibar = { [weak self] completion in
             guard let self, let coordinator = self.unifiedToggleInputCoordinator else { return }
-            self.dismissUnifiedToggleInputToOmnibar(coordinator: coordinator, completion: completion)
+            self.dismissUnifiedToggleInputOmnibarSession(coordinator: coordinator, completion: completion)
         }
         self.unifiedToggleInputCoordinator = coordinator
 
@@ -722,7 +722,7 @@ extension MainViewController {
         contentVC.onDismissRequested = { [weak self] in
             guard let self, let coordinator = self.unifiedToggleInputCoordinator else { return }
             if coordinator.isOmnibarSession {
-                self.dismissUnifiedToggleInputToOmnibar(coordinator: coordinator)
+                self.dismissUnifiedToggleInputOmnibarSession(coordinator: coordinator)
             } else if coordinator.isAITabExpanded {
                 coordinator.showCollapsed()
             }
@@ -842,6 +842,32 @@ private extension MainViewController {
         }
     }
 
+    /// Routes a UTI omnibar-session dismiss to the matching chrome — Duck.ai header restore for
+    /// AI tabs, standard omnibar morph for everything else.
+    func dismissUnifiedToggleInputOmnibarSession(coordinator: UnifiedToggleInputCoordinator,
+                                                 completion: (() -> Void)? = nil) {
+        if currentTab?.isAITab == true {
+            dismissFocusedOmnibarToAITabChrome(coordinator: coordinator, completion: completion)
+        } else {
+            dismissUnifiedToggleInputToOmnibar(coordinator: coordinator, completion: completion)
+        }
+    }
+
+    /// Snaps back to AI tab chrome — the two surfaces share no visual element, so a crossfade
+    /// would briefly show both. Pins coordinator to `.aiTab(.collapsed)` so refresh routes to
+    /// `.preserveCurrentPresentation` and skips the auto-expand.
+    func dismissFocusedOmnibarToAITabChrome(coordinator: UnifiedToggleInputCoordinator,
+                                            completion: (() -> Void)? = nil) {
+        viewCoordinator.unifiedInputContentContainer.isHidden = true
+        viewCoordinator.showAIChatTabChatHeader()
+        coordinator.deactivateToOmnibar(resetView: false, animateDismiss: false)
+        coordinator.showCollapsed()
+        if let tab = currentTab {
+            refreshUnifiedToggleInput(for: tab)
+        }
+        completion?()
+    }
+
     func handleUnifiedToggleInputSearchSubmission(_ query: String) {
         let isAITabSubmission = currentTab?.isAITab == true
         if isAITabSubmission {
@@ -905,6 +931,11 @@ extension MainViewController: UnifiedToggleInputDelegate {
         let trimmed = prefilledText.trimmingWhitespace()
         unifiedToggleInputCoordinator?.clearText()
         unifiedToggleInputCoordinator?.handleExternalSubmission(.prompt)
+        // On a Duck.ai tab, load a new chat URL here so the previous chat goes into WebView back-history.
+        if currentTab?.isAITab == true {
+            currentTab?.load(trimmed.isEmpty ? nil : trimmed, autoSend: !trimmed.isEmpty)
+            return
+        }
         onAIChatPressed(prefilledText: trimmed.isEmpty ? nil : trimmed)
     }
 
@@ -1019,12 +1050,23 @@ extension MainViewController: AIChatTabChatHeaderViewDelegate {
         if currentTab?.canGoBack == true {
             onBackPressed()
         } else {
-            showTabSwitcher()
+            presentFocusedOmnibarFromAITab()
         }
     }
 
     func aiChatTabChatHeaderDidTapForward() {
         onForwardPressed()
+    }
+
+    /// Hides only the AI Chat header (NOT the nav chrome via `hideAITabChrome()`) so the standard
+    /// omnibar stays suppressed and dismiss skips its omnibar crossfade.
+    private func presentFocusedOmnibarFromAITab() {
+        guard let coordinator = unifiedToggleInputCoordinator else { return }
+        viewCoordinator.hideAIChatTabChatHeader()
+        applyUnifiedInputChromeBackground(.standardChrome)
+
+        let position: UnifiedToggleInputCardPosition = appSettings.currentAddressBarPosition == .bottom ? .bottom : .top
+        coordinator.activateFromOmnibar(prefilledText: nil, inputMode: .search, cardPosition: position)
     }
 }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -873,6 +873,7 @@ private extension MainViewController {
                                             completion: (() -> Void)? = nil) {
         viewCoordinator.unifiedInputContentContainer.isHidden = true
         viewCoordinator.showAIChatTabChatHeader()
+        viewCoordinator.animateUnifiedToggleInputOmnibarDismissLayout()
         coordinator.deactivateToOmnibar(resetView: false, animateDismiss: false)
         coordinator.showCollapsed()
         if let tab = currentTab {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -575,6 +575,8 @@ private extension MainViewController {
         applyUnifiedInputChromeBackground(.aiTabChatChromeHidden)
 
         applyAITabRefreshBehavior(behavior, coordinator: coordinator)
+        // Re-run: the early reconcile read pre-transition coordinator state.
+        reconcileToolbarVisibilityForCurrentTab()
 
         updateUnifiedInputContentVisibility(for: coordinator)
         refreshAIChatTabChatHeaderSubscriptionState()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -145,11 +145,24 @@ extension MainViewController {
         aiChatTabChatHeaderView?.setForceBackButtonVisible(!isAIChatSearchInputToggleEnabledForCurrentOnboardingState())
     }
 
-    /// Hides the toolbar on AI tabs; restores it on non-AI tabs. Idempotent.
-    /// Safe to call with the feature flag off — `isCurrentTabUsingUnifiedInputAIChrome` is
-    /// already flag-gated, so the else branch reduces to the legacy width/minimal-chrome rule.
+    /// Programmatic dismiss of an active UTI omnibar session (the intent-path used by
+    /// `dismissOmniBar`, toolbar buttons, etc.). On a Duck.ai tab this routes through the snap
+    /// dismiss so the AI tab's auto-expand doesn't bring the keyboard back up.
+    func deactivateUnifiedToggleInputOmnibarSession() {
+        guard let coordinator = unifiedToggleInputCoordinator, coordinator.isOmnibarSession else { return }
+        if currentTab?.isAITab == true {
+            dismissFocusedOmnibarToAITabChrome(coordinator: coordinator)
+        } else {
+            coordinator.deactivateToOmnibar()
+        }
+    }
+
+    /// Hides the toolbar on AI tabs; restores it on non-AI tabs. The focused omnibar session
+    /// opened from a Duck.ai tab counts as "tab-like" — keep the toolbar so the user has the
+    /// standard browser controls while searching. Idempotent; safe with the feature flag off.
     func reconcileToolbarVisibilityForCurrentTab() {
-        if isCurrentTabUsingUnifiedInputAIChrome {
+        let isFocusedOmnibarSession = unifiedToggleInputCoordinator?.isOmnibarSession == true
+        if isCurrentTabUsingUnifiedInputAIChrome && !isFocusedOmnibarSession {
             viewCoordinator.toolbar.isHidden = true
         } else {
             viewCoordinator.toolbar.isHidden = AppWidthObserver.shared.isLargeWidth || isInMinimalChromeLayout
@@ -1067,6 +1080,7 @@ extension MainViewController: AIChatTabChatHeaderViewDelegate {
 
         let position: UnifiedToggleInputCardPosition = appSettings.currentAddressBarPosition == .bottom ? .bottom : .top
         coordinator.activateFromOmnibar(prefilledText: nil, inputMode: .search, cardPosition: position)
+        reconcileToolbarVisibilityForCurrentTab()
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214736034727333

### Description

When the Search/Duck.ai toggle is OFF in Settings and the user is on a Duck.ai tab with no web back-history, tapping the AI Chat header's back arrow used to open the tab switcher (shipped in #4841). That hard-cuts the user out of the chat.

This change routes that tap into the standard focused-omnibar UI on the same tab — same surface the user sees by tapping the omnibar on a fresh NTP (search input + favorites + suggestions). The chat URL stays loaded in the WebView, so:

- **Submit a search** → loads in this tab; chat URL sits in web back-history → standard toolbar back returns to the chat.
- **Dismiss without submitting** → snaps back to Duck.ai chat chrome. No animation, no keyboard re-ascent: focused omnibar and AI tab chrome share no visual element, so any crossfade would briefly show both.

Additionally: when the AI chat shortcut button (sparkle) is tapped while the focused state is open on a Duck.ai tab, it loads a new chat URL in this tab (instead of opening a contextual sheet). The previous chat goes into web back-history; if the user typed something in the omnibar first, it becomes the new chat's first prompt.

### Testing Steps

> All scenarios below: Settings → AI Chat → ensure Search/Duck.ai toggle is **OFF**. Repeat with both top and bottom address bar position.

1. **Fresh Duck.ai tab → tap back → dismiss without submitting**
   - Open a fresh Duck.ai tab via the omnibar Duck.ai shortcut.
   - Tap the header back arrow → focused omnibar appears (search input + favorites + suggestions + keyboard).
   - Tap the header back arrow → Duck.ai chat chrome reinstalls; you land back on the same chat. No flicker, no "Duck.ai" URL flash, no UTI sliding up from the bottom.

2. **Fresh Duck.ai tab → tap back → submit a search**
   - Tap back arrow → type a query → submit.
   - Search result loads in this tab; standard chrome (omnibar + toolbar) appears.
   - Tap toolbar back → Duck.ai chat URL is restored → AI Chat header reinstalls.

3. **Fresh Duck.ai tab → tap back → tap sparkle (empty omnibar)**
   - Tap back arrow → tap the duck.ai on the right of the focused omnibar (no typed text).
   - New chat loads in this same tab; toolbar back returns to the previous chat.

4. **Fresh Duck.ai tab → tap back → type → tap sparkle**
   - Tap back arrow → type "hello world" → tap the duck.ai.
   - New chat loads in this same tab with "hello world" submitted as the first prompt; toolbar back returns to the previous chat.

5. **Regression: toggle ON**
   - Turn the Search/Duck.ai toggle ON.
   - On a Duck.ai tab with no web history, the header back arrow should not be force-shown (existing behavior, unchanged).

### Impact and Risks

**Low** — UI affordance change scoped to Duck.ai tabs with the Search/Duck.ai toggle OFF. No protocol or data changes. The standard `dismissUnifiedToggleInputToOmnibar` path is untouched for regular tabs.

#### What could go wrong?

- **Dismiss leaves UTI in stale state**: mitigated by routing through `refreshUnifiedToggleInput` after the snap, which is the central per-tab reconciler.
- **Auto-expand re-shows keyboard after dismiss**: explicitly prevented by pinning `coordinator.showCollapsed()` before refresh, so `refreshAction` routes to `.preserveCurrentPresentation` and skips the deferred `showExpanded`.

### Quality Considerations

- Manual verification across top + bottom address bar positions, fresh + existing chat states (15 build/install/relaunch cycles).
- No unit tests added — the new code is pure UIKit chrome wiring (chrome show/hide + coordinator state transitions), where unit coverage adds no signal over integration/visual checks.
- Behavior is gated by tab type (`currentTab?.isAITab`) and the existing `setForceBackButtonVisible` flag.

### Notes to Reviewer

- `dismissFocusedOmnibarToAITabChrome` deliberately **snaps** (no `UIView.animate`) — the focused omnibar and the Duck.ai chat chrome share no visual element, so any crossfade briefly shows both.
- The explicit `coordinator.showCollapsed()` before refresh is load-bearing: it transitions the coordinator into `.aiTab(.collapsed)` so `refreshAction` matches the `isAITabState` branch and returns `.preserveCurrentPresentation(allowsEarlyReturn: viewCoordinator.isNavigationChromeHidden)`. Without it, the refresh would route through `.showCollapsed(expandAfterRefresh: true)` and the deferred `showExpanded` would slide the bottom input back up with the keyboard.
- `presentFocusedOmnibarFromAITab` intentionally does NOT call `hideAITabChrome()` — leaving `isNavigationChromeHidden = true` is what makes `dismissUnifiedToggleInputToOmnibar` skip its omnibar crossfade. No "Duck.ai" URL label flash on dismiss.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI-state risk: changes unified toggle input dismissal/activation paths and toolbar visibility logic on Duck.ai tabs, which could cause stuck/incorrect chrome or keyboard behavior if coordinator state mismatches.
> 
> **Overview**
> On Duck.ai tabs with no web back-history, the AI Chat header back action now opens a *focused omnibar* (search input surface) instead of routing to the tab switcher.
> 
> Adds AI-tab-specific routing for Unified Toggle Input omnibar sessions: programmatic dismissals and user dismiss requests now **snap back to Duck.ai chat chrome** (no crossfade/keyboard re-raise), while non-AI tabs keep the existing omnibar morph. Toolbar visibility reconciliation is updated so the focused omnibar session from a Duck.ai tab keeps standard toolbar controls.
> 
> When the Duck.ai shortcut is triggered from the focused omnibar on a Duck.ai tab, it now loads a **new chat in the same tab** (pushing the previous chat into WebView back history) rather than using the prior non-tab flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 412ff5fc8dc1c87500e9c3df1fbe889c70bffb78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->