### PR TITLE
[iOS] update Crash UI to use correct close button

### DIFF
--- a/iOS/DuckDuckGo/CrashCollectionOnboardingView.swift
+++ b/iOS/DuckDuckGo/CrashCollectionOnboardingView.swift
@@ -27,18 +27,32 @@ struct CrashCollectionOnboardingView: View {
     @ObservedObject var model: CrashCollectionOnboardingViewModel
 
     var body: some View {
-        if #available(iOS 16.0, *) {
-            // Using NavigationStack here in order to fix presentation on the iPad, where `Navigation` would use Split Navigation view.
-            NavigationStack {
+        ZStack(alignment: .topTrailing) {
+            if #available(iOS 16.0, *) {
+                // This is only required because on iPad you get semi-transparent bars either side.
+                // Previously it was closed to place the close button but we're placing that explicitly now like
+                //  in other sheets.
+                NavigationStack {
+                    contents
+                }
+            } else {
                 contents
             }
-            .background(Color(designSystemColor: .backgroundSheets))
-        } else {
-            NavigationView {
-                contents
-            }
-            .background(Color(designSystemColor: .backgroundSheets))
+            closeButton
+                .padding(16)
         }
+        .padding(0)
+        .ignoresSafeArea()
+        .background(Color(designSystemColor: .backgroundTertiary))
+    }
+
+    private var closeButton: some View {
+        Button {
+            model.onDismiss(.undetermined)
+        } label: {
+            Image(uiImage: DesignSystemImages.Glyphs.Size24.close)
+        }
+        .buttonStyle(CloseButtonStyle())
     }
 
     var contents: some View {
@@ -108,18 +122,6 @@ struct CrashCollectionOnboardingView: View {
                 .frame(maxWidth: 360)
             }
             .padding(.init(top: 24, leading: 24, bottom: 0, trailing: 24))
-        }
-        .toolbar {
-            ToolbarItemGroup(placement: .topBarLeading) {
-                Button {
-                    withAnimation {
-                        model.onDismiss(.undetermined)
-                    }
-                } label: {
-                    Text(UserText.keyCommandClose)
-                }
-                .buttonStyle(.plain)
-            }
         }
     }
 

--- a/iOS/DuckDuckGo/CrashCollectionOnboardingView.swift
+++ b/iOS/DuckDuckGo/CrashCollectionOnboardingView.swift
@@ -42,7 +42,6 @@ struct CrashCollectionOnboardingView: View {
                 .padding(16)
         }
         .padding(0)
-        .ignoresSafeArea()
         .background(Color(designSystemColor: .backgroundTertiary))
     }
 

--- a/iOS/DuckDuckGo/CrashCollectionOnboardingView.swift
+++ b/iOS/DuckDuckGo/CrashCollectionOnboardingView.swift
@@ -53,6 +53,7 @@ struct CrashCollectionOnboardingView: View {
             Image(uiImage: DesignSystemImages.Glyphs.Size24.close)
         }
         .buttonStyle(CloseButtonStyle())
+        .accessibilityLabel(UserText.keyCommandClose)
     }
 
     var contents: some View {

--- a/iOS/DuckDuckGo/CrashDebugScreen.swift
+++ b/iOS/DuckDuckGo/CrashDebugScreen.swift
@@ -22,6 +22,8 @@ import Crashes
 
 struct CrashDebugScreen: View {
 
+    @State private var forcedOnboarding: CrashCollectionOnboarding?
+
     var body: some View {
         List {
             Section {
@@ -61,7 +63,35 @@ struct CrashDebugScreen: View {
                 ActionMessageView.present(message: "Crash Send logs reset")
             }, isButton: true)
 
+            SettingsCellView(label: "Force Crash Onboarding", action: {
+                forceCrashOnboarding()
+            }, isButton: true)
+
         }.navigationTitle("Crashes")
+    }
+
+    private func forceCrashOnboarding() {
+        let settings = AppUserDefaults()
+        settings.crashCollectionOptInStatus = .undetermined
+
+        let onboarding = CrashCollectionOnboarding(appSettings: settings)
+        forcedOnboarding = onboarding
+
+        let stub = """
+        {"crashDiagnostics":[{"diagnosticMetaData":{"appVersion":"DEBUG","exceptionType":1,"exceptionCode":1,"signal":11,"objectiveCexceptionReason":{"composedMessage":"Simulator forced onboarding","stackTrace":["0 test"]}},"callStackTree":{"callStacks":[],"callStackPerThread":true}}],"timeStampBegin":"2026-01-01 12:00:00","timeStampEnd":"2026-01-01 12:00:00"}
+        """
+
+        guard let payload = stub.data(using: .utf8),
+              let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let root = scene.windows.first(where: { $0.isKeyWindow })?.rootViewController ?? scene.windows.first?.rootViewController else {
+            forcedOnboarding = nil
+            return
+        }
+
+        let presenter = root.presentedViewController ?? root
+        onboarding.presentOnboardingIfNeeded(for: [payload], from: presenter, sendReport: {
+            print("[CrashDebug] sendReport invoked")
+        })
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1215138599231974?focus=true
Tech Design URL:
CC:

### Description
See title

### Testing Steps
1. Trigger the crash view on iPhone and iPad (I did this by hacking CrashCollectionService)
2. Check UI looks correct and works

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Break crash collection opt-in

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to crash onboarding dismissal and styling; debug-only helper does not affect production crash reporting paths unless used manually.
> 
> **Overview**
> The crash collection opt-in sheet now uses the same **top-trailing close control** as other sheets: a design-system close glyph with `CloseButtonStyle` and an accessibility label, instead of a leading toolbar text button. Layout is a `ZStack` so the button sits above content; **sheet background** moves from `backgroundSheets` to `backgroundTertiary`. On iOS 16+, `NavigationStack` remains mainly for iPad side-bar presentation; pre-iOS 16 no longer wraps content in `NavigationView`.
> 
> **Crash debug** adds a **Force Crash Onboarding** action that resets opt-in status, presents onboarding with stub crash JSON, and keeps the onboarding object in `@State` for the presentation lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9c35cedb51710bd1463b13400a658a7dba94ba0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->