### PR TITLE
[macOS] RMF asset update

### DIFF
--- a/SharedPackages/BrowserServicesKit/Package.resolved
+++ b/SharedPackages/BrowserServicesKit/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "d3e17cb6e45b15420637d9d689c45bff81df1a4a",
-        "version" : "14.8.0"
+        "revision" : "c3d43a3f971d8c21ba3624e0e1c2ee2598ddfd1c",
+        "version" : "14.9.0"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
         .package(url: "https://github.com/1024jp/GzipSwift.git", exact: "6.0.1"),
         .package(url: "https://github.com/vapor/jwt-kit.git", exact: "4.13.5"),
         .package(url: "https://github.com/pointfreeco/swift-clocks.git", exact: "1.0.6"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts.git", exact: "14.8.0"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts.git", exact: "14.9.0"),
         .package(path: "../URLPredictor"),
     ],
     targets: [

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
@@ -398,6 +398,8 @@ struct JsonToRemoteMessageModelMapper {
             return .subscription
         case .veryCriticalUpdate:
             return .veryCriticalUpdate
+        case .youtubeNew:
+            return .youtubeNew
         case .none:
             return .announce
         }

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Model/JsonRemoteMessagingConfig.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Model/JsonRemoteMessagingConfig.swift
@@ -176,6 +176,7 @@ public enum RemoteMessageResponse {
         case pir = "PIR"
         case subscription = "Subscription"
         case veryCriticalUpdate = "VeryCriticalUpdate"
+        case youtubeNew = "YoutubeNew"
     }
 
     public enum StatusError: Error {

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Model/RemoteMessageModel.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Model/RemoteMessageModel.swift
@@ -349,4 +349,5 @@ public enum RemotePlaceholder: String, Codable, CaseIterable {
     case veryCriticalUpdate = "RemoteMessageVeryCriticalUpdate"
     case newTabOptions = "RemoteMessageNewTabOptions"
     case splitBarMobile = "RemoteMessageSplitBarMobile"
+    case youtubeNew = "RemoteMessageYoutubeNew" // macOS only
 }

--- a/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Mappers/JsonToRemoteMessageModelMapperCardsListTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Mappers/JsonToRemoteMessageModelMapperCardsListTests.swift
@@ -355,6 +355,7 @@ struct JsonToRemoteMessageModelMapperCardsListTests {
             ("KeyImport", .keyImport),
             ("NewTabOptions", .newTabOptions),
             ("SplitBarMobile", .splitBarMobile),
+            ("YoutubeNew", .youtubeNew),
             ("PIR", .pir),
             ("Subscription", .subscription),
             (nil, nil)

--- a/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Mappers/JsonToRemoteMessageModelMapperPlaceholdersTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Mappers/JsonToRemoteMessageModelMapperPlaceholdersTests.swift
@@ -44,6 +44,7 @@ struct JsonToRemoteMessageModelMapperPlaceholdersTests {
         (.pir, .pir),
         (.subscription, .subscription),
         (.veryCriticalUpdate, .veryCriticalUpdate),
+        (.youtubeNew, .youtubeNew),
     ]
 
     @Test("Check Placeholder Mapping Coverage")

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/RMF/NewTabPageDataModel+RMF.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/RMF/NewTabPageDataModel+RMF.swift
@@ -124,6 +124,7 @@ extension NewTabPageDataModel {
         case radarCheckPurple = "RadarCheckPurple"
         case subscriptionIcon = "Subscription"
         case veryCriticalUpdate = "VeryCriticalUpdate"
+        case youtubeNew = "YoutubeNew"
 
         init(_ placeholder: RemotePlaceholder) {
             switch placeholder {
@@ -149,6 +150,8 @@ extension NewTabPageDataModel {
                 self = .subscriptionIcon
             case .veryCriticalUpdate:
                 self = .veryCriticalUpdate
+            case .youtubeNew:
+                self = .youtubeNew
             default:
                 self = .ddgAnnounce
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214636049052935?focus=true
Tech Design URL:
CC:

### Description
Adds YoutubeNew RMF mapping for asset added in CSS release 14.9.0

### Testing Steps
1. Override the RMF config URL with https://pastebin.com/raw/kb4siynj
2. Confirm remote message presents in new tab with new YouTube asset
<img width="641" height="145" alt="image" src="https://github.com/user-attachments/assets/49c0f5de-f37a-43dc-a39d-4ea690732428" />


### Impact and Risks
What's the impact on users if something goes wrong?
Low: Minor visual changes, small bug fixes, improvement to existing features

<!-- CURSOR_SUMMARY -->
--

> [!NOTE]
> **Low Risk**
> Low risk: this is a dependency version bump plus additive enum/mapping/test updates for a new RMF asset; main risk is a missing/incorrect mapping causing the wrong icon or fallback rendering on macOS.
> 
> **Overview**
> Updates `content-scope-scripts` to `14.9.0`.
> 
> Adds support for the new RMF placeholder **`YoutubeNew`** by extending the remote messaging JSON placeholder enum/model, mapping it in `JsonToRemoteMessageModelMapper`, and wiring it through the macOS New Tab Page RMF icon mapping; unit tests are updated to include the new placeholder and keep mapping coverage exhaustive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 759350bb4b70c6f93ecae3568e17eb527350a4e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->