### PR TITLE
iOS: Fix bottom UTI covering toolbar after keyboard dismiss

### DIFF
--- a/iOS/DuckDuckGo/MainViewCoordinator.swift
+++ b/iOS/DuckDuckGo/MainViewCoordinator.swift
@@ -258,7 +258,11 @@ class MainViewCoordinator {
         if !constraints.navigationBarContainerBottom.isActive {
             constraints.navigationBarContainerBottom.isActive = true
         }
-        setNavBarContainerBottomToKeyboard()
+        // Hidden toolbars keep their 49pt frame in auto layout — pinning the UTI above an
+        // invisible toolbar (landscape minimal chrome) would leave a toolbar-sized gap, so
+        // fall back to the safe-area floor when there's no visible toolbar to respect.
+        let floor: NSLayoutYAxisAnchor? = toolbar.isHidden ? nil : toolbar.topAnchor
+        setNavBarContainerBottomToKeyboard(floorAnchor: floor)
     }
 
 
@@ -501,7 +505,7 @@ class MainViewCoordinator {
         }
     }
 
-    func setNavBarContainerBottomToKeyboard() {
+    func setNavBarContainerBottomToKeyboard(floorAnchor: NSLayoutYAxisAnchor? = nil) {
         constraints.navigationBarContainerBottom.isActive = false
         constraints.navigationBarContainerBottomSafeAreaFloor?.isActive = false
 
@@ -510,9 +514,13 @@ class MainViewCoordinator {
         constraints.navigationBarContainerBottom.priority = .defaultHigh
         constraints.navigationBarContainerBottom.isActive = true
 
-        // Prevent the nav bar from going below safe area when keyboard is hidden
+        // Cap how far the nav bar can follow the keyboard guide down. Default floor is the
+        // safe-area bottom (AI tab — toolbar is hidden, so the UTI is meant to sit at the
+        // screen bottom). Callers anchored above a visible toolbar pass `toolbar.topAnchor`
+        // so the UTI doesn't slide over the toolbar when the keyboard is dragged off-screen.
+        let floor = floorAnchor ?? superview.safeAreaLayoutGuide.bottomAnchor
         let safeAreaFloor = navigationBarContainer.bottomAnchor
-            .constraint(lessThanOrEqualTo: superview.safeAreaLayoutGuide.bottomAnchor)
+            .constraint(lessThanOrEqualTo: floor)
         safeAreaFloor.isActive = true
         constraints.navigationBarContainerBottomSafeAreaFloor = safeAreaFloor
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1215082123261786?focus=true

### Description

Fixes a regression introduced in #4242 (Mar 30) where the Unified Toggle Input, when shown above a bottom-positioned omnibar, would slide down over the app toolbar after the keyboard was dismissed (drag-down gesture, or any state where `keyboardLayoutGuide.topAnchor` collapsed to the safe-area bottom — including hardware keyboard sessions).

Root cause: `setNavBarContainerBottomToKeyboard` capped the nav-bar container's bottom at `safeAreaLayoutGuide.bottomAnchor`, which is also where the toolbar's bottom sits, leaving 49pt of room for the UTI to slide into the toolbar. The fix passes `toolbar.topAnchor` as the floor for the bottom-omnibar editing path, with a fallback to the safe-area bottom when the toolbar isn't visible (landscape minimal chrome).

### Testing Steps
1. Set Address Bar Position to **Bottom** (Settings → Appearance → Address Bar Position).
2. Open a search results page (e.g. search "test").
3. Tap the bottom omnibar — the UTI should appear above the on-screen keyboard.
4. Drag the keyboard down with a downward swipe from the suggestions list.
   - Expected: the UTI settles directly **above** the toolbar; the toolbar's back/forward/fire/tabs/menu buttons remain visible.
   - Before the fix: the UTI dropped past the toolbar's top and covered it.
5. AI tab regression check: open a Duck.ai tab and confirm the collapsed/expanded UTI still sits at the screen bottom (toolbar hidden — safe-area floor used).

### Impact and Risks

Low. One-line change to a `<=` floor anchor used only by the bottom-omnibar editing path. AI tab and other callers keep the prior safe-area floor by falling through the default.

#### What could go wrong?
- If a future caller of `setNavBarContainerBottomToKeyboard` lives above a hidden toolbar and passes `toolbar.topAnchor` blindly, the UTI would leave a toolbar-sized gap. The `restoreNavBarToKeyboardForOmnibarActive` call site guards against that via `toolbar.isHidden`.

### Notes to Reviewer
- Bug exists since #4242 — see commit \`684c493ec8\`.
- Verified manually on iPhone 17 Pro Max iOS 26.5 sim: pre-fix \`searchEntry\` at y=860–906 overlapping \`Toolbar\` at y=873–922; post-fix \`searchEntry\` at y=811–857 with the toolbar fully visible below.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Auto Layout floor anchor change for bottom-omnibar editing; AI tab and hidden-toolbar paths keep the prior safe-area default.
> 
> **Overview**
> Fixes bottom **Unified Toggle Input** layout when the keyboard is dismissed (drag-down or hardware keyboard): the nav bar container no longer settles on top of the app toolbar.
> 
> `setNavBarContainerBottomToKeyboard` now accepts an optional **floor** anchor for the `<=` cap that limits how far the bar can follow `keyboardLayoutGuide`. The default remains the **safe-area bottom** (unchanged for AI-tab callers). Bottom-omnibar editing passes **`toolbar.topAnchor`** when the toolbar is visible so the UTI stops above the toolbar instead of overlapping it. When the toolbar is hidden (e.g. landscape minimal chrome), the floor stays at the safe area so a hidden 49pt toolbar frame does not leave a gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4421e6e2dc4a9876ec1f1af6341cf01044a9e6de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->