### PR TITLE
iOS: Fix UTI auto-collapse on mid-load redirects

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -2094,6 +2094,7 @@
 		CB1143DE2AF6D4B600C1CCD3 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = CB1143DC2AF6D4B600C1CCD3 /* InfoPlist.strings */; };
 		CB14D5832E269A7F002E897E /* UserAgentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB14D5822E269A73002E897E /* UserAgentConfiguration.swift */; };
 		CB18A3662E2790C700BE9D8D /* UserAgentConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB18A3652E2790C700BE9D8D /* UserAgentConfigurationTests.swift */; };
+		CB22D7A22FC603EB00128979 /* MainViewControllerRefreshActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB22D7A12FC603EB00128979 /* MainViewControllerRefreshActionTests.swift */; };
 		CB258D1229A4F24900DEBA24 /* ConfigurationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB258D0F29A4D0FD00DEBA24 /* ConfigurationManager.swift */; };
 		CB258D1329A4F24E00DEBA24 /* ConfigurationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB84C7C029A3F0280088A5B8 /* ConfigurationStore.swift */; };
 		CB258D1D29A52AF900DEBA24 /* EtagStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9896632322C56716007BE4FE /* EtagStorage.swift */; };
@@ -2129,11 +2130,6 @@
 		CB6D17892FA2106100ECD5AE /* DuckAIURLSuggestionsLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17882FA2106100ECD5AE /* DuckAIURLSuggestionsLoader.swift */; };
 		CB6D178B2FA2109C00ECD5AE /* DuckAIURLSuggestionsLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D178A2FA2109C00ECD5AE /* DuckAIURLSuggestionsLoaderTests.swift */; };
 		CB6D178D2FA2138200ECD5AE /* DuckAISuggestionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D178C2FA2138200ECD5AE /* DuckAISuggestionsViewController.swift */; };
-		CB6D17B02FA2138200ECD5AE /* AIChatSyncPromoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B12FA2138200ECD5AE /* AIChatSyncPromoView.swift */; };
-		CB6D17B42FB000000ECD5AE /* AIChatSyncPromoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B52FB000000ECD5AE /* AIChatSyncPromoViewModel.swift */; };
-		CB6D17B72FB000000ECD5AE /* AIChatSyncPromoViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B62FB000000ECD5AE /* AIChatSyncPromoViewModelTests.swift */; };
-		CB6D17B82FB100000ECD5AE /* AIChatSyncIntroSheetPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B92FB100000ECD5AE /* AIChatSyncIntroSheetPresenter.swift */; };
-		CB6D17B22FA2138200ECD5AE /* AIChatSyncIntroSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B32FA2138200ECD5AE /* AIChatSyncIntroSheetView.swift */; };
 		CB6D178F2FA213DD00ECD5AE /* URL+SuggestionDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D178E2FA213DD00ECD5AE /* URL+SuggestionDisplay.swift */; };
 		CB6D17912FA2147600ECD5AE /* DuckAISuggestionsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17902FA2147600ECD5AE /* DuckAISuggestionsCoordinator.swift */; };
 		CB6D17972FA232E000ECD5AE /* Suggestion+URLFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17962FA232E000ECD5AE /* Suggestion+URLFilter.swift */; };
@@ -2146,6 +2142,11 @@
 		CB6D17A82FA39FC900ECD5AE /* AIChatContextualUTIHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17A72FA39FC900ECD5AE /* AIChatContextualUTIHost.swift */; };
 		CB6D17AA2FA4B57900ECD5AE /* AIChatContextualUTIHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17A92FA4B57900ECD5AE /* AIChatContextualUTIHostTests.swift */; };
 		CB6D17AC2FA8C59900ECD5AE /* DuckAISuggestionsCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17AB2FA8C59900ECD5AE /* DuckAISuggestionsCoordinatorTests.swift */; };
+		CB6D17B02FA2138200ECD5AE /* AIChatSyncPromoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B12FA2138200ECD5AE /* AIChatSyncPromoView.swift */; };
+		CB6D17B22FA2138200ECD5AE /* AIChatSyncIntroSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B32FA2138200ECD5AE /* AIChatSyncIntroSheetView.swift */; };
+		CB6D17B42FB000000ECD5AE /* AIChatSyncPromoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B52FB000000ECD5AE /* AIChatSyncPromoViewModel.swift */; };
+		CB6D17B72FB000000ECD5AE /* AIChatSyncPromoViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B62FB000000ECD5AE /* AIChatSyncPromoViewModelTests.swift */; };
+		CB6D17B82FB100000ECD5AE /* AIChatSyncIntroSheetPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B92FB100000ECD5AE /* AIChatSyncIntroSheetPresenter.swift */; };
 		CB6D17C02FB488BE00ECD5AE /* UTIDismissSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17BF2FB488BE00ECD5AE /* UTIDismissSnapshot.swift */; };
 		CB7CF9FA2F9A6C100051BEE9 /* CircularButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7CF9F92F9A6C100051BEE9 /* CircularButton.swift */; };
 		CB7E0A212D5E1D96002A7C0C /* UIInteractionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7E0A202D5E1D96002A7C0C /* UIInteractionManager.swift */; };
