### PR TITLE
macOS: Link to Duck.ai Settings from Settings → AI Features

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatUserScriptMessages.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatUserScriptMessages.swift
@@ -65,5 +65,8 @@ public enum AIChatUserScriptMessages: String, CaseIterable {
     case sendToSetupSync
     case setAIChatHistoryEnabled
     case submitSyncStatusChanged
+
+    /// Pushed to the duck.ai page to open the Duck.ai Settings modal.
+    case submitOpenSettingsAction
 }
 // swiftlint:enable inclusive_language

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -427,6 +427,9 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// Controls deletion of Synced chats
     case supportsSyncChatsDeletion
 
+    /// Shows a link in Settings → AI Features that opens the Duck.ai Settings modal.
+    case settingsLinkInAiFeatures
+
     case sidebarResizable
 
     case sidebarFloating

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -2684,6 +2684,7 @@
 		8A96290053C27B6C1245838B /* QuickFeedbackDiagnosticsCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABD3D561804AB2C73BB789AC /* QuickFeedbackDiagnosticsCollectorTests.swift */; };
 		91A52F01ECBA4869A0042EAA /* AdBlockingAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = A86EE9A7B2E24D47BACF8241 /* AdBlockingAvailability.swift */; };
 		92351A6719194A9F4DD19D56 /* AIChatSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F72808BE3E5BF485C31627B8 /* AIChatSettingsTests.swift */; };
+		9C685D9290AE488FABE0EDDA /* AIChatSettingsLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE7CA3678B14EDD94FD8D76 /* AIChatSettingsLinkTests.swift */; };
 		9264F7AF4D4841749D18B650 /* RebrandedContextualOnboardingDialogs+TrySearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228E1D6E1E824085A874C175 /* RebrandedContextualOnboardingDialogs+TrySearch.swift */; };
 		93BD7FEAF65A45E5AF6465EE /* TabSuspensionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 590E11956C6E4C788AF09F9A /* TabSuspensionServiceTests.swift */; };
 		9812D895276CEDA5004B6181 /* ContentBlockerRulesLists.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9812D894276CEDA5004B6181 /* ContentBlockerRulesLists.swift */; };
@@ -6918,6 +6919,7 @@
 		F4A6198B283CFFBB007F2080 /* ContentScopeFeatureFlagging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentScopeFeatureFlagging.swift; sourceTree = "<group>"; };
 		F511D9CB8F68D9D9B0341314 /* QuickFeedbackDiagnosticsCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickFeedbackDiagnosticsCollector.swift; sourceTree = "<group>"; };
 		F72808BE3E5BF485C31627B8 /* AIChatSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSettingsTests.swift; sourceTree = "<group>"; };
+		6AE7CA3678B14EDD94FD8D76 /* AIChatSettingsLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSettingsLinkTests.swift; sourceTree = "<group>"; };
 		FAC0C468BD3373676AC82B61 /* DarkReaderFeatureSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkReaderFeatureSettingsTests.swift; sourceTree = "<group>"; };
 		FB1380633D7A4C9CA3AD18CD /* AutoplayPreferencesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoplayPreferencesTests.swift; sourceTree = "<group>"; };
 		FB37FB37FB37FB37FB37FB37 /* InternalFeedbackFormTabExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalFeedbackFormTabExtensionTests.swift; sourceTree = "<group>"; };
@@ -9543,6 +9545,7 @@
 				31DE49202EE2299500F3940A /* AIChatMultilinePasteTests.swift */,
 				31DE49222EE2299500F3940A /* AIChatOmnibarTests.swift */,
 				F72808BE3E5BF485C31627B8 /* AIChatSettingsTests.swift */,
+				6AE7CA3678B14EDD94FD8D76 /* AIChatSettingsLinkTests.swift */,
 				EED735352BB46B6000F173D6 /* AutocompleteTests.swift */,
 				844905442E54ADD40054F4FD /* AutoconsentUITests.swift */,
 				EE54F7B22BBFEA48006218DB /* BookmarksAndFavoritesTests.swift */,
@@ -16909,6 +16912,7 @@
 				31DE49212EE2299500F3940A /* AIChatMultilinePasteTests.swift in Sources */,
 				31DE49232EE2299500F3940A /* AIChatOmnibarTests.swift in Sources */,
 				92351A6719194A9F4DD19D56 /* AIChatSettingsTests.swift in Sources */,
+				9C685D9290AE488FABE0EDDA /* AIChatSettingsLinkTests.swift in Sources */,
 				5680BCA72F17EC6400BD624E /* SSLErrorTests.swift in Sources */,
 				8449054B2E55BBD60054F4FD /* NavigationProtectionUITests.swift in Sources */,
 				EED735362BB46B6000F173D6 /* AutocompleteTests.swift in Sources */,

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -459,6 +459,8 @@
 		31FBF22F2CDD068000626C17 /* AIChatUserScriptHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FBF22D2CDD068000626C17 /* AIChatUserScriptHandling.swift */; };
 		31FBF2312CDD130900626C17 /* AIChatUserScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FBF2302CDD12FE00626C17 /* AIChatUserScriptTests.swift */; };
 		31FBF2322CDD130900626C17 /* AIChatUserScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FBF2302CDD12FE00626C17 /* AIChatUserScriptTests.swift */; };
+		E41E58E59C4B4B578F57BE4B /* AIChatTabOpenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DF815DCDE34CFBA7F38DFA /* AIChatTabOpenerTests.swift */; };
+		6A06A7E014E04F60B399531F /* AIChatTabOpenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DF815DCDE34CFBA7F38DFA /* AIChatTabOpenerTests.swift */; };
 		31FC23512DB7A86F00900574 /* AddressBarMenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FC23502DB7A86A00900574 /* AddressBarMenuButton.swift */; };
 		31FC23522DB7A86F00900574 /* AddressBarMenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FC23502DB7A86A00900574 /* AddressBarMenuButton.swift */; };
 		3646AC402F88EC880093AEA7 /* PromoServiceFactory+SubscriptionPromo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3646AC3F2F88EC880093AEA7 /* PromoServiceFactory+SubscriptionPromo.swift */; };
