### PR TITLE
iOS: Fix Duck.ai header navigation flicker

### DIFF
--- a/iOS/DuckDuckGo/AIChat/AIChatTabChatHeaderView.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatTabChatHeaderView.swift
@@ -58,12 +58,13 @@ final class AIChatTabChatHeaderView: UIView {
         var canGoForward: Bool = false
         /// Renders the back arrow even when there's no web history, so the user always has an exit.
         var forceBackButtonVisible: Bool = false
+        var reservesNavigationControls: Bool = false
 
         var effectiveCanGoBack: Bool { canGoBack || forceBackButtonVisible }
-        var showsNavPair: Bool { effectiveCanGoBack && canGoForward }
-        var showsStandaloneBack: Bool { effectiveCanGoBack && !canGoForward }
-        var showsStandaloneForward: Bool { canGoForward && !effectiveCanGoBack }
-        var isNavigationVisible: Bool { effectiveCanGoBack || canGoForward }
+        var showsNavigationControls: Bool { reservesNavigationControls || effectiveCanGoBack || canGoForward }
+        var showsNavPair: Bool { effectiveCanGoBack && canGoForward && !reservesNavigationControls }
+        var showsStandaloneBack: Bool { reservesNavigationControls || (effectiveCanGoBack && !canGoForward) }
+        var showsStandaloneForward: Bool { canGoForward && !effectiveCanGoBack && !reservesNavigationControls }
     }
 
     private var state = ViewState() {
@@ -312,6 +313,10 @@ final class AIChatTabChatHeaderView: UIView {
         state.forceBackButtonVisible = visible
     }
 
+    func setReservesNavigationControls(_ reserved: Bool) {
+        state.reservesNavigationControls = reserved
+    }
+
     /// Hides the chats / new-chat pill while a voice session is in progress for this tab.
     /// Back/forward arrows remain so the user can exit.
     func setVoiceSessionActive(_ active: Bool) {
@@ -324,14 +329,19 @@ final class AIChatTabChatHeaderView: UIView {
         // Voice session locks the user in — hide every left-side pill so they can only exit via
         // the in-page mic dismiss (which triggers FE → voiceSessionEnded → chrome restores).
         let hideLeft = state.isVoiceSessionActive
-        // Both arrows crowd the row — drop the title slot. Hidden wrapper hides both children.
+        let showsNavigationControls = state.showsNavigationControls
         titleHolder.isHidden = state.showsNavPair || hideLeft
         backPill.isHidden = hideLeft || !state.showsStandaloneBack
         forwardPill.isHidden = hideLeft || !state.showsStandaloneForward
         navPairPill.isHidden = hideLeft || !state.showsNavPair
         leftPairPill.isHidden = hideLeft
-        // Compose suppressed when nav arrows are visible — the row gets cluttered.
-        newChatButton.isHidden = state.isNavigationVisible
+        backPill.alpha = state.effectiveCanGoBack ? 1.0 : 0.0
+        backButton.isEnabled = state.effectiveCanGoBack
+        backButton.isAccessibilityElement = state.effectiveCanGoBack
+        forwardButton.isEnabled = state.canGoForward
+        navBackButton.isEnabled = state.effectiveCanGoBack
+        navForwardButton.isEnabled = state.canGoForward
+        newChatButton.isHidden = showsNavigationControls
         // When the title slot is hidden the left stack needs the freed width — otherwise the
         // greater/less-than inequalities keep reserving the center and squeeze the nav-pair pill.
         titleSpacingConstraints.forEach { $0.isActive = !titleHolder.isHidden }

--- a/iOS/DuckDuckGo/AIChat/AIChatTabChatHeaderView.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatTabChatHeaderView.swift
@@ -58,10 +58,8 @@ final class AIChatTabChatHeaderView: UIView {
         var canGoForward: Bool = false
         /// Renders the back arrow even when there's no web history, so the user always has an exit.
         var forceBackButtonVisible: Bool = false
-        /// Layout-only Back-slot placeholder for the gap between a Duck.ai prompt submission
-        /// and WebKit reporting `canGoBack = true`. Keeps the Back pill in the layout (alpha
-        /// driven to 0 in `applyState`), while Forward and Compose stay hidden so no slot
-        /// shifts when the real Back arrow appears.
+        /// Layout-only Back-slot placeholder used between prompt submission and `canGoBack`.
+        /// Holds the slot via `backPill` with `alpha = 0` (see `applyState`).
         var reservesNavigationControls: Bool = false
 
         var effectiveCanGoBack: Bool { canGoBack || forceBackButtonVisible }

--- a/iOS/DuckDuckGo/AIChat/AIChatTabChatHeaderView.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatTabChatHeaderView.swift
@@ -58,6 +58,10 @@ final class AIChatTabChatHeaderView: UIView {
         var canGoForward: Bool = false
         /// Renders the back arrow even when there's no web history, so the user always has an exit.
         var forceBackButtonVisible: Bool = false
+        /// Layout-only Back-slot placeholder for the gap between a Duck.ai prompt submission
+        /// and WebKit reporting `canGoBack = true`. Keeps the Back pill in the layout (alpha
+        /// driven to 0 in `applyState`), while Forward and Compose stay hidden so no slot
+        /// shifts when the real Back arrow appears.
         var reservesNavigationControls: Bool = false
 
         var effectiveCanGoBack: Bool { canGoBack || forceBackButtonVisible }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4818,6 +4818,11 @@ extension MainViewController: TabDelegate {
     }
     
     func tabDidFinishNavigation(_ tab: TabViewController) {
+        // Clear the AI-chat header reservation/lock on settle, not in
+        // `tabLoadingStateDidChange`: `TabViewController.url.didSet` can call
+        // tabLoadingStateDidChange synchronously before WebKit starts loading the new URL,
+        // which would drop a reservation set during prompt submission before it ever gets
+        // to bridge the canGoBack delay it exists to bridge.
         let didClearAIChatTabHeaderNavigationLock = clearAIChatTabChatHeaderNavigationLock(for: tab)
         if currentTab == tab {
             if didClearAIChatTabHeaderNavigationLock {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2160,8 +2160,10 @@ class MainViewController: UIViewController {
         refreshBackForwardMenuItems()
         updateChromeForDuckPlayer()
         refreshMiddleButton()
-        aiChatTabChatHeaderView?.setNavAvailable(canGoBack: currentTab?.canGoBack ?? false,
-                                                  canGoForward: currentTab?.canGoForward ?? false)
+        let aiChatTabHeaderNavAvailability = displayedAIChatTabChatHeaderNavigationAvailability(for: currentTab)
+        aiChatTabChatHeaderView?.setNavAvailable(canGoBack: aiChatTabHeaderNavAvailability.canGoBack,
+                                                  canGoForward: aiChatTabHeaderNavAvailability.canGoForward)
+        aiChatTabChatHeaderView?.setReservesNavigationControls(shouldReserveAIChatTabChatHeaderNavigationControls(for: currentTab))
         reconcileBackArrowForceVisibility()
         // Belt-and-braces reconciliation. Most explicit transitions also call this directly
         // (NTP attach, AI-tab refresh, etc.); doing it here too means any future state-change
@@ -4816,11 +4818,25 @@ extension MainViewController: TabDelegate {
     }
     
     func tabDidFinishNavigation(_ tab: TabViewController) {
+        let didClearAIChatTabHeaderNavigationLock = clearAIChatTabChatHeaderNavigationLock(for: tab)
+        if currentTab == tab {
+            if didClearAIChatTabHeaderNavigationLock {
+                refreshControls()
+            }
+            return
+        }
+
         // For the current tab, `tabLoadingStateDidChange` (called immediately before this)
         // already triggers a save, so skip here to avoid a redundant save in the same run loop.
-        guard currentTab != tab else { return }
         _ = tabManager.save()
         tabsBarController?.reloadCell(for: tab.tabModel)
+    }
+
+    func tabDidInterruptProvisionalNavigation(_ tab: TabViewController) {
+        let didClearAIChatTabHeaderNavigationLock = clearAIChatTabChatHeaderNavigationLock(for: tab)
+        if currentTab == tab, didClearAIChatTabHeaderNavigationLock {
+            refreshControls()
+        }
     }
 
     func tab(_ tab: TabViewController, didUpdatePreview preview: UIImage) {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4818,11 +4818,8 @@ extension MainViewController: TabDelegate {
     }
     
     func tabDidFinishNavigation(_ tab: TabViewController) {
-        // Clear the AI-chat header reservation/lock on settle, not in
-        // `tabLoadingStateDidChange`: `TabViewController.url.didSet` can call
-        // tabLoadingStateDidChange synchronously before WebKit starts loading the new URL,
-        // which would drop a reservation set during prompt submission before it ever gets
-        // to bridge the canGoBack delay it exists to bridge.
+        // Clear on settle, not in tabLoadingStateDidChange: `url.didSet` can fire that
+        // synchronously and drop the reservation before it can bridge the canGoBack delay.
         let didClearAIChatTabHeaderNavigationLock = clearAIChatTabChatHeaderNavigationLock(for: tab)
         if currentTab == tab {
             if didClearAIChatTabHeaderNavigationLock {

--- a/iOS/DuckDuckGo/TabDelegate.swift
+++ b/iOS/DuckDuckGo/TabDelegate.swift
@@ -68,6 +68,8 @@ protocol TabDelegate: AnyObject {
     /// after a navigation resolves, not on every loading-state tick.
     func tabDidFinishNavigation(_ tab: TabViewController)
 
+    func tabDidInterruptProvisionalNavigation(_ tab: TabViewController)
+
     func tab(_ tab: TabViewController, didUpdatePreview preview: UIImage)
 
     func tab(_ tab: TabViewController, didChangePrivacyInfo privacyInfo: PrivacyInfo?)
@@ -172,5 +174,7 @@ extension TabDelegate {
     }
 
     func tabDidFinishNavigation(_ tab: TabViewController) {}
+
+    func tabDidInterruptProvisionalNavigation(_ tab: TabViewController) {}
 
 }

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -2235,6 +2235,7 @@ extension TabViewController: WKNavigationDelegate {
 
         // Ignore Frame Load Interrupted that will be caused when a download starts
         if error.code == 102 && error.domain == "WebKitErrorDomain" {
+            delegate?.tabDidInterruptProvisionalNavigation(self)
             return
         }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -26,6 +26,9 @@ import Suggestions
 import UIKit
 import WebKit
 
+/// Snapshot of the `canGoBack` / `canGoForward` values WebKit reports for a tab at a given
+/// instant. Modelled as a value type so it can be captured at one moment (e.g. pre-Back-tap)
+/// and consulted later without being affected by WebKit's mid-flight state.
 struct AIChatTabChatHeaderNavigationAvailability: Equatable {
     static let unavailable = AIChatTabChatHeaderNavigationAvailability(canGoBack: false, canGoForward: false)
 
@@ -33,13 +36,43 @@ struct AIChatTabChatHeaderNavigationAvailability: Equatable {
     let canGoForward: Bool
 }
 
+/// Pre-tap navigation snapshot pinned to a specific tab. The Duck.ai header keeps
+/// displaying `availability` for `tabUID` until that tab's next navigation settles, so
+/// transient WebKit reports during the in-flight back/forward navigation cannot flip the
+/// visible arrow direction. The tab UUID prevents the snapshot from leaking into other
+/// tabs whose `refreshControls()` may run before settle.
 private struct AIChatTabChatHeaderNavigationLock {
+    /// UUID of the tab the snapshot was captured from. A lock only applies while the header
+    /// is being rendered for this same tab; any other tab passes through to live availability.
     let tabUID: TabUID
+    /// Pre-tap `canGoBack` / `canGoForward` to keep displaying until navigation settles.
     let availability: AIChatTabChatHeaderNavigationAvailability
 }
 
+/// Suppresses two distinct Duck.ai header flicker windows during WebKit's settle-time.
+///
+/// - `reservedTabUID` covers the *before-Back-exists* gap. Set when Unified Input submits a
+///   Duck.ai prompt from a non-AI tab; reserves the Back-button slot in layout before WebKit
+///   reports `canGoBack = true`. Layout-only — it never overrides the live
+///   `canGoBack`/`canGoForward` values.
+///
+/// - `lock` covers the *after-Back/Forward-tap* gap. Stores the pre-tap availability
+///   snapshot so transient WebKit reports during the in-flight navigation cannot flip the
+///   visible arrow direction. The two states have independent lifetimes and meanings, so
+///   they live in separate slots.
+///
+/// Both states are scoped to a specific tab UUID: `refreshControls()` can fire for any tab
+/// (or none), and a reservation/lock from one tab must not leak into another.
 struct AIChatTabChatHeaderNavigationState {
+    /// Pre-tap availability snapshot pinned to a tab. Non-nil only while we want the header
+    /// to ignore WebKit's mid-flight `canGoBack` / `canGoForward` reports for that tab.
+    /// Cleared on settle (`tabDidFinishNavigation` / `tabDidInterruptProvisionalNavigation`),
+    /// when a refresh runs for a different tab UUID, or when there is no current tab.
     private var lock: AIChatTabChatHeaderNavigationLock?
+    /// UUID of the tab whose Back-button slot is being reserved in layout. Non-nil only
+    /// during the gap between a prompt submission on a non-AI tab and WebKit reporting
+    /// `canGoBack = true` for the resulting Duck.ai navigation. Carries no availability
+    /// data — it influences layout only.
     private var reservedTabUID: TabUID?
 
     init() {}
@@ -80,11 +113,16 @@ struct AIChatTabChatHeaderNavigationState {
         return true
     }
 
+    /// First-write-wins: a relock for the same tab is a no-op so rapid taps keep the original
+    /// pre-tap snapshot instead of overwriting it with mid-flight WebKit state.
     mutating func lockAvailability(for tabUID: TabUID, availability: AIChatTabChatHeaderNavigationAvailability) {
         guard lock?.tabUID != tabUID else { return }
         lock = AIChatTabChatHeaderNavigationLock(tabUID: tabUID, availability: availability)
     }
 
+    /// Clears both the lock and the reservation for `tabUID` — both temporary states drop
+    /// once a navigation settles. Returns true if either changed, so callers can decide
+    /// whether a refresh is needed.
     mutating func clearLock(for tabUID: TabUID) -> Bool {
         let didClearLock = lock?.tabUID == tabUID
         let didClearReservation = reservedTabUID == tabUID

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -26,9 +26,7 @@ import Suggestions
 import UIKit
 import WebKit
 
-/// Snapshot of the `canGoBack` / `canGoForward` values WebKit reports for a tab at a given
-/// instant. Modelled as a value type so it can be captured at one moment (e.g. pre-Back-tap)
-/// and consulted later without being affected by WebKit's mid-flight state.
+/// Snapshot of WebKit's `canGoBack` / `canGoForward` for a tab at a single instant.
 struct AIChatTabChatHeaderNavigationAvailability: Equatable {
     static let unavailable = AIChatTabChatHeaderNavigationAvailability(canGoBack: false, canGoForward: false)
 
@@ -36,43 +34,21 @@ struct AIChatTabChatHeaderNavigationAvailability: Equatable {
     let canGoForward: Bool
 }
 
-/// Pre-tap navigation snapshot pinned to a specific tab. The Duck.ai header keeps
-/// displaying `availability` for `tabUID` until that tab's next navigation settles, so
-/// transient WebKit reports during the in-flight back/forward navigation cannot flip the
-/// visible arrow direction. The tab UUID prevents the snapshot from leaking into other
-/// tabs whose `refreshControls()` may run before settle.
+/// Pre-tap availability pinned to a tab, used to ignore WebKit's mid-flight reports until
+/// the next navigation settles.
 private struct AIChatTabChatHeaderNavigationLock {
-    /// UUID of the tab the snapshot was captured from. A lock only applies while the header
-    /// is being rendered for this same tab; any other tab passes through to live availability.
     let tabUID: TabUID
-    /// Pre-tap `canGoBack` / `canGoForward` to keep displaying until navigation settles.
     let availability: AIChatTabChatHeaderNavigationAvailability
 }
 
-/// Suppresses two distinct Duck.ai header flicker windows during WebKit's settle-time.
-///
-/// - `reservedTabUID` covers the *before-Back-exists* gap. Set when Unified Input submits a
-///   Duck.ai prompt from a non-AI tab; reserves the Back-button slot in layout before WebKit
-///   reports `canGoBack = true`. Layout-only — it never overrides the live
-///   `canGoBack`/`canGoForward` values.
-///
-/// - `lock` covers the *after-Back/Forward-tap* gap. Stores the pre-tap availability
-///   snapshot so transient WebKit reports during the in-flight navigation cannot flip the
-///   visible arrow direction. The two states have independent lifetimes and meanings, so
-///   they live in separate slots.
-///
-/// Both states are scoped to a specific tab UUID: `refreshControls()` can fire for any tab
-/// (or none), and a reservation/lock from one tab must not leak into another.
+/// Suppresses two Duck.ai header flicker windows during WebKit's settle-time:
+/// - `reservedTabUID` covers the *before-Back-exists* gap after a prompt submission from a
+///   non-AI tab. Layout-only — reserves the Back slot until WebKit reports `canGoBack`.
+/// - `lock` covers the *after-Back/Forward-tap* gap. Pins the pre-tap availability so
+///   transient WebKit reports cannot flip the visible arrow direction.
+/// Both are scoped to a tab UUID because `refreshControls()` can fire for any tab.
 struct AIChatTabChatHeaderNavigationState {
-    /// Pre-tap availability snapshot pinned to a tab. Non-nil only while we want the header
-    /// to ignore WebKit's mid-flight `canGoBack` / `canGoForward` reports for that tab.
-    /// Cleared on settle (`tabDidFinishNavigation` / `tabDidInterruptProvisionalNavigation`),
-    /// when a refresh runs for a different tab UUID, or when there is no current tab.
     private var lock: AIChatTabChatHeaderNavigationLock?
-    /// UUID of the tab whose Back-button slot is being reserved in layout. Non-nil only
-    /// during the gap between a prompt submission on a non-AI tab and WebKit reporting
-    /// `canGoBack = true` for the resulting Duck.ai navigation. Carries no availability
-    /// data — it influences layout only.
     private var reservedTabUID: TabUID?
 
     init() {}
@@ -113,16 +89,13 @@ struct AIChatTabChatHeaderNavigationState {
         return true
     }
 
-    /// First-write-wins: a relock for the same tab is a no-op so rapid taps keep the original
-    /// pre-tap snapshot instead of overwriting it with mid-flight WebKit state.
+    /// First-write-wins so rapid taps keep the original pre-tap snapshot.
     mutating func lockAvailability(for tabUID: TabUID, availability: AIChatTabChatHeaderNavigationAvailability) {
         guard lock?.tabUID != tabUID else { return }
         lock = AIChatTabChatHeaderNavigationLock(tabUID: tabUID, availability: availability)
     }
 
-    /// Clears both the lock and the reservation for `tabUID` — both temporary states drop
-    /// once a navigation settles. Returns true if either changed, so callers can decide
-    /// whether a refresh is needed.
+    /// Clears both the lock and the reservation for `tabUID`. Returns true if either changed.
     mutating func clearLock(for tabUID: TabUID) -> Bool {
         let didClearLock = lock?.tabUID == tabUID
         let didClearReservation = reservedTabUID == tabUID

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -26,6 +26,78 @@ import Suggestions
 import UIKit
 import WebKit
 
+struct AIChatTabChatHeaderNavigationAvailability: Equatable {
+    static let unavailable = AIChatTabChatHeaderNavigationAvailability(canGoBack: false, canGoForward: false)
+
+    let canGoBack: Bool
+    let canGoForward: Bool
+}
+
+private struct AIChatTabChatHeaderNavigationLock {
+    let tabUID: TabUID
+    let availability: AIChatTabChatHeaderNavigationAvailability
+}
+
+struct AIChatTabChatHeaderNavigationState {
+    private var lock: AIChatTabChatHeaderNavigationLock?
+    private var reservedTabUID: TabUID?
+
+    init() {}
+
+    mutating func displayedAvailability(
+        for tabUID: TabUID?,
+        currentAvailability: AIChatTabChatHeaderNavigationAvailability
+    ) -> AIChatTabChatHeaderNavigationAvailability {
+        guard let tabUID else {
+            lock = nil
+            return .unavailable
+        }
+
+        if lock?.tabUID != tabUID {
+            lock = nil
+        }
+        if reservedTabUID != tabUID {
+            reservedTabUID = nil
+        }
+
+        return lock?.availability ?? currentAvailability
+    }
+
+    mutating func reserveNavigationControls(for tabUID: TabUID) {
+        reservedTabUID = tabUID
+    }
+
+    mutating func reservesNavigationControls(for tabUID: TabUID?) -> Bool {
+        guard let tabUID else {
+            return false
+        }
+
+        if reservedTabUID != tabUID {
+            reservedTabUID = nil
+            return false
+        }
+
+        return true
+    }
+
+    mutating func lockAvailability(for tabUID: TabUID, availability: AIChatTabChatHeaderNavigationAvailability) {
+        guard lock?.tabUID != tabUID else { return }
+        lock = AIChatTabChatHeaderNavigationLock(tabUID: tabUID, availability: availability)
+    }
+
+    mutating func clearLock(for tabUID: TabUID) -> Bool {
+        let didClearLock = lock?.tabUID == tabUID
+        let didClearReservation = reservedTabUID == tabUID
+        if didClearLock {
+            lock = nil
+        }
+        if didClearReservation {
+            reservedTabUID = nil
+        }
+        return didClearLock || didClearReservation
+    }
+}
+
 // MARK: - Unified Toggle Input Setup
 
 extension MainViewController {
@@ -704,6 +776,43 @@ private extension MainViewController {
 
 extension MainViewController {
 
+    func displayedAIChatTabChatHeaderNavigationAvailability(for tab: TabViewController?) -> AIChatTabChatHeaderNavigationAvailability {
+        let currentAvailability = tab.map {
+            AIChatTabChatHeaderNavigationAvailability(canGoBack: $0.canGoBack, canGoForward: $0.canGoForward)
+        } ?? .unavailable
+
+        guard let unifiedToggleInputCoordinator else { return currentAvailability }
+        return unifiedToggleInputCoordinator.aiChatTabChatHeaderNavigationState.displayedAvailability(
+            for: tab?.tabModel.uid,
+            currentAvailability: currentAvailability
+        )
+    }
+
+    func shouldReserveAIChatTabChatHeaderNavigationControls(for tab: TabViewController?) -> Bool {
+        guard let unifiedToggleInputCoordinator else { return false }
+        return unifiedToggleInputCoordinator.aiChatTabChatHeaderNavigationState.reservesNavigationControls(for: tab?.tabModel.uid)
+    }
+
+    func reserveAIChatTabChatHeaderNavigationControlsForCurrentTabIfNeeded() {
+        guard let currentTab,
+              currentTab.isAITab != true,
+              currentTab.canGoBack || currentTab.canGoForward || currentTab.webView.url != nil else {
+            return
+        }
+        unifiedToggleInputCoordinator?.aiChatTabChatHeaderNavigationState.reserveNavigationControls(for: currentTab.tabModel.uid)
+    }
+
+    func lockAIChatTabChatHeaderNavigationAvailability(for tab: TabViewController) {
+        unifiedToggleInputCoordinator?.aiChatTabChatHeaderNavigationState.lockAvailability(
+            for: tab.tabModel.uid,
+            availability: AIChatTabChatHeaderNavigationAvailability(canGoBack: tab.canGoBack, canGoForward: tab.canGoForward)
+        )
+    }
+
+    func clearAIChatTabChatHeaderNavigationLock(for tab: TabViewController) -> Bool {
+        unifiedToggleInputCoordinator?.aiChatTabChatHeaderNavigationState.clearLock(for: tab.tabModel.uid) ?? false
+    }
+
     func updateUnifiedInputContentVisibility(for coordinator: UnifiedToggleInputCoordinator) {
         updateUnifiedInputContentVisibility(for: coordinator, renderState: coordinator.computeRenderState())
     }
@@ -1003,6 +1112,7 @@ extension MainViewController: UnifiedToggleInputDelegate {
     }
 
     func unifiedToggleInputDidSubmitPrompt(_ prompt: String, modelId: String?, tools: [AIChatRAGTool]?, reasoningEffort: AIChatReasoningEffort?, images: [AIChatNativePrompt.NativePromptImage]?, files: [AIChatNativePrompt.NativePromptFile]?) {
+        reserveAIChatTabChatHeaderNavigationControlsForCurrentTabIfNeeded()
         openAIChat(prompt, autoSend: true, tools: tools, modelId: modelId, reasoningEffort: reasoningEffort, images: images, files: files)
     }
 
@@ -1143,7 +1253,8 @@ extension MainViewController: AIChatTabChatHeaderViewDelegate {
     }
 
     func aiChatTabChatHeaderDidTapBack() {
-        if currentTab?.canGoBack == true {
+        if let currentTab, currentTab.canGoBack {
+            lockAIChatTabChatHeaderNavigationAvailability(for: currentTab)
             onBackPressed()
         } else {
             presentFocusedOmnibarFromAITab()
@@ -1151,6 +1262,8 @@ extension MainViewController: AIChatTabChatHeaderViewDelegate {
     }
 
     func aiChatTabChatHeaderDidTapForward() {
+        guard let currentTab, currentTab.canGoForward else { return }
+        lockAIChatTabChatHeaderNavigationAvailability(for: currentTab)
         onForwardPressed()
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -236,6 +236,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     private let toggleModeStorage: ToggleModeStoring
     private let stateStore: UnifiedInputStateStoring
     private(set) var currentTabUID: TabUID?
+    var aiChatTabChatHeaderNavigationState = AIChatTabChatHeaderNavigationState()
     private var isApplyingState = false
     /// True while a dismiss-time visible-text clear is in flight. The deferred
     /// `clearText()` is a UI cleanup, not a user intent to delete their typed text;

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputFeatureTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputFeatureTests.swift
@@ -17,6 +17,7 @@
 //  limitations under the License.
 //
 
+import UIKit
 import XCTest
 @testable import DuckDuckGo
 @testable import Core
@@ -92,5 +93,289 @@ final class UnifiedToggleInputFeatureTests: XCTestCase {
         UnifiedToggleInputFeature.resolve(using: flagger)
         XCTAssertFalse(feature.isAvailable,
                        "After re-resolving the snapshot must flip — otherwise resolve isn't doing its job")
+    }
+}
+
+final class AIChatTabChatHeaderNavigationStateTests: XCTestCase {
+
+    func test_displayedAvailability_usesLockedAvailabilityUntilLockClears() {
+        var state = AIChatTabChatHeaderNavigationState()
+        let preTapAvailability = AIChatTabChatHeaderNavigationAvailability(canGoBack: true, canGoForward: false)
+        let webKitAvailabilityAfterBackTap = AIChatTabChatHeaderNavigationAvailability(canGoBack: false, canGoForward: true)
+
+        state.lockAvailability(for: "tab-1", availability: preTapAvailability)
+
+        XCTAssertEqual(
+            state.displayedAvailability(for: "tab-1", currentAvailability: webKitAvailabilityAfterBackTap),
+            preTapAvailability
+        )
+
+        XCTAssertTrue(state.clearLock(for: "tab-1"))
+        XCTAssertEqual(
+            state.displayedAvailability(for: "tab-1", currentAvailability: webKitAvailabilityAfterBackTap),
+            webKitAvailabilityAfterBackTap
+        )
+    }
+
+    func test_displayedAvailability_clearsLockWhenTabChanges() {
+        var state = AIChatTabChatHeaderNavigationState()
+        let lockedAvailability = AIChatTabChatHeaderNavigationAvailability(canGoBack: true, canGoForward: false)
+        let currentAvailability = AIChatTabChatHeaderNavigationAvailability(canGoBack: false, canGoForward: true)
+
+        state.lockAvailability(for: "tab-1", availability: lockedAvailability)
+
+        XCTAssertEqual(
+            state.displayedAvailability(for: "tab-2", currentAvailability: currentAvailability),
+            currentAvailability
+        )
+    }
+
+    func test_displayedAvailability_clearsLockWhenThereIsNoTab() {
+        var state = AIChatTabChatHeaderNavigationState()
+        let lockedAvailability = AIChatTabChatHeaderNavigationAvailability(canGoBack: true, canGoForward: false)
+
+        state.lockAvailability(for: "tab-1", availability: lockedAvailability)
+
+        XCTAssertEqual(
+            state.displayedAvailability(for: nil, currentAvailability: lockedAvailability),
+            .unavailable
+        )
+    }
+
+    func test_lockAvailability_keepsEarliestSnapshotDuringRapidTaps() {
+        var state = AIChatTabChatHeaderNavigationState()
+        let firstTapAvailability = AIChatTabChatHeaderNavigationAvailability(canGoBack: true, canGoForward: false)
+        let secondTapAvailability = AIChatTabChatHeaderNavigationAvailability(canGoBack: false, canGoForward: true)
+
+        state.lockAvailability(for: "tab-1", availability: firstTapAvailability)
+        state.lockAvailability(for: "tab-1", availability: secondTapAvailability)
+
+        XCTAssertEqual(
+            state.displayedAvailability(for: "tab-1", currentAvailability: secondTapAvailability),
+            firstTapAvailability
+        )
+    }
+
+    func test_lockAvailability_canRelockSameTabAfterClear() {
+        var state = AIChatTabChatHeaderNavigationState()
+        let firstTapAvailability = AIChatTabChatHeaderNavigationAvailability(canGoBack: true, canGoForward: false)
+        let secondTapAvailability = AIChatTabChatHeaderNavigationAvailability(canGoBack: false, canGoForward: true)
+
+        state.lockAvailability(for: "tab-1", availability: firstTapAvailability)
+        XCTAssertTrue(state.clearLock(for: "tab-1"))
+        state.lockAvailability(for: "tab-1", availability: secondTapAvailability)
+
+        XCTAssertEqual(
+            state.displayedAvailability(for: "tab-1", currentAvailability: firstTapAvailability),
+            secondTapAvailability
+        )
+    }
+
+    func test_displayedAvailability_doesNotClearReservationWhenThereIsNoTab() {
+        var state = AIChatTabChatHeaderNavigationState()
+        let liveAvailability = AIChatTabChatHeaderNavigationAvailability(canGoBack: true, canGoForward: false)
+
+        state.reserveNavigationControls(for: "tab-1")
+
+        XCTAssertEqual(
+            state.displayedAvailability(for: nil, currentAvailability: .unavailable),
+            .unavailable
+        )
+        XCTAssertFalse(state.reservesNavigationControls(for: nil))
+        XCTAssertTrue(state.reservesNavigationControls(for: "tab-1"))
+        XCTAssertEqual(
+            state.displayedAvailability(for: "tab-1", currentAvailability: liveAvailability),
+            liveAvailability
+        )
+    }
+
+    func test_displayedAvailability_doesNotClearReservationForSameTabRead() {
+        var state = AIChatTabChatHeaderNavigationState()
+
+        state.reserveNavigationControls(for: "tab-1")
+
+        XCTAssertEqual(
+            state.displayedAvailability(for: "tab-1", currentAvailability: .unavailable),
+            .unavailable
+        )
+        XCTAssertTrue(state.reservesNavigationControls(for: "tab-1"))
+    }
+
+    func test_reservesNavigationControls_clearsReservationWhenTabChanges() {
+        var state = AIChatTabChatHeaderNavigationState()
+
+        state.reserveNavigationControls(for: "tab-1")
+
+        XCTAssertTrue(state.reservesNavigationControls(for: "tab-1"))
+        XCTAssertFalse(state.reservesNavigationControls(for: "tab-2"))
+        XCTAssertFalse(state.reservesNavigationControls(for: "tab-1"))
+    }
+}
+
+@MainActor
+final class AIChatTabChatHeaderViewNavigationSlotTests: XCTestCase {
+
+    func test_navigationButtonsAreHiddenWhenNavigationIsUnavailableAndNotReserved() {
+        let sut = AIChatTabChatHeaderView(frame: CGRect(x: 0, y: 0, width: 390, height: 60))
+
+        sut.setNavAvailable(canGoBack: false, canGoForward: false)
+        sut.layoutIfNeeded()
+
+        XCTAssertTrue(visibleButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserBack).isEmpty)
+        XCTAssertTrue(visibleButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserForward).isEmpty)
+        XCTAssertEqual(visibleButtons(in: sut, accessibilityLabel: UserText.aiChatHeaderNewChatAccessibilityLabel).count, 1)
+        XCTAssertEqual(visibleButtons(in: sut, accessibilityLabel: UserText.aiChatHeaderRecentChatsAccessibilityLabel).count, 1)
+    }
+
+    func test_navigationButtonsReserveBackSlotWithoutShowingForwardWhenNavigationIsReserved() {
+        let sut = AIChatTabChatHeaderView(frame: CGRect(x: 0, y: 0, width: 390, height: 60))
+
+        sut.setReservesNavigationControls(true)
+        sut.setNavAvailable(canGoBack: false, canGoForward: false)
+        sut.layoutIfNeeded()
+
+        XCTAssertEqual(layoutSlotButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserBack).count, 1)
+        XCTAssertTrue(visibleButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserBack).isEmpty)
+        XCTAssertTrue(visibleButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserForward).isEmpty)
+        XCTAssertTrue(visibleButtons(in: sut, accessibilityLabel: UserText.aiChatHeaderNewChatAccessibilityLabel).isEmpty)
+        XCTAssertEqual(visibleButtons(in: sut, accessibilityLabel: UserText.aiChatHeaderRecentChatsAccessibilityLabel).count, 1)
+    }
+
+    func test_navigationButtonsReserveBackSlotWithoutShowingForwardWhenForwardNavigationIsAvailable() {
+        let sut = AIChatTabChatHeaderView(frame: CGRect(x: 0, y: 0, width: 390, height: 60))
+
+        sut.setReservesNavigationControls(true)
+        sut.setNavAvailable(canGoBack: false, canGoForward: true)
+        sut.layoutIfNeeded()
+
+        XCTAssertEqual(layoutSlotButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserBack).count, 1)
+        XCTAssertTrue(visibleButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserBack).isEmpty)
+        XCTAssertTrue(layoutSlotButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserForward).isEmpty)
+        XCTAssertTrue(visibleButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserForward).isEmpty)
+        XCTAssertTrue(visibleButtons(in: sut, accessibilityLabel: UserText.aiChatHeaderNewChatAccessibilityLabel).isEmpty)
+        XCTAssertEqual(visibleButtons(in: sut, accessibilityLabel: UserText.aiChatHeaderRecentChatsAccessibilityLabel).count, 1)
+    }
+
+    func test_navigationButtonsReserveBackSlotWithoutShowingNavPairWhenBackAndForwardNavigationAreAvailable() {
+        let sut = AIChatTabChatHeaderView(frame: CGRect(x: 0, y: 0, width: 390, height: 60))
+
+        sut.setReservesNavigationControls(true)
+        sut.setNavAvailable(canGoBack: true, canGoForward: true)
+        sut.layoutIfNeeded()
+
+        XCTAssertEqual(layoutSlotButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserBack).count, 1)
+        XCTAssertEqual(visibleButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserBack).count, 1)
+        XCTAssertTrue(layoutSlotButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserForward).isEmpty)
+        XCTAssertTrue(visibleButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserForward).isEmpty)
+    }
+
+    func test_navigationButtonsShowNavPairWhenBackAndForwardNavigationAreAvailableAndNotReserved() {
+        let sut = AIChatTabChatHeaderView(frame: CGRect(x: 0, y: 0, width: 390, height: 60))
+
+        sut.setNavAvailable(canGoBack: true, canGoForward: true)
+        sut.layoutIfNeeded()
+
+        XCTAssertEqual(layoutSlotButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserBack).count, 1)
+        XCTAssertEqual(layoutSlotButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserForward).count, 1)
+        XCTAssertEqual(visibleButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserBack).count, 1)
+        XCTAssertEqual(visibleButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserForward).count, 1)
+        XCTAssertTrue(visibleButtons(in: sut, accessibilityLabel: UserText.aiChatHeaderNewChatAccessibilityLabel).isEmpty)
+    }
+
+    func test_reservedBackSlotBecomesVisibleWhenBackNavigationBecomesAvailable() throws {
+        let sut = AIChatTabChatHeaderView(frame: CGRect(x: 0, y: 0, width: 390, height: 60))
+
+        sut.setReservesNavigationControls(true)
+        sut.setNavAvailable(canGoBack: false, canGoForward: false)
+        sut.layoutIfNeeded()
+
+        let reservedBackButton = try XCTUnwrap(layoutSlotButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserBack).first)
+
+        sut.setNavAvailable(canGoBack: true, canGoForward: false)
+        sut.layoutIfNeeded()
+
+        let enabledBackButton = try XCTUnwrap(visibleButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserBack).first)
+
+        XCTAssertTrue(reservedBackButton === enabledBackButton)
+        XCTAssertTrue(enabledBackButton.isEnabled)
+        XCTAssertTrue(visibleButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserForward).isEmpty)
+    }
+
+    func test_reservedBackSlotRemainsStableWhenReservationClearsAfterBackNavigationBecomesAvailable() throws {
+        let sut = AIChatTabChatHeaderView(frame: CGRect(x: 0, y: 0, width: 390, height: 60))
+
+        sut.setReservesNavigationControls(true)
+        sut.setNavAvailable(canGoBack: false, canGoForward: false)
+        sut.layoutIfNeeded()
+
+        let reservedBackButton = try XCTUnwrap(layoutSlotButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserBack).first)
+
+        sut.setNavAvailable(canGoBack: true, canGoForward: false)
+        sut.setReservesNavigationControls(false)
+        sut.layoutIfNeeded()
+
+        let visibleBackButton = try XCTUnwrap(visibleButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserBack).first)
+
+        XCTAssertTrue(reservedBackButton === visibleBackButton)
+        XCTAssertTrue(visibleBackButton.isEnabled)
+        XCTAssertTrue(visibleButtons(in: sut, accessibilityLabel: UserText.keyCommandBrowserForward).isEmpty)
+    }
+
+    private func visibleButtons(in view: UIView, accessibilityLabel: String) -> [UIButton] {
+        var result: [UIButton] = []
+        collectVisibleButtons(in: view, accessibilityLabel: accessibilityLabel, result: &result)
+        return result
+    }
+
+    private func collectVisibleButtons(in view: UIView, accessibilityLabel: String, result: inout [UIButton]) {
+        if let button = view as? UIButton,
+           button.accessibilityLabel == accessibilityLabel,
+           isEffectivelyVisible(button) {
+            result.append(button)
+        }
+
+        view.subviews.forEach {
+            collectVisibleButtons(in: $0, accessibilityLabel: accessibilityLabel, result: &result)
+        }
+    }
+
+    private func layoutSlotButtons(in view: UIView, accessibilityLabel: String) -> [UIButton] {
+        var result: [UIButton] = []
+        collectLayoutSlotButtons(in: view, accessibilityLabel: accessibilityLabel, result: &result)
+        return result
+    }
+
+    private func collectLayoutSlotButtons(in view: UIView, accessibilityLabel: String, result: inout [UIButton]) {
+        if let button = view as? UIButton,
+           button.accessibilityLabel == accessibilityLabel,
+           isInVisibleLayout(button) {
+            result.append(button)
+        }
+
+        view.subviews.forEach {
+            collectLayoutSlotButtons(in: $0, accessibilityLabel: accessibilityLabel, result: &result)
+        }
+    }
+
+    private func isEffectivelyVisible(_ view: UIView) -> Bool {
+        var currentView: UIView? = view
+        while let view = currentView {
+            if view.isHidden || view.alpha <= 0.01 {
+                return false
+            }
+            currentView = view.superview
+        }
+        return true
+    }
+
+    private func isInVisibleLayout(_ view: UIView) -> Bool {
+        var currentView: UIView? = view
+        while let view = currentView {
+            if view.isHidden {
+                return false
+            }
+            currentView = view.superview
+        }
+        return true
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214995870352473?focus=true
Tech Design URL:
CC:

### Description

Fixes Duck.ai header back/forward flicker while Unified Input navigation state is still settling.

### Testing Steps

Automated:
1. Run `UnitTests/AIChatTabChatHeaderNavigationStateTests`.
2. Run `UnitTests/AIChatTabChatHeaderViewNavigationSlotTests`.

Manual test case 1: prompt submit from an existing site
1. Open a normal website, for example `https://example.com`.
2. Tap the omnibar Duck.ai toggle.
3. Type a prompt and press Return.
4. Confirm the Duck.ai header does not show Forward at any point.
5. Confirm Compose is hidden while navigation is reserved, Recent Chats remains visible, and Back appears in place once navigation becomes available.

Manual test case 2: true no-history Duck.ai empty state
1. Open a fresh tab with no previous page history.
2. Open Duck.ai from the omnibar toggle and wait for the empty header state.
3. Confirm Recent Chats and Compose are both visible.
4. Confirm Back and Forward are not visible.

Manual test case 3: header Back tap during slow navigation
1. Optionally enable a slow network profile.
2. Repeat manual test case 1 and wait until Back is visible in the Duck.ai header.
3. Tap Back.
4. Confirm the header does not briefly switch to Forward before the visible page changes.
5. Confirm navigation completes to the previous page without leaving a stale Duck.ai header button state.

### Impact and Risks
Low.

#### What could go wrong?
Duck.ai header navigation buttons could render the wrong left-side state. Covered by targeted state and view tests for reserved, no-history, nav-pair, rapid-tap, and reservation-clear cases.

### Quality Considerations
Focused tests cover the slow-navigation race and header-button regression matrix.

### Notes to Reviewer
The regular browser toolbar is unchanged.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tab navigation delegate flow and AI chat header state gating; incorrect lock clearing or reservation could leave stale/disabled nav controls or hide compose unexpectedly, though changes are localized and covered by new unit tests.
> 
> **Overview**
> Prevents Duck.ai header back/forward UI flicker by introducing a per-tab `AIChatTabChatHeaderNavigationState` that can **reserve** the back slot after prompt submission and **lock** pre-tap back/forward availability until navigation settles.
> 
> `MainViewController` now feeds the AI chat header a *displayed* (possibly locked) nav availability snapshot and a reservation flag on `refreshControls()`, locks availability on back/forward taps, and clears the lock on navigation completion or provisional navigation interruption. `AIChatTabChatHeaderView` adds a reservation mode that keeps the back pill in-layout with `alpha = 0` and hides compose while reserved.
> 
> Adds targeted unit tests covering lock/reservation semantics and header button visibility/layout behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfac1c29184d511d7910f2d92c7b82664312aeb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

