### PR TITLE
[iPad perf] Reload only changed cells in tabs bar refresh

### DIFF
--- a/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
+++ b/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
@@ -133,6 +133,13 @@ class SwipeTabsCoordinator: NSObject {
     weak var preview: UIView?
     weak var currentView: UIView?
 
+    // Tracks the structural shape of the last refresh so we can perform a
+    // selective `reloadItems(at:)` when only the selected tab changed.
+    // See iPad-perf investigation: avoids re-creating omnibar template cells
+    // on every tab switch.
+    private var lastReloadedTabUIDs: [String] = []
+    private var lastSelectedIndex: Int?
+
     /// The overlay that hosts per-tab full-screen snapshots during a swipe. Set by the host.
     /// When present, all visual rendering of the swipe is delegated to the overlay and the
     /// legacy mechanisms (cell-based omnibar slide, auxiliary view translation, chromePreview
@@ -656,10 +663,35 @@ extension SwipeTabsCoordinator {
 
     func refresh(tabsModel: TabsModelManaging, scrollToSelected: Bool = false) {
         self.tabsModel = tabsModel
-        coordinator.navigationBarCollectionView.reloadData()
-        
+
+        let currentUIDs = tabsModel.tabs.map { $0.uid }
+        let currentSelectedIndex = tabsModel.currentIndex
+        let collectionView = coordinator.navigationBarCollectionView
+
+        if !lastReloadedTabUIDs.isEmpty, currentUIDs == lastReloadedTabUIDs {
+            // Structure unchanged. Only re-render the previously selected and the
+            // newly selected cells, so the other template cells are not torn down
+            // and rebuilt on every tab switch.
+            let itemCount = collectionView.numberOfItems(inSection: 0)
+            var indexPathsToReload: Set<IndexPath> = []
+            if let last = lastSelectedIndex, last < itemCount {
+                indexPathsToReload.insert(IndexPath(item: last, section: 0))
+            }
+            if let current = currentSelectedIndex, current < itemCount {
+                indexPathsToReload.insert(IndexPath(item: current, section: 0))
+            }
+            if !indexPathsToReload.isEmpty {
+                collectionView.reloadItems(at: Array(indexPathsToReload))
+            }
+        } else {
+            collectionView.reloadData()
+        }
+
+        lastReloadedTabUIDs = currentUIDs
+        lastSelectedIndex = currentSelectedIndex
+
         updateLayout()
-        
+
         if scrollToSelected {
             scrollToCurrent()
         }

--- a/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
+++ b/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
@@ -49,6 +49,11 @@ class SwipeTabsCoordinator: NSObject {
                 state = .idle
             }
             updateLayout()
+            // Toggling isEnabled changes the data source count
+            // (1 cell when disabled, tabs.count [+1] when enabled), so the
+            // refresh fast path's uid-equality check would otherwise miss
+            // this structural change.
+            lastReloadedTabUIDs = []
             collectionView.reloadData()
         }
     }
@@ -180,6 +185,9 @@ class SwipeTabsCoordinator: NSObject {
         updateLayout()
         scrollToCurrent()
 
+        // Force the next refresh to take the full reloadData path so the
+        // cache cannot disagree with the freshly rebuilt collection view.
+        lastReloadedTabUIDs = []
         collectionView.reloadData()
         collectionView.layoutIfNeeded()
     }
@@ -668,16 +676,24 @@ extension SwipeTabsCoordinator {
         let currentSelectedIndex = tabsModel.currentIndex
         let collectionView = coordinator.navigationBarCollectionView
 
-        if !lastReloadedTabUIDs.isEmpty, currentUIDs == lastReloadedTabUIDs {
+        // The data source count also depends on `isEnabled` and on whether the
+        // last tab has a link (trailing "new tab" placeholder), so a uid-only
+        // equality check is not sufficient to confirm structural sameness.
+        let expectedItemCount = self.collectionView(collectionView, numberOfItemsInSection: 0)
+        let cachedItemCount = collectionView.numberOfItems(inSection: 0)
+        let structureUnchanged = !lastReloadedTabUIDs.isEmpty
+            && currentUIDs == lastReloadedTabUIDs
+            && expectedItemCount == cachedItemCount
+
+        if structureUnchanged {
             // Structure unchanged. Only re-render the previously selected and the
             // newly selected cells, so the other template cells are not torn down
             // and rebuilt on every tab switch.
-            let itemCount = collectionView.numberOfItems(inSection: 0)
             var indexPathsToReload: Set<IndexPath> = []
-            if let last = lastSelectedIndex, last < itemCount {
+            if let last = lastSelectedIndex, last < cachedItemCount {
                 indexPathsToReload.insert(IndexPath(item: last, section: 0))
             }
-            if let current = currentSelectedIndex, current < itemCount {
+            if let current = currentSelectedIndex, current < cachedItemCount {
                 indexPathsToReload.insert(IndexPath(item: current, section: 0))
             }
             if !indexPathsToReload.isEmpty {

--- a/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
+++ b/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
@@ -674,7 +674,7 @@ extension SwipeTabsCoordinator {
 
         let currentUIDs = tabsModel.tabs.map { $0.uid }
         let currentSelectedIndex = tabsModel.currentIndex
-        let collectionView = coordinator.navigationBarCollectionView
+        let collectionView = self.collectionView
 
         // The data source count also depends on `isEnabled` and on whether the
         // last tab has a link (trailing "new tab" placeholder), so a uid-only

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -265,6 +265,9 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
 
     func backgroundTabAdded() {
         recomputeItemSize()
+        // Force the next refresh to take the full reloadData path so the
+        // cache cannot disagree with the collection view we just rebuilt.
+        lastReloadedTabUIDs = []
         reloadData()
         tabSwitcherButton.animateUpdate {
             self.tabSwitcherButton.tabCount = self.tabsCount

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -87,8 +87,15 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
     private lazy var tabSwitcherButton: TabSwitcherStaticButton = TabSwitcherStaticButton(showMenuOnLongPress: false)
 
     private let longPressTabGesture = UILongPressGestureRecognizer()
-    
+
     private weak var pressedCell: TabsBarCell?
+
+    // Tracks the structural shape of the last refresh so we can perform a
+    // selective `reloadItems(at:)` when only the selected tab changed.
+    // See iPad-perf investigation: avoids re-resolving favicons for every
+    // visible cell on every tab switch.
+    private var lastReloadedTabUIDs: [String] = []
+    private var lastSelectedIndex: Int?
     
     var tabsCount: Int {
         return tabsModel?.count ?? 0
@@ -196,7 +203,30 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
         tabSwitcherButton.accessibilityHint = UserText.numberOfTabs(tabsCount)
 
         recomputeItemSize()
-        reloadData()
+
+        let currentUIDs = tabsModel?.tabs.map { $0.uid } ?? []
+        let currentSelectedIndex = self.currentIndex
+
+        if !lastReloadedTabUIDs.isEmpty, currentUIDs == lastReloadedTabUIDs {
+            // Structure unchanged. Only re-render the previously selected and the
+            // newly selected cells, so unaffected cells avoid re-resolving favicons.
+            var indexPathsToReload: Set<IndexPath> = []
+            if let last = lastSelectedIndex, last < currentUIDs.count {
+                indexPathsToReload.insert(IndexPath(item: last, section: 0))
+            }
+            if let current = currentSelectedIndex, current < currentUIDs.count {
+                indexPathsToReload.insert(IndexPath(item: current, section: 0))
+            }
+            if !indexPathsToReload.isEmpty {
+                collectionView.reloadItems(at: Array(indexPathsToReload))
+            }
+            updateTabSwitcherButtonState()
+        } else {
+            reloadData()
+        }
+
+        lastReloadedTabUIDs = currentUIDs
+        lastSelectedIndex = currentSelectedIndex
 
         if scrollToSelected {
             DispatchQueue.main.async {
@@ -224,6 +254,10 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
 
     private func reloadData() {
         collectionView.reloadData()
+        updateTabSwitcherButtonState()
+    }
+
+    private func updateTabSwitcherButtonState() {
         tabSwitcherButton.tabCount = tabsCount
         tabSwitcherButton.isFireMode = (tabManager?.currentBrowsingMode ?? .normal) == .fire
         tabSwitcherButton.hasUnread = hasUnread


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1214542770140529
Tech Design URL:
CC:

### Description

`TabsBarViewController.refresh()` and `SwipeTabsCoordinator.refresh()` both called `collectionView.reloadData()` unconditionally on every tab switch. This rebuilt every visible cell, including the favicon resolves and the omnibar template cells, even though only the selection had changed.

This change caches the structural shape of the last refresh (tab UID list + selected index, plus the data source's expected item count for SwipeTabs) and, when the structure is unchanged, calls `reloadItems(at: [oldSelected, newSelected])` instead of `reloadData()`. Add/remove/reorder still take the full reload path, gated by a uid-list mismatch. Bypass paths that call `reloadData()` directly (`backgroundTabAdded`, `invalidateLayout`, `isEnabled` didSet on SwipeTabs) clear the cache so the next refresh is guaranteed to take the full path.

### Testing Steps

1. Open the app on an iPad with the tabs bar visible.
2. Open ~10 tabs, then switch between them by tapping cells in the tabs bar. Verify selection visual updates correctly (highlighted cell, others not), favicons unchanged for non-selected cells.
3. Add a tab from the `+` button in the tabs bar. Verify the new tab cell appears and existing cells resize. Tab switcher counter updates.
4. Remove a tab via the close button on a cell. Verify cells reflow.
5. Long-press a cell and reorder it. Verify the new position is reflected.
6. Toggle fire mode (long-press tab switcher icon or use the fire flow). Verify tabs bar visuals match the mode.
7. Open a background tab via long-press on a link in another tab, "Open in Background Tab". Verify the new cell appears in the tabs bar.
8. Rotate the device. Verify cells re-layout for the new width.
9. iPhone: open a tab, swipe horizontally to the next tab via the omnibar swipe gesture. Verify the swipe still works smoothly and lands on the adjacent tab.
10. iPhone: open new tab through the omnibar. Verify the omnibar collection view rebuilds correctly.

### Impact and Risks

Medium. Both refresh paths are touched on every tab switch. The cache reset on the bypass paths is the part where correctness can drift if a future contributor adds a new place that mutates the data source without going through refresh.

#### What could go wrong?

- A future code path mutates the tabs model without going through `refresh()`. The cache would not invalidate and the next refresh would skip rebuilding the changed cells. Guard: bypass paths (`backgroundTabAdded`, `invalidateLayout`, `isEnabled` didSet) reset the cache today. If a new mutation path appears, the test plan above (open background tab, reorder, fire-mode toggle) catches the symptom.
- SwipeTabs data source count depends on `isEnabled` and on whether the last tab has a link. The fast path compares `expectedItemCount` from the data source against `collectionView.numberOfItems(inSection:)`, so a count mismatch falls back to full reload.
- `lastSelectedIndex` could point at a cell that no longer exists when the tab set shrinks. The fast path is skipped entirely when uid-lists differ, so this case takes the full reload path.

### Quality Considerations

Measured A/B on iPad A16 (iOS 26.4), 12-tab heavy-media workload (YouTube, Netflix, Vimeo, news pages), baseline = `main` with fix #1 already merged, post = this branch.

Hangs (Instruments potential-hangs table):

| metric             | baseline | this branch | delta  |
|--------------------|---------:|------------:|-------:|
| hangs >=500ms / s  | 0.127    | 0.061       | -52%   |
| ms-hung / s        | 142      | 115         | -19%   |
| worst hang         | 1042 ms  | 786 ms      | -25%   |

Signposts (rate-normalized counts):

| metric                   | baseline | this branch | delta |
|--------------------------|---------:|------------:|------:|
| TabsBar.refresh count /s | 2.70     | 1.61        | -40%  |
| TabManager.save count /s | 2.90     | 1.85        | -36% (likely workload variance, not directly affected by this fix) |

Caveats:

- Baseline trace was 39 s, post-fix trace was 65 s. Workload mix differs (more idle time in the longer run), so absolute event counts cannot be compared directly. Rates and percentile-style metrics are the meaningful signal.
- Per-call `TabsBar.refresh` average duration rose (0.42 ms → 4.35 ms) because `reloadData()` (baseline) marks the collection view dirty and `cellForItemAt` runs asynchronously in the next layout pass, outside the signpost. `reloadItems(at:)` (this branch) drives `cellForItemAt` synchronously inside the call, so the same work is attributed to the wrapped interval. This is a measurement artifact, not a regression - total main-thread time spent in cell rendering is the same or less.

### Notes to Reviewer

This is the second PR in the iPad perf series. Fix #1 has now merged to main (#4951). The branch was rebased onto main, so it stands alone with the 2 fix #2 commits:

1. Initial implementation in `TabsBarViewController` and `SwipeTabsCoordinator`.
2. Review feedback: SwipeTabs data source count depends on more than the tab UID list (`isEnabled`, trailing placeholder), so the fast path also checks expected vs cached item count. Bypass paths clear the cache.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)