@@ -4967,6 +4969,7 @@
 		31F28C5228C8EECA00119F70 /* DuckURLSchemeHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DuckURLSchemeHandler.swift; sourceTree = "<group>"; };
 		31FBF22D2CDD068000626C17 /* AIChatUserScriptHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatUserScriptHandling.swift; sourceTree = "<group>"; };
 		31FBF2302CDD12FE00626C17 /* AIChatUserScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatUserScriptTests.swift; sourceTree = "<group>"; };
+		49DF815DCDE34CFBA7F38DFA /* AIChatTabOpenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTabOpenerTests.swift; sourceTree = "<group>"; };
 		31FC23502DB7A86A00900574 /* AddressBarMenuButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBarMenuButton.swift; sourceTree = "<group>"; };
 		336B39E22726B4B700C417D3 /* LocalUnprotectedDomains.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalUnprotectedDomains.swift; sourceTree = "<group>"; };
 		361EABC017D9923C4758C171 /* DarkReaderFeatureSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkReaderFeatureSettings.swift; sourceTree = "<group>"; };
@@ -7839,6 +7842,7 @@
 				37AA017E2E2164A500844427 /* AIChatUserScriptHandlerTests.swift */,
 				3135647D2D9EBB9900BF4B5D /* AIChatAddressBarPromptExtractorTests.swift */,
 				31FBF2302CDD12FE00626C17 /* AIChatUserScriptTests.swift */,
+				49DF815DCDE34CFBA7F38DFA /* AIChatTabOpenerTests.swift */,
 				317B39D92ED9CBD1001B5600 /* AIChatOmnibarControllerTests.swift */,
 				7BAB1A0100000000A0000030 /* AIChatMentionTokenDetectorTests.swift */,
 				7BAB1A0100000000A00000A0 /* AIChatMentionPickerFilterTests.swift */,
@@ -16447,6 +16451,7 @@
 				3706FE72293F661700E42796 /* ClickToLoadTDSTests.swift in Sources */,
 				9F1556782DDC3B0600A35DBA /* DefaultBrowserAndDockPromptTypeDeciderTests.swift in Sources */,
 				31FBF2322CDD130900626C17 /* AIChatUserScriptTests.swift in Sources */,
+				E41E58E59C4B4B578F57BE4B /* AIChatTabOpenerTests.swift in Sources */,
 				1D4B03DA2CA55DDF00224E99 /* BookmarkUrlExtensionTests.swift in Sources */,
 				311309782ECE77BC00FCD220 /* AddressBarSharedTextStateTests.swift in Sources */,
 				CC951A5B2EB4E10C0047E245 /* FireCoordinatorTests.swift in Sources */,
@@ -18403,6 +18408,7 @@
 				4B59024C26B38BB800489384 /* ChromiumLoginReaderTests.swift in Sources */,
 				CCC87D732E1429570091344D /* ChromiumTopSitesReaderTests.swift in Sources */,
 				31FBF2312CDD130900626C17 /* AIChatUserScriptTests.swift in Sources */,
+				6A06A7E014E04F60B399531F /* AIChatTabOpenerTests.swift in Sources */,
 				F1AFDBD42C231B9700710F2C /* SubscriptionErrorReporterTests.swift in Sources */,
 				1D1B4A472EDF97F400FE43C9 /* PermissionAuthorizationTypeTests.swift in Sources */,
 				1D8C2FEA2B70F5A7005E4BBD /* MockWebViewSnapshotRenderer.swift in Sources */,

--- a/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
@@ -54,6 +54,11 @@ enum AIChatOpenTrigger {
     /// must route to a specific flow based on the mode — same mechanism image-generation submissions use.
     /// - Parameter mode: The mode string forwarded in the native prompt payload (e.g. `AIChatNativePrompt.voiceMode`).
     case mode(String)
+
+    /// Opens duck.ai in a new tab and arms the user script to push the open-settings
+    /// action once the page's subscriptions are wired. Used by Settings → AI Features →
+    /// "Open Duck.ai Settings".
+    case openSettings
 }
 
 /// Protocol defining the interface for opening AI chat tabs.
@@ -145,6 +150,9 @@ struct AIChatTabOpener: AIChatTabOpening {
             let prompt = AIChatNativePrompt.queryPrompt("", autoSubmit: false, mode: mode)
             promptHandler.setData(prompt)
             aiChatTabManaging.openAIChat(aiChatRemoteSettings.aiChatURL, with: behavior, hasPrompt: true)
+
+        case .openSettings:
+            aiChatTabManaging.insertAIChatTabRequestingOpenSettings(with: aiChatRemoteSettings.aiChatURL)
         }
     }
 
