### PR TITLE
iOS: UTI Search bottom padding + paid AI Chat title icon

### DIFF
--- a/iOS/DuckDuckGo/AIChat/AIChatTabChatHeaderView.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatTabChatHeaderView.swift
@@ -45,6 +45,8 @@ final class AIChatTabChatHeaderView: UIView {
         static let pillInnerHorizontalPadding: CGFloat = 6
         static let pillInnerIconSpacing: CGFloat = 20
         static let pillButtonSize: CGFloat = 36
+        static let paidIconSize: CGFloat = 16
+        static let paidIconTitleSpacing: CGFloat = 6
     }
 
     weak var delegate: AIChatTabChatHeaderViewDelegate?
@@ -181,8 +183,8 @@ final class AIChatTabChatHeaderView: UIView {
         return container
     }()
 
-    /// Wraps both `titleContainer` (free upgrade plate) and `titleLabel` (paid nav title) so the
-    /// "row crowded by back+forward arrows" rule can hide the title slot via a single
+    /// Wraps both `titleContainer` (free upgrade plate) and `paidTitleStack` (paid icon + title)
+    /// so the "row crowded by back+forward arrows" rule can hide the title slot via a single
     /// `isHidden` toggle on this wrapper, leaving `configure(isSubscriptionActive:)` to swap
     /// just the two children inside.
     private lazy var titleHolder: UIView = {
@@ -230,6 +232,22 @@ final class AIChatTabChatHeaderView: UIView {
         label.textAlignment = .center
         label.adjustsFontForContentSizeCategory = true
         return label
+    }()
+
+    private lazy var paidIconView: UIImageView = {
+        let imageView = UIImageView(image: DesignSystemImages.Color.Size16.aiChat)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+
+    private lazy var paidTitleStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [paidIconView, titleLabel])
+        stack.axis = .horizontal
+        stack.spacing = Constants.paidIconTitleSpacing
+        stack.alignment = .center
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
     }()
 
     private lazy var freePlanRow: UIStackView = {
@@ -320,7 +338,7 @@ final class AIChatTabChatHeaderView: UIView {
 
     private func applyState() {
         titleContainer.isHidden = state.isSubscriptionActive != false
-        titleLabel.isHidden = state.isSubscriptionActive != true
+        paidTitleStack.isHidden = state.isSubscriptionActive != true
         // Voice session locks the user in — hide every left-side pill so they can only exit via
         // the in-page mic dismiss (which triggers FE → voiceSessionEnded → chrome restores).
         let hideLeft = state.isVoiceSessionActive
@@ -349,7 +367,7 @@ final class AIChatTabChatHeaderView: UIView {
         addSubview(leftStack)
         addSubview(rightStack)
         addSubview(titleHolder)
-        titleHolder.addSubview(titleLabel)
+        titleHolder.addSubview(paidTitleStack)
         titleHolder.addSubview(titleContainer)
         addSubview(bottomSeparator)
 
@@ -444,10 +462,13 @@ final class AIChatTabChatHeaderView: UIView {
             freeTitleStack.trailingAnchor.constraint(equalTo: titleContainer.layoutMarginsGuide.trailingAnchor),
             freeTitleStack.bottomAnchor.constraint(equalTo: titleContainer.layoutMarginsGuide.bottomAnchor),
 
-            titleLabel.centerXAnchor.constraint(equalTo: titleHolder.centerXAnchor),
-            titleLabel.centerYAnchor.constraint(equalTo: titleHolder.centerYAnchor),
-            titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: titleHolder.leadingAnchor),
-            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: titleHolder.trailingAnchor),
+            paidTitleStack.centerXAnchor.constraint(equalTo: titleHolder.centerXAnchor),
+            paidTitleStack.centerYAnchor.constraint(equalTo: titleHolder.centerYAnchor),
+            paidTitleStack.leadingAnchor.constraint(greaterThanOrEqualTo: titleHolder.leadingAnchor),
+            paidTitleStack.trailingAnchor.constraint(lessThanOrEqualTo: titleHolder.trailingAnchor),
+
+            paidIconView.widthAnchor.constraint(equalToConstant: Constants.paidIconSize),
+            paidIconView.heightAnchor.constraint(equalToConstant: Constants.paidIconSize),
 
             freeChevronView.widthAnchor.constraint(equalToConstant: Constants.chevronSize),
             freeChevronView.heightAnchor.constraint(equalToConstant: Constants.chevronSize),

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -93,9 +93,9 @@ final class UnifiedToggleInputView: UIView {
         static let toggleTopPadding: CGFloat = 8
         static let toggleBottomPadding: CGFloat = 4
         /// Bottom padding between the input content and the card edge when the AI tools
-        /// toolbar is hidden, mirroring `toggleBottomPadding` so the input sits centered
-        /// inside its 64pt row per the Figma spec.
-        static let inputBottomPadding: CGFloat = 4
+        /// toolbar is hidden. Slightly larger than the matching top gap so the cursor doesn't
+        /// crowd the card's bottom curve in Search mode.
+        static let inputBottomPadding: CGFloat = 8
         static let toggleHeight: CGFloat = 40
         static let toggleHorizontalPadding: CGFloat = 8
         static let animationDuration: TimeInterval = 0.25


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1214995978971464
Tech Design URL:
CC:

### Description

Two small visual polish changes from designer feedback:

1. **UTI Search-mode bottom padding** (`UnifiedToggleInputView`): bumps `inputBottomPadding` from 4pt to 8pt so the cursor doesn't crowd the card's bottom curve when the Unified Toggle Input is expanded in Search mode (toggle on, no AI tools toolbar). Only affects the `toggleEnabledNoToolbarPadding` path; toggle-on Duck.ai (toolbar flush), toggle-off, collapsed, and flanked layouts are unchanged.

2. **AI Chat paid tab title icon** (`AIChatTabChatHeaderView`): renders a 16pt color AI icon (`DesignSystemImages.Color.Size16.aiChat`) next to the paid-tier title label, via a new `paidTitleStack` (`UIStackView`) that replaces the lone `titleLabel` inside `titleHolder`. Free-tier "Free Plan / Upgrade" plate (`titleContainer`) is untouched.

### Testing Steps

**UTI Search-mode bottom padding**

1. Settings → AI Features → "Toggle between Search and Duck.ai"
2. Tap the omnibar to focus the UTI; ensure the Search side of the toggle is active and no AI tools toolbar is visible
3. Confirm the cursor has visible breathing room above the bottom edge of the card (~4pt more than before)
4. Switch the toggle to Duck.ai → toolbar should appear flush to the card bottom (unchanged behavior)
5. Settings → AI Features → "Search only" → focus the UTI → no toolbar present, card layout unchanged
6. Tap the inline back chevron to dismiss → omnibar↔UTI handoff animation should still hand off cleanly (PR #5008 polish preserved)

**Paid AI Chat title icon**

1. On a subscribed account, open a Duck.ai chat tab → confirm the nav title shows "AI Chat" with a 16pt color AI icon to its left
2. On a free account, open a Duck.ai chat tab → "Free Plan / Upgrade" plate still appears (no icon, unchanged)
3. Start a voice session in Duck.ai → both title variants hide via the existing `titleHolder` toggle

### Impact and Risks

Low — pure visual polish, no behavior or navigation changes:

- (1) is a single constant bump touching one expanded-state code path. Collapsed/flanked/toolbar/toggle-off paths are untouched, so PR #5008 animation polish is preserved.
- (2) only swaps the layout container of the existing `titleLabel`; subscription-state branching uses the same `applyState()` logic against a new `paidTitleStack.isHidden` instead of `titleLabel.isHidden`.

#### What could go wrong?

- **(1)** — If a designer wanted exact pre-change alignment, the cursor will now sit 4pt higher relative to the card bottom in Search mode. This is the intent per the feedback.
- **(2)** — If `DesignSystemImages.Color.Size16.aiChat` recolors poorly on dark or fire-mode chrome, the paid title icon will look off. Verified the asset resolves on light and dark.

### Notes to Reviewer

The two changes are independent. Happy to split into separate PRs if you'd prefer — they're bundled here only because both were in the working tree when opening the PR.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only layout tweaks: adjusts a single padding constant in `UnifiedToggleInputView` and wraps the paid AI Chat header title in a stack with an icon, without changing navigation or subscription logic.
> 
> **Overview**
> Polishes two iOS UI layouts.
> 
> In `UnifiedToggleInputView`, increases Search-mode expanded-state bottom padding when the AI tools toolbar is hidden (via `inputBottomPadding`), giving the cursor more space from the card’s bottom curve.
> 
> In `AIChatTabChatHeaderView`, updates the paid-tier nav title to show a 16pt color AI icon next to the existing title by replacing the standalone `titleLabel` with a `paidTitleStack`, and updates state/constraints to hide/show this stack instead of the label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5105a82d76880c543a88a8e29d5cb25f8b3c06a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->