### PR TITLE
tab bloat idle return pixels

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -91,8 +91,8 @@ extension Pixel {
         case tabLongPressMenuNewFireTab
         case tabLongPressMenuNewNormalTab
         case tabSwitcherOpenedDaily
-        case appOpenDailyTabCountIdleNTP
-        case appOpenDailyTabCountIdleLastTab
+        case appOpenTabCountIdleNTPDaily
+        case appOpenTabCountIdleLastTabDaily
         case tabManagerSwitchToAITab
         case tabManagerSwitchToWebTab
         case tabManagerCloseAITab
@@ -1960,8 +1960,8 @@ extension Pixel.Event {
         case .tabLongPressMenuNewFireTab: return "m_tab_long_press_menu_new_fire_tab"
         case .tabLongPressMenuNewNormalTab: return "m_tab_long_press_menu_new_normal_tab"
         case .tabSwitcherOpenedDaily: return "m_tab_manager_opened_daily"
-        case .appOpenDailyTabCountIdleNTP: return "m_app_open_daily_tab_count_idle_ntp"
-        case .appOpenDailyTabCountIdleLastTab: return "m_app_open_daily_tab_count_idle_last_tab"
+        case .appOpenTabCountIdleNTPDaily: return "m_app_open_tab_count_idle_ntp_daily"
+        case .appOpenTabCountIdleLastTabDaily: return "m_app_open_tab_count_idle_last_tab_daily"
         case .tabManagerSwitchToAITab: return "m_tab_manager_switch_to_ai_tab"
         case .tabManagerSwitchToWebTab: return "m_tab_manager_switch_to_web_tab"
         case .tabManagerCloseAITab: return "m_tab_manager_close_ai_tab"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -91,6 +91,8 @@ extension Pixel {
         case tabLongPressMenuNewFireTab
         case tabLongPressMenuNewNormalTab
         case tabSwitcherOpenedDaily
+        case appOpenDailyTabCountIdleNTP
+        case appOpenDailyTabCountIdleLastTab
         case tabManagerSwitchToAITab
         case tabManagerSwitchToWebTab
         case tabManagerCloseAITab
@@ -1958,6 +1960,8 @@ extension Pixel.Event {
         case .tabLongPressMenuNewFireTab: return "m_tab_long_press_menu_new_fire_tab"
         case .tabLongPressMenuNewNormalTab: return "m_tab_long_press_menu_new_normal_tab"
         case .tabSwitcherOpenedDaily: return "m_tab_manager_opened_daily"
+        case .appOpenDailyTabCountIdleNTP: return "m_app_open_daily_tab_count_idle_ntp"
+        case .appOpenDailyTabCountIdleLastTab: return "m_app_open_daily_tab_count_idle_last_tab"
         case .tabManagerSwitchToAITab: return "m_tab_manager_switch_to_ai_tab"
         case .tabManagerSwitchToWebTab: return "m_tab_manager_switch_to_web_tab"
         case .tabManagerCloseAITab: return "m_tab_manager_close_ai_tab"

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		275A9E842551836ECC9E6873 /* UnifiedToggleInputModelMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC9145E578E99B3052757F /* UnifiedToggleInputModelMenuTests.swift */; };
 		286810A915227B119AC60831 /* DefaultTogglePositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8AD06BCB81EA991F22DD66 /* DefaultTogglePositionTests.swift */; };
 		2CCD716C578642B8BC760D55 /* NTPAfterIdleInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0742FD8DD5F46AB8243103F /* NTPAfterIdleInstrumentation.swift */; };
+		2CCD716C578642B8BCA1A001 /* IdleReturnTabCountInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0742FD8DD5F46AB8243A001 /* IdleReturnTabCountInstrumentation.swift */; };
 		2DC3FC65C6D9DA634426672D /* AutofillNoAuthAvailableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC3FBD62FBAF21E87610FA8 /* AutofillNoAuthAvailableView.swift */; };
 		3105BCF12DF214A000EB755E /* AIChatPixelMetricHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3105BCF02DF214A000EB755E /* AIChatPixelMetricHandler.swift */; };
 		3105BCF52DF2154800EB755E /* AIChatPixelMetricHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3105BCF32DF2154800EB755E /* AIChatPixelMetricHandlerTests.swift */; };
@@ -1677,6 +1678,7 @@
 		9FFDA83F2DFA907A007923F7 /* MockPictureInPictureController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FFDA83E2DFA9073007923F7 /* MockPictureInPictureController.swift */; };
 		A06E1D600618608596891F29 /* AIChatRecentChatsPopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0B70EF2418A35A5D863506 /* AIChatRecentChatsPopupViewController.swift */; };
 		A1B2C3D4E5F60001AABB0001 /* NTPAfterIdleInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001AABB0002 /* NTPAfterIdleInstrumentationTests.swift */; };
+		A1B2C3D4E5F60002AABBA001 /* IdleReturnTabCountInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60002AABBA002 /* IdleReturnTabCountInstrumentationTests.swift */; };
 		A1B2C3D4E5F60002A1B2C3D4 /* UnifiedInputContentContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001A1B2C3D4 /* UnifiedInputContentContainerViewController.swift */; };
 		A1B2C3D4E5F60012A1B2C3D4 /* AIChatReasoningMode+UnifiedToggleInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60011A1B2C3D4 /* AIChatReasoningMode+UnifiedToggleInput.swift */; };
 		A1B2C3D4E5F60014A1B2C3D4 /* UnifiedToggleInputReasoningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60013A1B2C3D4 /* UnifiedToggleInputReasoningTests.swift */; };
