### PR TITLE
Wire AI Chat sync promo into Duck.ai suggestions

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -2123,6 +2123,7 @@
 		CB6D17B02FA2138200ECD5AE /* AIChatSyncPromoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B12FA2138200ECD5AE /* AIChatSyncPromoView.swift */; };
 		CB6D17B42FB000000ECD5AE /* AIChatSyncPromoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B52FB000000ECD5AE /* AIChatSyncPromoViewModel.swift */; };
 		CB6D17B72FB000000ECD5AE /* AIChatSyncPromoViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B62FB000000ECD5AE /* AIChatSyncPromoViewModelTests.swift */; };
+		CB6D17B82FB100000ECD5AE /* AIChatSyncIntroSheetPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B92FB100000ECD5AE /* AIChatSyncIntroSheetPresenter.swift */; };
 		CB6D17B22FA2138200ECD5AE /* AIChatSyncIntroSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B32FA2138200ECD5AE /* AIChatSyncIntroSheetView.swift */; };
 		CB6D178F2FA213DD00ECD5AE /* URL+SuggestionDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D178E2FA213DD00ECD5AE /* URL+SuggestionDisplay.swift */; };
 		CB6D17912FA2147600ECD5AE /* DuckAISuggestionsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17902FA2147600ECD5AE /* DuckAISuggestionsCoordinator.swift */; };
@@ -4777,6 +4778,7 @@
 		CB6D17B12FA2138200ECD5AE /* AIChatSyncPromoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSyncPromoView.swift; sourceTree = "<group>"; };
 		CB6D17B52FB000000ECD5AE /* AIChatSyncPromoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSyncPromoViewModel.swift; sourceTree = "<group>"; };
 		CB6D17B62FB000000ECD5AE /* AIChatSyncPromoViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSyncPromoViewModelTests.swift; sourceTree = "<group>"; };
+		CB6D17B92FB100000ECD5AE /* AIChatSyncIntroSheetPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSyncIntroSheetPresenter.swift; sourceTree = "<group>"; };
 		CB6D17B32FA2138200ECD5AE /* AIChatSyncIntroSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSyncIntroSheetView.swift; sourceTree = "<group>"; };
 		CB6D178E2FA213DD00ECD5AE /* URL+SuggestionDisplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+SuggestionDisplay.swift"; sourceTree = "<group>"; };
 		CB6D17902FA2147600ECD5AE /* DuckAISuggestionsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAISuggestionsCoordinator.swift; sourceTree = "<group>"; };
@@ -9865,6 +9867,7 @@
 				CB6D17902FA2147600ECD5AE /* DuckAISuggestionsCoordinator.swift */,
 				CB6D17B12FA2138200ECD5AE /* AIChatSyncPromoView.swift */,
 				CB6D17B52FB000000ECD5AE /* AIChatSyncPromoViewModel.swift */,
+				CB6D17B92FB100000ECD5AE /* AIChatSyncIntroSheetPresenter.swift */,
 				CB6D17B32FA2138200ECD5AE /* AIChatSyncIntroSheetView.swift */,
 			);
 			path = Suggestions;
@@ -12735,6 +12738,7 @@
 				CB6D178D2FA2138200ECD5AE /* DuckAISuggestionsViewController.swift in Sources */,
 				CB6D17B02FA2138200ECD5AE /* AIChatSyncPromoView.swift in Sources */,
 				CB6D17B42FB000000ECD5AE /* AIChatSyncPromoViewModel.swift in Sources */,
+				CB6D17B82FB100000ECD5AE /* AIChatSyncIntroSheetPresenter.swift in Sources */,
 				CB6D17B22FA2138200ECD5AE /* AIChatSyncIntroSheetView.swift in Sources */,
 				980891A52237D4F500313A70 /* FeedbackNavigator.swift in Sources */,
 				1E8AD1C927BFAD1500ABA377 /* DirectoryMonitor.swift in Sources */,

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/AIChatSyncIntroSheetPresenter.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/AIChatSyncIntroSheetPresenter.swift
@@ -1,0 +1,47 @@
+//
+//  AIChatSyncIntroSheetPresenter.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+import UIKit
+
+protocol AIChatSyncIntroSheetPresenting {
+    @MainActor
+    func present(from viewController: UIViewController, onSyncSetupRequested: @escaping () -> Void)
+}
+
+final class AIChatSyncIntroSheetPresenter: AIChatSyncIntroSheetPresenting {
+
+    @MainActor
+    func present(from viewController: UIViewController, onSyncSetupRequested: @escaping () -> Void) {
+        let sheet = AIChatSyncIntroSheetView(
+            onScanTap: { [weak viewController] in
+                viewController?.dismiss(animated: true, completion: onSyncSetupRequested)
+            },
+            onNotNowTap: { [weak viewController] in
+                viewController?.dismiss(animated: true)
+            }
+        )
+        let hostingController = UIHostingController(rootView: sheet)
+        if let presentation = hostingController.sheetPresentationController {
+            presentation.detents = [.medium()]
+            presentation.prefersGrabberVisible = true
+        }
+        viewController.present(hostingController, animated: true)
+    }
+}

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/DuckAISuggestionsCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/DuckAISuggestionsCoordinator.swift
@@ -19,6 +19,7 @@
 
 import AIChat
 import Combine
+import DDGSync
 import Suggestions
 import UIKit
 
@@ -26,6 +27,7 @@ protocol DuckAISuggestionsCoordinatorDelegate: AnyObject {
     func duckAISuggestionsDidSelectChat(_ chat: AIChatSuggestion)
     func duckAISuggestionsDidSelectURL(_ suggestion: Suggestion)
     func duckAISuggestionsDidSelectSearchDuckDuckGo(query: String)
+    func duckAISuggestionsDidRequestSyncSetup()
 }
 
 /// Owns the chat fetcher, URL fetcher, and multi-section VC for Duck.ai mode; container talks to this instead of the fetchers directly.
