### PR TITLE
[macOS] Instrument count-variant impression pixels for Freemium DBP banner

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionFreemiumPixels.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionFreemiumPixels.swift
@@ -26,7 +26,10 @@ public class DataBrokerProtectionFreemiumPixelHandler: EventMapping<DataBrokerPr
             switch event {
             case .subscription:
                 PixelKit.fire(event, frequency: .uniqueByName, withAdditionalParameters: params)
-            case .newTabScanClickCount,
+            case .newTabScanImpressionCount,
+                    .newTabResultsImpressionCount,
+                    .newTabNoResultsImpressionCount,
+                    .newTabScanClickCount,
                     .newTabResultsClickCount,
                     .newTabNoResultsClickCount:
                 PixelKit.fire(event, frequency: .standard)
@@ -46,16 +49,19 @@ public enum DataBrokerProtectionFreemiumPixels: PixelKitEvent {
 
     // Before the first scan
     case newTabScanImpression
+    case newTabScanImpressionCount
     case newTabScanClick
     case newTabScanClickCount
     case newTabScanDismiss
     // When receiving results
     case newTabResultsImpression
+    case newTabResultsImpressionCount
     case newTabResultsClick
     case newTabResultsClickCount
     case newTabResultsDismiss
     // When receiving no results
     case newTabNoResultsImpression
+    case newTabNoResultsImpressionCount
     case newTabNoResultsClick
     case newTabNoResultsClickCount
     case newTabNoResultsDismiss
@@ -72,6 +78,8 @@ public enum DataBrokerProtectionFreemiumPixels: PixelKitEvent {
         switch self {
         case .newTabScanImpression:
             return "dbp-free_newtab_scan_impression_u"
+        case .newTabScanImpressionCount:
+            return "dbp-free_newtab_scan_impression_c"
         case .newTabScanClick:
             return "dbp-free_newtab_scan_click_u"
         case .newTabScanClickCount:
@@ -80,6 +88,8 @@ public enum DataBrokerProtectionFreemiumPixels: PixelKitEvent {
             return "dbp-free_newtab_scan_dismiss_u"
         case .newTabResultsImpression:
             return "dbp-free_newtab_results_impression_u"
+        case .newTabResultsImpressionCount:
+            return "dbp-free_newtab_results_impression_c"
         case .newTabResultsClick:
             return "dbp-free_newtab_results_click_u"
         case .newTabResultsClickCount:
@@ -88,6 +98,8 @@ public enum DataBrokerProtectionFreemiumPixels: PixelKitEvent {
             return "dbp-free_newtab_results_dismiss_u"
         case .newTabNoResultsImpression:
             return "dbp-free_newtab_no-results_impression_u"
+        case .newTabNoResultsImpressionCount:
+            return "dbp-free_newtab_no-results_impression_c"
         case .newTabNoResultsClick:
             return "dbp-free_newtab_no-results_click_u"
         case .newTabNoResultsClickCount:
@@ -112,14 +124,17 @@ public enum DataBrokerProtectionFreemiumPixels: PixelKitEvent {
     public var standardParameters: [PixelKitStandardParameter]? {
         switch self {
         case .newTabScanImpression,
+                .newTabScanImpressionCount,
                 .newTabScanClick,
                 .newTabScanClickCount,
                 .newTabScanDismiss,
                 .newTabResultsImpression,
+                .newTabResultsImpressionCount,
                 .newTabResultsClick,
                 .newTabResultsClickCount,
                 .newTabResultsDismiss,
                 .newTabNoResultsImpression,
+                .newTabNoResultsImpressionCount,
                 .newTabNoResultsClick,
                 .newTabNoResultsClickCount,
                 .newTabNoResultsDismiss,

--- a/macOS/DuckDuckGo/Freemium/DBP/FreemiumDBPPromotionViewCoordinator.swift
+++ b/macOS/DuckDuckGo/Freemium/DBP/FreemiumDBPPromotionViewCoordinator.swift
@@ -104,6 +104,10 @@ final class FreemiumDBPPromotionViewCoordinator: ObservableObject {
         subscribeToFeatureAvailabilityUpdates()
         observeFreemiumDBPNotifications()
         observeContextualOnboardingCompletion()
+
+        Task { @MainActor [weak self] in
+            self?.observeFreemiumDBPBannerImpressions()
+        }
     }
 
     @MainActor
@@ -257,4 +261,74 @@ private extension FreemiumDBPPromotionViewCoordinator {
         }
     }
 
+}
+
+// MARK: - Freemium DBP Promo Banner Impression Observation
+
+/// Observes per-window tab-selection changes to detect when the New Tab Page becomes the active tab,
+/// which is the moment the Freemium DBP promo banner (when visible) is presented to the user.
+/// Drives per-impression banner-view counting — `.newTabPageWebViewDidAppear` only fires on
+/// webview-to-window attach, not on tab activation back to an existing NTP, so it cannot.
+private extension FreemiumDBPPromotionViewCoordinator {
+
+    @MainActor
+    func observeFreemiumDBPBannerImpressions() {
+        let manager = Application.appDelegate.windowControllersManager
+
+        // Windows that already existed when this observer started: their @Published replay is
+        // ambient launch-time state, not a fresh impression event.
+        for windowController in manager.mainWindowControllers {
+            observeFreemiumDBPBannerImpressions(in: windowController, opened: false)
+        }
+
+        // Windows opened later (Cmd-N, deeplinks): the first emission is the user's fresh new tab.
+        manager.didRegisterWindowController
+            .sink { [weak self] windowController in
+                self?.observeFreemiumDBPBannerImpressions(in: windowController, opened: true)
+            }
+            .store(in: &cancellables)
+    }
+
+    @MainActor
+    func observeFreemiumDBPBannerImpressions(in windowController: MainWindowController, opened: Bool) {
+        let selectedTabPublisher = windowController.mainViewController.tabCollectionViewModel.$selectedTabViewModel
+            .compactMap { $0 }
+
+        // The first value @Published replays when we subscribe means very different things depending
+        // on when the window was registered:
+        //  - For windows that were already open at observer-setup time, the replay is the *current
+        //    ambient state* — the user has been looking at this tab; counting it as an impression
+        //    would conflate launch noise (e.g. placeholder→restored tab swaps) with real events.
+        //    Drop it, and rely on subsequent user-driven changes to fire.
+        //  - For just-opened windows, the first emission IS the impression — the user just opened
+        //    a new window and is seeing whatever tab landed in it (typically NTP). Keep it.
+        let pipeline: AnyPublisher<TabViewModel, Never> = opened
+            ? selectedTabPublisher.eraseToAnyPublisher()
+            : selectedTabPublisher.dropFirst().eraseToAnyPublisher()
+
+        pipeline
+            .sink { [weak self] selectedTabViewModel in
+                self?.handleSelectedTabChanged(selectedTabViewModel)
+            }
+            .store(in: &cancellables)
+    }
+
+    @MainActor
+    func handleSelectedTabChanged(_ selectedTabViewModel: TabViewModel) {
+        // Burner (Fire) Window NTPs don't render the freemium banner — skip to avoid over-counting.
+        guard case .newtab = selectedTabViewModel.tab.content,
+              !selectedTabViewModel.tab.burnerMode.isBurner else { return }
+
+        // Banner must actually be presentable. `viewModel == nil` means PromoService / feature
+        // gating has not produced a renderable promotion for this user/state.
+        guard viewModel != nil else { return }
+
+        execute(resultsAction: {
+            self.dataBrokerProtectionFreemiumPixelHandler.fire(DataBrokerProtectionFreemiumPixels.newTabResultsImpressionCount)
+        }, orNoResultsAction: {
+            self.dataBrokerProtectionFreemiumPixelHandler.fire(DataBrokerProtectionFreemiumPixels.newTabNoResultsImpressionCount)
+        }, orPromotionAction: {
+            self.dataBrokerProtectionFreemiumPixelHandler.fire(DataBrokerProtectionFreemiumPixels.newTabScanImpressionCount)
+        })
+    }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -1075,6 +1075,48 @@
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
+    "dbp-free_newtab_scan_impression_u": {
+        "description": "Fires once per user when the Freemium DBP promo banner first becomes eligible to be shown on the New Tab Page, in the pre-scan state (no scan results available yet).",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "dbp-free_newtab_scan_impression_c": {
+        "description": "Fires every time the user sees the Freemium DBP promo banner on the New Tab Page in the pre-scan state — emitted when the NTP becomes the active tab and the banner is renderable. Counted variant of dbp-free_newtab_scan_impression_u.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "dbp-free_newtab_results_impression_u": {
+        "description": "Fires once per user when the Freemium DBP promo banner first becomes eligible to be shown on the New Tab Page, while showing scan results (one or more matches found).",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "dbp-free_newtab_results_impression_c": {
+        "description": "Fires every time the user sees the Freemium DBP promo banner on the New Tab Page while it is showing scan results (one or more matches found) — emitted when the NTP becomes the active tab and the banner is renderable. Counted variant of dbp-free_newtab_results_impression_u.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "dbp-free_newtab_no-results_impression_u": {
+        "description": "Fires once per user when the Freemium DBP promo banner first becomes eligible to be shown on the New Tab Page, while showing the no-results state (scan completed with zero matches).",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "dbp-free_newtab_no-results_impression_c": {
+        "description": "Fires every time the user sees the Freemium DBP promo banner on the New Tab Page while it is showing the no-results state (scan completed with zero matches) — emitted when the NTP becomes the active tab and the banner is renderable. Counted variant of dbp-free_newtab_no-results_impression_u.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource"]
+    },
     "dbp-free_newtab_scan_click_u": {
         "description": "Fires once per user when they click the scan CTA on the Freemium DBP promo banner on the New Tab Page, in the pre-scan state (no scan results available yet).",
         "owners": ["hanyutang-sandra"],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214978255724646?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1214432127962356?focus=true
CC:

### Description

Adds `_c` (count) variants for the three freemium DBP New Tab Page banner impression pixels, completing the deferred items from #4793. The `_c` variants fire from a per-window tab-selection observer in `FreemiumDBPPromotionViewCoordinator` — each time the NTP becomes the active tab while the banner is renderable. Existing `_u` (unique-by-name) fires in `createViewModel()` are preserved (they represent a distinct, sparser semantic bounded by PromoService eligibility events).

**New pixels**
- `dbp-free_newtab_scan_impression_c`
- `dbp-free_newtab_results_impression_c`
- `dbp-free_newtab_no-results_impression_c`

**JSON5 definitions registered for existing pixels**
- `dbp-free_newtab_scan_impression_u`
- `dbp-free_newtab_results_impression_u`
- `dbp-free_newtab_no-results_impression_u`

Approach based on the probe in #4746, refined for production: real pixel fires (vs `print`), `viewModel != nil` gate, burner-window NTP filter, and three-way dispatch via the existing `execute(resultsAction:orNoResultsAction:orPromotionAction:)` helper.

### Testing Steps

1. `npm run validate-pixel-defs` passes from `macOS/`
2. Xcode build succeeds for the macOS target
3. **Fresh window opens NTP**
   - Cmd-N → NTP shown → `dbp-free_newtab_{scan|results|no-results}_impression_c` fires (variant depends on user's scan-result state)
4. **Tab switching within a window**
   - Switch from non-NTP tab to NTP tab → `_impression_c` fires
   - Switch NTP → non-NTP → no pixel
   - Switch back to NTP → `_impression_c` fires again
5. **Banner-visible gate**
   - When `viewModel == nil` (banner suppressed by feature gating) → no `_impression_c` fires on NTP activation
6. **Burner (Fire) Window**
   - Open Fire Window, switch to its NTP → no `_impression_c` fires
7. **Pre-existing windows (launch noise)**
   - Cold launch with restored windows → no `_impression_c` fires from the ambient `@Published` replay
   - Subsequent user-driven tab switches in those windows → `_impression_c` fires normally
8. **Variant dispatch**
   - `firstScanResults == nil` → `dbp-free_newtab_scan_impression_c`
   - `firstScanResults.matchesCount > 0` → `dbp-free_newtab_results_impression_c`
   - `firstScanResults.matchesCount == 0` → `dbp-free_newtab_no-results_impression_c`

### Impact and Risks

Low — pixel instrumentation only. No user-facing behavior change.

#### What could go wrong?

- Per-window Combine subscriptions are stored in `cancellables` for the coordinator's lifetime; each per-window publisher completes naturally when its window deinits. `[weak self]` is used throughout to prevent retain cycles.
- `_c` and `_u` will diverge by design (per-impression vs sparse). Analytics consumers should not attempt to reconcile them 1:1.
- Pixel-defs validation could fail if naming or parameter format drifts; mitigated by running `npm run validate-pixel-defs` locally.

### Quality Considerations

- `_c` pixels fire via `.standard` PixelKit frequency (every fire counts); `_u` cousins retain `.uniqueByName`.
- Variant dispatch reuses the existing `execute(resultsAction:orNoResultsAction:orPromotionAction:)` helper — same branching logic `createViewModel()` uses for `_u` fires, so `_c` attribution stays consistent with `_u`.
- Burner-window filter is defense-in-depth: the freemium banner is not rendered in burner windows today, so `viewModel != nil` would already suppress these fires — the explicit filter makes intent unambiguous and resilient to future banner-availability changes.

### Notes to Reviewer

- Pre-existing `_u` fires in `createViewModel()` are intentionally untouched.
- JSON5 defs for the `_u` siblings are added in this PR for the first time — they were previously Swift-only.
- No unit tests added for the new observer: would require dependency injection of `Application.appDelegate.windowControllersManager` (currently a global singleton). Can be tackled as a follow-up.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk instrumentation-only change; main risk is over/under-counting impressions due to new tab-selection observation and lifecycle edge cases.
> 
> **Overview**
> Adds new *_count* (`_c`) Freemium DBP New Tab Page banner **impression** pixels and routes them through `PixelKit` with `.standard` frequency.
> 
> Implements a per-window tab-selection observer in `FreemiumDBPPromotionViewCoordinator` to fire the `_c` impression pixels whenever the NTP becomes the active tab *and* the promo banner is renderable (skipping burner windows and ignoring initial `@Published` replay for pre-existing windows).
> 
> Registers JSON5 definitions for the three existing unique (`_u`) impression pixels and the three new counted (`_c`) variants in `data_broker_protection.json5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1708c850fd361ced9f7fdf67c818293502db5eee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->