### PR TITLE
Fix ICS Maestro happy path test for iOS 26

### DIFF
--- a/.maestro/browser_features/ics_calendar_links_happy_path.yaml
+++ b/.maestro/browser_features/ics_calendar_links_happy_path.yaml
@@ -26,15 +26,12 @@ tags:
 - inputText: "https://privacy-test-pages.site/features/download/calendar-single.ics"
 - pressKey: Enter
 
-# EKEventEditViewController's nav bar shows "Cancel" and "Add" buttons. Asserting on those
-# avoids matching anything in our app chrome.
+# EKEventEditViewController shows "New Event" as the nav title across iOS versions.
+# Avoids the iOS 26 change that replaced "Cancel"/"Add" text buttons with icons.
 - extendedWaitUntil:
-    visible: "Add"
+    visible: "New Event"
     timeout: 10000
-- assertVisible: "Cancel"
 
 # No fallback toast for a happy-path single event.
 - assertNotVisible: "Multiple events aren't supported"
 - assertNotVisible: "This file can't be processed"
-
-- tapOn: "Cancel"


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1215008885821066?focus=true
Tech Design URL:
CC: @brindy 

### Description
`EKEventEditViewController` on iOS 26 shows icons instead of `Add`/`Cancel` labeled buttons. This PR fixes the Maestro test to assert on the title of the populated “New Event” UI.

### Testing Steps
Make sure CI stays 🟢 
- https://github.com/duckduckgo/apple-browsers/actions/runs/26245559231

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d7155f997b425a79e7e10d99f4c8e9b7389ea8e6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->