### PR TITLE
[iOS/macOS] Improve wide event logging

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit.swift
@@ -597,6 +597,13 @@ public final class PixelKit {
     }
 
     private func printDebugInfo(pixelName: String, frequency: Frequency, parameters: [String: String], skipped: Bool = false) {
+        // Wide-event pixels (`m_mac_wide_*` / `m_ios_wide_*`) also log their parameters via the
+        // POST endpoint payload in `DefaultWideEventSender`; skip the params here to avoid the noise.
+        guard !pixelName.contains("_wide_") else {
+            logger.debug("👾[\(frequency.description, privacy: .public)-\(skipped ? "Skipped" : "Fired", privacy: .public)] \(pixelName, privacy: .public)")
+            return
+        }
+
         let params = parameters
             .filter { key, _ in key != "test" }
             .sorted { $0.key < $1.key }

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/WideEvent/WideEvent.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/WideEvent/WideEvent.swift
@@ -111,8 +111,13 @@ public final class WideEvent: WideEventManaging {
         let globalID = data.globalData.id
 
         do {
-            try Self.storageQueue.sync { try storage.update(data) }
-            Self.logger.info("Wide event \(globalID, privacy: .public) updated: \(data.pixelParameters())")
+            let previousParameters: [String: String] = try Self.storageQueue.sync {
+                let previous: T = try storage.load(globalID: globalID)
+                let previousParameters = previous.pixelParameters()
+                try storage.update(data)
+                return previousParameters
+            }
+            Self.logUpdate(featureName: T.metadata.featureName, previous: previousParameters, current: data.pixelParameters())
         } catch {
             if case WideEventError.flowNotFound = error {
                 Self.logger.info("Wide event update ignored for non-existent flow: \(T.metadata.pixelName, privacy: .public), global ID: \(globalID, privacy: .public)")
@@ -124,14 +129,15 @@ public final class WideEvent: WideEventManaging {
 
     public func updateFlow<T: WideEventData>(globalID: String, update: (inout T) -> Void) {
         do {
-            let updatedData = try Self.storageQueue.sync { () -> T in
+            let (previousParameters, updatedData) = try Self.storageQueue.sync { () -> ([String: String], T) in
                 var data: T = try storage.load(globalID: globalID)
+                let previousParameters = data.pixelParameters()
                 update(&data)
                 try storage.update(data)
-                return data
+                return (previousParameters, data)
             }
 
-            Self.logger.info("Wide event \(globalID, privacy: .public) updated: \(updatedData.pixelParameters())")
+            Self.logUpdate(featureName: T.metadata.featureName, previous: previousParameters, current: updatedData.pixelParameters())
         } catch {
             if case WideEventError.flowNotFound = error {
                 Self.logger.info("Wide event update ignored for non-existent flow: \(T.metadata.pixelName, privacy: .public), global ID: \(globalID, privacy: .public)")
@@ -139,6 +145,33 @@ public final class WideEvent: WideEventManaging {
                 report(.updateFailed(pixelName: T.metadata.pixelName, error: error), error: error, params: nil)
             }
         }
+    }
+
+    private static func logUpdate(featureName: String, previous: [String: String], current: [String: String]) {
+        var added: [String: String] = [:]
+        var modified: [String: String] = [:]
+        var removed: [String: String] = [:]
+
+        for (key, value) in current {
+            if let previousValue = previous[key] {
+                if previousValue != value {
+                    modified[key] = "\(previousValue) → \(value)"
+                }
+            } else {
+                added[key] = value
+            }
+        }
+        for (key, value) in previous where current[key] == nil {
+            removed[key] = value
+        }
+
+        var lines: [String] = ["Wide event '\(featureName)' updated"]
+        if !added.isEmpty { lines.append("  Added: \(added)") }
+        if !modified.isEmpty { lines.append("  Modified: \(modified)") }
+        if !removed.isEmpty { lines.append("  Removed: \(removed)") }
+        if lines.count == 1 { lines.append("  No changes") }
+
+        logger.info("\(lines.joined(separator: "\n"), privacy: .public)")
     }
 
     public func getFlowData<T: WideEventData>(_ type: T.Type, globalID: String) -> T? {

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/WideEvent/WideEventSending.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/WideEvent/WideEventSending.swift
@@ -198,15 +198,16 @@ public final class DefaultWideEventSender: WideEventSending {
             return
         }
 
-        let jsonString = String(data: jsonData, encoding: .utf8) ?? "{}"
-        Self.logger.info("Wide event POST request:\nEndpoint: \(Self.postEndpoint.absoluteString, privacy: .public)\nPayload: \(jsonString, privacy: .public)")
+        let prettyJSONString = (try? JSONSerialization.data(withJSONObject: nested, options: [.prettyPrinted, .sortedKeys]))
+            .flatMap { String(data: $0, encoding: .utf8) }
+            ?? String(data: jsonData, encoding: .utf8)
+            ?? "{}"
+        Self.logger.info("Wide event POST request:\nEndpoint: \(Self.postEndpoint.absoluteString, privacy: .public)\nPayload:\n\(prettyJSONString, privacy: .public)")
 
         let headers = ["Content-Type": "application/json"]
 
         postRequestHandler(Self.postEndpoint, jsonData, headers) { success, error in
-            if success {
-                Self.logger.info("Wide event POST request sent successfully")
-            } else {
+            if !success {
                 Self.logger.error("Wide event POST request failed: \(String(describing: error), privacy: .public)")
             }
         }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1214877248343951?focus=true
Tech Design URL:
CC:

### Description

This PR improves wide event logging in a few ways:
1. Removes redundant parameter logs from PixelKit, since we log the parameters as part of the POST endpoint
2. Update the "wide event updated" logs to print what actually changed, instead of printing the entire event contents every single time
3. Pretty print the POST endpoint parameters so that they are easier to read

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Test wide events locally to confirm the logging changes look okay - you could do this by signing into a subscription account for example

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to logging output for wide events and do not alter pixel firing, persistence, or network request behavior. Main risk is increased verbosity or inadvertent exposure of parameter values in logs if log levels are enabled in production.
> 
> **Overview**
> Improves wide-event logging to reduce noise and make changes easier to inspect.
> 
> `PixelKit` no longer logs parameter lists for wide-event pixel names (they’re already logged with the POST payload). Wide-event `updateFlow` logging now reports *added/modified/removed* parameters instead of dumping the full event, and POST request logs now pretty-print and sort the JSON payload while removing the redundant “sent successfully” log line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c016b6271603a2b57b11ee0754d02fd667e77f08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->