### PR TITLE
iOS: UTI ↔ omnibar transition polish (animation + alignment)

### DIFF
--- a/SharedPackages/UIComponents/Sources/UIComponents/iOS/CompositeShadowView+CustomShadow.swift
+++ b/SharedPackages/UIComponents/Sources/UIComponents/iOS/CompositeShadowView+CustomShadow.swift
@@ -59,8 +59,7 @@ extension CompositeShadowView.Shadow {
 }
 
 public extension CompositeShadowView.Shadow {
-    /// Returns a copy with a different `id` so a shadow definition can be reused across
-    /// `CompositeShadowView`s that key their sublayers under different naming schemes.
+    /// Copy with overridden `id` — reuse a shadow under a different sublayer key.
     func withID(_ id: String) -> Self {
         Self(id: id, color: color, opacity: opacity, radius: radius, offset: offset)
     }

--- a/SharedPackages/UIComponents/Sources/UIComponents/iOS/CompositeShadowView+CustomShadow.swift
+++ b/SharedPackages/UIComponents/Sources/UIComponents/iOS/CompositeShadowView+CustomShadow.swift
@@ -25,7 +25,7 @@ extension CompositeShadowView.Shadow {
     private static let defaultColor: UIColor = UIColor(designSystemColor: .shadowSecondary)
     private static let focusColor: UIColor = UIColor(designSystemColor: .shadowTertiary)
 
-    static let defaultLayer1 = CompositeShadowView.Shadow(
+    public static let defaultLayer1 = CompositeShadowView.Shadow(
         id: "ddg.shadow1",
         color: defaultColor,
         opacity: 1,
@@ -33,7 +33,7 @@ extension CompositeShadowView.Shadow {
         offset: CGSize(width: 0, height: 4)
     )
 
-    static let defaultLayer2 = CompositeShadowView.Shadow(
+    public static let defaultLayer2 = CompositeShadowView.Shadow(
         id: "ddg.shadow2",
         color: defaultColor,
         opacity: 1,
@@ -56,6 +56,14 @@ extension CompositeShadowView.Shadow {
         radius: 32.0,
         offset: CGSize(width: 0, height: 16)
     )
+}
+
+public extension CompositeShadowView.Shadow {
+    /// Returns a copy with a different `id` so a shadow definition can be reused across
+    /// `CompositeShadowView`s that key their sublayers under different naming schemes.
+    func withID(_ id: String) -> Self {
+        Self(id: id, color: color, opacity: opacity, radius: radius, offset: offset)
+    }
 }
 
 public extension CompositeShadowView {

--- a/SharedPackages/UIComponents/Sources/UIComponents/iOS/CompositeShadowView.swift
+++ b/SharedPackages/UIComponents/Sources/UIComponents/iOS/CompositeShadowView.swift
@@ -63,8 +63,7 @@ public class CompositeShadowView: UIView {
         shadowView.layer.applyShadowProperties(shadow, in: self)
     }
 
-    /// Updates each shadow by `id` — see `updateShadow(_:)`. Callers without `id`s should use
-    /// `shadows = …` instead.
+    /// Batch variant of `updateShadow(_:)`.
     public func updateShadows(_ shadows: [Shadow]) {
         shadows.forEach(updateShadow)
     }

--- a/SharedPackages/UIComponents/Sources/UIComponents/iOS/CompositeShadowView.swift
+++ b/SharedPackages/UIComponents/Sources/UIComponents/iOS/CompositeShadowView.swift
@@ -63,6 +63,12 @@ public class CompositeShadowView: UIView {
         shadowView.layer.applyShadowProperties(shadow, in: self)
     }
 
+    /// Updates each shadow by `id` — see `updateShadow(_:)`. Callers without `id`s should use
+    /// `shadows = …` instead.
+    public func updateShadows(_ shadows: [Shadow]) {
+        shadows.forEach(updateShadow)
+    }
+
     /// Applies an opacity multiplier to all configured shadow layers.
     /// Useful when gradually revealing/hiding shadows during animated transitions.
     public func applyShadowOpacityMultiplier(_ multiplier: Float) {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarButtonsView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarButtonsView.swift
@@ -270,37 +270,22 @@ class SwitchBarButtonsView: UIView {
         separatorView.isHidden = !buttonState.showsSeparator
     }
 
-    /// Hides every button except the duck.ai chip so the chip can solo-animate to the omnibar's
-    /// chat-icon position without clear/voice/stop lingering and colliding with the omnibar icons
-    /// fading in. Iterates the stack so newly-added buttons are auto-covered.
-    func hideNonChipButtonsForDismissCollapse() {
+    /// Iterates the stack so newly-added buttons are auto-covered — the duck.ai chip stays
+    /// visible so it can solo-animate to the omnibar's chat-icon position via
+    /// `setAIChatShortcutDismissed`.
+    func setNonChipButtonsAlpha(_ alpha: CGFloat) {
         for view in stack.arrangedSubviews where view !== aiChatShortcutButton {
-            view.alpha = 0
+            view.alpha = alpha
         }
     }
 
-    func restoreNonChipButtonsAfterDismissCollapse() {
-        for view in stack.arrangedSubviews where view !== aiChatShortcutButton {
-            view.alpha = 1
-        }
-    }
-
-    /// Slides the duck.ai chip to the omnibar's chat-icon resting position and fades it out so
-    /// it crossfades with the omnibar's aiChat button (which fades in at its own X) — avoids the
-    /// two-icons-visible-at-once moment when the chip's final X doesn't exactly match.
-    func fadeAIChatShortcutForDismiss(duration: TimeInterval, horizontalOffset: CGFloat) {
+    /// Slides + fades the duck.ai chip so it crossfades with the omnibar's aiChat button (which
+    /// fades in at its own X) — avoids the two-icons-visible-at-once moment when the chip's
+    /// landing X doesn't exactly match. Restore via `setAIChatShortcutDismissed(false, …)`.
+    func setAIChatShortcutDismissed(_ dismissed: Bool, duration: TimeInterval, horizontalOffset: CGFloat = 0) {
         UIView.animate(withDuration: duration, delay: 0, options: [.beginFromCurrentState, .curveEaseInOut]) {
-            self.aiChatShortcutButton.transform = CGAffineTransform(translationX: horizontalOffset, y: 0)
-            self.aiChatShortcutButton.alpha = 0
-        }
-    }
-
-    /// Restores the override applied by `fadeAIChatShortcutForDismiss` so the reused chip
-    /// re-presents in sync — back at its resting position, fully opaque.
-    func restoreAIChatShortcutAfterDismiss(duration: TimeInterval) {
-        UIView.animate(withDuration: duration, delay: 0, options: [.beginFromCurrentState, .curveEaseInOut]) {
-            self.aiChatShortcutButton.transform = .identity
-            self.aiChatShortcutButton.alpha = 1
+            self.aiChatShortcutButton.transform = dismissed ? CGAffineTransform(translationX: horizontalOffset, y: 0) : .identity
+            self.aiChatShortcutButton.alpha = dismissed ? 0 : 1
         }
     }
 

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarButtonsView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarButtonsView.swift
@@ -270,23 +270,37 @@ class SwitchBarButtonsView: UIView {
         separatorView.isHidden = !buttonState.showsSeparator
     }
 
-    /// Fades the duck.ai chip's circular fill and slides the chip horizontally so it lands at
-    /// the omnibar's chat-icon resting position. Icon stays at full alpha throughout the
-    /// surrounding dismiss/collapse animation.
-    func fadeAIChatShortcutBackdrop(duration: TimeInterval, horizontalOffset: CGFloat) {
-        UIView.animate(withDuration: duration, delay: 0, options: [.beginFromCurrentState, .curveEaseInOut]) {
-            self.aiChatShortcutBackdrop.alpha = 0
-            self.aiChatShortcutButton.transform = CGAffineTransform(translationX: horizontalOffset, y: 0)
+    /// Hides every button except the duck.ai chip so the chip can solo-animate to the omnibar's
+    /// chat-icon position without clear/voice/stop lingering and colliding with the omnibar icons
+    /// fading in. Iterates the stack so newly-added buttons are auto-covered.
+    func hideNonChipButtonsForDismissCollapse() {
+        for view in stack.arrangedSubviews where view !== aiChatShortcutButton {
+            view.alpha = 0
         }
     }
 
-    /// Restore the override applied by `fadeAIChatShortcutBackdrop`. Eases the backdrop back
-    /// in and slides the chip from its dismissed offset to the resting position; mirrors the
-    /// dismiss fade so the chip transitions both ways.
-    func restoreAIChatShortcutBackdrop(duration: TimeInterval) {
+    func restoreNonChipButtonsAfterDismissCollapse() {
+        for view in stack.arrangedSubviews where view !== aiChatShortcutButton {
+            view.alpha = 1
+        }
+    }
+
+    /// Slides the duck.ai chip to the omnibar's chat-icon resting position and fades it out so
+    /// it crossfades with the omnibar's aiChat button (which fades in at its own X) — avoids the
+    /// two-icons-visible-at-once moment when the chip's final X doesn't exactly match.
+    func fadeAIChatShortcutForDismiss(duration: TimeInterval, horizontalOffset: CGFloat) {
         UIView.animate(withDuration: duration, delay: 0, options: [.beginFromCurrentState, .curveEaseInOut]) {
-            self.aiChatShortcutBackdrop.alpha = 1
+            self.aiChatShortcutButton.transform = CGAffineTransform(translationX: horizontalOffset, y: 0)
+            self.aiChatShortcutButton.alpha = 0
+        }
+    }
+
+    /// Restores the override applied by `fadeAIChatShortcutForDismiss` so the reused chip
+    /// re-presents in sync — back at its resting position, fully opaque.
+    func restoreAIChatShortcutAfterDismiss(duration: TimeInterval) {
+        UIView.animate(withDuration: duration, delay: 0, options: [.beginFromCurrentState, .curveEaseInOut]) {
             self.aiChatShortcutButton.transform = .identity
+            self.aiChatShortcutButton.alpha = 1
         }
     }
 

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -351,17 +351,18 @@ class SwitchBarTextEntryView: UIView {
         setPlaceholderText(placeholderText(for: snapshot.placeholderMode))
         updatePlaceholderVisibility()
         // Handler.buttonState lags the dismiss (text isn't cleared until completion), so clear/voice/
-        // shortcut buttons would otherwise linger and collide with the omnibar icons fading in.
-        buttonsView.alpha = 0
-        buttonsView.fadeAIChatShortcutBackdrop(duration: Constants.buttonStateAnimationDuration,
-                                                horizontalOffset: Constants.dismissedChipHorizontalOffset)
+        // stop would otherwise linger and collide with the omnibar icons fading in. The chip stays
+        // animatable so it can slide+fade and crossfade with the omnibar's aiChat icon.
+        buttonsView.hideNonChipButtonsForDismissCollapse()
+        buttonsView.fadeAIChatShortcutForDismiss(duration: Constants.buttonStateAnimationDuration,
+                                                  horizontalOffset: Constants.dismissedChipHorizontalOffset)
     }
 
     /// Restore the override applied by `applyDismissSnapshot` so the reused view re-presents
-    /// in sync with the handler — chip backdrop visible, text reflecting `handler.currentText`.
+    /// in sync with the handler — chip visible at its resting position.
     func clearDismissSnapshot() {
-        buttonsView.alpha = 1
-        buttonsView.restoreAIChatShortcutBackdrop(duration: Constants.buttonStateAnimationDuration)
+        buttonsView.restoreNonChipButtonsAfterDismissCollapse()
+        buttonsView.restoreAIChatShortcutAfterDismiss(duration: Constants.buttonStateAnimationDuration)
         setPlaceholderText(placeholderText(for: currentMode))
         if textView.text != handler.currentText {
             textView.text = handler.currentText

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -350,19 +350,19 @@ class SwitchBarTextEntryView: UIView {
         textView.text = snapshot.text
         setPlaceholderText(placeholderText(for: snapshot.placeholderMode))
         updatePlaceholderVisibility()
-        // Handler.buttonState lags the dismiss (text isn't cleared until completion), so clear/voice/
-        // stop would otherwise linger and collide with the omnibar icons fading in. The chip stays
-        // animatable so it can slide+fade and crossfade with the omnibar's aiChat icon.
-        buttonsView.hideNonChipButtonsForDismissCollapse()
-        buttonsView.fadeAIChatShortcutForDismiss(duration: Constants.buttonStateAnimationDuration,
-                                                  horizontalOffset: Constants.dismissedChipHorizontalOffset)
+        // State lags dismiss — hide non-chip buttons explicitly so they don't collide with the
+        // omnibar icons fading in. Chip stays animatable to crossfade with the omnibar's aiChat.
+        buttonsView.setNonChipButtonsAlpha(0)
+        buttonsView.setAIChatShortcutDismissed(true,
+                                                duration: Constants.buttonStateAnimationDuration,
+                                                horizontalOffset: Constants.dismissedChipHorizontalOffset)
     }
 
     /// Restore the override applied by `applyDismissSnapshot` so the reused view re-presents
     /// in sync with the handler — chip visible at its resting position.
     func clearDismissSnapshot() {
-        buttonsView.restoreNonChipButtonsAfterDismissCollapse()
-        buttonsView.restoreAIChatShortcutAfterDismiss(duration: Constants.buttonStateAnimationDuration)
+        buttonsView.setNonChipButtonsAlpha(1)
+        buttonsView.setAIChatShortcutDismissed(false, duration: Constants.buttonStateAnimationDuration)
         setPlaceholderText(placeholderText(for: currentMode))
         if textView.text != handler.currentText {
             textView.text = handler.currentText

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -830,14 +830,25 @@ class SwitchBarTextEntryView: UIView {
         placeholderLabel.transform = transform
     }
 
+    /// Horizontally shifts text content so the leading edge of the first glyph lands at `windowX`.
+    /// Uses the visible surface's actual glyph leading (textView's `firstRect` vs placeholderLabel
+    /// origin) because UITextView's caret sits 1pt left of its glyph (`lineFragmentPadding`).
     @discardableResult
-    func alignPlaceholderHorizontally(toWindowX windowX: CGFloat) -> CGFloat {
+    func alignVisibleTextLeadingEdge(toWindowX windowX: CGFloat) -> CGFloat {
         setTextHorizontalShift(0)
         guard placeholderLabel.window != nil else { return 0 }
-        let currentX = placeholderLabel.convert(CGPoint.zero, to: nil).x
-        let shift = windowX - currentX
+        let shift = windowX - visibleTextLeadingWindowX
         setTextHorizontalShift(shift)
         return shift
+    }
+
+    private var visibleTextLeadingWindowX: CGFloat {
+        if placeholderLabel.isHidden,
+           let end = textView.position(from: textView.beginningOfDocument, offset: 1),
+           let range = textView.textRange(from: textView.beginningOfDocument, to: end) {
+            return textView.convert(textView.firstRect(for: range).origin, to: nil).x
+        }
+        return placeholderLabel.convert(CGPoint.zero, to: nil).x
     }
 
     private func disableAutoCorrectionAndSpellChecking() {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -830,9 +830,8 @@ class SwitchBarTextEntryView: UIView {
         placeholderLabel.transform = transform
     }
 
-    /// Horizontally shifts text content so the leading edge of the first glyph lands at `windowX`.
-    /// Uses the visible surface's actual glyph leading (textView's `firstRect` vs placeholderLabel
-    /// origin) because UITextView's caret sits 1pt left of its glyph (`lineFragmentPadding`).
+    /// Shifts text so its first glyph (not caret) lands at `windowX` — UITextView's caret sits
+    /// 1pt left of its glyph (`lineFragmentPadding`).
     @discardableResult
     func alignVisibleTextLeadingEdge(toWindowX windowX: CGFloat) -> CGFloat {
         setTextHorizontalShift(0)

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -350,6 +350,9 @@ class SwitchBarTextEntryView: UIView {
         textView.text = snapshot.text
         setPlaceholderText(placeholderText(for: snapshot.placeholderMode))
         updatePlaceholderVisibility()
+        // Handler.buttonState lags the dismiss (text isn't cleared until completion), so clear/voice/
+        // shortcut buttons would otherwise linger and collide with the omnibar icons fading in.
+        buttonsView.alpha = 0
         buttonsView.fadeAIChatShortcutBackdrop(duration: Constants.buttonStateAnimationDuration,
                                                 horizontalOffset: Constants.dismissedChipHorizontalOffset)
     }
@@ -357,6 +360,7 @@ class SwitchBarTextEntryView: UIView {
     /// Restore the override applied by `applyDismissSnapshot` so the reused view re-presents
     /// in sync with the handler — chip backdrop visible, text reflecting `handler.currentText`.
     func clearDismissSnapshot() {
+        buttonsView.alpha = 1
         buttonsView.restoreAIChatShortcutBackdrop(duration: Constants.buttonStateAnimationDuration)
         setPlaceholderText(placeholderText(for: currentMode))
         if textView.text != handler.currentText {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -646,15 +646,11 @@ class SwitchBarTextEntryView: UIView {
             .removeDuplicates()
             .sink { [weak self] _ in
                 guard let self else { return }
-
-                if self.handler.isUsingFadeOutAnimation {
-                    self.window?.layoutIfNeeded()
+                // Snap — animating the buttonsView-driven width change reveals the new placeholder
+                // tail progressively. Pose Y is animated by `setInputMode`'s outer UIView.animate.
+                UIView.performWithoutAnimation {
                     self.updateForCurrentMode()
-                    UIView.animate(withDuration: 0.25) {
-                        self.window?.layoutIfNeeded()
-                    }
-                } else {
-                    self.updateForCurrentMode()
+                    self.layoutIfNeeded()
                 }
             }
             .store(in: &cancellables)

--- a/iOS/DuckDuckGo/DefaultOmniBarSearchView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarSearchView.swift
@@ -98,6 +98,22 @@ final class DefaultOmniBarSearchView: UIView {
 
         textField.alpha = 1
     }
+
+    /// Leaf icons (not containers) so alpha is set directly and can't be defeated by parent re-renders.
+    var iconViewsForFadeIn: [UIView] {
+        [
+            loupeIconView,
+            dismissButtonView,
+            privacyInfoContainer,
+            customIconView,
+            clearButton,
+            voiceSearchButton,
+            reloadButton,
+            cancelButton,
+            customizableButton,
+            aiChatButton,
+        ]
+    }
     
     func updateFireModeAppearance(fireMode: Bool) {
         textField.tintColor = fireMode

--- a/iOS/DuckDuckGo/DefaultOmniBarSearchView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarSearchView.swift
@@ -99,20 +99,11 @@ final class DefaultOmniBarSearchView: UIView {
         textField.alpha = 1
     }
 
-    /// Leaf icons (not containers) so alpha is set directly and can't be defeated by parent re-renders.
-    var iconViewsForFadeIn: [UIView] {
-        [
-            loupeIconView,
-            dismissButtonView,
-            privacyInfoContainer,
-            customIconView,
-            clearButton,
-            voiceSearchButton,
-            reloadButton,
-            cancelButton,
-            customizableButton,
-            aiChatButton,
-        ]
+    /// Sets `alpha` on the search-area containers whose alpha cascades to every icon-bearing child.
+    func setIconContainersAlpha(_ alpha: CGFloat) {
+        leftIconContainerPlaceholder.alpha = alpha
+        privacyInfoContainer.alpha = alpha
+        trailingItemsContainer.alpha = alpha
     }
     
     func updateFireModeAppearance(fireMode: Bool) {

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -407,6 +407,8 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
     private let searchAreaContainerView = CompositeShadowView.defaultShadowView()
     private var omniBarLongPressInteraction: UIContextMenuInteraction?
     private let defaultBackgroundColor = UIColor(designSystemColor: .background)
+    fileprivate var savedBarChromeBackgroundColor: UIColor?
+    fileprivate var savedBarViewBackgroundColor: UIColor?
 
     /// Spans to available width of the omni bar and allows the input field to center horizontally
     private let searchAreaAlignmentView = UIView()
@@ -1151,6 +1153,34 @@ extension DefaultOmniBarView {
     func revealButtons() {
         privacyInfoContainer.alpha = 1
         searchAreaView.revealButtons()
+    }
+
+    var iconViewsForFadeIn: [UIView] { searchAreaView.iconViewsForFadeIn }
+
+    func hideBarChrome() {
+        if savedBarChromeBackgroundColor == nil {
+            savedBarChromeBackgroundColor = searchAreaContainerView.backgroundColor
+        }
+        if savedBarViewBackgroundColor == nil {
+            savedBarViewBackgroundColor = backgroundColor
+        }
+        searchAreaContainerView.backgroundColor = .clear
+        searchAreaContainerView.applyShadowOpacityMultiplier(0)
+        backgroundColor = .clear
+        textField.alpha = 0
+    }
+
+    func restoreBarChrome() {
+        if let saved = savedBarChromeBackgroundColor {
+            searchAreaContainerView.backgroundColor = saved
+            savedBarChromeBackgroundColor = nil
+        }
+        if let saved = savedBarViewBackgroundColor {
+            backgroundColor = saved
+            savedBarViewBackgroundColor = nil
+        }
+        searchAreaContainerView.applyShadowOpacityMultiplier(1)
+        textField.alpha = 1
     }
 
     /// Configures the omnibar UI for AI Chat mode. Shows AI Chat buttons, hides search elements.

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -1155,7 +1155,7 @@ extension DefaultOmniBarView {
         searchAreaView.revealButtons()
     }
 
-    var iconViewsForFadeIn: [UIView] { searchAreaView.iconViewsForFadeIn }
+    func setIconContainersAlpha(_ alpha: CGFloat) { searchAreaView.setIconContainersAlpha(alpha) }
 
     func hideBarChrome() {
         if savedBarChromeBackgroundColor == nil {

--- a/iOS/DuckDuckGo/MainViewCoordinator.swift
+++ b/iOS/DuckDuckGo/MainViewCoordinator.swift
@@ -347,7 +347,7 @@ class MainViewCoordinator {
             unifiedToggleInputContainer.isHidden = true
             unifiedToggleInputContainer.alpha = 1
             omniBar?.barView.restoreBarChrome()
-            omniBar?.barView.iconViewsForFadeIn.forEach { $0.alpha = 1 }
+            omniBar?.barView.setIconContainersAlpha(1)
         }
     }
 

--- a/iOS/DuckDuckGo/MainViewCoordinator.swift
+++ b/iOS/DuckDuckGo/MainViewCoordinator.swift
@@ -314,6 +314,14 @@ class MainViewCoordinator {
         animator.startAnimation()
     }
 
+    /// Hides chrome and brings the omnibar collection above UTI so icons can fade in on top of the collapsing UTI.
+    func prepareOmnibarForInlineDismissReveal() {
+        guard !isNavigationChromeHidden, let barView = omniBar?.barView else { return }
+        barView.hideBarChrome()
+        navigationBarCollectionView.alpha = 1
+        navigationBarContainer.bringSubviewToFront(navigationBarCollectionView)
+    }
+
     /// Call inside an animation context — alpha swap is deferred to completion to avoid a crossfade gap.
     func animateUnifiedToggleInputOmnibarDismissLayout() {
         if addressBarPosition.isBottom {
@@ -334,10 +342,12 @@ class MainViewCoordinator {
             unifiedToggleInputContainer.isHidden = false
             unifiedToggleInputContainer.alpha = 1
         } else {
-            // Snap omnibar in, no fade — crossfading would produce visible double-text mid-dismiss.
+            // Snap chrome (pill + text field) back now that UTI is gone; icons faded in alongside the collapse.
             navigationBarCollectionView.alpha = 1
             unifiedToggleInputContainer.isHidden = true
             unifiedToggleInputContainer.alpha = 1
+            omniBar?.barView.restoreBarChrome()
+            omniBar?.barView.iconViewsForFadeIn.forEach { $0.alpha = 1 }
         }
     }
 

--- a/iOS/DuckDuckGo/OmniBarView.swift
+++ b/iOS/DuckDuckGo/OmniBarView.swift
@@ -117,8 +117,8 @@ protocol OmniBarView: UIView, OmniBarStatusUpdateable {
     func prepareForMoveTransition()
     func moveTransitionCompleted()
 
-    /// Leaf icon subviews intended to fade in independently of the bar's pill and text field.
-    var iconViewsForFadeIn: [UIView] { get }
+    /// Sets `alpha` on the search-area containers whose alpha cascades to every icon-bearing child.
+    func setIconContainersAlpha(_ alpha: CGFloat)
 
     /// Hides the bar's pill background, shadow, and text field while leaving icon subviews intact.
     func hideBarChrome()

--- a/iOS/DuckDuckGo/OmniBarView.swift
+++ b/iOS/DuckDuckGo/OmniBarView.swift
@@ -116,6 +116,15 @@ protocol OmniBarView: UIView, OmniBarStatusUpdateable {
     func refreshFireMode(fireMode: Bool)
     func prepareForMoveTransition()
     func moveTransitionCompleted()
+
+    /// Leaf icon subviews intended to fade in independently of the bar's pill and text field.
+    var iconViewsForFadeIn: [UIView] { get }
+
+    /// Hides the bar's pill background, shadow, and text field while leaving icon subviews intact.
+    func hideBarChrome()
+
+    /// Restores bar pill background, shadow, and text field. Idempotent.
+    func restoreBarChrome()
 }
 
 /// iPad-specific extension for the duck.ai mode toggle and expandable search area.

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1062,14 +1062,16 @@ extension MainViewController: UnifiedToggleInputDelegate {
     }
 
     func unifiedToggleInputDismissSnapshot() -> UTIDismissSnapshot {
-        let preferredMode = preferredTextEntryModeForCurrentTab() ?? .search
         let tab = tabManager.currentTabsModel.currentTab
-        // AI tab reuses the same textView for the flanked input — text here bleeds past the
-        // collapse. AI-mode tabs likewise show a placeholder rather than the URL.
-        let isAIDestination = tab?.isAITab == true || preferredMode == .aiChat
-        let placeholderMode: TextEntryMode = isAIDestination ? .aiChat : preferredMode
-        let text = isAIDestination ? "" : AddressDisplayHelper.plainDisplayString(for: tab?.link?.url)
-        return UTIDismissSnapshot(text: text, placeholderMode: placeholderMode)
+        // AI tab reuses the same textView for the flanked input — populating it with the URL
+        // would bleed past the collapse, so match the AI chrome (empty + aiChat placeholder).
+        if tab?.isAITab == true {
+            return UTIDismissSnapshot(text: "", placeholderMode: .aiChat)
+        }
+        return UTIDismissSnapshot(
+            text: AddressDisplayHelper.plainDisplayString(for: tab?.link?.url),
+            placeholderMode: preferredTextEntryModeForCurrentTab() ?? .search
+        )
     }
 }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -886,7 +886,7 @@ private extension MainViewController {
         }
 
         viewCoordinator.prepareOmnibarForInlineDismissReveal()
-        let omnibarIconsToReveal = viewCoordinator.omniBar?.barView.iconViewsForFadeIn ?? []
+        let revealBarView = viewCoordinator.omniBar?.barView
 
         UIView.animate(
             withDuration: duration,
@@ -903,7 +903,7 @@ private extension MainViewController {
                     self.viewCoordinator.unifiedInputContentContainer.alpha = 0
                 }
                 if let omnibarPlaceholderWindowX {
-                    coordinator.viewController.alignPlaceholderHorizontally(toWindowX: omnibarPlaceholderWindowX)
+                    coordinator.viewController.alignVisibleTextLeadingEdge(toWindowX: omnibarPlaceholderWindowX)
                 }
             },
             completion: { [weak self] _ in
@@ -940,13 +940,13 @@ private extension MainViewController {
 
         // Outer commits alpha=0 to the presentation layer before the fade animator captures `from`.
         UIView.animate(withDuration: 0, animations: {
-            omnibarIconsToReveal.forEach { $0.alpha = 0 }
+            revealBarView?.setIconContainersAlpha(0)
         }, completion: { _ in
             UIView.animate(
                 withDuration: duration * Constants.omnibarIconFadeInDurationMultiplier,
                 delay: 0,
                 options: [.curveEaseIn, .allowUserInteraction],
-                animations: { omnibarIconsToReveal.forEach { $0.alpha = 1 } }
+                animations: { revealBarView?.setIconContainersAlpha(1) }
             )
         })
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -938,17 +938,18 @@ private extension MainViewController {
             )
         }
 
-        // Outer commits alpha=0 to the presentation layer before the fade animator captures `from`.
-        UIView.animate(withDuration: 0, animations: {
+        // Snap alpha to 0 outside the surrounding dismiss animate so the fade animator captures
+        // `from = 0`. Without `performWithoutAnimation`, the alpha set would interpolate with
+        // the dismiss transaction and the icons would briefly become visible mid-collapse.
+        UIView.performWithoutAnimation {
             revealBarView?.setIconContainersAlpha(0)
-        }, completion: { _ in
-            UIView.animate(
-                withDuration: duration * Constants.omnibarIconFadeInDurationMultiplier,
-                delay: 0,
-                options: [.curveEaseIn, .allowUserInteraction],
-                animations: { revealBarView?.setIconContainersAlpha(1) }
-            )
-        })
+        }
+        UIView.animate(
+            withDuration: duration * Constants.omnibarIconFadeInDurationMultiplier,
+            delay: 0,
+            options: [.curveEaseIn, .allowUserInteraction],
+            animations: { revealBarView?.setIconContainersAlpha(1) }
+        )
     }
 
     /// Routes a UTI omnibar-session dismiss to the matching chrome — Duck.ai header restore for

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -41,6 +41,9 @@ extension MainViewController {
             isBottom ? 0.35 : 0.25
         }
 
+        /// Stretch the icon fade-in past UTI's collapse so the build-up reads rather than front-loading.
+        static let omnibarIconFadeInDurationMultiplier: Double = 1.2
+
         static let bottomDaxLogoTransitionYOffset: CGFloat = -DefaultOmniBarView.expectedHeight / 2
         static let topDaxLogoTransitionYOffset: CGFloat = 2
     }
@@ -882,6 +885,9 @@ private extension MainViewController {
             coordinator.contentViewController.daxLogoManager.setLogoYOffset(currentOffset + offset)
         }
 
+        viewCoordinator.prepareOmnibarForInlineDismissReveal()
+        let omnibarIconsToReveal = viewCoordinator.omniBar?.barView.iconViewsForFadeIn ?? []
+
         UIView.animate(
             withDuration: duration,
             delay: 0,
@@ -931,6 +937,18 @@ private extension MainViewController {
                 duration: duration
             )
         }
+
+        // Outer commits alpha=0 to the presentation layer before the fade animator captures `from`.
+        UIView.animate(withDuration: 0, animations: {
+            omnibarIconsToReveal.forEach { $0.alpha = 0 }
+        }, completion: { _ in
+            UIView.animate(
+                withDuration: duration * Constants.omnibarIconFadeInDurationMultiplier,
+                delay: 0,
+                options: [.curveEaseIn, .allowUserInteraction],
+                animations: { omnibarIconsToReveal.forEach { $0.alpha = 1 } }
+            )
+        })
     }
 
     /// Routes a UTI omnibar-session dismiss to the matching chrome — Duck.ai header restore for

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
@@ -194,7 +194,7 @@ private extension MainViewController {
         }
 
         if let omnibarPlaceholderWindowX {
-            coordinator.viewController.alignPlaceholderHorizontally(toWindowX: omnibarPlaceholderWindowX)
+            coordinator.viewController.alignVisibleTextLeadingEdge(toWindowX: omnibarPlaceholderWindowX)
         }
 
         // For logo-to-logo: place the UTI Logo at the NTP Logo's position, swap visibility
@@ -265,7 +265,7 @@ private extension MainViewController {
             let duration = Constants.omnibarTransitionDuration(isBottom: viewCoordinator.addressBarPosition.isBottom)
             let slideUTIText: () -> Void = { [weak coordinator] in
                 guard let coordinator, let omnibarPlaceholderWindowX else { return }
-                coordinator.viewController.alignPlaceholderHorizontally(toWindowX: omnibarPlaceholderWindowX)
+                coordinator.viewController.alignVisibleTextLeadingEdge(toWindowX: omnibarPlaceholderWindowX)
             }
             viewCoordinator.hideUnifiedToggleInputOmnibar(additionalAnimations: slideUTIText, completion: onDismissed)
             if let coordinator, let omnibarPlaceholderColor, let utiPlaceholderColor {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -612,6 +612,10 @@ final class UnifiedToggleInputView: UIView {
         if isToggleEnabled {
             toggleView.setMode(mode, animated: animated)
         }
+        // Drive textView pose synchronously inside the caller's UIView.animate so the
+        // placeholder constraint switch animates rather than snapping when the publisher
+        // subscriber fires after the animation transaction has already committed.
+        textEntryView.updatePoseForCurrentState()
         updateToolbarVisibility(for: mode, animated: animated)
         updateToggleDisabledSearchPadding(for: mode)
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -99,6 +99,7 @@ final class UnifiedToggleInputView: UIView {
         static let toggleHeight: CGFloat = 40
         static let toggleHorizontalPadding: CGFloat = 8
         static let animationDuration: TimeInterval = 0.25
+        static let dismissToggleFadeDuration: TimeInterval = 0.18
         static let toggleDisabledSearchTopPadding: CGFloat = 6
         static let toolbarHeight: CGFloat = 56
         static let expandedBorderWidth: CGFloat = 0.5
@@ -164,6 +165,14 @@ final class UnifiedToggleInputView: UIView {
     /// See `SwitchBarTextEntryView.applyDismissSnapshot`.
     func applyDismissSnapshot(_ snapshot: UTIDismissSnapshot) {
         textEntryView.applyDismissSnapshot(snapshot)
+        // Toggle pill fades over the full dismiss with easeOut, leaving the labels visible
+        // near the end; run a quick fade so they're gone well before UTI lands on the omnibar.
+        UIView.animate(withDuration: Constants.dismissToggleFadeDuration,
+                       delay: 0,
+                       options: [.curveEaseOut, .beginFromCurrentState],
+                       animations: { [weak self] in
+            self?.toggleView.alpha = 0
+        })
     }
 
     func refreshPlaceholderForCurrentMode() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -429,6 +429,22 @@ final class UnifiedToggleInputView: UIView {
         ]
     }
 
+    /// Shadow values that match `CompositeShadowView.applyDefaultShadow()` (used by the standard
+    /// omnibar). Applied during dismiss so the UTI's composite shadow morphs to the omnibar's
+    /// shadow shape by the time the omnibar takes over — no visible "shadow swap" at hand-off.
+    private var omnibarMatchingShadows: [CompositeShadowView.Shadow] {
+        [
+            .init(id: ShadowID.outer,
+                  color: UIColor(designSystemColor: .shadowSecondary),
+                  radius: 24,
+                  offset: CGSize(width: 0, height: 8)),
+            .init(id: ShadowID.rim,
+                  color: UIColor(designSystemColor: .shadowSecondary),
+                  radius: 12,
+                  offset: CGSize(width: 0, height: 4)),
+        ]
+    }
+
     /// Stable IDs so we can mutate shadows in place at runtime via `updateShadow(_:)`
     /// instead of reassigning `.shadows` (which recreates sublayers mid-animation).
     private enum ShadowID {
@@ -592,8 +608,8 @@ final class UnifiedToggleInputView: UIView {
     }
 
     @discardableResult
-    func alignPlaceholderHorizontally(toWindowX windowX: CGFloat) -> CGFloat {
-        textEntryView.alignPlaceholderHorizontally(toWindowX: windowX)
+    func alignVisibleTextLeadingEdge(toWindowX windowX: CGFloat) -> CGFloat {
+        textEntryView.alignVisibleTextLeadingEdge(toWindowX: windowX)
     }
 
     func updateToggleEnabled(_ enabled: Bool, showsToolbar: Bool) {
@@ -839,6 +855,13 @@ final class UnifiedToggleInputView: UIView {
         case (_, _):
             applyCardLayout(.collapsed, animated: false)
         }
+        // Pre-stage the composite shadow to match the omnibar's shape so the show animation
+        // morphs from omnibar-shape to UTI-expanded inside the surrounding `UIView.animate`.
+        for shadow in omnibarMatchingShadows {
+            expandedShadowView.updateShadow(shadow)
+        }
+        expandedShadowView.isHidden = false
+        cardView.layer.shadowOpacity = 0
     }
 
     /// Active editing pose. Call inside a UIView.animate block.
@@ -849,6 +872,9 @@ final class UnifiedToggleInputView: UIView {
             layoutIfNeeded()
         case (_, _):
             applyCardLayout(.expanded(showsToggle: isToggleEnabled, showsToolbar: isToggleEnabled && toggleView.selectedMode == .aiChat), animated: false)
+        }
+        for shadow in expandedShadows {
+            expandedShadowView.updateShadow(shadow)
         }
     }
 
@@ -862,6 +888,9 @@ final class UnifiedToggleInputView: UIView {
             layoutIfNeeded()
         case (_, _):
             applyCardLayout(.collapsed, animated: false, updateShadow: false)
+        }
+        for shadow in omnibarMatchingShadows {
+            expandedShadowView.updateShadow(shadow)
         }
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -429,19 +429,12 @@ final class UnifiedToggleInputView: UIView {
         ]
     }
 
-    /// Shadow values that match `CompositeShadowView.applyDefaultShadow()` (used by the standard
-    /// omnibar). Applied during dismiss so the UTI's composite shadow morphs to the omnibar's
-    /// shadow shape by the time the omnibar takes over — no visible "shadow swap" at hand-off.
+    /// Mirrors `CompositeShadowView.applyDefaultShadow()` (used by the standard omnibar) so the
+    /// UTI's composite shadow can morph to the omnibar's shape without a visible swap.
     private var omnibarMatchingShadows: [CompositeShadowView.Shadow] {
         [
-            .init(id: ShadowID.outer,
-                  color: UIColor(designSystemColor: .shadowSecondary),
-                  radius: 24,
-                  offset: CGSize(width: 0, height: 8)),
-            .init(id: ShadowID.rim,
-                  color: UIColor(designSystemColor: .shadowSecondary),
-                  radius: 12,
-                  offset: CGSize(width: 0, height: 4)),
+            CompositeShadowView.Shadow.defaultLayer2.withID(ShadowID.outer),
+            CompositeShadowView.Shadow.defaultLayer1.withID(ShadowID.rim),
         ]
     }
 
@@ -701,7 +694,7 @@ final class UnifiedToggleInputView: UIView {
         }
     }
 
-    func applyCardLayout(_ layout: UnifiedToggleInputCardLayout, animated: Bool, updateShadow: Bool = true) {
+    func applyCardLayout(_ layout: UnifiedToggleInputCardLayout, animated: Bool, updateShadow: Bool = true, updateCornerRadius: Bool = true) {
         let expanded = layout.isExpanded
         isExpanded = expanded
         handler.isExpanded = expanded
@@ -768,9 +761,7 @@ final class UnifiedToggleInputView: UIView {
         if updateShadow {
             let useCompositeShadow = expanded || layout == .flanked
             // In-place mutation preserves the in-flight cornerRadius CAAnimation.
-            for shadow in (layout == .flanked ? flankedShadows : expandedShadows) {
-                expandedShadowView.updateShadow(shadow)
-            }
+            expandedShadowView.updateShadows(layout == .flanked ? flankedShadows : expandedShadows)
             expandedShadowView.isHidden = !useCompositeShadow
             cardView.layer.shadowOpacity = useCompositeShadow ? 0 : 1.0
         }
@@ -789,7 +780,9 @@ final class UnifiedToggleInputView: UIView {
         cardView.layer.borderColor = showToolbar ? expandedBorderColor : UIColor.clear.cgColor
         let changes = {
             self.setCardFlanked(layout == .flanked)
-            self.cardView.layer.cornerRadius = dimensions.cornerRadius
+            if updateCornerRadius {
+                self.cardView.layer.cornerRadius = dimensions.cornerRadius
+            }
             self.cardTopConstraint.constant = topMargin
             self.cardLeadingConstraint.constant = hLeadingMargin
             self.cardTrailingConstraint.constant = -hTrailingMargin
@@ -851,15 +844,15 @@ final class UnifiedToggleInputView: UIView {
         switch (cardPosition, isToggleEnabled) {
         case (.top, true):
             applyCardLayout(.collapsed, animated: false)
-            applyCardLayout(.expanded(showsToggle: false, showsToolbar: false), animated: false)
+            // Skip cornerRadius so it stays at the collapsed value and `applyToggleRevealChanges`
+            // can animate it inside the surrounding `UIView.animate`.
+            applyCardLayout(.expanded(showsToggle: false, showsToolbar: false), animated: false, updateCornerRadius: false)
         case (_, _):
             applyCardLayout(.collapsed, animated: false)
         }
-        // Pre-stage the composite shadow to match the omnibar's shape so the show animation
-        // morphs from omnibar-shape to UTI-expanded inside the surrounding `UIView.animate`.
-        for shadow in omnibarMatchingShadows {
-            expandedShadowView.updateShadow(shadow)
-        }
+        // Start the composite shadow at the omnibar's shape so the surrounding `UIView.animate`
+        // morphs it to UTI-expanded.
+        expandedShadowView.updateShadows(omnibarMatchingShadows)
         expandedShadowView.isHidden = false
         cardView.layer.shadowOpacity = 0
     }
@@ -873,9 +866,7 @@ final class UnifiedToggleInputView: UIView {
         case (_, _):
             applyCardLayout(.expanded(showsToggle: isToggleEnabled, showsToolbar: isToggleEnabled && toggleView.selectedMode == .aiChat), animated: false)
         }
-        for shadow in expandedShadows {
-            expandedShadowView.updateShadow(shadow)
-        }
+        expandedShadowView.updateShadows(expandedShadows)
     }
 
     /// Inactive editing pose. Call inside a UIView.animate block.
@@ -889,9 +880,7 @@ final class UnifiedToggleInputView: UIView {
         case (_, _):
             applyCardLayout(.collapsed, animated: false, updateShadow: false)
         }
-        for shadow in omnibarMatchingShadows {
-            expandedShadowView.updateShadow(shadow)
-        }
+        expandedShadowView.updateShadows(omnibarMatchingShadows)
     }
 
     /// Snap the shadow to its collapsed-pose state. Bottom and top + toggle-off both defer the

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -418,10 +418,7 @@ final class UnifiedToggleInputView: UIView {
 
     private var flankedShadows: [CompositeShadowView.Shadow] {
         [
-            .init(id: ShadowID.outer,
-                  color: UIColor(designSystemColor: .shadowSecondary),
-                  radius: 12,
-                  offset: CGSize(width: 0, height: 4)),
+            CompositeShadowView.Shadow.defaultLayer1.withID(ShadowID.outer),
             .init(id: ShadowID.rim,
                   color: flankedHaloColor,
                   radius: 6,
@@ -853,10 +850,12 @@ final class UnifiedToggleInputView: UIView {
         case (.top, true):
             applyToggleRevealChanges()
             layoutIfNeeded()
+            // applyCardLayout's `(_, _)` case applies expandedShadows internally; the toggle-reveal
+            // path bypasses it, so morph the omnibar-matching pre-stage shadows back here.
+            expandedShadowView.updateShadows(expandedShadows)
         case (_, _):
             applyCardLayout(.expanded(showsToggle: isToggleEnabled, showsToolbar: isToggleEnabled && toggleView.selectedMode == .aiChat), animated: false)
         }
-        expandedShadowView.updateShadows(expandedShadows)
     }
 
     /// Inactive editing pose. Call inside a UIView.animate block.

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -850,8 +850,6 @@ final class UnifiedToggleInputView: UIView {
         case (_, _):
             applyCardLayout(.collapsed, animated: false, updateShadow: false)
         }
-        // applyCardLayout's collapse pose sets `.aiVoicePlain`, flickering mid-dismiss; force hidden.
-        textEntryView.setVoiceButtonAppearance(.hidden, animated: false)
     }
 
     /// Snap the shadow to its collapsed-pose state. Bottom and top + toggle-off both defer the

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -850,6 +850,8 @@ final class UnifiedToggleInputView: UIView {
         case (_, _):
             applyCardLayout(.collapsed, animated: false, updateShadow: false)
         }
+        // applyCardLayout's collapse pose sets `.aiVoicePlain`, flickering mid-dismiss; force hidden.
+        textEntryView.setVoiceButtonAppearance(.hidden, animated: false)
     }
 
     /// Snap the shadow to its collapsed-pose state. Bottom and top + toggle-off both defer the

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -877,12 +877,18 @@ final class UnifiedToggleInputView: UIView {
     /// omnibar so the UTI ↔ omnibar transition has no visible chrome snap at hand-off.
     private func alignWithOmnibarChrome() {
         if cardPosition == .top {
+            // Match the omnibar's symmetric 8pt nav-bar insets; otherwise the top override alone
+            // would stretch the pinned 44pt height to 46pt (defaultHigh priority loses to bottom).
             cardTopConstraint.constant = Constants.cardVerticalMargin
+            cardBottomConstraint.constant = -Constants.cardVerticalMargin
         }
         cardView.layer.cornerRadius = Constants.cardCornerRadiusCollapsed
         expandedShadowView.updateShadows(omnibarMatchingShadows)
         expandedShadowView.isHidden = false
         cardView.layer.shadowOpacity = 0
+        // The prior applyCardLayout committed the frame with the .collapsed margins; commit
+        // again so our cardVerticalMargin overrides propagate to the cardView's actual frame.
+        layoutIfNeeded()
     }
 
     /// Snap the shadow to its collapsed-pose state. Bottom and top + toggle-off both defer the

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -694,7 +694,7 @@ final class UnifiedToggleInputView: UIView {
         }
     }
 
-    func applyCardLayout(_ layout: UnifiedToggleInputCardLayout, animated: Bool, updateShadow: Bool = true, updateCornerRadius: Bool = true) {
+    func applyCardLayout(_ layout: UnifiedToggleInputCardLayout, animated: Bool) {
         let expanded = layout.isExpanded
         isExpanded = expanded
         handler.isExpanded = expanded
@@ -758,13 +758,11 @@ final class UnifiedToggleInputView: UIView {
 
         textEntryView.isExpandable = expanded
 
-        if updateShadow {
-            let useCompositeShadow = expanded || layout == .flanked
-            // In-place mutation preserves the in-flight cornerRadius CAAnimation.
-            expandedShadowView.updateShadows(layout == .flanked ? flankedShadows : expandedShadows)
-            expandedShadowView.isHidden = !useCompositeShadow
-            cardView.layer.shadowOpacity = useCompositeShadow ? 0 : 1.0
-        }
+        let useCompositeShadow = expanded || layout == .flanked
+        // In-place mutation preserves the in-flight cornerRadius CAAnimation.
+        expandedShadowView.updateShadows(layout == .flanked ? flankedShadows : expandedShadows)
+        expandedShadowView.isHidden = !useCompositeShadow
+        cardView.layer.shadowOpacity = useCompositeShadow ? 0 : 1.0
         let dimensions = Self.cardDimensions(for: layout)
         if let pinned = dimensions.pinnedHeight {
             cardPinnedHeightConstraint.constant = pinned
@@ -780,9 +778,7 @@ final class UnifiedToggleInputView: UIView {
         cardView.layer.borderColor = showToolbar ? expandedBorderColor : UIColor.clear.cgColor
         let changes = {
             self.setCardFlanked(layout == .flanked)
-            if updateCornerRadius {
-                self.cardView.layer.cornerRadius = dimensions.cornerRadius
-            }
+            self.cardView.layer.cornerRadius = dimensions.cornerRadius
             self.cardTopConstraint.constant = topMargin
             self.cardLeadingConstraint.constant = hLeadingMargin
             self.cardTrailingConstraint.constant = -hTrailingMargin
@@ -844,17 +840,11 @@ final class UnifiedToggleInputView: UIView {
         switch (cardPosition, isToggleEnabled) {
         case (.top, true):
             applyCardLayout(.collapsed, animated: false)
-            // Skip cornerRadius so it stays at the collapsed value and `applyToggleRevealChanges`
-            // can animate it inside the surrounding `UIView.animate`.
-            applyCardLayout(.expanded(showsToggle: false, showsToolbar: false), animated: false, updateCornerRadius: false)
+            applyCardLayout(.expanded(showsToggle: false, showsToolbar: false), animated: false)
         case (_, _):
             applyCardLayout(.collapsed, animated: false)
         }
-        // Start the composite shadow at the omnibar's shape so the surrounding `UIView.animate`
-        // morphs it to UTI-expanded.
-        expandedShadowView.updateShadows(omnibarMatchingShadows)
-        expandedShadowView.isHidden = false
-        cardView.layer.shadowOpacity = 0
+        alignWithOmnibarChrome()
     }
 
     /// Active editing pose. Call inside a UIView.animate block.
@@ -878,9 +868,21 @@ final class UnifiedToggleInputView: UIView {
             applyToggleHideChanges()
             layoutIfNeeded()
         case (_, _):
-            applyCardLayout(.collapsed, animated: false, updateShadow: false)
+            applyCardLayout(.collapsed, animated: false)
         }
+        alignWithOmnibarChrome()
+    }
+
+    /// Matches the UTI's chrome (top margin, corner radius, composite shadow) to the standard
+    /// omnibar so the UTI ↔ omnibar transition has no visible chrome snap at hand-off.
+    private func alignWithOmnibarChrome() {
+        if cardPosition == .top {
+            cardTopConstraint.constant = Constants.cardVerticalMargin
+        }
+        cardView.layer.cornerRadius = Constants.cardCornerRadiusCollapsed
         expandedShadowView.updateShadows(omnibarMatchingShadows)
+        expandedShadowView.isHidden = false
+        cardView.layer.shadowOpacity = 0
     }
 
     /// Snap the shadow to its collapsed-pose state. Bottom and top + toggle-off both defer the

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
@@ -319,8 +319,8 @@ final class UnifiedToggleInputViewController: UIViewController {
     }
 
     @discardableResult
-    func alignPlaceholderHorizontally(toWindowX windowX: CGFloat) -> CGFloat {
-        inputBarView.alignPlaceholderHorizontally(toWindowX: windowX)
+    func alignVisibleTextLeadingEdge(toWindowX windowX: CGFloat) -> CGFloat {
+        inputBarView.alignVisibleTextLeadingEdge(toWindowX: windowX)
     }
 
     func updateToggleEnabled(_ enabled: Bool, showsToolbar: Bool) {

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/OmniBar/MockOmniBar.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/OmniBar/MockOmniBar.swift
@@ -122,6 +122,9 @@ final class MockOmniBar: OmniBar {
         func refreshLongPressMenuAvailability() { }
         func prepareForMoveTransition() { }
         func moveTransitionCompleted() { }
+        func setIconContainersAlpha(_ alpha: CGFloat) { }
+        func hideBarChrome() { }
+        func restoreBarChrome() { }
 
         var progressView: DuckDuckGo.ProgressView?
         var privacyIconView: UIView?


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214960121177987
Tech Design URL:
CC:

### Description

Polish pass on the UTI ↔ omnibar transition (show + inline-back dismiss). The animation now feels coherent across both directions: the bar pill, corner radius, shadow, text glyph position, and toggle/icon visibility all morph in sync instead of snapping at the hand-off.

Per-commit summary (chronological):

1. **`d61846bc31` iOS: fade omnibar icons during UTI inline dismiss** — omnibar's privacy/loupe/clear/voice/ai-chat icons now fade in as the UTI collapses, rather than appearing instantly when the swap happens.
2. **`f94bf945bd` iOS: hide UTI voice button during inline dismiss collapse** — initial fix to prevent the UTI's `.aiVoicePlain` voice button from briefly flying across the screen during the collapse.
3. **`789383b60d` iOS: hide UTI buttons during inline dismiss, replacing voice-button override** — generalized the above by hiding the whole UTI right-side button column during the dismiss snapshot, removing the voice-specific patch.
4. **`8df1859bad` iOS: fade UTI toggle out faster during inline dismiss** — toggle "Search/Duck.ai" labels fade faster than the overall collapse so they don't linger when the surface starts looking like the omnibar.
5. **`3ad8e6b3ed` iOS: animate UTI textView pose during search/duck.ai toggle** — placeholder Y position (top vs center) animates with the toggle instead of snapping after the publisher sink fires (regression introduced by #4911; root caused via bisect).
6. **`e98f230e7e` iOS: simplify omnibar icon fade-in to container-level alpha** — replaces the leaf-icon array with a container-level `setIconContainersAlpha(_:)`. New icons added to the omnibar are auto-covered.
7. **`61769501e0` iOS: smooth UTI ↔ omnibar text and shadow handoff** — fixes a ~1pt horizontal drift in the URL text at swap time (UITextView's caret sits 1pt left of its glyph due to `lineFragmentPadding`). New `alignVisibleTextLeadingEdge(toWindowX:)` aligns the glyph leading edge of the actually-visible surface (`textView.firstRect` when text shown, `placeholderLabel` when not). Also adds shadow morphing so the UTI's composite shadow blends to the omnibar's at swap time instead of snapping.
8. **`e5703ed549` UIComponents: add `Shadow.withID` and `CompositeShadowView.updateShadows`** — small shared-package helpers consumed by #9.
9. **`a3e7768090` iOS: morph UTI corner radius on show, dedupe shadow constants** — corner radius now morphs from 16pt (omnibar pill) to 28pt (UTI expanded) during the show animation instead of snapping at frame 1. Also dedupes `omnibarMatchingShadows` against `CompositeShadowView.Shadow.defaultLayer1/2` via the new `.withID(...)` helper.
10. **`79d2f8345f` iOS: align UTI Y with omnibar pill during show/dismiss** — fixes the UTI sitting 1-2pt below the omnibar pill during the toggle-off top-bar transition. Adds a single `alignWithOmnibarChrome()` helper that owns the top margin, corner radius, and shadow morphing for the UTI ↔ omnibar handoff. Also removes the `updateShadow`/`updateCornerRadius` skip-flag parameters from `applyCardLayout` that were no longer needed.
11. **`4a34c09edc` iOS: snap UTI placeholder swap to prevent tail-reveal on mode switch** — when toggling search↔duck.ai, the longer placeholder text no longer animates in (which previously made the "tail" of the longer text appear as the label width grew). Pose Y animation is preserved because it runs in a separate synchronous `UIView.animate`.
12. **`15e6e173d2` iOS: fix UTI dismiss placeholder flash after back from duck.ai** — `unifiedToggleInputDismissSnapshot` no longer treats "tab's preferred mode is duck.ai" as the same as "tab is an AI tab", so a regular site dismissed with the toggle still on duck.ai no longer briefly flashes "Ask anything privately" during the collapse.
13. **`aa8d17cb9c` iOS: commit UTI omnibar-chrome alignment and match bottom inset** — completes the Y alignment by overriding `cardBottomConstraint` too, so the pinned height matches the omnibar's symmetric 8/44/8 inset layout (was stretching to 46pt because the override was top-only).
14. **`af07ab5001` iOS: crossfade UTI duck.ai chip with omnibar aiChat icon on dismiss** — fixes "two duck.ai icons visible at once" during the dismiss. The UTI chip now slides + fades toward the omnibar's aiChat icon position while the omnibar's icon fades in at its own X, so they crossfade through each other instead of both being fully visible at slightly offset positions. Non-chip buttons hide via dynamic iteration of the buttons stack (auto-covers future additions).
15. **`b16ab4f50b` iOS: simplify UTI polish per /simplify review** — collapsed paired hide/restore methods into one parameterized variant each (`setNonChipButtonsAlpha`, `setAIChatShortcutDismissed`), replaced a `UIView.animate(withDuration: 0, …, completion:)` timing workaround with `UIView.performWithoutAnimation`, deduped `flankedShadows.outer` against `defaultLayer1`, dropped a redundant `updateShadows(expandedShadows)` write, trimmed verbose doc comments.

### Testing Steps

For each of the four state combinations below, focus on the visual continuity at the swap moment (no snap, no flash):

1. **Top bar, toggle OFF** — tap omnibar to show UTI, then tap inline-dismiss back arrow. Verify text glyph, corner radius, shadow extent, and Y position all stay aligned with the omnibar's pill throughout (especially the end frame — UTI should hand off at Y=70, height=44).
2. **Top bar, toggle ON, Search mode** — same.
3. **Top bar, toggle ON, Duck.ai mode** — same. Additionally toggle search↔duck.ai: placeholder text should snap (no tail-reveal animation), toggle indicator + pose Y still animate.
4. **Bottom bar (any toggle)** — show + dismiss should be unchanged (only top-bar paths were touched by the chrome alignment).
5. **Dismiss after back-from-duck.ai** — on a regular site, tap omnibar → toggle duck.ai → type → submit. From duck.ai chrome, navigate back. Tap omnibar (URL shows). Tap inline-dismiss. Verify no "Ask anything privately" placeholder flash during the collapse.
6. **Duck.ai chip handoff** — in duck.ai mode dismiss path, verify the chip slides + fades while the omnibar's aiChat icon fades in (no "two icons visible at once" moment).

### Impact and Risks

Medium — touches the visible UTI ↔ omnibar transition animation, which most users see every time they tap the address bar. Visual regressions would be noticeable. No logic changes to navigation, suggestions, or state management.

#### What could go wrong?

- **Bottom bar regression** — chrome-alignment overrides are guarded `if cardPosition == .top`. Verified the bottom-bar pose methods are untouched.
- **AI tab handoff regression** — AI tab handoff goes through `dismissFocusedOmnibarToAITabChrome`, which doesn't call `alignWithOmnibarChrome`. Untouched.
- **Toggle-off-but-not-omnibar regression** — `flankedShadows.outer` switched from a literal to `.defaultLayer1.withID(...)`. Same values, but the IDs are stable so `updateShadow` mutates the existing sublayer in place.
- **CircularButton appearance regression** — left `CircularButton.swift` untouched on this branch (we explored changing it; reverted to defer that conversation).

### Quality Considerations

- All visible changes are gated to user-driven transitions (one shot per tap), so there's no per-frame hot path concern.
- No new observers, timers, publishers, or unbounded data structures.
- No tests added: this branch is all UI animation polish; integration coverage would belong to a separate fixture-driven UI-test pass.

### Notes to Reviewer

The chronological commit order matches the iteration order — earlier commits sometimes introduce a small regression that a later commit fixes (e.g. #2/#3 voice button, #11/#12/#13 chrome alignment). Reviewing per-file (final-state diff) is probably easier than per-commit.

`CircularButton` changes the conversation alluded to in #14's slide-target alignment are explicitly *not* in this PR — that's a follow-up around press feedback for the `applyAIVoiceChatStyle`/`applyReturnKeyStyle` variants on subtle backdrops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: touches high-visibility omnibar/UTI transition animations and layout/shadow code, so regressions would be immediately noticeable but are largely UI-only (no navigation/state logic changes).
> 
> **Overview**
> Improves the **Unified Toggle Input (UTI) ↔ omnibar handoff** so pill chrome, shadows, icons, and text alignment morph smoothly instead of snapping during show/dismiss.
> 
> Adds omnibar-side helpers to **fade icon containers** and temporarily **hide/restore bar chrome** (background, shadow, text field) so omnibar icons can fade in above the collapsing UTI, and updates the coordinator to drive that fade-in during inline dismiss.
> 
> Updates UTI text entry to **hide non-chip buttons** during dismiss, **crossfade/slide the duck.ai chip**, snap placeholder updates to avoid “tail reveal”, and replace placeholder-based alignment with `alignVisibleTextLeadingEdge(toWindowX:)` for more accurate glyph positioning. Also adds shared shadow utilities (`Shadow.withID`, public default layers, `updateShadows`) and uses them to better match UTI composite shadows to the omnibar during transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d8caa64ceeadb7b8fd4a10857c8c043abf5d25a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->