### PR TITLE
Fix About warning text vanishing on click on Big Sur

### DIFF
--- a/macOS/LocalPackages/SwiftUIExtensions/Sources/SwiftUIExtensions/NSAttributedTextView.swift
+++ b/macOS/LocalPackages/SwiftUIExtensions/Sources/SwiftUIExtensions/NSAttributedTextView.swift
@@ -80,25 +80,25 @@ public class SelfSizingTextView: NSTextView {
     }
 
     private func heightForWidth(_ width: CGFloat) -> CGFloat {
-        guard let textContainer = textContainer,
-              let layoutManager = layoutManager else {
+        // Measure on a throwaway TextKit stack so we never mutate the live
+        // textContainer / layoutManager that NSTextView is drawing from.
+        // On Big Sur, mutating them here raced with click-driven glyph
+        // layout and caused the visible text to vanish.
+        guard let source = textStorage else {
             return 0
         }
 
-        // Save current container size
-        let originalSize = textContainer.containerSize
+        let storage = NSTextStorage(attributedString: source)
+        let manager = NSLayoutManager()
+        let container = NSTextContainer(
+            size: CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)
+        )
+        container.lineFragmentPadding = textContainer?.lineFragmentPadding ?? 0
+        storage.addLayoutManager(manager)
+        manager.addTextContainer(container)
 
-        // Set container to use specified width with unlimited height
-        textContainer.containerSize = CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)
-
-        // Force layout and get used rect
-        layoutManager.ensureLayout(for: textContainer)
-        let usedRect = layoutManager.usedRect(for: textContainer)
-
-        // Restore original container size
-        textContainer.containerSize = originalSize
-
-        return max(usedRect.height, 1)
+        manager.ensureLayout(for: container)
+        return max(manager.usedRect(for: container).height, 1)
     }
 
     public override func setFrameSize(_ newSize: NSSize) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1212716291476663

### Description

In Settings > About on macOS Big Sur, the second paragraph of the unsupported-OS warning vanished whenever the user clicked anywhere on it. This PR fixes it by measuring the paragraph height on a disposable TextKit stack instead of mutating the live one.

### Testing Steps

1. Launch DuckDuckGo on macOS Big Sur (11).
   - The unsupported-OS warning appears at the top of Settings > About.
2. Click anywhere inside the second paragraph (the one containing the "macOS X.Y" link).
   - The paragraph text stays visible.

### Impact and Risks

Low. The change only affects how height is measured for views rendered via NSAttributedTextView — currently the unsupported-OS warning and the App Store update notice in Settings > About. The rendered output is identical; only the measurement path differs.

#### What could go wrong?

Unclear.

### Quality Considerations

None.

### Notes to Reviewer

None.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the intrinsic height measurement path for `SelfSizingTextView`, but could affect text sizing/wrapping if the disposable TextKit stack diverges from the live configuration.
> 
> **Overview**
> Fixes a Big Sur-specific issue where clicking selectable attributed text could cause it to disappear by changing `SelfSizingTextView.heightForWidth` to measure with a **new, disposable TextKit stack** instead of temporarily mutating the live `textContainer`/`layoutManager`.
> 
> The new measurement path clones the current `textStorage`, preserves `lineFragmentPadding`, performs layout on the throwaway `NSTextContainer`, and returns the resulting used height.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eba0d30d30f6d48cf921beaa935a4542b2224b84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->