### PR TITLE
macOS: Route the canBe… tab-bar handlers through the bound view model

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -2253,16 +2253,11 @@ extension TabBarViewController: TabBarViewItemDelegate {
     }
 
     func tabBarViewItemCanBeDuplicated(_ tabBarViewItem: TabBarViewItem) -> Bool {
-        let isPinned = tabBarViewItem.tabViewModel?.isPinned == true
-        let collectionView = isPinned ? pinnedTabsCollectionView : self.collectionView
-
-        guard let indexPath = collectionView?.indexPath(for: tabBarViewItem) else {
-            assertionFailure("TabBarViewController: Failed to get index path of tab bar view item")
+        guard let tabViewModel = tabBarViewItem.tabViewModel else {
+            assertionFailure("TabBarViewController: Failed to get tab view model for tab bar view item")
             return false
         }
-
-        let tabIndex: TabIndex = isPinned ? .pinned(indexPath.item) : .unpinned(indexPath.item)
-        return tabCollectionViewModel.tabBarViewModel(at: tabIndex)?.tabContent.canBeDuplicated ?? false
+        return tabViewModel.tabContent.canBeDuplicated
     }
 
     func tabBarViewItemNewToTheRightAction(_ tabBarViewItem: TabBarViewItem) {
@@ -2287,16 +2282,12 @@ extension TabBarViewController: TabBarViewItemDelegate {
     }
 
     func tabBarViewItemCanBePinned(_ tabBarViewItem: TabBarViewItem) -> Bool {
-        let isPinned = tabBarViewItem.tabViewModel?.isPinned == true
-        guard !isPinned else {
+        guard let tabViewModel = tabBarViewItem.tabViewModel else {
+            assertionFailure("TabBarViewController: Failed to get tab view model for tab bar view item")
             return false
         }
-        guard let indexPath = collectionView.indexPath(for: tabBarViewItem) else {
-            assertionFailure("TabBarViewController: Failed to get index path of tab bar view item")
-            return false
-        }
-
-        return tabCollectionViewModel.tabBarViewModel(at: .unpinned(indexPath.item))?.tabContent.canBePinned ?? false
+        guard !tabViewModel.isPinned else { return false }
+        return tabViewModel.tabContent.canBePinned
     }
 
     func tabBarViewItemPinAction(_ tabBarViewItem: TabBarViewItem) {
@@ -2363,16 +2354,11 @@ extension TabBarViewController: TabBarViewItemDelegate {
     }
 
     func tabBarViewItemCanBeBookmarked(_ tabBarViewItem: TabBarViewItem) -> Bool {
-        let isPinned = tabBarViewItem.tabViewModel?.isPinned == true
-        let collectionView = isPinned ? pinnedTabsCollectionView : self.collectionView
-
-        guard let indexPath = collectionView?.indexPath(for: tabBarViewItem) else {
-            assertionFailure("TabBarViewController: Failed to get index path of tab bar view item")
+        guard let tabViewModel = tabBarViewItem.tabViewModel else {
+            assertionFailure("TabBarViewController: Failed to get tab view model for tab bar view item")
             return false
         }
-
-        let tabIndex: TabIndex = isPinned ? .pinned(indexPath.item) : .unpinned(indexPath.item)
-        return tabCollectionViewModel.tabBarViewModel(at: tabIndex)?.tabContent.canBeBookmarked ?? false
+        return tabViewModel.tabContent.canBeBookmarked
     }
 
     func tabBarViewItemIsAlreadyBookmarked(_ tabBarViewItem: TabBarViewItem) -> Bool {


### PR DESCRIPTION
### Description

Several tab-bar item delegate handlers re-derive the tab they should act on by looking up its index in a collection view, even though the bound view model already carries every property they need. This PR collapses three such handlers — the `canBe…` style menu-availability checks that decide whether the Duplicate / Pin / Bookmark context-menu items are enabled for a given tab — to read directly from the bound view model.

No behaviour change: each handler still returns the same value for the same input, and still asserts in debug when the bound view model is missing (analogous to the previous "indexPath not found" assertion).

**Scope**

- Three `Bool`-returning tab-bar delegate handlers that back context-menu enabled-state checks.

Out of scope: the remaining handlers that act on the tab and genuinely need its *index* in the collection (close-other, close-to-the-left/right, move-to-new-window, pin, duplicate, suspend, drop). Those follow a different shape and will be a separate follow-up.

### Testing Steps

1. Open a regular site (e.g. duckduckgo.com).
2. Right-click the tab.
   - Expected: Duplicate Tab, Pin Tab, and Bookmark This Page are all enabled.
3. Open a New Tab page.
4. Right-click that tab.
   - Expected: Duplicate / Pin / Bookmark availability matches `main` for the same content (typically Bookmark is disabled).
5. Pin a site tab.
6. Right-click the pinned tab.
   - Expected: Pin Tab is replaced by Unpin Tab; Duplicate and Bookmark availability match the unpinned behaviour for the same content.

### Impact and Risks

Low. Pure refactor with no behaviour change. The handlers continue to assert in debug when the bound view model is missing, matching the prior assertion behaviour for indexPath lookup failure.

#### What could go wrong?

If a future tab bar item is ever bound to something other than the expected view model conformer, the `Bool` checks would assert in debug and return false in release — the same fallback as today.

### Notes to Reviewer

None.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to context-menu enabled-state checks; behavior should be unchanged aside from relying on `tabBarViewItem.tabViewModel` being present (asserts + returns false if missing).
> 
> **Overview**
> Refactors `TabBarViewController`’s tab-bar delegate handlers for **Duplicate**, **Pin**, and **Bookmark** enabled-state checks to use the `TabBarViewItem`’s bound `tabViewModel` (`tabContent.canBeDuplicated/canBePinned/canBeBookmarked`) rather than recomputing a `TabIndex` via collection-view `indexPath` lookups.
> 
> The handlers now assert when the view model is missing (instead of when `indexPath` lookup fails) and otherwise return the same capability flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9415d6681e9588df700a8abba4b6231316bc7b2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->