### PR TITLE
Escape Hatch: Fixes Long Press Overlap

### DIFF
--- a/iOS/DuckDuckGo/ReturnToTabCard.swift
+++ b/iOS/DuckDuckGo/ReturnToTabCard.swift
@@ -36,12 +36,11 @@ struct ReturnToTabCard: View {
         GeometryReader { proxy in
             if model.isActionsEnabled {
                 bodyWithActions(width: proxy.size.width)
-                    .frame(height: Metrics.height)
             } else {
                 contentView
-                    .frame(height: Metrics.height)
             }
         }
+        .frame(height: Metrics.height)
     }
 
     @ViewBuilder

--- a/iOS/DuckDuckGo/ReturnToTabCard.swift
+++ b/iOS/DuckDuckGo/ReturnToTabCard.swift
@@ -70,13 +70,18 @@ struct ReturnToTabCard: View {
                 menuView
             }
         }
-        .padding(.horizontal, Metrics.horizontalPadding)
+        .padding(contentPaddingEdges, Metrics.horizontalPadding)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .frame(height: Metrics.height)
         .background(
             Capsule()
                 .fill(Color(designSystemColor: .controlsFillSecondary))
         )
+    }
+
+    private var contentPaddingEdges: Edge.Set {
+        /// Avoid trailing padding when the Menu is visible
+        model.isActionsEnabled ? .leading : .horizontal
     }
 
     private var mainView: some View {

--- a/iOS/DuckDuckGo/ReturnToTabCard.swift
+++ b/iOS/DuckDuckGo/ReturnToTabCard.swift
@@ -33,23 +33,35 @@ struct ReturnToTabCard: View {
     @State private var menuFrameInWindow: CGRect = .zero
 
     var body: some View {
-        Group {
+        GeometryReader { proxy in
             if model.isActionsEnabled {
-                SwipeActionView(onCommit: model.primarySwipeAction.perform) {
-                    contentView
-                } actions: {
-                    swipeableActionsView
-                }
-                .contextMenu {
-                    menuContentView
-                }
-                // We're Clipping with the shape `( ]` as the `swipeableActionsView` subview is not expected to be a perfect pill, on its right hand side during Swipe
-                .clipShape(LeftCapsuleShape())
+                bodyWithActions(width: proxy.size.width)
+                    .frame(height: Metrics.height)
             } else {
                 contentView
+                    .frame(height: Metrics.height)
             }
         }
-        .frame(height: Metrics.height)
+    }
+
+    @ViewBuilder
+    private func bodyWithActions(width: CGFloat) -> some View {
+        SwipeActionView(onCommit: model.primarySwipeAction.perform) {
+            contentView
+        } actions: {
+            swipeableActionsView
+        }
+
+        // `.contentMenu` causes the Preview View to overlap with surrounding elements.
+        // We're relying on the `.contextMenu(preview:)` API, as it allows us to fine tune the Preview dimensions.
+        .contextMenuWithPreviewIfAvailable {
+            menuContentView
+        } preview: {
+            contentView
+                .frame(width: width, height: Metrics.height)
+        }
+        // We're Clipping with the shape `( ]` as the `swipeableActionsView` subview is not expected to be a perfect pill, on its right hand side during Swipe
+        .clipShape(LeftCapsuleShape())
     }
 
     private var contentView: some View {

--- a/iOS/DuckDuckGo/ViewExtension.swift
+++ b/iOS/DuckDuckGo/ViewExtension.swift
@@ -95,3 +95,15 @@ extension View {
         }
     }
 }
+
+extension View {
+
+    @ViewBuilder
+    func contextMenuWithPreviewIfAvailable<M: View, P: View>(@ViewBuilder menuItems: () -> M, @ViewBuilder preview: () -> P) -> some View {
+        if #available(iOS 16, *) {
+            contextMenu(menuItems: menuItems, preview: preview)
+        } else {
+            contextMenu(menuItems: menuItems)
+        }
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671677432066/task/1215139332383833?focus=true
Tech Design URL:
CC:

### Description
This PR fixes an Overlap visual glitch, triggered when long-pressing the Escape Hatch.
**Plus** we're addressing Design Feedback: removing an extra right padding in the Escape Hatch.

### Testing Steps
1. Enable the `escapeHatchActions` Feature Flag
2. Open `Settings > Debug > Idle Return NTP` and set the override to 1s
3. Open any website
4. Background + Foreground

- [ ] Verify that if you long press on the Escape Hatch, we no longer overflow over the Tab Switcher component

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing in particular

### Quality Considerations
This fix will only work on iOS +16

### Notes to Reviewer
Thank you!!

### Screenshots

Before: Light | Now: Light
-|-
<img width="300" src="https://github.com/user-attachments/assets/e0185912-7884-4f38-a9de-4244fe39dac2" />| <img width="300" src="https://github.com/user-attachments/assets/047ea40a-e798-4716-ad9a-c6addef0ff69" />

Before: Dark | Now: Dark
-|-
<img width="300" src="https://github.com/user-attachments/assets/af3a088b-9b9c-491a-bc1b-1fb9c194e737" /> | <img width="300" src="https://github.com/user-attachments/assets/ece34054-6bee-4618-8f18-08c21ba4b260" />


Before: More Button | Now: More Button
-|-
<img width="300" src="https://github.com/user-attachments/assets/ec24e3b9-6ab4-41bb-9fd3-57a5323fdbe2" /> | <img width="300" src="https://github.com/user-attachments/assets/aa299a5e-3af0-437d-9f03-6d5fd7120900" />

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to ReturnToTabCard and a small View extension; preview sizing requires iOS 16+ but older OS versions keep the prior menu behavior without a custom preview.
> 
> **Overview**
> Fixes the Escape Hatch **Return to Tab** card long-press preview overlapping nearby UI (e.g. tab switcher) by driving the context menu through a new `contextMenuWithPreviewIfAvailable` helper that uses iOS 16’s `contextMenu(preview:)` with an explicitly sized preview (`contentView` at the card’s measured width and `Metrics.height`). The actions-enabled layout is refactored behind `GeometryReader` and `bodyWithActions(width:)` so that width is available for the preview.
> 
> Also applies design feedback: when the more menu is shown, horizontal padding is **leading-only** via `contentPaddingEdges`, removing extra trailing inset next to the menu button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e83850bf6a9e9ff16fc71da57055635298c5c50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->