### PR TITLE
iOS: Native Duck.ai chat history sheet — flag + placeholder + entry-point

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -798,6 +798,7 @@ public enum DuckAiChatHistorySubfeature: String, PrivacySubfeature {
     public var parent: PrivacyFeature { .duckAiChatHistory }
 
     case featureEnabled
+    case nativeChatHistory
 }
 
 public enum PromoQueueSubfeature: String, PrivacySubfeature {

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -305,6 +305,9 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212745919983886?focus=true
     case aiChatSuggestions
 
+    /// https://app.asana.com/1/137249556945/project/1204186595873227/task/1213651297612976?focus=true
+    case aiChatNativeChatHistory
+
     /// https://app.asana.com/1/137249556945/project/1208671677432066/task/1213651262338059
     case aiChatContextualSheetImprovements
 
@@ -655,6 +658,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(SyncSubfeature.aiChatSyncPromo))
         case .aiChatSuggestions:
             Config(defaultValue: .enabled, source: .remoteReleasable(DuckAiChatHistorySubfeature.featureEnabled))
+        case .aiChatNativeChatHistory:
+            Config(defaultValue: .disabled, source: .remoteReleasable(DuckAiChatHistorySubfeature.nativeChatHistory))
         case .aiChatContextualSheetImprovements:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.contextualSheetImprovements))
         case .showWhatsNewPromptOnDemand:

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -2222,6 +2222,7 @@
 		CCC9F3BA2EA66E0F00D442CA /* VPNSubscriptionPromotionHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC9F3B92EA66E0F00D442CA /* VPNSubscriptionPromotionHelperTests.swift */; };
 		CCCFFCD52FA3B82A0093CF07 /* OnboardingSharedPixelsStoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCFFCD42FA3B81F0093CF07 /* OnboardingSharedPixelsStoring.swift */; };
 		CF65ADDC7C8E902826B7931B /* AIChatTabChatHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA8E5DCD620608EB3A162D3D /* AIChatTabChatHeaderView.swift */; };
+		5AB12C3D4E5F60718293A4B5 /* AIChatHistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB12C3D4E5F60718293A4B6 /* AIChatHistoryViewController.swift */; };
 		D1A0B0112F92000100A1B001 /* DataImportEntryPointHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A0B0012F92000100A1B001 /* DataImportEntryPointHandlerTests.swift */; };
 		D1A0B0122F92000100A1B001 /* DataImportUserActivityHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A0B0022F92000100A1B001 /* DataImportUserActivityHandlerTests.swift */; };
 		D1A0B0132F92000100A1B001 /* ImportPasswordSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A0B0032F92000100A1B001 /* ImportPasswordSourceTests.swift */; };
@@ -5001,6 +5002,7 @@
 		E7971E90992B46FABF42A908 /* AIChatContextualWebViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualWebViewControllerTests.swift; sourceTree = "<group>"; };
 		EA39B7E1268A1A35000C62CD /* privacy-reference-tests */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = folder; name = "privacy-reference-tests"; path = "../SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Resources/privacy-reference-tests"; sourceTree = SOURCE_ROOT; };
 		EA8E5DCD620608EB3A162D3D /* AIChatTabChatHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTabChatHeaderView.swift; sourceTree = "<group>"; };
+		5AB12C3D4E5F60718293A4B6 /* AIChatHistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatHistoryViewController.swift; sourceTree = "<group>"; };
 		EAB19ED9268963510015D3EA /* DomainMatchingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainMatchingTests.swift; sourceTree = "<group>"; };
 		ED225CDF2F9FCBA500B6E6CB /* MockSyncSetupExperimentPixelFiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSyncSetupExperimentPixelFiring.swift; sourceTree = "<group>"; };
 		ED3811FA2F3F362700F0D0DD /* MockAutofillOnboardingExperimentPixelFiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAutofillOnboardingExperimentPixelFiring.swift; sourceTree = "<group>"; };
@@ -5860,6 +5862,7 @@
 				31F43E1E2F472F3C001BBCDA /* AIChatAddressBarExperience.swift */,
 				31A2B6DF2E1C3BDF00391020 /* SubscriptionAIChatStateHandler.swift */,
 				EA8E5DCD620608EB3A162D3D /* AIChatTabChatHeaderView.swift */,
+				5AB12C3D4E5F60718293A4B6 /* AIChatHistoryViewController.swift */,
 				31C314A12D2EF60A009A412A /* AIChatViewControllerManager.swift */,
 				C150EB1F2F0D814C00A98C97 /* AIChatFeatureFlagProvider.swift */,
 				316AA4592CF8E31F00A2ED28 /* AIChatSettings.swift */,