@@ -4292,6 +4294,7 @@
 		A1B2C3D42F7F111100ABCDEF /* SaveRecoveryKeyViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SaveRecoveryKeyViewModelTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001A1B2C3D4 /* UnifiedInputContentContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedInputContentContainerViewController.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001AABB0002 /* NTPAfterIdleInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPAfterIdleInstrumentationTests.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60002AABBA002 /* IdleReturnTabCountInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleReturnTabCountInstrumentationTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60011A1B2C3D4 /* AIChatReasoningMode+UnifiedToggleInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AIChatReasoningMode+UnifiedToggleInput.swift"; sourceTree = "<group>"; };
 		A1B2C3D4E5F60013A1B2C3D4 /* UnifiedToggleInputReasoningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputReasoningTests.swift; sourceTree = "<group>"; };
 		A1B2C3D62F7F111100ABCDEF /* SyncSettingsViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncSettingsViewModelTests.swift; sourceTree = "<group>"; };
@@ -4929,6 +4932,7 @@
 		DA0001042F3D000100000002 /* DarkReaderFeatureSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkReaderFeatureSettings.swift; sourceTree = "<group>"; };
 		DD503EBD506182525F5E8107 /* RebrandedOnboardingView+Landing.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "RebrandedOnboardingView+Landing.swift"; sourceTree = "<group>"; };
 		E0742FD8DD5F46AB8243103F /* NTPAfterIdleInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPAfterIdleInstrumentation.swift; sourceTree = "<group>"; };
+		E0742FD8DD5F46AB8243A001 /* IdleReturnTabCountInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleReturnTabCountInstrumentation.swift; sourceTree = "<group>"; };
 		E29382A31F7E094527FD807C /* IPadTabChatHistoryCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadTabChatHistoryCoordinator.swift; sourceTree = "<group>"; };
 		E44F90E856A0488A976B6AFE /* FileCorruptErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCorruptErrorView.swift; sourceTree = "<group>"; };
 		E7971E90992B46FABF42A908 /* AIChatContextualWebViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualWebViewControllerTests.swift; sourceTree = "<group>"; };
@@ -9849,6 +9853,7 @@
 				CBAD0F3A2D02EE5B006267B8 /* IdleReturnCohort.swift */,
 				CBAD0F2C2D02EE4F006267B8 /* IdleReturnEligibilityManager.swift */,
 				E0742FD8DD5F46AB8243103F /* NTPAfterIdleInstrumentation.swift */,
+				E0742FD8DD5F46AB8243A001 /* IdleReturnTabCountInstrumentation.swift */,
 				D1A2B3C4E5F60001AABB0002 /* PostIdleSessionWideEventData.swift */,
 				D1A2B3C4E5F60001AABB0006 /* PostIdleSessionInstrumentation.swift */,
 				CBAD0F242D02EE48006267B8 /* LastBackgroundDateStore.swift */,
@@ -10706,6 +10711,7 @@
 				9770D4AF2F7B000200293610 /* VoiceSessionStateManagerTests.swift */,
 				9770D4B12F7B000300293610 /* VoiceEntryPointPixelTests.swift */,
 				A1B2C3D4E5F60001AABB0002 /* NTPAfterIdleInstrumentationTests.swift */,
+				A1B2C3D4E5F60002AABBA002 /* IdleReturnTabCountInstrumentationTests.swift */,
 				D1A2B3C4E5F60001AABB0004 /* PostIdleSessionWideEventDataTests.swift */,
 				D1A2B3C4E5F60001AABB0008 /* PostIdleSessionInstrumentationTests.swift */,
 				CBAD0F302D02EE50006267B8 /* IdleReturnEligibilityManagerTests.swift */,
@@ -12385,6 +12391,7 @@
 				CBAD0F2D2D02EE50006267B8 /* IdleReturnEligibilityManager.swift in Sources */,
 				EDDEC0152F99679E00FBE920 /* SyncSetupExperimentPixels.swift in Sources */,
 				2CCD716C578642B8BC760D55 /* NTPAfterIdleInstrumentation.swift in Sources */,
+				2CCD716C578642B8BCA1A001 /* IdleReturnTabCountInstrumentation.swift in Sources */,
 				D1A2B3C4E5F60001AABB0001 /* PostIdleSessionWideEventData.swift in Sources */,
 				D1A2B3C4E5F60001AABB0005 /* PostIdleSessionInstrumentation.swift in Sources */,
 				CBAD0F252D02EE49006267B8 /* LastBackgroundDateStore.swift in Sources */,
@@ -13448,6 +13455,7 @@
 				9770D4AE2F7B000200293610 /* VoiceSessionStateManagerTests.swift in Sources */,
 				9770D4B02F7B000300293610 /* VoiceEntryPointPixelTests.swift in Sources */,
 				A1B2C3D4E5F60001AABB0001 /* NTPAfterIdleInstrumentationTests.swift in Sources */,
+				A1B2C3D4E5F60002AABBA001 /* IdleReturnTabCountInstrumentationTests.swift in Sources */,
 				D1A2B3C4E5F60001AABB0003 /* PostIdleSessionWideEventDataTests.swift in Sources */,
 				D1A2B3C4E5F60001AABB0007 /* PostIdleSessionInstrumentationTests.swift in Sources */,
 				CBAD0F312D02EE50006267B8 /* IdleReturnEligibilityManagerTests.swift in Sources */,

--- a/iOS/DuckDuckGo/AppLifecycle/IdleReturnTabCountInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/IdleReturnTabCountInstrumentation.swift
@@ -45,8 +45,8 @@ final class DefaultIdleReturnTabCountInstrumentation: IdleReturnTabCountInstrume
 
         let pixel: Pixel.Event
         switch eligibilityManager.effectiveAfterInactivityOption() {
-        case .newTab: pixel = .appOpenDailyTabCountIdleNTP
-        case .lastUsedTab: pixel = .appOpenDailyTabCountIdleLastTab
+        case .newTab: pixel = .appOpenTabCountIdleNTPDaily
+        case .lastUsedTab: pixel = .appOpenTabCountIdleLastTabDaily
         }
 
         var params = TabSwitcherOpenDailyPixel().parameters(with: tabs)

