### PR TITLE
Revert "Bump native-github-asana-sync to v2.4"

### DIFF
--- a/.github/workflows/privacy-review.yml
+++ b/.github/workflows/privacy-review.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout native actions repo
         uses: actions/checkout@v6
         with:
-            ref: v2.4
+            ref: v2.1
             # Do not change the below path (downstream actions expect it)
             path: native-github-asana-sync
             repository: duckduckgo/native-github-asana-sync


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1215176598918332?focus=true

Reverts duckduckgo/apple-browsers#5081 due to the Privacy Triage workflow failing (see https://github.com/duckduckgo/apple-browsers/actions/runs/26525828811/job/78129074988?pr=5128)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes a CI workflow dependency pin; no app runtime, auth, or data-handling code.
> 
> **Overview**
> Rolls back the **Privacy Review** GitHub Actions workflow so it checks out `duckduckgo/native-github-asana-sync` at **`v2.1`** instead of **`v2.4`**.
> 
> That restores the prior behavior after the v2.4 bump caused the Privacy Triage workflow to fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd153112ea0419488ef43c3baecc197530c809ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->