### PR TITLE
[macOS] Add canUpgradeOS RMF matcher

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
@@ -48,6 +48,7 @@ private enum AttributesKey: String, CaseIterable {
     case interactedWithMessage
     case interactedWithDeprecatedMacRemoteMessage
     case installedMacAppStore
+    case canUpgradeOS
     case pinnedTabs
     case customHomePage
     case duckPlayerOnboarded
@@ -94,6 +95,7 @@ private enum AttributesKey: String, CaseIterable {
             jsonMatchingAttribute: jsonMatchingAttribute
         )
         case .installedMacAppStore: return IsInstalledMacAppStoreMatchingAttribute(jsonMatchingAttribute: jsonMatchingAttribute)
+        case .canUpgradeOS: return OSUpgradeCapabilityMatchingAttribute(jsonMatchingAttribute: jsonMatchingAttribute)
         case .pinnedTabs: return PinnedTabsMatchingAttribute(jsonMatchingAttribute: jsonMatchingAttribute)
         case .customHomePage: return CustomHomePageMatchingAttribute(jsonMatchingAttribute: jsonMatchingAttribute)
         case .duckPlayerOnboarded: return DuckPlayerOnboardedMatchingAttribute(jsonMatchingAttribute: jsonMatchingAttribute)

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Matchers/AppAttributeMatcher.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Matchers/AppAttributeMatcher.swift
@@ -30,11 +30,19 @@ public typealias MobileAppAttributeMatcher = CommonAppAttributeMatcher
 
 public struct DesktopAppAttributeMatcher: AttributeMatching {
     private let isInstalledMacAppStore: Bool
+    private let canUpgradeOS: Bool
 
     private let commonAppAttributeMatcher: CommonAppAttributeMatcher
 
-    public init(statisticsStore: StatisticsStore, variantManager: VariantManager, isInternalUser: Bool = true, isInstalledMacAppStore: Bool) {
+    public init(
+        statisticsStore: StatisticsStore,
+        variantManager: VariantManager,
+        isInternalUser: Bool = true,
+        isInstalledMacAppStore: Bool,
+        canUpgradeOS: Bool = true
+    ) {
         self.isInstalledMacAppStore = isInstalledMacAppStore
+        self.canUpgradeOS = canUpgradeOS
 
         commonAppAttributeMatcher = .init(statisticsStore: statisticsStore, variantManager: variantManager, isInternalUser: isInternalUser)
     }
@@ -45,9 +53,11 @@ public struct DesktopAppAttributeMatcher: AttributeMatching {
         isInternalUser: Bool,
         statisticsStore: StatisticsStore,
         variantManager: VariantManager,
-        isInstalledMacAppStore: Bool
+        isInstalledMacAppStore: Bool,
+        canUpgradeOS: Bool = true
     ) {
         self.isInstalledMacAppStore = isInstalledMacAppStore
+        self.canUpgradeOS = canUpgradeOS
 
         commonAppAttributeMatcher = .init(
             bundleId: bundleId,
@@ -62,6 +72,8 @@ public struct DesktopAppAttributeMatcher: AttributeMatching {
         switch matchingAttribute {
         case let matchingAttribute as IsInstalledMacAppStoreMatchingAttribute:
             return matchingAttribute.evaluate(for: isInstalledMacAppStore)
+        case let matchingAttribute as OSUpgradeCapabilityMatchingAttribute:
+            return matchingAttribute.evaluate(for: canUpgradeOS)
         default:
             return commonAppAttributeMatcher.evaluate(matchingAttribute: matchingAttribute)
         }

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Model/MatchingAttributes.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Model/MatchingAttributes.swift
@@ -194,6 +194,11 @@ struct IsInstalledMacAppStoreMatchingAttribute: SingleValueMatching {
     var fallback: Bool?
 }
 
+struct OSUpgradeCapabilityMatchingAttribute: SingleValueMatching {
+    var value: Bool?
+    var fallback: Bool?
+}
+
 struct PinnedTabsMatchingAttribute: NumericRangeMatching {
     var min: Int = MatchingAttributeDefaults.intDefaultValue
     var max: Int = MatchingAttributeDefaults.intDefaultMaxValue

--- a/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Matchers/DesktopAppAttributeMatcherTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Matchers/DesktopAppAttributeMatcherTests.swift
@@ -36,7 +36,12 @@ class DesktopAppAttributeMatcherTests: XCTestCase {
         mockStatisticsStore.searchRetentionAtb = "v105-88"
 
         let manager = MockVariantManager(isSupportedReturns: true, currentVariant: MockVariant(name: "zo", weight: 44, isIncluded: { return true }, features: [.dummy]))
-        matcher = DesktopAppAttributeMatcher(statisticsStore: mockStatisticsStore, variantManager: manager, isInstalledMacAppStore: false)
+        matcher = DesktopAppAttributeMatcher(
+            statisticsStore: mockStatisticsStore,
+            variantManager: manager,
+            isInstalledMacAppStore: false,
+            canUpgradeOS: true
+        )
     }
 
     override func tearDownWithError() throws {
@@ -54,6 +59,34 @@ class DesktopAppAttributeMatcherTests: XCTestCase {
 
     func testWhenWidgetAddedDoesNotMatchThenReturnFail() throws {
         XCTAssertEqual(matcher.evaluate(matchingAttribute: IsInstalledMacAppStoreMatchingAttribute(value: true, fallback: nil)),
+                       .fail)
+    }
+
+    // MARK: - OSUpgradeCapability (canUpgradeOS)
+
+    func testWhenCanUpgradeOSMatchesThenReturnMatch() throws {
+        XCTAssertEqual(matcher.evaluate(matchingAttribute: OSUpgradeCapabilityMatchingAttribute(value: true, fallback: nil)),
+                       .match)
+    }
+
+    func testWhenCanUpgradeOSDoesNotMatchThenReturnFail() throws {
+        XCTAssertEqual(matcher.evaluate(matchingAttribute: OSUpgradeCapabilityMatchingAttribute(value: false, fallback: nil)),
+                       .fail)
+    }
+
+    func testWhenCannotUpgradeOSAndAttributeIsFalseThenReturnMatch() throws {
+        let mockStatisticsStore = MockStatisticsStore()
+        let manager = MockVariantManager(isSupportedReturns: true, currentVariant: MockVariant(name: "zo", weight: 44, isIncluded: { return true }, features: [.dummy]))
+        let incapableMatcher = DesktopAppAttributeMatcher(
+            statisticsStore: mockStatisticsStore,
+            variantManager: manager,
+            isInstalledMacAppStore: false,
+            canUpgradeOS: false
+        )
+
+        XCTAssertEqual(incapableMatcher.evaluate(matchingAttribute: OSUpgradeCapabilityMatchingAttribute(value: false, fallback: nil)),
+                       .match)
+        XCTAssertEqual(incapableMatcher.evaluate(matchingAttribute: OSUpgradeCapabilityMatchingAttribute(value: true, fallback: nil)),
                        .fail)
     }
 }

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -1243,6 +1243,8 @@
 		379E877729E98729001C8BB0 /* BookmarksCleanupErrorHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 379E877529E98729001C8BB0 /* BookmarksCleanupErrorHandling.swift */; };
 		37A089FB2C510FE0003BB417 /* RemoteMessagingDebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37A089FA2C510FE0003BB417 /* RemoteMessagingDebugMenu.swift */; };
 		37A089FC2C510FE0003BB417 /* RemoteMessagingDebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37A089FA2C510FE0003BB417 /* RemoteMessagingDebugMenu.swift */; };
+		D1E601A12D510FE0003BB417 /* OSUpgradeCapabilityOverride.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E601A02D510FE0003BB417 /* OSUpgradeCapabilityOverride.swift */; };
+		D1E601A22D510FE0003BB417 /* OSUpgradeCapabilityOverride.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E601A02D510FE0003BB417 /* OSUpgradeCapabilityOverride.swift */; };
 		37A0BA1D2D7475BC00130447 /* HistoryViewTabOpening.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37A0BA1C2D7475B900130447 /* HistoryViewTabOpening.swift */; };
 		37A0BA1E2D7475BC00130447 /* HistoryViewTabOpening.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37A0BA1C2D7475B900130447 /* HistoryViewTabOpening.swift */; };
 		37A0BA202D747A9300130447 /* WindowControllersManager+URLOpening.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37A0BA1F2D747A8E00130447 /* WindowControllersManager+URLOpening.swift */; };
