### PR TITLE
Declare channel parameter on m_mac_address-bar_render-perf

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/address_bar_perf_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/address_bar_perf_pixels.json5
@@ -8,6 +8,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "channel",
             {
                 "key": "stages",
                 "type": "string",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1215086005183318?focus=true

### Description

The failing-pixel report flags `m_mac_address-bar_render-perf` for sending an undeclared `channel` parameter. This declares `channel` on the pixel def so its schema matches what gets emitted on the wire, clearing the report finding.

### Testing Steps

1. Verify the CI is green.

### Impact and Risks

Low — definitions-only change. No Swift code is modified.

#### What could go wrong?

Nothing on the client; `channel` is already being sent. The schema now matches reality and the failing-pixel report should stop flagging this pixel.

### Quality Considerations

N/A — pixel-definition update, no runtime behaviour change.

### Notes to Reviewer

N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only update in pixel definitions; `channel` was already sent and no client code changes.
> 
> **Overview**
> Declares the **`channel`** parameter on **`m_mac_address-bar_render-perf`** in `address_bar_perf_pixels.json5`, alongside existing `appVersion` and `pixelSource`, so the pixel schema matches what the client already emits and clears the failing-pixel report for an undeclared parameter.
> 
> No runtime or Swift changes—definitions only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59f6598f7914f13dd7ccfbede13ee9b87f565126. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->