### PR TITLE
Add native input URL handling for Duck.ai

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatURLParameters.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatURLParameters.swift
@@ -27,6 +27,10 @@ public enum AIChatURLParameters {
     public static let autoSubmitPromptQueryValue = "1"
     /// Repeating parameter for selecting one or more RAG tools.
     public static let toolChoiceName = "toolChoice"
+    /// Flag indicating the host app renders the chat input natively.
+    public static let nativeInputName = "native-input"
+    /// Value used with `nativeInputName` when native input is enabled.
+    public static let nativeInputValue = "true"
     /// Flow selector key used for onboarding-specific Duck.ai behavior.
     public static let flowQueryName = "flow"
     /// Flow selector value for mobile app onboarding.
@@ -52,6 +56,31 @@ public enum AIChatURLParameters {
     /// Appends `?sidebar=open` to the given base URL.
     public static func sidebarOpenURL(from baseURL: URL) -> URL {
         baseURL.addingOrReplacing(URLQueryItem(name: sidebarName, value: sidebarOpenValue))
+    }
+
+    /// Appends `?native-input=true` to the given base URL.
+    public static func nativeInputURL(from baseURL: URL) -> URL {
+        baseURL.addingOrReplacing(URLQueryItem(name: nativeInputName, value: nativeInputValue))
+    }
+
+    /// Removes `native-input` from the given base URL.
+    public static func removingNativeInputURL(from baseURL: URL) -> URL {
+        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+            return baseURL
+        }
+        var queryItems = components.queryItems ?? []
+        queryItems.removeAll { $0.name == nativeInputName }
+        components.queryItems = queryItems.isEmpty ? nil : queryItems
+        return components.url ?? baseURL
+    }
+
+    /// Adds or removes `native-input` for URLs that support the native input contract.
+    public static func updatingNativeInputURL(from baseURL: URL, isNativeInputAvailable: Bool, isSupportedURL: Bool) -> URL {
+        guard isSupportedURL else { return baseURL }
+        if isNativeInputAvailable {
+            return nativeInputURL(from: baseURL)
+        }
+        return removingNativeInputURL(from: baseURL)
     }
 
     private static func modeURL(from baseURL: URL, mode: String) -> URL {

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatURLParametersTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatURLParametersTests.swift
@@ -86,4 +86,79 @@ final class AIChatURLParametersTests: XCTestCase {
         XCTAssertEqual(result.absoluteString, "https://duck.ai/chat?mode=image")
     }
 
+    func testNativeInputURLAppendsNativeInputParameter() {
+        let baseURL = URL(string: "https://duck.ai/chat")!
+        let result = AIChatURLParameters.nativeInputURL(from: baseURL)
+        XCTAssertEqual(result.absoluteString, "https://duck.ai/chat?native-input=true")
+    }
+
+    func testNativeInputURLPreservesExistingQueryItems() {
+        let baseURL = URL(string: "https://duck.ai/chat?mode=voice")!
+        let result = AIChatURLParameters.nativeInputURL(from: baseURL)
+
+        let components = URLComponents(url: result, resolvingAgainstBaseURL: false)!
+        let queryItems = components.queryItems ?? []
+        XCTAssertTrue(queryItems.contains(URLQueryItem(name: "mode", value: "voice")))
+        XCTAssertTrue(queryItems.contains(URLQueryItem(name: "native-input", value: "true")))
+    }
+
+    func testNativeInputURLReplacesExistingNativeInputParameter() {
+        let baseURL = URL(string: "https://duck.ai/chat?native-input=false")!
+        let result = AIChatURLParameters.nativeInputURL(from: baseURL)
+
+        let components = URLComponents(url: result, resolvingAgainstBaseURL: false)!
+        let nativeInputItems = (components.queryItems ?? []).filter { $0.name == "native-input" }
+        XCTAssertEqual(nativeInputItems.count, 1)
+        XCTAssertEqual(nativeInputItems.first?.value, "true")
+    }
+
+    func testRemovingNativeInputURLRemovesNativeInputParameter() {
+        let baseURL = URL(string: "https://duck.ai/chat?native-input=true&mode=voice")!
+        let result = AIChatURLParameters.removingNativeInputURL(from: baseURL)
+
+        let components = URLComponents(url: result, resolvingAgainstBaseURL: false)!
+        let queryItems = components.queryItems ?? []
+        XCTAssertFalse(queryItems.contains { $0.name == "native-input" })
+        XCTAssertTrue(queryItems.contains(URLQueryItem(name: "mode", value: "voice")))
+    }
+
+    func testRemovingNativeInputURLRemovesTrailingQueryWhenNativeInputIsOnlyParameter() {
+        let baseURL = URL(string: "https://duck.ai/chat?native-input=true")!
+        let result = AIChatURLParameters.removingNativeInputURL(from: baseURL)
+
+        XCTAssertEqual(result.absoluteString, "https://duck.ai/chat")
+    }
+
+    func testUpdatingNativeInputURLAddsWhenAvailableAndSupported() {
+        let baseURL = URL(string: "https://duck.ai/chat")!
+        let result = AIChatURLParameters.updatingNativeInputURL(
+            from: baseURL,
+            isNativeInputAvailable: true,
+            isSupportedURL: true
+        )
+
+        XCTAssertEqual(result.absoluteString, "https://duck.ai/chat?native-input=true")
+    }
+
+    func testUpdatingNativeInputURLRemovesWhenUnavailableAndSupported() {
+        let baseURL = URL(string: "https://duck.ai/chat?native-input=true")!
+        let result = AIChatURLParameters.updatingNativeInputURL(
+            from: baseURL,
+            isNativeInputAvailable: false,
+            isSupportedURL: true
+        )
+
+        XCTAssertEqual(result.absoluteString, "https://duck.ai/chat")
+    }
+
+    func testUpdatingNativeInputURLLeavesUnsupportedURLUnchanged() {
+        let baseURL = URL(string: "https://example.com/chat?native-input=true")!
+        let result = AIChatURLParameters.updatingNativeInputURL(
+            from: baseURL,
+            isNativeInputAvailable: false,
+            isSupportedURL: false
+        )
+
+        XCTAssertEqual(result, baseURL)
+    }
 }

--- a/iOS/DuckDuckGo/AIChat/AIChatContentHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatContentHandler.swift
@@ -129,6 +129,8 @@ final class AIChatContentHandler: AIChatContentHandling {
     private let productSurfaceTelemetry: ProductSurfaceTelemetry
     private let freeTrialConversionService: FreeTrialConversionInstrumentationService
     private let statisticsLoader: StatisticsLoader
+    private let unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding
+    private let debugSettings: AIChatDebugSettingsHandling
 
     private var userScript: AIChatUserScriptProviding?
 
@@ -145,6 +147,8 @@ final class AIChatContentHandler: AIChatContentHandling {
          productSurfaceTelemetry: ProductSurfaceTelemetry,
          freeTrialConversionService: FreeTrialConversionInstrumentationService = AppDependencyProvider.shared.freeTrialConversionService,
          statisticsLoader: StatisticsLoader = .shared,
+         unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature(),
+         debugSettings: AIChatDebugSettingsHandling = AIChatDebugSettings(),
          getPageContext: ((PageContextRequestReason) -> AIChatPageContextData?)? = nil) {
         self.aiChatSettings = aiChatSettings
         self.payloadHandler = payloadHandler
@@ -153,6 +157,8 @@ final class AIChatContentHandler: AIChatContentHandling {
         self.productSurfaceTelemetry = productSurfaceTelemetry
         self.freeTrialConversionService = freeTrialConversionService
         self.statisticsLoader = statisticsLoader
+        self.unifiedToggleInputFeature = unifiedToggleInputFeature
+        self.debugSettings = debugSettings
         self.getPageContext = getPageContext
     }
 
@@ -173,42 +179,54 @@ final class AIChatContentHandler: AIChatContentHandling {
     
     /// Builds a query URL with optional prompt, auto-submit, onboarding flow and RAG tools.
     func buildQueryURL(query: String?, autoSend: Bool, flowType: AIChatOnboardingFlowType = .default, tools: [AIChatRAGTool]?) -> URL {
-        guard let query, var components = URLComponents(url: aiChatSettings.aiChatURL, resolvingAgainstBaseURL: false) else {
-            return aiChatSettings.aiChatURL
+        guard var components = URLComponents(url: aiChatSettings.aiChatURL, resolvingAgainstBaseURL: false) else {
+            return updatingNativeInputParameterIfNeeded(in: aiChatSettings.aiChatURL)
         }
 
         var queryItems = components.queryItems ?? []
 
-        if !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            queryItems.removeAll { $0.name == AIChatURLParameters.promptQueryName }
-            queryItems.append(URLQueryItem(name: AIChatURLParameters.promptQueryName, value: query))
-        }
+        if let query {
+            if !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                queryItems.removeAll { $0.name == AIChatURLParameters.promptQueryName }
+                queryItems.append(URLQueryItem(name: AIChatURLParameters.promptQueryName, value: query))
+            }
 
-        if autoSend {
-            queryItems.removeAll { $0.name == AIChatURLParameters.autoSubmitPromptQueryName }
-            queryItems.append(URLQueryItem(name: AIChatURLParameters.autoSubmitPromptQueryName, value: AIChatURLParameters.autoSubmitPromptQueryValue))
-        }
+            if autoSend {
+                queryItems.removeAll { $0.name == AIChatURLParameters.autoSubmitPromptQueryName }
+                queryItems.append(URLQueryItem(
+                    name: AIChatURLParameters.autoSubmitPromptQueryName,
+                    value: AIChatURLParameters.autoSubmitPromptQueryValue
+                ))
+            }
 
-        if let flowValue = flowType.flowQueryValue {
-            queryItems.removeAll { $0.name == AIChatURLParameters.flowQueryName }
-            queryItems.append(URLQueryItem(name: AIChatURLParameters.flowQueryName, value: flowValue))
-        } else {
-            queryItems.removeAll { $0.name == AIChatURLParameters.flowQueryName }
-        }
+            if let flowValue = flowType.flowQueryValue {
+                queryItems.removeAll { $0.name == AIChatURLParameters.flowQueryName }
+                queryItems.append(URLQueryItem(name: AIChatURLParameters.flowQueryName, value: flowValue))
+            } else {
+                queryItems.removeAll { $0.name == AIChatURLParameters.flowQueryName }
+            }
 
-        if let tools = tools, !tools.isEmpty {
-            queryItems.removeAll { $0.name == AIChatURLParameters.toolChoiceName }
-            for tool in tools {
-                queryItems.append(URLQueryItem(name: AIChatURLParameters.toolChoiceName, value: tool.rawValue))
+            if let tools = tools, !tools.isEmpty {
+                queryItems.removeAll { $0.name == AIChatURLParameters.toolChoiceName }
+                for tool in tools {
+                    queryItems.append(URLQueryItem(name: AIChatURLParameters.toolChoiceName, value: tool.rawValue))
+                }
             }
         }
 
-        components.queryItems = queryItems
-        return components.url ?? aiChatSettings.aiChatURL
+        if isNativeInputParameterSupported(for: aiChatSettings.aiChatURL) {
+            queryItems.removeAll { $0.name == AIChatURLParameters.nativeInputName }
+            if unifiedToggleInputFeature.isAvailable {
+                queryItems.append(URLQueryItem(name: AIChatURLParameters.nativeInputName, value: AIChatURLParameters.nativeInputValue))
+            }
+        }
+
+        components.queryItems = queryItems.isEmpty ? nil : queryItems
+        return components.url ?? updatingNativeInputParameterIfNeeded(in: aiChatSettings.aiChatURL)
     }
     
     func buildVoiceModeURL() -> URL {
-        AIChatURLParameters.voiceModeURL(from: aiChatSettings.aiChatURL)
+        updatingNativeInputParameterIfNeeded(in: AIChatURLParameters.voiceModeURL(from: aiChatSettings.aiChatURL))
     }
 
     func submitPrompt(_ prompt: String, pageContext: AIChatPageContextData? = nil) {
@@ -248,6 +266,18 @@ final class AIChatContentHandler: AIChatContentHandling {
         productSurfaceTelemetry.duckAIUsed()
         pixelMetricHandler?.fireOpenAIChat()
         featureDiscovery.setWasUsedBefore(.aiChat)
+    }
+
+    private func updatingNativeInputParameterIfNeeded(in url: URL) -> URL {
+        AIChatURLParameters.updatingNativeInputURL(
+            from: url,
+            isNativeInputAvailable: unifiedToggleInputFeature.isAvailable,
+            isSupportedURL: isNativeInputParameterSupported(for: url)
+        )
+    }
+
+    private func isNativeInputParameterSupported(for url: URL) -> Bool {
+        url.isDuckAIURL || debugSettings.matchesCustomURL(url)
     }
 }
 

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -191,7 +191,7 @@ final class AIChatContextualSheetCoordinator {
     func notifyPageChanged() async {
         guard hasActiveSheet else { return }
         // Native UTI handles nav via the chip view-model's `originatingURLPublisher` subscription.
-        if unifiedToggleInputFeature.isFeatureFlagEnabled { return }
+        if unifiedToggleInputFeature.isAvailable { return }
         sessionState.notifyPageChanged()
 
         if sessionState.shouldAutoCollectContext {
@@ -292,6 +292,7 @@ private extension AIChatContextualSheetCoordinator {
             contentBlockingAssetsPublisher: contentBlockingAssetsPublisher,
             featureDiscovery: featureDiscovery,
             featureFlagger: featureFlagger,
+            unifiedToggleInputFeature: unifiedToggleInputFeature,
             isFireTab: isFireTab,
             duckAiFireModeStorageHandler: duckAiFireModeStorageHandler,
             downloadHandler: downloadHandler,

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
@@ -883,8 +883,7 @@ private extension AIChatContextualSheetViewController {
         case .nativeInput:
             // When returning to native input (new chat), reload the default URL on existing web VC
             if isWebViewVisible, let webVC = webViewController {
-                let defaultURL = aiChatSettings.aiChatURL.appendingParameter(name: "placement", value: "sidebar")
-                webVC.loadChatURL(defaultURL)
+                webVC.loadDefaultChatURL()
                 isWebViewVisible = false
             }
             fireButton.isHidden = true

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
@@ -157,6 +157,8 @@ final class AIChatContextualWebViewController: UIViewController {
             aiChatSettings: aiChatSettings,
             featureDiscovery: featureDiscovery,
             productSurfaceTelemetry: productSurfaceTelemetry,
+            unifiedToggleInputFeature: unifiedToggleInputFeature,
+            debugSettings: debugSettings,
             getPageContext: getPageContext
         )
 
@@ -173,7 +175,7 @@ final class AIChatContextualWebViewController: UIViewController {
         super.viewDidLoad()
         Logger.aiChat.debug("[ContextualWebVC] viewDidLoad - initialURL: \(String(describing: self.initialURL?.absoluteString))")
         setupUI()
-        if isUTIEnabled, let utiHostInstaller {
+        if shouldInstallUTIHost, let utiHostInstaller {
             utiHost = utiHostInstaller(self)
         }
         aiChatContentHandler.fireAIChatTelemetry()
@@ -248,7 +250,8 @@ final class AIChatContextualWebViewController: UIViewController {
     }
 
     func loadChatURL(_ url: URL) {
-        Logger.aiChat.debug("[ContextualWebVC] loadChatURL - resetting page ready flag and loading: \(url.absoluteString)")
+        let urlToLoad = chatURLForLoading(url)
+        Logger.aiChat.debug("[ContextualWebVC] loadChatURL - resetting page ready flag and loading: \(urlToLoad.absoluteString)")
         isPageReady = false
         isFrontendReady = false
         pendingPrompt = nil
@@ -256,7 +259,19 @@ final class AIChatContextualWebViewController: UIViewController {
         hasPendingChipContext = false
         pendingChipContext = nil
         loadingView.startAnimating()
-        webView.load(URLRequest(url: url))
+        webView.load(URLRequest(url: urlToLoad))
+    }
+
+    func loadDefaultChatURL() {
+        loadChatURL(defaultChatURL)
+    }
+
+    func chatURLForLoading(_ url: URL) -> URL {
+        AIChatURLParameters.updatingNativeInputURL(
+            from: url,
+            isNativeInputAvailable: unifiedToggleInputFeature.isAvailable,
+            isSupportedURL: url.isDuckAIURL || debugSettings.matchesCustomURL(url)
+        )
     }
 
     // MARK: - Private Methods
@@ -293,14 +308,15 @@ final class AIChatContextualWebViewController: UIViewController {
     }
 
     private func loadAIChat() {
-        loadingView.startAnimating()
-        let contextualURL = aiChatSettings.aiChatURL.appendingParameter(name: "placement", value: "sidebar")
-        Logger.aiChat.debug("[ContextualWebVC] loadAIChat - loading URL: \(contextualURL.absoluteString)")
-        webView.load(URLRequest(url: contextualURL))
+        loadChatURL(defaultChatURL)
     }
 
-    private var isUTIEnabled: Bool {
-        unifiedToggleInputFeature.isFeatureFlagEnabled && utiHostInstaller != nil
+    private var shouldInstallUTIHost: Bool {
+        unifiedToggleInputFeature.isAvailable && utiHostInstaller != nil
+    }
+
+    private var defaultChatURL: URL {
+        aiChatSettings.aiChatURL.addingOrReplacing(URLQueryItem(name: "placement", value: "sidebar"))
     }
 
     private func setupDownloadHandler() {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
@@ -140,14 +140,14 @@ final class SwitchBarHandler: SwitchBarHandling {
     }
 
     var isUsingFadeOutAnimation: Bool {
-        guard unifiedToggleInputFeature.isFeatureFlagEnabled else {
+        guard unifiedToggleInputFeature.isAvailable else {
             return devicePlatform.isIphone
         }
         return false
     }
 
     var shouldDisableAutocorrectOnEmpty: Bool {
-        unifiedToggleInputFeature.isFeatureFlagEnabled || devicePlatform.isIphone
+        unifiedToggleInputFeature.isAvailable || devicePlatform.isIphone
     }
 
     var isVoiceSearchEnabled: Bool {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
@@ -147,7 +147,7 @@ final class SwitchBarHandler: SwitchBarHandling {
     }
 
     var shouldDisableAutocorrectOnEmpty: Bool {
-        unifiedToggleInputFeature.isAvailable || devicePlatform.isIphone
+        devicePlatform.isIphone
     }
 
     var isVoiceSearchEnabled: Bool {

--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -259,7 +259,7 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
             supportsContextualMode = aichatContextualModeFeature.isAvailable || defaults.supportsAIChatContextualMode
         }
 
-        let supportsNativeChatInput = (supportsFullMode || supportsContextualMode) && unifiedToggleInputFeature.isFeatureFlagEnabled
+        let supportsNativeChatInput = (supportsFullMode || supportsContextualMode) && unifiedToggleInputFeature.isAvailable
         let supportsNativePrompt = supportsNativeChatInput || defaults.supportsNativePrompt
         let fireMode = isFireModeProvider?() ?? false
 

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -148,7 +148,6 @@ class TabViewController: UIViewController {
     private(set) var webView: WKWebView!
     private lazy var appRatingPrompt: AppRatingPrompt = AppRatingPrompt(featureFlagger: self.featureFlagger)
     private let unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding
-    private let aiChatDebugSettings: AIChatDebugSettingsHandling
     public weak var privacyDashboard: PrivacyDashboardViewController?
     
     private var storageCache: StorageCache = AppDependencyProvider.shared.storageCache
@@ -455,7 +454,6 @@ class TabViewController: UIViewController {
                                    daxDialogsManager: DaxDialogsManaging,
                                    aiChatSettings: AIChatSettingsProvider,
                                    productSurfaceTelemetry: ProductSurfaceTelemetry,
-                                   aiChatDebugSettings: AIChatDebugSettingsHandling = AIChatDebugSettings(),
                                    sharedSecureVault: (any AutofillSecureVault)? = nil,
                                    privacyStats: PrivacyStatsProviding,
                                    voiceSearchHelper: VoiceSearchHelperProtocol,
@@ -493,7 +491,6 @@ class TabViewController: UIViewController {
                               daxDialogsManager: daxDialogsManager,
                               aiChatSettings: aiChatSettings,
                               productSurfaceTelemetry: productSurfaceTelemetry,
-                              aiChatDebugSettings: aiChatDebugSettings,
                               sharedSecureVault: sharedSecureVault,
                               privacyStats: privacyStats,
                               voiceSearchHelper: voiceSearchHelper,
@@ -593,8 +590,7 @@ class TabViewController: UIViewController {
             tabURLPublishers: AIChatTabURLPublishers(originating: urlPublisher, didFinish: didFinishURLPublisher),
             isFireTab: tabModel.fireTab,
             duckAiNativeStorageHandler: duckAiNativeStorageHandler,
-            duckAiFireModeStorageHandler: duckAiFireModeStorageHandler,
-            debugSettings: aiChatDebugSettings
+            duckAiFireModeStorageHandler: duckAiFireModeStorageHandler
         )
         coordinator.delegate = self
         return coordinator
@@ -633,7 +629,6 @@ class TabViewController: UIViewController {
                    productSurfaceTelemetry: ProductSurfaceTelemetry,
                    aiChatFullModeFeature: AIChatFullModeFeatureProviding = AIChatFullModeFeature(),
                    unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature(),
-                   aiChatDebugSettings: AIChatDebugSettingsHandling = AIChatDebugSettings(),
                    sharedSecureVault: (any AutofillSecureVault)? = nil,
                    privacyStats: PrivacyStatsProviding,
                    voiceSearchHelper: VoiceSearchHelperProtocol,
@@ -679,12 +674,10 @@ class TabViewController: UIViewController {
         self.aiChatSettings = aiChatSettings
         self.aiChatFullModeFeature = aiChatFullModeFeature
         self.unifiedToggleInputFeature = unifiedToggleInputFeature
-        self.aiChatDebugSettings = aiChatDebugSettings
         self.aiChatContentHandler = AIChatContentHandler(aiChatSettings: aiChatSettings,
                                                          featureDiscovery: featureDiscovery,
                                                          productSurfaceTelemetry: productSurfaceTelemetry,
-                                                         unifiedToggleInputFeature: unifiedToggleInputFeature,
-                                                         debugSettings: aiChatDebugSettings)
+                                                         unifiedToggleInputFeature: unifiedToggleInputFeature)
         self.subscriptionAIChatStateHandler = SubscriptionAIChatStateHandler()
         self.voiceSearchHelper = voiceSearchHelper
         self.darkReaderFeatureSettings = darkReaderFeatureSettings
@@ -2297,24 +2290,6 @@ extension TabViewController: WKNavigationDelegate {
         return request
     }
 
-    private func sanitizedAIChatNativeInputRequestIfNeeded(for navigationAction: WKNavigationAction) -> URLRequest? {
-        guard isAITab,
-              navigationAction.isTargetingMainFrame(),
-              let url = navigationAction.request.url else { return nil }
-
-        let sanitizedURL = AIChatURLParameters.updatingNativeInputURL(
-            from: url,
-            isNativeInputAvailable: unifiedToggleInputFeature.isAvailable,
-            isSupportedURL: url.isDuckAIURL || aiChatDebugSettings.matchesCustomURL(url)
-        )
-        guard sanitizedURL != url else { return nil }
-
-        var request = navigationAction.request
-        request.url = sanitizedURL
-        request.attribution = .user
-        return request
-    }
-
     // swiftlint:disable cyclomatic_complexity
 
     func webView(_ webView: WKWebView,
@@ -2330,12 +2305,6 @@ extension TabViewController: WKNavigationDelegate {
                 }
                 return
             }
-        }
-
-        if let request = sanitizedAIChatNativeInputRequestIfNeeded(for: navigationAction) {
-            decisionHandler(.cancel)
-            load(urlRequest: request)
-            return
         }
         
         if duckPlayerNavigationHandler.handleDelegateNavigation(navigationAction: navigationAction, webView: webView) {

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -147,7 +147,7 @@ class TabViewController: UIViewController {
 
     private(set) var webView: WKWebView!
     private lazy var appRatingPrompt: AppRatingPrompt = AppRatingPrompt(featureFlagger: self.featureFlagger)
-    private lazy var unifiedToggleInputFeature = UnifiedToggleInputFeature()
+    private let unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding
     public weak var privacyDashboard: PrivacyDashboardViewController?
     
     private var storageCache: StorageCache = AppDependencyProvider.shared.storageCache
@@ -585,6 +585,7 @@ class TabViewController: UIViewController {
             contentBlockingAssetsPublisher: contentBlockingAssetsPublisher,
             featureDiscovery: featureDiscovery,
             featureFlagger: featureFlagger,
+            unifiedToggleInputFeature: unifiedToggleInputFeature,
             pageContextHandler: pageContextHandler,
             tabURLPublishers: AIChatTabURLPublishers(originating: urlPublisher, didFinish: didFinishURLPublisher),
             isFireTab: tabModel.fireTab,
@@ -627,6 +628,7 @@ class TabViewController: UIViewController {
                    aiChatSettings: AIChatSettingsProvider,
                    productSurfaceTelemetry: ProductSurfaceTelemetry,
                    aiChatFullModeFeature: AIChatFullModeFeatureProviding = AIChatFullModeFeature(),
+                   unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature(),
                    sharedSecureVault: (any AutofillSecureVault)? = nil,
                    privacyStats: PrivacyStatsProviding,
                    voiceSearchHelper: VoiceSearchHelperProtocol,
@@ -671,9 +673,11 @@ class TabViewController: UIViewController {
         
         self.aiChatSettings = aiChatSettings
         self.aiChatFullModeFeature = aiChatFullModeFeature
+        self.unifiedToggleInputFeature = unifiedToggleInputFeature
         self.aiChatContentHandler = AIChatContentHandler(aiChatSettings: aiChatSettings,
                                                          featureDiscovery: featureDiscovery,
-                                                         productSurfaceTelemetry: productSurfaceTelemetry)
+                                                         productSurfaceTelemetry: productSurfaceTelemetry,
+                                                         unifiedToggleInputFeature: unifiedToggleInputFeature)
         self.subscriptionAIChatStateHandler = SubscriptionAIChatStateHandler()
         self.voiceSearchHelper = voiceSearchHelper
         self.darkReaderFeatureSettings = darkReaderFeatureSettings
@@ -2286,6 +2290,24 @@ extension TabViewController: WKNavigationDelegate {
         return request
     }
 
+    private func sanitizedAIChatNativeInputRequestIfNeeded(for navigationAction: WKNavigationAction) -> URLRequest? {
+        guard isAITab,
+              navigationAction.isTargetingMainFrame(),
+              let url = navigationAction.request.url else { return nil }
+
+        let sanitizedURL = AIChatURLParameters.updatingNativeInputURL(
+            from: url,
+            isNativeInputAvailable: unifiedToggleInputFeature.isAvailable,
+            isSupportedURL: url.isDuckAIURL || AIChatDebugSettings().matchesCustomURL(url)
+        )
+        guard sanitizedURL != url else { return nil }
+
+        var request = navigationAction.request
+        request.url = sanitizedURL
+        request.attribution = .user
+        return request
+    }
+
     // swiftlint:disable cyclomatic_complexity
 
     func webView(_ webView: WKWebView,
@@ -2301,6 +2323,12 @@ extension TabViewController: WKNavigationDelegate {
                 }
                 return
             }
+        }
+
+        if let request = sanitizedAIChatNativeInputRequestIfNeeded(for: navigationAction) {
+            decisionHandler(.cancel)
+            load(urlRequest: request)
+            return
         }
         
         if duckPlayerNavigationHandler.handleDelegateNavigation(navigationAction: navigationAction, webView: webView) {

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -148,6 +148,7 @@ class TabViewController: UIViewController {
     private(set) var webView: WKWebView!
     private lazy var appRatingPrompt: AppRatingPrompt = AppRatingPrompt(featureFlagger: self.featureFlagger)
     private let unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding
+    private let aiChatDebugSettings: AIChatDebugSettingsHandling
     public weak var privacyDashboard: PrivacyDashboardViewController?
     
     private var storageCache: StorageCache = AppDependencyProvider.shared.storageCache
@@ -454,6 +455,7 @@ class TabViewController: UIViewController {
                                    daxDialogsManager: DaxDialogsManaging,
                                    aiChatSettings: AIChatSettingsProvider,
                                    productSurfaceTelemetry: ProductSurfaceTelemetry,
+                                   aiChatDebugSettings: AIChatDebugSettingsHandling = AIChatDebugSettings(),
                                    sharedSecureVault: (any AutofillSecureVault)? = nil,
                                    privacyStats: PrivacyStatsProviding,
                                    voiceSearchHelper: VoiceSearchHelperProtocol,
@@ -491,6 +493,7 @@ class TabViewController: UIViewController {
                               daxDialogsManager: daxDialogsManager,
                               aiChatSettings: aiChatSettings,
                               productSurfaceTelemetry: productSurfaceTelemetry,
+                              aiChatDebugSettings: aiChatDebugSettings,
                               sharedSecureVault: sharedSecureVault,
                               privacyStats: privacyStats,
                               voiceSearchHelper: voiceSearchHelper,
@@ -590,7 +593,8 @@ class TabViewController: UIViewController {
             tabURLPublishers: AIChatTabURLPublishers(originating: urlPublisher, didFinish: didFinishURLPublisher),
             isFireTab: tabModel.fireTab,
             duckAiNativeStorageHandler: duckAiNativeStorageHandler,
-            duckAiFireModeStorageHandler: duckAiFireModeStorageHandler
+            duckAiFireModeStorageHandler: duckAiFireModeStorageHandler,
+            debugSettings: aiChatDebugSettings
         )
         coordinator.delegate = self
         return coordinator
@@ -629,6 +633,7 @@ class TabViewController: UIViewController {
                    productSurfaceTelemetry: ProductSurfaceTelemetry,
                    aiChatFullModeFeature: AIChatFullModeFeatureProviding = AIChatFullModeFeature(),
                    unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature(),
+                   aiChatDebugSettings: AIChatDebugSettingsHandling = AIChatDebugSettings(),
                    sharedSecureVault: (any AutofillSecureVault)? = nil,
                    privacyStats: PrivacyStatsProviding,
                    voiceSearchHelper: VoiceSearchHelperProtocol,
@@ -674,10 +679,12 @@ class TabViewController: UIViewController {
         self.aiChatSettings = aiChatSettings
         self.aiChatFullModeFeature = aiChatFullModeFeature
         self.unifiedToggleInputFeature = unifiedToggleInputFeature
+        self.aiChatDebugSettings = aiChatDebugSettings
         self.aiChatContentHandler = AIChatContentHandler(aiChatSettings: aiChatSettings,
                                                          featureDiscovery: featureDiscovery,
                                                          productSurfaceTelemetry: productSurfaceTelemetry,
-                                                         unifiedToggleInputFeature: unifiedToggleInputFeature)
+                                                         unifiedToggleInputFeature: unifiedToggleInputFeature,
+                                                         debugSettings: aiChatDebugSettings)
         self.subscriptionAIChatStateHandler = SubscriptionAIChatStateHandler()
         self.voiceSearchHelper = voiceSearchHelper
         self.darkReaderFeatureSettings = darkReaderFeatureSettings
@@ -2298,7 +2305,7 @@ extension TabViewController: WKNavigationDelegate {
         let sanitizedURL = AIChatURLParameters.updatingNativeInputURL(
             from: url,
             isNativeInputAvailable: unifiedToggleInputFeature.isAvailable,
-            isSupportedURL: url.isDuckAIURL || AIChatDebugSettings().matchesCustomURL(url)
+            isSupportedURL: url.isDuckAIURL || aiChatDebugSettings.matchesCustomURL(url)
         )
         guard sanitizedURL != url else { return nil }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputFeature.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputFeature.swift
@@ -24,12 +24,11 @@ import PrivacyConfig
 
 protocol UnifiedToggleInputFeatureProviding {
     var isAvailable: Bool { get }
-    var isFeatureFlagEnabled: Bool { get }
 }
 
 struct UnifiedToggleInputFeature: UnifiedToggleInputFeatureProviding {
 
-    static let isFeatureFlagEnabledKey = "com.duckduckgo.unifiedToggleInput.session.enabled"
+    private static let isFeatureFlagEnabledKey = "com.duckduckgo.unifiedToggleInput.session.enabled"
 
     /// Evaluate the feature flag once and persist the result for the session.
     /// Must be called early in the app launch sequence, before any consumer
@@ -45,7 +44,7 @@ struct UnifiedToggleInputFeature: UnifiedToggleInputFeatureProviding {
         self.devicePlatform = devicePlatform
     }
 
-    var isFeatureFlagEnabled: Bool {
+    private var isFeatureFlagEnabled: Bool {
         UserDefaults.app.bool(forKey: Self.isFeatureFlagEnabledKey)
     }
 

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContentHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContentHandlerTests.swift
@@ -35,6 +35,7 @@ final class AIChatContentHandlerTests: XCTestCase {
     var mockMetricHandler: MockAIChatPixelMetricHandler!
     var mockProductSurfaceTelemetry: MockProductSurfaceTelemetry!
     var mockFreeTrialConversionService: MockFreeTrialConversionInstrumentationService!
+    var mockUnifiedToggleInputFeature: MockUnifiedToggleInputFeatureProvider!
 
     override func setUpWithError() throws {
         mockSettings = MockAIChatSettingsProvider()
@@ -42,6 +43,7 @@ final class AIChatContentHandlerTests: XCTestCase {
         mockMetricHandler = MockAIChatPixelMetricHandler()
         mockProductSurfaceTelemetry = MockProductSurfaceTelemetry()
         mockFreeTrialConversionService = MockFreeTrialConversionInstrumentationService()
+        mockUnifiedToggleInputFeature = MockUnifiedToggleInputFeatureProvider()
 
         handler = AIChatContentHandler(
             aiChatSettings: mockSettings,
@@ -50,7 +52,8 @@ final class AIChatContentHandlerTests: XCTestCase {
             featureDiscovery: MockFeatureDiscovery(),
             productSurfaceTelemetry: mockProductSurfaceTelemetry,
             freeTrialConversionService: mockFreeTrialConversionService,
-            statisticsLoader: StatisticsLoader(fireSearchExperimentPixels: {})
+            statisticsLoader: StatisticsLoader(fireSearchExperimentPixels: {}),
+            unifiedToggleInputFeature: mockUnifiedToggleInputFeature
         )
     }
 
@@ -253,6 +256,100 @@ final class AIChatContentHandlerTests: XCTestCase {
 
         // Then
         XCTAssertEqual(url, mockSettings.aiChatURL)
+    }
+
+    func testBuildQueryURLWithNativeInputAvailableAddsNativeInputParameter() throws {
+        mockSettings.aiChatURL = URL(string: "https://duck.ai")!
+        mockUnifiedToggleInputFeature.isAvailable = true
+
+        let url = handler.buildQueryURL(query: "test", autoSend: false, flowType: .default, tools: nil)
+
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            XCTFail("Invalid URL components")
+            return
+        }
+
+        let nativeInputItem = components.queryItems?.first { $0.name == AIChatURLParameters.nativeInputName }
+        XCTAssertEqual(nativeInputItem?.value, AIChatURLParameters.nativeInputValue)
+    }
+
+    func testBuildQueryURLWithNativeInputAvailableAndNilQueryAddsNativeInputParameter() throws {
+        mockSettings.aiChatURL = URL(string: "https://duck.ai")!
+        mockUnifiedToggleInputFeature.isAvailable = true
+
+        let url = handler.buildQueryURL(query: nil, autoSend: false, flowType: .default, tools: nil)
+
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            XCTFail("Invalid URL components")
+            return
+        }
+
+        let promptItem = components.queryItems?.first { $0.name == AIChatURLParameters.promptQueryName }
+        let nativeInputItem = components.queryItems?.first { $0.name == AIChatURLParameters.nativeInputName }
+        XCTAssertEqual(url, AIChatURLParameters.nativeInputURL(from: mockSettings.aiChatURL))
+        XCTAssertNil(promptItem)
+        XCTAssertEqual(nativeInputItem?.value, AIChatURLParameters.nativeInputValue)
+    }
+
+    func testBuildQueryURLWithNativeInputUnavailableRemovesStaleNativeInputParameter() throws {
+        mockSettings.aiChatURL = URL(string: "https://duck.ai?native-input=true")!
+        mockUnifiedToggleInputFeature.isAvailable = false
+
+        let url = handler.buildQueryURL(query: nil, autoSend: false, flowType: .default, tools: nil)
+
+        XCTAssertEqual(url.absoluteString, "https://duck.ai")
+    }
+
+    func testBuildQueryURLWithNativeInputAvailableDoesNotAddNativeInputParameterToUnsupportedURL() throws {
+        mockSettings.aiChatURL = URL(string: "https://example.com")!
+        mockUnifiedToggleInputFeature.isAvailable = true
+
+        let url = handler.buildQueryURL(query: nil, autoSend: false, flowType: .default, tools: nil)
+
+        XCTAssertEqual(url, mockSettings.aiChatURL)
+    }
+
+    func testBuildQueryURLWithNativeInputAvailableAndEmptyQueryAddsNativeInputParameter() throws {
+        mockSettings.aiChatURL = URL(string: "https://duck.ai")!
+        mockUnifiedToggleInputFeature.isAvailable = true
+
+        let url = handler.buildQueryURL(query: "", autoSend: false, flowType: .default, tools: nil)
+
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            XCTFail("Invalid URL components")
+            return
+        }
+
+        let promptItem = components.queryItems?.first { $0.name == AIChatURLParameters.promptQueryName }
+        let nativeInputItem = components.queryItems?.first { $0.name == AIChatURLParameters.nativeInputName }
+        XCTAssertNil(promptItem)
+        XCTAssertEqual(nativeInputItem?.value, AIChatURLParameters.nativeInputValue)
+    }
+
+    func testBuildVoiceModeURLWithNativeInputAvailableAddsNativeInputParameter() throws {
+        mockSettings.aiChatURL = URL(string: "https://duck.ai")!
+        mockUnifiedToggleInputFeature.isAvailable = true
+
+        let url = handler.buildVoiceModeURL()
+
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            XCTFail("Invalid URL components")
+            return
+        }
+
+        let modeItem = components.queryItems?.first { $0.name == AIChatURLParameters.modeName }
+        let nativeInputItem = components.queryItems?.first { $0.name == AIChatURLParameters.nativeInputName }
+        XCTAssertEqual(modeItem?.value, AIChatURLParameters.voiceModeValue)
+        XCTAssertEqual(nativeInputItem?.value, AIChatURLParameters.nativeInputValue)
+    }
+
+    func testBuildVoiceModeURLWithNativeInputUnavailableRemovesStaleNativeInputParameter() throws {
+        mockSettings.aiChatURL = URL(string: "https://duck.ai?native-input=true")!
+        mockUnifiedToggleInputFeature.isAvailable = false
+
+        let url = handler.buildVoiceModeURL()
+
+        XCTAssertEqual(url.absoluteString, "https://duck.ai?mode=voice")
     }
 
     func testBuildQueryURLReplacesExistingQueryParameters() throws {
@@ -569,6 +666,14 @@ final class AIChatContentHandlerTests: XCTestCase {
 final class MockAIChatRequestAuthHandler: AIChatRequestAuthorizationHandling {
     func shouldAllowRequestWithNavigationAction(_ navigationAction: WKNavigationAction) -> Bool {
         true
+    }
+}
+
+final class MockUnifiedToggleInputFeatureProvider: UnifiedToggleInputFeatureProviding {
+    var isAvailable: Bool
+
+    init(isAvailable: Bool = false) {
+        self.isAvailable = isAvailable
     }
 }
 

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualWebViewControllerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualWebViewControllerTests.swift
@@ -76,6 +76,46 @@ final class AIChatContextualWebViewControllerTests: XCTestCase {
         XCTAssertNotNil(webView?.customUserAgent)
         XCTAssertFalse(webView?.customUserAgent?.isEmpty ?? true)
     }
+
+    @MainActor
+    func testChatURLForLoadingWhenNativeInputUnavailableRemovesStaleNativeInputParameter() {
+        let sut = AIChatContextualWebViewController(
+            aiChatSettings: MockAIChatSettingsProvider(),
+            privacyConfigurationManager: MockPrivacyConfigurationManager(),
+            contentBlockingAssetsPublisher: Empty().eraseToAnyPublisher(),
+            featureDiscovery: MockFeatureDiscovery(),
+            featureFlagger: MockFeatureFlagger(),
+            unifiedToggleInputFeature: MockUnifiedToggleInputFeatureProvider(isAvailable: false),
+            downloadHandler: StubDownloadHandler(),
+            getPageContext: nil,
+            pixelHandler: StubContextualModePixelHandler()
+        )
+        let restoreURL = URL(string: "https://duck.ai/chat?native-input=true")!
+
+        let url = sut.chatURLForLoading(restoreURL)
+
+        XCTAssertEqual(url.absoluteString, "https://duck.ai/chat")
+    }
+
+    @MainActor
+    func testChatURLForLoadingDoesNotRewriteNonDuckAIURL() {
+        let sut = AIChatContextualWebViewController(
+            aiChatSettings: MockAIChatSettingsProvider(),
+            privacyConfigurationManager: MockPrivacyConfigurationManager(),
+            contentBlockingAssetsPublisher: Empty().eraseToAnyPublisher(),
+            featureDiscovery: MockFeatureDiscovery(),
+            featureFlagger: MockFeatureFlagger(),
+            unifiedToggleInputFeature: MockUnifiedToggleInputFeatureProvider(isAvailable: true),
+            downloadHandler: StubDownloadHandler(),
+            getPageContext: nil,
+            pixelHandler: StubContextualModePixelHandler()
+        )
+        let url = URL(string: "https://example.com/path")!
+
+        let result = sut.chatURLForLoading(url)
+
+        XCTAssertEqual(result, url)
+    }
 }
 
 // MARK: - Helpers

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputFeatureTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputFeatureTests.swift
@@ -31,8 +31,15 @@ final class UnifiedToggleInputFeatureTests: XCTestCase {
 
     // MARK: - Setup
 
+    override func setUp() {
+        super.setUp()
+        UnifiedToggleInputFeature.resolve(using: MockFeatureFlagger(enabledFeatureFlags: []))
+        MockDevicePlatform.isIphone = false
+    }
+
     override func tearDown() {
-        UserDefaults.app.removeObject(forKey: UnifiedToggleInputFeature.isFeatureFlagEnabledKey)
+        UnifiedToggleInputFeature.resolve(using: MockFeatureFlagger(enabledFeatureFlags: []))
+        MockDevicePlatform.isIphone = false
         super.tearDown()
     }
 
@@ -65,32 +72,25 @@ final class UnifiedToggleInputFeatureTests: XCTestCase {
 
     // MARK: - Snapshot semantics
 
-    /// Mid-session flag flips (e.g. debug-menu toggle, remote-config update) must NOT
-    /// change the captured value. The resolve writes the launch-time value into UserDefaults,
-    /// and readers must never re-consult the live flagger — even if the same flagger object
-    /// that was passed to resolve subsequently reports a different value. This is the whole
-    /// point of the snapshot: a re-evaluating implementation would let the live flagger drag
-    /// `isFeatureFlagEnabled` along with it and would fail this test.
-    func test_isFeatureFlagEnabled_ignoresLiveFlaggerMutationAfterResolve() {
+    /// Mid-session flag flips must not change availability. Resolve writes the launch-time flag
+    /// value into UserDefaults, while readers still apply the device availability gate.
+    func test_isAvailable_usesLaunchResolvedFlagSnapshot() {
+        MockDevicePlatform.isIphone = true
         let flagger = MockFeatureFlagger(enabledFeatureFlags: [.unifiedToggleInput])
         UnifiedToggleInputFeature.resolve(using: flagger)
         let feature = UnifiedToggleInputFeature(devicePlatform: MockDevicePlatform.self)
-        XCTAssertTrue(feature.isFeatureFlagEnabled, "Precondition: snapshot is ON after resolve")
+        XCTAssertTrue(feature.isAvailable, "Precondition: availability is ON after resolve")
 
-        // Simulate "the user toggled the flag off in the debug menu" by mutating the same
-        // flagger that was passed to resolve. A re-evaluating implementation would observe
-        // this and flip; the snapshot must not.
         flagger.enabledFeatureFlags = []
         XCTAssertFalse(flagger.isFeatureOn(.unifiedToggleInput),
                        "Sanity: the live flagger now reports the flag as off")
-        XCTAssertTrue(feature.isFeatureFlagEnabled,
+        XCTAssertTrue(feature.isAvailable,
                       "Snapshot must ignore the post-resolve mutation on the same instance")
-        XCTAssertTrue(UnifiedToggleInputFeature(devicePlatform: MockDevicePlatform.self).isFeatureFlagEnabled,
+        XCTAssertTrue(UnifiedToggleInputFeature(devicePlatform: MockDevicePlatform.self).isAvailable,
                       "A fresh instance must read the same snapshot, not the mutated live flagger")
 
-        // Only an explicit re-resolve (i.e. the next app launch) flips the snapshot.
         UnifiedToggleInputFeature.resolve(using: flagger)
-        XCTAssertFalse(feature.isFeatureFlagEnabled,
+        XCTAssertFalse(feature.isAvailable,
                        "After re-resolving the snapshot must flip — otherwise resolve isn't doing its job")
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214899040601362

### Description

Adds `native-input=true` to Duck.ai URLs when Unified Toggle Input is available so the frontend hides its React placeholder while native input is active. The URL handling now strips stale `native-input` when the feature is unavailable, including restored full-tab and contextual Duck.ai loads, and all UTI consumers route through `isAvailable` so the iPhone gate is preserved.

### Testing Steps
1. Enable the Unified Toggle Input feature flag. Coming from a web tab, submit a duck.ai prompt. Confirm a React/web placeholder is NOT briefly displayed when the duck.ai page is first loading.
2. Disable the Unified Toggle Input feature flag. Force quit and relaunch. Coming from a web tab, submit a duck.ai prompt. Confirm a React/web placeholder is briefly displayed when the duck.ai page is first loading.
3. On iPad, enable the Unified Toggle Input feature flag. Force quit and relaunch, open the contextual sheet, and confirm Unified Input is not displayed.

### Impact and Risks

Medium. Duck.ai URL loading and UTI availability gates are shared by full-tab and contextual chat surfaces.

#### What could go wrong?

A stale or missing `native-input` URL parameter could make the frontend show the wrong composer state. The implementation adds and strips the parameter through shared helpers and sanitizes restored full-tab/contextual Duck.ai loads based on current `isAvailable`.

### Quality Considerations

The UTI flag snapshot remains session-stable, but consumers now use `isAvailable`, which includes the iPhone-only gate. URL mutation is limited to Duck.ai/debug URLs so unrelated pages are not tagged with Duck.ai-specific query parameters.

### Notes to Reviewer

The iPad + flag-on behavior now follows `isAvailable`, so native input support is not advertised when the iPhone-only device gate fails.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Medium Risk**
> Touches Duck.ai URL construction and WKWebView navigation policy in both full-tab and contextual chat surfaces; incorrect rewriting could cause the frontend to render the wrong composer state or affect chat restores.
> 
> **Overview**
> **Adds first-class handling for a new `native-input=true` Duck.ai URL contract.** Shared `AIChatURLParameters` now supports adding/removing `native-input` and a single helper to *conditionally* apply it only for supported URLs.
> 
> iOS chat URL builders and loaders now automatically **append `native-input` when Unified Toggle Input is available** and **strip stale `native-input` when unavailable**, including voice-mode URLs, contextual sheet reloads/default loads, and restored URLs. Full-tab navigation additionally sanitizes main-frame AI tab requests by cancelling/reloading with the rewritten URL.
> 
> Unified Toggle Input consumers are normalized to use `isAvailable` (preserving the iPhone gate), with dependency injection updates and expanded unit test coverage around URL rewriting and availability snapshot semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0d579d4d39df5531cdce7762f7bdcf2aa20997e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Duck.ai URL construction and loading paths across full-tab and contextual chat; incorrect query rewriting could leave stale `native-input` state and cause the frontend to show the wrong composer.
> 
> **Overview**
> **Adds first-class support for a Duck.ai `native-input=true` URL contract.** `AIChatURLParameters` now can add/remove/conditionally update the `native-input` query item, with unit tests covering replacement, removal, and unsupported-URL behavior.
> 
> iOS chat URL builders/loaders (`AIChatContentHandler`, contextual sheet/web VC) now automatically **append `native-input` when Unified Toggle Input is available** and **strip stale `native-input` when it isn’t**, including voice-mode URLs, default contextual loads, and restored URLs; the UTI host install and other consumers are normalized to gate on `unifiedToggleInputFeature.isAvailable` (preserving the iPhone-only check).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e8a3e17eabf3a270316c9e0eee446ed34515df8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->