### PR TITLE
Add diagnostic overlay for unresponsive Tab Switcher bug

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1688,8 +1688,8 @@
 		9FFDA83F2DFA907A007923F7 /* MockPictureInPictureController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FFDA83E2DFA9073007923F7 /* MockPictureInPictureController.swift */; };
 		A06E1D600618608596891F29 /* AIChatRecentChatsPopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0B70EF2418A35A5D863506 /* AIChatRecentChatsPopupViewController.swift */; };
 		A1B2C3D4E5F60001AABB0001 /* NTPAfterIdleInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001AABB0002 /* NTPAfterIdleInstrumentationTests.swift */; };
-		A1B2C3D4E5F60002AABBA001 /* IdleReturnTabCountInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60002AABBA002 /* IdleReturnTabCountInstrumentationTests.swift */; };
 		A1B2C3D4E5F60002A1B2C3D4 /* UnifiedInputContentContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001A1B2C3D4 /* UnifiedInputContentContainerViewController.swift */; };
+		A1B2C3D4E5F60002AABBA001 /* IdleReturnTabCountInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60002AABBA002 /* IdleReturnTabCountInstrumentationTests.swift */; };
 		A1B2C3D4E5F60012A1B2C3D4 /* AIChatReasoningMode+UnifiedToggleInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60011A1B2C3D4 /* AIChatReasoningMode+UnifiedToggleInput.swift */; };
 		A1B2C3D4E5F60014A1B2C3D4 /* UnifiedToggleInputReasoningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60013A1B2C3D4 /* UnifiedToggleInputReasoningTests.swift */; };
 		A1B2C3D52F7F111100ABCDEF /* SaveRecoveryKeyViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42F7F111100ABCDEF /* SaveRecoveryKeyViewModelTests.swift */; };
@@ -2082,6 +2082,7 @@
 		C1FFBD462C761BE20073622B /* SyncPromoManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FFBD452C761BE20073622B /* SyncPromoManagerTests.swift */; };
 		C1FFBD482C7749A90073622B /* SyncSettingsViewController+PlatformLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FFBD472C7749A90073622B /* SyncSettingsViewController+PlatformLinks.swift */; };
 		C590E41C21CD46E99C4A5B2E /* AIChatContextualWebViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7971E90992B46FABF42A908 /* AIChatContextualWebViewControllerTests.swift */; };
+		CB0AAE4A2FC0AA3B0023C541 /* TabSwitcherDiagnosticsOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0AAE492FC0AA3B0023C541 /* TabSwitcherDiagnosticsOverlay.swift */; };
 		CB1143DE2AF6D4B600C1CCD3 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = CB1143DC2AF6D4B600C1CCD3 /* InfoPlist.strings */; };
 		CB14D5832E269A7F002E897E /* UserAgentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB14D5822E269A73002E897E /* UserAgentConfiguration.swift */; };
 		CB18A3662E2790C700BE9D8D /* UserAgentConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB18A3652E2790C700BE9D8D /* UserAgentConfigurationTests.swift */; };
@@ -2152,11 +2153,9 @@
 		CBAD0F252D02EE49006267B8 /* LastBackgroundDateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAD0F242D02EE48006267B8 /* LastBackgroundDateStore.swift */; };
 		CBAD0F272D02EE4B006267B8 /* AfterInactivitySettingStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAD0F262D02EE4A006267B8 /* AfterInactivitySettingStorage.swift */; };
 		CBAD0F2B2D02EE4E006267B8 /* AfterInactivityEffectiveOptionResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAD0F2A2D02EE4D006267B8 /* AfterInactivityEffectiveOptionResolver.swift */; };
-		F2DE024241BD443BAA7E32E3 /* AfterInactivityOptionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3663DD21563403B96D50EF0 /* AfterInactivityOptionAdapter.swift */; };
 		CBAD0F2D2D02EE50006267B8 /* IdleReturnEligibilityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAD0F2C2D02EE4F006267B8 /* IdleReturnEligibilityManager.swift */; };
 		CBAD0F312D02EE50006267B8 /* IdleReturnEligibilityManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAD0F302D02EE50006267B8 /* IdleReturnEligibilityManagerTests.swift */; };
 		CBAD0F332D02EE50006267B8 /* AfterInactivityEffectiveOptionResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAD0F322D02EE50006267B8 /* AfterInactivityEffectiveOptionResolverTests.swift */; };
-		022BB4A030C8410C953B133B /* AfterInactivityOptionAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC7D7E5EB7B04D2385E0E48E /* AfterInactivityOptionAdapterTests.swift */; };
 		CBAD0F3B2D02EE5B006267B8 /* IdleReturnCohort.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAD0F3A2D02EE5B006267B8 /* IdleReturnCohort.swift */; };
 		CBAD1A002D02EE45006267B8 /* IdleReturnThresholdResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAD1A012D02EE45006267B8 /* IdleReturnThresholdResolverTests.swift */; };
 		CBC88EE12C7F834300F0F8C5 /* SpecialErrorPageUserScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC88EE02C7F834300F0F8C5 /* SpecialErrorPageUserScriptTests.swift */; };
@@ -4736,6 +4735,7 @@
 		C1FFBD452C761BE20073622B /* SyncPromoManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncPromoManagerTests.swift; sourceTree = "<group>"; };
 		C1FFBD472C7749A90073622B /* SyncSettingsViewController+PlatformLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SyncSettingsViewController+PlatformLinks.swift"; sourceTree = "<group>"; };
 		C8EBB73CB1254EBFA67E5D22 /* FireModePromotionsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireModePromotionsCoordinator.swift; sourceTree = "<group>"; };
+		CB0AAE492FC0AA3B0023C541 /* TabSwitcherDiagnosticsOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSwitcherDiagnosticsOverlay.swift; sourceTree = "<group>"; };
 		CB1143DD2AF6D4B600C1CCD3 /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		CB14D5822E269A73002E897E /* UserAgentConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentConfiguration.swift; sourceTree = "<group>"; };
 		CB15F4762AF6D5100062A994 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -4814,11 +4814,9 @@
 		CBAD0F242D02EE48006267B8 /* LastBackgroundDateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastBackgroundDateStore.swift; sourceTree = "<group>"; };
 		CBAD0F262D02EE4A006267B8 /* AfterInactivitySettingStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterInactivitySettingStorage.swift; sourceTree = "<group>"; };
 		CBAD0F2A2D02EE4D006267B8 /* AfterInactivityEffectiveOptionResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterInactivityEffectiveOptionResolver.swift; sourceTree = "<group>"; };
-		E3663DD21563403B96D50EF0 /* AfterInactivityOptionAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterInactivityOptionAdapter.swift; sourceTree = "<group>"; };
 		CBAD0F2C2D02EE4F006267B8 /* IdleReturnEligibilityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleReturnEligibilityManager.swift; sourceTree = "<group>"; };
 		CBAD0F302D02EE50006267B8 /* IdleReturnEligibilityManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleReturnEligibilityManagerTests.swift; sourceTree = "<group>"; };
 		CBAD0F322D02EE50006267B8 /* AfterInactivityEffectiveOptionResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterInactivityEffectiveOptionResolverTests.swift; sourceTree = "<group>"; };
-		AC7D7E5EB7B04D2385E0E48E /* AfterInactivityOptionAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterInactivityOptionAdapterTests.swift; sourceTree = "<group>"; };
 		CBAD0F3A2D02EE5B006267B8 /* IdleReturnCohort.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleReturnCohort.swift; sourceTree = "<group>"; };
 		CBAD1A012D02EE45006267B8 /* IdleReturnThresholdResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleReturnThresholdResolverTests.swift; sourceTree = "<group>"; };
 		CBB6B2542AF6D543006B777C /* lt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lt; path = lt.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -7354,6 +7352,7 @@
 				C18390C52F5077EA001939B9 /* UnifiedToggleInput */,
 				CB6D178E2FA213DD00ECD5AE /* URL+SuggestionDisplay.swift */,
 				CB6D17962FA232E000ECD5AE /* Suggestion+URLFilter.swift */,
+				CB0AAE492FC0AA3B0023C541 /* TabSwitcherDiagnosticsOverlay.swift */,
 			);
 			path = DuckDuckGo;
 			sourceTree = "<group>";
@@ -13443,6 +13442,7 @@
 				9FE08BD32C2A5B88001D5EBC /* OnboardingTextStyles.swift in Sources */,
 				C17023AA2E589C6E00090178 /* DaxEasterEggLogoCache.swift in Sources */,
 				9FD6E6112DFA6B3200C2B032 /* PictureInPictureConfiguration.swift in Sources */,
+				CB0AAE4A2FC0AA3B0023C541 /* TabSwitcherDiagnosticsOverlay.swift in Sources */,
 				F17669D71E43401C003D3222 /* MainViewController.swift in Sources */,
 				EB636BDE30C2031DD6A90899 /* StartupOnboardingCover.swift in Sources */,
 				6FE127462C2054A900EB5724 /* NewTabPageViewController.swift in Sources */,

--- a/iOS/DuckDuckGo/MainViewController+Segues.swift
+++ b/iOS/DuckDuckGo/MainViewController+Segues.swift
@@ -240,9 +240,11 @@ extension MainViewController {
                                       daxDialogsManager: self.daxDialogsManager,
                                       initialTrackerCountState: initialTrackerCountState)
         }) else {
+            TabSwitcherDiagnosticsOverlay.recordEvent("TSVC instantiation FAILED — storyboard returned nil")
             assertionFailure()
             return
         }
+        TabSwitcherDiagnosticsOverlay.recordEvent("TSVC instantiated \(ObjectIdentifier(controller).debugDescription)")
 
         controller.transitioningDelegate = tabSwitcherTransition
         controller.delegate = self
@@ -253,9 +255,10 @@ extension MainViewController {
 
         tabSwitcherController = controller
 
-        TabSwitcherDiagnosticsOverlay.recordEvent("calling present(TSVC) (presentedVC was \(presentedViewController.map { "\(type(of: $0))" } ?? "nil"))")
+        let tsvcID = ObjectIdentifier(controller).debugDescription
+        TabSwitcherDiagnosticsOverlay.recordEvent("calling present(TSVC=\(tsvcID)) (presentedVC was \(presentedViewController.map { "\(type(of: $0))" } ?? "nil"))")
         present(controller, animated: true) {
-            TabSwitcherDiagnosticsOverlay.recordEvent("present(TSVC) completion fired — actually presented")
+            TabSwitcherDiagnosticsOverlay.recordEvent("present(TSVC=\(tsvcID)) completion fired — actually presented")
         }
     }
 

