### PR TITLE
iOS: Restore iPad webview bottom anchor (regression from #4841)

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3537,8 +3537,10 @@ extension MainViewController: BrowserChromeDelegate {
         }
         bottomHeight += view.safeAreaInsets.bottom
         // Minimal chrome owns the toolbar slot as a permanent offscreen spacer for the bottom
-        // address bar; everywhere else the slot tracks `ratio` (chrome-animator visibility).
-        let multiplier = isInMinimalChromeLayout ? 1.0 : 1.0 - ratio
+        // address bar, and on iPad the toolbar is permanently hidden (its layout slot would
+        // otherwise leave a 49pt gap below the webview). Everywhere else the slot tracks
+        // `ratio` (chrome-animator visibility).
+        let multiplier = (viewCoordinator.toolbar.isHidden || isInMinimalChromeLayout) ? 1.0 : 1.0 - ratio
         viewCoordinator.constraints.toolbarBottom.constant = bottomHeight * multiplier
 
         if isInMinimalChromeLayout, viewCoordinator.addressBarPosition.isBottom {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1214928390344106?focus=true
Tech Design URL:
CC:

### Description

Restores the iPad webview's bottom anchor reaching the bottom safe area. On `main`, the webview stops ~80pt above the bottom (49pt toolbar slot + the iPad bottom safe-area inset), leaving a visible empty band below page content.

Root cause: PR #4841 (`260912685c`) changed the predicate in `MainViewController.updateToolbarConstant` from `toolbar.isHidden` to `isInMinimalChromeLayout`:

```swift
// before #4841 (iPad-good):
let multiplier = viewCoordinator.toolbar.isHidden ? 1.0 : 1.0 - ratio
// after #4841 (iPad-bad):
let multiplier = isInMinimalChromeLayout ? 1.0 : 1.0 - ratio
```

`updateToolbarConstant` parks the toolbar permanently offscreen (multiplier=1.0 ⇒ `toolbarBottom.constant = bottomHeight`) when the toolbar isn't part of the chrome-animator slide. On iPad the toolbar is permanently hidden (`isHidden = true`), so the old predicate kept it parked offscreen — and since `contentContainer.bottom = toolbar.top`, the webview reached the bottom safe area. `isInMinimalChromeLayout` is false on iPad, so the new predicate let the toolbar settle at its default position (`bottom = safeArea.bottom, height = 49`), pulling the contentContainer's bottom 49pt above the safe area.

#4841's intent was to fix an AI-tab toolbar-stuck-offscreen bug. Restoring the original predicate **plus** the `isInMinimalChromeLayout` check (OR-combined) keeps that fix while restoring iPad behaviour.

Bisected (`908396519e` → `e59e8cc557`) over 7 builds to commit `260912685c` (PR #4841).

### Testing Steps

1. Run on iPad Pro 11-inch (M5) sim, iOS 26.2 (or any iPad sim ≥ iOS 18).
2. Open `https://en.wikipedia.org/wiki/Tokamak` in a regular tab.
3. Confirm: page content reaches the bottom safe area — no empty band below the webview, no curl-page indicator hanging in dead space.
4. Scroll down a few screens, then scroll back to top. Top alignment and bottom alignment both stable.
5. **Regression check for #4841's fix:** open a Duck.ai tab. Swipe between AI tabs and non-AI tabs a few times. Toolbar should never get stuck offscreen on a non-AI tab.
6. (Optional) Repeat in landscape — iPad chrome should still reach the bottom safe area in both orientations.

### Impact and Risks

**Low.** One-line predicate change in `updateToolbarConstant`. The added clause restores behaviour that existed pre-#4841 (until 14 May 2026); only path affected is the toolbar-park multiplier on iPad and other large-width contexts.

### Quality Considerations

- No test coverage exists for `updateToolbarConstant` / `toolbarBottom`. A unit test would need to mock `AppWidthObserver`, `viewCoordinator.toolbar.isHidden`, and the layout pass — overkill for a 1-line predicate. Manual coverage from Testing Steps replaces it.
- The bisect range was deterministic — see commit message for full pin.

### Notes to Reviewer

- Verified on iPad Pro 11-inch (M5) iOS 26.2 sim with `unifiedToggleInputFeature` ON (default).
- The PR description for #4841 explicitly flagged this area: *"narrow, but worth a manual smoke pass on iPad regular-width and bottom-address-bar layouts because the previous condition had conflated semantics."* — this PR is that follow-up.
- Considered a wider refactor consolidating bottom-anchor mode selection through a single `reconcileContentContainerBottomAnchor()` predicate; rejected as out of scope for a regression hotfix.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small predicate change in layout math for the toolbar bottom constraint; impact is limited to UI positioning and could regress bar animations on specific layouts.
> 
> **Overview**
> Fixes an iPad layout regression where the webview/content container could stop above the bottom safe area, leaving an empty band.
> 
> Updates `MainViewController.updateToolbarConstant` so the toolbar slot is treated as a permanent offscreen spacer when the toolbar is *either* hidden (e.g., iPad) *or* in minimal chrome, instead of only in minimal chrome, restoring the expected bottom anchoring while keeping minimal-chrome behavior intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26fbc73b5281615c0521247c25326927575d1720. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->