### PR TITLE
Disable contextual onboarding rebranding for macOS <= 12

### DIFF
--- a/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/Rebranding/ContextualDaxDialogsProvider.swift
+++ b/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/Rebranding/ContextualDaxDialogsProvider.swift
@@ -57,7 +57,9 @@ final class ContextualDaxDialogsProvider: ContextualDaxDialogsFactory {
     }
 
     private var factory: ContextualDaxDialogsFactory {
-        if featureFlagger.isFeatureOn(.onboardingRebranding) {
+        // Rebranded panel layout breaks on macOS 12 and below. For now, we'll just
+        // ensure we show the legacy contextual dialogs on those versions.
+        if #available(macOS 13.0, *), featureFlagger.isFeatureOn(.onboardingRebranding) {
             rebrandedDaxDialogsFactory
         } else {
             legacyDaxDialogsFactory


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1176956903599313/task/1215138600735057?focus=true
Tech Design URL:
CC:

### Description

This PR disables the contextual onboarding rebranding for macOS versions <= 12, due to a bug with positioning of the visual elements. macOS 12 and below will see the legacy contextual onboarding.

### Testing Steps

1. Build and run on macOS > 12
2. Ensure the onboardRebranding FF is enabled. Click Debug > Reset Data > Reset Contextual Onboarding.
3. Open a new window, check you see the new onboarding.

Repeat on macOS 12 and check you see the legacy onboarding.

### Impact and Risks

Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?

Nothing really, reverting to legacy flow.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small factory-selection change with a safe fallback to the existing legacy onboarding UI.
> 
> **Overview**
> Contextual onboarding rebranding now only applies on **macOS 13+** when the onboarding rebranding feature flag is on. On **macOS 12 and earlier**, the app always uses the **legacy** contextual Dax dialogs because the rebranded panel layout mispositions UI elements on those OS versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b76ecd7a5d4a896be4f09fcd766dadbb40ed21c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->