### PR TITLE
Tech Debt: Removes Escape Hatch from Fire UI

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/DaxLogo/DaxLogoManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/DaxLogo/DaxLogoManager.swift
@@ -75,8 +75,7 @@ final class DaxLogoManager {
     func installInViewController(_ parentController: UIViewController,
                                  asSubviewOf parentView: UIView,
                                  anchorView: UIView? = nil,
-                                 isTopBarPosition: Bool,
-                                 escapeHatch: EscapeHatchModel? = nil) {
+                                 isTopBarPosition: Bool) {
 
         if !isFireTab && isTopBarPosition && anchorView == nil {
             assertionFailure("Non-fire top-bar Dax logo install requires an anchor view.")
@@ -88,7 +87,7 @@ final class DaxLogoManager {
         parentView.addSubview(logoContainerView)
 
         if isFireTab {
-            installFireTabContent(in: parentController, escapeHatch: escapeHatch)
+            installFireTabContent(in: parentController)
             installFireTabConstraints(parentView: parentView, anchorView: anchorView, isTopBarPosition: isTopBarPosition)
         } else {
             installDaxLogoContent()
@@ -289,10 +288,10 @@ final class DaxLogoManager {
         ])
     }
 
-    private func installFireTabContent(in parentController: UIViewController, escapeHatch: EscapeHatchModel?) {
-        let hostingController = UIHostingController(
-            rootView: FireModeEmptyStateView(type: .tab,
-                                             escapeHatch: escapeHatch))
+    private func installFireTabContent(in parentController: UIViewController) {
+        let rootView = FireModeEmptyStateView(type: .tab)
+        let hostingController = UIHostingController(rootView: rootView)
+
         // Opaque NTP background so the fire empty state fully covers any favorites/suggestion tray content layered beneath.
         hostingController.view.backgroundColor = UIColor(designSystemColor: .background)
         hostingController.view.translatesAutoresizingMaskIntoConstraints = false

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -446,8 +446,7 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
             daxLogoManager.installInViewController(self,
                                                    asSubviewOf: contentContainerView,
                                                    anchorView: switchBarVC.view,
-                                                   isTopBarPosition: isUsingTopBarPosition,
-                                                   escapeHatch: escapeHatchModel)
+                                                   isTopBarPosition: isUsingTopBarPosition)
         } else if let view = switchBarVC.segmentedPickerView {
             daxLogoManager.installInViewController(self,
                                                    asSubviewOf: contentContainerView,

--- a/iOS/DuckDuckGo/FireMode/FireModeEmptyStateView.swift
+++ b/iOS/DuckDuckGo/FireMode/FireModeEmptyStateView.swift
@@ -54,7 +54,6 @@ struct FireModeEmptyStateView: View {
     // MARK: - Variables
 
     private let type: ViewType
-    private let escapeHatch: EscapeHatchModel?
 
     private var onNewFireTab: NewFireTabBlock? {
         if case .tabSwitcher(let onNewFireTab) = type {
@@ -65,17 +64,15 @@ struct FireModeEmptyStateView: View {
 
     // MARK: - Initializer
 
-    init(type: ViewType, escapeHatch: EscapeHatchModel? = nil) {
+    init(type: ViewType) {
         self.type = type
-        self.escapeHatch = escapeHatch
     }
-    
+
     // MARK: - Body
 
     var body: some View {
         ScrollView {
             VStack(spacing: Constants.mainSectionSpacing) {
-                escapeHatchSection
                 headerSection
                 contentCard
             }
@@ -84,15 +81,6 @@ struct FireModeEmptyStateView: View {
             .frame(maxWidth: Constants.maxViewWidth)
         }
         .modifier(ScrollBounceBehaviorModifier())
-    }
-
-    // MARK: - Escape Hatch
-
-    @ViewBuilder
-    private var escapeHatchSection: some View {
-        if let escapeHatch {
-            ReturnToTabCard(model: escapeHatch)
-        }
     }
 
     // MARK: - Header

--- a/iOS/DuckDuckGo/NewTabPageView.swift
+++ b/iOS/DuckDuckGo/NewTabPageView.swift
@@ -135,7 +135,7 @@ private extension NewTabPageView {
     @ViewBuilder
     private var emptyStateView: some View {
         if viewModel.fireTab {
-            FireModeEmptyStateView(type: .tab, escapeHatch: viewModel.escapeHatch)
+            FireModeEmptyStateView(type: .tab)
         } else {
             logoEmptyView
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671677432066/task/1214817119799261?focus=true
Tech Design URL:
CC:

### Description
This is a Tech Debt PR: we're removing the Escape Hatch from `FireModeEmptyStateView`, as there is no flow in which it's being actually presented.

### Testing Steps
1. Enable the `escapeHatchActions` Feature Flag
2. Open `Settings > Debug > Idle Return NTP` and set the Override to 1
3. Open any website
4. Background + Foreground to trigger the **Escape Hatch**

- [ ] Verify the Escape Hatch is presented

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing really

### Quality Considerations
None

### Notes to Reviewer
Thank you!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk tech-debt cleanup that removes unused UI plumbing; main impact is that any previously wired-but-unused “escape hatch” card can no longer render in fire empty state screens.
> 
> **Overview**
> Removes the *Escape Hatch* card from the fire-mode empty state by deleting `EscapeHatchModel` plumbing from `FireModeEmptyStateView` and its layout.
> 
> Updates call sites to the simplified initializer and removes the `escapeHatch` parameter from `DaxLogoManager.installInViewController(...)`/fire-tab hosting, so fire-tab empty states (`NewTabPageView` and omni-bar fire-tab Dax logo) no longer attempt to pass or render escape-hatch content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a940d1dcabab422d025b71ad8cd15f5043e3fce3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->