### PR TITLE
Fix white line above title bar in fullscreen on Liquid Glass UI

### DIFF
--- a/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
@@ -352,6 +352,15 @@ extension MainWindowController: ThemeUpdateListening {
     func applyThemeStyle(theme: ThemeStyleProviding) {
         // Prevent a 2px white line from appearing above the tab bar on macOS 26
         window?.backgroundColor = theme.colorsProvider.baseBackgroundColor
+
+        // The tab bar is added to the titlebarView with a 2pt top padding on Liquid Glass,
+        // leaving a thin strip above it that shows through to whatever is behind the titlebarView.
+        // In fullscreen the titlebarView lives in an auxiliary window whose contentView is opaque
+        // white, so coloring the titlebarView's layer itself is the only way to fill that strip.
+        if AppVersion.isLiquidGlassSupported, let titlebarView = window?.titlebarView {
+            titlebarView.wantsLayer = true
+            titlebarView.layer?.backgroundColor = theme.colorsProvider.baseBackgroundColor.cgColor
+        }
     }
 }
 
@@ -433,6 +442,12 @@ extension MainWindowController: NSWindowDelegate {
 
     func windowDidEnterFullScreen(_ notification: Notification) {
         guard let window = self.window else { return }
+
+        // Color the auxiliary fullscreen toolbar window's background to match the theme,
+        // hiding the white line above the title bar that appears on macOS 26 Liquid Glass UI.
+        if AppVersion.isLiquidGlassSupported {
+            applyThemeStyle()
+        }
 
         // Detect split screen vs regular fullscreen mode
         if window.isApproximatelyHalfScreenWide {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1214911299163148?focus=true

### Description

In fullscreen on macOS 26 with Liquid Glass UI (i.e. when `UIDesignRequiresCompatibility` is removed), a thin white horizontal strip was visible between the system menu bar and the window title bar whenever the menu bar was revealed.

The strip is the 2pt gap above the tab bar created by `tabBarBackgroundTopPadding = 2` (applied only on Liquid Glass to fix a separate Xcode 26 layout glitch). In windowed mode, this gap is already covered by the existing `window.backgroundColor = baseBackgroundColor` fix in `applyThemeStyle`. In fullscreen, however, the titlebarView is moved to an auxiliary toolbar window whose contentView is opaque, so the main window's background color is never visible.

The fix colors the titlebarView's own layer with `baseBackgroundColor` so the gap is filled in both windowed and fullscreen mode. `applyThemeStyle` is re-invoked on `windowDidEnterFullScreen` because at that point `window.titlebarView` resolves to a different view, owned by the auxiliary window.

All new behavior is gated on `AppVersion.isLiquidGlassSupported`, so non–Liquid-Glass builds and macOS 15 are unaffected.

### Testing Steps
1. Launch the app (`UIDesignRequiresCompatibility` flag is removed).
2. Enter fullscreen.
3. Move the cursor to the top of the screen so the menu bar slides down.
4. Verify there is no white strip between the menu bar and the title bar — the area should match the tab bar background color.
5. Switch between Light and Dark theme while in fullscreen; the area should track the theme.
6. Exit fullscreen and re-enter; the area should still be correctly colored.

### Impact and Risks
Low — visual-only change scoped to the title bar background, gated on Liquid Glass.

#### What could go wrong?
- The titlebarView is layer-backed already (the existing `masksToBounds = true` relies on this), so setting `wantsLayer = true` and `layer?.backgroundColor` is safe; worst case it remains transparent and the white strip persists.
- If the titlebarView is replaced again after `windowDidEnterFullScreen`, the color could be lost — verified by toggling fullscreen multiple times.

### Quality Considerations
- Idempotent and cheap to call from `applyThemeStyle`, so theme changes during fullscreen update the color correctly.
- No effect on macOS 15 or compatibility-mode builds (gated on `AppVersion.isLiquidGlassSupported`).

### Notes to Reviewer
Targets `dominik/macos-26-ship-review` since this is a macOS 26 ship-blocking visual fix.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a UI-only theming tweak gated behind `AppVersion.isLiquidGlassSupported`, mainly affecting fullscreen titlebar rendering on macOS 26.
> 
> **Overview**
> Fixes a thin white strip above the tab bar when entering fullscreen on macOS 26 *Liquid Glass*.
> 
> `applyThemeStyle` now also paints the `window.titlebarView` layer background to the current theme color (in addition to `window.backgroundColor`), and `windowDidEnterFullScreen` re-applies the theme so the auxiliary fullscreen toolbar/titlebar view is recolored as soon as fullscreen is entered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a2d41983bd613f0c9f1789a477e5aec0fd32ba1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->