### PR TITLE
[iOS][Tailored Onboarding] UI fixes and Pixels implementation

### DIFF
--- a/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
@@ -157,6 +157,7 @@ public enum OnboardingSharedPixelEvent: PixelKitEvent, Equatable {
     case welcome(EngagementEvent)
     case skipOnboarding(EngagementEvent) // iOS only
     case setDefault(EngagementEvent)
+    case aiComparison(EngagementEvent) // iOS only (AI Protections Activated!)
     case addToDock(EngagementEvent)
     case appIconColor(AppIconColorEvent) // iOS only
     case addressBarPosition(AddressBarPositionEvent) // iOS only
@@ -289,6 +290,7 @@ private extension OnboardingSharedPixelEvent {
         case .welcome: return "welcome"
         case .skipOnboarding: return "skip-onboarding"
         case .setDefault: return "set-default"
+        case .aiComparison: return "ai-comparison"
         case .addToDock: return "add-to-dock"
         case .appIconColor: return "app-icon-color"
         case .addressBarPosition: return "address-bar-position"
@@ -318,6 +320,7 @@ private extension OnboardingSharedPixelEvent {
         switch self {
         case .welcome(let event),
                 .setDefault(let event),
+                .aiComparison(let event),
                 .addToDock(let event),
                 .importData(let event),
                 .duckPlayer(let event),
@@ -385,6 +388,7 @@ private extension OnboardingSharedPixelEvent {
         switch self {
         case .welcome(let event),
                 .setDefault(let event),
+                .aiComparison(let event),
                 .addToDock(let event),
                 .importData(let event),
                 .duckPlayer(let event),

--- a/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
@@ -290,7 +290,7 @@ private extension OnboardingSharedPixelEvent {
         case .welcome: return "welcome"
         case .skipOnboarding: return "skip-onboarding"
         case .setDefault: return "set-default"
-        case .aiComparison: return "ai-comparison"
+        case .aiComparison: return "ai-intro"
         case .addToDock: return "add-to-dock"
         case .appIconColor: return "app-icon-color"
         case .addressBarPosition: return "address-bar-position"

--- a/SharedPackages/Onboarding/Sources/Onboarding/Rebranding/Shared/Theme/OnboardingTheme+LinearFlow.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/Rebranding/Shared/Theme/OnboardingTheme+LinearFlow.swift
@@ -35,7 +35,6 @@ public extension OnboardingTheme {
             lhs.contentInnerSpacing == rhs.contentInnerSpacing &&
             lhs.buttonSpacing == rhs.buttonSpacing &&
             lhs.bubbleMaxWidth == rhs.bubbleMaxWidth &&
-            lhs.bubbleTailOffset == rhs.bubbleTailOffset &&
             lhs.topMarginRatio == rhs.topMarginRatio &&
             lhs.minTopMargin == rhs.minTopMargin &&
             lhs.maxTopMargin == rhs.maxTopMargin &&
@@ -56,8 +55,6 @@ public extension OnboardingTheme {
         public let actionsSpacing: CGFloat
         /// Maximum width for linear onboarding bubbles.
         public let bubbleMaxWidth: CGFloat
-        /// Horizontal offset for the bubble tail position (0.0–1.0).
-        public let bubbleTailOffset: CGFloat
         /// Ratio used to compute the top margin from the available height.
         public let topMarginRatio: CGFloat
         /// Minimum top margin.
@@ -84,7 +81,6 @@ public extension OnboardingTheme {
             contentInnerSpacing: CGFloat,
             buttonSpacing: CGFloat,
             bubbleMaxWidth: CGFloat,
-            bubbleTailOffset: CGFloat,
             topMarginRatio: CGFloat,
             minTopMargin: CGFloat,
             maxTopMargin: CGFloat,
@@ -99,7 +95,6 @@ public extension OnboardingTheme {
             self.contentInnerSpacing = contentInnerSpacing
             self.buttonSpacing = buttonSpacing
             self.bubbleMaxWidth = bubbleMaxWidth
-            self.bubbleTailOffset = bubbleTailOffset
             self.topMarginRatio = topMarginRatio
             self.minTopMargin = minTopMargin
             self.maxTopMargin = maxTopMargin
@@ -116,7 +111,6 @@ public extension OnboardingTheme {
             contentInnerSpacing: CGFloat,
             buttonSpacing: CGFloat,
             bubbleMaxWidth: CGFloat,
-            bubbleTailOffset: CGFloat,
             topMarginRatio: CGFloat,
             minTopMargin: CGFloat,
             maxTopMargin: CGFloat,
@@ -130,7 +124,6 @@ public extension OnboardingTheme {
             self.contentInnerSpacing = contentInnerSpacing
             self.buttonSpacing = buttonSpacing
             self.bubbleMaxWidth = bubbleMaxWidth
-            self.bubbleTailOffset = bubbleTailOffset
             self.topMarginRatio = topMarginRatio
             self.minTopMargin = minTopMargin
             self.maxTopMargin = maxTopMargin

--- a/SharedPackages/Onboarding/Sources/Onboarding/Rebranding/iOS/Theme/OnboardingTheme-iOS.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/Rebranding/iOS/Theme/OnboardingTheme-iOS.swift
@@ -91,7 +91,6 @@ public extension OnboardingTheme {
             contentInnerSpacing: 20,
             buttonSpacing: 12,
             bubbleMaxWidth: 360,
-            bubbleTailOffset: 0.8,
             topMarginRatio: 0.18,
             minTopMargin: 16,
             maxTopMargin: 16,

--- a/SharedPackages/Onboarding/Sources/Onboarding/Rebranding/macOS/Theme/OnboardingTheme-macOS.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/Rebranding/macOS/Theme/OnboardingTheme-macOS.swift
@@ -160,7 +160,6 @@ public extension OnboardingTheme {
                 contentInnerSpacing: 20,
                 buttonSpacing: 12,
                 bubbleMaxWidth: 340,
-                bubbleTailOffset: 0.2,
                 topMarginRatio: 0.18,
                 minTopMargin: 32,
                 maxTopMargin: 32,

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -730,8 +730,8 @@
 		83E2D2B3253CC16B005605F5 /* httpsMobileV2FalsePositives.json in Resources */ = {isa = PBXBuildFile; fileRef = 83E2D2B0253CC16B005605F5 /* httpsMobileV2FalsePositives.json */; };
 		83E2D2B4253CC16B005605F5 /* httpsMobileV2BloomSpec.json in Resources */ = {isa = PBXBuildFile; fileRef = 83E2D2B1253CC16B005605F5 /* httpsMobileV2BloomSpec.json */; };
 		83EDCC411F86B89C005CDFCD /* StatisticsLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83EDCC3F1F86B895005CDFCD /* StatisticsLoaderTests.swift */; };
-		8453AA902F7D32950062888E /* DuckAIQueryExperimentMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8453AA8F2F7D32950062888E /* DuckAIQueryExperimentMode.swift */; };
 		847A387E2FC4673E00F97D54 /* ExperimentDuckAIFireOnboardingLockSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847A387D2FC4673E00F97D54 /* ExperimentDuckAIFireOnboardingLockSyncTests.swift */; };
+		8453AA902F7D32950062888E /* DuckAIQueryMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8453AA8F2F7D32950062888E /* DuckAIQueryMode.swift */; };
 		84AD2FE12F87E95200151B7F /* OnboardingResumeStepStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84AD2FE02F87E95200151B7F /* OnboardingResumeStepStore.swift */; };
 		84C529A12F7D67E200B075D8 /* MainViewController+DuckAIExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C529A02F7D67E200B075D8 /* MainViewController+DuckAIExperiment.swift */; };
 		84D6780A2D830E9F0030BC82 /* SuggestionJsonScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D678092D830E9F0030BC82 /* SuggestionJsonScenarioTests.swift */; };
@@ -3287,8 +3287,8 @@
 		83E2D2B0253CC16B005605F5 /* httpsMobileV2FalsePositives.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = httpsMobileV2FalsePositives.json; sourceTree = "<group>"; };
 		83E2D2B1253CC16B005605F5 /* httpsMobileV2BloomSpec.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = httpsMobileV2BloomSpec.json; sourceTree = "<group>"; };
 		83EDCC3F1F86B895005CDFCD /* StatisticsLoaderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatisticsLoaderTests.swift; sourceTree = "<group>"; };
-		8453AA8F2F7D32950062888E /* DuckAIQueryExperimentMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAIQueryExperimentMode.swift; sourceTree = "<group>"; };
 		847A387D2FC4673E00F97D54 /* ExperimentDuckAIFireOnboardingLockSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentDuckAIFireOnboardingLockSyncTests.swift; sourceTree = "<group>"; };
+		8453AA8F2F7D32950062888E /* DuckAIQueryMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAIQueryMode.swift; sourceTree = "<group>"; };
 		84AD2FE02F87E95200151B7F /* OnboardingResumeStepStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingResumeStepStore.swift; sourceTree = "<group>"; };
 		84C529A02F7D67E200B075D8 /* MainViewController+DuckAIExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainViewController+DuckAIExperiment.swift"; sourceTree = "<group>"; };
 		84D678092D830E9F0030BC82 /* SuggestionJsonScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionJsonScenarioTests.swift; sourceTree = "<group>"; };
@@ -8209,7 +8209,7 @@
 			children = (
 				9F9C1F322F2889CA005E0D4F /* Components */,
 				9F0369F52F231EA000A00DCA /* Rebranding */,
-				8453AA8F2F7D32950062888E /* DuckAIQueryExperimentMode.swift */,
+				8453AA8F2F7D32950062888E /* DuckAIQueryMode.swift */,
 				9FE08BDB2C2A88FA001D5EBC /* OnboardingIntroViewController.swift */,
 				9FD3DB3C2FB6EA4F00A7C56E /* OnboardingIntroContext.swift */,
 				9FD3DB3A2FB6E82000A7C56E /* OnboardingIntroFactory.swift */,
@@ -13552,7 +13552,7 @@
 				6FA343922C3D3C3B00470677 /* FavoriteIconView.swift in Sources */,
 				4B8E798D2F2C191900FDFC65 /* VPNConnectionError.swift in Sources */,
 				9F4CC5272C4E230C006A96EB /* PrivacyIconContextualOnboardingAnimator.swift in Sources */,
-				8453AA902F7D32950062888E /* DuckAIQueryExperimentMode.swift in Sources */,
+				8453AA902F7D32950062888E /* DuckAIQueryMode.swift in Sources */,
 				CBC88EE52C8097B500F0F8C5 /* URLCredentialCreator.swift in Sources */,
 				8505836C219F424500ED4EDB /* TextFieldWithInsets.swift in Sources */,
 				CBD4F13F279EBFAF00B20FD7 /* HomeMessageViewModel.swift in Sources */,

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1489,7 +1489,6 @@
 		9F4CC5172C48B8D4006A96EB /* TabViewControllerDaxDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC5162C48B8D4006A96EB /* TabViewControllerDaxDialogTests.swift */; };
 		9F4CC5272C4E230C006A96EB /* PrivacyIconContextualOnboardingAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC5262C4E230C006A96EB /* PrivacyIconContextualOnboardingAnimator.swift */; };
 		9F4D2B202FFC000100A1B2C3 /* OnboardingView+DuckAIExperimentSearchContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4D2B1F2FFC000100A1B2C3 /* OnboardingView+DuckAIExperimentSearchContent.swift */; };
-		9F4D2B212FFC000100A1B2C3 /* DuckAIQueryExperimentMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4D2B202FFC000200A1B2C4 /* DuckAIQueryExperimentMode.swift */; };
 		9F5179D82D54598800E40B40 /* DaxDialogsOnboardingMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5179D72D54598800E40B40 /* DaxDialogsOnboardingMigrator.swift */; };
 		9F5179DA2D545D4300E40B40 /* DaxDialogsOnboardingMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5179D92D545D4300E40B40 /* DaxDialogsOnboardingMigratorTests.swift */; };
 		9F5412772E3998B000DBF008 /* SetDefaultBrowserTestSupport in Frameworks */ = {isa = PBXBuildFile; productRef = 9F5412762E3998B000DBF008 /* SetDefaultBrowserTestSupport */; };
@@ -8215,7 +8214,6 @@
 				9FD3DB3A2FB6E82000A7C56E /* OnboardingIntroFactory.swift */,
 				9FB0271C2C293619009EA190 /* OnboardingIntroViewModel.swift */,
 				9FC0E3D32FAAED9000B11ECD /* OnboardingIntroContentProvider.swift */,
-				9F4D2B202FFC000200A1B2C4 /* DuckAIQueryExperimentMode.swift */,
 				C1A1B9CC2F6BC7A400B12345 /* OnboardingRestorePromptHandler.swift */,
 				9FB0271A2C2927D0009EA190 /* OnboardingView.swift */,
 				9F7CFF7E2C8A94F70012833E /* OnboardingView+AddressBarPositionContent.swift */,
@@ -12671,7 +12669,6 @@
 				8586A10D24CBA7070049720E /* FindInPageActivity.swift in Sources */,
 				9F0B19B42EA5E4FA001FA867 /* DefaultBrowserModalPromptProvider.swift in Sources */,
 				9FB0271D2C293619009EA190 /* OnboardingIntroViewModel.swift in Sources */,
-				9F4D2B212FFC000100A1B2C3 /* DuckAIQueryExperimentMode.swift in Sources */,
 				C1A1B9CD2F6BC7A400B12345 /* OnboardingRestorePromptHandler.swift in Sources */,
 				C1F9D9172EEF8BFB00E35AD5 /* AIChatContextualSheetCoordinator.swift in Sources */,
 				1E1626072968413B0004127F /* ViewExtension.swift in Sources */,

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1843,7 +1843,10 @@ class MainViewController: UIViewController {
         if isExperimentDuckAIFireFlow {
             // Keep this path scoped to the onboarding experiment: single "Delete This Chat" action only,
             // whether the contextual dialog has already appeared or is still pending.
-            contextualOnboardingPixelReporter.measureDuckAIExperimentFireButtonCTAAction()
+            // Fire experiment pixel only if flow is default.
+            if onboardingManager.currentOnboardingFlow == .default {
+                contextualOnboardingPixelReporter.measureDuckAIExperimentFireButtonCTAAction()
+            }
             presentExperimentDuckAIFireConfirmation()
             performCancel()
             return

--- a/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/ContextualDaxDialogsFactory.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/ContextualDaxDialogsFactory.swift
@@ -97,12 +97,13 @@ final class DefaultContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
                     onSizeUpdate: onSizeUpdate
                 )
             )
-        case .fire:
+        case .fire(let fireVariant):
             rootView = AnyView(
                 fireDialog(
                     title: spec.title,
                     message: spec.message,
                     delegate: delegate,
+                    fireVariant: fireVariant,
                     pixelName: spec.pixelName,
                     allowsManualDismiss: spec.allowsManualDismiss
                 )
@@ -273,6 +274,7 @@ final class DefaultContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
         title: String?,
         message: String,
         delegate: ContextualOnboardingDelegate,
+        fireVariant: DaxDialogs.BrowsingSpec.SpecType.FireVariant,
         pixelName: Pixel.Event,
         allowsManualDismiss: Bool
     ) -> some View {
@@ -283,8 +285,16 @@ final class DefaultContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
 
         return OnboardingFireDialog(title: title, message: message, onManualDismiss: onManualDismiss)
             .onFirstAppear { [weak self] in
-                self?.contextualOnboardingPixelReporter.measureScreenImpression(event: pixelName)
-                self?.contextualOnboardingPixelReporter.measureScreenImpression(.fireButton(.shown))
+                guard let self else { return }
+                switch fireVariant {
+                case .standard:
+                    self.contextualOnboardingPixelReporter.measureScreenImpression(event: pixelName)
+                case .duckAIOnboarding:
+                    if self.onboardingManager.currentOnboardingFlow == .default {
+                        self.contextualOnboardingPixelReporter.measureDuckAIExperimentFireDialogImpression()
+                    }
+                }
+                self.contextualOnboardingPixelReporter.measureScreenImpression(.fireButton(.shown))
             }
     }
 

--- a/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/NewTabDaxDialogFactory.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/NewTabDaxDialogFactory.swift
@@ -205,7 +205,9 @@ final class NewTabDaxDialogFactory: NewTabDaxDialogProviding {
             .onboardingContextualBackgroundStyle(background: .illustratedGradient)
             .onFirstAppear { [weak self] in
                 self?.daxDialogsFlowCoordinator.setFinalOnboardingDialogSeen()
-                self?.onboardingPixelReporter.measureDuckAIExperimentFinalDialogImpression()
+                if self?.onboardingFlowProvider.currentOnboardingFlow == .default {
+                    self?.onboardingPixelReporter.measureDuckAIExperimentFinalDialogImpression()
+                }
             }
         )
     }

--- a/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/Rebranding/RebrandedContextualDaxDialogFactory.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/Rebranding/RebrandedContextualDaxDialogFactory.swift
@@ -283,8 +283,16 @@ private extension RebrandedContextualDaxDialogFactory {
         }
         .applyAnimatedContextualOnboardingBackground(backgroundType: backgroundType)
         .onFirstAppear { [weak self] in
-            self?.contextualOnboardingPixelReporter.measureScreenImpression(event: pixelName)
-            self?.contextualOnboardingPixelReporter.measureScreenImpression(.fireButton(.shown))
+            guard let self else { return }
+            switch fireVariant {
+            case .standard:
+                self.contextualOnboardingPixelReporter.measureScreenImpression(event: pixelName)
+            case .duckAIOnboarding:
+                if self.onboardingManager.currentOnboardingFlow == .default {
+                    self.contextualOnboardingPixelReporter.measureDuckAIExperimentFireDialogImpression()
+                }
+            }
+            self.contextualOnboardingPixelReporter.measureScreenImpression(.fireButton(.shown))
         }
     }
 

