### PR TITLE
[macOS] Fix onboarding shown pixel in rebranded contextual onboarding

### DIFF
--- a/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/Rebranding/RebrandedContextualDaxDialogsFactory.swift
+++ b/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/Rebranding/RebrandedContextualDaxDialogsFactory.swift
@@ -90,7 +90,8 @@ struct RebrandedContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
     }
 
     func makeView(for type: ContextualDialogType, delegate: any OnboardingNavigationDelegate, onDismiss: @escaping () -> Void, onManualDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onFireButtonPressed: @escaping () -> Void, onSuggestionPressed: @escaping () -> Void) -> AnyView {
-        AnyView(
+        onboardingPixelReporter.measureDialogShown(dialogType: type)
+        return AnyView(
             ContextualDialogView(
                 type: type,
                 delegate: delegate,

--- a/macOS/UnitTests/Onboarding/ContextualOnboarding/ContextualDaxDialogsFactoryTests.swift
+++ b/macOS/UnitTests/Onboarding/ContextualOnboarding/ContextualDaxDialogsFactoryTests.swift
@@ -63,6 +63,22 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         fireCoordinator = nil
     }
 
+    // MARK: - Rebranded Onboarding
+
+    func testWhenMakeRebrandedViewThenDialogShownPixelIsFiredForDialogType() {
+        // GIVEN
+        let dialogType = ContextualDialogType.tryASearch
+        let factory = RebrandedContextualDaxDialogsFactory(onboardingPixelReporter: reporter, fireCoordinator: fireCoordinator)
+
+        // WHEN
+        _ = factory.makeView(for: dialogType, delegate: delegate, onDismiss: {}, onManualDismiss: {}, onGotItPressed: {}, onFireButtonPressed: {}, onSuggestionPressed: {})
+
+        // THEN
+        XCTAssertEqual(reporter.shownDialog, dialogType)
+    }
+
+    // MARK: - Default Onboarding
+
     func testWhenMakeViewForTryASearchThenOnboardingTrySearchDialogViewCreatedAndOnActionExpectedSearchOccurs() throws {
         // GIVEN
         let dialogType = ContextualDialogType.tryASearch


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1215121242601398?focus=true
Tech Design URL:
CC:

### Description

The shared pixel for when an onboarding step is shown stopped firing for contextual onboarding dialogs in macOS 1.190, when rebranded onboarding was enabled. (The pixel firing was unintentionally removed in https://github.com/duckduckgo/apple-browsers/pull/4454.) 

To fix it:

* Restores `onboardingPixelReporter.measureDialogShown(dialogType:)` in `RebrandedContextualDaxDialogsFactory.makeView`, aligned with the default contextual dialog factory.
* Adds a unit test so the rebranded factory cannot regress to omitting the dialog shown pixel.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Build and run the app.
2. Debug menu → Reset Data → Reset Onboarding
3. Restart the app.
4. Proceed through the linear onboarding steps.
5. When contextual onboarding starts, continue through the dialogs and confirm that when each dialog appears a pixel is fired for that step (e.g. `m_mac_onboarding_search`) with a parameter `"e": "shown"`.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
6. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
None: Internal tooling, documentation

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
Confirmed pixel fires for the correct dialog type at the correct time, and added a unit test to prevent future regressions.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only change in onboarding UI factory code with a focused unit test; no auth, data, or core browsing behavior changes.
> 
> **Overview**
> Restores **onboarding “dialog shown” analytics** for rebranded macOS contextual onboarding by calling `onboardingPixelReporter.measureDialogShown(dialogType:)` at the start of `RebrandedContextualDaxDialogsFactory.makeView`, matching `DefaultContextualDaxDialogViewFactory`.
> 
> Adds a unit test that building a rebranded view records the expected dialog type on the pixel reporter so this path cannot silently drop the shown pixel again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c53fb7ba7fb003c6d3b6a5f824b622120508160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->