### PR TITLE
[iOS/macOS] Add daily pixels for Duck.ai native storage

### DIFF
--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -450,7 +450,9 @@ struct DuckAiNativeStoragePixelAdapter: DuckAiNativeStoragePixelFiring {
         case .initSuccess:
             Pixel.fire(pixel: .duckAiNativeStorageInitSuccess)
         case .initError(let error):
-            Pixel.fire(pixel: .duckAiNativeStorageInitError, error: error)
+            DailyPixel.fireDailyAndCount(pixel: .duckAiNativeStorageInitError,
+                                         pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes,
+                                         error: error)
         case .migrationDone(let key):
             UniquePixel.fire(pixel: .duckAiNativeStorageMigrationDoneUnique(key: key))
             Pixel.fire(pixel: .duckAiNativeStorageMigrationDoneCount(key: key))
@@ -463,29 +465,53 @@ struct DuckAiNativeStoragePixelAdapter: DuckAiNativeStoragePixelFiring {
         case .migrationError(let error):
             Pixel.fire(pixel: .duckAiNativeStorageMigrationError, error: error)
         case .settingsPutError(let error):
-            Pixel.fire(pixel: .duckAiNativeStorageSettingsPutError, error: error)
+            DailyPixel.fireDailyAndCount(pixel: .duckAiNativeStorageSettingsPutError,
+                                         pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes,
+                                         error: error)
         case .settingsGetError(let error):
-            Pixel.fire(pixel: .duckAiNativeStorageSettingsGetError, error: error)
+            DailyPixel.fireDailyAndCount(pixel: .duckAiNativeStorageSettingsGetError,
+                                         pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes,
+                                         error: error)
         case .settingsDeleteError(let error):
-            Pixel.fire(pixel: .duckAiNativeStorageSettingsDeleteError, error: error)
+            DailyPixel.fireDailyAndCount(pixel: .duckAiNativeStorageSettingsDeleteError,
+                                         pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes,
+                                         error: error)
         case .chatPutError(let error):
-            Pixel.fire(pixel: .duckAiNativeStorageChatPutError, error: error)
+            DailyPixel.fireDailyAndCount(pixel: .duckAiNativeStorageChatPutError,
+                                         pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes,
+                                         error: error)
         case .chatGetError(let error):
-            Pixel.fire(pixel: .duckAiNativeStorageChatGetError, error: error)
+            DailyPixel.fireDailyAndCount(pixel: .duckAiNativeStorageChatGetError,
+                                         pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes,
+                                         error: error)
         case .chatDeleteError(let error):
-            Pixel.fire(pixel: .duckAiNativeStorageChatDeleteError, error: error)
+            DailyPixel.fireDailyAndCount(pixel: .duckAiNativeStorageChatDeleteError,
+                                         pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes,
+                                         error: error)
         case .filePutError(let error):
-            Pixel.fire(pixel: .duckAiNativeStorageFilePutError, error: error)
+            DailyPixel.fireDailyAndCount(pixel: .duckAiNativeStorageFilePutError,
+                                         pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes,
+                                         error: error)
         case .fileGetError(let error):
-            Pixel.fire(pixel: .duckAiNativeStorageFileGetError, error: error)
+            DailyPixel.fireDailyAndCount(pixel: .duckAiNativeStorageFileGetError,
+                                         pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes,
+                                         error: error)
         case .fileListError(let error):
-            Pixel.fire(pixel: .duckAiNativeStorageFileListError, error: error)
+            DailyPixel.fireDailyAndCount(pixel: .duckAiNativeStorageFileListError,
+                                         pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes,
+                                         error: error)
         case .fileDeleteError(let error):
-            Pixel.fire(pixel: .duckAiNativeStorageFileDeleteError, error: error)
+            DailyPixel.fireDailyAndCount(pixel: .duckAiNativeStorageFileDeleteError,
+                                         pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes,
+                                         error: error)
         case .lastUsedModelParseError(let error):
-            Pixel.fire(pixel: .duckAiNativeStorageLastUsedModelParseError, error: error)
+            DailyPixel.fireDailyAndCount(pixel: .duckAiNativeStorageLastUsedModelParseError,
+                                         pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes,
+                                         error: error)
         case .lastUsedReasoningModeParseError(let error):
-            Pixel.fire(pixel: .duckAiNativeStorageLastUsedReasoningModeParseError, error: error)
+            DailyPixel.fireDailyAndCount(pixel: .duckAiNativeStorageLastUsedReasoningModeParseError,
+                                         pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes,
+                                         error: error)
         }
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
@@ -5,170 +5,170 @@
 {
     "m_duck-ai_native-storage_migration_done_chats_unique": {
         "description": "Fires once per install when Duck.ai migration from web to native storage completes for chats",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "m_duck-ai_native-storage_migration_done_chats_count": {
         "description": "Count of Duck.ai chats migration completion notifications from the web frontend",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "m_duck-ai_native-storage_migration_done_files_unique": {
         "description": "Fires once per install when Duck.ai migration from web to native storage completes for files",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "m_duck-ai_native-storage_migration_done_files_count": {
         "description": "Count of Duck.ai files migration completion notifications from the web frontend",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "m_duck-ai_native-storage_migration_done_entries_unique": {
         "description": "Fires once per install when Duck.ai migration from web to native storage completes for entries (general-purpose key-value store)",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "m_duck-ai_native-storage_migration_done_entries_count": {
         "description": "Count of Duck.ai entries migration completion notifications from the web frontend",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "m_duck-ai_native-storage_migration_done_blank_count": {
         "description": "Count of Duck.ai markMigrationDone messages received with a missing or blank key, indicating a protocol error from the frontend",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "m_duck-ai_native-storage_init_success": {
         "description": "Fires when DuckAiNativeStorageProvider initializes successfully",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "m_duck-ai_native-storage_init_error": {
         "description": "Fires when DuckAiNativeStorageProvider init fails (DB or directory creation)",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["platform", "form_factor"],
+        "suffixes": ["daily_standard", "platform", "form_factor"],
         "parameters": ["appVersion", "errorDomain", "errorCode"]
     },
     "m_duck-ai_native-storage_migration_started": {
         "description": "Fires when the web layer calls markMigrationDone (migration was attempted)",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "m_duck-ai_native-storage_migration_already-done": {
         "description": "Fires when isMigrationDone returns true (page load found migration already complete)",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "m_duck-ai_native-storage_migration_error": {
         "description": "Fires when isMigrationDone or markMigrationDone throws",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion", "errorDomain", "errorCode"]
     },
     "m_duck-ai_native-storage_settings-put_error": {
         "description": "Fires when putEntry (Settings) fails",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["platform", "form_factor"],
+        "suffixes": ["daily_standard", "platform", "form_factor"],
         "parameters": ["appVersion", "errorDomain", "errorCode"]
     },
     "m_duck-ai_native-storage_settings-get_error": {
         "description": "Fires when getEntry or getAllEntries (Settings) fails",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["platform", "form_factor"],
+        "suffixes": ["daily_standard", "platform", "form_factor"],
         "parameters": ["appVersion", "errorDomain", "errorCode"]
     },
     "m_duck-ai_native-storage_settings-delete_error": {
         "description": "Fires when deleteEntry, deleteAllEntries, or replaceAllEntries (Settings) fails",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["platform", "form_factor"],
+        "suffixes": ["daily_standard", "platform", "form_factor"],
         "parameters": ["appVersion", "errorDomain", "errorCode"]
     },
     "m_duck-ai_native-storage_chat-put_error": {
         "description": "Fires when putChat or putChats fails",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["platform", "form_factor"],
+        "suffixes": ["daily_standard", "platform", "form_factor"],
         "parameters": ["appVersion", "errorDomain", "errorCode"]
     },
     "m_duck-ai_native-storage_chat-get_error": {
         "description": "Fires when getChat or getAllChats fails",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["platform", "form_factor"],
+        "suffixes": ["daily_standard", "platform", "form_factor"],
         "parameters": ["appVersion", "errorDomain", "errorCode"]
     },
     "m_duck-ai_native-storage_chat-delete_error": {
         "description": "Fires when deleteChat or deleteAllChats fails",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["platform", "form_factor"],
+        "suffixes": ["daily_standard", "platform", "form_factor"],
         "parameters": ["appVersion", "errorDomain", "errorCode"]
     },
     "m_duck-ai_native-storage_file-put_error": {
         "description": "Fires when putFile fails",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["platform", "form_factor"],
+        "suffixes": ["daily_standard", "platform", "form_factor"],
         "parameters": ["appVersion", "errorDomain", "errorCode"]
     },
     "m_duck-ai_native-storage_file-get_error": {
         "description": "Fires when getFile fails",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["platform", "form_factor"],
+        "suffixes": ["daily_standard", "platform", "form_factor"],
         "parameters": ["appVersion", "errorDomain", "errorCode"]
     },
     "m_duck-ai_native-storage_file-list_error": {
         "description": "Fires when listFiles fails",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["platform", "form_factor"],
+        "suffixes": ["daily_standard", "platform", "form_factor"],
         "parameters": ["appVersion", "errorDomain", "errorCode"]
     },
     "m_duck-ai_native-storage_file-delete_error": {
         "description": "Fires when deleteFile, deleteFiles (by chatId), or deleteAllFiles fails",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["platform", "form_factor"],
+        "suffixes": ["daily_standard", "platform", "form_factor"],
         "parameters": ["appVersion", "errorDomain", "errorCode"]
     },
     "m_duck-ai_native-storage_last-used-model-parse_error": {
         "description": "Fires when decoding the persisted chat JSON to read the last-used model fails",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["platform", "form_factor"],
+        "suffixes": ["daily_standard", "platform", "form_factor"],
         "parameters": ["appVersion", "errorDomain", "errorCode"]
     },
     "m_duck-ai_native-storage_last-used-reasoning-mode-parse_error": {
         "description": "Fires when decoding the persisted chat JSON to read the last-used reasoning mode fails",
-        "owners": ["pikorddg"],
+        "owners": ["pikorddg", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["platform", "form_factor"],
+        "suffixes": ["daily_standard", "platform", "form_factor"],
         "parameters": ["appVersion", "errorDomain", "errorCode"]
     }
 }

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -2416,7 +2416,7 @@ struct DuckAiNativeStoragePixelAdapter: DuckAiNativeStoragePixelFiring {
         case .initSuccess:
             PixelKit.fire(GeneralPixel.duckAiNativeStorageInitSuccess)
         case .initError(let error):
-            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageInitError, error: error))
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageInitError, error: error), frequency: .dailyAndStandard)
         case .migrationDone(let key):
             PixelKit.fire(GeneralPixel.duckAiNativeStorageMigrationDoneUnique(key: key), frequency: .uniqueByName)
             PixelKit.fire(GeneralPixel.duckAiNativeStorageMigrationDoneCount(key: key))
@@ -2429,25 +2429,25 @@ struct DuckAiNativeStoragePixelAdapter: DuckAiNativeStoragePixelFiring {
         case .migrationError(let error):
             PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageMigrationError, error: error))
         case .settingsPutError(let error):
-            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageSettingsPutError, error: error))
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageSettingsPutError, error: error), frequency: .dailyAndStandard)
         case .settingsGetError(let error):
-            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageSettingsGetError, error: error))
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageSettingsGetError, error: error), frequency: .dailyAndStandard)
         case .settingsDeleteError(let error):
