### PR TITLE
[macOS] Bump the WebKit process pool limit

### DIFF
--- a/macOS/LocalPackages/TestUtilities/Sources/SharedTestUtilities/Common/TestRunHelper.swift
+++ b/macOS/LocalPackages/TestUtilities/Sources/SharedTestUtilities/Common/TestRunHelper.swift
@@ -145,7 +145,7 @@ extension TestRunHelper: XCTestObservation {
                 let imp = method_getImplementation(method)
                 typealias SetWebProcessCountLimitType = @convention(c) (AnyClass, ObjectiveC.Selector, UInt32) -> Void
                 let setWebProcessCountLimit = unsafeBitCast(imp, to: SetWebProcessCountLimitType.self)
-                setWebProcessCountLimit(WKProcessPool.self, selector, 5)
+                setWebProcessCountLimit(WKProcessPool.self, selector, 10)
             }
         }
         processPool.perform(NSSelectorFromString("setWebViewsUsingProcessPool:"), with: Set([NSValue(point: .zero)])) // avoid deallocation checks on this process pool


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1215181163850312?focus=true
Tech Design URL:
CC:

### Description

This PR attempts to mitigate a WebKit crash on CI.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that CI did not crash due to process limit reasons

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change in test harness setup; no production app or user-facing behavior.
> 
> **Overview**
> Raises the **WebKit web process pool cap** used during macOS test runs from **5 to 10** by calling the private `WKProcessPool` API `_setWebProcessCountLimit:` in `TestRunHelper.testBundleWillStart`.
> 
> This is **test-only** infrastructure (shared `WKProcessPool` setup for `WKWebView` in tests) and is intended to reduce **CI crashes** when many web views or processes are created in parallel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dccea5ae76add0a60e3c4b24274a055ba3be637. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->