### PR TITLE
ATB install date not triggering assert anymore

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "85cc5632cc315ba2b693145a2f7d6db53697285b9b92d72eff40322e3621706f",
+  "originHash" : "0ecf7ffde3949fb49981b2ea974fce4871016de82c64ed08d3949ffd00116cdf",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "4d35a8c3e8e613bc4f5217c9ff3238e6857e1ad7",
-        "version" : "14.7.0"
+        "revision" : "d3e17cb6e45b15420637d9d689c45bff81df1a4a",
+        "version" : "14.8.0"
       }
     },
     {

--- a/SharedPackages/AttributedMetric/Sources/AttributedMetric/AttributedMetricManager.swift
+++ b/SharedPackages/AttributedMetric/Sources/AttributedMetric/AttributedMetricManager.swift
@@ -254,10 +254,12 @@ public final class AttributedMetricManager: @unchecked Sendable {
             return
         }
 
-        guard installDateProvider.installDate != nil else {
-            Logger.attributedMetric.error("Install date is nil")
+        guard let installDate = installDateProvider.installDate else {
+            Logger.attributedMetric.log("Install date is nil")
             return
         }
+
+        Logger.attributedMetric.debug("Install date: \(installDate)")
 
         guard !returningUserProvider.isReturningUser else {
             Logger.attributedMetric.log("Returning user, skipping")

--- a/SharedPackages/AttributedMetric/Sources/AttributedMetric/AttributedMetricManager.swift
+++ b/SharedPackages/AttributedMetric/Sources/AttributedMetric/AttributedMetricManager.swift
@@ -254,9 +254,8 @@ public final class AttributedMetricManager: @unchecked Sendable {
             return
         }
 
-        guard let installDate = installDateProvider.installDate else {
+        guard installDateProvider.installDate != nil else {
             Logger.attributedMetric.error("Install date is nil")
-            assertionFailure("Install date is nil")
             return
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1214896574383425?focus=true
Tech Design URL:
CC:

### Description

ATB install date not triggering assert anymore

### Testing Steps
1. Clean simulator
2. Start the app
3. Not crashing 🟢 

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low code-change risk (removes an `assertionFailure` and adds debug logging), but includes a `content-scope-scripts` dependency bump which could have broader runtime impact depending on script changes.
> 
> **Overview**
> Prevents `AttributedMetricManager.process(trigger:)` from triggering an `assertionFailure` when the install date is unavailable; it now logs and returns, and adds a debug log of the resolved install date.
> 
> Updates SwiftPM resolution to `content-scope-scripts` `14.8.0` (from `14.7.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e367e8704c30d56a5e18da410bdc3193d535cc82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->