### PR TITLE
Update QuitSurveyView for macOS 26 Liquid Glass UI

### DIFF
--- a/macOS/DuckDuckGo/QuitSurvey/QuitSurveyView.swift
+++ b/macOS/DuckDuckGo/QuitSurvey/QuitSurveyView.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import Common
 import DesignResourcesKit
 import DesignResourcesKitIcons
 import PrivacyConfig
@@ -110,6 +111,7 @@ private struct QuitSurveyInitialView: View {
             footer()
         }
         .frame(width: QuitSurveyViewController.Constants.initialWidth)
+        .padding(.horizontal, AppVersion.isLiquidGlassSupported ? 20 : 24)
         .fixedSize(horizontal: false, vertical: true)
     }
 
@@ -123,7 +125,7 @@ private struct QuitSurveyInitialView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.top, 20)
-        .padding([.leading, .trailing, .bottom], 24)
+        .padding([.bottom], 24)
     }
 
     private func responseOptions() -> some View {
@@ -155,7 +157,6 @@ private struct QuitSurveyInitialView: View {
             RoundedRectangle(cornerRadius: 6)
                 .stroke(Color(.separatorColor), lineWidth: 1)
         )
-        .padding([.leading, .trailing], 24)
         .padding(.bottom, 16)
     }
 
@@ -166,9 +167,8 @@ private struct QuitSurveyInitialView: View {
             Text(UserText.quitSurveyCloseAndQuit)
                 .frame(maxWidth: .infinity)
         }
-        .buttonStyle(DefaultActionButtonStyle(enabled: true, topPadding: 8, bottomPadding: 8))
-        .padding([.leading, .trailing], 24)
-        .padding(.bottom, 16)
+        .buttonStyle(DefaultActionButtonStyle(enabled: true, topPadding: 8, bottomPadding: 8, pillShape: true))
+        .padding(.bottom, AppVersion.isLiquidGlassSupported ? 20 : 16)
     }
 }
 
@@ -306,7 +306,7 @@ private struct QuitSurveyPositiveView: View {
 
             Text(UserText.quitSurveyAutoQuitMessage(seconds: viewModel.autoQuitCountdown))
                 .systemLabel(color: .textSecondary)
-                .padding([.leading, .trailing], 24)
+                .padding(.horizontal, AppVersion.isLiquidGlassSupported ? 20 : 24)
 
             Button {
                 viewModel.quit()
@@ -314,9 +314,9 @@ private struct QuitSurveyPositiveView: View {
                 Text(UserText.quitSurveyQuitNow)
                     .frame(maxWidth: .infinity)
             }
-            .buttonStyle(DefaultActionButtonStyle(enabled: true, topPadding: 8, bottomPadding: 8))
-            .padding([.leading, .trailing], 24)
-            .padding(.bottom, 16)
+            .buttonStyle(DefaultActionButtonStyle(enabled: true, topPadding: 8, bottomPadding: 8, pillShape: true))
+            .padding(.horizontal, AppVersion.isLiquidGlassSupported ? 20 : 24)
+            .padding(.bottom, AppVersion.isLiquidGlassSupported ? 20 : 16)
         }
         .frame(width: QuitSurveyViewController.Constants.positiveWidth)
         .fixedSize(horizontal: false, vertical: true)
@@ -331,7 +331,7 @@ private struct QuitSurveyPositiveView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.top, 20)
-        .padding([.leading, .trailing], 24)
+        .padding(.horizontal, AppVersion.isLiquidGlassSupported ? 20 : 24)
     }
 }
 
@@ -453,11 +453,13 @@ private struct QuitSurveyNegativeView: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(24)
+        .padding(.horizontal, AppVersion.isLiquidGlassSupported ? 20 : 24)
+        .padding(.top, AppVersion.isLiquidGlassSupported ? 20 : 24)
+        .padding(.bottom, 24)
     }
 
     private func optionsPills() -> some View {
-        let horizontalPadding: CGFloat = 24
+        let horizontalPadding: CGFloat = AppVersion.isLiquidGlassSupported ? 20 : 24
         return FlexibleView(
             availableWidth: QuitSurveyViewController.Constants.negativeWidth - (horizontalPadding * 2),
             data: viewModel.availableOptions,
@@ -471,7 +473,7 @@ private struct QuitSurveyNegativeView: View {
                 viewModel.toggleOption(option.id)
             }
         }
-        .padding([.leading, .trailing], horizontalPadding)
+        .padding(.horizontal, horizontalPadding)
         .padding(.bottom, 24)
         .background(
             GeometryReader { geometry in
@@ -526,7 +528,7 @@ private struct QuitSurveyNegativeView: View {
                     }
                 )
         }
-        .padding([.leading, .trailing], 24)
+        .padding(.horizontal, AppVersion.isLiquidGlassSupported ? 20 : 24)
         .padding(.bottom, 8)
     }
 
