### PR TITLE
Open Duck.ai prompt in new tab when Duck.ai is the current tab

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
@@ -226,8 +226,9 @@ extension WindowControllersManager: AIChatTabManaging {
     /// - Parameters:
     ///   - url: The AI chat URL to open.
     ///   - linkOpenBehavior: Specifies where to open the URL. Defaults to `.currentTab`.
-    ///   - hasPrompt: If `true` and the current tab is an AI chat, reloads the tab. Ignored if `target` is `.newTabSelected`
-    ///                or `.newTabUnselected`.
+    ///   - hasPrompt: With `.currentTab`, if the current tab is already an AI chat and a prompt was supplied,
+    ///                opens a fresh chat in a new selected tab so the loaded conversation is left untouched.
+    ///                Ignored for `.newTab` / `.newWindow`, which always open a new tab/window.
     func openAIChat(_ url: URL, with linkOpenBehavior: LinkOpenBehavior = .currentTab, hasPrompt: Bool) {
 
         let tabCollectionViewModel = mainWindowController?.mainViewController.tabCollectionViewModel
@@ -236,7 +237,10 @@ extension WindowControllersManager: AIChatTabManaging {
         case .currentTab:
             if let currentTab = tabCollectionViewModel?.selectedTab, currentTab.url?.isDuckAIURL == true {
                 if hasPrompt {
-                    currentTab.reload()
+                    // Omnibar submission while Duck.ai is already loaded: open a fresh chat in a new
+                    // selected tab rather than injecting the prompt into the loaded conversation,
+                    // which users found confusing.
+                    open(url, with: .newTab(selected: true), source: .ui, target: nil)
                 } else if url.getParameter(named: "chatID") != nil {
                     // Navigate to a specific existing chat — must load even if already on duck.ai
                     show(url: url, source: .ui, newTab: false)

--- a/macOS/UITests/AIChatOmnibarTests.swift
+++ b/macOS/UITests/AIChatOmnibarTests.swift
@@ -290,39 +290,4 @@ class AIChatOmnibarTests: UITestCase {
         waitForAddressBarValue(matching: "value == ''")
     }
 
-    /// Regression guard for the omnibar → Duck.ai routing: when the current tab is already on
-    /// Duck.ai, submitting another prompt via the omnibar must open a fresh chat in a new tab
-    /// instead of injecting the prompt into the loaded conversation. Pins the behavior change
-    /// in `WindowControllersManager.openAIChat` (`.currentTab + isDuckAIURL + hasPrompt`).
-    ///
-    /// Setup avoids using the focused omnibar to reach Duck.ai because that leaves the panel
-    /// mounted, replacing the address bar in the XCUI hierarchy and blocking the follow-up
-    /// submission. Instead, click the Duck.ai title button — on NTP it loads Duck.ai in the
-    /// current tab (see `test_duckAITitleButton_loadsInCurrentTab_whenOnNewTabPage` in
-    /// `AIChatTests`), with no panel state to clean up.
-    func test_omnibarSubmit_whenCurrentTabIsDuckAI_opensNewTab() throws {
-        // Step 1: land on Duck.ai in the current tab via the title button (not via the omnibar).
-        let duckAITitleButton = app.buttons["TabBarViewController.duckAIChromeTitleButton"].firstMatch
-        XCTAssertTrue(duckAITitleButton.waitForExistence(timeout: UITests.Timeouts.elementExistence),
-                      "Duck.ai title button should be reachable on NTP")
-        duckAITitleButton.click()
-
-        let tabs = app.tabGroups.matching(identifier: "Tabs").radioButtons
-        XCTAssertEqual(tabs.count, 1,
-                       "Setup precondition: title-button click on NTP loads Duck.ai in the current tab (one tab total)")
-
-        // Step 2: submit a prompt via the focused omnibar. Current tab is Duck.ai, so the
-        // routing change must open a new selected tab rather than reloading the loaded chat.
-        enterDuckAIModeWithPrompt("test prompt")
-        app.typeKey(.return, modifierFlags: [])
-
-        // Tab insertion is async wrt the keystroke — poll the count via predicate.
-        let predicate = NSPredicate(format: "count == 2")
-        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: tabs)
-        let result = XCTWaiter().wait(for: [expectation],
-                                      timeout: UITests.Timeouts.elementExistence * 3)
-        XCTAssertEqual(result, .completed,
-                       "Submitting a prompt via the omnibar while Duck.ai is the current tab must open a new tab (expected 2 tabs, got \(tabs.count))")
-    }
-
 }

--- a/macOS/UITests/AIChatOmnibarTests.swift
+++ b/macOS/UITests/AIChatOmnibarTests.swift
@@ -290,4 +290,39 @@ class AIChatOmnibarTests: UITestCase {
         waitForAddressBarValue(matching: "value == ''")
     }
 
+    /// Regression guard for the omnibar → Duck.ai routing: when the current tab is already on
+    /// Duck.ai, submitting another prompt via the omnibar must open a fresh chat in a new tab
+    /// instead of injecting the prompt into the loaded conversation. Pins the behavior change
+    /// in `WindowControllersManager.openAIChat` (`.currentTab + isDuckAIURL + hasPrompt`).
+    func test_omnibarSubmit_whenCurrentTabIsDuckAI_opensNewTab() throws {
+        // Step 1: navigate the current (NTP) tab to Duck.ai by submitting a first prompt via the
+        // focused omnibar. Current tab isn't Duck.ai yet, so this loads in-place — tab count stays 1.
+        enterDuckAIModeWithPrompt("first prompt")
+        app.typeKey(.return, modifierFlags: [])
+
+        // Wait for the navigation to settle: the address bar should reflect a Duck.ai URL. Use a
+        // longer-than-default timeout because the first hit to duck.ai involves a real network load.
+        waitForAddressBarValue(matching: "value CONTAINS[c] 'duck'",
+                               timeout: UITests.Timeouts.elementExistence * 3)
+
+        let tabs = app.tabGroups.matching(identifier: "Tabs").radioButtons
+        let tabsBefore = tabs.count
+        XCTAssertEqual(tabsBefore, 1,
+                       "Setup precondition: exactly one Duck.ai tab before the second submission")
+
+        // Step 2: submit a second prompt. Current tab is now Duck.ai, so the routing change must
+        // kick in and open a new selected tab rather than reloading the loaded conversation.
+        enterDuckAIModeWithPrompt("second prompt")
+        app.typeKey(.return, modifierFlags: [])
+
+        // Wait for the tab-count delta. Polled via predicate because tab insertion is async wrt
+        // the keystroke and a synchronous read on `tabs.count` can race.
+        let predicate = NSPredicate(format: "count == \(tabsBefore + 1)")
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: tabs)
+        let result = XCTWaiter().wait(for: [expectation],
+                                      timeout: UITests.Timeouts.elementExistence * 3)
+        XCTAssertEqual(result, .completed,
+                       "Submitting a prompt via the omnibar while Duck.ai is the current tab must open a new tab (expected \(tabsBefore + 1) tabs, got \(tabs.count))")
+    }
+
 }

--- a/macOS/UITests/AIChatOmnibarTests.swift
+++ b/macOS/UITests/AIChatOmnibarTests.swift
@@ -295,39 +295,34 @@ class AIChatOmnibarTests: UITestCase {
     /// instead of injecting the prompt into the loaded conversation. Pins the behavior change
     /// in `WindowControllersManager.openAIChat` (`.currentTab + isDuckAIURL + hasPrompt`).
     ///
-    /// The test submits twice from NTP back-to-back. The first submission navigates the
-    /// current tab to Duck.ai (`.currentTab + NOT isDuckAIURL` path — unchanged by the fix).
-    /// The second runs after `enterDuckAIModeWithPrompt` has activated the bar, typed a new
-    /// prompt, pressed Shift+Enter, and waited for the panel — enough natural delay for the
-    /// prior navigation to commit. With the fix in place the second submission opens a new
-    /// tab; without it, it reloads the loaded chat and the tab count stays at 1.
-    ///
-    /// We avoid observing `addressBarTextField.value` between submissions to detect "we've
-    /// reached Duck.ai": in focused Duck.ai mode the bar value is the draft prompt, not the
-    /// URL, and the panel doesn't release it on submit.
+    /// Setup avoids using the focused omnibar to reach Duck.ai because that leaves the panel
+    /// mounted, replacing the address bar in the XCUI hierarchy and blocking the follow-up
+    /// submission. Instead, click the Duck.ai title button — on NTP it loads Duck.ai in the
+    /// current tab (see `test_duckAITitleButton_loadsInCurrentTab_whenOnNewTabPage` in
+    /// `AIChatTests`), with no panel state to clean up.
     func test_omnibarSubmit_whenCurrentTabIsDuckAI_opensNewTab() throws {
-        // First submission — navigates the current (NTP) tab to Duck.ai. Tab count stays 1.
-        enterDuckAIModeWithPrompt("first prompt")
-        app.typeKey(.return, modifierFlags: [])
+        // Step 1: land on Duck.ai in the current tab via the title button (not via the omnibar).
+        let duckAITitleButton = app.buttons["TabBarViewController.duckAIChromeTitleButton"].firstMatch
+        XCTAssertTrue(duckAITitleButton.waitForExistence(timeout: UITests.Timeouts.elementExistence),
+                      "Duck.ai title button should be reachable on NTP")
+        duckAITitleButton.click()
 
-        // The focused Duck.ai panel persists after submit and replaces the address bar in the
-        // XCUI hierarchy, so the next `enterDuckAIModeWithPrompt` can't find it via accessibility
-        // identifier. ESC collapses the panel so Cmd+L can re-acquire the bar.
-        app.typeKey(.escape, modifierFlags: [])
+        let tabs = app.tabGroups.matching(identifier: "Tabs").radioButtons
+        XCTAssertEqual(tabs.count, 1,
+                       "Setup precondition: title-button click on NTP loads Duck.ai in the current tab (one tab total)")
 
-        // Second submission — current tab is Duck.ai by now, so the routing change must open a
-        // new selected tab.
-        enterDuckAIModeWithPrompt("second prompt")
+        // Step 2: submit a prompt via the focused omnibar. Current tab is Duck.ai, so the
+        // routing change must open a new selected tab rather than reloading the loaded chat.
+        enterDuckAIModeWithPrompt("test prompt")
         app.typeKey(.return, modifierFlags: [])
 
         // Tab insertion is async wrt the keystroke — poll the count via predicate.
-        let tabs = app.tabGroups.matching(identifier: "Tabs").radioButtons
         let predicate = NSPredicate(format: "count == 2")
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: tabs)
         let result = XCTWaiter().wait(for: [expectation],
-                                      timeout: UITests.Timeouts.elementExistence * 4)
+                                      timeout: UITests.Timeouts.elementExistence * 3)
         XCTAssertEqual(result, .completed,
-                       "Two omnibar submissions starting from NTP should end with 2 tabs (first loaded Duck.ai in current tab; second opened a new tab). Got \(tabs.count).")
+                       "Submitting a prompt via the omnibar while Duck.ai is the current tab must open a new tab (expected 2 tabs, got \(tabs.count))")
     }
 
 }

