### PR TITLE
Add AI Chat sync promo plumbing

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -573,6 +573,7 @@ public enum SyncSubfeature: String, PrivacySubfeature {
     case syncCreditCards
     case syncIdentities
     case aiChatSync
+    case aiChatSyncPromo
     case simplifiedSyncSetupExperiment
     case allowSingleDeviceOnConnectScreen
 }

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -299,6 +299,9 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212980785692847?focus=true
     case aiChatSync
 
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214965000466711?focus=true
+    case aiChatSyncPromo
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212745919983886?focus=true
     case aiChatSuggestions
 
@@ -637,6 +640,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(AIChatSubfeature.iPadPageContext))
         case .aiChatSync:
             Config(source: .remoteReleasable(SyncSubfeature.aiChatSync))
+        case .aiChatSyncPromo:
+            Config(source: .remoteReleasable(SyncSubfeature.aiChatSyncPromo))
         case .aiChatSuggestions:
             Config(defaultValue: .enabled, source: .remoteReleasable(DuckAiChatHistorySubfeature.featureEnabled))
         case .aiChatContextualSheetImprovements:

--- a/iOS/DuckDuckGo/AutofillLoginListViewModel.swift
+++ b/iOS/DuckDuckGo/AutofillLoginListViewModel.swift
@@ -94,7 +94,7 @@ class AutofillLoginListViewModel: ObservableObject {
                                                                                                                                       reporter: SecureVaultReporter(),
                                                                                                                                       tld: tld)
 
-    private lazy var syncPromoManager: SyncPromoManaging = SyncPromoManager(syncService: syncService)
+    private let syncPromoManager: SyncPromoManaging
 
     private lazy var autofillCredentialsImportManager: AutofillCredentialsImportPresentationManager = AutofillCredentialsImportPresentationManager(loginImportStateProvider: AutofillLoginImportState(keyValueStore: keyValueStore))
 
