### PR TITLE
Fix pixel definitions for live validation failures

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/broken_site_reporting.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/broken_site_reporting.json5
@@ -38,6 +38,7 @@
                     "login",
                     "other",
                     "paywall",
+                    "popups-not-opening",
                     "shopping",
                     "videos"
                 ]
@@ -354,6 +355,16 @@
                 "key": "extendedPerformance.totalResourcesSizeBucket",
                 "type": "string",
                 "description": "Total resources size bucket"
+            },
+            {
+                "key": "loadedWebExtensions",
+                "type": "string",
+                "description": "Comma-separated short labels of currently installed web extensions (e.g. embedded,darkMode,adBlocking)"
+            },
+            {
+                "key": "adBlockingExtensionScriptletsVersion",
+                "type": "string",
+                "description": "Cached scriptlets version for the ad-blocking web extension"
             },
             "channel"
         ]
@@ -673,6 +684,16 @@
                 "key": "extendedPerformance.totalResourcesSizeBucket",
                 "type": "string",
                 "description": "Total resources size bucket"
+            },
+            {
+                "key": "loadedWebExtensions",
+                "type": "string",
+                "description": "Comma-separated short labels of currently installed web extensions (e.g. embedded,darkMode,adBlocking)"
+            },
+            {
+                "key": "adBlockingExtensionScriptletsVersion",
+                "type": "string",
+                "description": "Cached scriptlets version for the ad-blocking web extension"
             },
             "channel"
         ]

--- a/macOS/PixelDefinitions/pixels/definitions/crash_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/crash_pixels.json5
@@ -11,6 +11,21 @@
                 "key": "failedToReadCrashVersion",
                 "description": "Set to true when the crash version could not be read from the crash report",
                 "type": "boolean"
+            },
+            {
+                "key": "code",
+                "type": "string",
+                "description": "MXDiagnostic exception code (App Store builds only); '-1' when unavailable"
+            },
+            {
+                "key": "signal",
+                "type": "string",
+                "description": "MXDiagnostic POSIX signal number (App Store builds only); '-1' when unavailable"
+            },
+            {
+                "key": "type",
+                "type": "string",
+                "description": "MXDiagnostic Mach exception type (App Store builds only); '-1' when unavailable"
             }
         ]
     },
@@ -22,6 +37,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "channel",
             {
                 "key": "failedToReadCrashVersion",
                 "description": "Set to true when the crash version could not be read from the crash report",
@@ -52,6 +68,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "channel",
             {
                 "key": "failedToReadCrashVersion",
                 "description": "Set to true when the crash version could not be read from the crash report",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1215086005162823?focus=true

### Description

Updates macOS pixel definitions to match parameters actually fired in production, fixing the live-validation failures reported for `epbf`, `m_mac_protection-toggled-off-breakage-report`, `m_mac_crash`, `m_mac_crash_dbp`, and `m_mac_crash_vpnextension`.

No firing code is changed — these are schema-only updates so the validator stops flagging legitimate live traffic.

### Testing Steps

From `macOS/`, run `npm run validate-pixel-defs` and verify that it passes cleanly.

### Impact and Risks

None — pixel-definition JSON5 files only. No production code, no user-visible behavior, no app build changes.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSON5 pixel-definition-only change; no runtime behavior, telemetry volume, or user-facing impact.
> 
> **Overview**
> Aligns macOS pixel definition schemas with parameters already sent in production so live pixel validation stops failing—**no firing or app logic changes**.
> 
> For **`epbf`** and **`m_mac_protection-toggled-off-breakage-report`**, the definitions now include **`loadedWebExtensions`** and **`adBlockingExtensionScriptletsVersion`** (from `BrokenSiteReport` / privacy dashboard). **`epbf`** also adds **`popups-not-opening`** to the **`category`** enum, matching iOS.
> 
> For **`m_mac_crash`**, **`code`**, **`signal`**, and **`type`** are declared (App Store **`MXDiagnostic`** fields, with `"-1"` when missing). **`m_mac_crash_dbp`** and **`m_mac_crash_vpnextension`** declare the shared **`channel`** parameter used on canary/dev builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9571aa56891d003c7ba8ff8371eaa3ced80ced4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->