--- a/iOS/DuckDuckGo/AppLifecycle/IdleReturnTabCountInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/IdleReturnTabCountInstrumentation.swift
@@ -19,17 +19,11 @@
 
 import Core
 
-/// Tab-count snapshot instrumentation for the NTP-after-idle Tab Bloat investigation.
-///
-/// Fires once per day on app foreground when the feature is available, emitting either
-/// `appOpenDailyTabCountIdleNTP` or `appOpenDailyTabCountIdleLastTab` based on the user's
-/// effective after-inactivity setting. Parameters mirror the existing
-/// `m_tab_manager_opened_daily` pixel (via `TabSwitcherOpenDailyPixel`) so the two
-/// distributions can be compared directly.
+/// Daily tab-count snapshot on app foreground, segmented by NTP-after-idle setting.
+/// Reuses `TabSwitcherOpenDailyPixel` buckets to be comparable with `m_tab_manager_opened_daily`.
 protocol IdleReturnTabCountInstrumentation: AnyObject {
 
-    /// Records a foreground event. No-op when the NTP-after-idle feature is unavailable.
-    /// Throttled to once-per-day per pixel by `DailyPixel`.
+    /// No-op when the feature is unavailable. Once-per-day throttled by `DailyPixel`.
     func recordAppForeground(tabs: [Tab], browsingMode: String)
 }
 

