### PR TITLE
iOS: Consolidate Address Bar toggle into Navigation Bar on iPad

### DIFF
--- a/iOS/DuckDuckGo/AIChat/AIChatAddressBarExperience.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatAddressBarExperience.swift
@@ -32,6 +32,12 @@ struct SystemUserInterfaceIdiomProvider: UserInterfaceIdiomProviding {
     }
 }
 
+protocol LargeWidthProviding {
+    var isLargeWidth: Bool { get }
+}
+
+extension AppWidthObserver: LargeWidthProviding {}
+
 protocol AIChatAddressBarExperienceProviding {
     var shouldShowDuckAIAddressBarButton: Bool { get }
     var shouldShowModeToggle: Bool { get }
@@ -44,13 +50,16 @@ struct AIChatAddressBarExperience: AIChatAddressBarExperienceProviding {
     private let featureFlagger: FeatureFlagger
     private let aiChatSettings: AIChatSettingsProvider
     private let userInterfaceIdiomProvider: UserInterfaceIdiomProviding
+    private let largeWidthProvider: LargeWidthProviding
 
     init(featureFlagger: FeatureFlagger,
          aiChatSettings: AIChatSettingsProvider,
-         userInterfaceIdiomProvider: UserInterfaceIdiomProviding = SystemUserInterfaceIdiomProvider()) {
+         userInterfaceIdiomProvider: UserInterfaceIdiomProviding = SystemUserInterfaceIdiomProvider(),
+         largeWidthProvider: LargeWidthProviding = AppWidthObserver.shared) {
         self.featureFlagger = featureFlagger
         self.aiChatSettings = aiChatSettings
         self.userInterfaceIdiomProvider = userInterfaceIdiomProvider
+        self.largeWidthProvider = largeWidthProvider
     }
 
     var isIPadAIToggleExperienceEnabled: Bool {
@@ -58,7 +67,18 @@ struct AIChatAddressBarExperience: AIChatAddressBarExperienceProviding {
             && featureFlagger.isFeatureOn(.iPadAIToggle)
     }
 
+    private var isIPadChromeShortcutInPlay: Bool {
+        userInterfaceIdiomProvider.userInterfaceIdiom == .pad
+            && featureFlagger.isFeatureOn(.aiChatChromeShortcutIPad)
+    }
+
     var shouldShowDuckAIAddressBarButton: Bool {
+        if isIPadChromeShortcutInPlay {
+            return DuckAIChromeShortcutVisibility.isAddressBarButtonVisibleOnIPad(
+                isLargeWidth: largeWidthProvider.isLargeWidth,
+                isAIChatNavigationBarUserSettingsEnabled: aiChatSettings.isAIChatNavigationBarUserSettingsEnabled
+            )
+        }
         return aiChatSettings.isAIChatAddressBarUserSettingsEnabled
     }
 

--- a/iOS/DuckDuckGo/AIChat/AIChatSettings.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatSettings.swift
@@ -66,6 +66,20 @@ final class AIChatSettings: AIChatSettingsProvider {
         self.notificationCenter = notificationCenter
         self.featureFlagger = featureFlagger
         self.switchBarFunnel = switchBarFunnel
+
+        migrateAddressBarSettingIfNeeded()
+    }
+
+    /// One-shot: if a user had the legacy Address Bar toggle off, carry that into the
+    /// Navigation Bar toggle so the iPad chrome shortcut doesn't silently re-enable
+    /// the surface under a new name.
+    private func migrateAddressBarSettingIfNeeded() {
+        guard keyValueStore.object(forKey: .showAIChatNavigationBarKey) == nil,
+              let legacyAddressBarValue = keyValueStore.object(forKey: .showAIChatAddressBarKey) as? Bool,
+              legacyAddressBarValue == false else {
+            return
+        }
+        keyValueStore.set(false, forKey: .showAIChatNavigationBarKey)
     }
 
     // MARK: - Public

--- a/iOS/DuckDuckGo/SettingsAIChatShortcutsView.swift
+++ b/iOS/DuckDuckGo/SettingsAIChatShortcutsView.swift
@@ -36,6 +36,11 @@ enum DuckAIChromeShortcutVisibility {
         isIPad && featureFlagger.isFeatureOn(.aiChatChromeShortcutIPad)
     }
 
+    /// Address Bar settings row hides whenever the Navigation Bar row is shown — they describe the same surface.
+    static func isAddressBarRowVisible(isIPad: Bool, featureFlagger: FeatureFlagger) -> Bool {
+        !isSettingsRowVisible(isIPad: isIPad, featureFlagger: featureFlagger)
+    }
+
     /// No `isIPad` parameter — the only caller (`TabsBarViewController`) is iPad-only by construction.
     static func isChromeButtonVisible(
         featureFlagger: FeatureFlagger,
@@ -43,6 +48,15 @@ enum DuckAIChromeShortcutVisibility {
     ) -> Bool {
         featureFlagger.isFeatureOn(.aiChatChromeShortcutIPad)
             && isAIChatNavigationBarUserSettingsEnabled
+    }
+
+    /// On iPad with the chrome shortcut in play, the in-address-bar Duck.ai icon only
+    /// shows at narrow widths where the tabs bar (and chrome pill) is hidden.
+    static func isAddressBarButtonVisibleOnIPad(
+        isLargeWidth: Bool,
+        isAIChatNavigationBarUserSettingsEnabled: Bool
+    ) -> Bool {
+        !isLargeWidth && isAIChatNavigationBarUserSettingsEnabled
     }
 }
 
@@ -55,8 +69,10 @@ struct SettingsAIChatShortcutsView: View {
                 SettingsCellView(label: UserText.aiChatSettingsEnableBrowsingMenuToggle,
                                  accessory: .toggle(isOn: viewModel.aiChatBrowsingMenuEnabledBinding))
 
-                SettingsCellView(label: UserText.aiChatSettingsEnableAddressBarToggle,
-                                 accessory: .toggle(isOn: viewModel.aiChatAddressBarEnabledBinding))
+                if shouldShowAddressBarShortcut {
+                    SettingsCellView(label: UserText.aiChatSettingsEnableAddressBarToggle,
+                                     accessory: .toggle(isOn: viewModel.aiChatAddressBarEnabledBinding))
+                }
 
                 if shouldShowNavigationBarShortcut {
                     SettingsCellView(label: UserText.aiChatSettingsEnableNavigationBarToggle,
@@ -138,7 +154,10 @@ struct SettingsAIChatShortcutsView: View {
     }
 
     private var shouldShowAddressBarShortcut: Bool {
-        !(viewModel.featureFlagger.isFeatureOn(.iPadAIToggle) && UIDevice.current.userInterfaceIdiom == .pad)
+        DuckAIChromeShortcutVisibility.isAddressBarRowVisible(
+            isIPad: UIDevice.current.userInterfaceIdiom == .pad,
+            featureFlagger: viewModel.featureFlagger
+        )
     }
 
     private var shouldShowNavigationBarShortcut: Bool {

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -98,7 +98,11 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
     var historyManager: HistoryManaging?
     var fireproofing: Fireproofing?
     var aiChatSettings: AIChatSettingsProvider?
-    var featureFlagger: FeatureFlagger?
+    var featureFlagger: FeatureFlagger? {
+        didSet {
+            registerForFeatureFlagChanges()
+        }
+    }
     var keyValueStore: ThrowingKeyValueStoring?
     var daxDialogsManager: DaxDialogsManaging?
     var fireModeCapability: FireModeCapable? {
@@ -147,7 +151,6 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
         configureGestures()
         enableInteractionsWithPointer()
         registerForAIChatSettingsChanges()
-        registerForFeatureFlagChanges()
     }
 
     private func setUpSubviews() {
@@ -196,7 +199,6 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
     }
 
     private func registerForFeatureFlagChanges() {
-        // Picks up internal-debug toggles of `aiChatChromeShortcutIPad` while the tabs bar is on screen.
         guard let overridesHandler = featureFlagger?.localOverrides?.actionHandler as? FeatureFlagOverridesPublishingHandler<FeatureFlag> else {
             return
         }

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -197,9 +197,13 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
 
     private func registerForFeatureFlagChanges() {
         // Picks up internal-debug toggles of `aiChatChromeShortcutIPad` while the tabs bar is on screen.
-        featureFlagger?.updatesPublisher
+        guard let overridesHandler = featureFlagger?.localOverrides?.actionHandler as? FeatureFlagOverridesPublishingHandler<FeatureFlag> else {
+            return
+        }
+        overridesHandler.flagDidChangePublisher
+            .filter { $0.0 == .aiChatChromeShortcutIPad }
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] in
+            .sink { [weak self] _ in
                 self?.updateAIChatButtonVisibility()
             }
             .store(in: &cancellables)

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -147,6 +147,7 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
         configureGestures()
         enableInteractionsWithPointer()
         registerForAIChatSettingsChanges()
+        registerForFeatureFlagChanges()
     }
 
     private func setUpSubviews() {
@@ -189,6 +190,16 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
         NotificationCenter.default.publisher(for: .aiChatSettingsChanged)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
+                self?.updateAIChatButtonVisibility()
+            }
+            .store(in: &cancellables)
+    }
+
+    private func registerForFeatureFlagChanges() {
+        // Picks up internal-debug toggles of `aiChatChromeShortcutIPad` while the tabs bar is on screen.
+        featureFlagger?.updatesPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
                 self?.updateAIChatButtonVisibility()
             }
             .store(in: &cancellables)

--- a/iOS/DuckDuckGoTests/AIChat/AIChatAddressBarExperienceTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatAddressBarExperienceTests.swift
@@ -152,4 +152,72 @@ final class AIChatAddressBarExperienceTests: XCTestCase {
 
         XCTAssertFalse(testee.shouldShowModeToggle)
     }
+
+    // MARK: - iPad chrome shortcut consolidation
+
+    func testWhenIPadAndChromeShortcutOnAndLargeWidthThenAddressBarButtonHidden() {
+        MockUIDevice.mockUserInterfaceIdiom = .pad
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.aiChatChromeShortcutIPad])
+        let aiChatSettings = MockAIChatSettingsProvider(isAIChatNavigationBarUserSettingsEnabled: true)
+        let testee = AIChatAddressBarExperience(featureFlagger: featureFlagger,
+                                                aiChatSettings: aiChatSettings,
+                                                largeWidthProvider: MockLargeWidthProvider(isLargeWidth: true))
+
+        XCTAssertFalse(testee.shouldShowDuckAIAddressBarButton)
+    }
+
+    func testWhenIPadAndChromeShortcutOnAndNarrowWidthThenAddressBarButtonShown() {
+        MockUIDevice.mockUserInterfaceIdiom = .pad
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.aiChatChromeShortcutIPad])
+        let aiChatSettings = MockAIChatSettingsProvider(isAIChatNavigationBarUserSettingsEnabled: true)
+        let testee = AIChatAddressBarExperience(featureFlagger: featureFlagger,
+                                                aiChatSettings: aiChatSettings,
+                                                largeWidthProvider: MockLargeWidthProvider(isLargeWidth: false))
+
+        XCTAssertTrue(testee.shouldShowDuckAIAddressBarButton)
+    }
+
+    func testWhenIPadAndChromeShortcutOnAndNavigationBarOffThenAddressBarButtonHiddenAtAnyWidth() {
+        MockUIDevice.mockUserInterfaceIdiom = .pad
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.aiChatChromeShortcutIPad])
+        let aiChatSettings = MockAIChatSettingsProvider(isAIChatNavigationBarUserSettingsEnabled: false)
+
+        let large = AIChatAddressBarExperience(featureFlagger: featureFlagger,
+                                               aiChatSettings: aiChatSettings,
+                                               largeWidthProvider: MockLargeWidthProvider(isLargeWidth: true))
+        let narrow = AIChatAddressBarExperience(featureFlagger: featureFlagger,
+                                                aiChatSettings: aiChatSettings,
+                                                largeWidthProvider: MockLargeWidthProvider(isLargeWidth: false))
+
+        XCTAssertFalse(large.shouldShowDuckAIAddressBarButton)
+        XCTAssertFalse(narrow.shouldShowDuckAIAddressBarButton)
+    }
+
+    func testWhenIPadAndChromeShortcutOnThenIgnoresLegacyAddressBarSetting() {
+        // Legacy Address Bar value should not affect address-bar button visibility under the new flag.
+        MockUIDevice.mockUserInterfaceIdiom = .pad
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.aiChatChromeShortcutIPad])
+        let aiChatSettings = MockAIChatSettingsProvider(isAIChatAddressBarUserSettingsEnabled: true,
+                                                        isAIChatNavigationBarUserSettingsEnabled: false)
+        let testee = AIChatAddressBarExperience(featureFlagger: featureFlagger,
+                                                aiChatSettings: aiChatSettings,
+                                                largeWidthProvider: MockLargeWidthProvider(isLargeWidth: false))
+
+        XCTAssertFalse(testee.shouldShowDuckAIAddressBarButton)
+    }
+
+    func testWhenIPhoneAndChromeShortcutFlagOnThenStillReadsLegacyAddressBarSetting() {
+        MockUIDevice.mockUserInterfaceIdiom = .phone
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.aiChatChromeShortcutIPad])
+        let aiChatSettings = MockAIChatSettingsProvider(isAIChatAddressBarUserSettingsEnabled: false,
+                                                        isAIChatNavigationBarUserSettingsEnabled: true)
+        let testee = AIChatAddressBarExperience(featureFlagger: featureFlagger,
+                                                aiChatSettings: aiChatSettings)
+
+        XCTAssertFalse(testee.shouldShowDuckAIAddressBarButton)
+    }
+}
+
+private struct MockLargeWidthProvider: LargeWidthProviding {
+    let isLargeWidth: Bool
 }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatSettingsTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatSettingsTests.swift