@@ -2250,9 +2251,6 @@
 		D65625922C22D340006EF297 /* WebDuckPlayerNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D63FF8892C1B21C2006DE24D /* WebDuckPlayerNavigationHandler.swift */; };
 		D65625952C22D382006EF297 /* TabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F159BDA31F0BDB5A00B4A01D /* TabViewController.swift */; };
 		D65625A12C232F5E006EF297 /* SettingsYouTubeAdBlockingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65625A02C232F5E006EF297 /* SettingsYouTubeAdBlockingView.swift */; };
-		D6AD810C260500010000A0A1 /* YouTubeAdBlockPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6AD810C260500010000A0A0 /* YouTubeAdBlockPicker.swift */; };
-		D6AD810D260500010000A0A1 /* YouTubeAdBlockBreakageReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6AD810D260500010000A0A0 /* YouTubeAdBlockBreakageReport.swift */; };
-		D6AD810E260500010000A0A1 /* YouTubeAdBlockUnavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6AD810E260500010000A0A0 /* YouTubeAdBlockUnavailable.swift */; };
 		D65625A22C232F5F006EF298 /* SettingsDuckPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65625A12C232F5F006EF298 /* SettingsDuckPlayerView.swift */; };
 		D65CEA702B6AC6C9008A759B /* Subscription.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D65CEA6F2B6AC6C9008A759B /* Subscription.xcassets */; };
 		D664C7B62B289AA200CBFA76 /* SubscriptionFlowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D664C7942B289AA000CBFA76 /* SubscriptionFlowViewModel.swift */; };
@@ -2277,6 +2275,9 @@
 		D68DF81E2B5830380023DBEA /* SubscriptionRestoreViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68DF81D2B5830380023DBEA /* SubscriptionRestoreViewModel.swift */; };
 		D69FBF762B28BE3600B505F1 /* SettingsSubscriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69FBF752B28BE3600B505F1 /* SettingsSubscriptionView.swift */; };
 		D6ACEA322BBD55BF008FADDF /* TabURLInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6ACEA312BBD55BF008FADDF /* TabURLInterceptor.swift */; };
+		D6AD810C260500010000A0A1 /* YouTubeAdBlockPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6AD810C260500010000A0A0 /* YouTubeAdBlockPicker.swift */; };
+		D6AD810D260500010000A0A1 /* YouTubeAdBlockBreakageReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6AD810D260500010000A0A0 /* YouTubeAdBlockBreakageReport.swift */; };
+		D6AD810E260500010000A0A1 /* YouTubeAdBlockUnavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6AD810E260500010000A0A0 /* YouTubeAdBlockUnavailable.swift */; };
 		D6B9E8D22CDA4420002B640C /* DuckPlayerOverlayUsagePixels.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B9E8D12CDA4418002B640C /* DuckPlayerOverlayUsagePixels.swift */; };
 		D6BFCB5F2B7524AA0051FF81 /* SubscriptionPIRMoveToDesktopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6BFCB5E2B7524AA0051FF81 /* SubscriptionPIRMoveToDesktopView.swift */; };
 		D6BFCB612B7525160051FF81 /* SubscriptionPIRViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6BFCB602B7525160051FF81 /* SubscriptionPIRViewModel.swift */; };
