### PR TITLE
macOS: Preserve default data types when switching import source

### DIFF
--- a/macOS/DuckDuckGo/DataImport/Model/DataImportViewModel.swift
+++ b/macOS/DuckDuckGo/DataImport/Model/DataImportViewModel.swift
@@ -910,8 +910,13 @@ extension DataImportViewModel {
             wideEvent.discardFlow(dataImportWideEventData)
             self.dataImportWideEventData = nil
         }
+        // If every selectable type is currently selected, the user hasn't narrowed
+        // the selection — so the next source should default to all of *its* types
+        // rather than inheriting a selection that was implicitly filtered by this
+        // source's capabilities (e.g. password-manager sources only offer passwords).
+        let userNarrowedSelection = selectedDataTypes != selectableImportTypes
         self = .init(importSource: importSource,
-                     selectedDataTypes: self.selectedDataTypes,
+                     selectedDataTypes: userNarrowedSelection ? selectedDataTypes : nil,
                      isPickerExpanded: self.isPickerExpanded,
                      isPasswordManagerAutolockEnabled: isPasswordManagerAutolockEnabled,
                      syncFeatureVisibility: syncFeatureVisibility,

--- a/macOS/DuckDuckGo/DataImport/Model/DataImportViewModel.swift
+++ b/macOS/DuckDuckGo/DataImport/Model/DataImportViewModel.swift
@@ -104,11 +104,9 @@ struct DataImportViewModel {
     var selectedProfile: BrowserProfile?
     /// selected Data Types to import (bookmarks/passwords)
     var selectedDataTypes: Set<DataType> = []
-    /// Whether the user has explicitly toggled a data-type checkbox on this flow.
-    /// Drives source-switch behaviour in `update(with:)`: when false, switching
-    /// sources defaults to all of the new source's selectable types (so a stop
-    /// at a single-type source doesn't implicitly narrow the selection); when
-    /// true, the user's explicit selection is preserved across switches.
+    /// True once the user explicitly toggles a data-type checkbox.
+    /// Lets `update(with:)` tell user intent apart from a selection that's
+    /// just a side-effect of the current source's supported types.
     var hasUserModifiedDataTypeSelection: Bool = false
     var isPickerExpanded: Bool = false
 
@@ -918,11 +916,8 @@ extension DataImportViewModel {
             wideEvent.discardFlow(dataImportWideEventData)
             self.dataImportWideEventData = nil
         }
-        // Only forward `selectedDataTypes` if the user has explicitly toggled a
-        // checkbox. Otherwise the current selection is just a function of this
-        // source's capabilities (e.g. a password-manager source forced it to
-        // `{.passwords}`), and the next source should default to all of *its*
-        // selectable types instead of inheriting that implicit narrowing.
+        // Only carry the user's selection forward if they actually chose it.
+        // Otherwise let the new source default to its full set of types.
         self = .init(importSource: importSource,
                      selectedDataTypes: hasUserModifiedDataTypeSelection ? selectedDataTypes : nil,
                      hasUserModifiedDataTypeSelection: hasUserModifiedDataTypeSelection,

--- a/macOS/DuckDuckGo/DataImport/Model/DataImportViewModel.swift
+++ b/macOS/DuckDuckGo/DataImport/Model/DataImportViewModel.swift
@@ -104,6 +104,12 @@ struct DataImportViewModel {
     var selectedProfile: BrowserProfile?
     /// selected Data Types to import (bookmarks/passwords)
     var selectedDataTypes: Set<DataType> = []
+    /// Whether the user has explicitly toggled a data-type checkbox on this flow.
+    /// Drives source-switch behaviour in `update(with:)`: when false, switching
+    /// sources defaults to all of the new source's selectable types (so a stop
+    /// at a single-type source doesn't implicitly narrow the selection); when
+    /// true, the user's explicit selection is preserved across switches.
+    var hasUserModifiedDataTypeSelection: Bool = false
     var isPickerExpanded: Bool = false
 
     enum DataTypeSelection: Equatable {
@@ -206,6 +212,7 @@ struct DataImportViewModel {
          preferredImportSources: [Source] = [.chrome, .firefox, .safari],
          summary: [DataTypeImportResult] = [],
          selectedDataTypes: Set<DataType>? = nil,
+         hasUserModifiedDataTypeSelection: Bool = false,
          isPickerExpanded: Bool = false,
          isPasswordManagerAutolockEnabled: Bool = AutofillPreferences().isAutoLockEnabled,
          syncFeatureVisibility: SyncFeatureVisibility = .hide,
@@ -263,6 +270,7 @@ struct DataImportViewModel {
             previousSelectedTypes: selectedDataTypes,
             availableTypes: availableImportTypes
         )
+        self.hasUserModifiedDataTypeSelection = hasUserModifiedDataTypeSelection
 
         self.summary = summary
         self.isPickerExpanded = isPickerExpanded
@@ -910,13 +918,14 @@ extension DataImportViewModel {
             wideEvent.discardFlow(dataImportWideEventData)
             self.dataImportWideEventData = nil
         }
-        // If every selectable type is currently selected, the user hasn't narrowed
-        // the selection — so the next source should default to all of *its* types
-        // rather than inheriting a selection that was implicitly filtered by this
-        // source's capabilities (e.g. password-manager sources only offer passwords).
-        let userNarrowedSelection = selectedDataTypes != selectableImportTypes
+        // Only forward `selectedDataTypes` if the user has explicitly toggled a
+        // checkbox. Otherwise the current selection is just a function of this
+        // source's capabilities (e.g. a password-manager source forced it to
+        // `{.passwords}`), and the next source should default to all of *its*
+        // selectable types instead of inheriting that implicit narrowing.
         self = .init(importSource: importSource,
-                     selectedDataTypes: userNarrowedSelection ? selectedDataTypes : nil,
+                     selectedDataTypes: hasUserModifiedDataTypeSelection ? selectedDataTypes : nil,
+                     hasUserModifiedDataTypeSelection: hasUserModifiedDataTypeSelection,
                      isPickerExpanded: self.isPickerExpanded,
                      isPasswordManagerAutolockEnabled: isPasswordManagerAutolockEnabled,
                      syncFeatureVisibility: syncFeatureVisibility,

--- a/macOS/DuckDuckGo/DataImport/View/DataImportTypePicker.swift
+++ b/macOS/DuckDuckGo/DataImport/View/DataImportTypePicker.swift
@@ -120,6 +120,10 @@ struct DataImportTypePicker: View {
 extension DataImportViewModel {
 
     mutating func setDataType(_ dataType: DataType, selected: Bool) {
+        // No-op on unchanged values so just opening and confirming the type
+        // sheet without changes doesn't flip `hasUserModifiedDataTypeSelection`.
+        guard selectedDataTypes.contains(dataType) != selected else { return }
+        hasUserModifiedDataTypeSelection = true
         if selected {
             selectedDataTypes.insert(dataType)
         } else {

--- a/macOS/DuckDuckGo/DataImport/View/DataImportTypePicker.swift
+++ b/macOS/DuckDuckGo/DataImport/View/DataImportTypePicker.swift
@@ -120,8 +120,7 @@ struct DataImportTypePicker: View {
 extension DataImportViewModel {
 
     mutating func setDataType(_ dataType: DataType, selected: Bool) {
-        // No-op on unchanged values so just opening and confirming the type
-        // sheet without changes doesn't flip `hasUserModifiedDataTypeSelection`.
+        // Ignore no-op writes so confirming the type sheet unchanged isn't treated as user intent.
         guard selectedDataTypes.contains(dataType) != selected else { return }
         hasUserModifiedDataTypeSelection = true
         if selected {

--- a/macOS/UnitTests/DataImport/DataImportViewModelTests.swift
+++ b/macOS/UnitTests/DataImport/DataImportViewModelTests.swift
@@ -381,6 +381,54 @@ final class DataImportViewModelTests: XCTestCase {
         XCTAssertEqual(result, [.passwords])
     }
 
+    @MainActor
+    func testUpdateWithSource_roundTripThroughPasswordManager_restoresBookmarks() {
+        // GIVEN: Chrome with all selectable types selected (default state)
+        model = DataImportViewModel(
+            importSource: .chrome,
+            syncFeatureVisibility: .hide,
+            loadProfiles: { browser in
+                let defaultProfile = BrowserProfile.default(fileStore: self.fileStore)(browser)
+                return .init(browser: browser, profiles: [defaultProfile])
+            }
+        )
+        XCTAssertEqual(model.selectedDataTypes, [.bookmarks, .passwords])
+
+        // WHEN: switch to a password-manager source (which only offers passwords)
+        model.update(with: .bitwarden)
+        XCTAssertEqual(model.selectableImportTypes, [.passwords])
+        XCTAssertEqual(model.selectedDataTypes, [.passwords])
+
+        // AND: switch back to a browser source
+        model.update(with: .chrome)
+
+        // THEN: both bookmarks and passwords are selected again; the narrowing
+        // from the password-manager source doesn't bleed across
+        XCTAssertEqual(model.selectedDataTypes, [.bookmarks, .passwords])
+    }
+
+    @MainActor
+    func testUpdateWithSource_userNarrowedSelection_isPreservedAcrossSourceSwitch() {
+        // GIVEN: Chrome, then user unchecks bookmarks (explicit narrowing)
+        model = DataImportViewModel(
+            importSource: .chrome,
+            syncFeatureVisibility: .hide,
+            loadProfiles: { browser in
+                let defaultProfile = BrowserProfile.default(fileStore: self.fileStore)(browser)
+                return .init(browser: browser, profiles: [defaultProfile])
+            }
+        )
+        model.setDataType(.bookmarks, selected: false)
+        XCTAssertEqual(model.selectedDataTypes, [.passwords])
+
+        // WHEN: switch to another browser that also supports both types
+        model.update(with: .firefox)
+
+        // THEN: the explicit narrowing is preserved
+        XCTAssertEqual(model.selectableImportTypes, [.bookmarks, .passwords])
+        XCTAssertEqual(model.selectedDataTypes, [.passwords])
+    }
+
     // MARK: - Button State Tests
 
     @MainActor

--- a/macOS/UnitTests/DataImport/DataImportViewModelTests.swift
+++ b/macOS/UnitTests/DataImport/DataImportViewModelTests.swift
@@ -429,6 +429,62 @@ final class DataImportViewModelTests: XCTestCase {
         XCTAssertEqual(model.selectedDataTypes, [.passwords])
     }
 
+    @MainActor
+    func testUpdateWithSource_userNarrowingSurvivesRoundTripThroughSingleTypeSource() {
+        // GIVEN: Chrome with both types, then user unchecks passwords
+        model = DataImportViewModel(
+            importSource: .chrome,
+            syncFeatureVisibility: .hide,
+            loadProfiles: { browser in
+                let defaultProfile = BrowserProfile.default(fileStore: self.fileStore)(browser)
+                return .init(browser: browser, profiles: [defaultProfile])
+            }
+        )
+        model.setDataType(.passwords, selected: false)
+        XCTAssertEqual(model.selectedDataTypes, [.bookmarks])
+
+        // WHEN: switch to a bookmarks-only source (e.g. Tor), then back to Chrome
+        model.update(with: .tor)
+        XCTAssertEqual(model.selectableImportTypes, [.bookmarks])
+        XCTAssertEqual(model.selectedDataTypes, [.bookmarks])
+
+        model.update(with: .chrome)
+
+        // THEN: passwords stays deselected — the round trip through a source
+        // whose selectable set equals the user's narrowed selection doesn't
+        // erase the explicit intent.
+        XCTAssertEqual(model.selectableImportTypes, [.bookmarks, .passwords])
+        XCTAssertEqual(model.selectedDataTypes, [.bookmarks])
+    }
+
+    @MainActor
+    func testSetDataType_unchangedValue_doesNotMarkSelectionAsUserModified() {
+        // GIVEN: Chrome with both types selected by default
+        model = DataImportViewModel(
+            importSource: .chrome,
+            syncFeatureVisibility: .hide,
+            loadProfiles: { browser in
+                let defaultProfile = BrowserProfile.default(fileStore: self.fileStore)(browser)
+                return .init(browser: browser, profiles: [defaultProfile])
+            }
+        )
+        XCTAssertFalse(model.hasUserModifiedDataTypeSelection)
+
+        // WHEN: setDataType is called with values that match the current state
+        // (this happens when the type-picker sheet's Done button re-emits every
+        // item's current state)
+        model.setDataType(.bookmarks, selected: true)
+        model.setDataType(.passwords, selected: true)
+
+        // THEN: the flag stays false, and a source round trip still resets to
+        // all-of-new-source's-types
+        XCTAssertFalse(model.hasUserModifiedDataTypeSelection)
+
+        model.update(with: .bitwarden)
+        model.update(with: .chrome)
+        XCTAssertEqual(model.selectedDataTypes, [.bookmarks, .passwords])
+    }
+
     // MARK: - Button State Tests
 
     @MainActor


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200930669568058/task/1215105161398769?focus=true
Tech Design URL:
CC:

### Description

On the data-import source picker, the default state for a browser source is Bookmarks + Passwords both selected. Picking a password-manager source (1Password, Bitwarden, LastPass — only supports Passwords) and then picking a browser source again left Bookmarks unchecked, even though the user never deselected it.

Root cause: `DataImportViewModel.update(with:)` forwarded the current `selectedDataTypes` to the new instance verbatim. Switching to a password manager correctly narrowed the set to `{.passwords}` (intersection with the source's `supportedDataTypes`). Switching back to a browser then inherited that narrowed set instead of re-defaulting to all of the browser's selectable types — the implicit narrowing was indistinguishable from the user explicitly deselecting Bookmarks.

Fix: in `update(with:)`, detect the "user hasn't narrowed anything" case (`selectedDataTypes == selectableImportTypes`) and pass `nil` so the new instance's init defaults to all of the new source's supported types. Explicit user narrowing (a strict subset) is still forwarded and survives source switches.

### Testing Steps

1. Open Settings → Import…
2. Confirm the default browser source has both Bookmarks + Passwords selected.
3. Click a password-manager card (Bitwarden / 1Password / LastPass) — only Passwords available.
4. Click a browser card again — Bookmarks + Passwords should both be selected. (Before the fix, only Passwords.)
5. Regression: on a browser, open the type sheet and uncheck Bookmarks; switch to another browser. Passwords-only should persist.

### Impact and Risks

Low. Scope is confined to one method on the data-import view model; explicit user narrowing path is covered by a new unit test.

#### What could go wrong?

The "all selectable currently selected" heuristic could mis-fire if a new source had a strictly larger `selectableImportTypes` than the previous one — but in practice the available data types are a closed set (`bookmarks`, `passwords`) and sources only narrow it. Two unit tests pin the behaviour for both the bug path and the explicit-narrowing path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to data-import view model selection when changing sources; unit tests cover default restore and explicit user narrowing.
> 
> **Overview**
> Fixes macOS data import so switching import source no longer keeps a **password-only** selection after visiting a password manager when the user never narrowed types themselves.
> 
> **`DataImportViewModel`** adds **`hasUserModifiedDataTypeSelection`**. **`update(with:)`** forwards **`selectedDataTypes`** only when that flag is true; otherwise it passes **`nil`** so the new source gets the full default selectable set (e.g. bookmarks + passwords again after Chrome → Bitwarden → Chrome). **`setDataType`** ignores no-op toggles (e.g. type sheet re-applying current state) and sets the flag only on real checkbox changes, so implicit narrowing from a single-type source is not treated as user intent.
> 
> New unit tests cover the password-manager round trip, preserved explicit narrowing, and no-op **`setDataType`** calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 464bcc845e2a8342d8b451400e5e6509cb2af459. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->