### PR TITLE
[macOS] Instrument VPN menu-bar agent subscription funnel

### DIFF
--- a/macOS/DuckDuckGo/Statistics/SubscriptionPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/SubscriptionPixel.swift
@@ -107,6 +107,11 @@ enum SubscriptionPixel: PixelKitEvent {
     case subscriptionToolbarVPNPopoverShown
     case subscriptionToolbarVPNPopoverExpiredViewShown
     case subscriptionToolbarVPNPopoverExpiredViewSubscribeButtonClicked
+    // Menu Bar Agent - Subscribed VPN
+    case subscriptionMenuBarVPNButtonClicked
+    case subscriptionMenuBarVPNPopoverShown
+    case subscriptionMenuBarVPNPopoverExpiredViewShown
+    case subscriptionMenuBarVPNPopoverExpiredViewSubscribeButtonClicked
     // Win-back Offer
     case subscriptionWinBackOfferLaunchPromptShown
     case subscriptionWinBackOfferLaunchPromptCTAClicked
@@ -217,6 +222,11 @@ enum SubscriptionPixel: PixelKitEvent {
         case .subscriptionToolbarVPNPopoverShown: return "m_mac_subscription_toolbar_vpn_popover_shown"
         case .subscriptionToolbarVPNPopoverExpiredViewShown: return "m_mac_subscription_toolbar_vpn_popover_expired_view_shown"
         case .subscriptionToolbarVPNPopoverExpiredViewSubscribeButtonClicked: return "m_mac_subscription_toolbar_vpn_popover_expired_view_subscribe_button_clicked"
+            // Menu Bar Agent - Subscribed VPN
+        case .subscriptionMenuBarVPNButtonClicked: return "m_mac_subscription_menu_bar_vpn_button_clicked"
+        case .subscriptionMenuBarVPNPopoverShown: return "m_mac_subscription_menu_bar_vpn_popover_shown"
+        case .subscriptionMenuBarVPNPopoverExpiredViewShown: return "m_mac_subscription_menu_bar_vpn_popover_expired_view_shown"
+        case .subscriptionMenuBarVPNPopoverExpiredViewSubscribeButtonClicked: return "m_mac_subscription_menu_bar_vpn_popover_expired_view_subscribe_button_clicked"
             // Win-back Offer
         case .subscriptionWinBackOfferLaunchPromptShown: return "m_mac_\(appDistribution)_privacy-pro_winback_launch_prompt_shown"
         case .subscriptionWinBackOfferLaunchPromptCTAClicked: return "m_mac_\(appDistribution)_privacy-pro_winback_launch_prompt_cta_clicked"
@@ -354,6 +364,10 @@ enum SubscriptionPixel: PixelKitEvent {
                 .subscriptionToolbarButtonPopoverProceedButtonClicked,
                 .subscriptionToolbarVPNPopoverExpiredViewShown,
                 .subscriptionToolbarVPNPopoverExpiredViewSubscribeButtonClicked,
+                .subscriptionMenuBarVPNButtonClicked,
+                .subscriptionMenuBarVPNPopoverShown,
+                .subscriptionMenuBarVPNPopoverExpiredViewShown,
+                .subscriptionMenuBarVPNPopoverExpiredViewSubscribeButtonClicked,
                 .subscriptionWinBackOfferLaunchPromptShown,
                 .subscriptionWinBackOfferLaunchPromptCTAClicked,
                 .subscriptionWinBackOfferLaunchPromptDismissed,

--- a/macOS/DuckDuckGoVPN/DuckDuckGoVPNAppDelegate.swift
+++ b/macOS/DuckDuckGoVPN/DuckDuckGoVPNAppDelegate.swift
@@ -466,6 +466,18 @@ final class DuckDuckGoVPNAppDelegate: NSObject, NSApplicationDelegate {
                     // Intentional no-op: we already anonymously track VPN uninstallation failures using
                     // pixels within the vpn uninstaller.
                 }
+            },
+            buttonClickedHandler: {
+                PixelKit.fire(SubscriptionPixel.subscriptionMenuBarVPNButtonClicked)
+            },
+            popoverShownHandler: {
+                PixelKit.fire(SubscriptionPixel.subscriptionMenuBarVPNPopoverShown)
+            },
+            subscriptionExpiredViewAppearHandler: {
+                PixelKit.fire(SubscriptionPixel.subscriptionMenuBarVPNPopoverExpiredViewShown)
+            },
+            subscriptionExpiredViewSubscribeButtonClickPixelHandler: {
+                PixelKit.fire(SubscriptionPixel.subscriptionMenuBarVPNPopoverExpiredViewSubscribeButtonClicked)
             }
         )
     }

