### PR TITLE
Closing unloaded tab not alerting about floating duck.ai window

### DIFF
--- a/macOS/DuckDuckGo/Tab/ViewModel/UnloadedTabViewModel.swift
+++ b/macOS/DuckDuckGo/Tab/ViewModel/UnloadedTabViewModel.swift
@@ -40,6 +40,7 @@ final class UnloadedTabViewModel: TabBarViewModel, Previewable {
 
     // MARK: - TabBarViewModel
 
+    var uuid: TabIdentifier { unloadedTab.uuid }
     var tabContent: Tab.TabContent { unloadedTab.content }
     var isPinned: Bool { false }
     var title: String {

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -2424,7 +2424,7 @@ extension TabBarViewController: TabBarViewItemDelegate {
             return
         }
 
-        if let tabID = tabCollectionViewModel.tabViewModel(at: tabIndex)?.tab.uuid {
+        if let tabID = tabCollectionViewModel.tabBarViewModel(at: tabIndex)?.uuid {
             aiChatCoordinator?.closeFloatingWindow(for: tabID)
         }
         tabCollectionViewModel.remove(at: tabIndex)
@@ -2436,7 +2436,7 @@ extension TabBarViewController: TabBarViewItemDelegate {
 
     @discardableResult
     func tryPresentWarnBeforeCloseForFloatingAIChatIfNeeded(for tabIndex: TabIndex) -> Bool {
-        guard let tabID = tabCollectionViewModel.tabViewModel(at: tabIndex)?.tab.uuid,
+        guard let tabID = tabCollectionViewModel.tabBarViewModel(at: tabIndex)?.uuid,
               shouldWarnBeforeClosingFloatingAIChat(tabID: tabID),
               let tabBarViewItem = tabBarViewItem(for: tabIndex) else {
             return false

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -32,6 +32,7 @@ struct OtherTabBarViewItemsState {
 }
 
 protocol TabBarViewModel {
+    var uuid: TabIdentifier { get }
     var tabContent: Tab.TabContent { get }
     var isPinned: Bool { get }
     var title: String { get }
@@ -52,6 +53,7 @@ protocol TabBarViewModel {
 }
 
 extension TabViewModel: TabBarViewModel {
+    var uuid: TabIdentifier { tab.uuid }
     var isPinned: Bool {
         tab.isPinned
     }
@@ -1761,6 +1763,7 @@ extension TabBarViewItem {
         func tabBarViewItemSuspendAction(_: TabBarViewItem) {}
 
         final class TabBarViewModelMock: TabBarViewModel {
+            let uuid: TabIdentifier = UUID().uuidString
             var url: URL?
             var width: CGFloat
             var isSelected: Bool

--- a/macOS/UnitTests/TabBar/View/TabBarViewItemTests.swift
+++ b/macOS/UnitTests/TabBar/View/TabBarViewItemTests.swift
@@ -364,6 +364,7 @@ final class TabBarViewItemTests: XCTestCase {
 }
 
 private class TabBarViewModelMock: TabBarViewModel {
+    let uuid: TabIdentifier = UUID().uuidString
     var width: CGFloat
     var isSelected: Bool
     var isPinned: Bool


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1214883824177310?focus=true

### Description

Closes a gap where closing an unloaded tab whose AI chat was floating before the previous quit destroys the persisted chat session with no warning. The AIChat cleanup hooks in TabBarViewController now resolve the tab id for both loaded and unloaded tabs.

### Testing Steps

1. Launch the app.
2. Open Debug Menu > UI Triggers > Insert 50 tabs.
3. Select the last tab.
4. Open the AI chat side panel.
5. Detach the chat into a floating window.
   - Expected: floating window appears tied to the last tab.
6. Select the first tab.
   - Expected: floating window stays visible.
7. Quit the app.
8. Relaunch the app.
   - Expected: first tab is loaded and selected; the rest are in the bar but unloaded; no floating window is on screen.
9. Right-click the last tab and choose Close.
   - Expected: the close-tab warning appears; the persisted floating session is not destroyed silently.

### Impact and Risks

Low. Loaded tabs follow the same code path as before. Unloaded tabs now produce a tab id at the two cleanup sites, so the warning fires when there is a persisted floating session and `closeFloatingWindow` runs unconditionally.

#### What could go wrong?

A new conformer to \`TabBarViewModel\` could wire \`uuid\` incorrectly. Today the conformers are \`TabViewModel\` and \`UnloadedTabViewModel\`, both one-line accessors over an underlying tab id.

### Quality Considerations

Floating-window cleanup is no longer gated on a tab being loaded at close time.

### Notes to Reviewer

Other \`tabViewModel(at:)\` callers will be migrated in follow-up PRs.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to how tab IDs are resolved for close/warning logic; main risk is an incorrect `uuid` implementation by a `TabBarViewModel` conformer causing missed warnings or wrong chat cleanup.
> 
> **Overview**
> Fixes a gap where closing an *unloaded* tab could bypass floating Duck.ai chat cleanup/warning by making the tab bar resolve the tab identifier from the tab bar view model rather than only from a loaded `TabViewModel`.
> 
> This adds `uuid` to the `TabBarViewModel` protocol, implements it for both `TabViewModel` and `UnloadedTabViewModel`, updates `TabBarViewController` to use `tabBarViewModel(at:)?.uuid` in the close/warn paths, and updates mocks/tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95af00f4e93fc54ec7ee242597eb88feef8d0771. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->