### PR TITLE
[macOS] Fix PromoService main-thread precondition crash

### DIFF
--- a/macOS/DuckDuckGo/Promotions/PromoService.swift
+++ b/macOS/DuckDuckGo/Promotions/PromoService.swift
@@ -272,6 +272,16 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
     /// Serial queue that protects all mutable state and runs trigger evaluation off the main thread.
     private let stateQueue: DispatchQueue
 
+    /// Per-instance key used to tag `stateQueue` so callers can non-fatally check whether they are
+    /// already on it. See `isOnStateQueue`.
+    private static let stateQueueKey = DispatchSpecificKey<ObjectIdentifier>()
+
+    /// Non-fatal check for whether the current execution context is `stateQueue`. Use this to
+    /// re-dispatch off-queue callers via `stateQueue.async` rather than trap.
+    private var isOnStateQueue: Bool {
+        DispatchQueue.getSpecific(key: Self.stateQueueKey) == ObjectIdentifier(self)
+    }
+
     // MARK: - Init
 
     init(
@@ -305,6 +315,9 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
             }
         }
         self.recordsSubject = CurrentValueSubject(initialSnapshot)
+        // Tag the queue so `isOnStateQueue` can identify this instance's queue without trapping.
+        // Using ObjectIdentifier(self) lets multiple PromoService instances safely share a queue.
+        stateQueue.setSpecific(key: Self.stateQueueKey, value: ObjectIdentifier(self))
 
         triggerPublisher
             .receive(on: stateQueue)
@@ -403,7 +416,12 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
     }
 
     private func applyExternalVisibility(visible: Bool, promoId: String, delegate: ExternalPromoDelegate) {
-        dispatchPrecondition(condition: .onQueue(stateQueue))
+        guard isOnStateQueue else {
+            stateQueue.async { [weak self] in
+                self?.applyExternalVisibility(visible: visible, promoId: promoId, delegate: delegate)
+            }
+            return
+        }
         if visible {
             externalVisiblePromoIds.insert(promoId)
             var record = historyStore.record(for: promoId)
@@ -601,7 +619,12 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
     }
 
     private func recordResultAndCleanup(promoId: String, result: PromoResult) {
-        dispatchPrecondition(condition: .onQueue(stateQueue))
+        guard isOnStateQueue else {
+            stateQueue.async { [weak self] in
+                self?.recordResultAndCleanup(promoId: promoId, result: result)
+            }
+            return
+        }
         guard var session = activeSessions[promoId] else { return }
         if session.isResultRecorded { return }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214294661819890/task/1215116626193384?focus=true

### Description

`PromoService` guards every private state mutator with `dispatchPrecondition(.onQueue(stateQueue))`. Sentry shows the precondition tripping on `com.apple.main-thread` at `recordResultAndCleanup`, with the most likely entry being the new `applyExternalVisibility → hideInternalPromosConflictingWithCurrentVisibility → recordResultAndCleanup` path added in #4724.

This change replaces the asserting precondition at the top of `applyExternalVisibility` and `recordResultAndCleanup` with a non-fatal check: if the caller is not already on `stateQueue`, the call is re-dispatched via `stateQueue.async` instead of trapping. Detection uses a per-instance `DispatchSpecificKey` so multiple `PromoService` instances can safely share a queue.

The other `dispatchPrecondition` calls in the file are kept — they're only reachable from already-correct queue contexts and continue to surface programmer error in those spots.

### Testing Steps

1. Build and run `macOS Unit Tests/PromoServiceTests` — all 59 tests should pass (existing PR #4724 retraction tests cover the new path).
2. Manually: open a new tab, click the customizer's "Add image" button to open `NSOpenPanel`. While the modal is up, trigger an external-promo visibility change (e.g. dismiss/re-show Next Steps cards via Debug menu, or change the active remote message). The app should not crash.

### Impact and Risks

Medium: touches the `PromoService` queue discipline that gates promo visibility on the new tab page. An incorrect bounce would delay (not lose) an internal-promo retraction.

#### What could go wrong?

- An off-queue caller of `applyExternalVisibility` previously trapped immediately; now it dispatches async. If a follow-up read on `stateQueue` observes the pre-bounce state, the retraction is one queue-hop late. Acceptable — `hideInternalPromosConflictingWithCurrentVisibility` only retracts internal promos that conflict, and a marginally-later retraction is preferable to a crash.
- `setSpecific(key:value:)` is called once during `init`, after all stored properties are initialized; the key is per-class and the value (`ObjectIdentifier(self)`) is per-instance, so multiple `PromoService` instances sharing a `stateQueue` won't collide.

### Quality Considerations

- Behaviour is unchanged on the normal (on-queue) path: the `guard isOnStateQueue else { ... }` falls through and the original logic runs synchronously, exactly as before.
- No new unit test added for the bounce: the crashing entry point can't be reached through the public API without changing access levels. Existing PR #4724 tests (`testWhenInternalPromoVisibleAndExternalBecomesVisible_…`, `testWhenInternalAndExternalMutuallyCoexist_…`) continue to exercise the happy path.

### Notes to Reviewer

The Asana RCA proposed two fixes; this PR implements option (b) (trap → async bounce on `applyExternalVisibility` and `recordResultAndCleanup`). I could not identify the originating off-queue caller from static analysis — every Combine sink in `PromoService.swift` already has an explicit `.receive(on: stateQueue)` hop — so this lands as a defensive fix targeted at the path the Sentry crash signature implicates. If you have a hypothesis for the upstream caller, a follow-up PR can tighten that entrypoint specifically.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes promo visibility queue discipline on the new-tab path; a bad bounce could delay internal promo retraction by one async hop but should not drop work.
> 
> **Overview**
> Fixes a **main-thread crash** where `dispatchPrecondition(.onQueue(stateQueue))` could fire when external-promo visibility updates reached `applyExternalVisibility` / `recordResultAndCleanup` off `stateQueue` (e.g. via `hideInternalPromosConflictingWithCurrentVisibility`).
> 
> **`PromoService`** now tags `stateQueue` with a per-instance `DispatchSpecificKey` and uses **`isOnStateQueue`** instead of trapping at the start of **`applyExternalVisibility`** and **`recordResultAndCleanup`**: off-queue callers are **`stateQueue.async`**-bounced and the same logic runs on the serial queue. On-queue behavior stays synchronous. Other `dispatchPrecondition` sites are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6958131f734d30c07f44f3d0c974e0a5acc4a861. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->