### PR TITLE
macOS: Declare channel parameter on 5 failing pixel definitions

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/aichat_addressbar_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_addressbar_pixels.json5
@@ -236,7 +236,7 @@
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_recent_chat_delete_button_clicked": {
         "description": "Fired when user clicks the delete button on a recent chat suggestion in the address bar",

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_main_menu_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_main_menu_pixels.json5
@@ -81,7 +81,7 @@
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_view_all_chats_main_menu": {
         "description": "Fired when user taps View All Chats... from the main menu",

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_ntp_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_ntp_pixels.json5
@@ -41,7 +41,7 @@
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_ntp_image_generation_submitted": {
         "description": "Fired when user submits a prompt while image generation mode is active on the New Tab Page",

--- a/macOS/PixelDefinitions/pixels/definitions/quit_survey_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/quit_survey_pixels.json5
@@ -61,6 +61,6 @@
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/serp_settings_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/serp_settings_pixels.json5
@@ -33,6 +33,6 @@
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1215086119134131
Tech Design URL:
CC:

### Description

PixelKit automatically appends a `channel` parameter for non-production builds (`canary` for internal users, `dev` for alpha/review). Five pixel definitions did not declare `channel` in their parameters list, so live validation rejected them with:

> must NOT have additional properties. Found extra property 'channel'

Fix: add `"channel"` to the `parameters` array of each affected definition. `channel` is already defined in `params_dictionary.json5` and is the same fix already applied to neighboring pixels in these files.

Pixels updated:
- `m_mac_aichat_delete_all_chats_more_options_menu`
- `m_mac_aichat_new_voice_chat_omnibar_native`
- `m_mac_aichat_new_voice_chat_omnibar_ntp`
- `m_mac_serp_settings_open_duck_ai_button_click`
- `m_mac_quit-survey-thumbs-up-return`

### Testing Steps
1. CI's pixel-definition validation passes (`npm run validate-pixel-defs` in the macOS folder).
2. Live validation no longer reports these 5 pixels.

### Impact and Risks

Low — definition-only change. No Swift code touched, no behavior change at runtime. Brings the listed pixels in line with how other pixels in the same files already declare `channel`.

#### What could go wrong?

Nothing affecting users: this only changes the JSON5 schema used to validate incoming pixels.

### Notes to Reviewer

Other pixels in these same files still omit `channel` but were not flagged in the report — likely because they haven't been emitted yet from a non-production build. Out of scope for this PR; happy to follow up if we want to proactively fix the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSON5 schema-only updates; no app behavior or analytics emission logic changes.
> 
> **Overview**
> Adds **`channel`** to the `parameters` list on **five** macOS pixel definitions that were failing live validation when PixelKit auto-injected `channel` on non-production builds (`canary` / `dev`).
> 
> Affected pixels span Duck.ai (delete all chats from more-options menu, new voice chat from native and NTP omnibars), SERP settings (open Duck AI button), and quit survey (thumbs-up return). Each change mirrors neighboring definitions in the same JSON5 files; no Swift or emission logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab49dde624f6195e86f1bd178c56307ab546b937. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->