### PR TITLE
iOS: Restore legacy Duck.ai placeholder top alignment

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
@@ -146,6 +146,10 @@ final class SwitchBarHandler: SwitchBarHandling {
         return false
     }
 
+    var usesExpandedAIChatTextEntryLayout: Bool {
+        devicePlatform.isIphone && !unifiedToggleInputFeature.isAvailable
+    }
+
     var shouldDisableAutocorrectOnEmpty: Bool {
         devicePlatform.isIphone
     }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -339,6 +339,27 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         XCTAssertEqual(placeholderLabel.center.y, textView.center.y, accuracy: 1)
     }
 
+    func test_legacyExpandedAIChatLayoutTopPlaceholderAlignsWithTextContainerTopInset() throws {
+        let handler = LegacyTextEntryMockHandler(
+            currentToggleState: .aiChat,
+            isTopBarPosition: true,
+            isUsingFadeOutAnimation: true,
+            usesExpandedAIChatTextEntryLayout: true
+        )
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut)
+        let height = applyFittingHeight(to: sut)
+
+        let textView = try XCTUnwrap(firstDescendant(of: UITextView.self, in: sut))
+        let placeholderLabel = try XCTUnwrap(firstDescendant(of: UILabel.self, in: sut))
+        let expectedPlaceholderMinY = textView.convert(CGPoint(x: 0, y: textView.textContainerInset.top), to: sut).y
+
+        XCTAssertEqual(height, 68, accuracy: 1)
+        XCTAssertFalse(placeholderLabel.isHidden)
+        XCTAssertEqual(placeholderLabel.frame.minY, expectedPlaceholderMinY, accuracy: 1)
+    }
+
     func test_barPositionChangeRefreshesExpandedAIChatPose() {
         let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
         handler.updateBarPosition(isTop: false)
@@ -591,6 +612,7 @@ private final class LegacyTextEntryMockHandler: SwitchBarHandling {
     var isFireTab: Bool = false
     var isUsingExpandedBottomBarHeight: Bool = false
     var isUsingFadeOutAnimation: Bool
+    var usesExpandedAIChatTextEntryLayout: Bool
     var shouldDisableAutocorrectOnEmpty: Bool = false
     var hidesVoiceButton: Bool = false
     var hasSubmittedPrompt: Bool = false
@@ -606,10 +628,14 @@ private final class LegacyTextEntryMockHandler: SwitchBarHandling {
     var isCurrentTextValidURLPublisher: AnyPublisher<Bool, Never> { Empty().eraseToAnyPublisher() }
     var currentButtonStatePublisher: AnyPublisher<SwitchBarButtonState, Never> { Empty().eraseToAnyPublisher() }
 
-    init(currentToggleState: TextEntryMode, isTopBarPosition: Bool, isUsingFadeOutAnimation: Bool) {
+    init(currentToggleState: TextEntryMode,
+         isTopBarPosition: Bool,
+         isUsingFadeOutAnimation: Bool,
+         usesExpandedAIChatTextEntryLayout: Bool = false) {
         self.currentToggleState = currentToggleState
         self.isTopBarPosition = isTopBarPosition
         self.isUsingFadeOutAnimation = isUsingFadeOutAnimation
+        self.usesExpandedAIChatTextEntryLayout = usesExpandedAIChatTextEntryLayout
     }
 
     func updateCurrentText(_ text: String) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1215158745886758?focus=true
Tech Design URL: N/A
CC:

### Description

Fixes a regression introduced inside PR #4911: the placeholder in the legacy (UTI-off) Duck.ai top-bar input sits ~22pt below the caret on iPhone instead of pinning to the text top inset.

The first commit on #4911 applied the top-aligned placeholder broadly, then a review-feedback commit narrowed it behind a new `usesExpandedAIChatTextEntryLayout` flag. `UnifiedToggleInputHandler` was updated to return `true`; `SwitchBarHandler` (legacy) was never updated to override the protocol default of `false`. The legacy `currentMinHeight` still grows the text view to 68pt in AI chat + top bar on iPhone (via `isUsingFadeOutAnimation`), so a 68pt textView ended up with a centerY-aligned placeholder.

Override `usesExpandedAIChatTextEntryLayout` on `SwitchBarHandler` to match the exact condition under which the legacy path grows to 68pt: `devicePlatform.isIphone && !unifiedToggleInputFeature.isAvailable`. The pose decision is now driven by a layout-named signal rather than the animation flag.

### Testing Steps

#### Legacy toggle Duck.ai placeholder alignment (the regression)
1. Disable the **Unified Toggle Input** feature flag.
2. Set Address Bar Position to **Top**.
3. Open the omnibar, switch to Duck.ai mode, and focus the empty input.
4. **Expected:** The Duck.ai placeholder aligns with the caret / text top inset, stays pinned there while focused, and does *not* sit below the cursor. Switch back to Search and the Search placeholder stays centered as before.

#### No regression on UTI / iPad
1. Re-enable the Unified Toggle Input feature flag → top and bottom bar Duck.ai placeholder behavior is unchanged from #4911 (top-aligned at top, centered at bottom).
2. Run the legacy flow on iPad → input stays at 44pt with a centered placeholder (unchanged).

### Impact and Risks

**Low.** The change is a single computed property on `SwitchBarHandler` that opts the legacy iPhone path into the existing `.tallTopAlignedAIChat` pose. No layout primitives or constraint setup change.

#### What could go wrong?

The pose toggle activates a different placeholder constraint (top vs. centerY). If the gating condition is wrong for some configuration, the placeholder could end up misaligned. Mitigations:
- The new test `test_legacyExpandedAIChatLayoutTopPlaceholderAlignsWithTextContainerTopInset` asserts 68pt height and pinned placeholder.
- The existing `test_legacyNonFadeOutTopAIChatTextEntryStaysCompactWhenExpandable` confirms the compact pose is preserved when the flag is `false` (e.g. iPad / UTI-on).
- Existing UTI placeholder tests (`test_topAIChatPlaceholderAlignsWithTextContainerTopInset`, `test_bottomAIChatPlaceholderStaysVerticallyCenteredInPill`, etc.) continue to pass.

### Quality Considerations

- The pose gate intentionally stays on the layout-named flag (`usesExpandedAIChatTextEntryLayout`), not on `isUsingFadeOutAnimation`. The two flags happen to coincide for the legacy handler today, but driving a layout decision off an animation flag is the same kind of accidental coupling that let the original regression slip through.
- The legacy mock (`LegacyTextEntryMockHandler`) now exposes `usesExpandedAIChatTextEntryLayout` so future tests can exercise both poses on the legacy path symmetrically to the UTI path.

### Notes to Reviewer

This is targeted at `release/ios/7.222.0` because the regression is user-visible in the current release line. PR #4911 was the source of both the original fix and the regression — see [the side-by-side of the two commits](https://github.com/duckduckgo/apple-browsers/pull/4911/files) for context.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single computed-property override on the legacy handler; layout pose logic already exists and is covered by new and existing placeholder tests.
> 
> **Overview**
> Fixes a **legacy omnibar (Unified Toggle Input off) regression** on iPhone where the Duck.ai placeholder sat below the caret in the tall top-bar layout.
> 
> **`SwitchBarHandler`** now overrides **`usesExpandedAIChatTextEntryLayout`** to `true` when `devicePlatform.isIphone && !unifiedToggleInputFeature.isAvailable`, matching when the legacy path uses the 68pt expanded AI chat text entry. That opts the view into the existing **`.tallTopAlignedAIChat`** pose (placeholder pinned to the text container top inset) instead of relying on the protocol default `false`.
> 
> A unit test and **`LegacyTextEntryMockHandler`** updates exercise the expanded legacy layout; UTI behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9b8923f8b2db733449ed54f16b394f61ea69e37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->