### PR TITLE
[macOS] Rename VPN location selection CTA from "Submit" to "Done"

### DIFF
--- a/macOS/DuckDuckGo/Common/Localizables/UserText+NetworkProtection.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText+NetworkProtection.swift
@@ -242,7 +242,7 @@ extension UserText {
 
     static let vpnLocationCustomSectionTitle = NSLocalizedString("vpn.location.custom.section.title", value: "Custom", comment: "Title of the VPN location list custom section")
 
-    static let vpnLocationSubmitButtonTitle = NSLocalizedString("vpn.location.submit.button.title", value: "Submit", comment: "Title of the VPN location list submit button")
+    static let vpnLocationSubmitButtonTitle = NSLocalizedString("vpn.location.submit.button.title", value: "Done", comment: "Title of the VPN location list confirm button (confirms the user's location selection)")
 
     static let vpnLocationCancelButtonTitle = NSLocalizedString("vpn.location.cancel.button.title", value: "Cancel", comment: "Title of the VPN location list cancel button (Note: seems like a duplicate key with a different purpose, please check)")
 

--- a/macOS/DuckDuckGo/Common/Localizables/UserText+NetworkProtection.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText+NetworkProtection.swift
@@ -242,7 +242,7 @@ extension UserText {
 
     static let vpnLocationCustomSectionTitle = NSLocalizedString("vpn.location.custom.section.title", value: "Custom", comment: "Title of the VPN location list custom section")
 
-    static let vpnLocationSubmitButtonTitle = NSLocalizedString("vpn.location.submit.button.title", value: "Done", comment: "Title of the VPN location list confirm button (confirms the user's location selection)")
+    static let vpnLocationDoneButtonTitle = NSLocalizedString("vpn.location.done.button.title", value: "Done", comment: "Title of the VPN location list confirm button (confirms the user's location selection)")
 
     static let vpnLocationCancelButtonTitle = NSLocalizedString("vpn.location.cancel.button.title", value: "Cancel", comment: "Title of the VPN location list cancel button (Note: seems like a duplicate key with a different purpose, please check)")
 

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -111389,7 +111389,7 @@
         }
       }
     },
-    "vpn.location.submit.button.title" : {
+    "vpn.location.done.button.title" : {
       "comment" : "Title of the VPN location list confirm button (confirms the user's location selection)",
       "extractionState" : "extracted_with_value",
       "localizations" : {

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -111390,61 +111390,13 @@
       }
     },
     "vpn.location.submit.button.title" : {
-      "comment" : "Title of the VPN location list submit button",
+      "comment" : "Title of the VPN location list confirm button (confirms the user's location selection)",
       "extractionState" : "extracted_with_value",
       "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abschicken"
-          }
-        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Submit"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviar"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Envoyer"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invia"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verzenden"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prześlij"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Submeter"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отправить"
+            "value" : "Done"
           }
         }
       }

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNLocation/VPNLocationView.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNLocation/VPNLocationView.swift
@@ -265,7 +265,7 @@ private struct VPNLocationViewButtons: View {
                     .keyboardShortcut(.cancelAction)
                     .buttonStyle(DismissActionButtonStyle())
 
-                button(text: UserText.vpnLocationSubmitButtonTitle, action: onDone)
+                button(text: UserText.vpnLocationDoneButtonTitle, action: onDone)
                     .keyboardShortcut(.defaultAction)
                     .buttonStyle(DefaultActionButtonStyle(enabled: true))
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1213610207499655?focus=true

### Description

Rename the VPN location selection screen's primary CTA from "Submit" to "Done". The button confirms the user's location selection — nothing is being submitted — so "Submit" read as the wrong verb. "Done" matches the existing onDone callback and reads naturally for a settings confirmation.

### Testing Steps
1. Open VPN settings on macOS and click the location row to open the location picker.
2. Confirm the primary CTA reads "Done" (not "Submit").
3. Select a different location and click Done.
   - Expected: the picker dismisses and the new location is applied.
4. Reopen the picker and click Cancel.
   - Expected: the picker dismisses and the previous location is retained.

### Impact and Risks

Low — copy-only change on a single button on the macOS VPN location picker. No behavior changes.

#### What could go wrong?

N/A

### Quality Considerations

N/A

### Notes to Reviewer

iOS doesn't have this button — change is macOS-only.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk copy-only change: replaces the VPN location picker’s primary button label and localization key, with no behavior changes.
> 
> **Overview**
> Renames the macOS VPN location picker’s primary CTA from **“Submit”** to **“Done”** by introducing `vpn.location.done.button.title` and wiring the view to use `UserText.vpnLocationDoneButtonTitle`.
> 
> Removes the old `vpn.location.submit.button.title` localization entry (and its existing translations), leaving the new key with only an English string marked as new.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 901ff73bbe500cbdc2bec675f3384ef2e7160204. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->