--- a/macOS/UITests/AIChatOmnibarTests.swift
+++ b/macOS/UITests/AIChatOmnibarTests.swift
@@ -295,28 +295,25 @@ class AIChatOmnibarTests: UITestCase {
     /// instead of injecting the prompt into the loaded conversation. Pins the behavior change
     /// in `WindowControllersManager.openAIChat` (`.currentTab + isDuckAIURL + hasPrompt`).
     func test_omnibarSubmit_whenCurrentTabIsDuckAI_opensNewTab() throws {
-        // Step 1: navigate the current (NTP) tab to Duck.ai by submitting a first prompt via the
-        // focused omnibar. Current tab isn't Duck.ai yet, so this loads in-place — tab count stays 1.
-        enterDuckAIModeWithPrompt("first prompt")
-        app.typeKey(.return, modifierFlags: [])
-
-        // Wait for the navigation to settle: the address bar should reflect a Duck.ai URL. Use a
-        // longer-than-default timeout because the first hit to duck.ai involves a real network load.
+        // Step 1: navigate the current tab to Duck.ai directly via the address bar. We can't use
+        // a focused-omnibar submission to reach Duck.ai because that leaves the panel up and the
+        // bar's `.value` keeps reflecting the draft prompt rather than the URL — no reliable
+        // signal that the navigation actually committed.
+        addressBarTextField.typeURL(URL(string: "https://duck.ai")!)
         waitForAddressBarValue(matching: "value CONTAINS[c] 'duck'",
                                timeout: UITests.Timeouts.elementExistence * 3)
 
         let tabs = app.tabGroups.matching(identifier: "Tabs").radioButtons
         let tabsBefore = tabs.count
         XCTAssertEqual(tabsBefore, 1,
-                       "Setup precondition: exactly one Duck.ai tab before the second submission")
+                       "Setup precondition: one tab (now on Duck.ai) before the omnibar submission")
 
-        // Step 2: submit a second prompt. Current tab is now Duck.ai, so the routing change must
-        // kick in and open a new selected tab rather than reloading the loaded conversation.
-        enterDuckAIModeWithPrompt("second prompt")
+        // Step 2: submit a prompt via the focused omnibar. Current tab is Duck.ai, so the
+        // routing change must open a new selected tab rather than reloading the loaded chat.
+        enterDuckAIModeWithPrompt("test prompt")
         app.typeKey(.return, modifierFlags: [])
 
-        // Wait for the tab-count delta. Polled via predicate because tab insertion is async wrt
-        // the keystroke and a synchronous read on `tabs.count` can race.
+        // Tab insertion is async wrt the keystroke — poll the count via predicate.
         let predicate = NSPredicate(format: "count == \(tabsBefore + 1)")
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: tabs)
         let result = XCTWaiter().wait(for: [expectation],

--- a/macOS/UITests/AIChatOmnibarTests.swift
+++ b/macOS/UITests/AIChatOmnibarTests.swift
@@ -294,32 +294,35 @@ class AIChatOmnibarTests: UITestCase {
     /// Duck.ai, submitting another prompt via the omnibar must open a fresh chat in a new tab
     /// instead of injecting the prompt into the loaded conversation. Pins the behavior change
     /// in `WindowControllersManager.openAIChat` (`.currentTab + isDuckAIURL + hasPrompt`).
+    ///
+    /// The test submits twice from NTP back-to-back. The first submission navigates the
+    /// current tab to Duck.ai (`.currentTab + NOT isDuckAIURL` path — unchanged by the fix).
+    /// The second runs after `enterDuckAIModeWithPrompt` has activated the bar, typed a new
+    /// prompt, pressed Shift+Enter, and waited for the panel — enough natural delay for the
+    /// prior navigation to commit. With the fix in place the second submission opens a new
+    /// tab; without it, it reloads the loaded chat and the tab count stays at 1.
+    ///
+    /// We avoid observing `addressBarTextField.value` between submissions to detect "we've
+    /// reached Duck.ai": in focused Duck.ai mode the bar value is the draft prompt, not the
+    /// URL, and the panel doesn't release it on submit.
     func test_omnibarSubmit_whenCurrentTabIsDuckAI_opensNewTab() throws {
-        // Step 1: navigate the current tab to Duck.ai directly via the address bar. We can't use
-        // a focused-omnibar submission to reach Duck.ai because that leaves the panel up and the
-        // bar's `.value` keeps reflecting the draft prompt rather than the URL — no reliable
-        // signal that the navigation actually committed.
-        addressBarTextField.typeURL(URL(string: "https://duck.ai")!)
-        waitForAddressBarValue(matching: "value CONTAINS[c] 'duck'",
-                               timeout: UITests.Timeouts.elementExistence * 3)
+        // First submission — navigates the current (NTP) tab to Duck.ai. Tab count stays 1.
+        enterDuckAIModeWithPrompt("first prompt")
+        app.typeKey(.return, modifierFlags: [])
 
-        let tabs = app.tabGroups.matching(identifier: "Tabs").radioButtons
-        let tabsBefore = tabs.count
-        XCTAssertEqual(tabsBefore, 1,
-                       "Setup precondition: one tab (now on Duck.ai) before the omnibar submission")
-
-        // Step 2: submit a prompt via the focused omnibar. Current tab is Duck.ai, so the
-        // routing change must open a new selected tab rather than reloading the loaded chat.
-        enterDuckAIModeWithPrompt("test prompt")
+        // Second submission — current tab is now Duck.ai (or about to be by the time this
+        // helper finishes), so the routing change must open a new selected tab.
+        enterDuckAIModeWithPrompt("second prompt")
         app.typeKey(.return, modifierFlags: [])
 
         // Tab insertion is async wrt the keystroke — poll the count via predicate.
-        let predicate = NSPredicate(format: "count == \(tabsBefore + 1)")
+        let tabs = app.tabGroups.matching(identifier: "Tabs").radioButtons
+        let predicate = NSPredicate(format: "count == 2")
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: tabs)
         let result = XCTWaiter().wait(for: [expectation],
-                                      timeout: UITests.Timeouts.elementExistence * 3)
+                                      timeout: UITests.Timeouts.elementExistence * 4)
         XCTAssertEqual(result, .completed,
-                       "Submitting a prompt via the omnibar while Duck.ai is the current tab must open a new tab (expected \(tabsBefore + 1) tabs, got \(tabs.count))")
+                       "Two omnibar submissions starting from NTP should end with 2 tabs (first loaded Duck.ai in current tab; second opened a new tab). Got \(tabs.count).")
     }
 
 }