@@ -197,6 +205,12 @@ protocol AIChatTabManaging {
     @MainActor
     func insertAIChatTab(with url: URL, restorationData: AIChatRestorationData)
 
+    /// Inserts a new Duck.ai tab and arms its `AIChatUserScript` to push the open-settings
+    /// action once the page's subscriptions are wired. Used by Settings → AI Features →
+    /// "Open Duck.ai Settings".
+    @MainActor
+    func insertAIChatTabRequestingOpenSettings(with url: URL)
+
     /// If a tab in `sourceCollection`'s window currently hosts an active Duck.ai voice session,
     /// focuses that window and selects the tab. When the original session was hosted in a Duck.ai
     /// sidebar, also surfaces the sidebar so the user lands on the in-progress voice UI.
@@ -247,6 +261,13 @@ extension WindowControllersManager: AIChatTabManaging {
         guard let tabCollectionViewModel = lastKeyMainWindowController?.mainViewController.tabCollectionViewModel else { return }
         let newAIChatTab = Tab(content: .url(url, source: .ui), burnerMode: tabCollectionViewModel.burnerMode)
         newAIChatTab.aiChat?.setAIChatRestorationData(restorationData)
+        tabCollectionViewModel.insertOrAppend(tab: newAIChatTab, selected: true)
+    }
+
+    func insertAIChatTabRequestingOpenSettings(with url: URL) {
+        guard let tabCollectionViewModel = lastKeyMainWindowController?.mainViewController.tabCollectionViewModel else { return }
+        let newAIChatTab = Tab(content: .url(url, source: .ui), burnerMode: tabCollectionViewModel.burnerMode)
+        newAIChatTab.aiChat?.requestOpenSettings()
         tabCollectionViewModel.insertOrAppend(tab: newAIChatTab, selected: true)
     }
 

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
@@ -34,8 +34,23 @@ final class AIChatUserScript: NSObject, Subfeature {
 
     private var cancellables: Set<AnyCancellable> = []
 
+    /// When true, the next two messages received from the page act as a readiness
+    /// handshake: after the second message we push `submitOpenSettingsAction`. Mirrors
+    /// the Windows two-phase TabId flag — by the second message the FE subscriptions
+    /// are wired so the push won't be dropped.
+    private(set) var pendingOpenSettingsAction = false
+    private var openSettingsMessageCount = 0
+
     public func with(broker: UserScriptMessageBroker) {
         self.broker = broker
+    }
+
+    /// Arms the two-phase open-settings handshake. Called when a Duck.ai tab is opened
+    /// from Settings → AI Features so the FE's settings modal opens automatically once
+    /// the page has wired up its subscriptions.
+    func requestOpenSettingsAction() {
+        pendingOpenSettingsAction = true
+        openSettingsMessageCount = 0
     }
 
     init(handler: AIChatUserScriptHandling, urlSettings: any KeyedStoring<AIChatDebugURLSettings>) {
@@ -101,6 +116,15 @@ final class AIChatUserScript: NSObject, Subfeature {
         broker?.push(method: AIChatUserScriptMessages.submitAIChatPageContext.rawValue, params: response, for: self, into: webView)
     }
 
+    private func submitOpenSettingsAction() {
+        guard let webView,
+              let host = webView.url?.host,
+              messageDestinationPolicy.isAllowed(host) else {
+            return
+        }
+        broker?.push(method: AIChatUserScriptMessages.submitOpenSettingsAction.rawValue, params: nil, for: self, into: webView)
+    }
+
     private func submitSyncStatusChanged(_ status: AIChatSyncHandler.SyncStatus) {
         // Push only to websites matching origin policy
         guard let webView,
@@ -113,6 +137,23 @@ final class AIChatUserScript: NSObject, Subfeature {
     }
 
     func handler(forMethodNamed methodName: String) -> Subfeature.Handler? {
+        let handler = resolveHandler(forMethodNamed: methodName)
+        if handler != nil {
+            advanceOpenSettingsHandshake()
+        }
+        return handler
+    }
+
+    private func advanceOpenSettingsHandshake() {
+        guard pendingOpenSettingsAction else { return }
+        openSettingsMessageCount += 1
+        guard openSettingsMessageCount >= 2 else { return }
+        pendingOpenSettingsAction = false
+        openSettingsMessageCount = 0
+        submitOpenSettingsAction()
+    }
+
+    private func resolveHandler(forMethodNamed methodName: String) -> Subfeature.Handler? {
         switch AIChatUserScriptMessages(rawValue: methodName) {
         case .openAIChatSettings:
             return handler.openAIChatSettings

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -655,6 +655,7 @@ struct UserText {
     static let hideAIGeneratedImagesSettings = NSLocalizedString("duckai.hide-ai-generated-images-settings", value: "Hide AI-Generated Images", comment: "The section name in preferences for Hide AI-Generated Images Settings")
     static let hideAIGeneratedImagesSettingsDescription = NSLocalizedString("duckai.hide-ai-generated-images-settings.description", value: "Filter out AI-generated images from image search results", comment: "Description of the section in Settings")
     static let searchAIFeaturesSettingsLink = NSLocalizedString("duckai.search-ai-features-settings.link", value: "Open Search AI Features", comment: "Button to open the Search AI Features Settings")
+    static let duckAiSettingsLink = NSLocalizedString("duckai.duckai-settings.link", value: "Open Duck.ai Settings", comment: "Button to open the Duck.ai Settings in a new tab from Settings → AI Features")
     static let aiChatSidebarTitle = NSLocalizedString("aichat.sidebar.title", value: "Duck.ai", comment: "Title for the Duck.ai sidebar")
     static let aiChatSidebarExpandButtonTooltip = NSLocalizedString("aichat.sidebar.expand-button.tooltip", value: "Expand", comment: "Tooltip for button to open duck.ai chat from sidebar in a full tab")
     static let aiChatSidebarDetachButtonTooltip = NSLocalizedString("aichat.sidebar.detach-button.tooltip", value: "Move to separate window", comment: "Tooltip for button to detach the duck.ai sidebar into a floating window")

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -27764,6 +27764,18 @@
         }
       }
     },
+    "duckai.duckai-settings.link" : {
+      "comment" : "Button to open the Duck.ai Settings in a new tab from Settings → AI Features",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Open Duck.ai Settings"
+          }
+        }
+      }
+    },
     "duckai.enable.button" : {
       "comment" : "Button to enable Duck.ai feature",
       "extractionState" : "extracted_with_value",

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -2368,7 +2368,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bild oder Datei hinzufügen"
+            "value" : "Bilder oder PDFs hinzufügen"
           }
         },
         "en" : {
@@ -2380,43 +2380,43 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Añadir imagen o archivo"
+            "value" : "Añadir imágenes o archivos PDF"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ajouter une image ou un fichier"
+            "value" : "Ajouter des images ou des PDF"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aggiungi immagine o file"
+            "value" : "Aggiungi immagini o PDF"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Afbeelding of bestand toevoegen"
+            "value" : "Afbeeldingen of PDF's toevoegen"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dodaj obraz lub plik"
+            "value" : "Dodaj obrazy lub pliki PDF"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Adicionar Imagem ou Ficheiro"
+            "value" : "Adicionar Imagens ou PDFs"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Добавить изображение или файл"
+            "value" : "Добавить изображения или PDF-файлы"
           }
         }
       }
