### PR TITLE
Remove showHideAIGeneratedImagesSection feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -418,9 +418,6 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// Enables the default omnibar toggle position setting for AI Chat
     case omnibarDefaultPosition
 
-    /// Controls showing the Hide AI section in Settings -> AI Features
-    case showHideAiGeneratedImages
-
     case unifiedToggleInput
 
     /// Signals that the iOS app should display duck.ai chats in "contextual mode" when opened from specific entry points

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -246,9 +246,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866472842661
     case storeSerpSettings
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866715575447
-    case showHideAIGeneratedImagesSection
-
     /// https://app.asana.com/1/137249556945/project/1201141132935289/task/1210497696306780?focus=true
     case standaloneMigration
 
@@ -615,8 +612,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .disabled, supportsLocalOverriding: true)
         case .storeSerpSettings:
             Config(source: .remoteReleasable(SERPSubfeature.storeSerpSettings))
-        case .showHideAIGeneratedImagesSection:
-            Config(source: .remoteReleasable(AIChatSubfeature.showHideAiGeneratedImages))
         case .standaloneMigration:
             Config(source: .remoteReleasable(AIChatSubfeature.standaloneMigration))
         case .allowProTierPurchase:

--- a/iOS/DuckDuckGo/SettingsAIFeaturesView.swift
+++ b/iOS/DuckDuckGo/SettingsAIFeaturesView.swift
@@ -129,18 +129,16 @@ struct SettingsAIFeaturesView: View {
                     }
                     .listRowBackground(Color(designSystemColor: .surface))
 
-                    if viewModel.shouldShowHideAIGeneratedImagesSection {
-                        NavigationLink(destination: SERPSettingsView(page: .hideAIGeneratedImages, featureFlagger: viewModel.featureFlagger)
-                                .onAppear {
-                                    PixelKit.fire(SERPSettingsPixel.hideAIGeneratedImagesButtonClicked, frequency: .dailyAndStandard)
-                                }
-                        ) {
-                            SettingsCellView(label: UserText.settingsAiFeaturesHideAIGeneratedImages,
-                                             subtitle: UserText.settingsAiFeaturesHideAIGeneratedImagesSubtitle,
-                                             image: Image(uiImage: DesignSystemImages.Glyphs.Size24.imageAIHide))
-                        }
-                        .listRowBackground(Color(designSystemColor: .surface))
+                    NavigationLink(destination: SERPSettingsView(page: .hideAIGeneratedImages, featureFlagger: viewModel.featureFlagger)
+                            .onAppear {
+                                PixelKit.fire(SERPSettingsPixel.hideAIGeneratedImagesButtonClicked, frequency: .dailyAndStandard)
+                            }
+                    ) {
+                        SettingsCellView(label: UserText.settingsAiFeaturesHideAIGeneratedImages,
+                                         subtitle: UserText.settingsAiFeaturesHideAIGeneratedImagesSubtitle,
+                                         image: Image(uiImage: DesignSystemImages.Glyphs.Size24.imageAIHide))
                     }
+                    .listRowBackground(Color(designSystemColor: .surface))
                 }
             }
         }.applySettingsListModifiers(title: UserText.settingsAiFeatures,

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -201,10 +201,6 @@ final class SettingsViewModel: ObservableObject {
         }
     }
 
-    var shouldShowHideAIGeneratedImagesSection: Bool {
-        featureFlagger.isFeatureOn(.showHideAIGeneratedImagesSection)
-    }
-
     var isDefaultOmnibarModeEnabled: Bool {
         featureFlagger.isFeatureOn(.aiChatOmnibarDefaultPosition)
     }

--- a/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
@@ -116,10 +116,6 @@ final class AIChatPreferences: ObservableObject {
         featureFlagger.isFeatureOn(.newTabPageOmnibar)
     }
 
-    var shouldShowHideAIGeneratedImagesSection: Bool {
-        featureFlagger.isFeatureOn(.showHideAIGeneratedImagesSection)
-    }
-
     var shouldShowDuckAiSettingsLink: Bool {
         featureFlagger.isFeatureOn(.aiChatSettingsLinkInAiFeatures)
     }

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
@@ -194,28 +194,26 @@ extension Preferences {
                     }
                 }
 
