### PR TITLE
[macOS] Address bar bug fixes — padding, icon overlap, shield-on-placeholder, tall-height-on-restore

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -1742,6 +1742,15 @@ final class AddressBarButtonsViewController: NSViewController {
         }
         updateAskAIChatButtonVisibility()
         updateButtonsPosition()
+
+        /// Force an immediate layout pass after the visibility flips above. NSStackView's
+        /// `detachesHiddenViews=YES` only marks the stack for layout on `isHidden` changes —
+        /// the actual reflow is deferred to the next runloop. If a display pass lands in the
+        /// gap (e.g. from an `image =` mutation in `updateImageButton`/`updatePrivacyEntryPointIcon`,
+        /// or a Lottie shield appearing during URL load), newly-shown buttons render at their
+        /// stale pre-layout frames and the privacy shield / permission center icons visibly
+        /// overlap at x=0 for a frame. Covers both leading and trailing stacks in one pass.
+        view.layoutSubtreeIfNeeded()
     }
 
     private func updateToggleExpansionState(shouldShowToggle: Bool) {

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -220,6 +220,11 @@ final class AddressBarButtonsViewController: NSViewController {
     var textFieldValue: AddressBarTextField.Value? {
         didSet {
             updateButtons()
+            /// Shield animation views live outside `privacyDashboardButton` (in `animationWrapperView`),
+            /// so `updateButtons()` alone won't hide the Lottie shield when the bar transitions to/from
+            /// empty. Re-evaluate the entry-point icon here so the protected-site shield hides cleanly
+            /// when the bar is cleared (placeholder shown) and re-appears when a URL is restored.
+            updatePrivacyEntryPointIcon()
         }
     }
     var isMouseOverNavigationBar = false {
@@ -876,11 +881,18 @@ final class AddressBarButtonsViewController: NSViewController {
         /// `hasPendingBarInput` covers `.text(userTyped: true)`, `.url(userTyped: true)`, and `.suggestion` —
         /// any state where the bar is showing the user's pending edit (typed draft or autocomplete suggestion
         /// surfaced over it). The shield belongs to the loaded page, not to the edit.
+        ///
+        /// `isAddressBarEmpty` covers the "user cleared the URL, then switched tabs and came back" state where
+        /// the bar shows the placeholder ("Search or enter address") but `hasPendingBarInput` is false (the
+        /// stored value isn't `userTyped`). Without this check the shield would render next to an empty
+        /// placeholder, which doesn't match any URL.
+        let isAddressBarEmpty = textFieldValue?.isEmpty ?? true
         privacyDashboardButton.isShown = !isEditingMode
         && !isTextFieldEditorFirstResponder
         && isHypertextUrl
         && !tabViewModel.isShowingErrorPage
         && !hasPendingBarInput
+        && !isAddressBarEmpty
         && !isLocalUrl
         && !isAIChatPanelActive
 
@@ -893,6 +905,7 @@ final class AddressBarButtonsViewController: NSViewController {
         && privacyDashboardButton.isHidden
         && !isOnboarding
         && !isAIChatPanelActive
+        && !isAddressBarEmpty
     }
 
     /// Whether the address bar currently shows pending user input — a typed value (`.text` or `.url`
@@ -905,12 +918,15 @@ final class AddressBarButtonsViewController: NSViewController {
     }
 
     /// Whether the privacy shield indicators should be suppressed because the user is interacting with
-    /// the address bar, or because the duck.ai panel is covering it (its prompt overlay would otherwise
-    /// clash with shield rendering at the overlay edges).
+    /// the address bar, the duck.ai panel is covering it (its prompt overlay would otherwise clash with
+    /// shield rendering at the overlay edges), or the bar is empty (showing placeholder — there's no URL
+    /// for the shield to refer to). The Lottie shield lives in `animationWrapperView` outside
+    /// `privacyDashboardButton`, so gating it here is required even when the button itself is hidden.
     private var shouldHideShieldsForInputOrAIChat: Bool {
         if isAIChatPanelActive { return true }
         if hasPendingBarInput { return true }
         if isTextFieldEditorFirstResponder { return true }
+        if textFieldValue?.isEmpty ?? true { return true }
         return false
     }
 

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -954,9 +954,9 @@ final class AddressBarViewController: NSViewController {
             return
         }
 
-        self.passiveTextFieldMinXConstraint.constant = minX
+        self.passiveTextFieldMinXConstraint.constant = max(minX, duckAILeadingPadding)
         let isAddressBarFocused = view.window?.firstResponder == addressBarTextField.currentEditor()
-        let adjustedMinX: CGFloat = (!self.isSelected || self.mode.isEditing) ? minX : Constants.defaultActiveTextFieldMinX
+        let adjustedMinX: CGFloat = (!self.isSelected || self.mode.isEditing) ? max(minX, duckAILeadingPadding) : Constants.defaultActiveTextFieldMinX
 
         /// The negative offset compensates for the leading padding of the search icon so the typed text sits
         /// flush against it (the buttons side sets a matching positive pad on the privacy-shield constraint —

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -149,6 +149,16 @@ final class AddressBarViewController: NSViewController {
     private var mode: Mode = .editing(.text) {
         didSet {
             addressBarButtonsViewController?.controllerMode = mode
+            /// `shouldUseTallAddressBarLayout` keys off `mode.isEditing`, but the height-driving
+            /// `resizeAddressBar` only re-runs on tab content changes and focus transitions — not on
+            /// mode flips. When a window opens with a stored URL tab, the initial resize reads the
+            /// default `mode = .editing(.text)` and locks the bar at the tall focused height; once
+            /// the bar's value updates to the loaded URL `mode` flips to `.browsing` but nothing
+            /// re-evaluates the height. Trigger a resize on the editing-ness flip so the compact
+            /// layout applies immediately on session restore / "Open in New Window".
+            if oldValue.isEditing != mode.isEditing {
+                delegate?.resizeAddressBarForHomePage(self)
+            }
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1214650828403479?focus=true
https://app.asana.com/1/137249556945/project/1148564399326804/task/1214561283905501?focus=true
CC:

### Description

Four small address-bar fixes that surfaced together during testing. Independent root causes — one commit each so any of them can be reverted on its own.

1. **Padding when the Duck.ai toggle is disabled.** Focusing the bar made typed text sit flush against the left edge. The toggle-visible path already clamped the leading inset to 20pt; the toggle-hidden path didn't.
2. **Privacy shield / permission center overlap on URL load.** Most reproducible via right-click → "Open Link in New Window" on a slow target. NSStackView with `detachesHiddenViews=YES` defers reflow when multiple subviews flip visibility together, so both icons momentarily rendered at x=0. Forced a synchronous layout pass at the end of `updateButtons()`.
3. **Shield rendered next to the empty placeholder.** Clearing the URL and tab-switching away/back came back showing the empty placeholder *and* the privacy shield. Gated both the static button image and the Lottie shield on the bar having content.
4. **Address bar opening at the tall/focused height on session restore.** The initial resize fires while `mode` is still the default `.editing(.text)`; when `mode` flips to `.browsing` after the URL loads, nothing re-runs the resize. Added a resize trigger when the editing-ness flips.

### Testing Steps

#### Bug 1 — leading padding when the Duck.ai toggle is disabled

1. Open Settings (Cmd+,).
2. Select the **AI Chat** tab.
3. Uncheck **Show Search and Duck.ai Toggle**.
4. Close Settings.
5. Open a new tab (Cmd+T).
6. Click the address bar to focus it.
7. Type any text (e.g. `hello`).
8. **Check:** the typed text starts roughly 20pt from the bar's left edge — not flush against it.
9. Go back to Settings → **AI Chat** → re-check **Show Search and Duck.ai Toggle**.
10. Click the address bar again.
11. Type the same text.
12. **Check:** padding looks identical to step 8.
13. Navigate to https://example.com.
14. Click outside the bar to unfocus it.
15. **Check:** the privacy shield sits at the left and the URL text follows it — padding unchanged from before this PR (no regression in unfocused browsing).
16. File → **New Burner Window**.
17. In the burner window, click the address bar and type any text.
18. **Check:** same padding behaviour.

#### Bug 2 — privacy shield / permission center overlap on URL load

1. Open a GitHub PR (or any page that contains links to a slow-loading destination — Asana pages were the cleanest reproducer).
2. Right-click an external link.
3. Choose **Open Link in New Window**.
4. **Check:** the new window's address bar, the instant the URL paints — the privacy shield and the permission center icons render side-by-side, never on top of one another.
5. Close the new window.
6. Repeat steps 2–5 four more times (the bug was timing-dependent).
7. **Check:** no overlap on any attempt.
8. Open a new tab (Cmd+T).
9. Type a slow-loading URL (e.g. an Asana page) and press Enter.
10. **Check:** no overlap as the URL paints.
11. Visit a site where you've previously granted camera or microphone access (so the permission center icon is shown for that domain).
12. Open a new window with that URL via right-click → **Open Link in New Window**.
13. **Check:** both icons fade in cleanly, side-by-side.
14. Repeat step 12 with a fresh domain you've never granted permissions to.
15. **Check:** only the privacy shield appears (no regression).
16. Open a new HTTPS page that you haven't visited recently.
17. **Check:** the privacy-shield Lottie still animates on first load.
18. Visit a tracker-heavy site (e.g. a news homepage).
19. **Check:** the trackers-blocked badge animation still plays.

#### Bug 3 — privacy shield rendered next to the empty placeholder

1. Open any HTTPS site so the privacy shield is visible.
2. Click the address bar.
3. Select all (Cmd+A).
4. Delete (Backspace).
5. Switch to another tab.
6. Switch back to the original tab.
7. **Check:** the bar shows the placeholder "Search or enter address" and the privacy shield is **not** visible.
8. Type a URL and press Enter.
9. **Check:** the shield reappears once the page loads.
10. Visit an HTTP site (e.g. http://example.com) so the shield-with-dot variant is shown.
11. Repeat steps 2–6.
12. **Check:** the shield-with-dot is hidden over the placeholder.
13. (Optional, if you can flag a site as malicious in testing) Visit a site flagged as malicious so the red alert icon is shown.
14. Repeat steps 2–6.
15. **Check:** the red alert icon is hidden over the placeholder.
16. Open a new tab and navigate to any HTTPS site.
17. **Check:** the shield Lottie animation plays on first load as usual (no regression).
18. On a loaded URL tab, focus the bar and start typing.
19. **Check:** the shield is hidden while typing (existing behaviour, not regressed).
20. Keep typing so autocompletion suggestions appear; cycle through them with the up/down arrow keys.
21. **Check:** the shield stays hidden and does not flicker as suggestions change.

#### Bug 4 — address bar opens at tall (focused) height on session restore

1. Open one window with one or more URL tabs (e.g. https://example.com).
2. Cmd+Q to quit the app.
3. Re-launch the app from the dock.
4. **Check:** each restored URL tab opens with the address bar at the compact (unfocused) height — the same height it has after a manual focus + unfocus.
5. Open a window with one URL tab and one new-tab page (NTP).
6. Cmd+Q, then re-launch.
7. **Check:** the URL tab opens compact; the NTP opens tall and focused (its normal state).
8. Switch between the two tabs.
9. **Check:** each tab's bar lands at its correct height — no manual focus + unfocus needed.
10. Visit any page with external links.
11. Right-click an external link.
12. Choose **Open Link in New Window**.
13. **Check:** the new window's bar opens compact immediately — does **not** briefly render tall and snap to compact.
14. Cmd+T to open a new tab.
15. **Check:** the NTP opens tall and focused, as before (no regression).
16. On a URL tab (compact bar), click the bar and start typing.
17. **Check:** the bar expands to the tall height.
18. Press Esc (or click outside the bar).
19. **Check:** the bar returns to compact.
20. Focus the bar, type a partial URL, accept an autocompletion suggestion with Enter.
21. **Check:** after navigation, the bar is compact.
22. Focus the bar, type a query that produces multiple suggestions, cycle them with arrow keys.
23. **Check:** the bar height does **not** change while cycling.
24. If the Duck.ai toggle feature is enabled, switch to Duck.ai mode and back.
25. **Check:** the bar resizes correctly between modes.
26. Trigger a popup window (e.g. an OAuth login flow on a third-party site).
27. **Check:** the popup window's bar layout is unchanged from before this PR.
28. File → **New Burner Window**, load a URL, Cmd+Q, re-launch.
29. **Check:** the restored burner window's bar opens compact (same as a regular session).

### Impact and Risks

Low. Four address-bar layout fixes; no behaviour change outside the macOS navigation bar; no state-machine changes.

#### What could go wrong?

- Bug 4's resize-on-mode-flip could fire at unexpected moments during AI-chat transitions. Mitigated by the `oldValue.isEditing != mode.isEditing` guard and by `resizeAddressBarForHomePage`'s existing no-op for themes without `shouldShowNewSearchIcon`.
- Bug 2's `view.layoutSubtreeIfNeeded()` runs synchronously per `updateButtons()` call. Frequency is bounded by tab/value transitions; no perceptible cost in testing.
- Bug 3's added `updatePrivacyEntryPointIcon()` in `textFieldValue.didSet` fires per value change (not per keystroke — `value` updates at specific points). Early-returns via `shouldHideShieldsForInputOrAIChat` keep repeated calls cheap.

### Notes to Reviewer

Four standalone commits, bisect-friendly. Each is small (≤20 lines including comments).