### PR TITLE
[Freemium PIR] Stop maintenance scans for Freemium users

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/BrokerProfileJob.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/BrokerProfileJob.swift
@@ -170,24 +170,7 @@ public class BrokerProfileJob: Operation, @unchecked Sendable {
             .filter { $0.dataBroker.id == dataBrokerID }
             .excludingIneligibleBrokers(isAuthenticatedUser: isAuthenticatedUser)
 
-        var didFireFreemiumMaintenanceScanSkippedPixel = false
-        let filteredAndSortedJobData = Self.sortedEligibleJobs(brokerProfileQueriesData: brokerProfileQueriesData,
-                                                               jobType: jobType,
-                                                               priorityDate: priorityDate,
-                                                               sortPredicate: jobDependencies.jobSortPredicate)
-            .filter { jobData in
-                guard isFreeScan, let scanJobData = jobData as? ScanJobData else {
-                    return true
-                }
-
-                let scanType = scanJobData.scanType()
-                didFireFreemiumMaintenanceScanSkippedPixel = fireFreemiumMaintenanceScanSkippedPixelIfNeeded(
-                    for: scanType,
-                    didFirePixel: didFireFreemiumMaintenanceScanSkippedPixel
-                )
-
-                return scanType != .maintenance
-            }
+        let filteredAndSortedJobData = makeFilteredAndSortedJobData(for: brokerProfileQueriesData, isFreeScan: isFreeScan)
 
         Logger.dataBrokerProtection.log("filteredAndSortedOperationsData count: \(filteredAndSortedJobData.count, privacy: .public) for brokerID \(self.dataBrokerID, privacy: .public)")
 
@@ -278,6 +261,27 @@ public class BrokerProfileJob: Operation, @unchecked Sendable {
                                                                      isFreeScan: isFreeScan)
             }
         }