@@ -4766,6 +4767,7 @@
 		CB18F2712AF6D4E400A0F8FE /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		CB1AEFB02799AA940031AE3D /* SwiftUICollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUICollectionViewCell.swift; sourceTree = "<group>"; };
 		CB1FAE472AF6D59B003F452F /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		CB22D7A12FC603EB00128979 /* MainViewControllerRefreshActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewControllerRefreshActionTests.swift; sourceTree = "<group>"; };
 		CB24F70E29A3EB15006DCC58 /* AppConfigurationURLProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppConfigurationURLProvider.swift; path = ../Core/AppConfigurationURLProvider.swift; sourceTree = "<group>"; };
 		CB258D0C29A4CD0500DEBA24 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		CB258D0F29A4D0FD00DEBA24 /* ConfigurationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationManager.swift; sourceTree = "<group>"; };
@@ -4793,11 +4795,6 @@
 		CB6D17882FA2106100ECD5AE /* DuckAIURLSuggestionsLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAIURLSuggestionsLoader.swift; sourceTree = "<group>"; };
 		CB6D178A2FA2109C00ECD5AE /* DuckAIURLSuggestionsLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAIURLSuggestionsLoaderTests.swift; sourceTree = "<group>"; };
 		CB6D178C2FA2138200ECD5AE /* DuckAISuggestionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAISuggestionsViewController.swift; sourceTree = "<group>"; };
-		CB6D17B12FA2138200ECD5AE /* AIChatSyncPromoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSyncPromoView.swift; sourceTree = "<group>"; };
-		CB6D17B52FB000000ECD5AE /* AIChatSyncPromoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSyncPromoViewModel.swift; sourceTree = "<group>"; };
-		CB6D17B62FB000000ECD5AE /* AIChatSyncPromoViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSyncPromoViewModelTests.swift; sourceTree = "<group>"; };
-		CB6D17B92FB100000ECD5AE /* AIChatSyncIntroSheetPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSyncIntroSheetPresenter.swift; sourceTree = "<group>"; };
-		CB6D17B32FA2138200ECD5AE /* AIChatSyncIntroSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSyncIntroSheetView.swift; sourceTree = "<group>"; };
 		CB6D178E2FA213DD00ECD5AE /* URL+SuggestionDisplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+SuggestionDisplay.swift"; sourceTree = "<group>"; };
 		CB6D17902FA2147600ECD5AE /* DuckAISuggestionsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAISuggestionsCoordinator.swift; sourceTree = "<group>"; };
 		CB6D17962FA232E000ECD5AE /* Suggestion+URLFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Suggestion+URLFilter.swift"; sourceTree = "<group>"; };
@@ -4810,6 +4807,11 @@
 		CB6D17A72FA39FC900ECD5AE /* AIChatContextualUTIHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualUTIHost.swift; sourceTree = "<group>"; };
 		CB6D17A92FA4B57900ECD5AE /* AIChatContextualUTIHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualUTIHostTests.swift; sourceTree = "<group>"; };
 		CB6D17AB2FA8C59900ECD5AE /* DuckAISuggestionsCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAISuggestionsCoordinatorTests.swift; sourceTree = "<group>"; };
+		CB6D17B12FA2138200ECD5AE /* AIChatSyncPromoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSyncPromoView.swift; sourceTree = "<group>"; };
+		CB6D17B32FA2138200ECD5AE /* AIChatSyncIntroSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSyncIntroSheetView.swift; sourceTree = "<group>"; };
+		CB6D17B52FB000000ECD5AE /* AIChatSyncPromoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSyncPromoViewModel.swift; sourceTree = "<group>"; };
+		CB6D17B62FB000000ECD5AE /* AIChatSyncPromoViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSyncPromoViewModelTests.swift; sourceTree = "<group>"; };
+		CB6D17B92FB100000ECD5AE /* AIChatSyncIntroSheetPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSyncIntroSheetPresenter.swift; sourceTree = "<group>"; };
 		CB6D17BF2FB488BE00ECD5AE /* UTIDismissSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIDismissSnapshot.swift; sourceTree = "<group>"; };
 		CB7407BC2AF6D56D0090A41C /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		CB75AA132AF6D5AA00AED266 /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -4921,9 +4923,6 @@
 		D64648AE2B5993890033090B /* SubscriptionEmailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionEmailViewModel.swift; sourceTree = "<group>"; };
 		D652E24D2DDE8B3600BCD978 /* DuckPlayerPixelFiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckPlayerPixelFiring.swift; sourceTree = "<group>"; };
 		D65625A02C232F5E006EF297 /* SettingsYouTubeAdBlockingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsYouTubeAdBlockingView.swift; sourceTree = "<group>"; };
-		D6AD810C260500010000A0A0 /* YouTubeAdBlockPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeAdBlockPicker.swift; sourceTree = "<group>"; };
-		D6AD810D260500010000A0A0 /* YouTubeAdBlockBreakageReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeAdBlockBreakageReport.swift; sourceTree = "<group>"; };
-		D6AD810E260500010000A0A0 /* YouTubeAdBlockUnavailable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeAdBlockUnavailable.swift; sourceTree = "<group>"; };
 		D65625A12C232F5F006EF298 /* SettingsDuckPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsDuckPlayerView.swift; sourceTree = "<group>"; };
 		D65CEA6F2B6AC6C9008A759B /* Subscription.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Subscription.xcassets; sourceTree = "<group>"; };
 		D664C7942B289AA000CBFA76 /* SubscriptionFlowViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionFlowViewModel.swift; sourceTree = "<group>"; };
@@ -4949,6 +4948,9 @@
 		D68DF81D2B5830380023DBEA /* SubscriptionRestoreViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionRestoreViewModel.swift; sourceTree = "<group>"; };
 		D69FBF752B28BE3600B505F1 /* SettingsSubscriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSubscriptionView.swift; sourceTree = "<group>"; };
 		D6ACEA312BBD55BF008FADDF /* TabURLInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabURLInterceptor.swift; sourceTree = "<group>"; };
+		D6AD810C260500010000A0A0 /* YouTubeAdBlockPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeAdBlockPicker.swift; sourceTree = "<group>"; };
+		D6AD810D260500010000A0A0 /* YouTubeAdBlockBreakageReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeAdBlockBreakageReport.swift; sourceTree = "<group>"; };
+		D6AD810E260500010000A0A0 /* YouTubeAdBlockUnavailable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeAdBlockUnavailable.swift; sourceTree = "<group>"; };
 		D6B9E8D12CDA4418002B640C /* DuckPlayerOverlayUsagePixels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckPlayerOverlayUsagePixels.swift; sourceTree = "<group>"; };
 		D6BFCB5E2B7524AA0051FF81 /* SubscriptionPIRMoveToDesktopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPIRMoveToDesktopView.swift; sourceTree = "<group>"; };
 		D6BFCB602B7525160051FF81 /* SubscriptionPIRViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPIRViewModel.swift; sourceTree = "<group>"; };
@@ -9425,6 +9427,7 @@
 				CB6D179A2FA2524F00ECD5AE /* EmptySuggestionLoadingDataSource.swift */,
 				CB6D17A12FA397FC00ECD5AE /* UnifiedToggleInputPageContextChipViewModelTests.swift */,
 				CB6D17AB2FA8C59900ECD5AE /* DuckAISuggestionsCoordinatorTests.swift */,
+				CB22D7A12FC603EB00128979 /* MainViewControllerRefreshActionTests.swift */,
 			);
 			path = UnifiedToggleInput;
 			sourceTree = "<group>";
@@ -10378,7 +10381,6 @@
 			children = (
 				F99D6557A506491EFDAD68A2 /* DBPIOSContentBlockingTests.swift */,
 			);
