### PR TITLE
[macOS] Fix selection skipping unloaded tab when closing adjacent tab

### DIFF
--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabIndex.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabIndex.swift
@@ -275,7 +275,8 @@ extension TabIndex {
 
         /// Given of the nature of when this method is called, the tab index being manipulated (self) could be the tab to the right.
         /// So we need to check for self to see if it exists, if it exists, we return it.
-        if viewModel.tabViewModel(at: self) != nil {
+        /// Use `tabBarViewModel(at:)` so unloaded tabs are not skipped — they materialize on selection.
+        if viewModel.tabBarViewModel(at: self) != nil {
             return self
         }
 

--- a/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelCloseTabLogicTests.swift
+++ b/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelCloseTabLogicTests.swift
@@ -270,6 +270,29 @@ final class TabCollectionViewModelCloseTabLogicTests: XCTestCase {
         /// Verify: Previously Active Tab goes back to the pre-move state
         XCTAssertEqual(destinationTabCollectionViewModel.selectedTabIndex, .unpinned(2))
     }
+
+    @MainActor
+    func testWhenClosingTabAdjacentToUnloadedTab_thenNextUnloadedTabIsSelected() {
+        autoreleasepool {
+            /// Simulate lazy-loaded state: a few loaded tabs followed by unloaded tabs (as after state restoration).
+            let loadedTabs: [AnyTab] = (0..<3).map { _ in .loaded(Tab(content: .none)) }
+            let unloadedTabs: [AnyTab] = (0..<3).map { _ in
+                .unloaded(UnloadedTab(content: .url(.duckDuckGo, credential: nil, source: .pendingStateRestoration)))
+            }
+            let tabCollection = TabCollection(tabs: loadedTabs + unloadedTabs)
+            let tabCollectionViewModel = TabCollectionViewModel(tabCollection: tabCollection, pinnedTabsManagerProvider: nil)
+
+            /// Select the last loaded tab (the one next to the first unloaded tab).
+            tabCollectionViewModel.select(at: .unpinned(2))
+            let expectedNextTab = tabCollectionViewModel.tabCollection.tabs[3]
+
+            tabCollectionViewModel.remove(at: .unpinned(2))
+
+            /// After closing the loaded tab at index 2, the tab that was at index 3 (now at index 2) should be selected.
+            XCTAssertEqual(tabCollectionViewModel.selectionIndex, .unpinned(2))
+            XCTAssertEqual(tabCollectionViewModel.tabCollection.tabs[2].uuid, expectedNextTab.uuid)
+        }
+    }
 }
 
 fileprivate extension TabCollectionViewModel {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1214875701630606?focus=true

### Description

Fixes selection logic so that closing a loaded tab next to an unloaded one selects the immediately-adjacent tab instead of skipping it.

In `TabIndex.findNewSelectionIndexWithoutParent` (step 4), the "does a tab exist at this index?" check used `viewModel.tabViewModel(at:)`. That method casts via `as? TabViewModel`, which returns `nil` for `UnloadedTabViewModel`. So when the post-removal index pointed at an unloaded tab, the check failed, the algorithm fell through to `getRighteousTab`, and selection jumped one position past the intended tab.

The fix switches that single check to `viewModel.tabBarViewModel(at:)`, which returns the broader `TabBarViewModel` and treats loaded and unloaded tabs uniformly. The unloaded tab still materializes on selection as before.

### Testing Steps

1. Launch the app.
2. Append 50 tabs via the debug menu.
3. Select the first tab.
4. Quit and reopen the app.
5. After relaunch, wait until the first 20 tabs are loaded; tabs to the right remain unloaded.
6. Select tab 20 (the last lazy-loaded tab).
7. Close it.

**Expected:** Tab 21 becomes selected (and materializes).
**Before this fix:** Tab 22 was selected; closing further tabs in this state also skipped forward by one.

A regression test `testWhenClosingTabAdjacentToUnloadedTab_thenNextUnloadedTabIsSelected` was added to `TabCollectionViewModelCloseTabLogicTests`. It fails on the unmodified code (returns `.unpinned(3)`) and passes with the fix (returns `.unpinned(2)`).

### Impact and Risks

Low. The change is a one-line predicate swap within the post-close selection algorithm. Behavior for loaded-only tab arrangements is unchanged because `tabBarViewModel(at:)` returns non-nil for any tab `tabViewModel(at:)` already returned non-nil for.

#### What could go wrong?

- If an index points past the end of `tabCollection.tabs`, both helpers return `nil`, so out-of-bounds handling is unchanged.
- Selecting an unloaded tab triggers materialization through the existing `selectTab` path, exercised by `testSelectingUnloadedTabMaterializesIt`.

### Quality Considerations

All 12 tests in `TabCollectionViewModelCloseTabLogicTests` pass; the broader `TabCollectionViewModelTests` + `TabCollectionTests` suites (167 tests) pass with the change.

### Notes to Reviewer

The bug was introduced as a side-effect of lazy-loading: `UnloadedTabViewModel` is silently filtered out by the `as? TabViewModel` cast in `tabViewModel(at:)`, which most call sites want, but step 4 of the post-close logic uses the result purely as a presence check. `tabBarViewModel(at:)` (already defined in the same file) is the correct neighbour to ask for that.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line presence check swap in tab-close selection logic plus a focused regression test; main risk is subtle behavior change in edge cases around unloaded tabs/indexing.
> 
> **Overview**
> Fixes tab-close selection so **unloaded (lazy-restored) tabs are treated as valid adjacent targets** instead of being skipped.
> 
> In `TabIndex.findNewSelectionIndexWithoutParent`, the “does this index still exist?” check now uses `tabBarViewModel(at:)` (covers loaded + unloaded) rather than `tabViewModel(at:)`. Adds a unit test ensuring closing a loaded tab next to an unloaded one selects the immediately adjacent unloaded tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d260173725e020ef129ec31f0513aad9ca19336. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->