@@ -2428,7 +2428,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Keine offenen Tabs"
+            "value" : "Kein Seiteninhalt verfügbar"
           }
         },
         "en" : {
@@ -2440,43 +2440,43 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No hay pestañas abiertas"
+            "value" : "No hay contenido de página disponible"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aucun onglet ouvert"
+            "value" : "Aucun contenu de page disponible"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nessuna scheda aperta"
+            "value" : "Nessun contenuto della pagina disponibile"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Geen open tabbladen"
+            "value" : "Geen pagina-inhoud beschikbaar"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Brak otwartych kart"
+            "value" : "Brak dostępnej zawartości strony"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nenhum separador aberto"
+            "value" : "Não há conteúdo disponível da página"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Нет открытых вкладок"
+            "value" : "Содержимое страницы недоступно"
           }
         }
       }
@@ -3565,10 +3565,58 @@
       "comment" : "Placeholder shown inside the @-mention tab picker when the typed filter doesn't match any open browser tab",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine passenden Tabs"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No matching tabs"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay pestañas coincidentes"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun onglet correspondant"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna scheda corrispondente"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geen overeenkomende tabbladen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brak pasujących kart"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhum separador correspondente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет соответствующих вкладок"
           }
         }
       }
@@ -27768,10 +27816,58 @@
       "comment" : "Button to open the Duck.ai Settings in a new tab from Settings → AI Features",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duck.ai-Einstellungen öffnen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Open Duck.ai Settings"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir ajustes de Duck.ai"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir les paramètres Duck.ai"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apri le impostazioni di Duck.ai"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duck.ai-instellingen openen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otwórz ustawienia Duck.ai"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir as definições do Duck.ai"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Открыть настройки Duck.ai"
           }
         }
       }

--- a/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
@@ -120,6 +120,10 @@ final class AIChatPreferences: ObservableObject {
         featureFlagger.isFeatureOn(.showHideAIGeneratedImagesSection)
     }
 
+    var shouldShowDuckAiSettingsLink: Bool {
+        featureFlagger.isFeatureOn(.aiChatSettingsLinkInAiFeatures)
+    }
+
     var shouldShowSearchAndDuckAIToggleOption: Bool {
         featureFlagger.isFeatureOn(.aiChatOmnibarToggle)
     }
@@ -191,6 +195,21 @@ final class AIChatPreferences: ObservableObject {
 
     @MainActor func openSearchAssistSettings() {
         windowControllersManager.show(url: URL.aiChatSettings, source: .ui, newTab: true, selected: true)
+    }
+
+    /// Opens duck.ai in a new tab and triggers the Duck.ai Settings modal once the page
+    /// has wired up its message subscriptions.
+    @MainActor func openDuckAiSettings() {
+        guard let windowController = windowControllersManager.lastKeyMainWindowController else {
+            // No window to host the tab — fall back to a plain open of duck.ai.
+            windowControllersManager.show(url: URL.duckAi, source: .ui, newTab: true, selected: true)
+            return
+        }
+        let tabCollectionViewModel = windowController.mainViewController.tabCollectionViewModel
+        let tab = Tab(content: .url(URL.duckAi, source: .ui), burnerMode: tabCollectionViewModel.burnerMode)
+        tab.aiChat?.requestOpenSettings()
+        tabCollectionViewModel.insertOrAppend(tab: tab, selected: true)
+        windowController.window?.makeKeyAndOrderFront(self)
     }
 
     private func subscribeToDuckAIChromeButtonsVisibilityChanges() {

--- a/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
@@ -200,16 +200,7 @@ final class AIChatPreferences: ObservableObject {
     /// Opens duck.ai in a new tab and triggers the Duck.ai Settings modal once the page
     /// has wired up its message subscriptions.
     @MainActor func openDuckAiSettings() {
-        guard let windowController = windowControllersManager.lastKeyMainWindowController else {
-            // No window to host the tab — fall back to a plain open of duck.ai.
-            windowControllersManager.show(url: URL.duckAi, source: .ui, newTab: true, selected: true)
-            return
-        }
-        let tabCollectionViewModel = windowController.mainViewController.tabCollectionViewModel
-        let tab = Tab(content: .url(URL.duckAi, source: .ui), burnerMode: tabCollectionViewModel.burnerMode)
-        tab.aiChat?.requestOpenSettings()
-        tabCollectionViewModel.insertOrAppend(tab: tab, selected: true)
-        windowController.window?.makeKeyAndOrderFront(self)
+        NSApp.delegateTyped.aiChatTabOpener.openAIChatTab(with: .openSettings, behavior: .newTab(selected: true))
     }
 
     private func subscribeToDuckAIChromeButtonsVisibilityChanges() {

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
@@ -64,6 +64,7 @@ extension Preferences {
                                 }
                                 .buttonStyle(.plain)
                                 .padding(.top, 6)
+                                .accessibilityIdentifier("Preferences.AIChat.duckAiSettingsLink")
                                 .visibility(model.shouldShowAIFeatures ? .visible : .gone)
                             }
                         }

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
@@ -50,6 +50,22 @@ extension Preferences {
                                                        image: Image(nsImage: DesignSystemImages.Color.Size16.aiChatGradient),
                                                        bottomPadding: 2)
                             TextMenuItemCaption(UserText.aiChatDescription)
+
+                            if model.shouldShowDuckAiSettingsLink {
+                                Button {
+                                    model.openDuckAiSettings()
+                                } label: {
+                                    HStack {
+                                        Text(UserText.duckAiSettingsLink)
+                                        Image(.externalAppScheme)
+                                    }
+                                    .foregroundColor(Color.linkBlue)
+                                    .cursor(.pointingHand)
+                                }
+                                .buttonStyle(.plain)
+                                .padding(.top, 6)
+                                .visibility(model.shouldShowAIFeatures ? .visible : .gone)
+                            }
                         }
 
                         Button(model.isAIFeaturesEnabled ? UserText.aiChatDisableButton : UserText.aiChatEnableButton) {

--- a/macOS/DuckDuckGo/Tab/TabExtensions/AIChatTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/AIChatTabExtension.swift
@@ -122,6 +122,11 @@ final class AIChatTabExtension {
                     self?.aiChatUserScript?.handler.submitAIChatPageContext(pageContext)
                     self?.temporaryPageContext = nil
                 }
+
+                if self?.temporaryOpenSettingsRequest == true {
+                    self?.aiChatUserScript?.requestOpenSettingsAction()
+                    self?.temporaryOpenSettingsRequest = false
+                }
             }
         }.store(in: &cancellables)
     }