--- a/iOS/DuckDuckGo/AppLifecycle/IdleReturnTabCountInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/IdleReturnTabCountInstrumentation.swift
@@ -1,0 +1,62 @@
+//
+//  IdleReturnTabCountInstrumentation.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Core
+
+/// Tab-count snapshot instrumentation for the NTP-after-idle Tab Bloat investigation.
+///
+/// Fires once per day on app foreground when the feature is available, emitting either
+/// `appOpenDailyTabCountIdleNTP` or `appOpenDailyTabCountIdleLastTab` based on the user's
+/// effective after-inactivity setting. Parameters mirror the existing
+/// `m_tab_manager_opened_daily` pixel (via `TabSwitcherOpenDailyPixel`) so the two
+/// distributions can be compared directly.
+protocol IdleReturnTabCountInstrumentation: AnyObject {
+
+    /// Records a foreground event. No-op when the NTP-after-idle feature is unavailable.
+    /// Throttled to once-per-day per pixel by `DailyPixel`.
+    func recordAppForeground(tabs: [Tab], browsingMode: String)
+}
+
+final class DefaultIdleReturnTabCountInstrumentation: IdleReturnTabCountInstrumentation {
+
+    private let eligibilityManager: IdleReturnEligibilityManaging
+    private let fireDaily: (Pixel.Event, [String: String]) -> Void
+
+    init(eligibilityManager: IdleReturnEligibilityManaging,
+         fireDaily: @escaping (Pixel.Event, [String: String]) -> Void = { event, params in
+             DailyPixel.fireDaily(event, withAdditionalParameters: params)
+         }) {
+        self.eligibilityManager = eligibilityManager
+        self.fireDaily = fireDaily
+    }
+
+    func recordAppForeground(tabs: [Tab], browsingMode: String) {
+        guard eligibilityManager.isFeatureAvailable() else { return }
+
+        let pixel: Pixel.Event
+        switch eligibilityManager.effectiveAfterInactivityOption() {
+        case .newTab: pixel = .appOpenDailyTabCountIdleNTP
+        case .lastUsedTab: pixel = .appOpenDailyTabCountIdleLastTab
+        }
+
+        var params = TabSwitcherOpenDailyPixel().parameters(with: tabs)
+        params[PixelParameters.browsingMode] = browsingMode
+        fireDaily(pixel, params)
+    }
+}

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -185,6 +185,7 @@ class MainViewController: UIViewController {
     private let longPressBarMenuBuilder = LongPressBarMenuBuilder()
     let idleReturnEligibilityManager: IdleReturnEligibilityManaging
     let ntpAfterIdleInstrumentation: NTPAfterIdleInstrumentation
+    let idleReturnTabCountInstrumentation: IdleReturnTabCountInstrumentation
     let postIdleSessionInstrumentation: PostIdleSessionInstrumentation
     let syncAutoRestoreHandler: SyncAutoRestoreHandling
     private let lastActiveTabStore: LastActiveTabStoring
@@ -484,6 +485,7 @@ class MainViewController: UIViewController {
         self.idleReturnEligibilityManager = idleReturnEligibilityManager
         self.lastActiveTabStore = lastActiveTabStore
         self.ntpAfterIdleInstrumentation = DefaultNTPAfterIdleInstrumentation(eligibilityManager: idleReturnEligibilityManager)
+        self.idleReturnTabCountInstrumentation = DefaultIdleReturnTabCountInstrumentation(eligibilityManager: idleReturnEligibilityManager)
         self.postIdleSessionInstrumentation = DefaultPostIdleSessionInstrumentation(wideEvent: AppDependencyProvider.shared.wideEvent)
         self.syncAutoRestoreHandler = syncAutoRestoreHandler
         self.fireproofing = fireproofing
@@ -1827,7 +1829,9 @@ class MainViewController: UIViewController {
         fireAIChatIsEnabledPixel()
         fireKeyboardSettingsPixels()
         fireTemporaryTelemetryPixels()
-        fireIdleReturnTabCountDailyPixel()
+        idleReturnTabCountInstrumentation.recordAppForeground(
+            tabs: tabManager.allTabsModel.tabs,
+            browsingMode: tabManager.currentBrowsingMode.pixelParamValue)
         skipSERPFlow = true
 
         /// Dismiss any keyboard restored by WKWebView when returning to foreground
@@ -1856,30 +1860,6 @@ class MainViewController: UIViewController {
 
         let toolbarButton = customizationState.currentToolbarButton.rawValue
         DailyPixel.fireDaily(.temporaryTelemetrySettingsCustomizedToolbarButton(button: toolbarButton))
-    }
-
-    /// Fires a daily snapshot of tab count + staleness on app foreground, segmented by the
-    /// user's effective "after inactivity" setting (New Tab vs Last Used Tab).
-    ///
-    /// Supports the Tab Bloat investigation: by comparing distributions across the two
-    /// pixels we can tell whether defaulting users to a New Tab on idle return is causing
-    /// tabs to accumulate. Reuses `TabSwitcherOpenDailyPixel` so buckets match the existing
-    /// `m_tab_manager_opened_daily` pixel and the data is directly comparable.
-    ///
-    /// Gated on `isFeatureAvailable()` so we only measure users for whom the setting
-    /// actually controls app behavior; `DailyPixel.fireDaily` handles once-per-day throttling.
-    private func fireIdleReturnTabCountDailyPixel() {
-        guard idleReturnEligibilityManager.isFeatureAvailable() else { return }
-
-        let pixel: Pixel.Event
-        switch idleReturnEligibilityManager.effectiveAfterInactivityOption() {
-        case .newTab: pixel = .appOpenDailyTabCountIdleNTP
-        case .lastUsedTab: pixel = .appOpenDailyTabCountIdleLastTab
-        }
-
-        var params = TabSwitcherOpenDailyPixel().parameters(with: tabManager.allTabsModel.tabs)
-        params[PixelParameters.browsingMode] = tabManager.currentBrowsingMode.pixelParamValue
-        DailyPixel.fireDaily(pixel, withAdditionalParameters: params)
     }
 
     /// Represents the policy for reusing existing tabs for a query or URL being opened.

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1827,6 +1827,7 @@ class MainViewController: UIViewController {
         fireAIChatIsEnabledPixel()
         fireKeyboardSettingsPixels()
         fireTemporaryTelemetryPixels()
+        fireIdleReturnTabCountDailyPixel()
         skipSERPFlow = true
 
         /// Dismiss any keyboard restored by WKWebView when returning to foreground
@@ -1855,6 +1856,30 @@ class MainViewController: UIViewController {
 
         let toolbarButton = customizationState.currentToolbarButton.rawValue
         DailyPixel.fireDaily(.temporaryTelemetrySettingsCustomizedToolbarButton(button: toolbarButton))
+    }
+
+    /// Fires a daily snapshot of tab count + staleness on app foreground, segmented by the
+    /// user's effective "after inactivity" setting (New Tab vs Last Used Tab).
+    ///
+    /// Supports the Tab Bloat investigation: by comparing distributions across the two
+    /// pixels we can tell whether defaulting users to a New Tab on idle return is causing
+    /// tabs to accumulate. Reuses `TabSwitcherOpenDailyPixel` so buckets match the existing
+    /// `m_tab_manager_opened_daily` pixel and the data is directly comparable.
+    ///
+    /// Gated on `isFeatureAvailable()` so we only measure users for whom the setting
+    /// actually controls app behavior; `DailyPixel.fireDaily` handles once-per-day throttling.
+    private func fireIdleReturnTabCountDailyPixel() {
+        guard idleReturnEligibilityManager.isFeatureAvailable() else { return }
+
+        let pixel: Pixel.Event
+        switch idleReturnEligibilityManager.effectiveAfterInactivityOption() {
+        case .newTab: pixel = .appOpenDailyTabCountIdleNTP
+        case .lastUsedTab: pixel = .appOpenDailyTabCountIdleLastTab
+        }
+
+        var params = TabSwitcherOpenDailyPixel().parameters(with: tabManager.allTabsModel.tabs)
+        params[PixelParameters.browsingMode] = tabManager.currentBrowsingMode.pixelParamValue
+        DailyPixel.fireDaily(pixel, withAdditionalParameters: params)
     }
 
     /// Represents the policy for reusing existing tabs for a query or URL being opened.

--- a/iOS/DuckDuckGoTests/IdleReturnTabCountInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/IdleReturnTabCountInstrumentationTests.swift
@@ -86,16 +86,14 @@ struct IdleReturnTabCountInstrumentationTests {
     // MARK: - Parameter content
 
     @available(iOS 16, *)
-    @Test("Fired params include bucketed tab_count, new_tab_count, staleness buckets and browsing_mode", .timeLimit(.minutes(1)))
+    @Test("Fires expected parameter keys and bucket values", .timeLimit(.minutes(1)))
     func paramsIncludeExpectedKeysAndBuckets() {
         let (sut, collector) = makeSUT(effectiveOption: .newTab)
-        // 3 tabs total, all blank (no link) → tab_count "2-5", new_tab_count "2-10".
         sut.recordAppForeground(tabs: [Tab(), Tab(), Tab()], browsingMode: "fire")
 
         let params = try? #require(collector.fired.first?.params)
         #expect(params?["tab_count"] == "2-5")
         #expect(params?["new_tab_count"] == "2-10")
-        // No tabs have a lastViewedDate, so all staleness buckets report "0".
         #expect(params?["tab_active_7d"] == "0")
         #expect(params?["tab_inactive_1w"] == "0")
         #expect(params?["tab_inactive_2w"] == "0")
@@ -119,8 +117,6 @@ struct IdleReturnTabCountInstrumentationTests {
         let (sut, collector) = makeSUT(effectiveOption: .newTab)
         sut.recordAppForeground(tabs: [Tab()], browsingMode: "normal")
         sut.recordAppForeground(tabs: [Tab()], browsingMode: "normal")
-        // Both calls hit the injected fireDaily closure — DailyPixel.fireDaily is what
-        // would dedupe per day in production. We verify the type doesn't add its own gate.
         #expect(collector.fired.count == 2)
     }
 }

--- a/iOS/DuckDuckGoTests/IdleReturnTabCountInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/IdleReturnTabCountInstrumentationTests.swift
@@ -1,0 +1,126 @@
+//
+//  IdleReturnTabCountInstrumentationTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Testing
+import Core
+@testable import DuckDuckGo
+
+@Suite("Idle Return Tab Count Instrumentation")
+struct IdleReturnTabCountInstrumentationTests {
+
+    private final class PixelCollector {
+        var fired: [(name: String, params: [String: String])] = []
+    }
+
+    private func makeSUT(
+        featureAvailable: Bool = true,
+        effectiveOption: AfterInactivityOption = .newTab
+    ) -> (DefaultIdleReturnTabCountInstrumentation, PixelCollector) {
+        let eligibility = MockIdleReturnEligibilityManager()
+        eligibility.isFeatureAvailableResult = featureAvailable
+        eligibility.effectiveAfterInactivityOptionResult = effectiveOption
+        let collector = PixelCollector()
+        let sut = DefaultIdleReturnTabCountInstrumentation(
+            eligibilityManager: eligibility,
+            fireDaily: { event, params in
+                collector.fired.append((event.name, params))
+            })
+        return (sut, collector)
+    }
+
+    // MARK: - Eligibility gating
+
+    @available(iOS 16, *)
+    @Test("When feature unavailable then no pixel is fired", .timeLimit(.minutes(1)))
+    func whenFeatureUnavailableThenFiresNothing() {
+        let (sut, collector) = makeSUT(featureAvailable: false, effectiveOption: .newTab)
+        sut.recordAppForeground(tabs: [Tab(), Tab()], browsingMode: "normal")
+        #expect(collector.fired.isEmpty)
+    }
+
+    @available(iOS 16, *)
+    @Test("When feature unavailable then last-used-tab setting also fires nothing", .timeLimit(.minutes(1)))
+    func whenFeatureUnavailableLastUsedTabFiresNothing() {
+        let (sut, collector) = makeSUT(featureAvailable: false, effectiveOption: .lastUsedTab)
+        sut.recordAppForeground(tabs: [Tab(), Tab()], browsingMode: "normal")
+        #expect(collector.fired.isEmpty)
+    }
+
+    // MARK: - Pixel selection by setting
+
+    @available(iOS 16, *)
+    @Test("When setting is New Tab then fires the idle_ntp pixel", .timeLimit(.minutes(1)))
+    func whenSettingNewTabThenFiresNTPPixel() {
+        let (sut, collector) = makeSUT(effectiveOption: .newTab)
+        sut.recordAppForeground(tabs: [Tab()], browsingMode: "normal")
+        #expect(collector.fired.count == 1)
+        #expect(collector.fired.first?.name == Pixel.Event.appOpenDailyTabCountIdleNTP.name)
+    }
+
+    @available(iOS 16, *)
+    @Test("When setting is Last Used Tab then fires the idle_last_tab pixel", .timeLimit(.minutes(1)))
+    func whenSettingLastUsedTabThenFiresLastTabPixel() {
+        let (sut, collector) = makeSUT(effectiveOption: .lastUsedTab)
+        sut.recordAppForeground(tabs: [Tab()], browsingMode: "normal")
+        #expect(collector.fired.count == 1)
+        #expect(collector.fired.first?.name == Pixel.Event.appOpenDailyTabCountIdleLastTab.name)
+    }
+
+    // MARK: - Parameter content
+
+    @available(iOS 16, *)
+    @Test("Fired params include bucketed tab_count, new_tab_count, staleness buckets and browsing_mode", .timeLimit(.minutes(1)))
+    func paramsIncludeExpectedKeysAndBuckets() {
+        let (sut, collector) = makeSUT(effectiveOption: .newTab)
+        // 3 tabs total, all blank (no link) → tab_count "2-5", new_tab_count "2-10".
+        sut.recordAppForeground(tabs: [Tab(), Tab(), Tab()], browsingMode: "fire")
+
+        let params = try? #require(collector.fired.first?.params)
+        #expect(params?["tab_count"] == "2-5")
+        #expect(params?["new_tab_count"] == "2-10")
+        // No tabs have a lastViewedDate, so all staleness buckets report "0".
+        #expect(params?["tab_active_7d"] == "0")
+        #expect(params?["tab_inactive_1w"] == "0")
+        #expect(params?["tab_inactive_2w"] == "0")
+        #expect(params?["tab_inactive_3w"] == "0")
+        #expect(params?[PixelParameters.browsingMode] == "fire")
+    }
+
+    @available(iOS 16, *)
+    @Test("Browsing mode parameter passes through verbatim", .timeLimit(.minutes(1)))
+    func browsingModeParameterPassesThrough() {
+        let (sut, collector) = makeSUT(effectiveOption: .lastUsedTab)
+        sut.recordAppForeground(tabs: [Tab()], browsingMode: "normal")
+        #expect(collector.fired.first?.params[PixelParameters.browsingMode] == "normal")
+    }
+
+    // MARK: - Multiple invocations (no throttling here — that's DailyPixel's job)
+
+    @available(iOS 16, *)
+    @Test("Each call fires once; daily throttling is delegated to DailyPixel", .timeLimit(.minutes(1)))
+    func eachCallFiresOnceThrottlingIsDelegated() {
+        let (sut, collector) = makeSUT(effectiveOption: .newTab)
+        sut.recordAppForeground(tabs: [Tab()], browsingMode: "normal")
+        sut.recordAppForeground(tabs: [Tab()], browsingMode: "normal")
+        // Both calls hit the injected fireDaily closure — DailyPixel.fireDaily is what
+        // would dedupe per day in production. We verify the type doesn't add its own gate.
+        #expect(collector.fired.count == 2)
+    }
+}

--- a/iOS/DuckDuckGoTests/IdleReturnTabCountInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/IdleReturnTabCountInstrumentationTests.swift
@@ -87,18 +87,18 @@ struct IdleReturnTabCountInstrumentationTests {
 
     @available(iOS 16, *)
     @Test("Fires expected parameter keys and bucket values", .timeLimit(.minutes(1)))
-    func paramsIncludeExpectedKeysAndBuckets() {
+    func paramsIncludeExpectedKeysAndBuckets() throws {
         let (sut, collector) = makeSUT(effectiveOption: .newTab)
         sut.recordAppForeground(tabs: [Tab(), Tab(), Tab()], browsingMode: "fire")
 
-        let params = try? #require(collector.fired.first?.params)
-        #expect(params?["tab_count"] == "2-5")
-        #expect(params?["new_tab_count"] == "2-10")
-        #expect(params?["tab_active_7d"] == "0")
-        #expect(params?["tab_inactive_1w"] == "0")
-        #expect(params?["tab_inactive_2w"] == "0")
-        #expect(params?["tab_inactive_3w"] == "0")
-        #expect(params?[PixelParameters.browsingMode] == "fire")
+        let params = try #require(collector.fired.first?.params)
+        #expect(params["tab_count"] == "2-5")
+        #expect(params["new_tab_count"] == "2-10")
+        #expect(params["tab_active_7d"] == "0")
+        #expect(params["tab_inactive_1w"] == "0")
+        #expect(params["tab_inactive_2w"] == "0")
+        #expect(params["tab_inactive_3w"] == "0")
+        #expect(params[PixelParameters.browsingMode] == "fire")
     }
 
     @available(iOS 16, *)

--- a/iOS/DuckDuckGoTests/IdleReturnTabCountInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/IdleReturnTabCountInstrumentationTests.swift
@@ -71,7 +71,7 @@ struct IdleReturnTabCountInstrumentationTests {
         let (sut, collector) = makeSUT(effectiveOption: .newTab)
         sut.recordAppForeground(tabs: [Tab()], browsingMode: "normal")
         #expect(collector.fired.count == 1)
-        #expect(collector.fired.first?.name == Pixel.Event.appOpenDailyTabCountIdleNTP.name)
+        #expect(collector.fired.first?.name == Pixel.Event.appOpenTabCountIdleNTPDaily.name)
     }
 
     @available(iOS 16, *)
@@ -80,7 +80,7 @@ struct IdleReturnTabCountInstrumentationTests {
         let (sut, collector) = makeSUT(effectiveOption: .lastUsedTab)
         sut.recordAppForeground(tabs: [Tab()], browsingMode: "normal")
         #expect(collector.fired.count == 1)
-        #expect(collector.fired.first?.name == Pixel.Event.appOpenDailyTabCountIdleLastTab.name)
+        #expect(collector.fired.first?.name == Pixel.Event.appOpenTabCountIdleLastTabDaily.name)
     }
 
     // MARK: - Parameter content

--- a/iOS/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
@@ -133,5 +133,99 @@
                 "enum": ["0", "60", "300", "600", "1800", "3600", "43200"]
             }
         ]
+    },
+    "m_app_open_daily_tab_count_idle_ntp": {
+        "description": "Fires once per day on app foreground for users whose effective after-inactivity setting is New Tab. Carries the same bucketed tab-count and staleness parameters as m_tab_manager_opened_daily so the two distributions can be compared. Supports the Tab Bloat investigation: determines whether defaulting users to a new tab on idle return causes tabs to accumulate.",
+        "owners": ["SabrinaTardio"],
+        "triggers": ["other"],
+        "expires": "2026-11-20",
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "browsingMode",
+            {
+                "key": "tab_count",
+                "type": "string",
+                "description": "Bucketed total tab count at app foreground.",
+                "enum": ["1", "2-5", "6-10", "11-20", "21-40", "41-60", "61-80", "81+"]
+            },
+            {
+                "key": "new_tab_count",
+                "type": "string",
+                "description": "Bucketed count of tabs with no link (blank/new tab pages).",
+                "enum": ["0-1", "2-10", "11+"]
+            },
+            {
+                "key": "tab_active_7d",
+                "type": "string",
+                "description": "Bucketed count of tabs last viewed within the past 7 days.",
+                "enum": ["0", "1-5", "6-10", "11-20", "21+"]
+            },
+            {
+                "key": "tab_inactive_1w",
+                "type": "string",
+                "description": "Bucketed count of tabs last viewed 8-14 days ago.",
+                "enum": ["0", "1-5", "6-10", "11-20", "21+"]
+            },
+            {
+                "key": "tab_inactive_2w",
+                "type": "string",
+                "description": "Bucketed count of tabs last viewed 15-21 days ago.",
+                "enum": ["0", "1-5", "6-10", "11-20", "21+"]
+            },
+            {
+                "key": "tab_inactive_3w",
+                "type": "string",
+                "description": "Bucketed count of tabs last viewed 22+ days ago.",
+                "enum": ["0", "1-5", "6-10", "11-20", "21+"]
+            }
+        ]
+    },
+    "m_app_open_daily_tab_count_idle_last_tab": {
+        "description": "Fires once per day on app foreground for users whose effective after-inactivity setting is Last Used Tab. Carries the same bucketed tab-count and staleness parameters as m_tab_manager_opened_daily so the two distributions can be compared. Supports the Tab Bloat investigation: determines whether defaulting users to a new tab on idle return causes tabs to accumulate.",
+        "owners": ["SabrinaTardio"],
+        "triggers": ["other"],
+        "expires": "2026-11-20",
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "browsingMode",
+            {
+                "key": "tab_count",
+                "type": "string",
+                "description": "Bucketed total tab count at app foreground.",
+                "enum": ["1", "2-5", "6-10", "11-20", "21-40", "41-60", "61-80", "81+"]
+            },
+            {
+                "key": "new_tab_count",
+                "type": "string",
+                "description": "Bucketed count of tabs with no link (blank/new tab pages).",
+                "enum": ["0-1", "2-10", "11+"]
+            },
+            {
+                "key": "tab_active_7d",
+                "type": "string",
+                "description": "Bucketed count of tabs last viewed within the past 7 days.",
+                "enum": ["0", "1-5", "6-10", "11-20", "21+"]
+            },
+            {
+                "key": "tab_inactive_1w",
+                "type": "string",
+                "description": "Bucketed count of tabs last viewed 8-14 days ago.",
+                "enum": ["0", "1-5", "6-10", "11-20", "21+"]
+            },
+            {
+                "key": "tab_inactive_2w",
+                "type": "string",
+                "description": "Bucketed count of tabs last viewed 15-21 days ago.",
+                "enum": ["0", "1-5", "6-10", "11-20", "21+"]
+            },
+            {
+                "key": "tab_inactive_3w",
+                "type": "string",
+                "description": "Bucketed count of tabs last viewed 22+ days ago.",
+                "enum": ["0", "1-5", "6-10", "11-20", "21+"]
+            }
+        ]
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
@@ -134,7 +134,7 @@
             }
         ]
     },