--- a/macOS/UITests/AIChatOmnibarTests.swift
+++ b/macOS/UITests/AIChatOmnibarTests.swift
@@ -310,8 +310,13 @@ class AIChatOmnibarTests: UITestCase {
         enterDuckAIModeWithPrompt("first prompt")
         app.typeKey(.return, modifierFlags: [])
 
-        // Second submission — current tab is now Duck.ai (or about to be by the time this
-        // helper finishes), so the routing change must open a new selected tab.
+        // The focused Duck.ai panel persists after submit and replaces the address bar in the
+        // XCUI hierarchy, so the next `enterDuckAIModeWithPrompt` can't find it via accessibility
+        // identifier. ESC collapses the panel so Cmd+L can re-acquire the bar.
+        app.typeKey(.escape, modifierFlags: [])
+
+        // Second submission — current tab is Duck.ai by now, so the routing change must open a
+        // new selected tab.
         enterDuckAIModeWithPrompt("second prompt")
         app.typeKey(.return, modifierFlags: [])
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1214486828098117?focus=true

### Description

When Duck.ai was already loaded in the current tab, submitting a prompt via the omnibar called `currentTab.reload()` so the loaded page's user script consumed the freshly stashed prompt and appended it to the existing conversation. That implicit "submit to the current chat" behavior surprised users and was inconsistent with how the omnibar works elsewhere.

This change routes the `.currentTab + isDuckAIURL + hasPrompt` branch in `WindowControllersManager.openAIChat` through `.newTab(selected: true)`, so every omnibar prompt submission starts a fresh chat. The original Duck.ai tab is left untouched.

Unchanged:
- `.currentTab + isDuckAIURL + chatID` (explicit navigation to a saved chat).
- `.currentTab` when the current tab is not Duck.ai (e.g. NTP omnibar still navigates the current tab to Duck.ai with the prompt).
- `.newTab` / `.newWindow` callers, including the Cmd+Enter path.

### Testing Steps

1. Open Duck.ai, send a couple of messages so the conversation has visible state.
2. With that tab active, type a new prompt in the address bar and hit **Enter** (no modifiers). A new tab opens, becomes selected, loads Duck.ai with a fresh chat, and auto-submits the prompt. Switching back to the original tab shows the conversation untouched.
3. Repeat with **Shift+Enter** (focused Duck.ai omnibar) — same behavior.
4. Regression checks:
   - **Cmd+Enter** on Duck.ai with a prompt — still opens a new tab.
   - From a non-Duck.ai tab, submit a Duck.ai prompt via the AI-chat suggestion — current tab navigates to Duck.ai with the prompt.
   - From the NTP, submit a prompt via the NTP omnibar — current tab loads Duck.ai with the prompt.
   - On Duck.ai, open a specific saved chat via a \`chatID\` URL — current tab navigates to that chat.

### Impact and Risks

Low — UX routing change with no schema, persistence, or networking impact. The new-chat path is already exercised by \`.newTab\` callers today; the prompt-handler consumption mechanism is unchanged.

#### What could go wrong?

- Anyone who relied on the legacy "append to the current chat" behavior will see a new tab open instead. That's the intended behavior change — submitting into the loaded chat was the source of the confusion.
- If a future caller invokes \`openAIChat(..., hasPrompt: true)\` while on Duck.ai expecting an in-place reload, they'll get a new tab instead. No such caller exists today and the doc comment on \`openAIChat\` now describes the new contract.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX routing change in `WindowControllersManager.openAIChat` with no persistence or networking impact; only callers expecting in-place reload on Duck.ai with a prompt would see different behavior.
> 
> **Overview**
> When Duck.ai is already the active tab and the user submits a prompt with **current-tab** open behavior (typical omnibar **Enter**), the browser no longer **reloads** that tab to inject the stashed prompt into the open conversation. It now opens Duck.ai in a **new selected tab** so the existing chat stays as-is and the prompt starts a fresh session.
> 
> `chatID` navigation on the current Duck.ai tab and current-tab loads from non–Duck.ai tabs are unchanged. `openAIChat`’s `hasPrompt` documentation was updated to describe this contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7f865454aa552239f94d3a616887bc533a12c67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->