### PR TITLE
[macOS][Bookmarks] Add ‘channel’ to the list of pixel parameters

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/bookmarks_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/bookmarks_pixels.json5
@@ -5,6 +5,6 @@
         "owners": ["alessandroboron"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1214877193425811?focus=true
Tech Design URL:
CC:

### Description

This PR adds the ‘channel’ parameter to Bookmark all tabs pixel. 

### Testing Steps
1. Ensure that Pixel specs includes the ‘channel’ parameter in spec as per Asana task

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes the pixel definition metadata by adding an extra parameter, with no functional logic changes.
> 
> **Overview**
> Updates the pixel specification for `m_mac_bookmarks_save-all-open-tabs` to include `channel` in its `parameters` list, aligning the bookmarks “save all open tabs” pixel with updated tracking requirements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f6b5d503be61efaf55c13d1601ede5eefc32f00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->