### PR TITLE
Fix duck.ai suggestion truncation and View all chats double selection

### DIFF
--- a/macOS/DuckDuckGo/AIChat/Suggestions/AIChatSuggestionRowView.swift
+++ b/macOS/DuckDuckGo/AIChat/Suggestions/AIChatSuggestionRowView.swift
@@ -34,19 +34,11 @@ protocol SuggestionRowThemeProviding {
 /// Default implementation that uses the app's theme manager.
 struct DefaultSuggestionRowThemeProvider: SuggestionRowThemeProviding {
     var accentPrimaryColor: NSColor {
-        var color: NSColor = .controlAccentColor
-        NSAppearance.withAppAppearance {
-            color = NSApp.delegateTyped.themeManager.theme.palette.accentPrimary
-        }
-        return color
+        NSApp.delegateTyped.themeManager.theme.palette.accentPrimary
     }
 
     var selectedTintColor: NSColor {
-        var color: NSColor = NSColor(designSystemColor: .accentContentPrimary)
-        NSAppearance.withAppAppearance {
-            color = NSApp.delegateTyped.themeManager.theme.palette.accentContentPrimary
-        }
-        return color
+        NSApp.delegateTyped.themeManager.theme.palette.accentContentPrimary
     }
 
     var suggestionHighlightCornerRadius: CGFloat {
@@ -224,23 +216,34 @@ final class AIChatSuggestionRowView: NSView {
         CATransaction.begin()
         CATransaction.setDisableActions(true)
 
-        let isHighlighted = isSelected || isHovered
-        if isHighlighted {
-            let tintColor = themeProvider.selectedTintColor
-            backgroundLayer.backgroundColor = themeProvider.accentPrimaryColor.cgColor
-            titleLabel.textColor = tintColor
-            iconImageView.contentTintColor = tintColor
-            deleteButton.contentTintColor = tintColor
-        } else {
-            backgroundLayer.backgroundColor = NSColor.clear.cgColor
-            titleLabel.textColor = Constants.textColor
-            iconImageView.contentTintColor = Constants.iconColor
-            deleteButton.contentTintColor = Constants.iconColor
+        // Resolve dynamic colors under the view's effective appearance so the
+        // accent CGColor matches the active dark/light variant. Without this,
+        // `.cgColor` resolves against NSAppearance.current (defaults to .aqua),
+        // producing the light-mode accent on dark-mode windows.
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            let isHighlighted = isSelected || isHovered
+            if isHighlighted {
+                let tintColor = themeProvider.selectedTintColor
+                backgroundLayer.backgroundColor = themeProvider.accentPrimaryColor.cgColor
+                titleLabel.textColor = tintColor
+                iconImageView.contentTintColor = tintColor
+                deleteButton.contentTintColor = tintColor
+            } else {
+                backgroundLayer.backgroundColor = NSColor.clear.cgColor
+                titleLabel.textColor = Constants.textColor
+                iconImageView.contentTintColor = Constants.iconColor
+                deleteButton.contentTintColor = Constants.iconColor
+            }
+
+            deleteButton.isHidden = !canDelete || !isHighlighted
         }
 
-        deleteButton.isHidden = !canDelete || !isHighlighted
-
         CATransaction.commit()
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateAppearance()
     }
 
     @objc private func deleteButtonClicked() {

--- a/macOS/DuckDuckGo/AIChat/Suggestions/AIChatSuggestionsView.swift
+++ b/macOS/DuckDuckGo/AIChat/Suggestions/AIChatSuggestionsView.swift
@@ -267,6 +267,9 @@ final class AIChatSuggestionsView: NSView {
         let isViewAllSelected = selectedIndex == rowViews.count
         viewAllChatsRowView?.isSelected = isViewAllSelected
         viewAllChatsRowView?.isKeyboardNavigating = isKeyboardNavigating
+        if isKeyboardNavigating {
+            viewAllChatsRowView?.isHovered = false
+        }
     }
 
     /// Binds the view to a view model for automatic updates.

--- a/macOS/DuckDuckGo/AIChat/Suggestions/AIChatViewAllChatsRowView.swift
+++ b/macOS/DuckDuckGo/AIChat/Suggestions/AIChatViewAllChatsRowView.swift
@@ -179,25 +179,33 @@ final class AIChatViewAllChatsRowView: NSView {
         CATransaction.begin()
         CATransaction.setDisableActions(true)
 
-        let isHighlighted = isSelected || isHovered
-        if isHighlighted {
-            let tintColor = themeProvider.selectedTintColor
-            backgroundLayer.backgroundColor = themeProvider.accentPrimaryColor.cgColor
-            titleLabel.textColor = tintColor
-            openDuckAILabel.textColor = tintColor
-            iconImageView.contentTintColor = tintColor
-            arrowImageView.contentTintColor = tintColor
-            keyboardShortcutView.isHighlighted = true
-        } else {
-            backgroundLayer.backgroundColor = NSColor.clear.cgColor
-            titleLabel.textColor = Constants.textColor
-            openDuckAILabel.textColor = themeProvider.accentPrimaryColor
-            iconImageView.contentTintColor = Constants.iconColor
-            arrowImageView.contentTintColor = themeProvider.accentPrimaryColor
-            keyboardShortcutView.isHighlighted = false
+        // See AIChatSuggestionRowView.updateAppearance for the appearance note.
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            let isHighlighted = isSelected || isHovered
+            if isHighlighted {
+                let tintColor = themeProvider.selectedTintColor
+                backgroundLayer.backgroundColor = themeProvider.accentPrimaryColor.cgColor
+                titleLabel.textColor = tintColor
+                openDuckAILabel.textColor = tintColor
+                iconImageView.contentTintColor = tintColor
+                arrowImageView.contentTintColor = tintColor
+                keyboardShortcutView.isHighlighted = true
+            } else {
+                backgroundLayer.backgroundColor = NSColor.clear.cgColor
+                titleLabel.textColor = Constants.textColor
+                openDuckAILabel.textColor = themeProvider.accentPrimaryColor
+                iconImageView.contentTintColor = Constants.iconColor
+                arrowImageView.contentTintColor = themeProvider.accentPrimaryColor
+                keyboardShortcutView.isHighlighted = false
+            }
         }
 
         CATransaction.commit()
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateAppearance()
     }
 
     // MARK: - Mouse Tracking

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -1120,12 +1120,15 @@ extension AddressBarTextField {
                 }
             case .openTab(title: _, url: let url, _, _):
                 self = .openTab(url)
-            case .unknown, .askAIChat:
+            case .askAIChat:
+                self = Suffix.aiChat
+            case .unknown:
                 self = Suffix.search
             }
         }
 
         case search
+        case aiChat
         case visit(host: String)
         case url(URL)
         case title(String)
@@ -1141,6 +1144,7 @@ extension AddressBarTextField {
         }
 
         static let searchSuffix = " – \(UserText.searchDuckDuckGoSuffix)"
+        static let aiChatSuffix = " – \(UserText.aiChatAddressBarTrustedIndicator)"
         static let searchOpenTabSuffix = " – \(UserText.duckDuckGoSearchSuffix)"
         static let internalPageOpenTabSuffix = " – \(UserText.duckDuckGo)"
         static let visitSuffix = " – \(UserText.addressBarVisitSuffix)"
@@ -1149,6 +1153,8 @@ extension AddressBarTextField {
             switch self {
             case .search:
                 return Self.searchSuffix
+            case .aiChat:
+                return Self.aiChatSuffix
             case .visit(host: let host):
                 return "\(Self.visitSuffix) \(host)"
             case .openTab(let url) where url.isDuckDuckGoSearch:

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -156,11 +156,11 @@ final class AddressBarTextField: NSTextField {
         suggestionResultCancellable = suggestionContainerViewModel?.suggestionContainer.$result
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                guard let self = self else { return }
-                if self.suggestionContainerViewModel?.suggestionContainer.result?.count ?? 0 > 0 {
-                    self.performanceCoordinator?.markSuggestionsUpdated()
-                    self.showSuggestionWindow()
-                }
+                guard let self,
+                      let viewModel = self.suggestionContainerViewModel,
+                      viewModel.numberOfRows > 0 else { return }
+                self.performanceCoordinator?.markSuggestionsUpdated()
+                self.showSuggestionWindow()
             }
     }
 

--- a/macOS/DuckDuckGo/Suggestions/View/KeyboardShortcutView.swift
+++ b/macOS/DuckDuckGo/Suggestions/View/KeyboardShortcutView.swift
@@ -29,7 +29,9 @@ final class KeyboardShortcutView: NSView {
         static let normalBackgroundColor = NSColor.black.withAlphaComponent(0.08)
         static let selectedBackgroundColor = NSColor.white.withAlphaComponent(0.15)
         static let normalTextColor = NSColor.suggestionText
-        static let selectedTextColor = NSColor.selectedSuggestionTint
+        // Match the chip label and arrow next to the key caps so the whole
+        // "Ask privately" chip reads as one element when the row is highlighted.
+        static let selectedTextColor = NSColor(designSystemColor: .accentContentSecondary)
     }
 
     private let stackView: NSStackView = {

--- a/macOS/DuckDuckGo/Suggestions/View/SuggestionTableCellView.swift
+++ b/macOS/DuckDuckGo/Suggestions/View/SuggestionTableCellView.swift
@@ -202,7 +202,8 @@ final class SuggestionTableCellView: NSTableCellView {
         self.suggestion = nil
 
         let attributes: [NSAttributedString.Key: Any] = [
-            .font: NSFont.systemFont(ofSize: 13)
+            .font: NSFont.systemFont(ofSize: 13),
+            .paragraphStyle: SuggestionViewModel.paragraphStyle
         ]
         attributedString = NSAttributedString(string: userText, attributes: attributes)
         iconImageView.image = icon

--- a/macOS/DuckDuckGo/Suggestions/ViewModel/SuggestionContainerViewModel.swift
+++ b/macOS/DuckDuckGo/Suggestions/ViewModel/SuggestionContainerViewModel.swift
@@ -438,7 +438,7 @@ final class SuggestionContainerViewModel {
             nextRow += 1
         }
 
-        wrapAroundOrClearSelection(using: firstSelectableRow)
+        clearRowSelection()
     }
 
     func selectPreviousIfPossible() {
@@ -458,16 +458,7 @@ final class SuggestionContainerViewModel {
             prevRow -= 1
         }
 
-        wrapAroundOrClearSelection(using: lastSelectableRow)
-    }
-
-    /// Wraps around to the given row when aiChatOmnibarToggle is on, otherwise clears selection
-    private func wrapAroundOrClearSelection(using selectableRow: () -> Int?) {
-        if featureFlagger.isFeatureOn(.aiChatOmnibarToggle), let row = selectableRow() {
-            selectRow(at: row)
-        } else {
-            clearRowSelection()
-        }
+        clearRowSelection()
     }
 
     private func firstSelectableRow() -> Int? {

--- a/macOS/DuckDuckGo/Suggestions/ViewModel/SuggestionContainerViewModel.swift
+++ b/macOS/DuckDuckGo/Suggestions/ViewModel/SuggestionContainerViewModel.swift
@@ -373,6 +373,16 @@ final class SuggestionContainerViewModel {
     private func updateSelectedSuggestionViewModel() {
         if let selectionIndex {
             selectedSuggestionViewModel = suggestionViewModel(at: selectionIndex)
+        } else if selectedRowContent == .aiChatCell, let userStringValue, !userStringValue.isEmpty {
+            // Synthesize an .askAIChat view model so the address bar renders the
+            // " – Duck.ai" context clue when the synthetic Ask-privately row is selected.
+            selectedSuggestionViewModel = SuggestionViewModel(
+                isHomePage: isHomePage,
+                suggestion: .askAIChat(value: userStringValue),
+                userStringValue: userStringValue,
+                themeManager: themeManager,
+                featureFlagger: featureFlagger
+            )
         } else {
             selectedSuggestionViewModel = nil
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1214450331857403
https://app.asana.com/1/137249556945/project/1204912272578138/task/1212943926426596
https://app.asana.com/1/137249556945/project/1148564399326804/task/1213734134708912?focus=true


### Description

Seven small fixes to address bar suggestions, all related to the new duck.ai surface:

1. **"Ask privately" wrapped to two lines on long input.** The user-text attributed string built in `SuggestionTableCellView.display(userText:style:icon:isBurner:)` did not include a paragraph style, so the `byTruncatingTail` line break mode set in the XIB was overridden by the attributed string default and the text wrapped. The regular suggestion path goes through `SuggestionViewModel.tableCellViewAttributedString`, which already applies `SuggestionViewModel.paragraphStyle` — use the same paragraph style for the search / aiChat / visit cells so very long input stays on one line and truncates with "…".

2. **"View all chats" stayed highlighted after switching to keyboard navigation.** `AIChatSuggestionsView.updateSelection(_:isKeyboardNavigating:)` already clears `isHovered` on every regular row when keyboard nav starts, but the same clear was missing for the "View all chats" footer row, so it kept its hover highlight in addition to the keyboard-selected row. Clear the footer row's hover too.

3. **Suggestion window didn't reopen on edit when backend returned nothing.** `AddressBarTextField.subscribeToSuggestionResult` opened the window only when `result.count > 0`. For long input that returns no backend suggestions, refocusing and typing another character left the window hidden even though the synthetic "Ask privately" / "Search the web" rows would otherwise display. Gate on `numberOfRows > 0` instead, mirroring the close-side check in `SuggestionViewController.displayNewSuggestions`.

4. **Address-bar suffix stayed " – Search DuckDuckGo" when the Ask-privately row was keyboard-selected.** The synthetic aiChat row has no real `SuggestionViewModel`, so selection always fell through to the default search suffix. Synthesize a `.askAIChat` view model in `updateSelectedSuggestionViewModel()` when that row is selected, and route a new `Suffix.aiChat` case to " – Duck.ai" — matching the dropdown row's own suffix.

5. **"⌃ ⏎" key caps used the wrong color in the highlighted Ask-privately chip.** The caps hardcoded `selectedSuggestionTint` (pure white) while the chip label and arrow use `accentContentSecondary`. In dark mode this made the caps read as foreign elements. Switch the caps to the same design-system token.

6. **Duck.ai row highlight rendered the light-mode accent on dark-mode windows.** The CALayer-based row was assigning `.cgColor` of the dynamic accent color from a property `didSet`, where `NSAppearance.current` defaults to `.aqua` and resolves the wrong variant. Run the highlight setup inside `effectiveAppearance.performAsCurrentDrawingAppearance` and refresh on `viewDidChangeEffectiveAppearance`.

7. **Keyboard cycling trapped the user on the only selectable row.** With the search and Ask-privately synthetic rows visible but no backend suggestions, arrowing past the ends wrapped back to the first/last row (gated by the `aiChatOmnibarToggle` flag) — never landing on the "no row selected → just typed input" state. Drop the wrap branch in `wrapAroundOrClearSelection`, matching what `AIChatSuggestionsViewModel` already does for the duck.ai chat list.

### Testing Steps

1. Type a very long search query in the address bar. The "Ask privately" row stays on one line and truncates with "…".
2. Open duck.ai mode with enough chats to show "View all chats". Hover that row, then press up; only one row highlighted. Reverse direction; still only one row highlighted.
3. Type a very long input that returns no backend suggestions, unfocus the address bar, click back in, and type another character. The window reopens with the "Ask privately" / "Search the web" rows.
4. With any input in search mode, arrow down past the search row onto the Duck.ai row. Address-bar suffix shifts from " – Search DuckDuckGo" to " – Duck.ai" and back as you cycle.
5. In dark mode, hover or arrow-select the Duck.ai row. The "⌃" / "⏎" key caps read in the same near-black tone as "Ask privately" and the arrow.
6. In dark mode, compare the row highlight in search-mode suggestions and duck.ai chat suggestions — the blue should match.
7. With only the two synthetic rows visible, arrow down repeatedly. Cycle goes: search row → Ask-privately row → no row selected (just typed input) → back to search row. Arrow up does the mirror.

### Impact and Risks

Low: visual / behavioural fixes to the suggestions dropdown. No new model state — only view-layer wiring and the existing selection/value plumbing.

#### What could go wrong?

Fix 4 makes the address-bar value transition into `.suggestion(synthetic)` whenever the Ask-privately row is selected. The synthetic view model produces the same `string` as the user's typed input, so no visible text change. Fix 7 changes keyboard cycling for users with the `aiChatOmnibarToggle` feature flag on (currently the dev/internal default) — they lose the wrap-around and gain an escape-to-typed-input state. Fix 6's `viewDidChangeEffectiveAppearance` override may run on every appearance toggle, but `updateAppearance` is cheap (a CATransaction with disabled animations).