-			name = DBP;
 			path = DBP;
 			sourceTree = "<group>";
 		};
@@ -14011,6 +14013,7 @@
 				317045C02858C6B90016ED1F /* AutofillInterfaceEmailTruncatorTests.swift in Sources */,
 				65D748412D9D34C900554B1D /* DuckPlayerNativeUIPresenterTests.swift in Sources */,
 				987130C6294AAB9F00AB05E0 /* BookmarkListViewModelTests.swift in Sources */,
+				CB22D7A22FC603EB00128979 /* MainViewControllerRefreshActionTests.swift in Sources */,
 				CCC9F3BA2EA66E0F00D442CA /* VPNSubscriptionPromotionHelperTests.swift in Sources */,
 				6F03CB022C32ED47004179A8 /* NewTabPageMessagesModelTests.swift in Sources */,
 				BB1D99DD2EB9F3860050D8CF /* MockWinBackOfferCoordinator.swift in Sources */,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -315,6 +315,83 @@ extension MainViewController {
 
 }
 
+// MARK: - UTI Refresh-Action Decision (pure)
+
+enum UnifiedToggleInputRefreshAction: Equatable {
+    case unbindInactiveNonAITab
+    case refreshAITab(AITabRefreshBehavior)
+    case refreshNonAITab
+    /// The coordinator is mid-omnibar session on a non-AI tab — leave it alone.
+    case preserveOmnibarSession
+}
+
+enum AITabRefreshBehavior: Equatable {
+    case preserveCurrentPresentation(allowsEarlyReturn: Bool)
+    case showCollapsed(expandAfterRefresh: Bool)
+}
+
+/// Pure-data snapshot of everything `decideRefreshAction` reads. Built from the live
+/// `TabViewController` / `UnifiedToggleInputCoordinator` / view coordinator at the call site
+/// so the decision itself stays free of UIKit dependencies and is unit-testable.
+struct UnifiedToggleInputRefreshActionInputs: Equatable {
+    let tabHasLink: Bool
+    let tabIsAITab: Bool
+    let tabIsLoading: Bool
+    let tabURL: URL?
+    let tabLinkURL: URL?
+    let tabIsVoiceModeRequested: Bool
+    let coordinatorIsAITabState: Bool
+    let coordinatorIsActive: Bool
+    let coordinatorIsOmnibarSession: Bool
+    let coordinatorHasSubmittedPrompt: Bool
+    let isAITabChatHeaderContainerHidden: Bool
+    let isNavigationChromeHidden: Bool
+}
+
+extension MainViewController {
+
+    static func decideRefreshAction(for inputs: UnifiedToggleInputRefreshActionInputs) -> UnifiedToggleInputRefreshAction {
+        // During a fresh navigation (e.g. opening a chat in a new tab), `tabModel.link` is briefly
+        // set to nil before WebView reports the new URL. `tab.isAITab` is link-derived, so it would
+        // momentarily report false and route us through `refreshNonAITab` → `coordinator.hide()`,
+        // tearing down the UTI we just set up. Preserve the current AI presentation through that
+        // window — the next refresh, after WebView reports the URL, resolves correctly.
+        if !inputs.tabHasLink && inputs.coordinatorIsAITabState {
+            return .refreshAITab(.preserveCurrentPresentation(allowsEarlyReturn: true))
+        }
+
+        if !inputs.tabIsAITab {
+            if !inputs.coordinatorIsActive && inputs.isAITabChatHeaderContainerHidden {
+                return .unbindInactiveNonAITab
+            }
+            // Preserve any active omnibar session across navigation events. Without this,
+            // chained server redirects (which fire `url didSet` → `tabLoadingStateDidChange`
+            // while `isLoading == true`) would tear down a UTI the user just opened mid-load.
+            // The user-driven submit path explicitly deactivates the coordinator *before* the
+            // nav starts, so by the time this runs after a real submission `isOmnibarSession`
+            // is already false and the bar collapses normally.
+            if inputs.coordinatorIsOmnibarSession {
+                return .preserveOmnibarSession
+            }
+            return .refreshNonAITab
+        }
+
+        if inputs.coordinatorIsAITabState {
+            return .refreshAITab(.preserveCurrentPresentation(allowsEarlyReturn: inputs.isNavigationChromeHidden))
+        }
+
+        // `tab.url` lags behind `tab.link?.url` during a freshly-opened tab; use the same
+        // fallback for hasExistingChat so we don't spuriously auto-expand the UTI on top of
+        // an existing-chat URL whose query string only just arrived.
+        let resolvedURL = inputs.tabURL ?? inputs.tabLinkURL
+        let hasExistingChat = resolvedURL?.duckAIChatID != nil
+        let isVoiceMode = resolvedURL?.isDuckAIVoiceMode == true || inputs.tabIsVoiceModeRequested
+        let isSidebarOpen = resolvedURL?.isDuckAISidebarOpen == true
+        let shouldExpandAfterRefresh = !hasExistingChat && !inputs.coordinatorHasSubmittedPrompt && !isVoiceMode && !isSidebarOpen
+        return .refreshAITab(.showCollapsed(expandAfterRefresh: shouldExpandAfterRefresh))
+    }
+}
+
 private extension MainViewController {
 
     /// While Dax Dialogs are still in progress, the onboarding Search vs Search & Duck.ai choice
@@ -322,19 +399,6 @@ private extension MainViewController {
     /// Search-only hides the toggle, while Search & Duck.ai keeps it visible.
     func isAIChatSearchInputToggleEnabledForCurrentOnboardingState() -> Bool {
         onboardingSearchExperienceSettingsResolver.deferredValue ?? aiChatSettings.isAIChatSearchInputUserSettingsEnabled
-    }
-
-    enum UnifiedToggleInputRefreshAction {
-        case unbindInactiveNonAITab
-        case refreshAITab(AITabRefreshBehavior)
-        case refreshNonAITab
-        /// The coordinator is mid-omnibar session on a non-AI tab — leave it alone.
-        case preserveOmnibarSession
-    }
-
-    enum AITabRefreshBehavior {
-        case preserveCurrentPresentation(allowsEarlyReturn: Bool)
-        case showCollapsed(expandAfterRefresh: Bool)
     }
 
     func installUnifiedToggleInputViewController(_ inputVC: UnifiedToggleInputViewController) {
@@ -542,43 +606,21 @@ private extension MainViewController {
     }
 
     func refreshAction(for tab: TabViewController, coordinator: UnifiedToggleInputCoordinator) -> UnifiedToggleInputRefreshAction {
-        // During a fresh navigation (e.g. opening a chat in a new tab), `tabModel.link` is briefly
-        // set to nil before WebView reports the new URL. `tab.isAITab` is link-derived, so it would
-        // momentarily report false and route us through `refreshNonAITab` → `coordinator.hide()`,
-        // tearing down the UTI we just set up. Preserve the current AI presentation through that
-        // window — the next refresh, after WebView reports the URL, resolves correctly.
-        if tab.link == nil && coordinator.isAITabState {
-            return .refreshAITab(.preserveCurrentPresentation(allowsEarlyReturn: true))
-        }
-
-        if !tab.isAITab {
-            if !coordinator.isActive && viewCoordinator.aiChatTabChatHeaderContainer.isHidden {
-                return .unbindInactiveNonAITab
-            }
-            // The coordinator was just activated for an omnibar editing session (e.g. the
-            // visit-site onboarding dialog activates the UTI from NTP.viewDidAppear).
-            // Collapsing it here would undo that activation before the keyboard appears.
-            // Once navigation starts (tab is loading), stop preserving so refreshNonAITab
-            // can collapse the bar normally.
-            if coordinator.isOmnibarSession, !tab.isLoading {
-                return .preserveOmnibarSession
-            }
-            return .refreshNonAITab
-        }
-
-        if coordinator.isAITabState {
-            return .refreshAITab(.preserveCurrentPresentation(allowsEarlyReturn: viewCoordinator.isNavigationChromeHidden))
-        }
-
-        // `tab.url` lags behind `tab.link?.url` during a freshly-opened tab; use the same
-        // fallback for hasExistingChat so we don't spuriously auto-expand the UTI on top of
-        // an existing-chat URL whose query string only just arrived.
-        let tabURL = tab.url ?? tab.link?.url
-        let hasExistingChat = tabURL?.duckAIChatID != nil
-        let isVoiceMode = tabURL?.isDuckAIVoiceMode == true || tab.isVoiceModeRequested
-        let isSidebarOpen = tabURL?.isDuckAISidebarOpen == true
-        let shouldExpandAfterRefresh = !hasExistingChat && !coordinator.hasSubmittedPrompt && !isVoiceMode && !isSidebarOpen
-        return .refreshAITab(.showCollapsed(expandAfterRefresh: shouldExpandAfterRefresh))
+        let inputs = UnifiedToggleInputRefreshActionInputs(
+            tabHasLink: tab.link != nil,
+            tabIsAITab: tab.isAITab,
+            tabIsLoading: tab.isLoading,
+            tabURL: tab.url,
+            tabLinkURL: tab.link?.url,
+            tabIsVoiceModeRequested: tab.isVoiceModeRequested,
+            coordinatorIsAITabState: coordinator.isAITabState,
+            coordinatorIsActive: coordinator.isActive,
+            coordinatorIsOmnibarSession: coordinator.isOmnibarSession,
+            coordinatorHasSubmittedPrompt: coordinator.hasSubmittedPrompt,
+            isAITabChatHeaderContainerHidden: viewCoordinator.aiChatTabChatHeaderContainer.isHidden,
+            isNavigationChromeHidden: viewCoordinator.isNavigationChromeHidden
+        )
+        return MainViewController.decideRefreshAction(for: inputs)
     }
 
     func refreshInactiveNonAITab(tab: TabViewController, coordinator: UnifiedToggleInputCoordinator) {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -330,13 +330,8 @@ enum AITabRefreshBehavior: Equatable {
     case showCollapsed(expandAfterRefresh: Bool)
 }
 
-/// Pure-data snapshot of everything `decideRefreshAction` reads. Built from the live
-/// `TabViewController` / `UnifiedToggleInputCoordinator` / view coordinator at the call site
-/// so the decision itself stays free of UIKit dependencies and is unit-testable.
 struct UnifiedToggleInputRefreshActionInputs: Equatable {
-    let tabHasLink: Bool
     let tabIsAITab: Bool
-    let tabIsLoading: Bool
     let tabURL: URL?
     let tabLinkURL: URL?
     let tabIsVoiceModeRequested: Bool
@@ -356,7 +351,7 @@ extension MainViewController {
         // momentarily report false and route us through `refreshNonAITab` → `coordinator.hide()`,
         // tearing down the UTI we just set up. Preserve the current AI presentation through that
         // window — the next refresh, after WebView reports the URL, resolves correctly.
-        if !inputs.tabHasLink && inputs.coordinatorIsAITabState {
+        if inputs.tabLinkURL == nil && inputs.coordinatorIsAITabState {
             return .refreshAITab(.preserveCurrentPresentation(allowsEarlyReturn: true))
         }
 
@@ -364,12 +359,6 @@ extension MainViewController {
             if !inputs.coordinatorIsActive && inputs.isAITabChatHeaderContainerHidden {
                 return .unbindInactiveNonAITab
             }
-            // Preserve any active omnibar session across navigation events. Without this,
-            // chained server redirects (which fire `url didSet` → `tabLoadingStateDidChange`
-            // while `isLoading == true`) would tear down a UTI the user just opened mid-load.
-            // The user-driven submit path explicitly deactivates the coordinator *before* the
-            // nav starts, so by the time this runs after a real submission `isOmnibarSession`
-            // is already false and the bar collapses normally.
             if inputs.coordinatorIsOmnibarSession {
                 return .preserveOmnibarSession
             }
@@ -607,9 +596,7 @@ private extension MainViewController {
 
     func refreshAction(for tab: TabViewController, coordinator: UnifiedToggleInputCoordinator) -> UnifiedToggleInputRefreshAction {
         let inputs = UnifiedToggleInputRefreshActionInputs(
-            tabHasLink: tab.link != nil,
             tabIsAITab: tab.isAITab,
-            tabIsLoading: tab.isLoading,
             tabURL: tab.url,
             tabLinkURL: tab.link?.url,
             tabIsVoiceModeRequested: tab.isVoiceModeRequested,

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/MainViewControllerRefreshActionTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/MainViewControllerRefreshActionTests.swift
@@ -22,33 +22,16 @@ import XCTest
 
 final class MainViewControllerRefreshActionTests: XCTestCase {
 
-    // MARK: - Bug regression: omnibar session + tab loading
-
-    /// JL1 regression: chained server redirects (cnn.com → www.cnn.com → edition.cnn.com) reassign
-    /// `tab.url` while `isLoading == true`, firing `tabLoadingStateDidChange` and routing through
-    /// `refreshAction`. Before the fix the action collapsed back to `.refreshNonAITab` because the
-    /// guard required `!tab.isLoading`, tearing down the UTI the user had just reopened mid-load.
-    func test_nonAITab_omnibarSession_loading_preservesSession() {
-        let inputs = makeInputs(
-            tabIsAITab: false,
-            tabIsLoading: true,
-            coordinatorIsActive: true,
-            coordinatorIsOmnibarSession: true
-        )
-        XCTAssertEqual(MainViewController.decideRefreshAction(for: inputs), .preserveOmnibarSession)
-    }
-
-    func test_nonAITab_omnibarSession_notLoading_preservesSession() {
-        let inputs = makeInputs(
-            tabIsAITab: false,
-            tabIsLoading: false,
-            coordinatorIsActive: true,
-            coordinatorIsOmnibarSession: true
-        )
-        XCTAssertEqual(MainViewController.decideRefreshAction(for: inputs), .preserveOmnibarSession)
-    }
-
     // MARK: - Non-AI tab paths
+
+    func test_nonAITab_omnibarSession_preservesSession() {
+        let inputs = makeInputs(
+            tabIsAITab: false,
+            coordinatorIsActive: true,
+            coordinatorIsOmnibarSession: true
+        )
+        XCTAssertEqual(MainViewController.decideRefreshAction(for: inputs), .preserveOmnibarSession)
+    }
 
     func test_nonAITab_coordinatorInactive_chatHeaderHidden_unbinds() {
         let inputs = makeInputs(
@@ -63,20 +46,6 @@ final class MainViewControllerRefreshActionTests: XCTestCase {
     func test_nonAITab_coordinatorActive_notOmnibarSession_refreshesNonAITab() {
         let inputs = makeInputs(
             tabIsAITab: false,
-            tabIsLoading: false,
-            coordinatorIsActive: true,
-            coordinatorIsOmnibarSession: false
-        )
-        XCTAssertEqual(MainViewController.decideRefreshAction(for: inputs), .refreshNonAITab)
-    }
-
-    // Submitting from the UTI deactivates the coordinator *before* the new nav reaches us,
-    // so by the time `decideRefreshAction` runs after a real user submission `isOmnibarSession`
-    // is already false and the bar collapses normally.
-    func test_nonAITab_postUserSubmit_loading_refreshesNonAITab() {
-        let inputs = makeInputs(
-            tabIsAITab: false,
-            tabIsLoading: true,
             coordinatorIsActive: true,
             coordinatorIsOmnibarSession: false
         )
@@ -85,12 +54,10 @@ final class MainViewControllerRefreshActionTests: XCTestCase {
 
     // MARK: - AI tab paths
 
-    /// During a fresh AI-tab navigation the link briefly goes nil and `isAITab` flips false;
-    /// the guard at the top of `decideRefreshAction` keeps the AI presentation in place.
     func test_nilLink_coordinatorInAITabState_preservesAIPresentation() {
         let inputs = makeInputs(
-            tabHasLink: false,
             tabIsAITab: false,
+            tabLinkURL: nil,
             coordinatorIsAITabState: true
         )
         XCTAssertEqual(
@@ -140,9 +107,7 @@ final class MainViewControllerRefreshActionTests: XCTestCase {
     // MARK: - Helpers
 
     private func makeInputs(
-        tabHasLink: Bool = true,
         tabIsAITab: Bool = false,
-        tabIsLoading: Bool = false,
         tabURL: URL? = URL(string: "https://example.com/"),
         tabLinkURL: URL? = URL(string: "https://example.com/"),
         tabIsVoiceModeRequested: Bool = false,
@@ -154,9 +119,7 @@ final class MainViewControllerRefreshActionTests: XCTestCase {
         isNavigationChromeHidden: Bool = false
     ) -> UnifiedToggleInputRefreshActionInputs {
         UnifiedToggleInputRefreshActionInputs(
-            tabHasLink: tabHasLink,
             tabIsAITab: tabIsAITab,
-            tabIsLoading: tabIsLoading,
             tabURL: tabURL,
             tabLinkURL: tabLinkURL,
             tabIsVoiceModeRequested: tabIsVoiceModeRequested,

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/MainViewControllerRefreshActionTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/MainViewControllerRefreshActionTests.swift
@@ -1,0 +1,171 @@
+//
+//  MainViewControllerRefreshActionTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo
+
+final class MainViewControllerRefreshActionTests: XCTestCase {
+
+    // MARK: - Bug regression: omnibar session + tab loading
+
+    /// JL1 regression: chained server redirects (cnn.com → www.cnn.com → edition.cnn.com) reassign
+    /// `tab.url` while `isLoading == true`, firing `tabLoadingStateDidChange` and routing through
+    /// `refreshAction`. Before the fix the action collapsed back to `.refreshNonAITab` because the
+    /// guard required `!tab.isLoading`, tearing down the UTI the user had just reopened mid-load.
+    func test_nonAITab_omnibarSession_loading_preservesSession() {
+        let inputs = makeInputs(
+            tabIsAITab: false,
+            tabIsLoading: true,
+            coordinatorIsActive: true,
+            coordinatorIsOmnibarSession: true
+        )
+        XCTAssertEqual(MainViewController.decideRefreshAction(for: inputs), .preserveOmnibarSession)
+    }
+
+    func test_nonAITab_omnibarSession_notLoading_preservesSession() {
+        let inputs = makeInputs(
+            tabIsAITab: false,
+            tabIsLoading: false,
+            coordinatorIsActive: true,
+            coordinatorIsOmnibarSession: true
+        )
+        XCTAssertEqual(MainViewController.decideRefreshAction(for: inputs), .preserveOmnibarSession)
+    }
+
+    // MARK: - Non-AI tab paths
+
+    func test_nonAITab_coordinatorInactive_chatHeaderHidden_unbinds() {
+        let inputs = makeInputs(
+            tabIsAITab: false,
+            coordinatorIsActive: false,
+            coordinatorIsOmnibarSession: false,
+            isAITabChatHeaderContainerHidden: true
+        )
+        XCTAssertEqual(MainViewController.decideRefreshAction(for: inputs), .unbindInactiveNonAITab)
+    }
+
+    func test_nonAITab_coordinatorActive_notOmnibarSession_refreshesNonAITab() {
+        let inputs = makeInputs(
+            tabIsAITab: false,
+            tabIsLoading: false,
+            coordinatorIsActive: true,
+            coordinatorIsOmnibarSession: false
+        )
+        XCTAssertEqual(MainViewController.decideRefreshAction(for: inputs), .refreshNonAITab)
+    }
+
+    // Submitting from the UTI deactivates the coordinator *before* the new nav reaches us,
+    // so by the time `decideRefreshAction` runs after a real user submission `isOmnibarSession`
+    // is already false and the bar collapses normally.
+    func test_nonAITab_postUserSubmit_loading_refreshesNonAITab() {
+        let inputs = makeInputs(
+            tabIsAITab: false,
+            tabIsLoading: true,
+            coordinatorIsActive: true,
+            coordinatorIsOmnibarSession: false
+        )
+        XCTAssertEqual(MainViewController.decideRefreshAction(for: inputs), .refreshNonAITab)
+    }
+
+    // MARK: - AI tab paths
+
+    /// During a fresh AI-tab navigation the link briefly goes nil and `isAITab` flips false;
+    /// the guard at the top of `decideRefreshAction` keeps the AI presentation in place.
+    func test_nilLink_coordinatorInAITabState_preservesAIPresentation() {
+        let inputs = makeInputs(
+            tabHasLink: false,
+            tabIsAITab: false,
+            coordinatorIsAITabState: true
+        )
+        XCTAssertEqual(
+            MainViewController.decideRefreshAction(for: inputs),
+            .refreshAITab(.preserveCurrentPresentation(allowsEarlyReturn: true))
+        )
+    }
+
+    func test_aiTab_coordinatorInAITabState_chromeHidden_preservesWithEarlyReturn() {
+        let inputs = makeInputs(
+            tabIsAITab: true,
+            coordinatorIsAITabState: true,
+            isNavigationChromeHidden: true
+        )
+        XCTAssertEqual(
+            MainViewController.decideRefreshAction(for: inputs),
+            .refreshAITab(.preserveCurrentPresentation(allowsEarlyReturn: true))
+        )
+    }
+
+    func test_aiTab_freshChat_showsCollapsedAndExpandsAfterRefresh() {
+        let inputs = makeInputs(
+            tabIsAITab: true,
+            tabURL: URL(string: "https://duckduckgo.com/?q=hello&ia=chat&duckai=2"),
+            coordinatorIsAITabState: false,
+            coordinatorHasSubmittedPrompt: false
+        )
+        XCTAssertEqual(
+            MainViewController.decideRefreshAction(for: inputs),
+            .refreshAITab(.showCollapsed(expandAfterRefresh: true))
+        )
+    }
+
+    func test_aiTab_voiceModeRequested_showsCollapsedWithoutExpand() {
+        let inputs = makeInputs(
+            tabIsAITab: true,
+            tabIsVoiceModeRequested: true,
+            coordinatorIsAITabState: false,
+            coordinatorHasSubmittedPrompt: false
+        )
+        XCTAssertEqual(
+            MainViewController.decideRefreshAction(for: inputs),
+            .refreshAITab(.showCollapsed(expandAfterRefresh: false))
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func makeInputs(
+        tabHasLink: Bool = true,
+        tabIsAITab: Bool = false,
+        tabIsLoading: Bool = false,
+        tabURL: URL? = URL(string: "https://example.com/"),
+        tabLinkURL: URL? = URL(string: "https://example.com/"),
+        tabIsVoiceModeRequested: Bool = false,
+        coordinatorIsAITabState: Bool = false,
+        coordinatorIsActive: Bool = false,
+        coordinatorIsOmnibarSession: Bool = false,
+        coordinatorHasSubmittedPrompt: Bool = false,
+        isAITabChatHeaderContainerHidden: Bool = true,
+        isNavigationChromeHidden: Bool = false
+    ) -> UnifiedToggleInputRefreshActionInputs {
+        UnifiedToggleInputRefreshActionInputs(
+            tabHasLink: tabHasLink,
+            tabIsAITab: tabIsAITab,
+            tabIsLoading: tabIsLoading,
+            tabURL: tabURL,
+            tabLinkURL: tabLinkURL,
+            tabIsVoiceModeRequested: tabIsVoiceModeRequested,
+            coordinatorIsAITabState: coordinatorIsAITabState,
+            coordinatorIsActive: coordinatorIsActive,
+            coordinatorIsOmnibarSession: coordinatorIsOmnibarSession,
+            coordinatorHasSubmittedPrompt: coordinatorHasSubmittedPrompt,
+            isAITabChatHeaderContainerHidden: isAITabChatHeaderContainerHidden,
+            isNavigationChromeHidden: isNavigationChromeHidden
+        )
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215043849443418
CC:

### Description

Fixes the JL1 bug where the UTI auto-collapses (losing the user's typed text) when the user reopens it mid-load and the page then completes a chained redirect (e.g. `cnn.com` → `https://cnn.com` → `www.cnn.com` → `edition.cnn.com`).

Each redirect reassigns `tab.url`, which fires `tabLoadingStateDidChange` while `tab.isLoading == true`. The guard in `refreshAction(for:coordinator:)` required `!tab.isLoading` to take the `.preserveOmnibarSession` branch, so the in-flight redirect routed through `.refreshNonAITab` and tore down the coordinator. The fix drops the `!isLoading` qualifier; the user-driven submit path explicitly deactivates the coordinator before nav starts, so the auto-collapse on real submissions is unaffected (covered by `test_nonAITab_coordinatorActive_notOmnibarSession_refreshesNonAITab`).

The decision is also extracted into a pure static `MainViewController.decideRefreshAction(for: UnifiedToggleInputRefreshActionInputs)` so it's unit-testable without spinning up UIKit.

### Testing Steps

Requires `unifiedToggleInputFeature` ON.

1. From the omnibar/NTP, type `cnn.com` and press Enter.
2. Before the page settles, tap the omnibar to reopen the UTI and start typing (e.g. `youtube.com`).
3. Wait for CNN to fully resolve through its redirect chain (http → https → www → edition).
4. **Expected:** UTI stays open with your typed text intact.
5. Regression: submit a URL from the UTI on any page — the UTI should still collapse normally on submission (the submit path deactivates the coordinator before nav starts).
6. Flag OFF: production behaviour unchanged.

### Impact and Risks

Low. Scope is one boolean removed from a single guard in `refreshAction`; behavior change is limited to the non-AI-tab branch when an omnibar session is open. The submit path is already deactivated by the time the decision runs, so the auto-collapse on real submissions is preserved.

#### What could go wrong?

A user-opened UTI session could now persist across a navigation event that historically tore it down. Mitigated by:
- Submit path deactivates the coordinator before the new nav reaches the decision (verified in logs and by `test_nonAITab_coordinatorActive_notOmnibarSession_refreshesNonAITab`).
- Tab-switch path explicitly calls `resetUnifiedToggleInputForTabTransition` before refreshing for the new tab, so `isOmnibarSession` is false by then.

### Notes to Reviewer

- The refactor adds `UnifiedToggleInputRefreshActionInputs` + a static `decideRefreshAction(for:)` to make the decision unit-testable; the instance `refreshAction(for:coordinator:)` is now a thin adapter. The inputs struct deliberately omits `isLoading` so the regression is also locked in structurally.
- Tests in `MainViewControllerRefreshActionTests.swift`; the regression case was verified to fail on the pre-fix code (`refreshNonAITab` instead of `preserveOmnibarSession`) then pass with the fix.