-            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageSettingsDeleteError, error: error))
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageSettingsDeleteError, error: error), frequency: .dailyAndStandard)
         case .chatPutError(let error):
-            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageChatPutError, error: error))
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageChatPutError, error: error), frequency: .dailyAndStandard)
         case .chatGetError(let error):
-            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageChatGetError, error: error))
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageChatGetError, error: error), frequency: .dailyAndStandard)
         case .chatDeleteError(let error):
-            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageChatDeleteError, error: error))
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageChatDeleteError, error: error), frequency: .dailyAndStandard)
         case .filePutError(let error):
-            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageFilePutError, error: error))
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageFilePutError, error: error), frequency: .dailyAndStandard)
         case .fileGetError(let error):
-            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageFileGetError, error: error))
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageFileGetError, error: error), frequency: .dailyAndStandard)
         case .fileListError(let error):
-            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageFileListError, error: error))
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageFileListError, error: error), frequency: .dailyAndStandard)
         case .fileDeleteError(let error):
-            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageFileDeleteError, error: error))
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageFileDeleteError, error: error), frequency: .dailyAndStandard)
         case .lastUsedModelParseError:
             break
         case .lastUsedReasoningModeParseError:

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
@@ -5,156 +5,156 @@
 {
     "m_mac_duck-ai_native-storage_migration_done_chats_u": {
         "description": "Fires once per install when Duck.ai migration from web to native storage completes for chats",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_duck-ai_native-storage_migration_done_chats_count": {
         "description": "Count of Duck.ai chats migration completion notifications from the web frontend",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_duck-ai_native-storage_migration_done_files_u": {
         "description": "Fires once per install when Duck.ai migration from web to native storage completes for files",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_duck-ai_native-storage_migration_done_files_count": {
         "description": "Count of Duck.ai files migration completion notifications from the web frontend",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_duck-ai_native-storage_migration_done_entries_u": {
         "description": "Fires once per install when Duck.ai migration from web to native storage completes for entries (general-purpose key-value store)",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_duck-ai_native-storage_migration_done_entries_count": {
         "description": "Count of Duck.ai entries migration completion notifications from the web frontend",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_duck-ai_native-storage_migration_done_blank_count": {
         "description": "Count of Duck.ai markMigrationDone messages received with a missing or blank key, indicating a protocol error from the frontend",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource"]
     },
     "m_mac_duck-ai_native-storage_init_success": {
         "description": "Fires when DuckAiNativeStorageProvider initializes successfully",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_duck-ai_native-storage_init_error": {
         "description": "Fires when DuckAiNativeStorageProvider init fails (DB or directory creation)",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": [],
+        "suffixes": ["daily_standard"],
         "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
     },
     "m_mac_duck-ai_native-storage_migration_started": {
         "description": "Fires when the web layer calls markMigrationDone (migration was attempted)",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_duck-ai_native-storage_migration_already-done": {
         "description": "Fires when isMigrationDone returns true (page load found migration already complete)",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_duck-ai_native-storage_migration_error": {
         "description": "Fires when isMigrationDone or markMigrationDone throws",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
     },
     "m_mac_duck-ai_native-storage_settings-put_error": {
         "description": "Fires when putEntry (Settings) fails",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": [],
+        "suffixes": ["daily_standard"],
         "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
     },
     "m_mac_duck-ai_native-storage_settings-get_error": {
         "description": "Fires when getEntry or getAllEntries (Settings) fails",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": [],
+        "suffixes": ["daily_standard"],
         "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
     },
     "m_mac_duck-ai_native-storage_settings-delete_error": {
         "description": "Fires when deleteEntry, deleteAllEntries, or replaceAllEntries (Settings) fails",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": [],
+        "suffixes": ["daily_standard"],
         "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
     },
     "m_mac_duck-ai_native-storage_chat-put_error": {
         "description": "Fires when putChat or putChats fails",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": [],
+        "suffixes": ["daily_standard"],
         "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
     },
     "m_mac_duck-ai_native-storage_chat-get_error": {
         "description": "Fires when getChat or getAllChats fails",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": [],
+        "suffixes": ["daily_standard"],
         "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
     },
     "m_mac_duck-ai_native-storage_chat-delete_error": {
         "description": "Fires when deleteChat or deleteAllChats fails",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": [],
+        "suffixes": ["daily_standard"],
         "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
     },
     "m_mac_duck-ai_native-storage_file-put_error": {
         "description": "Fires when putFile fails",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": [],
+        "suffixes": ["daily_standard"],
         "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
     },
     "m_mac_duck-ai_native-storage_file-get_error": {
         "description": "Fires when getFile fails",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": [],
+        "suffixes": ["daily_standard"],
         "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
     },
     "m_mac_duck-ai_native-storage_file-list_error": {
         "description": "Fires when listFiles fails",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": [],
+        "suffixes": ["daily_standard"],
         "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
     },
     "m_mac_duck-ai_native-storage_file-delete_error": {
         "description": "Fires when deleteFile, deleteFiles (by chatId), or deleteAllFiles fails",
-        "owners": ["Bunn"],
+        "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": [],
+        "suffixes": ["daily_standard"],
         "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1207679781959993/task/1215174792094130?focus=true
Tech Design URL:
CC:

### Description

This PR adds daily pixels for Duck.ai native storage. The existing pixels are not changing.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that existing pixels have not changed
2. Check that daily pixels are now fired in addition to the regular ones

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only changes to error pixel firing and definitions; no storage, auth, or user-facing behavior changes.
> 
> **Overview**
> Adds **daily + standard** telemetry for Duck.ai **native storage error** events on iOS and macOS so spikes in volume can be compared to affected users per day.
> 
> On **iOS**, `DuckAiNativeStoragePixelAdapter` routes init, settings/chat/file CRUD, and last-used model/reasoning parse failures from `Pixel.fire` to `DailyPixel.fireDailyAndCount` with `dailyAndStandardSuffixes` (keeps the existing standard event and adds a once-per-day variant). **Success and migration lifecycle** pixels are unchanged; `migrationError` still uses a single standard fire.
> 
> On **macOS**, the same storage error cases in `DuckAiNativeStoragePixelAdapter` now pass `frequency: .dailyAndStandard` to `PixelKit.fire`. Parse-error cases remain no-ops on macOS.
> 
> **Pixel definitions** (`aichat_native_storage_pixels.json5` on both platforms) add the `daily_standard` suffix to those error pixels and add **samsymons** as an owner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 137f0fe568934e40cd7537f2766dde24bd28b5ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->