### PR TITLE
Fix dismissing modals on macOS 12/13 after dropping Big Sur support

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ff02866819c02c800a7eac0a7128f60c1bac0a936fe4ae650fb3f8fb9b09d136",
+  "originHash" : "046e2a8fc9db22b753b4c15b1844d30c079d8e535fe7d1d57139ea8d5c9c4094",
   "pins" : [
     {
       "identity" : "apple-toolbox",

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "046e2a8fc9db22b753b4c15b1844d30c079d8e535fe7d1d57139ea8d5c9c4094",
+  "originHash" : "ff02866819c02c800a7eac0a7128f60c1bac0a936fe4ae650fb3f8fb9b09d136",
   "pins" : [
     {
       "identity" : "apple-toolbox",

--- a/macOS/DuckDuckGo/Common/View/SwiftUI/SheetHostingWindow.swift
+++ b/macOS/DuckDuckGo/Common/View/SwiftUI/SheetHostingWindow.swift
@@ -24,7 +24,9 @@ internal class SheetHostingWindow<Content: View>: NSWindow {
 
     init(rootView: Content) {
         super.init(contentRect: .zero, styleMask: [.titled, .closable, .docModalWindow], backing: .buffered, defer: false)
-        self.contentView = NSHostingView(rootView: rootView)
+        self.contentView = NSHostingView(rootView: rootView.legacyOnDismiss { [weak self] in
+            self?.performClose(nil)
+        })
     }
 
     override func performClose(_ sender: Any?) {

--- a/macOS/DuckDuckGo/Common/View/SwiftUI/ViewExtension.swift
+++ b/macOS/DuckDuckGo/Common/View/SwiftUI/ViewExtension.swift
@@ -29,6 +29,29 @@ extension View {
 
 }
 
+extension View {
+
+    @available(macOS, obsoleted: 14.0, message: "This needs to be removed as it‘s no longer necessary.")
+    @ViewBuilder
+    func legacyOnDismiss(_ onDismiss: @escaping () -> Void) -> some View {
+        if #available(macOS 14.0, *) {
+            self
+
+        } else if let presentationModeKey = \EnvironmentValues.presentationMode as? WritableKeyPath {
+            // hacky way to set the @Environment.presentationMode.
+            // here we downcast a (non-writable) \.presentationMode KeyPath to a WritableKeyPath
+            self.environment(presentationModeKey, Binding<PresentationMode>(onDismiss: onDismiss))
+        } else {
+            legacyMacOS11OnDismiss(onDismiss)
+        }
+    }
+
+    @available(macOS, obsoleted: 14.0, message: "This needs to be removed when macOS 11 support is dropped.")
+    private func legacyMacOS11OnDismiss(_ onDismiss: @escaping () -> Void) -> some View {
+        self.environment(\.legacyDismiss, onDismiss)
+    }
+}
+
 extension Binding where Value == PresentationMode {
 
     init(isPresented: Bool = true, onDismiss: @escaping () -> Void) {
@@ -48,6 +71,41 @@ extension Binding where Value == PresentationMode {
         }
     }
 
+}
+
+@available(macOS, obsoleted: 14.0, message: "This needs to be removed when macOS 11 support is dropped.")
+struct DismissAction {
+    let dismiss: () -> Void
+    public func callAsFunction() {
+        dismiss()
+    }
+}
+
+@available(macOS, obsoleted: 14.0, message: "This needs to be removed when macOS 11 support is dropped.")
+struct LegacyDismissAction: EnvironmentKey {
+    static var defaultValue: () -> Void { { } }
+}
+
+extension EnvironmentValues {
+    @available(macOS, obsoleted: 14.0, message: "This extension needs to be removed when macOS 11 support is dropped.")
+    var dismiss: DismissAction {
+        DismissAction {
+            if \EnvironmentValues.presentationMode is WritableKeyPath {
+                presentationMode.wrappedValue.dismiss()
+            } else {
+                self[LegacyDismissAction.self]()
+            }
+        }
+    }
+    @available(macOS, obsoleted: 14.0, message: "This extension needs to be removed when macOS 11 support is dropped.")
+    fileprivate var legacyDismiss: () -> Void {
+        get {
+            self[LegacyDismissAction.self]
+        }
+        set {
+            self[LegacyDismissAction.self] = newValue
+        }
+    }
 }
 
 private struct RoundedCorner: Shape {

--- a/macOS/DuckDuckGo/Common/View/SwiftUI/ViewExtension.swift
+++ b/macOS/DuckDuckGo/Common/View/SwiftUI/ViewExtension.swift
@@ -41,14 +41,7 @@ extension View {
             // hacky way to set the @Environment.presentationMode.
             // here we downcast a (non-writable) \.presentationMode KeyPath to a WritableKeyPath
             self.environment(presentationModeKey, Binding<PresentationMode>(onDismiss: onDismiss))
-        } else {
-            legacyMacOS11OnDismiss(onDismiss)
         }
-    }
-
-    @available(macOS, obsoleted: 14.0, message: "This needs to be removed when macOS 11 support is dropped.")
-    private func legacyMacOS11OnDismiss(_ onDismiss: @escaping () -> Void) -> some View {
-        self.environment(\.legacyDismiss, onDismiss)
     }
 }
 
@@ -73,7 +66,7 @@ extension Binding where Value == PresentationMode {
 
 }
 
-@available(macOS, obsoleted: 14.0, message: "This needs to be removed when macOS 11 support is dropped.")
+@available(macOS, obsoleted: 14.0, message: "This needs to be removed as it‘s no longer necessary.")
 struct DismissAction {
     let dismiss: () -> Void
     public func callAsFunction() {
@@ -81,13 +74,13 @@ struct DismissAction {
     }
 }
 
-@available(macOS, obsoleted: 14.0, message: "This needs to be removed when macOS 11 support is dropped.")
+@available(macOS, obsoleted: 14.0, message: "This needs to be removed as it‘s no longer necessary.")
 struct LegacyDismissAction: EnvironmentKey {
     static var defaultValue: () -> Void { { } }
 }
 
 extension EnvironmentValues {
-    @available(macOS, obsoleted: 14.0, message: "This extension needs to be removed when macOS 11 support is dropped.")
+    @available(macOS, obsoleted: 14.0, message: "This needs to be removed as it‘s no longer necessary.")
     var dismiss: DismissAction {
         DismissAction {
             if \EnvironmentValues.presentationMode is WritableKeyPath {
@@ -97,7 +90,7 @@ extension EnvironmentValues {
             }
         }
     }
-    @available(macOS, obsoleted: 14.0, message: "This extension needs to be removed when macOS 11 support is dropped.")
+    @available(macOS, obsoleted: 14.0, message: "This needs to be removed as it‘s no longer necessary.")
     fileprivate var legacyDismiss: () -> Void {
         get {
             self[LegacyDismissAction.self]

--- a/macOS/DuckDuckGo/Common/View/SwiftUI/ViewExtension.swift
+++ b/macOS/DuckDuckGo/Common/View/SwiftUI/ViewExtension.swift
@@ -66,41 +66,6 @@ extension Binding where Value == PresentationMode {
 
 }
 
-@available(macOS, obsoleted: 14.0, message: "This needs to be removed as it‘s no longer necessary.")
-struct DismissAction {
-    let dismiss: () -> Void
-    public func callAsFunction() {
-        dismiss()
-    }
-}
-
-@available(macOS, obsoleted: 14.0, message: "This needs to be removed as it‘s no longer necessary.")
-struct LegacyDismissAction: EnvironmentKey {
-    static var defaultValue: () -> Void { { } }
-}
-
-extension EnvironmentValues {
-    @available(macOS, obsoleted: 14.0, message: "This needs to be removed as it‘s no longer necessary.")
-    var dismiss: DismissAction {
-        DismissAction {
-            if \EnvironmentValues.presentationMode is WritableKeyPath {
-                presentationMode.wrappedValue.dismiss()
-            } else {
-                self[LegacyDismissAction.self]()
-            }
-        }
-    }
-    @available(macOS, obsoleted: 14.0, message: "This needs to be removed as it‘s no longer necessary.")
-    fileprivate var legacyDismiss: () -> Void {
-        get {
-            self[LegacyDismissAction.self]
-        }
-        set {
-            self[LegacyDismissAction.self] = newValue
-        }
-    }
-}
-
 private struct RoundedCorner: Shape {
 
     var radius: CGFloat = 0


### PR DESCRIPTION
### Description
This change restores `View.legacyOnDismiss` with support for macOS 12 and 13 via setting presentationMode.

### Testing Steps
Run this review build on macOS Monterey or Ventura and verify that modal dialogs can be dismissed.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Uses unsafe KeyPath casting and unsafeBitCast on PresentationMode for older macOS only; behavior is limited to sheet UI but relies on fragile SwiftUI internals.
> 
> **Overview**
> Restores **modal sheet dismissal** on macOS 12–13 by reintroducing `View.legacyOnDismiss` and wiring it into `SheetHostingWindow`.
> 
> On **macOS 14+**, `legacyOnDismiss` is a no-op. On older systems it injects `presentationMode` via a forced `WritableKeyPath` cast and a custom `Binding<PresentationMode>` that uses `unsafeBitCast` so SwiftUI dismiss actions invoke the supplied callback. **`SheetHostingWindow`** now wraps hosted content with `legacyOnDismiss` so that callback calls `performClose(nil)` and properly ends AppKit sheets.
> 
> The helper is marked obsolete at macOS 14 with intent to remove once Big Sur–era support is dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1a0c638a3ad2ff7ed2d080a163e3cfb7cb24c2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->