### PR TITLE
iOS: Cherry-pick UTI newline fixes to 7.221

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
@@ -56,6 +56,7 @@ protocol SwitchBarHandling: AnyObject {
 
     var isUsingExpandedBottomBarHeight: Bool { get }
     var isUsingFadeOutAnimation: Bool { get }
+    var usesExpandedAIChatTextEntryLayout: Bool { get }
     var shouldDisableAutocorrectOnEmpty: Bool { get }
 
     /// Suppresses the in-pill voice button — used when an external flank already provides one.
@@ -94,6 +95,7 @@ protocol SwitchBarHandling: AnyObject {
 extension SwitchBarHandling {
     func saveToggleState() {}
     func stopGeneratingButtonTapped() {}
+    var usesExpandedAIChatTextEntryLayout: Bool { false }
     var submitsAIChatOnKeyboardReturn: Bool { true }
     var submitsAIChatOnKeyboardReturnPublisher: AnyPublisher<Bool, Never> { Just(true).eraseToAnyPublisher() }
 }

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -84,6 +84,10 @@ class SwitchBarTextEntryView: UIView {
     }
 
     private var currentMinHeight: CGFloat {
+        if isExpandable && currentMode == .aiChat && handler.isTopBarPosition {
+            return Constants.minHeightAIChat
+        }
+
         guard handler.isUsingFadeOutAnimation else {
             return Constants.minHeight
         }
@@ -107,10 +111,16 @@ class SwitchBarTextEntryView: UIView {
         handler.isUsingExpandedBottomBarHeight
     }
 
+    private var usesTopAlignedPlaceholder: Bool {
+        isExpandable && currentMode == .aiChat
+    }
+
     private var cancellables = Set<AnyCancellable>()
 
     private var heightConstraint: NSLayoutConstraint?
     private var buttonsTrailingConstraint: NSLayoutConstraint?
+    private var placeholderTopConstraint: NSLayoutConstraint?
+    private var placeholderCenterYConstraint: NSLayoutConstraint?
 
     private var wasTextEmptyForAutocorrection: Bool = true
 
@@ -131,8 +141,14 @@ class SwitchBarTextEntryView: UIView {
 
     var isExpandable: Bool = false {
         didSet {
+            updatePlaceholderVerticalAlignment()
             updateTextViewHeight()
         }
+    }
+
+    func refreshLayoutForBarPositionChange() {
+        updatePlaceholderVerticalAlignment()
+        updateTextViewHeight()
     }
 
     /// A visible trailing button (e.g. stop-generating) forces `.natural` regardless of this
@@ -272,6 +288,11 @@ class SwitchBarTextEntryView: UIView {
 
         buttonsTrailingConstraint = buttonsView.trailingAnchor.constraint(equalTo: trailingAnchor)
         buttonsTrailingConstraint?.isActive = true
+        let placeholderTopConstraint = placeholderLabel.topAnchor.constraint(equalTo: textView.topAnchor, constant: Constants.placeholderTopOffset)
+        let placeholderCenterYConstraint = placeholderLabel.centerYAnchor.constraint(equalTo: textView.centerYAnchor)
+        self.placeholderTopConstraint = placeholderTopConstraint
+        self.placeholderCenterYConstraint = placeholderCenterYConstraint
+        placeholderTopConstraint.isActive = false
 
         NSLayoutConstraint.activate([
             textView.topAnchor.constraint(equalTo: topAnchor),
@@ -279,7 +300,7 @@ class SwitchBarTextEntryView: UIView {
             textView.bottomAnchor.constraint(equalTo: bottomAnchor),
             textView.trailingAnchor.constraint(equalTo: trailingAnchor),
 
-            placeholderLabel.centerYAnchor.constraint(equalTo: textView.centerYAnchor),
+            placeholderCenterYConstraint,
             placeholderLabel.leadingAnchor.constraint(equalTo: textView.leadingAnchor, constant: Constants.placeholderHorizontalOffset),
             // Trail to the buttons so a visible stop / search-go-to / voice button truncates the
             // placeholder. When `.noButtons`, buttonsView has zero width so this is a no-op.
@@ -345,6 +366,7 @@ class SwitchBarTextEntryView: UIView {
             }
         }
         updateKeyboardConfiguration()
+        updatePlaceholderVerticalAlignment()
         updatePlaceholderVisibility()
         updateButtonState()
         updateTextViewHeight()
@@ -401,6 +423,18 @@ class SwitchBarTextEntryView: UIView {
 
     private func updatePlaceholderAlignment() {
         placeholderLabel.textAlignment = currentButtonState.showsAnyButton ? .natural : placeholderTextAlignment
+    }
+
+    private func updatePlaceholderVerticalAlignment() {
+        guard placeholderTopConstraint?.isActive != usesTopAlignedPlaceholder else { return }
+
+        if usesTopAlignedPlaceholder {
+            placeholderCenterYConstraint?.isActive = false
+            placeholderTopConstraint?.isActive = true
+        } else {
+            placeholderTopConstraint?.isActive = false
+            placeholderCenterYConstraint?.isActive = true
+        }
     }
 
     private func updateVoiceButtonStyle() {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -33,6 +33,29 @@ class SwitchBarTextEntryView: UIView {
         case hidden
     }
 
+    private enum TextEntryPose: Equatable {
+        case compact
+        case tallTopAlignedAIChat
+
+        var minHeight: CGFloat {
+            switch self {
+            case .compact:
+                return Constants.minHeight
+            case .tallTopAlignedAIChat:
+                return Constants.minHeightAIChat
+            }
+        }
+
+        var usesTopAlignedPlaceholder: Bool {
+            switch self {
+            case .compact:
+                return false
+            case .tallTopAlignedAIChat:
+                return true
+            }
+        }
+    }
+
     private enum Constants {
         static let maxHeight: CGFloat = 120
         static let maxHeightWhenUsingFadeOutAnimation: CGFloat = 132
@@ -83,9 +106,17 @@ class SwitchBarTextEntryView: UIView {
         handler.currentToggleState
     }
 
+    private var currentPose: TextEntryPose {
+        if isExpandable && currentMode == .aiChat && handler.isTopBarPosition && handler.usesExpandedAIChatTextEntryLayout {
+            return .tallTopAlignedAIChat
+        }
+
+        return .compact
+    }
+
     private var currentMinHeight: CGFloat {
-        if isExpandable && currentMode == .aiChat && handler.isTopBarPosition {
-            return Constants.minHeightAIChat
+        if currentPose == .tallTopAlignedAIChat {
+            return currentPose.minHeight
         }
 
         guard handler.isUsingFadeOutAnimation else {
@@ -112,7 +143,7 @@ class SwitchBarTextEntryView: UIView {
     }
 
     private var usesTopAlignedPlaceholder: Bool {
-        isExpandable && currentMode == .aiChat
+        currentPose.usesTopAlignedPlaceholder
     }
 
     private var cancellables = Set<AnyCancellable>()
@@ -141,12 +172,11 @@ class SwitchBarTextEntryView: UIView {
 
     var isExpandable: Bool = false {
         didSet {
-            updatePlaceholderVerticalAlignment()
-            updateTextViewHeight()
+            updatePoseForCurrentState()
         }
     }
 
-    func refreshLayoutForBarPositionChange() {
+    func updatePoseForCurrentState() {
         updatePlaceholderVerticalAlignment()
         updateTextViewHeight()
     }
@@ -366,10 +396,9 @@ class SwitchBarTextEntryView: UIView {
             }
         }
         updateKeyboardConfiguration()
-        updatePlaceholderVerticalAlignment()
+        updatePoseForCurrentState()
         updatePlaceholderVisibility()
         updateButtonState()
-        updateTextViewHeight()
     }
 
     private func updateKeyboardConfiguration() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
@@ -27,7 +27,7 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
 
     // MARK: - SwitchBarHandling — Fixed Values
 
-    var isTopBarPosition: Bool = false
+    private(set) var isTopBarPosition: Bool = false
     let isUsingExpandedBottomBarHeight: Bool = false
     /// The fadeOutOnToggle experiment applies only to the OmniBar editing state, not here.
     let isUsingFadeOutAnimation: Bool = false
@@ -226,7 +226,11 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
         customizeResponsesButtonTappedSubject.send()
     }
 
-    func updateBarPosition(isTop: Bool) {}
+    func updateBarPosition(isTop: Bool) {
+        guard isTopBarPosition != isTop else { return }
+        isTopBarPosition = isTop
+        updateButtonState()
+    }
 
     // MARK: - Private
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
@@ -29,6 +29,7 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
 
     private(set) var isTopBarPosition: Bool = false
     let isUsingExpandedBottomBarHeight: Bool = false
+    let usesExpandedAIChatTextEntryLayout: Bool = true
     /// The fadeOutOnToggle experiment applies only to the OmniBar editing state, not here.
     let isUsingFadeOutAnimation: Bool = false
     let shouldDisableAutocorrectOnEmpty: Bool = true

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -254,7 +254,10 @@ final class UnifiedToggleInputView: UIView {
 
     var handlerIsTopBarPosition: Bool {
         get { handler.isTopBarPosition }
-        set { handler.isTopBarPosition = newValue }
+        set {
+            handler.updateBarPosition(isTop: newValue)
+            textEntryView.refreshLayoutForBarPositionChange()
+        }
     }
 
     // MARK: - Attachment Callbacks
@@ -1343,7 +1346,6 @@ private extension UnifiedToggleInputView {
             .store(in: &cancellables)
 
         textEntryView.textHeightChangeSubject
-            .receive(on: DispatchQueue.main)
             .sink { [weak self] in
                 self?.onNeedsHierarchyLayout?()
             }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -255,8 +255,9 @@ final class UnifiedToggleInputView: UIView {
     var handlerIsTopBarPosition: Bool {
         get { handler.isTopBarPosition }
         set {
+            guard handler.isTopBarPosition != newValue else { return }
             handler.updateBarPosition(isTop: newValue)
-            textEntryView.refreshLayoutForBarPositionChange()
+            textEntryView.updatePoseForCurrentState()
         }
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
@@ -380,7 +380,6 @@ final class UnifiedToggleInputViewController: UIViewController {
     }
 
     private func notifyHeightDidChange() {
-        view.window?.layoutIfNeeded()
         delegate?.unifiedToggleInputVCDidChangeHeight(self)
     }
 }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputHandlerTests.swift
@@ -62,6 +62,7 @@ final class UnifiedToggleInputHandlerTests: XCTestCase {
         XCTAssertFalse(sut.isTopBarPosition)
         XCTAssertFalse(sut.isUsingExpandedBottomBarHeight)
         XCTAssertFalse(sut.isCurrentTextValidURL)
+        XCTAssertTrue(sut.usesExpandedAIChatTextEntryLayout)
     }
 
     // MARK: - Fire Tab
@@ -400,9 +401,11 @@ final class UnifiedToggleInputHandlerTests: XCTestCase {
 
     // MARK: - updateBarPosition
 
-    func test_updateBarPosition_doesNotChangeConstants() {
-        sut.updateBarPosition(isTop: true)
+    func test_updateBarPosition_updatesTopBarPosition() {
         XCTAssertFalse(sut.isTopBarPosition)
+
+        sut.updateBarPosition(isTop: true)
+        XCTAssertTrue(sut.isTopBarPosition)
 
         sut.updateBarPosition(isTop: false)
         XCTAssertFalse(sut.isTopBarPosition)

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -241,12 +241,161 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         XCTAssertEqual(handler.currentText, "he\nllo")
     }
 
+    func test_topAIChatTextEntryDoesNotGrowOnFirstFloatingReturnNewline() {
+        let expectedTopAIChatMinimumHeight: CGFloat = 68
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.updateBarPosition(isTop: true)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut)
+        sut.setQueryText("hello")
+        let initialHeight = applyFittingHeight(to: sut)
+
+        sut.insertNewlineAtCursor()
+        let heightAfterFirstNewline = applyFittingHeight(to: sut)
+
+        XCTAssertEqual(initialHeight, expectedTopAIChatMinimumHeight, accuracy: 1)
+        XCTAssertEqual(heightAfterFirstNewline, initialHeight, accuracy: 1)
+    }
+
+    func test_topAIChatPlaceholderAlignsWithTextContainerTopInset() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.updateBarPosition(isTop: true)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut)
+        applyFittingHeight(to: sut)
+
+        let textView = try XCTUnwrap(firstDescendant(of: UITextView.self, in: sut))
+        let placeholderLabel = try XCTUnwrap(firstDescendant(of: UILabel.self, in: sut))
+        let expectedPlaceholderMinY = textView.convert(CGPoint(x: 0, y: textView.textContainerInset.top), to: sut).y
+
+        XCTAssertFalse(placeholderLabel.isHidden)
+        XCTAssertEqual(placeholderLabel.frame.minY, expectedPlaceholderMinY, accuracy: 1)
+    }
+
+    func test_collapsedAIChatPlaceholderStaysVerticallyCenteredInPill() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        prepareForFitting(sut, height: 48)
+        applyFittingHeight(to: sut, height: 48)
+
+        let textView = try XCTUnwrap(firstDescendant(of: UITextView.self, in: sut))
+        let placeholderLabel = try XCTUnwrap(firstDescendant(of: UILabel.self, in: sut))
+
+        XCTAssertFalse(placeholderLabel.isHidden)
+        XCTAssertEqual(placeholderLabel.center.y, textView.center.y, accuracy: 1)
+    }
+
+    func test_expandedSearchPlaceholderStaysVerticallyCenteredInPill() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.setToggleState(.search)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut, height: 48)
+        applyFittingHeight(to: sut, height: 48)
+
+        let textView = try XCTUnwrap(firstDescendant(of: UITextView.self, in: sut))
+        let placeholderLabel = try XCTUnwrap(firstDescendant(of: UILabel.self, in: sut))
+
+        XCTAssertFalse(placeholderLabel.isHidden)
+        XCTAssertEqual(placeholderLabel.center.y, textView.center.y, accuracy: 1)
+    }
+
+    func test_expandedPlaceholderAlignmentUpdatesWhenToggleSwitchesMode() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.updateBarPosition(isTop: true)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut)
+        applyFittingHeight(to: sut)
+
+        let textView = try XCTUnwrap(firstDescendant(of: UITextView.self, in: sut))
+        let placeholderLabel = try XCTUnwrap(firstDescendant(of: UILabel.self, in: sut))
+        let expectedPlaceholderMinY = textView.convert(CGPoint(x: 0, y: textView.textContainerInset.top), to: sut).y
+
+        XCTAssertEqual(placeholderLabel.frame.minY, expectedPlaceholderMinY, accuracy: 1)
+
+        handler.setToggleState(.search)
+        flushMainQueue()
+        applyFittingHeight(to: sut)
+
+        XCTAssertEqual(placeholderLabel.center.y, textView.center.y, accuracy: 1)
+
+        handler.setToggleState(.aiChat)
+        flushMainQueue()
+        applyFittingHeight(to: sut)
+
+        XCTAssertEqual(placeholderLabel.frame.minY, expectedPlaceholderMinY, accuracy: 1)
+    }
+
+    func test_clearButtonStaysPinnedToTopLineWhenTextEntryExpands() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.updateBarPosition(isTop: true)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut)
+        sut.setQueryText("hello")
+        let initialHeight = applyFittingHeight(to: sut)
+        let clearButton = try XCTUnwrap(findButton(accessibilityLabel: "Clear text", in: sut))
+        let initialClearButtonMinY = clearButton.convert(clearButton.bounds, to: sut).minY
+
+        sut.insertNewlineAtCursor()
+        sut.insertNewlineAtCursor()
+        let expandedHeight = applyFittingHeight(to: sut)
+        let expandedClearButtonMinY = clearButton.convert(clearButton.bounds, to: sut).minY
+
+        XCTAssertGreaterThan(expandedHeight, initialHeight)
+        XCTAssertEqual(expandedClearButtonMinY, initialClearButtonMinY, accuracy: 1)
+    }
+
+    func test_topAIChatToggleDoesNotCompressWhenFloatingReturnExpandsTextEntry() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        let sut = UnifiedToggleInputView(handler: handler)
+        sut.handlerIsTopBarPosition = true
+        sut.applyCardLayout(.expanded(showsToggle: true, showsToolbar: true), animated: false)
+        prepareForFitting(sut, width: 402, height: 192)
+        applyFittingHeight(to: sut, width: 402)
+        sut.onNeedsHierarchyLayout = { [weak sut] in
+            guard let sut else { return }
+            self.applyFittingHeight(to: sut, width: 402)
+        }
+        sut.text = "hello"
+        applyFittingHeight(to: sut, width: 402)
+        let duckAIButton = try XCTUnwrap(findButton(accessibilityIdentifier: "AddressBar.Button.DuckAI", in: sut))
+
+        sut.insertNewlineAtCursor()
+        sut.insertNewlineAtCursor()
+        sut.layoutIfNeeded()
+
+        XCTAssertEqual(duckAIButton.frame.height, 36, accuracy: 1)
+    }
+
     private func flushMainQueue() {
         let expectation = expectation(description: "main queue flushed")
         DispatchQueue.main.async {
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 1)
+    }
+
+    private func prepareForFitting(_ view: UIView, width: CGFloat = 320, height: CGFloat = 68) {
+        view.frame = CGRect(x: 0, y: 0, width: width, height: height)
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+    }
+
+    @discardableResult
+    private func applyFittingHeight(to view: UIView, width: CGFloat = 320, height proposedHeight: CGFloat = UIView.layoutFittingCompressedSize.height) -> CGFloat {
+        let height = view.systemLayoutSizeFitting(
+            CGSize(width: width, height: proposedHeight),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        ).height
+        view.frame = CGRect(x: 0, y: 0, width: width, height: height)
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+        return height
     }
 
     private func makeInvalidFileAttachment(
@@ -290,12 +439,20 @@ final class UnifiedToggleInputViewTests: XCTestCase {
     }
 
     private func findButton(accessibilityLabel: String, in view: UIView) -> UIButton? {
-        if let button = view as? UIButton, button.accessibilityLabel == accessibilityLabel {
+        findButton(in: view) { $0.accessibilityLabel == accessibilityLabel }
+    }
+
+    private func findButton(accessibilityIdentifier: String, in view: UIView) -> UIButton? {
+        findButton(in: view) { $0.accessibilityIdentifier == accessibilityIdentifier }
+    }
+
+    private func findButton(in view: UIView, where matches: (UIButton) -> Bool) -> UIButton? {
+        if let button = view as? UIButton, matches(button) {
             return button
         }
 
         for subview in view.subviews {
-            if let button = findButton(accessibilityLabel: accessibilityLabel, in: subview) {
+            if let button = findButton(in: subview, where: matches) {
                 return button
             }
         }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -18,6 +18,7 @@
 //
 
 import AIChat
+import Combine
 import DesignResourcesKitIcons
 import XCTest
 import UIKit
@@ -302,6 +303,55 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         XCTAssertEqual(placeholderLabel.center.y, textView.center.y, accuracy: 1)
     }
 
+    func test_bottomAIChatPlaceholderStaysVerticallyCenteredInPill() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.updateBarPosition(isTop: false)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut, height: 48)
+        applyFittingHeight(to: sut, height: 48)
+
+        let textView = try XCTUnwrap(firstDescendant(of: UITextView.self, in: sut))
+        let placeholderLabel = try XCTUnwrap(firstDescendant(of: UILabel.self, in: sut))
+
+        XCTAssertFalse(placeholderLabel.isHidden)
+        XCTAssertEqual(placeholderLabel.center.y, textView.center.y, accuracy: 1)
+    }
+
+    func test_legacyNonFadeOutTopAIChatTextEntryStaysCompactWhenExpandable() throws {
+        let handler = LegacyTextEntryMockHandler(
+            currentToggleState: .aiChat,
+            isTopBarPosition: true,
+            isUsingFadeOutAnimation: false
+        )
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut, height: 44)
+        let height = applyFittingHeight(to: sut, height: 44)
+
+        let textView = try XCTUnwrap(firstDescendant(of: UITextView.self, in: sut))
+        let placeholderLabel = try XCTUnwrap(firstDescendant(of: UILabel.self, in: sut))
+
+        XCTAssertEqual(height, 44, accuracy: 1)
+        XCTAssertFalse(placeholderLabel.isHidden)
+        XCTAssertEqual(placeholderLabel.center.y, textView.center.y, accuracy: 1)
+    }
+
+    func test_barPositionChangeRefreshesExpandedAIChatPose() {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.updateBarPosition(isTop: false)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut, height: 44)
+
+        XCTAssertEqual(applyFittingHeight(to: sut, height: 44), 44, accuracy: 1)
+
+        handler.updateBarPosition(isTop: true)
+        sut.updatePoseForCurrentState()
+
+        XCTAssertEqual(applyFittingHeight(to: sut), 68, accuracy: 1)
+    }
+
     func test_expandedPlaceholderAlignmentUpdatesWhenToggleSwitchesMode() throws {
         let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
         handler.updateBarPosition(isTop: true)
@@ -369,6 +419,24 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         sut.layoutIfNeeded()
 
         XCTAssertEqual(duckAIButton.frame.height, 36, accuracy: 1)
+    }
+
+    func test_topAIChatHierarchyLayoutCallbackFiresSynchronouslyWhenNewlineExpandsTextEntry() {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        let sut = UnifiedToggleInputView(handler: handler)
+        sut.handlerIsTopBarPosition = true
+        sut.applyCardLayout(.expanded(showsToggle: true, showsToolbar: true), animated: false)
+        prepareForFitting(sut, width: 402, height: 192)
+        applyFittingHeight(to: sut, width: 402)
+        sut.text = "hello"
+        applyFittingHeight(to: sut, width: 402)
+
+        var callbacks = 0
+        sut.onNeedsHierarchyLayout = { callbacks += 1 }
+        sut.insertNewlineAtCursor()
+        sut.insertNewlineAtCursor()
+
+        XCTAssertGreaterThan(callbacks, 0)
     }
 
     private func flushMainQueue() {
@@ -466,5 +534,62 @@ private final class SpyFloatingReturnKeyDelegate: UnifiedToggleInputFloatingRetu
 
     func floatingReturnKeyDidTap() {
         returnKeyTapCount += 1
+    }
+}
+
+private final class LegacyTextEntryMockHandler: SwitchBarHandling {
+    var currentText: String = ""
+    var currentToggleState: TextEntryMode
+    var isVoiceSearchEnabled: Bool = false
+    var isAIVoiceChatEnabled: Bool = false
+    var hasUserInteractedWithText: Bool = false
+    var isCurrentTextValidURL: Bool = false
+    var buttonState: SwitchBarButtonState = .noButtons
+    var isTopBarPosition: Bool
+    var isToggleEnabled: Bool = true
+    var isFireTab: Bool = false
+    var isUsingExpandedBottomBarHeight: Bool = false
+    var isUsingFadeOutAnimation: Bool
+    var shouldDisableAutocorrectOnEmpty: Bool = false
+    var hidesVoiceButton: Bool = false
+    var hasSubmittedPrompt: Bool = false
+    var modeParameters: [String: String] = [:]
+
+    var hasSubmittedPromptPublisher: AnyPublisher<Bool, Never> { Just(false).eraseToAnyPublisher() }
+    var currentTextPublisher: AnyPublisher<String, Never> { Empty().eraseToAnyPublisher() }
+    var toggleStatePublisher: AnyPublisher<TextEntryMode, Never> { Empty().eraseToAnyPublisher() }
+    var textSubmissionPublisher: AnyPublisher<(text: String, mode: TextEntryMode), Never> { Empty().eraseToAnyPublisher() }
+    var microphoneButtonTappedPublisher: AnyPublisher<Void, Never> { Empty().eraseToAnyPublisher() }
+    var clearButtonTappedPublisher: AnyPublisher<Void, Never> { Empty().eraseToAnyPublisher() }
+    var hasUserInteractedWithTextPublisher: AnyPublisher<Bool, Never> { Empty().eraseToAnyPublisher() }
+    var isCurrentTextValidURLPublisher: AnyPublisher<Bool, Never> { Empty().eraseToAnyPublisher() }
+    var currentButtonStatePublisher: AnyPublisher<SwitchBarButtonState, Never> { Empty().eraseToAnyPublisher() }
+
+    init(currentToggleState: TextEntryMode, isTopBarPosition: Bool, isUsingFadeOutAnimation: Bool) {
+        self.currentToggleState = currentToggleState
+        self.isTopBarPosition = isTopBarPosition
+        self.isUsingFadeOutAnimation = isUsingFadeOutAnimation
+    }
+
+    func updateCurrentText(_ text: String) {
+        currentText = text
+    }
+
+    func submitText(_ text: String) {}
+
+    func setToggleState(_ state: TextEntryMode) {
+        currentToggleState = state
+    }
+
+    func clearText() {}
+
+    func microphoneButtonTapped() {}
+
+    func markUserInteraction() {}
+
+    func clearButtonTapped() {}
+
+    func updateBarPosition(isTop: Bool) {
+        isTopBarPosition = isTop
     }
 }


### PR DESCRIPTION
Task/Issue URL:https://app.asana.com/1/137249556945/project/1206488453854252/task/1214812457808116


### Description

Cherry-picks PR #4911 onto the iOS 7.221 release branch. This brings over the Unified Toggle Input newline height, placeholder alignment, and synchronous layout fixes plus the review-follow-up regression coverage.

### Testing Steps
1. CI should pass for this release-branch PR.
2. Verified locally with XcodeBuildMCP: UnitTests/UnifiedToggleInputHandlerTests and UnitTests/UnifiedToggleInputViewTests passed, 79 tests, 0 failures.

### Impact and Risks
Low: release-branch cherry-pick of a focused Unified Toggle Input layout bug fix and tests.

#### What could go wrong?
Unified input height or placeholder alignment could regress in top/bottom Duck.ai or legacy switchbar paths. The cherry-pick includes regression tests for top AI chat expansion, bottom AI chat placeholder centering, legacy compact layout, and synchronous newline layout callbacks.

### Quality Considerations
The release branch was tested with a clean DerivedData path after the first run surfaced stale build artifacts. Xcode rewrote Package.resolved during local builds; that generated change was restored and is not part of this PR.

### Notes to Reviewer
This PR contains the two commits from merged PR #4911 cherry-picked onto release/ios/7.221.0.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/layout change confined to `UnifiedToggleInput`/`SwitchBarTextEntryView`, with extensive new regression tests around newline expansion, placeholder positioning, and top/bottom bar pose updates.
> 
> **Overview**
> Fixes **Unified Toggle Input / switchbar text entry layout** issues triggered by newline insertion and top-bar AI chat.
> 
> `SwitchBarTextEntryView` now supports an *expanded top AI chat pose* (taller min height + top-aligned placeholder) behind a new `SwitchBarHandling.usesExpandedAIChatTextEntryLayout` flag, and updates placeholder constraints/height together via `updatePoseForCurrentState()`.
> 
> `UnifiedToggleInputHandler` now tracks bar position changes via `updateBarPosition(isTop:)` (instead of a no-op/settable property), and `UnifiedToggleInputView` triggers pose refresh when the bar position changes; synchronous layout calls were also tightened (removing an extra `.receive(on:)` in the height-change pipeline and dropping a `window?.layoutIfNeeded()` in the VC height notification). Comprehensive new unit tests cover top/bottom AI chat placeholder alignment, first-newline height stability, clear-button pinning, toggle non-compression, and legacy compact behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d4eca9f2cd71f8ba990776ec5872c586966cd8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->