### PR TITLE
Restore /pro URL interception for legacy subscription links

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2864,7 +2864,7 @@ class MainViewController: UIViewController {
             .sink { [weak self] notification in
                 let deepLinkTarget: SettingsViewModel.SettingsDeepLinkSection
                 if let redirectURLComponents = notification.userInfo?[TabURLInterceptorParameter.interceptedURLComponents] as? URLComponents {
-                    if redirectURLComponents.path == "/subscriptions/plans" {
+                    if redirectURLComponents.path == "/subscriptions/plans" || redirectURLComponents.path == "/pro/plans" {
                         deepLinkTarget = .subscriptionPlanChangeFlow(redirectURLComponents: redirectURLComponents)
                     } else {
                         deepLinkTarget = .subscriptionFlow(redirectURLComponents: redirectURLComponents)

--- a/iOS/DuckDuckGo/TabURLInterceptor.swift
+++ b/iOS/DuckDuckGo/TabURLInterceptor.swift
@@ -57,6 +57,7 @@ final class TabURLInterceptorDefault: TabURLInterceptor {
     }
 
     static let interceptedURLs: [InterceptedURLInfo] = [
+        InterceptedURLInfo(id: .subscription, path: "/pro"),
         InterceptedURLInfo(id: .subscription, path: "/subscriptions"),
         InterceptedURLInfo(id: .subscription, path: "/subscriptions/plans")
     ]

--- a/iOS/DuckDuckGo/TabURLInterceptor.swift
+++ b/iOS/DuckDuckGo/TabURLInterceptor.swift
@@ -58,6 +58,7 @@ final class TabURLInterceptorDefault: TabURLInterceptor {
 
     static let interceptedURLs: [InterceptedURLInfo] = [
         InterceptedURLInfo(id: .subscription, path: "/pro"),
+        InterceptedURLInfo(id: .subscription, path: "/pro/plans"),
         InterceptedURLInfo(id: .subscription, path: "/subscriptions"),
         InterceptedURLInfo(id: .subscription, path: "/subscriptions/plans")
     ]

--- a/iOS/DuckDuckGoTests/TabURLInterceptorTests.swift
+++ b/iOS/DuckDuckGoTests/TabURLInterceptorTests.swift
@@ -71,6 +71,21 @@ class TabURLInterceptorDefaultTests: XCTestCase {
         }
     }
 
+    func testNotificationForInterceptedLegacyProPath() {
+        _ = self.expectation(forNotification: .urlInterceptSubscription, object: nil, handler: nil)
+
+        let url = URL(string: "https://duckduckgo.com/pro")!
+        let canNavigate = urlInterceptor.allowsNavigatingTo(url: url)
+
+        XCTAssertFalse(canNavigate)
+
+        waitForExpectations(timeout: 1) { error in
+            if let error = error {
+                XCTFail("Notification expectation failed: \(error)")
+            }
+        }
+    }
+
     func testWhenURLIsSubscriptionAndHasOriginQueryParameterThenNotificationUserInfoHasOriginSet() throws {
         // GIVEN
         var capturedNotification: Notification?

--- a/iOS/DuckDuckGoTests/TabURLInterceptorTests.swift
+++ b/iOS/DuckDuckGoTests/TabURLInterceptorTests.swift
@@ -86,6 +86,21 @@ class TabURLInterceptorDefaultTests: XCTestCase {
         }
     }
 
+    func testNotificationForInterceptedLegacyProPlansPath() {
+        _ = self.expectation(forNotification: .urlInterceptSubscription, object: nil, handler: nil)
+
+        let url = URL(string: "https://duckduckgo.com/pro/plans")!
+        let canNavigate = urlInterceptor.allowsNavigatingTo(url: url)
+
+        XCTAssertFalse(canNavigate)
+
+        waitForExpectations(timeout: 1) { error in
+            if let error = error {
+                XCTFail("Notification expectation failed: \(error)")
+            }
+        }
+    }
+
     func testWhenURLIsSubscriptionAndHasOriginQueryParameterThenNotificationUserInfoHasOriginSet() throws {
         // GIVEN
         var capturedNotification: Notification?


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1214951418317658?focus=true
cc @samsymons @aataraxiaa 

### Description

PR #3671 (shipped in 7.209.0 on March 2) replaced `/pro` with `/subscriptions` and `/subscriptions/plans` in `TabURLInterceptor.interceptedURLs` rather than adding the new paths alongside the legacy one. As a result, iOS users arriving via the legacy `/pro` URL are no longer intercepted into the native subscription flow.
This change adds `/pro` back to the intercepted URL list. The existing `MainViewController` handler routes `/pro` to the standard `subscriptionFlow` (the `else` branch of the path check), matching the pre-regression behavior.

### Steps to test this PR

1. Open the app on iOS
2. Navigate to `https://duckduckgo.com/pro` (e.g. via tapping a link, typing the URL, or following a bookmark)
3. Confirm the native subscription purchase flow opens (App Store IAP), rather than loading the web page
4. Repeat for `https://duckduckgo.com/subscriptions` and `https://duckduckgo.com/subscriptions/plans` — both should still open their respective native flows

### Definition of Done

- [x] Restore `/pro` in `TabURLInterceptor.interceptedURLs`
- [x] Add unit test covering the `/pro` path
- [ ] Manual verification on device/simulator


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small URL-path matching changes limited to subscription deep-link interception, with added unit coverage for the new legacy paths.
> 
> **Overview**
> Restores native interception for legacy subscription URLs by adding `/pro` and `/pro/plans` to the intercepted URL list and routing `/pro/plans` into the plan-change flow (matching `/subscriptions/plans`).
> 
> Adds unit tests to ensure navigating to the legacy `/pro` paths posts `.urlInterceptSubscription` and prevents web navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6863bce34cb8890bc4d703f6a122346a8c792f1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->