### PR TITLE
Preserve Duck.ai omnibar state when a tab moves to a new window

### DIFF
--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -87,6 +87,10 @@ protocol TabDelegate: ContentOverlayUserScriptDelegate {
     let crashIndicatorModel = TabCrashIndicatorModel()
     let pinnedTabsManagerProvider: PinnedTabsManagerProviding
 
+    /// Per-tab Duck.ai omnibar state (prompt text, selection, mode, tool, attachments).
+    /// Owned by Tab so it survives TabViewModel recreation when the tab moves to a new window.
+    let addressBarSharedTextState = AddressBarSharedTextState()
+
     private let webViewConfiguration: WKWebViewConfiguration
 
     let startupPreferences: StartupPreferences

--- a/macOS/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
+++ b/macOS/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
@@ -71,8 +71,9 @@ final class TabViewModel: NSObject {
 
     var lastAddressBarTextFieldValue: AddressBarTextField.Value?
 
-    /// Shared text state for the address bar and AI Chat omnibar for this tab
-    let addressBarSharedTextState = AddressBarSharedTextState()
+    /// Shared text state for the address bar and AI Chat omnibar for this tab.
+    /// Owned by `Tab` so it survives TabViewModel recreation on cross-window moves.
+    var addressBarSharedTextState: AddressBarSharedTextState { tab.addressBarSharedTextState }
 
     @Published private(set) var title: String = UserText.tabHomeTitle
     @Published private(set) var favicon: NSImage?

--- a/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests.swift
+++ b/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests.swift
@@ -1424,6 +1424,51 @@ final class TabCollectionViewModelTests: XCTestCase {
         XCTAssertNotNil(vm.tabViewModel(at: 1))
         XCTAssertEqual(vm.selectionIndex, .unpinned(1))
     }
+
+    // MARK: - addressBarSharedTextState survives cross-collection moves
+
+    @MainActor
+    func testWhenTabIsMovedToAnotherCollection_addressBarSharedTextStateSurvives() {
+        let source = TabCollectionViewModel.aTabCollectionViewModel()
+        let dest = TabCollectionViewModel.aTabCollectionViewModel()
+        let tab = Tab(content: .newtab)
+        guard let sourceIndex = source.append(tab: tab, selected: true) else {
+            return XCTFail("Failed to append tab to source")
+        }
+
+        tab.addressBarSharedTextState.updateText("hello duck.ai")
+        tab.addressBarSharedTextState.setDuckAIMode(true)
+        tab.addressBarSharedTextState.setAIChatToolMode(.imageGeneration)
+
+        source.moveTab(at: sourceIndex, to: dest, at: 0)
+
+        let movedVM = dest.tabViewModel(at: 0)
+        XCTAssertTrue(movedVM?.tab === tab, "moveTab must reuse the same Tab instance in the destination")
+        XCTAssertEqual(movedVM?.addressBarSharedTextState.text, "hello duck.ai")
+        XCTAssertEqual(movedVM?.addressBarSharedTextState.isInDuckAIMode, true)
+        XCTAssertEqual(movedVM?.addressBarSharedTextState.aiChatToolMode, .imageGeneration)
+    }
+
+    @MainActor
+    func testWhenTabCollectionViewModelIsInitializedWithStatefulTab_tabViewModelExposesSameState() {
+        // Mirrors the WindowsManager.openNewWindow(with: tab) path: a fresh TabCollectionViewModel
+        // is built around a TabCollection that already contains a Tab carrying live omnibar state.
+        let tab = Tab(content: .newtab)
+        tab.addressBarSharedTextState.updateText("draft prompt")
+        tab.addressBarSharedTextState.setDuckAIMode(true)
+        tab.addressBarSharedTextState.setAIChatToolMode(.webSearch)
+
+        let vm = TabCollectionViewModel(
+            tabCollection: TabCollection(tabs: [tab]),
+            pinnedTabsManagerProvider: PinnedTabsManagerProvidingMock()
+        )
+
+        let tabVM = vm.tabViewModel(at: 0)
+        XCTAssertTrue(tabVM?.tab === tab)
+        XCTAssertEqual(tabVM?.addressBarSharedTextState.text, "draft prompt")
+        XCTAssertEqual(tabVM?.addressBarSharedTextState.isInDuckAIMode, true)
+        XCTAssertEqual(tabVM?.addressBarSharedTextState.aiChatToolMode, .webSearch)
+    }
 }
 
 fileprivate extension TabCollectionViewModel {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1214876623171659?focus=true

### Description

Dragging a tab out to a new window (or dropping it onto another window's tab bar) recreated the tab's `TabViewModel`. `AddressBarSharedTextState` — which holds the omnibar's Duck.ai prompt, mode flag, active tool, and image / page / file attachments — was a stored property on `TabViewModel`, so it was dropped on the floor and the new window's omnibar opened empty in search mode even though the tab itself was unchanged.

- Move `AddressBarSharedTextState` ownership from `TabViewModel` onto `Tab`. The state is conceptually per-tab, and `Tab` is the instance that actually survives the move.
- Forward the existing `tabViewModel.addressBarSharedTextState` accessor as a computed property so the ~28 call sites in `AddressBarViewController`, `AddressBarTextField`, `AIChatOmnibarController`, `MainViewController` and tests keep working unchanged.
- Covers every TabViewModel-recreation path automatically: drag-to-new-window (via `WindowsManager.openNewWindow(with: tab)`), cross-window drop (via `TabCollectionViewModel.moveTab(at:to:otherViewModel:at:)`), and the normal `subscribeToTabs` rebuild on insertion.

### Testing Steps

1. Open a window with at least two tabs.
2. In one tab, toggle Duck.ai mode in the address bar and type a prompt.
3. Pick an active tool (image generation or web search).
4. Attach an image
5. Drag the tab out of the window to spawn a new window. **Expected:** Duck.ai mode chip, typed prompt, selected tool, image attachment and tab attachment all survive in the new window's omnibar.
6. Click into the address bar to re-focus. **Expected:** panel re-opens cleanly with everything intact.
7. Repeat by dragging a tab onto a second existing window's tab bar instead of tearing off. Same expectation.
8. Sanity: with no detach, switch between tabs in one window. Per-tab Duck.ai state should still survive tab switches as before.

Unit tests added in `TabCollectionViewModelTests`:
- `testWhenTabIsMovedToAnotherCollection_addressBarSharedTextStateSurvives`
- `testWhenTabCollectionViewModelIsInitializedWithStatefulTab_tabViewModelExposesSameState`

### Impact and Risks

Low. Refactors ownership of one already-per-tab state holder; no API or behaviour change for any existing reader.

#### What could go wrong?

- `AddressBarSharedTextState` is an `ObservableObject` and several call sites subscribe to `$text`, `$isInDuckAIMode`, `$aiChatToolMode`, etc. Identity becomes *more* stable now (one instance per Tab instead of per TabViewModel), which is strictly better for subscribers — none compare by identity, so no regression.
- Other transient `TabViewModel` state (zoom, `addressBarString`, progress, find-in-page) intentionally still resets on move; the fix is additive and doesn't touch those.
- Session restoration on relaunch and Undo Close Tab both create a fresh `Tab` and therefore a fresh state — same as before. Omnibar drafts remain ephemeral by design.
- Burner safety: state travels with the `Tab`, `Tab.burnerMode` is immutable, and cross-burner drags are already blocked at `TabDragAndDropManager` and `TabCollectionViewModel.subscribeToTabs`. No new leak vector.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Ownership refactor of per-tab UI state with a forwarding accessor; behavior for in-window tab switches is unchanged and tests cover cross-collection moves.
> 
> **Overview**
> Dragging a tab to another window (or tearing off into a new one) rebuilds **`TabViewModel`**, which used to own **`AddressBarSharedTextState`**—so Duck.ai omnibar drafts (prompt, mode, tool, attachments) were lost even though the **`Tab`** instance was reused.
> 
> **`AddressBarSharedTextState`** is now created on **`Tab`** and exposed from **`TabViewModel`** as a computed property forwarding to **`tab.addressBarSharedTextState`**, so existing omnibar call sites keep the same API while state survives **`TabViewModel`** recreation on cross-window moves and fresh **`TabCollectionViewModel`** setup.
> 
> Unit tests in **`TabCollectionViewModelTests`** cover **`moveTab`** between collections and initializing a collection with a tab that already has omnibar state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbb44d7d0f43126ed373e61b4fbe0036109f4b3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->