### PR TITLE
[iOS][Duck Sans] Improve documentation for external contributors  

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ We use submodules, so you will need to bring them into the project in order to b
 
 Run `git submodule update --init --recursive`
 
+### External contributors: Duck Sans package
+
+The project depends on a private `DuckSansFont` Swift package that ships our licensed Duck Sans typeface. The repository is private, so building a fork without access will fail at SPM resolution. To build as an external contributor, remove the package before building:
+
+1. Open `iOS/DuckDuckGo-iOS.xcodeproj` (or the workspace) in Xcode.
+2. Select the project in the Project Navigator, then open the **Package Dependencies** tab.
+3. Select **DuckSansFont** and click the **−** button to remove it. The app will fall back to the system font at runtime.
+4. Clean and rebuild the project.
+
 ### iOS developer details
 
 If you're not part of the DuckDuckGo team, you should provide your Apple developer account id, app id, and group id prefix in an `ExternalDeveloper.xcconfig` file. To do that:

--- a/README.md
+++ b/README.md
@@ -57,4 +57,6 @@ DuckDuckGo is distributed under the Apache 2.0 [license](https://github.com/duck
 
 Copyright 2026 DuckDuckGo
 
-Duck Sans is a proprietary typeface created by Fontwerk and licensed to DuckDuckGo under commercial terms. Duck Sans font files are not licensed under the Apache License, Version 2.0, or covered by any open-source license applicable to this repository. You may not extract, copy, distribute, modify, or use Duck Sans font files for any purpose outside of running this software as distributed by DuckDuckGo. If you are building this software from source and do not have a valid Duck Sans license, the build system will substitute a placeholder font. Redistributions of compiled builds that include Duck Sans must retain this notice. All rights in and to Duck Sans are reserved by Fontwerk (fontwerk.com).
+Duck Sans is a proprietary typeface created by Fontwerk and licensed to DuckDuckGo under commercial terms. Duck Sans font files are not licensed under the Apache License, Version 2.0, or covered by any open-source license applicable to this repository. You may not extract, copy, distribute, modify, or use Duck Sans font files for any purpose outside of running this software as distributed by DuckDuckGo. Redistributions of compiled builds that include Duck Sans must retain this notice. All rights in and to Duck Sans are reserved by Fontwerk (fontwerk.com).
+
+If you do not have a valid Duck Sans license, remove the DuckSansFont package and the app will fall back to the system font at runtime.

--- a/iOS/DuckDuckGo/AppConfiguration/AppConfiguration.swift
+++ b/iOS/DuckDuckGo/AppConfiguration/AppConfiguration.swift
@@ -25,7 +25,9 @@ import Networking
 import Configuration
 import Persistence
 import WebKit
+#if canImport(DuckSansFont)
 import DuckSansFont
+#endif
 import PrivacyConfig
 
 struct AppConfiguration {
@@ -42,8 +44,10 @@ struct AppConfiguration {
     }
 
     func start(isBookmarksDBFilePresent: Bool?) throws {
+#if canImport(DuckSansFont)
         // Register DuckSans custom font
         DuckSansFont.registerFonts()
+#endif
 
         KeyboardConfiguration.disableHardwareKeyboardForUITests()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1213878498403796?focus=true.
Tech Design URL:
CC:

### Description

### Testing Steps
1. Follow the instructions in the Asana task to remove DuckSans dependency and run the app.
2. Fresh install the app.
2. Verify the project compiles, the app run and onboarding defaults to system font.

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and conditional compilation around optional font registration; no auth, data, or production behavior changes for internal builds that still include the package.
> 
> **Overview**
> Documents how **external contributors** can build without the private **`DuckSansFont`** Swift package (Xcode steps to remove the dependency, plus a shorter license note that points to the same fallback).
> 
> **`AppConfiguration`** now imports and calls **`DuckSansFont.registerFonts()`** only when the package is present (`#if canImport(DuckSansFont)`), so removing the SPM dependency no longer breaks compilation while the app can still use the system font at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12812f967b35e6ae72bb75fdfd831616db3cb6f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->