### PR TITLE
macOS: Fix live-validation failures for 7 permission/aichat/web-extension pixels

### DIFF
--- a/macOS/DuckDuckGo/Statistics/PermissionPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/PermissionPixel.swift
@@ -130,9 +130,9 @@ extension PermissionType {
         case .notification:
             return "notification"
         case .externalScheme:
-            return "external_scheme"
+            return "external-scheme"
         case .autoplayPolicy:
-            return "autoplay_policy"
+            return "autoplay-policy"
         }
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_addressbar_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_addressbar_pixels.json5
@@ -292,20 +292,20 @@
         "owners": ["tomasstrba"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_addressbar_web_search_deactivated": {
         "description": "Fired when user dismisses the web search chip (X button)",
         "owners": ["tomasstrba"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_addressbar_web_search_submitted": {
         "description": "Fired when user submits a prompt while web search mode is active",
         "owners": ["tomasstrba"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/permission_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/permission_pixels.json5
@@ -14,7 +14,7 @@
                 "enum": ["allow", "deny"]
             }
         ],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_permission_center_changed": {
         "description": "Fired when user changes a permission decision in the Permission Center dropdown",
@@ -37,6 +37,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "channel",
             {
                 "key": "from",
                 "type": "string",
@@ -67,6 +68,6 @@
                 "enum": ["camera", "microphone", "geolocation", "notification"]
             }
         ],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/permission_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/permission_pixels.json5
@@ -7,7 +7,7 @@
         "suffixes": [
             {
                 "description": "Permission type being requested",
-                "enum": ["camera", "microphone", "geolocation", "popups", "notification", "external_scheme"]
+                "enum": ["camera", "microphone", "geolocation", "popups", "notification", "external-scheme"]
             },
             {
                 "description": "User's decision",
@@ -23,7 +23,7 @@
         "suffixes": [
             {
                 "description": "Permission type being changed",
-                "enum": ["camera", "microphone", "geolocation", "popups", "notification", "external_scheme", "autoplay_policy"]
+                "enum": ["camera", "microphone", "geolocation", "popups", "notification", "external-scheme", "autoplay-policy"]
             },
             {
                 "description": "Literal 'to' separator",
@@ -52,7 +52,7 @@
         "suffixes": [
             {
                 "description": "Permission type being reset",
-                "enum": ["camera", "microphone", "geolocation", "popups", "notification", "external_scheme", "autoplay_policy"]
+                "enum": ["camera", "microphone", "geolocation", "popups", "notification", "external-scheme", "autoplay-policy"]
             }
         ],
         "parameters": ["appVersion", "pixelSource", "channel"]

--- a/macOS/PixelDefinitions/pixels/definitions/web_extensions.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/web_extensions.json5
@@ -53,7 +53,7 @@
         "owners": ["tomasstrba"],
         "triggers": ["exception"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource", "errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain"]
+        "parameters": ["appVersion", "pixelSource", "channel", "errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_mac_web_extension_embedded_installed": {
         "description": "Fires when the embedded (bundled) web extension is successfully installed for the first time.",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1215086317490089

### Description

Live pixel validation rejected 7 owned pixels. Two independent root causes:

- **Underscored values inside a suffix `enum` get split by the validator.** Permission-type values `external_scheme` and `autoplay_policy` contain `_`, so a fire like `m_mac_permission_authorization_external_scheme_allow` parses as three suffix segments against a two-position schema. Affected: `m_mac_permission_authorization`, `m_mac_permission_center_changed`, `m_mac_permission_center_reset`. Fixed by renaming the two values to dash-style (`external-scheme`, `autoplay-policy`) in both the Swift `pixelName` extension and the JSON5 enum entries. `PermissionType.rawValue` (used as a persisted UserDefaults key) is intentionally untouched.

- **`channel` parameter undeclared.** PixelKit auto-injects `channel` on every fire when the app runs on a non-production channel (canary/dev). Seven owned definitions did not list it, so live validation flagged it as an extra property. Added `"channel"` to all of them.

### Testing Steps

1. From `macOS/`: `npm run validate-pixel-defs` — passes (schema + Prettier).
2. Debug build of `macOS Browser` succeeds with no new warnings.
3. In the Debug build, click a `mailto:` link and accept/deny the permission dialog → fires `m_mac_permission_authorization_external-scheme_{allow,deny}` (verify in `~/Library/Caches/pixelkit-validation-log.txt`).
4. In Settings → Privacy → Site Permissions, change and then reset a recorded permission decision → fires `m_mac_permission_center_changed_..._to_...` and `m_mac_permission_center_reset_...` with dash-style names where applicable.
5. Optional: `cd macOS && ./scripts/validate_pixels.sh` cross-checks fired pixels against the updated definitions.

### Impact and Risks

Low. Only affects observability — these pixels were already failing live validation, so there is no analytic-continuity loss; the renamed wire names start clean. No user-facing behaviour changes.

#### What could go wrong?

- Permission-type renames change the wire name (e.g. `m_mac_permission_authorization_external-scheme_allow` instead of `..._external_scheme_allow`). Anyone consuming the underscored form in dashboards/queries will need to switch to the dash form. The old series was rejected by live validation anyway, so this is the natural cutover.
- Single-word permission types (camera, microphone, geolocation, popups, notification) are not renamed and continue to fire under the same names.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only: fixes previously rejected pixels; external-scheme/autoplay-policy wire names change for dashboards that assumed underscores.
> 
> **Overview**
> Fixes **live pixel validation** failures for seven macOS analytics events by aligning wire names and schema with how PixelKit parses and sends pixels.
> 
> **Permission pixels:** `PermissionType.pixelName` now emits **`external-scheme`** and **`autoplay-policy`** (dash) instead of underscored values, and the matching **`permission_pixels.json5`** suffix enums were updated. Underscores inside a suffix segment were being split by the validator, breaking events like authorization for external schemes. Persisted **`PermissionType.rawValue`** (e.g. `autoplay_policy`) is unchanged.
> 
> **Parameter schema:** **`channel`** was added to pixel definitions that were missing it—permission pixels, three duck.ai address bar web-search events, and **`m_mac_web_extension_load_error`**—so non-production builds no longer fail validation when PixelKit auto-injects `channel`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0709837c3a898e73ac5aee079950fbb5324a15ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->