### PR TITLE
[macOS] Move tab to new window not working with unloaded tabs 

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -1260,12 +1260,11 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
             return
         }
 
-        guard let tabViewModel = tabCollectionViewModel.tabViewModel(at: unpinnedIndex) else {
-            assertionFailure("TabBarViewController: Failed to get tab view model")
+        guard let tab = tabCollectionViewModel.materialize(at: sourceTab) else {
+            assertionFailure("TabBarViewController: Failed to get tab")
             return
         }
 
-        let tab = tabViewModel.tab
         tabCollectionViewModel.remove(at: sourceTab, published: false)
         WindowsManager.openNewWindow(with: tab, droppingPoint: droppingPoint)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214883824177305?focus=true

### Description

Right-clicking "Move to New Window" or drag-detaching an unloaded tab tripped an `assertionFailure` in debug and silently no-op'd in release. Switches the tab lookup so the move works for both loaded and unloaded tabs.

### Testing Steps

1. Launch the app.
2. Append ~50 tabs via the debug menu.
3. Select the first tab.
4. Quit the app.
5. Reopen the app.
6. Wait until only the first ~20 tabs have lazy-loaded.
7. Right-click an unloaded tab (one past index 20).
8. Click "Move to New Window".
9. Expected: a new window opens with that tab.
10. Repeat from step 7 using a drag-detach off the tab bar instead.

### Impact and Risks

Low. The loaded-tab path is unchanged.

#### What could go wrong?

Nothing observed; the destination window would have materialized the moved tab on init regardless of how it arrived.

### Quality Considerations

Manual testing only — `TabBarViewController` has no test fixture and `WindowsManager.openNewWindow` creates real `NSWindow` instances. Adding either is out of scope here.

### Notes to Reviewer

Follows up on #4918, same conflation pattern at a different call site.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change in tab detaching logic; primary impact is on lazy/unloaded tab handling when creating a new window.
> 
> **Overview**
> Fixes detaching/moving an *unloaded* tab to a new window on macOS.
> 
> `TabBarViewController.moveToNewWindow` now uses `tabCollectionViewModel.materialize(at:)` to obtain a `Tab` (instead of requiring a loaded `TabViewModel`), preventing an assertion/no-op and allowing both loaded and unloaded tabs to be moved into a newly opened window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d25aad1a9d55bb434f75a82ff59126dc14cf01ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->