### PR TITLE
iOS - Roll back previews guard in VPN embed script

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -12215,7 +12215,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Conditionally embeds PacketTunnelProvider extension for Debug and Alpha builds.\n\nif [ \"${ENABLE_PREVIEWS:-NO}\" = \"YES\" ] || [ \"${ENABLE_XOJIT_PREVIEWS:-NO}\" = \"YES\" ]; then\n    exit 0\nfi\n\n# Conditionally embeds the PacketTunnelProvider extension for debug builds.\\n# To be moved to the Embed App Extensions phase on release.\n\nif [ \"${CONFIGURATION}\" = \"Debug\" ] || [ \"${CONFIGURATION}\" = \"Release\" ] || [ \"${CONFIGURATION}\" = \"Alpha\" ] || [ \"${CONFIGURATION}\" = \"Alpha Debug\" ]; then\n# Copy the extension    \n    rsync -r --copy-links \"${CONFIGURATION_BUILD_DIR}/PacketTunnelProvider.appex\" \"${CONFIGURATION_BUILD_DIR}/${PLUGINS_FOLDER_PATH}\"\nfi\n";
+			shellScript = "# Conditionally embeds the PacketTunnelProvider extension for debug builds.\\n# To be moved to the Embed App Extensions phase on release.\n\nif [ \"${CONFIGURATION}\" = \"Debug\" ] || [ \"${CONFIGURATION}\" = \"Release\" ] || [ \"${CONFIGURATION}\" = \"Alpha\" ] || [ \"${CONFIGURATION}\" = \"Alpha Debug\" ]; then\n# Copy the extension    \n    rsync -r --copy-links \"${CONFIGURATION_BUILD_DIR}/PacketTunnelProvider.appex\" \"${CONFIGURATION_BUILD_DIR}/${PLUGINS_FOLDER_PATH}\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1215021166828705?focus=true

### Description

Rolls back the previews guard in the iOS PacketTunnelProvider embed script so the VPN extension is embedded again in Debug builds. The previews check was causing the extension to be skipped in normal Debug runs, which broke the VPN locally.

### Testing Steps
1. Check out the branch and build the iOS app in the Debug configuration on a device.
2. Enable the VPN from settings and confirm it connects.

### Impact and Risks

Low. The script returns to its prior behavior — the extension is embedded for Debug, Release, Alpha, and Alpha Debug configurations.

#### What could go wrong?

SwiftUI previews that rely on the previously-added `ENABLE_PREVIEWS`/`ENABLE_XOJIT_PREVIEWS` short-circuit may regress. If preview builds fail, the guard will need a different mechanism that doesn't skip embedding in regular Debug builds.

### Quality Considerations

VPN extension embedding can only be exercised on-device, so this is verified manually rather than via automated tests.

### Notes to Reviewer

The diff is a single line in `project.pbxproj` removing the previews early-exit from the embed script.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: reverts a build-phase guard so the VPN extension is copied into the app bundle in standard Debug/Alpha configurations. Potential impact is limited to SwiftUI preview builds that previously relied on skipping the embed step.
> 
> **Overview**
> Reverts the `ENABLE_PREVIEWS`/`ENABLE_XOJIT_PREVIEWS` short-circuit in the `Embed PacketTunnelProvider` build phase so the VPN `PacketTunnelProvider.appex` is embedded again for `Debug`, `Release`, `Alpha`, and `Alpha Debug` configurations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61c26b021bf061e2d86433f60a3b27456a1f31b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->