### PR TITLE
iOS: Fix missing toolbar after New Chat → back chevron

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -168,10 +168,15 @@ extension MainViewController {
     /// standard browser controls while searching. Idempotent; safe with the feature flag off.
     func reconcileToolbarVisibilityForCurrentTab() {
         let isFocusedOmnibarSession = unifiedToggleInputCoordinator?.isOmnibarSession == true
+        let wasHidden = viewCoordinator.toolbar.isHidden
         if isCurrentTabUsingUnifiedInputAIChrome && !isFocusedOmnibarSession {
             viewCoordinator.toolbar.isHidden = true
         } else {
             viewCoordinator.toolbar.isHidden = AppWidthObserver.shared.isLargeWidth || isInMinimalChromeLayout
+        }
+        // `toolbarBottom.constant` is derived from `isHidden`; recompute when it flips.
+        if wasHidden != viewCoordinator.toolbar.isHidden {
+            setBarsVisibility(currentBarsVisibility, animated: false, animationDuration: nil)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1215043905491222?focus=true

### Description

Fixes a bug where the bottom toolbar was missing — leaving the user stuck — after opening "New Chat" from the menu on an empty New Tab Page and tapping the AI chat header's back chevron.

Root cause: `toolbarBottom.constant` is computed against `toolbar.isHidden` and cached eagerly. When `reconcileToolbarVisibilityForCurrentTab()` flips `isHidden` from `true` → `false`, the cached constant (baked while hidden) keeps the toolbar pushed off-screen. Other call sites that flip `isHidden` already recompute the constant downstream (`showBars()` in `refreshNonAITab`, explicit assignment in `applyMinimalChromeWidth`); the focused-omnibar-from-AI-tab path did not. The fix lifts the recompute into `reconcileToolbarVisibilityForCurrentTab` so the invariant holds for every caller.

### Testing Steps

1. Make sure the unified toggle input feature flag is on.
2. Start on an empty New Tab Page.
3. Tap the menu in the bottom toolbar → tap **New Chat**.
4. On the AI chat tab, tap the back chevron in the AI chat header.
5. Expected: the focused omnibar appears at the top and the standard bottom toolbar is visible. **Before this fix:** toolbar was missing and the user was stuck.

### Impact and Risks

Low. Single recompute call inside an existing function, gated on a real `isHidden` flip. Mirrors the pattern already used in `applyMinimalChromeWidth` and `refreshNonAITab`.

#### What could go wrong?

- Recompute uses `animated: false`, so no transition regression.
- Reads `currentBarsVisibility` which derives from current alpha; if called mid-animation it could pick up an intermediate value. Not observed in testing.

### Notes to Reviewer

A separate cosmetic "omnibar flies in from the top" issue is **not** addressed here — it's a deferred animation, likely keyboard-driven, that exists independently of the toolbar bug and didn't go away with the suppression attempts I tried during investigation. Filing as a separate follow-up.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, gated layout recompute when `toolbar.isHidden` changes; main risk is minor layout timing differences if invoked during in-flight chrome animations.
> 
> **Overview**
> Fixes a unified-toggle-input edge case where the bottom toolbar could remain off-screen after returning from an AI "New Chat" flow.
> 
> `reconcileToolbarVisibilityForCurrentTab()` now detects when `toolbar.isHidden` flips and forces a non-animated `setBarsVisibility(currentBarsVisibility, ...)` pass so the derived `toolbarBottom` constraint is recomputed whenever toolbar visibility changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5451e86f7965b9b60fb930049448a65caf9477b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->