-    "m_app_open_daily_tab_count_idle_ntp": {
+    "m_app_open_tab_count_idle_ntp_daily": {
         "description": "Fires once per day on app foreground for users whose effective after-inactivity setting is New Tab. Carries the same bucketed tab-count and staleness parameters as m_tab_manager_opened_daily so the two distributions can be compared. Supports the Tab Bloat investigation: determines whether defaulting users to a new tab on idle return causes tabs to accumulate.",
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],
@@ -181,7 +181,7 @@
             }
         ]
     },
-    "m_app_open_daily_tab_count_idle_last_tab": {
+    "m_app_open_tab_count_idle_last_tab_daily": {
         "description": "Fires once per day on app foreground for users whose effective after-inactivity setting is Last Used Tab. Carries the same bucketed tab-count and staleness parameters as m_tab_manager_opened_daily so the two distributions can be compared. Supports the Tab Bloat investigation: determines whether defaulting users to a new tab on idle return causes tabs to accumulate.",
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],

--- a/iOS/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
@@ -143,42 +143,12 @@
         "parameters": [
             "appVersion",
             "browsingMode",
-            {
-                "key": "tab_count",
-                "type": "string",
-                "description": "Bucketed total tab count at app foreground.",
-                "enum": ["1", "2-5", "6-10", "11-20", "21-40", "41-60", "61-80", "81+"]
-            },
-            {
-                "key": "new_tab_count",
-                "type": "string",
-                "description": "Bucketed count of tabs with no link (blank/new tab pages).",
-                "enum": ["0-1", "2-10", "11+"]
-            },
-            {
-                "key": "tab_active_7d",
-                "type": "string",
-                "description": "Bucketed count of tabs last viewed within the past 7 days.",
-                "enum": ["0", "1-5", "6-10", "11-20", "21+"]
-            },
-            {
-                "key": "tab_inactive_1w",
-                "type": "string",
-                "description": "Bucketed count of tabs last viewed 8-14 days ago.",
-                "enum": ["0", "1-5", "6-10", "11-20", "21+"]
-            },
-            {
-                "key": "tab_inactive_2w",
-                "type": "string",
-                "description": "Bucketed count of tabs last viewed 15-21 days ago.",
-                "enum": ["0", "1-5", "6-10", "11-20", "21+"]
-            },
-            {
-                "key": "tab_inactive_3w",
-                "type": "string",
-                "description": "Bucketed count of tabs last viewed 22+ days ago.",
-                "enum": ["0", "1-5", "6-10", "11-20", "21+"]
-            }
+            "tabCount",
+            "newTabCount",
+            "tabActive7d",
+            "tabInactive1w",
+            "tabInactive2w",
+            "tabInactive3w"
         ]
     },
     "m_app_open_tab_count_idle_last_tab_daily": {
@@ -190,42 +160,12 @@
         "parameters": [
             "appVersion",
             "browsingMode",
-            {
-                "key": "tab_count",
-                "type": "string",
-                "description": "Bucketed total tab count at app foreground.",
-                "enum": ["1", "2-5", "6-10", "11-20", "21-40", "41-60", "61-80", "81+"]
-            },
-            {
-                "key": "new_tab_count",
-                "type": "string",
-                "description": "Bucketed count of tabs with no link (blank/new tab pages).",
-                "enum": ["0-1", "2-10", "11+"]
-            },
-            {
-                "key": "tab_active_7d",
-                "type": "string",
-                "description": "Bucketed count of tabs last viewed within the past 7 days.",
-                "enum": ["0", "1-5", "6-10", "11-20", "21+"]
-            },
-            {
-                "key": "tab_inactive_1w",
-                "type": "string",
-                "description": "Bucketed count of tabs last viewed 8-14 days ago.",
-                "enum": ["0", "1-5", "6-10", "11-20", "21+"]
-            },
-            {
-                "key": "tab_inactive_2w",
-                "type": "string",
-                "description": "Bucketed count of tabs last viewed 15-21 days ago.",
-                "enum": ["0", "1-5", "6-10", "11-20", "21+"]
-            },
-            {
-                "key": "tab_inactive_3w",
-                "type": "string",
-                "description": "Bucketed count of tabs last viewed 22+ days ago.",
-                "enum": ["0", "1-5", "6-10", "11-20", "21+"]
-            }
+            "tabCount",
+            "newTabCount",
+            "tabActive7d",
+            "tabInactive1w",
+            "tabInactive2w",
+            "tabInactive3w"
         ]
     }
 }

