### PR TITLE
iOS: Gate Unified Input by Duck.ai experiment cohort

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -5809,6 +5809,10 @@ extension MainViewController: OnboardingDelegate {
 
     func onboardingCompleted(controller: UIViewController) {
         markOnboardingSeen()
+        // Now that linear onboarding has finished, any experiment cohort
+        // enrollment that occurred is in place. Run the unified-toggle-input
+        // setup that was deferred at viewDidLoad.
+        setUpUnifiedToggleInputIfNeeded()
         if experimentDuckAIFireOnboardingFlow.state == .awaitingFirstResponse {
             onboardingCompletedWithExperimentTransition(controller: controller)
             return

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -52,6 +52,11 @@ extension MainViewController {
     }
 
     func setUpUnifiedToggleInputIfNeeded() {
+        // Defer setup until linear onboarding has completed, so that any experiment
+        // cohort enrollment that happens during onboarding is reflected in
+        // `unifiedToggleInputFeature.isAvailable` before we wire up the coordinator.
+        // Returning users (who skip linear onboarding) fall through immediately.
+        guard !needsToShowOnboardingIntro() else { return }
         guard unifiedToggleInputFeature.isAvailable else { return }
 
         let aiChatPreferences = AIChatPreferencesPersistor()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputFeature.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputFeature.swift
@@ -30,6 +30,13 @@ struct UnifiedToggleInputFeature: UnifiedToggleInputFeatureProviding {
 
     private static let isFeatureFlagEnabledKey = "com.duckduckgo.unifiedToggleInput.session.enabled"
 
+    private static let controlCohortID = FeatureFlag.DuckAIQueryExperimentCohort.control.rawValue
+
+    private static let nonControlCohortExcludedExperimentIDs: Set<SubfeatureID> = [
+        AIChatSubfeature.onboardingDuckAIQueryExperiment.rawValue,
+        AIChatSubfeature.onboardingDuckAIQueryTrackersDemoExperiment.rawValue,
+    ]
+
     /// Evaluate the feature flag once and persist the result for the session.
     /// Must be called early in the app launch sequence, before any consumer
     /// reads `isAvailable`, so that every component sees the same value.
@@ -38,9 +45,12 @@ struct UnifiedToggleInputFeature: UnifiedToggleInputFeatureProviding {
         UserDefaults.app.set(enabled, forKey: isFeatureFlagEnabledKey)
     }
 
+    private let featureFlagger: FeatureFlagger
     private let devicePlatform: DevicePlatformProviding.Type
 
-    init(devicePlatform: DevicePlatformProviding.Type = DevicePlatform.self) {
+    init(featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
+         devicePlatform: DevicePlatformProviding.Type = DevicePlatform.self) {
+        self.featureFlagger = featureFlagger
         self.devicePlatform = devicePlatform
     }
 
@@ -49,6 +59,15 @@ struct UnifiedToggleInputFeature: UnifiedToggleInputFeatureProviding {
     }
 
     var isAvailable: Bool {
-        isFeatureFlagEnabled && devicePlatform.isIphone
+        isFeatureFlagEnabled && devicePlatform.isIphone && !isInExcludedExperimentCohort
+    }
+
+    private var isInExcludedExperimentCohort: Bool {
+        Self.nonControlCohortExcludedExperimentIDs.contains { experimentID in
+            guard let cohortID = featureFlagger.allActiveExperiments[experimentID]?.cohortID else {
+                return false
+            }
+            return cohortID != Self.controlCohortID
+        }
     }
 }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputFeatureTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputFeatureTests.swift
@@ -20,6 +20,7 @@
 import XCTest
 @testable import DuckDuckGo
 @testable import Core
+import PrivacyConfig
 
 final class UnifiedToggleInputFeatureTests: XCTestCase {
 
@@ -27,6 +28,11 @@ final class UnifiedToggleInputFeatureTests: XCTestCase {
 
     private final class MockDevicePlatform: DevicePlatformProviding {
         static var isIphone: Bool = false
+    }
+
+    private enum ExperimentID {
+        static let duckAIQuery = AIChatSubfeature.onboardingDuckAIQueryExperiment.rawValue
+        static let duckAIQueryTrackersDemo = AIChatSubfeature.onboardingDuckAIQueryTrackersDemoExperiment.rawValue
     }
 
     // MARK: - Setup
@@ -45,11 +51,19 @@ final class UnifiedToggleInputFeatureTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func makeFeature(flagEnabled: Bool, isIphone: Bool) -> UnifiedToggleInputFeature {
+    private func makeFeature(flagEnabled: Bool, isIphone: Bool, activeExperiments: Experiments = [:]) -> UnifiedToggleInputFeature {
         MockDevicePlatform.isIphone = isIphone
         let flags: [FeatureFlag] = flagEnabled ? [.unifiedToggleInput] : []
-        UnifiedToggleInputFeature.resolve(using: MockFeatureFlagger(enabledFeatureFlags: flags))
-        return UnifiedToggleInputFeature(devicePlatform: MockDevicePlatform.self)
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: flags)
+        featureFlagger.mockActiveExperiments = activeExperiments
+        UnifiedToggleInputFeature.resolve(using: featureFlagger)
+        return UnifiedToggleInputFeature(featureFlagger: featureFlagger, devicePlatform: MockDevicePlatform.self)
+    }
+
+    private func makeExperimentData(for subfeature: AIChatSubfeature, cohortID: CohortID) -> ExperimentData {
+        ExperimentData(parentID: subfeature.parent.rawValue,
+                       cohortID: cohortID,
+                       enrollmentDate: Date())
     }
 
     // MARK: - Tests
@@ -70,6 +84,121 @@ final class UnifiedToggleInputFeatureTests: XCTestCase {
         XCTAssertFalse(makeFeature(flagEnabled: false, isIphone: false).isAvailable)
     }
 
+    func test_isAvailable_whenEnrolledInControlCohort() {
+        let feature = makeFeature(flagEnabled: true,
+                                  isIphone: true,
+                                  activeExperiments: [
+                                      ExperimentID.duckAIQuery: makeExperimentData(
+                                          for: .onboardingDuckAIQueryExperiment,
+                                          cohortID: FeatureFlag.DuckAIQueryExperimentCohort.control.rawValue
+                                      ),
+                                      ExperimentID.duckAIQueryTrackersDemo: makeExperimentData(
+                                          for: .onboardingDuckAIQueryTrackersDemoExperiment,
+                                          cohortID: FeatureFlag.DuckAIQueryExperimentCohort.control.rawValue
+                                      )
+                                  ])
+
+        XCTAssertTrue(feature.isAvailable)
+    }
+
+    func test_isNotAvailable_whenEnrolledInTreatmentACohort() {
+        let feature = makeFeature(flagEnabled: true,
+                                  isIphone: true,
+                                  activeExperiments: [
+                                      ExperimentID.duckAIQuery: makeExperimentData(
+                                          for: .onboardingDuckAIQueryExperiment,
+                                          cohortID: FeatureFlag.DuckAIQueryExperimentCohort.treatmentA.rawValue
+                                      )
+                                  ])
+
+        XCTAssertFalse(feature.isAvailable)
+    }
+
+    func test_isNotAvailable_whenEnrolledInTreatmentBCohort() {
+        let feature = makeFeature(flagEnabled: true,
+                                  isIphone: true,
+                                  activeExperiments: [
+                                      ExperimentID.duckAIQuery: makeExperimentData(
+                                          for: .onboardingDuckAIQueryExperiment,
+                                          cohortID: FeatureFlag.DuckAIQueryExperimentCohort.treatmentB.rawValue
+                                      )
+                                  ])
+
+        XCTAssertFalse(feature.isAvailable)
+    }
+
+    func test_isNotAvailable_whenEnrolledInUnknownNonControlCohort() {
+        let feature = makeFeature(flagEnabled: true,
+                                  isIphone: true,
+                                  activeExperiments: [
+                                      ExperimentID.duckAIQuery: makeExperimentData(
+                                          for: .onboardingDuckAIQueryExperiment,
+                                          cohortID: "treatmentC"
+                                      )
+                                  ])
+
+        XCTAssertFalse(feature.isAvailable)
+    }
+
+    func test_isNotAvailable_whenEnrolledInTrackersDemoTreatmentACohort() {
+        let feature = makeFeature(flagEnabled: true,
+                                  isIphone: true,
+                                  activeExperiments: [
+                                      ExperimentID.duckAIQueryTrackersDemo: makeExperimentData(
+                                          for: .onboardingDuckAIQueryTrackersDemoExperiment,
+                                          cohortID: FeatureFlag.DuckAIQueryExperimentCohort.treatmentA.rawValue
+                                      )
+                                  ])
+
+        XCTAssertFalse(feature.isAvailable)
+    }
+
+    func test_isNotAvailable_whenEnrolledInTrackersDemoTreatmentBCohort() {
+        let feature = makeFeature(flagEnabled: true,
+                                  isIphone: true,
+                                  activeExperiments: [
+                                      ExperimentID.duckAIQueryTrackersDemo: makeExperimentData(
+                                          for: .onboardingDuckAIQueryTrackersDemoExperiment,
+                                          cohortID: FeatureFlag.DuckAIQueryExperimentCohort.treatmentB.rawValue
+                                      )
+                                  ])
+
+        XCTAssertFalse(feature.isAvailable)
+    }
+
+    func test_isNotAvailable_whenEnrolledInTrackersDemoUnknownNonControlCohort() {
+        let feature = makeFeature(flagEnabled: true,
+                                  isIphone: true,
+                                  activeExperiments: [
+                                      ExperimentID.duckAIQueryTrackersDemo: makeExperimentData(
+                                          for: .onboardingDuckAIQueryTrackersDemoExperiment,
+                                          cohortID: "treatmentC"
+                                      )
+                                  ])
+
+        XCTAssertFalse(feature.isAvailable)
+    }
+
+    func test_isAvailable_whenTreatmentCohortBelongsToAnotherExperiment() {
+        let feature = makeFeature(flagEnabled: true,
+                                  isIphone: true,
+                                  activeExperiments: [
+                                      "otherExperiment": ExperimentData(parentID: "aiChat", cohortID: "treatment", enrollmentDate: Date())
+                                  ])
+
+        XCTAssertTrue(feature.isAvailable)
+    }
+
+    func test_isAvailable_doesNotResolveExperimentCohort() {
+        MockDevicePlatform.isIphone = true
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.unifiedToggleInput])
+        UnifiedToggleInputFeature.resolve(using: featureFlagger)
+        let feature = UnifiedToggleInputFeature(featureFlagger: featureFlagger, devicePlatform: MockDevicePlatform.self)
+
+        XCTAssertTrue(feature.isAvailable)
+        XCTAssertFalse(featureFlagger.didCallResolveCohort)
+    }
+
     // MARK: - Snapshot semantics
 
     /// Mid-session flag flips must not change availability. Resolve writes the launch-time flag
@@ -78,7 +207,7 @@ final class UnifiedToggleInputFeatureTests: XCTestCase {
         MockDevicePlatform.isIphone = true
         let flagger = MockFeatureFlagger(enabledFeatureFlags: [.unifiedToggleInput])
         UnifiedToggleInputFeature.resolve(using: flagger)
-        let feature = UnifiedToggleInputFeature(devicePlatform: MockDevicePlatform.self)
+        let feature = UnifiedToggleInputFeature(featureFlagger: flagger, devicePlatform: MockDevicePlatform.self)
         XCTAssertTrue(feature.isAvailable, "Precondition: availability is ON after resolve")
 
         flagger.enabledFeatureFlags = []
@@ -86,7 +215,7 @@ final class UnifiedToggleInputFeatureTests: XCTestCase {
                        "Sanity: the live flagger now reports the flag as off")
         XCTAssertTrue(feature.isAvailable,
                       "Snapshot must ignore the post-resolve mutation on the same instance")
-        XCTAssertTrue(UnifiedToggleInputFeature(devicePlatform: MockDevicePlatform.self).isAvailable,
+        XCTAssertTrue(UnifiedToggleInputFeature(featureFlagger: flagger, devicePlatform: MockDevicePlatform.self).isAvailable,
                       "A fresh instance must read the same snapshot, not the mutated live flagger")
 
         UnifiedToggleInputFeature.resolve(using: flagger)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1214600833047335?focus=true
Tech Design URL:
CC:

### Description

Updates Unified Toggle Input availability so users enrolled in non-control cohorts of the relevant Duck.ai onboarding experiments fall back to the standard input experience.

The existing launch-time `unifiedToggleInput` feature flag snapshot and iPhone-only gate are preserved. The experiment check reads already-active experiment enrollment data so availability checks do not assign/enroll users into an experiment.

### Testing Steps

Prerequisites:
1. In the Xcode scheme Run arguments, add:

```text
-ff.unifiedToggleInput true
```

`-ff.unifiedToggleInput true` is required because Unified Toggle Input is not enabled by default. 

Baseline:
1. Build and run the app from Xcode
3. Complete or skip onboarding if needed, then open a New Tab Page.
4. Verify the Unified Toggle Input is shown.

Control-cohort check:
1. Stop the app.
2. In `iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputFeature.swift`, find this guard block inside `isInExcludedExperimentCohort`:

```swift
guard let cohortID = featureFlagger.allActiveExperiments[experimentID]?.cohortID else {
    return false
}
```

Temporarily replace that guard block with:

```swift
let testCohortID: CohortID? = experimentID == AIChatSubfeature.onboardingDuckAIQueryTrackersDemoExperiment.rawValue
    ? FeatureFlag.DuckAIQueryExperimentCohort.control.rawValue
    : nil
guard let cohortID = testCohortID else {
    return false
}
```

This fakes a `control` cohort only for `onboardingDuckAIQueryTrackersDemoExperiment`. Leave the excluded experiment list and the final `return cohortID != Self.controlCohortID` line unchanged.

3. Build and run again from Xcode with the setup argument still enabled.
5. Open a New Tab Page.
6. Verify the Unified Toggle Input is still shown.

Treatment-cohort check:
1. Stop the app.
2. In the temporary `testCohortID` line, change `.control.rawValue` to `.treatmentA.rawValue`.
3. Build and run again from Xcode with the setup argument still enabled.
4. Open a New Tab Page.
5. Verify the Unified Toggle Input is not shown and the standard New Tab Page input is used instead.
7. Revert the temporary local edit.

### Impact and Risks

Low. This narrows Unified Toggle Input availability for users already enrolled in the Duck.ai onboarding experiment cohorts that should retain the standard input experience.

#### What could go wrong?

If active experiment enrollment data is misread, UTI could be shown to users who should remain on the standard input. Unit coverage verifies control, treatment, unknown non-control, unrelated experiment, and no explicit cohort-resolution calls.

### Quality Considerations

- Preserves the existing launch-time feature flag snapshot.
- Preserves iPhone-only availability.
- Uses `allActiveExperiments` so checking UTI availability does not enroll users into an experiment.
- Manual testing uses a narrow temporary fake cohort lookup for `onboardingDuckAIQueryTrackersDemoExperiment` because the debug Feature Flags cohort picker and `-experiment.*` launch arguments override `resolveCohort`, while this implementation intentionally reads `allActiveExperiments`.

### Notes to Reviewer

The older `onboardingDuckAIQueryExperiment` is also included in the exclusion set and covered by unit tests, but it is disabled in the current bundled config. The manual steps verify the visible app behavior at the gate without requiring brittle simulator `ExperimentsData` seeding.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Low Risk**
> Low risk: availability logic is narrowed with a simple additional check against existing experiment enrollment data and is covered by expanded unit tests.
> 
> **Overview**
> **Unified Toggle Input availability is now additionally gated by Duck.ai onboarding experiment cohort.** Even when the launch-time `unifiedToggleInput` snapshot flag is enabled (and on iPhone), the feature is disabled if the user is actively enrolled in either `onboardingDuckAIQueryExperiment` or `onboardingDuckAIQueryTrackersDemoExperiment` with a *non-control* cohort.
> 
> The availability check is implemented by reading `featureFlagger.allActiveExperiments` (to avoid cohort resolution/enrollment side effects) and `UnifiedToggleInputFeature` now accepts an injected `FeatureFlagger`. Unit tests are expanded to cover control vs multiple treatment/unknown cohorts, unrelated experiments, and to assert no `resolveCohort` calls occur during availability checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6babc2cffda7e8b32a35f5c3a60657c9065ba333. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrows `UnifiedToggleInputFeature.isAvailable` based on already-active experiment enrollment and defers setup until onboarding completes, with expanded unit coverage to prevent unintended cohort resolution/enrollment.
> 
> **Overview**
> **Unified Toggle Input availability is further gated by Duck.ai onboarding experiment cohort.** Even when the launch-time `unifiedToggleInput` snapshot flag is enabled (and on iPhone), the feature is now disabled for users enrolled in non-control cohorts of the `onboardingDuckAIQueryExperiment` or `onboardingDuckAIQueryTrackersDemoExperiment`.
> 
> Setup of Unified Toggle Input in `MainViewController` is deferred until linear onboarding finishes so cohort enrollment is finalized before wiring the coordinator. `UnifiedToggleInputFeature` now takes an injected `FeatureFlagger` and checks `featureFlagger.allActiveExperiments` (avoiding cohort resolution side effects), with new tests covering control/treatment/unknown cohorts, unrelated experiments, and asserting no cohort resolution calls occur.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5243234fbb2b5db6c0f3eea7bad7d822fc8c40f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->