@@ -13173,6 +13176,7 @@
 				CBF259C72D4ED93F00AC63E4 /* OnboardingConfiguration.swift in Sources */,
 				31A2B6E02E1C3BE000391020 /* SubscriptionAIChatStateHandler.swift in Sources */,
 				CF65ADDC7C8E902826B7931B /* AIChatTabChatHeaderView.swift in Sources */,
+				5AB12C3D4E5F60718293A4B5 /* AIChatHistoryViewController.swift in Sources */,
 				9F0B19B72EA5E74F001FA867 /* ModalPromptCoordinationManager.swift in Sources */,
 				CBD4F13C279EBF4A00B20FD7 /* HomeMessage.swift in Sources */,
 				6FB2A67E2C2DAFB4004D20C8 /* NewTabPageGridView.swift in Sources */,

--- a/iOS/DuckDuckGo/AIChat/AIChatHistoryViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatHistoryViewController.swift
@@ -1,0 +1,47 @@
+//
+//  AIChatHistoryViewController.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+
+/// Placeholder container for the native Duck.ai chat-history sheet.
+final class AIChatHistoryViewController: UIViewController {
+
+    static func makePresentableSheet() -> UIViewController {
+        let content = AIChatHistoryViewController()
+        let navigationController = UINavigationController(rootViewController: content)
+        navigationController.modalPresentationStyle = .automatic
+        return navigationController
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        title = UserText.aiChatRecentChatsTitle
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            title: UserText.navigationTitleDone,
+            style: .plain,
+            target: self,
+            action: #selector(doneButtonTapped)
+        )
+    }
+
+    @objc private func doneButtonTapped() {
+        dismiss(animated: true)
+    }
+}

