### PR TITLE
[iOS] align FireModePromotionsCoordinator tests with show-at-most-once contract

### DIFF
--- a/iOS/DuckDuckGoTests/FireMode/FireModePromotionsCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/FireMode/FireModePromotionsCoordinatorTests.swift
@@ -99,27 +99,13 @@ final class FireModePromotionsCoordinatorTests: XCTestCase {
         XCTAssertFalse(sut.isNTPPromotionEligible)
     }
 
-    // MARK: - NTP Promotion: Expiration
+    // MARK: - NTP Promotion: Show At Most Once
 
-    func testWhenPromotionShownWithinThreeDaysThenEligible() {
+    func testWhenPromotionShownThenNotEligibleAgain() {
         setNTPEligibleState()
         sut.markNTPPromotionShown()
 
-        XCTAssertTrue(sut.isNTPPromotionEligible)
-    }
-
-    func testWhenPromotionShownMoreThanThreeDaysAgoThenNotEligible() {
-        setNTPEligibleState()
-        let fourDaysAgo = Date().addingTimeInterval(-4 * 24 * 60 * 60)
-        storage.ntpFirstSeenDate = fourDaysAgo
-
         XCTAssertFalse(sut.isNTPPromotionEligible)
-    }
-
-    func testWhenPromotionNeverShownAndConditionsMetThenEligible() {
-        setNTPEligibleState()
-
-        XCTAssertTrue(sut.isNTPPromotionEligible)
     }
 
     // MARK: - NTP Promotion: markNTPPromotionShown


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215100205604068?focus=true
Tech Design URL:
CC: @brindy

### Description

Test follow-up to #5060. Aligns `FireModePromotionsCoordinatorTests` with the new "show at most once" NTP-promotion contract.

- Removes `testWhenPromotionShownWithinThreeDaysThenEligible` — failed deterministically after #5060 because `markNTPPromotionShown` now writes `ntpFirstSeenDate` and the new eligibility check requires `ntpFirstSeenDate == nil`. The 3-day-window contract this test exercised no longer exists.
- Removes `testWhenPromotionShownMoreThanThreeDaysAgoThenNotEligible` — still passed but for the wrong reason; the 3-day window is gone.
- Removes `testWhenPromotionNeverShownAndConditionsMetThenEligible` — became a duplicate of `testWhenFeatureFlagIsEnabledAndConditionsMetThenEligible` once the surrounding contrast cases were removed.
- Renames the `// MARK: - NTP Promotion: Expiration` section to `Show At Most Once`.
- Adds `testWhenPromotionShownThenNotEligibleAgain` asserting the new contract.

### Testing Steps

CI stays 🟢 

### Impact and Risks

None. Test-only change.

#### What could go wrong?

Nothing user-facing. If the new positive-baseline test (`testWhenFeatureFlagIsEnabledAndConditionsMetThenEligible`) is later removed, we lose the "never shown ⇒ eligible" assertion entirely. If you want a dedicated test under the new section header, happy to add one back.

### Notes to Reviewer

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to `FireModePromotionsCoordinatorTests`; no production or user-facing behavior.
> 
> **Overview**
> Updates **`FireModePromotionsCoordinatorTests`** so NTP promotion coverage matches the **show-at-most-once** behavior from #5060 (eligibility requires `ntpFirstSeenDate == nil` after `markNTPPromotionShown`).
> 
> Removes three tests tied to the old **3-day expiration** window and a redundant “never shown” case. Renames the section from **Expiration** to **Show At Most Once** and adds **`testWhenPromotionShownThenNotEligibleAgain`** to assert a second show is not eligible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11de3bac8e58700b745372fe073c08a585a646f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->