### PR TITLE
Fix variant DMG not uploaded to S3 when custom DMG URL is used

### DIFF
--- a/.github/workflows/macos_create_variant.yml
+++ b/.github/workflows/macos_create_variant.yml
@@ -177,7 +177,7 @@ jobs:
         retention-days: 5
 
     - name: Upload variant DMG to S3
-      if: ${{ env.DRY_RUN != 'true' && !env.DMG_URL }}
+      if: ${{ env.DRY_RUN != 'true' }}
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_RELEASE_S3 }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_RELEASE_S3 }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1214905371185281?focus=true

### Description

The `Upload variant DMG to S3` step in `macos_create_variant.yml` was gated on `${{ env.DRY_RUN != 'true' && !env.DMG_URL }}`. Because the artifact upload step is gated on `env.DRY_RUN == 'true'`, combining a non-empty `DMG_URL` (passed explicitly via `workflow_dispatch`, or implicitly inherited from the parent workflow's `github.event.inputs.dmg-url`) with `dry-run=false` resulted in **no destination at all** for the produced variant DMG — the run succeeded but the artifact was lost.

This PR drops the `!env.DMG_URL` guard so the S3 upload runs whenever dry-run is false, regardless of the source of the input DMG.

### Testing Steps
See test workflow run here: https://github.com/duckduckgo/apple-browsers/actions/runs/26063145025

### Impact and Risks

Low. The change only widens the condition under which a successful build publishes to the release S3 bucket. The previous behaviour silently dropped output; the new behaviour matches the historical intent of the workflow.

#### What could go wrong?

A non-dry-run run started with a hand-rolled custom `dmg-url` will now overwrite the canonical variant DMG in S3 for that variant name. This was already possible by running the workflow without `dmg-url` and relying on the release artifact, so it is not a new exposure — but operators should be aware that `dry-run=true` is the right switch when testing with a custom DMG.

### Quality Considerations

No code paths other than the conditional were touched. No new secrets or permissions. The S3 destination, ACL, and naming all remain identical.

### Notes to Reviewer

Worth a sanity check on whether `dry-run` is the intended switch for "don't publish" — if not, we may want a separate `publish` toggle later. For now this restores the workflow's original behaviour.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow change that only broadens when the S3 publish step runs; main risk is unintentionally publishing/overwriting a variant DMG in S3 when using a custom `dmg-url`.
> 
> **Overview**
> Fixes the `macos_create_variant.yml` publish logic so `Upload variant DMG to S3` runs whenever `dry-run` is false, instead of being skipped when `DMG_URL` is set.
> 
> This prevents successful variant builds from producing no persisted output when a custom DMG URL is used, while keeping the artifact-only behavior for `dry-run=true` unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c912490a40aeb71bfad530202b1c6e8d9938a811. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->