### PR TITLE
ddg-sentry-report skill: fix custom-field filter to use .contains

### DIFF
--- a/.claude/skills/ddg-sentry-report/SKILL.md
+++ b/.claude/skills/ddg-sentry-report/SKILL.md
@@ -170,11 +170,11 @@ Runs BEFORE culprit investigation. For each new-in-version cluster (after culpri
 asana_search_tasks(workspace="137249556945",
   projects.any="1214294661819890",
   sections.any="<PLATFORM_SECTION>",
-  custom_fields.1214294661819893.value="<SHORT_ID>",
+  custom_fields.1214294661819893.contains="<SHORT_ID>",
   opt_fields="name,permalink_url,custom_fields,memberships.section.gid,tags,tags.name,completed")
 ```
 
-`completed` and `tags.name` are required for gating. The `value` filter is substring-match and the custom field is comma-separated, so **split the returned value on commas and require an exact element match** — substring matches like `APPLE-IOS-D6N` matching `APPLE-IOS-D6N6` are false positives. Fall back to `sections.any="1214294661819891"` only if the platform section misses.
+`completed` and `tags.name` are required for gating. Use `.contains` (substring match), not `.value` — `.value` is a literal **equals** match against the whole custom-field string, which fails as soon as a cluster's field holds multiple comma-separated short-IDs. `.contains` then necessarily over-matches (e.g. `APPLE-IOS-D6N` matches a task whose field contains `APPLE-IOS-D6N6`), so **split the returned value on commas and require an exact element match** client-side to discard those false positives. Fall back to `sections.any="1214294661819891"` only if the platform section misses.
 
 **Tag parsing.** Tag names look like `<platform>-app-release-X.Y.Z`. Strip the prefix; parse the remainder as semver-ish; compare numerically. If multiple version tags exist on one task, the **highest** wins.
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1215059159305205?focus=true

### Description

Fixes a bug in the `ddg-sentry-report` skill's step 5 (existing tracking-task lookup). The documented Asana query used `custom_fields.<gid>.value="<SHORT_ID>"`, which is a literal **equals** match against the whole custom-field string. Since the field is comma-separated (one task can carry multiple sibling Sentry short-IDs), `.value` silently fails to find any task whose field holds more than one ID — exactly the dedupe case the lookup exists to handle.

Swaps `.value` for `.contains` (substring match into the comma-joined value) and clarifies why the client-side comma-split + exact-element check (already documented) is still required to discard the false positives `.contains` introduces (e.g. `APPLE-IOS-D6N` matching a field containing `APPLE-IOS-D6N6`).

### Testing Steps

This is a doc/skill change, not app code. To verify:
1. Read the updated step 5 in `.claude/skills/ddg-sentry-report/SKILL.md`.
2. Confirm the example query uses `custom_fields.1214294661819893.contains="<SHORT_ID>"` and the prose explains the `.contains` + client-side dedupe combination.
3. Next time `/ddg-sentry-report` is run, the step 5 lookup should match tracking tasks that hold multiple comma-separated short-IDs (previously missed under `.value`).

### Impact and Risks

None — skill documentation only. No app code changes, no shipped behaviour change.

#### What could go wrong?

The skill instructs the model to issue a query with a slightly different filter operator next time it runs. If the underlying Asana MCP rejects `.contains` on this custom field for any reason, the skill run would surface the error and the user would notice immediately. No production user-facing impact.

### Quality Considerations

- Edge case the fix targets: clusters whose tracking task already lists multiple sibling short-IDs comma-separated in the custom field — previously unreachable via `.value`.
- Edge case the fix preserves: substring false positives (`APPLE-IOS-D6N` vs `APPLE-IOS-D6N6`) — still discarded by the existing client-side split-and-exact-match step.

### Notes to Reviewer

Single-line operator change in the example plus a paragraph rewrite that names both operators so a future reader doesn't re-introduce `.value`.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates the Asana search filter used by the `ddg-sentry-report` skill; main risk is limited to potential lookup mismatches if `.contains` behaves unexpectedly.
> 
> **Overview**
> Updates the `ddg-sentry-report` skill’s Step 5 Asana lookup to query the tracking-task custom field with `.contains` instead of `.value`, so existing tasks that store multiple comma-separated Sentry short-IDs can be found.
> 
> Clarifies in the doc that `.contains` can over-match, and that the workflow must still split the returned field value on commas and require an exact element match client-side to avoid false positives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9da170a9454367ae5c179f51078e2cfa4e7f08cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->