### PR TITLE
Fix failing pixel anomaly reports

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -968,7 +968,7 @@
         "description": "Fired when a data broker scan or opt-out operation fails with an HTTP error.",
         "owners": ["jozsef-vesza"],
         "triggers": ["other"],
-        "suffixes": ["legacy_daily_count", "count"],
+        "suffixes": ["daily_count"],
         "parameters": [
             "appVersion",
             "pixelSource",
@@ -989,7 +989,7 @@
         "description": "Fired when a data broker scan or opt-out operation fails with a non-HTTP, non-action error.",
         "owners": ["jozsef-vesza"],
         "triggers": ["other"],
-        "suffixes": ["legacy_daily_count", "count"],
+        "suffixes": ["daily_count"],
         "parameters": [
             "appVersion",
             "pixelSource",

--- a/macOS/PixelDefinitions/pixels/definitions/free_trial_conversion_wide_event.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/free_trial_conversion_wide_event.json5
@@ -11,6 +11,7 @@
             "wideEventPlatform",
             "wideEventType",
             "wideEventSampleRate",
+            "wideEventIsFirstDailyOccurrence",
             "wideEventFeatureStatus",
             "wideEventFeatureStatusReason",
             "wideEventMetaVersion",

--- a/macOS/PixelDefinitions/pixels/definitions/privacy_pro_toolbar_button.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/privacy_pro_toolbar_button.json5
@@ -6,7 +6,7 @@
         "description": "Fired when the Privacy Pro toolbar button is displayed to a new, non-subscriber user",
         "owners": ["jozsef-vesza"],
         "triggers": ["other"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
 
     "m_mac_privacy-pro_toolbar_button_popover_shown": {

--- a/macOS/PixelDefinitions/pixels/definitions/subscription.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/subscription.json5
@@ -744,13 +744,13 @@
         "description": "Fired when user dismisses the subscription Next Steps card on the New Tab Page (App Store distribution)",
         "owners": ["jozsef-vesza"],
         "triggers": ["other"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_direct_privacy-pro_new_tab_page_next_steps_card_dismissed": {
         "description": "Fired when user dismisses the subscription Next Steps card on the New Tab Page (direct distribution)",
         "owners": ["jozsef-vesza"],
         "triggers": ["other"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
 
     // Free Trial Journey Pixels - App Store Distribution
@@ -758,7 +758,7 @@
         "description": "Fired when a user starts a free trial subscription (App Store distribution). Used to measure total trialists independent of trial completion.",
         "owners": ["jozsef-vesza"],
         "triggers": ["other"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "pixelSource"]
     },
     "m_mac_store_privacy-pro_freetrial_vpn_activation": {
         "description": "Fired when a user activates VPN for the first time during a free trial (App Store distribution). Includes activation day to distinguish D1 vs D2-D7 activators.",
@@ -766,6 +766,7 @@
         "triggers": ["other"],
         "parameters": [
             "appVersion",
+            "pixelSource",
             {
                 "key": "activation_day",
                 "type": "string",
@@ -780,6 +781,7 @@
         "triggers": ["other"],
         "parameters": [
             "appVersion",
+            "pixelSource",
             {
                 "key": "activation_day",
                 "type": "string",
@@ -794,6 +796,7 @@
         "triggers": ["other"],
         "parameters": [
             "appVersion",
+            "pixelSource",
             {
                 "key": "activation_day",
                 "type": "string",
@@ -808,7 +811,7 @@
         "description": "Fired when a user starts a free trial subscription (direct distribution). Used to measure total trialists independent of trial completion.",
         "owners": ["jozsef-vesza"],
         "triggers": ["other"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_direct_privacy-pro_freetrial_vpn_activation": {
         "description": "Fired when a user activates VPN for the first time during a free trial (direct distribution). Includes activation day to distinguish D1 vs D2-D7 activators.",
@@ -816,6 +819,7 @@
         "triggers": ["other"],
         "parameters": [
             "appVersion",
+            "pixelSource",
             {
                 "key": "activation_day",
                 "type": "string",
@@ -830,6 +834,7 @@
         "triggers": ["other"],
         "parameters": [
             "appVersion",
+            "pixelSource",
             {
                 "key": "activation_day",
                 "type": "string",
@@ -844,6 +849,7 @@
         "triggers": ["other"],
         "parameters": [
             "appVersion",
+            "pixelSource",
             {
                 "key": "activation_day",
                 "type": "string",

--- a/macOS/PixelDefinitions/pixels/definitions/subscription.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/subscription.json5
@@ -758,7 +758,7 @@
         "description": "Fired when a user starts a free trial subscription (App Store distribution). Used to measure total trialists independent of trial completion.",
         "owners": ["jozsef-vesza"],
         "triggers": ["other"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_store_privacy-pro_freetrial_vpn_activation": {
         "description": "Fired when a user activates VPN for the first time during a free trial (App Store distribution). Includes activation day to distinguish D1 vs D2-D7 activators.",
@@ -767,6 +767,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "channel",
             {
                 "key": "activation_day",
                 "type": "string",
@@ -782,6 +783,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "channel",
             {
                 "key": "activation_day",
                 "type": "string",
@@ -797,6 +799,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "channel",
             {
                 "key": "activation_day",
                 "type": "string",
@@ -820,6 +823,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "channel",
             {
                 "key": "activation_day",
                 "type": "string",
@@ -835,6 +839,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "channel",
             {
                 "key": "activation_day",
                 "type": "string",
@@ -850,6 +855,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "channel",
             {
                 "key": "activation_day",
                 "type": "string",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215086024068387
Tech Design URL:
CC:

### Description

Updates 4 macOS pixel JSON5 schemas so they match what the apps are already firing on the wire. Definitions-only — no Swift changes.

Closes the schema-side of the 15 open "Failing pixels report for József" Asana tasks dated 2026-03-22 through 2026-05-24 (most recent task linked above). The 5 iOS tasks in that set are stale: the relevant iOS fix landed in #4554 and the current iOS definitions already pass `validate-ddg-pixel-defs`.

Changes:

- **`data_broker_protection.json5`** — `m_mac_dbp_data_broker_http_error` and `m_mac_dbp_data_broker_other_error` switch `suffixes` from `["legacy_daily_count", "count"]` to `["daily_count"]`. `PixelKit.fire(..., frequency: .dailyAndCount, ...)` (used by `DataBrokerProtectionSharedPixels.swift:758`) appends `_daily`/`_count`, not the legacy `_d`/`_c`. iOS already had the matching `daily_count` schema.
- **`free_trial_conversion_wide_event.json5`** — declare `wideEventIsFirstDailyOccurrence` (key `global.is_first_daily_occurrence`). iOS sibling already had this via #4554.
- **`subscription.json5`** — add `pixelSource` to all 8 freetrial pixels (store + direct, `_start` and 3 `_activation` variants). Add `channel` to all 8 freetrial pixels as well, plus both `_next_steps_card_dismissed` pixels (store + direct).
- **`privacy_pro_toolbar_button.json5`** — add `channel` to `m_mac_privacy-pro_toolbar_button_shown`.

The `channel` additions cover pixels missed by #4648's bulk channel pass.

### Testing Steps

1. From `macOS/`, run `npm run validate-pixel-defs` and confirm it exits 0 with no schema errors and Prettier clean.
2. Spot-check the diff: 4 files in `macOS/PixelDefinitions/pixels/definitions/`, +21/-8 lines across two commits.

### Impact and Risks

**None** — pixel schema definitions only. No Swift code is modified. The added parameters are already on the wire today; declaring them in the schema just stops validation from flagging them as unexpected. The DBP suffix change aligns the schema with the existing PixelKit firing behavior — no client behavior changes.

#### What could go wrong?

The DBP suffix change is the only one that could in principle change downstream behavior. It does not: the wire format `_daily`/`_count` is unchanged; only the schema's notion of "valid suffix value" moves from the legacy `["d","c"]` enum to the modern `["daily","count"]` enum, which is what the wire has been sending all along. Anyone querying these pixels in a dashboard was already querying `_daily`/`_count` names.

### Quality Considerations

- Validator (`validate-ddg-pixel-defs`) and Prettier both pass against the modified tree.
- No new files. No deletions. No renames.

### Notes to Reviewer

iOS reports in the open set (5 tasks) are stale rather than unfixed — see Description. Running `npm run validate-pixel-defs` from `iOS/` against the current main also exits 0.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only updates to analytics definitions; no product logic, auth, or client firing behavior changes.
> 
> **Overview**
> Aligns four macOS pixel definition files with events the app already sends, so anomaly validation stops failing. **No runtime or Swift changes.**
> 
> In **`data_broker_protection.json5`**, `m_mac_dbp_data_broker_http_error` and `m_mac_dbp_data_broker_other_error` now use suffix `daily_count` instead of `legacy_daily_count` + `count`, matching `PixelKit`’s `_daily` / `_count` naming (aligned with iOS and sibling DBP error pixels).
> 
> **`free_trial_conversion_wide_event.json5`** adds parameter `wideEventIsFirstDailyOccurrence` to `m_mac_wide_free_trial_conversion`, matching other wide events and iOS.
> 
> **`subscription.json5`** extends Privacy Pro free-trial and NTP Next Steps pixels with `pixelSource` and/or `channel` where the client already attaches them (eight freetrial variants plus dismiss/toolbar-related events).
> 
> **`privacy_pro_toolbar_button.json5`** adds `channel` to `m_mac_privacy-pro_toolbar_button_shown`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03b54e8e0ac6176cdcb6e19cb0019d9293239169. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->