### PR TITLE
macOS: Don't push empty Duck.ai page context after submit

### DIFF
--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -224,6 +224,16 @@ final class PageContextTabExtension {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
                 guard let self else { return }
+                // `togglePageContextTelemetry(enabled: false)` is fired by the FE for BOTH
+                // user-initiated chip removal AND the auto-clear after a prompt submit.
+                // When the FE has just consumed the context, pushing setPageContext(nil)
+                // back makes the FE treat it as a context reset and re-show
+                // "Add page content" on the same URL. The stored snapshot was already
+                // cleared by `consumeData()` during submit, so nothing else to do here.
+                // The consumed flag is set first via `pageContextConsumedSubject` because
+                // the FE reports `userDidSubmitPrompt` before the chip-removed telemetry,
+                // and both publishers are serialized on the main queue.
+                guard !self.hasContextBeenConsumedByChat else { return }
                 self.userRemovedContext = true
                 self.cachedPageContext = nil
                 // Also clear the stored pageContext inside messageHandling. Otherwise a

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -224,21 +224,14 @@ final class PageContextTabExtension {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
                 guard let self else { return }
-                // `togglePageContextTelemetry(enabled: false)` is fired by the FE for BOTH
-                // user-initiated chip removal AND the auto-clear after a prompt submit.
-                // When the FE has just consumed the context, pushing setPageContext(nil)
-                // back makes the FE treat it as a context reset and re-show
-                // "Add page content" on the same URL. The stored snapshot was already
-                // cleared by `consumeData()` during submit, so nothing else to do here.
-                // The consumed flag is set first via `pageContextConsumedSubject` because
-                // the FE reports `userDidSubmitPrompt` before the chip-removed telemetry,
-                // and both publishers are serialized on the main queue.
+                // The FE fires this for both user X-click and the auto-clear after submit.
+                // After submit the context was already consumed; pushing nil back would
+                // make the FE re-show "Add page content" on the same URL.
                 guard !self.hasContextBeenConsumedByChat else { return }
                 self.userRemovedContext = true
                 self.cachedPageContext = nil
-                // Also clear the stored pageContext inside messageHandling. Otherwise a
-                // subsequent FE `getAIChatPageContext(reason: userAction)` would return
-                // the stale snapshot and skip requesting a fresh collect.
+                // Clear the stored pageContext too, so a later FE `getAIChatPageContext`
+                // returns nil and triggers a fresh collect instead of the stale snapshot.
                 self.aiChatSessionStore.sessions[self.tabID]?.chatViewController?.setPageContext(nil)
             }
             .store(in: &sidebarCancellables)

--- a/macOS/UnitTests/AIChat/PageContextMultipleContextsTests.swift
+++ b/macOS/UnitTests/AIChat/PageContextMultipleContextsTests.swift
@@ -121,22 +121,17 @@ struct ConsumedFlagResetTests {
 
 // MARK: - Removal-After-Consume Guard Tests
 
-/// Guards against the regression where `togglePageContextTelemetry(false)` fired by the FE
-/// after a submit (the chip transitions from attached → absent as part of consume) would
-/// cause native to push `setPageContext(nil)`. That push makes the FE re-show
-/// "Add page content" on the same URL, defeating the just-completed submit.
 struct RemovalAfterConsumeTests {
 
-    /// Mirrors the guarded removal handler in `PageContextTabExtension`:
-    /// when context was just consumed by submit, skip the local-cache/nil-push cleanup.
+    /// Mirrors the removal-handler guard in PageContextTabExtension.
     private func shouldClearOnRemoval(consumed: Bool) -> Bool { !consumed }
 
-    @Test("Removal after submit (consumed=true) does NOT clear or push nil")
+    @Test("Consumed context skips removal cleanup", .timeLimit(.minutes(1)))
     func consumedSkipsCleanup() {
         #expect(shouldClearOnRemoval(consumed: true) == false)
     }
 
-    @Test("Removal without prior submit (consumed=false) clears and pushes nil")
+    @Test("Non-consumed context runs removal cleanup", .timeLimit(.minutes(1)))
     func notConsumedRunsCleanup() {
         #expect(shouldClearOnRemoval(consumed: false) == true)
     }

--- a/macOS/UnitTests/AIChat/PageContextMultipleContextsTests.swift
+++ b/macOS/UnitTests/AIChat/PageContextMultipleContextsTests.swift
@@ -126,12 +126,12 @@ struct RemovalAfterConsumeTests {
     /// Mirrors the removal-handler guard in PageContextTabExtension.
     private func shouldClearOnRemoval(consumed: Bool) -> Bool { !consumed }
 
-    @Test("Consumed context skips removal cleanup", .timeLimit(.minutes(1)))
+    @Test("Consumed context skips removal cleanup")
     func consumedSkipsCleanup() {
         #expect(shouldClearOnRemoval(consumed: true) == false)
     }
 
-    @Test("Non-consumed context runs removal cleanup", .timeLimit(.minutes(1)))
+    @Test("Non-consumed context runs removal cleanup")
     func notConsumedRunsCleanup() {
         #expect(shouldClearOnRemoval(consumed: false) == true)
     }

--- a/macOS/UnitTests/AIChat/PageContextMultipleContextsTests.swift
+++ b/macOS/UnitTests/AIChat/PageContextMultipleContextsTests.swift
@@ -118,3 +118,26 @@ struct ConsumedFlagResetTests {
         #expect(shouldResetConsumedFlag(pageContext: context) == true)
     }
 }
+
+// MARK: - Removal-After-Consume Guard Tests
+
+/// Guards against the regression where `togglePageContextTelemetry(false)` fired by the FE
+/// after a submit (the chip transitions from attached → absent as part of consume) would
+/// cause native to push `setPageContext(nil)`. That push makes the FE re-show
+/// "Add page content" on the same URL, defeating the just-completed submit.
+struct RemovalAfterConsumeTests {
+
+    /// Mirrors the guarded removal handler in `PageContextTabExtension`:
+    /// when context was just consumed by submit, skip the local-cache/nil-push cleanup.
+    private func shouldClearOnRemoval(consumed: Bool) -> Bool { !consumed }
+
+    @Test("Removal after submit (consumed=true) does NOT clear or push nil")
+    func consumedSkipsCleanup() {
+        #expect(shouldClearOnRemoval(consumed: true) == false)
+    }
+
+    @Test("Removal without prior submit (consumed=false) clears and pushes nil")
+    func notConsumedRunsCleanup() {
+        #expect(shouldClearOnRemoval(consumed: false) == true)
+    }
+}

--- a/macOS/UnitTests/AIChat/PageContextMultipleContextsTests.swift
+++ b/macOS/UnitTests/AIChat/PageContextMultipleContextsTests.swift
@@ -118,21 +118,3 @@ struct ConsumedFlagResetTests {
         #expect(shouldResetConsumedFlag(pageContext: context) == true)
     }
 }
-
-// MARK: - Removal-After-Consume Guard Tests
-
-struct RemovalAfterConsumeTests {
-
-    /// Mirrors the removal-handler guard in PageContextTabExtension.
-    private func shouldClearOnRemoval(consumed: Bool) -> Bool { !consumed }
-
-    @Test("Consumed context skips removal cleanup")
-    func consumedSkipsCleanup() {
-        #expect(shouldClearOnRemoval(consumed: true) == false)
-    }
-
-    @Test("Non-consumed context runs removal cleanup")
-    func notConsumedRunsCleanup() {
-        #expect(shouldClearOnRemoval(consumed: false) == true)
-    }
-}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1214842784870382?focus=true
Tech Design URL:
CC:

### Description

- **Bug**: after attaching page content on a supported page (e.g. https://bbc.com) and submitting the prompt, the Duck.ai sidebar shows "Add page content" again on the same URL. Expected: stays hidden until the URL changes.
- **Fix**: skip the cleanup in the removal sink when `hasContextBeenConsumedByChat` is true. After submit, `consumeData()` has already cleared `pageContextHandler` (one-time read in `AIChatPageContextHandler.consumeData`), so there is nothing for native to clean up. The X-click path is unchanged because the consumed flag is false there. Publishers are serialized on the main queue and `userDidSubmitPrompt` fires before the chip-removed telemetry, so the flag is set when the removal sink runs.

### Testing Steps

**The fix — same-URL submit (the regression):**
1. AI Features settings → set *Automatically send page content* **OFF**.
2. Open `https://www.bbc.com`, open the Duck.ai sidebar, click **Add page content** (chip shows bbc.com).
3. Type a prompt and submit.
4. **Expected**: chip stays gone and the *Add page content* button stays **hidden** until you change the URL.

**PR #4801's original fix still works:**
5. Open `https://www.nytimes.com` in a new tab, open the sidebar, click **Add page content** (chip shows nytimes).
6. Click the chip's **X** to remove it. Navigate to a different URL. Click **Add page content** again.
7. **Expected**: chip shows the *new* page's title, not nytimes.

**Same-URL reload preserves attachment:**
8. On a supported page, attach the chip and ⌘R reload.
9. **Expected**: chip still attached to the same page.

### Impact and Risks

Low. One file changed in production code (`PageContextTabExtension.swift`, ~9 lines including comment). New `RemovalAfterConsumeTests` mirror the same gate logic the existing helper-style tests in `PageContextMultipleContextsTests.swift` use.

#### What could go wrong?

- **Ordering**: the fix relies on `pageContextConsumedSubject` firing before `pageContextRemovedSubject` so the flag is set when the removal sink runs. Both publishers are `receive(on: DispatchQueue.main)` and the FE reports `userDidSubmitPrompt` before the chip-removed telemetry, so they're serialized in the right order. Documented inline so a future JS change inverting that order is investigable.
- **Re-attach after submit**: when the user re-attaches on the same URL after submitting, `handle()` resets `hasContextBeenConsumedByChat` to false, so a subsequent X-click goes through the full cleanup path as before.

### Notes to Reviewer

The lone production change is the early-return guard at the top of the `pageContextRemovedPublisher` sink. Everything below the guard is the #4801 fix, untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single guarded early return in sidebar page-context handling; relies on main-queue ordering of consumed-before-removed events, which the PR documents.
> 
> **Overview**
> Fixes a Duck.ai sidebar regression where **Add page content** reappeared on the same URL right after submitting a prompt with manually attached page content.
> 
> In `PageContextTabExtension`, the `pageContextRemovedPublisher` handler now **returns early** when `hasContextBeenConsumedByChat` is already true. The frontend emits removal for both an explicit chip **X** and the post-submit auto-clear; after submit, context was already consumed, so the previous cleanup (`setPageContext(nil)`, clearing cache) wrongly told the UI there was no attachment. Explicit **X** removal is unchanged because the consumed flag stays false until a new attachable context is pushed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ea82f97fb40fd8347c949ff6bcc03dbb9910a59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->