@@ -200,6 +205,16 @@ final class AIChatTabExtension {
         }
 
         aiChatUserScript.handler.submitAIChatNativePrompt(prompt)
+    }
+
+    private var temporaryOpenSettingsRequest = false
+    func requestOpenSettings() {
+        guard let aiChatUserScript else {
+            // User script not yet loaded — apply when it becomes available
+            temporaryOpenSettingsRequest = true
+            return
+        }
+        aiChatUserScript.requestOpenSettingsAction()
     }
 
     private var temporaryPageContext: AIChatPageContextData?
@@ -325,6 +340,7 @@ protocol AIChatProtocol: AnyObject, NavigationResponder {
     func setAIChatRestorationData(_ data: AIChatRestorationData?)
     func submitAIChatNativePrompt(_ prompt: AIChatNativePrompt)
     func submitAIChatPageContext(_ pageContext: AIChatPageContextData?)
+    func requestOpenSettings()
 
     var pageContextRequestedPublisher: AnyPublisher<Void, Never> { get }
     var pageContextConsumedPublisher: AnyPublisher<Void, Never> { get }

--- a/macOS/DuckDuckGo/Windows/Model/WindowControllersManagerMock.swift
+++ b/macOS/DuckDuckGo/Windows/Model/WindowControllersManagerMock.swift
@@ -146,6 +146,13 @@ final class WindowControllersManagerMock: WindowControllersManagerProtocol, AICh
         insertAIChatTabCalls.append(InsertAIChatTabCall(url: url, payload: nil, restorationData: restorationData))
     }
 
+    var insertAIChatTabRequestingOpenSettingsCalls: [URL] = []
+
+    @MainActor
+    func insertAIChatTabRequestingOpenSettings(with url: URL) {
+        insertAIChatTabRequestingOpenSettingsCalls.append(url)
+    }
+
     /// Stubs `focusActiveVoiceSessionTab(inSourceCollection:)` for tests. When `true`, the tab
     /// opener short-circuits to "switch to existing tab" and skips opening a new one.
     var focusActiveVoiceSessionTabResult: Bool = false

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -384,6 +384,10 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enables the custom NSPanel-based bookmarks bar menu (replacing NSPopover) with NSGlassEffectView on macOS 26
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214684208036378
     case bookmarksBarMenusCustomWindow
+
+    /// Shows a link in Settings → AI Features that opens the Duck.ai Settings modal.
+    /// https://app.asana.com/1/137249556945/task/1214533186882448
+    case aiChatSettingsLinkInAiFeatures
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
@@ -647,6 +651,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .disabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.autoplayPolicy), supportsLocalOverriding: true)
         case .bookmarksBarMenusCustomWindow:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(MacOSBrowserConfigSubfeature.bookmarksBarMenusCustomWindow))
+        case .aiChatSettingsLinkInAiFeatures:
+            Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.settingsLinkInAiFeatures), category: .duckAI)
         }
     }
 

--- a/macOS/UITests/AIChatSettingsLinkTests.swift
+++ b/macOS/UITests/AIChatSettingsLinkTests.swift
@@ -49,31 +49,29 @@ class AIChatSettingsLinkTests: UITestCase {
         let settingsLink = app.windows.firstMatch.buttons[Identifiers.duckAiSettingsLink]
         XCTAssertTrue(settingsLink.waitForExistence(timeout: UITests.Timeouts.elementExistence),
                       "'Open Duck.ai Settings' link should be visible when the feature flag is on and Duck.ai is enabled")
-        settingsLink.click()
 
-        // A new tab should open on duck.ai — the URL is the first signal that the click was
-        // routed through AIChatTabOpener and a tab was created. Page navigation isn't instant,
-        // so poll the address bar value until it reflects duck.ai (or the navigation timeout).
-        let addressBar = app.addressBar
-        XCTAssertTrue(addressBar.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        let urlContainsDuckAi = NSPredicate(format: "self CONTAINS[c] %@", "duck.ai")
-        let started = Date()
-        while !urlContainsDuckAi.evaluate(with: addressBar.value as? String ?? "") {
-            if Date().timeIntervalSince(started) > UITests.Timeouts.navigation { break }
-            usleep(200_000)
-        }
-        XCTAssertTrue(urlContainsDuckAi.evaluate(with: addressBar.value as? String ?? ""),
-                      "Expected the new tab to load duck.ai; address bar value: \(addressBar.value ?? "<nil>")")
+        settingsLink.click()
 
         // Duck.ai's Settings modal should be visible inside the WebView. The modal is opened
         // by the FE in response to the `submitOpenSettingsAction` push from the two-phase
         // handshake — so its presence proves the end-to-end wiring works.
-        // The predicate matches a stable header label inside the modal. If Duck.ai's modal
-        // a11y labels evolve, adjust the string here.
-        let modalElement = app.webViews.descendants(matching: .any)
-            .matching(NSPredicate(format: "label CONTAINS[c] %@", "Settings"))
-            .firstMatch
-        XCTAssertTrue(modalElement.waitForExistence(timeout: UITests.Timeouts.navigation),
-                      "Duck.ai Settings modal should be visible after clicking the link")
+        //
+        // Two checks for resilience:
+        //
+        // 1. The modal's "close dialog" button. `.buttons` deterministically maps from
+        //    AXButton across macOS versions, the label is unique inside this WebView,
+        //    and the button only exists while the modal is open.
+        //
+        // 2. The modal container itself, labeled "Duck.ai Settings". The dialog is an
+        //    AXGroup with AXApplicationDialog subrole — XCUI surfaces this under
+        //    `.otherElements` on current macOS. If a future macOS or WebKit revision
+        //    maps it to `.groups` instead, swap `.otherElements` for `.groups` below.
+        let closeDialogButton = app.webViews.buttons["close dialog"]
+        XCTAssertTrue(closeDialogButton.waitForExistence(timeout: UITests.Timeouts.navigation),
+                      "Duck.ai Settings modal's close button should be visible after clicking the link")
+
+        let settingsModal = app.webViews.groups["Duck.ai Settings"]
+        XCTAssertTrue(settingsModal.waitForExistence(timeout: UITests.Timeouts.elementExistence),
+                      "Duck.ai Settings modal container labeled 'Duck.ai Settings' should be visible")
     }
 }

