### PR TITLE
Fix iPad duck.ai toggle text/icon bleed-through on quick re-tap

### DIFF
--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -1180,7 +1180,9 @@ extension DefaultOmniBarView {
             savedBarViewBackgroundColor = nil
         }
         searchAreaContainerView.applyShadowOpacityMultiplier(1)
-        textField.alpha = 1
+        if !isSearchAreaExpanded {
+            textField.alpha = 1
+        }
     }
 
     /// Configures the omnibar UI for AI Chat mode. Shows AI Chat buttons, hides search elements.
@@ -1357,6 +1359,7 @@ extension DefaultOmniBarView {
             let currentText = textField.text ?? ""
             textField.text = ""
             textField.alpha = currentText.isEmpty ? 1 : 0
+            privacyInfoContainer.alpha = 0
 
             aiChatTextView.text = currentText
             aiChatTextView.isHidden = false
@@ -1373,6 +1376,7 @@ extension DefaultOmniBarView {
 
             textField.text = currentText
             textField.alpha = 1
+            privacyInfoContainer.alpha = 1
         }
     }
 

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -132,11 +132,7 @@ final class DefaultOmniBarViewController: OmniBarViewController {
             return true
         }
 
-        let result = super.textFieldShouldBeginEditing(textField)
-        if result, state.showAIChatModeToggle {
-            omniBarView.isPrivacyInfoContainerHidden = true
-        }
-        return result
+        return super.textFieldShouldBeginEditing(textField)
     }
 
     override func textFieldDidBeginEditing(_ textField: UITextField) {

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -132,7 +132,11 @@ final class DefaultOmniBarViewController: OmniBarViewController {
             return true
         }
 
-        return super.textFieldShouldBeginEditing(textField)
+        let result = super.textFieldShouldBeginEditing(textField)
+        if result, state.showAIChatModeToggle {
+            omniBarView.isPrivacyInfoContainerHidden = true
+        }
+        return result
     }
 
     override func textFieldDidBeginEditing(_ textField: UITextField) {

--- a/iOS/DuckDuckGo/OmniBarNotificationAnimator.swift
+++ b/iOS/DuckDuckGo/OmniBarNotificationAnimator.swift
@@ -94,8 +94,15 @@ final class OmniBarNotificationAnimator: NSObject {
         // Reset visual state
         omniBar.notificationContainer.removePreviousNotification()
         omniBar.notificationContainer.alpha = 0
-        omniBar.textField.alpha = 1
-        omniBar.privacyInfoContainer.alpha = 1
+
+        /// Don't restore alpha when the iPad duck.ai search area is expanded — the textField
+        /// and favicon are intentionally hidden behind the aiChatTextView there, so unconditionally
+        /// setting alpha = 1 would bleed them through the active aiChat input.
+        /// https://app.asana.com/1/137249556945/project/1201011656765697/task/1215084286493408?focus=true
+        if (omniBar as? ExpandableOmniBarView)?.isSearchAreaExpanded != true {
+            omniBar.textField.alpha = 1
+            omniBar.privacyInfoContainer.alpha = 1
+        }
     }
 }
 

--- a/iOS/DuckDuckGo/OmniBarNotificationAnimator.swift
+++ b/iOS/DuckDuckGo/OmniBarNotificationAnimator.swift
@@ -94,15 +94,6 @@ final class OmniBarNotificationAnimator: NSObject {
         // Reset visual state
         omniBar.notificationContainer.removePreviousNotification()
         omniBar.notificationContainer.alpha = 0
-
-        /// Don't restore alpha when the iPad duck.ai search area is expanded — the textField
-        /// and favicon are intentionally hidden behind the aiChatTextView there, so unconditionally
-        /// setting alpha = 1 would bleed them through the active aiChat input.
-        /// https://app.asana.com/1/137249556945/project/1201011656765697/task/1215084286493408?focus=true
-        if (omniBar as? ExpandableOmniBarView)?.isSearchAreaExpanded != true {
-            omniBar.textField.alpha = 1
-            omniBar.privacyInfoContainer.alpha = 1
-        }
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1215084286493408?focus=true
Tech Design URL:
CC:

### Description
On iPad with the duck.ai toggle, submitting a prompt and immediately tapping the address bar left the URL display peeking through the active aiChat input, and the favicon could briefly flash while the bar was being selected. The textField/favicon alpha resets in `OmniBarNotificationAnimator.cancelAnimations` and `DefaultOmniBarView.restoreBarChrome` now respect `isSearchAreaExpanded`, and `applyTextViewVisibility` plus `textFieldShouldBeginEditing` hide the privacy icon synchronously so the state-driven `isHidden` update can catch up without a flash.

### Testing Steps
1. On iPad, with the duck.ai toggle, submit a prompt and immediately tap the address bar — no URL/text overlap.
2. On iPad, tap the address bar (either toggle side) — the favicon never appears once the bar is selected.
3. On iPhone, run through normal browsing/editing — behavior unchanged.

### Impact and Risks
Low

#### What could go wrong?
The new guards depend on `isSearchAreaExpanded` and `state.showAIChatModeToggle` correctly reflecting the iPad-only paths; an unexpected state where those are wrong could leave the textField or favicon hidden when they shouldn't be.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only alpha and animation-cancel behavior scoped to iPad expanded AI chat; wrong `isSearchAreaExpanded` could leave the text field or favicon hidden in edge cases.
> 
> **Overview**
> Fixes **iPad duck.ai** omnibar glitches where the URL field and **privacy/favicon** chrome briefly showed through the expanded AI chat input after a fast re-tap or when canceling notification animations.
> 
> **`restoreBarChrome`** no longer forces `textField.alpha = 1` while **`isSearchAreaExpanded`** is true, so chrome restore after unified-toggle transitions does not resurrect the hidden URL layer. **`applyTextViewVisibility`** now drives **`privacyInfoContainer.alpha`** to **0** in the expanded AI path and back to **1** on collapse, keeping the favicon aligned with the text view swap. **`OmniBarNotificationAnimator.cancelAnimations`** stops resetting text field and privacy container alpha on cancel, avoiding a flash when animations are torn down during editing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1273cd83d82f849e9b1c2ca9ee4dc7d8f0589612. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->