### PR TITLE
iOS: Add Navigation Bar toggle to Manage Duck.ai Shortcuts settings

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/iOS/PublicAPI/AIChatSettingsProvider.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/iOS/PublicAPI/AIChatSettingsProvider.swift
@@ -57,6 +57,9 @@ public protocol AIChatSettingsProvider {
     /// The user settings state for the AI Chat in tab manager
     var isAIChatTabSwitcherUserSettingsEnabled: Bool { get }
 
+    /// The user settings state for the Duck.ai shortcut in the iPad browser chrome (tabs bar).
+    var isAIChatNavigationBarUserSettingsEnabled: Bool { get }
+
     /// The user settings state for automatically attaching page context
     var isAutomaticContextAttachmentEnabled: Bool { get }
 
@@ -77,6 +80,9 @@ public protocol AIChatSettingsProvider {
 
     /// Updates the user settings state for the AI Chat voice search
     func enableAIChatTabSwitcherUserSettings(enable: Bool)
+
+    /// Updates the user settings state for the Duck.ai shortcut in the iPad browser chrome.
+    func enableAIChatNavigationBarUserSettings(enable: Bool)
 
     /// Updates the user settings state for the AI Chat Search Input
     func enableAIChatSearchInputUserSettings(enable: Bool)

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -516,6 +516,9 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// surfaces a "System microphone disabled" warning when the OS has denied access, and
     /// presents the Permission Center popover when the FE reports `getUserMedia` failure.
     case nativeVoicePermissionFlow
+
+    /// Displays the Duck.ai shortcut in the iPad browser chrome (tabs bar).
+    case iPadChromeShortcut
 }
 
 public enum HtmlNewTabPageSubfeature: String, Equatable, PrivacySubfeature {

--- a/SharedPackages/SERPSettings/Tests/SERPSettingsTests/Mocks/MockSERPSettingsProvider.swift
+++ b/SharedPackages/SERPSettings/Tests/SERPSettingsTests/Mocks/MockSERPSettingsProvider.swift
@@ -95,6 +95,7 @@ final class MockAIChatSettingsProvider: AIChatSettingsProvider {
     var isAIChatBrowsingMenuUserSettingsEnabled: Bool = false
     var isAIChatVoiceSearchUserSettingsEnabled: Bool = false
     var isAIChatTabSwitcherUserSettingsEnabled: Bool = false
+    var isAIChatNavigationBarUserSettingsEnabled: Bool = false
     var isAIChatFullModeEnabled: Bool = false
     var isAutomaticContextAttachmentEnabled: Bool = false
     var isChatSuggestionsEnabled: Bool = true
@@ -107,6 +108,7 @@ final class MockAIChatSettingsProvider: AIChatSettingsProvider {
     func enableAIChatAddressBarUserSettings(enable: Bool) {}
     func enableAIChatVoiceSearchUserSettings(enable: Bool) {}
     func enableAIChatTabSwitcherUserSettings(enable: Bool) {}
+    func enableAIChatNavigationBarUserSettings(enable: Bool) {}
     func enableAIChatSearchInputUserSettings(enable: Bool) {}
     func enableAIChatFullModeSetting(enable: Bool) {}
     func enableAutomaticContextAttachment(enable: Bool) {}

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -410,6 +410,10 @@ public enum FeatureFlag: String {
     /// Failsafe feature flag. Routes tapped .ics calendar links through EKEventEditViewController.
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214740849233380
     case icsCalendarLinks
+
+    /// Gates the Duck.ai shortcut in the iPad browser chrome (tabs bar).
+    /// https://app.asana.com/1/137249556945/project/1204006570077678/task/1215105704317047
+    case aiChatChromeShortcutIPad
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
@@ -716,6 +720,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.defaultExistingIPhoneUsersToNewTabAfterIdle))
         case .icsCalendarLinks:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(iOSBrowserConfigSubfeature.icsCalendarLinks))
+        case .aiChatChromeShortcutIPad:
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.iPadChromeShortcut))
         }
     }
 

--- a/iOS/DuckDuckGo/AIChat/AIChatSettings.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatSettings.swift
@@ -122,6 +122,11 @@ final class AIChatSettings: AIChatSettingsProvider {
             && isAIChatEnabled
     }
 
