### PR TITLE
[macOS] Add channel parameter to pixel definitions

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/aichat_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_pixels.json5
@@ -47,14 +47,14 @@
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_history_autoclear_disabled": {
         "description": "Fired when user disables the setting to auto-clear Duck.ai chat history in Data Clearing preferences",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_history_delete_requested": {
         "description": "Fired when user requests to delete Duck.ai chat history from the fire button or history delete dialog",

--- a/macOS/PixelDefinitions/pixels/definitions/app_settings_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/app_settings_pixels.json5
@@ -33,7 +33,7 @@
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "channel"]
     },
     "m_mac_settings_youtubeadblocking_opened": {
         "description": "Fired daily when the YouTube Ad Blocking settings pane is opened",

--- a/macOS/PixelDefinitions/pixels/definitions/default-browser-and-dock-prompt-inactive-user.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/default-browser-and-dock-prompt-inactive-user.json5
@@ -6,6 +6,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "channel",
             {
                 "key": "contentType",
                 "description": "Indicates the type of prompt shown",
@@ -20,6 +21,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "channel",
             {
                 "key": "contentType",
                 "description": "Indicates the type of prompt shown",
@@ -34,6 +36,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "channel",
             {
                 "key": "contentType",
                 "description": "Indicates the type of prompt shown",
@@ -46,27 +49,27 @@
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count"],
-        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
+        "parameters": ["appVersion", "pixelSource", "channel", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_mac_debug_set-as-default-add-to-dock_inactive-user_failed-to-save-modal-shown": {
         "description": "Fired when we fail to save the flag to indicate we have already shown the modal prompt for inactive users.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count"],
-        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
+        "parameters": ["appVersion", "pixelSource", "channel", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_mac_debug_set-as-default-add-to-dock_inactive-user_failed-to-retrieve-current-activity": {
         "description": "Fired when we fail to retrieve the current user activity, used to determine a user's eligibility for the inactive user prompt.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count"],
-        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
+        "parameters": ["appVersion", "pixelSource", "channel", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_mac_debug_set-as-default-add-to-dock_inactive-user_failed-to-save-current-activity": {
         "description": "Fired when we fail to save the current user activity, used to determine a user's eligibility for the inactive user prompt.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count"],
-        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
+        "parameters": ["appVersion", "pixelSource", "channel", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/new_tab_page_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/new_tab_page_pixels.json5
@@ -123,7 +123,7 @@
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "channel"]
     },
     "m_mac_new-tab-page_next-steps_duckplayer_dismissed": {
         "description": "Fires when a user dismisses the DuckPlayer Next Steps card on the New Tab Page. Used to understand onboarding engagement.",
@@ -144,98 +144,98 @@
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "channel"]
     },
     "m_mac_new-tab-page_next-steps_emailProtection_dismissed": {
         "description": "Fires when a user dismisses the Email Protection Next Steps card on the New Tab Page. Used to understand onboarding engagement.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "channel"]
     },
     "m_mac_new-tab-page_next-steps_emailProtection_shown": {
         "description": "Fires when the Email Protection Next Steps card is shown on the New Tab Page. Used to understand onboarding engagement.",
         "owners": ["rachelmcr"],
         "triggers": ["new_tab"],
         "suffixes": [],
-        "parameters": []
+        "parameters": ["channel"]
     },
     "m_mac_new-tab-page_next-steps_bringStuff_clicked": {
         "description": "Fires when a user clicks on the Import Next Steps card on the New Tab Page. Used to understand onboarding engagement.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "channel"]
     },
     "m_mac_new-tab-page_next-steps_bringStuff_dismissed": {
         "description": "Fires when a user dismisses the Import Next Steps card on the New Tab Page. Used to understand onboarding engagement.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "channel"]
     },
     "m_mac_new-tab-page_next-steps_bringStuff_shown": {
         "description": "Fires when the Import Next Steps card is shown on the New Tab Page. Used to understand onboarding engagement.",
         "owners": ["rachelmcr"],
         "triggers": ["new_tab"],
         "suffixes": [],
-        "parameters": []
+        "parameters": ["channel"]
     },
     "m_mac_new-tab-page_next-steps_addAppToDockMac_clicked": {
         "description": "Fires when a user clicks on the Add to Dock Next Steps card on the New Tab Page. Used to understand onboarding engagement.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "channel"]
     },
     "m_mac_new-tab-page_next-steps_addAppToDockMac_dismissed": {
         "description": "Fires when a user dismisses the Add to Dock Next Steps card on the New Tab Page. Used to understand onboarding engagement.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "channel"]
     },
     "m_mac_new-tab-page_next-steps_addAppToDockMac_shown": {
         "description": "Fires when the Add to Dock Next Steps card is shown on the New Tab Page. Used to understand onboarding engagement.",
         "owners": ["rachelmcr"],
         "triggers": ["new_tab"],
         "suffixes": [],
-        "parameters": []
+        "parameters": ["channel"]
     },
     "m_mac_new-tab-page_next-steps_defaultApp_clicked": {
         "description": "Fires when a user clicks on the Set as Default Next Steps card on the New Tab Page. Used to understand onboarding engagement.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "channel"]
     },
     "m_mac_new-tab-page_next-steps_defaultApp_dismissed": {
         "description": "Fires when a user dismisses the Set as Default Next Steps card on the New Tab Page. Used to understand onboarding engagement.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "channel"]
     },
     "m_mac_new-tab-page_next-steps_defaultApp_shown": {
         "description": "Fires when the Set as Default Next Steps card is shown on the New Tab Page. Used to understand onboarding engagement.",
         "owners": ["rachelmcr"],
         "triggers": ["new_tab"],
         "suffixes": [],
-        "parameters": []
+        "parameters": ["channel"]
     },
     "m_mac_new-tab-page_next-steps_subscription_clicked": {
         "description": "Fires when a user clicks on the Subscription Next Steps card on the New Tab Page. Used to understand onboarding engagement.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "channel"]
     },
     "m_mac_new-tab-page_next-steps_subscription_dismissed": {
         "description": "Fires when a user dismisses the Subscription Next Steps card on the New Tab Page. Used to understand onboarding engagement.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "channel"]
     },
     "m_mac_new-tab-page_next-steps_subscription_shown": {
         "description": "Fires when the Subscription Next Steps card is shown on the New Tab Page. Used to understand onboarding engagement.",
@@ -249,28 +249,28 @@
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "channel"]
     },
     "m_mac_new-tab-page_next-steps_personalizeBrowser_dismissed": {
         "description": "Fires when a user dismisses the Personalize Browser Next Steps card on the New Tab Page. Used to understand onboarding engagement.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "channel"]
     },
     "m_mac_new-tab-page_next-steps_personalizeBrowser_shown": {
         "description": "Fires when the Personalize Browser Next Steps card is shown on the New Tab Page. Used to understand onboarding engagement.",
         "owners": ["rachelmcr"],
         "triggers": ["new_tab"],
         "suffixes": [],
-        "parameters": []
+        "parameters": ["channel"]
     },
     "m_mac_new-tab-page_next-steps_sync_clicked": {
         "description": "Fires when a user clicks on the Sync Next Steps card on the New Tab Page. Used to understand onboarding engagement.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "channel"]
     },
     "m_mac_new-tab-page_next-steps_sync_dismissed": {
         "description": "Fires when a user dismisses the Sync Next Steps card on the New Tab Page. Used to understand onboarding engagement.",

--- a/macOS/PixelDefinitions/pixels/definitions/user_script.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/user_script.json5
@@ -8,6 +8,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "channel",
             "errorCode",
             "errorDomain",
             "underlyingErrorCode",


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1215086005205011?focus=true
Tech Design URL:
CC:

### Description

PixelKit automatically appends a `channel` parameter for non-production builds. Four pixels had live validation errors due to the parameter missing in the pixel definition:

> must NOT have additional properties. Found extra property 'channel'

Affected pixels:

* `m_mac_set-as-default-add-to-dock_inactive-user_modal-cancel-action`
* `m_mac_set-as-default-add-to-dock_inactive-user_modal-shown`
* `m_mac_new-tab-page_next-steps_subscription_dismissed`
* `m_mac_new-tab-page_next-steps_sync_clicked`

This adds the `channel` parameter to those four failing pixels and proactively adds it for other pixel definitions I own.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Confirm CI checks pass.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
None: Internal tooling, documentation

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
No effect on users; only updates are to JSON5 pixel definitions for live validation.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSON5 analytics schema updates only; no app logic or user-facing behavior changes.
> 
> **Overview**
> Adds the shared **`channel`** parameter to multiple macOS pixel definitions so they match what **PixelKit** already sends on non-production builds, fixing live validation errors (`must NOT have additional properties … 'channel'`).
> 
> Updates span **Duck.ai history** autoclear pixels, **settings** (Add to Dock “show me how”), **inactive-user default browser / dock** modal and related debug pixels, **New Tab Page Next Steps** onboarding pixels (click/dismiss/shown variants), and **`m_mac_debug_user_script_load_js_failed`**. Several NTP “shown” pixels that had empty or `appVersion`-only parameter lists now declare **`channel`** (and click/dismiss events gain **`channel`** alongside **`appVersion`** where missing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbfe1c61180edddaad3c1566cc09d92a06509c87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->