@@ -5126,6 +5128,7 @@
 		379E4D5F2D4383CE00A901B1 /* NewTabPageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageCoordinator.swift; sourceTree = "<group>"; };
 		379E877529E98729001C8BB0 /* BookmarksCleanupErrorHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksCleanupErrorHandling.swift; sourceTree = "<group>"; };
 		37A089FA2C510FE0003BB417 /* RemoteMessagingDebugMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteMessagingDebugMenu.swift; sourceTree = "<group>"; };
+		D1E601A02D510FE0003BB417 /* OSUpgradeCapabilityOverride.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSUpgradeCapabilityOverride.swift; sourceTree = "<group>"; };
 		37A0BA1C2D7475B900130447 /* HistoryViewTabOpening.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewTabOpening.swift; sourceTree = "<group>"; };
 		37A0BA1F2D747A8E00130447 /* WindowControllersManager+URLOpening.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WindowControllersManager+URLOpening.swift"; sourceTree = "<group>"; };
 		37A0BA232D747B9E00130447 /* CapturingContextMenuPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturingContextMenuPresenter.swift; sourceTree = "<group>"; };
@@ -7923,6 +7926,7 @@
 				371209292C2333A0003ADF3D /* RemoteMessagingDatabase.swift */,
 				3712092B2C23383C003ADF3D /* RemoteMessagingStoreErrorHandling.swift */,
 				37A089FA2C510FE0003BB417 /* RemoteMessagingDebugMenu.swift */,