--- a/macOS/UITests/AIChatSettingsLinkTests.swift
+++ b/macOS/UITests/AIChatSettingsLinkTests.swift
@@ -1,0 +1,79 @@
+//
+//  AIChatSettingsLinkTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+
+class AIChatSettingsLinkTests: UITestCase {
+    private var addressBarTextField: XCUIElement!
+
+    private enum Identifiers {
+        static let duckAiSettingsLink = "Preferences.AIChat.duckAiSettingsLink"
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        continueAfterFailure = false
+        app = XCUIApplication.setUp(featureFlags: ["aiChatSettingsLinkInAiFeatures": true])
+        addressBarTextField = app.addressBar
+        app.enforceSingleWindow()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        app.terminate()
+    }
+
+    /// Happy path: with the sub-feature flag on, clicking "Open Duck.ai Settings" from
+    /// Settings → AI Features should open duck.ai in a new tab AND surface the Duck.ai
+    /// Settings modal via the two-phase `submitOpenSettingsAction` push.
+    func test_openDuckAiSettingsLink_opensDuckAiAndShowsSettings() {
+        // Navigate to AI Features settings
+        addressBarTextField.typeURL(URL(string: "duck://settings/aichat")!)
+
+        // Click the new link
+        let settingsLink = app.windows.firstMatch.buttons[Identifiers.duckAiSettingsLink]
+        XCTAssertTrue(settingsLink.waitForExistence(timeout: UITests.Timeouts.elementExistence),
+                      "'Open Duck.ai Settings' link should be visible when the feature flag is on and Duck.ai is enabled")
+        settingsLink.click()
+
+        // A new tab should open on duck.ai — the URL is the first signal that the click was
+        // routed through AIChatTabOpener and a tab was created. Page navigation isn't instant,
+        // so poll the address bar value until it reflects duck.ai (or the navigation timeout).
+        let addressBar = app.addressBar
+        XCTAssertTrue(addressBar.waitForExistence(timeout: UITests.Timeouts.elementExistence))
+        let urlContainsDuckAi = NSPredicate(format: "self CONTAINS[c] %@", "duck.ai")
+        let started = Date()
+        while !urlContainsDuckAi.evaluate(with: addressBar.value as? String ?? "") {
+            if Date().timeIntervalSince(started) > UITests.Timeouts.navigation { break }
+            usleep(200_000)
+        }
+        XCTAssertTrue(urlContainsDuckAi.evaluate(with: addressBar.value as? String ?? ""),
+                      "Expected the new tab to load duck.ai; address bar value: \(addressBar.value ?? "<nil>")")
+
+        // Duck.ai's Settings modal should be visible inside the WebView. The modal is opened
+        // by the FE in response to the `submitOpenSettingsAction` push from the two-phase
+        // handshake — so its presence proves the end-to-end wiring works.
+        // The predicate matches a stable header label inside the modal. If Duck.ai's modal
+        // a11y labels evolve, adjust the string here.
+        let modalElement = app.webViews.descendants(matching: .any)
+            .matching(NSPredicate(format: "label CONTAINS[c] %@", "Settings"))
+            .firstMatch
+        XCTAssertTrue(modalElement.waitForExistence(timeout: UITests.Timeouts.navigation),
+                      "Duck.ai Settings modal should be visible after clicking the link")
+    }
+}

