### PR TITLE
macOS: record local clear for sync when deleting all Duck.ai chats from menu

### DIFF
--- a/macOS/DuckDuckGo/Menus/AIChatMenu.swift
+++ b/macOS/DuckDuckGo/Menus/AIChatMenu.swift
@@ -260,7 +260,8 @@ extension AIChatMenu.Actions {
         remoteSettings: AIChatRemoteSettings,
         tabOpener: AIChatTabOpening,
         historyCleaner: AIChatHistoryCleaning,
-        windowControllersManager: WindowControllersManager
+        windowControllersManager: WindowControllersManagerProtocol,
+        aiChatSyncCleaner: @escaping () -> AIChatSyncCleaning?
     ) -> AIChatMenu.Actions {
         AIChatMenu.Actions(
             openNewChat: {
@@ -283,6 +284,7 @@ extension AIChatMenu.Actions {
                     Logger.aiChat.error("Failed to delete all Duck.ai chats: \(error.localizedDescription)")
                     return
                 }
+                await aiChatSyncCleaner()?.recordLocalClear(date: Date())
                 for windowController in windowControllersManager.mainWindowControllers {
                     for tab in windowController.mainViewController.tabCollectionViewModel.tabs where tab.url?.isDuckAIURL == true {
                         tab.reload()

--- a/macOS/DuckDuckGo/Menus/MainMenu.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenu.swift
@@ -1216,7 +1216,8 @@ final class MainMenu: NSMenu {
             remoteSettings: AIChatRemoteSettings(),
             tabOpener: NSApp.delegateTyped.aiChatTabOpener,
             historyCleaner: aiChatHistoryCleaner,
-            windowControllersManager: Application.appDelegate.windowControllersManager
+            windowControllersManager: Application.appDelegate.windowControllersManager,
+            aiChatSyncCleaner: { Application.appDelegate.aiChatSyncCleaner }
         )
         return AIChatMenu(suggestionsReader: aiChatSuggestionsReader, actions: actions, maxChatItems: 8)
     }

--- a/macOS/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
@@ -564,7 +564,8 @@ final class MoreOptionsMenu: NSMenu, NSMenuDelegate {
             remoteSettings: AIChatRemoteSettings(),
             tabOpener: NSApp.delegateTyped.aiChatTabOpener,
             historyCleaner: NSApp.delegateTyped.aiChatHistoryCleaner,
-            windowControllersManager: Application.appDelegate.windowControllersManager
+            windowControllersManager: Application.appDelegate.windowControllersManager,
+            aiChatSyncCleaner: { Application.appDelegate.aiChatSyncCleaner }
         )
         return AIChatMenu(suggestionsReader: aiChatSuggestionsReader, actions: actions, maxChatItems: 8, origin: .moreOptionsMenu)
     }

--- a/macOS/UnitTests/AIChat/AIChatMenuTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatMenuTests.swift
@@ -277,6 +277,76 @@ final class AIChatMenuTests: XCTestCase {
         XCTAssertEqual(openedChat?.chatId, "abc")
     }
 
+    // MARK: - Delete all chats sync handoff
+
+    func testDeleteAllChats_recordsLocalClearForSyncOnSuccess() async {
+        let historyCleaner = StubAIChatHistoryCleaner(result: .success(()))
+        let syncCleaner = StubAIChatSyncCleaning()
+        let defaultActions = AIChatMenu.Actions.makeDefault(
+            remoteSettings: AIChatRemoteSettings(),
+            tabOpener: MockAIChatTabOpener(),
+            historyCleaner: historyCleaner,
+            windowControllersManager: WindowControllersManagerMock(),
+            aiChatSyncCleaner: { syncCleaner }
+        )
+
+        await defaultActions.deleteAllChats()
+
+        XCTAssertEqual(syncCleaner.recordLocalClearDates.count, 1)
+        XCTAssertNotNil(syncCleaner.recordLocalClearDates.first ?? nil)
+    }
+
+    func testDeleteAllChats_doesNotRecordLocalClearOnFailure() async {
+        let historyCleaner = StubAIChatHistoryCleaner(result: .failure(NSError(domain: "test", code: 0)))
+        let syncCleaner = StubAIChatSyncCleaning()
+        let defaultActions = AIChatMenu.Actions.makeDefault(
+            remoteSettings: AIChatRemoteSettings(),
+            tabOpener: MockAIChatTabOpener(),
+            historyCleaner: historyCleaner,
+            windowControllersManager: WindowControllersManagerMock(),
+            aiChatSyncCleaner: { syncCleaner }
+        )
+
+        await defaultActions.deleteAllChats()
+
+        XCTAssertTrue(syncCleaner.recordLocalClearDates.isEmpty)
+    }
+
+    func testDeleteAllChats_succeedsWhenSyncCleanerIsNil() async {
+        let historyCleaner = StubAIChatHistoryCleaner(result: .success(()))
+        let defaultActions = AIChatMenu.Actions.makeDefault(
+            remoteSettings: AIChatRemoteSettings(),
+            tabOpener: MockAIChatTabOpener(),
+            historyCleaner: historyCleaner,
+            windowControllersManager: WindowControllersManagerMock(),
+            aiChatSyncCleaner: { nil }
+        )
+
+        await defaultActions.deleteAllChats()
+
+        XCTAssertTrue(historyCleaner.cleanAIChatHistoryCalled)
+    }
+
+    func testDeleteAllChats_resolvesSyncCleanerLazilyAtCallTime() async {
+        let historyCleaner = StubAIChatHistoryCleaner(result: .success(()))
+        var syncCleaner: StubAIChatSyncCleaning?
+        let defaultActions = AIChatMenu.Actions.makeDefault(
+            remoteSettings: AIChatRemoteSettings(),
+            tabOpener: MockAIChatTabOpener(),
+            historyCleaner: historyCleaner,
+            windowControllersManager: WindowControllersManagerMock(),
+            aiChatSyncCleaner: { syncCleaner }
+        )
+
+        // Sync cleaner becomes available after the actions are constructed,
+        // mirroring AppDelegate setting `aiChatSyncCleaner` after MainMenu init.
+        syncCleaner = StubAIChatSyncCleaning()
+
+        await defaultActions.deleteAllChats()
+
+        XCTAssertEqual(syncCleaner?.recordLocalClearDates.count, 1)
+    }
+
     // MARK: - Private helpers
 
     private func makeChat(chatId: String, title: String, timestamp: Date = .distantPast) -> AIChatSuggestion {
@@ -284,7 +354,45 @@ final class AIChatMenuTests: XCTestCase {
     }
 }
 
-// MARK: - Mock
+// MARK: - Mocks
+
+private final class StubAIChatHistoryCleaner: AIChatHistoryCleaning {
+    private let result: Result<Void, Error>
+    private(set) var cleanAIChatHistoryCalled = false
+
+    @Published
+    var shouldDisplayCleanAIChatHistoryOption: Bool = false
+
+    var shouldDisplayCleanAIChatHistoryOptionPublisher: AnyPublisher<Bool, Never> {
+        $shouldDisplayCleanAIChatHistoryOption.eraseToAnyPublisher()
+    }
+
+    init(result: Result<Void, Error>) {
+        self.result = result
+    }
+
+    @MainActor
+    func cleanAIChatHistory() async -> Result<Void, Error> {
+        cleanAIChatHistoryCalled = true
+        return result
+    }
+}
+
+private final class StubAIChatSyncCleaning: AIChatSyncCleaning {
+    private(set) var recordLocalClearDates: [Date?] = []
+
+    func recordAutoClearBackgroundTimestamp(date: Date?) async {}
+
+    func recordLocalClear(date: Date?) async {
+        recordLocalClearDates.append(date)
+    }
+
+    func recordLocalClearFromAutoClearBackgroundTimestampIfPresent() async {}
+
+    func recordChatDeletion(chatID: String) async {}
+
+    func deleteIfNeeded() async {}
+}
 
 private final class MockAIChatSuggestionsReader: AIChatSuggestionsReading {
     var maxHistoryCount: Int = 10


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1214930971587674?focus=true
Tech Design URL:
CC:

### Description

The "Delete All Chats" action in the Duck.ai menu (both the main menu and the More Options popup) only cleared chat history locally — it never recorded a "local clear" timestamp on `AIChatSyncCleaner`. As a result, when chat history sync was enabled, the server kept its copy of the chats and pushed them back to the device on the next sync, making it look like the deletion did not work.

Every other clear-all entry point (Fire button, History view clear, AutoClear) already pairs the local clear with `AIChatSyncCleaner.recordLocalClear(date:)`. This PR aligns the menu path with that pattern:

- `AIChatMenu.Actions.makeDefault` now takes an `aiChatSyncCleaner: AIChatSyncCleaning?` and calls `await aiChatSyncCleaner?.recordLocalClear(date: Date())` after a successful local clear, so the registered `AIChatDeleteOperation` issues the server-side `sync.deleteAIChats(until:)` on the next sync trigger.
- The two call sites (`MainMenu` and `MoreOptionsMenu`) pass `Application.appDelegate.aiChatSyncCleaner`.
- `windowControllersManager` parameter is typed against `WindowControllersManagerProtocol` (was the concrete class) so the factory is unit-testable; call sites are unchanged.

### Testing Steps

1. Set up Duck.ai chat history sync between two devices (or with a Cloud account) and confirm a few chats are present on both sides.
2. On the device under test, open the Duck.ai menu (either the top-level Duck.ai menu or More Options → Duck.ai) and choose "Delete All Chats". Confirm the dialog.
3. Verify locally:
   - The chats disappear from the menu's recent list.
   - Open Duck.ai tabs reload to an empty state.
4. Trigger a sync (or wait for the next sync cycle) and verify the chats also disappear from the other synced device and do not come back on the device under test.
5. With chat history sync **disabled** (or signed out of sync), repeat steps 2–3 and confirm behavior is unchanged from before.
6. Run the new unit tests: `AIChatMenuTests` → `testDeleteAllChats_recordsLocalClearForSyncOnSuccess`, `testDeleteAllChats_doesNotRecordLocalClearOnFailure`, `testDeleteAllChats_succeedsWhenSyncCleanerIsNil`.

### Impact and Risks

**Medium** — affects user data: a chat the user explicitly chose to delete was previously coming back via sync. With this fix the deletion now propagates to the server.

#### What could go wrong?

- If `cleanAIChatHistory()` fails locally we deliberately do **not** record the sync clear, so a transient local-clear failure cannot silently wipe server-side chats. Covered by `testDeleteAllChats_doesNotRecordLocalClearOnFailure`.
- `recordLocalClear` is gated inside `AIChatSyncCleaner` by `isAIChatSyncEnabled() && supportsSyncChatsDeletion() && sync.authState != .inactive && isChatHistoryEnabled`, so the new call is a no-op for users who don't have chat history sync active.
- `aiChatSyncCleaner` is optional and the menu must work before `AppDelegate` finishes wiring sync; `testDeleteAllChats_succeedsWhenSyncCleanerIsNil` covers that path.

### Quality Considerations

- Edge cases covered by new tests: success path records clear, failure path does not, nil sync cleaner does not crash.
- No performance impact — `recordLocalClear` is a single key/value write inside an actor.
- No new pixels; existing `aiChatDeleteHistorySuccessful` / `aiChatDeleteHistoryFailed` pixels are unchanged.
- Privacy: this PR strengthens the user-facing "delete" promise; the only network call it enables (server-side `deleteAIChats(until:)`) is already gated by sync auth and the `supportsSyncChatsDeletion` remote feature flag.

### Notes to Reviewer

- The behaviour mirrors `FireCoordinator.swift:280-284` (Fire/main-menu burn), `AutoClearHandler.swift:131` and `HistoryViewActionsManagerExtension.swift:40` — same `recordLocalClear` handoff, just from the Duck.ai menu's "Delete All Chats" entry point.
- The `WindowControllersManager` → `WindowControllersManagerProtocol` parameter retype is purely to keep the factory testable; production call sites pass the same concrete instance as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Duck.ai menu "Delete All Chats" path to also record a sync "local clear" timestamp after a successful local wipe, affecting user data deletion behavior across devices. Risk is moderate because it touches sync-related deletion signaling, but is gated behind successful local deletion and covered by new unit tests.
> 
> **Overview**
> **Duck.ai menu deletes now propagate to sync.** After a successful `cleanAIChatHistory()` from the Duck.ai menu, `AIChatMenu.Actions.makeDefault` now calls `aiChatSyncCleaner()?.recordLocalClear(date:)` before reloading open Duck.ai tabs.
> 
> `makeDefault` is updated to accept a `WindowControllersManagerProtocol` and a *lazy* `aiChatSyncCleaner` provider; both `MainMenu` and `MoreOptionsMenu` pass `Application.appDelegate.aiChatSyncCleaner`. New unit tests validate the success/failure/nil/lazy-resolution behaviors for the sync handoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c83b7ec73935f0d2247891fab5b1017b1c0b1a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->