--- a/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/Rebranding/RebrandedNewTabDaxDialogFactory.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/Rebranding/RebrandedNewTabDaxDialogFactory.swift
@@ -102,7 +102,9 @@ extension RebrandedNewTabDaxDialogFactory {
 
     func createExperimentCompletionDialog(message: String, onDismiss: @escaping () -> Void) -> AnyView {
         let onDismiss = { [weak self] in
-            self?.onboardingPixelReporter.measureDuckAIExperimentFinalDialogCTAAction()
+            if self?.onboardingFlowProvider.currentOnboardingFlow == .default {
+                self?.onboardingPixelReporter.measureDuckAIExperimentFinalDialogCTAAction()
+            }
             onDismiss()
         }
 
@@ -124,7 +126,10 @@ extension RebrandedNewTabDaxDialogFactory {
             .applyNewTabOnboardingBackground(backgroundType: .endOfJourneyNTPChat)
             .onFirstAppear { [weak self] in
                 self?.daxDialogsFlowCoordinator.setFinalOnboardingDialogSeen()
-                self?.onboardingPixelReporter.measureDuckAIExperimentFinalDialogImpression()
+                if self?.onboardingFlowProvider.currentOnboardingFlow == .default {
+                    self?.onboardingPixelReporter.measureDuckAIExperimentFinalDialogImpression()
+                }
+                self?.onboardingPixelReporter.measureScreenImpression(.end(.shown))
             }
         )
     }

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/DuckAIQueryMode.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/DuckAIQueryMode.swift
@@ -1,5 +1,5 @@
 //
-//  DuckAIQueryExperimentMode.swift
+//  DuckAIQueryMode.swift
 //  DuckDuckGo
 //
 //  Copyright © 2026 DuckDuckGo. All rights reserved.
@@ -18,7 +18,7 @@
 //
 
 /// The search mode selected by the user in the Duck.ai query experiment onboarding step.
-enum DuckAIQueryExperimentMode {
+enum DuckAIQueryMode {
     case search
     case duckAI
 }

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
@@ -267,11 +267,13 @@ final class OnboardingIntroViewModel: ObservableObject {
     }
 
     func selectDuckAIQueryExperimentAction(selection: DuckAIQueryMode) {
-        switch selection {
-        case .duckAI:
-            pixelReporter.measureDuckAIQueryExperimentChooseAIChat()
-        case .search:
-            pixelReporter.measureDuckAIQueryExperimentChooseSearchOnly()
+        if resolveDuckAIQueryExperimentCohortID() != nil {
+            switch selection {
+            case .duckAI:
+                pixelReporter.measureDuckAIQueryExperimentChooseAIChat()
+            case .search:
+                pixelReporter.measureDuckAIQueryExperimentChooseSearchOnly()
+            }
         }
         makeNextViewState()
     }

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
@@ -537,7 +537,14 @@ private extension OnboardingIntroViewModel {
         case .chooseSearchExperienceDialog:
             pixelReporter.measureSearchExperienceSelectionImpression()
         case .duckAIQueryExperimentDialog:
-            pixelReporter.measureDuckAIQueryExperimentSelectionImpression()
+            // Both the experiment and the Duck.ai tailored flow reach this view state. Only the
+            // experiment cohort should fire experiment-flavoured pixels; tailored-flow users get
+            // the plain shared toggle-shown pixel.
+            if resolveDuckAIQueryExperimentCohortID() != nil {
+                pixelReporter.measureDuckAIQueryExperimentSelectionImpression()
+            } else {
+                pixelReporter.measureDuckAIQuerySelectionImpression()
+            }
         }
     }
 

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
@@ -228,6 +228,7 @@ final class OnboardingIntroViewModel: ObservableObject {
     }
 
     func aiComparisonAction() {
+        pixelReporter.measureAiComparisonCTAAction()
         makeNextViewState()
     }
 
@@ -519,7 +520,7 @@ private extension OnboardingIntroViewModel {
         case .browsersComparisonDialog:
             pixelReporter.measureBrowserComparisonImpression()
         case .aiComparisonDialog:
-            break
+            pixelReporter.measureAiComparisonImpression()
         case .addToDockPromoDialog:
             pixelReporter.measureAddToDockPromoImpression()
         case .chooseAppIconDialog:

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
@@ -266,7 +266,7 @@ final class OnboardingIntroViewModel: ObservableObject {
         makeNextViewState()
     }
 
-    func selectDuckAIQueryExperimentAction(selection: DuckAIQueryExperimentMode) {
+    func selectDuckAIQueryExperimentAction(selection: DuckAIQueryMode) {
         switch selection {
         case .duckAI:
             pixelReporter.measureDuckAIQueryExperimentChooseAIChat()
@@ -288,11 +288,18 @@ final class OnboardingIntroViewModel: ObservableObject {
         onSearchFromOnboarding?(query)
     }
 
-    func measureDuckAIQueryExperimentQuerySubmission(selection: DuckAIQueryExperimentMode, promptSource: DuckAIQueryExperimentPromptSource) {
-        pixelReporter.measureDuckAIQueryExperimentQuerySubmission(
-            selection: selection,
-            promptSource: promptSource
-        )
+    func measureDuckAIQuerySubmission(selection: DuckAIQueryMode, promptSource: DuckAIQueryPromptSource) {
+        if resolveDuckAIQueryExperimentCohortID() != nil {
+            pixelReporter.measureDuckAIQueryExperimentQuerySubmission(
+                selection: selection,
+                promptSource: promptSource
+            )
+        } else {
+            pixelReporter.measureDuckAIQuerySubmission(
+                selection: selection,
+                promptSource: promptSource
+            )
+        }
     }
 
     func restoreSyncAccountAction() {
@@ -402,7 +409,7 @@ private extension OnboardingIntroViewModel {
             case .duckAIQuerySelection:
                 let isDuckAiTailoredFlow = onboardingManager.currentOnboardingFlow == .duckAI
                 // Duck.ai Tailored flow shows only Duck.ai options while experiment shows toggle with "Search" and "Ask AI"
-                let duckAIQueryMode: DuckAIQueryExperimentMode = isDuckAiTailoredFlow ? .duckAI : duckAIQueryExperimentDefaultMode
+                let duckAIQueryMode: DuckAIQueryMode = isDuckAiTailoredFlow ? .duckAI : duckAIQueryExperimentDefaultMode
                 // Duck.ai Tailored flow shows step counter while experiment does not.
                 let progressStep: OnboardingView.ViewState.Intro.StepInfo = isDuckAiTailoredFlow ? stepInfo() : .hidden
                 return .onboarding(
@@ -545,7 +552,7 @@ private extension OnboardingIntroViewModel {
         introSteps.insert(.duckAIQuerySelection, at: currentStepIndex + 1)
     }
 
-    var duckAIQueryExperimentDefaultMode: DuckAIQueryExperimentMode {
+    var duckAIQueryExperimentDefaultMode: DuckAIQueryMode {
         switch resolveDuckAIQueryExperimentCohortID() {
         case .treatmentB:
             .search

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingView+DuckAIExperimentSearchContent.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingView+DuckAIExperimentSearchContent.swift
@@ -84,10 +84,10 @@ extension OnboardingView {
         @Environment(\.onboardingTheme) private var onboardingTheme
         @Environment(\.accessibilityReduceMotion) private var reduceMotion
         private let content: OnboardingDuckAIQueryContent
-        private let onModeConfirmed: (DuckAIQueryExperimentMode) -> Void
+        private let onModeConfirmed: (DuckAIQueryMode) -> Void
         private let openAIChatAction: (String?, Bool) -> Void
         private let openSearchAction: (String) -> Void
-        private let measureQuerySubmissionAction: (DuckAIQueryExperimentMode, DuckAIQueryExperimentPromptSource) -> Void
+        private let measureQuerySubmissionAction: (DuckAIQueryMode, DuckAIQueryPromptSource) -> Void
         private let startExitTransitionAction: () -> Void
         private let visualStyle: VisualStyle
         private var animateTitle: Binding<Bool>
@@ -96,7 +96,7 @@ extension OnboardingView {
 
         // MARK: State
         @State private var query = ""
-        @State private var selectedMode: DuckAIQueryExperimentMode
+        @State private var selectedMode: DuckAIQueryMode
         @State private var isInputFocused = false
         @State private var visibleSuggestionCount = 0
         @State private var isTransitioningOut = false
@@ -130,13 +130,13 @@ extension OnboardingView {
                 aiPlaceholder: UserText.Onboarding.DuckAIQueryExperiment.aiPlaceholder,
                 isToggleVisible: true
             ),
-            defaultMode: DuckAIQueryExperimentMode,
+            defaultMode: DuckAIQueryMode,
             visualStyle: VisualStyle = .legacy,
             animateTitle: Binding<Bool> = .constant(false),
-            onModeConfirmed: @escaping (DuckAIQueryExperimentMode) -> Void,
+            onModeConfirmed: @escaping (DuckAIQueryMode) -> Void,
             openAIChatAction: @escaping (String?, Bool) -> Void,
             openSearchAction: @escaping (String) -> Void,
-            measureQuerySubmissionAction: @escaping (DuckAIQueryExperimentMode, DuckAIQueryExperimentPromptSource) -> Void,
+            measureQuerySubmissionAction: @escaping (DuckAIQueryMode, DuckAIQueryPromptSource) -> Void,
             startExitTransitionAction: @escaping () -> Void
         ) {
             self.content = content
@@ -192,7 +192,7 @@ extension OnboardingView {
                             .frame(width: Metrics.pickerWidth, height: Metrics.pickerContainerHeight)
                         // Drive content mode (Search vs Duck.ai) from user picker selection.
                             .onChange(of: pickerViewModel.selectedItem) { [reduceMotion] selectedItem in
-                                let newMode: DuckAIQueryExperimentMode = selectedItem == Self.pickerItems[1] ? .duckAI : .search
+                                let newMode: DuckAIQueryMode = selectedItem == Self.pickerItems[1] ? .duckAI : .search
                                 if reduceMotion {
                                     selectedMode = newMode
                                 } else {
@@ -416,7 +416,7 @@ extension OnboardingView {
             !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
 
-        private func openSelectedExperience(prompt: String?, autoSend: Bool, promptSource: DuckAIQueryExperimentPromptSource) {
+        private func openSelectedExperience(prompt: String?, autoSend: Bool, promptSource: DuckAIQueryPromptSource) {
             if autoSend {
                 measureQuerySubmissionAction(selectedMode, promptSource)
             }
@@ -743,7 +743,7 @@ private struct OnboardingSuggestionChips: View {
     let isDuckAIMode: Bool
     let visibleCount: Int
     let visualStyle: OnboardingView.DuckAIExperimentSearchContent.VisualStyle
-    let onItemTap: (ContextualOnboardingListItem, DuckAIQueryExperimentPromptSource) -> Void
+    let onItemTap: (ContextualOnboardingListItem, DuckAIQueryPromptSource) -> Void
 
     // MARK: Computed Properties
     private var visibleItems: [ContextualOnboardingListItem] {
@@ -774,7 +774,7 @@ private struct OnboardingSuggestionChips: View {
         return OnboardingSuggestionsChipsMetrics.interChipSpacingLegacy
     }
 
-    private func promptSource(for index: Int) -> DuckAIQueryExperimentPromptSource {
+    private func promptSource(for index: Int) -> DuckAIQueryPromptSource {
         switch index {
         case 0: return .option1
         case 1: return .option2

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingView.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingView.swift
@@ -259,14 +259,14 @@ struct OnboardingView: View {
         .onboardingDaxDialogStyle()
     }
 
-    private func experimentSearchExperienceSelectionView(defaultMode: DuckAIQueryExperimentMode) -> some View {
+    private func experimentSearchExperienceSelectionView(defaultMode: DuckAIQueryMode) -> some View {
         DuckAIExperimentSearchContent(
             defaultMode: defaultMode,
             animateTitle: $model.introState.animateIntroText,
             onModeConfirmed: model.selectDuckAIQueryExperimentAction(selection:),
             openAIChatAction: model.openAIChatFromOnboarding,
             openSearchAction: model.searchFromOnboarding,
-            measureQuerySubmissionAction: model.measureDuckAIQueryExperimentQuerySubmission,
+            measureQuerySubmissionAction: model.measureDuckAIQuerySubmission,
             startExitTransitionAction: {
                 beginExperimentExitTransition()
             }
@@ -353,7 +353,7 @@ extension OnboardingView.ViewState.Intro {
         case chooseAppIconDialog(content: OnboardingAppIconColorContent)
         case chooseAddressBarPositionDialog(content: OnboardingAddressBarPositionContent)
         case chooseSearchExperienceDialog(content: OnboardingSearchExperienceContent)
-        case duckAIQueryExperimentDialog(content: OnboardingDuckAIQueryContent, defaultMode: DuckAIQueryExperimentMode)
+        case duckAIQueryExperimentDialog(content: OnboardingDuckAIQueryContent, defaultMode: DuckAIQueryMode)
     }
 
     struct StepInfo: Equatable {
@@ -374,7 +374,7 @@ private extension OnboardingView.ViewState.Intro.IntroType {
         }
     }
 
-    var duckAIQueryExperimentDefaultMode: DuckAIQueryExperimentMode? {
+    var duckAIQueryExperimentDefaultMode: DuckAIQueryMode? {
         if case .duckAIQueryExperimentDialog(_, let mode) = self {
             return mode
         }

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView+AIComparisonContent.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView+AIComparisonContent.swift
@@ -25,27 +25,41 @@ extension OnboardingRebranding.OnboardingView {
 
     struct AIComparisonContent: View {
         @Environment(\.onboardingTheme) private var onboardingTheme
+        @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-        @Binding var showContent: Bool
+        @Binding var isVisible: Bool
+        @State private var shouldStartTyping = false
+        @State private var showContent = false
+
         private let content: OnboardingAIComparisonContent
         private let continueAction: () -> Void
 
         init(
             content: OnboardingAIComparisonContent,
-            showContent: Binding<Bool>,
+            isVisible: Binding<Bool>,
             continueAction: @escaping () -> Void,
         ) {
             self.content = content
-            self._showContent = showContent
+            self._isVisible = isVisible
             self.continueAction = continueAction
         }
 
         var body: some View {
             VStack(spacing: onboardingTheme.linearOnboardingMetrics.contentInnerSpacing) {
-                Text(content.title)
-                    .foregroundColor(onboardingTheme.colorPalette.textPrimary)
-                    .font(onboardingTheme.typography.title)
-                    .multilineTextAlignment(.center)
+                TypingText(
+                    content.title,
+                    startAnimating: $shouldStartTyping,
+                    onTypingFinished: { [reduceMotion] in
+                        if reduceMotion {
+                            showContent = true
+                        } else {
+                            withAnimation { showContent = true }
+                        }
+                    }
+                )
+                .foregroundColor(onboardingTheme.colorPalette.textPrimary)
+                .font(onboardingTheme.typography.title)
+                .multilineTextAlignment(.center)
 
                 VStack(spacing: onboardingTheme.linearOnboardingMetrics.contentInnerSpacing) {
                     RebrandedOnboardingComparisonTableView(
@@ -58,14 +72,16 @@ extension OnboardingRebranding.OnboardingView {
                         availableFeatureAnimation: .animated(startAnimation: showContent)
                     )
 
-                    VStack(spacing: onboardingTheme.linearOnboardingMetrics.buttonSpacing) {
-                        Button(action: continueAction) {
-                            Text(content.primaryCTA)
-                        }
-                        .buttonStyle(onboardingTheme.primaryButtonStyle.style)
+                    Button(action: continueAction) {
+                        Text(content.primaryCTA)
                     }
+                    .buttonStyle(onboardingTheme.primaryButtonStyle.style)
+
                 }
+                .opacity(showContent ? 1 : 0)
+                .animation(reduceMotion ? nil : .easeIn(duration: 0.25), value: showContent)
             }
+            .onBubbleVisibilityChanged(isVisible: $isVisible, shouldStartTyping: $shouldStartTyping, showContent: $showContent)
         }
 
     }

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView.swift
@@ -582,7 +582,7 @@ extension OnboardingRebranding {
         }
 
         /// Hide → action → show sequence prevents cross-fading between steps.
-        private func experimentSearchExperienceSelectionView(content: OnboardingDuckAIQueryContent, defaultMode: DuckAIQueryExperimentMode) -> some View {
+        private func experimentSearchExperienceSelectionView(content: OnboardingDuckAIQueryContent, defaultMode: DuckAIQueryMode) -> some View {
             LegacyOnboardingView.DuckAIExperimentSearchContent(
                 content: content,
                 defaultMode: defaultMode,
@@ -590,7 +590,7 @@ extension OnboardingRebranding {
                 onModeConfirmed: model.selectDuckAIQueryExperimentAction(selection:),
                 openAIChatAction: model.openAIChatFromOnboarding,
                 openSearchAction: model.searchFromOnboarding,
-                measureQuerySubmissionAction: model.measureDuckAIQueryExperimentQuerySubmission,
+                measureQuerySubmissionAction: model.measureDuckAIQuerySubmission,
                 startExitTransitionAction: {
                     beginExperimentExitTransition()
                 }
@@ -756,7 +756,7 @@ private extension OnboardingRebranding.OnboardingView.BubbleBackedDialogConfigur
     init(tailOffset: CGFloat, tailDirection: OnboardingRebranding.OnboardingView.BubbleTail.Direction, additionalTopMargin: CGFloat = 0, isVisible: Bool) {
         self.init(tail: .init(offset: tailOffset, direction: tailDirection), additionalTopMargin: additionalTopMargin, isVisible: isVisible)
     }
-    
+
 }
 
 // MARK: - Bubble Visibility Typing Modifier

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView.swift
@@ -195,20 +195,6 @@ extension OnboardingRebranding {
             self.model = model
         }
 
-        /// Direction the bubble's tail arrow points toward.
-        private enum BubbleTailDirection {
-            case leading
-            case trailing
-        }
-
-        /// Per-step layout configuration for the bubble dialog (tail position, spacing, visibility).
-        private struct BubbleBackedDialogConfiguration {
-            let tailOffset: CGFloat
-            let tailDirection: BubbleTailDirection
-            var additionalTopMargin: CGFloat = 0
-            let isVisible: Bool
-        }
-
         var body: some View {
             ZStack(alignment: .topTrailing) {
                 switch model.state {
@@ -460,12 +446,13 @@ extension OnboardingRebranding {
         ) -> some View {
             // Leading tails are mirrored (theme 0.8 → 0.2 from left); trailing tails use the
             // offset directly. Hidden on compact viewports / AX text sizes.
-            let tail: OnboardingBubbleView<Content>.TailPosition? = OnboardingBubbleAnimationMetrics.shouldHideBubbleTail(for: dynamicTypeSize) ? nil : {
-                switch configuration.tailDirection {
-                case .leading: return .bottom(offset: 1 - configuration.tailOffset, direction: .leading)
-                case .trailing: return .bottom(offset: configuration.tailOffset, direction: .trailing)
+            let tail: OnboardingBubbleView<Content>.TailPosition? = configuration.tail.flatMap { tail in
+                guard !OnboardingBubbleAnimationMetrics.shouldHideBubbleTail(for: dynamicTypeSize) else { return nil }
+                switch tail.direction {
+                case .leading: return .bottom(offset: 1 - tail.offset, direction: .leading)
+                case .trailing: return .bottom(offset: tail.offset, direction: .trailing)
                 }
-            }()
+            }
             OnboardingBubbleView.withStepProgressIndicator(
                 tailPosition: tail,
                 currentStep: stepInfo.currentStep,
@@ -495,57 +482,6 @@ extension OnboardingRebranding {
                 searchExperienceSelectionView(content: content)
             case let .duckAIQueryExperimentDialog(content, defaultMode):
                 experimentSearchExperienceSelectionView(content: content, defaultMode: defaultMode)
-            }
-        }
-
-        private func bubbleBackedDialogConfiguration(for type: ViewState.Intro.IntroType) -> BubbleBackedDialogConfiguration {
-            let tailLeadingOffset = 0.7
-            let tailTrailingOffset = 0.2
-            switch type {
-            case .startOnboardingDialog:
-                return BubbleBackedDialogConfiguration(
-                    tailOffset: tailLeadingOffset,
-                    tailDirection: .leading,
-                    additionalTopMargin: BubbleBackedDialogMetrics.introAdditionalTopMargin,
-                    isVisible: model.introState.showIntroViewContent
-                )
-            case .browsersComparisonDialog, .aiComparisonDialog:
-                return BubbleBackedDialogConfiguration(
-                    tailOffset: tailTrailingOffset,
-                    tailDirection: .leading,
-                    isVisible: true
-                )
-            case .addToDockPromoDialog:
-                return BubbleBackedDialogConfiguration(
-                    tailOffset: tailLeadingOffset,
-                    tailDirection: .leading,
-                    isVisible: true
-                )
-            case .chooseAppIconDialog:
-                return BubbleBackedDialogConfiguration(
-                    tailOffset: tailLeadingOffset,
-                    tailDirection: .trailing,
-                    isVisible: true
-                )
-            case .chooseAddressBarPositionDialog:
-                return BubbleBackedDialogConfiguration(
-                    tailOffset: tailTrailingOffset,
-                    tailDirection: .leading,
-                    isVisible: true
-                )
-            case .chooseSearchExperienceDialog:
-                return BubbleBackedDialogConfiguration(
-                    tailOffset: tailLeadingOffset,
-                    tailDirection: .leading,
-                    isVisible: true
-                )
-            case .duckAIQueryExperimentDialog:
-                return BubbleBackedDialogConfiguration(
-                    tailOffset: onboardingTheme.linearOnboardingMetrics.bubbleTailOffset,
-                    tailDirection: .leading,
-                    additionalTopMargin: BubbleBackedDialogMetrics.searchExperienceAdditionalTopMargin,
-                    isVisible: true
-                )
             }
         }
 
@@ -739,6 +675,88 @@ extension OnboardingRebranding {
 
     }
 
+}
+
+// MARK: - OnboardingView + Configuration
+
+private extension OnboardingRebranding.OnboardingView {
+
+    struct BubbleTail {
+        /// Direction the bubble's tail arrow points toward.
+        enum Direction {
+            case leading
+            case trailing
+        }
+
+        let offset: CGFloat
+        let direction: BubbleTail.Direction
+    }
+
+    /// Per-step layout configuration for the bubble dialog (tail position, spacing, visibility).
+    struct BubbleBackedDialogConfiguration {
+        let tail: BubbleTail?
+        var additionalTopMargin: CGFloat = 0
+        let isVisible: Bool
+    }
+
+    func bubbleBackedDialogConfiguration(for type: ViewState.Intro.IntroType) -> BubbleBackedDialogConfiguration {
+        let tailLeadingOffset = 0.7
+        let tailTrailingOffset = 0.2
+        switch type {
+        case .startOnboardingDialog:
+            return BubbleBackedDialogConfiguration(
+                tailOffset: tailLeadingOffset,
+                tailDirection: .leading,
+                additionalTopMargin: BubbleBackedDialogMetrics.introAdditionalTopMargin,
+                isVisible: model.introState.showIntroViewContent
+            )
+        case .browsersComparisonDialog, .aiComparisonDialog:
+            return BubbleBackedDialogConfiguration(
+                tailOffset: tailTrailingOffset,
+                tailDirection: .leading,
+                isVisible: true
+            )
+        case .addToDockPromoDialog:
+            return BubbleBackedDialogConfiguration(
+                tailOffset: tailLeadingOffset,
+                tailDirection: .leading,
+                isVisible: true
+            )
+        case .chooseAppIconDialog:
+            return BubbleBackedDialogConfiguration(
+                tailOffset: tailLeadingOffset,
+                tailDirection: .trailing,
+                isVisible: true
+            )
+        case .chooseAddressBarPositionDialog:
+            return BubbleBackedDialogConfiguration(
+                tailOffset: tailTrailingOffset,
+                tailDirection: .leading,
+                isVisible: true
+            )
+        case .chooseSearchExperienceDialog:
+            return BubbleBackedDialogConfiguration(
+                tailOffset: tailLeadingOffset,
+                tailDirection: .leading,
+                isVisible: true
+            )
+        case .duckAIQueryExperimentDialog:
+            return BubbleBackedDialogConfiguration(
+                tail: nil,
+                additionalTopMargin: BubbleBackedDialogMetrics.searchExperienceAdditionalTopMargin,
+                isVisible: true
+            )
+        }
+    }
+    
+}
+
+private extension OnboardingRebranding.OnboardingView.BubbleBackedDialogConfiguration {
+
+    init(tailOffset: CGFloat, tailDirection: OnboardingRebranding.OnboardingView.BubbleTail.Direction, additionalTopMargin: CGFloat = 0, isVisible: Bool) {
+        self.init(tail: .init(offset: tailOffset, direction: tailDirection), additionalTopMargin: additionalTopMargin, isVisible: isVisible)
+    }
+    
 }
 
 // MARK: - Bubble Visibility Typing Modifier

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView.swift
@@ -398,7 +398,7 @@ extension OnboardingRebranding {
         private func aiComparisonView(content: OnboardingAIComparisonContent) -> some View {
             AIComparisonContent(
                 content: content,
-                showContent: $showBubbleContent,
+                isVisible: $showBubbleContent,
                 continueAction: {
                     animateContentTransition {
                         model.aiComparisonAction()

--- a/iOS/DuckDuckGo/OnboardingFlow/Pixels/OnboardingPixelReporter.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/Pixels/OnboardingPixelReporter.swift
@@ -130,6 +130,7 @@ protocol OnboardingDaxDialogsReporting {
     func measureTrackersDialogDismissButtonTapped()
     func measureFireDialogDismissButtonTapped()
     func measureDuckAIExperimentFireButtonCTAAction()
+    func measureDuckAIExperimentFireDialogImpression()
     func measureDuckAIExperimentFinalDialogImpression()
     func measureDuckAIExperimentFinalDialogCTAAction()
     func measureEndOfJourneyDialogNewTabDismissButtonTapped()
@@ -519,9 +520,6 @@ extension OnboardingPixelReporter: OnboardingDaxDialogsReporting {
 
     func measureScreenImpression(event: Pixel.Event) {
         fire(event: event, unique: true)
-        if case .onboardingDuckAIExperimentFireDialogShownUnique = event {
-            fireExperimentScreenImpressionPixel(value: .fireDialog)
-        }
     }
 
     func measureScreenImpression(_ event: OnboardingSharedPixelEvent) {
@@ -638,6 +636,11 @@ extension OnboardingPixelReporter: OnboardingDaxDialogsReporting {
     func measureDuckAIExperimentFireButtonCTAAction() {
         fire(event: .onboardingDuckAIExperimentFireButtonCTAPressed, unique: false)
         fireExperimentCTAPressedPixel(value: .fireButtonPressed)
+    }
+
+    func measureDuckAIExperimentFireDialogImpression() {
+        fire(event: .onboardingDuckAIExperimentFireDialogShownUnique, unique: true)
+        fireExperimentScreenImpressionPixel(value: .fireDialog)
     }
 
     func measureDuckAIExperimentFinalDialogImpression() {

--- a/iOS/DuckDuckGo/OnboardingFlow/Pixels/OnboardingPixelReporter.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/Pixels/OnboardingPixelReporter.swift
@@ -85,6 +85,8 @@ protocol OnboardingIntroPixelReporting: OnboardingIntroImpressionReporting {
     func measureAutoRestoreOnboardingSkipCTAAction()
     func measureBrowserComparisonImpression()
     func measureChooseBrowserCTAAction()
+    func measureAiComparisonImpression()
+    func measureAiComparisonCTAAction()
     func measureChooseAppIconImpression()
     func measureChooseAppIconColor(_ color: AppIcon)
     func measureAddressBarPositionSelectionImpression()
@@ -318,6 +320,18 @@ extension OnboardingPixelReporter: OnboardingIntroPixelReporting {
     func measureChooseBrowserCTAAction() {
         fire(event: .onboardingIntroChooseBrowserCTAPressed, unique: false)
         sharedPixelHandler.fire(.setDefault(.clicked(.engage)),
+                                source: sharedPixelsStorage.onboardingSource,
+                                flow: sharedPixelsStorage.onboardingFlow)
+    }
+
+    func measureAiComparisonImpression() {
+        sharedPixelHandler.fire(.aiComparison(.shown),
+                                source: sharedPixelsStorage.onboardingSource,
+                                flow: sharedPixelsStorage.onboardingFlow)
+    }
+
+    func measureAiComparisonCTAAction() {
+        sharedPixelHandler.fire(.aiComparison(.clicked(.engage)),
                                 source: sharedPixelsStorage.onboardingSource,
                                 flow: sharedPixelsStorage.onboardingFlow)
     }

--- a/iOS/DuckDuckGo/OnboardingFlow/Pixels/OnboardingPixelReporter.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/Pixels/OnboardingPixelReporter.swift
@@ -97,7 +97,9 @@ protocol OnboardingIntroPixelReporting: OnboardingIntroImpressionReporting {
     func measureDuckAIQueryExperimentSelectionImpression()
     func measureDuckAIQueryExperimentChooseSearchOnly()
     func measureDuckAIQueryExperimentChooseAIChat()
-    func measureDuckAIQueryExperimentQuerySubmission(selection: DuckAIQueryExperimentMode, promptSource: DuckAIQueryExperimentPromptSource)
+    func measureDuckAIQueryExperimentQuerySubmission(selection: DuckAIQueryMode, promptSource: DuckAIQueryPromptSource)
+    func measureDuckAIQuerySelectionImpression()
+    func measureDuckAIQuerySubmission(selection: DuckAIQueryMode, promptSource: DuckAIQueryPromptSource)
     func measureSkipOnboardingScreenImpression()
     func measureSetDefaultBrowserSkipped()
 }
@@ -197,7 +199,7 @@ final class OnboardingPixelReporter {
 
 }
 
-enum DuckAIQueryExperimentPromptSource: String {
+enum DuckAIQueryPromptSource: String {
     case custom
     case option1
     case option2
@@ -397,9 +399,7 @@ extension OnboardingPixelReporter: OnboardingIntroPixelReporting {
     func measureDuckAIQueryExperimentSelectionImpression() {
         fire(event: .onboardingIntroDuckAIExperimentToggleImpressionUnique, unique: true)
         fireExperimentScreenImpressionPixel(value: .toggleScreen)
-        sharedPixelHandler.fire(.searchChatToggle(.shown),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+        measureDuckAIQuerySelectionImpression()
     }
 
     func measureDuckAIQueryExperimentChooseSearchOnly() {
@@ -412,7 +412,7 @@ extension OnboardingPixelReporter: OnboardingIntroPixelReporting {
         fireExperimentCTAPressedPixel(value: .continuePressedAI)
     }
 
-    func measureDuckAIQueryExperimentQuerySubmission(selection: DuckAIQueryExperimentMode, promptSource: DuckAIQueryExperimentPromptSource) {
+    func measureDuckAIQueryExperimentQuerySubmission(selection: DuckAIQueryMode, promptSource: DuckAIQueryPromptSource) {
         let metricName: DuckAIQueryExperimentMetric.Name
         switch selection {
         case .duckAI:
@@ -429,28 +429,34 @@ extension OnboardingPixelReporter: OnboardingIntroPixelReporting {
                 value: promptSource.rawValue
             )
         }
+        sharedPixelsStorage.onboardingVariant = OnboardingPixelParameter.Variant(selection)
+        measureDuckAIQuerySubmission(selection: selection, promptSource: promptSource)
+    }
 
+    func measureDuckAIQuerySelectionImpression() {
+        sharedPixelHandler.fire(.searchChatToggle(.shown),
+                                source: sharedPixelsStorage.onboardingSource,
+                                flow: sharedPixelsStorage.onboardingFlow)
+    }
+
+    func measureDuckAIQuerySubmission(selection: DuckAIQueryMode, promptSource: DuckAIQueryPromptSource) {
         switch (promptSource, selection) {
         case (.custom, .duckAI):
             sharedPixelHandler.fire(.searchChatToggle(.clicked(.customChat)),
                                     source: sharedPixelsStorage.onboardingSource,
                                     flow: sharedPixelsStorage.onboardingFlow)
-            sharedPixelsStorage.onboardingVariant = .duckAIChat
         case (.custom, .search):
             sharedPixelHandler.fire(.searchChatToggle(.clicked(.customSearch)),
                                     source: sharedPixelsStorage.onboardingSource,
                                     flow: sharedPixelsStorage.onboardingFlow)
-            sharedPixelsStorage.onboardingVariant = .duckAISearch
         case (_, .duckAI):
             sharedPixelHandler.fire(.searchChatToggle(.clicked(.suggestedChat)),
                                     source: sharedPixelsStorage.onboardingSource,
                                     flow: sharedPixelsStorage.onboardingFlow)
-            sharedPixelsStorage.onboardingVariant = .duckAIChat
         case (_, .search):
             sharedPixelHandler.fire(.searchChatToggle(.clicked(.suggestedSearch)),
                                     source: sharedPixelsStorage.onboardingSource,
                                     flow: sharedPixelsStorage.onboardingFlow)
-            sharedPixelsStorage.onboardingVariant = .duckAISearch
         }
     }
 
@@ -707,6 +713,19 @@ extension OnboardingPixelReporter: OnboardingAddToDockReporting {
     
     func measureAddToDockTutorialDismissCTAAction() {
         fire(event: .onboardingAddToDockTutorialDismissCTATapped, unique: false)
+    }
+
+}
+
+extension OnboardingPixelParameter.Variant {
+
+    init(_ mode: DuckAIQueryMode) {
+        switch mode {
+        case .duckAI:
+            self = .duckAIChat
+        case .search:
+            self = .duckAISearch
+        }
     }
 
 }

--- a/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
@@ -1184,7 +1184,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         XCTAssertFalse(pixelReporterMock.didCallMeasureDuckAIQueryExperimentChooseAIChat)
     }
 
-    func testWhenStateChangesToDuckAIQueryExperimentDialogThenImpressionPixelFires() {
+    func testWhenStateChangesToDuckAIQueryExperimentDialog_AndCohortEnrolled_ThenExperimentImpressionPixelFires() {
         // GIVEN
         let mockSearchExperienceProvider = MockOnboardingSearchExperienceProvider()
         mockSearchExperienceProvider.didEnableAIChatSearchInputDuringOnboarding = true
@@ -1202,6 +1202,24 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
         // THEN
         XCTAssertTrue(pixelReporterMock.didCallMeasureDuckAIQueryExperimentSelectionImpression)
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDuckAIQuerySelectionImpression)
+    }
+
+    func testWhenStateChangesToDuckAIQueryExperimentDialog_AndDuckAITailoredFlow_ThenOnlyPlainImpressionPixelFires() {
+        // GIVEN: Duck.ai tailored flow reuses the same view state but the user is NOT in the
+        // experiment cohort — experiment-flavoured pixels would pollute the experiment funnel.
+        onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedDuckAISteps(isReturningUser: false)
+        onboardingManagerMock.currentOnboardingFlow = .duckAI
+        let sut = makeSUT(currentOnboardingStep: .duckAIQuerySelection)
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDuckAIQueryExperimentSelectionImpression)
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDuckAIQuerySelectionImpression)
+
+        // WHEN
+        sut.onAppear()
+
+        // THEN: only the plain selection-impression fires; experiment pixels must NOT fire.
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDuckAIQueryExperimentSelectionImpression)
+        XCTAssertTrue(pixelReporterMock.didCallMeasureDuckAIQuerySelectionImpression)
     }
 
     func testWhenStateChangesToAiComparisonDialogThenImpressionPixelFires() {

--- a/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
@@ -1156,10 +1156,12 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
     // MARK: Pixels
 
-    func testWhenSelectDuckAIQueryExperimentChooseDuckAIThenCorrectPixelFires() {
+    func testWhenSelectDuckAIQueryExperimentChooseDuckAI_AndCohortEnrolled_ThenCorrectPixelFires() {
         // GIVEN
         onboardingManagerMock.onboardingSteps = [.duckAIQuerySelection]
-        let sut = makeSUT(currentOnboardingStep: .duckAIQuerySelection)
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.onboardingDuckAIQueryTrackersDemoExperiment])
+        featureFlagger.cohortToReturn = FeatureFlag.DuckAIQueryExperimentCohort.treatmentA
+        let sut = makeSUT(currentOnboardingStep: .duckAIQuerySelection, featureFlagger: featureFlagger)
         XCTAssertFalse(pixelReporterMock.didCallMeasureDuckAIQueryExperimentChooseAIChat)
 
         // WHEN
@@ -1170,10 +1172,12 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         XCTAssertFalse(pixelReporterMock.didCallMeasureDuckAIQueryExperimentChooseSearchOnly)
     }
 
-    func testWhenSelectDuckAIQueryExperimentChooseSearchThenCorrectPixelFires() {
+    func testWhenSelectDuckAIQueryExperimentChooseSearch_AndCohortEnrolled_ThenCorrectPixelFires() {
         // GIVEN
         onboardingManagerMock.onboardingSteps = [.duckAIQuerySelection]
-        let sut = makeSUT(currentOnboardingStep: .duckAIQuerySelection)
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.onboardingDuckAIQueryTrackersDemoExperiment])
+        featureFlagger.cohortToReturn = FeatureFlag.DuckAIQueryExperimentCohort.treatmentA
+        let sut = makeSUT(currentOnboardingStep: .duckAIQuerySelection, featureFlagger: featureFlagger)
         XCTAssertFalse(pixelReporterMock.didCallMeasureDuckAIQueryExperimentChooseSearchOnly)
 
         // WHEN

--- a/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
@@ -1204,6 +1204,71 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         XCTAssertTrue(pixelReporterMock.didCallMeasureDuckAIQueryExperimentSelectionImpression)
     }
 
+    func testWhenStateChangesToAiComparisonDialogThenImpressionPixelFires() {
+        // GIVEN: Duck.ai tailored flow places AI Comparison immediately after the intro step.
+        onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedDuckAISteps(isReturningUser: false)
+        onboardingManagerMock.currentOnboardingFlow = .duckAI
+        let sut = makeSUT()
+        XCTAssertFalse(pixelReporterMock.didCallMeasureAiComparisonImpression)
+
+        // WHEN: advancing into the AI Comparison step.
+        sut.startOnboardingAction()
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallMeasureAiComparisonImpression)
+    }
+
+    func testWhenAiComparisonActionIsCalledThenCTAPixelFires() {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedDuckAISteps(isReturningUser: false)
+        onboardingManagerMock.currentOnboardingFlow = .duckAI
+        let sut = makeSUT(currentOnboardingStep: .aiComparison)
+        XCTAssertFalse(pixelReporterMock.didCallMeasureAiComparisonCTAAction)
+
+        // WHEN
+        sut.aiComparisonAction()
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallMeasureAiComparisonCTAAction)
+    }
+
+    // MARK: Duck.ai Pixel routing
+
+    func testWhenMeasureDuckAIQuerySubmissionAndCohortEnrolledThenForwardsToExperimentSubmission() {
+        // GIVEN: default flow + experiment flag on + cohort resolved → user is enrolled.
+        onboardingManagerMock.currentOnboardingFlow = .default
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.onboardingDuckAIQueryTrackersDemoExperiment])
+        featureFlagger.cohortToReturn = FeatureFlag.DuckAIQueryExperimentCohort.treatmentA
+        let sut = makeSUT(featureFlagger: featureFlagger)
+
+        // WHEN
+        sut.measureDuckAIQuerySubmission(selection: .search, promptSource: .option2)
+
+        // THEN: view-model routes to the experiment submission with the caller's selection/source,
+        // and does NOT call the plain submission method directly.
+        XCTAssertTrue(pixelReporterMock.didCallMeasureDuckAIQueryExperimentQuerySubmission)
+        XCTAssertEqual(pixelReporterMock.didCaptureDuckAIQueryExperimentSelection, .search)
+        XCTAssertEqual(pixelReporterMock.didCaptureDuckAIQueryExperimentPromptSourceValue, DuckAIQueryPromptSource.option2.rawValue)
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDuckAIQuerySubmission)
+    }
+
+    func testWhenMeasureDuckAIQuerySubmissionAndDuckAITailoredFlowThenForwardsToPlainSubmission() {
+        // GIVEN: Duck.ai tailored flow makes resolveDuckAIQueryExperimentCohortID() return nil even with the flag on.
+        onboardingManagerMock.currentOnboardingFlow = .duckAI
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.onboardingDuckAIQueryTrackersDemoExperiment])
+        featureFlagger.cohortToReturn = FeatureFlag.DuckAIQueryExperimentCohort.treatmentA
+        let sut = makeSUT(featureFlagger: featureFlagger)
+
+        // WHEN: caller passes .search to assert the view-model overrides it to .duckAI for the tailored flow.
+        sut.measureDuckAIQuerySubmission(selection: .duckAI, promptSource: .option1)
+
+        // THEN: experiment method is skipped
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDuckAIQueryExperimentQuerySubmission)
+        XCTAssertTrue(pixelReporterMock.didCallMeasureDuckAIQuerySubmission)
+        XCTAssertEqual(pixelReporterMock.capturedDuckAIQuerySubmissionSelection, .duckAI)
+        XCTAssertEqual(pixelReporterMock.capturedDuckAIQuerySubmissionPromptSourceValue, DuckAIQueryPromptSource.option1.rawValue)
+    }
+
 }
 
 // MARK: - Onboarding resume step persistence and restoration

--- a/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
@@ -221,6 +221,42 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
     }
 
+    func testWhenMeasureAiComparisonImpressionThenAiComparisonShownSharedPixelFires() {
+        // GIVEN
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [])
+        XCTAssertFalse(OnboardingPixelFireMock.didCallFire)
+        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
+
+        // WHEN
+        sut.measureAiComparisonImpression()
+
+        // THEN
+        XCTAssertFalse(OnboardingPixelFireMock.didCallFire)
+        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.aiComparison(.shown)])
+        XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
+        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+    }
+
+    func testWhenMeasureAiComparisonCTAActionThenAiComparisonEngageSharedPixelFires() {
+        // GIVEN
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [])
+        XCTAssertFalse(OnboardingPixelFireMock.didCallFire)
+        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
+
+        // WHEN
+        sut.measureAiComparisonCTAAction()
+
+        // THEN
+        XCTAssertFalse(OnboardingPixelFireMock.didCallFire)
+        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.aiComparison(.clicked(.engage))])
+        XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
+        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+    }
+
     func testWhenMeasureStartOnboardingCTAActionThenWelcomeEngageSharedPixelFires() {
         // GIVEN
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [])
@@ -736,6 +772,84 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
         XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
         XCTAssertEqual(sharedPixelsStorageMock.onboardingVariant, .duckAIChat)
+    }
+
+    // MARK: - Duck AI query (non-experiment)
+
+    func testWhenMeasureDuckAIQuerySelectionImpressionThenOnlySearchChatToggleShownSharedPixelFires() {
+        // GIVEN
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [])
+        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertTrue(OnboardingExperimentPixelFireMock.firedMetrics.isEmpty)
+
+        // WHEN
+        sut.measureDuckAIQuerySelectionImpression()
+
+        // THEN
+        // Non-experiment entry point: must not fire the experiment toggle-impression-unique pixel
+        // or any experiment metric pixel — only the shared search/chat toggle "shown" event.
+        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertTrue(OnboardingExperimentPixelFireMock.firedMetrics.isEmpty)
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.searchChatToggle(.shown)])
+        XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
+        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+    }
+
+    func testWhenMeasureDuckAIQuerySubmissionWithCustomDuckAIThenOnlyCustomChatSharedPixelFires() {
+        // GIVEN
+        let initialVariant = sharedPixelsStorageMock.onboardingVariant
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [])
+
+        // WHEN
+        sut.measureDuckAIQuerySubmission(selection: .duckAI, promptSource: .custom)
+
+        // THEN
+        XCTAssertTrue(OnboardingExperimentPixelFireMock.firedMetrics.isEmpty)
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.searchChatToggle(.clicked(.customChat))])
+        XCTAssertEqual(sharedPixelsStorageMock.onboardingVariant, initialVariant)
+    }
+
+    func testWhenMeasureDuckAIQuerySubmissionWithCustomSearchThenOnlyCustomSearchSharedPixelFires() {
+        // GIVEN
+        let initialVariant = sharedPixelsStorageMock.onboardingVariant
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [])
+
+        // WHEN
+        sut.measureDuckAIQuerySubmission(selection: .search, promptSource: .custom)
+
+        // THEN
+        XCTAssertTrue(OnboardingExperimentPixelFireMock.firedMetrics.isEmpty)
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.searchChatToggle(.clicked(.customSearch))])
+        XCTAssertEqual(sharedPixelsStorageMock.onboardingVariant, initialVariant)
+    }
+
+    func testWhenMeasureDuckAIQuerySubmissionWithSuggestedDuckAIThenOnlySuggestedChatSharedPixelFires() {
+        // GIVEN
+        let initialVariant = sharedPixelsStorageMock.onboardingVariant
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [])
+
+        // WHEN
+        sut.measureDuckAIQuerySubmission(selection: .duckAI, promptSource: .option2)
+
+        // THEN
+        XCTAssertTrue(OnboardingExperimentPixelFireMock.firedMetrics.isEmpty)
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.searchChatToggle(.clicked(.suggestedChat))])
+        XCTAssertEqual(sharedPixelsStorageMock.onboardingVariant, initialVariant)
+    }
+
+    func testWhenMeasureDuckAIQuerySubmissionWithSuggestedSearchThenOnlySuggestedSearchSharedPixelFires() {
+        // GIVEN
+        let initialVariant = sharedPixelsStorageMock.onboardingVariant
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [])
+
+        // WHEN
+        sut.measureDuckAIQuerySubmission(selection: .search, promptSource: .option3)
+
+        // THEN
+        XCTAssertTrue(OnboardingExperimentPixelFireMock.firedMetrics.isEmpty)
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.searchChatToggle(.clicked(.suggestedSearch))])
+        XCTAssertEqual(sharedPixelsStorageMock.onboardingVariant, initialVariant)
     }
 
     // MARK: - Manual Dismiss

--- a/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
@@ -496,13 +496,12 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertTrue(sharedPixelHandlerMock.eventsFired.isEmpty)
     }
 
-    func testWhenMeasureScreenImpressionWithDuckAIFireDialogEventThenLegacyFireDialogShownUniqueAndExperimentPixelsFireWithoutSharedPixels() {
+    func testWhenMeasureDuckAIExperimentFireDialogImpressionThenLegacyFireDialogShownUniqueAndExperimentPixelsFire() {
         // GIVEN
         let expectedPixel = Pixel.Event.onboardingDuckAIExperimentFireDialogShownUnique
-        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [])
 
         // WHEN
-        sut.measureScreenImpression(event: expectedPixel)
+        sut.measureDuckAIExperimentFireDialogImpression()
 
         // THEN
         XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)

--- a/iOS/PixelDefinitions/pixels/definitions/onboarding_shared.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/onboarding_shared.json5
@@ -44,7 +44,7 @@
             "onboardingFlow"
         ]
     },
-    "m_ios_onboarding_ai-comparison": {
+    "m_ios_onboarding_ai-intro": {
         "description": "Fired during linear onboarding on the AI Comparison ('AI Protections Activated!') step of the Duck.ai tailored flow.",
         "owners": ["alessandroboron"],
         "triggers": ["other"],

--- a/iOS/PixelDefinitions/pixels/definitions/onboarding_shared.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/onboarding_shared.json5
@@ -44,6 +44,21 @@
             "onboardingFlow"
         ]
     },
+    "m_ios_onboarding_ai-comparison": {
+        "description": "Fired during linear onboarding on the AI Comparison ('AI Protections Activated!') step of the Duck.ai tailored flow.",
+        "owners": ["alessandroboron"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "onboardingEventType",
+            "onboardingClickedValue",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingSource",
+            "onboardingFlow"
+        ]
+    },
     "m_ios_onboarding_add-to-dock": {
         "description": "Fired during linear onboarding on the Add to Dock step.",
         "owners": ["rachelmcr"],

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/OnboardingPixelReporterMock.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/OnboardingPixelReporterMock.swift
@@ -33,6 +33,8 @@ final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, Onboardi
     private(set) var didCallMeasureAutoRestoreOnboardingSkipTapped = false
     private(set) var didCallMeasureBrowserComparisonImpression = false
     private(set) var didCallMeasureChooseBrowserCTAAction = false
+    private(set) var didCallMeasureAiComparisonImpression = false
+    private(set) var didCallMeasureAiComparisonCTAAction = false
     private(set) var didCallMeasureChooseAppIconImpression = false
     private(set) var didCallMeasureChooseAppIconColor = false
     private(set) var didCaptureAppIconColorSelection: AppIcon?
@@ -69,7 +71,11 @@ final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, Onboardi
     private(set) var didCallMeasureDuckAIQueryExperimentChooseAIChat = false
     private(set) var didCallMeasureDuckAIQueryExperimentQuerySubmission = false
     private(set) var didCaptureDuckAIQueryExperimentPromptSourceValue: String?
-    private(set) var didCaptureDuckAIQueryExperimentSelection: DuckAIQueryExperimentMode?
+    private(set) var didCaptureDuckAIQueryExperimentSelection: DuckAIQueryMode?
+    private(set) var didCallMeasureDuckAIQuerySelectionImpression = false
+    private(set) var didCallMeasureDuckAIQuerySubmission = false
+    private(set) var capturedDuckAIQuerySubmissionPromptSourceValue: String?
+    private(set) var capturedDuckAIQuerySubmissionSelection: DuckAIQueryMode?
     private(set) var didCallMeasureDuckAIExperimentFireButtonCTAAction = false
     private(set) var didCallMeasureDuckAIExperimentFinalDialogImpression = false
     private(set) var didCallMeasureDuckAIExperimentFinalDialogCTAAction = false
@@ -141,6 +147,14 @@ final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, Onboardi
 
     func measureChooseBrowserCTAAction() {
         didCallMeasureChooseBrowserCTAAction = true
+    }
+
+    func measureAiComparisonImpression() {
+        didCallMeasureAiComparisonImpression = true
+    }
+
+    func measureAiComparisonCTAAction() {
+        didCallMeasureAiComparisonCTAAction = true
     }
 
     func measureChooseAppIconImpression() {
@@ -263,10 +277,20 @@ final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, Onboardi
         didCallMeasureDuckAIQueryExperimentChooseAIChat = true
     }
 
-    func measureDuckAIQueryExperimentQuerySubmission(selection: DuckAIQueryExperimentMode, promptSource: DuckAIQueryExperimentPromptSource) {
+    func measureDuckAIQueryExperimentQuerySubmission(selection: DuckAIQueryMode, promptSource: DuckAIQueryPromptSource) {
         didCallMeasureDuckAIQueryExperimentQuerySubmission = true
         didCaptureDuckAIQueryExperimentPromptSourceValue = promptSource.rawValue
         didCaptureDuckAIQueryExperimentSelection = selection
+    }
+
+    func measureDuckAIQuerySelectionImpression() {
+        didCallMeasureDuckAIQuerySelectionImpression = true
+    }
+
+    func measureDuckAIQuerySubmission(selection: DuckAIQueryMode, promptSource: DuckAIQueryPromptSource) {
+        didCallMeasureDuckAIQuerySubmission = true
+        capturedDuckAIQuerySubmissionPromptSourceValue = promptSource.rawValue
+        capturedDuckAIQuerySubmissionSelection = selection
     }
 
     func measureTrySearchDialogSuggestedSearchTapped() {

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/OnboardingPixelReporterMock.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/OnboardingPixelReporterMock.swift
@@ -77,6 +77,7 @@ final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, Onboardi
     private(set) var capturedDuckAIQuerySubmissionPromptSourceValue: String?
     private(set) var capturedDuckAIQuerySubmissionSelection: DuckAIQueryMode?
     private(set) var didCallMeasureDuckAIExperimentFireButtonCTAAction = false
+    private(set) var didCallMeasureDuckAIExperimentFireDialogImpression = false
     private(set) var didCallMeasureDuckAIExperimentFinalDialogImpression = false
     private(set) var didCallMeasureDuckAIExperimentFinalDialogCTAAction = false
 
@@ -327,6 +328,10 @@ final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, Onboardi
 
     func measureDuckAIExperimentFireButtonCTAAction() {
         didCallMeasureDuckAIExperimentFireButtonCTAAction = true
+    }
+
+    func measureDuckAIExperimentFireDialogImpression() {
+        didCallMeasureDuckAIExperimentFireDialogImpression = true
     }
 
     func measureDuckAIExperimentFinalDialogImpression() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214068803741451
Tech Design URL:
CC:

### Description

UI and pixels cleanup for the tailored Duck.ai onboarding flow

**Key Changes:**
- **UI:** Removes the bubble tail from the Search and Duck.ai Toggle dialog in the rebranded onboarding flow.
- **AI Comparison pixel:** Adds a new `aiComparison` shared onboarding pixel (impression + CTA on engage) for the "AI Protections Activated!" step in the Duck.ai tailored flow, plus the matching `m_ios_onboarding_ai-intro` definition.
- **Duck.ai tailored-flow pixel cleanup:**
  - Splits `measureDuckAIQueryExperimentQuerySubmission` into an experiment-flavoured wrapper + a plain `measureDuckAIQuerySubmission`. The view model now routes to the plain path when the user is not in the experiment cohort, so tailored flow no longer fires experiment metric pixels.
  - Renames `DuckAIQueryExperimentMode` → `DuckAIQueryMode` and `DuckAIQueryExperimentPromptSource` → `DuckAIQueryPromptSource` (the types are reused by both paths now).
  - Adds an unconditional `.end(.shown)` shared-pixel fire to `RebrandedNewTabDaxDialogFactory.createExperimentCompletionDialog`, and gates the experiment-specific impression/CTA pixels on `currentOnboardingFlow == .default` so the dialog (now reused by the tailored flow) doesn't pollute the experiment funnel.

### Testing Steps
**Scenario 1 - Duck.ai tailored flow**
1. In `FeatureFlag.swift` set `Config(source: .remoteReleasable(.feature(.iOSBrowserConfig)))` for `.onboardingDuckAIFlow`
2. In `CustomProductPage+Onboarding` -> `extension AppStoreCustomProductPageEvaluator` add `let url = URL(string: "ddgCPP://duckAI”)` at line 33 to simulate launching the app from Duck.ai CPP.                                                                     
3. Fresh install the app and step through onboarding to the Duck.ai query screen.  Confirm in the pixel debug log:
   - On the AI Comparison step: `m_ios_onboarding_ai-intro` fires once on impression and once on Continue (`onboardingClickedValue=engage`).
   - On the search/chat toggle and submission: `m_ios_onboarding_search-chat-toggle` fires; no experiment-flavoured pixels (`m_preonboarding_duckai_*`) fire and variant set.
   - On the end-of-journey dialog: `m_ios_onboarding_end` (`.end(.shown)`) fires; `m_preonboarding_duckai_final-dialog-impression_unique` does NOT.
4. Visual check: Search and Duck.ai Toggle dialog no longer renders the bubble tail.

**Scenario 2 - Duck.ai experiment**
1. Remove code changed in step 1-2 of Scenario 1.
2. Ensure the use will be enrolled in the experiment
 - Reset iOS simulator to simulate new installer (From main menu `Device` -> `Erase all content and settings…`)
 - Change iOS scheme `App Language` -> `English`, and `App Region` -> `United States`
3. Fresh install the app.
4. Go through the default flow with the Duck.ai query experiment cohort active. Confirm the experiment-flavoured pixels DO fire alongside the shared ones, as before.

### Impact and Risks
**Medium**: Pixel changes touch onboarding telemetry, which feeds experiment dashboards.

#### What could go wrong?
- Experiment metric pixels could stop firing for users who are in the cohort if the routing in `OnboardingIntroViewModel.measureDuckAIQuerySubmission` is misread. Mitigated by view-model routing tests covering all three branches (cohort enrolled, tailored flow, flag-off).
- The `onboardingVariant` storage write previously happened as a side effect of `measureDuckAIQueryExperimentQuerySubmission` for every call. After this PR it only fires for users in the experiment cohort. Downstream Dax-dialog pixels in the Duck.ai tailored flow will now read `variant: nil` on those events.

### Quality Considerations
Added unit tests to cover new cases and ensured existing tests do not break.

### Notes to Reviewer
- The legacy `NewTabDaxDialogFactory.createExperimentCompletionDialog` (non-rebranded) is intentionally unchanged in this PR as we’re not planning to disable the onboarding rebranding anytime soon.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Onboarding and experiment pixels drive dashboards; mis-routed cohort/flow checks could drop experiment events or leave variant nil for downstream Dax pixels in the tailored flow.
> 
> **Overview**
> This PR polishes the **Duck.ai tailored onboarding** flow with UI tweaks and **telemetry separation** so tailored users no longer pollute the Duck.ai query experiment funnel.
> 
> **UI:** The rebranded Search/Duck.ai toggle step no longer shows a bubble tail (`bubbleTailOffset` removed from shared linear metrics; Duck.ai query step uses a tail-less bubble). The AI Comparison step uses **typing animation** and reveals the comparison table/CTA after the title finishes.
> 
> **Pixels:** Adds shared **`aiComparison`** events (`m_ios_onboarding_ai-intro`) for the “AI Protections Activated!” step (shown + engage on Continue). Renames query types to **`DuckAIQueryMode`** / **`DuckAIQueryPromptSource`** and routes submissions: experiment cohort → experiment metrics + variant storage; otherwise → plain **`search-chat-toggle`** clicks only. Toggle **impression** uses experiment pixels only when a cohort is resolved; tailored flow gets the plain toggle-shown pixel. **Experiment-only** fire/final dialog and fire-button pixels are gated on **`currentOnboardingFlow == .default`**; fire dialog impressions go through **`measureDuckAIExperimentFireDialogImpression`**. Rebranded completion dialog also fires **`.end(.shown)`**.
> 
> **Contextual fire:** Fire Dax dialogs branch on **`FireVariant`** (standard vs duck AI onboarding) for which legacy/experiment impression pixels fire.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c981695ecfe8b839887feeeee373a85b831a8ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->