### PR TITLE
[WIP] [macOS] Fix premature 'Bitwarden is not responding' alert

### DIFF
--- a/macOS/LocalPackages/BWIntegration/Sources/BWManagement/BWManager.swift
+++ b/macOS/LocalPackages/BWIntegration/Sources/BWManagement/BWManager.swift
@@ -248,19 +248,30 @@ final class BWManager: BWManagement, ObservableObject {
         }
     }
 
+    private static let statusResponseTimeoutInterval: TimeInterval = 15
+    private static let maxStatusResponseRetries = 1
+
     private var verificationTimer: Timer?
+    private var statusResponseRetries = 0
 
     private func verifyBitwardenIsResponding() {
-        verificationTimer = Timer.scheduledTimer(withTimeInterval: 5, repeats: false) { [weak self] _ in
+        verificationTimer = Timer.scheduledTimer(withTimeInterval: Self.statusResponseTimeoutInterval, repeats: false) { [weak self] _ in
             guard let self else { return }
             verificationTimer?.invalidate()
             verificationTimer = nil
 
-            if status == .waitingForStatusResponse {
-                pixelFiring?.fire(DebugEvent(BWManagementPixels.bitwardenNotResponding))
-                showRestartBitwardenAlert { [weak self] in
-                    self?.restartBitwarden()
-                }
+            guard status == .waitingForStatusResponse else { return }
+
+            if statusResponseRetries < Self.maxStatusResponseRetries {
+                statusResponseRetries += 1
+                sendStatus()
+                verifyBitwardenIsResponding()
+                return
+            }
+
+            pixelFiring?.fire(DebugEvent(BWManagementPixels.bitwardenNotResponding))
+            showRestartBitwardenAlert { [weak self] in
+                self?.restartBitwarden()
             }
         }
     }
@@ -583,6 +594,7 @@ final class BWManager: BWManagement, ObservableObject {
             }
             verificationTimer?.invalidate()
             verificationTimer = nil
+            statusResponseRetries = 0
         }
     }
     var statusPublisher: Published<BWStatus>.Publisher { $status }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1213654203367102

### Description

When the user launches Bitwarden after DDG is already running, the initial status query can take longer than the 5s `verificationTimer` because the Bitwarden app is still finishing its own launch. The current code then shows "Bitwarden is not responding. Please restart" even though the channel is healthy.

Bump the timeout from 5s to 15s and resend the status query once before showing the alert. Worst case the user waits ~30s before the alert, vs. the current 5s. Late status responses (received before the second timeout) are already handled correctly by `handleStatusResponse`, so the alert no longer fires for a transient slow start.

### Testing Steps

1. Quit Bitwarden if it's running.
2. Launch this build of DDG and set Bitwarden as the password manager in Settings → Passwords.
3. Launch `Bitwarden.app` from Spotlight/Finder.
4. Switch back to DDG within a few seconds.
5. Expected: no "Bitwarden is not responding" alert. Bitwarden status surfaces as connected.
6. Regression: with Bitwarden truly unresponsive (e.g. `kill -STOP <bitwarden pid>` then trigger a reconnect), the alert should still appear after ~30s.

### Impact and Risks

Low — single file change to a timeout/retry path, no behaviour change once Bitwarden responds normally. Only the failure path is delayed (5s → 30s) before the user sees the alert.

#### What could go wrong?

The alert is shown later when Bitwarden is genuinely stuck. Mitigated by the retry: if Bitwarden is just slow, the retry recovers without user interaction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a timeout/retry path around Bitwarden status polling; primary impact is delaying the restart alert when Bitwarden is truly unresponsive.
> 
> **Overview**
> Prevents premature “Bitwarden is not responding” prompts during slow Bitwarden startup by increasing the status response timeout (5s → 15s) and adding a single automatic `sendStatus()` retry before firing the pixel and showing the restart alert.
> 
> Resets the new retry counter whenever `status` changes to avoid retries leaking across connection attempts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1daad44e6126c0aac1cbd3a32f038f59f29cf56f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->