+    var isAIChatNavigationBarUserSettingsEnabled: Bool {
+        keyValueStore.bool(.showAIChatNavigationBarKey, defaultValue: .showAIChatNavigationBarDefaultValue)
+            && isAIChatEnabled
+    }
+
     var isAIChatVoiceSearchUserSettingsEnabled: Bool {
         keyValueStore.bool(.showAIChatVoiceSearchKey, defaultValue: .showAIChatVoiceSearchDefaultValue)
             && isAIChatEnabled
@@ -236,6 +241,11 @@ final class AIChatSettings: AIChatSettingsProvider {
         }
     }
 
+    func enableAIChatNavigationBarUserSettings(enable: Bool) {
+        keyValueStore.set(enable, forKey: .showAIChatNavigationBarKey)
+        triggerSettingsChangedNotification()
+    }
+
     func enableChatSuggestions(enable: Bool) {
         keyValueStore.set(enable, forKey: .showChatSuggestionsKey)
         triggerSettingsChangedNotification()
@@ -305,6 +315,7 @@ private extension String {
     static let showAIChatAddressBarKey = "aichat.settings.showAIChatAddressBar"
     static let showAIChatVoiceSearchKey = "aichat.settings.showAIChatVoiceSearch"
     static let showAIChatTabSwitcherKey = "aichat.settings.showAIChatTabSwitcher"
+    static let showAIChatNavigationBarKey = "aichat.settings.showAIChatNavigationBar"
     static let showAIChatExperimentalSearchInputKey = "aichat.settings.showAIChatExperimentalSearchInput"
     static let showChatSuggestionsKey = "aichat.settings.showChatSuggestions"
     static let isAIChatAutomaticContextAttachmentEnabledKey = "aichat.settings.isAIChatAutomaticContextAttachmentEnabled"
@@ -332,6 +343,7 @@ private extension Bool {
     static let showAIChatAddressBarDefaultValue = true
     static let showAIChatVoiceSearchDefaultValue = true
     static let showAIChatTabSwitcherDefaultValue = true
+    static let showAIChatNavigationBarDefaultValue = true
     static let showAIChatExperimentalSearchInputDefaultValue = false
     static let showChatSuggestionsDefaultValue = true
 

--- a/iOS/DuckDuckGo/AIChat/AIChatSettings.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatSettings.swift
@@ -329,6 +329,7 @@ enum LegacyAiChatUserDefaultsKeys {
     static let showAIChatAddressBarKey: String = .showAIChatAddressBarKey
     static let showAIChatVoiceSearchKey: String = .showAIChatVoiceSearchKey
     static let showAIChatTabSwitcherKey: String = .showAIChatTabSwitcherKey
+    static let showAIChatNavigationBarKey: String = .showAIChatNavigationBarKey
     static let showAIChatExperimentalSearchInputKey: String = .showAIChatExperimentalSearchInputKey
     static let defaultOmnibarModeKey: String = .defaultOmnibarModeKey
 

--- a/iOS/DuckDuckGo/SettingsAIChatShortcutsView.swift
+++ b/iOS/DuckDuckGo/SettingsAIChatShortcutsView.swift
@@ -21,6 +21,21 @@ import SwiftUI
 import DesignResourcesKit
 import DesignResourcesKitIcons
 import Core
+import PrivacyConfig
+
+/// Visibility logic for the Duck.ai chrome shortcut surfaces.
+///
+/// The chrome shortcut (the Duck.ai pill in the iPad tabs bar and its matching
+/// row in Settings → AI Features → Manage Duck.ai Shortcuts) is iPad-only and
+/// gated behind the `aiChatChromeShortcutIPad` feature flag.
+///
+/// Extracted as a free type so the platform check can be exercised in tests
+/// without depending on `UIDevice.current`.
+enum DuckAIChromeShortcutVisibility {
+    static func isSettingsRowVisible(isIPad: Bool, featureFlagger: FeatureFlagger) -> Bool {
+        isIPad && featureFlagger.isFeatureOn(.aiChatChromeShortcutIPad)
+    }
+}
 
 struct SettingsAIChatShortcutsView: View {
     @EnvironmentObject var viewModel: SettingsViewModel
@@ -33,6 +48,12 @@ struct SettingsAIChatShortcutsView: View {
 
                 SettingsCellView(label: UserText.aiChatSettingsEnableAddressBarToggle,
                                  accessory: .toggle(isOn: viewModel.aiChatAddressBarEnabledBinding))
+
+                if shouldShowNavigationBarShortcut {
+                    SettingsCellView(label: UserText.aiChatSettingsEnableNavigationBarToggle,
+                                     subtitle: UserText.aiChatSettingsEnableNavigationBarSubtitle,
+                                     accessory: .toggle(isOn: viewModel.aiChatNavigationBarEnabledBinding))
+                }
 
                 if viewModel.state.voiceSearchEnabled {
                     SettingsCellView(label: UserText.aiChatSettingsEnableVoiceSearchToggle,
@@ -109,6 +130,13 @@ struct SettingsAIChatShortcutsView: View {
 
     private var shouldShowAddressBarShortcut: Bool {
         !(viewModel.featureFlagger.isFeatureOn(.iPadAIToggle) && UIDevice.current.userInterfaceIdiom == .pad)
+    }
+
+    private var shouldShowNavigationBarShortcut: Bool {
+        DuckAIChromeShortcutVisibility.isSettingsRowVisible(
+            isIPad: UIDevice.current.userInterfaceIdiom == .pad,
+            featureFlagger: viewModel.featureFlagger
+        )
     }
 }
 

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -1817,6 +1817,15 @@ extension SettingsViewModel {
         )
     }
 
+    var aiChatNavigationBarEnabledBinding: Binding<Bool> {
+        Binding<Bool>(
+            get: { self.aiChatSettings.isAIChatNavigationBarUserSettingsEnabled },
+            set: { newValue in
+                self.aiChatSettings.enableAIChatNavigationBarUserSettings(enable: newValue)
+            }
+        )
+    }
+
     var isAutomaticContextAttachmentEnabled: Binding<Bool> {
         Binding<Bool>(
             get: { self.aiChatSettings.isAutomaticContextAttachmentEnabled },

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -2204,6 +2204,10 @@ public struct UserText {
     public static let aiChatSettingsEnableVoiceSearchToggle = NSLocalizedString("duckai.settings.enable.voice-search-toggle", value: "Voice Search", comment: "Toggle text to enable/disable Duck.ai in voice search")
 
     public static let aiChatSettingsEnableTabSwitcherToggle = NSLocalizedString("duckai.settings.enable.tab-switcher-toggle", value: "Tabs Screen", comment: "Toggle text to enable/disable Duck.ai in tab manager")
+
+    public static let aiChatSettingsEnableNavigationBarToggle = NSLocalizedString("duckai.settings.enable.navigation-bar-toggle", value: "Navigation Bar", comment: "Toggle text to enable/disable Duck.ai shortcut in the iPad browser chrome (tabs bar)")
+
+    public static let aiChatSettingsEnableNavigationBarSubtitle = NSLocalizedString("duckai.settings.enable.navigation-bar-subtitle", value: "Show in the browser navigation bar or address bar, depending on window size.", comment: "Subtitle for the Navigation Bar toggle row in Manage Duck.ai Shortcuts settings")
     
     public static let aiChatSettingsBrowserShortcutsSectionTitle = NSLocalizedString("duckai.settings.browserShortcuts.section.title", value: "Browser shortcuts", comment: "Title for section that groups shortcuts related to browser")
 

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -2205,9 +2205,11 @@ public struct UserText {
 
     public static let aiChatSettingsEnableTabSwitcherToggle = NSLocalizedString("duckai.settings.enable.tab-switcher-toggle", value: "Tabs Screen", comment: "Toggle text to enable/disable Duck.ai in tab manager")
 
-    public static let aiChatSettingsEnableNavigationBarToggle = NSLocalizedString("duckai.settings.enable.navigation-bar-toggle", value: "Navigation Bar", comment: "Toggle text to enable/disable Duck.ai shortcut in the iPad browser chrome (tabs bar)")
+    // Held as NotLocalizedString until copy is approved at Ship Review; convert to NSLocalizedString afterwards.
+    public static let aiChatSettingsEnableNavigationBarToggle = NotLocalizedString("duckai.settings.enable.navigation-bar-toggle", value: "Navigation Bar", comment: "Toggle text to enable/disable Duck.ai shortcut in the iPad browser chrome (tabs bar)")
 
-    public static let aiChatSettingsEnableNavigationBarSubtitle = NSLocalizedString("duckai.settings.enable.navigation-bar-subtitle", value: "Show in the browser navigation bar or address bar, depending on window size.", comment: "Subtitle for the Navigation Bar toggle row in Manage Duck.ai Shortcuts settings")
+    // Held as NotLocalizedString until copy is approved at Ship Review; convert to NSLocalizedString afterwards.
+    public static let aiChatSettingsEnableNavigationBarSubtitle = NotLocalizedString("duckai.settings.enable.navigation-bar-subtitle", value: "Show in the browser navigation bar or address bar, depending on window size.", comment: "Subtitle for the Navigation Bar toggle row in Manage Duck.ai Shortcuts settings")
     
     public static let aiChatSettingsBrowserShortcutsSectionTitle = NSLocalizedString("duckai.settings.browserShortcuts.section.title", value: "Browser shortcuts", comment: "Title for section that groups shortcuts related to browser")
 

--- a/iOS/DuckDuckGo/en.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/en.lproj/Localizable.strings
@@ -1630,12 +1630,6 @@
 /* Toggle text to enable/disable AI Chat in the browsing menu */
 "duckai.settings.enable.browsing-menu-toggle" = "Browser Menu";
 
-/* Subtitle for the Navigation Bar toggle row in Manage Duck.ai Shortcuts settings */
-"duckai.settings.enable.navigation-bar-subtitle" = "Show in the browser navigation bar or address bar, depending on window size.";
-
-/* Toggle text to enable/disable Duck.ai shortcut in the iPad browser chrome (tabs bar) */
-"duckai.settings.enable.navigation-bar-toggle" = "Navigation Bar";
-
 /* Toggle text to enable/disable Duck.ai in tab manager */
 "duckai.settings.enable.tab-switcher-toggle" = "Tabs Screen";
 

--- a/iOS/DuckDuckGo/en.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/en.lproj/Localizable.strings
@@ -1630,6 +1630,12 @@
 /* Toggle text to enable/disable AI Chat in the browsing menu */
 "duckai.settings.enable.browsing-menu-toggle" = "Browser Menu";
 
+/* Subtitle for the Navigation Bar toggle row in Manage Duck.ai Shortcuts settings */
+"duckai.settings.enable.navigation-bar-subtitle" = "Show in the browser navigation bar or address bar, depending on window size.";
+
+/* Toggle text to enable/disable Duck.ai shortcut in the iPad browser chrome (tabs bar) */
+"duckai.settings.enable.navigation-bar-toggle" = "Navigation Bar";
+
 /* Toggle text to enable/disable Duck.ai in tab manager */
 "duckai.settings.enable.tab-switcher-toggle" = "Tabs Screen";
 

--- a/iOS/DuckDuckGoTests/AIChat/AIChatSettingsTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatSettingsTests.swift
@@ -178,6 +178,83 @@ class AIChatSettingsTests: XCTestCase {
         XCTAssertTrue(settings.isAutomaticContextAttachmentEnabled)
     }
 
+    // MARK: - Navigation Bar shortcut (iPad Duck.ai chrome)
+
+    func testIsAIChatNavigationBarUserSettingsEnabled_returnsTrueByDefault() {
+        let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
+                                      debugSettings: mockAIChatDebugSettings,
+                                      keyValueStore: mockKeyValueStore,
+                                      notificationCenter: mockNotificationCenter,
+                                      featureFlagger: mockFeatureFlagger)
+
+        XCTAssertTrue(settings.isAIChatNavigationBarUserSettingsEnabled)
+    }
+
+    func testEnableAIChatNavigationBarUserSettings_persistsValue() {
+        let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
+                                      debugSettings: mockAIChatDebugSettings,
+                                      keyValueStore: mockKeyValueStore,
+                                      notificationCenter: mockNotificationCenter,
+                                      featureFlagger: mockFeatureFlagger)
+
+        settings.enableAIChatNavigationBarUserSettings(enable: false)
+        XCTAssertFalse(settings.isAIChatNavigationBarUserSettingsEnabled)
+
+        settings.enableAIChatNavigationBarUserSettings(enable: true)
+        XCTAssertTrue(settings.isAIChatNavigationBarUserSettingsEnabled)
+    }
+
+    func testIsAIChatNavigationBarUserSettingsEnabled_returnsFalse_whenAIChatGloballyDisabled() {
+        let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
+                                      debugSettings: mockAIChatDebugSettings,
+                                      keyValueStore: mockKeyValueStore,
+                                      notificationCenter: mockNotificationCenter,
+                                      featureFlagger: mockFeatureFlagger)
+        settings.enableAIChatNavigationBarUserSettings(enable: true)
+        settings.enableAIChat(enable: false)
+
+        XCTAssertFalse(settings.isAIChatNavigationBarUserSettingsEnabled)
+    }
+
+    func testEnableAIChatNavigationBarUserSettings_postsNotification() {
+        let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
+                                      debugSettings: mockAIChatDebugSettings,
+                                      keyValueStore: mockKeyValueStore,
+                                      notificationCenter: mockNotificationCenter,
+                                      featureFlagger: mockFeatureFlagger)
+
+        let expectation = self.expectation(description: "Notification posted on Navigation Bar setting change")
+        let observer = mockNotificationCenter.addObserver(forName: .aiChatSettingsChanged, object: nil, queue: nil) { _ in
+            expectation.fulfill()
+        }
+
+        settings.enableAIChatNavigationBarUserSettings(enable: false)
+        waitForExpectations(timeout: 1, handler: nil)
+        mockNotificationCenter.removeObserver(observer)
+    }
+
+    // MARK: - DuckAIChromeShortcutVisibility
+
+    func testDuckAIChromeShortcutVisibility_settingsRowVisible_onIPad_whenFlagOn() {
+        let flagger = MockFeatureFlagger(enabledFeatureFlags: [.aiChatChromeShortcutIPad])
+        XCTAssertTrue(DuckAIChromeShortcutVisibility.isSettingsRowVisible(isIPad: true, featureFlagger: flagger))
+    }
+
+    func testDuckAIChromeShortcutVisibility_settingsRowHidden_onIPhone_evenWhenFlagOn() {
+        let flagger = MockFeatureFlagger(enabledFeatureFlags: [.aiChatChromeShortcutIPad])
+        XCTAssertFalse(DuckAIChromeShortcutVisibility.isSettingsRowVisible(isIPad: false, featureFlagger: flagger))
+    }
+
+    func testDuckAIChromeShortcutVisibility_settingsRowHidden_onIPad_whenFlagOff() {
+        let flagger = MockFeatureFlagger(enabledFeatureFlags: [])
+        XCTAssertFalse(DuckAIChromeShortcutVisibility.isSettingsRowVisible(isIPad: true, featureFlagger: flagger))
+    }
+
+    func testDuckAIChromeShortcutVisibility_settingsRowHidden_onIPhone_whenFlagOff() {
+        let flagger = MockFeatureFlagger(enabledFeatureFlags: [])
+        XCTAssertFalse(DuckAIChromeShortcutVisibility.isSettingsRowVisible(isIPad: false, featureFlagger: flagger))
+    }
+
 }
 
 final class MockAIChatDebugSettings: AIChatDebugSettingsHandling {

--- a/iOS/DuckDuckGoTests/AIChat/AIChatSettingsTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatSettingsTests.swift
@@ -180,12 +180,15 @@ class AIChatSettingsTests: XCTestCase {
 
     // MARK: - Navigation Bar shortcut (iPad Duck.ai chrome)
 
-    func testIsAIChatNavigationBarUserSettingsEnabled_returnsTrueByDefault() {
+    func testIsAIChatNavigationBarUserSettingsEnabled_returnsTrueByDefault_whenAIChatIsEnabled() {
         let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
                                       debugSettings: mockAIChatDebugSettings,
                                       keyValueStore: mockKeyValueStore,
                                       notificationCenter: mockNotificationCenter,
                                       featureFlagger: mockFeatureFlagger)
+        // Pin the AI Chat global gate explicitly so the test only depends on
+        // showAIChatNavigationBarDefaultValue, not the isAIChatEnabled default.
+        settings.enableAIChat(enable: true)
 
         XCTAssertTrue(settings.isAIChatNavigationBarUserSettingsEnabled)
     }

--- a/iOS/SharedTestUtils/Mocks/AIChat/MockAIChatSettingsProvider.swift
+++ b/iOS/SharedTestUtils/Mocks/AIChat/MockAIChatSettingsProvider.swift
@@ -29,6 +29,7 @@ public class MockAIChatSettingsProvider: AIChatSettingsProvider {
     public var isAIChatAddressBarShortcutFeatureEnabled: Bool
     public var isAIChatVoiceSearchUserSettingsEnabled: Bool
     public var isAIChatTabSwitcherUserSettingsEnabled: Bool
+    public var isAIChatNavigationBarUserSettingsEnabled: Bool
     public var sessionTimerInMinutes: Int
     public var isAIChatSearchInputUserSettingsEnabled: Bool
     public var isAIChatSearchInputUserSettingsDisabledByUser: Bool
@@ -44,6 +45,7 @@ public class MockAIChatSettingsProvider: AIChatSettingsProvider {
                 isAIChatAddressBarShortcutFeatureEnabled: Bool = false,
                 isAIChatVoiceSearchUserSettingsEnabled: Bool = false,
                 isAIChatTabSwitcherUserSettingsEnabled: Bool = false,
+                isAIChatNavigationBarUserSettingsEnabled: Bool = false,
                 isAIChatSearchInputUserSettingsEnabled: Bool = false,
                 isAIChatSearchInputUserSettingsDisabledByUser: Bool = false,
                 isAutomaticContextAttachmentEnabled: Bool = false,
@@ -58,6 +60,7 @@ public class MockAIChatSettingsProvider: AIChatSettingsProvider {
         self.isAIChatAddressBarShortcutFeatureEnabled = isAIChatAddressBarShortcutFeatureEnabled
         self.isAIChatVoiceSearchUserSettingsEnabled = isAIChatVoiceSearchUserSettingsEnabled
         self.isAIChatTabSwitcherUserSettingsEnabled = isAIChatTabSwitcherUserSettingsEnabled
+        self.isAIChatNavigationBarUserSettingsEnabled = isAIChatNavigationBarUserSettingsEnabled
         self.isAIChatSearchInputUserSettingsEnabled = isAIChatSearchInputUserSettingsEnabled
         self.isAIChatSearchInputUserSettingsDisabledByUser = isAIChatSearchInputUserSettingsDisabledByUser
         self.isAutomaticContextAttachmentEnabled = isAutomaticContextAttachmentEnabled
@@ -80,6 +83,10 @@ public class MockAIChatSettingsProvider: AIChatSettingsProvider {
 
     public func enableAIChatTabSwitcherUserSettings(enable: Bool) {
         isAIChatTabSwitcherUserSettingsEnabled = enable
+    }
+
+    public func enableAIChatNavigationBarUserSettings(enable: Bool) {
+        isAIChatNavigationBarUserSettingsEnabled = enable
     }
 
     public func enableAIChat(enable: Bool) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215119474036174
Tech Design URL:
CC:

### Description

> **Note on base branch:** this PR is stacked on top of #5068 (the feature flag declaration). Once #5068 lands the base will be changed to `main` automatically.

Adds storage and the UI row for the new **"Navigation Bar"** toggle in **Settings → AI Features → Manage Duck.ai Shortcuts**. The toggle is the user-facing control for showing/hiding the Duck.ai chrome shortcut in the iPad tabs bar.

**Storage layer**
- New `isAIChatNavigationBarUserSettingsEnabled` getter and `enableAIChatNavigationBarUserSettings(enable:)` setter on `AIChatSettingsProvider`.
- Concrete impl in `AIChatSettings` persists `aichat.settings.showAIChatNavigationBar` to the shared key-value store (default `true`), is gated on the global `isAIChatEnabled`, and broadcasts via the existing `.aiChatSettingsChanged` notification.
- `MockAIChatSettingsProvider` updated to match.

**Settings UI**
- New `SettingsCellView` row with the subtitle *"Show in the browser navigation bar or address bar, depending on window size."*
- Row is gated on **iPad** AND the `aiChatChromeShortcutIPad` feature flag, so it's invisible on iPhone and in production builds while the flag is off.
- Visibility logic is extracted to `DuckAIChromeShortcutVisibility.isSettingsRowVisible(isIPad:featureFlagger:)` so the platform check is injectable for tests.

**Tests** — 8 new tests in `AIChatSettingsTests`:
- Storage: default value, persistence, global-Duck.ai-disable interaction, notification broadcast.
- Visibility helper: iPad × flag matrix (4 cases).

### Testing Steps

1. Run `UnitTests/AIChatSettingsTests` — all pass.
2. Build the **iOS Browser** scheme on an iPad simulator.
3. Enable the `aiChatChromeShortcutIPad` feature flag via Debug → Feature Flags.
4. In the app, open Settings → AI Features → Manage Duck.ai Shortcuts → confirm the **Navigation Bar** toggle appears between "Address Bar" and "Voice Search" with the subtitle copy above.
5. Toggle it on/off — the value is persisted; no observer wired in this PR yet, so no visible browser-chrome change is expected here (that lands in the visibility-wiring PR).
6. Confirm that with the feature flag **off**, the row is **hidden** on iPad.
7. On iPhone (any simulator), confirm the row never appears regardless of flag state.
8. Disable Duck.ai globally (Settings → AI Features → main Duck.ai toggle off) — the underlying value still reads `false` for the gated getter (covered by `testIsAIChatNavigationBarUserSettingsEnabled_returnsFalse_whenAIChatGloballyDisabled`).

### Impact and Risks

**Low** — protected on three sides:
- The feature flag (`aiChatChromeShortcutIPad`, default `internalOnly`) hides the row in production.
- An idiom check hides the row on iPhone.
- No consumer reads the new setting yet, so toggling it has no user-visible effect outside Settings.

#### What could go wrong?

- A new protocol requirement was added to `AIChatSettingsProvider`. All in-tree conformers were updated (`AIChatSettings` and `MockAIChatSettingsProvider`); CI catches any external conformer I missed at compile time.
- The new `Localizable.strings` entries were auto-generated by Xcode; double-check the diff there before merging.

### Quality Considerations

- Mirrors the exact pattern used by the existing Browser Menu / Address Bar / Voice Search / Tabs Screen toggles.
- Settings-change pixels are intentionally **not** added here — they're scoped to the dedicated pixels task ([Add pixels for shortcut interactions](https://app.asana.com/1/137249556945/task/1215105848409865)).

### Notes to Reviewer

- Stacked on #5068 — review that PR first.
- The `DuckAIChromeShortcutVisibility` helper lives in `SettingsAIChatShortcutsView.swift` for now to avoid touching the `.pbxproj`. If a follow-up needs to use it from elsewhere, splitting it into its own file makes sense.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings-only change behind an internal feature flag and iPad gating; no runtime UI reads the new preference yet. Protocol extension requires all `AIChatSettingsProvider` conformers to compile.
> 
> **Overview**
> Adds a **Navigation Bar** user preference for the iPad Duck.ai chrome shortcut, following the same pattern as other Manage Duck.ai Shortcuts toggles.
> 
> `AIChatSettingsProvider` gains `isAIChatNavigationBarUserSettingsEnabled` and `enableAIChatNavigationBarUserSettings`; `AIChatSettings` persists `aichat.settings.showAIChatNavigationBar` (default on), respects the global Duck.ai master switch, and posts `.aiChatSettingsChanged`. Mocks and `SettingsViewModel` bindings wire the new toggle.
> 
> **Manage Duck.ai Shortcuts** shows a conditional **Navigation Bar** row (title + subtitle via `NotLocalizedString` until Ship Review), visible only on iPad when `aiChatChromeShortcutIPad` is on, via `DuckAIChromeShortcutVisibility`. Nothing in the browser chrome reads this setting yet—toggling only affects storage/UI.
> 
> Eight unit tests cover persistence, global-disable gating, notifications, and the iPad × flag visibility matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03c0ef6c70cbbdffb88cfb6f20d20d9a0586df4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->