### PR TITLE
[iOS] fix failing maestro tests

### DIFF
--- a/.maestro/browser_features/state_restoration.yaml
+++ b/.maestro/browser_features/state_restoration.yaml
@@ -38,7 +38,8 @@ tags:
 - assertVisible: "DuckDuckGo.*"
 
 # Load a new tab
-- longPressOn: "Tab Switcher"
+- tapOn: "Tab Switcher"
+- tapOn: "New Tab"
 - assertVisible:
     id: "searchEntry"
 - tapOn: 

--- a/.maestro/release_tests/autoclear.yaml
+++ b/.maestro/release_tests/autoclear.yaml
@@ -61,7 +61,8 @@ tags:
 - assertVisible: "Storage Counter: 1"
 
 # Load a new tab
-- longPressOn: "Tab Switcher"
+- tapOn: "Tab Switcher"
+- tapOn: "New Tab"
 - assertVisible:
     id: "searchEntry"
 - tapOn: 

--- a/.maestro/release_tests/firebutton.yaml
+++ b/.maestro/release_tests/firebutton.yaml
@@ -29,7 +29,8 @@ tags:
 - assertVisible: "Storage Counter: 1"
 
 # Load a new tab
-- longPressOn: "Tab Switcher"
+- tapOn: "Tab Switcher"
+- tapOn: "New Tab"
 - assertVisible:
     id: "searchEntry"
 - tapOn: 

--- a/.maestro/shared/remove_local_bookmarks.yaml
+++ b/.maestro/shared/remove_local_bookmarks.yaml
@@ -3,7 +3,7 @@ appId: com.duckduckgo.mobile.ios
 
 - tapOn: Bookmarks
 - tapOn: Edit
-- tapOn: Spread Privacy
+- tapOn: ".*Spread Privacy.*"
 - scroll
 - scroll
 - tapOn: Delete

--- a/.maestro/shared/sync_setup.yaml
+++ b/.maestro/shared/sync_setup.yaml
@@ -18,4 +18,4 @@ appId: com.duckduckgo.mobile.ios
         currentAppVariant: ${APP_VARIANT}
         isRunningUITests: true
         ff.browsingMenuSheetEnabledByDefault: "true"
-        "experiment.simplifiedSyncSetupExperiment": "control"
+        experiment.simplifiedSyncSetupExperiment: "control"

--- a/.maestro/shared/sync_verify_bookmarks.yaml
+++ b/.maestro/shared/sync_verify_bookmarks.yaml
@@ -19,7 +19,7 @@ appId: com.duckduckgo.mobile.ios
     commands:
       - tapOn: Not Now
 
-- assertVisible: Spread Privacy
+- assertVisible: ".*Spread Privacy.*"
 - assertVisible: Stack Overflow - Where Developers Learn, Share, & Build Careers
 - assertVisible: DuckDuckGo — Privacy, simplified.
 - assertVisible: DuckDuckGo · GitHub


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1214875448438027?focus=true
Tech Design URL:
CC:

### Description
Updates the maestro tests for reliability.

### Testing Steps

1. Ideally run them locally (but I have)
2. CI is green

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Maestro YAML test flows and only adjust UI selectors/tap sequences to reduce flakiness.
> 
> **Overview**
> Improves iOS Maestro test reliability by switching the “new tab” step from a `longPressOn` to explicit taps on `Tab Switcher` then `New Tab` in the state restoration and release test flows.
> 
> Updates bookmark-related flows to use regex matching for the “Spread Privacy” entry, and fixes the `sync_setup` launch argument key formatting for `experiment.simplifiedSyncSetupExperiment` to be parsed consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06e57bd55f07d82b5dc78dd65b0dfb9a3b1baeea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->