### PR TITLE
iOS 7.222.0 maestro: revert Duck Player nesting via Ad Blocking from #5049

### DIFF
--- a/.maestro/duckplayer_classic/shared/close_settings.yaml
+++ b/.maestro/duckplayer_classic/shared/close_settings.yaml
@@ -1,10 +1,7 @@
 appId: com.duckduckgo.mobile.ios
 ---
 # Close Settings - need to go back twice on iPad
-# Duck Player is now nested under Ad Blocking — step back one level first.
-- tapOn:
-    text: "Ad Blocking"
-- tapOn:
+- tapOn: 
     text: "Settings"
-- tapOn:
+- tapOn: 
     text: "Done"

--- a/.maestro/duckplayer_classic/shared/open_settings.yaml
+++ b/.maestro/duckplayer_classic/shared/open_settings.yaml
@@ -7,29 +7,17 @@ appId: com.duckduckgo.mobile.ios
 - waitForAnimationToEnd:
     timeout: 1000
     
-- tapOn: Settings
-
-- waitForAnimationToEnd
-
-# Duck Player now lives inside the Ad Blocking screen (under Privacy Protections).
-- scrollUntilVisible:
-    element:
-      text: "Ad Blocking"
-    direction: DOWN
-    centerElement: true
-
-- tapOn:
-    text: "Ad Blocking"
+- tapOn: Settings    
 
 - waitForAnimationToEnd
 
 - scrollUntilVisible:
-    element:
+    element: 
       text: "Duck Player"
     direction: DOWN
     centerElement: true
-
-- tapOn:
+    
+- tapOn: 
     text: "Duck Player"
-
+    
 - waitForAnimationToEnd

--- a/.maestro/duckplayer_native/shared/close_settings.yaml
+++ b/.maestro/duckplayer_native/shared/close_settings.yaml
@@ -5,11 +5,6 @@ appId: com.duckduckgo.mobile.ios
 - runFlow:
     file: constants.yaml
 
-# Duck Player is now nested under Ad Blocking — step back one level first.
-- tapOn: ${output.adBlockingLabel}
-
-- waitForAnimationToEnd
-
 - tapOn: ${output.settingsLabel}
 
 - waitForAnimationToEnd

--- a/.maestro/duckplayer_native/shared/constants.yaml
+++ b/.maestro/duckplayer_native/shared/constants.yaml
@@ -11,7 +11,6 @@ appId: com.duckduckgo.mobile.ios
 - evalScript: "${output.chevronUpId = 'chevron.up'}"
 - evalScript: "${output.duckPlayerSettingsId = 'DuckPlayerOpenSettings'}"
 - evalScript: "${output.duckPlayerLabel = 'Duck Player'}"
-- evalScript: "${output.adBlockingLabel = 'Ad Blocking'}"
 - evalScript: "${output.settingsLabel = 'Settings'}"
 - evalScript: "${output.doneLabel = 'Done'}"
 - evalScript: "${output.browsingMenuLabel = 'Browsing Menu'}"

--- a/.maestro/duckplayer_native/shared/open_settings.yaml
+++ b/.maestro/duckplayer_native/shared/open_settings.yaml
@@ -11,21 +11,11 @@ appId: com.duckduckgo.mobile.ios
 
 - tapOn: ${output.settingsLabel}
 
-# Duck Player now lives inside the Ad Blocking screen (under Privacy Protections).
-- scrollUntilVisible:
-    centerElement: true
-    element: ${output.adBlockingLabel}
-    direction: DOWN
-
-- tapOn: ${output.adBlockingLabel}
-
-- waitForAnimationToEnd
-
 - scrollUntilVisible:
     centerElement: true
     element: ${output.duckPlayerLabel}
     direction: DOWN
-
+    
 - tapOn: ${output.duckPlayerLabel}
 
 - waitForAnimationToEnd


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1215158749092594?focus=true
Tech Design URL: N/A
CC:

### Description

Reverts the Duck Player maestro flow changes brought into `release/ios/7.222.0` via PR #5049. Those changes added `scrollUntilVisible/tapOn "Ad Blocking"` to navigate into the new nested Duck Player location, but the **Ad Blocking** row in iOS Privacy Protections only renders when `featureFlagger.isFeatureOn(.webExtensions)` is true (see `AdBlockingAvailability.isFeatureSupported`), and the maestro launch (`.maestro/shared/setup.yaml`) doesn't enable that flag.

Net effect: Duck Player maestro tests on the 7.222.0 release branch fail with `No visible element found: "Ad Blocking"`. This was the same failure mode that triggered the earlier revert (#4814 of #4765).

This revert restores the pre-#5049 navigation (scroll to `Duck Player` → tap), unblocking the 7.222.0 train. Companion PR against `main` is opened separately to keep the two branches in sync.

### Testing Steps

1. Run Duck Player maestro suite (`duckplayer_classic` and `duckplayer_native`) on the release/ios/7.222.0 build — flows that previously failed at `open_settings.yaml`/`close_settings.yaml` should now navigate Settings → Duck Player correctly.

### Impact and Risks

Low. Test-infra only. Restores a working flow; no production code touched. Unblocks the 7.222.0 release train.

#### What could go wrong?

If the `webExtensions` flag gets enabled by default in the maestro env, Duck Player will be nested under Ad Blocking and this flow will fail again — at that point #5049's maestro changes should be brought back instead of this revert.

### Notes to Reviewer

Same 5 files as in PR #5049's maestro hunks; the diff is the inverse of that section. Companion PR against `main` keeps the two branches consistent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Maestro YAML only; no app code changes. Tests may break again if maestro enables webExtensions and Duck Player moves back under Ad Blocking.
> 
> **Overview**
> Reverts Maestro Duck Player settings navigation to the **pre–#5049** path so release **7.222.0** UI tests pass again.
> 
> **Open/close settings** flows in `duckplayer_classic` and `duckplayer_native` no longer scroll to or tap **Ad Blocking**; they go **Settings → scroll to Duck Player → tap**, and closing no longer backs out through Ad Blocking first. The native **`adBlockingLabel`** constant is removed.
> 
> This undoes test flows that assumed Duck Player lived under Ad Blocking when `webExtensions` is on—Maestro setup does not enable that flag, so those steps failed with no visible **Ad Blocking** row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 646659d1b16c9b29c281e504e4256c005a398b5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->