### PR TITLE
Bump native-github-asana-sync to v2.4

### DIFF
--- a/.github/workflows/privacy-review.yml
+++ b/.github/workflows/privacy-review.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout native actions repo
         uses: actions/checkout@v6
         with:
-            ref: v2.1
+            ref: v2.4
             # Do not change the below path (downstream actions expect it)
             path: native-github-asana-sync
             repository: duckduckgo/native-github-asana-sync


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215113750466059
Tech Design URL: N/A
CC:

### Description

Bumps the `duckduckgo/native-github-asana-sync` checkout in `.github/workflows/privacy-review.yml` from `v2.1` to `v2.4`. v2.4 brings in the privacy automation work that exposes the new triage_task_id / triage_task_permalink / original_task_id outputs and points the classifier dispatch at `main`. No other workflows touched.

This is part of [Merge Stage 1](https://app.asana.com/1/137249556945/task/1215113750466052). Despite the Asana subtask title saying "refs" (plural), scope here is the privacy-review.yml integration only (confirmed with task author). Other older `native-github-asana-sync@v1.x` references across the repo are out of scope for this PR.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Open a draft PR against `main` on this repo and add the `privacy review` label.
2. Verify the "Create Asana task for Privacy Review" workflow runs, checks out `duckduckgo/native-github-asana-sync@v2.4`, and creates a Privacy Triage task in Asana.

### Impact and Risks

Low — this is internal automation that only fires on PRs labeled `privacy review`. The integration was previously pinned at `v2.1`; `v2.4` is the current latest tagged release.

#### What could go wrong?

- A typo/missing tag would cause the `actions/checkout` step to fail on labeled PRs. Mitigated: `v2.4` was confirmed to exist on the remote before this change.
- Behavioural changes between v2.1 and v2.4 in the privacy-review composite action are limited to additional task outputs and the classifier-dispatch ref change; existing inputs are unchanged.

### Notes to Reviewer

This is a one-line change pinning the checkout `ref:` to the newer tagged release. The privacy-review composite action's input contract has not changed between v2.1 and v2.4.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow ref bump for label-triggered internal automation; no app or auth code changes.
> 
> **Overview**
> Updates the **privacy review** GitHub workflow so `actions/checkout` of `duckduckgo/native-github-asana-sync` uses tag **`v2.4`** instead of **`v2.1`**. The composite action inputs (`team_name`, `trigger-phrase`, Asana/GitHub PATs) are unchanged.
> 
> **v2.4** is expected to add privacy automation outputs (`triage_task_id`, `triage_task_permalink`, `original_task_id`) and to point classifier dispatch at `main`. The workflow still runs only when a PR gets the `privacy review` label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a2790a9277e4b839e07578ebd68df43e4d8b5c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->