### PR TITLE
iOS: scope new-chat model default to actual new-chat picks

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIModelStore.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIModelStore.swift
@@ -33,6 +33,8 @@ final class UTIModelStore {
     private let subscriptionManager: any SubscriptionManager
     private var modelsFetchTask: Task<Void, Never>?
 
+    private var liveModelId: String?
+
     var onModelsUpdated: (() -> Void)?
 
     init(
@@ -46,18 +48,13 @@ final class UTIModelStore {
     }
 
     var persistedModelId: String? {
-        let id = preferences.selectedModelId
-        if let id, !models.isEmpty {
-            if let model = models.first(where: { $0.id == id }) {
-                return model.entityHasAccess ? id : firstAccessibleModelId
-            }
-            return firstAccessibleModelId
-        }
-        return id ?? firstAccessibleModelId
+        if let resolved = resolve(modelId: liveModelId) { return resolved }
+        if let resolved = resolve(modelId: preferences.selectedModelId) { return resolved }
+        return firstAccessibleModelId
     }
 
     var currentModelId: String? {
-        preferences.selectedModelId
+        liveModelId
     }
 
     var selectedReasoningMode: AIChatReasoningMode? {
@@ -67,6 +64,14 @@ final class UTIModelStore {
     var selectedModel: AIChatModel? {
         guard let persistedModelId else { return nil }
         return models.first(where: { $0.id == persistedModelId })
+    }
+
+    var displayShortName: String? {
+        if let liveModelId,
+           let shortName = models.first(where: { $0.id == liveModelId })?.shortName {
+            return shortName
+        }
+        return preferences.selectedModelShortName
     }
 
     var selectedModelSupportsImageUpload: Bool {
@@ -88,6 +93,13 @@ final class UTIModelStore {
 
     private var firstAccessibleModelId: String? {
         models.first(where: { $0.entityHasAccess })?.id
+    }
+
+    private func resolve(modelId id: String?) -> String? {
+        guard let id else { return nil }
+        guard !models.isEmpty else { return id }
+        guard let model = models.first(where: { $0.id == id }) else { return nil }
+        return model.entityHasAccess ? id : nil
     }
 
     func fetchModels() {
@@ -114,9 +126,12 @@ final class UTIModelStore {
         }
     }
 
-    func updateSelectedModel(_ modelId: String) {
-        preferences.selectedModelId = modelId
-        preferences.selectedModelShortName = models.first(where: { $0.id == modelId })?.shortName
+    func updateSelectedModel(_ modelId: String, isNewChatContext: Bool) {
+        liveModelId = modelId
+        if isNewChatContext {
+            preferences.selectedModelId = modelId
+            preferences.selectedModelShortName = models.first(where: { $0.id == modelId })?.shortName
+        }
         clearStaleReasoningModeIfNeeded()
     }
 
@@ -134,17 +149,8 @@ final class UTIModelStore {
         preferences.selectedReasoningMode = mode
     }
 
-    /// Used by per-tab restoration to mirror a tab's stored selection into preferences,
-    /// including nil values. Bypasses the validity checks of `updateSelectedModel`/
-    /// `updateSelectedReasoningMode` so the live state matches the stored state exactly.
     func applyPersistedSelection(modelID: String?, reasoningMode: AIChatReasoningMode?) {
-        preferences.selectedModelId = modelID
-        // Always assign — including nil when the model isn't (yet) in `models` —
-        // otherwise the previous tab's cached short name lingers in preferences
-        // until handleModelsUpdated() corrects it.
-        preferences.selectedModelShortName = modelID.flatMap { id in
-            models.first(where: { $0.id == id })?.shortName
-        }
+        liveModelId = modelID
         preferences.selectedReasoningMode = reasoningMode
     }
 
@@ -187,17 +193,15 @@ final class UTIModelStore {
         }
     }
 
-    func cacheSelectedModelShortName(_ shortName: String) {
-        preferences.selectedModelShortName = shortName
-    }
-
     func clearStaleModelSelectionIfNeeded() {
-        guard let selectedId = preferences.selectedModelId, !models.isEmpty else { return }
+        guard !models.isEmpty else { return }
 
-        let selectedModel = models.first(where: { $0.id == selectedId })
-        let isStale = selectedModel == nil || selectedModel?.entityHasAccess == false
+        if let id = liveModelId, !models.contains(where: { $0.id == id && $0.entityHasAccess }) {
+            liveModelId = nil
+        }
 
-        if isStale {
+        if let preferredId = preferences.selectedModelId,
+           !models.contains(where: { $0.id == preferredId && $0.entityHasAccess }) {
             preferences.selectedModelId = nil
             preferences.selectedModelShortName = nil
         }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputStateStore.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputStateStore.swift
@@ -64,16 +64,15 @@ final class UnifiedInputStateStore: UnifiedInputStateStoring {
         Logger.unifiedInputState.debug("update flush for tab [\(uid)]: \(state.summary)")
     }
 
-    func recordUserChoice(_ state: TabInputState, for uid: TabUID) {
+    func recordUserChoice(_ state: TabInputState, for uid: TabUID, isNewChatContext: Bool) {
         states[uid] = state
         trackedLastUsed = LastUsedInputDefaults(
             toggleMode: state.toggleMode,
-            selectedModelID: state.selectedModelID,
+            selectedModelID: isNewChatContext ? state.selectedModelID : trackedLastUsed.selectedModelID,
             selectedReasoningMode: state.selectedReasoningMode,
             selectedTool: state.selectedTool
         )
         toggleModeStorage.save(state.toggleMode)
-        preferences.selectedModelId = state.selectedModelID
         preferences.selectedReasoningMode = state.selectedReasoningMode
         preferences.selectedTool = state.selectedTool
 
@@ -84,7 +83,7 @@ final class UnifiedInputStateStore: UnifiedInputStateStoring {
             inputState.selectedTool = state.selectedTool
             tab.unifiedInputState = inputState
         }
-        Logger.unifiedInputState.debug("recordUserChoice for tab [\(uid)]: \(state.summary)")
+        Logger.unifiedInputState.debug("recordUserChoice for tab [\(uid)] (newChat=\(isNewChatContext)): \(state.summary)")
     }
 
     func remove(for uid: TabUID) {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputStateStoring.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputStateStoring.swift
@@ -40,7 +40,7 @@ protocol UnifiedInputStateStoring: AnyObject {
     /// Records a user-deliberate choice. Updates the entry for `uid`, the `lastUsed`
     /// snapshot used to seed new tabs, and writes through the seedable fields to
     /// their canonical global homes.
-    func recordUserChoice(_ state: TabInputState, for uid: TabUID)
+    func recordUserChoice(_ state: TabInputState, for uid: TabUID, isNewChatContext: Bool)
 
     /// Removes the entry for `uid`. No-op if absent.
     func remove(for uid: TabUID)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -444,7 +444,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         subscribeToDuckAIWideEventSignals()
         viewController.isToolsButtonHidden = true
 
-        if let cachedLabel = modelStore.preferences.selectedModelShortName {
+        if let cachedLabel = modelStore.displayShortName {
             viewController.modelName = cachedLabel
         }
 
@@ -552,7 +552,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             return
         }
         Logger.unifiedInputState.debug("restoreLastUsedModel [\(chatID, privacy: .public)]: loaded model '\(modelID, privacy: .public)'")
-        modelStore.updateSelectedModel(modelID)
+        modelStore.updateSelectedModel(modelID, isNewChatContext: false)
         handleModelsUpdated()
     }
 
@@ -667,7 +667,11 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     /// preference homes so other components (e.g. NTP omnibar) observe the change.
     private func recordUserChoiceToStore() {
         guard !isApplyingState, !isPerformingDismissCleanup, let uid = currentTabUID else { return }
-        stateStore.recordUserChoice(snapshotCurrentState(), for: uid)
+        stateStore.recordUserChoice(snapshotCurrentState(), for: uid, isNewChatContext: isNewChatContext)
+    }
+
+    private var isNewChatContext: Bool {
+        !hasSubmittedPrompt
     }
 
     private func clearStoreEntryAfterSubmission() {
@@ -678,7 +682,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         cleared.text = ""
         cleared.attachments = []
         cleared.selectedTool = nil
-        stateStore.recordUserChoice(cleared, for: uid)
+        stateStore.recordUserChoice(cleared, for: uid, isNewChatContext: false)
         Logger.unifiedInputState.debug("submission cleared store text + attachments + tool for tab [\(uid)]")
     }
 
@@ -1332,7 +1336,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     }
 
     func updateSelectedModel(_ modelId: String) {
-        modelStore.updateSelectedModel(modelId)
+        modelStore.updateSelectedModel(modelId, isNewChatContext: isNewChatContext)
         handleModelsUpdated()
         recordUserChoiceToStore()
     }
@@ -1573,7 +1577,6 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         let shortName = modelMenuFactory.selectedShortName(models: modelStore.models, selectedId: selectedId)
         if let shortName {
             viewController.modelName = shortName
-            modelStore.cacheSelectedModelShortName(shortName)
         }
         viewController.modelPickerMenu = modelStore.models.isEmpty ? nil : modelMenuFactory.makeMenu(
             models: modelStore.models,

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIModelStoreTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIModelStoreTests.swift
@@ -102,6 +102,170 @@ final class UTIModelStoreTests: XCTestCase {
         XCTAssertNil(sut.persistedModelId)
     }
 
+    // MARK: - persistedModelId: live current-tab model
+
+    func test_persistedModelId_whenLiveModelSet_prefersLiveModel() {
+        preferences.selectedModelId = "gpt-5"
+        sut.models = [
+            makeModel(id: "gpt-5", access: true),
+            makeModel(id: "mistral", access: true)
+        ]
+
+        sut.updateSelectedModel("mistral", isNewChatContext: false)
+
+        XCTAssertEqual(sut.persistedModelId, "mistral")
+    }
+
+    func test_persistedModelId_whenLiveModelInaccessible_fallsBackToPreferredNewChatModel() {
+        preferences.selectedModelId = "haiku"
+        sut.models = [
+            makeModel(id: "haiku", access: true),
+            makeModel(id: "premium", access: false),
+            makeModel(id: "free", access: true)
+        ]
+
+        sut.updateSelectedModel("premium", isNewChatContext: false)
+
+        XCTAssertEqual(sut.persistedModelId, "haiku")
+    }
+
+    func test_persistedModelId_whenNoLiveAndPreferredAccessible_returnsPreferred() {
+        preferences.selectedModelId = "haiku"
+        sut.models = [
+            makeModel(id: "gpt-5", access: true),
+            makeModel(id: "haiku", access: true)
+        ]
+
+        XCTAssertEqual(sut.persistedModelId, "haiku")
+    }
+
+    func test_persistedModelId_whenNoLiveAndPreferredInaccessible_returnsFirstAccessible() {
+        preferences.selectedModelId = "premium"
+        sut.models = [
+            makeModel(id: "premium", access: false),
+            makeModel(id: "free", access: true)
+        ]
+
+        XCTAssertEqual(sut.persistedModelId, "free")
+    }
+
+    // MARK: - updateSelectedModel: isNewChatContext
+
+    func test_updateSelectedModel_onNewChat_writesPreferredModelToPreferences() {
+        sut.models = [
+            AIChatModel(id: "haiku", name: "Haiku 4.5", shortName: "H4.5", provider: .anthropic, supportsImageUpload: false, entityHasAccess: true)
+        ]
+
+        sut.updateSelectedModel("haiku", isNewChatContext: true)
+
+        XCTAssertEqual(preferences.selectedModelId, "haiku")
+        XCTAssertEqual(preferences.selectedModelShortName, "H4.5")
+    }
+
+    func test_updateSelectedModel_onOngoingChat_doesNotWritePreferredModelToPreferences() {
+        preferences.selectedModelId = "haiku"
+        preferences.selectedModelShortName = "H4.5"
+        sut.models = [
+            makeModel(id: "haiku", access: true),
+            makeModel(id: "mistral", access: true)
+        ]
+
+        sut.updateSelectedModel("mistral", isNewChatContext: false)
+
+        XCTAssertEqual(preferences.selectedModelId, "haiku", "ongoing-chat picks must not retarget the new-chat default")
+        XCTAssertEqual(preferences.selectedModelShortName, "H4.5")
+    }
+
+    func test_updateSelectedModel_onOngoingChat_stillUpdatesLiveModel() {
+        sut.models = [
+            makeModel(id: "haiku", access: true),
+            makeModel(id: "mistral", access: true)
+        ]
+        sut.updateSelectedModel("haiku", isNewChatContext: true)
+
+        sut.updateSelectedModel("mistral", isNewChatContext: false)
+
+        XCTAssertEqual(sut.persistedModelId, "mistral")
+        XCTAssertEqual(sut.currentModelId, "mistral")
+    }
+
+    // MARK: - applyPersistedSelection
+
+    func test_applyPersistedSelection_doesNotTouchPreferredModelPreference() {
+        preferences.selectedModelId = "haiku"
+        preferences.selectedModelShortName = "H4.5"
+        sut.models = [
+            makeModel(id: "haiku", access: true),
+            makeModel(id: "mistral", access: true)
+        ]
+
+        sut.applyPersistedSelection(modelID: "mistral", reasoningMode: nil)
+
+        XCTAssertEqual(preferences.selectedModelId, "haiku")
+        XCTAssertEqual(preferences.selectedModelShortName, "H4.5")
+        XCTAssertEqual(sut.currentModelId, "mistral")
+    }
+
+    func test_applyPersistedSelection_nil_clearsLiveButPreservesPreferredModel() {
+        preferences.selectedModelId = "haiku"
+        sut.models = [
+            makeModel(id: "haiku", access: true),
+            makeModel(id: "gpt-5", access: true)
+        ]
+        sut.updateSelectedModel("mistral", isNewChatContext: false)
+
+        sut.applyPersistedSelection(modelID: nil, reasoningMode: nil)
+
+        XCTAssertNil(sut.currentModelId)
+        XCTAssertEqual(sut.persistedModelId, "haiku", "fresh tab activation should return to the preferred new-chat default")
+    }
+
+    // MARK: - clearStaleModelSelectionIfNeeded
+
+    func test_clearStale_clearsLiveModel_whenInaccessible() {
+        preferences.selectedModelId = "haiku"
+        sut.models = [
+            makeModel(id: "haiku", access: true),
+            makeModel(id: "premium", access: false)
+        ]
+        sut.updateSelectedModel("premium", isNewChatContext: false)
+
+        sut.clearStaleModelSelectionIfNeeded()
+
+        XCTAssertNil(sut.currentModelId)
+    }
+
+    func test_clearStale_preservesLiveModel_whenAccessible() {
+        sut.models = [
+            makeModel(id: "haiku", access: true),
+            makeModel(id: "mistral", access: true)
+        ]
+        sut.updateSelectedModel("mistral", isNewChatContext: false)
+
+        sut.clearStaleModelSelectionIfNeeded()
+
+        XCTAssertEqual(sut.currentModelId, "mistral")
+    }
+
+    // MARK: - displayShortName
+
+    func test_displayShortName_returnsLiveModelShortName_whenLiveModelInModels() {
+        sut.models = [
+            AIChatModel(id: "haiku", name: "Haiku 4.5", shortName: "H4.5", provider: .anthropic, supportsImageUpload: false, entityHasAccess: true)
+        ]
+
+        sut.applyPersistedSelection(modelID: "haiku", reasoningMode: nil)
+
+        XCTAssertEqual(sut.displayShortName, "H4.5")
+    }
+
+    func test_displayShortName_fallsBackToPreferencesCache_beforeModelsLoad() {
+        preferences.selectedModelShortName = "Cached"
+        sut.models = []
+
+        XCTAssertEqual(sut.displayShortName, "Cached")
+    }
+
     // MARK: - selectedModelSupportsImageUpload
 
     func test_selectedModelSupportsImageUpload_whenNoModels_returnsFalse() {
@@ -208,7 +372,7 @@ final class UTIModelStoreTests: XCTestCase {
             AIChatModel(id: "gpt-5", name: "GPT-5", shortName: "G5", provider: .openAI, supportsImageUpload: false, entityHasAccess: true)
         ]
 
-        sut.updateSelectedModel("gpt-5")
+        sut.updateSelectedModel("gpt-5", isNewChatContext: true)
 
         XCTAssertEqual(preferences.selectedModelId, "gpt-5")
         XCTAssertEqual(preferences.selectedModelShortName, "G5")
@@ -220,7 +384,7 @@ final class UTIModelStoreTests: XCTestCase {
             makeModel(id: "gpt-5", access: true, supportedReasoningEffort: [.none, .low])
         ]
 
-        sut.updateSelectedModel("gpt-5")
+        sut.updateSelectedModel("gpt-5", isNewChatContext: true)
 
         XCTAssertNil(preferences.selectedReasoningMode)
     }
@@ -231,7 +395,7 @@ final class UTIModelStoreTests: XCTestCase {
             makeModel(id: "gpt-5", access: true, supportedReasoningEffort: [.none, .low, .medium])
         ]
 
-        sut.updateSelectedModel("gpt-5")
+        sut.updateSelectedModel("gpt-5", isNewChatContext: true)
 
         XCTAssertEqual(preferences.selectedReasoningMode, .extendedReasoning)
     }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedInputStateStoreTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedInputStateStoreTests.swift
@@ -108,33 +108,47 @@ final class UnifiedInputStateStoreTests: XCTestCase {
     func test_recordUserChoice_writesThroughToggleModeToStorage() {
         var state = TabInputState()
         state.toggleMode = .aiChat
-        sut.recordUserChoice(state, for: "tab-1")
+        sut.recordUserChoice(state, for: "tab-1", isNewChatContext: true)
         XCTAssertEqual(toggleStorage.stored, .aiChat)
-    }
-
-    func test_recordUserChoice_writesThroughSelectedModelIDToPreferences() {
-        var state = TabInputState()
-        state.selectedModelID = "claude-opus"
-        sut.recordUserChoice(state, for: "tab-1")
-        XCTAssertEqual(preferences.selectedModelId, "claude-opus")
     }
 
     func test_recordUserChoice_writesThroughReasoningModeToPreferences() {
         var state = TabInputState()
         state.selectedReasoningMode = .reasoning
-        sut.recordUserChoice(state, for: "tab-1")
+        sut.recordUserChoice(state, for: "tab-1", isNewChatContext: true)
         XCTAssertEqual(preferences.selectedReasoningMode, .reasoning)
     }
 
-    func test_recordUserChoice_updatesLastUsed() {
+    func test_recordUserChoice_doesNotWriteSelectedModelIdToPreferences() {
+        var state = TabInputState()
+        state.selectedModelID = "claude-opus"
+        sut.recordUserChoice(state, for: "tab-1", isNewChatContext: true)
+        XCTAssertNil(preferences.selectedModelId)
+    }
+
+    func test_recordUserChoice_onNewChat_updatesLastUsed() {
         var state = TabInputState()
         state.toggleMode = .aiChat
         state.selectedModelID = "claude-opus"
         state.selectedTool = .webSearch
-        sut.recordUserChoice(state, for: "tab-1")
+        sut.recordUserChoice(state, for: "tab-1", isNewChatContext: true)
         XCTAssertEqual(sut.lastUsed.toggleMode, .aiChat)
         XCTAssertEqual(sut.lastUsed.selectedModelID, "claude-opus")
         XCTAssertEqual(sut.lastUsed.selectedTool, .webSearch)
+    }
+
+    func test_recordUserChoice_onOngoingChat_preservesLastUsedModel() {
+        var newChat = TabInputState()
+        newChat.selectedModelID = "haiku"
+        sut.recordUserChoice(newChat, for: "tab-A", isNewChatContext: true)
+        XCTAssertEqual(sut.lastUsed.selectedModelID, "haiku")
+
+        var ongoing = TabInputState()
+        ongoing.selectedModelID = "mistral"
+        sut.recordUserChoice(ongoing, for: "tab-A", isNewChatContext: false)
+
+        XCTAssertEqual(sut.lastUsed.selectedModelID, "haiku",
+                       "an ongoing-chat pick must not retarget the new-tab seed")
     }
 
     // Regression for the new-tab inheritance bug: tab-flush after a user choice in another
@@ -142,7 +156,7 @@ final class UnifiedInputStateStoreTests: XCTestCase {
     func test_update_afterRecordUserChoiceElsewhere_preservesLastUsed() {
         var deliberateA = TabInputState()
         deliberateA.selectedModelID = "user-picked-A"
-        sut.recordUserChoice(deliberateA, for: "tab-A")
+        sut.recordUserChoice(deliberateA, for: "tab-A", isNewChatContext: true)
 
         // Simulate a tab-switch flush of an unrelated, never-deliberately-chosen tab.
         var driftB = TabInputState()
@@ -225,7 +239,8 @@ final class UnifiedInputStateStoreTests: XCTestCase {
 
         sut.recordUserChoice(
             TabInputState(toggleMode: .aiChat, selectedModelID: "claude-opus", selectedReasoningMode: .reasoning),
-            for: "writeback"
+            for: "writeback",
+            isNewChatContext: true
         )
 
         XCTAssertEqual(tab.unifiedInputState.selectedModelID, "claude-opus")
@@ -247,7 +262,8 @@ final class UnifiedInputStateStoreTests: XCTestCase {
 
         sut.recordUserChoice(
             TabInputState(toggleMode: .aiChat, selectedModelID: nil, selectedReasoningMode: nil),
-            for: "clear-mirror"
+            for: "clear-mirror",
+            isNewChatContext: true
         )
 
         XCTAssertNil(tab.unifiedInputState.selectedModelID)

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -1408,6 +1408,64 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         XCTAssertEqual(mockPreferences.selectedModelId, "gpt-5")
     }
 
+    // MARK: - Model Selection: new-chat vs ongoing-chat picks
+
+    func test_updateSelectedModel_onNewChat_writesPreferredModelToPreferences() {
+        sut.modelStore.models = [makeModel(id: "haiku", access: true)]
+        XCTAssertFalse(sut.hasSubmittedPrompt)
+
+        sut.updateSelectedModel("haiku")
+
+        XCTAssertEqual(mockPreferences.selectedModelId, "haiku")
+    }
+
+    func test_updateSelectedModel_afterPromptSubmitted_doesNotChangePreferredModel() {
+        sut.modelStore.models = [
+            makeModel(id: "haiku", access: true),
+            makeModel(id: "mistral", access: true)
+        ]
+        sut.updateSelectedModel("haiku")
+        XCTAssertEqual(mockPreferences.selectedModelId, "haiku")
+        sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "hello", mode: .aiChat)
+        XCTAssertTrue(sut.hasSubmittedPrompt)
+
+        sut.updateSelectedModel("mistral")
+
+        XCTAssertEqual(mockPreferences.selectedModelId, "haiku",
+                       "ongoing-chat picks must not retarget the cross-platform new-chat default")
+        XCTAssertEqual(sut.modelStore.currentModelId, "mistral",
+                       "ongoing-chat pick still updates the live current-tab model")
+    }
+
+    func test_updateSelectedModel_onExistingChatBoundTab_doesNotChangePreferredModel() {
+        sut.modelStore.models = [
+            makeModel(id: "haiku", access: true),
+            makeModel(id: "mistral", access: true)
+        ]
+        sut.updateSelectedModel("haiku")
+        let userScript = makeTestUserScript()
+        sut.bindToTab(userScript, hasExistingChat: true)
+        XCTAssertTrue(sut.hasSubmittedPrompt)
+
+        sut.updateSelectedModel("mistral")
+
+        XCTAssertEqual(mockPreferences.selectedModelId, "haiku")
+    }
+
+    func test_persistedModelId_fallsBackToPreferredModel_onFreshTabActivation() {
+        sut.modelStore.models = [
+            makeModel(id: "gpt-5", access: true),
+            makeModel(id: "haiku", access: true)
+        ]
+        sut.updateSelectedModel("haiku")
+        sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "hello", mode: .aiChat)
+
+        sut.modelStore.applyPersistedSelection(modelID: nil, reasoningMode: nil)
+
+        XCTAssertEqual(sut.persistedModelId, "haiku",
+                       "opening a new tab should return to the user's last new-chat pick")
+    }
+
     func test_handleModelSelection_whenModelHasAccess_persistsToPreferences() {
         sut.modelStore.models = [makeModel(id: "plus-model", access: true, accessTier: ["plus"])]
 
@@ -2358,11 +2416,11 @@ private final class FakeInputStateStore: UnifiedInputStateStoring {
         states[uid] = state
     }
 
-    func recordUserChoice(_ state: TabInputState, for uid: TabUID) {
+    func recordUserChoice(_ state: TabInputState, for uid: TabUID, isNewChatContext: Bool) {
         states[uid] = state
         lastUsedDefaults = LastUsedInputDefaults(
             toggleMode: state.toggleMode,
-            selectedModelID: state.selectedModelID,
+            selectedModelID: isNewChatContext ? state.selectedModelID : lastUsedDefaults.selectedModelID,
             selectedReasoningMode: state.selectedReasoningMode,
             selectedTool: state.selectedTool
         )


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1215031458892288?focus=true
Tech Design URL:
CC:

### Description
Splits `UTIModelStore`'s state in two: an in-memory live model for the current tab/chat, and the persisted `AIChatPreferencesPersisting.selectedModelId` which now represents the user's preferred new-chat model (same contract macOS already uses). `updateSelectedModel(_:isNewChatContext:)` and `UnifiedInputStateStore.recordUserChoice(_:for:isNewChatContext:)` only write the preferred-model preference when the pick happens before the first submit; tab activation, FE-driven restore, and ongoing-chat switches no longer retarget the default. Opening a new tab now lands on the user's last new-chat pick instead of the first accessible model.

### Testing Steps
1. Pick a non-default model (e.g. Haiku 4.5) on a fresh chat, submit a prompt, then open a new tab — the chip should show Haiku 4.5, not GPT-5 fast.
2. Open an existing chat with a different model (e.g. Mistral), then open a new tab — the new tab should still default to Haiku 4.5 (the last new-chat pick), not Mistral.
ps. there's currently a bug that starting a new chat by using the new chat button will not show the model picker, to test this PR open a new tab and open duck.ai

### Impact and Risks
Low

#### What could go wrong?
A user who never picked a model on a new chat in the previous build will see whatever value was in `selectedModelId` (likely their last live model) as the new-chat default until they pick again — degraded only on first launch after upgrade.

### Notes to Reviewer
Surfaced during testing: tapping the in-chat "New chat" button after a submission leaves the model chip hidden because `hasSubmittedPrompt` is never reset. This is pre-existing on `main` (introduced by PR #4930, which made `syncChipVisibility` upgrade-only) and is **not** caused by this PR — none of the files touched here own that path. Tracking it separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Preference and tab-seeding behavior only; no auth or network changes. First launch after upgrade may briefly use a legacy `selectedModelId` as the default until the user picks again.
> 
> **Overview**
> **iOS Duck.ai model selection** now separates the **current tab’s live model** from the **persisted new-chat default** (`selectedModelId`), matching macOS.
> 
> `UTIModelStore` keeps an in-memory `liveModelId` for the active tab; `updateSelectedModel(_:isNewChatContext:)` and tab restore only update **preferences** when the pick happens **before the first prompt submit**. Ongoing chats, FE restore, and tab switches update the live model without retargeting the global default. `persistedModelId` resolves live → preferred → first accessible model; **`displayShortName`** drives the chip label.
> 
> `UnifiedInputStateStore.recordUserChoice` takes **`isNewChatContext`** so `lastUsed` / new-tab seeding only changes when the user picks a model on a fresh chat—not after submit or when switching models mid-conversation.
> 
> **New tabs** should open on the user’s last **new-chat** model pick, not whatever model an existing chat last used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c57c27f2e0330dbdb51013f290cf47a907e23efd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->