### PR TITLE
iOS: Add feature flag for iPad Duck.ai chrome shortcut

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -516,6 +516,9 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// surfaces a "System microphone disabled" warning when the OS has denied access, and
     /// presents the Permission Center popover when the FE reports `getUserMedia` failure.
     case nativeVoicePermissionFlow
+
+    /// Displays the Duck.ai shortcut in the iPad browser chrome (tabs bar).
+    case iPadChromeShortcut
 }
 
 public enum HtmlNewTabPageSubfeature: String, Equatable, PrivacySubfeature {

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -410,6 +410,10 @@ public enum FeatureFlag: String {
     /// Failsafe feature flag. Routes tapped .ics calendar links through EKEventEditViewController.
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214740849233380
     case icsCalendarLinks
+
+    /// Gates the Duck.ai shortcut in the iPad browser chrome (tabs bar).
+    /// https://app.asana.com/1/137249556945/project/1204006570077678/task/1215105704317047
+    case aiChatChromeShortcutIPad
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
@@ -716,6 +720,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.defaultExistingIPhoneUsersToNewTabAfterIdle))
         case .icsCalendarLinks:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(iOSBrowserConfigSubfeature.icsCalendarLinks))
+        case .aiChatChromeShortcutIPad:
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.iPadChromeShortcut))
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1215105704317047
Tech Design URL:
CC:

### Description

Declares the feature flag that will gate the iPad Duck.ai chrome shortcut once it ships.

- Adds `aiChatChromeShortcutIPad` to `FeatureFlag` (iOS).
- Adds the matching `iPadChromeShortcut` subfeature to `AIChatSubfeature` so the flag can be remote-released.
- Default value: `.internalOnly`. The flag is **not consumed** by any code in this PR — gating the visibility of the chrome shortcut is a follow-up task in the same project.

This is the first of several small PRs scoped under the parent project [[iPad] - 1 click access to duck.ai from browser chrome](https://app.asana.com/1/137249556945/project/1204006570077678/task/1213971185527068).

### Testing Steps

1. Build the iOS Browser scheme — no warnings or errors.
2. Open Debug → Feature Flags and confirm `aiChatChromeShortcutIPad` appears in the list, off by default.
3. No user-visible changes are expected.

### Impact and Risks

**Low** — flag is declared but not consumed. Default is `internalOnly` so it has zero effect on production builds.

#### What could go wrong?

Nothing user-facing. The only risk would be a typo in the subfeature `rawValue`, which would only surface when the consuming PR lands and the remote config returns a payload that doesn't match. The string matches the convention used by existing iPad-prefixed AIChat subfeatures (`iPadDuckaiOnTab`, `iPadAIChatToggle`, `iPadPageContext`).

### Notes to Reviewer

Intentionally minimal — this PR is just the flag declaration. The visibility gating, the Settings toggle, the long-press menu, and the contextual-sheet split-button each land as their own PRs (see the project's subtasks for the full sequence).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flag-only change with internalOnly default and no call sites; only risk is a remote-config key mismatch when consumption lands.
> 
> **Overview**
> Adds remote-release plumbing for a future **iPad Duck.ai shortcut in the browser chrome (tabs bar)**. No UI or behavior reads the flag yet.
> 
> **Shared privacy config:** new `AIChatSubfeature.iPadChromeShortcut` under the `aiChat` feature.
> 
> **iOS:** new `FeatureFlag.aiChatChromeShortcutIPad` mapped to that subfeature with default **`.internalOnly`**, so production users are unaffected until follow-up PRs gate the shortcut and related settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bf915f7a27807d0ddaaaabaa6b467aa52cbaa34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->