### PR TITLE
[iOS][Tailored Onboarding] Present Final dialog for Duck.ai flow

### DIFF
--- a/iOS/DuckDuckGo/MainViewController+DuckAIExperiment.swift
+++ b/iOS/DuckDuckGo/MainViewController+DuckAIExperiment.swift
@@ -189,10 +189,10 @@ extension MainViewController {
         daxDialogsManager.setSearchMessageSeen()
         experimentDuckAIFireOnboardingFlow.pendingCompletionDialogMessage = nil
         OnboardingResumeCheckpointStore.clearAll(in: onboardingResumeStepStore)
-        ensureExperimentCompletionDialogPresentationPrerequisites()
+        ensureDuckAiCompletionDialogPresentationPrerequisites()
     }
 
-    private func ensureExperimentCompletionDialogPresentationPrerequisites() {
+    func ensureDuckAiCompletionDialogPresentationPrerequisites() {
         // Defer disabling dialogs when a subscription promo is still pending: the NTP's
         // showNextDaxDialogNew will call dialogProvider.dismiss() (equivalent) after the
         // promo is dismissed, so contextual dialogs are disabled at the right time.

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -597,6 +597,7 @@ class MainViewController: UIViewController {
             subscriptionDataReporting: subscriptionDataReporter,
             newTabDialogFactory: newTabDaxDialogFactory,
             newTabDaxDialogManager: daxDialogsManager,
+            onboardingFlowProvider: onboardingManager,
             faviconLoader: faviconLoader,
             faviconsCache: favicons,
             remoteMessagingActionHandler: remoteMessagingActionHandler,
@@ -1648,6 +1649,7 @@ class MainViewController: UIViewController {
                                                   subscriptionDataReporting: subscriptionDataReporter,
                                                   newTabDialogFactory: newTabDaxDialogFactory,
                                                   daxDialogsManager: daxDialogsManager,
+                                                  onboardingFlowProvider: onboardingManager,
                                                   faviconLoader: faviconLoader,
                                                   remoteMessagingActionHandler: remoteMessagingActionHandler,
                                                   remoteMessagingImageLoader: remoteMessagingImageLoader,
@@ -1691,9 +1693,7 @@ class MainViewController: UIViewController {
         // ie remove back/forward and show bookmarks/passwords
         // but also before any other UI updates so that data from the old tab doesn't find its way into the new one
         refreshControls()
-        DispatchQueue.main.async { [weak self] in
-            self?.presentChatPathOnboardingCompletionIfNeeded()
-        }
+        presentContextualOnboardingDialogIfNeeded()
 
         // It's possible for this to be called when in the background of the
         //  switcher, and we only want to show the pixel when it's actually
@@ -2184,6 +2184,17 @@ class MainViewController: UIViewController {
         // hook that fires `refreshControls` self-corrects the toolbar's hidden state without
         // the caller having to remember.
         reconcileToolbarVisibilityForCurrentTab()
+    }
+
+    private func presentContextualOnboardingDialogIfNeeded() {
+        // In Duck.ai tailored the completion dialog is presented explicitly from `MainViewController.onboardingCompleted`.
+        // Without this gate, the flow would attempt to present the completion dialog
+        // twice — once from the post-fire tab switch and again on `onboardingCompleted`.
+        guard onboardingManager.currentOnboardingFlow == .default else { return }
+
+        DispatchQueue.main.async { [weak self] in
+            self?.presentChatPathOnboardingCompletionIfNeeded()
+        }
     }
 
     private func refreshMiddleButton() {
@@ -5903,9 +5914,26 @@ extension MainViewController: OnboardingDelegate {
             return
         }
 
+        // For Duck.ai tailored flow, the NTP completion dialog hosts inside `OmniBarEditingStateViewController`,
+        // which only installs when `shouldUseExperimentalEditingState` is true — itself gated on
+        // `aiChatSettings.isAIChatSearchInputUserSettingsEnabled`.
+        //
+        // IMPORTANT: Contrary to the Duck.ai experiment on the default flow we do not call `ensureDuckAiCompletionDialogPresentationPrerequisites()`.
+        // The full prerequisite also calls `daxDialogsManager.disableContextualDaxDialogs()`, which would set
+        // `isEnabled = false` before the tailored completion dialog is presented, breaking the subscription
+        // chain inside the dialog's `onDismiss` (`nextHomeScreenMessageNew()` would return `nil` from its
+        // `guard isEnabled` and the EOJ → subscription transition would silently drop).
+        if onboardingManager.currentOnboardingFlow == .duckAI && !aiChatSettings.isAIChatSearchInputUserSettingsEnabled {
+            aiChatSettings.enableAIChatSearchInputUserSettings(enable: true)
+        }
+
         controller.modalTransitionStyle = .crossDissolve
-        controller.dismiss(animated: true)
-        newTabPageViewController?.onboardingCompleted()
+        // The Duck.ai tailored flow's NTP completion dialog presents `OmniBarEditingStateViewController`.
+        // Wait for the OnboardingIntroViewController to be dismissed before presenting `OmniBarEditingStateViewController`
+        // otherwise `OmniBarEditingStateViewController` will not be presented while the onboarding is mid-dismissal.
+        controller.dismiss(animated: true) { [weak self] in
+            self?.newTabPageViewController?.onboardingCompleted()
+        }
     }
 
     func markOnboardingSeen() {

--- a/iOS/DuckDuckGo/NewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPageViewController.swift
@@ -46,6 +46,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
 
     private let newTabDialogFactory: any NewTabDaxDialogProviding
     private let daxDialogsManager: NewTabDialogSpecProvider & SubscriptionPromotionCoordinating
+    private let onboardingFlowProvider: OnboardingFlowProviding
 
     private let newTabPageViewModel: NewTabPageViewModel
     private let messagesModel: NewTabPageMessagesModel
@@ -73,6 +74,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
          subscriptionDataReporting: SubscriptionDataReporting? = nil,
          newTabDialogFactory: any NewTabDaxDialogProviding,
          daxDialogsManager: NewTabDialogSpecProvider & SubscriptionPromotionCoordinating,
+         onboardingFlowProvider: OnboardingFlowProviding,
          faviconLoader: FavoritesFaviconLoading,
          remoteMessagingActionHandler: RemoteMessagingActionHandling,
          remoteMessagingImageLoader: RemoteMessagingImageLoading,
@@ -90,6 +92,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
         self.associatedTab = tab
         self.newTabDialogFactory = newTabDialogFactory
         self.daxDialogsManager = daxDialogsManager
+        self.onboardingFlowProvider = onboardingFlowProvider
         self.appSettings = appSettings
         self.appWidthObserver = appWidthObserver
         self.internalUserCommands = internalUserCommands
@@ -157,7 +160,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
 
         associatedTab.viewed = true
 
-        presentNextDaxDialog()
+        presentNextDaxDialog(event: .nextDialogRequested)
 
         if !favoritesModel.isEmpty {
             borderView.insertSelf(into: view)
@@ -258,7 +261,11 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
     private func launchNewSearch() {
         // If we are displaying a Subscription promotion on a new tab, do not activate search
         guard !daxDialogsManager.isShowingSubscriptionPromotion else { return }
-        chromeDelegate?.omniBar.beginEditing(animated: true)
+        // Duck.ai tailored flow surfaces the omnibar in AI-chat mode by default so users land in the
+        // experience the onboarding emphasised. Other flows pass `nil` to let the omnibar fall back
+        // to its default mode (search).
+        let textEntryMode: TextEntryMode? = onboardingFlowProvider.currentOnboardingFlow == .duckAI ? .aiChat : nil
+        chromeDelegate?.omniBar.beginEditing(animated: true, forTextEntryMode: textEntryMode)
     }
 
     func dismiss() {
@@ -275,23 +282,22 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
     }
 
     func showNextDaxDialog() {
-        presentNextDaxDialog()
+        presentNextDaxDialog(event: .nextDialogRequested)
     }
 
     func onboardingCompleted() {
-        presentNextDaxDialog()
-        // Show Keyboard when showing the first Dax tip
-        chromeDelegate?.omniBar.beginEditing(animated: true)
+        presentNextDaxDialog(event: .linearOnboardingCompleted)
     }
 
-    func showDuckAIOnboardingCompletionWithActiveAddressBar(message: String) {
+    func showDuckAIOnboardingCompletionWithActiveAddressBar(message: String, textEntryMode: TextEntryMode? = nil) {
         // Note: the editing-state Dax suppression and NTP `view.alpha = 0` are pre-armed
         // synchronously in `MainViewController.tabDidRequestNewTab` /
         // `presentChatPathOnboardingCompletionIfNeeded` BEFORE this async hop runs, so
         // we don't repeat them here — re-setting the pending flag at this point would
         // leak past the EOJ flow and incorrectly suppress the Dax in the next-created
         // editing state (e.g. after the subscription promo's "No, Thanks").
-        chromeDelegate?.omniBar.beginEditing(animated: true)
+        chromeDelegate?.omniBar.beginEditing(animated: true, forTextEntryMode: textEntryMode)
+
         DispatchQueue.main.async { [weak self] in
             self?.showDuckAIOnboardingCompletionDialog(message: message)
         }
@@ -299,10 +305,48 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
 
     // MARK: - Onboarding
 
-    private func presentNextDaxDialog() {
+    private func presentNextDaxDialog(event: NewTabPageOnboardingDialogEvent) {
         // If linear onboarding is not completed do not attempt to present any Dax dialog.
         guard tutorialSettings.hasSeenOnboarding else { return }
-        // Present Dax dialog if needed.
+
+        switch onboardingFlowProvider.currentOnboardingFlow {
+        case .default:
+            presentDefaultFlowDialog(for: event)
+        case .duckAI:
+            presentDuckAITailoredDialog(for: event)
+        }
+    }
+
+    private func presentDefaultFlowDialog(for event: NewTabPageOnboardingDialogEvent) {
+        switch event {
+        case .nextDialogRequested:
+            showNextDaxDialogNew(dialogProvider: daxDialogsManager, factory: newTabDialogFactory)
+        case .linearOnboardingCompleted:
+            showNextDaxDialogNew(dialogProvider: daxDialogsManager, factory: newTabDialogFactory)
+            // Show keyboard when surfacing the first Dax tip after linear onboarding.
+            chromeDelegate?.omniBar.beginEditing(animated: true)
+        }
+    }
+
+    private func presentDuckAITailoredDialog(for event: NewTabPageOnboardingDialogEvent) {
+        switch event {
+        case .nextDialogRequested:
+            // Tailored flow never enters the regular Dax sequence. Only the subscription promo can
+            // surface here — chained from the completion dialog's onDismiss via `showNextDaxDialog()`
+            // after `setFinalOnboardingDialogSeen()` flips `subscriptionPromotionPending` true.
+            presentSubscriptionPromotionIfPending()
+        case .linearOnboardingCompleted:
+            // Skip branch does not show Dax dialogs. Land the user in a new tab page with the AI-chat-mode address bar prompted.
+            if tutorialSettings.hasSkippedOnboarding {
+                chromeDelegate?.omniBar.beginEditing(animated: true, forTextEntryMode: .aiChat)
+            } else {
+                showDuckAIOnboardingCompletionWithActiveAddressBar(message: UserText.Onboarding.DuckAICPP.Contextual.onboardingEndOfJourneyMessage, textEntryMode: .aiChat)
+            }
+        }
+    }
+
+    private func presentSubscriptionPromotionIfPending() {
+        guard daxDialogsManager.subscriptionPromotionPending else { return }
         showNextDaxDialogNew(dialogProvider: daxDialogsManager, factory: newTabDialogFactory)
     }
 
@@ -529,4 +573,18 @@ extension NewTabPageViewController {
         view.alpha = 1
         delegate?.newTabPageDidDismissDuckAIExperimentCompletion(self)
     }
+}
+
+/// Onboarding-dialog triggers handled by `presentNextDaxDialog(event:)`.
+private enum NewTabPageOnboardingDialogEvent {
+    /// The linear-onboarding modal has just dismissed. Carries side effects that differ per flow:
+    /// - `default` → render next Dax tip + begin editing the omnibar
+    /// - `duckAi` → present the completion dialog (or begin editing in `.aiChat` mode when the user skipped onboarding).
+    case linearOnboardingCompleted
+
+    /// "Compute and surface the next dialog, if any." Fired by:
+    ///  - `viewDidAppear`
+    ///  - `forgetAllWithAnimation`'s post-fire callback
+    ///  - `showNextDaxDialog()` recursively inside the completion-dialog dismiss chain.
+    case nextDialogRequested
 }

--- a/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/NewTabDaxDialogFactory.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/NewTabDaxDialogFactory.swift
@@ -222,7 +222,8 @@ private extension NewTabDaxDialogFactory {
                 proceedAction: { [weak self] in
                     self?.onboardingPixelReporter.measureSubscriptionPromoEngageCTAAction()
                     self?.onboardingSubscriptionPromotionHelper.fireTapPixel()
-                    let urlComponents = self?.onboardingSubscriptionPromotionHelper.redirectURLComponents()
+                    let featurePage: OnboardingSubscriptionPromotionPage? = self?.onboardingFlowProvider.currentOnboardingFlow == .duckAI ? .duckAI : nil
+                    let urlComponents = self?.onboardingSubscriptionPromotionHelper.redirectURLComponents(featurePage: featurePage)
                     NotificationCenter.default.post(
                         name: .settingsDeepLinkNotification,
                         object: SettingsViewModel.SettingsDeepLinkSection.subscriptionFlow(redirectURLComponents: urlComponents),

--- a/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/NewTabDaxDialogFactory.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/NewTabDaxDialogFactory.swift
@@ -54,17 +54,21 @@ final class NewTabDaxDialogFactory: NewTabDaxDialogProviding {
     private var daxDialogsFlowCoordinator: DaxDialogsFlowCoordinator
     private let onboardingPixelReporter: OnboardingPixelReporting
     private let onboardingSubscriptionPromotionHelper: OnboardingSubscriptionPromotionHelping
+    private let onboardingFlowProvider: OnboardingFlowProviding
 
     init(
         delegate: OnboardingNavigationDelegate?,
         daxDialogsFlowCoordinator: DaxDialogsFlowCoordinator,
         onboardingPixelReporter: OnboardingPixelReporting,
-        onboardingSubscriptionPromotionHelper: OnboardingSubscriptionPromotionHelping = OnboardingSubscriptionPromotionHelper()
+        onboardingSubscriptionPromotionHelper: OnboardingSubscriptionPromotionHelping = OnboardingSubscriptionPromotionHelper(),
+        onboardingFlowProvider: OnboardingFlowProviding = OnboardingManager()
+
     ) {
         self.delegate = delegate
         self.daxDialogsFlowCoordinator = daxDialogsFlowCoordinator
         self.onboardingPixelReporter = onboardingPixelReporter
         self.onboardingSubscriptionPromotionHelper = onboardingSubscriptionPromotionHelper
+        self.onboardingFlowProvider = onboardingFlowProvider
     }
 
     @ViewBuilder

--- a/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/Rebranding/RebrandedContextualOnboardingDialogs+EndOfJourney.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/Rebranding/RebrandedContextualOnboardingDialogs+EndOfJourney.swift
@@ -68,13 +68,7 @@ extension OnboardingRebranding {
                 OnboardingRebranding.ContextualDaxDialogContent(
                     orientation: OnboardingRebranding.ContextualDynamicMetrics.dialogOrientation(horizontalAlignment: .center).build(v: vSizeClass, h: hSizeClass),
                     title: AttributedString(title),
-                    message: AttributedString(
-                        message.attributedString(
-                            withPlaceholder: UserText.Onboarding.ContextualOnboarding.onboardingChatIconToken,
-                            replacedByImage: DesignSystemImages.Glyphs.Size16.aiChatOnboarding,
-                            verticalOffset: -2
-                        ) ?? NSAttributedString(string: message)
-                    )
+                    message: AttributedString(OnboardingRichTextMessageRenderer.render(message))
                 ) {
                     Button(action: dismissAction) {
                         Text(cta)

--- a/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/Rebranding/RebrandedNewTabDaxDialogFactory.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/Rebranding/RebrandedNewTabDaxDialogFactory.swift
@@ -22,23 +22,30 @@ import SwiftUI
 import Onboarding
 import Subscription
 import Common
+import PrivacyConfig
 
 final class RebrandedNewTabDaxDialogFactory: NewTabDaxDialogProviding {
     private var delegate: OnboardingNavigationDelegate?
     private var daxDialogsFlowCoordinator: DaxDialogsFlowCoordinator
     private let onboardingPixelReporter: OnboardingPixelReporting
     private let onboardingSubscriptionPromotionHelper: OnboardingSubscriptionPromotionHelping
+    private let onboardingFlowProvider: OnboardingFlowProviding
+    private let featureFlagger: FeatureFlagger
 
     init(
         delegate: OnboardingNavigationDelegate?,
         daxDialogsFlowCoordinator: DaxDialogsFlowCoordinator,
         onboardingPixelReporter: OnboardingPixelReporting,
-        onboardingSubscriptionPromotionHelper: OnboardingSubscriptionPromotionHelping = OnboardingSubscriptionPromotionHelper()
+        onboardingSubscriptionPromotionHelper: OnboardingSubscriptionPromotionHelping = OnboardingSubscriptionPromotionHelper(),
+        onboardingFlowProvider: OnboardingFlowProviding = OnboardingManager(),
+        featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger
     ) {
         self.delegate = delegate
         self.daxDialogsFlowCoordinator = daxDialogsFlowCoordinator
         self.onboardingPixelReporter = onboardingPixelReporter
         self.onboardingSubscriptionPromotionHelper = onboardingSubscriptionPromotionHelper
+        self.onboardingFlowProvider = onboardingFlowProvider
+        self.featureFlagger = featureFlagger
     }
 
     @ViewBuilder
@@ -237,7 +244,16 @@ private extension RebrandedNewTabDaxDialogFactory {
 
         let isChatPath = daxDialogsFlowCoordinator.isChatFirstPath
         let title = UserText.SubscriptionPromotionOnboarding.Promo.title
-        let message = AppDependencyProvider.shared.featureFlagger.isFeatureOn(.paidAIChat) ? createSubscriptionPromoMessage() : createSubscriptionPromoMessageDeprecated()
+        let message = switch onboardingFlowProvider.currentOnboardingFlow {
+        case .default:
+            if featureFlagger.isFeatureOn(.paidAIChat){
+                createSubscriptionPromoMessage()
+            } else {
+                createSubscriptionPromoMessageDeprecated()
+            }
+        case .duckAI:
+            AttributedString(UserText.Onboarding.DuckAICPP.Contextual.subscriptionMessage)
+        }
         let dismissText = UserText.SubscriptionPromotionOnboarding.Buttons.Rebranding.skip
         let manualDismissAction: (() -> Void)? = isChatPath ? nil : { [weak self] in
             self?.onboardingSubscriptionPromotionHelper.fireDismissPixel()

--- a/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/Rebranding/RebrandedNewTabDaxDialogFactory.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/Rebranding/RebrandedNewTabDaxDialogFactory.swift
@@ -269,7 +269,8 @@ private extension RebrandedNewTabDaxDialogFactory {
                 proceedAction: { [weak self] in
                     self?.onboardingPixelReporter.measureSubscriptionPromoEngageCTAAction()
                     self?.onboardingSubscriptionPromotionHelper.fireTapPixel()
-                    let urlComponents = self?.onboardingSubscriptionPromotionHelper.redirectURLComponents()
+                    let featurePage: OnboardingSubscriptionPromotionPage? = self?.onboardingFlowProvider.currentOnboardingFlow == .duckAI ? .duckAI : nil
+                    let urlComponents = self?.onboardingSubscriptionPromotionHelper.redirectURLComponents(featurePage: featurePage)
                     // Pass onDismiss as a post-presentation callback so it fires only after
                     // the settings sheet is fully on screen — keeping the promo dialog visible
                     // until the sheet covers it completely, avoiding an NTP flash.

--- a/iOS/DuckDuckGo/OnboardingHelpers/OnboardingSubscriptionPromotionHelper.swift
+++ b/iOS/DuckDuckGo/OnboardingHelpers/OnboardingSubscriptionPromotionHelper.swift
@@ -23,6 +23,16 @@ import Foundation
 import PrivacyConfig
 import Subscription
 
+/// Landing-page hint appended to the subscription purchase URL so the web flow can deep-link to a specific feature of the Subscription.
+///
+/// Raw values are passed to the subscription web flow as the `featurePage` query parameter via
+/// `SubscriptionURL.purchaseURLComponentsWithOriginAndFeaturePage(origin:featurePage:)`.
+/// Add a new case here whenever a new onboarding flow needs its own dedicated landing page; the raw value
+/// must match what the subscription web flow expects.
+enum OnboardingSubscriptionPromotionPage: String {
+    case duckAI = "duckai"
+}
+
 /// Protocol defining the interface for the Subscription onboarding promotion helper.
 ///
 /// Conforming types provide logic for determining when the Subscription promotion should be shown during onboarding,
@@ -37,8 +47,11 @@ protocol OnboardingSubscriptionPromotionHelping {
 
     /// Provides the URL components for redirecting as part of the onboarding promotion experiment.
     ///
+    /// - Parameter featurePage: Optional landing-page hint appended to the purchase URL as the
+    ///   `featurePage` query parameter. Pass `nil` for the default purchase landing page; pass a
+    ///   case (e.g. `.duckAI`) when an onboarding flow should deep-link into a feature-specific page.
     /// - Returns: URL components for the experiment, or `nil` if not applicable.
-    func redirectURLComponents() -> URLComponents?
+    func redirectURLComponents(featurePage: OnboardingSubscriptionPromotionPage?) -> URLComponents?
 
     /// Fires a pixel when the onboarding promotion is shown to the user.
     func fireImpressionPixel()
@@ -101,9 +114,12 @@ struct OnboardingSubscriptionPromotionHelper: OnboardingSubscriptionPromotionHel
 
     /// Provides the URL components for redirecting as part of the onboarding promotion experiment.
     ///
+    /// - Parameter featurePage: Optional landing-page hint appended to the purchase URL as the
+    ///   `featurePage` query parameter. Pass `nil` for the default purchase landing page; pass a
+    ///   case (e.g. `.duckAI`) when an onboarding flow should deep-link into a feature-specific page.
     /// - Returns: URL components for the experiment, or `nil` if not applicable.
-    func redirectURLComponents() -> URLComponents? {
-        SubscriptionURL.purchaseURLComponentsWithOrigin(SubscriptionFunnelOrigin.onboarding.rawValue)
+    func redirectURLComponents(featurePage: OnboardingSubscriptionPromotionPage?) -> URLComponents? {
+        SubscriptionURL.purchaseURLComponentsWithOriginAndFeaturePage(origin: SubscriptionFunnelOrigin.onboarding.rawValue, featurePage: featurePage?.rawValue)
     }
 
     /// Fires a pixel when the onboarding promotion is shown to the user.

--- a/iOS/DuckDuckGo/SuggestionTrayViewController.swift
+++ b/iOS/DuckDuckGo/SuggestionTrayViewController.swift
@@ -29,6 +29,7 @@ import UIComponents
 import RemoteMessaging
 import AIChat
 import Subscription
+import Onboarding
 
 class SuggestionTrayViewController: UIViewController {
     
@@ -126,6 +127,7 @@ class SuggestionTrayViewController: UIViewController {
         let subscriptionDataReporting: SubscriptionDataReporting?
         let newTabDialogFactory: NewTabDaxDialogsProvider
         let newTabDaxDialogManager: NewTabDialogSpecProvider & SubscriptionPromotionCoordinating
+        let onboardingFlowProvider: OnboardingFlowProviding
         let faviconLoader: FavoritesFaviconLoading
         let faviconsCache: FavoritesFaviconCaching
         let remoteMessagingActionHandler: RemoteMessagingActionHandling
@@ -374,6 +376,7 @@ class SuggestionTrayViewController: UIViewController {
             subscriptionDataReporting: dependencies.subscriptionDataReporting,
             newTabDialogFactory: dependencies.newTabDialogFactory,
             daxDialogsManager: dependencies.newTabDaxDialogManager,
+            onboardingFlowProvider: dependencies.onboardingFlowProvider,
             faviconLoader: dependencies.faviconLoader,
             remoteMessagingActionHandler: dependencies.remoteMessagingActionHandler,
             remoteMessagingImageLoader: dependencies.remoteMessagingImageLoader,

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -2514,6 +2514,18 @@ public struct UserText {
                     comment: "The title of the dialog to show the privacy features that DuckDuckGo offers"
                 )
             }
+
+            public enum Contextual {
+                static let onboardingEndOfJourneyMessage = NotLocalizedString(
+                    "onboarding.duckai.contextual.end-of-journey.message",
+                    value: "Start a private AI chat with Duck.ai or toggle to Search for protected browsing.\n\nYou can use Duck.ai from anywhere you see the chat icon [[chat_icon]]",
+                    comment: "Message of the last screen of the onboarding to the browser app for the Duck.ai flow.")
+                static let subscriptionMessage = NotLocalizedString(
+                    "onboarding.duckai.contextual.subscription.message",
+                    value: "We also offer a paid subscription featuring advanced AI models with higher chat limits from GPT, Claude, and Llama, a secure VPN, and more.",
+                    comment: "Body text of the subscription promo for Duck.ai flow."
+                )
+            }
         }
 
         enum ContextualOnboarding {

--- a/iOS/DuckDuckGoTests/DaxDialogTests.swift
+++ b/iOS/DuckDuckGoTests/DaxDialogTests.swift
@@ -1154,7 +1154,7 @@ final class MockOnboardingSubscriptionPromotionHelper: OnboardingSubscriptionPro
         shouldDisplayValue
     }
 
-    func redirectURLComponents() -> URLComponents? {
+    func redirectURLComponents(featurePage: DuckDuckGo.OnboardingSubscriptionPromotionPage?) -> URLComponents? {
         return nil
     }
 

--- a/iOS/DuckDuckGoTests/Onboarding/OnboardingSubscriptionPromotionHelpingTests.swift
+++ b/iOS/DuckDuckGoTests/Onboarding/OnboardingSubscriptionPromotionHelpingTests.swift
@@ -179,13 +179,39 @@ final class OnboardingSubscriptionPromotionHelpingTests: XCTestCase {
 
     func testRedirectURLAlwaysUsesOnboardingOrigin() {
         // When
-        let components = sut.redirectURLComponents()
+        let components = sut.redirectURLComponents(featurePage: nil)
 
         // Then
         XCTAssertNotNil(components)
         XCTAssertEqual(
             components?.queryItems?.first(where: { $0.name == "origin" })?.value,
             SubscriptionFunnelOrigin.onboarding.rawValue
+        )
+    }
+
+    func testRedirectURLWithNilFeaturePageOmitsFeaturePageQueryItem() throws {
+        // Given
+        let featurePage: OnboardingSubscriptionPromotionPage? = nil
+
+        // When
+        let components = try XCTUnwrap(sut.redirectURLComponents(featurePage: featurePage))
+
+        // Then
+        // Passing nil keeps the URL at the default purchase landing page — no `featurePage` query item should be appended.
+        XCTAssertNil(components.queryItems?.first(where: { $0.name == "featurePage" }))
+    }
+
+    func testRedirectURLWithDuckAIFeaturePageIncludesFeaturePageQueryItemWithRawValue() throws {
+        // Given
+        let featurePage = OnboardingSubscriptionPromotionPage.duckAI
+
+        // When
+        let components = try XCTUnwrap(sut.redirectURLComponents(featurePage: featurePage))
+
+        // Then
+        XCTAssertEqual(
+            components.queryItems?.first(where: { $0.name == "featurePage" })?.value,
+            "duckai"
         )
     }
 }

--- a/iOS/SharedStateTests/NewTabPageControllerDaxDialogTests.swift
+++ b/iOS/SharedStateTests/NewTabPageControllerDaxDialogTests.swift
@@ -28,6 +28,7 @@ import BrowserServicesKit
 import RemoteMessaging
 import RemoteMessagingTestsUtils
 import SubscriptionTestingUtilities
+import Onboarding
 
 @testable import Configuration
 
@@ -42,12 +43,16 @@ final class NewTabPageControllerDaxDialogTests: XCTestCase {
     var variantManager: CapturingVariantManager!
     var dialogFactory: CapturingNewTabDaxDialogProvider!
     var specProvider: MockNewTabDialogSpecProvider!
+    var flowProvider: MockOnboardingFlowProvider!
+    var tutorialSettings: MockTutorialSettings!
     var hvc: NewTabPageViewController!
 
     override func setUpWithError() throws {
         variantManager = CapturingVariantManager()
         dialogFactory = CapturingNewTabDaxDialogProvider()
         specProvider = MockNewTabDialogSpecProvider()
+        flowProvider = MockOnboardingFlowProvider()
+        tutorialSettings = MockTutorialSettings(hasSeenOnboarding: true)
 
         let homePageConfiguration = HomePageConfiguration(remoteMessagingStore: MockRemoteMessagingStore(), subscriptionDataReporter: MockSubscriptionDataReporter(), isStillOnboarding: { true })
         hvc = NewTabPageViewController(
@@ -58,6 +63,7 @@ final class NewTabPageControllerDaxDialogTests: XCTestCase {
             homePageMessagesConfiguration: homePageConfiguration,
             newTabDialogFactory: dialogFactory,
             daxDialogsManager: specProvider,
+            onboardingFlowProvider: flowProvider,
             faviconLoader: EmptyFaviconLoading(),
             remoteMessagingActionHandler: MockRemoteMessagingActionHandler(),
             remoteMessagingImageLoader: MockRemoteMessagingImageLoader(),
@@ -65,7 +71,7 @@ final class NewTabPageControllerDaxDialogTests: XCTestCase {
             faviconsCache: Favicons(),
             subscriptionManager: SubscriptionManagerMock(),
             internalUserCommands: MockURLBasedDebugCommands(),
-            tutorialSettings: MockTutorialSettings(hasSeenOnboarding: true),
+            tutorialSettings: tutorialSettings,
         )
 
         let window = UIWindow(frame: UIScreen.main.bounds)
@@ -87,6 +93,8 @@ final class NewTabPageControllerDaxDialogTests: XCTestCase {
         variantManager = nil
         dialogFactory = nil
         specProvider = nil
+        flowProvider = nil
+        tutorialSettings = nil
         hvc = nil
     }
 
@@ -126,6 +134,63 @@ final class NewTabPageControllerDaxDialogTests: XCTestCase {
 
         // THEN
         XCTAssertTrue(specProvider.nextHomeScreenMessageNewCalled)
+    }
+
+    // MARK: - Duck.ai tailored flow router branches
+
+    func testWhenDuckAITailoredFlow_AndOnboardingCompleted_AndNotSkipped_ThenDoesNotPeekRegularSpec() {
+        // GIVEN
+        flowProvider.currentOnboardingFlow = .duckAI
+        tutorialSettings.hasSkippedOnboarding = false
+
+        // WHEN
+        hvc.onboardingCompleted()
+
+        // THEN
+        // Tailored completion routes to `showDuckAIOnboardingCompletionWithActiveAddressBar`, not
+        // through the regular Dax sequence — confirms the tailored branch is taken, not default.
+        XCTAssertFalse(specProvider.nextHomeScreenMessageNewCalled)
+    }
+
+    func testWhenDuckAITailoredFlow_AndOnboardingCompleted_AndSkipped_ThenDoesNotPeekRegularSpec() {
+        // GIVEN
+        flowProvider.currentOnboardingFlow = .duckAI
+        tutorialSettings.hasSkippedOnboarding = true
+
+        // WHEN
+        hvc.onboardingCompleted()
+
+        // THEN
+        // Skip branch only calls `omniBar.beginEditing` for AI chat; no Dax dialog should be peeked.
+        XCTAssertFalse(specProvider.nextHomeScreenMessageNewCalled)
+    }
+
+    func testWhenDuckAITailoredFlow_AndDialogRequested_AndSubscriptionPromoPending_ThenPeeksSpecToRenderPromo() {
+        // GIVEN
+        flowProvider.currentOnboardingFlow = .duckAI
+        specProvider.subscriptionPromotionPending = true
+
+        // WHEN
+        hvc.showNextDaxDialog()
+
+        // THEN
+        // Tailored router only proceeds to showNextDaxDialogNew (which peeks the spec) when the
+        // subscription promo is pending — confirming the gate is read and the promo path is taken.
+        XCTAssertTrue(specProvider.nextHomeScreenMessageNewCalled)
+    }
+
+    func testWhenDuckAITailoredFlow_AndDialogRequested_AndSubscriptionPromoNotPending_ThenDoesNotPeekSpec() {
+        // GIVEN
+        flowProvider.currentOnboardingFlow = .duckAI
+        specProvider.subscriptionPromotionPending = false
+
+        // WHEN
+        hvc.showNextDaxDialog()
+
+        // THEN
+        // Tailored router must NOT enter the regular Dax sequence when there is no promo — otherwise
+        // a stray `.initial`/`.subsequent` dialog could leak into the Duck.ai onboarding completion UX.
+        XCTAssertFalse(specProvider.nextHomeScreenMessageNewCalled)
     }
 
     private func randomDialogType() -> DaxDialogs.HomeScreenSpec {
@@ -190,6 +255,10 @@ class MockNewTabDialogSpecProvider: NewTabDialogSpecProvider, SubscriptionPromot
     func dismiss() {
         dismissCalled = true
     }
+}
+
+final class MockOnboardingFlowProvider: OnboardingFlowProviding {
+    var currentOnboardingFlow: OnboardingFlowType = .default
 }
 
 struct MockVariant: Variant {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214080667430308
Tech Design URL:
CC:

### Description

Adds the Duck.ai-tailored onboarding completion dialog and routes the subscription promo, reusing the existing infrastructure made for the Duck.ai onboarding experiment.

### Key Changes:
- New Duck.ai copy for the end-of-journey completion message and subscription promo (`UserText.Onboarding.DuckAICPP.Contextual`).
- `NewTabPageViewController` now branches on `OnboardingFlowProviding.currentOnboardingFlow`. A new `NewTabPageOnboardingDialogEvent` enum splits the previously-overloaded `presentNextDaxDialog()` into two intents: `linearOnboardingCompleted` (post-modal) and `nextDialogRequested` (everything else). The tailored flow skips the regular Dax sequence and only surfaces the subscription promo when `subscriptionPromotionPending` is set.
- On the tailored flow, the NTP launches the omnibar in `.aiChat` mode (both for the completion CTA and the skip branch) so users land in the Duck.ai experience the onboarding emphasised.
- Subscription promo redirect now accepts an `OnboardingSubscriptionPromotionPage?`; the Duck.ai flow passes `.duckAI`, appending `featurePage=duckai` to the purchase URL. Default flow passes `nil` (unchanged behaviour).
- `MainViewController.onboardingCompleted` waits for `OnboardingIntroViewController` dismissal before calling `newTabPageViewController?.onboardingCompleted()` so the editing-state controller can install. It also enables `aiChatSearchInputUserSettings` for the tailored flow (skipping the broader prerequisite to avoid disabling contextual dialogs mid-chain).
- `presentContextualOnboardingDialogIfNeeded()` gates the post-fire completion dialog to the default flow, preventing the tailored flow from presenting twice.
- `RebrandedContextualOnboardingDialogs+EndOfJourney` now uses `OnboardingRichTextMessageRenderer` for the chat-icon placeholder rendering.

### Testing Steps
**Scenario 1 - Duck.ai flow**
1. In `FeatureFlag.swift` set `Config(source: .remoteReleasable(.feature(.iOSBrowserConfig)))` for `.onboardingDuckAIFlow` 
2. In `CustomProductPage+Onboarding` -> `extension AppStoreCustomProductPageEvaluator` add `let url = URL(string: "ddgCPP://duckAI”)` at line 33 to simulate launching the app from Duck.ai CPP.
3. Fresh install the app and complete the linear onboarding (don't skip).
4. Verify the NTP shows the Duck.ai completion dialog with the chat icon inline, address bar opens in AI-chat mode.
5. Tap the completion dialog's CTA → subscription promo appears with the Duck.ai-specific body copy. 
6. Tap **Get DuckDuckGo Pro** → confirm the opened URL contains `featurePage=duckai`.
7. Repeat step 3-5, this time tapping **Skip** during linear onboarding: verify NTP shows no Dax dialog and the omnibar opens directly in AI-chat mode.

**Scenario 2- Default flow**
1. Remove code added at step 1&2 of Scenario 1.
2. Fresh install the app.
3. Run the default onboarding flow end-to-end and confirm the regular Dax sequence, completion dialog, and promo URL (no `featurePage`) are unchanged.

**Scenario 3- Duck.ai experiment**
1. Smoke test experiment it works as expected.

### Impact and Risks
**Medium**: Touches the onboarding completion handoff and NTP dialog routing for both default and Duck.ai flows.

#### What could go wrong?
- **Default flow regression on the new event router.** Mitigation: `presentDefaultFlowDialog` preserves the previous behaviour (`showNextDaxDialogNew` + `beginEditing` on completion); existing tests still pass.
- **Tailored completion dialog presented twice.** The `presentContextualOnboardingDialogIfNeeded()` gate ensures the post-fire path no-ops in the tailored flow; the explicit `onboardingCompleted` callback is the single entry point.
- **`OmniBarEditingStateViewController` failing to install** because `aiChatSearchInputUserSettings` is off. Mitigated by enabling the setting just-in-time in `onboardingCompleted`.
- **Subscription promo `featurePage` query item drift.** New unit tests pin both the present and absent cases.

### Quality Considerations
- Edge case: user skips linear onboarding in the tailored flow → covered by `MockTutorialSettings.hasSkippedOnboarding` branch and unit test.
- No new pixels or privacy surface; subscription URL change only adds a query parameter visible to the purchase web flow.

### Notes to Reviewer
- This PR does not include **UTI** fixes.
- The two long comments in `MainViewController.onboardingCompleted` and `NewTabPageViewController.showDuckAIOnboardingCompletionWithActiveAddressBar` document non-obvious sequencing constraints; please flag if they're unclear.
- `ensureExperimentCompletionDialogPresentationPrerequisites` was renamed to `ensureDuckAiCompletionDialogPresentationPrerequisites` and made internal so the tailored flow can reference it (it does not call it, see the comment for why).
- Pixel updates will happen in a subsequent PR.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes onboarding completion timing, NTP Dax routing, and subscription purchase URLs for both default and Duck.ai flows; regressions could break dialog chains or default onboarding.
> 
> **Overview**
> Adds the **Duck.ai tailored** post-linear onboarding path on the new tab page: after the intro modal dismisses, users see Duck.ai-specific end-of-journey copy (with inline chat icon via `OnboardingRichTextMessageRenderer`) and the omnibar opens in **`.aiChat`** mode; skip onboarding lands in AI chat without Dax tips.
> 
> `NewTabPageViewController` now routes NTP dialogs through `OnboardingFlowProviding` and a `NewTabPageOnboardingDialogEvent` split (`linearOnboardingCompleted` vs `nextDialogRequested`). The tailored flow **skips** the regular Dax sequence and only chains the **subscription promo** when `subscriptionPromotionPending` is set, with Duck.ai promo copy and purchase URLs that append `featurePage=duckai`.
> 
> `MainViewController` defers NTP handoff until onboarding intro dismissal, enables AI search input settings for tailored completion without calling `disableContextualDaxDialogs` (to preserve promo → EOJ chaining), and gates post-tab-switch completion to the **default** flow so tailored completion is not shown twice.
> 
> Default onboarding behavior is preserved behind the same event router; tests cover tailored branches and subscription URL query parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5ccfd54476d6931dda93ca1cfd5616cb6b1aca0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->