@@ -133,7 +133,8 @@ class AutofillLoginListViewModel: ObservableObject {
          keyValueStore: ThrowingKeyValueStoring,
          locale: Locale = Locale.current,
          extensionPromotionManager: AutofillExtensionPromotionManaging? = nil,
-         featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger) {
+         featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
+         syncPromoManager: SyncPromoManaging? = nil) {
         self.appSettings = appSettings
         self.tld = tld
         self.secureVault = secureVault
@@ -145,6 +146,7 @@ class AutofillLoginListViewModel: ObservableObject {
         self.locale = locale
         self.extensionPromotionManager = extensionPromotionManager ?? AutofillExtensionPromotionManager(keyValueStore: keyValueStore)
         self.featureFlagger = featureFlagger
+        self.syncPromoManager = syncPromoManager ?? SyncPromoManager(syncService: syncService)
 
         if let count = getAccountsCount() {
             authenticationNotRequired = count == 0 || AppDependencyProvider.shared.autofillLoginSession.isSessionValid
@@ -329,7 +331,7 @@ class AutofillLoginListViewModel: ObservableObject {
     }
 
     func dismissSyncPromo() {
-        syncPromoManager.dismissPromoFor(.passwords)
+        syncPromoManager.dismissPromoFor(.passwords, reason: .userTapped)
     }
 
     func getSurveyToPresent() -> AutofillSurveyManager.AutofillSurvey? {

--- a/iOS/DuckDuckGo/BookmarksViewController.swift
+++ b/iOS/DuckDuckGo/BookmarksViewController.swift
@@ -150,7 +150,7 @@ class BookmarksViewController: UIViewController, UITableViewDelegate {
             self?.segueToSync(source: SyncSettingsViewController.SourceConstants.bookmarksPromotion)
             Pixel.fire(.syncPromoConfirmed, withAdditionalParameters: ["source": SyncPromoManager.Touchpoint.bookmarks.rawValue])
         }, dismissButtonAction: { [weak self] in
-            self?.syncPromoManager.dismissPromoFor(.bookmarks)
+            self?.syncPromoManager.dismissPromoFor(.bookmarks, reason: .userTapped)
             self?.refreshTableHeaderView()
         }))
 

--- a/iOS/DuckDuckGo/DataImport/DataImportSummaryViewModel.swift
+++ b/iOS/DuckDuckGo/DataImport/DataImportSummaryViewModel.swift
@@ -319,7 +319,7 @@ final class DataImportSummaryViewModel: ObservableObject {
         if let importHubPixelContext {
             Pixel.fire(pixel: .importHubResultSyncPromoDismissed, withAdditionalParameters: importHubPixelContext.parameters)
         }
-        syncPromoManager.dismissPromoFor(.dataImport)
+        syncPromoManager.dismissPromoFor(.dataImport, reason: .userTapped)
         dismiss()
     }
 

--- a/iOS/DuckDuckGo/SyncPromoManager.swift
+++ b/iOS/DuckDuckGo/SyncPromoManager.swift
@@ -27,8 +27,20 @@ import DDGSync
 
 protocol SyncPromoManaging {
     func shouldPresentPromoFor(_ touchpoint: SyncPromoManager.Touchpoint, count: Int) -> Bool
-    func dismissPromoFor(_ touchpoint: SyncPromoManager.Touchpoint)
+    func markPromoHandledFor(_ touchpoint: SyncPromoManager.Touchpoint)
+    func recordImpressionFor(_ touchpoint: SyncPromoManager.Touchpoint)
+    func dismissPromoFor(_ touchpoint: SyncPromoManager.Touchpoint, reason: SyncPromoManager.DismissalReason)
     func resetPromos()
+}
+
+enum SyncPromoStorageKeyNames: String, StorageKeyDescribing {
+    case aiChatDismissed = "sync-promo-ai-chat-dismissed"
+    case aiChatImpressions = "sync-promo-ai-chat-impressions"
+}
+
+struct SyncPromoStorageKeys: StoringKeys {
+    let aiChatDismissed = StorageKey<Date>(SyncPromoStorageKeyNames.aiChatDismissed)
+    let aiChatImpressions = StorageKey<Int>(SyncPromoStorageKeyNames.aiChatImpressions)
 }
 
 final class SyncPromoManager: SyncPromoManaging {
@@ -37,10 +49,21 @@ final class SyncPromoManager: SyncPromoManaging {
         case bookmarks
         case passwords
         case dataImport = "data_import"
+        case aiChat = "ai_chat"
     }
+
+    enum DismissalReason: String {
+        case userTapped = "user_tapped"
+        case impressionCap = "impression_cap"
+    }
+
+    static let aiChatImpressionCap = 3
 
     private let featureFlagger: FeatureFlagger
     private let syncService: DDGSyncing
+    private let privacyConfigurationManager: PrivacyConfigurationManaging
+    private let storage: any KeyedStoring<SyncPromoStorageKeys>
+    private let pixelFiring: any PixelFiring.Type
 
     @UserDefaultsWrapper(key: .syncPromoBookmarksDismissed, defaultValue: nil)
     private var syncPromoBookmarksDismissed: Date?
@@ -51,10 +74,26 @@ final class SyncPromoManager: SyncPromoManaging {
     @UserDefaultsWrapper(key: .syncPromoDataImportDismissed, defaultValue: nil)
     private var syncPromoDataImportDismissed: Date?
 
+    private var syncPromoAIChatDismissed: Date? {
+        get { storage.aiChatDismissed }
+        set { storage.aiChatDismissed = newValue }
+    }
+
+    private var syncPromoAIChatImpressions: Int {
+        get { storage.aiChatImpressions ?? 0 }
+        set { storage.aiChatImpressions = newValue }
+    }
+
     init(syncService: DDGSyncing,
-         featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger) {
+         featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
+         privacyConfigurationManager: PrivacyConfigurationManaging = ContentBlocking.shared.privacyConfigurationManager,
+         storage: (any KeyedStoring<SyncPromoStorageKeys>) = UserDefaults.app.keyedStoring(),
+         pixelFiring: any PixelFiring.Type = Pixel.self) {
         self.featureFlagger = featureFlagger
         self.syncService = syncService
+        self.privacyConfigurationManager = privacyConfigurationManager
+        self.storage = storage
+        self.pixelFiring = pixelFiring
     }
 
     func shouldPresentPromoFor(_ touchpoint: Touchpoint, count: Int) -> Bool {
@@ -82,12 +121,23 @@ final class SyncPromoManager: SyncPromoManaging {
                count > 0 {
                 return true
             }
+        case .aiChat:
+            if syncService.authState == .inactive,
+               featureFlagger.isFeatureOn(.sync),
+               featureFlagger.isFeatureOn(.aiChatSync),
+               featureFlagger.isFeatureOn(.aiChatSyncPromo),
+               privacyConfigurationManager.privacyConfig.isEnabled(featureKey: .duckAiChatHistory),
+               syncPromoAIChatDismissed == nil,
+               syncPromoAIChatImpressions < Self.aiChatImpressionCap,
+               count > 0 {
+                return true
+            }
         }
 
         return false
     }
 
-    func dismissPromoFor(_ touchpoint: Touchpoint) {
+    func markPromoHandledFor(_ touchpoint: Touchpoint) {
         switch touchpoint {
         case .bookmarks:
             syncPromoBookmarksDismissed = Date()
@@ -95,14 +145,35 @@ final class SyncPromoManager: SyncPromoManaging {
             syncPromoPasswordsDismissed = Date()
         case .dataImport:
             syncPromoDataImportDismissed = Date()
+        case .aiChat:
+            syncPromoAIChatDismissed = Date()
         }
+    }
 
-        Pixel.fire(.syncPromoDismissed, withAdditionalParameters: ["source": touchpoint.rawValue])
+    func recordImpressionFor(_ touchpoint: Touchpoint) {
+        switch touchpoint {
+        case .bookmarks, .passwords, .dataImport:
+            break
+        case .aiChat:
+            syncPromoAIChatImpressions += 1
+            if syncPromoAIChatImpressions >= Self.aiChatImpressionCap {
+                dismissPromoFor(.aiChat, reason: .impressionCap)
+            }
+        }
+    }
+
+    func dismissPromoFor(_ touchpoint: Touchpoint, reason: DismissalReason) {
+        markPromoHandledFor(touchpoint)
+
+        pixelFiring.fire(.syncPromoDismissed,
+                         withAdditionalParameters: ["source": touchpoint.rawValue, "reason": reason.rawValue])
     }
 
     func resetPromos() {
         syncPromoBookmarksDismissed = nil
         syncPromoPasswordsDismissed = nil
         syncPromoDataImportDismissed = nil
+        syncPromoAIChatDismissed = nil
+        syncPromoAIChatImpressions = 0
     }
 }

--- a/iOS/DuckDuckGo/SyncPromoViewModel.swift
+++ b/iOS/DuckDuckGo/SyncPromoViewModel.swift
@@ -33,7 +33,7 @@ struct SyncPromoViewModel {
             UserText.syncPromoBookmarksTitle
         case .passwords:
             UserText.syncPromoPasswordsTitle
-        case .dataImport:
+        case .dataImport, .aiChat:
             ""
         }
     }
@@ -44,7 +44,7 @@ struct SyncPromoViewModel {
             UserText.syncPromoBookmarksMessage
         case .passwords:
             UserText.syncPromoPasswordsMessage
-        case .dataImport:
+        case .dataImport, .aiChat:
             ""
         }
     }

--- a/iOS/DuckDuckGoTests/AutofillLoginListViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/AutofillLoginListViewModelTests.swift
@@ -553,6 +553,21 @@ class AutofillLoginListViewModelTests: XCTestCase {
         XCTAssertNil(model.getSurveyToPresent())
     }
 
+    func testDismissSyncPromo_DismissesPasswordPromoWithUserTappedReason() {
+        let syncPromoManager = MockSyncPromoManager()
+        let model = MockAutofillLoginListViewModel(appSettings: appSettings,
+                                                   tld: tld,
+                                                   secureVault: vault,
+                                                   syncService: syncService,
+                                                   keyValueStore: mockStore,
+                                                   syncPromoManager: syncPromoManager)
+
+        model.dismissSyncPromo()
+
+        XCTAssertEqual(syncPromoManager.dismissedTouchpoint, .passwords)
+        XCTAssertEqual(syncPromoManager.dismissalReason, .userTapped)
+    }
+
     func testWhenAllConditionsAreMetThenSurveyIsReturnedAndWhenDismissedNotSurveyIsReturned() {
         let model = MockAutofillLoginListViewModel(appSettings: appSettings,
                                                    tld: tld,
@@ -913,4 +928,24 @@ class MockAutofillLoginListViewModel: AutofillLoginListViewModel {
             storageConfiguration: .autofillConfig
         )
     }
+}
+
+private final class MockSyncPromoManager: SyncPromoManaging {
+    private(set) var dismissedTouchpoint: SyncPromoManager.Touchpoint?
+    private(set) var dismissalReason: SyncPromoManager.DismissalReason?
+
+    func shouldPresentPromoFor(_ touchpoint: SyncPromoManager.Touchpoint, count: Int) -> Bool {
+        false
+    }
+
+    func markPromoHandledFor(_ touchpoint: SyncPromoManager.Touchpoint) {}
+
+    func recordImpressionFor(_ touchpoint: SyncPromoManager.Touchpoint) {}
+
+    func dismissPromoFor(_ touchpoint: SyncPromoManager.Touchpoint, reason: SyncPromoManager.DismissalReason) {
+        dismissedTouchpoint = touchpoint
+        dismissalReason = reason
+    }
+
+    func resetPromos() {}
 }

--- a/iOS/DuckDuckGoTests/DataImportSummaryViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/DataImportSummaryViewModelTests.swift
@@ -114,6 +114,23 @@ class DataImportSummaryViewModelTests: XCTestCase {
         XCTAssertTrue(mockDelegate.completeCalled)
     }
 
+    func testDismissSyncPromo_DismissesDataImportPromoWithUserTappedReasonAndNotifiesDelegate() {
+        let syncPromoManager = MockSyncPromoManager(shouldPresentPromo: true)
+        viewModel = DataImportSummaryViewModel(
+            summary: createSummary(),
+            importScreen: .bookmarks,
+            syncService: mockSyncService,
+            syncPromoManager: syncPromoManager
+        )
+        viewModel.delegate = mockDelegate
+
+        viewModel.dismissSyncPromo()
+
+        XCTAssertEqual(syncPromoManager.dismissedTouchpoint, .dataImport)
+        XCTAssertEqual(syncPromoManager.dismissalReason, .userTapped)
+        XCTAssertTrue(mockDelegate.completeCalled)
+    }
+
     func testInit_WithCreditCardsSummary_SetsCreditCardsProperty() {
         let summary = createSummary(creditCards: true)
         viewModel = DataImportSummaryViewModel(summary: summary, importScreen: .bookmarks, syncService: mockSyncService)
@@ -369,6 +386,8 @@ private class MockDataImportSummaryViewModelDelegate: DataImportSummaryViewModel
 
 private final class MockSyncPromoManager: SyncPromoManaging {
     private let shouldPresentPromo: Bool
+    private(set) var dismissedTouchpoint: SyncPromoManager.Touchpoint?
+    private(set) var dismissalReason: SyncPromoManager.DismissalReason?
 
     init(shouldPresentPromo: Bool) {
         self.shouldPresentPromo = shouldPresentPromo
@@ -378,7 +397,14 @@ private final class MockSyncPromoManager: SyncPromoManaging {
         shouldPresentPromo
     }
 
-    func dismissPromoFor(_ touchpoint: SyncPromoManager.Touchpoint) {}
+    func markPromoHandledFor(_ touchpoint: SyncPromoManager.Touchpoint) {}
+
+    func recordImpressionFor(_ touchpoint: SyncPromoManager.Touchpoint) {}
+
+    func dismissPromoFor(_ touchpoint: SyncPromoManager.Touchpoint, reason: SyncPromoManager.DismissalReason) {
+        dismissedTouchpoint = touchpoint
+        dismissalReason = reason
+    }
 
     func resetPromos() {}
 }

--- a/iOS/DuckDuckGoTests/SyncPromoManagerTests.swift
+++ b/iOS/DuckDuckGoTests/SyncPromoManagerTests.swift
@@ -32,6 +32,7 @@ final class SyncPromoManagerTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
+        PixelFiringMock.tearDown()
         customSuite = UserDefaults(suiteName: testGroupName)
         customSuite.removePersistentDomain(forName: testGroupName)
         syncService = MockDDGSyncing(authState: .inactive, scheduler: CapturingScheduler(), isSyncInProgress: false)
@@ -39,6 +40,7 @@ final class SyncPromoManagerTests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
+        PixelFiringMock.tearDown()
         UserDefaults.app = .standard
         syncService = nil
 
@@ -92,7 +94,7 @@ final class SyncPromoManagerTests: XCTestCase {
 
         let syncPromoManager = SyncPromoManager(syncService: syncService, featureFlagger: featureFlagger)
         syncPromoManager.resetPromos()
-        syncPromoManager.dismissPromoFor(.bookmarks)
+        syncPromoManager.dismissPromoFor(.bookmarks, reason: .userTapped)
 
         XCTAssertFalse(syncPromoManager.shouldPresentPromoFor(.bookmarks, count: 1))
     }
@@ -153,7 +155,7 @@ final class SyncPromoManagerTests: XCTestCase {
 
         let syncPromoManager = SyncPromoManager(syncService: syncService, featureFlagger: featureFlagger)
         syncPromoManager.resetPromos()
-        syncPromoManager.dismissPromoFor(.passwords)
+        syncPromoManager.dismissPromoFor(.passwords, reason: .userTapped)
 
         XCTAssertFalse(syncPromoManager.shouldPresentPromoFor(.passwords, count: 1))
     }
@@ -206,7 +208,7 @@ final class SyncPromoManagerTests: XCTestCase {
 
         let syncPromoManager = SyncPromoManager(syncService: syncService, featureFlagger: featureFlagger)
         syncPromoManager.resetPromos()
-        syncPromoManager.dismissPromoFor(.dataImport)
+        syncPromoManager.dismissPromoFor(.dataImport, reason: .userTapped)
 
         XCTAssertFalse(syncPromoManager.shouldPresentPromoFor(.dataImport, count: 1))
     }
@@ -221,12 +223,229 @@ final class SyncPromoManagerTests: XCTestCase {
         XCTAssertFalse(syncPromoManager.shouldPresentPromoFor(.dataImport, count: 0))
     }
 
+    // MARK: - AI Chat Tests
+
+    func testWhenAllConditionsMetThenShouldPresentPromoForAIChat() {
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync, .aiChatSyncPromo])
+        syncService.authState = .inactive
+
+        let syncPromoManager = SyncPromoManager(syncService: syncService,
+                                                featureFlagger: featureFlagger,
+                                                privacyConfigurationManager: makePrivacyConfigManager(historyEnabled: true))
+        syncPromoManager.resetPromos()
+
+        XCTAssertTrue(syncPromoManager.shouldPresentPromoFor(.aiChat, count: 1))
+    }
+
+    func testWhenSyncFeatureFlagDisabledThenShouldNotPresentPromoForAIChat() {
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.aiChatSync, .aiChatSyncPromo])
+        syncService.authState = .inactive
+
+        let syncPromoManager = SyncPromoManager(syncService: syncService,
+                                                featureFlagger: featureFlagger,
+                                                privacyConfigurationManager: makePrivacyConfigManager(historyEnabled: true))
+        syncPromoManager.resetPromos()
+
+        XCTAssertFalse(syncPromoManager.shouldPresentPromoFor(.aiChat, count: 1))
+    }
+
+    func testWhenAIChatHistoryIsEmptyThenShouldNotPresentPromoForAIChat() {
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync, .aiChatSyncPromo])
+        syncService.authState = .inactive
+
+        let syncPromoManager = SyncPromoManager(syncService: syncService,
+                                                featureFlagger: featureFlagger,
+                                                privacyConfigurationManager: makePrivacyConfigManager(historyEnabled: true))
+        syncPromoManager.resetPromos()
+
+        XCTAssertFalse(syncPromoManager.shouldPresentPromoFor(.aiChat, count: 0))
+    }
+
+    func testWhenAIChatSyncPromoFeatureFlagDisabledThenShouldNotPresentPromoForAIChat() {
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync])
+        syncService.authState = .inactive
+
+        let syncPromoManager = SyncPromoManager(syncService: syncService,
+                                                featureFlagger: featureFlagger,
+                                                privacyConfigurationManager: makePrivacyConfigManager(historyEnabled: true))
+        syncPromoManager.resetPromos()
+
+        XCTAssertFalse(syncPromoManager.shouldPresentPromoFor(.aiChat, count: 1))
+    }
+
+    func testWhenAIChatSyncFeatureFlagDisabledThenShouldNotPresentPromoForAIChat() {
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSyncPromo])
+        syncService.authState = .inactive
+
+        let syncPromoManager = SyncPromoManager(syncService: syncService,
+                                                featureFlagger: featureFlagger,
+                                                privacyConfigurationManager: makePrivacyConfigManager(historyEnabled: true))
+        syncPromoManager.resetPromos()
+
+        XCTAssertFalse(syncPromoManager.shouldPresentPromoFor(.aiChat, count: 1))
+    }
+
+    func testWhenAIChatHistoryDisabledThenShouldNotPresentPromoForAIChat() {
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync, .aiChatSyncPromo])
+        syncService.authState = .inactive
+
+        let syncPromoManager = SyncPromoManager(syncService: syncService,
+                                                featureFlagger: featureFlagger,
+                                                privacyConfigurationManager: makePrivacyConfigManager(historyEnabled: false))
+        syncPromoManager.resetPromos()
+
+        XCTAssertFalse(syncPromoManager.shouldPresentPromoFor(.aiChat, count: 1))
+    }
+
+    func testWhenSyncServiceAuthStateActiveThenShouldNotPresentPromoForAIChat() {
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync, .aiChatSyncPromo])
+        syncService.authState = .active
+
+        let syncPromoManager = SyncPromoManager(syncService: syncService,
+                                                featureFlagger: featureFlagger,
+                                                privacyConfigurationManager: makePrivacyConfigManager(historyEnabled: true))
+        syncPromoManager.resetPromos()
+
+        XCTAssertFalse(syncPromoManager.shouldPresentPromoFor(.aiChat, count: 1))
+    }
+
+    func testWhenSyncPromoAIChatDismissedThenShouldNotPresentPromoForAIChat() {
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync, .aiChatSyncPromo])
+        syncService.authState = .inactive
+
+        let syncPromoManager = SyncPromoManager(syncService: syncService,
+                                                featureFlagger: featureFlagger,
+                                                privacyConfigurationManager: makePrivacyConfigManager(historyEnabled: true))
+        syncPromoManager.resetPromos()
+        syncPromoManager.dismissPromoFor(.aiChat, reason: .userTapped)
+
+        XCTAssertFalse(syncPromoManager.shouldPresentPromoFor(.aiChat, count: 1))
+    }
+
+    func testWhenImpressionsBelowCapThenShouldPresentPromoForAIChat() {
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync, .aiChatSyncPromo])
+        syncService.authState = .inactive
+
+        let syncPromoManager = SyncPromoManager(syncService: syncService,
+                                                featureFlagger: featureFlagger,
+                                                privacyConfigurationManager: makePrivacyConfigManager(historyEnabled: true))
+        syncPromoManager.resetPromos()
+
+        syncPromoManager.recordImpressionFor(.aiChat)
+        syncPromoManager.recordImpressionFor(.aiChat)
+
+        XCTAssertTrue(syncPromoManager.shouldPresentPromoFor(.aiChat, count: 1))
+    }
+
+    func testWhenImpressionsReachCapThenShouldNotPresentPromoForAIChat() {
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync, .aiChatSyncPromo])
+        syncService.authState = .inactive
+
+        let syncPromoManager = SyncPromoManager(syncService: syncService,
+                                                featureFlagger: featureFlagger,
+                                                privacyConfigurationManager: makePrivacyConfigManager(historyEnabled: true))
+        syncPromoManager.resetPromos()
+
+        for _ in 0..<SyncPromoManager.aiChatImpressionCap {
+            syncPromoManager.recordImpressionFor(.aiChat)
+        }
+
+        XCTAssertFalse(syncPromoManager.shouldPresentPromoFor(.aiChat, count: 1))
+    }
+
+    func testWhenResetPromosThenAIChatImpressionsAreCleared() {
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync, .aiChatSyncPromo])
+        syncService.authState = .inactive
+
+        let syncPromoManager = SyncPromoManager(syncService: syncService,
+                                                featureFlagger: featureFlagger,
+                                                privacyConfigurationManager: makePrivacyConfigManager(historyEnabled: true))
+        syncPromoManager.resetPromos()
+
+        for _ in 0..<SyncPromoManager.aiChatImpressionCap {
+            syncPromoManager.recordImpressionFor(.aiChat)
+        }
+        XCTAssertFalse(syncPromoManager.shouldPresentPromoFor(.aiChat, count: 1))
+
+        syncPromoManager.resetPromos()
+
+        XCTAssertTrue(syncPromoManager.shouldPresentPromoFor(.aiChat, count: 1))
+    }
+
+    func testRecordImpressionIsNoOpForUncappedTouchpoints() {
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.syncPromotionBookmarks, .sync])
+        syncService.authState = .inactive
+
+        let syncPromoManager = SyncPromoManager(syncService: syncService,
+                                                featureFlagger: featureFlagger,
+                                                privacyConfigurationManager: makePrivacyConfigManager(historyEnabled: true))
+        syncPromoManager.resetPromos()
+
+        for _ in 0..<10 {
+            syncPromoManager.recordImpressionFor(.bookmarks)
+        }
+
+        XCTAssertTrue(syncPromoManager.shouldPresentPromoFor(.bookmarks, count: 1))
+    }
+
+    // MARK: - Pixels
+
+    func testDismissPromoFiresDismissedPixelWithTouchpointAndReason() {
+        let syncPromoManager = SyncPromoManager(syncService: syncService,
+                                                pixelFiring: PixelFiringMock.self)
+
+        for touchpoint in [SyncPromoManager.Touchpoint.bookmarks, .passwords, .dataImport, .aiChat] {
+            PixelFiringMock.tearDown()
+
+            syncPromoManager.dismissPromoFor(touchpoint, reason: .userTapped)
+
+            XCTAssertEqual(PixelFiringMock.allPixelsFired.count, 1)
+            XCTAssertEqual(PixelFiringMock.lastPixelName, Pixel.Event.syncPromoDismissed.name)
+            XCTAssertEqual(PixelFiringMock.lastParams, [
+                "source": touchpoint.rawValue,
+                "reason": SyncPromoManager.DismissalReason.userTapped.rawValue
+            ])
+        }
+    }
+
+    func testRecordImpressionForAIChatWhenCapReachedFiresDismissedPixelWithImpressionCapReason() {
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync, .aiChatSyncPromo])
+        syncService.authState = .inactive
+
+        let syncPromoManager = SyncPromoManager(syncService: syncService,
+                                                featureFlagger: featureFlagger,
+                                                privacyConfigurationManager: makePrivacyConfigManager(historyEnabled: true),
+                                                pixelFiring: PixelFiringMock.self)
+        syncPromoManager.resetPromos()
+
+        for _ in 0..<SyncPromoManager.aiChatImpressionCap {
+            syncPromoManager.recordImpressionFor(.aiChat)
+        }
+
+        XCTAssertEqual(PixelFiringMock.allPixelsFired.count, 1)
+        XCTAssertEqual(PixelFiringMock.lastPixelName, Pixel.Event.syncPromoDismissed.name)
+        XCTAssertEqual(PixelFiringMock.lastParams, [
+            "source": SyncPromoManager.Touchpoint.aiChat.rawValue,
+            "reason": SyncPromoManager.DismissalReason.impressionCap.rawValue
+        ])
+    }
+
     // MARK: - Mock Creation
 
     private func createFeatureFlagger(withFeatureFlagsEnabled featureFlags: [FeatureFlag]) -> FeatureFlagger {
         let mockFeatureFlagger = MockFeatureFlagger()
         mockFeatureFlagger.enabledFeatureFlags.append(contentsOf: featureFlags)
         return mockFeatureFlagger
+    }
+
+    private func makePrivacyConfigManager(historyEnabled: Bool) -> MockPrivacyConfigurationManager {
+        let manager = MockPrivacyConfigurationManager()
+        let config = MockPrivacyConfiguration()
+        config.isFeatureKeyEnabled = { feature, _ in
+            feature == .duckAiChatHistory ? historyEnabled : true
+        }
+        manager.privacyConfig = config
+        return manager
     }
 
 }

