### PR TITLE
ddg-sentry-report skill: portable Asana MCP tool names

### DIFF
--- a/.claude/skills/ddg-sentry-report/SKILL.md
+++ b/.claude/skills/ddg-sentry-report/SKILL.md
@@ -45,7 +45,7 @@ Produces a structured Sentry crash triage report for a DuckDuckGo Apple release 
 ### 1.0 Load MCP tools (via ToolSearch)
 
 - Sentry: `mcp__sentry__find_projects`, `mcp__sentry__find_releases`, `mcp__sentry__list_issues`, `mcp__sentry__get_sentry_resource`
-- Asana: `mcp__plugin_asana_asana__asana_get_task`, `mcp__plugin_asana_asana__asana_update_task`, `mcp__plugin_asana_asana__asana_search_tasks`, `mcp__plugin_asana_asana__asana_create_task`, `mcp__plugin_asana_asana__asana_add_task_followers`
+- Asana: `asana_get_task`, `asana_update_task`, `asana_search_tasks`, `asana_create_task`, `asana_add_task_followers` — the namespace prefix varies by environment: `mcp__asana__` (Claude Agent SDK / direct Asana MCP) or `mcp__plugin_asana_asana__` (Claude Code with the Asana plugin). Pass whichever full name `ToolSearch` surfaces in the current session to `select:`; the rest of this skill refers to the short names only.
 
 ### 1.1 Resolve `<TIME_RANGE>`
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1214997979983945?focus=true

### Description

The `ddg-sentry-report` skill's step 1.0 (`Load MCP tools (via ToolSearch)`) hardcoded the `mcp__plugin_asana_asana__` prefix for every Asana tool. That prefix only exists in Claude Code when the Asana plugin is installed. When the skill is invoked from the Claude Agent SDK (or any environment that loads the Asana MCP directly without the plugin wrapper), the same tools are exposed as `mcp__asana__*`, so the `ToolSearch(query="select:mcp__plugin_asana_asana__asana_get_task,…")` call silently misses and the workflow can't load the schemas it needs.

Switched the listing to short names (`asana_get_task`, `asana_update_task`, etc.) and documented both possible prefixes inline, with the instruction to pass whichever full name `ToolSearch` actually surfaces in the current session. The rest of the skill already references these tools by short name (`asana_search_tasks(...)`, `asana_get_task(...)`, …), so no other steps needed touching.

### Testing Steps
1. Open `.claude/skills/ddg-sentry-report/SKILL.md` and inspect step `1.0 Load MCP tools (via ToolSearch)` — confirm Asana tools are listed by short name with both `mcp__asana__` and `mcp__plugin_asana_asana__` prefixes documented.
2. (Optional) Run `/ddg-sentry-report` in Claude Code with the Asana plugin loaded — `ToolSearch` should still surface and load the plugin-prefixed tool names.
3. (Optional) Run the same skill from the Claude Agent SDK with Asana MCP loaded directly — `ToolSearch` should now surface and load the `mcp__asana__*` names instead of failing.

### Impact and Risks

None. Documentation-only change to a user-invoked skill file; affects only how an LLM agent loads tool schemas at the start of a `/ddg-sentry-report` run. No production code or build artifacts touched.

#### What could go wrong?

The agent could mis-parse the inline prefix note and pass an unprefixed short name to `ToolSearch select:`. Mitigated by the explicit "Pass whichever full name ToolSearch surfaces" instruction and by the fact that `ToolSearch select:` with an unknown name returns an error that the agent can recover from.

### Notes to Reviewer

One-line diff in `.claude/skills/ddg-sentry-report/SKILL.md`. The Sentry tool list above it was left alone — `mcp__sentry__*` is the same in both Claude Code and Agent SDK.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change to the `ddg-sentry-report` skill; main risk is minor confusion if an agent misapplies the prefix guidance when selecting tools.
> 
> **Overview**
> Updates the `ddg-sentry-report` skill’s step `1.0` to stop hard-coding the Asana tool namespace, listing Asana tools by short name and documenting that the prefix may be `mcp__asana__` or `mcp__plugin_asana_asana__` depending on environment.
> 
> This is intended to make the skill’s initial `ToolSearch`/`select:` step work in both Claude Code (Asana plugin) and Agent SDK (direct Asana MCP) without changing the rest of the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b233d43b7e698851c85c884ab1afad2e68f47185. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->