### PR TITLE
[iPad perf] Optimize tab refresh and save paths during loading

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4792,6 +4792,10 @@ extension MainViewController: TabDelegate {
         // https://app.asana.com/0/414235014887631/1206847376910045/f
     }
     
+    func tabDidFinishNavigation(_ tab: TabViewController) {
+        _ = tabManager.save()
+    }
+
     func tab(_ tab: TabViewController, didUpdatePreview preview: UIImage) {
         previewsSource.update(preview: preview, forTab: tab.tabModel)
     }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4793,6 +4793,9 @@ extension MainViewController: TabDelegate {
     }
     
     func tabDidFinishNavigation(_ tab: TabViewController) {
+        // For the current tab, `tabLoadingStateDidChange` (called immediately before this)
+        // already triggers a save, so skip here to avoid a redundant save in the same run loop.
+        guard currentTab != tab else { return }
         _ = tabManager.save()
     }
 

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4783,10 +4783,9 @@ extension MainViewController: TabDelegate {
             }
         }
 
-        if currentTab == tab {
-            refreshControls()
-            themeColorManager.updateThemeColor()
-        }
+        guard currentTab == tab else { return }
+        refreshControls()
+        themeColorManager.updateThemeColor()
         _ = tabManager.save()
         tabsBarController?.refresh(tabsModel: tabManager.currentTabsModel)
         // note: model in swipeTabsCoordinator doesn't need to be updated here

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4797,6 +4797,7 @@ extension MainViewController: TabDelegate {
         // already triggers a save, so skip here to avoid a redundant save in the same run loop.
         guard currentTab != tab else { return }
         _ = tabManager.save()
+        tabsBarController?.reloadCell(for: tab.tabModel)
     }
 
     func tab(_ tab: TabViewController, didUpdatePreview preview: UIImage) {

--- a/iOS/DuckDuckGo/TabDelegate.swift
+++ b/iOS/DuckDuckGo/TabDelegate.swift
@@ -62,6 +62,12 @@ protocol TabDelegate: AnyObject {
              inheritingAttribution: AdClickAttributionLogic.State?)
 
     func tabLoadingStateDidChange(tab: TabViewController)
+
+    /// Called once per settled navigation: WKNavigationDelegate didFinish or didFail.
+    /// Fired regardless of whether the tab is current. Use this to persist tab state
+    /// after a navigation resolves, not on every loading-state tick.
+    func tabDidFinishNavigation(_ tab: TabViewController)
+
     func tab(_ tab: TabViewController, didUpdatePreview preview: UIImage)
 
     func tab(_ tab: TabViewController, didChangePrivacyInfo privacyInfo: PrivacyInfo?)
@@ -164,5 +170,7 @@ extension TabDelegate {
     func tabDidRequestClose(_ tab: TabViewController) {
         tabDidRequestClose(tab.tabModel, behavior: .onlyClose, clearTabHistory: true)
     }
+
+    func tabDidFinishNavigation(_ tab: TabViewController) {}
 
 }

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -1972,6 +1972,7 @@ extension TabViewController: WKNavigationDelegate {
 
         tabModel.link = link
         delegate?.tabLoadingStateDidChange(tab: self)
+        delegate?.tabDidFinishNavigation(self)
 
         // Present the Dax dialog with a delay to mitigate issue where user script detec trackers after the dialog is show to the user
         // Debounce to avoid showing multiple animations on redirects. e.g. !image baby ducklings
@@ -2212,8 +2213,9 @@ extension TabViewController: WKNavigationDelegate {
             privacyInfo = PrivacyInfo(url: .empty, parentEntity: nil, protectionStatus: .init(unprotectedTemporary: false, enabledFeatures: [], allowlisted: false, denylisted: false), isSpecialErrorPageVisible: true)
             onPrivacyInfoChanged()
         }
-        
+
         self.delegate?.tabLoadingStateDidChange(tab: self)
+        self.delegate?.tabDidFinishNavigation(self)
     }
     
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -236,7 +236,14 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
             self.tabSwitcherButton.tabCount = self.tabsCount
         }
     }