--- a/iOS/DuckDuckGo/MainViewController+Segues.swift
+++ b/iOS/DuckDuckGo/MainViewController+Segues.swift
@@ -200,6 +200,7 @@ extension MainViewController {
 
         // Guard against concurrent presentations
         guard tabSwitcherController == nil else {
+            TabSwitcherDiagnosticsOverlay.recordEvent("guard1 REJECTED (pre-async, ts-ref non-nil)")
             Logger.lifecycle.debug("Tab switcher presentation already in progress or active")
             return
         }
@@ -216,6 +217,7 @@ extension MainViewController {
 
         // Check again after async work in case another presentation started
         guard tabSwitcherController == nil else {
+            TabSwitcherDiagnosticsOverlay.recordEvent("guard2 REJECTED (post-async, ts-ref non-nil)")
             Logger.lifecycle.debug("Tab switcher presentation already in progress")
             return
         }
@@ -251,7 +253,10 @@ extension MainViewController {
 
         tabSwitcherController = controller
 
-        present(controller, animated: true)
+        TabSwitcherDiagnosticsOverlay.recordEvent("calling present(TSVC) (presentedVC was \(presentedViewController.map { "\(type(of: $0))" } ?? "nil"))")
+        present(controller, animated: true) {
+            TabSwitcherDiagnosticsOverlay.recordEvent("present(TSVC) completion fired — actually presented")
+        }
     }
 
     func segueToSettings() {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -5186,6 +5186,7 @@ extension MainViewController: TabDelegate {
 extension MainViewController: TabSwitcherDelegate {
 
     func tabSwitcher(_ tabSwitcher: TabSwitcherViewController, didFinishWithSelectedTab tab: Tab?) {
+        TabSwitcherDiagnosticsOverlay.recordEvent("tabSwitcher dismissed by selection (tab \(tab == nil ? "nil" : "set"))")
         defer {
             showMenuHighlighterIfNeeded()
             applyWidth()
@@ -5392,6 +5393,8 @@ extension MainViewController: TabSwitcherButtonDelegate {
     /// Not `private` because the UTI extension in `MainViewController+UnifiedToggleInput`
     /// calls it from another file.
     func requestTabSwitcher() {
+        TabSwitcherDiagnosticsOverlay.recordEvent("requestTabSwitcher entered (ts-ref=\(tabSwitcherController == nil ? "nil" : "live"), presentedVC=\(presentedViewController.map { "\(type(of: $0))" } ?? "nil"))")
+
         Pixel.fire(pixel: .tabBarTabSwitcherOpened,
                    withAdditionalParameters: [PixelParameters.browsingMode: tabManager.currentBrowsingMode.pixelParamValue])
         var openedDailyParams = TabSwitcherOpenDailyPixel().parameters(with: tabManager.allTabsModel.tabs)

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -5186,7 +5186,7 @@ extension MainViewController: TabDelegate {
 extension MainViewController: TabSwitcherDelegate {
 
     func tabSwitcher(_ tabSwitcher: TabSwitcherViewController, didFinishWithSelectedTab tab: Tab?) {
-        TabSwitcherDiagnosticsOverlay.recordEvent("tabSwitcher dismissed by selection (tab \(tab == nil ? "nil" : "set"))")
+        TabSwitcherDiagnosticsOverlay.recordEvent("tabSwitcher dismissed (TSVC=\(ObjectIdentifier(tabSwitcher).debugDescription), tab \(tab == nil ? "nil" : "set"))")
         defer {
             showMenuHighlighterIfNeeded()
             applyWidth()

--- a/iOS/DuckDuckGo/TabSwitcherDiagnosticsOverlay.swift
+++ b/iOS/DuckDuckGo/TabSwitcherDiagnosticsOverlay.swift
@@ -1,0 +1,582 @@
+//
+//  TabSwitcherDiagnosticsOverlay.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+import Core
+import os.log
+import OSLog
+
+/// Self-diagnostic overlay for the "unresponsive Tab Switcher" bug.
+/// Triggered when the user taps the tab switcher button rapidly without the switcher opening,
+/// snapshots app state into a screenshottable overlay so the team can capture it from the field.
+///
+/// Why a UIWindow-attached overlay rather than UIViewController.present? The whole bug
+/// hypothesis is that UIKit's modal presentation is silently failing — so we cannot rely on
+/// `present(_:animated:)` to display the diagnostic. Adding a UIView directly to the key
+/// window's subview list puts the overlay above any presented modal containers.
+@MainActor
+enum TabSwitcherDiagnosticsOverlay {
+
+    /// Number of taps within `tapWindow` that triggers the overlay. Fires regardless of
+    /// the current tab-switcher visibility state — we want the diagnostic any time the
+    /// user is tap-mashing the button, so the team can capture full state.
+    static let tapThreshold = 3
+    /// Sliding window over which `tapThreshold` is measured.
+    static let tapWindow: TimeInterval = 6
+
+    /// Shared mutable state used by `MainViewController` to track tap timestamps, recent
+    /// request outcomes, and avoid re-presenting the overlay while it's already on screen.
+    final class State {
+        static let shared = State()
+        var tapTimestamps: [Date] = []
+        var overlayVisible = false
+        /// Ring buffer of the last `maxRecentEvents` outcomes from the tab-switcher launch
+        /// pipeline (entered → guard hit / presenting / present completion / dismissed).
+        /// This is the trace you actually need to tell whether the bug is "guard rejected
+        /// the tap", "present silently failed", or "nothing at all reached the chain".
+        var recentEvents: [(Date, String)] = []
+        static let maxRecentEvents = 12
+        private init() {}
+    }
+
+    /// Append an event to the per-request outcome trace. Cheap; safe to call from any
+    /// point in the tab-switcher launch chain.
+    static func recordEvent(_ label: String) {
+        State.shared.recentEvents.append((Date(), label))
+        let overflow = State.shared.recentEvents.count - State.maxRecentEvents
+        if overflow > 0 {
+            State.shared.recentEvents.removeFirst(overflow)
+        }
+    }
+
+    /// Whether the overlay is allowed to surface to the user. Limited to non-production
+    /// builds (DEBUG/ALPHA/EXPERIMENTAL) and to internal users on production builds.
+    /// Production users tap-mashing the button won't see this dialog.
+    static var isEnabled: Bool {
+        if !BuildFlags.isProductionBuild { return true }
+        return AppDependencyProvider.shared.internalUserDecider.isInternalUser
+    }
+
+    /// Record a tab-switcher tap. Returns `true` when the caller should *also* show the
+    /// diagnostic overlay — fires purely on the tap-rate threshold, irrespective of whether
+    /// the switcher is currently open. The diagnostic itself captures everything about the
+    /// hierarchy state so we can tell whether the switcher is missing, hidden behind another
+    /// view, in the wrong window, etc.
+    static func recordTapAndShouldShow() -> Bool {
+        guard isEnabled else { return false }
+        let state = State.shared
+        let now = Date()
+        state.tapTimestamps = state.tapTimestamps.filter { now.timeIntervalSince($0) <= tapWindow }
+        state.tapTimestamps.append(now)
+        if state.overlayVisible { return false }
+        return state.tapTimestamps.count >= tapThreshold
+    }
+
+    /// Clear the tap counter — call from the `present` completion when the tab switcher
+    /// actually appears, so a subsequent tap doesn't carry stale history.
+    static func clearTapHistory() {
+        State.shared.tapTimestamps.removeAll()
+    }
+
+    /// Show the diagnostic overlay over the supplied MainViewController's key window.
+    /// Logs the same content via `Logger.lifecycle.error` so it also appears in device logs.
+    static func show(from mainVC: MainViewController) {
+        guard isEnabled else { return }
+        guard !State.shared.overlayVisible, let window = mainVC.view.window else { return }
+        let snapshot = collect(from: mainVC)
+        Logger.lifecycle.error("[TabSwitcherDiagnostics]\n\(snapshot, privacy: .public)")
+        let overlay = OverlayView(text: snapshot) {
+            State.shared.overlayVisible = false
+            State.shared.tapTimestamps.removeAll()
+        }
+        overlay.frame = window.bounds
+        overlay.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        window.addSubview(overlay)
+        State.shared.overlayVisible = true
+    }
+
+    // MARK: - Diagnostics
+
+    private static let timestampFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+        return f
+    }()
+
+    static func collect(from mainVC: MainViewController) -> String {
+        var lines: [String] = []
+
+        // Per-request timeline — most actionable signal. Tells us whether each recent
+        // tap reached `present`, was rejected by a guard, or completed presentation.
+        lines.append("[RECENT REQUESTS] (last \(State.maxRecentEvents))")
+        if State.shared.recentEvents.isEmpty {
+            lines.append("(none recorded)")
+        } else {
+            let now = Date()
+            for (ts, label) in State.shared.recentEvents {
+                let age = String(format: "%6.2fs ago", now.timeIntervalSince(ts))
+                lines.append("\(age)  \(label)")
+            }
+        }
+        lines.append("")
+
+        // Tab switcher VC state
+        lines.append("[TAB SWITCHER VC]")
+        if let tsvc = mainVC.tabSwitcherController {
+            lines.append("ref: live(\(addr(tsvc)))")
+            lines.append("isViewLoaded: \(tsvc.isViewLoaded)")
+            if let view = tsvc.viewIfLoaded {
+                lines.append("view.window: \(view.window != nil ? "in-window(level=\(view.window!.windowLevel.rawValue))" : "no-window")")
+                lines.append("view.alpha: \(view.alpha)")
+                lines.append("view.isHidden: \(view.isHidden)")
+                lines.append("view.frame: \(stringify(view.frame))")
+                lines.append("view.bounds: \(stringify(view.bounds))")
+                // Walk superview ancestry — if the view is detached or buried under
+                // some unexpected container, this shows where it lives now.
+                lines.append("view ancestry (innermost → outermost):")
+                var cursor: UIView? = view
+                var ancestryDepth = 0
+                while let v = cursor, ancestryDepth < 14 {
+                    let indent = String(repeating: "  ", count: ancestryDepth + 1)
+                    let alphaTag = v.alpha < 1 ? " α=\(v.alpha)" : ""
+                    let hiddenTag = v.isHidden ? " HIDDEN" : ""
+                    let interactiveTag = v.isUserInteractionEnabled ? "" : " NO-UI"
+                    lines.append("\(indent)- \(type(of: v))(\(addr(v))) frame=\(stringify(v.frame))\(alphaTag)\(hiddenTag)\(interactiveTag)")
+                    cursor = v.superview
+                    ancestryDepth += 1
+                }
+                // Sibling z-order — if the TSVC view is in a window but covered by a sibling
+                // with a higher index, we want to see the sibling on top.
+                if let parent = view.superview {
+                    lines.append("siblings in superview (back → front, * = TSVC view):")
+                    for (idx, sib) in parent.subviews.enumerated() {
+                        let marker = sib === view ? " *" : ""
+                        let alphaTag = sib.alpha < 1 ? " α=\(sib.alpha)" : ""
+                        let hiddenTag = sib.isHidden ? " HIDDEN" : ""
+                        lines.append("  [\(idx)]\(marker) \(type(of: sib))(\(addr(sib))) frame=\(stringify(sib.frame))\(alphaTag)\(hiddenTag)")
+                    }
+                }
+                // Hit-test sample at center to see what UIKit would route a tap to if
+                // someone tried to interact with where the TSVC should be.
+                if let window = view.window {
+                    let centerInWindow = view.convert(CGPoint(x: view.bounds.midX, y: view.bounds.midY), to: window)
+                    if let hit = window.hitTest(centerInWindow, with: nil) {
+                        lines.append("hitTest @ tsvc-center: \(type(of: hit))(\(addr(hit))) frame=\(stringify(hit.frame))")
+                    } else {
+                        lines.append("hitTest @ tsvc-center: nil")
+                    }
+                }
+            }
+            lines.append("isBeingPresented: \(tsvc.isBeingPresented)")
+            lines.append("isBeingDismissed: \(tsvc.isBeingDismissed)")
+            lines.append("parent: \(tsvc.parent.map { String(describing: type(of: $0)) } ?? "nil")")
+            lines.append("presentingVC: \(tsvc.presentingViewController.map { String(describing: type(of: $0)) } ?? "nil")")
+        } else {
+            lines.append("ref: nil (weak — never presented, or fully released)")
+        }
+        lines.append("")
+
+        // MainVC state
+        lines.append("[MAIN VC]")
+        lines.append("presentedVC: \(describe(vc: mainVC.presentedViewController))")
+        lines.append("presentingVC: \(describe(vc: mainVC.presentingViewController))")
+        lines.append("isBeingPresented: \(mainVC.isBeingPresented)")
+        lines.append("isBeingDismissed: \(mainVC.isBeingDismissed)")
+        lines.append("transitionCoordinator: \(mainVC.transitionCoordinator != nil ? "ACTIVE" : "nil")")
+        lines.append("view.window: \(mainVC.view.window != nil ? "in-window" : "no-window")")
+        lines.append("")
+
+        // Presentation chain
+        lines.append("[PRESENTATION CHAIN]")
+        var current: UIViewController? = mainVC.view.window?.rootViewController
+        var depth = 0
+        while let vc = current, depth < 12 {
+            let indent = String(repeating: "  ", count: depth)
+            let bP = vc.isBeingPresented ? " [bP]" : ""
+            let bD = vc.isBeingDismissed ? " [bD]" : ""
+            let tc = vc.transitionCoordinator != nil ? " [TC]" : ""
+            lines.append("\(indent)\(type(of: vc))(\(addr(vc)))\(bP)\(bD)\(tc)")
+            current = vc.presentedViewController
+            depth += 1
+        }
+        lines.append("")
+
+        // Full VC tree — children + presentedVC at every level. Catches container VCs
+        // (nav controllers, custom containers) and child VCs that the linear presentation
+        // chain would miss. Capped at 80 lines / depth 12 to keep the dump readable.
+        lines.append("[FULL VC TREE]")
+        if let key = mainVC.view.window?.windowScene?.windows.first(where: { $0.isKeyWindow }),
+           let root = key.rootViewController {
+            var emitted = 0
+            func walk(_ vc: UIViewController, depth: Int) {
+                guard emitted < 80, depth < 12 else { return }
+                let indent = String(repeating: "  ", count: depth)
+                let viewTag: String
+                if let v = vc.viewIfLoaded {
+                    let attached = v.window != nil ? "win" : "no-win"
+                    viewTag = " view=\(attached) frame=\(stringify(v.frame))"
+                } else {
+                    viewTag = " view-not-loaded"
+                }
+                let bP = vc.isBeingPresented ? " [bP]" : ""
+                let bD = vc.isBeingDismissed ? " [bD]" : ""
+                let tc = vc.transitionCoordinator != nil ? " [TC]" : ""
+                lines.append("\(indent)- \(type(of: vc))(\(addr(vc)))\(viewTag)\(bP)\(bD)\(tc)")
+                emitted += 1
+                for child in vc.children {
+                    walk(child, depth: depth + 1)
+                }
+                if let presented = vc.presentedViewController {
+                    lines.append("\(indent)  ↳ presents:")
+                    walk(presented, depth: depth + 1)
+                }
+            }
+            walk(root, depth: 0)
+            if emitted >= 80 {
+                lines.append("… (truncated at 80 entries)")
+            }
+        } else {
+            lines.append("(no key window)")
+        }
+        lines.append("")
+
+        // Toolbar tab switcher button
+        lines.append("[TOOLBAR TS BUTTON]")
+        if let customView = mainVC.viewCoordinator.toolbarTabSwitcherButton.customView {
+            lines.append("type: \(type(of: customView))")
+            lines.append("alpha: \(customView.alpha)")
+            lines.append("isHidden: \(customView.isHidden)")
+            lines.append("isUserInteractionEnabled: \(customView.isUserInteractionEnabled)")
+            lines.append("frame: \(stringify(customView.frame))")
+            lines.append("bounds: \(stringify(customView.bounds))")
+            lines.append("window: \(customView.window != nil ? "in-window" : "no-window")")
+            lines.append("gestureRecognizers: \(customView.gestureRecognizers?.count ?? 0)")
+            for r in customView.gestureRecognizers ?? [] {
+                lines.append("  - \(type(of: r)) state=\(stringify(r.state)) enabled=\(r.isEnabled)")
+            }
+        } else {
+            lines.append("customView: nil")
+        }
+        lines.append("barButton.isEnabled: \(mainVC.viewCoordinator.toolbarTabSwitcherButton.isEnabled)")
+        lines.append("")
+
+        // Header tab switcher button (Duck.ai chrome)
+        if let header = mainVC.aiChatTabChatHeaderView {
+            lines.append("[HEADER TS BUTTON]")
+            let btn = header.tabSwitcherButton
+            lines.append("alpha: \(btn.alpha)")
+            lines.append("isHidden: \(btn.isHidden)")
+            lines.append("isEnabled: \(btn.isEnabled)")
+            lines.append("isUserInteractionEnabled: \(btn.isUserInteractionEnabled)")
+            lines.append("frame: \(stringify(btn.frame))")
+            lines.append("bounds: \(stringify(btn.bounds))")
+            lines.append("window: \(btn.window != nil ? "in-window" : "no-window")")
+            lines.append("gestureRecognizers on button: \(btn.gestureRecognizers?.count ?? 0)")
+            for r in btn.gestureRecognizers ?? [] {
+                lines.append("  - \(type(of: r)) state=\(stringify(r.state)) enabled=\(r.isEnabled)")
+            }
+            // Hit-test sample at the button's center, from the window down. If hit-test
+            // returns anything OTHER than this button (or a descendant that forwards to
+            // it), some other view is sitting on top and stealing the touch — exactly the
+            // case where `touchesBegan` would never fire and this overlay would never appear.
+            if let window = btn.window {
+                let centerInWindow = btn.convert(CGPoint(x: btn.bounds.midX, y: btn.bounds.midY), to: window)
+                if let hit = window.hitTest(centerInWindow, with: nil) {
+                    let isSelfOrDescendant = hit === btn || hit.isDescendant(of: btn)
+                    let routingTag = isSelfOrDescendant ? "OK (routes to button)" : "INTERCEPTED — touch would NOT reach the button"
+                    lines.append("hitTest @ button-center: \(type(of: hit))(\(addr(hit))) — \(routingTag)")
+                } else {
+                    lines.append("hitTest @ button-center: nil")
+                }
+            }
+            // Ancestry: walk button → … → window. Any ancestor with isHidden=true,
+            // alpha < 0.01, or isUserInteractionEnabled=false blocks the touch from
+            // reaching the button regardless of the button's own state. Per-ancestor
+            // gestures show recognizers that might cancel touches mid-flight.
+            lines.append("button ancestry (innermost → outermost):")
+            var cursor: UIView? = btn
+            var depth = 0
+            while let v = cursor, depth < 14 {
+                let indent = String(repeating: "  ", count: depth + 1)
+                let alphaTag = v.alpha < 1 ? " α=\(v.alpha)" : ""
+                let hiddenTag = v.isHidden ? " HIDDEN" : ""
+                let interactiveTag = v.isUserInteractionEnabled ? "" : " NO-UI"
+                let grCount = v.gestureRecognizers?.count ?? 0
+                let grTag = grCount > 0 ? " gestures=\(grCount)" : ""
+                lines.append("\(indent)- \(type(of: v))(\(addr(v))) frame=\(stringify(v.frame))\(alphaTag)\(hiddenTag)\(interactiveTag)\(grTag)")
+                for r in v.gestureRecognizers ?? [] {
+                    lines.append("\(indent)    · \(type(of: r)) state=\(stringify(r.state)) enabled=\(r.isEnabled) cancels=\(r.cancelsTouchesInView)")
+                }
+                cursor = v.superview
+                depth += 1
+            }
+            lines.append("")
+        }
+
+        // First responder — useful if the keyboard or a text field is holding focus and
+        // diverting touches/events. Walk the responder chain from the key window.
+        lines.append("[FIRST RESPONDER]")
+        if let key = mainVC.view.window?.windowScene?.windows.first(where: { $0.isKeyWindow }) {
+            if let fr = findFirstResponder(in: key) {
+                lines.append("type: \(type(of: fr))(\(addr(fr)))")
+                if let v = fr as? UIView {
+                    lines.append("inWindow: \(v.window != nil)")
+                    lines.append("frame: \(stringify(v.frame))")
+                }
+            } else {
+                lines.append("none")
+            }
+        } else {
+            lines.append("no key window")
+        }
+        lines.append("")
+
+        // Gesture recognizers on the toolbar container (UnifiedInputSwipeTabsPanGestureRecognizer etc.)
+        lines.append("[TOOLBAR CONTAINER GESTURES]")
+        for r in mainVC.viewCoordinator.toolbar.gestureRecognizers ?? [] {
+            lines.append("  - \(type(of: r)) state=\(stringify(r.state)) enabled=\(r.isEnabled) cancels=\(r.cancelsTouchesInView)")
+        }
+        lines.append("")
+
+        // Current tab context
+        lines.append("[CURRENT TAB]")
+        if let tabVC = mainVC.currentTab {
+            lines.append("isAITab: \(tabVC.isAITab)")
+            lines.append("link.url.host: \(tabVC.link?.url.host ?? "nil")")
+        } else {
+            lines.append("currentTab: nil")
+        }
+        lines.append("browsingMode: \(mainVC.tabManager.currentBrowsingMode.pixelParamValue)")
+        lines.append("")
+
+        // Experiment lock — separate code path that disables the button entirely
+        lines.append("[EXPERIMENT FIRE-ONBOARDING]")
+        lines.append("controlsLocked: \(mainVC.experimentDuckAIFireOnboardingFlow.controlsLocked)")
+        lines.append("state: \(mainVC.experimentDuckAIFireOnboardingFlow.state)")
+        lines.append("")
+
+        // Windows summary
+        lines.append("[WINDOWS]")
+        if let scene = mainVC.view.window?.windowScene {
+            for (i, window) in scene.windows.enumerated() {
+                let key = window.isKeyWindow ? "key" : "   "
+                let level = window.windowLevel.rawValue
+                let root = window.rootViewController.map { String(describing: type(of: $0)) } ?? "nil"
+                lines.append("[\(i)] \(key) level=\(level) class=\(type(of: window)) root=\(root)")
+            }
+        }
+        lines.append("")
+
+        // Recent in-process log entries pulled from OSLogStore. Limited to our own
+        // subsystems and the last few minutes so the dump stays readable. Lets us see
+        // assertion-style errors, warning logs, and lifecycle traces that ran in the
+        // run-up to the user mashing the button. Cannot capture stderr (UIKit constraint
+        // warnings, NSLog) — those go through a separate sink and aren't reachable.
+        lines.append("[RECENT LOGS]")
+        let logLines = collectRecentLogs(lookbackSeconds: 60, maxEntries: 60)
+        if logLines.isEmpty {
+            lines.append("(none captured)")
+        } else {
+            lines.append(contentsOf: logLines)
+        }
+        lines.append("")
+
+        return lines.joined(separator: "\n")
+    }
+
+    private static let interestingLogSubsystems: Set<String> = [
+        "Lifecycle",
+        "Configuration",
+        "DuckPlayer",
+        "LaunchSource",
+        "AddressBar Picker",
+        "Custom Product Page",
+        "AD Attribution"
+    ]
+
+    private static func collectRecentLogs(lookbackSeconds: TimeInterval, maxEntries: Int) -> [String] {
+        do {
+            let store = try OSLogStore(scope: .currentProcessIdentifier)
+            let position = store.position(date: Date(timeIntervalSinceNow: -lookbackSeconds))
+            let allEntries = try store.getEntries(at: position)
+            var collected: [String] = []
+            for entry in allEntries {
+                guard let log = entry as? OSLogEntryLog else { continue }
+                guard interestingLogSubsystems.contains(log.subsystem) else { continue }
+                let age = String(format: "%6.1fs ago", -log.date.timeIntervalSinceNow)
+                let level = levelTag(log.level)
+                let category = log.category.isEmpty ? "" : "/\(log.category)"
+                collected.append("\(age) [\(level)] \(log.subsystem)\(category): \(log.composedMessage)")
+            }
+            // Take the most recent N — `allEntries` is in chronological order.
+            return Array(collected.suffix(maxEntries))
+        } catch {
+            return ["(OSLogStore unavailable: \(error.localizedDescription))"]
+        }
+    }
+
+    private static func levelTag(_ level: OSLogEntryLog.Level) -> String {
+        switch level {
+        case .undefined: return "—"
+        case .debug: return "D"
+        case .info: return "I"
+        case .notice: return "N"
+        case .error: return "E"
+        case .fault: return "F"
+        @unknown default: return "?"
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func addr(_ obj: AnyObject) -> String {
+        let raw = Unmanaged.passUnretained(obj).toOpaque()
+        return String(describing: raw)
+    }
+
+    private static func describe(vc: UIViewController?) -> String {
+        guard let vc else { return "nil" }
+        return "\(type(of: vc))(\(addr(vc)))"
+    }
+
+    private static func stringify(_ rect: CGRect) -> String {
+        return "{\(Int(rect.origin.x)),\(Int(rect.origin.y)) \(Int(rect.size.width))x\(Int(rect.size.height))}"
+    }
+
+    private static func findFirstResponder(in view: UIView) -> UIResponder? {
+        if view.isFirstResponder { return view }
+        for sub in view.subviews {
+            if let fr = findFirstResponder(in: sub) { return fr }
+        }
+        return nil
+    }
+
+    private static func stringify(_ state: UIGestureRecognizer.State) -> String {
+        switch state {
+        case .possible: return "possible"
+        case .began: return "began"
+        case .changed: return "changed"
+        case .ended: return "ended"
+        case .cancelled: return "cancelled"
+        case .failed: return "failed"
+        @unknown default: return "unknown(\(state.rawValue))"
+        }
+    }
+}
+
+// MARK: - OverlayView
+
+@MainActor
+private final class OverlayView: UIView {
+    private let textView = UITextView()
+    private let dismissHandler: () -> Void
+
+    init(text: String, dismissHandler: @escaping () -> Void) {
+        self.dismissHandler = dismissHandler
+        super.init(frame: .zero)
+        backgroundColor = UIColor.black.withAlphaComponent(0.85)
+        accessibilityIdentifier = "tabSwitcherDiagnosticsOverlay"
+
+        let card = UIView()
+        card.translatesAutoresizingMaskIntoConstraints = false
+        card.backgroundColor = UIColor.systemBackground
+        card.layer.cornerRadius = 14
+        card.clipsToBounds = true
+        addSubview(card)
+
+        let title = UILabel()
+        title.translatesAutoresizingMaskIntoConstraints = false
+        title.text = "⚠️ Did you find Tab Switcher unresponsive?"
+        title.font = .preferredFont(forTextStyle: .headline)
+        title.numberOfLines = 0
+        card.addSubview(title)
+
+        let subtitle = UILabel()
+        subtitle.translatesAutoresizingMaskIntoConstraints = false
+        subtitle.text = "If so, please screenshot this and share with the team — it's the data we need to find the cause. Otherwise, just dismiss."
+        subtitle.font = .preferredFont(forTextStyle: .footnote)
+        subtitle.textColor = .secondaryLabel
+        subtitle.numberOfLines = 0
+        card.addSubview(subtitle)
+
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.text = text
+        textView.font = UIFont.monospacedSystemFont(ofSize: 11, weight: .regular)
+        textView.isEditable = false
+        textView.alwaysBounceVertical = true
+        textView.backgroundColor = UIColor.secondarySystemBackground
+        textView.layer.cornerRadius = 8
+        textView.textContainerInset = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
+        card.addSubview(textView)
+
+        let copyButton = UIButton(type: .system)
+        copyButton.translatesAutoresizingMaskIntoConstraints = false
+        copyButton.setTitle("Copy", for: .normal)
+        // Capture `text` directly (closure copies the value) so the copy works even if
+        // `self` is gone; use [weak copyButton] to avoid the button → closure → button cycle.
+        copyButton.addAction(UIAction { [weak copyButton] _ in
+            UIPasteboard.general.string = text
+            // Read back to confirm — visible feedback also tells the user the copy went through.
+            let written = UIPasteboard.general.string ?? ""
+            copyButton?.setTitle("Copied (\(written.count) chars)", for: .normal)
+            Logger.lifecycle.error("[TabSwitcherDiagnostics] copied \(written.count, privacy: .public) chars to pasteboard")
+        }, for: .touchUpInside)
+        card.addSubview(copyButton)
+
+        let dismissButton = UIButton(type: .system)
+        dismissButton.translatesAutoresizingMaskIntoConstraints = false
+        dismissButton.setTitle("Dismiss", for: .normal)
+        dismissButton.addAction(UIAction { [weak self] _ in
+            self?.removeFromSuperview()
+            self?.dismissHandler()
+        }, for: .touchUpInside)
+        card.addSubview(dismissButton)
+
+        NSLayoutConstraint.activate([
+            card.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            card.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -16),
+            card.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 24),
+            card.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -24),
+
+            title.topAnchor.constraint(equalTo: card.topAnchor, constant: 16),
+            title.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 16),
+            title.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -16),
+
+            subtitle.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 4),
+            subtitle.leadingAnchor.constraint(equalTo: title.leadingAnchor),
+            subtitle.trailingAnchor.constraint(equalTo: title.trailingAnchor),
+
+            textView.topAnchor.constraint(equalTo: subtitle.bottomAnchor, constant: 12),
+            textView.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 12),
+            textView.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -12),
+
+            copyButton.topAnchor.constraint(equalTo: textView.bottomAnchor, constant: 8),
+            copyButton.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 16),
+            copyButton.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -12),
+
+            dismissButton.centerYAnchor.constraint(equalTo: copyButton.centerYAnchor),
+            dismissButton.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -16),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/iOS/DuckDuckGo/TabSwitcherDiagnosticsOverlay.swift
+++ b/iOS/DuckDuckGo/TabSwitcherDiagnosticsOverlay.swift
@@ -40,28 +40,24 @@ enum TabSwitcherDiagnosticsOverlay {
     /// Sliding window over which `tapThreshold` is measured.
     static let tapWindow: TimeInterval = 5
 
-    /// Shared mutable state used by `MainViewController` to track tap timestamps, recent
-    /// request outcomes, and avoid re-presenting the overlay while it's already on screen.
-    final class State {
-        static let shared = State()
-        var tapTimestamps: [Date] = []
-        var overlayVisible = false
-        /// Ring buffer of the last `maxRecentEvents` outcomes from the tab-switcher launch
-        /// pipeline (entered → guard hit / presenting / present completion / dismissed).
-        /// This is the trace you actually need to tell whether the bug is "guard rejected
-        /// the tap", "present silently failed", or "nothing at all reached the chain".
-        var recentEvents: [(Date, String)] = []
-        static let maxRecentEvents = 12
-        private init() {}
-    }
+    // MARK: Module-level mutable state (main-actor isolated by the enclosing enum)
+
+    private static var tapTimestamps: [Date] = []
+    private static var overlayVisible = false
+    /// Ring buffer of the last `maxRecentEvents` outcomes from the tab-switcher launch
+    /// pipeline (entered → guard hit / presenting / present completion / dismissed). This
+    /// is the trace that tells whether the bug is "guard rejected the tap", "present
+    /// silently failed", or "nothing at all reached the chain".
+    private static var recentEvents: [(Date, String)] = []
+    private static let maxRecentEvents = 12
 
     /// Append an event to the per-request outcome trace. Cheap; safe to call from any
     /// point in the tab-switcher launch chain.
     static func recordEvent(_ label: String) {
-        State.shared.recentEvents.append((Date(), label))
-        let overflow = State.shared.recentEvents.count - State.maxRecentEvents
+        recentEvents.append((Date(), label))
+        let overflow = recentEvents.count - maxRecentEvents
         if overflow > 0 {
-            State.shared.recentEvents.removeFirst(overflow)
+            recentEvents.removeFirst(overflow)
         }
     }
 
@@ -80,35 +76,34 @@ enum TabSwitcherDiagnosticsOverlay {
     /// view, in the wrong window, etc.
     static func recordTapAndShouldShow() -> Bool {
         guard isEnabled else { return false }
-        let state = State.shared
         let now = Date()
-        state.tapTimestamps = state.tapTimestamps.filter { now.timeIntervalSince($0) <= tapWindow }
-        state.tapTimestamps.append(now)
-        if state.overlayVisible { return false }
-        return state.tapTimestamps.count >= tapThreshold
+        tapTimestamps = tapTimestamps.filter { now.timeIntervalSince($0) <= tapWindow }
+        tapTimestamps.append(now)
+        if overlayVisible { return false }
+        return tapTimestamps.count >= tapThreshold
     }
 
     /// Clear the tap counter — call from the `present` completion when the tab switcher
     /// actually appears, so a subsequent tap doesn't carry stale history.
     static func clearTapHistory() {
-        State.shared.tapTimestamps.removeAll()
+        tapTimestamps.removeAll()
     }
 
     /// Show the diagnostic overlay over the supplied MainViewController's key window.
     /// Logs the same content via `Logger.lifecycle.error` so it also appears in device logs.
     static func show(from mainVC: MainViewController) {
         guard isEnabled else { return }
-        guard !State.shared.overlayVisible, let window = mainVC.view.window else { return }
+        guard !overlayVisible, let window = mainVC.view.window else { return }
         let snapshot = collect(from: mainVC)
         Logger.lifecycle.error("[TabSwitcherDiagnostics]\n\(snapshot, privacy: .public)")
         let overlay = OverlayView(text: snapshot) {
-            State.shared.overlayVisible = false
-            State.shared.tapTimestamps.removeAll()
+            overlayVisible = false
+            tapTimestamps.removeAll()
         }
         overlay.frame = window.bounds
         overlay.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         window.addSubview(overlay)
-        State.shared.overlayVisible = true
+        overlayVisible = true
     }
 
     // MARK: - Diagnostics
@@ -121,89 +116,127 @@ enum TabSwitcherDiagnosticsOverlay {
 
     static func collect(from mainVC: MainViewController) -> String {
         var lines: [String] = []
+        lines.append(contentsOf: collectRecentRequests())
+        lines.append(contentsOf: collectTabSwitcherVC(mainVC))
+        lines.append(contentsOf: collectMainVC(mainVC))
+        lines.append(contentsOf: collectPresentationChain(mainVC))
+        lines.append(contentsOf: collectFullVCTree(mainVC))
+        lines.append(contentsOf: collectToolbarTSButton(mainVC))
+        lines.append(contentsOf: collectHeaderTSButton(mainVC))
+        lines.append(contentsOf: collectFirstResponder(mainVC))
+        lines.append(contentsOf: collectToolbarContainerGestures(mainVC))
+        lines.append(contentsOf: collectCurrentTab(mainVC))
+        lines.append(contentsOf: collectExperimentState(mainVC))
+        lines.append(contentsOf: collectWindows(mainVC))
 
-        // Per-request timeline — most actionable signal. Tells us whether each recent
-        // tap reached `present`, was rejected by a guard, or completed presentation.
-        lines.append("[RECENT REQUESTS] (last \(State.maxRecentEvents))")
-        if State.shared.recentEvents.isEmpty {
+        // Recent in-process log entries pulled from OSLogStore. Limited to our own
+        // subsystems and the last few minutes so the dump stays readable. Lets us see
+        // assertion-style errors, warning logs, and lifecycle traces that ran in the
+        // run-up to the user mashing the button. Cannot capture stderr (UIKit constraint
+        // warnings, NSLog) — those go through a separate sink and aren't reachable.
+        lines.append("[RECENT LOGS]")
+        let logLines = collectRecentLogs(lookbackSeconds: 60, maxEntries: 60)
+        if logLines.isEmpty {
+            lines.append("(none captured)")
+        } else {
+            lines.append(contentsOf: logLines)
+        }
+        lines.append("")
+
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: - Section collectors
+
+    /// Per-request timeline — most actionable signal. Tells us whether each recent tap
+    /// reached `present`, was rejected by a guard, or completed presentation.
+    private static func collectRecentRequests() -> [String] {
+        var lines: [String] = ["[RECENT REQUESTS] (last \(maxRecentEvents))"]
+        if recentEvents.isEmpty {
             lines.append("(none recorded)")
         } else {
             let now = Date()
-            for (ts, label) in State.shared.recentEvents {
+            for (ts, label) in recentEvents {
                 let age = String(format: "%6.2fs ago", now.timeIntervalSince(ts))
                 lines.append("\(age)  \(label)")
             }
         }
         lines.append("")
+        return lines
+    }
 
-        // Tab switcher VC state
-        lines.append("[TAB SWITCHER VC]")
-        if let tsvc = mainVC.tabSwitcherController {
-            lines.append("ref: live(\(addr(tsvc)))")
-            lines.append("isViewLoaded: \(tsvc.isViewLoaded)")
-            if let view = tsvc.viewIfLoaded {
-                lines.append("view.window: \(view.window != nil ? "in-window(level=\(view.window!.windowLevel.rawValue))" : "no-window")")
-                lines.append("view.alpha: \(view.alpha)")
-                lines.append("view.isHidden: \(view.isHidden)")
-                lines.append("view.frame: \(stringify(view.frame))")
-                lines.append("view.bounds: \(stringify(view.bounds))")
-                // Walk superview ancestry — if the view is detached or buried under
-                // some unexpected container, this shows where it lives now.
-                lines.append("view ancestry (innermost → outermost):")
-                var cursor: UIView? = view
-                var ancestryDepth = 0
-                while let v = cursor, ancestryDepth < 14 {
-                    let indent = String(repeating: "  ", count: ancestryDepth + 1)
-                    let alphaTag = v.alpha < 1 ? " α=\(v.alpha)" : ""
-                    let hiddenTag = v.isHidden ? " HIDDEN" : ""
-                    let interactiveTag = v.isUserInteractionEnabled ? "" : " NO-UI"
-                    lines.append("\(indent)- \(type(of: v))(\(addr(v))) frame=\(stringify(v.frame))\(alphaTag)\(hiddenTag)\(interactiveTag)")
-                    cursor = v.superview
-                    ancestryDepth += 1
-                }
-                // Sibling z-order — if the TSVC view is in a window but covered by a sibling
-                // with a higher index, we want to see the sibling on top.
-                if let parent = view.superview {
-                    lines.append("siblings in superview (back → front, * = TSVC view):")
-                    for (idx, sib) in parent.subviews.enumerated() {
-                        let marker = sib === view ? " *" : ""
-                        let alphaTag = sib.alpha < 1 ? " α=\(sib.alpha)" : ""
-                        let hiddenTag = sib.isHidden ? " HIDDEN" : ""
-                        lines.append("  [\(idx)]\(marker) \(type(of: sib))(\(addr(sib))) frame=\(stringify(sib.frame))\(alphaTag)\(hiddenTag)")
-                    }
-                }
-                // Hit-test sample at center to see what UIKit would route a tap to if
-                // someone tried to interact with where the TSVC should be.
-                if let window = view.window {
-                    let centerInWindow = view.convert(CGPoint(x: view.bounds.midX, y: view.bounds.midY), to: window)
-                    if let hit = window.hitTest(centerInWindow, with: nil) {
-                        lines.append("hitTest @ tsvc-center: \(type(of: hit))(\(addr(hit))) frame=\(stringify(hit.frame))")
-                    } else {
-                        lines.append("hitTest @ tsvc-center: nil")
-                    }
-                }
-            }
-            lines.append("isBeingPresented: \(tsvc.isBeingPresented)")
-            lines.append("isBeingDismissed: \(tsvc.isBeingDismissed)")
-            lines.append("parent: \(tsvc.parent.map { String(describing: type(of: $0)) } ?? "nil")")
-            lines.append("presentingVC: \(tsvc.presentingViewController.map { String(describing: type(of: $0)) } ?? "nil")")
-        } else {
+    private static func collectTabSwitcherVC(_ mainVC: MainViewController) -> [String] {
+        var lines: [String] = ["[TAB SWITCHER VC]"]
+        guard let tsvc = mainVC.tabSwitcherController else {
             lines.append("ref: nil (weak — never presented, or fully released)")
+            lines.append("")
+            return lines
         }
+        lines.append("ref: live(\(addr(tsvc)))")
+        lines.append("isViewLoaded: \(tsvc.isViewLoaded)")
+        if let view = tsvc.viewIfLoaded {
+            lines.append(contentsOf: describeTSVCView(view))
+        }
+        lines.append("isBeingPresented: \(tsvc.isBeingPresented)")
+        lines.append("isBeingDismissed: \(tsvc.isBeingDismissed)")
+        lines.append("parent: \(tsvc.parent.map { String(describing: type(of: $0)) } ?? "nil")")
+        lines.append("presentingVC: \(tsvc.presentingViewController.map { String(describing: type(of: $0)) } ?? "nil")")
         lines.append("")
+        return lines
+    }
 
-        // MainVC state
-        lines.append("[MAIN VC]")
-        lines.append("presentedVC: \(describe(vc: mainVC.presentedViewController))")
-        lines.append("presentingVC: \(describe(vc: mainVC.presentingViewController))")
-        lines.append("isBeingPresented: \(mainVC.isBeingPresented)")
-        lines.append("isBeingDismissed: \(mainVC.isBeingDismissed)")
-        lines.append("transitionCoordinator: \(mainVC.transitionCoordinator != nil ? "ACTIVE" : "nil")")
-        lines.append("view.window: \(mainVC.view.window != nil ? "in-window" : "no-window")")
-        lines.append("")
+    /// Walk the TSVC view's superview ancestry + sibling z-order + hit-test sample.
+    private static func describeTSVCView(_ view: UIView) -> [String] {
+        var lines: [String] = []
+        let windowTag = view.window.map { "in-window(level=\($0.windowLevel.rawValue))" } ?? "no-window"
+        lines.append("view.window: \(windowTag)")
+        lines.append("view.alpha: \(view.alpha)")
+        lines.append("view.isHidden: \(view.isHidden)")
+        lines.append("view.frame: \(stringify(view.frame))")
+        lines.append("view.bounds: \(stringify(view.bounds))")
+        lines.append("view ancestry (innermost → outermost):")
+        var cursor: UIView? = view
+        var depth = 0
+        while let v = cursor, depth < 14 {
+            lines.append(ancestryLine(for: v, depth: depth, includeGestures: false))
+            cursor = v.superview
+            depth += 1
+        }
+        if let parent = view.superview {
+            lines.append("siblings in superview (back → front, * = TSVC view):")
+            for (idx, sib) in parent.subviews.enumerated() {
+                let marker = sib === view ? " *" : ""
+                let alphaTag = sib.alpha < 1 ? " α=\(sib.alpha)" : ""
+                let hiddenTag = sib.isHidden ? " HIDDEN" : ""
+                lines.append("  [\(idx)]\(marker) \(type(of: sib))(\(addr(sib))) frame=\(stringify(sib.frame))\(alphaTag)\(hiddenTag)")
+            }
+        }
+        if let window = view.window {
+            let centerInWindow = view.convert(CGPoint(x: view.bounds.midX, y: view.bounds.midY), to: window)
+            if let hit = window.hitTest(centerInWindow, with: nil) {
+                lines.append("hitTest @ tsvc-center: \(type(of: hit))(\(addr(hit))) frame=\(stringify(hit.frame))")
+            } else {
+                lines.append("hitTest @ tsvc-center: nil")
+            }
+        }
+        return lines
+    }
 
-        // Presentation chain
-        lines.append("[PRESENTATION CHAIN]")
+    private static func collectMainVC(_ mainVC: MainViewController) -> [String] {
+        return [
+            "[MAIN VC]",
+            "presentedVC: \(describe(vc: mainVC.presentedViewController))",
+            "presentingVC: \(describe(vc: mainVC.presentingViewController))",
+            "isBeingPresented: \(mainVC.isBeingPresented)",
+            "isBeingDismissed: \(mainVC.isBeingDismissed)",
+            "transitionCoordinator: \(mainVC.transitionCoordinator != nil ? "ACTIVE" : "nil")",
+            "view.window: \(mainVC.view.window != nil ? "in-window" : "no-window")",
+            ""
+        ]
+    }
+
+    private static func collectPresentationChain(_ mainVC: MainViewController) -> [String] {
+        var lines: [String] = ["[PRESENTATION CHAIN]"]
         var current: UIViewController? = mainVC.view.window?.rootViewController
         var depth = 0
         while let vc = current, depth < 12 {
@@ -216,48 +249,54 @@ enum TabSwitcherDiagnosticsOverlay {
             depth += 1
         }
         lines.append("")
+        return lines
+    }
 
-        // Full VC tree — children + presentedVC at every level. Catches container VCs
-        // (nav controllers, custom containers) and child VCs that the linear presentation
-        // chain would miss. Capped at 80 lines / depth 12 to keep the dump readable.
-        lines.append("[FULL VC TREE]")
-        if let key = mainVC.view.window?.windowScene?.windows.first(where: { $0.isKeyWindow }),
-           let root = key.rootViewController {
-            var emitted = 0
-            func walk(_ vc: UIViewController, depth: Int) {
-                guard emitted < 80, depth < 12 else { return }
-                let indent = String(repeating: "  ", count: depth)
-                let viewTag: String
-                if let v = vc.viewIfLoaded {
-                    let attached = v.window != nil ? "win" : "no-win"
-                    viewTag = " view=\(attached) frame=\(stringify(v.frame))"
-                } else {
-                    viewTag = " view-not-loaded"
-                }
-                let bP = vc.isBeingPresented ? " [bP]" : ""
-                let bD = vc.isBeingDismissed ? " [bD]" : ""
-                let tc = vc.transitionCoordinator != nil ? " [TC]" : ""
-                lines.append("\(indent)- \(type(of: vc))(\(addr(vc)))\(viewTag)\(bP)\(bD)\(tc)")
-                emitted += 1
-                for child in vc.children {
-                    walk(child, depth: depth + 1)
-                }
-                if let presented = vc.presentedViewController {
-                    lines.append("\(indent)  ↳ presents:")
-                    walk(presented, depth: depth + 1)
-                }
-            }
-            walk(root, depth: 0)
-            if emitted >= 80 {
-                lines.append("… (truncated at 80 entries)")
-            }
-        } else {
+    /// children + presentedVC at every level. Catches container VCs (nav controllers, custom
+    /// containers) and child VCs that the linear presentation chain would miss.
+    private static func collectFullVCTree(_ mainVC: MainViewController) -> [String] {
+        var lines: [String] = ["[FULL VC TREE]"]
+        guard let key = mainVC.view.window?.windowScene?.windows.first(where: { $0.isKeyWindow }),
+              let root = key.rootViewController else {
             lines.append("(no key window)")
+            lines.append("")
+            return lines
+        }
+        var emitted = 0
+        walkVCTree(root, depth: 0, emitted: &emitted, lines: &lines)
+        if emitted >= 80 {
+            lines.append("… (truncated at 80 entries)")
         }
         lines.append("")
+        return lines
+    }
 
-        // Toolbar tab switcher button
-        lines.append("[TOOLBAR TS BUTTON]")
+    private static func walkVCTree(_ vc: UIViewController, depth: Int, emitted: inout Int, lines: inout [String]) {
+        guard emitted < 80, depth < 12 else { return }
+        let indent = String(repeating: "  ", count: depth)
+        let viewTag: String
+        if let v = vc.viewIfLoaded {
+            let attached = v.window != nil ? "win" : "no-win"
+            viewTag = " view=\(attached) frame=\(stringify(v.frame))"
+        } else {
+            viewTag = " view-not-loaded"
+        }
+        let bP = vc.isBeingPresented ? " [bP]" : ""
+        let bD = vc.isBeingDismissed ? " [bD]" : ""
+        let tc = vc.transitionCoordinator != nil ? " [TC]" : ""
+        lines.append("\(indent)- \(type(of: vc))(\(addr(vc)))\(viewTag)\(bP)\(bD)\(tc)")
+        emitted += 1
+        for child in vc.children {
+            walkVCTree(child, depth: depth + 1, emitted: &emitted, lines: &lines)
+        }
+        if let presented = vc.presentedViewController {
+            lines.append("\(indent)  ↳ presents:")
+            walkVCTree(presented, depth: depth + 1, emitted: &emitted, lines: &lines)
+        }
+    }
+
+    private static func collectToolbarTSButton(_ mainVC: MainViewController) -> [String] {
+        var lines: [String] = ["[TOOLBAR TS BUTTON]"]
         if let customView = mainVC.viewCoordinator.toolbarTabSwitcherButton.customView {
             lines.append("type: \(type(of: customView))")
             lines.append("alpha: \(customView.alpha)")
@@ -275,87 +314,102 @@ enum TabSwitcherDiagnosticsOverlay {
         }
         lines.append("barButton.isEnabled: \(mainVC.viewCoordinator.toolbarTabSwitcherButton.isEnabled)")
         lines.append("")
+        return lines
+    }
 
-        // Header tab switcher button (Duck.ai chrome)
-        if let header = mainVC.aiChatTabChatHeaderView {
-            lines.append("[HEADER TS BUTTON]")
-            let btn = header.tabSwitcherButton
-            lines.append("alpha: \(btn.alpha)")
-            lines.append("isHidden: \(btn.isHidden)")
-            lines.append("isEnabled: \(btn.isEnabled)")
-            lines.append("isUserInteractionEnabled: \(btn.isUserInteractionEnabled)")
-            lines.append("frame: \(stringify(btn.frame))")
-            lines.append("bounds: \(stringify(btn.bounds))")
-            lines.append("window: \(btn.window != nil ? "in-window" : "no-window")")
-            lines.append("gestureRecognizers on button: \(btn.gestureRecognizers?.count ?? 0)")
-            for r in btn.gestureRecognizers ?? [] {
-                lines.append("  - \(type(of: r)) state=\(stringify(r.state)) enabled=\(r.isEnabled)")
-            }
-            // Hit-test sample at the button's center, from the window down. If hit-test
-            // returns anything OTHER than this button (or a descendant that forwards to
-            // it), some other view is sitting on top and stealing the touch — exactly the
-            // case where `touchesBegan` would never fire and this overlay would never appear.
-            if let window = btn.window {
-                let centerInWindow = btn.convert(CGPoint(x: btn.bounds.midX, y: btn.bounds.midY), to: window)
-                if let hit = window.hitTest(centerInWindow, with: nil) {
-                    let isSelfOrDescendant = hit === btn || hit.isDescendant(of: btn)
-                    let routingTag = isSelfOrDescendant ? "OK (routes to button)" : "INTERCEPTED — touch would NOT reach the button"
-                    lines.append("hitTest @ button-center: \(type(of: hit))(\(addr(hit))) — \(routingTag)")
-                } else {
-                    lines.append("hitTest @ button-center: nil")
-                }
-            }
-            // Ancestry: walk button → … → window. Any ancestor with isHidden=true,
-            // alpha < 0.01, or isUserInteractionEnabled=false blocks the touch from
-            // reaching the button regardless of the button's own state. Per-ancestor
-            // gestures show recognizers that might cancel touches mid-flight.
-            lines.append("button ancestry (innermost → outermost):")
-            var cursor: UIView? = btn
-            var depth = 0
-            while let v = cursor, depth < 14 {
-                let indent = String(repeating: "  ", count: depth + 1)
-                let alphaTag = v.alpha < 1 ? " α=\(v.alpha)" : ""
-                let hiddenTag = v.isHidden ? " HIDDEN" : ""
-                let interactiveTag = v.isUserInteractionEnabled ? "" : " NO-UI"
-                let grCount = v.gestureRecognizers?.count ?? 0
-                let grTag = grCount > 0 ? " gestures=\(grCount)" : ""
-                lines.append("\(indent)- \(type(of: v))(\(addr(v))) frame=\(stringify(v.frame))\(alphaTag)\(hiddenTag)\(interactiveTag)\(grTag)")
-                for r in v.gestureRecognizers ?? [] {
-                    lines.append("\(indent)    · \(type(of: r)) state=\(stringify(r.state)) enabled=\(r.isEnabled) cancels=\(r.cancelsTouchesInView)")
-                }
-                cursor = v.superview
-                depth += 1
-            }
-            lines.append("")
+    /// Duck.ai chrome's tab switcher button — the one the bug has been reported against.
+    /// Includes ancestry + hit-test routing to surface "touch can't reach button" cases.
+    private static func collectHeaderTSButton(_ mainVC: MainViewController) -> [String] {
+        guard let header = mainVC.aiChatTabChatHeaderView else { return [] }
+        let btn = header.tabSwitcherButton
+        var lines: [String] = ["[HEADER TS BUTTON]"]
+        lines.append("alpha: \(btn.alpha)")
+        lines.append("isHidden: \(btn.isHidden)")
+        lines.append("isEnabled: \(btn.isEnabled)")
+        lines.append("isUserInteractionEnabled: \(btn.isUserInteractionEnabled)")
+        lines.append("frame: \(stringify(btn.frame))")
+        lines.append("bounds: \(stringify(btn.bounds))")
+        lines.append("window: \(btn.window != nil ? "in-window" : "no-window")")
+        lines.append("gestureRecognizers on button: \(btn.gestureRecognizers?.count ?? 0)")
+        for r in btn.gestureRecognizers ?? [] {
+            lines.append("  - \(type(of: r)) state=\(stringify(r.state)) enabled=\(r.isEnabled)")
         }
-
-        // First responder — useful if the keyboard or a text field is holding focus and
-        // diverting touches/events. Walk the responder chain from the key window.
-        lines.append("[FIRST RESPONDER]")
-        if let key = mainVC.view.window?.windowScene?.windows.first(where: { $0.isKeyWindow }) {
-            if let fr = findFirstResponder(in: key) {
-                lines.append("type: \(type(of: fr))(\(addr(fr)))")
-                if let v = fr as? UIView {
-                    lines.append("inWindow: \(v.window != nil)")
-                    lines.append("frame: \(stringify(v.frame))")
-                }
-            } else {
-                lines.append("none")
+        lines.append(headerHitTestLine(for: btn))
+        lines.append("button ancestry (innermost → outermost):")
+        var cursor: UIView? = btn
+        var depth = 0
+        while let v = cursor, depth < 14 {
+            lines.append(ancestryLine(for: v, depth: depth, includeGestures: true))
+            let indent = String(repeating: "  ", count: depth + 1)
+            for r in v.gestureRecognizers ?? [] {
+                lines.append("\(indent)    · \(type(of: r)) state=\(stringify(r.state)) enabled=\(r.isEnabled) cancels=\(r.cancelsTouchesInView)")
             }
-        } else {
-            lines.append("no key window")
+            cursor = v.superview
+            depth += 1
         }
         lines.append("")
+        return lines
+    }
 
-        // Gesture recognizers on the toolbar container (UnifiedInputSwipeTabsPanGestureRecognizer etc.)
-        lines.append("[TOOLBAR CONTAINER GESTURES]")
+    private static func headerHitTestLine(for btn: UIView) -> String {
+        guard let window = btn.window else { return "hitTest @ button-center: (no window)" }
+        let centerInWindow = btn.convert(CGPoint(x: btn.bounds.midX, y: btn.bounds.midY), to: window)
+        guard let hit = window.hitTest(centerInWindow, with: nil) else {
+            return "hitTest @ button-center: nil"
+        }
+        let isSelfOrDescendant = hit === btn || hit.isDescendant(of: btn)
+        let routingTag = isSelfOrDescendant ? "OK (routes to button)" : "INTERCEPTED — touch would NOT reach the button"
+        return "hitTest @ button-center: \(type(of: hit))(\(addr(hit))) — \(routingTag)"
+    }
+
+    /// Renders one ancestry line; `includeGestures` controls whether the gesture-count
+    /// tag is appended (the per-ancestor list is rendered separately by the caller).
+    private static func ancestryLine(for v: UIView, depth: Int, includeGestures: Bool) -> String {
+        let indent = String(repeating: "  ", count: depth + 1)
+        let alphaTag = v.alpha < 1 ? " α=\(v.alpha)" : ""
+        let hiddenTag = v.isHidden ? " HIDDEN" : ""
+        let interactiveTag = v.isUserInteractionEnabled ? "" : " NO-UI"
+        let grTag: String
+        if includeGestures {
+            let count = v.gestureRecognizers?.count ?? 0
+            grTag = count > 0 ? " gestures=\(count)" : ""
+        } else {
+            grTag = ""
+        }
+        return "\(indent)- \(type(of: v))(\(addr(v))) frame=\(stringify(v.frame))\(alphaTag)\(hiddenTag)\(interactiveTag)\(grTag)"
+    }
+
+    private static func collectFirstResponder(_ mainVC: MainViewController) -> [String] {
+        var lines: [String] = ["[FIRST RESPONDER]"]
+        guard let key = mainVC.view.window?.windowScene?.windows.first(where: { $0.isKeyWindow }) else {
+            lines.append("no key window")
+            lines.append("")
+            return lines
+        }
+        if let fr = findFirstResponder(in: key) {
+            lines.append("type: \(type(of: fr))(\(addr(fr)))")
+            if let v = fr as? UIView {
+                lines.append("inWindow: \(v.window != nil)")
+                lines.append("frame: \(stringify(v.frame))")
+            }
+        } else {
+            lines.append("none")
+        }
+        lines.append("")
+        return lines
+    }
+
+    private static func collectToolbarContainerGestures(_ mainVC: MainViewController) -> [String] {
+        var lines: [String] = ["[TOOLBAR CONTAINER GESTURES]"]
         for r in mainVC.viewCoordinator.toolbar.gestureRecognizers ?? [] {
             lines.append("  - \(type(of: r)) state=\(stringify(r.state)) enabled=\(r.isEnabled) cancels=\(r.cancelsTouchesInView)")
         }
         lines.append("")
+        return lines
+    }
 
-        // Current tab context
-        lines.append("[CURRENT TAB]")
+    private static func collectCurrentTab(_ mainVC: MainViewController) -> [String] {
+        var lines: [String] = ["[CURRENT TAB]"]
         if let tabVC = mainVC.currentTab {
             lines.append("isAITab: \(tabVC.isAITab)")
             lines.append("link.url.host: \(tabVC.link?.url.host ?? "nil")")
@@ -364,15 +418,20 @@ enum TabSwitcherDiagnosticsOverlay {
         }
         lines.append("browsingMode: \(mainVC.tabManager.currentBrowsingMode.pixelParamValue)")
         lines.append("")
+        return lines
+    }
 
-        // Experiment lock — separate code path that disables the button entirely
-        lines.append("[EXPERIMENT FIRE-ONBOARDING]")
-        lines.append("controlsLocked: \(mainVC.experimentDuckAIFireOnboardingFlow.controlsLocked)")
-        lines.append("state: \(mainVC.experimentDuckAIFireOnboardingFlow.state)")
-        lines.append("")
+    private static func collectExperimentState(_ mainVC: MainViewController) -> [String] {
+        return [
+            "[EXPERIMENT FIRE-ONBOARDING]",
+            "controlsLocked: \(mainVC.experimentDuckAIFireOnboardingFlow.controlsLocked)",
+            "state: \(mainVC.experimentDuckAIFireOnboardingFlow.state)",
+            ""
+        ]
+    }
 
-        // Windows summary
-        lines.append("[WINDOWS]")
+    private static func collectWindows(_ mainVC: MainViewController) -> [String] {
+        var lines: [String] = ["[WINDOWS]"]
         if let scene = mainVC.view.window?.windowScene {
             for (i, window) in scene.windows.enumerated() {
                 let key = window.isKeyWindow ? "key" : "   "
@@ -382,22 +441,7 @@ enum TabSwitcherDiagnosticsOverlay {
             }
         }
         lines.append("")
-
-        // Recent in-process log entries pulled from OSLogStore. Limited to our own
-        // subsystems and the last few minutes so the dump stays readable. Lets us see
-        // assertion-style errors, warning logs, and lifecycle traces that ran in the
-        // run-up to the user mashing the button. Cannot capture stderr (UIKit constraint
-        // warnings, NSLog) — those go through a separate sink and aren't reachable.
-        lines.append("[RECENT LOGS]")
-        let logLines = collectRecentLogs(lookbackSeconds: 60, maxEntries: 60)
-        if logLines.isEmpty {
-            lines.append("(none captured)")
-        } else {
-            lines.append(contentsOf: logLines)
-        }
-        lines.append("")
-
-        return lines.joined(separator: "\n")
+        return lines
     }
 
     private static let interestingLogSubsystems: Set<String> = [

--- a/iOS/DuckDuckGo/TabSwitcherDiagnosticsOverlay.swift
+++ b/iOS/DuckDuckGo/TabSwitcherDiagnosticsOverlay.swift
@@ -83,12 +83,6 @@ enum TabSwitcherDiagnosticsOverlay {
         return tapTimestamps.count >= tapThreshold
     }
 
-    /// Clear the tap counter — call from the `present` completion when the tab switcher
-    /// actually appears, so a subsequent tap doesn't carry stale history.
-    static func clearTapHistory() {
-        tapTimestamps.removeAll()
-    }
-
     /// Show the diagnostic overlay over the supplied MainViewController's key window.
     /// Logs the same content via `Logger.lifecycle.error` so it also appears in device logs.
     static func show(from mainVC: MainViewController) {
@@ -586,9 +580,9 @@ private final class OverlayView: UIView {
         let dismissButton = UIButton(type: .system)
         dismissButton.translatesAutoresizingMaskIntoConstraints = false
         dismissButton.setTitle("Dismiss", for: .normal)
-        dismissButton.addAction(UIAction { [weak self] _ in
+        dismissButton.addAction(UIAction { [weak self, handler = dismissHandler] _ in
             self?.removeFromSuperview()
-            self?.dismissHandler()
+            handler()
         }, for: .touchUpInside)
         card.addSubview(dismissButton)
 

--- a/iOS/DuckDuckGo/TabSwitcherDiagnosticsOverlay.swift
+++ b/iOS/DuckDuckGo/TabSwitcherDiagnosticsOverlay.swift
@@ -38,7 +38,7 @@ enum TabSwitcherDiagnosticsOverlay {
     /// user is tap-mashing the button, so the team can capture full state.
     static let tapThreshold = 3
     /// Sliding window over which `tapThreshold` is measured.
-    static let tapWindow: TimeInterval = 6
+    static let tapWindow: TimeInterval = 5
 
     /// Shared mutable state used by `MainViewController` to track tap timestamps, recent
     /// request outcomes, and avoid re-presenting the overlay while it's already on screen.

--- a/iOS/DuckDuckGo/ToolbarButtons/TabSwitcherStaticButton.swift
+++ b/iOS/DuckDuckGo/ToolbarButtons/TabSwitcherStaticButton.swift
@@ -26,6 +26,13 @@ final class TabSwitcherStaticButton: BrowserChromeButton, TabSwitcherButton {
     private let tabSwitcherView = TabSwitcherStaticView()
     private var longPressRecognizer: UILongPressGestureRecognizer!
     weak var delegate: TabSwitcherButtonDelegate?
+
+    /// Fires the moment a touch lands on the button — *before* UIControl starts tracking
+    /// and before any gesture recognizer can cancel the touch. Set by the host (currently
+    /// the AI-chat header) to feed the unresponsive-tab-switcher diagnostic overlay's tap
+    /// counter; the standard `.touchUpInside` action wouldn't fire if tracking gets
+    /// cancelled, which is exactly the case we want to surface.
+    var onTouchDown: (() -> Void)?
     var showMenuOnLongPress: Bool {
         didSet {
             configureLongPressBehavior()
@@ -127,6 +134,11 @@ final class TabSwitcherStaticButton: BrowserChromeButton, TabSwitcherButton {
         }
 
         animator1.startAnimation()
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        onTouchDown?()
+        super.touchesBegan(touches, with: event)
     }
 
     override func tintColorDidChange() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -687,6 +687,15 @@ private extension MainViewController {
         headerView.translatesAutoresizingMaskIntoConstraints = false
         headerView.tabSwitcherButton.delegate = self
         headerView.tabSwitcherButton.showMenuOnLongPress = fireModeCapability.isFireModeEnabled
+        // Catch touches at the most upstream point — before UIControl tracking, before any
+        // gesture recognizer can cancel the tap. Surfaces the unresponsive-tab-switcher
+        // diagnostic even when `.touchUpInside` never fires (which is the bug we're hunting).
+        headerView.tabSwitcherButton.onTouchDown = { [weak self] in
+            guard let self else { return }
+            if TabSwitcherDiagnosticsOverlay.recordTapAndShouldShow() {
+                TabSwitcherDiagnosticsOverlay.show(from: self)
+            }
+        }
         viewCoordinator.aiChatTabChatHeaderContainer.addSubview(headerView)
         NSLayoutConstraint.activate([
             headerView.topAnchor.constraint(equalTo: viewCoordinator.aiChatTabChatHeaderContainer.topAnchor),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215028409030026

### Description

Adds a self-service diagnostic overlay for the intermittent "Tab Switcher unresponsive" bug. When an internal/alpha user taps the AI chat header's tab switcher button 3+ times within 6 seconds, an overlay drops down with a full snapshot of relevant app state so the team can screenshot it and share it back. No product behaviour changes — purely additive instrumentation, gated to non-production builds and internal users.

The overlay captures:

- **Recent requests** — the last 12 events from the tab-switcher launch pipeline (`requestTabSwitcher entered → guard1/2 rejected / calling present / present completion / dismissed`) with time-ago tags.
- **Tab Switcher VC** + **Main VC** — weak-ref status, presentation state, transition coordinator, `isBeingPresented`/`isBeingDismissed` flags.
- **Presentation chain** + **Full VC tree** — children + presentedVC walk from the key window's rootVC down.
- **Toolbar TS Button** + **Header TS Button** — alpha/hidden/enabled/userInteractionEnabled, attached gesture recognizers, frame & bounds.
- **Header button ancestry** — the full chain from the header tab-switcher button up to the window, with each ancestor's view flags, gesture recognizers, frame; plus a hit-test sample at the button's center that flags `INTERCEPTED — touch would NOT reach the button` when something else is on top.
- **First responder**, **Toolbar container gestures**, **Current tab** (isAITab, host), **Experiment fire-onboarding lock**, **All windows** with levels.
- **Recent logs** — last 60 seconds pulled from `OSLogStore` for our own subsystems.

The trigger lives in `TabSwitcherStaticButton.touchesBegan` (the most upstream hook — fires before UIControl tracking and before any gesture recognizer can cancel the touch). The toolbar's instance leaves `onTouchDown` nil, so this only fires for the Duck.ai header's tab switcher button.

### Testing Steps

1. Run a DEBUG/ALPHA build (or be flagged as an internal user on production).
2. Open a Duck.ai tab so the AI chat header pill is visible at the top.
3. Tap the tab switcher icon in the header pill **3 times within 5 seconds**.
4. Verify the diagnostic overlay appears with title "⚠️ Did you find Tab Switcher unresponsive?" and the labelled sections above.
5. Tap **Copy** — verify the title changes to "Copied (N chars)". Paste anywhere inside the sim to confirm the dump is in the pasteboard.
6. Tap **Dismiss** — overlay goes away; tap counter resets.
7. Verify single-tap behaviour: normal Tab Switcher opens cleanly without the overlay appearing.
8. Verify scope: tap the **toolbar** Tab Switcher button (on a non-Duck.ai tab) rapidly — overlay must **not** appear.
9. Verify a production-style build (no DEBUG/ALPHA/EXPERIMENTAL, non-internal user) does not show the overlay regardless of tap frequency.

### Impact and Risks

**Low** — purely additive observability with no business-logic changes.

- Gated to non-production builds *or* internal users via `TabSwitcherDiagnosticsOverlay.isEnabled` (`BuildFlags.isProductionBuild` + `internalUserDecider.isInternalUser`).
- Toolbar tab switcher button is untouched at runtime — the `touchesBegan` override only calls `onTouchDown?()`, which the toolbar host never sets.
- Overlay is added as a subview of the key window (not via `UIViewController.present`), so it doesn't depend on the very mechanism we're diagnosing.

#### What could go wrong?

- **False positive on enthusiastic tapping** — mitigated by the 3-in-6s threshold, the "If so, please screenshot... Otherwise, just dismiss" copy, and internal-user gating.
- **Slow `collect()` on overlay show** — bounded: ancestry walks are depth-capped, `OSLogStore` query is 60s/60 entries, only our own subsystems.
- **Sim ↔ Mac pasteboard sync flakiness** — copy works correctly inside the sim; "Copied (N chars)" confirms the byte count, and the same dump is also written to `Logger.lifecycle.error` for capture via device logs.

### Quality Considerations

- **Privacy**: no PII, URLs, or user content captured — only UI/view/VC/gesture/window state, and our own internal log lines. The dump stays on-device unless the user explicitly chooses to share.
- **Performance**: trigger is cheap (timestamp ring buffer); the full dump only runs at the 3-in-6s threshold; `OSLogStore` is bounded.
- **Gating**: reuses canonical `BuildFlags.isProductionBuild` and `AppDependencyProvider.shared.internalUserDecider.isInternalUser` (same as `SettingsViewModel.isInternalUser`, `TabViewController.internalUserDecider`).

### Notes to Reviewer

Main entry point: `iOS/DuckDuckGo/TabSwitcherDiagnosticsOverlay.swift` (new). `recordEvent` calls live at:

- `MainViewController.requestTabSwitcher` (entry + state snapshot)
- `MainViewController+Segues.swift` (both guards + `present` call + `present` completion)
- `MainViewController.tabSwitcher(_:didFinishWithSelectedTab:)` (dismiss event)

The `onTouchDown` callback is wired only inside `MainViewController+UnifiedToggleInput.setUpAIChatTabChatHeader`, so the toolbar `TabSwitcherStaticButton` is functionally unaffected.

**This PR does not attempt to fix the underlying bug.** It exists to capture enough state from the field to pinpoint the cause when an internal user next hits the bug — at which point we'll have a screenshot of `[RECENT REQUESTS]`, `[MAIN VC] presentedVC`, header-button ancestry, hit-test routing, etc., and can write a targeted fix in a follow-up.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, gated diagnostics and logging only; normal tab switcher flow is unchanged aside from lightweight event recording on existing code paths.
> 
> **Overview**
> Adds **field diagnostics** for the intermittent “Tab Switcher won’t open” issue on Duck.ai tabs—**no fix** to presentation logic.
> 
> A new **`TabSwitcherDiagnosticsOverlay`** (non-production or internal users) shows a **key-window subview** (not `present`) after **3 header tab-switcher touches in 5s**, with copy/dismiss and a monospaced dump: recent launch-pipeline events, tab switcher / main VC state, presentation and full VC trees, toolbar and **AI header** button + hit-test ancestry, gestures, windows, and bounded **OSLogStore** lines. The same snapshot is logged at error level.
> 
> **Instrumentation** along the existing path: `recordEvent` on `requestTabSwitcher`, both `segueToTabSwitcher` guards, storyboard failure, `present` + completion, and dismiss. **`TabSwitcherStaticButton`** gains optional **`onTouchDown`** in `touchesBegan`; only the AI chat header wires it to the tap counter and overlay.
> 
> The Xcode project also adds the new source file; unrelated **pbxproj** line moves / removal of idle-return adapter build entries look incidental to this feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf75427d57b130943f67c2ff8f8344d5e4083fd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->