+				D1E601A02D510FE0003BB417 /* OSUpgradeCapabilityOverride.swift */,
 			);
 			path = RemoteMessaging;
 			sourceTree = "<group>";
@@ -14934,6 +14938,7 @@
 				BBFE94EC2E391421000D4920 /* NotificationDotProviding.swift in Sources */,
 				BBFE94ED2E391421000D4920 /* NetworkProtectionButton.swift in Sources */,
 				37A089FC2C510FE0003BB417 /* RemoteMessagingDebugMenu.swift in Sources */,
+				D1E601A22D510FE0003BB417 /* OSUpgradeCapabilityOverride.swift in Sources */,
 				310E83F72ED79B1E006F80D2 /* KeyboardShortcutView.swift in Sources */,
 				B6BCC54B2AFDF24B002C5499 /* TaskWithProgress.swift in Sources */,
 				BBC90A2C2E3265D50013E52C /* ReportProblemFormViewModel.swift in Sources */,
@@ -17459,6 +17464,7 @@
 				B6F9BDDC2B45B7EE00677B33 /* WebsiteInfo.swift in Sources */,
 				4B67854A2AA8DE75008A5004 /* VPNFeatureGatekeeper.swift in Sources */,
 				37A089FB2C510FE0003BB417 /* RemoteMessagingDebugMenu.swift in Sources */,
+				D1E601A12D510FE0003BB417 /* OSUpgradeCapabilityOverride.swift in Sources */,
 				567A23D42C81E2180010F66C /* ContextualDaxDialogsFactory.swift in Sources */,
 				EEB617AD6A364BB6BB53BD23 /* FadeInView.swift in Sources */,
 				14B4C91EA50448BE99B64438 /* RebrandedContextualDaxDialogsFactory.swift in Sources */,

--- a/macOS/DuckDuckGo/Common/OSVersion/SupportedOsChecker.swift
+++ b/macOS/DuckDuckGo/Common/OSVersion/SupportedOsChecker.swift
@@ -39,6 +39,16 @@ enum OSUpgradeCapability: String {
         case .unknown: return "unknown"
         }
     }