-    
+
+    func reloadCell(for tab: Tab) {
+        guard let index = tabsModel?.indexOf(tab: tab) else { return }
+        let indexPath = IndexPath(item: index, section: 0)
+        guard collectionView.indexPathsForVisibleItems.contains(indexPath) else { return }
+        collectionView.reloadItems(at: [indexPath])
+    }
+
     private func configureGestures() {
         longPressTabGesture.addTarget(self, action: #selector(handleLongPressTabGesture))
         longPressTabGesture.minimumPressDuration = 0.1

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -190,22 +190,12 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
 
     func refresh(tabsModel: TabsModelManaging?, scrollToSelected: Bool = false) {
         self.tabsModel = tabsModel
-        
+
         tabSwitcherButton.isAccessibilityElement = true
         tabSwitcherButton.accessibilityLabel = UserText.tabSwitcherAccessibilityLabel
         tabSwitcherButton.accessibilityHint = UserText.numberOfTabs(tabsCount)
 
-        let availableWidth = collectionView.frame.size.width
-        let maxVisibleItems = min(maxItems, tabsCount)
-        
-        var itemWidth = availableWidth / CGFloat(maxVisibleItems)
-        itemWidth = max(itemWidth, Constants.minItemWidth)
-        itemWidth = min(itemWidth, availableWidth / 2)
-
-        if let flowLayout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
-            flowLayout.itemSize = CGSize(width: itemWidth, height: view.frame.size.height)
-        }
-        
+        recomputeItemSize()
         reloadData()
 
         if scrollToSelected {
@@ -218,6 +208,20 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
 
     }
 
+    private func recomputeItemSize() {
+        let availableWidth = collectionView.frame.size.width
+        let maxVisibleItems = min(maxItems, tabsCount)
+        guard maxVisibleItems > 0 else { return }
+
+        var itemWidth = availableWidth / CGFloat(maxVisibleItems)
+        itemWidth = max(itemWidth, Constants.minItemWidth)
+        itemWidth = min(itemWidth, availableWidth / 2)
+
+        if let flowLayout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
+            flowLayout.itemSize = CGSize(width: itemWidth, height: view.frame.size.height)
+        }
+    }
+
     private func reloadData() {
         collectionView.reloadData()
         tabSwitcherButton.tabCount = tabsCount
@@ -226,6 +230,7 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
     }
 
     func backgroundTabAdded() {
+        recomputeItemSize()
         reloadData()
         tabSwitcherButton.animateUpdate {
             self.tabSwitcherButton.tabCount = self.tabsCount


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1214543872030689
Tech Design URL:
CC:

### Description

Reduces main-thread work driven by `tabLoadingStateDidChange` storms from background tabs. Previously every tab's loading-state change ran `tabManager.save()` (full NSCoding of the tabs model) and `tabsBarController.refresh()` (full `reloadData()` of the tabs bar collection view), even for the 199 non-current tabs in heavy-load scenarios. With this change, the gated save + tabs bar refresh fire only when the loading tab is the current one.

Measured on iPad A16 (iOS 26) with a 12-tab heavy-media workload (4 YouTube + Netflix + Vimeo + assorted news pages): save events dropped 36%, tabs bar refresh dropped 34%, downstream favicon resolves dropped 37%, total hang time dropped 28% (from 19.4% of trace to 15.3%). Per-call duration unchanged, this only reduces call frequency.

Two follow-on commits in the same PR:

1. `TabsBarViewController` extracts `recomputeItemSize()` so `backgroundTabAdded()` also resizes cells for the new tab count. Without this, the new background tab cell renders with the previous itemSize because the gating change removes the implicit layout refresh the old code relied on.

2. Adds a new `TabDelegate.tabDidFinishNavigation` callback fired on WKNavigationDelegate `didFinish` and `didFail`. `MainViewController` calls `tabManager.save()` on it unconditionally. Closes the persistence gap: background-tab URL changes (server redirects, completed navigations) now reach disk once per settled navigation, not relying on the tab becoming current.

### Testing Steps

1. Open ~5 tabs.
2. Long-press a link in one tab and choose "Open in Background Tab", confirm the new tab cell appears in the tabs bar with the correct width.
3. Open multiple background tabs in a row from the same source tab, confirm each new cell is added and existing cells resize to fit.
4. Open 10+ tabs including a few heavy-media pages (YouTube, Netflix, Vimeo), switch to a tab whose content is still loading, confirm tab switch feels responsive (comparing to pre-fix state) and no visible regressions in the tabs bar (selection state, scroll position, favicon updates).
6. Open a background tab pointing to a URL with a known server redirect chain. Without switching to that tab, kill the app from app switcher. Relaunch. Verify the tab restores at the post-redirect URL, not the original.  (e.g. search for cnn, then open cnn.com as a background tab)
7. Open a background tab pointing to a URL that will fail (offline, bad cert). Without switching to it, kill the app. Relaunch. Verify the tab restores at the same URL (error state preserved). (e.g. go to badssl.com and open one of the bad cert links as a background tab)
8. Verify the tabs bar still updates correctly on tab close, tab move, fire-mode toggle, and orientation change.

### Impact and Risks

Medium. May affect background tab storing and UI updates.

#### What could go wrong?

The on-disk tabs model lags between save triggers. With `tabDidFinishNavigation` added, the worst-case lag for a background tab URL change is bounded by the next settled navigation on that tab (which is also when the URL stops changing). Crash mid-redirect still loses the in-flight URL, but the next launch resumes from the last settled URL, not the original one.

### Quality Considerations

Performance, measured on physical iPad (A16, iOS 26.4) with signposts

| metric                     | baseline | with fix | delta  |
|----------------------------|---------:|------------:|-------:|
| TabManager.save events/s   | 3.86     | 2.46        | -36.2% |
| TabsBar.refresh events/s   | 3.72     | 2.46        | -33.9% |
| loadFaviconSync events/s   | 31.49    | 19.84       | -37.0% |
| total hang time / trace    | 19.4%    | 15.3%       | -4.1pp |
| TabManager.save cumulative | 821 ms   | 499 ms      | -322 ms|

Per-call latency unchanged (the fix reduces frequency, not cost). Larger per-switch optimizations are planned in upcoming PR's.

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when tab state is persisted and when the tabs bar UI refreshes, which could cause stale tab restoration or missed UI updates if the new navigation-finish callback is not fired in all cases.
> 
> **Overview**
> Reduces main-thread work from background-tab loading storms by gating `tabLoadingStateDidChange` side effects (controls refresh, theme update, `tabManager.save()`, and full `tabsBarController.refresh()`) to only the current tab.
> 
> Adds a new `TabDelegate.tabDidFinishNavigation` callback fired on navigation settle (`didFinish`/`didFail`) so background tabs still persist updated state; `MainViewController` saves and refreshes only the affected tab cell via `TabsBarViewController.reloadCell(for:)`.
> 
> Refactors tabs bar sizing logic into `recomputeItemSize()` and ensures it runs when background tabs are added so cell widths stay correct without relying on full refreshes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93d0f90b4b0c344b99175cae2c4dbfae048fb158. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->