### PR TITLE
iOS: UTI - Disable all UTI toolbar controls while generating

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
@@ -65,6 +65,7 @@ final class UnifiedToggleInputToolbarView: UIView {
 
     private var isFireTab: Bool = false
     private var preservesSubmitStyleDuringDismissal = false
+    private var isImageButtonAvailable = true
 
     func refreshFireMode(fireMode: Bool) {
         isFireTab = fireMode
@@ -73,7 +74,10 @@ final class UnifiedToggleInputToolbarView: UIView {
     }
 
     var isGenerating: Bool = false {
-        didSet { updateGeneratingVisibility() }
+        didSet {
+            updateGeneratingVisibility()
+            updateToolbarControlsEnabledState()
+        }
     }
 
     func prepareForToolbarVisibilityChange(showToolbar: Bool) {
@@ -160,7 +164,10 @@ final class UnifiedToggleInputToolbarView: UIView {
 
     var isImageButtonEnabled: Bool {
         get { imageButton.isEnabled }
-        set { imageButton.isEnabled = newValue }
+        set {
+            isImageButtonAvailable = newValue
+            updateToolbarControlsEnabledState()
+        }
     }
 
     private var modelChipExplicitlyHidden = false
@@ -372,6 +379,7 @@ private extension UnifiedToggleInputToolbarView {
 
         updateChipVisibility()
         updateSubmitButtonState()
+        updateToolbarControlsEnabledState()
     }
 
     func makeToolButton(image: DesignSystemImage, accessibilityLabel: String, action: Selector?) -> UIButton {
@@ -458,6 +466,15 @@ private extension UnifiedToggleInputToolbarView {
             stopButton.isHidden = true
             submitButton.isHidden = false
         }
+    }
+
+    func updateToolbarControlsEnabledState() {
+        let controlsAreEnabled = !isGenerating
+        imageButton.isEnabled = controlsAreEnabled && isImageButtonAvailable
+        toolsButton.isEnabled = controlsAreEnabled
+        reasoningButton.isEnabled = controlsAreEnabled
+        modelChipButton.isEnabled = controlsAreEnabled
+        selectedToolClearButton.isEnabled = controlsAreEnabled
     }
 
     @objc private func selectedToolClearTapped() { onSelectedToolClearTapped?() }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -908,6 +908,21 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         XCTAssertFalse(handler.isGenerating)
     }
 
+    func test_aiChatStatus_ready_restoresAttachmentButtonAndMenuAfterGenerating() {
+        configureImageAttachments()
+        sut.updateImageButtonVisibility()
+        XCTAssertTrue(sut.viewController.isImageButtonEnabled)
+        XCTAssertNotNil(sut.viewController.attachmentMenu)
+
+        sut.aiChatStatus = .streaming
+        XCTAssertFalse(sut.viewController.isImageButtonEnabled)
+        XCTAssertNil(sut.viewController.attachmentMenu)
+
+        sut.aiChatStatus = .ready
+        XCTAssertTrue(sut.viewController.isImageButtonEnabled)
+        XCTAssertNotNil(sut.viewController.attachmentMenu)
+    }
+
     func test_unbind_whileGenerating_clearsIsGenerating() {
         let userScript = makeTestUserScript()
         sut.bindToTab(userScript)
@@ -2087,6 +2102,48 @@ final class UnifiedToggleInputToolbarViewTests: XCTestCase {
         XCTAssertEqual(stopFrame.height, submitFrame.height, accuracy: 0.5)
         XCTAssertEqual(stopButton.image(for: .normal)?.size, CGSize(width: 24, height: 24))
         XCTAssertTrue(stopButton.hitTest(CGPoint(x: -1, y: stopButton.bounds.midY), with: nil) === stopButton)
+    }
+
+    func test_isGenerating_disablesToolbarConfigurationButtons() {
+        let sut = UnifiedToggleInputToolbarView()
+        sut.isImageButtonEnabled = true
+        sut.selectedTool = .webSearch
+
+        let attachmentButton = findButton(accessibilityLabel: UserText.aiChatToolbarAttachButtonAccessibilityLabel, in: sut)
+        let toolsButton = findButton(accessibilityLabel: UserText.aiChatToolbarToolsButtonAccessibilityLabel, in: sut)
+        let reasoningButton = findButton(accessibilityIdentifier: "AIChat.Toolbar.Button.Reasoning", in: sut)
+        let modelChipButton = findButton(accessibilityIdentifier: "AIChat.Toolbar.Button.ModelChip", in: sut)
+        let selectedToolClearButton = findButton(accessibilityLabel: UserText.aiChatToolbarClearSelectedToolAccessibilityLabel, in: sut)
+
+        sut.isGenerating = true
+
+        XCTAssertFalse(attachmentButton?.isEnabled ?? true)
+        XCTAssertFalse(toolsButton?.isEnabled ?? true)
+        XCTAssertFalse(reasoningButton?.isEnabled ?? true)
+        XCTAssertFalse(modelChipButton?.isEnabled ?? true)
+        XCTAssertFalse(selectedToolClearButton?.isEnabled ?? true)
+
+        sut.isGenerating = false
+
+        XCTAssertTrue(attachmentButton?.isEnabled ?? false)
+        XCTAssertTrue(toolsButton?.isEnabled ?? false)
+        XCTAssertTrue(reasoningButton?.isEnabled ?? false)
+        XCTAssertTrue(modelChipButton?.isEnabled ?? false)
+        XCTAssertTrue(selectedToolClearButton?.isEnabled ?? false)
+    }
+
+    func test_isGenerating_doesNotReenableUnavailableAttachmentButton() {
+        let sut = UnifiedToggleInputToolbarView()
+        sut.isImageButtonEnabled = false
+
+        let attachmentButton = findButton(accessibilityLabel: UserText.aiChatToolbarAttachButtonAccessibilityLabel, in: sut)
+        let toolsButton = findButton(accessibilityLabel: UserText.aiChatToolbarToolsButtonAccessibilityLabel, in: sut)
+
+        sut.isGenerating = true
+        sut.isGenerating = false
+
+        XCTAssertFalse(attachmentButton?.isEnabled ?? true)
+        XCTAssertTrue(toolsButton?.isEnabled ?? false)
     }
 
     func test_reasoningButton_hasAccessibilityIdentifier() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1214895994110237?focus=true
Tech Design URL:
CC:

### Description

Keeps the Duck.ai unified input toolbar controls in a consistent state while a response is generating. Attach, Tools, Reasoning, Model chip, and selected-tool clear controls are disabled during streaming, then restored when generation finishes without re-enabling attachments that are unavailable for other reasons.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. In the Duck.ai tab, focus the unified input, submit a prompt, and while the response is streaming verify Attach, Tools, and Reasoning are disabled while Stop generating remains enabled.
2. Wait for the response to finish and verify Attach, Tools, and Reasoning are enabled again and the voice/submit button is available.

### Impact and Risks

Low. This only changes toolbar control enabled state while Duck.ai is generating.

#### What could go wrong?

Toolbar buttons could stay disabled after generation finishes, or an attachment button that is unavailable because of limits/capability state could be incorrectly re-enabled. Added focused coverage for both cases.

### Quality Considerations

Added focused tests for toolbar generating-state behavior, preserving unavailable attachment state, and coordinator restoration of the attachment button/menu after streaming ends.

Manual UI validation was also completed on iPhone 17 Pro #1 in light and dark mode.

### Notes to Reviewer

The model chip is hidden in the post-submit Duck.ai tab runtime path, so live UI validation covered the visible toolbar controls. The toolbar view test covers the model chip disabled/restored state directly.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state change that only toggles enabled/disabled states during streaming; main failure mode is controls staying disabled or incorrectly re-enabled after generation ends.
> 
> **Overview**
> Keeps the unified input toolbar’s configuration controls consistent during AI generation by **disabling Attach/Tools/Reasoning/Model chip/selected-tool clear while `isGenerating` is true**, then restoring them when generation finishes.
> 
> Adds state tracking (`isImageButtonAvailable`) and a centralized `updateToolbarControlsEnabledState()` to ensure attachments aren’t accidentally re-enabled, plus new tests covering toolbar control disabling and coordinator restoration of the attachment button/menu after streaming ends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f2e5c216ff44bd5b93e28532e758ed5bcc836e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->