### PR TITLE
iOS: remove stale UTI hasSubmittedPrompt reset test

### DIFF
--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -1776,13 +1776,6 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         XCTAssertTrue(sut.viewController.handler.hasSubmittedPrompt)
     }
 
-    func test_handlerHasSubmittedPrompt_resetAfterBindWithNewChat() {
-        sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "hello", mode: .aiChat)
-        let userScript = makeTestUserScript()
-        sut.bindToTab(userScript, hasExistingChat: false)
-        XCTAssertFalse(sut.viewController.handler.hasSubmittedPrompt)
-    }
-
     func test_handlerHasSubmittedPrompt_syncedAfterUnbind() {
         sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "hello", mode: .aiChat)
         sut.unbind()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1214919578055286

### Description

The test `test_handlerHasSubmittedPrompt_resetAfterBindWithNewChat` asserted that `bindToTab(_, hasExistingChat: false)` would downgrade `handler.hasSubmittedPrompt` to `false` via `syncChipVisibility`. PR #4930 deliberately made `syncChipVisibility` upgrade-only (to prevent the flanked-UTI placeholder from flickering to "Ask anything privately" while a new Duck.ai tab's URL was still missing its `chatID`) and did not update this test. The real reset paths — `startNewChat()` and `unbind()` — remain covered by the sibling tests `…_syncedAfterStartNewChat` and `…_syncedAfterUnbind`, so deleting the now-stale assertion is the cleanest fix.

### Testing Steps

CI should be green.

### Impact and Risks

Low. Test-only deletion — no production code change. The deleted assertion was the contradiction between #4879 and #4930; the real reset paths it conflated with `syncChipVisibility` remain covered by `…_syncedAfterStartNewChat` and `…_syncedAfterUnbind`.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a single outdated unit test assertion and does not change production code or behavior.
> 
> **Overview**
> Removes the obsolete `test_handlerHasSubmittedPrompt_resetAfterBindWithNewChat` from `UnifiedToggleInputCoordinatorTests`, which no longer matches the current `bindToTab(..., hasExistingChat: false)` behavior.
> 
> Keeps coverage for the real `hasSubmittedPrompt` reset paths via the existing `startNewChat()` and `unbind()` sync tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ccbaa65978951ca8a02edd89129b63948b4d59b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->