### PR TITLE
Surface unloaded tabs in address-bar tab suggestions

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7a1b081dd539e1946f211052ca54c974c6f407746baab16283b0330d07edd71b",
+  "originHash" : "85cc5632cc315ba2b693145a2f7d6db53697285b9b92d72eff40322e3621706f",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "d3e17cb6e45b15420637d9d689c45bff81df1a4a",
-        "version" : "14.8.0"
+        "revision" : "4d35a8c3e8e613bc4f5217c9ff3238e6857e1ad7",
+        "version" : "14.7.0"
       }
     },
     {

--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "85cc5632cc315ba2b693145a2f7d6db53697285b9b92d72eff40322e3621706f",
+  "originHash" : "7a1b081dd539e1946f211052ca54c974c6f407746baab16283b0330d07edd71b",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "4d35a8c3e8e613bc4f5217c9ff3238e6857e1ad7",
-        "version" : "14.7.0"
+        "revision" : "d3e17cb6e45b15420637d9d689c45bff81df1a4a",
+        "version" : "14.8.0"
       }
     },
     {

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -1671,12 +1671,12 @@ extension MainViewController {
     @MainActor
     @objc func crashAllTabs() {
         let windowControllersManager = Application.appDelegate.windowControllersManager
-        let allTabViewModels = windowControllersManager.allTabViewModels
-
-        for tabViewModel in allTabViewModels {
-            let tab = tabViewModel.tab
-            if tab.canKillWebContentProcess {
-                tab.killWebContentProcess()
+        for tabCollectionViewModel in windowControllersManager.allTabCollectionViewModels {
+            for case let tabViewModel as TabViewModel in tabCollectionViewModel.tabViewModels.values {
+                let tab = tabViewModel.tab
+                if tab.canKillWebContentProcess {
+                    tab.killWebContentProcess()
+                }
             }
         }
     }

--- a/macOS/DuckDuckGo/Suggestions/Model/SuggestionContainer.swift
+++ b/macOS/DuckDuckGo/Suggestions/Model/SuggestionContainer.swift
@@ -157,9 +157,9 @@ final class SuggestionContainer: SuggestionContainerProtocol {
     private static func defaultOpenTabsProvider(burnerMode: BurnerMode, windowControllersManager: WindowControllersManagerProtocol) -> OpenTabsProvider {
         { @MainActor in
             let selectedTab = windowControllersManager.selectedTab
-            let openTabBarViewModels = windowControllersManager.allTabViewModels(for: burnerMode, includingPinnedTabs: !burnerMode.isBurner)
+            let openTabViewModels = windowControllersManager.allTabViewModels(for: burnerMode, includingPinnedTabs: !burnerMode.isBurner)
             var usedUrls = Set<String>() // deduplicate
-            return openTabBarViewModels.compactMap { model in
+            return openTabViewModels.compactMap { model in
                 guard model.uuid != selectedTab?.uuid,
                       model.tabContent.displaysContentInWebView
                         || model.tabContent.urlForWebView?.isSettingsURL == true

--- a/macOS/DuckDuckGo/Suggestions/Model/SuggestionContainer.swift
+++ b/macOS/DuckDuckGo/Suggestions/Model/SuggestionContainer.swift
@@ -157,18 +157,18 @@ final class SuggestionContainer: SuggestionContainerProtocol {
     private static func defaultOpenTabsProvider(burnerMode: BurnerMode, windowControllersManager: WindowControllersManagerProtocol) -> OpenTabsProvider {
         { @MainActor in
             let selectedTab = windowControllersManager.selectedTab
-            let openTabViewModels = windowControllersManager.allTabViewModels(for: burnerMode, includingPinnedTabs: !burnerMode.isBurner)
+            let openTabBarViewModels = windowControllersManager.allTabViewModels(for: burnerMode, includingPinnedTabs: !burnerMode.isBurner)
             var usedUrls = Set<String>() // deduplicate
-            return openTabViewModels.compactMap { model in
-                guard model.tab !== selectedTab,
-                      model.tab.content.displaysContentInWebView
-                        || model.tab.content.urlForWebView?.isSettingsURL == true
-                        || model.tab.content.urlForWebView == .bookmarks,
-                      let url = model.tab.content.userEditableUrl,
+            return openTabBarViewModels.compactMap { model in
+                guard model.uuid != selectedTab?.uuid,
+                      model.tabContent.displaysContentInWebView
+                        || model.tabContent.urlForWebView?.isSettingsURL == true
+                        || model.tabContent.urlForWebView == .bookmarks,
+                      let url = model.tabContent.userEditableUrl,
                       url != selectedTab?.content.userEditableUrl, // doesn't match currently selected
                       usedUrls.insert(url.nakedString ?? "").inserted == true /* if did not contain */ else { return nil }
 
-                return OpenTab(tabId: model.tab.id, title: model.title, url: url)
+                return OpenTab(tabId: model.uuid, title: model.title, url: url)
             }
         }
     }

--- a/macOS/DuckDuckGo/UserNotifications/WebNotificationClickHandler.swift
+++ b/macOS/DuckDuckGo/UserNotifications/WebNotificationClickHandler.swift
@@ -19,11 +19,10 @@
 import Foundation
 import PixelKit
 
-/// Protocol for finding and focusing tabs, enabling isolated testing.
+/// Protocol for focusing tabs, enabling isolated testing.
 @MainActor
 protocol WebNotificationTabFinding: AnyObject {
-    func findTab(byUUID uuid: String) -> Tab?
-    func focusTab(_ tab: Tab)
+    func focusTab(byUUID uuid: String) -> Tab?
     func focusBrowser()
 }
 
@@ -45,13 +44,12 @@ final class WebNotificationClickHandler {
     ///   - tabUUID: The UUID of the tab that created the notification.
     ///   - notificationId: The notification's unique identifier.
     func handleClick(tabUUID: String, notificationId: String) {
-        guard let tab = tabFinder.findTab(byUUID: tabUUID) else {
-            // Tab was closed; just focus the browser window
+        guard let tab = tabFinder.focusTab(byUUID: tabUUID) else {
+            // No tab with this UUID; just focus the browser window
             tabFinder.focusBrowser()
             return
         }
 
-        tabFinder.focusTab(tab)
         PixelKit.fire(WebNotificationPixel.clicked, frequency: .dailyAndCount)
         tab.webNotifications?.sendClickEvent(notificationId: notificationId)
     }

--- a/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
+++ b/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
@@ -615,30 +615,19 @@ extension WindowControllersManagerProtocol {
 
     // MARK: - Web Notifications Support
 
-    /// Finds a tab by its UUID across all windows, materializing it if unloaded.
+    /// Focuses the tab with the given UUID across all windows, materializing it if unloaded.
     /// - Parameter uuid: The tab's UUID.
-    /// - Returns: The tab if found, nil otherwise.
-    func findTab(byUUID uuid: String) -> Tab? {
+    /// - Returns: The loaded tab if found, nil otherwise.
+    @discardableResult
+    func focusTab(byUUID uuid: String) -> Tab? {
         for windowController in mainWindowControllers {
             let tabCollectionViewModel = windowController.mainViewController.tabCollectionViewModel
             if let index = tabCollectionViewModel.indexInAllTabs(where: { $0.uuid == uuid }) {
-                return tabCollectionViewModel.materialize(at: index)
+                windowController.window?.makeKeyAndOrderFront(nil)
+                return tabCollectionViewModel.selectTab(at: index)
             }
         }
         return nil
-    }
-
-    /// Focuses the window containing the given tab and selects the tab.
-    /// - Parameter tab: The tab to focus.
-    func focusTab(_ tab: Tab) {
-        for windowController in mainWindowControllers {
-            let tabCollectionViewModel = windowController.mainViewController.tabCollectionViewModel
-            if let index = tabCollectionViewModel.indexInAllTabs(of: tab) {
-                windowController.window?.makeKeyAndOrderFront(nil)
-                tabCollectionViewModel.select(at: index)
-                return
-            }
-        }
     }
 
     /// Focuses the most recently active browser window.

--- a/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
+++ b/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
@@ -579,26 +579,22 @@ extension WindowControllersManagerProtocol {
         }
     }
 
-    var allTabViewModels: [TabViewModel] {
-        return allTabCollectionViewModels.flatMap {
-            $0.tabViewModels.values.compactMap { $0 as? TabViewModel }
-        }
-    }
-
-    func allTabViewModels(for burnerMode: BurnerMode, includingPinnedTabs: Bool = false) -> [TabViewModel] {
+    func allTabViewModels(for burnerMode: BurnerMode, includingPinnedTabs: Bool = false) -> [any TabBarViewModel] {
         let currentBurnerModeTabCollectionViewModels = allTabCollectionViewModels
             .filter { tabCollectionViewModel in
                 tabCollectionViewModel.burnerMode == burnerMode
             }
-        let tabViewModelsWithOriginalOrder = currentBurnerModeTabCollectionViewModels.flatMap {
-            (0..<$0.tabViewModels.count).compactMap($0.tabViewModel(at:)) // TabViewModels ordered by Index
+        let unpinnedTabBarViewModels = currentBurnerModeTabCollectionViewModels.flatMap { tabCollectionViewModel in
+            (0..<tabCollectionViewModel.tabViewModels.count).compactMap { index in
+                tabCollectionViewModel.tabBarViewModel(at: .unpinned(index))
+            }
         }
-        let pinnedTabSuggestions = includingPinnedTabs ? pinnedTabsManagerProvider.currentPinnedTabManagers.flatMap({
-            (0..<$0.tabViewModels.count).compactMap($0.tabViewModel(at:)) // TabViewModels ordered by Index
-        }) : []
-        let result = pinnedTabSuggestions + tabViewModelsWithOriginalOrder
-
-        return result
+        let pinnedTabBarViewModels: [any TabBarViewModel] = includingPinnedTabs ? pinnedTabsManagerProvider.currentPinnedTabManagers.flatMap { pinnedManager in
+            (0..<pinnedManager.tabViewModels.count).compactMap { index in
+                pinnedManager.tabBarViewModel(at: index)
+            }
+        } : []
+        return pinnedTabBarViewModels + unpinnedTabBarViewModels
     }
 
     func windowController(for tabCollectionViewModel: TabCollectionViewModel) -> MainWindowController? {

--- a/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
+++ b/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
@@ -372,7 +372,7 @@ extension WindowControllersManager {
             let tabCollectionViewModel = windowController.mainViewController.tabCollectionViewModel
             guard let index = tabCollectionViewModel.indexInAllTabs(where: {
                 if let tabId {
-                    return $0.id == tabId
+                    return $0.uuid == tabId
                 }
                 return $0.content.urlForWebView == url || (url.isSettingsURL && $0.content.urlForWebView?.isSettingsURL == true)
             }) else { continue }

--- a/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
+++ b/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
@@ -378,8 +378,7 @@ extension WindowControllersManager {
             }) else { continue }
 
             windowController.window?.makeKeyAndOrderFront(self)
-            tabCollectionViewModel.select(at: index)
-            if let tab = tabCollectionViewModel.tabViewModel(at: index)?.tab,
+            if let tab = tabCollectionViewModel.selectTab(at: index),
                tab.content.urlForWebView != url && url != URL.empty {
                 // navigate to another settings pane
                 tab.setContent(.contentFromURL(url, source: .switchToOpenTab))
@@ -616,14 +615,14 @@ extension WindowControllersManagerProtocol {
 
     // MARK: - Web Notifications Support
 
-    /// Finds a tab by its UUID across all windows.
+    /// Finds a tab by its UUID across all windows, materializing it if unloaded.
     /// - Parameter uuid: The tab's UUID.
     /// - Returns: The tab if found, nil otherwise.
     func findTab(byUUID uuid: String) -> Tab? {
         for windowController in mainWindowControllers {
             let tabCollectionViewModel = windowController.mainViewController.tabCollectionViewModel
             if let index = tabCollectionViewModel.indexInAllTabs(where: { $0.uuid == uuid }) {
-                return tabCollectionViewModel.tabViewModel(at: index)?.tab
+                return tabCollectionViewModel.materialize(at: index)
             }
         }
         return nil

--- a/macOS/UnitTests/Suggestions/Model/SuggestionContainerTests.swift
+++ b/macOS/UnitTests/Suggestions/Model/SuggestionContainerTests.swift
@@ -387,7 +387,7 @@ extension SuggestionContainerTests {
             return false
         }
         let tabs = openTabs.map {
-            Tab(id: $0.tabId, content: TabContent.contentFromURL($0.url, source: .link), webViewConfiguration: WKWebViewConfiguration(), privacyFeatures: privacyFeaturesMock, title: $0.title, burnerMode: burnerMode)
+            Tab(id: $0.tabId, uuid: $0.tabId, content: TabContent.contentFromURL($0.url, source: .link), webViewConfiguration: WKWebViewConfiguration(), privacyFeatures: privacyFeaturesMock, title: $0.title, burnerMode: burnerMode)
         }
         return TabCollection(tabs: tabs)
     }

--- a/macOS/UnitTests/UserNotifications/WebNotificationClickHandlerTests.swift
+++ b/macOS/UnitTests/UserNotifications/WebNotificationClickHandlerTests.swift
@@ -26,17 +26,12 @@ import XCTest
 final class MockWebNotificationTabFinder: WebNotificationTabFinding {
 
     var tabToReturn: Tab?
-    private(set) var findTabCalledWithUUID: String?
-    private(set) var focusTabCalledWithTab: Tab?
+    private(set) var focusTabCalledWithUUID: String?
     private(set) var focusBrowserCalled = false
 
-    func findTab(byUUID uuid: String) -> Tab? {
-        findTabCalledWithUUID = uuid
+    func focusTab(byUUID uuid: String) -> Tab? {
+        focusTabCalledWithUUID = uuid
         return tabToReturn
-    }
-
-    func focusTab(_ tab: Tab) {
-        focusTabCalledWithTab = tab
     }
 
     func focusBrowser() {
@@ -77,22 +72,13 @@ final class WebNotificationClickHandlerTests: XCTestCase {
 
     // MARK: - Tab Found Tests
 
-    func testWhenTabExistsThenFindsTabByUUID() {
+    func testWhenTabExistsThenFocusesTabByUUID() {
         let tab = Tab(content: .newtab)
         mockTabFinder.tabToReturn = tab
 
         handler.handleClick(tabUUID: "test-uuid-123", notificationId: "notif-1")
 
-        XCTAssertEqual(mockTabFinder.findTabCalledWithUUID, "test-uuid-123")
-    }
-
-    func testWhenTabExistsThenFocusesTab() {
-        let tab = Tab(content: .newtab)
-        mockTabFinder.tabToReturn = tab
-
-        handler.handleClick(tabUUID: "test-uuid", notificationId: "notif-1")
-
-        XCTAssertTrue(mockTabFinder.focusTabCalledWithTab === tab)
+        XCTAssertEqual(mockTabFinder.focusTabCalledWithUUID, "test-uuid-123")
     }
 
     func testWhenTabExistsThenDoesNotFocusBrowser() {
@@ -112,13 +98,5 @@ final class WebNotificationClickHandlerTests: XCTestCase {
         handler.handleClick(tabUUID: "missing-uuid", notificationId: "notif-1")
 
         XCTAssertTrue(mockTabFinder.focusBrowserCalled)
-    }
-
-    func testWhenTabNotFoundThenDoesNotFocusTab() {
-        mockTabFinder.tabToReturn = nil
-
-        handler.handleClick(tabUUID: "missing-uuid", notificationId: "notif-1")
-
-        XCTAssertNil(mockTabFinder.focusTabCalledWithTab)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214897782897237

### Description

After restart, tabs other than the selected one come back unloaded. The address bar's "Switch to Open Tab" suggestions silently omit those unloaded tabs, so typing a URL the user already has open creates a duplicate tab instead of focusing the existing one. Route the suggestion-providers' enumeration through the `AnyTab`-aware tab-bar accessor so loaded and unloaded tabs are surfaced uniformly.

### Testing Steps

1. In Settings > General, enable "Reopen all windows from last session" (or the equivalent state-restoration option).
2. Open Debug menu > UI Triggers > Insert 50 tabs.
3. In the last inserted tab, load a unique URL (e.g., rampancy.net).
4. Select the first tab.
5. Quit the app.
6. Reopen the app.
   - Expected: tabs are restored, with the rampancy.net tab unloaded (only the selected tab and the first ~20 are pre-loaded by the lazy-loader).
7. Focus the address bar and type "rampancy".
8. Confirm a "Switch to Open Tab" suggestion appears for rampancy.net.
9. Click the suggestion.
   - Expected: the existing rampancy.net tab is focused rather than a new tab being opened.

### Impact and Risks

#### What could go wrong?

Unclear.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tab enumeration and tab-id matching used by address-bar “Switch to Open Tab” and window tab focusing; could affect tab switching behavior across windows/pinned tabs if IDs or ordering assumptions are wrong.
> 
> **Overview**
> Fixes address-bar *“Switch to Open Tab”* suggestions after session restore by enumerating open tabs via the `TabBarViewModel`/`tabBarViewModel(at:)` accessors, so **unloaded tabs** are included alongside loaded ones.
> 
> Updates tab switching to consistently use `uuid` as the tab identifier (including `switchToOpenTab(withId:)`) and adjusts the debug `crashAllTabs` path to iterate per-window tab collections rather than a flattened `allTabViewModels`. Unit tests are updated to construct `Tab` with both `id` and `uuid` set so open-tab suggestions resolve correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a24df6e6d781f2eef1ab94da96b7e21e4677eef2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->