### PR TITLE
iOS: Fix unified input suggestion tap-ahead

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1090,6 +1090,10 @@ extension MainViewController: UnifiedInputContentContainerViewControllerDelegate
         handleSuggestionSelected(suggestion)
     }
 
+    func unifiedInputEditingStateDidRequestTextUpdate(_ text: String) {
+        unifiedToggleInputCoordinator?.setText(text)
+    }
+
     func unifiedInputEditingStateDidSelectChatHistory(url: URL) {
         onChatHistorySelected(url: url)
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -35,6 +35,7 @@ protocol UnifiedInputContentContainerViewControllerDelegate: AnyObject {
     func unifiedInputEditingStateDidSelectFavorite(_ favorite: BookmarkEntity)
     func unifiedInputEditingStateDidEditFavorite(_ favorite: BookmarkEntity)
     func unifiedInputEditingStateDidSelectSuggestion(_ suggestion: Suggestion)
+    func unifiedInputEditingStateDidRequestTextUpdate(_ text: String)
     func unifiedInputEditingStateDidSelectChatHistory(url: URL)
     func unifiedInputEditingStateDidRequestSwitchTab(_ tab: Tab)
     func unifiedInputEditingStateDidRequestTabSwitcher()
@@ -815,7 +816,7 @@ extension UnifiedInputContentContainerViewController: SuggestionTrayManagerDeleg
     }
 
     func suggestionTrayManager(_ manager: SuggestionTrayManager, shouldUpdateTextTo text: String) {
-        switchBarHandler.updateCurrentText(text)
+        delegate?.unifiedInputEditingStateDidRequestTextUpdate(text)
     }
 
     func suggestionTrayManager(_ manager: SuggestionTrayManager, requestsEditFavorite favorite: BookmarkEntity) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1214960121177993?focus=true

### Description

Fixes unified input search suggestion tap-ahead so tapping the arrow inserts the suggestion into the unified input field.

### Testing Steps
1. **Unified input tap-ahead**
   - Enable unified input, focus Search mode, type a partial query, and tap the arrow on a search suggestion.
   - Expected: the suggestion text fills the unified input without submitting.

2. **Legacy tap-ahead**
   - Disable unified input, focus the old input, type a partial query, and tap the arrow on a search suggestion.
   - Expected: the suggestion text fills the old input as before.

### Impact and Risks
Low. This only changes the unified-input suggestion tap-ahead route.

#### What could go wrong?
Suggestion arrow taps in unified input could fail to update the visible text field or could affect normal suggestion selection; the change keeps selection handling unchanged and only routes tap-ahead text through the unified input coordinator.

### Quality Considerations
No new privacy or performance impact. No automated test was added because this bug depends on active text-view first-responder behavior and is covered by the manual flow above.

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small event-routing change for suggestion “tap-ahead” text updates; primary risk is the unified input field not reflecting the new text if the delegate/coordinator path is miswired.
> 
> **Overview**
> Fixes unified-input suggestion *tap-ahead* so the “insert suggestion” action updates the actual unified input field.
> 
> `UnifiedInputContentContainerViewController` now forwards `SuggestionTrayManager.shouldUpdateTextTo` via a new delegate callback (`unifiedInputEditingStateDidRequestTextUpdate`), and `MainViewController` handles it by calling `unifiedToggleInputCoordinator?.setText(...)` (instead of updating the local `switchBarHandler` text directly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e5ba9b229514d666b109acc2586715f491196fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->