-                if model.shouldShowHideAIGeneratedImagesSection {
-                    PreferencePaneSection {
-                        VStack(alignment: .leading) {
-                            TextAndImageMenuItemHeader(UserText.hideAIGeneratedImagesSettings,
-                                                       image: Image(nsImage: DesignSystemImages.Color.Size16.hideAIGeneratedImages),
-                                                       bottomPadding: 2)
+                PreferencePaneSection {
+                    VStack(alignment: .leading) {
+                        TextAndImageMenuItemHeader(UserText.hideAIGeneratedImagesSettings,
+                                                   image: Image(nsImage: DesignSystemImages.Color.Size16.hideAIGeneratedImages),
+                                                   bottomPadding: 2)
 
-                            TextMenuItemCaption(UserText.hideAIGeneratedImagesSettingsDescription)
-                                .padding(.bottom, 6)
-                            Button {
-                                PixelKit.fire(GeneralPixel.hideAIGeneratedImagesButtonClicked, frequency: .dailyAndStandard)
-                                model.openSearchAssistSettings()
-                            } label: {
-                                HStack {
-                                    Text(UserText.searchAIFeaturesSettingsLink)
-                                    Image(.externalAppScheme)
-                                }
-                                .foregroundColor(Color.linkBlue)
-                                .cursor(.pointingHand)
+                        TextMenuItemCaption(UserText.hideAIGeneratedImagesSettingsDescription)
+                            .padding(.bottom, 6)
+                        Button {
+                            PixelKit.fire(GeneralPixel.hideAIGeneratedImagesButtonClicked, frequency: .dailyAndStandard)
+                            model.openSearchAssistSettings()
+                        } label: {
+                            HStack {
+                                Text(UserText.searchAIFeaturesSettingsLink)
+                                Image(.externalAppScheme)
                             }
-                            .buttonStyle(.plain)
+                            .foregroundColor(Color.linkBlue)
+                            .cursor(.pointingHand)
                         }
+                        .buttonStyle(.plain)
                     }
                 }
             }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -201,9 +201,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1205842942115003/task/1210884473312053
     case attributedMetrics
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866721557461
-    case showHideAIGeneratedImagesSection
-
     /// https://app.asana.com/1/137249556945/project/1201141132935289/task/1210497696306780?focus=true
     case standaloneMigration
 
@@ -553,8 +550,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(DataImportSubfeature.newDataImportExperience))
         case .attributedMetrics:
             Config(defaultValue: .enabled, source: .remoteReleasable(AttributedMetricsSubfeature.featureEnabled))
-        case .showHideAIGeneratedImagesSection:
-            Config(source: .remoteReleasable(AIChatSubfeature.showHideAiGeneratedImages))
         case .standaloneMigration:
             Config(source: .remoteReleasable(AIChatSubfeature.standaloneMigration), category: .duckAI)
         case .allowProTierPurchase:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1211866715575447
Tech Design URL:
CC:

### Description

The `showHideAIGeneratedImagesSection` feature flag was rolled out some time ago and is no longer needed. This PR removes the flag and its `showHideAiGeneratedImages` subfeature across iOS, macOS, and the shared `BrowserServicesKit` package. The "Hide AI-Generated Images" section in AI Chat / AI Features settings is now always shown.

Removed:
- `FeatureFlag.showHideAIGeneratedImagesSection` (iOS + macOS)
- `AIChatSubfeature.showHideAiGeneratedImages` (BrowserServicesKit)
- `SettingsViewModel.shouldShowHideAIGeneratedImagesSection` (iOS)
- `AIChatPreferences.shouldShowHideAIGeneratedImagesSection` (macOS)
- The `if` gates around the section in `SettingsAIFeaturesView` (iOS) and `PreferencesAIChat` (macOS)

The privacy config JSONs (`macos-config.json`, `ios-config.json`) were left untouched — they're regenerated from the `duckduckgo/privacy-configuration` repo and will drop the subfeature on the next refresh.

### Testing Steps
1. Open the macOS app, navigate to Settings → AI Chat. Confirm the "Hide AI-Generated Images" section is visible with its description and "Search Settings" link.
2. Click the link and confirm the `m_mac_aichat_hide_ai_generated_images_button_clicked` pixel fires (daily + standard).
3. On iOS, open Settings → AI Features. Confirm the "Hide AI-Generated Images" row is visible under the Search Assist section.
4. Tap the row, confirm it navigates to the `SERPSettingsView` for hide-AI-images and that `hideAIGeneratedImagesButtonClicked` fires.
5. Confirm no remaining references to `showHideAIGeneratedImagesSection` in either codebase.

### Impact and Risks

Low — removing a long-rolled-out feature flag. The user-visible section is unchanged; only the gating logic is gone.

#### What could go wrong?

If the flag were somehow still being toggled off remotely, the section would now stay visible. Since the rollout is complete, this is the intended end state.

### Quality Considerations

- Edge cases: none — the section is now unconditional.
- Performance: unaffected.
- Privacy/security: no changes to data collection. The `hideAIGeneratedImagesButtonClicked` pixel still fires the same way.
- Monitoring: existing pixel keeps reporting usage.

### Notes to Reviewer

Privacy config JSONs were intentionally left alone — they're managed by the privacy-configuration repo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flag cleanup only; user-visible settings UI and pixels stay the same, with no auth or data-handling changes.
> 
> **Overview**
> Removes the rolled-out **`showHideAIGeneratedImagesSection`** feature flag and the shared **`AIChatSubfeature.showHideAiGeneratedImages`** privacy subfeature across **BrowserServicesKit**, **iOS**, and **macOS**.
> 
> The **Hide AI-Generated Images** entry in AI Features settings is no longer gated: **iOS** always shows the navigation row in `SettingsAIFeaturesView` (pixels unchanged); **macOS** always shows the section in `PreferencesAIChat`. Related `shouldShowHideAIGeneratedImagesSection` helpers and flag wiring are deleted. Privacy config JSONs in-repo are unchanged and will drop the subfeature on the next config refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7ed64510cf9628df2b2b597e25655148088acc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->