+    }
+
+    private func makeFilteredAndSortedJobData(for brokerProfileQueriesData: [BrokerProfileQueryData], isFreeScan: Bool) -> [BrokerJobData] {
+        var didFireFreemiumMaintenanceScanSkippedPixel = false
+        return Self.sortedEligibleJobs(brokerProfileQueriesData: brokerProfileQueriesData,
+                                       jobType: jobType,
+                                       priorityDate: priorityDate,
+                                       sortPredicate: jobDependencies.jobSortPredicate)
+            .filter { jobData in
+                guard isFreeScan, let scanJobData = jobData as? ScanJobData else {
+                    return true
+                }
+
+                let scanType = scanJobData.scanType()
+                didFireFreemiumMaintenanceScanSkippedPixel = fireFreemiumMaintenanceScanSkippedPixelIfNeeded(
+                    for: scanType,
+                    didFirePixel: didFireFreemiumMaintenanceScanSkippedPixel
+                )
+
+                return scanType != .maintenance
+            }
     }
 
     private func fireFreemiumMaintenanceScanSkippedPixelIfNeeded(for scanType: ScanJobData.ScanType, didFirePixel: Bool) -> Bool {

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/BrokerProfileJob.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/BrokerProfileJob.swift
@@ -165,6 +165,7 @@ public class BrokerProfileJob: Operation, @unchecked Sendable {
         }
 
         let isAuthenticatedUser = await jobDependencies.isAuthenticatedUser()
+        let isFreeScan = !isAuthenticatedUser
         let brokerProfileQueriesData = allBrokerProfileQueryData
             .filter { $0.dataBroker.id == dataBrokerID }
             .excludingIneligibleBrokers(isAuthenticatedUser: isAuthenticatedUser)
@@ -173,6 +174,14 @@ public class BrokerProfileJob: Operation, @unchecked Sendable {
                                                                jobType: jobType,
                                                                priorityDate: priorityDate,
                                                                sortPredicate: jobDependencies.jobSortPredicate)
+            .filter { jobData in
+                guard isFreeScan, let scanJobData = jobData as? ScanJobData else {
+                    return true
+                }
+
+                // Do not execute maintenance scans for Freemium users
+                return scanJobData.scanType() != .maintenance
+            }
 
         Logger.dataBrokerProtection.log("filteredAndSortedOperationsData count: \(filteredAndSortedJobData.count, privacy: .public) for brokerID \(self.dataBrokerID, privacy: .public)")
 
@@ -192,7 +201,6 @@ public class BrokerProfileJob: Operation, @unchecked Sendable {
 
             Logger.dataBrokerProtection.log("Running operation: \(String(describing: jobData), privacy: .public)")
 
-            let isFreeScan = !isAuthenticatedUser
             let stepType: StepType? = {
                 switch jobData {
                 case is ScanJobData:

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/BrokerProfileJob.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/BrokerProfileJob.swift
@@ -170,6 +170,7 @@ public class BrokerProfileJob: Operation, @unchecked Sendable {
             .filter { $0.dataBroker.id == dataBrokerID }
             .excludingIneligibleBrokers(isAuthenticatedUser: isAuthenticatedUser)
 
+        var didFireFreemiumMaintenanceScanSkippedPixel = false
         let filteredAndSortedJobData = Self.sortedEligibleJobs(brokerProfileQueriesData: brokerProfileQueriesData,
                                                                jobType: jobType,
                                                                priorityDate: priorityDate,
@@ -179,8 +180,13 @@ public class BrokerProfileJob: Operation, @unchecked Sendable {
                     return true
                 }
 
-                // Do not execute maintenance scans for Freemium users
-                return scanJobData.scanType() != .maintenance
+                let scanType = scanJobData.scanType()
+                didFireFreemiumMaintenanceScanSkippedPixel = fireFreemiumMaintenanceScanSkippedPixelIfNeeded(
+                    for: scanType,
+                    didFirePixel: didFireFreemiumMaintenanceScanSkippedPixel
+                )
+
+                return scanType != .maintenance
             }
 
         Logger.dataBrokerProtection.log("filteredAndSortedOperationsData count: \(filteredAndSortedJobData.count, privacy: .public) for brokerID \(self.dataBrokerID, privacy: .public)")
@@ -272,6 +278,15 @@ public class BrokerProfileJob: Operation, @unchecked Sendable {
                                                                      isFreeScan: isFreeScan)
             }
         }
+    }
+
+    private func fireFreemiumMaintenanceScanSkippedPixelIfNeeded(for scanType: ScanJobData.ScanType, didFirePixel: Bool) -> Bool {
+        guard scanType == .maintenance, !didFirePixel else {
+            return didFirePixel
+        }
+
+        jobDependencies.pixelHandler.fire(.freemiumPIRMaintenanceScanSkipped)
+        return true
     }
 
     private func finish() {

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/BrokerProfileJob.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/BrokerProfileJob.swift
@@ -170,7 +170,7 @@ public class BrokerProfileJob: Operation, @unchecked Sendable {
             .filter { $0.dataBroker.id == dataBrokerID }
             .excludingIneligibleBrokers(isAuthenticatedUser: isAuthenticatedUser)
 
-        let filteredAndSortedJobData = makeFilteredAndSortedJobData(for: brokerProfileQueriesData, isFreeScan: isFreeScan)
+        let filteredAndSortedJobData = makeFilteredAndSortedJobData(brokerProfileQueriesData, isFreeScan: isFreeScan)
 
         Logger.dataBrokerProtection.log("filteredAndSortedOperationsData count: \(filteredAndSortedJobData.count, privacy: .public) for brokerID \(self.dataBrokerID, privacy: .public)")
 
@@ -263,7 +263,7 @@ public class BrokerProfileJob: Operation, @unchecked Sendable {
         }
     }
 
-    private func makeFilteredAndSortedJobData(for brokerProfileQueriesData: [BrokerProfileQueryData], isFreeScan: Bool) -> [BrokerJobData] {
+    private func makeFilteredAndSortedJobData(_ brokerProfileQueriesData: [BrokerProfileQueryData], isFreeScan: Bool) -> [BrokerJobData] {
         var didFireFreemiumMaintenanceScanSkippedPixel = false
         return Self.sortedEligibleJobs(brokerProfileQueriesData: brokerProfileQueriesData,
                                        jobType: jobType,

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionSharedPixels.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionSharedPixels.swift
@@ -809,7 +809,6 @@ public class DataBrokerProtectionSharedPixelsHandler: EventMapping<DataBrokerPro
                     .weeklyReportBackgroundTaskSession,
                     .weeklyReportStalledScans,
                     .weeklyReportStalledOptOuts,
-                    .freemiumPIRMaintenanceScanSkipped,
                     .optOutJobAt7DaysConfirmed,
                     .optOutJobAt7DaysUnconfirmed,
                     .optOutJobAt14DaysConfirmed,
@@ -838,6 +837,8 @@ public class DataBrokerProtectionSharedPixelsHandler: EventMapping<DataBrokerPro
                     .updateDataBrokersSuccess:
 
                 pixelKit.fire(event, withNamePrefix: platform.pixelNamePrefix)
+            case .freemiumPIRMaintenanceScanSkipped:
+                pixelKit.fire(event, frequency: .dailyAndCount, withNamePrefix: platform.pixelNamePrefix)
             case .firstScan, .freemiumUpsell:
                 pixelKit.fire(event, frequency: .uniqueByName, withNamePrefix: platform.pixelNamePrefix)
             case .updateDataBrokersFailure(_, _, _, let error):

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionSharedPixels.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionSharedPixels.swift
@@ -166,6 +166,9 @@ public enum DataBrokerProtectionSharedPixels {
     // freemium → paid upsell
     case freemiumUpsell
 
+    // Temporary Freemium PIR monitoring
+    case freemiumPIRMaintenanceScanSkipped
+
     // events
     case weeklyReportBackgroundTaskSession(started: Int, orphaned: Int, completed: Int, terminated: Int, durationMinMs: Double, durationMaxMs: Double, durationMedianMs: Double, isAuthenticated: Bool)
     case weeklyReportStalledScans(numTotal: Int, numStalled: Int, totalByBroker: String, stalledByBroker: String, isAuthenticated: Bool)
@@ -284,6 +287,9 @@ extension DataBrokerProtectionSharedPixels: PixelKitEvent {
 
             // freemium upsell
         case .freemiumUpsell: return "dbp_freemium_upsell_u"
+
+            // Temporary Freemium PIR monitoring
+        case .freemiumPIRMaintenanceScanSkipped: return "dbp_freemium_pir_maintenance_scan_skipped"
 
         case .weeklyReportBackgroundTaskSession: return "dbp_event_weekly-report_background-task_session"
         case .weeklyReportStalledScans: return "dbp_event_weekly-report_stalled-scans"
@@ -526,7 +532,8 @@ extension DataBrokerProtectionSharedPixels: PixelKitEvent {
                 .dashboardOpen(isAuthenticated: let isAuthenticated, isFreeScan: let isFreeScan),
                 .firstScan(isAuthenticated: let isAuthenticated, isFreeScan: let isFreeScan):
             return addingFreeScanParamIfNeeded(to: [Consts.isAuthenticated: isAuthenticated.description], isFreeScan: isFreeScan)
-        case .freemiumUpsell:
+        case .freemiumUpsell,
+                .freemiumPIRMaintenanceScanSkipped:
             return [:]
         case .scanningEventNewMatch(let dataBrokerURL),
                 .scanningEventReAppearance(let dataBrokerURL):
@@ -674,6 +681,7 @@ extension DataBrokerProtectionSharedPixels: PixelKitEvent {
                 .dashboardOpen,
                 .firstScan,
                 .freemiumUpsell,
+                .freemiumPIRMaintenanceScanSkipped,
                 .weeklyReportBackgroundTaskSession,
                 .weeklyReportStalledScans,
                 .weeklyReportStalledOptOuts,
@@ -801,6 +809,7 @@ public class DataBrokerProtectionSharedPixelsHandler: EventMapping<DataBrokerPro
                     .weeklyReportBackgroundTaskSession,
                     .weeklyReportStalledScans,
                     .weeklyReportStalledOptOuts,
+                    .freemiumPIRMaintenanceScanSkipped,
                     .optOutJobAt7DaysConfirmed,
                     .optOutJobAt7DaysUnconfirmed,
                     .optOutJobAt14DaysConfirmed,

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileJobTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileJobTests.swift
@@ -786,20 +786,24 @@ private extension BrokerProfileJobTests {
         optOutJobData: [OptOutJobData] = []
     ) -> BrokerProfileQueryData {
         BrokerProfileQueryData(
-            dataBroker: dataBroker ?? .mock(withId: brokerId),
+            dataBroker: dataBroker ?? makeBroker(id: brokerId, scanActionType: .click),
             profileQuery: makeProfileQuery(id: profileQueryId),
             scanJobData: scanJobData,
             optOutJobData: optOutJobData
         )
     }
 
-    func makeSubscriptionRequiredBroker(id: Int64) -> DataBroker {
+    func makeBroker(id: Int64, scanActionType: ActionType) -> DataBroker {
         DataBroker.mockWithDefaults(
             id: id,
             steps: [
-                Step(type: .scan, actions: [MockAction(actionType: .generateEmail)])
+                Step(type: .scan, actions: [MockAction(actionType: scanActionType)])
             ]
         )
+    }
+
+    func makeSubscriptionRequiredBroker(id: Int64) -> DataBroker {
+        makeBroker(id: id, scanActionType: .generateEmail)
     }
 
     func makeScanJobData(

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileJobTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileJobTests.swift
@@ -373,6 +373,158 @@ final class BrokerProfileJobTests: XCTestCase {
         XCTAssertTrue(delegate.errorIdentifiers.isEmpty)
     }
 
+    // MARK: - Freemium Maintenance Scan Filtering Tests
+
+    func testWhenFreeScheduledScanContainsMaintenanceScan_thenScanIsNotRun() async {
+        await assertFreeMaintenanceScanDoesNotRun(jobType: .scheduledScan)
+    }
+
+    func testWhenFreeManualScanContainsMaintenanceScan_thenScanIsNotRun() async {
+        await assertFreeMaintenanceScanDoesNotRun(jobType: .manualScan)
+    }
+
+    func testWhenFreeScheduledScanContainsNonMaintenanceScans_thenScanJobsRun() async {
+        let delegate = CompletedJobIdentifierCapturingDelegate()
+        let database = MockDatabase()
+        let mockDependencies = MockBrokerProfileJobDependencies()
+        mockDependencies.database = database
+        mockDependencies.isAuthenticatedUserProvider = { false }
+
+        let now = Date()
+        let brokerId: Int64 = 31
+        let initialProfileQueryId: Int64 = 1
+        let retryProfileQueryId: Int64 = 2
+        let confirmOptOutProfileQueryId: Int64 = 3
+        let otherProfileQueryId: Int64 = 4
+
+        database.brokerProfileQueryDataToReturn = [
+            makeBrokerProfileQueryData(
+                brokerId: brokerId,
+                profileQueryId: initialProfileQueryId,
+                scanJobData: makeScanJobData(brokerId: brokerId, profileQueryId: initialProfileQueryId, preferredRunDate: now)
+            ),
+            makeBrokerProfileQueryData(
+                brokerId: brokerId,
+                profileQueryId: retryProfileQueryId,
+                scanJobData: makeScanJobData(
+                    brokerId: brokerId,
+                    profileQueryId: retryProfileQueryId,
+                    preferredRunDate: now,
+                    historyEvents: [HistoryEvent.mock(type: .error(error: DataBrokerProtectionError.unknown("Test error")))]
+                )
+            ),
+            makeBrokerProfileQueryData(
+                brokerId: brokerId,
+                profileQueryId: confirmOptOutProfileQueryId,
+                scanJobData: makeScanJobData(
+                    brokerId: brokerId,
+                    profileQueryId: confirmOptOutProfileQueryId,
+                    preferredRunDate: now,
+                    historyEvents: [HistoryEvent.mock(type: .optOutRequested)]
+                )
+            ),
+            makeBrokerProfileQueryData(
+                brokerId: brokerId,
+                profileQueryId: otherProfileQueryId,
+                scanJobData: makeScanJobData(
+                    brokerId: brokerId,
+                    profileQueryId: otherProfileQueryId,
+                    preferredRunDate: now,
+                    historyEvents: [HistoryEvent.mock(type: .scanStarted)]
+                )
+            )
+        ]
+
+        let job = BrokerProfileJob(dataBrokerID: brokerId,
+                                   jobType: .scheduledScan,
+                                   priorityDate: now,
+                                   showWebView: false,
+                                   statusReportingDelegate: delegate,
+                                   jobDependencies: mockDependencies)
+
+        await run(job)
+
+        XCTAssertTrue(hasScanStarted(in: database.scanEvents, brokerId: brokerId, profileQueryId: initialProfileQueryId))
+        XCTAssertTrue(hasScanStarted(in: database.scanEvents, brokerId: brokerId, profileQueryId: retryProfileQueryId))
+        XCTAssertTrue(hasScanStarted(in: database.scanEvents, brokerId: brokerId, profileQueryId: confirmOptOutProfileQueryId))
+        XCTAssertTrue(hasScanStarted(in: database.scanEvents, brokerId: brokerId, profileQueryId: otherProfileQueryId))
+        XCTAssertEqual(database.scanEvents.filter { $0.type == .scanStarted }.count, 4)
+        XCTAssertEqual(delegate.successIdentifiers.count, 4)
+    }
+
+    func testWhenAuthenticatedScheduledScanContainsMaintenanceScan_thenScanJobRuns() async {
+        let delegate = CompletedJobIdentifierCapturingDelegate()
+        let database = MockDatabase()
+        let mockDependencies = MockBrokerProfileJobDependencies()
+        mockDependencies.database = database
+        mockDependencies.isAuthenticatedUserProvider = { true }
+
+        let now = Date()
+        let brokerId: Int64 = 41
+        let profileQueryId: Int64 = 1
+        database.brokerProfileQueryDataToReturn = [
+            makeBrokerProfileQueryData(
+                brokerId: brokerId,
+                profileQueryId: profileQueryId,
+                scanJobData: makeMaintenanceScanJobData(brokerId: brokerId, profileQueryId: profileQueryId, preferredRunDate: now)
+            )
+        ]
+
+        let job = BrokerProfileJob(dataBrokerID: brokerId,
+                                   jobType: .scheduledScan,
+                                   priorityDate: now,
+                                   showWebView: false,
+                                   statusReportingDelegate: delegate,
+                                   jobDependencies: mockDependencies)
+
+        await run(job)
+
+        XCTAssertTrue(mockDependencies.mockScanRunner.wasScanCalled)
+        XCTAssertTrue(hasScanStarted(in: database.scanEvents, brokerId: brokerId, profileQueryId: profileQueryId))
+        XCTAssertEqual(delegate.successIdentifiers.count, 1)
+    }
+
+    func testWhenJobErrors_thenIsFreeScanIsComputedOnceAndForwardedToErrorDelegate() async {
+        let delegate = CompletedJobIdentifierCapturingDelegate()
+        let database = MockDatabase()
+        let mockDependencies = MockBrokerProfileJobDependencies()
+        let authCounter = AuthenticationCallCounter(isAuthenticated: false)
+        mockDependencies.database = database
+        mockDependencies.isAuthenticatedUserProvider = { await authCounter.isAuthenticatedUser() }
+        mockDependencies.mockOptOutRunner.shouldOptOutThrow = { _ in true }
+
+        let now = Date()
+        let brokerId: Int64 = 43
+        let profileQueryId: Int64 = 1
+        let extractedProfileId: Int64 = 2
+        let extractedProfile = ExtractedProfile(id: extractedProfileId, name: "Some name", profileUrl: "abc", identifier: "abc")
+        let optOutData = [OptOutJobData.mock(with: extractedProfile, brokerId: brokerId, profileQueryId: profileQueryId, preferredRunDate: now)]
+
+        database.brokerProfileQueryDataToReturn = [
+            makeBrokerProfileQueryData(
+                brokerId: brokerId,
+                profileQueryId: profileQueryId,
+                scanJobData: makeScanJobData(brokerId: brokerId, profileQueryId: profileQueryId, preferredRunDate: now),
+                optOutJobData: optOutData
+            )
+        ]
+
+        let job = BrokerProfileJob(dataBrokerID: brokerId,
+                                   jobType: .optOut,
+                                   priorityDate: now,
+                                   showWebView: false,
+                                   statusReportingDelegate: delegate,
+                                   jobDependencies: mockDependencies)
+
+        await run(job)
+
+        let authCallCount = await authCounter.count
+        XCTAssertEqual(authCallCount, 1)
+        XCTAssertEqual(delegate.errorIsFreeScanValues, [true])
+        XCTAssertEqual(delegate.errorIdentifiers.count, 1)
+        XCTAssertEqual(delegate.errorIdentifiers.first?.stepType, .optOut)
+    }
+
     // MARK: - Filtering Tests
 
     func testWhenFilteringOptOutOperationData_thenAllButFuturePreferredRunDateIsReturned() {
@@ -574,6 +726,49 @@ final class BrokerProfileJobTests: XCTestCase {
 }
 
 private extension BrokerProfileJobTests {
+    func assertFreeMaintenanceScanDoesNotRun(jobType: JobType) async {
+        let delegate = CompletedJobIdentifierCapturingDelegate()
+        let database = MockDatabase()
+        let mockDependencies = MockBrokerProfileJobDependencies()
+        mockDependencies.database = database
+        mockDependencies.isAuthenticatedUserProvider = { false }
+
+        let now = Date()
+        let brokerId: Int64 = 29
+        let profileQueryId: Int64 = 1
+        database.brokerProfileQueryDataToReturn = [
+            makeBrokerProfileQueryData(
+                brokerId: brokerId,
+                profileQueryId: profileQueryId,
+                scanJobData: makeMaintenanceScanJobData(brokerId: brokerId, profileQueryId: profileQueryId, preferredRunDate: now)
+            )
+        ]
+
+        let job = BrokerProfileJob(dataBrokerID: brokerId,
+                                   jobType: jobType,
+                                   priorityDate: now,
+                                   showWebView: false,
+                                   statusReportingDelegate: delegate,
+                                   jobDependencies: mockDependencies)
+
+        await run(job)
+
+        XCTAssertFalse(mockDependencies.mockScanRunner.wasScanCalled)
+        XCTAssertFalse(hasScanStarted(in: database.scanEvents, brokerId: brokerId, profileQueryId: profileQueryId))
+        XCTAssertTrue(delegate.successIdentifiers.isEmpty)
+        XCTAssertTrue(delegate.errorIdentifiers.isEmpty)
+    }
+
+    func run(_ job: BrokerProfileJob) async {
+        let expectation = XCTestExpectation(description: "Job should finish")
+        job.completionBlock = {
+            expectation.fulfill()
+        }
+
+        job.start()
+        await fulfillment(of: [expectation], timeout: 15)
+    }
+
     func makeBrokerProfileQueryData(
         brokerId: Int64,
         profileQueryId: Int64,
@@ -598,6 +793,39 @@ private extension BrokerProfileJobTests {
         )
     }
 
+    func makeScanJobData(
+        brokerId: Int64,
+        profileQueryId: Int64,
+        preferredRunDate: Date,
+        historyEvents: [HistoryEvent] = []
+    ) -> ScanJobData {
+        ScanJobData(brokerId: brokerId,
+                    profileQueryId: profileQueryId,
+                    preferredRunDate: preferredRunDate,
+                    historyEvents: historyEvents)
+    }
+
+    func makeMaintenanceScanJobData(
+        brokerId: Int64,
+        profileQueryId: Int64,
+        preferredRunDate: Date
+    ) -> ScanJobData {
+        makeScanJobData(
+            brokerId: brokerId,
+            profileQueryId: profileQueryId,
+            preferredRunDate: preferredRunDate,
+            historyEvents: [HistoryEvent.mock(type: .matchesFound(count: 1))]
+        )
+    }
+
+    func hasScanStarted(in events: [HistoryEvent], brokerId: Int64, profileQueryId: Int64) -> Bool {
+        events.contains {
+            $0.brokerId == brokerId &&
+            $0.profileQueryId == profileQueryId &&
+            $0.type == .scanStarted
+        }
+    }
+
     func makeProfileQuery(id: Int64) -> ProfileQuery {
         ProfileQuery(id: id, firstName: "A", lastName: "B", city: "C", state: "D", birthYear: 1980)
     }
@@ -616,6 +844,7 @@ private struct MockAction: Action {
 private final class CompletedJobIdentifierCapturingDelegate: BrokerProfileJobStatusReportingDelegate {
     var successIdentifiers: [CompletedJobIdentifier] = []
     var errorIdentifiers: [CompletedJobIdentifier] = []
+    var errorIsFreeScanValues: [Bool?] = []
 
     func dataBrokerOperationDidError(_ error: any Error,
                                      withBrokerURL brokerURL: String?,
@@ -623,6 +852,7 @@ private final class CompletedJobIdentifierCapturingDelegate: BrokerProfileJobSta
                                      identifier: CompletedJobIdentifier?,
                                      dataBrokerParent: String?,
                                      isFreeScan: Bool?) {
+        errorIsFreeScanValues.append(isFreeScan)
         if let identifier {
             errorIdentifiers.append(identifier)
         }
@@ -633,5 +863,20 @@ private final class CompletedJobIdentifierCapturingDelegate: BrokerProfileJobSta
                                                     dataBrokerParent: String?,
                                                     identifier: CompletedJobIdentifier) {
         successIdentifiers.append(identifier)
+    }
+}
+
+private actor AuthenticationCallCounter {
+    private(set) var count = 0
+
+    private let isAuthenticated: Bool
+
+    init(isAuthenticated: Bool) {
+        self.isAuthenticated = isAuthenticated
+    }
+
+    func isAuthenticatedUser() -> Bool {
+        count += 1
+        return isAuthenticated
     }
 }

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileJobTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileJobTests.swift
@@ -21,6 +21,12 @@ import DataBrokerProtectionCoreTestsUtils
 import XCTest
 
 final class BrokerProfileJobTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+
+        MockDataBrokerProtectionPixelsHandler.lastPixelsFired = []
+    }
+
     lazy var mockOptOutQueryData: [BrokerProfileQueryData] = {
         let brokerId: Int64 = 1
 
@@ -450,6 +456,7 @@ final class BrokerProfileJobTests: XCTestCase {
         XCTAssertTrue(hasScanStarted(in: database.scanEvents, brokerId: brokerId, profileQueryId: otherProfileQueryId))
         XCTAssertEqual(database.scanEvents.filter { $0.type == .scanStarted }.count, 4)
         XCTAssertEqual(delegate.successIdentifiers.count, 4)
+        XCTAssertFalse(wasPixelFired(.freemiumPIRMaintenanceScanSkipped))
     }
 
     func testWhenAuthenticatedScheduledScanContainsMaintenanceScan_thenScanJobRuns() async {
@@ -482,6 +489,7 @@ final class BrokerProfileJobTests: XCTestCase {
         XCTAssertTrue(mockDependencies.mockScanRunner.wasScanCalled)
         XCTAssertTrue(hasScanStarted(in: database.scanEvents, brokerId: brokerId, profileQueryId: profileQueryId))
         XCTAssertEqual(delegate.successIdentifiers.count, 1)
+        XCTAssertFalse(wasPixelFired(.freemiumPIRMaintenanceScanSkipped))
     }
 
     func testWhenJobErrors_thenIsFreeScanIsComputedOnceAndForwardedToErrorDelegate() async {
@@ -757,6 +765,7 @@ private extension BrokerProfileJobTests {
         XCTAssertFalse(hasScanStarted(in: database.scanEvents, brokerId: brokerId, profileQueryId: profileQueryId))
         XCTAssertTrue(delegate.successIdentifiers.isEmpty)
         XCTAssertTrue(delegate.errorIdentifiers.isEmpty)
+        XCTAssertTrue(wasPixelFired(.freemiumPIRMaintenanceScanSkipped))
     }
 
     func run(_ job: BrokerProfileJob) async {
@@ -823,6 +832,12 @@ private extension BrokerProfileJobTests {
             $0.brokerId == brokerId &&
             $0.profileQueryId == profileQueryId &&
             $0.type == .scanStarted
+        }
+    }
+
+    func wasPixelFired(_ pixel: DataBrokerProtectionSharedPixels) -> Bool {
+        MockDataBrokerProtectionPixelsHandler.lastPixelsFired.contains {
+            $0.name == pixel.name
         }
     }
 

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
@@ -825,6 +825,22 @@ extension DataBrokerProtectionIOSManager: DBPIOSInterface.BackgroundTaskHandling
         }
     }
 
+    private func recordBackgroundTaskCompletedEvent(sessionId: String, startDate: Date) {
+        let completedAt = Date.now
+        let duration = completedAt.timeIntervalSince(startDate) * 1000.0
+        do {
+            let event = BackgroundTaskEvent(
+                sessionId: sessionId,
+                eventType: .completed,
+                timestamp: completedAt,
+                metadata: BackgroundTaskEvent.Metadata(durationInMs: duration)
+            )
+            try database.recordBackgroundTaskEvent(event)
+        } catch {
+            Logger.dataBrokerProtection.error("Failed to record background task completed event: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
     func handleBGProcessingTask(task: any DBPIOSInterface.BGTaskHandling) {
         Logger.dataBrokerProtection.log("Background task started")
         iOSPixelsHandler.fire(.backgroundTaskStarted)
@@ -879,6 +895,7 @@ extension DataBrokerProtectionIOSManager: DBPIOSInterface.BackgroundTaskHandling
             let isAuthenticated = await self.refreshFreeScanState()
             if self.shouldSkipFreemiumBackgroundScanWork(isAuthenticated: isAuthenticated) {
                 Logger.dataBrokerProtection.log("Freemium background scan window expired; skipping background task")
+                self.recordBackgroundTaskCompletedEvent(sessionId: sessionId, startDate: startDate)
                 task.setTaskCompleted(success: true)
                 return
             }
@@ -892,20 +909,7 @@ extension DataBrokerProtectionIOSManager: DBPIOSInterface.BackgroundTaskHandling
                 self.iOSPixelsHandler.fire(.backgroundTaskEndedHavingCompletedAllJobs(
                     duration: timeTaken * 1000.0))
 
-                // Record completed event
-                let duration = Date.now.timeIntervalSince(startDate) * 1000.0
-                do {
-                    let event = BackgroundTaskEvent(
-                        sessionId: sessionId,
-                        eventType: .completed,
-                        timestamp: Date.now,
-                        metadata: BackgroundTaskEvent.Metadata(durationInMs: duration)
-                    )
-                    try self.database.recordBackgroundTaskEvent(event)
-                } catch {
-                    Logger.dataBrokerProtection.error("Failed to record background task completed event: \(error.localizedDescription, privacy: .public)")
-                }
-
+                self.recordBackgroundTaskCompletedEvent(sessionId: sessionId, startDate: startDate)
                 self.scheduleBGProcessingTask()
                 task.setTaskCompleted(success: true)
             }

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
@@ -153,6 +153,9 @@ public final class DataBrokerProtectionIOSManager {
 
         /// Minimum delay before scheduling the next background task
         static let defaultMinBackgroundTaskWaitTime: TimeInterval = .minutes(15)
+
+        /// Maximum amount of time Freemium users should keep receiving background scan work after profile setup.
+        static let freemiumBackgroundScanWindow: TimeInterval = .days(7)
     }
 
     public static let backgroundTaskIdentifier = "com.duckduckgo.app.dbp.backgroundProcessing"
@@ -207,6 +210,18 @@ public final class DataBrokerProtectionIOSManager {
     /// check both conditions independently.
     private var canRunFreemiumScans: Bool {
         featureFlagger.isFreemiumPIREnabled && freemiumDBPUserStateManager.didActivate
+    }
+
+    private var isFreemiumBackgroundScanWindowExpired: Bool {
+        guard let firstProfileSavedTimestamp = freemiumDBPUserStateManager.firstProfileSavedTimestamp else {
+            return false
+        }
+
+        return Date().timeIntervalSince(firstProfileSavedTimestamp) >= Constants.freemiumBackgroundScanWindow
+    }
+
+    private func shouldSkipFreemiumBackgroundScanWork(isAuthenticated: Bool) -> Bool {
+        !isAuthenticated && canRunFreemiumScans && isFreemiumBackgroundScanWindowExpired
     }
 
     /// Snapshots the current authentication state and caches whether this is a free scan run.
@@ -748,6 +763,12 @@ extension DataBrokerProtectionIOSManager: DBPIOSInterface.BackgroundTaskHandling
                 return
             }
 
+            let isAuthenticated = await meetsAuthenticationRunPrequisite
+            if shouldSkipFreemiumBackgroundScanWork(isAuthenticated: isAuthenticated) {
+                Logger.dataBrokerProtection.log("Freemium background scan window expired; not scheduling next BG task")
+                return
+            }
+
             guard await !hasScheduledBackgroundTask else {
                 Logger.dataBrokerProtection.log("Background task already scheduled")
                 return
@@ -780,6 +801,27 @@ extension DataBrokerProtectionIOSManager: DBPIOSInterface.BackgroundTaskHandling
                 self.iOSPixelsHandler.fire(.backgroundTaskSchedulingFailed(error: error))
             }
 #endif
+        }
+    }
+
+    private func startBackgroundTaskOperations(isAuthenticated: Bool, completion: @escaping () -> Void) {
+        if isAuthenticated {
+            Logger.dataBrokerProtection.log("Starting all operations in background task")
+            queueManager.startScheduledAllOperationsIfPermitted(showWebView: false,
+                                                                isAuthenticatedUser: true,
+                                                                jobDependencies: jobDependencies,
+                                                                errorHandler: nil,
+                                                                completion: completion)
+        } else if canRunFreemiumScans {
+            Logger.dataBrokerProtection.log("Starting scan-only operations in background task (freemium)")
+            queueManager.startScheduledScanOperationsIfPermitted(showWebView: false,
+                                                                 isAuthenticatedUser: false,
+                                                                 jobDependencies: jobDependencies,
+                                                                 errorHandler: nil,
+                                                                 completion: completion)
+        } else {
+            Logger.dataBrokerProtection.log("No operations to start in background task")
+            completion()
         }
     }
 
@@ -835,31 +877,15 @@ extension DataBrokerProtectionIOSManager: DBPIOSInterface.BackgroundTaskHandling
             }
 
             let isAuthenticated = await self.refreshFreeScanState()
-            await checkForEmailConfirmationData()
-
-            let startOperations: (@escaping () -> Void) -> Void = { [weak self] completion in
-                guard let self else { return }
-                if isAuthenticated {
-                    Logger.dataBrokerProtection.log("Starting all operations in background task")
-                    self.queueManager.startScheduledAllOperationsIfPermitted(showWebView: false,
-                                                                            isAuthenticatedUser: true,
-                                                                            jobDependencies: self.jobDependencies,
-                                                                            errorHandler: nil,
-                                                                            completion: completion)
-                } else if self.canRunFreemiumScans {
-                    Logger.dataBrokerProtection.log("Starting scan-only operations in background task (freemium)")
-                    self.queueManager.startScheduledScanOperationsIfPermitted(showWebView: false,
-                                                                             isAuthenticatedUser: false,
-                                                                             jobDependencies: self.jobDependencies,
-                                                                             errorHandler: nil,
-                                                                             completion: completion)
-                } else {
-                    Logger.dataBrokerProtection.log("No operations to start in background task")
-                    completion()
-                }
+            if self.shouldSkipFreemiumBackgroundScanWork(isAuthenticated: isAuthenticated) {
+                Logger.dataBrokerProtection.log("Freemium background scan window expired; skipping background task")
+                task.setTaskCompleted(success: true)
+                return
             }
 
-            startOperations {
+            await checkForEmailConfirmationData()
+
+            self.startBackgroundTaskOperations(isAuthenticated: isAuthenticated) {
                 Logger.dataBrokerProtection.log("All operations completed in background task")
                 let timeTaken = Date.now.timeIntervalSince(startDate)
                 Logger.dataBrokerProtection.log("Background task finshed all operations with time taken: \(timeTaken)")

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerAuthGateTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerAuthGateTests.swift
@@ -194,6 +194,11 @@ final class DataBrokerProtectionIOSManagerAuthGateTests: XCTestCase {
         XCTAssertFalse(dependencies.queueManager.didCallStartScheduledScanOperationsIfPermitted)
         XCTAssertFalse(dependencies.queueManager.didCallStartScheduledAllOperationsIfPermitted)
         XCTAssertEqual(mockTask.completedSuccess, true)
+
+        let backgroundTaskEvents = dependencies.database.backgroundTaskEventsToReturn
+        XCTAssertEqual(backgroundTaskEvents.map(\.eventType), [.started, .completed])
+        XCTAssertEqual(backgroundTaskEvents.first?.sessionId, backgroundTaskEvents.last?.sessionId)
+        XCTAssertNotNil(backgroundTaskEvents.last?.metadata)
     }
 
     // MARK: - dashboardDidOpen routing

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerAuthGateTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerAuthGateTests.swift
@@ -17,9 +17,10 @@
 //
 
 import XCTest
-@testable import DataBrokerProtection_iOS
+import Common
 import DataBrokerProtectionCore
 import DataBrokerProtectionCoreTestsUtils
+@testable import DataBrokerProtection_iOS
 
 @MainActor
 final class DataBrokerProtectionIOSManagerAuthGateTests: XCTestCase {
@@ -154,6 +155,45 @@ final class DataBrokerProtectionIOSManagerAuthGateTests: XCTestCase {
 
         XCTAssertTrue(dependencies.queueManager.didCallStartScheduledScanOperationsIfPermitted)
         XCTAssertFalse(dependencies.queueManager.didCallStartScheduledAllOperationsIfPermitted)
+    }
+
+    func testHandleBGProcessingTask_freemiumActivatedWithinBackgroundScanWindow_startsScanOnlyOperations() async {
+        let featureFlagger = MockDBPFeatureFlagger(isFreemiumPIREnabled: true)
+        let (sut, dependencies) = DBPContinuedProcessingTestUtils.makeTestIOSManager(featureFlagger: featureFlagger)
+        dependencies.database.profile = DBPContinuedProcessingTestUtils.makeProfile()
+        dependencies.authenticationManager.isUserAuthenticatedValue = false
+        dependencies.freemiumDBPUserStateManager.didActivate = true
+        dependencies.freemiumDBPUserStateManager.firstProfileSavedTimestamp = Date()
+            .addingTimeInterval(-.days(6))
+
+        let mockTask = MockBGTask()
+        sut.handleBGProcessingTask(task: mockTask)
+
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertTrue(dependencies.queueManager.didCallStartScheduledScanOperationsIfPermitted)
+        XCTAssertFalse(dependencies.queueManager.didCallStartScheduledAllOperationsIfPermitted)
+    }
+
+    func testHandleBGProcessingTask_freemiumActivatedAfterBackgroundScanWindow_doesNotStartOperations() async {
+        let featureFlagger = MockDBPFeatureFlagger(isFreemiumPIREnabled: true)
+        let (sut, dependencies) = DBPContinuedProcessingTestUtils.makeTestIOSManager(featureFlagger: featureFlagger)
+        dependencies.database.profile = DBPContinuedProcessingTestUtils.makeProfile()
+        dependencies.authenticationManager.isUserAuthenticatedValue = false
+        dependencies.freemiumDBPUserStateManager.didActivate = true
+        dependencies.freemiumDBPUserStateManager.firstProfileSavedTimestamp = Date()
+            .addingTimeInterval(-.days(8))
+
+        let mockTask = MockBGTask()
+        sut.handleBGProcessingTask(task: mockTask)
+
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertFalse(dependencies.queueManager.didCallStartScheduledScanOperationsIfPermitted)
+        XCTAssertFalse(dependencies.queueManager.didCallStartScheduledAllOperationsIfPermitted)
+        XCTAssertEqual(mockTask.completedSuccess, true)
     }
 
     // MARK: - dashboardDidOpen routing

--- a/iOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -555,6 +555,14 @@
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource"]
     },
+    "m_ios_dbp_freemium_pir_maintenance_scan_skipped": {
+        "description": "Temporary telemetry fired when PIR skips at least one maintenance scan job for an unauthenticated freemium user.",
+        "owners": ["jozsef-vesza"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource"],
+        "expires": "2026-08-31"
+    },
     "m_ios_dbp_weekly_child-broker_orphaned-optouts": {
         "description": "Fired weekly with metrics about orphaned opt-outs for child brokers",
         "owners": ["quanganhdo"],

--- a/iOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -559,7 +559,7 @@
         "description": "Temporary telemetry fired when PIR skips at least one maintenance scan job for an unauthenticated freemium user.",
         "owners": ["jozsef-vesza"],
         "triggers": ["other"],
-        "suffixes": [],
+        "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource"],
         "expires": "2026-08-31"
     },

--- a/iOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -560,8 +560,7 @@
         "owners": ["jozsef-vesza"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource"],
-        "expires": "2026-08-31"
+        "parameters": ["appVersion", "pixelSource"]
     },
     "m_ios_dbp_weekly_child-broker_orphaned-optouts": {
         "description": "Fired weekly with metrics about orphaned opt-outs for child brokers",

--- a/iOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -560,7 +560,8 @@
         "owners": ["jozsef-vesza"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource"],
+        "expires": "2026-08-31"
     },
     "m_ios_dbp_weekly_child-broker_orphaned-optouts": {
         "description": "Fired weekly with metrics about orphaned opt-outs for child brokers",

--- a/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -1084,8 +1084,7 @@
         "owners": ["jozsef-vesza"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource", "channel"],
-        "expires": "2026-08-31"
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "dbp-free_newtab_scan_impression_u": {
         "description": "Fires once per user when the Freemium DBP promo banner first becomes eligible to be shown on the New Tab Page, in the pre-scan state (no scan results available yet).",

--- a/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -1084,7 +1084,8 @@
         "owners": ["jozsef-vesza"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource", "channel"]
+        "parameters": ["appVersion", "pixelSource", "channel"],
+        "expires": "2026-08-31"
     },
     "dbp-free_newtab_scan_impression_u": {
         "description": "Fires once per user when the Freemium DBP promo banner first becomes eligible to be shown on the New Tab Page, in the pre-scan state (no scan results available yet).",

--- a/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -1079,6 +1079,14 @@
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
+    "m_mac_dbp_freemium_pir_maintenance_scan_skipped": {
+        "description": "Temporary telemetry fired when PIR skips at least one maintenance scan job for an unauthenticated freemium user.",
+        "owners": ["jozsef-vesza"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource", "channel"],
+        "expires": "2026-08-31"
+    },
     "dbp-free_newtab_scan_impression_u": {
         "description": "Fires once per user when the Freemium DBP promo banner first becomes eligible to be shown on the New Tab Page, in the pre-scan state (no scan results available yet).",
         "owners": ["hanyutang-sandra"],

--- a/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -1083,7 +1083,7 @@
         "description": "Temporary telemetry fired when PIR skips at least one maintenance scan job for an unauthenticated freemium user.",
         "owners": ["jozsef-vesza"],
         "triggers": ["other"],
-        "suffixes": [],
+        "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource", "channel"],
         "expires": "2026-08-31"
     },


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214892858888017
Tech Design URL: https://app.asana.com/1/137249556945/project/1203581873609357/task/1214893957137410

### Description

Stops Freemium PIR maintenance scans in the shared `DataBrokerProtectionCore` execution path.

`BrokerProfileJob.runJob()` will now check auth status and filter only scan jobs classified as `.maintenance` for unauthenticated users. All other jobs keep their existing behavior.

I've also added a temporary pixel to use during rollout: it will fire once per job if a maintenance scan was filtered out for Freemium users.

### Testing Steps
Green CI

### Impact and Risks

Low. The behavior change is scoped to Freemium maintenance scan execution path.

#### What could go wrong?

N/A

### Quality Considerations

Added unit tests for the skipping/non-skipping paths as well.

### Notes to Reviewer

N/A


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which scan jobs run for unauthenticated users and when iOS schedules or runs background PIR work; behavior is gated to freemium/maintenance paths with new unit tests.
> 
> **Overview**
> **Freemium PIR** no longer runs **maintenance** scan jobs for unauthenticated users. In `BrokerProfileJob`, eligible jobs are filtered so free-scan runs drop `.maintenance` scans (manual and scheduled); paid users are unchanged. A temporary **`freemiumPIRMaintenanceScanSkipped`** pixel fires at most once per broker job when any maintenance scan is skipped (`daily_count` on iOS/macOS).
> 
> On **iOS**, freemium background work is capped to **7 days** after `firstProfileSavedTimestamp`: after that window, the manager skips scheduling the next BG task and completes incoming BG tasks without starting scan operations (still records started/completed events). BG handling is refactored into `startBackgroundTaskOperations` and `recordBackgroundTaskCompletedEvent`.
> 
> **Tests** cover maintenance filtering, pixel firing, auth vs free paths, single auth lookup for error reporting, and the iOS background window behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b85f4ea73734ba9eeea40876246ffd2f923d5a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->