### PR TITLE
iOS: SR - NC6, CT1, BB - UTI Content (suggesions, recents) Change Animation is Jarring

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FadeOutContainerViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FadeOutContainerViewController.swift
@@ -49,7 +49,6 @@ final class FadeOutContainerViewController: UIViewController {
 
     private var displayLink: CADisplayLink?
     private var targetProgress: CGFloat = 0.0
-    private var visibleMode: TextEntryMode?
 
     init(switchBarHandler: SwitchBarHandling) {
         self.switchBarHandler = switchBarHandler
@@ -147,20 +146,16 @@ final class FadeOutContainerViewController: UIViewController {
     }
 
     private func configureInitialState() {
-        let currentMode = switchBarHandler.currentToggleState
-        let isSearchMode = currentMode == .search
+        let isSearchMode = switchBarHandler.currentToggleState == .search
         searchPageContainer.alpha = isSearchMode ? 1.0 : 0.0
         chatPageContainer.alpha = isSearchMode ? 0.0 : 1.0
         transitionProgress = isSearchMode ? 0.0 : 1.0
-        visibleMode = currentMode
     }
 
     private func updateVisibility(animated: Bool) {
         guard searchPageContainer != nil, chatPageContainer != nil else { return }
 
         let newMode = switchBarHandler.currentToggleState
-        guard visibleMode != newMode else { return }
-
         let isSearchMode = newMode == .search
         targetProgress = isSearchMode ? 0.0 : 1.0
 
@@ -187,7 +182,6 @@ final class FadeOutContainerViewController: UIViewController {
             guard let self, finished else { return }
 
             self.updateTransitionProgress(self.targetProgress)
-            self.visibleMode = newMode
             self.delegate?.fadeOutContainerViewController(self, didTransitionToMode: newMode)
         }
 

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FadeOutContainerViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FadeOutContainerViewController.swift
@@ -49,6 +49,7 @@ final class FadeOutContainerViewController: UIViewController {
 
     private var displayLink: CADisplayLink?
     private var targetProgress: CGFloat = 0.0
+    private var visibleMode: TextEntryMode?
 
     init(switchBarHandler: SwitchBarHandling) {
         self.switchBarHandler = switchBarHandler
@@ -146,16 +147,21 @@ final class FadeOutContainerViewController: UIViewController {
     }
 
     private func configureInitialState() {
-        let isSearchMode = switchBarHandler.currentToggleState == .search
+        let currentMode = switchBarHandler.currentToggleState
+        let isSearchMode = currentMode == .search
         searchPageContainer.alpha = isSearchMode ? 1.0 : 0.0
         chatPageContainer.alpha = isSearchMode ? 0.0 : 1.0
         transitionProgress = isSearchMode ? 0.0 : 1.0
+        visibleMode = currentMode
     }
 
     private func updateVisibility(animated: Bool) {
         guard searchPageContainer != nil, chatPageContainer != nil else { return }
 
-        let isSearchMode = switchBarHandler.currentToggleState == .search
+        let newMode = switchBarHandler.currentToggleState
+        guard visibleMode != newMode else { return }
+
+        let isSearchMode = newMode == .search
         targetProgress = isSearchMode ? 0.0 : 1.0
 
         let isShowingSuggestions = delegate?.fadeOutContainerViewControllerIsShowingSuggestions(self) ?? false
@@ -181,7 +187,7 @@ final class FadeOutContainerViewController: UIViewController {
             guard let self, finished else { return }
 
             self.updateTransitionProgress(self.targetProgress)
-            let newMode: TextEntryMode = isSearchMode ? .search : .aiChat
+            self.visibleMode = newMode
             self.delegate?.fadeOutContainerViewController(self, didTransitionToMode: newMode)
         }
 

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FadeOutContainerViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FadeOutContainerViewController.swift
@@ -19,7 +19,6 @@
 
 import UIKit
 import Combine
-import PrivacyConfig
 
 protocol FadeOutContainerViewControllerDelegate: AnyObject {
     func fadeOutContainerViewController(_ controller: FadeOutContainerViewController, didTransitionToMode mode: TextEntryMode)
@@ -35,11 +34,14 @@ final class FadeOutContainerViewController: UIViewController {
     @Published private(set) var transitionProgress: CGFloat = 0.0
 
     private let switchBarHandler: SwitchBarHandling
-    private let featureFlagger: FeatureFlagger
     private var cancellables = Set<AnyCancellable>()
 
     private(set) var searchPageContainer: UIView!
     private(set) var chatPageContainer: UIView!
+
+    var isSwipeEnabled: Bool = true {
+        didSet { panGestureRecognizer?.isEnabled = isSwipeEnabled }
+    }
 
     private var panGestureRecognizer: UIPanGestureRecognizer!
     private let swipeVelocityThreshold: CGFloat = 500
@@ -48,10 +50,8 @@ final class FadeOutContainerViewController: UIViewController {
     private var displayLink: CADisplayLink?
     private var targetProgress: CGFloat = 0.0
 
-    init(switchBarHandler: SwitchBarHandling,
-         featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger) {
+    init(switchBarHandler: SwitchBarHandling) {
         self.switchBarHandler = switchBarHandler
-        self.featureFlagger = featureFlagger
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -74,8 +74,8 @@ final class FadeOutContainerViewController: UIViewController {
         setupBindings()
     }
 
-    func setMode(_ mode: TextEntryMode) {
-        updateVisibility(animated: true)
+    func setMode(_ mode: TextEntryMode, animated: Bool = true) {
+        updateVisibility(animated: animated)
     }
 
     // MARK: - Private
@@ -85,7 +85,7 @@ final class FadeOutContainerViewController: UIViewController {
             .receive(on: DispatchQueue.main)
             .removeDuplicates()
             .sink { [weak self] _ in
-                guard let self, switchBarHandler.isUsingFadeOutAnimation else { return }
+                guard let self else { return }
                 self.updateVisibility(animated: true)
             }
             .store(in: &cancellables)
@@ -119,6 +119,7 @@ final class FadeOutContainerViewController: UIViewController {
     private func setupSwipeGestures() {
         panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture(_:)))
         panGestureRecognizer.delegate = self
+        panGestureRecognizer.isEnabled = isSwipeEnabled
         view.addGestureRecognizer(panGestureRecognizer)
     }
 

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FadeOutContainerViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FadeOutContainerViewController.swift
@@ -49,6 +49,8 @@ final class FadeOutContainerViewController: UIViewController {
 
     private var displayLink: CADisplayLink?
     private var targetProgress: CGFloat = 0.0
+    private var visibleMode: TextEntryMode?
+    private var transitionID = 0
 
     init(switchBarHandler: SwitchBarHandling) {
         self.switchBarHandler = switchBarHandler
@@ -75,7 +77,7 @@ final class FadeOutContainerViewController: UIViewController {
     }
 
     func setMode(_ mode: TextEntryMode, animated: Bool = true) {
-        updateVisibility(animated: animated)
+        updateVisibility(to: mode, animated: animated)
     }
 
     // MARK: - Private
@@ -84,9 +86,10 @@ final class FadeOutContainerViewController: UIViewController {
         switchBarHandler.toggleStatePublisher
             .receive(on: DispatchQueue.main)
             .removeDuplicates()
-            .sink { [weak self] _ in
+            .sink { [weak self] mode in
                 guard let self else { return }
-                self.updateVisibility(animated: true)
+                guard mode == self.switchBarHandler.currentToggleState else { return }
+                self.updateVisibility(to: mode, animated: true)
             }
             .store(in: &cancellables)
     }
@@ -146,18 +149,24 @@ final class FadeOutContainerViewController: UIViewController {
     }
 
     private func configureInitialState() {
-        let isSearchMode = switchBarHandler.currentToggleState == .search
+        let currentMode = switchBarHandler.currentToggleState
+        let isSearchMode = currentMode == .search
         searchPageContainer.alpha = isSearchMode ? 1.0 : 0.0
         chatPageContainer.alpha = isSearchMode ? 0.0 : 1.0
         transitionProgress = isSearchMode ? 0.0 : 1.0
+        visibleMode = currentMode
     }
 
-    private func updateVisibility(animated: Bool) {
+    private func updateVisibility(to mode: TextEntryMode, animated: Bool) {
         guard searchPageContainer != nil, chatPageContainer != nil else { return }
+        guard visibleMode != mode else { return }
 
-        let newMode = switchBarHandler.currentToggleState
-        let isSearchMode = newMode == .search
-        targetProgress = isSearchMode ? 0.0 : 1.0
+        visibleMode = mode
+        transitionID += 1
+        let currentTransitionID = transitionID
+        let isSearchMode = mode == .search
+        let targetProgress = isSearchMode ? 0.0 : 1.0
+        self.targetProgress = targetProgress
 
         let isShowingSuggestions = delegate?.fadeOutContainerViewControllerIsShowingSuggestions(self) ?? false
         let shouldHideSearchImmediately = !isSearchMode && isShowingSuggestions
@@ -177,12 +186,13 @@ final class FadeOutContainerViewController: UIViewController {
         }
 
         let completion: (Bool) -> Void = { [weak self] finished in
-            self?.stopDisplayLink()
+            guard let self, self.transitionID == currentTransitionID else { return }
 
-            guard let self, finished else { return }
+            self.stopDisplayLink()
+            guard finished else { return }
 
-            self.updateTransitionProgress(self.targetProgress)
-            self.delegate?.fadeOutContainerViewController(self, didTransitionToMode: newMode)
+            self.updateTransitionProgress(targetProgress)
+            self.delegate?.fadeOutContainerViewController(self, didTransitionToMode: mode)
         }
 
         if animated {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/DaxLogo/DaxLogoManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/DaxLogo/DaxLogoManager.swift
@@ -151,6 +151,7 @@ final class DaxLogoManager {
             guard self?.pendingTransitionToken == token else { return }
             self?.pendingTransitionToken = nil
             self?.isAnimatingLogoTransition = false
+            self?.updateState()
         }
     }
 

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/DaxLogo/DaxLogoManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/DaxLogo/DaxLogoManager.swift
@@ -151,6 +151,7 @@ final class DaxLogoManager {
             guard self?.pendingTransitionToken == token else { return }
             self?.pendingTransitionToken = nil
             self?.isAnimatingLogoTransition = false
+            self?.currentProgress = targetProgress
             self?.updateState()
         }
     }

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SuggestionTrayManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SuggestionTrayManager.swift
@@ -68,6 +68,7 @@ final class SuggestionTrayManager: NSObject {
 
     private let switchBarHandler: SwitchBarHandling
     private let dependencies: SuggestionTrayDependencies
+    private let autocompleteHorizontalInset: CGFloat
     private var cancellables = Set<AnyCancellable>()
     
     private(set) var suggestionTrayViewController: SuggestionTrayViewController?
@@ -109,9 +110,10 @@ final class SuggestionTrayManager: NSObject {
 
     // MARK: - Initialization
     
-    init(switchBarHandler: SwitchBarHandling, dependencies: SuggestionTrayDependencies) {
+    init(switchBarHandler: SwitchBarHandling, dependencies: SuggestionTrayDependencies, autocompleteHorizontalInset: CGFloat = 0) {
         self.switchBarHandler = switchBarHandler
         self.dependencies = dependencies
+        self.autocompleteHorizontalInset = autocompleteHorizontalInset
         super.init()
         setupBindings()
     }
@@ -200,7 +202,7 @@ final class SuggestionTrayManager: NSObject {
         if canShow {
             // Don't set view.isHidden = false here — the tray stays hidden until
             // results arrive. autocompleteDidReloadResults shows it if non-empty.
-            suggestionTray.fill()
+            suggestionTray.fill(horizontalInset: autocompleteHorizontalInset)
             suggestionTray.show(for: .autocomplete(query: query), animated: animated)
         } else {
             suggestionTray.didHide(animated: animated)
@@ -269,10 +271,19 @@ final class SuggestionTrayManager: NSObject {
 
         if canShowSuggestion {
             suggestionTray.view.isHidden = false
-            suggestionTray.fill()
+            suggestionTray.fill(horizontalInset: horizontalInset(for: type))
             suggestionTray.show(for: type, animated: animated)
         } else {
             suggestionTray.didHide(animated: animated)
+        }
+    }
+
+    private func horizontalInset(for type: SuggestionTrayViewController.SuggestionType) -> CGFloat {
+        switch type {
+        case .autocomplete:
+            return autocompleteHorizontalInset
+        case .favorites:
+            return 0
         }
     }
     

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SwipeContainerManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SwipeContainerManager.swift
@@ -20,18 +20,30 @@
 import Combine
 import Foundation
 import UIKit
-import PrivacyConfig
 
 /// Manages the horizontal swipe container with pagination between search and AI chat modes
 final class SwipeContainerManager: NSObject {
 
+    enum ContentTransition {
+        case paged
+        case crossfade
+
+        init(switchBarHandler: SwitchBarHandling) {
+            self = switchBarHandler.isUsingFadeOutAnimation ? .crossfade : .paged
+        }
+    }
+
     // MARK: - Properties
 
     private let switchBarHandler: SwitchBarHandling
-    private let featureFlagger: FeatureFlagger
+    private let contentTransition: ContentTransition
+
+    private var usesFadeOutTransition: Bool {
+        contentTransition == .crossfade
+    }
 
     var searchPageContainer: UIView {
-        if switchBarHandler.isUsingFadeOutAnimation {
+        if usesFadeOutTransition {
             return fadeOutContainerViewController.searchPageContainer
         } else {
             return swipeContainerViewController.searchPageContainer
@@ -39,7 +51,7 @@ final class SwipeContainerManager: NSObject {
     }
 
     var chatPageContainer: UIView {
-        if switchBarHandler.isUsingFadeOutAnimation {
+        if usesFadeOutTransition {
             return fadeOutContainerViewController.chatPageContainer
         } else {
             return swipeContainerViewController.chatPageContainer
@@ -47,10 +59,10 @@ final class SwipeContainerManager: NSObject {
     }
 
     private lazy var swipeContainerViewController = SwipeContainerViewController(switchBarHandler: switchBarHandler)
-    private lazy var fadeOutContainerViewController = FadeOutContainerViewController(switchBarHandler: switchBarHandler, featureFlagger: featureFlagger)
+    private lazy var fadeOutContainerViewController = FadeOutContainerViewController(switchBarHandler: switchBarHandler)
 
     var containerViewController: UIViewController {
-        switchBarHandler.isUsingFadeOutAnimation ? fadeOutContainerViewController : swipeContainerViewController
+        usesFadeOutTransition ? fadeOutContainerViewController : swipeContainerViewController
     }
 
     var delegate: SwipeContainerViewControllerDelegate? {
@@ -64,8 +76,18 @@ final class SwipeContainerManager: NSObject {
     }
 
     var isSwipeEnabled: Bool {
-        get { swipeContainerViewController.isSwipeEnabled }
-        set { swipeContainerViewController.isSwipeEnabled = newValue }
+        get {
+            usesFadeOutTransition
+                ? fadeOutContainerViewController.isSwipeEnabled
+                : swipeContainerViewController.isSwipeEnabled
+        }
+        set {
+            if usesFadeOutTransition {
+                fadeOutContainerViewController.isSwipeEnabled = newValue
+            } else {
+                swipeContainerViewController.isSwipeEnabled = newValue
+            }
+        }
     }
 
     var fadeOutDelegate: FadeOutContainerViewControllerDelegate? {
@@ -76,9 +98,9 @@ final class SwipeContainerManager: NSObject {
     // MARK: - Initialization
     
     init(switchBarHandler: SwitchBarHandling,
-         featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger) {
+         contentTransition: ContentTransition? = nil) {
         self.switchBarHandler = switchBarHandler
-        self.featureFlagger = featureFlagger
+        self.contentTransition = contentTransition ?? ContentTransition(switchBarHandler: switchBarHandler)
         super.init()
     }
     
@@ -104,7 +126,7 @@ final class SwipeContainerManager: NSObject {
 
     /// Overlays the search page on the visible area, or returns it to its natural position.
     func setSearchPageVisible(_ visible: Bool, animated: Bool) {
-        if switchBarHandler.isUsingFadeOutAnimation {
+        if usesFadeOutTransition {
             applySearchPageFade(visible, animated: animated)
         } else {
             applySearchPageSlide(visible, animated: animated)
@@ -154,8 +176,8 @@ final class SwipeContainerManager: NSObject {
     }
 
     func syncVisibleMode(animated: Bool) {
-        if switchBarHandler.isUsingFadeOutAnimation {
-            fadeOutContainerViewController.setMode(switchBarHandler.currentToggleState)
+        if usesFadeOutTransition {
+            fadeOutContainerViewController.setMode(switchBarHandler.currentToggleState, animated: animated)
         } else {
             swipeContainerViewController.syncToCurrentMode(animated: animated)
         }

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/DuckAISuggestionsViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/DuckAISuggestionsViewController.swift
@@ -54,7 +54,7 @@ final class DuckAISuggestionsViewController: UIViewController {
         /// Extra clearance above the natural insetGrouped top padding so the first cell stays below the floating (x) dismiss button.
         static let topContentInset: CGFloat = 12
         static let escapeHatchCardHeight: CGFloat = 56
-        static let escapeHatchTopPadding: CGFloat = 8
+        static let escapeHatchTopPadding: CGFloat = 14
         static let headerBottomPadding: CGFloat = 24
         static let syncPromoInterCardSpacing: CGFloat = 20
         static let recentChatsHeaderHeight: CGFloat = 48
@@ -74,7 +74,7 @@ final class DuckAISuggestionsViewController: UIViewController {
         )
 
         static let unifiedToggleInput = LayoutConfiguration(
-            tableHorizontalInset: 0,
+            tableHorizontalInset: 8,
             escapeHatchHorizontalInset: Constants.horizontalInset,
             escapeHatchMaxWidth: nil
         )

--- a/iOS/DuckDuckGo/SuggestionTrayViewController.swift
+++ b/iOS/DuckDuckGo/SuggestionTrayViewController.swift
@@ -292,13 +292,14 @@ class SuggestionTrayViewController: UIViewController {
 
         variableWidthConstraint.constant = width
         fullWidthConstraint.isActive = false
+        fullWidthConstraint.constant = 0
         fullHeightConstraint.isActive = false
         fullHeightSafeAreaConstraint.isActive = false
         fullHeightSafeAreaInequalityConstraint.isActive = true
         applyTopConstraintForLayoutMode()
     }
 
-    func fill(bottomOffset: CGFloat = 0.0) {
+    func fill(bottomOffset: CGFloat = 0.0, horizontalInset: CGFloat = 0.0) {
         additionalSafeAreaInsets = .init(top: 0, left: 0, bottom: bottomOffset, right: 0)
 
         containerView.layer.shadowColor = UIColor.clear.cgColor
@@ -311,6 +312,7 @@ class SuggestionTrayViewController: UIViewController {
         backgroundView.backgroundColor = UIColor.clear
 
         fullWidthConstraint.isActive = true
+        fullWidthConstraint.constant = -(horizontalInset * 2)
         fullHeightConstraint.isActive = coversFullScreen
         fullHeightSafeAreaConstraint.isActive = !coversFullScreen
         fullHeightSafeAreaInequalityConstraint.isActive = !coversFullScreen

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -482,7 +482,8 @@ private extension MainViewController {
         syncBottomOmnibarAnchorIfNeeded(for: coordinator)
         adjustUI(withKeyboardFrame: latestKeyboardFrame, in: 0.2, animationCurve: .curveEaseInOut)
         unifiedToggleInputCoordinator?.syncContentInputMode(mode)
-        if !wasSwipeDriven {
+        let shouldAnimateLogoTransition = coordinator.contentViewController.daxLogoManager.isLogoVisible
+        if !wasSwipeDriven && shouldAnimateLogoTransition {
             coordinator.contentViewController.daxLogoManager.animateLogoTransition(
                 toMode: mode,
                 fromProgress: previousLottieProgress,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -415,7 +415,7 @@ final class UnifiedInputContentContainerViewController: UIViewController {
     }
 
     private func installSwipeContainer() {
-        let manager = SwipeContainerManager(switchBarHandler: switchBarHandler)
+        let manager = SwipeContainerManager(switchBarHandler: switchBarHandler, contentTransition: .crossfade)
         let containerVC = manager.containerViewController
         addChild(containerVC)
         contentContainerView.addSubview(containerVC.view)
@@ -438,7 +438,10 @@ final class UnifiedInputContentContainerViewController: UIViewController {
               let containerViewController = swipeContainerManager?.containerViewController,
               let searchContainer = swipeContainerManager?.searchPageContainer else { return }
 
-        let manager = SuggestionTrayManager(switchBarHandler: switchBarHandler, dependencies: dependencies)
+        let manager = SuggestionTrayManager(
+            switchBarHandler: switchBarHandler,
+            dependencies: dependencies,
+            autocompleteHorizontalInset: Metrics.suggestionsHorizontalInset)
         manager.delegate = self
         let trayEscapeHatchModel = switchBarHandler.isFireTab ? nil : escapeHatchModel
         manager.installInContainerView(searchContainer, parentViewController: containerViewController, escapeHatchModel: trayEscapeHatchModel)
@@ -707,6 +710,7 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         // chain positions the UTI hatch ~10pt below the NTP equivalent.
         static let escapeHatchTrayPullUp: CGFloat = -10
         static let toolbarCompensationOffset: CGFloat = 80
+        static let suggestionsHorizontalInset: CGFloat = 8
     }
 }
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/DuckAISuggestionsViewControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/DuckAISuggestionsViewControllerTests.swift
@@ -114,8 +114,8 @@ final class DuckAISuggestionsViewControllerTests: XCTestCase {
         let header = try XCTUnwrap(table.tableHeaderView)
         let hatchView = try XCTUnwrap(header.subviews.first)
         let hatchFrame = hatchView.convert(hatchView.bounds, to: vc.view)
-        let expectedTableInset: CGFloat = 0
-        let expectedHatchInset: CGFloat = 16
+        let expectedTableInset: CGFloat = 8
+        let expectedHatchInset: CGFloat = 24
 
         XCTAssertEqual(table.frame.minX, expectedTableInset, accuracy: 0.5)
         XCTAssertEqual(vc.view.bounds.width - table.frame.maxX, expectedTableInset, accuracy: 0.5)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214961162843601?focus=true
Tech Design URL:
CC:

### Description
This PR tries to address feedback about “jarring animation” when switching between Search <> Duck.ai when `unifiedToggleInput` feature flag is on.

Because fadeOut animation is currently used in production since end of December 2025, and because it was mentioned in one of the feedbacks _I feel like maybe we cross fade them in the production version which feels a little less jarring._ I went this way to fix this issue: using `FadeOutContainerViewController.swift` instead of `SwipeContainerViewController` in `UnifiedInputContentContainerViewController.swift`.

Also I had to change Search suggestions margins a bit as these changes https://github.com/duckduckgo/apple-browsers/pull/4845 were mistakenly reverted in https://github.com/duckduckgo/apple-browsers/pull/5002 

After changes in this PR, insets will match [latest Figma](https://www.figma.com/design/QUTLfN2oPR6ivG1Jwsw3Mg/%F0%9F%93%B1-Phase-5--Full-Screen-Integration--iOS-?node-id=2219-45307&m=dev)

There was also [a glitch with Dax animation](https://github.com/user-attachments/assets/a1287d9a-09cc-4b15-94ce-37f877a58750), so I implemented a fix, but without major rework, as Dax fixes are currently applied in different ticket.


### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
Enable `unifiedToggleInput` feature flag. Tap on omni bar to expand native input. In this state, switch between Search <> Duck\.ai few times and check the experience. Below you can find all possible configurations. 
Check with top and bottom address bar position.

- A1: Search, query empty, no favorites, no remote/sync message, no escape hatch.
  - Expected: search empty state/Home Dax, no suggestions list.
- A2: Search, query empty, favorites present.
  - Expected: favorites/NTP overlay, Dax doesn't collide with favorites.
- A3: Search, query empty, no favorites, escape hatch present.
  - Expected: escape hatch + Home Dax below, correct top inset.
- A4 (related to A10): Search, query empty, favorites present, escape hatch present.
  - Expected: favorites + hatch, no shifts and no empty state duplication.
- A5: Search, query empty, remote/sync-style promo present.
  - Expected: NTP promo/message lays out correctly in expanded container.
- A6 (<> A13, A14): Search, type query that returns search/autocomplete suggestions.
  - Expected: suggestions replace idle content; hatch/promo/favorites don't show through.
- A7: Duck.ai, query empty, no recent chats, no URL suggestions, no hatch/promo.
  - Expected: AI empty Dax, no suggestions table.
- A8: Duck.ai, query empty, recent chats present.
  - Expected: recent chats section/list, no AI empty Dax.
- A9: Duck.ai, query empty, no recent chats, escape hatch present.
  - Expected: hatch in table header, AI empty state without collisions.
- A10: Duck.ai, query empty, recent chats present, escape hatch present.
  - Expected: hatch above recent chats, correct spacing.
- A11: Duck.ai, query empty, sync promo eligible.
  - Expected: sync promo in header, correct header height.
- A12: Duck.ai, query empty, escape hatch + sync promo eligible.
  - Expected: hatch and sync promo in one header, spacing between cards.
- A13: Duck.ai, type query with no recent-chat match but URL/search available.
  - Expected: URL suggestions and/or "Search DuckDuckGo" row; hatch and sync promo disappear during typing.
- A14: Duck.ai, type query that filters recent chats and URL suggestions.
  - Expected: section order chats, URLs, Search DuckDuckGo; no layout jump on reload.

Note: to force displaying sync promo on Duck.ai view, simply force it by
```swift
    private var shouldShowSyncPromo: Bool {
        return true
    }
```
in `DuckAISuggestionsViewController`

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low. This is a visual/interaction polish change for the Unified Toggle Input content transition and related suggestion tray layout.


#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
Search/Duck.ai mode switching could regress in edge cases, especially around swipe gestures, top/bottom address bar positioning, or escape hatch visibility. The change keeps the existing production crossfade container behavior and scopes the new transition choice to UTI content.


### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->
The main edge cases are top vs bottom address bar, escape hatch present vs absent, empty Search state, Duck.ai suggestions/recents, and toggle-disabled states. No privacy or data handling impact expected.


### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->
Please focus on the UTI Search/Duck.ai transition behavior and whether the content crossfade feels less jarring than the previous paged movement.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and interaction polish for UTI mode switching and tray layout; no auth, data, or security surface changes.
> 
> **Overview**
> **Unified Toggle Input** now switches Search and Duck.ai content with a **crossfade** (`FadeOutContainerViewController`) instead of the paged swipe container, scoped via `SwipeContainerManager.ContentTransition.crossfade` for the UTI content host.
> 
> The fade container is tightened for UTI: **swipe enable/disable** is wired through `SwipeContainerManager`, mode updates are **deduped** (visible mode + transition tokens) to avoid jarring double animations, and toggle bindings drive transitions from the published mode.
> 
> **Layout polish** restores Figma-aligned horizontal insets: **8pt** for search autocomplete and Duck.ai recent-chat table layout; `SuggestionTrayViewController.fill(horizontalInset:)` narrows full-width trays accordingly. **Dax** only runs the programmatic Lottie mode transition when the logo is visible, and completes Lottie by syncing `currentProgress` / `updateState()` so morphs don’t stick or glitch after interruption.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a158b7b0297961b29366a2e2bda3e8f653d21152. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->