### PR TITLE
Add debug button to force crash collection onboarding

### DIFF
--- a/iOS/DuckDuckGo/CrashDebugScreen.swift
+++ b/iOS/DuckDuckGo/CrashDebugScreen.swift
@@ -22,6 +22,8 @@ import Crashes
 
 struct CrashDebugScreen: View {
 
+    @State private var forcedOnboarding: CrashCollectionOnboarding?
+
     var body: some View {
         List {
             Section {
@@ -61,7 +63,35 @@ struct CrashDebugScreen: View {
                 ActionMessageView.present(message: "Crash Send logs reset")
             }, isButton: true)
 
+            SettingsCellView(label: "Force Crash Onboarding", action: {
+                forceCrashOnboarding()
+            }, isButton: true)
+
         }.navigationTitle("Crashes")
+    }
+
+    private func forceCrashOnboarding() {
+        let settings = AppUserDefaults()
+        settings.crashCollectionOptInStatus = .undetermined
+
+        let onboarding = CrashCollectionOnboarding(appSettings: settings)
+        forcedOnboarding = onboarding
+
+        let stub = """
+        {"crashDiagnostics":[{"diagnosticMetaData":{"appVersion":"DEBUG","exceptionType":1,"exceptionCode":1,"signal":11,"objectiveCexceptionReason":{"composedMessage":"Simulator forced onboarding","stackTrace":["0 test"]}},"callStackTree":{"callStacks":[],"callStackPerThread":true}}],"timeStampBegin":"2026-01-01 12:00:00","timeStampEnd":"2026-01-01 12:00:00"}
+        """
+
+        guard let payload = stub.data(using: .utf8),
+              let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let root = scene.windows.first(where: { $0.isKeyWindow })?.rootViewController ?? scene.windows.first?.rootViewController else {
+            forcedOnboarding = nil
+            return
+        }
+
+        let presenter = root.presentedViewController ?? root
+        onboarding.presentOnboardingIfNeeded(for: [payload], from: presenter, sendReport: {
+            print("[CrashDebug] sendReport invoked")
+        })
     }
 
 }


### PR DESCRIPTION
Task/Issue URL:
Tech Design URL:
CC:

### Description

Adds a "Force Crash Onboarding" row to the Crashes debug screen. It resets `crashCollectionOptInStatus` to `.undetermined` and calls `CrashCollectionOnboarding.presentOnboardingIfNeeded` with a stub MXDiagnostic-style payload.

This bypasses MetricKit, which does not deliver crash diagnostics on the iOS simulator. Lets the opt-in sheet be exercised end-to-end in the simulator alongside the close-button fix in the base branch.

### Impact and Risks
None.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)