+
+    /// Boolean view used for RMF rule matching. `.unknown` is treated as `true`
+    /// to match the existing UI fallback in BigSurEndOfSupportNoticePresenter,
+    /// which shows the "Update macOS" CTA for unknown hardware.
+    var canUpgradeOS: Bool {
+        switch self {
+        case .capable, .unknown: return true
+        case .incapable: return false
+        }
+    }
 }
 
 protocol SupportedOSChecking {

--- a/macOS/DuckDuckGo/RemoteMessaging/OSUpgradeCapabilityOverride.swift
+++ b/macOS/DuckDuckGo/RemoteMessaging/OSUpgradeCapabilityOverride.swift
@@ -1,0 +1,80 @@
+//
+//  OSUpgradeCapabilityOverride.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Persistence
+
+enum OSUpgradeCapabilityOverride: String, CaseIterable {
+    case `default`
+    case forceCapable
+    case forceIncapable
+
+    var title: String {
+        switch self {
+        case .default: return "Default (use hardware check)"
+        case .forceCapable: return "Force capable (canUpgradeOS = true)"
+        case .forceIncapable: return "Force incapable (canUpgradeOS = false)"
+        }
+    }
+}
+
+struct OSUpgradeCapabilityOverridePersistor {
+
+    enum Key: String {
+        case override = "rmf.os-upgrade-capability.override"
+    }
+
+    private let keyValueStore: KeyValueStoring
+
+    init(keyValueStore: KeyValueStoring = UserDefaults.standard) {
+        self.keyValueStore = keyValueStore
+    }
+
+    var current: OSUpgradeCapabilityOverride {
+        get {
+            guard let raw = keyValueStore.object(forKey: Key.override.rawValue) as? String,
+                  let value = OSUpgradeCapabilityOverride(rawValue: raw) else {
+                return .default
+            }
+            return value
+        }
+        nonmutating set {
+            if newValue == .default {
+                keyValueStore.removeObject(forKey: Key.override.rawValue)
+            } else {
+                keyValueStore.set(newValue.rawValue, forKey: Key.override.rawValue)
+            }
+        }
+    }
+
+    /// Resolves `canUpgradeOS` against the stored override. In release builds the
+    /// override is ignored and `defaultValue` is returned unchanged — the debug
+    /// menu is the only writer, but this guarantees release behavior even if the
+    /// key somehow ends up set.
+    func canUpgradeOS(default defaultValue: Bool) -> Bool {
+        #if DEBUG
+        switch current {
+        case .default: return defaultValue
+        case .forceCapable: return true
+        case .forceIncapable: return false
+        }
+        #else
+        return defaultValue
+        #endif
+    }
+}

--- a/macOS/DuckDuckGo/RemoteMessaging/OSUpgradeCapabilityOverride.swift
+++ b/macOS/DuckDuckGo/RemoteMessaging/OSUpgradeCapabilityOverride.swift
@@ -33,6 +33,8 @@ enum OSUpgradeCapabilityOverride: String, CaseIterable {
     }
 }
 
