### PR TITLE
Migrate WindowControllersManager off tabViewModel(at:)

### DIFF
--- a/macOS/DuckDuckGo/UserNotifications/WebNotificationClickHandler.swift
+++ b/macOS/DuckDuckGo/UserNotifications/WebNotificationClickHandler.swift
@@ -19,11 +19,10 @@
 import Foundation
 import PixelKit
 
-/// Protocol for finding and focusing tabs, enabling isolated testing.
+/// Protocol for focusing tabs, enabling isolated testing.
 @MainActor
 protocol WebNotificationTabFinding: AnyObject {
-    func findTab(byUUID uuid: String) -> Tab?
-    func focusTab(_ tab: Tab)
+    func focusTab(byUUID uuid: String) -> Tab?
     func focusBrowser()
 }
 
@@ -45,13 +44,12 @@ final class WebNotificationClickHandler {
     ///   - tabUUID: The UUID of the tab that created the notification.
     ///   - notificationId: The notification's unique identifier.
     func handleClick(tabUUID: String, notificationId: String) {
-        guard let tab = tabFinder.findTab(byUUID: tabUUID) else {
-            // Tab was closed; just focus the browser window
+        guard let tab = tabFinder.focusTab(byUUID: tabUUID) else {
+            // No tab with this UUID; just focus the browser window
             tabFinder.focusBrowser()
             return
         }
 
-        tabFinder.focusTab(tab)
         PixelKit.fire(WebNotificationPixel.clicked, frequency: .dailyAndCount)
         tab.webNotifications?.sendClickEvent(notificationId: notificationId)
     }

--- a/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
+++ b/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
@@ -615,30 +615,19 @@ extension WindowControllersManagerProtocol {
 
     // MARK: - Web Notifications Support
 
-    /// Finds a tab by its UUID across all windows, materializing it if unloaded.
+    /// Focuses the tab with the given UUID across all windows, materializing it if unloaded.
     /// - Parameter uuid: The tab's UUID.
-    /// - Returns: The tab if found, nil otherwise.
-    func findTab(byUUID uuid: String) -> Tab? {
+    /// - Returns: The loaded tab if found, nil otherwise.
+    @discardableResult
+    func focusTab(byUUID uuid: String) -> Tab? {
         for windowController in mainWindowControllers {
             let tabCollectionViewModel = windowController.mainViewController.tabCollectionViewModel
             if let index = tabCollectionViewModel.indexInAllTabs(where: { $0.uuid == uuid }) {
-                return tabCollectionViewModel.materialize(at: index)
+                windowController.window?.makeKeyAndOrderFront(nil)
+                return tabCollectionViewModel.selectTab(at: index)
             }
         }
         return nil
-    }
-
-    /// Focuses the window containing the given tab and selects the tab.
-    /// - Parameter tab: The tab to focus.
-    func focusTab(_ tab: Tab) {
-        for windowController in mainWindowControllers {
-            let tabCollectionViewModel = windowController.mainViewController.tabCollectionViewModel
-            if let index = tabCollectionViewModel.indexInAllTabs(of: tab) {
-                windowController.window?.makeKeyAndOrderFront(nil)
-                tabCollectionViewModel.select(at: index)
-                return
-            }
-        }
     }
 
     /// Focuses the most recently active browser window.

--- a/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
+++ b/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
@@ -378,8 +378,7 @@ extension WindowControllersManager {
             }) else { continue }
 
             windowController.window?.makeKeyAndOrderFront(self)
-            tabCollectionViewModel.select(at: index)
-            if let tab = tabCollectionViewModel.tabViewModel(at: index)?.tab,
+            if let tab = tabCollectionViewModel.selectTab(at: index),
                tab.content.urlForWebView != url && url != URL.empty {
                 // navigate to another settings pane
                 tab.setContent(.contentFromURL(url, source: .switchToOpenTab))
@@ -616,14 +615,14 @@ extension WindowControllersManagerProtocol {
 
     // MARK: - Web Notifications Support
 
-    /// Finds a tab by its UUID across all windows.
+    /// Finds a tab by its UUID across all windows, materializing it if unloaded.
     /// - Parameter uuid: The tab's UUID.
     /// - Returns: The tab if found, nil otherwise.
     func findTab(byUUID uuid: String) -> Tab? {
         for windowController in mainWindowControllers {
             let tabCollectionViewModel = windowController.mainViewController.tabCollectionViewModel
             if let index = tabCollectionViewModel.indexInAllTabs(where: { $0.uuid == uuid }) {
-                return tabCollectionViewModel.tabViewModel(at: index)?.tab
+                return tabCollectionViewModel.materialize(at: index)
             }
         }
         return nil

--- a/macOS/UnitTests/UserNotifications/WebNotificationClickHandlerTests.swift
+++ b/macOS/UnitTests/UserNotifications/WebNotificationClickHandlerTests.swift
@@ -26,17 +26,12 @@ import XCTest
 final class MockWebNotificationTabFinder: WebNotificationTabFinding {
 
     var tabToReturn: Tab?
-    private(set) var findTabCalledWithUUID: String?
-    private(set) var focusTabCalledWithTab: Tab?
+    private(set) var focusTabCalledWithUUID: String?
     private(set) var focusBrowserCalled = false
 
-    func findTab(byUUID uuid: String) -> Tab? {
-        findTabCalledWithUUID = uuid
+    func focusTab(byUUID uuid: String) -> Tab? {
+        focusTabCalledWithUUID = uuid
         return tabToReturn
-    }
-
-    func focusTab(_ tab: Tab) {
-        focusTabCalledWithTab = tab
     }
 
     func focusBrowser() {
@@ -77,22 +72,13 @@ final class WebNotificationClickHandlerTests: XCTestCase {
 
     // MARK: - Tab Found Tests
 
-    func testWhenTabExistsThenFindsTabByUUID() {
+    func testWhenTabExistsThenFocusesTabByUUID() {
         let tab = Tab(content: .newtab)
         mockTabFinder.tabToReturn = tab
 
         handler.handleClick(tabUUID: "test-uuid-123", notificationId: "notif-1")
 
-        XCTAssertEqual(mockTabFinder.findTabCalledWithUUID, "test-uuid-123")
-    }
-
-    func testWhenTabExistsThenFocusesTab() {
-        let tab = Tab(content: .newtab)
-        mockTabFinder.tabToReturn = tab
-
-        handler.handleClick(tabUUID: "test-uuid", notificationId: "notif-1")
-
-        XCTAssertTrue(mockTabFinder.focusTabCalledWithTab === tab)
+        XCTAssertEqual(mockTabFinder.focusTabCalledWithUUID, "test-uuid-123")
     }
 
     func testWhenTabExistsThenDoesNotFocusBrowser() {
@@ -112,13 +98,5 @@ final class WebNotificationClickHandlerTests: XCTestCase {
         handler.handleClick(tabUUID: "missing-uuid", notificationId: "notif-1")
 
         XCTAssertTrue(mockTabFinder.focusBrowserCalled)
-    }
-
-    func testWhenTabNotFoundThenDoesNotFocusTab() {
-        mockTabFinder.tabToReturn = nil
-
-        handler.handleClick(tabUUID: "missing-uuid", notificationId: "notif-1")
-
-        XCTAssertNil(mockTabFinder.focusTabCalledWithTab)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214883824177321

### Description

Refactor in `WindowControllersManager` to replace load-gated `tabViewModel(at:)` lookups with `AnyTab`-aware accessors. Eliminates a `findTab → focusTab` round-trip by consolidating both into a single `focusTab(byUUID:)` primitive. Side benefit: lookups resolve both loaded and unloaded tabs uniformly.

### Testing Steps

**Window menu → switch to tab**
1. Launch the app.
2. Open a second window so two windows are present, each with a couple of tabs.
3. From one window, open the Window menu.
4. Click an entry for a tab in the other window.
5. Expected: the other window comes to front and that tab is selected.
6. Quit and reopen the app.
7. Repeat steps 3-4 before all tabs have lazy-loaded.
8. Expected: the picked unloaded tab loads and is selected.

**Web notification → focus originating tab**
1. Open a site that requests notification permission and grant it.
2. Background the app.
3. Trigger a web notification from the site.
4. Click the notification.
5. Expected: the app activates and the originating tab is focused.

### Impact and Risks

Medium. Changes tab selection/focus paths in `WindowControllersManager`, affecting Window menu switching and notification clicks across loaded and unloaded tabs.

#### What could go wrong?

A regression here would either fail to switch/focus the right tab or skip materializing an unloaded tab on focus. Both code paths were exercised against loaded and unloaded tabs.

### Notes to Reviewer

Follow-up to the same migration pattern as #4918 and #4919.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how tabs are identified/selected across windows (including unloaded-tab materialization) and adjusts the web-notification click path, which could affect tab focusing or close flows if IDs/indexing are wrong.
> 
> **Overview**
> Moves tab identification in the tab bar to a `TabBarViewModel.uuid` property (implemented by both `TabViewModel` and `UnloadedTabViewModel`) and updates close/AI-chat warning logic to use `tabBarViewModel(at:)` instead of load-gated `tabViewModel(at:)`.
> 
> Refactors web notification handling to use a single `focusTab(byUUID:)` primitive on `WindowControllersManager` (selecting/materializing the tab and bringing its window forward), removing the previous `findTab` + `focusTab` round-trip; associated unit tests/mocks are updated. Build number is bumped to `712`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8259ddb1bfd543fefa950e2fdc34226b1ddaa7b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
