### PR TITLE
iOS: SR - OM4 - Blank NTP After Prompt Submission

### DIFF
--- a/iOS/DuckDuckGo/AIChat/AIChatViewControllerManager.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatViewControllerManager.swift
@@ -530,7 +530,6 @@ private extension AIChatViewControllerManager {
                                             images: [AIChatNativePrompt.NativePromptImage]?,
                                             files: [AIChatNativePrompt.NativePromptFile]?) {
         guard images?.isEmpty == false || files?.isEmpty == false else { return }
-        guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
 
         let prompt = AIChatNativePrompt.queryPrompt(
             query,

--- a/iOS/DuckDuckGo/TabViewControllerAIChatExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerAIChatExtension.swift
@@ -59,7 +59,8 @@ extension TabViewController: AITabController {
         isVoiceModeRequested = false
 
         aiChatContentHandler.setPayload(payload: payload)
-        if let query, !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        let hasAttachments = images?.isEmpty == false || files?.isEmpty == false
+        if let query, !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || hasAttachments {
             let prompt = AIChatNativePrompt.queryPrompt(
                 query,
                 autoSubmit: autoSend,


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210947754188321/task/1215056187001450?focus=true
Tech Design URL:
CC:

### Description
Fixes Duck\.ai image-only prompt submission from unified input.

When a user submitted images without text, we loaded Duck\.ai but did not store a native prompt because the prompt text was empty. Duck\.ai then consumed `nil` native prompt data, dropping the images and leaving the user on a blank/new chat state.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Enable `unifiedToggleInput`.
2. Open Duck\.ai mode from the top omnibar.
3. Select a model with image upload support.
4. Attach one or more images.
5. Submit **without** entering text.
6. Confirm Duck\.ai receives the image-only prompt instead of showing a blank NTP/chat state.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low/Medium: scoped to Duck\.ai native prompt handoff for attachment submissions.

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
Attachment-only prompts now create native prompt data. Regressions would most likely affect Duck\.ai prompt handoff when images/files are present.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->
Manually verified image-only submissions after the fix. Text-only and text-with-attachments flows should continue through the existing prompt path.


### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to prompt gating for empty text with attachments; no auth, data migration, or broad navigation refactors.
> 
> **Overview**
> Fixes Duck.ai / full-mode tab loads when the user submits a prompt with **images or files but no text**, which could leave the new tab page blank because the native prompt was never handed to the web layer.
> 
> **`TabViewController.load`** now treats non-empty attachments like a valid prompt: it still writes to `AIChatPromptHandler` when the query is only whitespace but images or files are present. **`AIChatViewControllerManager.storePromptWithAttachmentsIfNeeded`** drops the requirement that the query string be non-empty, so attachment-only prompts are stored the same way as text+attachment prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c132d3a3003418eab35b0a768ab2f825bdf83da8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->