+/// Debug-menu only. The stored value is honored only under `#if DEBUG`; production
+/// code should rely on `SupportedOSChecker` directly.
 struct OSUpgradeCapabilityOverridePersistor {
 
     enum Key: String {

--- a/macOS/DuckDuckGo/RemoteMessaging/RemoteMessagingConfigMatcherProvider.swift
+++ b/macOS/DuckDuckGo/RemoteMessaging/RemoteMessagingConfigMatcherProvider.swift
@@ -208,7 +208,8 @@ final class RemoteMessagingConfigMatcherProvider: RemoteMessagingConfigMatcherPr
             flag.cohortType == nil && featureFlagger.isFeatureOn(for: flag)
         }.map(\.rawValue)
 
-        let canUpgradeOS = SupportedOSChecker(featureFlagger: featureFlagger).osUpgradeCapability.canUpgradeOS
+        let hardwareCanUpgradeOS = SupportedOSChecker(featureFlagger: featureFlagger).osUpgradeCapability.canUpgradeOS
+        let canUpgradeOS = OSUpgradeCapabilityOverridePersistor().canUpgradeOS(default: hardwareCanUpgradeOS)
 
         return RemoteMessagingConfigMatcher(
             appAttributeMatcher: AppAttributeMatcher(statisticsStore: statisticsStore,

--- a/macOS/DuckDuckGo/RemoteMessaging/RemoteMessagingConfigMatcherProvider.swift
+++ b/macOS/DuckDuckGo/RemoteMessaging/RemoteMessagingConfigMatcherProvider.swift
@@ -208,11 +208,14 @@ final class RemoteMessagingConfigMatcherProvider: RemoteMessagingConfigMatcherPr
             flag.cohortType == nil && featureFlagger.isFeatureOn(for: flag)
         }.map(\.rawValue)
 
+        let canUpgradeOS = SupportedOSChecker(featureFlagger: featureFlagger).osUpgradeCapability.canUpgradeOS
+
         return RemoteMessagingConfigMatcher(
             appAttributeMatcher: AppAttributeMatcher(statisticsStore: statisticsStore,
                                                      variantManager: variantManager(),
                                                      isInternalUser: internalUserDecider.isInternalUser,
-                                                     isInstalledMacAppStore: AppVersion.isAppStoreBuild),
+                                                     isInstalledMacAppStore: AppVersion.isAppStoreBuild,
+                                                     canUpgradeOS: canUpgradeOS),
             userAttributeMatcher: UserAttributeMatcher(statisticsStore: statisticsStore,
                                                        featureDiscovery: featureDiscovery,
                                                        variantManager: variantManager(),

--- a/macOS/DuckDuckGo/RemoteMessaging/RemoteMessagingDebugMenu.swift
+++ b/macOS/DuckDuckGo/RemoteMessaging/RemoteMessagingDebugMenu.swift
@@ -30,6 +30,8 @@ final class RemoteMessagingDebugMenu: NSMenu {
     private let configurationURLMenuItem: NSMenuItem = {
         return NSMenuItem(title: "")
     }()
+    private let osUpgradeCapabilityOverridePersistor = OSUpgradeCapabilityOverridePersistor()
+    private let osUpgradeCapabilityOverrideMenu = NSMenu(title: "")
 
     struct MessageModel: CustomStringConvertible {
         let id: String
@@ -79,6 +81,17 @@ final class RemoteMessagingDebugMenu: NSMenu {
                 .withAccessibilityIdentifier("RemoteMessagingDebugMenu.setCustomRemoteMessagingURL")
             NSMenuItem(title: "Reset Remote Messaging URL to Default", action: #selector(resetRemoteMessagingURLToDefault), target: self)
                 .withAccessibilityIdentifier("RemoteMessagingDebugMenu.resetRemoteMessagingURLToDefault")
+            NSMenuItem.separator()
+            NSMenuItem(title: "OS Upgrade Capability Override")
+                .submenu(osUpgradeCapabilityOverrideMenu)
+                .withAccessibilityIdentifier("RemoteMessagingDebugMenu.osUpgradeCapabilityOverride")
+        }
+
+        for override in OSUpgradeCapabilityOverride.allCases {
+            let item = NSMenuItem(title: override.title, action: #selector(setOSUpgradeCapabilityOverride(_:)), target: self)
+            item.representedObject = override
+            item.withAccessibilityIdentifier("RemoteMessagingDebugMenu.osUpgradeCapabilityOverride.\(override.rawValue)")
+            osUpgradeCapabilityOverrideMenu.addItem(item)
         }
     }
 
@@ -88,6 +101,7 @@ final class RemoteMessagingDebugMenu: NSMenu {
 
     override func update() {
         updateConfigurationURL()
+        updateOSUpgradeCapabilityOverrideMenu()
         populateMessages()
     }
 
@@ -95,9 +109,17 @@ final class RemoteMessagingDebugMenu: NSMenu {
         configurationURLMenuItem.title = "Configuration URL: \(configurationURLProvider.url(for: .remoteMessagingConfig).absoluteString)"
     }
 
+    private func updateOSUpgradeCapabilityOverrideMenu() {
+        let current = osUpgradeCapabilityOverridePersistor.current
+        for item in osUpgradeCapabilityOverrideMenu.items {
+            guard let override = item.representedObject as? OSUpgradeCapabilityOverride else { continue }
+            item.state = override == current ? .on : .off
+        }
+    }
+
     private func populateMessages() {
-        (8..<self.numberOfItems).forEach { _ in
-            removeItem(at: 8)
+        (10..<self.numberOfItems).forEach { _ in
+            removeItem(at: 10)
         }
 
         guard AppVersion.runType.requiresEnvironment, NSApp.delegateTyped.remoteMessagingClient.isRemoteMessagingDatabaseLoaded else {
@@ -129,6 +151,13 @@ final class RemoteMessagingDebugMenu: NSMenu {
             item.isEnabled = false
             addItem(item)
         }
+    }
+
+    @objc func setOSUpgradeCapabilityOverride(_ sender: NSMenuItem) {
+        guard let override = sender.representedObject as? OSUpgradeCapabilityOverride else { return }
+        osUpgradeCapabilityOverridePersistor.current = override
+        updateOSUpgradeCapabilityOverrideMenu()
+        NSApp.delegateTyped.remoteMessagingClient.refreshRemoteMessages()
     }
 
     @objc func fetchRemoteMessagesConfig() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215096436742098?focus=true
RMF PR: https://github.com/duckduckgo/remote-messaging-config/pull/362

### Description

The Remote Messaging Framework can't currently target macOS users by whether their hardware can be upgraded to a newer macOS version, which limits how precisely we can phrase end-of-support messaging. This change adds a `canUpgradeOS` boolean matching attribute, backed by `SupportedOSChecker`, so RMF rules can vary copy or CTAs based on upgrade capability.

Why now: ahead of the Big Sur drop, we want to hide the "Update macOS" CTA from users on hardware that physically can't take a newer OS. Unknown hardware is treated as upgradable, matching the existing `BigSurEndOfSupportNoticePresenter` fallback.

### Testing Steps

Testing notes:
- You need to be an internal user.
- After any Reset Remote Messages + Refresh Config, you might see a "Help us improve" survey in the title bar.  Dismiss it and do "Refresh Config" again.

1. Debug → Remote Messaging Framework → Override Remote Messaging URL… → paste `https://staticcdn.duckduckgo.com/remotemessaging/config/staging/362/macos-config.json`.
2. Debug → Remote Messaging Framework → OS Upgrade Capability Override → Force capable.
3. Debug → Remote Messaging Framework → Reset Remote Messages.
4. Debug → Remote Messaging Framework → Refresh Config.
5. Open a new tab. Expect the "Update macOS" card with a red `VeryCriticalUpdate` icon. (If you see the "Help us improve" survey instead, dismiss it and Refresh Config.)
6. Click "Update macOS". Expect System Settings → Software Update to open.
7. OS Upgrade Capability Override → Force incapable.
8. Reset Remote Messages.
9. Refresh Config.
10. Open a new tab. Expect the same Big Sur EOS card without a CTA button. (Same survey-dismissal caveat applies.)

### Impact and Risks

Low. The matcher is additive — rules that don't reference `canUpgradeOS` are unaffected. iOS evaluators fall through to `.nextMessage` if a rule references the attribute, same as `installedMacAppStore` today.

#### What could go wrong?

If `SupportedOSChecker` doesn't recognize a user's Mac model, the matcher reports `canUpgradeOS = true`. Worst case: a user whose hardware actually can't upgrade is shown an "Update macOS" CTA that won't help them. We accept this because the opposite bias — hiding the CTA from someone who genuinely could upgrade — leaves them stuck on an unsupported OS.

### Quality Considerations

The hardware-model lookup lives in `SupportedOSChecker` and is already exercised by the daily-active pixel. The matcher reuses that source of truth — there's no new state to keep in sync. No privacy impact: capability is derived locally from the OS-reported model identifier and never transmitted.

### Notes to Reviewer

None.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive RMF attribute and local hardware lookup only; default `canUpgradeOS` preserves prior behavior for unknown models (show upgrade CTA). Debug overrides are stripped in release builds.
> 
> **Overview**
> Adds a **`canUpgradeOS`** Remote Messaging Framework matching attribute on macOS so rules can branch on whether the Mac can upgrade to a newer macOS (e.g. show or hide an “Update macOS” CTA during Big Sur end-of-support).
> 
> BrowserServicesKit maps the JSON key to `OSUpgradeCapabilityMatchingAttribute` and evaluates it in `DesktopAppAttributeMatcher`. The value comes from `SupportedOSChecker.osUpgradeCapability.canUpgradeOS`, with **`.unknown` treated as `true`** to align with existing Big Sur EOS UI behavior. `RemoteMessagingConfigMatcherProvider` wires that into the app matcher, with a **DEBUG-only** override in the Remote Messaging debug menu (`OSUpgradeCapabilityOverridePersistor`) to force capable/incapable for QA. Unit tests cover match/fail paths. Rules that omit `canUpgradeOS` are unchanged; on iOS the attribute is not evaluated by the desktop matcher (same pattern as other mac-only keys).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ff8afb8829f745990367dc308e0417aaea1b729. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->