### PR TITLE
[macOS] Fix Passwords row hover buttons disappearing on cursor move

### DIFF
--- a/macOS/DuckDuckGo/SecureVault/View/PasswordManagementLoginItemView.swift
+++ b/macOS/DuckDuckGo/SecureVault/View/PasswordManagementLoginItemView.swift
@@ -138,7 +138,7 @@ private struct Buttons: View {
                 .keyboardShortcut(.cancelAction)
 
                 Button(UserText.pmSave) {
-                    model.save()
+                    _ = model.save()
                 }
                 .disabled(!model.isDirty)
                 .buttonStyle(DefaultActionButtonStyle(enabled: model.isDirty))

--- a/macOS/DuckDuckGo/SecureVault/View/PasswordManagementLoginItemView.swift
+++ b/macOS/DuckDuckGo/SecureVault/View/PasswordManagementLoginItemView.swift
@@ -21,6 +21,9 @@ import SwiftUI
 import BrowserServicesKit
 import SwiftUIExtensions
 import DesignResourcesKit
+#if DEBUG
+import Common
+#endif
 
 private let interItemSpacing: CGFloat = 20
 private let itemSpacing: CGFloat = 6
@@ -578,3 +581,44 @@ extension NSTextView {
     }
   }
 }
+
+#if DEBUG
+private extension PasswordManagementLoginModel {
+    static func preview(password: String = "MyStrongPassw0rd!",
+                        username: String = "user@example.com",
+                        domain: String = "example.com") -> PasswordManagementLoginModel {
+        let model = PasswordManagementLoginModel(
+            onSaveRequested: { _ in },
+            onDeleteRequested: { _ in },
+            urlMatcher: AutofillDomainNameUrlMatcher(),
+            emailManager: EmailManager(),
+            tld: TLD(),
+            urlSort: AutofillDomainNameUrlSort()
+        )
+        model.credentials = .init(
+            account: .init(id: "preview",
+                           title: nil,
+                           username: username,
+                           domain: domain,
+                           created: Date(),
+                           lastUpdated: Date()),
+            password: password.data(using: .utf8)
+        )
+        return model
+    }
+}
+
+#Preview("Password row — valid website") {
+    PasswordView()
+        .environmentObject(PasswordManagementLoginModel.preview())
+        .frame(width: 400)
+        .padding()
+}
+
+#Preview("Password row — empty website (bug repro)") {
+    PasswordView()
+        .environmentObject(PasswordManagementLoginModel.preview(domain: ""))
+        .frame(width: 400)
+        .padding()
+}
+#endif

--- a/macOS/DuckDuckGo/SecureVault/View/PasswordManagementLoginItemView.swift
+++ b/macOS/DuckDuckGo/SecureVault/View/PasswordManagementLoginItemView.swift
@@ -21,9 +21,7 @@ import SwiftUI
 import BrowserServicesKit
 import SwiftUIExtensions
 import DesignResourcesKit
-#if DEBUG
 import Common
-#endif
 
 private let interItemSpacing: CGFloat = 20
 private let itemSpacing: CGFloat = 6
@@ -382,14 +380,18 @@ private struct PasswordView: View {
                         let showEyeButton = isHovering || isPasswordVisible
                         SecureTextFieldButton(isVisible: $isPasswordVisible, toolTipHideText: UserText.hidePasswordTooltip, toolTipShowText: UserText.showPasswordTooltip)
                             .opacity(showEyeButton ? 1 : 0)
+                            .disabled(!showEyeButton)
                             .allowsHitTesting(showEyeButton)
+                            .accessibilityHidden(!showEyeButton)
 
                         CopyButton {
                             model.copy(model.password, fieldType: .password)
                         }
                         .tooltip(UserText.copyPasswordTooltip)
                         .opacity(isHovering ? 1 : 0)
+                        .disabled(!isHovering)
                         .allowsHitTesting(isHovering)
+                        .accessibilityHidden(!isHovering)
                     }
 
                     Spacer()
@@ -608,17 +610,9 @@ private extension PasswordManagementLoginModel {
     }
 }
 
