### PR TITLE
conflict-watch: skip release branches and automation users

### DIFF
--- a/scripts/conflict-watch/conflict-watch.py
+++ b/scripts/conflict-watch/conflict-watch.py
@@ -102,6 +102,9 @@ Optional (defaults shown):
                            names instead of Asana @-mentions — no inbox
                            notification fires; useful for first-run pilots)
     CW_BOT_AUTHORS=…      (comma-separated GitHub logins to skip)
+    CW_BRANCH_SKIP_PATTERNS=…
+                          (comma-separated fnmatch globs on branch name;
+                           default "release/*,hotfix/*")
     CW_USER_MAP_PATH=     (path to a flat YAML of github→asana gid)
 
 CLI flags
@@ -212,13 +215,24 @@ NO_MENTIONS = os.environ.get("CW_NO_MENTIONS", "0").lower() in ("1", "true", "ye
 DEFAULT_BOT_AUTHORS = (
     "dependabot[bot],"
     "renovate[bot],"
-    "github-actions[bot]"
+    "github-actions[bot],"
+    "daxtheduck,"
+    "ddg-automation-ci"
 )
 BOT_AUTHORS = {
     a.strip().lower()
     for a in os.environ.get("CW_BOT_AUTHORS", DEFAULT_BOT_AUTHORS).split(",")
     if a.strip()
 }
+
+DEFAULT_BRANCH_SKIP_PATTERNS = "release/*,hotfix/*"
+BRANCH_SKIP_PATTERNS = [
+    p.strip()
+    for p in os.environ.get(
+        "CW_BRANCH_SKIP_PATTERNS", DEFAULT_BRANCH_SKIP_PATTERNS
+    ).split(",")
+    if p.strip()
+]
 
 TITLE_PREFIX = "Likely merge conflict:"
 TITLE_SEP = " ↔ "
@@ -308,6 +322,7 @@ class RunSummary:
     branches_checked: int = 0
     branches_skipped_merged: int = 0
     branches_skipped_bot: int = 0
+    branches_skipped_pattern: int = 0
     branches_skipped_inactive_pr: int = 0
     pairs_probed: int = 0
     pairs_with_hard_conflicts: int = 0
@@ -434,6 +449,10 @@ def list_active_branches(within_hours: int, summary: RunSummary) -> list[Branch]
             continue
         name, iso, author_name, author_email, sha = parts
         if name == DEFAULT_BRANCH:
+            continue
+        if any(fnmatch.fnmatch(name, pat) for pat in BRANCH_SKIP_PATTERNS):
+            logger.debug("Skipping branch by pattern: %s", name)
+            summary.branches_skipped_pattern += 1
             continue
         try:
             ts = datetime.fromisoformat(iso)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1215011212193260?focus=true

### Description

The daily conflict-watch job was creating Asana tasks pairing dev branches with release branches (and other automation-owned branches). These aren't real coordination signals — release merges are owned by the release process, not by whoever happens to share a file.

Two changes to `scripts/conflict-watch/conflict-watch.py`:

- New `CW_BRANCH_SKIP_PATTERNS` env var, default `release/*,hotfix/*`. Branches matching any pattern are dropped during enumeration.
- Added `daxtheduck` and `ddg-automation-ci` to the default `CW_BOT_AUTHORS` list.

### Testing Steps

1. Run a dry-run locally on a checkout where recent `release/*` or `hotfix/*` branches exist:
   ```
   CW_DRY_RUN=1 CW_VERBOSE=1 python3 scripts/conflict-watch/conflict-watch.py
   ```
2. In the printed summary, expect `branches_skipped_pattern > 0` and no pair involving a `release/*` / `hotfix/*` branch.
3. Re-run with the filter disabled to prove those branches *would* otherwise be probed:
   ```
   CW_DRY_RUN=1 CW_BRANCH_SKIP_PATTERNS= python3 scripts/conflict-watch/conflict-watch.py
   ```

### Impact and Risks

Low. Internal tooling only — worst case is fewer Asana tasks created.

#### What could go wrong?

A pattern over-matches and hides a real dev branch. Mitigated by the `CW_BRANCH_SKIP_PATTERNS` env override, which can be set in the workflow YAML without a code change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk internal tooling change that only reduces which branches are considered for conflict tasks; main risk is an overly broad skip pattern suppressing a legitimate branch, mitigated via env override.
> 
> **Overview**
> Prevents `conflict-watch.py` from generating conflict tasks involving release-process branches by adding a configurable branch-name skip filter (`CW_BRANCH_SKIP_PATTERNS`, default `release/*,hotfix/*`) applied during branch enumeration and tracked in the run summary.
> 
> Expands the default bot-author ignore list to include `daxtheduck` and `ddg-automation-ci`, further reducing conflict alerts from automation-owned branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84a604b3a9ac964ad172174dbfc592c90b8392c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->