### PR TITLE
[TEST - DO NOT MERGE] decouple dispatch_pat for privacy-review

### DIFF
--- a/.github/workflows/privacy-review.yml
+++ b/.github/workflows/privacy-review.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout native actions repo
         uses: actions/checkout@v6
         with:
-            ref: v2.1
+            ref: la/decouple-dispatch-pat
             # Do not change the below path (downstream actions expect it)
             path: native-github-asana-sync
             repository: duckduckgo/native-github-asana-sync
@@ -24,3 +24,4 @@ jobs:
           trigger-phrase: 'Issue URL:'
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           github_pat: ${{ secrets.APPLE_GH_RO_PAT }}
+          dispatch_pat: ${{ secrets.GHA_ELEVATED_PERMISSIONS_TOKEN }}


### PR DESCRIPTION
Task/Issue URL: N/A (test PR)
Tech Design URL: N/A
CC:

### Description

**DO NOT MERGE.** This is a throwaway test PR to validate a proposed change to `duckduckgo/native-github-asana-sync`.

Background: PR #5081 bumped the privacy-review checkout from v2.1 to v2.4. That bump broke the workflow because v2.4 added a cross-repo dispatch step against `duckduckgo/privacy-review-automation`, and `APPLE_GH_RO_PAT` is read-only and lacks access to that repo.

The proposed action change ([branch la/decouple-dispatch-pat on native-github-asana-sync](https://github.com/duckduckgo/native-github-asana-sync/tree/la/decouple-dispatch-pat)) adds an optional `dispatch_pat` input that lets callers pass a separate token for the classifier dispatch step. This PR pins to that branch and passes `GHA_ELEVATED_PERMISSIONS_TOKEN` as `dispatch_pat`, while keeping `APPLE_GH_RO_PAT` as `github_pat` (which only needs read on `internal-github-asana-utils`).

### Testing Steps

1. Once this PR is open, label it with `privacy review`.
2. Watch the `Create Asana task for Privacy Review` run and verify:
   - `Get PR author Asana ID` succeeds (validates `APPLE_GH_RO_PAT` can still read `internal-github-asana-utils`).
   - `Dispatch AI Privacy Review classifier` succeeds (validates `GHA_ELEVATED_PERMISSIONS_TOKEN` has `actions:write` on `privacy-review-automation`).
3. If both pass: action change is good; we'll tag v2.5 on native-github-asana-sync and update the real privacy-review.yml. Close this PR after testing.
4. If `dispatch_pat` step still fails: `GHA_ELEVATED_PERMISSIONS_TOKEN` doesn't have the needed scope either; need to identify a different PAT.

### Impact and Risks

Low — workflow only runs on labeled PRs. Test PR itself does not modify app code.

#### What could go wrong?

- The dispatch step still fails: we learn the PAT candidate is wrong.
- The dispatch SUCCEEDS and a real classifier run kicks off on a test PR. That's expected and the consequence is one extra classifier run on `privacy-review-automation` against this PR's URL.

### Notes to Reviewer

**Do not approve, do not merge.** Close after testing.

Made with [Cursor](https://cursor.com)