@@ -550,7 +552,7 @@ private struct QuitSurveyNegativeView: View {
             }
             OtherDomainRow(viewModel: viewModel)
         }
-        .padding([.leading, .trailing], 24)
+        .padding(.horizontal, AppVersion.isLiquidGlassSupported ? 20 : 24)
         .padding(.bottom, 24)
         .background(
             GeometryReader { geometry in
@@ -571,7 +573,7 @@ private struct QuitSurveyNegativeView: View {
             Text(UserText.quitSurveyDisclaimer)
                 .caption2()
                 .multilineTextAlignment(.leading)
-                .padding([.leading, .trailing], 24)
+                .padding(.horizontal, AppVersion.isLiquidGlassSupported ? 20 : 24)
 
             Button {
                 viewModel.submitFeedback()
@@ -587,9 +589,9 @@ private struct QuitSurveyNegativeView: View {
                 .frame(maxWidth: .infinity)
             }
             .disabled(!viewModel.shouldEnableSubmit || viewModel.isSubmitting)
-            .buttonStyle(DefaultActionButtonStyle(enabled: viewModel.shouldEnableSubmit && !viewModel.isSubmitting))
-            .padding([.leading, .trailing], 24)
-            .padding(.bottom, 16)
+            .buttonStyle(DefaultActionButtonStyle(enabled: viewModel.shouldEnableSubmit && !viewModel.isSubmitting, topPadding: 8, bottomPadding: 8, pillShape: true))
+            .padding(.horizontal, AppVersion.isLiquidGlassSupported ? 20 : 24)
+            .padding(.bottom, AppVersion.isLiquidGlassSupported ? 20 : 16)
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1214940970488265?focus=true

### Description
This change updates paddings and buttons in the Quit Survey View.

### Testing Steps
Verify visuals of the Quit Survey View - see table below.
If you want to test it for pre-Liquid Glass, you'd need to add UIDesignRequiresCompatibility: NO to the Info.plist.

| UIDesignRequiresCompatibility: NO | UIDesignRequiresCompatibility: YES |
| --- | --- |
| <img width="456" height="253" alt="Screenshot 2026-05-19 at 17 37 42" src="https://github.com/user-attachments/assets/934408bb-513b-4ce5-9b9a-c8a496552877" /> | <img width="444" height="256" alt="Screenshot 2026-05-19 at 17 35 18" src="https://github.com/user-attachments/assets/6fd7ba7e-5e34-4433-a6fd-5a5164817aaf" /> |
| <img width="410" height="171" alt="Screenshot 2026-05-19 at 17 37 49" src="https://github.com/user-attachments/assets/dc7aed38-09f0-4d77-bf69-183abdc05007" /> | <img width="411" height="177" alt="Screenshot 2026-05-19 at 17 35 24" src="https://github.com/user-attachments/assets/9540a385-a9d0-4476-b3f2-0f68b836ebba" /> |
| <img width="458" height="436" alt="Screenshot 2026-05-19 at 17 38 02" src="https://github.com/user-attachments/assets/080efb68-f8f7-477d-8b8f-c100dcda9e91" /> | <img width="454" height="436" alt="Screenshot 2026-05-19 at 17 35 50" src="https://github.com/user-attachments/assets/d43c9b6d-b5a2-49b8-9027-3f5c87afa862" /> |
| <img width="459" height="592" alt="Screenshot 2026-05-19 at 17 38 08" src="https://github.com/user-attachments/assets/080774e0-42ef-45f6-9682-ec2efb704e8a" /> | <img width="458" height="595" alt="Screenshot 2026-05-19 at 17 35 56" src="https://github.com/user-attachments/assets/a4ce642f-5383-4303-a0a9-e09e1a609986" /> |

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: UI-only padding/button-style adjustments gated by `AppVersion.isLiquidGlassSupported`, with no behavioral or data-flow changes.
> 
> **Overview**
> Adjusts `QuitSurveyView` spacing to support macOS 26 Liquid Glass by switching many fixed 24pt insets to conditional `20/24` horizontal padding and updating header/footer top/bottom padding.
> 
> Updates primary actions (`Close and Quit`, `Quit Now`, and submit) to use *pill-shaped* `DefaultActionButtonStyle` and applies Liquid Glass-specific bottom padding, keeping pre-Liquid Glass layout intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 892d2f0b775618291fbe60fdcdf6c3c421dad40f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->