@@ -282,6 +282,120 @@ class AIChatSettingsTests: XCTestCase {
         ))
     }
 
+    // MARK: - DuckAIChromeShortcutVisibility — Address Bar row / button
+
+    func testDuckAIChromeShortcutVisibility_addressBarRowHidden_whenNavigationBarRowIsShown() {
+        let flagger = MockFeatureFlagger(enabledFeatureFlags: [.aiChatChromeShortcutIPad])
+        XCTAssertFalse(DuckAIChromeShortcutVisibility.isAddressBarRowVisible(isIPad: true, featureFlagger: flagger))
+    }
+
+    func testDuckAIChromeShortcutVisibility_addressBarRowVisible_onIPhone_evenWhenFlagOn() {
+        let flagger = MockFeatureFlagger(enabledFeatureFlags: [.aiChatChromeShortcutIPad])
+        XCTAssertTrue(DuckAIChromeShortcutVisibility.isAddressBarRowVisible(isIPad: false, featureFlagger: flagger))
+    }
+
+    func testDuckAIChromeShortcutVisibility_addressBarRowVisible_onIPad_whenFlagOff() {
+        let flagger = MockFeatureFlagger(enabledFeatureFlags: [])
+        XCTAssertTrue(DuckAIChromeShortcutVisibility.isAddressBarRowVisible(isIPad: true, featureFlagger: flagger))
+    }
+
+    func testDuckAIChromeShortcutVisibility_addressBarButtonHidden_onIPad_atLargeWidth() {
+        XCTAssertFalse(DuckAIChromeShortcutVisibility.isAddressBarButtonVisibleOnIPad(
+            isLargeWidth: true,
+            isAIChatNavigationBarUserSettingsEnabled: true
+        ))
+    }
+
+    func testDuckAIChromeShortcutVisibility_addressBarButtonVisible_onIPad_atNarrowWidth_whenSettingOn() {
+        XCTAssertTrue(DuckAIChromeShortcutVisibility.isAddressBarButtonVisibleOnIPad(
+            isLargeWidth: false,
+            isAIChatNavigationBarUserSettingsEnabled: true
+        ))
+    }
+
+    func testDuckAIChromeShortcutVisibility_addressBarButtonHidden_onIPad_atNarrowWidth_whenSettingOff() {
+        XCTAssertFalse(DuckAIChromeShortcutVisibility.isAddressBarButtonVisibleOnIPad(
+            isLargeWidth: false,
+            isAIChatNavigationBarUserSettingsEnabled: false
+        ))
+    }
+
+    // MARK: - Address Bar → Navigation Bar migration
+
+    func testMigration_preservesAddressBarOff_asNavigationBarOff() {
+        mockKeyValueStore.set(false, forKey: LegacyAiChatUserDefaultsKeys.showAIChatAddressBarKey)
+
+        let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
+                                      debugSettings: mockAIChatDebugSettings,
+                                      keyValueStore: mockKeyValueStore,
+                                      notificationCenter: mockNotificationCenter,
+                                      featureFlagger: mockFeatureFlagger)
+        settings.enableAIChat(enable: true)
+
+        XCTAssertFalse(settings.isAIChatNavigationBarUserSettingsEnabled)
+    }
+
+    func testMigration_doesNothing_whenAddressBarWasOn() {
+        mockKeyValueStore.set(true, forKey: LegacyAiChatUserDefaultsKeys.showAIChatAddressBarKey)
+
+        let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
+                                      debugSettings: mockAIChatDebugSettings,
+                                      keyValueStore: mockKeyValueStore,
+                                      notificationCenter: mockNotificationCenter,
+                                      featureFlagger: mockFeatureFlagger)
+        settings.enableAIChat(enable: true)
+
+        // No prior Nav Bar value, no migration override — falls through to default (true).
+        XCTAssertTrue(settings.isAIChatNavigationBarUserSettingsEnabled)
+    }
+
+    func testMigration_doesNothing_whenAddressBarValueNeverSet() {
+        let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
+                                      debugSettings: mockAIChatDebugSettings,
+                                      keyValueStore: mockKeyValueStore,
+                                      notificationCenter: mockNotificationCenter,
+                                      featureFlagger: mockFeatureFlagger)
+        settings.enableAIChat(enable: true)
+
+        XCTAssertTrue(settings.isAIChatNavigationBarUserSettingsEnabled)
+    }
+
+    func testMigration_doesNotOverrideExplicitNavigationBarValue() {
+        // User had Address Bar off AND Nav Bar already explicitly set to true — keep Nav Bar.
+        mockKeyValueStore.set(false, forKey: LegacyAiChatUserDefaultsKeys.showAIChatAddressBarKey)
+        mockKeyValueStore.set(true, forKey: LegacyAiChatUserDefaultsKeys.showAIChatNavigationBarKey)
+
+        let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
+                                      debugSettings: mockAIChatDebugSettings,
+                                      keyValueStore: mockKeyValueStore,
+                                      notificationCenter: mockNotificationCenter,
+                                      featureFlagger: mockFeatureFlagger)
+        settings.enableAIChat(enable: true)
+
+        XCTAssertTrue(settings.isAIChatNavigationBarUserSettingsEnabled)
+    }
+
+    func testMigration_isOneShot_subsequentAddressBarToggleDoesNotResetNavigationBar() {
+        mockKeyValueStore.set(false, forKey: LegacyAiChatUserDefaultsKeys.showAIChatAddressBarKey)
+
+        let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
+                                      debugSettings: mockAIChatDebugSettings,
+                                      keyValueStore: mockKeyValueStore,
+                                      notificationCenter: mockNotificationCenter,
+                                      featureFlagger: mockFeatureFlagger)
+        settings.enableAIChat(enable: true)
+        XCTAssertFalse(settings.isAIChatNavigationBarUserSettingsEnabled)
+
+        // User then turns Nav Bar back on; a new AIChatSettings instance must not re-migrate.
+        settings.enableAIChatNavigationBarUserSettings(enable: true)
+        let secondInstance = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
+                                            debugSettings: mockAIChatDebugSettings,
+                                            keyValueStore: mockKeyValueStore,
+                                            notificationCenter: mockNotificationCenter,
+                                            featureFlagger: mockFeatureFlagger)
+        XCTAssertTrue(secondInstance.isAIChatNavigationBarUserSettingsEnabled)
+    }
+
 }
 
 final class MockAIChatDebugSettings: AIChatDebugSettingsHandling {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215139117801656
Tech Design URL:
CC:

### Description

On iPad with the `aiChatChromeShortcutIPad` flag on, the *Settings → AI Features → Manage Duck.ai Shortcuts* screen was showing both the legacy **Address Bar** toggle and the new **Navigation Bar** toggle, even though they describe the same surface (the Navigation Bar subtitle promises "Show in the browser navigation bar or address bar, depending on window size").

This PR makes Navigation Bar the single iPad control:

- **Settings UI** — the Address Bar row is hidden whenever the Navigation Bar row is shown (iPad + flag). iPhone behavior is unchanged.
- **Address-bar Duck.ai icon** — on iPad with the flag, `AIChatAddressBarExperience.shouldShowDuckAIAddressBarButton` now reads the Navigation Bar setting and only shows the in-address-bar icon at narrow widths where the tabs bar (and chrome pill) is hidden. Result: the chrome pill and the in-address-bar icon are never visible at the same time on iPad.
- **One-shot migration** — at `AIChatSettings.init`, if no Navigation Bar value has been written yet and the legacy `showAIChatAddressBar` key is explicitly `false`, the Navigation Bar key is seeded with `false`. Users who had Address Bar off don't get the surface silently re-enabled under a new name. Users who had it on (or never touched it) fall through to the default (on).
- **Live flag toggle** — the chrome pill subscribes to `FeatureFlagOverridesPublishingHandler.flagDidChangePublisher` filtered to `aiChatChromeShortcutIPad` (same pattern used by `MaliciousSiteProtectionDatasetsFetcher` and `DarkReaderFeatureSettings`), so flipping the flag in internal debug settings hides/shows the pill in real time. The subscription is wired from `featureFlagger.didSet` because the property is injected after `viewDidLoad`.

### Testing Steps

1. Launch on iPad, turn on `aiChatChromeShortcutIPad` from Internal Settings → Feature Flags.
2. Open *Settings → AI Features → Manage Duck.ai Shortcuts* — confirm the Address Bar row is gone and only the Navigation Bar row is visible (with the "navigation bar or address bar, depending on window size" subtitle).
3. Toggle the Navigation Bar row off — the chrome pill in the tabs bar disappears.
4. Resize the app into Split View (narrow width) — the tabs bar hides and the in-address-bar Duck.ai icon also stays hidden (Navigation Bar is off).
5. Toggle Navigation Bar back on — chrome pill returns at wide width; in-address-bar icon returns when narrow. Confirm the two are never visible at the same time.
6. Migration: build with `aiChatChromeShortcutIPad` on, then in a fresh install set `aichat.settings.showAIChatAddressBar = false` via Internal → AI Chat (or relaunch with that key set). After app launch, confirm Navigation Bar shows as **off** in Settings.
7. Internal flag toggle: while the tabs bar is on screen, toggle `aiChatChromeShortcutIPad` off in Internal Settings → Feature Flags — the chrome pill should hide immediately without needing a backgrounding round-trip. Toggle back on — pill returns immediately.
8. Run targeted unit tests in *iOS Browser* scheme: `UnitTests/AIChatSettingsTests` (30 tests, includes 5 new migration tests + 6 helper tests) and `UnitTests/AIChatAddressBarExperienceTests` (16 tests, includes 6 new iPad+flag width-dependent tests).

### Impact and Risks

**Low.** Behavior change is gated on `aiChatChromeShortcutIPad`, which is internal-only. iPhone unchanged. The migration is one-shot and only widens the user's prior preference (Address Bar off → Navigation Bar off); never narrows.

#### What could go wrong?

- **Migration mis-fires for a user who explicitly set both Address Bar=off and Navigation Bar=on** — guarded by the `Nav Bar key has no value yet` precondition. Covered by `testMigration_doesNotOverrideExplicitNavigationBarValue`.
- **Address-bar icon flicker on width transitions** — `shouldShowDuckAIAddressBarButton` reads `AppWidthObserver.shared.isLargeWidth` dynamically; existing `applyWidth` → `omniBar.enterPadState/enterPhoneState` → `refreshOmniBar` flow re-evaluates on rotation / Split View resize.
- **Internal user with the flag off in production** — the previous Address Bar reading is preserved, so users see no change.

### Quality Considerations

- Width-dependent visibility uses an injectable `LargeWidthProviding` (defaults to `AppWidthObserver.shared`) so the iPad+flag branch is unit-testable without the singleton.
- `DuckAIChromeShortcutVisibility` gained two new pure helpers (`isAddressBarRowVisible`, `isAddressBarButtonVisibleOnIPad`) so the visibility logic stays free of `UIDevice.current` / singletons and can be exercised in tests.
- The flag observer pattern matches existing iOS code (`MaliciousSiteProtectionDatasetsFetcher.subscribeToScamProtectionFlagChanges`, `DarkReaderFeatureSettings`). It's flag-filtered, so no work for unrelated flag changes.
- 16 new unit tests added across two suites; all 46 in the targeted run pass.

### Notes to Reviewer

- Surfaced during code reviews from previous PRs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is gated on internal `aiChatChromeShortcutIPad`; iPhone paths unchanged, and migration only seeds Navigation Bar off from an explicit legacy Address Bar off without overriding an existing Navigation Bar value.
> 
> **Overview**
> On iPad with **`aiChatChromeShortcutIPad`**, Duck.ai chrome shortcuts are unified under a single **Navigation Bar** user setting instead of duplicating **Address Bar** and Navigation Bar controls.
> 
> **Settings** hides the Address Bar row whenever the Navigation Bar row is shown (`DuckAIChromeShortcutVisibility.isAddressBarRowVisible`); iPhone is unchanged.
> 
> **In-address-bar Duck.ai icon** (`AIChatAddressBarExperience`) uses the Navigation Bar preference and only appears at narrow widths (injectable `LargeWidthProviding`), so the tabs-bar chrome pill and the address-bar icon are not shown together.
> 
> **One-shot migration** in `AIChatSettings.init` copies legacy Address Bar **off** into Navigation Bar **off** when no Navigation Bar value exists yet.
> 
> **Tabs bar** refreshes chrome pill visibility when `aiChatChromeShortcutIPad` is toggled in internal feature-flag overrides (`featureFlagger` `didSet` subscription).
> 
> Extensive unit tests cover visibility helpers, width behavior, migration edge cases, and iPhone fallback to the legacy Address Bar setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80de99c64b5ac8ef890f2d3eba9419b6c7a25508. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->