### PR TITLE
iOS: Fix Duck.ai collapsed input shadow in dark mode

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -414,7 +414,7 @@ final class UnifiedToggleInputView: UIView {
                   radius: 12,
                   offset: CGSize(width: 0, height: 4)),
             .init(id: ShadowID.rim,
-                  color: flankedHaloColor,
+                  color: UIColor(designSystemColor: .shadowSecondary),
                   radius: 6,
                   offset: CGSize(width: 0, height: 2)),
         ]
@@ -425,14 +425,6 @@ final class UnifiedToggleInputView: UIView {
     private enum ShadowID {
         static let outer = "outer"
         static let rim = "rim"
-    }
-
-    private var flankedHaloColor: UIColor {
-        UIColor { trait in
-            trait.userInterfaceStyle == .dark
-                ? UIColor.white.withAlphaComponent(0.18)
-                : UIColor.black.withAlphaComponent(0.10)
-        }
     }
 
     private func cardBackgroundColor(isFireTab: Bool) -> UIColor {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -19,7 +19,9 @@
 
 import AIChat
 import Combine
+import DesignResourcesKit
 import DesignResourcesKitIcons
+import UIComponents
 import XCTest
 import UIKit
 import UniformTypeIdentifiers
@@ -439,6 +441,21 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         XCTAssertGreaterThan(callbacks, 0)
     }
 
+    func test_flankedAIChatShadowUsesTransparentBlackTokenInDarkMode() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        let sut = UnifiedToggleInputView(handler: handler)
+        sut.overrideUserInterfaceStyle = .dark
+        sut.applyCardLayout(.flanked, animated: false)
+        prepareForFitting(sut, width: 402, height: 80)
+
+        let shadowView = try XCTUnwrap(firstDescendant(of: CompositeShadowView.self, in: sut))
+        let rimShadowLayer = try XCTUnwrap(shadowView.subviews.first { $0.layer.name == "rim" }?.layer)
+        let expectedShadowColor = UIColor(designSystemColor: .shadowSecondary).resolvedColor(with: sut.traitCollection)
+
+        XCTAssertFalse(shadowView.isHidden)
+        assertColor(rimShadowLayer.shadowColor, equals: expectedShadowColor)
+    }
+
     private func flushMainQueue() {
         let expectation = expectation(description: "main queue flushed")
         DispatchQueue.main.async {
@@ -526,6 +543,30 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         }
 
         return nil
+    }
+
+    private func assertColor(_ actualColor: CGColor?, equals expectedColor: UIColor, file: StaticString = #filePath, line: UInt = #line) {
+        guard let actualColor else {
+            XCTFail("Expected color", file: file, line: line)
+            return
+        }
+
+        let actualComponents = rgbaComponents(of: UIColor(cgColor: actualColor))
+        let expectedComponents = rgbaComponents(of: expectedColor)
+
+        XCTAssertEqual(actualComponents.red, expectedComponents.red, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(actualComponents.green, expectedComponents.green, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(actualComponents.blue, expectedComponents.blue, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(actualComponents.alpha, expectedComponents.alpha, accuracy: 0.001, file: file, line: line)
+    }
+
+    private func rgbaComponents(of color: UIColor) -> (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return (red, green, blue, alpha)
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1214995870352490

### Description

Updates the collapsed Duck.ai tab follow-up input shadow to use the standard `shadowSecondary` design-system token instead of a custom dark-mode white halo. This keeps the dark-mode collapsed input from reading as a glow while preserving the existing layout and shadow geometry.

### Testing Steps
1. Open the Duck.ai tab with Unified input enabled.
2. Collapse the Unified input so it's at the bottom in an inactive state.
3. Switch to Dark mode and make sure you don't see a white glow behind the collapsed Unified input.

### Impact and Risks

Low. This is a scoped visual change to the Unified Input collapsed/flanked Duck.ai tab input shadow.

#### What could go wrong?

The collapsed Duck.ai tab input could lose too much visual separation in dark mode if the transparent-black token is too subtle. The regression test verifies the flanked dark-mode rim shadow resolves to the intended `shadowSecondary` token.

### Quality Considerations

No privacy, security, data, or performance impact expected. The change reuses an existing design-system color token and does not alter input sizing, layout, or shared switchbar text-entry behavior.

### Notes to Reviewer

This PR intentionally covers only the dark-mode collapsed Duck.ai tab shadow color issue. The earlier sizing feedback was archived/reverted and is not included here.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual tweak limited to the `.flanked` shadow color plus a targeted unit test; no behavior, data, or security logic changes.
> 
> **Overview**
> Fixes the collapsed/flanked Duck.ai input shadow in dark mode by replacing the custom halo color with the standard design-system `shadowSecondary` token for the rim shadow.
> 
> Adds a regression unit test (`test_flankedAIChatShadowUsesTransparentBlackTokenInDarkMode`) plus small test helpers to assert the resolved shadow color matches the token in dark mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28402fff419d775a9109394bded89e1e7a84bc1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->