### PR TITLE
macOS: Fix wrong drop index moving a bookmark into the overflow menu

### DIFF
--- a/macOS/DuckDuckGo/Bookmarks/Model/BookmarkOutlineViewDataSource.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Model/BookmarkOutlineViewDataSource.swift
@@ -325,11 +325,12 @@ final class BookmarkOutlineViewDataSource: NSObject, BookmarksOutlineViewDataSou
         }
 
         let index = {
-            // for folders-only calculate new real index based on the nearest folder index
+            // for folders-only and clipped-items menus the outline doesn‘t show every sibling,
+            // so translate the visible outline index into a real index in the parent folder.
             if contentMode == .foldersOnly || representedObject is PseudoFolder,
                index > -1,
-               // get folder before the insertion point (or the first one)
-               let nearestObject = (outlineView.child(max(0, index - 1), ofItem: item) as? BookmarkNode)?.representedObject as? BookmarkFolder,
+               // get the entity before the insertion point (or the first one)
+               let nearestObject = (outlineView.child(max(0, index - 1), ofItem: item) as? BookmarkNode)?.representedObject as? BaseBookmarkEntity,
                // get all the children of a new parent folder (take actual bookmark list for the root)
                let siblings = ((representedObject is PseudoFolder ? nil : representedObject) as? BookmarkFolder)?.children ?? bookmarkManager.list?.topLevelEntities {
 

--- a/macOS/DuckDuckGo/Bookmarks/Services/BookmarkStoreMock.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Services/BookmarkStoreMock.swift
@@ -238,9 +238,11 @@ final class BookmarkStoreMock: BookmarkStore, CustomDebugStringConvertible {
 
     var moveObjectUUIDCalled = false
     var capturedObjectUUIDs: [String]?
+    var capturedToIndex: Int?
     func move(objectUUIDs: [String], toIndex: Int?, withinParentFolder: ParentFolderType, completion: @escaping (Error?) -> Void) {
         moveObjectUUIDCalled = true
         capturedObjectUUIDs = objectUUIDs
+        capturedToIndex = toIndex
         capturedParentFolderType = withinParentFolder
         store?.move(objectUUIDs: objectUUIDs, toIndex: toIndex, withinParentFolder: withinParentFolder, completion: completion)
     }

--- a/macOS/UnitTests/Bookmarks/Model/BookmarkOutlineViewDataSourceTests.swift
+++ b/macOS/UnitTests/Bookmarks/Model/BookmarkOutlineViewDataSourceTests.swift
@@ -275,6 +275,59 @@ class BookmarkOutlineViewDataSourceTests: XCTestCase {
         XCTAssertTrue(cell.shouldShowChevron)
     }
 
+    @MainActor
+    func testWhenDroppingBookmarkIntoClippedItemsMenu_AndPrecedingRowIsBookmark_ThenMoveIndexIsRealTopLevelIndex() throws {
+        // GIVEN: top-level entities where bar-visible items come first (folderInBar, bookmarkInBar1, bookmarkInBar2)
+        //        and clippedBookmark1 / clippedBookmark2 are the clipped overflow items.
+        let folderInBar = BookmarkFolder(id: "folder-in-bar", title: "Folder In Bar")
+        let bookmarkInBar1 = Bookmark(id: "bm-bar-1", url: "https://1.example.com", title: "Bar 1", isFavorite: false)
+        let bookmarkInBar2 = Bookmark(id: "bm-bar-2", url: "https://2.example.com", title: "Bar 2", isFavorite: false)
+        let clippedBookmark1 = Bookmark(id: "bm-clipped-1", url: "https://3.example.com", title: "Clipped 1", isFavorite: false)
+        let clippedBookmark2 = Bookmark(id: "bm-clipped-2", url: "https://4.example.com", title: "Clipped 2", isFavorite: false)
+        let topLevel: [BaseBookmarkEntity] = [folderInBar, bookmarkInBar1, bookmarkInBar2, clippedBookmark1, clippedBookmark2]
+
+        // The clipped-items menu uses a synthetic folder whose id matches PseudoFolder.bookmarks.id;
+        // its children are only the clipped entries.
+        let clippedMenuRoot = BookmarkFolder(id: PseudoFolder.bookmarks.id, title: "Clipped", children: [clippedBookmark1, clippedBookmark2])
+
+        let bookmarkStoreMock = BookmarkStoreMock(bookmarks: topLevel)
+        let bookmarkManager = LocalBookmarkManager(bookmarkStore: bookmarkStoreMock, appearancePreferences: .mock)
+        bookmarkManager.loadBookmarks()
+
+        let treeDataSource = BookmarkListTreeControllerDataSource(bookmarkManager: bookmarkManager)
+        let treeController = BookmarkTreeController(dataSource: treeDataSource,
+                                                    sortMode: .manual,
+                                                    rootFolder: clippedMenuRoot,
+                                                    isBookmarksBarMenu: true)
+        let dragDropManager = BookmarkDragDropManager(bookmarkManager: bookmarkManager)
+        let dataSource = BookmarkOutlineViewDataSource(contentMode: .bookmarksMenu,
+                                                      bookmarkManager: bookmarkManager,
+                                                      treeController: treeController,
+                                                      dragDropManager: dragDropManager,
+                                                      sortMode: .manual)
+        let outlineView = BookmarksOutlineView()
+        outlineView.addTableColumn(NSTableColumn(identifier: NSUserInterfaceItemIdentifier("test")))
+        outlineView.dataSource = dataSource
+        outlineView.reloadData()
+
+        let draggedBookmark = Bookmark(id: "dragged-bookmark", url: "https://dragged.example.com", title: "Dragged", isFavorite: false)
+        let pasteboard = NSPasteboard.test()
+        pasteboard.writeObjects([draggedBookmark.pasteboardWriter])
+        let draggingInfo = MockDraggingInfo(draggingPasteboard: pasteboard)
+
+        // WHEN: drop at outline child index 1 — between clippedBookmark1 and clippedBookmark2.
+        // The row preceding the drop point is clippedBookmark1, a Bookmark (not a folder).
+        _ = dataSource.outlineView(outlineView, acceptDrop: draggingInfo, item: nil, childIndex: 1)
+
+        // THEN: the move must target the real top-level index just after clippedBookmark1 (which lives at
+        // index 3 in the top-level list) — i.e. 4. The raw outline-child index 1 would put it back inside
+        // the bookmarks bar, which is the bug we are guarding against.
+        XCTAssertTrue(bookmarkStoreMock.moveObjectUUIDCalled)
+        XCTAssertEqual(bookmarkStoreMock.capturedObjectUUIDs, [draggedBookmark.id])
+        XCTAssertEqual(bookmarkStoreMock.capturedParentFolderType, .root)
+        XCTAssertEqual(bookmarkStoreMock.capturedToIndex, 4)
+    }
+
     // MARK: - Private
 
     @MainActor


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1214230995537229?focus=true
Tech Design URL:
CC:

### Description

Dragging a bookmark from the bookmarks bar onto the overflow popover (`»` clipped-items menu) and dropping it inside the popover put the bookmark in the wrong place — frequently back inside the bar. Moving a bookmark into a *sub-folder* of the overflow worked correctly; only moves that stayed at the same (top) level were broken.

Root cause is in `BookmarkOutlineViewDataSource.outlineView(_:acceptDrop:item:childIndex:)`. The clipped-items menu only shows the overflow subset of top-level entities, so the data source translates the visible outline-row index into a real top-level index by looking at the entity preceding the drop point. The cast used in that translation was `as? BookmarkFolder`, a leftover from when the code only handled folders-only mode (Bookmark Manager). When the preceding outline row was a plain `Bookmark`, the cast failed, the translation was skipped, and the raw outline-child index — which only counts the clipped subset — was sent to `BookmarkManager.move`, landing the bookmark back inside the bar.

The fix widens the cast to `as? BaseBookmarkEntity` so the translation works regardless of whether the preceding overflow row is a folder or a bookmark. `BaseBookmarkEntity` is `Equatable`, so the subsequent `siblings.firstIndex(of:)` lookup still compiles. Folders-only mode is unaffected (folders are still `BaseBookmarkEntity`), and trailing `SpacerNode` / `MenuItemNode` rows still correctly fall through (they aren't `BaseBookmarkEntity`).

### Testing Steps
1. Have a window narrow enough that the bookmarks bar overflows — at least one bookmark should be clipped behind the `»` button.
2. Drag a bookmark from the bookmarks bar onto the `»` button and wait for the overflow popover to open.
3. Drop the bookmark between two bookmarks already in the popover.
4. Expected: the bookmark stays at the dropped position inside the popover.
5. Also try with the dragged source coming from inside the popover itself (reorder within overflow) and dropping into a sub-folder of the overflow (which previously already worked) to confirm no regression.

### Impact and Risks

Low — small, localized change in a single drop-index branch that only widens an `as?` cast. The code path affected is exclusively the bookmarks-bar overflow / folders-only Bookmark Manager tree view; ordinary in-window bookmark reorders use a different branch.

#### What could go wrong?
- Folders-only Bookmark Manager tree view (the original consumer of this branch) could regress. — Mitigated: folders are also `BaseBookmarkEntity`, so behavior is unchanged when every outline row is a folder.
- A trailing `SpacerNode` / "Open all in new tabs" row at the end of the overflow could now be picked up as the nearest neighbor. — Mitigated: neither type is a `BaseBookmarkEntity`, so the cast still fails and the existing fallback path is used.

### Quality Considerations
- New regression test `testWhenDroppingBookmarkIntoClippedItemsMenu_AndPrecedingRowIsBookmark_ThenMoveIndexIsRealTopLevelIndex` covers the exact scenario from the report (preceding overflow row is a `Bookmark`, not a folder). Verified to fail without the fix and pass with it; the surrounding 12 tests in the file still pass.
- `BookmarkStoreMock.move(...)` now captures `toIndex` (previously only `objectUUIDs` and `parentFolderType` were captured) so future drop-index regressions can be asserted directly.
- No privacy/security or performance impact.

### Notes to Reviewer
The widened cast preserves the existing `siblings.firstIndex(of:)` lookup — `BaseBookmarkEntity` is `Equatable` and both `Bookmark` and `BookmarkFolder` inherit from it, so the index math is identical, only the gate on entering the branch changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to drag-and-drop index calculation for bookmarks overflow/clipped-items menus plus a regression test; minimal impact outside this specific UI path.
> 
> **Overview**
> Fixes a drag-and-drop bug where dropping a bookmark into the bookmarks bar overflow (clipped-items) menu could compute the wrong destination index and place the item back in the visible bar.
> 
> The drop-index translation in `BookmarkOutlineViewDataSource.outlineView(_:acceptDrop:item:childIndex:)` now treats the nearest preceding row as any `BaseBookmarkEntity` (not just `BookmarkFolder`), so visible outline indices are correctly mapped to real sibling indices even when the preceding item is a bookmark.
> 
> Adds a unit test covering the overflow-menu reorder scenario and extends `BookmarkStoreMock` to capture `toIndex` so tests can assert the computed move target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 032cacbc794e2327a2b778b5711b4b35bf8f1cd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->