--- a/macOS/UITests/AIChatSettingsLinkTests.swift
+++ b/macOS/UITests/AIChatSettingsLinkTests.swift
@@ -63,9 +63,9 @@ class AIChatSettingsLinkTests: UITestCase {
         //    and the button only exists while the modal is open.
         //
         // 2. The modal container itself, labeled "Duck.ai Settings". The dialog is an
-        //    AXGroup with AXApplicationDialog subrole — XCUI surfaces this under
-        //    `.otherElements` on current macOS. If a future macOS or WebKit revision
-        //    maps it to `.groups` instead, swap `.otherElements` for `.groups` below.
+        //    AXGroup with AXApplicationDialog subrole — XCUI surfaces it under `.groups`
+        //    on current macOS. If a future macOS or WebKit revision moves it to
+        //    `.otherElements`, swap `.groups` for `.otherElements` below.
         let closeDialogButton = app.webViews.buttons["close dialog"]
         XCTAssertTrue(closeDialogButton.waitForExistence(timeout: UITests.Timeouts.navigation),
                       "Duck.ai Settings modal's close button should be visible after clicking the link")

--- a/macOS/UnitTests/AIChat/AIChatCoordinatorTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatCoordinatorTests.swift
@@ -1130,6 +1130,8 @@ class MockAIChatTabOpener: AIChatTabOpening {
             break
         case .mode:
             break
+        case .openSettings:
+            break
         }
 
         openMethodCalledExpectation?.fulfill()

--- a/macOS/UnitTests/AIChat/AIChatTabOpenerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatTabOpenerTests.swift
@@ -1,0 +1,52 @@
+//
+//  AIChatTabOpenerTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import XCTest
+
+@testable import DuckDuckGo_Privacy_Browser
+
+final class AIChatTabOpenerTests: XCTestCase {
+
+    @MainActor
+    func testOpenSettingsTriggerRequestsOpenSettingsTab() {
+        let mockManager = WindowControllersManagerMock()
+        let opener = AIChatTabOpener(promptHandler: AIChatPromptHandler.shared, aiChatTabManaging: mockManager)
+
+        opener.openAIChatTab(with: .openSettings, behavior: .newTab(selected: true))
+
+        XCTAssertEqual(mockManager.insertAIChatTabRequestingOpenSettingsCalls,
+                       [opener.aiChatRemoteSettings.aiChatURL],
+                       "openSettings trigger must insert exactly one tab armed with requestOpenSettings, using the canonical Duck.ai URL")
+        XCTAssertTrue(mockManager.insertAIChatTabCalls.isEmpty,
+                      "openSettings must not go through the payload/restoration insert paths")
+    }
+
+    @MainActor
+    func testOpenSettingsTriggerIgnoresBehavior() {
+        // The behavior argument is intentionally a no-op for .openSettings (same as .payload /
+        // .restoration). This pins down that contract: passing any behavior still results in
+        // exactly one armed insert.
+        let mockManager = WindowControllersManagerMock()
+        let opener = AIChatTabOpener(promptHandler: AIChatPromptHandler.shared, aiChatTabManaging: mockManager)
+
+        opener.openAIChatTab(with: .openSettings, behavior: .currentTab)
+
+        XCTAssertEqual(mockManager.insertAIChatTabRequestingOpenSettingsCalls.count, 1)
+    }
+}

--- a/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
@@ -143,6 +143,75 @@ final class AIChatUserScriptTests: XCTestCase {
 
         XCTAssertTrue(mockHandler.didGetAIChatTabContent, "getAIChatTabContent should be called")
     }
+
+    // MARK: - Open Settings handshake
+
+    @MainActor func testRequestOpenSettingsActionArmsHandshake() {
+        XCTAssertFalse(userScript.pendingOpenSettingsAction, "Handshake should not be armed by default")
+
+        userScript.requestOpenSettingsAction()
+
+        XCTAssertTrue(userScript.pendingOpenSettingsAction, "requestOpenSettingsAction should arm the handshake")
+    }
+
+    @MainActor func testOpenSettingsHandshakeStaysPendingAfterFirstMessage() {
+        userScript.requestOpenSettingsAction()
+
+        _ = userScript.handler(forMethodNamed: AIChatUserScriptMessages.getAIChatNativeConfigValues.rawValue)
+
+        XCTAssertTrue(userScript.pendingOpenSettingsAction,
+                      "Single page message must not fire the push — JS subscriptions are not guaranteed wired yet")
+    }
+
+    @MainActor func testOpenSettingsHandshakeFiresAfterSecondMessage() {
+        userScript.requestOpenSettingsAction()
+
+        _ = userScript.handler(forMethodNamed: AIChatUserScriptMessages.getAIChatNativeConfigValues.rawValue)
+        _ = userScript.handler(forMethodNamed: AIChatUserScriptMessages.getAIChatNativePrompt.rawValue)
+
+        XCTAssertFalse(userScript.pendingOpenSettingsAction,
+                       "Second page message must clear the pending flag (push fired)")
+    }
+
+    @MainActor func testOpenSettingsHandshakeIgnoresUnknownMethods() {
+        userScript.requestOpenSettingsAction()
+
+        // Two unknown method names — resolveHandler returns nil, so neither should count.
+        _ = userScript.handler(forMethodNamed: "definitelyNotAKnownMethod")
+        _ = userScript.handler(forMethodNamed: "stillNotKnown")
+
+        XCTAssertTrue(userScript.pendingOpenSettingsAction,
+                      "Unknown methods must not count toward the readiness handshake")
+    }
+
+    @MainActor func testMessagesWithoutRequestDoNotArmHandshake() {
+        // Two known messages, but no requestOpenSettingsAction() — the handshake must stay unarmed
+        // so the next time it IS armed, it starts fresh from zero.
+        _ = userScript.handler(forMethodNamed: AIChatUserScriptMessages.getAIChatNativeConfigValues.rawValue)
+        _ = userScript.handler(forMethodNamed: AIChatUserScriptMessages.getAIChatNativePrompt.rawValue)
+
+        XCTAssertFalse(userScript.pendingOpenSettingsAction)
+
+        userScript.requestOpenSettingsAction()
+        _ = userScript.handler(forMethodNamed: AIChatUserScriptMessages.getAIChatNativeConfigValues.rawValue)
+
+        XCTAssertTrue(userScript.pendingOpenSettingsAction,
+                      "Pre-arm messages must not be counted: one post-arm message should still leave the handshake pending")
+    }
+
+    @MainActor func testOpenSettingsHandshakeIsOneShot() {
+        userScript.requestOpenSettingsAction()
+        _ = userScript.handler(forMethodNamed: AIChatUserScriptMessages.getAIChatNativeConfigValues.rawValue)
+        _ = userScript.handler(forMethodNamed: AIChatUserScriptMessages.getAIChatNativePrompt.rawValue)
+        XCTAssertFalse(userScript.pendingOpenSettingsAction)
+
+        // Subsequent messages must not re-fire — the next request must be explicitly armed.
+        _ = userScript.handler(forMethodNamed: AIChatUserScriptMessages.getAIChatNativeConfigValues.rawValue)
+        _ = userScript.handler(forMethodNamed: AIChatUserScriptMessages.getAIChatNativePrompt.rawValue)
+
+        XCTAssertFalse(userScript.pendingOpenSettingsAction,
+                       "Handshake must not re-arm itself after firing")
+    }
 }
 
 // swiftlint:disable inclusive_language


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1215028388469384?focus=true
Tech Design URL:
CC:

