### PR TITLE
macOS: Migrate away from tableViewModel(at:) in TabBarViewController

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -2156,15 +2156,10 @@ extension TabBarViewController: NSCollectionViewDelegate {
 extension TabBarViewController: TabBarViewItemDelegate {
 
     func tabBarViewItemSelectTab(_ tabBarViewItem: TabBarViewItem) {
-        let isPinned = tabBarViewItem.tabViewModel?.isPinned == true
-        let collectionView = isPinned ? pinnedTabsCollectionView : self.collectionView
-
-        guard let indexPath = collectionView?.indexPath(for: tabBarViewItem) else {
+        guard let tabIndex = tabIndex(forTabBarViewItem: tabBarViewItem) else {
             assertionFailure("TabBarViewController: Failed to get index path of tab bar view item")
             return
         }
-
-        let tabIndex: TabIndex = isPinned ? .pinned(indexPath.item) : .unpinned(indexPath.item)
         tabCollectionViewModel.select(at: tabIndex)
     }
 
@@ -2269,15 +2264,11 @@ extension TabBarViewController: TabBarViewItemDelegate {
     }
 
     func tabBarViewItemDuplicateAction(_ tabBarViewItem: TabBarViewItem) {
-        let isPinned = tabBarViewItem.tabViewModel?.isPinned == true
-        let collectionView = isPinned ? pinnedTabsCollectionView : self.collectionView
-
-        guard let indexPath = collectionView?.indexPath(for: tabBarViewItem) else {
+        guard let tabIndex = tabIndex(forTabBarViewItem: tabBarViewItem) else {
             assertionFailure("TabBarViewController: Failed to get index path of tab bar view item")
             return
         }
-
-        duplicateTab(at: isPinned ? .pinned(indexPath.item) : .unpinned(indexPath.item))
+        duplicateTab(at: tabIndex)
     }
 
     func tabBarViewItemCanBePinned(_ tabBarViewItem: TabBarViewItem) -> Bool {
@@ -2405,15 +2396,11 @@ extension TabBarViewController: TabBarViewItemDelegate {
     }
 
     func tabBarViewItemCloseAction(_ tabBarViewItem: TabBarViewItem) {
-        let isPinned = tabBarViewItem.tabViewModel?.isPinned == true
-        let collectionView = isPinned ? pinnedTabsCollectionView : self.collectionView
-
-        guard let indexPath = collectionView?.indexPath(for: tabBarViewItem) else {
+        guard let tabIndex = tabIndex(forTabBarViewItem: tabBarViewItem) else {
             assertionFailure("TabBarViewController: Failed to get index path of tab bar view item")
             return
         }
 
-        let tabIndex: TabIndex = isPinned ? .pinned(indexPath.item) : .unpinned(indexPath.item)
         if tryPresentWarnBeforeCloseForFloatingAIChatIfNeeded(for: tabIndex) {
             return
         }
@@ -2569,15 +2556,11 @@ extension TabBarViewController: TabBarViewItemDelegate {
     func tabBarViewItemSuspendAction(_ tabBarViewItem: TabBarViewItem) {
         guard featureFlagger.isFeatureOn(.tabSuspension), featureFlagger.isFeatureOn(.tabSuspensionDebugging) else { return }
 
-        let isPinned = tabBarViewItem.tabViewModel?.isPinned == true
-        let collectionView = isPinned ? pinnedTabsCollectionView : self.collectionView
-
-        guard let indexPath = collectionView?.indexPath(for: tabBarViewItem) else {
+        guard let tabIndex = tabIndex(forTabBarViewItem: tabBarViewItem) else {
             assertionFailure("TabBarViewController: Failed to get index path of tab bar view item")
             return
         }
 
-        let tabIndex: TabIndex = isPinned ? .pinned(indexPath.item) : .unpinned(indexPath.item)
         if tabBarViewItem.tabViewModel is UnloadedTabViewModel {
             tabCollectionViewModel.resumeTab(at: tabIndex)
         } else {
@@ -2586,11 +2569,8 @@ extension TabBarViewController: TabBarViewItemDelegate {
     }
 
     func tabBarViewItem(_ tabBarViewItem: TabBarViewItem, replaceContentWithDroppedStringValue stringValue: String) {
-        let isPinned = tabBarViewItem.tabViewModel?.isPinned == true
-        let collectionView = isPinned ? pinnedTabsCollectionView : self.collectionView
-        guard let indexPath = collectionView?.indexPath(for: tabBarViewItem) else { return }
-        let tabIndex: TabIndex = isPinned ? .pinned(indexPath.item) : .unpinned(indexPath.item)
-        guard let tab = tabCollectionViewModel.materialize(at: tabIndex) else { return }
+        guard let tabIndex = tabIndex(forTabBarViewItem: tabBarViewItem),
+              let tab = tabCollectionViewModel.materialize(at: tabIndex) else { return }
 
         if let url = URL.makeURL(from: stringValue) {
             tab.setContent(.url(url, credential: nil, source: .userEntered(stringValue, downloadRequested: false)))

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -2535,47 +2535,22 @@ extension TabBarViewController: TabBarViewItemDelegate {
     }
 
     func tabBarViewItemFireproofSite(_ tabBarViewItem: TabBarViewItem) {
-        let isPinned = tabBarViewItem.tabViewModel?.isPinned == true
-        let collectionView = isPinned ? pinnedTabsCollectionView : self.collectionView
-        let tabCollection = isPinned ? tabCollectionViewModel.pinnedTabsCollection : tabCollectionViewModel.tabCollection
-
-        guard let indexPath = collectionView?.indexPath(for: tabBarViewItem),
-              let url = tabCollection?.tabs[safe: indexPath.item]?.url
-        else {
-            assertionFailure("TabBarViewController: Failed to get tab from tab bar view item")
+        guard let url = (tabBarViewItem.tabViewModel as? TabViewModel)?.tab.url else {
+            assertionFailure("TabBarViewController: Failed to get URL for tab bar view item")
             return
         }
-
         fireproof(url: url)
     }
 
     func tabBarViewItemMuteUnmuteSite(_ tabBarViewItem: TabBarViewItem) {
-        let isPinned = tabBarViewItem.tabViewModel?.isPinned == true
-        let collectionView = isPinned ? pinnedTabsCollectionView : self.collectionView
-        let tabCollection = isPinned ? tabCollectionViewModel.pinnedTabsCollection : tabCollectionViewModel.tabCollection
-
-        guard let indexPath = collectionView?.indexPath(for: tabBarViewItem),
-              let tab = tabCollection?.tabs[safe: indexPath.item]
-        else {
-            assertionFailure("TabBarViewController: Failed to get tab from tab bar view item")
-            return
-        }
-
-        tab.muteUnmuteTab()
+        (tabBarViewItem.tabViewModel as? TabViewModel)?.tab.muteUnmuteTab()
     }
 
     func tabBarViewItemRemoveFireproofing(_ tabBarViewItem: TabBarViewItem) {
-        let isPinned = tabBarViewItem.tabViewModel?.isPinned == true
-        let collectionView = isPinned ? pinnedTabsCollectionView : self.collectionView
-        let tabCollection = isPinned ? tabCollectionViewModel.pinnedTabsCollection : tabCollectionViewModel.tabCollection
-
-        guard let indexPath = collectionView?.indexPath(for: tabBarViewItem),
-              let url = tabCollection?.tabs[safe: indexPath.item]?.url
-        else {
-            assertionFailure("TabBarViewController: Failed to get tab from tab bar view item")
+        guard let url = (tabBarViewItem.tabViewModel as? TabViewModel)?.tab.url else {
+            assertionFailure("TabBarViewController: Failed to get URL for tab bar view item")
             return
         }
-
         removeFireproofing(url: url)
     }
 

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -2173,12 +2173,7 @@ extension TabBarViewController: TabBarViewItemDelegate {
     }
 
     func tabBarViewItemCrashMultipleTimesAction(_ tabBarViewItem: TabBarViewItem) {
-        guard let indexPath = collectionView.indexPath(for: tabBarViewItem) else {
-            assertionFailure("TabBarViewController: Failed to get index path of tab bar view item")
-            return
-        }
-
-        tabCollectionViewModel.tabViewModel(at: indexPath.item)?.tab.killWebContentProcessMultipleTimes()
+        (tabBarViewItem.tabViewModel as? TabViewModel)?.tab.killWebContentProcessMultipleTimes()
     }
 
     func tabBarViewItemDidUpdateCrashInfoPopoverVisibility(_ tabBarViewItem: TabBarViewItem, sender: NSButton, shouldShow: Bool) {

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -2475,10 +2475,8 @@ extension TabBarViewController: TabBarViewItemDelegate {
     }
 
     func tabBarViewItemTogglePermissionAction(_ tabBarViewItem: TabBarViewItem) {
-        guard let indexPath = collectionView.indexPath(for: tabBarViewItem),
-              let permissions = tabCollectionViewModel.tabViewModel(at: indexPath.item)?.tab.permissions
-        else {
-            assertionFailure("TabBarViewController: Failed to get index path of tab bar view item or its permissions")
+        guard let permissions = (tabBarViewItem.tabViewModel as? TabViewModel)?.tab.permissions else {
+            assertionFailure("TabBarViewController: Failed to get permissions for tab bar view item")
             return
         }
 

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -2169,11 +2169,19 @@ extension TabBarViewController: TabBarViewItemDelegate {
     }
 
     func tabBarViewItemCrashAction(_ tabBarViewItem: TabBarViewItem) {
-        (tabBarViewItem.tabViewModel as? TabViewModel)?.tab.killWebContentProcess()
+        guard let tab = (tabBarViewItem.tabViewModel as? TabViewModel)?.tab else {
+            assertionFailure("TabBarViewController: Failed to get tab for tab bar view item")
+            return
+        }
+        tab.killWebContentProcess()
     }
 
     func tabBarViewItemCrashMultipleTimesAction(_ tabBarViewItem: TabBarViewItem) {
-        (tabBarViewItem.tabViewModel as? TabViewModel)?.tab.killWebContentProcessMultipleTimes()
+        guard let tab = (tabBarViewItem.tabViewModel as? TabViewModel)?.tab else {
+            assertionFailure("TabBarViewController: Failed to get tab for tab bar view item")
+            return
+        }
+        tab.killWebContentProcessMultipleTimes()
     }
 
     func tabBarViewItemDidUpdateCrashInfoPopoverVisibility(_ tabBarViewItem: TabBarViewItem, sender: NSButton, shouldShow: Bool) {

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -2169,16 +2169,7 @@ extension TabBarViewController: TabBarViewItemDelegate {
     }
 
     func tabBarViewItemCrashAction(_ tabBarViewItem: TabBarViewItem) {
-        let isPinned = tabBarViewItem.tabViewModel?.isPinned == true
-        let collectionView = isPinned ? pinnedTabsCollectionView : self.collectionView
-
-        guard let indexPath = collectionView?.indexPath(for: tabBarViewItem) else {
-            assertionFailure("TabBarViewController: Failed to get index path of tab bar view item")
-            return
-        }
-
-        let tabIndex: TabIndex = isPinned ? .pinned(indexPath.item) : .unpinned(indexPath.item)
-        tabCollectionViewModel.tabViewModel(at: tabIndex)?.tab.killWebContentProcess()
+        (tabBarViewItem.tabViewModel as? TabViewModel)?.tab.killWebContentProcess()
     }
 
     func tabBarViewItemCrashMultipleTimesAction(_ tabBarViewItem: TabBarViewItem) {

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -2543,7 +2543,11 @@ extension TabBarViewController: TabBarViewItemDelegate {
     }
 
     func tabBarViewItemMuteUnmuteSite(_ tabBarViewItem: TabBarViewItem) {
-        (tabBarViewItem.tabViewModel as? TabViewModel)?.tab.muteUnmuteTab()
+        guard let tab = (tabBarViewItem.tabViewModel as? TabViewModel)?.tab else {
+            assertionFailure("TabBarViewController: Failed to get tab for tab bar view item")
+            return
+        }
+        tab.muteUnmuteTab()
     }
 
     func tabBarViewItemRemoveFireproofing(_ tabBarViewItem: TabBarViewItem) {

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -1565,13 +1565,11 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
         // don‘t show tab previews when a child window is shown (Suggestions, Bookmarks etc…)
         guard view.window?.childWindows?.contains(where: { !($0.windowController is TabPreviewWindowController) }) != true,
               let collectionView,
-              let indexPath = collectionView.indexPath(for: tabBarViewItem)
+              let tabIndex = tabIndex(forTabBarViewItem: tabBarViewItem)
         else {
             Logger.general.error("TabBarViewController: Showing tab preview window failed - cannot determine index path for tab")
             return
         }
-
-        let tabIndex: TabIndex = isPinned ? .pinned(indexPath.item) : .unpinned(indexPath.item)
 
         guard let previewable = tabCollectionViewModel.tabBarViewModel(at: tabIndex) as? Previewable else {
             Logger.general.error("TabBarViewController: Showing tab preview window failed - previewable not found for index \(String(reflecting: tabIndex))")

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -2483,10 +2483,13 @@ extension TabBarViewController: TabBarViewItemDelegate {
     }
 
     func tabBarViewItemTogglePermissionAction(_ tabBarViewItem: TabBarViewItem) {
-        guard let permissions = (tabBarViewItem.tabViewModel as? TabViewModel)?.tab.permissions else {
-            assertionFailure("TabBarViewController: Failed to get permissions for tab bar view item")
+        guard let tabViewModel = tabBarViewItem.tabViewModel as? TabViewModel else {
+            assertionFailure("TabBarViewController: Failed to get view model for tab bar view item")
             return
         }
+        // permissionButton is hidden on pinned tabs by design (asserted in `layoutForPinnedMode`).
+        guard !tabViewModel.isPinned else { return }
+        let permissions = tabViewModel.tab.permissions
 
         if permissions.permissions.camera.isActive || permissions.permissions.microphone.isActive {
             permissions.set([.camera, .microphone], muted: true)

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -1565,11 +1565,13 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
         // don‘t show tab previews when a child window is shown (Suggestions, Bookmarks etc…)
         guard view.window?.childWindows?.contains(where: { !($0.windowController is TabPreviewWindowController) }) != true,
               let collectionView,
-              let tabIndex = tabIndex(forTabBarViewItem: tabBarViewItem)
+              let indexPath = collectionView.indexPath(for: tabBarViewItem)
         else {
             Logger.general.error("TabBarViewController: Showing tab preview window failed - cannot determine index path for tab")
             return
         }
+
+        let tabIndex: TabIndex = isPinned ? .pinned(indexPath.item) : .unpinned(indexPath.item)
 
         guard let previewable = tabCollectionViewModel.tabBarViewModel(at: tabIndex) as? Previewable else {
             Logger.general.error("TabBarViewController: Showing tab preview window failed - previewable not found for index \(String(reflecting: tabIndex))")

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -2156,10 +2156,15 @@ extension TabBarViewController: NSCollectionViewDelegate {
 extension TabBarViewController: TabBarViewItemDelegate {
 
     func tabBarViewItemSelectTab(_ tabBarViewItem: TabBarViewItem) {
-        guard let tabIndex = tabIndex(forTabBarViewItem: tabBarViewItem) else {
+        let isPinned = tabBarViewItem.tabViewModel?.isPinned == true
+        let collectionView = isPinned ? pinnedTabsCollectionView : self.collectionView
+
+        guard let indexPath = collectionView?.indexPath(for: tabBarViewItem) else {
             assertionFailure("TabBarViewController: Failed to get index path of tab bar view item")
             return
         }
+
+        let tabIndex: TabIndex = isPinned ? .pinned(indexPath.item) : .unpinned(indexPath.item)
         tabCollectionViewModel.select(at: tabIndex)
     }
 
@@ -2264,11 +2269,15 @@ extension TabBarViewController: TabBarViewItemDelegate {
     }
 
     func tabBarViewItemDuplicateAction(_ tabBarViewItem: TabBarViewItem) {
-        guard let tabIndex = tabIndex(forTabBarViewItem: tabBarViewItem) else {
+        let isPinned = tabBarViewItem.tabViewModel?.isPinned == true
+        let collectionView = isPinned ? pinnedTabsCollectionView : self.collectionView
+
+        guard let indexPath = collectionView?.indexPath(for: tabBarViewItem) else {
             assertionFailure("TabBarViewController: Failed to get index path of tab bar view item")
             return
         }
-        duplicateTab(at: tabIndex)
+
+        duplicateTab(at: isPinned ? .pinned(indexPath.item) : .unpinned(indexPath.item))
     }
 
     func tabBarViewItemCanBePinned(_ tabBarViewItem: TabBarViewItem) -> Bool {
@@ -2396,11 +2405,15 @@ extension TabBarViewController: TabBarViewItemDelegate {
     }
 
     func tabBarViewItemCloseAction(_ tabBarViewItem: TabBarViewItem) {
-        guard let tabIndex = tabIndex(forTabBarViewItem: tabBarViewItem) else {
+        let isPinned = tabBarViewItem.tabViewModel?.isPinned == true
+        let collectionView = isPinned ? pinnedTabsCollectionView : self.collectionView
+
+        guard let indexPath = collectionView?.indexPath(for: tabBarViewItem) else {
             assertionFailure("TabBarViewController: Failed to get index path of tab bar view item")
             return
         }
 
+        let tabIndex: TabIndex = isPinned ? .pinned(indexPath.item) : .unpinned(indexPath.item)
         if tryPresentWarnBeforeCloseForFloatingAIChatIfNeeded(for: tabIndex) {
             return
         }
@@ -2556,11 +2569,15 @@ extension TabBarViewController: TabBarViewItemDelegate {
     func tabBarViewItemSuspendAction(_ tabBarViewItem: TabBarViewItem) {
         guard featureFlagger.isFeatureOn(.tabSuspension), featureFlagger.isFeatureOn(.tabSuspensionDebugging) else { return }
 
-        guard let tabIndex = tabIndex(forTabBarViewItem: tabBarViewItem) else {
+        let isPinned = tabBarViewItem.tabViewModel?.isPinned == true
+        let collectionView = isPinned ? pinnedTabsCollectionView : self.collectionView
+
+        guard let indexPath = collectionView?.indexPath(for: tabBarViewItem) else {
             assertionFailure("TabBarViewController: Failed to get index path of tab bar view item")
             return
         }
 
+        let tabIndex: TabIndex = isPinned ? .pinned(indexPath.item) : .unpinned(indexPath.item)
         if tabBarViewItem.tabViewModel is UnloadedTabViewModel {
             tabCollectionViewModel.resumeTab(at: tabIndex)
         } else {
@@ -2569,8 +2586,11 @@ extension TabBarViewController: TabBarViewItemDelegate {
     }
 
     func tabBarViewItem(_ tabBarViewItem: TabBarViewItem, replaceContentWithDroppedStringValue stringValue: String) {
-        guard let tabIndex = tabIndex(forTabBarViewItem: tabBarViewItem),
-              let tab = tabCollectionViewModel.materialize(at: tabIndex) else { return }
+        let isPinned = tabBarViewItem.tabViewModel?.isPinned == true
+        let collectionView = isPinned ? pinnedTabsCollectionView : self.collectionView
+        guard let indexPath = collectionView?.indexPath(for: tabBarViewItem) else { return }
+        let tabIndex: TabIndex = isPinned ? .pinned(indexPath.item) : .unpinned(indexPath.item)
+        guard let tab = tabCollectionViewModel.materialize(at: tabIndex) else { return }
 
         if let url = URL.makeURL(from: stringValue) {
             tab.setContent(.url(url, credential: nil, source: .userEntered(stringValue, downloadRequested: false)))

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -1175,7 +1175,7 @@ final class TabBarViewItem: NSCollectionViewItem {
             return
         }
 
-        guard !isPinned else {
+        guard isPinned else {
             cell.permissionButton.isHidden = true
             return
         }

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -1126,11 +1126,16 @@ final class TabBarViewItem: NSCollectionViewItem {
             cell.closeButton.isShown = false
             cell.faviconView.isShown = true
             cell.titleView.isShown = false
+            cell.permissionButton.isShown = false
         } else {
             let showCloseButton = (isMouseOver && (!widthStage.isCloseButtonHidden || NSApp.isCommandPressed)) || isSelected
             cell.closeButton.isShown = showCloseButton
             cell.faviconView.isShown = (widthStage != .withoutTitle || !showCloseButton)
             cell.titleView.isShown = !widthStage.isTitleHidden
+            cell.permissionButton.isShown = usedPermissions.camera.isActive
+                || usedPermissions.microphone.isActive
+                || usedPermissions.camera.isPaused
+                || usedPermissions.microphone.isPaused
         }
 
         updateSeparatorView()

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -1175,7 +1175,7 @@ final class TabBarViewItem: NSCollectionViewItem {
             return
         }
 
-        guard isPinned else {
+        guard !isPinned else {
             cell.permissionButton.isHidden = true
             return
         }

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -1126,16 +1126,11 @@ final class TabBarViewItem: NSCollectionViewItem {
             cell.closeButton.isShown = false
             cell.faviconView.isShown = true
             cell.titleView.isShown = false
-            cell.permissionButton.isShown = false
         } else {
             let showCloseButton = (isMouseOver && (!widthStage.isCloseButtonHidden || NSApp.isCommandPressed)) || isSelected
             cell.closeButton.isShown = showCloseButton
             cell.faviconView.isShown = (widthStage != .withoutTitle || !showCloseButton)
             cell.titleView.isShown = !widthStage.isTitleHidden
-            cell.permissionButton.isShown = usedPermissions.camera.isActive
-                || usedPermissions.microphone.isActive
-                || usedPermissions.camera.isPaused
-                || usedPermissions.microphone.isPaused
         }
 
         updateSeparatorView()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1214883824177324?focus=true

### Description

Several `TabBarViewItemDelegate` handlers in `TabBarViewController` reach the tab they should act on by looking up `indexPath(for: tabBarViewItem)` against a hard-coded or `isPinned`-branched collection view, then calling `tabCollectionViewModel.tabViewModel(at:)`. The tab bar item already has its view model bound (`tabBarViewItem.tabViewModel`), so the indexPath round-trip is redundant and easy to get wrong across the pinned/unpinned collection-view split.

These handlers now read directly from the bound view model. No user-visible behaviour change: each handler preserves its existing behaviour, and `tabBarViewItemTogglePermissionAction` keeps its pinned-tab no-op via an explicit guard, since `permissionButton` is hidden on pinned tabs by design (asserted in `layoutForPinnedMode`).

### Testing Steps

Each migrated handler should work identically on pinned and unpinned tabs. Run the steps below on an unpinned tab, then pin the tab and repeat.

Setup: open a tab and start audio playing (e.g. play a YouTube video).

1. Right-click the tab and choose Mute Tab.
   - Expected: audio stops.
2. Right-click and choose Unmute Tab.
   - Expected: audio resumes.
3. Right-click and choose Fireproof.
   - Expected: a fireproof confirmation appears.
4. Accept the confirmation.
   - Expected: the site is fireproofed.
5. Right-click and choose Remove Fireproofing.
   - Expected: the site is no longer fireproofed.

**Debug crash actions** (requires `tabCrashDebugging` feature flag)

6. Right-click an unpinned tab and choose Crash Tab.
   - Expected: the web-content-crashed UI is shown.
7. Right-click a pinned tab and choose Crash Tab Multiple Times in a Row.
   - Expected: the tab repeatedly crashes and recovers.

### Impact and Risks

Low. The migrated handlers are mechanical and the crash handlers are debug-only.

#### What could go wrong?

If a migrated handler is ever surfaced on a tab whose view model is something other than `TabViewModel` (today the only other conformer is `UnloadedTabViewModel`, whose buttons and menu items are already hidden), the click would silently do nothing instead of acting on the wrong tab.

### Notes to Reviewer

None.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)