### PR TITLE
macOS: Throttle release-notes update events during Sparkle progress

### DIFF
--- a/macOS/LocalPackages/AppUpdater/Sources/SparkleAppUpdater/ReleaseNotesNavigationResponder.swift
+++ b/macOS/LocalPackages/AppUpdater/Sources/SparkleAppUpdater/ReleaseNotesNavigationResponder.swift
@@ -101,7 +101,7 @@ public final class ReleaseNotesNavigationResponder: NavigationResponder {
             return
         }
         Publishers.CombineLatest(updateController.updateProgressPublisher, updateController.latestUpdatePublisher)
-            .receive(on: DispatchQueue.main)
+            .throttle(for: .milliseconds(250), scheduler: DispatchQueue.main, latest: true)
             .sink { [weak self] _ in
                 guard let self else { return }
                 self.releaseNotesUserScript?.onUpdate()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215118634345536

### Description

When downloading Sparkle updates we update progress too frequently.  Reduce the update frequency to 250ms to avoid any risk of creating performance issues.

### Testing Steps

1. Configure the app for Sparkle update testing as described in [these instructions](https://app.asana.com/1/137249556945/project/1202500774821704/task/1212917247399758?focus=true).
2. Trigger an app update download.
3. Open the release notes page.
4. Confirm the progress bar advances.
5. Wait for the download to finish.
6. Confirm the page leaves the downloading state.

### Impact and Risks

Low. The publisher chain still delivers updates; only the rate is capped.

#### What could go wrong?

The final progress value before completion could in theory be skipped, but the throttle keeps the latest value in each window, so the last tick still lands before the state changes.