### PR TITLE
iOS: Fix SwiftUI previews by making loc update idempotent

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -12203,7 +12203,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ $ENABLE_PREVIEWS == \"YES\" ]\nthen\n  exit 0\nelse\n  \"$SOURCE_ROOT/scripts/loc_update.sh\"\nfi\n";
+			shellScript = "\"$SOURCE_ROOT/scripts/loc_update.sh\"\n";
 		};
 		B6409DC62BC7D9BF00D66F9E /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/iOS/scripts/loc_update.sh
+++ b/iOS/scripts/loc_update.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 # Get the directory where the script is stored
 script_dir=$(dirname "$(readlink -f "$0")")
@@ -23,8 +24,21 @@ update_localizable_strings() {
 
 	echo "Processing ${source_dir}"
 	mkdir -p "${tmp_output_dir}"
-	find "${source_dir}/" -name "*.swift" -print0 | xargs -0 xcrun extractLocStrings -o "${tmp_output_dir}"
-	iconv -f UTF-16 -t UTF8 "${generated_strings}" > "${tmp_utf8_strings}"
+	if ! find "${source_dir}/" -name "*.swift" -print0 | xargs -0 xcrun extractLocStrings -o "${tmp_output_dir}"; then
+		echo "error: Failed to extract localization strings from ${source_dir}" >&2
+		return 1
+	fi
+
+	if [ ! -f "${generated_strings}" ]; then
+		echo "error: extractLocStrings did not generate ${generated_strings}" >&2
+		return 1
+	fi
+
+	if ! iconv -f UTF-16 -t UTF8 "${generated_strings}" > "${tmp_utf8_strings}"; then
+		rm -f "${tmp_utf8_strings}"
+		echo "error: Failed to convert ${generated_strings} to UTF-8" >&2
+		return 1
+	fi
 
 	if [ -f "${target_strings}" ] && cmp -s "${tmp_utf8_strings}" "${target_strings}"; then
 		echo "  Localizable.strings unchanged"

--- a/iOS/scripts/loc_update.sh
+++ b/iOS/scripts/loc_update.sh
@@ -3,23 +3,49 @@
 # Get the directory where the script is stored
 script_dir=$(dirname "$(readlink -f "$0")")
 base_dir="${script_dir}/.."
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/loc_update.XXXXXX")
+tmp_index=0
+
+cleanup() {
+	rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+trap 'cleanup; exit 1' HUP INT TERM
+
+update_localizable_strings() {
+	source_dir="$1"
+	output_dir="$2"
+	tmp_index=$((tmp_index + 1))
+	tmp_output_dir="${tmp_dir}/${tmp_index}"
+	tmp_utf8_strings="${tmp_output_dir}/Localizable-UTF8.strings"
+	generated_strings="${tmp_output_dir}/Localizable.strings"
+	target_strings="${output_dir}/Localizable.strings"
+
+	echo "Processing ${source_dir}"
+	mkdir -p "${tmp_output_dir}"
+	find "${source_dir}/" -name "*.swift" -print0 | xargs -0 xcrun extractLocStrings -o "${tmp_output_dir}"
+	iconv -f UTF-16 -t UTF8 "${generated_strings}" > "${tmp_utf8_strings}"
+
+	if [ -f "${target_strings}" ] && cmp -s "${tmp_utf8_strings}" "${target_strings}"; then
+		echo "  Localizable.strings unchanged"
+		return
+	fi
+
+	mkdir -p "${output_dir}"
+	mv "${tmp_utf8_strings}" "${target_strings}"
+	echo "  Updated ${target_strings}"
+}
 
 # Add target sub-directories here when needed
 set -- "${base_dir}/DuckDuckGo" "${base_dir}/Widgets" "${base_dir}/PacketTunnelProvider"
 
 for dir in "$@"; do
-	echo "Processing ${dir}"
-	find "${dir}/" -name "*.swift" -print0 | xargs -0 xcrun extractLocStrings -o "${dir}/en.lproj"
-	iconv -f UTF-16 -t UTF8 "${dir}/en.lproj/Localizable.strings" > "${dir}/en.lproj/Localizable-UTF8.strings"
-	mv "${dir}/en.lproj/Localizable-UTF8.strings" "${dir}/en.lproj/Localizable.strings"
+	update_localizable_strings "${dir}" "${dir}/en.lproj"
 done
 
 # Add LocalPackages sub-directories here when needed
 set -- "${base_dir}/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS"
 
 for dir in "$@"; do
-	echo "Processing ${dir}"
-	find "${dir}/" -name "*.swift" -print0 | xargs -0 xcrun extractLocStrings -o "${dir}/Resources/en.lproj"
-	iconv -f UTF-16 -t UTF8 "${dir}/Resources/en.lproj/Localizable.strings" > "${dir}/Resources/en.lproj/Localizable-UTF8.strings"
-	mv "${dir}/Resources/en.lproj/Localizable-UTF8.strings" "${dir}/Resources/en.lproj/Localizable.strings"
+	update_localizable_strings "${dir}" "${dir}/Resources/en.lproj"
 done


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214604323343316?focus=true
Tech Design URL: N/A
CC:

### Description
Follow up of https://github.com/duckduckgo/apple-browsers/pull/4882 that was reverted due to bugs introduced.
Fixes iOS SwiftUI Previews without using `ENABLE_XOJIT_PREVIEWS` to skip build phases.

The previous approach made previews render by skipping build scripts when `ENABLE_XOJIT_PREVIEWS=YES`, but that variable is also set for normal new-preview-capable Debug builds. As a result, normal app launches could skip build phases that still need to run.

This PR keeps the `Update Localizable.strings` build phase enabled and makes `loc_update.sh` safe to run during previews. The script now extracts localization strings into a temporary directory, converts the generated file to UTF-8 there, compares it with the existing checked-in `Localizable.strings`, and only replaces the checked-in file when the content actually changed. This avoids touching source-tree localization files on every build, which was causing Xcode automatic preview builds to restart repeatedly.

Preview mode expectations:

- iOS should use the new preview execution system. Legacy iOS previews fail because the legacy preview thunk cannot link private/new SwiftUI pieces such as `SwiftUICore` and local Swift package dependencies used by the app target.
- macOS should use Legacy Previews Execution. Xcode 26's new macOS preview analyzer fails while resolving Swift WebKit overlay libraries, specifically the `libswiftWebKit.dylib` path behind the SDK/cryptex layout for our deployment target. Legacy mode avoids that analyzer failure.

### Testing Steps

1. Open `iOS/DuckDuckGo-iOS.xcodeproj`.
2. Leave **Editor -> Canvas -> Use Legacy Previews Execution** disabled for iOS.
3. Open a SwiftUI preview in the iOS Browser target.
4. Confirm the preview renders while the `Update Localizable.strings` build phase remains enabled.
5. Confirm Xcode no longer repeatedly restarts automatic preview builds after `loc_update.sh` runs.
6. For macOS, open `macOS/DuckDuckGo-macOS.xcodeproj`, enable **Editor -> Canvas -> Use Legacy Previews Execution**, and confirm a Browser preview renders in legacy mode.

### Impact and Risks

Low. This changes build tooling only. Runtime app behavior should not change.

#### What could go wrong?

The localization update script now writes through a temporary directory and compares generated output before replacing files. If that comparison logic is wrong, localization files might not update when source strings change, or they might still be touched unnecessarily. The script still replaces `Localizable.strings` when generated content differs, so normal localization updates should continue to work.

### Quality Considerations

This avoids using `ENABLE_XOJIT_PREVIEWS` as a proxy for "currently rendering a preview." In Xcode's new preview system, Debug build products are preview-capable, so build scripts must be safe to run in normal Debug builds and preview builds alike.

The fix specifically addresses source-tree churn from `loc_update.sh`: unchanged generated localization content no longer updates file modification times, which prevents Xcode from invalidating and restarting previews in a loop.

### Notes to Reviewer

The key behavior to review is that `loc_update.sh` only updates checked-in `Localizable.strings` files when the generated UTF-8 content differs.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-tooling change, but it alters how `Localizable.strings` files are generated and may cause missed updates or continued churn if the compare/convert logic is incorrect.
> 
> **Overview**
> Keeps the `Update Localizable.strings` build phase always running (removes the `ENABLE_PREVIEWS` early-exit) so Debug builds and SwiftUI previews don’t accidentally skip required scripts.
> 
> Refactors `loc_update.sh` to be *idempotent*: extracts strings into a temp directory, converts to UTF-8, compares against the existing `Localizable.strings`, and only replaces the checked-in file when content changes (with added error handling and cleanup traps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f3417cf918927609a6b82d9edea5fb5cd72b66e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->