### PR TITLE
Address macOS 26 design review feedback (menus, VPN, bookmarks)

### DIFF
--- a/macOS/DuckDuckGo/Bookmarks/Model/BookmarkOutlineViewDataSource.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Model/BookmarkOutlineViewDataSource.swift
@@ -238,7 +238,16 @@ final class BookmarkOutlineViewDataSource: NSObject, BookmarksOutlineViewDataSou
         let rowView = RoundedSelectionRowView()
 
         rowView.requiresAccentColors = contentMode != .foldersOnly
-        let horizontalInset: CGFloat = (contentMode == .bookmarksMenu && AppVersion.isLiquidGlassSupported) ? 10 : 8
+        let horizontalInset: CGFloat
+        if AppVersion.isLiquidGlassSupported {
+            switch contentMode {
+            case .bookmarksMenu: horizontalInset = 10
+            case .bookmarksAndFolders: horizontalInset = 0
+            default: horizontalInset = 8
+            }
+        } else {
+            horizontalInset = 8
+        }
         rowView.insets = NSEdgeInsets(top: 0, left: horizontalInset, bottom: 0, right: horizontalInset)
 
         // observe row drag&drop target highlight state and update `targetRowForDropOperation`

--- a/macOS/DuckDuckGo/Bookmarks/View/AddBookmarkPopover.swift
+++ b/macOS/DuckDuckGo/Bookmarks/View/AddBookmarkPopover.swift
@@ -73,6 +73,9 @@ final class AddBookmarkPopover: NSPopover {
         guard let bookmark else { return }
         let viewModel = AddBookmarkPopoverViewModel(bookmark: bookmark, bookmarkManager: bookmarkManager)
         let syncButtonViewModel = DismissableSyncDeviceButtonModel(source: .bookmarkAdded, keyValueStore: UserDefaults.standard)
+        // Resolve sync-button visibility before measuring the hosting view so the
+        // initial intrinsicContentSize accounts for it and the popover anchors correctly.
+        syncButtonViewModel.viewDidLoad()
         let contentViewController = NSHostingController(rootView: AddBookmarkPopoverView(model: viewModel, syncButtonModel: syncButtonViewModel))
         // It's important to set the frame at least once here. If we don't, the popover
         // can miscalculate position, especially in macOS 26 (Sequoia)

--- a/macOS/DuckDuckGo/Bookmarks/View/AddBookmarkPopoverView.swift
+++ b/macOS/DuckDuckGo/Bookmarks/View/AddBookmarkPopoverView.swift
@@ -34,9 +34,7 @@ struct AddBookmarkPopoverView: View {
         if let addFolderViewModel = model.addFolderViewModel {
             AddBookmarkFolderPopoverView(model: addFolderViewModel)
         } else {
-            addBookmarkView.onAppear {
-                syncButtonModel.viewDidLoad()
-            }
+            addBookmarkView
         }
     }
 

--- a/macOS/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
+++ b/macOS/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
@@ -299,7 +299,6 @@ final class BookmarkListViewController: NSViewController {
         outlineView.addTableColumn(column)
         outlineView.columnAutoresizingStyle = .noColumnAutoresizing
         outlineView.focusRingType = .none
-        outlineView.translatesAutoresizingMaskIntoConstraints = showSyncPromo ? false : true
         if showSyncPromo {
             outlineView.translatesAutoresizingMaskIntoConstraints = false
         } else {
@@ -437,7 +436,7 @@ final class BookmarkListViewController: NSViewController {
         let availableHeightAbove = screenFrame.maxY - screenPosRect.maxY - bookmarkHeaderHeight
         let availableHeight = max(availableHeightAbove, availableHeightBelow)
 
-        let totalHeightForRootBookmarks = (CGFloat(outlineView.numberOfRows) * BookmarkOutlineCellView.rowHeight) + bookmarkHeaderHeight + 12.0 + Constants.panelInset
+        let totalHeightForRootBookmarks = (CGFloat(outlineView.numberOfRows) * BookmarkOutlineCellView.rowHeight) + bookmarkHeaderHeight + 12.0
         var contentSize = Constants.preferredContentSize
 
         if totalHeightForRootBookmarks > availableHeight {

--- a/macOS/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
+++ b/macOS/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
@@ -19,6 +19,7 @@
 import AppKit
 import Carbon
 import Combine
+import Common
 import SwiftUI
 import PixelKit
 
@@ -33,6 +34,7 @@ final class BookmarkListViewController: NSViewController {
 
     fileprivate enum Constants {
         static let preferredContentSize = CGSize(width: 420, height: 500)
+        static var panelInset: CGFloat { AppVersion.isLiquidGlassSupported ? 14 : 0 }
     }
 
     weak var delegate: BookmarkListViewControllerDelegate?
@@ -277,6 +279,7 @@ final class BookmarkListViewController: NSViewController {
         manageBookmarksButton.imageHugsTitle = true
 
         scrollView.borderType = .noBorder
+        scrollView.focusRingType = .none
         scrollView.drawsBackground = false
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.hasHorizontalScroller = false
@@ -286,11 +289,16 @@ final class BookmarkListViewController: NSViewController {
         scrollView.autohidesScrollers = true
         scrollView.automaticallyAdjustsContentInsets = false
         scrollView.scrollerInsets = NSEdgeInsets(top: 5, left: 0, bottom: 5, right: 0)
-        scrollView.contentInsets = NSEdgeInsets(top: 0, left: 0, bottom: 0, right: 12)
+        scrollView.contentInsets = NSEdgeInsets(top: 0, left: 0, bottom: AppVersion.isLiquidGlassSupported ? 20 : 6, right: 0)
 
         let column = NSTableColumn()
-        column.width = scrollView.frame.width - (showSyncPromo ? 44 : 32)
+        column.width = scrollView.frame.width - (showSyncPromo ? 44 : 32) - 2 * Constants.panelInset
+        column.minWidth = column.width
+        column.maxWidth = column.width
+        column.resizingMask = []
         outlineView.addTableColumn(column)
+        outlineView.columnAutoresizingStyle = .noColumnAutoresizing
+        outlineView.focusRingType = .none
         outlineView.translatesAutoresizingMaskIntoConstraints = showSyncPromo ? false : true
         if showSyncPromo {
             outlineView.translatesAutoresizingMaskIntoConstraints = false
@@ -378,8 +386,8 @@ final class BookmarkListViewController: NSViewController {
 
             scrollView.topAnchor.constraint(equalTo: boxDivider.bottomAnchor),
             scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.panelInset),
+            view.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor, constant: Constants.panelInset),
 
             emptyStateHostingView.topAnchor.constraint(equalTo: boxDivider.bottomAnchor),
             emptyStateHostingView.centerXAnchor.constraint(equalTo: boxDivider.centerXAnchor),
@@ -429,7 +437,7 @@ final class BookmarkListViewController: NSViewController {
         let availableHeightAbove = screenFrame.maxY - screenPosRect.maxY - bookmarkHeaderHeight
         let availableHeight = max(availableHeightAbove, availableHeightBelow)
 
-        let totalHeightForRootBookmarks = (CGFloat(outlineView.numberOfRows) * BookmarkOutlineCellView.rowHeight) + bookmarkHeaderHeight + 12.0
+        let totalHeightForRootBookmarks = (CGFloat(outlineView.numberOfRows) * BookmarkOutlineCellView.rowHeight) + bookmarkHeaderHeight + 12.0 + Constants.panelInset
         var contentSize = Constants.preferredContentSize
 
         if totalHeightForRootBookmarks > availableHeight {
@@ -929,11 +937,11 @@ extension BookmarkListViewController {
                                         documentView.topAnchor.constraint(equalTo: scrollView.contentView.topAnchor),
                                         documentView.leadingAnchor.constraint(equalTo: scrollView.contentView.leadingAnchor),
                                         documentView.trailingAnchor.constraint(lessThanOrEqualTo: scrollView.contentView.trailingAnchor),
-                                        documentView.widthAnchor.constraint(equalTo: scrollView.contentView.widthAnchor, constant: -12),
+                                        documentView.widthAnchor.constraint(equalTo: scrollView.contentView.widthAnchor),
 
-                                        syncPromoViewHostingView.topAnchor.constraint(equalTo: documentView.topAnchor, constant: 8),
-                                        syncPromoViewHostingView.leadingAnchor.constraint(equalTo: documentView.leadingAnchor, constant: 8),
-                                        syncPromoViewHostingView.trailingAnchor.constraint(equalTo: documentView.trailingAnchor, constant: -8),
+                                        syncPromoViewHostingView.topAnchor.constraint(equalTo: documentView.topAnchor, constant: AppVersion.isLiquidGlassSupported ? 14 : 8),
+                                        syncPromoViewHostingView.leadingAnchor.constraint(equalTo: documentView.leadingAnchor, constant: AppVersion.isLiquidGlassSupported ? 0 : 8),
+                                        syncPromoViewHostingView.trailingAnchor.constraint(equalTo: documentView.trailingAnchor, constant: AppVersion.isLiquidGlassSupported ? 0 : -8),
 
                                         outlineView.leadingAnchor.constraint(equalTo: documentView.leadingAnchor),
                                         outlineView.trailingAnchor.constraint(equalTo: documentView.trailingAnchor),

--- a/macOS/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
+++ b/macOS/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
@@ -289,7 +289,7 @@ final class BookmarkListViewController: NSViewController {
         scrollView.autohidesScrollers = true
         scrollView.automaticallyAdjustsContentInsets = false
         scrollView.scrollerInsets = NSEdgeInsets(top: 5, left: 0, bottom: 5, right: 0)
-        scrollView.contentInsets = NSEdgeInsets(top: 0, left: 0, bottom: AppVersion.isLiquidGlassSupported ? 20 : 6, right: 0)
+        scrollView.contentInsets = NSEdgeInsets(top: 0, left: 0, bottom: AppVersion.isLiquidGlassSupported ? 4 : -2, right: 0)
 
         let column = NSTableColumn()
         column.width = scrollView.frame.width - (showSyncPromo ? 44 : 32) - 2 * Constants.panelInset

--- a/macOS/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
+++ b/macOS/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
@@ -288,7 +288,7 @@ final class BookmarkListViewController: NSViewController {
         scrollView.usesPredominantAxisScrolling = false
         scrollView.autohidesScrollers = true
         scrollView.automaticallyAdjustsContentInsets = false
-        scrollView.scrollerInsets = NSEdgeInsets(top: 5, left: 0, bottom: 5, right: 0)
+        scrollView.scrollerInsets = NSEdgeInsets(top: 5, left: 0, bottom: 5, right: AppVersion.isLiquidGlassSupported ? -10 : 0)
         scrollView.contentInsets = NSEdgeInsets(top: 0, left: 0, bottom: AppVersion.isLiquidGlassSupported ? 4 : -2, right: 0)
 
         let column = NSTableColumn()

--- a/macOS/DuckDuckGo/Menus/HistoryMenu.swift
+++ b/macOS/DuckDuckGo/Menus/HistoryMenu.swift
@@ -122,6 +122,8 @@ final class HistoryMenu: NSMenu {
         clearOldVariableMenuItems()
         addRecentlyVisited()
         addClearAllAndShowHistoryOnTheBottom()
+
+        alignItemTextWithIcons()
     }
 
     private func clearOldVariableMenuItems() {

--- a/macOS/DuckDuckGo/Menus/MainMenu.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenu.swift
@@ -627,6 +627,8 @@ final class MainMenu: NSMenu {
         updateWebExtensionsMenuItem()
         updateAlwaysShowFirstTimeQuitSurvey()
         updateDuckAIChromeButtonMenuItems()
+
+        alignItemTextWithIconsRecursively()
     }
 
     private func updateAlwaysShowFirstTimeQuitSurvey() {

--- a/macOS/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
@@ -1209,6 +1209,7 @@ final class BookmarksSubMenu: NSMenu, NSMenuDelegate {
         exportBookmarItem.isEnabled = bookmarkManager.list?.totalBookmarks != 0
         addItem(exportBookmarItem)
 
+        alignItemTextWithIcons()
     }
 
     @MainActor

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -832,7 +832,6 @@ final class NavigationBarViewController: NSViewController {
         let menu = NSMenu()
         let title = pinningManager.shortcutTitle(for: .bookmarks)
         menu.addItem(withTitle: title, action: #selector(toggleBookmarksPanelPinning(_:)), keyEquivalent: "")
-            .withImage(DesignSystemImages.Glyphs.Size12.bookmarks)
 
         bookmarkListButton.menu = menu
 

--- a/macOS/LocalPackages/AppKitExtensions/Sources/AppKitExtensions/NSMenuExtension.swift
+++ b/macOS/LocalPackages/AppKitExtensions/Sources/AppKitExtensions/NSMenuExtension.swift
@@ -79,4 +79,56 @@ public extension NSMenu {
             addItem(item)
         }
     }
+
+    /// Aligns the title text of items without an `image` with the title text of items that have one,
+    /// section by section (sections are delimited by separator items).
+    ///
+    /// macOS 26's NSMenu auto-indent for image-less items is inconsistent — works in some menus,
+    /// not in others, even when item images are uniformly sized. For each section that contains at
+    /// least one item with an image, this sets a transparent placeholder image (sized to the largest
+    /// image in that section) on the section's image-less items, which forces AppKit to reserve the
+    /// icon column for them and aligns text. Sections with no icons are left untouched. Idempotent.
+    @MainActor
+    func alignItemTextWithIcons() {
+        var section: [NSMenuItem] = []
+        for item in items {
+            if item.isSeparatorItem {
+                alignTextInSection(section)
+                section.removeAll(keepingCapacity: true)
+            } else {
+                section.append(item)
+            }
+        }
+        alignTextInSection(section)
+    }
+
+    @MainActor
+    private func alignTextInSection(_ section: [NSMenuItem]) {
+        guard let maxSize = section.compactMap({ $0.image?.size }).max(by: { $0.width < $1.width }) else {
+            return
+        }
+        let placeholder = NSImage(size: maxSize)
+        for item in section where item.image == nil && item.view == nil && !item.isHeaderLike {
+            item.image = placeholder
+        }
+    }
+
+    /// Recursively calls ``alignItemTextWithIcons()`` on this menu and every submenu.
+    /// Skips submenus that haven't been populated yet (those should call
+    /// ``alignItemTextWithIcons()`` themselves after building their items).
+    @MainActor
+    func alignItemTextWithIconsRecursively() {
+        alignItemTextWithIcons()
+        for item in items where !item.isSeparatorItem {
+            item.submenu?.alignItemTextWithIconsRecursively()
+        }
+    }
+}
+
+private extension NSMenuItem {
+    /// Disabled items with no action render as section headers (small grey caption above a group).
+    /// They sit flush-left, not in the icon column, so they should be excluded from icon alignment.
+    var isHeaderLike: Bool {
+        !isEnabled && action == nil
+    }
 }

--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/SwiftUI/MenuItemCustomButton.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/SwiftUI/MenuItemCustomButton.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import Common
 import Foundation
 import SwiftUI
 
@@ -48,7 +49,7 @@ struct MenuItemCustomButton<Label: View>: View {
             buttonBackground(highlighted: isHovered)
         )
         .contentShape(Rectangle())
-        .cornerRadius(4)
+        .cornerRadius(AppVersion.isLiquidGlassSupported ? 7 : 4)
         .onTapGesture {
             buttonTapped()
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1214997979983952?focus=true

### Description

Addresses several macOS 26 design-review findings:

- Indent icon-less menu items in NSMenus so their text aligns with icon-bearing siblings (View menu, History menu, Bookmarks submenu of the More Options menu). Adds `NSMenu.alignItemTextWithIcons()` helper that runs section-by-section (between separators) and skips disabled-no-action header items.
- Match Nearest Location row corner radius to other VPN menu items under Liquid Glass.
- Fix Add/Edit Bookmark popover position when the sync nudge is shown.
- Add 14pt panel padding to the Bookmarks Panel under Liquid Glass.

### Testing Steps

1. **Menu alignment.** Open the View menu and confirm "Show Tabs and Bookmarks Bar in Full Screen" text aligns with neighbouring icon-bearing items, while "Stop / Reload Page" and the standalone "Home" item are NOT indented. Open the History menu and confirm "Recently Visited" stays flush-left (section header look) while "Example Domain" / favicon-less visit items align with the favicon-bearing ones. Open the … More Options → Bookmarks submenu and confirm "Bookmark All Tabs…" aligns with "Manage Bookmarks".
2. **VPN menu corner radius.** Open the VPN status bar menu and confirm the "Nearest Location" row has the same corner radius as the other rows on macOS 26 Liquid Glass.
3. **Add/Edit Bookmark popover.** Trigger the sync nudge in the address bar, then click the Add/Edit Bookmark button and confirm the popover anchors to the correct button without overlap.
4. **Bookmarks Panel padding.** Open the Bookmarks Panel on macOS 26 Liquid Glass and confirm there is 14pt padding around the panel content.

### Impact and Risks

Low. All changes are visual tweaks scoped to UI rendering — no data, networking, or privacy paths touched.

#### What could go wrong?

- The menu-alignment helper sets a transparent NSImage placeholder on items without an image; if NSMenu's internal layout changes in a future macOS update, the placeholder might be rendered as a 1pt blank space. Idempotent — repeat calls have no effect.
- Disabled-no-action item heuristic for header detection could incorrectly skip a future genuinely-disabled item we want indented; today no such items exist in the affected menus.
- Liquid Glass changes only apply on macOS 26 — older macOS versions are unaffected by VPN row / Bookmarks Panel tweaks.

### Quality Considerations

- Menu helper is idempotent and section-aware, so it can be called from any \`update()\` / \`menuNeedsUpdate(_:)\` without state leakage.
- No new pixels, persisted state, or feature flags introduced.
- Behaviour-only change for the Add/Edit Bookmark popover anchoring; no API surface change.

### Notes to Reviewer

The menu-alignment helper is wired into \`MainMenu.update()\` (recursive), \`HistoryMenu.update()\`, and \`BookmarksSubMenu.addMenuItems(...)\`. If you find other popups that mix icon/no-icon items and aren't aligning, call \`alignItemTextWithIcons()\` at the end of that menu's setup.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual/layout tweaks gated on `AppVersion.isLiquidGlassSupported`, primarily affecting menu indentation and panel/popup sizing without changing data or core behavior.
> 
> **Overview**
> Addresses macOS 26 (Liquid Glass) UI review feedback across menus, VPN, and bookmarks.
> 
> Adds `NSMenu.alignItemTextWithIcons()` (and recursive variant) to normalize icon-column alignment by inserting per-section placeholder images for image-less items, and wires it into `MainMenu.update()`, `HistoryMenu.update()`, and the bookmarks submenu in `MoreOptionsMenu`.
> 
> Adjusts Liquid Glass-specific layout/styling in bookmarks UI (panel padding/insets, fixed outline column sizing, and per-content-mode row insets) and fixes Add/Edit Bookmark popover anchoring by resolving sync-button visibility before measuring intrinsic size; also increases VPN menu custom button corner radius under Liquid Glass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6fbb5c7832c35cca990b932eb6f2fc9b54eb772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->