@@ -41,6 +43,8 @@ final class DuckAISuggestionsCoordinator {
     private let chatViewModel: AIChatSuggestionsViewModel
     private let queryProvider: () -> String
     private let layoutConfiguration: DuckAISuggestionsViewController.LayoutConfiguration
+    private let syncPromoManager: SyncPromoManaging?
+    private let syncService: DDGSyncing?
 
     private var viewController: DuckAISuggestionsViewController?
     private var cancellables = Set<AnyCancellable>()
@@ -66,12 +70,16 @@ final class DuckAISuggestionsCoordinator {
          urlLoader: DuckAIURLSuggestionsLoader,
          chatViewModel: AIChatSuggestionsViewModel,
          queryProvider: @escaping () -> String,
-         layoutConfiguration: DuckAISuggestionsViewController.LayoutConfiguration = .standard) {
+         layoutConfiguration: DuckAISuggestionsViewController.LayoutConfiguration = .standard,
+         syncPromoManager: SyncPromoManaging? = nil,
+         syncService: DDGSyncing? = nil) {
         self.chatManager = chatManager
         self.urlLoader = urlLoader
         self.chatViewModel = chatViewModel
         self.queryProvider = queryProvider
         self.layoutConfiguration = layoutConfiguration
+        self.syncPromoManager = syncPromoManager
+        self.syncService = syncService
     }
 
     func start<P: Publisher>(in containerView: UIView,
@@ -99,7 +107,9 @@ final class DuckAISuggestionsCoordinator {
             chatViewModel: chatViewModel,
             urlLoader: urlLoader,
             queryProvider: queryProvider,
-            layoutConfiguration: layoutConfiguration
+            layoutConfiguration: layoutConfiguration,
+            syncPromoManager: syncPromoManager,
+            syncService: syncService
         )
         vc.delegate = self
 
@@ -140,6 +150,10 @@ final class DuckAISuggestionsCoordinator {
         viewController?.setAdditionalTopInset(inset)
     }
 
+    func setIsVisibleContent(_ visible: Bool) {
+        viewController?.setIsVisibleContent(visible)
+    }
+
     func tearDown() {
         cancellables.removeAll()
         onContentChanged = nil
@@ -166,5 +180,9 @@ extension DuckAISuggestionsCoordinator: DuckAISuggestionsViewControllerDelegate 
 
     func duckAISuggestionsDidSelectSearchDuckDuckGo(query: String) {
         delegate?.duckAISuggestionsDidSelectSearchDuckDuckGo(query: query)
+    }
+
+    func duckAISuggestionsDidRequestSyncSetup() {
+        delegate?.duckAISuggestionsDidRequestSyncSetup()
     }
 }

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/DuckAISuggestionsViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/DuckAISuggestionsViewController.swift
@@ -20,6 +20,7 @@
 import AIChat
 import Combine
 import Core
+import DDGSync
 import DesignResourcesKit
 import DesignResourcesKitIcons
 import Suggestions
@@ -30,6 +31,7 @@ protocol DuckAISuggestionsViewControllerDelegate: AnyObject {
     func duckAISuggestionsDidSelectChat(_ chat: AIChatSuggestion)
     func duckAISuggestionsDidSelectURL(_ suggestion: Suggestion)
     func duckAISuggestionsDidSelectSearchDuckDuckGo(query: String)
+    func duckAISuggestionsDidRequestSyncSetup()
 }
 
 /// Three-section suggestions list under the Duck.ai-mode input: recent chats / top URL hits / "Search DuckDuckGo" row.
@@ -52,9 +54,9 @@ final class DuckAISuggestionsViewController: UIViewController {
         /// Extra clearance above the natural insetGrouped top padding so the first cell stays below the floating (x) dismiss button.
         static let topContentInset: CGFloat = 12
         static let escapeHatchCardHeight: CGFloat = 56
-        static let escapeHatchTopPadding: CGFloat = 16
-        /// 24pt gap below the hatch — matches Search-side breathing room around section title.
-        static let escapeHatchBottomPadding: CGFloat = 24
+        static let escapeHatchTopPadding: CGFloat = 8
+        static let headerBottomPadding: CGFloat = 24
+        static let syncPromoInterCardSpacing: CGFloat = 20
         static let recentChatsHeaderHeight: CGFloat = 48
         /// Gap between the "Recent Chats" title baseline and the first chat cell.
         static let recentChatsHeaderBottomPadding: CGFloat = 24
@@ -72,7 +74,7 @@ final class DuckAISuggestionsViewController: UIViewController {
         )
 
         static let unifiedToggleInput = LayoutConfiguration(
-            tableHorizontalInset: 10,
+            tableHorizontalInset: 0,
             escapeHatchHorizontalInset: Constants.horizontalInset,
             escapeHatchMaxWidth: nil
         )
@@ -133,14 +135,25 @@ final class DuckAISuggestionsViewController: UIViewController {
     /// Hatch is hidden while typing — mirrors Search-side, where the autocomplete view covers the NTP+hatch.
     private var isQueryActive = false
 
+    private let syncService: DDGSyncing?
+    private let syncPromoViewModel: AIChatSyncPromoViewModel?
+    private var syncPromoHostingController: UIHostingController<AIChatSyncPromoView>?
+    private var isVisibleContent = false
+
     init(chatViewModel: AIChatSuggestionsViewModel,
          urlLoader: DuckAIURLSuggestionsLoader,
          queryProvider: @escaping () -> String,
-         layoutConfiguration: LayoutConfiguration = .standard) {
+         layoutConfiguration: LayoutConfiguration = .standard,
+         syncPromoManager: SyncPromoManaging? = nil,
+         syncService: DDGSyncing? = nil,
+         syncPromoViewModel: AIChatSyncPromoViewModel? = nil) {
         self.chatViewModel = chatViewModel
         self.urlLoader = urlLoader
         self.queryProvider = queryProvider
         self.layoutConfiguration = layoutConfiguration
+        self.syncService = syncService
+        self.syncPromoViewModel = syncPromoViewModel
+            ?? syncPromoManager.map { AIChatSyncPromoViewModel(syncPromoManager: $0) }
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -165,8 +178,19 @@ final class DuckAISuggestionsViewController: UIViewController {
         let urlChanges = urlLoader.$topURLs.removeDuplicates().map { _ in () }.eraseToAnyPublisher()
         Publishers.MergeMany([chatChanges, urlChanges])
             .debounce(for: .milliseconds(Self.reloadCoalesceMilliseconds), scheduler: DispatchQueue.main)
-            .sink { [weak self] in self?.reload() }
+            .sink { [weak self] in
+                self?.rebuildHeader()
+                self?.reload()
+            }
             .store(in: &cancellables)
+
+        syncService?.authStatePublisher
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.rebuildHeader() }
+            .store(in: &cancellables)
+
+        rebuildHeader()
     }
 
     /// MUST stay computed: UITableView calls delegate methods with stale index paths during animated relayouts.
@@ -218,7 +242,7 @@ final class DuckAISuggestionsViewController: UIViewController {
         }
         guard next != currentEscapeHatch else { return }
         currentEscapeHatch = next
-        rebuildHatch()
+        rebuildHeader()
     }
 
     func setAdditionalTopInset(_ inset: CGFloat) {
@@ -232,11 +256,23 @@ final class DuckAISuggestionsViewController: UIViewController {
     func setQueryActive(_ active: Bool) {
         guard active != isQueryActive else { return }
         isQueryActive = active
-        rebuildHatch()
+        rebuildHeader()
         reload()
     }
 
-    private func rebuildHatch() {
+    func setIsVisibleContent(_ visible: Bool) {
+        guard visible != isVisibleContent else { return }
+        isVisibleContent = visible
+        recordSyncPromoImpressionIfNeeded()
+    }
+
+    // MARK: - Header (escape hatch + sync promo)
+
+    private var shouldShowSyncPromo: Bool {
+        syncPromoViewModel?.shouldShowPromo(isQueryActive: isQueryActive, chatCount: chats.count) ?? false
+    }
+
+    private func rebuildHeader() {
         if let existing = escapeHatchHostingController {
             existing.willMove(toParent: nil)
             existing.view.removeFromSuperview()
@@ -251,6 +287,24 @@ final class DuckAISuggestionsViewController: UIViewController {
             escapeHatchHostingController = hosting
             hosting.didMove(toParent: self)
         }
+
+        if let existing = syncPromoHostingController {
+            existing.willMove(toParent: nil)
+            existing.view.removeFromSuperview()
+            existing.removeFromParent()
+            syncPromoHostingController = nil
+        }
+        if shouldShowSyncPromo {
+            let view = AIChatSyncPromoView(
+                onCTATap: { [weak self] in self?.handleSyncPromoCTATap() },
+                onCloseTap: { [weak self] in self?.handleSyncPromoClose() }
+            )
+            let hosting = UIHostingController(rootView: view)
+            hosting.view.backgroundColor = .clear
+            addChild(hosting)
+            syncPromoHostingController = hosting
+            hosting.didMove(toParent: self)
+        }
         updateTableHeader()
         updateContentInset()
     }
@@ -263,72 +317,100 @@ final class DuckAISuggestionsViewController: UIViewController {
     private func updateTableHeader() {
         guard isViewLoaded else { return }
 
-        guard let hosting = escapeHatchHostingController else {
+        let hatchHosting = escapeHatchHostingController
+        let promoHosting = syncPromoHostingController
+
+        guard hatchHosting != nil || promoHosting != nil else {
             UIView.performWithoutAnimation { tableView.tableHeaderView = nil }
             return
         }
 
-        // Without this, the SwiftUI hosting view's first layout animates from a default position when the hatch reappears.
+        // Without this, the SwiftUI hosting views' first layout animates from a default position when (re)mounted.
         UIView.performWithoutAnimation {
             let effectiveTopPadding = Constants.escapeHatchTopPadding + additionalTopInset
-            let totalHeight = effectiveTopPadding + Constants.escapeHatchCardHeight + Constants.escapeHatchBottomPadding
             let width = tableView.bounds.width > 0 ? tableView.bounds.width : view.bounds.width
-            let container = UIView(frame: CGRect(x: 0, y: 0, width: width, height: totalHeight))
-            container.backgroundColor = UIColor(designSystemColor: .background)
+            let availableCardWidth = width - 2 * layoutConfiguration.escapeHatchHorizontalInset
+            let cardWidth = layoutConfiguration.escapeHatchMaxWidth.map { min(availableCardWidth, $0) } ?? availableCardWidth
 
-            hosting.view.translatesAutoresizingMaskIntoConstraints = false
-            container.addSubview(hosting.view)
-            var constraints = [
-                hosting.view.topAnchor.constraint(equalTo: container.topAnchor, constant: effectiveTopPadding),
-                hosting.view.heightAnchor.constraint(equalToConstant: Constants.escapeHatchCardHeight)
-            ]
-
-            if let maxWidth = layoutConfiguration.escapeHatchMaxWidth {
-                let preferredWidth = hosting.view.widthAnchor.constraint(equalToConstant: maxWidth)
-                preferredWidth.priority = .defaultHigh
-                let minimumLeading = hosting.view.leadingAnchor.constraint(
-                    greaterThanOrEqualTo: container.leadingAnchor,
-                    constant: layoutConfiguration.escapeHatchHorizontalInset
-                )
-                minimumLeading.priority = .required - 1
-                let minimumTrailing = hosting.view.trailingAnchor.constraint(
-                    lessThanOrEqualTo: container.trailingAnchor,
-                    constant: -layoutConfiguration.escapeHatchHorizontalInset
-                )
-                minimumTrailing.priority = .required - 1
-                constraints.append(contentsOf: [
-                    hosting.view.centerXAnchor.constraint(equalTo: container.centerXAnchor),
-                    hosting.view.widthAnchor.constraint(lessThanOrEqualToConstant: maxWidth),
-                    preferredWidth,
-                    minimumLeading,
-                    minimumTrailing
-                ])
-            } else {
-                constraints.append(contentsOf: [
-                    hosting.view.leadingAnchor.constraint(
-                        equalTo: container.leadingAnchor,
-                        constant: layoutConfiguration.escapeHatchHorizontalInset
-                    ),
-                    hosting.view.trailingAnchor.constraint(
-                        equalTo: container.trailingAnchor,
-                        constant: -layoutConfiguration.escapeHatchHorizontalInset
-                    )
-                ])
+            var hatchHeight: CGFloat = 0
+            if let hatchHosting {
+                hatchHeight = Constants.escapeHatchCardHeight
+                hatchHosting.view.frame.size = CGSize(width: cardWidth, height: hatchHeight)
+            }
+            var promoHeight: CGFloat = 0
+            if let promoHosting {
+                let target = CGSize(width: cardWidth, height: UIView.layoutFittingCompressedSize.height)
+                promoHeight = promoHosting.view.systemLayoutSizeFitting(
+                    target,
+                    withHorizontalFittingPriority: .required,
+                    verticalFittingPriority: .fittingSizeLevel
+                ).height
+                promoHosting.view.frame.size = CGSize(width: cardWidth, height: promoHeight)
             }
 
-            NSLayoutConstraint.activate(constraints)
-            container.layoutIfNeeded()
+            var totalHeight = effectiveTopPadding
+            if hatchHeight > 0 { totalHeight += hatchHeight }
+            if hatchHeight > 0 && promoHeight > 0 { totalHeight += Constants.syncPromoInterCardSpacing }
+            if promoHeight > 0 { totalHeight += promoHeight }
+            totalHeight += Constants.headerBottomPadding
+
+            let container = UIView(frame: CGRect(x: 0, y: 0, width: width, height: totalHeight))
+            container.backgroundColor = UIColor(designSystemColor: .background)
+            container.autoresizingMask = [.flexibleWidth]
+
+            let cardOriginX = (width - cardWidth) / 2
+            var nextY = effectiveTopPadding
+
+            if let hatchHosting {
+                hatchHosting.view.frame = CGRect(x: cardOriginX, y: nextY, width: cardWidth, height: hatchHeight)
+                hatchHosting.view.autoresizingMask = [.flexibleLeftMargin, .flexibleRightMargin]
+                container.addSubview(hatchHosting.view)
+                nextY += hatchHeight
+                if promoHosting != nil { nextY += Constants.syncPromoInterCardSpacing }
+            }
+
+            if let promoHosting {
+                promoHosting.view.frame = CGRect(x: cardOriginX, y: nextY, width: cardWidth, height: promoHeight)
+                promoHosting.view.autoresizingMask = [.flexibleLeftMargin, .flexibleRightMargin]
+                container.addSubview(promoHosting.view)
+                nextY += promoHeight
+            }
+
             tableView.tableHeaderView = container
+
+            recordSyncPromoImpressionIfNeeded()
         }
+    }
+
+    private func recordSyncPromoImpressionIfNeeded() {
+        syncPromoViewModel?.recordImpressionIfNeeded(
+            isVisibleContent: isVisibleContent,
+            isPromoVisible: syncPromoHostingController != nil
+        )
     }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         // Header view's frame doesn't auto-size with the tableView's width; rebuild on layout.
-        guard escapeHatchHostingController != nil,
+        let hasHeaderHost = escapeHatchHostingController != nil || syncPromoHostingController != nil
+        guard hasHeaderHost,
               let header = tableView.tableHeaderView,
               header.frame.width != tableView.bounds.width else { return }
         updateTableHeader()
+    }
+
+    // MARK: - Sync promo callbacks
+
+    private func handleSyncPromoCTATap() {
+        if syncPromoViewModel?.handleCTATap() == .requestSyncSetup {
+            delegate?.duckAISuggestionsDidRequestSyncSetup()
+        }
+        rebuildHeader()
+    }
+
+    private func handleSyncPromoClose() {
+        syncPromoViewModel?.handleCloseTap()
+        rebuildHeader()
     }
 
     // MARK: - Cell config

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -38,6 +38,7 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsRootView> {
         static let dataImportSummarySyncPromotion = "promotion_data_import_summary"
         static let bookmarksPromotion = "promotion_bookmarks"
         static let passwordsPromotion = "promotion_passwords"
+        static let aiChatPromotion = "promotion_ai_chat"
     }
 
     enum AutoRestorePromptSource: String {
@@ -391,7 +392,8 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsRootView> {
     }
 
     private func startSyncWithAnotherDeviceIfNecessary() {
-        guard source == SourceConstants.startSyncFlow,
+        let autoStartPairingSources = [SourceConstants.startSyncFlow, SourceConstants.aiChatPromotion]
+        guard let source, autoStartPairingSources.contains(source),
               syncService.authState == .inactive else {
             return
         }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -74,7 +74,8 @@ extension MainViewController {
             duckAiNativeStorageHandler: duckAiNativeStorageHandler,
             preferences: aiChatPreferences,
             toggleModeStorage: toggleModeStorage,
-            stateStore: stateStore
+            stateStore: stateStore,
+            syncService: syncService
         )
         coordinator.delegate = self
         coordinator.updateVoiceSearchAvailability(voiceSearchHelper.isVoiceSearchEnabled)
@@ -1134,6 +1135,11 @@ extension MainViewController: UnifiedInputContentContainerViewControllerDelegate
 
     func unifiedInputEditingStateDidChangeMode(_ mode: TextEntryMode) {
         unifiedToggleInputCoordinator?.syncInputModeFromExternalSource(mode)
+    }
+
+    func unifiedInputEditingStateDidRequestSyncSetup() {
+        unifiedToggleInputCoordinator?.contentViewController.dismissAnimated()
+        segueToSettingsSync(with: SyncSettingsViewController.SourceConstants.aiChatPromotion)
     }
 }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -25,6 +25,7 @@ import Bookmarks
 import Persistence
 import History
 import Core
+import DDGSync
 import Suggestions
 import AIChat
 import RemoteMessaging
@@ -41,6 +42,7 @@ protocol UnifiedInputContentContainerViewControllerDelegate: AnyObject {
     func unifiedInputEditingStateDidRequestTabSwitcher()
     func unifiedInputEditingStateDidRequestTryFireMode()
     func unifiedInputEditingStateDidChangeMode(_ mode: TextEntryMode)
+    func unifiedInputEditingStateDidRequestSyncSetup()
 }
 
 final class UnifiedInputContentContainerViewController: UIViewController {
@@ -86,6 +88,9 @@ final class UnifiedInputContentContainerViewController: UIViewController {
     private let privacyConfigurationManager: PrivacyConfigurationManaging
     private let aiChatSettings: AIChatSettingsProvider
     private let duckAiNativeStorageHandler: DuckAiNativeStorageHandling?
+    private let syncService: DDGSyncing?
+    private let syncPromoManager: SyncPromoManaging?
+    private let aiChatSyncIntroSheetPresenter: AIChatSyncIntroSheetPresenting
 
     // MARK: - Manager Components
 
@@ -111,7 +116,9 @@ final class UnifiedInputContentContainerViewController: UIViewController {
          featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
          privacyConfigurationManager: PrivacyConfigurationManaging = ContentBlocking.shared.privacyConfigurationManager,
          aiChatSettings: AIChatSettingsProvider = AIChatSettings(),
-         duckAiNativeStorageHandler: DuckAiNativeStorageHandling? = nil) {
+         duckAiNativeStorageHandler: DuckAiNativeStorageHandling? = nil,
+         syncService: DDGSyncing? = nil,
+         aiChatSyncIntroSheetPresenter: AIChatSyncIntroSheetPresenting = AIChatSyncIntroSheetPresenter()) {
         self.switchBarHandler = switchBarHandler
         self.daxLogoManager = DaxLogoManager(isFireTab: switchBarHandler.isFireTab)
         self.daxLogoManager.usesLottieTransition = true
@@ -120,6 +127,11 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         self.privacyConfigurationManager = privacyConfigurationManager
         self.aiChatSettings = aiChatSettings
         self.duckAiNativeStorageHandler = duckAiNativeStorageHandler
+        self.syncService = syncService
+        self.syncPromoManager = syncService.map { SyncPromoManager(syncService: $0,
+                                                                  featureFlagger: featureFlagger,
+                                                                  privacyConfigurationManager: privacyConfigurationManager) }
+        self.aiChatSyncIntroSheetPresenter = aiChatSyncIntroSheetPresenter
         self.isUsingTopBarPosition = appSettings.currentAddressBarPosition == .top
         self.isAdjustedForTopBar = self.isUsingTopBarPosition
 
@@ -219,6 +231,13 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         guard active != isContentActive else { return }
         isContentActive = active
         markNeedsVisibleRefresh()
+        updateDuckAISuggestionsActiveState()
+    }
+
+    private func updateDuckAISuggestionsActiveState() {
+        duckAISuggestionsCoordinator?.setIsVisibleContent(
+            isContentActive && switchBarHandler.currentToggleState == .aiChat
+        )
     }
 
     func refreshVisibleContentIfNeeded() {
@@ -487,7 +506,9 @@ final class UnifiedInputContentContainerViewController: UIViewController {
             urlLoader: urlLoader,
             chatViewModel: chatViewModel,
             queryProvider: { [weak self] in self?.switchBarHandler.currentText ?? "" },
-            layoutConfiguration: .unifiedToggleInput
+            layoutConfiguration: .unifiedToggleInput,
+            syncPromoManager: switchBarHandler.isFireTab ? nil : syncPromoManager,
+            syncService: switchBarHandler.isFireTab ? nil : syncService
         )
         coordinator.delegate = self
         coordinator.onContentChanged = { [weak self] in
@@ -504,6 +525,7 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         coordinator.setEscapeHatch(switchBarHandler.isFireTab ? nil : escapeHatchModel)
 
         duckAISuggestionsCoordinator = coordinator
+        updateDuckAISuggestionsActiveState()
     }
 
     private func installDaxLogoView() {
@@ -759,6 +781,7 @@ private extension UnifiedInputContentContainerViewController {
         // Duck.ai mode now renders chats / URLs / search-DDG inline via DuckAISuggestionsCoordinator,
         // so there's no fallback toggling to do here. Search mode is unchanged — the suggestion tray
         // decides its own visibility from query state.
+        updateDuckAISuggestionsActiveState()
     }
 }
 
@@ -877,5 +900,11 @@ extension UnifiedInputContentContainerViewController: DuckAISuggestionsCoordinat
         // flip toggle to Search and submit the query in one step.
         switchBarHandler.setToggleState(.search)
         delegate?.unifiedInputEditingStateDidSubmitQuery(query)
+    }
+
+    func duckAISuggestionsDidRequestSyncSetup() {
+        aiChatSyncIntroSheetPresenter.present(from: self) { [weak self] in
+            self?.delegate?.unifiedInputEditingStateDidRequestSyncSetup()
+        }
     }
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -21,6 +21,7 @@ import AIChat
 import BrowserServicesKit
 import Combine
 import Core
+import DDGSync
 import os.log
 import Subscription
 import UIKit
@@ -346,7 +347,8 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         preferences: AIChatPreferencesPersisting = AIChatPreferencesPersistor(),
         subscriptionManager: any SubscriptionManager = AppDependencyProvider.shared.subscriptionManager,
         toggleModeStorage: ToggleModeStoring = ToggleModeStorage(),
-        stateStore: UnifiedInputStateStoring? = nil
+        stateStore: UnifiedInputStateStoring? = nil,
+        syncService: DDGSyncing? = nil
     ) {
         self.host = host
         self.isToggleEnabled = isToggleEnabled
@@ -367,7 +369,8 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         viewController = UnifiedToggleInputViewController(isToggleEnabled: isToggleEnabled, isFireTab: isFireTab)
         contentViewController = UnifiedInputContentContainerViewController(
             switchBarHandler: viewController.handler,
-            duckAiNativeStorageHandler: duckAiNativeStorageHandler
+            duckAiNativeStorageHandler: duckAiNativeStorageHandler,
+            syncService: syncService
         )
         floatingReturnKeyViewController = UnifiedToggleInputFloatingReturnKeyViewController()
         super.init()

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/DuckAISuggestionsCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/DuckAISuggestionsCoordinatorTests.swift
@@ -17,11 +17,74 @@
 //  limitations under the License.
 //
 
+import AIChat
+import Combine
+import Suggestions
+import UIKit
 import XCTest
 @testable import DuckDuckGo
 
 @MainActor
 final class DuckAISuggestionsCoordinatorTests: XCTestCase {
+
+    private struct Harness {
+        let coordinator: DuckAISuggestionsCoordinator
+        let chatViewModel: AIChatSuggestionsViewModel
+        let urlLoader: DuckAIURLSuggestionsLoader
+        let textSubject = PassthroughSubject<String, Never>()
+        let containerView = UIView()
+        let parentViewController = UIViewController()
+        let queryBox: QueryBox
+    }
+
+    private final class QueryBox {
+        var value: String
+
+        init(_ value: String) {
+            self.value = value
+        }
+    }
+
+    private func makeHarness(query: String = "",
+                             syncPromoManager: SyncPromoManaging? = nil) -> Harness {
+        let queryBox = QueryBox(query)
+        let viewModel = AIChatSuggestionsViewModel()
+        let urlLoader = DuckAIURLSuggestionsLoader(dataSource: EmptySuggestionLoadingDataSource())
+        let chatManager = AIChatHistoryManager(
+            suggestionsReader: MockAIChatSuggestionsReader(),
+            aiChatSettings: MockAIChatSettingsProvider(),
+            viewModel: viewModel
+        )
+        let coordinator = DuckAISuggestionsCoordinator(
+            chatManager: chatManager,
+            urlLoader: urlLoader,
+            chatViewModel: viewModel,
+            queryProvider: { queryBox.value },
+            syncPromoManager: syncPromoManager,
+            syncService: nil
+        )
+        return Harness(coordinator: coordinator, chatViewModel: viewModel, urlLoader: urlLoader, queryBox: queryBox)
+    }
+
+    private func makeCoordinator() -> DuckAISuggestionsCoordinator {
+        makeHarness().coordinator
+    }
+
+    private func start(_ harness: Harness) {
+        harness.coordinator.start(
+            in: harness.containerView,
+            parentViewController: harness.parentViewController,
+            textPublisher: harness.textSubject
+        )
+    }
+
+    private func makeChat(id: String = "1") -> AIChatSuggestion {
+        AIChatSuggestion(id: id, title: "Chat \(id)", isPinned: false, chatId: "chat-\(id)")
+    }
+
+    private func tableView(in harness: Harness) throws -> UITableView {
+        try XCTUnwrap(findTableView(in: harness.containerView))
+    }
 
     func test_hasSettled_returnsFalseWhenOnlyChatHasSettled() {
         XCTAssertFalse(DuckAISuggestionsCoordinator.hasSettled(
@@ -46,4 +109,218 @@ final class DuckAISuggestionsCoordinatorTests: XCTestCase {
             forQuery: "wp", chatLastQuery: "w", urlLastQuery: "w"
         ))
     }
+
+    func test_hasContent_whenEverythingIsEmpty_returnsFalse() {
+        let harness = makeHarness()
+
+        XCTAssertFalse(harness.coordinator.hasContent)
+    }
+
+    func test_hasContent_whenQueryIsNotEmpty_returnsTrue() {
+        let harness = makeHarness(query: "ducks")
+
+        XCTAssertTrue(harness.coordinator.hasContent)
+    }
+
+    func test_hasContent_whenChatsExist_returnsTrue() {
+        let harness = makeHarness()
+        harness.chatViewModel.setChats(pinned: [], recent: [makeChat()])
+
+        XCTAssertTrue(harness.coordinator.hasContent)
+    }
+
+    func test_hasContent_whenURLSuggestionsExist_returnsTrue() throws {
+        let harness = makeHarness()
+        harness.urlLoader.publishURLsForTesting([
+            .website(url: try XCTUnwrap(URL(string: "https://example.com/")))
+        ])
+
+        XCTAssertTrue(harness.coordinator.hasContent)
+    }
+
+    func test_start_installsSuggestionsViewController() {
+        let harness = makeHarness()
+
+        start(harness)
+
+        XCTAssertEqual(harness.parentViewController.children.count, 1)
+        XCTAssertTrue(harness.parentViewController.children.first is DuckAISuggestionsViewController)
+        XCTAssertEqual(harness.containerView.subviews.count, 1)
+    }
+
+    func test_start_whenCalledTwice_installsOnlyOnce() {
+        let harness = makeHarness()
+
+        start(harness)
+        start(harness)
+
+        XCTAssertEqual(harness.parentViewController.children.count, 1)
+        XCTAssertEqual(harness.containerView.subviews.count, 1)
+    }
+
+    func test_setEscapeHatch_afterStart_forwardsToInstalledViewController() throws {
+        let harness = makeHarness()
+        start(harness)
+
+        harness.coordinator.setEscapeHatch(.testFixture)
+
+        XCTAssertNotNil(try tableView(in: harness).tableHeaderView)
+    }
+
+    func test_setAdditionalTopInset_afterStart_forwardsToInstalledViewController() throws {
+        let harness = makeHarness()
+        start(harness)
+
+        harness.coordinator.setAdditionalTopInset(8)
+
+        XCTAssertEqual(try tableView(in: harness).contentInset.top, 20, accuracy: 0.5)
+    }
+
+    func test_setIsVisibleContent_afterStart_forwardsToInstalledViewController() {
+        let syncPromoManager = MockSyncPromoManager()
+        syncPromoManager.shouldPresentForTouchpoint[.aiChat] = true
+        let harness = makeHarness(syncPromoManager: syncPromoManager)
+        start(harness)
+
+        harness.coordinator.setIsVisibleContent(true)
+
+        XCTAssertEqual(syncPromoManager.recordedImpressions, [.aiChat])
+    }
+
+    func test_tearDown_removesInstalledViewControllerAndClearsContent() throws {
+        let harness = makeHarness()
+        harness.chatViewModel.setChats(pinned: [], recent: [makeChat()])
+        harness.urlLoader.publishURLsForTesting([
+            .website(url: try XCTUnwrap(URL(string: "https://example.com/")))
+        ])
+        start(harness)
+        XCTAssertTrue(harness.coordinator.hasContent)
+
+        harness.coordinator.tearDown()
+
+        XCTAssertTrue(harness.parentViewController.children.isEmpty)
+        XCTAssertTrue(harness.containerView.subviews.isEmpty)
+        XCTAssertFalse(harness.coordinator.hasContent)
+    }
+
+    func test_duckAISuggestionsDidSelectChat_forwardsToDelegate() {
+        let coordinator = makeCoordinator()
+        let delegate = MockDuckAISuggestionsCoordinatorDelegate()
+        coordinator.delegate = delegate
+        let chat = AIChatSuggestion(id: "1", title: "Chat 1", isPinned: false, chatId: "chat-1")
+
+        coordinator.duckAISuggestionsDidSelectChat(chat)
+
+        XCTAssertEqual(delegate.selectedChat?.chatId, "chat-1")
+    }
+
+    func test_duckAISuggestionsDidSelectURL_forwardsToDelegate() throws {
+        let coordinator = makeCoordinator()
+        let delegate = MockDuckAISuggestionsCoordinatorDelegate()
+        coordinator.delegate = delegate
+        let suggestion = Suggestion.website(url: try XCTUnwrap(URL(string: "https://example.com/")))
+
+        coordinator.duckAISuggestionsDidSelectURL(suggestion)
+
+        XCTAssertEqual(delegate.selectedURLSuggestion?.url?.host, "example.com")
+    }
+
+    func test_duckAISuggestionsDidSelectSearchDuckDuckGo_forwardsToDelegate() {
+        let coordinator = makeCoordinator()
+        let delegate = MockDuckAISuggestionsCoordinatorDelegate()
+        coordinator.delegate = delegate
+
+        coordinator.duckAISuggestionsDidSelectSearchDuckDuckGo(query: "ducks")
+
+        XCTAssertEqual(delegate.selectedSearchQuery, "ducks")
+    }
+
+    func test_duckAISuggestionsDidRequestSyncSetup_forwardsToDelegate() {
+        let coordinator = makeCoordinator()
+        let delegate = MockDuckAISuggestionsCoordinatorDelegate()
+        coordinator.delegate = delegate
+
+        coordinator.duckAISuggestionsDidRequestSyncSetup()
+
+        XCTAssertEqual(delegate.syncSetupRequestCount, 1)
+    }
+}
+
+@MainActor
+private final class MockDuckAISuggestionsCoordinatorDelegate: DuckAISuggestionsCoordinatorDelegate {
+    var selectedChat: AIChatSuggestion?
+    var selectedURLSuggestion: Suggestion?
+    var selectedSearchQuery: String?
+    var syncSetupRequestCount = 0
+
+    func duckAISuggestionsDidSelectChat(_ chat: AIChatSuggestion) {
+        selectedChat = chat
+    }
+
+    func duckAISuggestionsDidSelectURL(_ suggestion: Suggestion) {
+        selectedURLSuggestion = suggestion
+    }
+
+    func duckAISuggestionsDidSelectSearchDuckDuckGo(query: String) {
+        selectedSearchQuery = query
+    }
+
+    func duckAISuggestionsDidRequestSyncSetup() {
+        syncSetupRequestCount += 1
+    }
+}
+
+@MainActor
+private final class MockAIChatSuggestionsReader: AIChatSuggestionsReading {
+    var maxHistoryCount: Int = 10
+
+    func fetchSuggestions(query: String?, maxChats: Int) async -> (pinned: [AIChatSuggestion], recent: [AIChatSuggestion]) {
+        ([], [])
+    }
+
+    func tearDown() {}
+}
+
+@MainActor
+private final class MockSyncPromoManager: SyncPromoManaging {
+    var shouldPresentForTouchpoint: [SyncPromoManager.Touchpoint: Bool] = [:]
+    var recordedImpressions: [SyncPromoManager.Touchpoint] = []
+
+    func shouldPresentPromoFor(_ touchpoint: SyncPromoManager.Touchpoint, count: Int) -> Bool {
+        shouldPresentForTouchpoint[touchpoint] ?? false
+    }
+
+    func markPromoHandledFor(_ touchpoint: SyncPromoManager.Touchpoint) {}
+
+    func recordImpressionFor(_ touchpoint: SyncPromoManager.Touchpoint) {
+        recordedImpressions.append(touchpoint)
+    }
+
+    func dismissPromoFor(_ touchpoint: SyncPromoManager.Touchpoint, reason: SyncPromoManager.DismissalReason) {}
+
+    func resetPromos() {}
+}
+
+private extension EscapeHatchModel {
+    static var testFixture: EscapeHatchModel {
+        .preview(title: "Test tab",
+                 subtitle: "example.com",
+                 tabType: .regular,
+                 domain: "example.com",
+                 targetTab: Tab(fireTab: false),
+                 tabCount: 1)
+    }
+}
+
+private func findTableView(in view: UIView?) -> UITableView? {
+    guard let view else { return nil }
+    if let tableView = view as? UITableView {
+        return tableView
+    }
+    for subview in view.subviews {
+        if let tableView = findTableView(in: subview) {
+            return tableView
+        }
+    }
+    return nil
 }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/DuckAISuggestionsViewControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/DuckAISuggestionsViewControllerTests.swift
@@ -18,6 +18,7 @@
 //
 
 import AIChat
+import Core
 import Suggestions
 import UIKit
 import XCTest
@@ -26,6 +27,16 @@ import XCTest
 @MainActor
 final class DuckAISuggestionsViewControllerTests: XCTestCase {
 
+    override func setUp() {
+        super.setUp()
+        PixelFiringMock.tearDown()
+    }
+
+    override func tearDown() {
+        PixelFiringMock.tearDown()
+        super.tearDown()
+    }
+
     private struct Harness {
         let viewController: DuckAISuggestionsViewController
         let chatViewModel: AIChatSuggestionsViewModel
@@ -33,14 +44,20 @@ final class DuckAISuggestionsViewControllerTests: XCTestCase {
     }
 
     private func makeHarness(query: String = "",
-                             layoutConfiguration: DuckAISuggestionsViewController.LayoutConfiguration = .standard) -> Harness {
+                             layoutConfiguration: DuckAISuggestionsViewController.LayoutConfiguration = .standard,
+                             syncPromoManager: SyncPromoManaging? = nil) -> Harness {
         let viewModel = AIChatSuggestionsViewModel()
         let loader = DuckAIURLSuggestionsLoader(dataSource: EmptySuggestionLoadingDataSource())
+        let syncPromoViewModel = syncPromoManager.map {
+            AIChatSyncPromoViewModel(syncPromoManager: $0, pixelFiring: PixelFiringMock.self)
+        }
         let vc = DuckAISuggestionsViewController(
             chatViewModel: viewModel,
             urlLoader: loader,
             queryProvider: { query },
-            layoutConfiguration: layoutConfiguration
+            layoutConfiguration: layoutConfiguration,
+            syncService: nil,
+            syncPromoViewModel: syncPromoViewModel
         )
         vc.loadViewIfNeeded()
         return Harness(viewController: vc, chatViewModel: viewModel, urlLoader: loader)
@@ -85,7 +102,7 @@ final class DuckAISuggestionsViewControllerTests: XCTestCase {
         XCTAssertEqual(vc.view.bounds.width - table.frame.maxX, 0, accuracy: 0.5)
     }
 
-    func test_unifiedToggleInputLayout_matchesRecentChatsHorizontalInset() throws {
+    func test_unifiedToggleInputLayout_matchesSearchHorizontalInset() throws {
         let vc = makeViewController(layoutConfiguration: .unifiedToggleInput)
         vc.view.frame = CGRect(x: 0, y: 0, width: 430, height: 800)
         vc.view.layoutIfNeeded()
@@ -97,8 +114,8 @@ final class DuckAISuggestionsViewControllerTests: XCTestCase {
         let header = try XCTUnwrap(table.tableHeaderView)
         let hatchView = try XCTUnwrap(header.subviews.first)
         let hatchFrame = hatchView.convert(hatchView.bounds, to: vc.view)
-        let expectedTableInset: CGFloat = 10
-        let expectedHatchInset: CGFloat = 26
+        let expectedTableInset: CGFloat = 0
+        let expectedHatchInset: CGFloat = 16
 
         XCTAssertEqual(table.frame.minX, expectedTableInset, accuracy: 0.5)
         XCTAssertEqual(vc.view.bounds.width - table.frame.maxX, expectedTableInset, accuracy: 0.5)
@@ -182,6 +199,131 @@ final class DuckAISuggestionsViewControllerTests: XCTestCase {
 
         XCTAssertEqual(table.numberOfSections, 3)
     }
+
+    // MARK: - Sync promo header
+
+    func test_syncPromo_whenManagerShouldPresent_installsTableHeaderViewWithPromo() throws {
+        let mockManager = MockSyncPromoManager()
+        mockManager.shouldPresentForTouchpoint[.aiChat] = true
+        let harness = makeHarness(syncPromoManager: mockManager)
+        harness.viewController.view.frame = CGRect(x: 0, y: 0, width: 390, height: 600)
+        harness.viewController.view.layoutIfNeeded()
+
+        let table = try tableView(in: harness.viewController)
+
+        let header = try XCTUnwrap(table.tableHeaderView, "promo eligibility → table header is installed")
+        XCTAssertGreaterThan(header.bounds.height, 0)
+        XCTAssertEqual(harness.viewController.children.count, 1, "promo hosting controller is added as a child")
+    }
+
+    func test_syncPromo_withEscapeHatch_usesExpectedInterCardSpacing() throws {
+        let mockManager = MockSyncPromoManager()
+        mockManager.shouldPresentForTouchpoint[.aiChat] = true
+        let harness = makeHarness(syncPromoManager: mockManager)
+        harness.viewController.view.frame = CGRect(x: 0, y: 0, width: 390, height: 600)
+        harness.viewController.view.layoutIfNeeded()
+
+        harness.viewController.setEscapeHatch(.testFixture)
+        harness.viewController.view.layoutIfNeeded()
+
+        let table = try tableView(in: harness.viewController)
+        let header = try XCTUnwrap(table.tableHeaderView)
+        XCTAssertEqual(header.subviews.count, 2)
+
+        let hatchFrame = header.subviews[0].frame
+        let promoFrame = header.subviews[1].frame
+
+        XCTAssertEqual(promoFrame.minY - hatchFrame.maxY, 20, accuracy: 0.5)
+    }
+
+    func test_syncPromo_whenManagerDeclinesToPresent_doesNotInstallHeader() throws {
+        let mockManager = MockSyncPromoManager()
+        mockManager.shouldPresentForTouchpoint[.aiChat] = false
+        let harness = makeHarness(syncPromoManager: mockManager)
+        harness.viewController.view.frame = CGRect(x: 0, y: 0, width: 390, height: 600)
+        harness.viewController.view.layoutIfNeeded()
+
+        let table = try tableView(in: harness.viewController)
+
+        XCTAssertNil(table.tableHeaderView)
+        XCTAssertTrue(harness.viewController.children.isEmpty)
+    }
+
+    func test_syncPromo_whenQueryActive_promoIsRemovedFromHeader() throws {
+        let mockManager = MockSyncPromoManager()
+        mockManager.shouldPresentForTouchpoint[.aiChat] = true
+        let harness = makeHarness(syncPromoManager: mockManager)
+        harness.viewController.view.frame = CGRect(x: 0, y: 0, width: 390, height: 600)
+        harness.viewController.view.layoutIfNeeded()
+
+        XCTAssertNotNil(try tableView(in: harness.viewController).tableHeaderView,
+                        "precondition: promo is initially visible")
+
+        harness.viewController.setQueryActive(true)
+
+        XCTAssertNil(try tableView(in: harness.viewController).tableHeaderView,
+                     "typing hides the entire promo header")
+        XCTAssertTrue(harness.viewController.children.isEmpty,
+                      "promo hosting controller is removed when typing starts")
+    }
+
+    func test_syncPromo_recordsExactlyOneImpressionPerVCLifetime() throws {
+        let mockManager = MockSyncPromoManager()
+        mockManager.shouldPresentForTouchpoint[.aiChat] = true
+        let harness = makeHarness(syncPromoManager: mockManager)
+        harness.viewController.view.frame = CGRect(x: 0, y: 0, width: 390, height: 600)
+        harness.viewController.view.layoutIfNeeded()
+        harness.viewController.setIsVisibleContent(true)
+
+        XCTAssertEqual(mockManager.recordedImpressions, [.aiChat])
+
+        harness.viewController.setQueryActive(true)
+        harness.viewController.setQueryActive(false)
+        harness.viewController.view.layoutIfNeeded()
+
+        XCTAssertEqual(mockManager.recordedImpressions, [.aiChat])
+    }
+
+    func test_syncPromo_doesNotRecordImpressionWhilePageIsInactive() throws {
+        let mockManager = MockSyncPromoManager()
+        mockManager.shouldPresentForTouchpoint[.aiChat] = true
+        let harness = makeHarness(syncPromoManager: mockManager)
+        harness.viewController.view.frame = CGRect(x: 0, y: 0, width: 390, height: 600)
+        harness.viewController.view.layoutIfNeeded()
+
+        XCTAssertNotNil(try tableView(in: harness.viewController).tableHeaderView)
+        XCTAssertEqual(mockManager.recordedImpressions, [])
+    }
+
+    func test_syncPromo_recordsImpressionWhenPageBecomesActiveAfterInstall() throws {
+        let mockManager = MockSyncPromoManager()
+        mockManager.shouldPresentForTouchpoint[.aiChat] = true
+        let harness = makeHarness(syncPromoManager: mockManager)
+        harness.viewController.view.frame = CGRect(x: 0, y: 0, width: 390, height: 600)
+        harness.viewController.view.layoutIfNeeded()
+        XCTAssertEqual(mockManager.recordedImpressions, [])
+
+        harness.viewController.setIsVisibleContent(true)
+
+        XCTAssertEqual(mockManager.recordedImpressions, [.aiChat])
+    }
+
+    func test_syncPromo_doesNotRecordWhenPromoReappearsAfterPageBecomesInactive() throws {
+        let mockManager = MockSyncPromoManager()
+        mockManager.shouldPresentForTouchpoint[.aiChat] = true
+        let harness = makeHarness(syncPromoManager: mockManager)
+        harness.viewController.view.frame = CGRect(x: 0, y: 0, width: 390, height: 600)
+        harness.viewController.view.layoutIfNeeded()
+
+        harness.viewController.setQueryActive(true)
+        harness.viewController.setIsVisibleContent(true)
+        harness.viewController.setIsVisibleContent(false)
+        harness.viewController.setQueryActive(false)
+        harness.viewController.view.layoutIfNeeded()
+
+        XCTAssertNotNil(try tableView(in: harness.viewController).tableHeaderView)
+        XCTAssertEqual(mockManager.recordedImpressions, [])
+    }
 }
 
 // MARK: - Test doubles
@@ -194,5 +336,37 @@ private extension EscapeHatchModel {
                  domain: "example.com",
                  targetTab: Tab(fireTab: false),
                  tabCount: 1)
+    }
+}
+
+private final class MockSyncPromoManager: SyncPromoManaging {
+    var shouldPresentForTouchpoint: [SyncPromoManager.Touchpoint: Bool] = [:]
+    var handledTouchpoints: [SyncPromoManager.Touchpoint] = []
+    var recordedImpressions: [SyncPromoManager.Touchpoint] = []
+    var dismissedTouchpoints: [(SyncPromoManager.Touchpoint, SyncPromoManager.DismissalReason)] = []
+
+    func shouldPresentPromoFor(_ touchpoint: SyncPromoManager.Touchpoint, count: Int) -> Bool {
+        shouldPresentForTouchpoint[touchpoint] ?? false
+    }
+
+    func markPromoHandledFor(_ touchpoint: SyncPromoManager.Touchpoint) {
+        handledTouchpoints.append(touchpoint)
+        shouldPresentForTouchpoint[touchpoint] = false
+    }
+
+    func recordImpressionFor(_ touchpoint: SyncPromoManager.Touchpoint) {
+        recordedImpressions.append(touchpoint)
+    }
+
+    func dismissPromoFor(_ touchpoint: SyncPromoManager.Touchpoint, reason: SyncPromoManager.DismissalReason) {
+        dismissedTouchpoints.append((touchpoint, reason))
+        markPromoHandledFor(touchpoint)
+    }
+
+    func resetPromos() {
+        shouldPresentForTouchpoint.removeAll()
+        handledTouchpoints.removeAll()
+        recordedImpressions.removeAll()
+        dismissedTouchpoints.removeAll()
     }
 }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedInputContentContainerViewControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedInputContentContainerViewControllerTests.swift
@@ -17,9 +17,15 @@
 //  limitations under the License.
 //
 
+import AIChat
+import Bookmarks
+import Combine
+import Suggestions
+import UIKit
 import XCTest
 @testable import DuckDuckGo
 
+@MainActor
 final class UnifiedInputContentContainerViewControllerTests: XCTestCase {
 
     // MARK: - computeSuggestionTrayEscapeHatchInset
@@ -44,4 +50,91 @@ final class UnifiedInputContentContainerViewControllerTests: XCTestCase {
             -10
         )
     }
+
+    func testDuckAISuggestionsDidRequestSyncSetup_PresentsIntroSheetAndCallbackRequestsSyncSetup() {
+        let presenter = MockAIChatSyncIntroSheetPresenter()
+        let delegate = MockUnifiedInputContentContainerDelegate()
+        let viewController = UnifiedInputContentContainerViewController(
+            switchBarHandler: MockUnifiedInputSwitchBarHandler(),
+            aiChatSyncIntroSheetPresenter: presenter
+        )
+        viewController.delegate = delegate
+
+        viewController.duckAISuggestionsDidRequestSyncSetup()
+
+        XCTAssertTrue(presenter.presentingViewController === viewController)
+        XCTAssertEqual(delegate.syncSetupRequestCount, 0)
+
+        presenter.onSyncSetupRequested?()
+
+        XCTAssertEqual(delegate.syncSetupRequestCount, 1)
+    }
+}
+
+private final class MockAIChatSyncIntroSheetPresenter: AIChatSyncIntroSheetPresenting {
+    private(set) weak var presentingViewController: UIViewController?
+    private(set) var onSyncSetupRequested: (() -> Void)?
+
+    func present(from viewController: UIViewController, onSyncSetupRequested: @escaping () -> Void) {
+        presentingViewController = viewController
+        self.onSyncSetupRequested = onSyncSetupRequested
+    }
+}
+
+private final class MockUnifiedInputContentContainerDelegate: UnifiedInputContentContainerViewControllerDelegate {
+    private(set) var syncSetupRequestCount = 0
+
+    func unifiedInputEditingStateDidSubmitQuery(_ query: String) {}
+    func unifiedInputEditingStateDidSubmitPrompt(_ query: String, tools: [AIChatRAGTool]?) {}
+    func unifiedInputEditingStateDidSelectFavorite(_ favorite: BookmarkEntity) {}
+    func unifiedInputEditingStateDidEditFavorite(_ favorite: BookmarkEntity) {}
+    func unifiedInputEditingStateDidSelectSuggestion(_ suggestion: Suggestion) {}
+    func unifiedInputEditingStateDidRequestTextUpdate(_ text: String) {}
+    func unifiedInputEditingStateDidSelectChatHistory(url: URL) {}
+    func unifiedInputEditingStateDidRequestSwitchTab(_ tab: Tab) {}
+    func unifiedInputEditingStateDidRequestTabSwitcher() {}
+    func unifiedInputEditingStateDidRequestTryFireMode() {}
+    func unifiedInputEditingStateDidChangeMode(_ mode: TextEntryMode) {}
+
+    func unifiedInputEditingStateDidRequestSyncSetup() {
+        syncSetupRequestCount += 1
+    }
+}
+
+private final class MockUnifiedInputSwitchBarHandler: SwitchBarHandling {
+    var currentText: String = ""
+    var currentToggleState: TextEntryMode = .search
+    var isVoiceSearchEnabled = false
+    var isAIVoiceChatEnabled = false
+    var hasUserInteractedWithText = false
+    var isCurrentTextValidURL = false
+    var buttonState: SwitchBarButtonState = .noButtons
+    var isTopBarPosition = true
+    var isToggleEnabled = true
+    var isFireTab = false
+    var isUsingExpandedBottomBarHeight = false
+    var isUsingFadeOutAnimation = false
+    var shouldDisableAutocorrectOnEmpty = false
+    var hidesVoiceButton = false
+    var hasSubmittedPrompt = false
+    var modeParameters: [String: String] = [:]
+
+    var hasSubmittedPromptPublisher: AnyPublisher<Bool, Never> { Just(false).eraseToAnyPublisher() }
+    var currentTextPublisher: AnyPublisher<String, Never> { Empty().eraseToAnyPublisher() }
+    var toggleStatePublisher: AnyPublisher<TextEntryMode, Never> { Empty().eraseToAnyPublisher() }
+    var textSubmissionPublisher: AnyPublisher<(text: String, mode: TextEntryMode), Never> { Empty().eraseToAnyPublisher() }
+    var microphoneButtonTappedPublisher: AnyPublisher<Void, Never> { Empty().eraseToAnyPublisher() }
+    var clearButtonTappedPublisher: AnyPublisher<Void, Never> { Empty().eraseToAnyPublisher() }
+    var hasUserInteractedWithTextPublisher: AnyPublisher<Bool, Never> { Empty().eraseToAnyPublisher() }
+    var isCurrentTextValidURLPublisher: AnyPublisher<Bool, Never> { Empty().eraseToAnyPublisher() }
+    var currentButtonStatePublisher: AnyPublisher<SwitchBarButtonState, Never> { Empty().eraseToAnyPublisher() }
+
+    func updateCurrentText(_ text: String) {}
+    func submitText(_ text: String) {}
+    func setToggleState(_ state: TextEntryMode) {}
+    func clearText() {}
+    func microphoneButtonTapped() {}
+    func markUserInteraction() {}
+    func clearButtonTapped() {}
+    func updateBarPosition(isTop: Bool) {}
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214486865537637?focus=true
Tech Design URL: N/A
CC:

### Description

Wires the AI Chat sync promo into the Duck.ai suggestions surface.

This PR is stacked on https://github.com/duckduckgo/apple-browsers/pull/5002 and contains the runtime integration layer only. It mounts the promo in the new unified input Duck.ai suggestions page, presents the sync intro sheet from the promo CTA, and routes the flow into Sync setup.

Promo impressions are recorded only once the Duck.ai content is actually visible, so hidden or inactive mounted content does not consume impression count.

### Testing Steps
1. Show the promo when all of the following are true:
   - Unified input flow flag is enabled. Legacy flow is out of scope.
   - AI Chat history is enabled: privacy-config feature `.duckAiChatHistory` is on.
   - Sync is off.
   - `sync`, `aiChatSync` and `aiChatSyncPromo` feature flags are on.
   - Recent chats count is greater than `0`.
   - AI Chat sync promo impressions shown is less than `3`.
   - The promo was not previously dismissed by X tap, CTA tap, or impression cap.
   - The current tab is not a Fire tab.
2. Hide the promo without counting an impression while the user is actively typing.
3. Dismiss the promo permanently when any of these happens:
   - The 3rd impression is reached. Note: impression means here viewcontroller instantiation so kill the app or use fire button to count a new impression.
   - The user taps X.
   - The user taps the CTA.
 Note: to test again reset user defaults with internal option `reset sync promos`.

### Impact and Risks

Low: this is a gated promo surface for AI Chat sync. If something goes wrong, users may see the promo too often, not see it when eligible, or have an impression recorded before the promo is visible.

#### What could go wrong?

The main risk is incorrect visibility/impression accounting in the Duck.ai suggestions UI. The implementation records impressions only when Duck.ai suggestions are the visible active content.

### Quality Considerations

Only affects the new unified input flow and it depends on the chat sync feature being enabled.

### Notes to Reviewer

Please focus on the unified-input-only UI integration and the visibility/impression behavior around Duck.ai suggestions being mounted but not visible. The standalone components live in the base PR, and the SyncPromoManager eligibility/pixel plumbing lives one PR below that.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new UI + state/visibility logic around Sync promotions and auto-start pairing, which could cause incorrect promo impression accounting or unintended sync-flow presentation if eligibility/visibility gating is wrong.
> 
> **Overview**
> Adds an **AI Chat Sync promo surface** to the unified-input Duck.ai suggestions list by mounting a SwiftUI promo card in the table header alongside the existing escape hatch, with header layout rebuilt based on query activity, chat count, and `DDGSync` auth state.
> 
> Wires the promo CTA to a new `AIChatSyncIntroSheetPresenter` that presents an intro sheet and, on confirmation, propagates a new `...DidRequestSyncSetup` delegate event up through `UnifiedInputContentContainerViewController` to `MainViewController`, which deep-links into Sync settings using a new `SyncSettingsViewController.SourceConstants.aiChatPromotion` source (also enabling auto-start pairing for that source).
> 
> Adds visibility-aware impression recording (only when Duck.ai content is actually visible) and updates/extends unit tests to cover coordinator/view-controller forwarding, header composition/spacing, and impression behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ff2fd865c30efae59c598cefb9355a6feff0a33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->