### PR TITLE
Duck.ai dark mode: Surface-Canvas / Surface-Secondary tokens

### DIFF
--- a/iOS/DuckDuckGo/AIChat/AIChatTabChatHeaderView.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatTabChatHeaderView.swift
@@ -345,7 +345,7 @@ final class AIChatTabChatHeaderView: UIView {
     }()
 
     private func setupUI() {
-        backgroundColor = UIColor(designSystemColor: .surfaceTertiary)
+        backgroundColor = UIColor(designSystemColor: .surface)
         addSubview(leftStack)
         addSubview(rightStack)
         addSubview(titleHolder)

--- a/iOS/DuckDuckGo/MainViewCoordinator.swift
+++ b/iOS/DuckDuckGo/MainViewCoordinator.swift
@@ -241,7 +241,6 @@ class MainViewCoordinator {
 
     func updateUnifiedToggleInputColors(inputView: UIView?) {
         inputView?.backgroundColor = .clear
-        unifiedToggleInputContainer.backgroundColor = .clear
     }
 
     @MainActor
@@ -498,9 +497,7 @@ class MainViewCoordinator {
         case .omnibarEditing, .aiTabSearchChromeHidden:
             UIColor(designSystemColor: .panel)
         case .aiTabChatChromeHidden:
-            // Match the AI chat header's `.surfaceTertiary` background so the safe-area inset
-            // above it doesn't show as a different colour band.
-            UIColor(designSystemColor: .surfaceTertiary)
+            UIColor(designSystemColor: .surface)
         }
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -252,12 +252,10 @@ extension MainViewController {
                 unifiedToggleInputContainerColor = .clear
                 webViewBackgroundColor = rootBackgroundColor
             } else {
-                // Match Figma's `--ds-surface-tertiary` (#3D3D3D dark / white light) so the chrome
-                // is the same tone as the card. The card defines itself via its halo rim shadow.
-                rootBackgroundColor = UIColor(designSystemColor: .backgroundTertiary)
+                rootBackgroundColor = UIColor(designSystemColor: .surface)
                 navigationBarContainerColor = .clear
-                unifiedToggleInputContainerColor = .clear
-                webViewBackgroundColor = .clear
+                unifiedToggleInputContainerColor = UIColor(designSystemColor: .surface)
+                webViewBackgroundColor = UIColor(designSystemColor: .surfaceCanvas)
             }
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214995870352489

### Description

Per ship-review BB2: adopt the design-system Surface tokens on Duck.ai in dark mode.

- Duck.ai tab background → `Surface-Canvas`
- AI Chat tab header → `Surface-Secondary` (`.surface` — the existing token is annotated `T-surface/secondary` in `SemanticColor`)
- Bottom UTI footer band + status-bg above the header → `Surface-Secondary`

`updateUnifiedToggleInputColors` previously hard-reset the UTI container's background to `.clear` outside the chrome-state apply, which was overriding the new container paint. It now only updates the input view it's named after; the chrome-state apply is the single source of truth for the container's background.

### Testing Steps

1. Dark mode + Duck.ai tab: header, status-bg band above it, and footer band around the UTI all read as Surface-Secondary (medium gray). Chat body reads as Surface-Canvas (darker).
2. Light mode + Duck.ai tab: no visible regression.
3. Switch Duck.ai → Search → Duck.ai: chrome repaints correctly each way; no leaked colors on the Search side.
4. Open omnibar editing on a non-AI tab: UTI container doesn't pick up `.surface`.

### Impact and Risks

Low — visual-only change. Voice mode shows a brief color transition when the bottom chrome hides (Surface-Secondary footer band collapses into Surface-Canvas web view). This is pre-existing chrome / FE-render timing; acceptable for ship.

### Notes to Reviewer

The one structural change is removing `unifiedToggleInputContainer.backgroundColor = .clear` from `updateUnifiedToggleInputColors`. Both callers (`showUnifiedToggleInput` and `applyTopChromeState`) sit inside chrome-state-aware flows; the explicit `.clear` paths (`showUnifiedToggleInputOmnibar`, `hideUnifiedToggleInput`) set the container directly already.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only theming changes; main behavior change is removing an extra `.clear` reset that could affect UTI background color in some transitions.
> 
> **Overview**
> Updates Duck.ai chrome theming to use design-system surface tokens, aligning the AI chat header, status-bar safe-area band, and unified toggle input footer with `surface`/`surfaceCanvas` colors.
> 
> Removes a hard-coded `unifiedToggleInputContainer.backgroundColor = .clear` reset in `MainViewCoordinator.updateUnifiedToggleInputColors`, making `applyUnifiedInputChromeBackground` the single source of truth for UTI container/background painting during AI-tab state transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4c6c161b3abc6f217e887562c2142cc941f9ddb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->