### PR TITLE
[iOS/macOS] Backfill the VPN leak detection schemas

### DIFF
--- a/iOS/PixelDefinitions/wide_events/generated_schemas/ios-vpn-ip-leak-check-1.1.0.json
+++ b/iOS/PixelDefinitions/wide_events/generated_schemas/ios-vpn-ip-leak-check-1.1.0.json
@@ -1,0 +1,303 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Sent at the end of each VPN IP leak check cycle (HTTP/HTTPS/STUN probes over IPv4 and IPv6 against the leak check endpoint, classified against the current tunnel egress IP)",
+    "$comment": "{\"owners\":[\"samsymons\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "ios-vpn-ip-leak-check" }, "version": { "const": "1.1.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application",
+                    "enum": ["DuckDuckGo", "DuckDuckGo-Alpha", "DuckDuckGo-Experimental", "PacketTunnelProvider"]
+                },
+                "version": { "type": "string", "description": "The version of the application", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
+                "form_factor": { "type": "string", "description": "The form factor of the device", "enum": ["phone", "tablet"] }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["iOS"] },
+                "type": { "type": "string", "description": "The type of application", "enum": ["app"] },
+                "sample_rate": { "type": "number", "description": "Sample rate for this event", "minimum": 0, "maximum": 1 },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first occurrence of this event today. Only included when true."
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["vpn-ip-leak-check"] },
+                "status": {
+                    "type": "string",
+                    "description": "The overall status of the operation",
+                    "enum": ["SUCCESS", "FAILURE", "UNKNOWN"]
+                },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "trigger": {
+                                    "type": "string",
+                                    "description": "What caused the leak check cycle to run",
+                                    "enum": ["tunnel_start", "reassert", "periodic", "rekey"]
+                                },
+                                "status_reason": {
+                                    "type": "string",
+                                    "description": "Reason attached to an UNKNOWN status: one or more probes errored without a leak, or the cycle did not complete",
+                                    "enum": ["checks_errored", "check_interrupted"]
+                                },
+                                "latency_ms_bucketed": {
+                                    "type": "integer",
+                                    "description": "Total cycle duration, rounded up to the nearest 500 ms and capped at 5000",
+                                    "enum": [500, 1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000]
+                                },
+                                "egress_server_name": {
+                                    "type": "string",
+                                    "description": "Name of the VPN egress server the cycle ran against"
+                                },
+                                "ipv4": {
+                                    "type": "object",
+                                    "description": "IPv4 probe outcomes",
+                                    "properties": {
+                                        "leak_ip_type": {
+                                            "type": "string",
+                                            "description": "Classification of the leaked IPv4 address, present when any IPv4 probe reported a leak",
+                                            "enum": ["public", "private", "unknown"]
+                                        },
+                                        "http": {
+                                            "type": "object",
+                                            "description": "IPv4 HTTP probe result",
+                                            "properties": {
+                                                "status": {
+                                                    "type": "string",
+                                                    "description": "Outcome of the IPv4 HTTP probe",
+                                                    "enum": ["success", "leak", "error"]
+                                                },
+                                                "error_domain": {
+                                                    "type": "string",
+                                                    "description": "Outer error domain when status is error"
+                                                },
+                                                "error_code": { "type": "integer", "description": "Outer error code when status is error" },
+                                                "underlying_domain": {
+                                                    "type": "string",
+                                                    "description": "Underlying error domain when the outer error wraps another"
+                                                },
+                                                "underlying_code": {
+                                                    "type": "integer",
+                                                    "description": "Underlying error code paired with underlying_domain"
+                                                },
+                                                "leak_octet1_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 1 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                },
+                                                "leak_octet2_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 2 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                },
+                                                "leak_octet3_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 3 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                },
+                                                "leak_octet4_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 4 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                }
+                                            }
+                                        },
+                                        "https": {
+                                            "type": "object",
+                                            "description": "IPv4 HTTPS probe result",
+                                            "properties": {
+                                                "status": {
+                                                    "type": "string",
+                                                    "description": "Outcome of the IPv4 HTTPS probe",
+                                                    "enum": ["success", "leak", "error"]
+                                                },
+                                                "error_domain": {
+                                                    "type": "string",
+                                                    "description": "Outer error domain when status is error"
+                                                },
+                                                "error_code": { "type": "integer", "description": "Outer error code when status is error" },
+                                                "underlying_domain": {
+                                                    "type": "string",
+                                                    "description": "Underlying error domain when the outer error wraps another"
+                                                },
+                                                "underlying_code": {
+                                                    "type": "integer",
+                                                    "description": "Underlying error code paired with underlying_domain"
+                                                },
+                                                "leak_octet1_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 1 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                },
+                                                "leak_octet2_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 2 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                },
+                                                "leak_octet3_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 3 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                },
+                                                "leak_octet4_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 4 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                }
+                                            }
+                                        },
+                                        "stun": {
+                                            "type": "object",
+                                            "description": "IPv4 STUN probe result",
+                                            "properties": {
+                                                "status": {
+                                                    "type": "string",
+                                                    "description": "Outcome of the IPv4 STUN probe",
+                                                    "enum": ["success", "leak", "error"]
+                                                },
+                                                "error_domain": {
+                                                    "type": "string",
+                                                    "description": "Outer error domain when status is error"
+                                                },
+                                                "error_code": { "type": "integer", "description": "Outer error code when status is error" },
+                                                "underlying_domain": {
+                                                    "type": "string",
+                                                    "description": "Underlying error domain when the outer error wraps another"
+                                                },
+                                                "underlying_code": {
+                                                    "type": "integer",
+                                                    "description": "Underlying error code paired with underlying_domain"
+                                                },
+                                                "leak_octet1_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 1 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                },
+                                                "leak_octet2_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 2 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                },
+                                                "leak_octet3_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 3 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                },
+                                                "leak_octet4_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 4 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "ipv6": {
+                                    "type": "object",
+                                    "description": "IPv6 probe outcomes",
+                                    "properties": {
+                                        "leak_ip_type": {
+                                            "type": "string",
+                                            "description": "Classification of the leaked IPv6 address, present when any IPv6 probe reported a leak",
+                                            "enum": ["public", "private", "unknown"]
+                                        },
+                                        "http": {
+                                            "type": "object",
+                                            "description": "IPv6 HTTP probe result",
+                                            "properties": {
+                                                "status": {
+                                                    "type": "string",
+                                                    "description": "Outcome of the IPv6 HTTP probe",
+                                                    "enum": ["success", "leak", "error"]
+                                                },
+                                                "error_domain": {
+                                                    "type": "string",
+                                                    "description": "Outer error domain when status is error"
+                                                },
+                                                "error_code": { "type": "integer", "description": "Outer error code when status is error" },
+                                                "underlying_domain": {
+                                                    "type": "string",
+                                                    "description": "Underlying error domain when the outer error wraps another"
+                                                },
+                                                "underlying_code": {
+                                                    "type": "integer",
+                                                    "description": "Underlying error code paired with underlying_domain"
+                                                }
+                                            }
+                                        },
+                                        "https": {
+                                            "type": "object",
+                                            "description": "IPv6 HTTPS probe result",
+                                            "properties": {
+                                                "status": {
+                                                    "type": "string",
+                                                    "description": "Outcome of the IPv6 HTTPS probe",
+                                                    "enum": ["success", "leak", "error"]
+                                                },
+                                                "error_domain": {
+                                                    "type": "string",
+                                                    "description": "Outer error domain when status is error"
+                                                },
+                                                "error_code": { "type": "integer", "description": "Outer error code when status is error" },
+                                                "underlying_domain": {
+                                                    "type": "string",
+                                                    "description": "Underlying error domain when the outer error wraps another"
+                                                },
+                                                "underlying_code": {
+                                                    "type": "integer",
+                                                    "description": "Underlying error code paired with underlying_domain"
+                                                }
+                                            }
+                                        },
+                                        "stun": {
+                                            "type": "object",
+                                            "description": "IPv6 STUN probe result",
+                                            "properties": {
+                                                "status": {
+                                                    "type": "string",
+                                                    "description": "Outcome of the IPv6 STUN probe",
+                                                    "enum": ["success", "leak", "error"]
+                                                },
+                                                "error_domain": {
+                                                    "type": "string",
+                                                    "description": "Outer error domain when status is error"
+                                                },
+                                                "error_code": { "type": "integer", "description": "Outer error code when status is error" },
+                                                "underlying_domain": {
+                                                    "type": "string",
+                                                    "description": "Underlying error domain when the outer error wraps another"
+                                                },
+                                                "underlying_code": {
+                                                    "type": "integer",
+                                                    "description": "Underlying error code paired with underlying_domain"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/macOS/PixelDefinitions/wide_events/generated_schemas/macos-vpn-ip-leak-check-1.1.0.json
+++ b/macOS/PixelDefinitions/wide_events/generated_schemas/macos-vpn-ip-leak-check-1.1.0.json
@@ -1,0 +1,317 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Sent at the end of each VPN IP leak check cycle (HTTP/HTTPS/STUN probes over IPv4 and IPv6 against the leak check endpoint, classified against the current tunnel egress IP)",
+    "$comment": "{\"owners\":[\"samsymons\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "macos-vpn-ip-leak-check" }, "version": { "const": "1.1.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the app sending the event, taken from CFBundleName. Varies across build configurations and the target (main app, VPN agent, network extension). Extend this enum when adding wide events fired from other macOS targets.",
+                    "enum": [
+                        "DuckDuckGo",
+                        "DuckDuckGo Alpha",
+                        "DuckDuckGo Review",
+                        "DuckDuckGo App Store",
+                        "DuckDuckGo VPN",
+                        "DuckDuckGo VPN Alpha",
+                        "DuckDuckGo VPN Review",
+                        "DuckDuckGo VPN App Store",
+                        "NetworkProtectionAppExtension",
+                        "com.duckduckgo.macos.vpn.network-extension",
+                        "com.duckduckgo.macos.vpn.network-extension.debug",
+                        "com.duckduckgo.macos.vpn.network-extension.review",
+                        "com.duckduckgo.macos.vpn.network-extension.alpha",
+                        "com.duckduckgo.mobile.ios.vpn.agent.network-extension"
+                    ]
+                },
+                "version": { "type": "string", "description": "The version of the application", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["macOS"] },
+                "type": { "type": "string", "description": "The type of application", "enum": ["app"] },
+                "sample_rate": { "type": "number", "description": "Sample rate for this event", "minimum": 0, "maximum": 1 },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first occurrence of this event today. Only included when true."
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["vpn-ip-leak-check"] },
+                "status": {
+                    "type": "string",
+                    "description": "The overall status of the operation",
+                    "enum": ["SUCCESS", "FAILURE", "UNKNOWN"]
+                },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "trigger": {
+                                    "type": "string",
+                                    "description": "What caused the leak check cycle to run",
+                                    "enum": ["tunnel_start", "reassert", "periodic", "rekey"]
+                                },
+                                "status_reason": {
+                                    "type": "string",
+                                    "description": "Reason attached to an UNKNOWN status: one or more probes errored without a leak, or the cycle did not complete",
+                                    "enum": ["checks_errored", "check_interrupted"]
+                                },
+                                "latency_ms_bucketed": {
+                                    "type": "integer",
+                                    "description": "Total cycle duration, rounded up to the nearest 500 ms and capped at 5000",
+                                    "enum": [500, 1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000]
+                                },
+                                "egress_server_name": {
+                                    "type": "string",
+                                    "description": "Name of the VPN egress server the cycle ran against"
+                                },
+                                "ipv4": {
+                                    "type": "object",
+                                    "description": "IPv4 probe outcomes",
+                                    "properties": {
+                                        "leak_ip_type": {
+                                            "type": "string",
+                                            "description": "Classification of the leaked IPv4 address, present when any IPv4 probe reported a leak",
+                                            "enum": ["public", "private", "unknown"]
+                                        },
+                                        "http": {
+                                            "type": "object",
+                                            "description": "IPv4 HTTP probe result",
+                                            "properties": {
+                                                "status": {
+                                                    "type": "string",
+                                                    "description": "Outcome of the IPv4 HTTP probe",
+                                                    "enum": ["success", "leak", "error"]
+                                                },
+                                                "error_domain": {
+                                                    "type": "string",
+                                                    "description": "Outer error domain when status is error"
+                                                },
+                                                "error_code": { "type": "integer", "description": "Outer error code when status is error" },
+                                                "underlying_domain": {
+                                                    "type": "string",
+                                                    "description": "Underlying error domain when the outer error wraps another"
+                                                },
+                                                "underlying_code": {
+                                                    "type": "integer",
+                                                    "description": "Underlying error code paired with underlying_domain"
+                                                },
+                                                "leak_octet1_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 1 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                },
+                                                "leak_octet2_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 2 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                },
+                                                "leak_octet3_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 3 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                },
+                                                "leak_octet4_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 4 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                }
+                                            }
+                                        },
+                                        "https": {
+                                            "type": "object",
+                                            "description": "IPv4 HTTPS probe result",
+                                            "properties": {
+                                                "status": {
+                                                    "type": "string",
+                                                    "description": "Outcome of the IPv4 HTTPS probe",
+                                                    "enum": ["success", "leak", "error"]
+                                                },
+                                                "error_domain": {
+                                                    "type": "string",
+                                                    "description": "Outer error domain when status is error"
+                                                },
+                                                "error_code": { "type": "integer", "description": "Outer error code when status is error" },
+                                                "underlying_domain": {
+                                                    "type": "string",
+                                                    "description": "Underlying error domain when the outer error wraps another"
+                                                },
+                                                "underlying_code": {
+                                                    "type": "integer",
+                                                    "description": "Underlying error code paired with underlying_domain"
+                                                },
+                                                "leak_octet1_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 1 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                },
+                                                "leak_octet2_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 2 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                },
+                                                "leak_octet3_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 3 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                },
+                                                "leak_octet4_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 4 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                }
+                                            }
+                                        },
+                                        "stun": {
+                                            "type": "object",
+                                            "description": "IPv4 STUN probe result",
+                                            "properties": {
+                                                "status": {
+                                                    "type": "string",
+                                                    "description": "Outcome of the IPv4 STUN probe",
+                                                    "enum": ["success", "leak", "error"]
+                                                },
+                                                "error_domain": {
+                                                    "type": "string",
+                                                    "description": "Outer error domain when status is error"
+                                                },
+                                                "error_code": { "type": "integer", "description": "Outer error code when status is error" },
+                                                "underlying_domain": {
+                                                    "type": "string",
+                                                    "description": "Underlying error domain when the outer error wraps another"
+                                                },
+                                                "underlying_code": {
+                                                    "type": "integer",
+                                                    "description": "Underlying error code paired with underlying_domain"
+                                                },
+                                                "leak_octet1_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 1 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                },
+                                                "leak_octet2_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 2 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                },
+                                                "leak_octet3_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 3 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                },
+                                                "leak_octet4_matched": {
+                                                    "type": "boolean",
+                                                    "description": "Whether octet 4 of the observed IPv4 address matched the egress IP, present only when status is leak"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "ipv6": {
+                                    "type": "object",
+                                    "description": "IPv6 probe outcomes",
+                                    "properties": {
+                                        "leak_ip_type": {
+                                            "type": "string",
+                                            "description": "Classification of the leaked IPv6 address, present when any IPv6 probe reported a leak",
+                                            "enum": ["public", "private", "unknown"]
+                                        },
+                                        "http": {
+                                            "type": "object",
+                                            "description": "IPv6 HTTP probe result",
+                                            "properties": {
+                                                "status": {
+                                                    "type": "string",
+                                                    "description": "Outcome of the IPv6 HTTP probe",
+                                                    "enum": ["success", "leak", "error"]
+                                                },
+                                                "error_domain": {
+                                                    "type": "string",
+                                                    "description": "Outer error domain when status is error"
+                                                },
+                                                "error_code": { "type": "integer", "description": "Outer error code when status is error" },
+                                                "underlying_domain": {
+                                                    "type": "string",
+                                                    "description": "Underlying error domain when the outer error wraps another"
+                                                },
+                                                "underlying_code": {
+                                                    "type": "integer",
+                                                    "description": "Underlying error code paired with underlying_domain"
+                                                }
+                                            }
+                                        },
+                                        "https": {
+                                            "type": "object",
+                                            "description": "IPv6 HTTPS probe result",
+                                            "properties": {
+                                                "status": {
+                                                    "type": "string",
+                                                    "description": "Outcome of the IPv6 HTTPS probe",
+                                                    "enum": ["success", "leak", "error"]
+                                                },
+                                                "error_domain": {
+                                                    "type": "string",
+                                                    "description": "Outer error domain when status is error"
+                                                },
+                                                "error_code": { "type": "integer", "description": "Outer error code when status is error" },
+                                                "underlying_domain": {
+                                                    "type": "string",
+                                                    "description": "Underlying error domain when the outer error wraps another"
+                                                },
+                                                "underlying_code": {
+                                                    "type": "integer",
+                                                    "description": "Underlying error code paired with underlying_domain"
+                                                }
+                                            }
+                                        },
+                                        "stun": {
+                                            "type": "object",
+                                            "description": "IPv6 STUN probe result",
+                                            "properties": {
+                                                "status": {
+                                                    "type": "string",
+                                                    "description": "Outcome of the IPv6 STUN probe",
+                                                    "enum": ["success", "leak", "error"]
+                                                },
+                                                "error_domain": {
+                                                    "type": "string",
+                                                    "description": "Outer error domain when status is error"
+                                                },
+                                                "error_code": { "type": "integer", "description": "Outer error code when status is error" },
+                                                "underlying_domain": {
+                                                    "type": "string",
+                                                    "description": "Underlying error domain when the outer error wraps another"
+                                                },
+                                                "underlying_code": {
+                                                    "type": "integer",
+                                                    "description": "Underlying error code paired with underlying_domain"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1215110366496977?focus=true
Tech Design URL:
CC:

### Description

This PR backfills version 1.1.0 of the VPN leak detection schema.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. No checks needed

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only additions with no runtime behavior changes; mis-specified fields could affect downstream validation or analytics parsing.
> 
> **Overview**
> Adds **version 1.1.0** generated JSON Schemas for the VPN IP leak check wide event on **iOS** (`ios-vpn-ip-leak-check`) and **macOS** (`macos-vpn-ip-leak-check`), filling a gap in `PixelDefinitions/wide_events/generated_schemas` alongside existing 1.0.x files.
> 
> Each schema pins `meta.version` to **1.1.0** and documents the end-of-cycle telemetry payload: cycle **trigger** and **UNKNOWN** reasons, bucketed **latency**, **egress server name**, and per-family **IPv4/IPv6** outcomes for **HTTP**, **HTTPS**, and **STUN** probes (including IPv4 **leak octet match** flags when a leak is reported). No application or tunnel logic changes appear in this diff—only schema artifacts for validation and pipeline consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5940f037033c55b38b7144c82bbf1a67aa378029. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->