--- a/iOS/DuckDuckGo/BrowsingMenu/SheetPresentationMenu/BrowsingMenuBuilder.swift
+++ b/iOS/DuckDuckGo/BrowsingMenu/SheetPresentationMenu/BrowsingMenuBuilder.swift
@@ -82,6 +82,7 @@ final class BrowsingMenuBuilder: BrowsingMenuBuilding {
 
         // MARK: Shortcuts group
         let shortcutsItems: [BrowsingMenuModel.Entry] = [
+            .init(entryBuilder.makeDuckAiChatsEntry()),
             .init(entryBuilder.makeOpenBookmarksEntry()),
             .init(entryBuilder.makeAutoFillEntry()),
             .init(entryBuilder.makeDownloadsEntry())
@@ -176,6 +177,7 @@ final class BrowsingMenuBuilder: BrowsingMenuBuilding {
 
         // MARK: Shortcuts group
         let shortcutItems: [BrowsingMenuModel.Entry] = [
+            .init(entryBuilder.makeDuckAiChatsEntry()),
             .init(entryBuilder.makeOpenBookmarksEntry()),
             .init(entryBuilder.makeAutoFillEntry()),
             .init(entryBuilder.makeDownloadsEntry())

--- a/iOS/DuckDuckGo/BrowsingMenu/SheetPresentationMenu/BrowsingMenuBuilding.swift
+++ b/iOS/DuckDuckGo/BrowsingMenu/SheetPresentationMenu/BrowsingMenuBuilding.swift
@@ -40,6 +40,7 @@ protocol BrowsingMenuEntryBuilding: AnyObject {
 
     func makeNewTabEntry() -> BrowsingMenuEntry
     func makeChatEntry() -> BrowsingMenuEntry?
+    func makeDuckAiChatsEntry() -> BrowsingMenuEntry?
     func makeSettingsEntry() -> BrowsingMenuEntry
     func makeShareEntry() -> BrowsingMenuEntry
     func makePrintEntry() -> BrowsingMenuEntry

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -5140,6 +5140,14 @@ extension MainViewController: TabDelegate {
         openAIChat()
     }
 
+    func tabDidRequestAIChatHistory(tab: TabViewController) {
+        openAIChatHistory()
+    }
+
+    func openAIChatHistory() {
+        present(AIChatHistoryViewController.makePresentableSheet(), animated: true)
+    }
+
     func tabDidRequestBookmarks(tab: TabViewController) {
         Pixel.fire(pixel: .bookmarksButtonPressed,
                    withAdditionalParameters: [PixelParameters.originatedFromMenu: "1"])

--- a/iOS/DuckDuckGo/TabDelegate.swift
+++ b/iOS/DuckDuckGo/TabDelegate.swift
@@ -92,6 +92,8 @@ protocol TabDelegate: AnyObject {
 
     func tabDidRequestAIChat(tab: TabViewController)
 
+    func tabDidRequestAIChatHistory(tab: TabViewController)
+
     func tab(_ tab: TabViewController,
              didRequestAutofillLogins account: SecureVaultModels.WebsiteAccount?,
              source: AutofillSettingsSource,

--- a/iOS/DuckDuckGo/TabViewControllerMenuBuilderExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerMenuBuilderExtension.swift
@@ -269,6 +269,10 @@ extension TabViewController {
             entries.append(.separator)
         }
 
+        if featureFlagger.isFeatureOn(.aiChatNativeChatHistory) {
+            entries.append(buildDuckAiChatsEntry())
+        }
+
         entries.append(buildOpenBookmarksEntry())
 
         if featureFlagger.isFeatureOn(.autofillAccessCredentialManagement) {
@@ -508,6 +512,15 @@ extension TabViewController {
             self?.openNewChatInNewTab()
         })
     }
+
+    private func buildDuckAiChatsEntry(withSmallIcon smallIcon: Bool = true) -> BrowsingMenuEntry {
+        .regular(name: UserText.actionAIChatHistory,
+                 accessibilityLabel: UserText.actionAIChatHistory,
+                 image: smallIcon ? DesignSystemImages.Glyphs.Size16.aiChatHistory : DesignSystemImages.Glyphs.Size24.aiChatHistory,
+                 action: { [weak self] in
+            self?.openAIChatHistory()
+        })
+    }
     
     private func buildAIChatSidebarEntry(useSmallIcon: Bool = true) -> BrowsingMenuEntry {
         .regular(name: UserText.actionAIChatHistory,
@@ -727,6 +740,10 @@ extension TabViewController {
         delegate?.tabDidRequestAIChat(tab: self)
     }
 
+    private func openAIChatHistory() {
+        delegate?.tabDidRequestAIChatHistory(tab: self)
+    }
+
     private func buildToggleProtectionEntry(forDomain domain: String, useSmallIcon: Bool = true) -> BrowsingMenuEntry {
         let config = ContentBlocking.shared.privacyConfigurationManager.privacyConfig
         let isProtected = !config.isUserUnprotected(domain: domain)
@@ -888,12 +905,17 @@ extension TabViewController: BrowsingMenuEntryBuilding {
     func makeChatEntry() -> BrowsingMenuEntry? {
         let settings = AIChatSettings(privacyConfigurationManager: ContentBlocking.shared.privacyConfigurationManager)
         guard settings.isAIChatBrowsingMenuUserSettingsEnabled else { return nil }
-        
+
         if aiChatFullModeFeature.isAvailable {
             return buildNewAIChatEntry(withSmallIcon: false)
         } else {
             return buildChatEntry(withSmallIcon: false)
         }
+    }
+
+    func makeDuckAiChatsEntry() -> BrowsingMenuEntry? {
+        guard featureFlagger.isFeatureOn(.aiChatNativeChatHistory) else { return nil }
+        return buildDuckAiChatsEntry(withSmallIcon: false)
     }
     
     func makeSettingsEntry() -> BrowsingMenuEntry {

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
@@ -87,6 +87,8 @@ final class MockTabDelegate: TabDelegate {
 
     func tabDidRequestAIChat(tab: TabViewController) {}
 
+    func tabDidRequestAIChatHistory(tab: TabViewController) {}
+
     func tabDidRequestNewPrivateEmailAddress(tab: TabViewController) {}
 
     func tabDidRequestSettings(tab: DuckDuckGo.TabViewController) {}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1215102192207840
Tech Design URL:
CC:

### Description

adds FF for native chat history and sheet presentation and menu entry points

**What lands here:**

- New `DuckAiChatHistorySubfeature.nativeChatHistory` privacy-config subfeature.
- New `FeatureFlag.aiChatNativeChatHistory`, default `.disabled`, with local-override support so engineers can flip it in Debug → Feature Flags.
- New `AIChatHistoryViewController` — placeholder sheet shell wrapped in a `UINavigationController`. Title is "Recent Chats", Done button matches `BookmarksViewController` (plain bar button, not `.done` system item). Sheet presentation mirrors Bookmarks (`modalPresentationStyle = .automatic`, default detents, no grabber). Body is intentionally empty — the real Recent Chats list UI lands in [task 1215102326454828](https://app.asana.com/1/137249556945/task/1215102326454828).
- New `tabDidRequestAIChatHistory` on `TabDelegate`, implemented by `MainViewController.openAIChatHistory()` and stubbed on `MockTabDelegate`.
- New "Duck.ai Chats" browser-menu row, gated on the flag, inserted at the top of the shortcuts section in both the new-tab and website variants of `BrowsingMenuBuilder`. A `makeDuckAiChatsEntry()` method on the `BrowsingMenuEntryBuilding` protocol carries the flag-gating (`nil` when the flag is off; `compactMap` in the builder drops it from the section). Legacy `buildShortcutsEntries` path is also gated for safety.
- Reuses the existing `UserText.actionAIChatHistory` ("Duck.ai Chats") string, `UserText.aiChatRecentChatsTitle` ("Recent Chats"), and the `aiChatHistory` glyph from the design system.

**Out of scope (covered by later subtasks):**

- Real chat history list UI — [task 1215102326454828](https://app.asana.com/1/137249556945/task/1215102326454828) (3d)
- Omnibar autocomplete "View all Chats" footer — [task 1215103929876537](https://app.asana.com/1/137249556945/task/1215103929876537)
- Deep-link scheme — deferred until a concrete consumer (widget / shortcut) exists

### Testing Steps

1. Build & run the app.
2. **Baseline:** Open the browser menu (≡). Confirm there is **no** "Duck.ai Chats" row.
3. Settings → scroll to bottom → **Debug → Feature Flags Overrides** → find `aiChatNativeChatHistory` → toggle override **ON**.
4. Re-open the browser menu from the new-tab page. Confirm **"Duck.ai Chats"** appears as the **first row of the shortcuts section** (above Bookmarks), with the chat-history glyph icon.
5. Load any URL (e.g. `duckduckgo.com`) and open the browser menu again. Confirm the entry appears here too.
6. Tap **Duck.ai Chats**. Sheet should look indistinguishable from the Bookmarks sheet: same nav bar style, "Recent Chats" title, plain "Done" button on the right, body intentionally empty.
7. Tap **Done** → sheet dismisses. Drag the sheet down → also dismisses.
8. Toggle the flag override **OFF** → "Duck.ai Chats" row disappears; the existing top-action "Duck.ai" button still opens the legacy web sheet (no regression).

### Impact and Risks

**Low.** All behavior is gated behind a remote feature flag that defaults to `.disabled` (off for everyone including internal users). With the flag off, the diff is a no-op at runtime — no new menu rows, no new code paths reachable.

#### What could go wrong?

- **Build / target membership** — the new `AIChatHistoryViewController.swift` is registered in the iOS Browser target via hand-rolled pbxproj UUIDs (`5AB12C3D4E5F60718293A4B5/6`). Functional but stylistically distinct from Xcode-generated ones; flag if you'd prefer Xcode regenerate them.
- **Menu-builder coverage** — the new sheet-style menu (`BrowsingMenuBuilder`) is what users see; the legacy `buildShortcutsEntries` path is also gated, so the entry shows up consistently regardless of which builder is active.

### Quality Considerations

- **Pixel definitions:** intentionally **not** added in this PR. Android shipped pixel definitions in a separate task, and iOS has a dedicated [Pixel definitions task (1215106021853890)](https://app.asana.com/1/137249556945/task/1215106021853890) for Week 3. Easy to slot in later.
- **Localization:** reused `UserText.actionAIChatHistory` ("Duck.ai Chats") and `UserText.aiChatRecentChatsTitle` ("Recent Chats") — both already exist, no new strings.
- **Icons:** reused `DesignSystemImages.Glyphs.Size16.aiChatHistory` / `Size24.aiChatHistory`.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is behind a remote flag defaulting to disabled; with the flag off, no new menu rows or presentation paths run. The sheet is a UI shell with no data or auth changes.
> 
> **Overview**
> Introduces a **remote-gated** path to open a native **Recent Chats** sheet for Duck.ai, wired from the browser menu while the real list UI is still a follow-up.
> 
> Adds `DuckAiChatHistorySubfeature.nativeChatHistory` and iOS `FeatureFlag.aiChatNativeChatHistory` (default **off**, local debug override). When enabled, a new **Duck.ai Chats** shortcut appears at the top of the browsing menu shortcuts section (new tab and website menus, including the legacy shortcuts builder). Tapping it presents `AIChatHistoryViewController` inside a navigation controller with automatic sheet presentation, **Recent Chats** title, and a **Done** dismiss control—the body is intentionally empty.
> 
> Presentation is routed through new `tabDidRequestAIChatHistory` / `openAIChatHistory()` on the tab delegate and `MainViewController`; mocks are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1871afc6fbc27316feea33cd5aa182c6219eab9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->