### PR TITLE
Update post-idle session wide event definition

### DIFF
--- a/iOS/PixelDefinitions/wide_events/definitions/post-idle-session.json5
+++ b/iOS/PixelDefinitions/wide_events/definitions/post-idle-session.json5
@@ -4,7 +4,7 @@
         "owners": ["samsymons", "SabrinaTardio"],
         "meta": {
             "type": "ios-post-idle-session",
-            "version": "0.0"
+            "version": "1.0"
         },
         "feature": {
             "name": "post_idle_session",
@@ -29,13 +29,15 @@
                             "app_terminated"
                         ]
                     },
-                    "session_duration_ms": {
-                        "type": "integer",
-                        "description": "Total time in milliseconds the post-idle surface was visible, from session start until the terminal action or background. Absent when the session was orphaned (UNKNOWN / app_terminated)."
+                    "session_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Total time the post-idle surface was visible, from session start until the terminal action or background, bucketed (lower end of bucket, in ms). Absent when the session was orphaned (UNKNOWN / app_terminated).",
+                        "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
                     },
-                    "time_to_first_interaction_ms": {
-                        "type": "integer",
-                        "description": "Time in milliseconds from session start to the first user interaction with the post-idle surface (page engagement, toggle, back, or terminal action). Absent if the session ended without any interaction."
+                    "time_to_first_interaction_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from session start to the first user interaction with the post-idle surface (page engagement, toggle, back, or terminal action), bucketed (lower end of bucket, in ms). Absent if the session ended without any interaction.",
+                        "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
                     },
                     "page_engaged": {
                         "type": "boolean",

--- a/iOS/PixelDefinitions/wide_events/generated_schemas/ios-post-idle-session-1.1.0.json
+++ b/iOS/PixelDefinitions/wide_events/generated_schemas/ios-post-idle-session-1.1.0.json
@@ -10,7 +10,7 @@
             "type": "object",
             "required": ["type", "version"],
             "additionalProperties": false,
-            "properties": { "type": { "const": "ios-post-idle-session" }, "version": { "const": "1.0.0" } }
+            "properties": { "type": { "const": "ios-post-idle-session" }, "version": { "const": "1.1.0" } }
         },
         "app": {
             "type": "object",


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1193060753475688/task/1214909096767038?focus=true
Tech Design URL:
CC:

### Description

This PR updates the post-idle wide event definition to match what is actually being sent.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Trigger the post-idle wide event locally, by returning to the app from the background after a period of inactivity and then triggering some action like a Duck.ai chat
2. Check that the event has sent
3. Now run `./iOS/scripts/validate_wide_events.sh` and confirm that it passes. You should see the following:

```
Validating wide event log...

> ios@1.0.0 validate-wide-event-debug-logs
> validate-ddg-wide-event-logs /Users/samsymons/Code/DuckDuckGo/Monorepo/iOS/scripts/../PixelDefinitions /Users/samsymons/Library/Developer/CoreSimulator/Devices/***/data/Containers/Data/Application/***/Library/Caches/wide-event-validation-log.jsonl

✅ Valid: 'ios-post-idle-session@1.1.0'
```

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
5. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to wide-event schema/definition files, but downstream analytics/validation must align with the renamed and retyped timing fields and new schema version.
> 
> **Overview**
> Updates the `ios-post-idle-session` wide-event definition by bumping its meta version and changing timing fields from raw integer milliseconds to bucketed string enums (renaming `session_duration_ms` and `time_to_first_interaction_ms` to `*_ms_bucketed`).
> 
> Regenerates the `1.0.0` JSON schema to reflect these field changes and adds a new `ios-post-idle-session-1.1.0.json` schema for the updated event version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 586e9e48211e6e77b1d11c60202ab1123e620289. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->