### PR TITLE
Further wide event validation fix

### DIFF
--- a/iOS/PixelDefinitions/wide_events/generated_schemas/ios-post-idle-session-1.0.0.json
+++ b/iOS/PixelDefinitions/wide_events/generated_schemas/ios-post-idle-session-1.0.0.json
@@ -80,11 +80,21 @@
                                 },
                                 "session_duration_ms": {
                                     "type": "integer",
-                                    "description": "Total time in milliseconds the post-idle surface was visible, from session start until the terminal action or background. Absent when the session was orphaned (UNKNOWN / app_terminated)."
+                                    "description": "Total time in milliseconds the post-idle surface was visible, from session start until the terminal action or background. Absent when the session was orphaned (UNKNOWN / app_terminated). Emitted by pre-bucketing builds; newer builds emit session_duration_ms_bucketed instead."
                                 },
                                 "time_to_first_interaction_ms": {
                                     "type": "integer",
-                                    "description": "Time in milliseconds from session start to the first user interaction with the post-idle surface (page engagement, toggle, back, or terminal action). Absent if the session ended without any interaction."
+                                    "description": "Time in milliseconds from session start to the first user interaction with the post-idle surface (page engagement, toggle, back, or terminal action). Absent if the session ended without any interaction. Emitted by pre-bucketing builds; newer builds emit time_to_first_interaction_ms_bucketed instead."
+                                },
+                                "session_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Bucketed (lower bound, in ms) total time the post-idle surface was visible. Emitted by builds that send meta.version 1.0.0 with bucketed durations; older builds emit session_duration_ms instead.",
+                                    "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "time_to_first_interaction_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Bucketed (lower bound, in ms) time from session start to the first user interaction with the post-idle surface. Emitted by builds that send meta.version 1.0.0 with bucketed durations; older builds emit time_to_first_interaction_ms instead.",
+                                    "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
                                 },
                                 "page_engaged": {
                                     "type": "boolean",


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1193060753475688/task/1214909096767038?focus=true
Tech Design URL:
CC:

### Description

Follows up on https://github.com/duckduckgo/apple-browsers/pull/4942 with another fix - it turns out this event is using the same format for two versions, which is why the initial fixes didn't work.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. N/A

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk schema-only change that broadens validation to allow either raw or bucketed duration fields for the same event version. Risk is limited to analytics validation/ingestion if downstream expects only one of the fields.
> 
> **Overview**
> Updates the `ios-post-idle-session-1.0.0` wide-event schema to clarify that `session_duration_ms` and `time_to_first_interaction_ms` are legacy fields, and to add `session_duration_ms_bucketed` and `time_to_first_interaction_ms_bucketed` (with allowed bucket enums) for newer builds that emit bucketed durations under the same `meta.version`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e87757cd0d958f3a8d0d54d0e3e70f31cb469134. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->