### PR TITLE
Fix pixel validation errors for 9 macOS pixels

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/aichat_main_menu_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_main_menu_pixels.json5
@@ -4,7 +4,7 @@
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_new_chat_main_menu": {
         "description": "Fired when user opens a new Duck.ai chat from the main menu",
@@ -18,7 +18,7 @@
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_new_image_chat_main_menu": {
         "description": "Fired when user opens a new Duck.ai image chat from the main menu",
@@ -39,7 +39,7 @@
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_open_duck_ai_more_options_menu": {
         "description": "Fired when user taps Open Duck.ai from the more options menu",
@@ -53,7 +53,7 @@
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_new_voice_chat_more_options_menu": {
         "description": "Fired when user opens a new Duck.ai voice chat from the more options menu",

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_ntp_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_ntp_pixels.json5
@@ -27,14 +27,14 @@
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_ntp_view_all_chats_clicked": {
         "description": "Fired when user taps 'View all chats' from the New Tab Page omnibar",
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_new_voice_chat_omnibar_ntp": {
         "description": "Fired when user opens a new Duck.ai voice chat from the New Tab Page omnibar",

--- a/macOS/PixelDefinitions/pixels/definitions/update_flow_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/update_flow_pixels.json5
@@ -13,7 +13,8 @@
                 "enum": ["about", "more_options", "main_menu"]
             },
             "appVersion",
-            "pixelSource"
+            "pixelSource",
+            "channel"
         ]
     },
     "m_mac_update_notification_shown": {
@@ -38,30 +39,7 @@
         "description": "Fired when the network request to fetch latest release information fails",
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
-        "parameters": [
-            {
-                "key": "e",
-                "type": "integer",
-                "description": "Error code of the LatestReleaseError enum"
-            },
-            {
-                "key": "d",
-                "type": "string",
-                "description": "Error description of the LatestReleaseError enum"
-            },
-            {
-                "key": "ud",
-                "type": "string",
-                "description": "Error domain of the LatestReleaseError enum"
-            },
-            {
-                "key": "ud2",
-                "type": "string",
-                "description": "Underlying error of the LatestReleaseError enum"
-            },
-            "appVersion",
-            "pixelSource"
-        ]
+        "parameters": ["errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain", "appVersion", "pixelSource", "channel"]
     },
     "m_mac_release_notes_loading_error": {
         "description": "Fires when the release notes page shows a loading error (no update info available after update cycle completes or hasn't started). Debounced by 1 second.",

--- a/macOS/PixelDefinitions/pixels/definitions/wc_memory_usage_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/wc_memory_usage_pixels.json5
@@ -125,7 +125,8 @@
                 "key": "uptime",
                 "type": "integer",
                 "description": "Minutes elapsed since app launch (raw value, not bucketed)"
-            }
+            },
+            "channel"
         ]
     },
     "m_mac_memory_usage_webview_65536_more": {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1214877193426029
Tech Design URL:
CC:

### Description

9 macOS pixels failed live validation with `must NOT have additional properties` errors. This PR updates the JSON5 definitions to match what is actually sent at runtime.

**Add `channel` parameter** to the following definitions — these pixels include `channel` in their fired payloads but the schema didn't list it:

- `m_mac_aichat_open_duck_ai_main_menu`
- `m_mac_aichat_new_voice_chat_main_menu`
- `m_mac_aichat_delete_all_chats_main_menu`
- `m_mac_aichat_new_chat_more_options_menu`
- `m_mac_aichat_ntp_reasoning_effort_selected`
- `m_mac_aichat_ntp_view_all_chats_clicked`
- `m_mac_app_store_check_for_update`
- `m_mac_memory_usage_webview_32768_65535`

**Fix `m_mac_release_metadata_fetch_failed`** — the live pixel fails with extra properties `ue` and `ue2`. The schema previously defined `e`, `d`, `ud`, `ud2` inline (with partially incorrect descriptions: `d` was labeled as "description" rather than domain, `ud2` was labeled as "underlying error" instead of root underlying error domain). Replaced these with the standard `errorCode`, `errorDomain`, `underlyingErrorCode`, and `underlyingErrorDomain` references from `params_dictionary.json5`. Those use `keyPattern` `^ue[0-9]?$` / `^ud[0-9]?$`, which accept the `ue`/`ue2`/`ud`/`ud2` keys produced by PixelKit when serialising errors with chained underlying errors. Also added the missing `channel` parameter.

### Testing Steps
1. From the repo root, run the JSON5 pixel-definition validation (whatever the team's local validation step is, e.g. the same validator used in CI / live validation).
2. Confirm the 9 pixel names listed above are no longer reported with `must NOT have additional properties`.
3. Optionally, trigger one of the affected pixels in a dev build (e.g. open Duck.ai from the main menu on a `dev` channel build) and verify the live validator no longer rejects it.

### Impact and Risks

**Low.** This PR only updates JSON5 pixel schema definitions. No app code changes. The fix aligns the schemas with what is already being sent, so it resolves a documentation/validation gap rather than changing behavior.

#### What could go wrong?
- Could mask a legitimate issue if the pixel was incorrectly sending `channel` outside production builds. `channel` is a standard parameter (`canary` or `dev`) that's set on non-production builds and omitted in release — so adding it to the schema is the expected fix.

### Notes to Reviewer
- Other pixels in `wc_memory_usage_pixels.json5` (e.g. `m_mac_memory_usage_webview_65536_more`) likely have the same gap but weren't flagged in this validation report. I intentionally limited scope to the failures listed, happy to expand if reviewers prefer.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk schema-only updates to pixel definition JSON5 files; no runtime code changes, but incorrect parameter lists could still cause validation noise if mismatched elsewhere.
> 
> **Overview**
> Fixes live pixel validation failures by updating macOS pixel definition schemas to match what the app already sends.
> 
> Adds missing `channel` to several Duck.ai main-menu/NTP, update-flow (`m_mac_app_store_check_for_update`), and WebContent memory-usage pixels, and simplifies `m_mac_release_metadata_fetch_failed` to use the standard error parameter set (`errorCode`, `errorDomain`, `underlyingErrorCode`, `underlyingErrorDomain`) plus `channel`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb838d02d84be5cf11567e7983f79532d163fb03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->