### PR TITLE
Default excludeLocalNetworks to true on macOS

### DIFF
--- a/SharedPackages/VPN/Sources/VPN/Settings/Extensions/UserDefaults+excludeLocalNetworks.swift
+++ b/SharedPackages/VPN/Sources/VPN/Settings/Extensions/UserDefaults+excludeLocalNetworks.swift
@@ -24,11 +24,7 @@ extension UserDefaults {
         "networkProtectionSettingExcludeLocalNetworks"
     }
 
-    #if os(macOS)
-    static let excludeLocalNetworksDefaultValue = false
-    #else
     static let excludeLocalNetworksDefaultValue = true
-    #endif
 
     @objc
     dynamic var networkProtectionSettingExcludeLocalNetworks: Bool {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207603085593419/task/1214931207335175?focus=true

### Description

Aligns the macOS VPN with iOS so local networks are excluded from the tunnel by default. Local-network traffic (printers, NAS, AirPlay, etc.) now bypasses the VPN out of the box on a fresh install, matching the long-standing iOS behavior and the friendlier default for most users.

The persisted value is only written when the user explicitly toggles the switch (or via an IPC settings change from the tunnel), so existing users who toggled it keep their choice. The new default only takes effect for users who never touched the switch.

### Testing Steps

1. Quit the Debug app.
2. Clear any persisted value (skip if you've never toggled the switch on this machine):
   ```
   defaults delete ~/Library/Group\ Containers/HKE973VLUW.com.duckduckgo.macos.browser.network-protection.system-extension.debug/Library/Preferences/HKE973VLUW.com.duckduckgo.macos.browser.network-protection.system-extension.debug.plist networkProtectionSettingExcludeLocalNetworks
   ```
3. Launch the Debug app and open VPN preferences. "Exclude local networks" should be on.
4. With the VPN connected, confirm a device on the local network (e.g. printer or NAS at `192.168.x.x`) is reachable.

### Impact and Risks

Low. The persisted value is only written on explicit user toggle, so this change only affects users who never touched the switch. Anyone who deliberately enabled or disabled it keeps their choice through the upgrade. New installs and never-touched-it users now get the friendlier default that matches iOS.

#### What could go wrong?

- A never-touched-it user finds their LAN devices reachable when previously they weren't. Mitigation: the toggle is still in VPN preferences and easy to flip back.

### Quality Considerations

No automated test changes — the existing routing tests already cover both `true` and `false` paths.

### Notes to Reviewer

The change is one line collapsing the per-OS `#if` so both platforms share `true` as the default.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line default value change that only affects users without a persisted `networkProtectionSettingExcludeLocalNetworks` setting, and does not alter routing logic itself.
> 
> **Overview**
> Aligns macOS with iOS by changing `excludeLocalNetworksDefaultValue` to `true` for `networkProtectionSettingExcludeLocalNetworks` (removing the macOS-only default of `false`).
> 
> This only changes the fallback behavior when the UserDefaults key is unset; existing users with a stored value continue to use their current setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bec98ae7480f9d67b84ce23d6794df93debcb7a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->