### Description

Adds an "Open Duck.ai Settings" link to the Duck.ai section of Settings → AI Features. Clicking it opens duck.ai in a new tab and automatically opens the Duck.ai Settings modal once the page's subscriptions are wired up.

Mirrors the Windows feature ([PR #7537](https://github.com/duckduckgo/windows-browser/pull/7537), shipped May 2026). Gated by the `aiChat.settingsLinkInAiFeatures` sub-feature flag (shared with Windows).

Mechanism:
- New `submitOpenSettingsAction` subscription event in shared `AIChatUserScriptMessages`.
- Two-phase readiness handshake on `AIChatUserScript`: `requestOpenSettingsAction()` arms it; after the second known page message, the push fires (by then FE subscriptions are wired). Mirrors the Windows `ConcurrentDictionary<TabId, bool>` two-phase flag.
- Deferred-apply pattern on `AIChatTabExtension` (`temporaryOpenSettingsRequest`) so the request survives the async user-script attachment — same idiom as `temporaryAIChatNativeHandoffData` and friends in the same file.
- New `.openSettings` case on `AIChatOpenTrigger` + `insertAIChatTabRequestingOpenSettings(with:)` on `AIChatTabManaging` so `AIChatPreferences.openDuckAiSettings()` goes through the canonical AI Chat tab opener (same path as `.payload` / `.restoration`) instead of hand-rolling `Tab(content:)` / `tabCollectionViewModel.insertOrAppend(...)`.

### Testing Steps
1. Enable the `aiChat.settingsLinkInAiFeatures` sub-feature flag (local override) and restart.
2. Open Settings → AI Features.
3. **Duck.ai enabled + flag ON:** verify the "Open Duck.ai Settings" link appears in the Duck.ai section, below the description.
4. Click it → a new duck.ai tab should open AND the Duck.ai Settings modal should appear automatically.
5. **Duck.ai disabled + flag ON:** click "Disable Duck.ai…" and confirm → the link disappears (along with the Shortcuts section).
6. Re-enable Duck.ai → the link reappears.
7. **Flag OFF:** disable the sub-feature → the link is hidden.
8. **Multiple tabs:** open another duck.ai tab manually first, then click the link → only the new tab gets the modal; the existing tab is untouched.
9. **Dark/light mode:** toggle theme → link color and external-link glyph adapt correctly.

### Impact and Risks

Low. Additive UI behind a feature flag.

#### What could go wrong?

- **Push timing:** if FE bootstrap order changes and fewer than 2 messages are sent before the settings-action subscriber is wired, the push could miss. Mitigated by mirroring the Windows handshake, which has been in production since May 2026.
- **Wrong tab gets the modal:** state lives per-`AIChatUserScript` instance (per-tab), so the modal opens only in the tab opened from the settings link.
- **Pushing to non-duck.ai page:** if the user navigates the new tab away before the handshake completes, the push could in principle go to a non-duck.ai origin. Guarded by `messageDestinationPolicy.isAllowed(host)` in `submitOpenSettingsAction()`, same pattern as `submitSyncStatusChanged`.

### Quality Considerations

- **6 tests in `AIChatUserScriptTests`** cover the handshake state machine: arming, single-message-stays-pending, second-message-fires, unknown-method filtering, no-spurious-arming, one-shot semantics.
- **2 tests in `AIChatTabOpenerTests` (new file)** cover the new trigger: `.openSettings` routes to `insertAIChatTabRequestingOpenSettings` with the canonical Duck.ai URL, and the `behavior:` arg is intentionally ignored (same contract as `.payload` / `.restoration`).
- **1 UI test in `AIChatSettingsLinkTests` (new file)** covers the happy path end-to-end: flag on → navigate to Settings → AI Features → click the link → new tab loads duck.ai → Settings modal becomes visible in the WebView. The modal-visible assertion uses a `label CONTAINS[c] "Settings"` predicate against `app.webViews` — if Duck.ai's modal a11y labels evolve, the predicate is the place to adjust.
- Translation PR will follow for the new `duckai.duckai-settings.link` string.

### Notes to Reviewer

- This is a direct port of the Windows feature. The two-phase handshake is intentional — Duck.ai's web frontend has no `/settings` URL; the only way to open the settings modal is the `submitOpenSettingsAction` push, which must arrive AFTER FE subscriptions are wired.
- I exposed `AIChatUserScript.pendingOpenSettingsAction` as `private(set)` purely to make the handshake testable, mirroring the existing `messageDestinationPolicy` pattern on the same class. No production behavior change.
- `AIChatPreferences.openDuckAiSettings()` was originally a 12-line method that reached into `lastKeyMainWindowController` and built/inserted the tab inline. It's now 1 line through `AIChatTabOpener` — the new `.openSettings` enum case carries the new tab-opener responsibility and keeps `AIChatPreferences` out of window-controller-level concerns.
- The UI test depends on duck.ai loading in the test environment and on the FE's modal exposing a label containing "Settings". If it flakes against duck.ai outages or label drift, prefer dropping the modal-visible assertion (keep the URL-loaded assertion) over wholesale skipping the test.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Duck.ai settings deep-link flow that opens a tab and triggers a user-script push after a readiness handshake; while feature-flagged, it touches tab creation and webview messaging where timing regressions could affect UX.
> 
> **Overview**
> Adds an **"Open Duck.ai Settings"** link to Settings → AI Features (gated by new `aiChatSettingsLinkInAiFeatures` flag) that opens `duck.ai` in a new tab.
> 
> Implements a new `.openSettings` tab-open trigger plus a per-tab user-script *two-message readiness handshake* that pushes the new `submitOpenSettingsAction` message to automatically open the Duck.ai Settings modal once the page is ready.
> 
> Includes new unit/UI tests to cover the open-settings trigger routing and handshake behavior, updates mocks/project wiring, and adds the new localized string plus minor copy tweaks in `Localizable.xcstrings`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62975c0ec23e0e818543fb1da7676dd7ef723359. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->