### PR TITLE
iOS: Open Duck.ai chat links in new tabs

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatModelsService.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatModelsService.swift
@@ -223,15 +223,22 @@ extension AIChatModel {
 
 extension AIChatModel.ModelProvider {
     public static func from(id: String, providerString: String) -> AIChatModel.ModelProvider {
-        if id.hasPrefix("meta-llama/") || id.hasPrefix("meta-llama_") || providerString == "azure" {
+        let normalizedProviderString = providerString.lowercased()
+        let isMetaProvider = id.hasPrefix("meta-llama/") || id.hasPrefix("meta-llama_") || normalizedProviderString == "azure"
+        let isMistralProvider = id.hasPrefix("mistralai/")
+            || id.hasPrefix("mistralai_")
+            || normalizedProviderString == "mistral"
+            || normalizedProviderString == "mistralai"
+
+        if isMetaProvider {
             return .meta
-        } else if id.hasPrefix("mistralai/") || id.hasPrefix("mistralai_") {
+        } else if isMistralProvider {
             return .mistral
         } else if id.contains("gpt-oss") {
             return .oss
-        } else if providerString == "anthropic" {
+        } else if normalizedProviderString == "anthropic" {
             return .anthropic
-        } else if providerString == "openai" {
+        } else if normalizedProviderString == "openai" {
             return .openAI
         } else {
             return .unknown

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatModelsServiceTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatModelsServiceTests.swift
@@ -443,6 +443,16 @@ final class AIChatModelsServiceTests: XCTestCase {
         XCTAssertEqual(provider, .mistral)
     }
 
+    func testWhenProviderIsMistralString_ThenMapsToMistral() {
+        let provider = AIChatModel.ModelProvider.from(id: "mistral-small-2603", providerString: "mistral")
+        XCTAssertEqual(provider, .mistral)
+    }
+
+    func testWhenProviderIsMistralAIString_ThenMapsToMistral() {
+        let provider = AIChatModel.ModelProvider.from(id: "ministral-3b", providerString: "mistralai")
+        XCTAssertEqual(provider, .mistral)
+    }
+
     func testWhenModelIdContainsGptOss_ThenMapsToOSS() {
         let provider = AIChatModel.ModelProvider.from(id: "openai_gpt-oss-120b", providerString: "togetherai")
         XCTAssertEqual(provider, .oss)

--- a/iOS/DuckDuckGo/AIChat/AIChatContentHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatContentHandler.swift
@@ -32,6 +32,7 @@ protocol AIChatUserScriptProviding: AnyObject {
     var delegate: AIChatUserScriptDelegate? { get set }
     var webView: WKWebView? { get set }
     func setPayloadHandler(_ payloadHandler: any AIChatConsumableDataHandling)
+    func setOpenLinkHandler(_ openLinkHandler: ((URL) -> Void)?)
     func setPageContextProvider(_ provider: ((PageContextRequestReason) -> AIChatPageContextData?)?)
     func setContextualModePixelHandler(_ pixelHandler: AIChatContextualModePixelFiring)
     func setDisplayMode(_ displayMode: AIChatDisplayMode)
@@ -69,6 +70,8 @@ protocol AIChatContentHandlingDelegate: AnyObject {
 
     /// Called when the frontend requests page context (`getAIChatPageContext`), signaling it has initialized and registered its JS message handlers.
     func aiChatContentHandlerDidReceivePageContextRequest(_ handler: AIChatContentHandling)
+
+    func aiChatContentHandler(_ handler: AIChatContentHandling, didRequestToOpen url: URL)
 }
 
 /// Handles content initialization, payload management, and URL building for AIChat.
@@ -117,6 +120,7 @@ extension AIChatContentHandling {
 extension AIChatContentHandlingDelegate {
     func aiChatContentHandlerDidReceivePageContextRequest(_ handler: AIChatContentHandling) {}
     func aiChatContentHandlerDidReceiveVoiceSessionUserEndedRequest(_ handler: AIChatContentHandling) {}
+    func aiChatContentHandler(_ handler: AIChatContentHandling, didRequestToOpen url: URL) {}
 }
 
 final class AIChatContentHandler: AIChatContentHandling {
@@ -161,6 +165,10 @@ final class AIChatContentHandler: AIChatContentHandling {
         self.userScript?.delegate = self
         self.userScript?.setDisplayMode(displayMode)
         self.userScript?.setPayloadHandler(payloadHandler)
+        self.userScript?.setOpenLinkHandler { [weak self] url in
+            guard let self else { return }
+            self.delegate?.aiChatContentHandler(self, didRequestToOpen: url)
+        }
         self.userScript?.webView = webView
         self.userScript?.setPageContextProvider(getPageContext)
     }

--- a/iOS/DuckDuckGo/AIChat/AIChatViewControllerManager.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatViewControllerManager.swift
@@ -566,6 +566,10 @@ extension AIChatViewControllerManager: UserContentControllerDelegate {
         }
         aiChatUserScript?.delegate = self
         aiChatUserScript?.setPayloadHandler(payloadHandler)
+        aiChatUserScript?.setOpenLinkHandler { [weak self] url in
+            guard let self, let chatViewController = self.chatViewController else { return }
+            self.aiChatViewController(chatViewController, didRequestToLoad: url)
+        }
         aiChatUserScript?.webView = chatViewController?.webView
     }
 }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
@@ -853,6 +853,10 @@ extension AIChatContextualSheetViewController: AIChatContentHandlingDelegate {
     func aiChatContentHandlerDidReceivePageContextRequest(_ handler: AIChatContentHandling) {
         webViewController?.markFrontendAsReady()
     }
+
+    func aiChatContentHandler(_ handler: AIChatContentHandling, didRequestToOpen url: URL) {
+        delegate?.aiChatContextualSheetViewController(self, didRequestToLoad: url)
+    }
 }
 
 // MARK: - ViewModel Binding

--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
@@ -44,7 +44,6 @@ protocol AIChatUserScriptDelegate: AnyObject {
 // MARK: - AIChatUserScript Class
 
 final class AIChatUserScript: NSObject, Subfeature {
-
     // MARK: - Push Message Enum
 
     enum AIChatPushMessage {
@@ -187,6 +186,12 @@ final class AIChatUserScript: NSObject, Subfeature {
             return handler.getAIChatPageContext
         case .openAIChat:
             return handler.openAIChat
+        case .openSummarizationSourceLink:
+            return handler.openSummarizationSourceLink
+        case .openTranslationSourceLink:
+            return handler.openTranslationSourceLink
+        case .openAIChatLink:
+            return handler.openAIChatLink
         case .hideChatInput:
             return handler.hideChatInput
         case .showChatInput:
@@ -234,6 +239,10 @@ final class AIChatUserScript: NSObject, Subfeature {
 
     func setPayloadHandler(_ payloadHandler: any AIChatConsumableDataHandling) {
         handler.setPayloadHandler(payloadHandler)
+    }
+
+    func setOpenLinkHandler(_ openLinkHandler: ((URL) -> Void)?) {
+        handler.setOpenLinkHandler(openLinkHandler)
     }
 
     func setDisplayMode(_ displayMode: AIChatDisplayMode) {

--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -153,7 +153,11 @@ protocol AIChatUserScriptHandling: AnyObject {
     func getAIChatNativeHandoffData(params: Any, message: UserScriptMessage) -> Encodable?
     func getAIChatPageContext(params: Any, message: UserScriptMessage) -> Encodable?
     func openAIChat(params: Any, message: UserScriptMessage) async -> Encodable?
+    @MainActor func openSummarizationSourceLink(params: Any, message: UserScriptMessage) async -> Encodable?
+    @MainActor func openTranslationSourceLink(params: Any, message: UserScriptMessage) async -> Encodable?
+    @MainActor func openAIChatLink(params: Any, message: UserScriptMessage) async -> Encodable?
     func setPayloadHandler(_ payloadHandler: (any AIChatConsumableDataHandling)?)
+    func setOpenLinkHandler(_ handler: ((URL) -> Void)?)
     func setAIChatInputBoxHandler(_ inputBoxHandler: (any AIChatInputBoxHandling)?)
     func setMetricReportingHandler(_ metricHandler: (any AIChatMetricReportingHandling)?)
     func setSyncStatusChangedHandler(_ handler: ((AIChatSyncHandler.SyncStatus) -> Void)?)
@@ -186,6 +190,7 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
     private var payloadHandler: (any AIChatConsumableDataHandling)?
     private let promptHandler: any AIChatConsumableDataHandling
     private var inputBoxHandler: (any AIChatInputBoxHandling)?
+    private var openLinkHandler: ((URL) -> Void)?
     private weak var metricReportingHandler: (any AIChatMetricReportingHandling)?
     private let experimentalAIChatManager: ExperimentalAIChatManager
     private let syncHandler: AIChatSyncHandling
@@ -255,6 +260,27 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
             userInfo: nil
         )
 
+        return nil
+    }
+
+    @MainActor func openSummarizationSourceLink(params: Any, message: UserScriptMessage) async -> Encodable? {
+        return await openAIChatLink(params: params, message: message)
+    }
+
+    @MainActor func openTranslationSourceLink(params: Any, message: UserScriptMessage) async -> Encodable? {
+        return await openAIChatLink(params: params, message: message)
+    }
+
+    @MainActor func openAIChatLink(params: Any, message: UserScriptMessage) async -> Encodable? {
+        guard let openLinkParams: OpenLink = DecodableHelper.decode(from: params),
+              let url = URL(string: openLinkParams.url),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              url.host != nil else {
+            return nil
+        }
+
+        openLinkHandler?(url)
         return nil
     }
 
@@ -418,6 +444,10 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
 
     func setPayloadHandler(_ payloadHandler: (any AIChatConsumableDataHandling)?) {
         self.payloadHandler = payloadHandler
+    }
+
+    func setOpenLinkHandler(_ handler: ((URL) -> Void)?) {
+        openLinkHandler = handler
     }
 
     func setAIChatInputBoxHandler(_ inputBoxHandler: (any AIChatInputBoxHandling)?) {
@@ -690,3 +720,10 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
     }
 }
 // swiftlint:enable inclusive_language
+
+extension AIChatUserScriptHandler {
+
+    struct OpenLink: Codable, Equatable {
+        let url: String
+    }
+}

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2875,7 +2875,6 @@ class MainViewController: UIViewController {
             .sink { [weak self] notification in
                 let interceptedURL = notification.userInfo?[TabURLInterceptorParameter.interceptedURL] as? URL
                 let payload = notification.object as? AIChatPayload
-                
                 var query: String?
                 var shouldAutoSend = false
                 if let url = interceptedURL,
@@ -6024,6 +6023,11 @@ extension MainViewController: AIChatContentHandlingDelegate {
 
     func aiChatContentHandlerDidReceivePromptSubmission(_ handler: AIChatContentHandling) {
         // No action needed for full mode - notification handles metrics
+    }
+
+    func aiChatContentHandler(_ handler: AIChatContentHandling, didRequestToOpen url: URL) {
+        loadUrlInNewTab(url, inheritedAttribution: nil)
+        currentTab?.adClickExternalOpenDetector.invalidateForUserInitiated()
     }
 
     private func closeCurrentTab() {

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -2334,6 +2334,22 @@ extension TabViewController: WKNavigationDelegate {
             delegate?.tabDidRequestNavigationToDifferentSite(tab: self)
         }
 
+        switch Self.aiChatNewWindowDecision(currentURL: webView.url, navigationAction: navigationAction) {
+        case .loadInTab(let aiChatNewWindowURL):
+            decisionHandler(.cancel)
+            load(url: aiChatNewWindowURL)
+            return
+        case .openInNewTab(let aiChatNewWindowURL):
+            decisionHandler(.cancel)
+            delegate?.tab(self,
+                          didRequestNewTabForUrl: aiChatNewWindowURL,
+                          openedByPage: true,
+                          inheritingAttribution: adClickAttributionLogic.state)
+            return
+        case .ignore:
+            break
+        }
+
         // This check needs to happen before GPC checks. Otherwise the navigation type may be rewritten to `.other`
         // which would skip link rewrites.
         if navigationAction.navigationType != .backForward,

--- a/iOS/DuckDuckGo/TabViewControllerAIChatExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerAIChatExtension.swift
@@ -20,6 +20,7 @@
 import AIChat
 import Foundation
 import UIKit
+import WebKit
 
 /// Protocol for tab controllers that support full mode AIChat content loading.
 protocol AITabController {
@@ -119,5 +120,32 @@ extension TabViewController: AITabController {
         if isAITab {
             webView.reload()
         }
+    }
+}
+
+extension TabViewController {
+
+    enum AIChatNewWindowDecision: Equatable {
+        case ignore
+        case loadInTab(URL)
+        case openInNewTab(URL)
+    }
+
+    static func aiChatNewWindowDecision(currentURL: URL?,
+                                        navigationAction: WKNavigationAction) -> AIChatNewWindowDecision {
+        guard navigationAction.navigationType == .linkActivated,
+              navigationAction.targetFrame == nil,
+              currentURL?.isDuckAIURL == true,
+              let url = navigationAction.request.url,
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https" else {
+            return .ignore
+        }
+
+        if url.isDuckAIURL {
+            return .loadInTab(url)
+        }
+
+        return .openInNewTab(url)
     }
 }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContentHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContentHandlerTests.swift
@@ -80,6 +80,18 @@ final class AIChatContentHandlerTests: XCTestCase {
         XCTAssertTrue(mockUserScript.payloadHandlerSet)
     }
 
+    func testSetupSetsOpenLinkHandler() throws {
+        // Given
+        let mockUserScript = MockAIChatUserScript()
+        let mockWebView = WKWebView()
+
+        // When
+        handler.setup(with: mockUserScript, webView: mockWebView, displayMode: .fullTab)
+
+        // Then
+        XCTAssertTrue(mockUserScript.openLinkHandlerSet)
+    }
+
     func testSetupSetsWebView() throws {
         // Given
         let mockUserScript = MockAIChatUserScript()
@@ -476,6 +488,23 @@ final class AIChatContentHandlerTests: XCTestCase {
         XCTAssertEqual(mockDelegate.didReceivePageContextRequestCallCount, 0)
     }
 
+    func testOpenLinkHandlerNotifiesDelegate() throws {
+        // Given
+        let mockUserScript = MockAIChatUserScript()
+        let mockWebView = WKWebView()
+        let mockDelegate = MockAIChatContentHandlingDelegate()
+        let url = URL(string: "https://duckduckgo.com/?q=cat%20breeds&t=duck_ai")!
+        handler.delegate = mockDelegate
+        handler.setup(with: mockUserScript, webView: mockWebView, displayMode: .fullTab)
+
+        // When
+        mockUserScript.openLinkHandler?(url)
+
+        // Then
+        XCTAssertEqual(mockDelegate.didRequestToOpenCallCount, 1)
+        XCTAssertEqual(mockDelegate.requestedOpenURL, url)
+    }
+
     func testDidReceiveVoiceSessionUserEndedNotifiesDelegate() throws {
         // Given
         let mockUserScript = MockAIChatUserScript()
@@ -585,6 +614,8 @@ final class MockAIChatUserScript: AIChatUserScriptProviding {
     var delegateSet = false
     var webViewSet = false
     var payloadHandlerSet = false
+    var openLinkHandlerSet = false
+    var openLinkHandler: ((URL) -> Void)?
     var pageContextProviderSet = false
     var submitPromptCallCount = 0
     var lastSubmittedPrompt: String?
@@ -598,6 +629,11 @@ final class MockAIChatUserScript: AIChatUserScriptProviding {
 
     func setPayloadHandler(_ payloadHandler: any AIChat.AIChatConsumableDataHandling) {
         payloadHandlerSet = true
+    }
+
+    func setOpenLinkHandler(_ openLinkHandler: ((URL) -> Void)?) {
+        openLinkHandlerSet = true
+        self.openLinkHandler = openLinkHandler
     }
 
     func setPageContextProvider(_ provider: ((PageContextRequestReason) -> AIChatPageContextData?)?) {
@@ -647,7 +683,11 @@ final class MockAIChatUserScriptHandling: AIChatUserScriptHandling {
     func getAIChatNativeHandoffData(params: Any, message: UserScriptMessage) -> Encodable? { nil }
     func getAIChatPageContext(params: Any, message: UserScriptMessage) -> Encodable? { nil }
     func openAIChat(params: Any, message: UserScriptMessage) async -> Encodable? { nil }
+    @MainActor func openSummarizationSourceLink(params: Any, message: UserScriptMessage) async -> Encodable? { nil }
+    @MainActor func openTranslationSourceLink(params: Any, message: UserScriptMessage) async -> Encodable? { nil }
+    @MainActor func openAIChatLink(params: Any, message: UserScriptMessage) async -> Encodable? { nil }
     func setPayloadHandler(_ payloadHandler: (any AIChatConsumableDataHandling)?) {}
+    func setOpenLinkHandler(_ handler: ((URL) -> Void)?) {}
     func setAIChatInputBoxHandler(_ inputBoxHandler: (any AIChatInputBoxHandling)?) {}
     func setMetricReportingHandler(_ metricHandler: (any AIChatMetricReportingHandling)?) {}
     func setSyncStatusChangedHandler(_ handler: ((AIChatSyncHandler.SyncStatus) -> Void)?) {}

--- a/iOS/DuckDuckGoTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -249,6 +249,126 @@ class AIChatUserScriptHandlerTests: XCTestCase {
         await fulfillment(of: [expectation])
     }
 
+    @MainActor
+    func testOpenAIChatLinkCallsOpenLinkHandler() async {
+        let urlString = "https://duckduckgo.com/?q=cat%20breeds&t=duck_ai"
+        let params: [String: Any] = [
+            "url": urlString
+        ]
+        var openedURL: URL?
+        aiChatUserScriptHandler.setOpenLinkHandler { url in
+            openedURL = url
+        }
+
+        let result = await aiChatUserScriptHandler.openAIChatLink(
+            params: params,
+            message: MockUserScriptMessage(name: "test", body: params)
+        )
+
+        XCTAssertNil(result)
+        XCTAssertEqual(openedURL?.absoluteString, urlString)
+    }
+
+    @MainActor
+    func testOpenAIChatLinkIgnoresUnusedTargetAndNameFields() async {
+        let urlString = "https://duckduckgo.com/?q=cat%20breeds&t=duck_ai"
+        let params: [String: Any] = [
+            "url": urlString,
+            "target": "external-app",
+            "name": "future-source"
+        ]
+        var openedURL: URL?
+        aiChatUserScriptHandler.setOpenLinkHandler { url in
+            openedURL = url
+        }
+
+        let result = await aiChatUserScriptHandler.openAIChatLink(
+            params: params,
+            message: MockUserScriptMessage(name: "test", body: params)
+        )
+
+        XCTAssertNil(result)
+        XCTAssertEqual(openedURL?.absoluteString, urlString)
+    }
+
+    @MainActor
+    func testOpenSummarizationSourceLinkCallsOpenLinkHandler() async {
+        let urlString = "https://example.com/source"
+        let params: [String: Any] = [
+            "url": urlString
+        ]
+        var openedURL: URL?
+        aiChatUserScriptHandler.setOpenLinkHandler { url in
+            openedURL = url
+        }
+
+        let result = await aiChatUserScriptHandler.openSummarizationSourceLink(
+            params: params,
+            message: MockUserScriptMessage(name: "test", body: params)
+        )
+
+        XCTAssertNil(result)
+        XCTAssertEqual(openedURL?.absoluteString, urlString)
+    }
+
+    @MainActor
+    func testOpenTranslationSourceLinkCallsOpenLinkHandler() async {
+        let urlString = "https://example.com/source"
+        let params: [String: Any] = [
+            "url": urlString
+        ]
+        var openedURL: URL?
+        aiChatUserScriptHandler.setOpenLinkHandler { url in
+            openedURL = url
+        }
+
+        let result = await aiChatUserScriptHandler.openTranslationSourceLink(
+            params: params,
+            message: MockUserScriptMessage(name: "test", body: params)
+        )
+
+        XCTAssertNil(result)
+        XCTAssertEqual(openedURL?.absoluteString, urlString)
+    }
+
+    @MainActor
+    func testOpenAIChatLinkIgnoresInvalidURL() async {
+        let params: [String: Any] = [
+            "url": "invalid"
+        ]
+        var openedURL: URL?
+        aiChatUserScriptHandler.setOpenLinkHandler { url in
+            openedURL = url
+        }
+
+        let result = await aiChatUserScriptHandler.openAIChatLink(
+            params: params,
+            message: MockUserScriptMessage(name: "test", body: params)
+        )
+
+        XCTAssertNil(result)
+        XCTAssertNil(openedURL)
+    }
+
+    @MainActor
+    func testOpenAIChatLinkIgnoresNonHTTPURL() async {
+        let params: [String: Any] = [
+            "url": "intent://example.com/path"
+        ]
+        var openedURL: URL?
+        aiChatUserScriptHandler.setOpenLinkHandler { url in
+            openedURL = url
+        }
+
+        let result = await aiChatUserScriptHandler.openAIChatLink(
+            params: params,
+            message: MockUserScriptMessage(name: "test", body: params)
+        )
+
+        XCTAssertNil(result)
+        XCTAssertNil(openedURL)
+    }
+
     func testResponseReceivedPostsNotification() async {
         // Given
         let expectation = expectation(forNotification: .aiChatResponseReceived, object: nil)

--- a/iOS/DuckDuckGoTests/TabTests.swift
+++ b/iOS/DuckDuckGoTests/TabTests.swift
@@ -19,6 +19,8 @@
 
 import XCTest
 import AIChat
+import BrowserServicesKitTestsUtils
+import WebKit
 
 @testable import Core
 @testable import DuckDuckGo
@@ -506,6 +508,74 @@ class TabTests: XCTestCase {
         return Link(title: "title", url: URL(string: "http://example.com")!)
     }
 
+}
+
+final class TabViewControllerAIChatNewWindowDecisionTests: XCTestCase {
+
+    func testWhenNewTargetBlankFromAIChatToExternalHTTPSThenOpenInNewTab() {
+        let url = URL(string: "https://example.com/cat")!
+        let navigationAction = MockNavigationAction(request: URLRequest(url: url))
+
+        let decision = TabViewController.aiChatNewWindowDecision(currentURL: aiChatURL(),
+                                                                 navigationAction: navigationAction)
+
+        XCTAssertEqual(decision, .openInNewTab(url))
+    }
+
+    func testWhenNewTargetBlankFromAIChatToAnotherAIChatURLThenLoadInSameTab() {
+        let url = URL(string: "https://duck.ai/chat?duckai=4&chatID=123")!
+        let navigationAction = MockNavigationAction(request: URLRequest(url: url))
+
+        let decision = TabViewController.aiChatNewWindowDecision(currentURL: aiChatURL(),
+                                                                 navigationAction: navigationAction)
+
+        XCTAssertEqual(decision, .loadInTab(url))
+    }
+
+    func testWhenNewTargetBlankFromAIChatToNonHTTPSchemeThenIgnore() {
+        let url = URL(string: "mailto:test@example.com")!
+        let navigationAction = MockNavigationAction(request: URLRequest(url: url))
+
+        let decision = TabViewController.aiChatNewWindowDecision(currentURL: aiChatURL(),
+                                                                 navigationAction: navigationAction)
+
+        XCTAssertEqual(decision, .ignore)
+    }
+
+    func testWhenNewTargetBlankFromNonAIChatTabThenIgnore() {
+        let url = URL(string: "https://example.com/cat")!
+        let navigationAction = MockNavigationAction(request: URLRequest(url: url))
+
+        let decision = TabViewController.aiChatNewWindowDecision(currentURL: URL(string: "https://example.com")!,
+                                                                 navigationAction: navigationAction)
+
+        XCTAssertEqual(decision, .ignore)
+    }
+
+    func testWhenLinkActivatedWithTargetFrameFromAIChatThenIgnore() {
+        let url = URL(string: "https://example.com/cat")!
+        let targetFrame = WKFrameInfo.mock(isMainFrame: true, securityOriginHost: "example.com")
+        let navigationAction = MockNavigationAction(request: URLRequest(url: url), targetFrame: targetFrame)
+
+        let decision = TabViewController.aiChatNewWindowDecision(currentURL: aiChatURL(),
+                                                                 navigationAction: navigationAction)
+
+        XCTAssertEqual(decision, .ignore)
+    }
+
+    func testWhenNavigationTypeIsNotLinkActivatedFromAIChatThenIgnore() {
+        let url = URL(string: "https://example.com/cat")!
+        let navigationAction = MockNavigationAction(request: URLRequest(url: url), navigationType: .other)
+
+        let decision = TabViewController.aiChatNewWindowDecision(currentURL: aiChatURL(),
+                                                                 navigationAction: navigationAction)
+
+        XCTAssertEqual(decision, .ignore)
+    }
+
+    private func aiChatURL() -> URL {
+        URL(string: "https://duck.ai/chat?duckai=4")!
+    }
 }
 
 private class CoderStub: NSCoder {

--- a/iOS/SharedTestUtils/Mocks/AIChat/MockAIChatContentHandlingDelegate.swift
+++ b/iOS/SharedTestUtils/Mocks/AIChat/MockAIChatContentHandlingDelegate.swift
@@ -27,6 +27,8 @@ public final class MockAIChatContentHandlingDelegate: AIChatContentHandlingDeleg
     public var didReceiveOpenSyncSettingsRequestCallCount = 0
     public var didReceivePromptSubmissionCallCount = 0
     public var didReceivePageContextRequestCallCount = 0
+    public var didRequestToOpenCallCount = 0
+    public var requestedOpenURL: URL?
 
     public init() {}
 
@@ -52,5 +54,10 @@ public final class MockAIChatContentHandlingDelegate: AIChatContentHandlingDeleg
 
     public func aiChatContentHandlerDidReceivePageContextRequest(_ handler: AIChatContentHandling) {
         didReceivePageContextRequestCallCount += 1
+    }
+
+    public func aiChatContentHandler(_ handler: AIChatContentHandling, didRequestToOpen url: URL) {
+        didRequestToOpenCallCount += 1
+        requestedOpenURL = url
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1214961162843595
Tech Design URL: N/A
CC:

### Description

Fixes two Duck.ai iOS issues:
- maps Mistral model providers so Mistral models show the correct icon in the model picker
- opens Duck.ai chat links in a new browser tab

Search/source links use Duck.ai's existing native `openAIChatLink` bridge. Duck.ai new-window link activations are handled natively when the current tab is Duck.ai: Duck.ai URLs stay in the current chat tab, while non-Duck.ai http(s) URLs open in a new browser tab.

### Testing Steps

**Mistral Model Icon**
1. Open Duck.ai with the unified input model picker available.
2. Find a Mistral or Ministral model in the picker.
3. Expected: the Mistral icon is shown instead of a missing or unknown icon.

**Full Duck.ai Search Result Opens New Tab**
1. Open Duck.ai in a full browser tab and submit a prompt with web search enabled.
2. Tap a normal web search result in the chat response.
3. Expected: the result opens in a new browser tab and the Duck.ai tab remains available.

**Full Duck.ai Related Search Opens New Tab**
1. Open Duck.ai in a full browser tab and submit a prompt with web search enabled.
2. Tap a related search.
3. Expected: the related search opens in a new browser tab and does not replace the Duck.ai tab.

**Contextual Sheet Link Opens New Tab**
1. Open the contextual Duck.ai sheet and submit a prompt with web search enabled.
2. Tap a web result or related search in the chat response.
3. Expected: the URL is handed off to the browser as a new tab, matching the full-tab behavior.

**Regular Web Navigation Is Unchanged**
1. Open a normal non-Duck.ai webpage in a browser tab.
2. Tap normal page links, including links that open new tabs.
3. Expected: existing browser navigation behavior is unchanged.

### Impact and Risks

Medium: this touches AI chat link routing. A regression could open Duck.ai links in the wrong place or fail to open external chat links.

#### What could go wrong?

The main risk is over-intercepting normal web page links. The new-window navigation branch is limited to link activations from an existing Duck.ai tab where WebKit reports no target frame; all other browser navigation stays on the existing path.

### Quality Considerations

Added unit coverage for Mistral provider mapping, AI chat open-link delegate wiring, open-link bridge validation, and graceful decoding of future bridge enum values.

Validated:
- `git diff --check`
- no newly added `AICHATNAV`, `Logger`, `print`, `os_log`, injected click listener, `preventDefault`, or `stopPropagation`
- XcodeBuildMCP `build_sim` for `DuckDuckGo.xcworkspace`, scheme `iOS Browser`, Debug, iOS Simulator

### Notes to Reviewer

Claude Code review was attempted twice through the Beekeeper helper, but the local Claude CLI returned `Not logged in · Please run /login`. A manual adversarial review was run separately; the actionable findings were addressed by tightening URL validation and graceful decoding. A previous injected-click-interceptor approach was removed.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes AI chat link routing/bridging and intercepts certain `WKNavigationAction`s, so regressions could open links in the wrong tab or suppress navigation if the decision logic is too broad. Scope is constrained to Duck.ai contexts and http(s) URLs with added unit coverage.
> 
> **Overview**
> Improves AI model provider detection so Mistral models map correctly even when the backend sends provider strings like `mistral`/`mistralai` (case-insensitive), fixing icon selection in the model picker.
> 
> Adds a native open-link path for Duck.ai: the user script now exposes `openSummarizationSourceLink`/`openTranslationSourceLink`/`openAIChatLink`, validates decoded URLs are http(s), and forwards them via a new `setOpenLinkHandler` callback that bubbles through `AIChatContentHandler` delegates to open the URL in the app (e.g., `MainViewController` loads it in a new tab).
> 
> Updates full-tab navigation handling so `target=_blank` link activations from an existing Duck.ai tab are intercepted: Duck.ai URLs reload in the same tab, while external http(s) URLs open in a new tab; includes new unit tests for provider mapping, open-link wiring/validation, and the new-window decision logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a6cefcbacbdff242947fe4059e87ee1993bfe88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->