--- a/iOS/PixelDefinitions/pixels/params_dictionary.json5
+++ b/iOS/PixelDefinitions/pixels/params_dictionary.json5
@@ -371,5 +371,41 @@
         "type": "string",
         "description": "Variant of the onboarding flow the user selected after branching on the 'Try a search or AI chat' step",
         "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
+    },
+    "tabCount": {
+        "key": "tab_count",
+        "type": "string",
+        "description": "Bucketed total tab count.",
+        "enum": ["1", "2-5", "6-10", "11-20", "21-40", "41-60", "61-80", "81+"]
+    },
+    "newTabCount": {
+        "key": "new_tab_count",
+        "type": "string",
+        "description": "Bucketed count of tabs with no link (blank/new tab pages).",
+        "enum": ["0-1", "2-10", "11+"]
+    },
+    "tabActive7d": {
+        "key": "tab_active_7d",
+        "type": "string",
+        "description": "Bucketed count of tabs last viewed within the past 7 days.",
+        "enum": ["0", "1-5", "6-10", "11-20", "21+"]
+    },
+    "tabInactive1w": {
+        "key": "tab_inactive_1w",
+        "type": "string",
+        "description": "Bucketed count of tabs last viewed 8-14 days ago.",
+        "enum": ["0", "1-5", "6-10", "11-20", "21+"]
+    },
+    "tabInactive2w": {
+        "key": "tab_inactive_2w",
+        "type": "string",
+        "description": "Bucketed count of tabs last viewed 15-21 days ago.",
+        "enum": ["0", "1-5", "6-10", "11-20", "21+"]
+    },
+    "tabInactive3w": {
+        "key": "tab_inactive_3w",
+        "type": "string",
+        "description": "Bucketed count of tabs last viewed 22+ days ago.",
+        "enum": ["0", "1-5", "6-10", "11-20", "21+"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211654189969294/task/1213762520460888?focus=true

### Description

Adds two daily pixels fired on app foreground for the Tab Bloat investigation:

- `m_app_open_daily_tab_count_idle_ntp` — fires for users whose effective after-inactivity setting is **New Tab**
- `m_app_open_daily_tab_count_idle_last_tab` — fires for users whose effective setting is **Last Used Tab**

Both pixels carry the same bucketed parameters as the existing `m_tab_manager_opened_daily` (`tab_count`, `new_tab_count`, `tab_active_7d`, `tab_inactive_1w/2w/3w`) by reusing `TabSwitcherOpenDailyPixel`. Same buckets → distributions are directly comparable across the two settings, which lets us answer: *does defaulting users to a new tab on idle return cause tabs to accumulate?*

Gated on `IdleReturnEligibilityManaging.isFeatureAvailable()` so we only measure users for whom the setting actually controls app behavior. `DailyPixel.fireDaily` handles once-per-day throttling.

The firing logic lives in a new dedicated `IdleReturnTabCountInstrumentation` type (mirrors the existing `NTPAfterIdleInstrumentation` pattern on the same surface), so it's unit-testable in isolation.

### Testing Steps

1. Foreground the app: confirm exactly one of the two pixels fires, matching the user's after-inactivity setting.
2. Foreground again the same day: confirm the same pixel does **not** re-fire (daily throttling).
3. Toggle the setting in Settings → General → After inactivity, force-quit, foreground next day: confirm the other pixel fires.
4. Disable the feature flag and foreground: confirm neither pixel fires.

Unit tests (`IdleReturnTabCountInstrumentationTests`) cover eligibility gating, pixel selection by setting, parameter content (bucket values + `browsing_mode`), and that throttling is delegated to `DailyPixel`. 7 tests, all passing.

### Impact and Risks

**Low** — adds two new daily pixels with bucketed (not raw) tab metadata. No behavior change to the app; existing `m_tab_manager_opened_daily` is unaffected.

#### What could go wrong?

- **Setting toggled mid-day.** If a user toggles New Tab → Last Used Tab after the first fire, both pixels could fire the same day (each is throttled independently by name). Acceptable for the analysis.
- **Setting-not-yet-explicit users.** `effectiveAfterInactivityOption()` resolves a value even when the user hasn't picked one; this is what controls actual app behavior, so it's the right segmentation.

### Quality Considerations

- Pixel definitions added to `iOS/PixelDefinitions/pixels/definitions/ntp_after_idle.json5` with `expires: 2026-11-20` (investigation-scoped).
- Validated via `npm run validate-pixel-defs` (schema + prettier clean).
- Bucketing reuses `TabSwitcherOpenDailyPixel` verbatim, no duplication.

### Notes to Reviewer

- The existing `m_tab_manager_opened_daily` pixel has no `.json5` definition in the repo — out of scope here, but worth a follow-up to backfill.
- An alternative was proposed in the Asana thread to add new-tab-opened counters; deferred since the snapshot pixels already answer the bloat question directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new analytics pixels and a small foreground hook gated by feature availability, with no change to user-facing behavior or data writes beyond telemetry.
> 
> **Overview**
> Adds two new *daily* pixels (`m_app_open_tab_count_idle_ntp_daily` and `m_app_open_tab_count_idle_last_tab_daily`) fired on app foreground, segmented by the effective after-inactivity setting and carrying bucketed tab-count/staleness parameters plus `browsingMode`.
> 
> Introduces `IdleReturnTabCountInstrumentation` (wired into `MainViewController.onForeground()` and gated by `IdleReturnEligibilityManaging.isFeatureAvailable()`), updates pixel enums/definitions/parameter dictionary, and includes unit tests for gating, pixel selection, and parameter contents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6cd5c2f515494745e04a4a5ae0f006675c74fd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->