### PR TITLE
Switch conflict-watch cross-ref filter to three-dot diff

### DIFF
--- a/scripts/conflict-watch/conflict-watch.py
+++ b/scripts/conflict-watch/conflict-watch.py
@@ -860,21 +860,28 @@ _branch_files_vs_main_cache: dict[str, set[str]] = {}
 
 
 def _branch_files_vs_main(branch: str) -> set[str]:
-    """Set of files where the branch's tip differs from main's tip.
+    """Set of files the branch added on top of its merge-base with main.
 
-    Used by probe_pair to drop "false-positive via merge-from-main"
-    conflicts: a branch that merged main in inherits main's recent
-    edits, which from an old pair-merge-base look like the branch's
-    own changes. If diff(main..branch) doesn't include a file, the
-    branch's owner isn't actually contributing changes to it — so
-    pinging them about a conflict on that file is misleading.
+    Used by probe_pair to drop "false-positive via inheritance" conflicts:
+    a branch whose apparent change to a file came from somewhere other
+    than its own commits (either an explicit merge-from-main or — far
+    more commonly — main moving ahead of the branch's base) shouldn't be
+    pinged when that file conflicts with another branch's real edit.
+
+    Uses three-dot (``main...branch``, == ``diff $(merge-base main
+    branch)..branch``) deliberately. Two-dot would also include files
+    where main moved past the branch's base — those show up in
+    ``diff main..branch`` even though the branch contributed nothing to
+    them, which re-introduces exactly the false positives this filter
+    exists to drop. (Contrast with ``_is_merged_into_default``, which
+    deliberately wants two-dot tip-tree semantics — see its docstring.)
 
     Cached per branch within a single run.
     """
     if branch in _branch_files_vs_main_cache:
         return _branch_files_vs_main_cache[branch]
     proc = git(["diff", "--name-only",
-                f"{DEFAULT_BRANCH}..{branch}"], check=False)
+                f"{DEFAULT_BRANCH}...{branch}"], check=False)
     if proc.returncode != 0:
         files: set[str] = set()
     else:
@@ -1461,6 +1468,41 @@ def run_self_test() -> int:
             ok = False
         else:
             print("PASS: pbx1 vs pbx2 → ignored by always-ignore filter")
+
+        # _branch_files_vs_main must use three-dot semantics. Reproduce
+        # the production false-positive class: a branch is created and
+        # never touches X; main then moves ahead on X (some unrelated PR
+        # lands). Two-dot would include X in the branch's "vs main"
+        # set — since the branch is now behind main on X — and the
+        # cross-reference filter in probe_pair would then keep X as a
+        # conflict candidate against any branch that does edit X. The
+        # filter must instead reflect only what the branch contributed.
+        run(["git", "-C", str(wc), "checkout", "main"])
+        run(["git", "-C", str(wc), "checkout", "-b", "feature/passive-on-X"])
+        (wc / "Side").write_text("side\n")
+        run(["git", "-C", str(wc), "add", "Side"])
+        run(["git", "-C", str(wc), "commit", "-m", "passive: edit Side, not X"])
+        run(["git", "-C", str(wc), "push", "origin", "feature/passive-on-X"])
+
+        run(["git", "-C", str(wc), "checkout", "main"])
+        (wc / "X").write_text("line1\nMAIN-MOVED-2\nline3\n")
+        run(["git", "-C", str(wc), "commit", "-am", "main: PR edits X line 2"])
+        run(["git", "-C", str(wc), "push", "origin", "main"])
+
+        _branch_files_vs_main_cache.clear()
+        passive_files = _branch_files_vs_main("feature/passive-on-X")
+        if "X" in passive_files or "Side" not in passive_files:
+            print(
+                f"FAIL: _branch_files_vs_main(passive-on-X) → {passive_files} "
+                "(expected Side present, X absent)"
+            )
+            ok = False
+        else:
+            print(
+                "PASS: _branch_files_vs_main is three-dot — branch that "
+                "didn't touch X stays out of X's vs-main set when main "
+                "moves ahead"
+            )
 
         # User-map parser
         sample = (


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1215097277192572?focus=true

### Description

The daily conflict-watch script was flooding Asana with tasks naming the same files: 4 OmniBar files on 05-21 (~12 tasks), `UnifiedToggleInput` files on 05-24 (~6 tasks), `AIChatContentHandler.swift` on 05-24 (~25 tasks). Root cause is in `_branch_files_vs_main`: it used two-dot `git diff main..branch` to decide whether a branch "actually touches" a conflicting file. Two-dot is symmetric — it also includes files where **main has moved ahead** of the branch's base, so any branch that predates a recently-landed multi-file PR looks like it touched the PR's files. The cross-reference filter then stops dropping the inherited files, and any pair of such branches gets a task naming them.

Example: `tom/fix-ntp-autocomplete-suggestions-setting` (macOS-only, 12 files in its 3-dot diff, no OmniBar) was paired with `sabrina/fix-pro-url-interception` (3 files in 3-dot diff, also no OmniBar) and the task named 4 OmniBar files. Neither branch's 3-dot diff against main includes OmniBar — both just predate #4544 (Duck.ai chat-path onboarding), which landed on main on 05-19.

Fix is one operator: `..` → `...` in `_branch_files_vs_main`. Three-dot is `diff $(merge-base main branch)..branch` — only what the branch contributed on top of its base, which is what the docstring already described as the intent. `_is_merged_into_default` keeps two-dot tip-tree semantics (its docstring explains why) and is unchanged. Docstring rewritten to spell out the contrast. Self-test reproducer added that fails with two-dot and passes with three-dot.

### Testing Steps

1. `ASANA_PAT=stub python3 scripts/conflict-watch/conflict-watch.py --self-test` — passes, including the new three-dot case.
2. Local `--once` probes against yesterday's false-positive pairs all return `has_conflicts: false`:
   - `pikor/uti/new-pixels..tom/fix-ntp-autocomplete-suggestions-setting`
   - `jacek/voice-mode-keep-tab-open..diego/route-handlers-through-tab-index-helper`
   - `jacek/voice-mode-keep-tab-open..tom/fix-ntp-autocomplete-suggestions-setting`
3. Control pair `pikor/uti/new-pixels..jacek/voice-mode-keep-tab-open` (both branches genuinely edit a UTI file) still surfaces — correctly as a soft conflict since their line ranges don't overlap.

### Impact and Risks

Low — internal tooling. No user-facing code path.

#### What could go wrong?

`_is_merged_into_default` deliberately uses two-dot tip-tree semantics; not touched. Stale false-positive tasks won't all auto-close on the next scheduled run — `sweep_existing_tasks` only closes pairs whose hard-conflict-line count drops below `CW_MIN_CONFLICT_LINES` (20). Most should fall below since the named files are the bulk of those totals, but a manual bulk-close may be wanted.