-#Preview("Password row — valid website") {
-    PasswordView()
+#Preview("Login item view") {
+    PasswordManagementLoginItemView()
         .environmentObject(PasswordManagementLoginModel.preview())
-        .frame(width: 400)
-        .padding()
-}
-
-#Preview("Password row — empty website (bug repro)") {
-    PasswordView()
-        .environmentObject(PasswordManagementLoginModel.preview(domain: ""))
-        .frame(width: 400)
-        .padding()
+        .frame(width: 480, height: 600)
 }
 #endif

--- a/macOS/DuckDuckGo/SecureVault/View/PasswordManagementLoginItemView.swift
+++ b/macOS/DuckDuckGo/SecureVault/View/PasswordManagementLoginItemView.swift
@@ -17,7 +17,6 @@
 //
 
 import Foundation
-
 import SwiftUI
 import BrowserServicesKit
 import SwiftUIExtensions
@@ -376,15 +375,18 @@ private struct PasswordView: View {
 
                     HiddenText(isVisible: isPasswordVisible, text: model.password, hiddenTextLength: 12)
 
-                    if (isHovering || isPasswordVisible) && model.password != "" {
+                    if model.password != "" {
+                        let showEyeButton = isHovering || isPasswordVisible
                         SecureTextFieldButton(isVisible: $isPasswordVisible, toolTipHideText: UserText.hidePasswordTooltip, toolTipShowText: UserText.showPasswordTooltip)
-                    }
+                            .opacity(showEyeButton ? 1 : 0)
+                            .allowsHitTesting(showEyeButton)
 
-                    if isHovering && model.password != "" {
                         CopyButton {
                             model.copy(model.password, fieldType: .password)
                         }
                         .tooltip(UserText.copyPasswordTooltip)
+                        .opacity(isHovering ? 1 : 0)
+                        .allowsHitTesting(isHovering)
                     }
 
                     Spacer()
@@ -394,6 +396,7 @@ private struct PasswordView: View {
             }
 
         }
+        .contentShape(Rectangle())
         .onHover {
             isHovering = $0
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214200115953388/task/1215077497922282

### Description

In the macOS Passwords manager, the eye/copy buttons in a password row were conditionally inserted into the `HStack` on hover, which forced a layout pass and made the parent `VStack`'s hover hit-area unstable — the buttons appeared on hover then disappeared as the cursor moved to click them. Anya reliably reproduced this on entries whose Website field is empty or an invalid URL. The fix always renders the buttons (gated only on a non-empty password) and toggles `.opacity()` + `.allowsHitTesting()` based on hover state, plus a `.contentShape(Rectangle())` on the VStack so the full frame participates in hover detection. Adds a `#Preview` of the full login item view for future iteration.

### Testing Steps
1. Open the macOS app, go to Passwords, and pick a credential whose Website field is empty or not a valid URL.
2. Hover the row's password value — the eye + copy buttons should appear next to the dots.
3. Move the cursor onto the eye/copy buttons and click — they should stay visible and respond. Repeat on an entry with a valid website URL to confirm the regular hover/click flow still works.

### Impact and Risks
Low

#### What could go wrong?
The buttons are now always in the view hierarchy (just invisible and hit-test-disabled when not hovering), so VoiceOver / accessibility could expose them when it shouldn't — worth a quick screen-reader pass.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only SwiftUI behavior in the Passwords manager; main follow-up is a quick accessibility pass since controls remain in the hierarchy when hidden.
> 
> **Overview**
> Fixes **Passwords** login-item rows where the **show/hide** and **copy** controls vanished when moving the cursor to click them—especially on credentials with an **empty or invalid Website** field.
> 
> The password row now **always keeps** those controls in the layout (when the password is non-empty) and only toggles **visibility and hit-testing** via opacity and related modifiers, instead of inserting/removing views on hover. A **`.contentShape(Rectangle())`** on the password section stabilizes hover detection across the full row frame.
> 
> Also adds a **DEBUG `#Preview`** for the full login item view and discards the return value from **`model.save()`** on the Save button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3080b165355d4e2a32542366414e90a5ddf96f81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->