--- a/iOS/PixelDefinitions/pixels/definitions/sync_promotion.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/sync_promotion.json5
@@ -1,0 +1,53 @@
+{
+    "sync_promotion_displayed": {
+        "description": "Fired when a Sync promotion is displayed.",
+        "owners": ["frosty"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The surface where the Sync promotion was displayed.",
+                "enum": ["bookmarks", "passwords", "data_import", "ai_chat"]
+            }
+        ]
+    },
+    "sync_promotion_confirmed": {
+        "description": "Fired when a user confirms a Sync promotion.",
+        "owners": ["frosty"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The surface where the Sync promotion was confirmed.",
+                "enum": ["bookmarks", "passwords", "data_import", "ai_chat"]
+            }
+        ]
+    },
+    "sync_promotion_dismissed": {
+        "description": "Fired when a Sync promotion is dismissed.",
+        "owners": ["frosty"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The surface where the Sync promotion was dismissed.",
+                "enum": ["bookmarks", "passwords", "data_import", "ai_chat"]
+            },
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "The reason the Sync promotion was dismissed.",
+                "enum": ["user_tapped", "impression_cap"]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214486865537637?focus=true
Tech Design URL: N/A
CC:

### Description

Adds the AI Chat sync promo eligibility and tracking plumbing.

This introduces AI Chat sync promo eligibility, feature flag wiring, SyncPromoManager touchpoint support, impression/dismissal storage, a 3-impression cap, reset behavior, and updated sync-promo pixels.

There are no visual changes in this PR. The Duck.ai promo UI and unified input integration will land in a follow-up PR.

### Impact and Risks

Low: this is gated promo plumbing for AI Chat sync. If something goes wrong, users may see the future promo too often, not see it when eligible, or have incorrect promo pixels/impression accounting once the UI lands.

#### What could go wrong?

The main risk is incorrect eligibility or impression accounting. The implementation gates presentation through `SyncPromoManager`, caps AI Chat promo impressions, stores dismissal state, and includes dismissal reasons in sync-promo pixels.

### Quality Considerations

Only affects sync promo eligibility/tracking plumbing and depends on the chat sync feature being enabled.

Added pixels following other banner conventions for monitoring. Unit coverage was added for the new eligibility, impression cap, dismissal/reset behavior, and existing promo dismissal call sites affected by the dismissal reason API.

### Notes to Reviewer

Please focus on the SyncPromoManager eligibility, impression cap, dismissal/reset behavior, and sync-promo pixel parameters. Visual changes will be reviewed separately in the follow-up Duck.ai UI PR.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is feature-flagged promo eligibility/tracking logic and pixel plumbing; main impact is whether/when users see the promo and how impressions/dismissals are recorded.
> 
> **Overview**
> Adds plumbing to support an **AI Chat Sync promo** behind a new `aiChatSyncPromo` flag wired through PrivacyConfig (`SyncSubfeature.aiChatSyncPromo`) and iOS `FeatureFlag`.
> 
> Extends `SyncPromoManager` with a new `.aiChat` touchpoint, persistent dismissal/impression tracking (including a 3-impression cap), and a richer dismissal API that records a dismissal *reason*; existing promo call sites were updated to pass `.userTapped`.
> 
> Updates sync-promo pixel definitions/usage to include the new `ai_chat` source and a `reason` parameter, and adds unit coverage for the new eligibility/cap/reset behavior and updated dismissal calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b6601a297e69407a7950720bcc9790eed07829a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->