### PR TITLE
Additional wide event schema fix

### DIFF
--- a/iOS/PixelDefinitions/wide_events/generated_schemas/ios-post-idle-session-1.0.0.json
+++ b/iOS/PixelDefinitions/wide_events/generated_schemas/ios-post-idle-session-1.0.0.json
@@ -78,15 +78,13 @@
                                         "app_terminated"
                                     ]
                                 },
-                                "session_duration_ms_bucketed": {
-                                    "type": "string",
-                                    "description": "Total time the post-idle surface was visible, from session start until the terminal action or background, bucketed (lower end of bucket, in ms). Absent when the session was orphaned (UNKNOWN / app_terminated).",
-                                    "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                "session_duration_ms": {
+                                    "type": "integer",
+                                    "description": "Total time in milliseconds the post-idle surface was visible, from session start until the terminal action or background. Absent when the session was orphaned (UNKNOWN / app_terminated)."
                                 },
-                                "time_to_first_interaction_ms_bucketed": {
-                                    "type": "string",
-                                    "description": "Time from session start to the first user interaction with the post-idle surface (page engagement, toggle, back, or terminal action), bucketed (lower end of bucket, in ms). Absent if the session ended without any interaction.",
-                                    "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                "time_to_first_interaction_ms": {
+                                    "type": "integer",
+                                    "description": "Time in milliseconds from session start to the first user interaction with the post-idle surface (page engagement, toggle, back, or terminal action). Absent if the session ended without any interaction."
                                 },
                                 "page_engaged": {
                                     "type": "boolean",


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1193060753475688/task/1214909096767038?focus=true
Tech Design URL:
CC:

### Description

Follow-up fix to https://github.com/duckduckgo/apple-browsers/pull/4939.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1.  See https://github.com/duckduckgo/apple-browsers/pull/4939

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the analytics event schema contract for duration fields, which may break validation or downstream ingestion if producers/consumers still send/expect the bucketed string parameters.
> 
> **Overview**
> Updates the `ios-post-idle-session-1.0.0` wide-event schema to replace the bucketed duration fields (`session_duration_ms_bucketed`, `time_to_first_interaction_ms_bucketed`) with integer millisecond values (`session_duration_ms`, `time_to_first_interaction_ms`). This removes the fixed bucket enums and changes the expected parameter names and types for post-idle session timing telemetry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcf8a36520a9a92ad91ad69074bf1958ae9549ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->