### PR TITLE
Improve matching of getStartedButton in onboarding flow UI test

### DIFF
--- a/macOS/UITests/OnboardingUITests.swift
+++ b/macOS/UITests/OnboardingUITests.swift
@@ -50,7 +50,9 @@ final class OnboardingUITests: UITestCase {
         // Get Started
         XCTAssertTrue(welcomeWindow.webViews["Welcome"].staticTexts["Ready for a faster browser that keeps you protected?"].waitForExistence(timeout: UITests.Timeouts.elementExistence))
 
-        let getStartedButton = welcomeWindow.webViews["Welcome"].buttons["Let’s do it!"]
+        let getStartedButton = welcomeWindow.webViews["Welcome"].buttons
+            .matching(NSPredicate(format: "label ==[c] %@", "Let’s do it!"))
+            .firstMatch
         XCTAssertTrue(getStartedButton.waitForExistence(timeout: UITests.Timeouts.elementExistence))
         // Use coordinate tap to avoid overlay/hittability quirks
         let centerCoordinate = getStartedButton.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.1))


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1215156971793264?focus=true
Tech Design URL:
CC:

### Description

This PR should fix the onboarding UI test failure.

The v3 onboarding's ElasticButton set an explicit `aria-label={text}` on its `<button>`, which WebKit's accessibility bridge exposed as both the identifier and the label — so our previous `buttons["Let's do it!"]` subscript just worked. 

The v4 Button component (used when the `onboardingRebranding` flag is on) renders its text as plain children with no aria-label, leaving the identifier empty – so the subscript approach doesn't match.

Switching to an explicit predicate match on label queries the property that's still populated, restoring the assertion.

I also made the title check case insensitive, as the casing changed between v3 and v4 – this should mean we don't get a failure if we toggle the flag at any point.

### Testing Steps

1. Check CI is happy! I already ran UI tests here: https://github.com/duckduckgo/apple-browsers/actions/runs/26514735629

### Impact and Risks

None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to element queries; no product or security impact.
> 
> **Overview**
> Updates the macOS onboarding UI test so the **“Let’s do it!”** control is found by **accessibility label** instead of the identifier-based `buttons["…"]` subscript.
> 
> Rebranded onboarding buttons no longer expose that text as the identifier, so the test uses an `NSPredicate` with case-insensitive label matching (`==[c]`) and `firstMatch`, keeping the same coordinate tap flow afterward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d58f51255c8f456d99e46aac4966ea2ff3e9e4a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->