### PR TITLE
iOS: SR - OM9 - Contextual Followup Prompts Includes ‘Page Content From'

### DIFF
--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -182,7 +182,7 @@ final class AIChatContextualUTIHost {
             coordinator.restoreLastUsedModel(forChatID: chatID)
         }
         userScript.attachedPageContextProvider = { [weak self] in
-            self?.chipViewModel.attachedContext?.contextData
+            self?.chipViewModel.pendingAttachedContextData
         }
         userScript.onPromptSubmitted = { [weak self] in
             self?.chipViewModel.markPromptSubmitted()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
@@ -113,6 +113,11 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
         onRemoveActionRequested?()
     }
 
+    var pendingAttachedContextData: AIChatPageContextData? {
+        guard attachmentDeliveryState == .pendingSubmit else { return nil }
+        return attachedContext?.contextData
+    }
+
     /// Mark the current attachment as delivered (submitted in a prompt). Hides the chip if the
     /// attachment is matching — we don't need to keep showing what's silently riding along.
     func markPromptSubmitted() {

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
@@ -329,6 +329,40 @@ final class AIChatContextualUTIHostTests: XCTestCase {
         XCTAssertEqual(pageContextHandler.triggerContextCollectionCallCount, 1)
     }
 
+    // MARK: - Bound user-script provider
+
+    func test_bindToUserScript_attachedPageContextProvider_returnsContextWhilePending() {
+        // User taps chip → collection → context lands as .pendingSubmit. The next prompt's
+        // payload must carry it so duck.ai can attribute the initial prompt.
+        let url = URL(string: "https://example.com/a")!
+        originatingURL.send(url)
+        makeSUT()
+        sut.chipViewModel.tapToAttach()
+        pageContextHandler.sendContext(makeContext(title: "Page A", url: url.absoluteString))
+
+        let userScript = makeTestUserScript()
+        sut.bindToUserScript(userScript)
+
+        XCTAssertEqual(userScript.attachedPageContextProvider?()?.title, "Page A")
+    }
+
+    func test_bindToUserScript_attachedPageContextProvider_returnsNilAfterMarkPromptSubmitted() {
+        // Once the chip flips to .delivered, the bound provider must
+        // stop emitting context — otherwise every follow-up prompt's payload carries it and
+        // duck.ai renders "Page content from..." beneath each follow-up.
+        let url = URL(string: "https://example.com/a")!
+        originatingURL.send(url)
+        makeSUT()
+        sut.chipViewModel.tapToAttach()
+        pageContextHandler.sendContext(makeContext(title: "Page A", url: url.absoluteString))
+
+        let userScript = makeTestUserScript()
+        sut.bindToUserScript(userScript)
+        sut.markPromptSubmitted()
+
+        XCTAssertNil(userScript.attachedPageContextProvider?() ?? nil)
+    }
+
     // MARK: - Helpers
 
     private func makeContext(title: String, url: String) -> AIChatPageContext {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPageContextChipViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPageContextChipViewModelTests.swift
@@ -344,6 +344,70 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         XCTAssertEqualState(sut.state, .placeholder)
     }
 
+    // MARK: - Pending attached context (provider for prompt payload)
+
+    func test_pendingAttachedContextData_noAttachment_returnsNil() {
+        makeSUT()
+        XCTAssertNil(sut.pendingAttachedContextData)
+    }
+
+    func test_pendingAttachedContextData_afterSetAttached_returnsContextData() {
+        let url = "https://en.wikipedia.org/wiki/Cat"
+        originatingURL.send(URL(string: url))
+        makeSUT()
+        sut.setAttached(makeContext(title: "Cat", url: url))
+        XCTAssertEqual(sut.pendingAttachedContextData?.title, "Cat")
+    }
+
+    func test_pendingAttachedContextData_afterMarkPromptSubmitted_returnsNil() {
+        // Once the chip flips to `.delivered`, every
+        // subsequent prompt must ship `pageContext: nil` — otherwise duck.ai renders a
+        // "Page content from..." attribution beneath each follow-up prompt.
+        let url = "https://en.wikipedia.org/wiki/Cat"
+        originatingURL.send(URL(string: url))
+        makeSUT()
+        sut.setAttached(makeContext(title: "Cat", url: url))
+        sut.markPromptSubmitted()
+        XCTAssertNil(sut.pendingAttachedContextData)
+    }
+
+    func test_pendingAttachedContextData_initialDelivered_returnsNil() {
+        // Carry-over from half-sheet arrives `.delivered` — the FE already has it for the
+        // initial submission, so the next prompt's payload must not duplicate it.
+        let url = "https://en.wikipedia.org/wiki/Cat"
+        originatingURL.send(URL(string: url))
+        makeSUT(
+            initialAttachedContext: makeContext(title: "Cat", url: url),
+            initialAttachmentDeliveryState: .delivered
+        )
+        XCTAssertNil(sut.pendingAttachedContextData)
+    }
+
+    func test_pendingAttachedContextData_initialPending_returnsContextData() {
+        let url = "https://en.wikipedia.org/wiki/Cat"
+        originatingURL.send(URL(string: url))
+        makeSUT(
+            initialAttachedContext: makeContext(title: "Cat", url: url),
+            initialAttachmentDeliveryState: .pendingSubmit
+        )
+        XCTAssertEqual(sut.pendingAttachedContextData?.title, "Cat")
+    }
+
+    func test_pendingAttachedContextData_reAttachAfterSubmit_returnsContextData() {
+        // Detach + re-attach is a fresh user action that restarts the pending cycle — the next
+        // prompt should carry the newly attached context.
+        let url = "https://en.wikipedia.org/wiki/Cat"
+        originatingURL.send(URL(string: url))
+        makeSUT()
+        sut.setAttached(makeContext(title: "Cat", url: url))
+        sut.markPromptSubmitted()
+        XCTAssertNil(sut.pendingAttachedContextData)
+
+        sut.clearAttached()
+        sut.setAttached(makeContext(title: "Cat", url: url))
+        XCTAssertEqual(sut.pendingAttachedContextData?.title, "Cat")
+    }
+
     // MARK: - Helpers
 
     private func makeContext(title: String, url: String) -> AIChatPageContext {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210947754188321/task/1215056187001456
Tech Design URL:
CC:

### Description
With `unifiedToggleInput` enabled, in Duck\.ai contextual chat, the "Page content from..." attribution renders under every follow-up prompt instead of only under the first prompt that introduces page context.

**Root cause:** `AIChatContextualUTIHost.bindToUserScript` wired `attachedPageContextProvider` to `chipViewModel.attachedContext?.contextData` unconditionally. After the first submit the chip flips to `.delivered`, but the provider keeps emitting the same context — so every follow-up `submitAIChatNativePrompt` payload carries `pageContext`, and the FE treats each one as a new context introduction.

**Fix:** New `pendingAttachedContextData` computed property on `UnifiedToggleInputPageContextChipViewModel` that gates on `attachmentDeliveryState == .pendingSubmit`. The host's provider now routes through it, so only the prompt that actually introduces (or re-introduces) context ships it on the wire.

This matches the semantics of the legacy non-UTI flow, where `handlePromptSubmission` ships page context only for the initial native prompt. The separate `submitAIChatPageContext` push channel (which the FE retains for the LLM) is untouched — this only affects the per-prompt `pageContext` signal used for the attribution UI.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Enable `unifiedToggleInput`
2. Navigate to website A (e.g. a Wikipedia article) and open the contextual web chat sheet on a page 
3. Tap the Duck\.ai button to open contextual chat. Tap chip to attach the page, then submit a first prompt. Confirm "Page content from..." attribution renders **once** beneath that prompt.
4. Send a follow-up prompt **without**. Confirm no attribution is rendered under the follow-up.
5. Navigate to website B within the same tab. Tap chip to attach new content. Then submit another prompt. Confirm attribution renders again under that prompt only, referencing website B.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low — single chat surface, UTI flow only. Non-UTI contextual chat path is unaffected.


#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->
- Provider returning `nil` for a prompt that should carry context. Mitigated: `.pendingSubmit` is the same state the chip uses to decide it's "attachable to next prompt"; tests cover initial-pending, post-submit, and re-attach.

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UTI contextual chat only; narrows when page context is sent in prompt payloads, with tests for pending, delivered, and re-attach cases.
> 
> **Overview**
> Fixes contextual Duck.ai (unified toggle input) showing **"Page content from…"** under every follow-up prompt.
> 
> **`attachedPageContextProvider`** no longer always reads **`attachedContext?.contextData`**. It uses new **`pendingAttachedContextData`**, which only returns context while **`attachmentDeliveryState`** is **`.pendingSubmit`**. After **`markPromptSubmitted()`**, follow-up **`submitPrompt`** payloads omit **`pageContext`** for attribution UI; re-attach restarts the pending cycle.
> 
> Unit tests cover the chip view model and **`AIChatContextualUTIHost`** binding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff012f59219d63d6cf8aa4d0badd17969452852f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->