### PR TITLE
Enable AI Chat sync promo by default

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -645,7 +645,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .aiChatSync:
             Config(source: .remoteReleasable(SyncSubfeature.aiChatSync))
         case .aiChatSyncPromo:
-            Config(source: .remoteReleasable(SyncSubfeature.aiChatSyncPromo))
+            Config(defaultValue: .enabled, source: .remoteReleasable(SyncSubfeature.aiChatSyncPromo))
         case .aiChatSuggestions:
             Config(defaultValue: .enabled, source: .remoteReleasable(DuckAiChatHistorySubfeature.featureEnabled))
         case .aiChatContextualSheetImprovements:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1214424137958309?focus=true
Tech Design URL: N/A
CC: N/A

### Description

- Enables the `aiChatSyncPromo` feature flag by default when its remote subfeature is absent from privacy config.
- Keeps `aiChatSyncPromo` remote controlled, so privacy config can still explicitly disable the promo.

### Testing Steps

1. Install a build where privacy config does not define the `sync.aiChatSyncPromo` subfeature.
2. Sign out of Sync, ensure Duck.ai chat history has at least one item, and open Duck.ai suggestions.
3. Verify the AI Chat sync promo appears.
4. Configure privacy config to explicitly disable `sync.aiChatSyncPromo`.
5. Relaunch or refresh config and verify the AI Chat sync promo does not appear.

### Impact and Risks

**Impact Level: Low**

#### What could go wrong?

- The promo could appear by default in environments where the remote subfeature is missing. The remote flag remains the source of truth and can explicitly disable the promo.
- Existing Sync, AI Chat sync, history availability, authentication state, dismissal, and impression-cap checks still gate promo display.

### Quality Considerations

- No privacy or security model changes.
- No new pixels or logging changes.
- No performance impact expected; this only changes the feature flag fallback value.

### Notes to Reviewer

- I intentionally did not add a unit test for the default value in `SyncPromoManagerTests` because the flag is remote controlled and the manager behavior is already covered through enabled/disabled feature-flag scenarios.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line feature-flag default change with no auth, data, or security model changes; remote config can still disable the promo.
> 
> **Overview**
> The **AI Chat sync promo** is now **on by default** when privacy config does not define the `sync.aiChatSyncPromo` subfeature. The change adds `defaultValue: .enabled` to the `.aiChatSyncPromo` entry in `FeatureFlag.swift`; remote config still controls the flag and can explicitly disable the promo.
> 
> `SyncPromoManager` already requires this flag (along with sync, AI chat sync, signed-out state, history, dismissals, and impression limits) before showing the Duck.ai sync promo—this PR only changes the fallback when the remote subfeature is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b901f40f5840ec76f5e8f942e8ecb38214a28e25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->