--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Menu/StatusBarMenu.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Menu/StatusBarMenu.swift
@@ -51,6 +51,10 @@ public final class StatusBarMenu: NSObject {
     private let locationFormatter: VPNLocationFormatting
     private let uninstallHandler: UninstallHandler
     private let onWillShowPopover: (() async -> Void)?
+    private let buttonClickedHandler: (() -> Void)?
+    private let popoverShownHandler: (() -> Void)?
+    private let subscriptionExpiredViewAppearHandler: (() -> Void)?
+    private let subscriptionExpiredViewSubscribeButtonClickPixelHandler: (() -> Void)?
 
     // MARK: - NetP Icon publisher
 
@@ -79,7 +83,11 @@ public final class StatusBarMenu: NSObject {
                 userDefaults: UserDefaults,
                 locationFormatter: VPNLocationFormatting,
                 onWillShowPopover: (() async -> Void)? = nil,
-                uninstallHandler: @escaping UninstallHandler) {
+                uninstallHandler: @escaping UninstallHandler,
+                buttonClickedHandler: (() -> Void)? = nil,
+                popoverShownHandler: (() -> Void)? = nil,
+                subscriptionExpiredViewAppearHandler: (() -> Void)? = nil,
+                subscriptionExpiredViewSubscribeButtonClickPixelHandler: (() -> Void)? = nil) {
 
         self.model = model
         let statusItem = statusItem ?? NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -98,6 +106,10 @@ public final class StatusBarMenu: NSObject {
         self.locationFormatter = locationFormatter
         self.uninstallHandler = uninstallHandler
         self.onWillShowPopover = onWillShowPopover
+        self.buttonClickedHandler = buttonClickedHandler
+        self.popoverShownHandler = popoverShownHandler
+        self.subscriptionExpiredViewAppearHandler = subscriptionExpiredViewAppearHandler
+        self.subscriptionExpiredViewSubscribeButtonClickPixelHandler = subscriptionExpiredViewSubscribeButtonClickPixelHandler
 
         super.init()
 
@@ -118,6 +130,8 @@ public final class StatusBarMenu: NSObject {
             showContextMenu()
             return
         }
+
+        buttonClickedHandler?()
 
         Task { @MainActor in
             await togglePopover(isOptionKeyPressed: isOptionKeyPressed)
@@ -187,7 +201,9 @@ public final class StatusBarMenu: NSObject {
                 isMenuBarStatusView: isMenuBarStatusView,
                 userDefaults: userDefaults,
                 locationFormatter: locationFormatter,
-                uninstallHandler: uninstallHandler)
+                uninstallHandler: uninstallHandler,
+                subscriptionExpiredViewAppearHandler: subscriptionExpiredViewAppearHandler,
+                subscriptionExpiredViewSubscribeButtonClickPixelHandler: subscriptionExpiredViewSubscribeButtonClickPixelHandler)
 
             popover = NetworkProtectionPopover(
                 statusViewModel: statusViewModel,
@@ -197,6 +213,7 @@ public final class StatusBarMenu: NSObject {
                 debugInformationViewModel: debugInformationViewModel)
             popover?.behavior = .transient
 
+            popoverShownHandler?()
             popover?.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         }
     }

--- a/macOS/PixelDefinitions/pixels/definitions/privacy_pro_toolbar_button.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/privacy_pro_toolbar_button.json5
@@ -63,5 +63,33 @@
         "owners": ["hanyutang-sandra"],
         "triggers": ["user_submitted"],
         "parameters": ["appVersion", "pixelSource"]
+    },
+
+    "m_mac_subscription_menu_bar_vpn_button_clicked": {
+        "description": "Fired when a subscribed user clicks the VPN status item in the macOS menu bar (with either an active subscription or in the subscription-revoked state). Use the expired-view-shown pixel to distinguish the revoked sub-case.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["user_submitted"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+
+    "m_mac_subscription_menu_bar_vpn_popover_shown": {
+        "description": "Fired when the subscription VPN menu-bar popover is displayed to a subscribed user (either active subscription or revoked state). Use the expired-view-shown pixel to distinguish the revoked sub-case.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+
+    "m_mac_subscription_menu_bar_vpn_popover_expired_view_shown": {
+        "description": "Fired when the subscription-expired view is displayed inside the subscription VPN menu-bar popover (revoked subscription case)",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+
+    "m_mac_subscription_menu_bar_vpn_popover_expired_view_subscribe_button_clicked": {
+        "description": "Fired when the subscribe button is clicked in the subscription-expired view inside the subscription VPN menu-bar popover",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["user_submitted"],
+        "parameters": ["appVersion", "pixelSource"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214978255724647?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1214432127962356?focus=true

### Description

Closes the remaining VPN entry-point gap by instrumenting the **macOS VPN menu-bar agent** subscription funnel — the surface owned by the `DuckDuckGoVPN` target (the menu-bar status item + popover that runs as a separate process from the browser).

Today the menu-bar agent fires **zero pixels**; this PR adds four, mirroring the browser-side toolbar family one-for-one.

**New pixels (macOS — menu-bar agent):**
- `m_mac_subscription_menu_bar_vpn_button_clicked` — left-click on the menu-bar status item (right-click → context menu is excluded).
- `m_mac_subscription_menu_bar_vpn_popover_shown` — fires only when the popover is opening (closing is a no-op).
- `m_mac_subscription_menu_bar_vpn_popover_expired_view_shown` — `SubscriptionExpiredView` impression inside the menu-bar popover.
- `m_mac_subscription_menu_bar_vpn_popover_expired_view_subscribe_button_clicked` — Subscribe-click in the menu-bar expired view.

### Implementation Notes

- The shared SwiftUI view (`NetworkProtectionStatusView` in the `NetworkProtectionUI` package) is reused for both the browser toolbar popover and the menu-bar agent popover, but each surface constructs its own `NetworkProtectionStatusView.Model` with its own injected handlers. So the same expired-view code path fires the correct pixel for whichever surface presented it — no cross-firing.
- `StatusBarMenu` gains four optional handler-closure init parameters: `buttonClickedHandler`, `popoverShownHandler`, `subscriptionExpiredViewAppearHandler`, `subscriptionExpiredViewSubscribeButtonClickPixelHandler`. The latter two are forwarded into the `NetworkProtectionStatusView.Model` init, which already had the injection points from #4980 but received `nil` from the agent path.
- `SubscriptionPixel.swift` is already a target member of `DuckDuckGoVPN` (verified in `.pbxproj`), so the agent fires `PixelKit.fire(SubscriptionPixel.subscriptionMenuBarVPN*)` directly — no shared-module refactor needed.
- Pixel-name convention parallels the existing toolbar family: `subscription_toolbar_vpn_*` ↔ `subscription_menu_bar_vpn_*`.

### Out of scope (known gap)

- **Origin propagation to `m_mac_{dist}_privacy-pro_offer_screen_impression`** — the menu-bar agent's `VPNUIActionHandler.showSubscription(origin:)` accepts an `origin` parameter for protocol conformance but discards it (the IPC plumbing back to the browser to ship the origin string is deferred). So the agent fires the menu-bar funnel-entry events, but the downstream offer-screen-impression on the browser won't carry a `menu_bar` origin. Funnel-entry instrumentation is the value-add here; origin attribution is a follow-up.

### Testing Steps

1. `npm run validate-pixel-defs` passes from `macOS/`.
2. Xcode build succeeds for `DuckDuckGoVPN` and `macOS Browser` schemes.
3. **Menu-bar VPN active subscriber:**
   - Open the VPN menu-bar status item as an active subscriber → 📍 `subscription_menu_bar_vpn_button_clicked` fires + popover opens → 📍 `subscription_menu_bar_vpn_popover_shown` fires.
   - Right-click the status item → context menu opens → no `button_clicked` pixel (right-click is excluded).
4. **Menu-bar VPN subscription-revoked:**
   - Force the user into a revoked state (set `networkProtectionEntitlementsExpired = true` in `UserDefaults.netP`).
   - Click status item → popover opens with the expired view rendered → 📍 `subscription_menu_bar_vpn_button_clicked`, `..._popover_shown`, and `..._popover_expired_view_shown` all fire.
   - Click Subscribe → 📍 `..._popover_expired_view_subscribe_button_clicked` fires; browser opens purchase URL (without `origin` — see "Out of scope").
5. Sanity-check the browser toolbar surface is unaffected: clicking the **browser nav-bar VPN button** still fires only the toolbar family (`subscription_toolbar_vpn_*`), no menu-bar pixels.

### Impact and Risks

Low — pixel instrumentation only. No user-facing behavior change.

#### What could go wrong?

- **Pixel-defs validation could fail** if naming drifts from the dictionary; mitigated by `npm run validate-pixel-defs`.
- **Closure injection mis-wiring**: `StatusBarMenu` accepts the four closures as optional; if a future call site forgets to pass them, pixels silently don't fire. The browser side doesn't construct `StatusBarMenu`, so the regression surface is limited to the agent only.
- **Pixel-source attribution**: agent fires use `pixelSource: vpnAgent` (or `vpnAgentAppStore` for App Store build) per the agent's existing PixelKit configuration — distinct from the browser's `pixelSource: browser`. Analytics consumers slicing by source will see the menu-bar pixels under the agent source.

### Quality Considerations

- All new pixels include `appVersion` and `pixelSource` per macOS pixel convention.
- The shared `NetworkProtectionStatusView` SwiftUI view is unchanged — only the model's injected handlers differ between toolbar and menu-bar surfaces.
- `subscriptionExpiredViewAppearHandler` / `subscriptionExpiredViewSubscribeButtonClickPixelHandler` were added in #4980 as injection points; this PR finally wires them from the agent side.
- Right-click context-menu opens deliberately do not fire `button_clicked` — the click pixel measures intent-to-open-VPN-popover, not all status-item interactions.

### Notes to Reviewer

- This PR is stacked on `htang/ios+macos/instrument-missing-pixels-for-subscription-funnels` (#4793). Merge that one first.
- The `origin` parameter remaining discarded in the agent's `VPNUIActionHandler.showSubscription(origin:)` is documented in #4793's description and that file's inline comment. IPC plumbing for cross-process origin attribution is intentionally out of scope here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk instrumentation-only change that adds pixel firing hooks to the VPN menu-bar status item and popover; primary risk is missed analytics if handlers aren’t wired or pixels are misnamed.
> 
> **Overview**
> Adds **subscription funnel pixel instrumentation** for the macOS VPN *menu-bar agent* to match the existing toolbar VPN tracking.
> 
> Introduces four new `SubscriptionPixel` cases and pixel definitions, and wires them from `DuckDuckGoVPNAppDelegate` into `StatusBarMenu` via new optional handler closures that fire on left-click, popover show, expired-view impression, and expired-view subscribe click (right-click/context menu remains excluded).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af0e01e72d18c25da17b690143aa0520c092840d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->