### PR TITLE
iOS: Fix tab switcher retain cycle from fireTabsTipTask

### DIFF
--- a/iOS/DuckDuckGo/TabSwitcherViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController.swift
@@ -290,8 +290,8 @@ class TabSwitcherViewController: UIViewController {
         }
 
         fireTabsTipTask = Task { @MainActor [weak self] in
-            guard let self else { return }
             for await shouldDisplay in tip.shouldDisplayUpdates {
+                guard let self else { return }
                 if shouldDisplay {
                     self.fireModePromotionsCoordinator?.markTabSwitcherTipShown()
                     let popoverController = TipUIPopoverViewController(tip, sourceItem: sourceView)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1215028409030026
CC: @samsymons @aataraxiaa 

### Description

`TabSwitcherViewController.fireTabsTipTask` strong-captures `self` for the lifetime of its `for await` loop, causing the controller to leak after dismissal. Subsequent taps on the toolbar tab switcher button hit the `guard tabSwitcherController == nil else { return }` in `MainViewController+Segues.swift:202` and silently no-op. Long-press still works (different code path that doesn't go through `segueToTabSwitcher`).

The strong capture happens because `guard let self else { return }` is at the top of the closure, upgrading `[weak self]` to a strong binding for the entire (infinite) loop. Moving the guard inside the loop binds `self` strongly only per-iteration; between yields it's weak, so the controller can deinit and the task terminates naturally on the next yield.

Pre-existing bug; introduced in #4500 (merged 2026-04-23, first shipped in 7.218.0).

### Testing Steps

1. Open the tab switcher in **normal** mode while the Fire Tabs tip is eligible (fresh install with `iOSBrowserConfig.fireMode` enabled, no recorded `tabSwitcherTipFirstSeenDate`).
2. Wait for the popover to appear, or trigger via `forceFireTabsTip`.
3. Dismiss the tab switcher by tapping + button in the toolbar while the popover is still on screen.
4. Tap the toolbar tab switcher button again — should open as expected (previously: silently broken until app relaunch).
5. Long-press menu (fire / normal new tab) continues to work in both states.

### Impact and Risks

Medium. Affects users with the fire mode rollout enabled who interact with the tip popover. After the leak triggers, the toolbar tab switcher button is dead until app relaunch.

#### What could go wrong?

One-line change to capture semantics. The task body briefly executes with weak `self` possibly nil mid-iteration — handled by the new `guard let self else { return }` returning early. No additional teardown is required because the task naturally exits on the next yield once the controller deinits.

### Notes to Reviewer

Single-line move (`guard let self else { return }` from above the `for await` into the loop body). Consider cherry-picking onto `release/ios/7.222.0` if the team wants this in the next iOS release.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line capture-semantics change in an async tip loop; version config updates only. No auth, data, or security surface.
> 
> **Overview**
> Fixes a **retain cycle** in `TabSwitcherViewController` where `fireTabsTipTask` kept the tab switcher alive after dismiss. **`guard let self`** is moved from above the `for await tip.shouldDisplayUpdates` loop into the loop body so `[weak self]` stays weak between yields; the controller can deinit and the toolbar tab switcher button works again instead of no-op’ing on `tabSwitcherController == nil`.
> 
> Also bumps **marketing version** to `7.221.1` (`Version.xcconfig`, Settings bundle) and resets **build number** to `0` in `BuildNumber.xcconfig`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13012a2c91cfbf068d9178ce6d8ed7c7f03ec570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->