### PR TITLE
iPad: refresh WKWebView viewport on willEnterForeground

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -212,6 +212,7 @@ class MainViewController: UIViewController {
     private var feedbackCancellable: AnyCancellable?
     private var aiChatCancellables = Set<AnyCancellable>()
     private var settingsCancellables = Set<AnyCancellable>()
+    private var webViewViewportRefreshCancellable: AnyCancellable?
     private var lastForegroundEntryDate = Date.distantPast
     private var syncRecoveryPromptService: SyncRecoveryPromptService?
     private var currentNTPEscapeHatch: EscapeHatchModel?
@@ -1189,16 +1190,13 @@ class MainViewController: UIViewController {
                                                selector: #selector(onAppDidEnterBackground),
                                                name: UIApplication.didEnterBackgroundNotification,
                                                object: nil)
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(onAppWillEnterForeground),
-                                               name: UIApplication.willEnterForegroundNotification,
-                                               object: nil)
-    }
 
-    @objc private func onAppWillEnterForeground() {
-        if AppWidthObserver.shared.isPad {
-            refreshCurrentWebViewViewportAfterForeground()
-        }
+        webViewViewportRefreshCancellable = NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard AppWidthObserver.shared.isPad else { return }
+                self?.refreshCurrentWebViewViewportAfterForeground()
+            }
     }
 
     @objc private func onAppDidEnterBackground() {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1189,6 +1189,16 @@ class MainViewController: UIViewController {
                                                selector: #selector(onAppDidEnterBackground),
                                                name: UIApplication.didEnterBackgroundNotification,
                                                object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(onAppWillEnterForeground),
+                                               name: UIApplication.willEnterForegroundNotification,
+                                               object: nil)
+    }
+
+    @objc private func onAppWillEnterForeground() {
+        if AppWidthObserver.shared.isPad {
+            refreshCurrentWebViewViewportAfterForeground()
+        }
     }
 
     @objc private func onAppDidEnterBackground() {
@@ -1868,6 +1878,24 @@ class MainViewController: UIViewController {
         // Show Fire Pulse only if Privacy button pulse should not be shown. In control group onboarding `shouldShowPrivacyButtonPulse` is always false.
         if daxDialogsManager.shouldShowFireButtonPulse && !daxDialogsManager.shouldShowPrivacyButtonPulse {
             showFireButtonPulse()
+        }
+    }
+
+    /// Forces a viewport-size IPC to the WebContent process after foreground. Works around a
+    /// WKWebView bug where iOS's iPad multitasking snapshot cycle can leave the page stuck on a
+    /// stale `window.outerWidth` / `innerHeight`, breaking `vh`/`vw`-based layouts.
+    /// https://app.asana.com/1/137249556945/project/1201011656765697/task/1214469654462812?focus=true
+    private func refreshCurrentWebViewViewportAfterForeground() {
+        guard let webView = currentTab?.webView else { return }
+        let originalFrame = webView.frame
+        guard originalFrame.width > 0, originalFrame.height > 1 else { return }
+
+        var nudged = originalFrame
+        nudged.size.height -= 1
+        webView.frame = nudged
+
+        DispatchQueue.main.async { [weak webView] in
+            webView?.frame = originalFrame
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1214469654462812?focus=true
Tech Design URL:
CC:

### Description
On iPad, iOS's multitasking snapshot cycle resizes the WKWebView through portrait/split-view sizes while the WebContent process is suspending, and the final resize back to landscape can be dropped — leaving the page stuck on a stale `window.outerWidth` / `innerHeight` and breaking `vh`/`vw`-based layouts (e.g. duck.ai rendering "cut in half" after returning from background). Nudging the WKWebView frame by 1pt on `willEnterForeground` and restoring it on the next runloop forces a fresh viewport-size IPC to the WebContent process, so the page re-lays out before the user sees the screen. iPad-only.

### Testing Steps
1. On an iPad in landscape with duck.ai or any responsive site open, send the app to the background, wait a moment, then re-open it. The page should render at the correct viewport (no cut-in-half / empty bottom strip).
2. Repeat on iPhone — behavior should be unchanged (workaround is gated on `AppWidthObserver.shared.isPad`).
3. Switch tabs and rotate the device while in the foreground — scroll position, zoom, and page layout should behave normally.

### Impact and Risks
Low

#### What could go wrong?
The 1pt frame nudge could cause a brief visual flicker or interfere with an unusual layout pass; both are bounded to a single runloop and only fire on iPad foreground.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to iPad on foreground with a 1pt reversible frame change on the active web view; possible brief flicker but no auth, data, or broad layout refactors.
> 
> **Overview**
> Adds an **iPad-only** workaround in `MainViewController` for a **WKWebView** bug where multitasking/background snapshots can leave the WebContent process with a **stale viewport** (`window.outerWidth` / `innerHeight`), breaking **`vh`/`vw`** layouts after return from background.
> 
> On **`UIApplication.willEnterForegroundNotification`**, the app briefly **shrinks the current tab’s web view frame by 1pt** and restores it on the next main runloop, forcing a fresh viewport-size IPC. **iPhone is unchanged** via `AppWidthObserver.shared.isPad`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 453a90e5cebf7806c9bd89279e3d1042a5ed88c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->