### PR TITLE
iOS: Add right-click context menu parity for Duck.ai chip

### DIFF
--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -162,7 +162,7 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
         addTabButton.addTarget(self, action: #selector(onNewTabPressed), for: .touchUpInside)
         aiChatChip.textButton.addTarget(self, action: #selector(onAIChatPressed), for: .touchUpInside)
         aiChatChip.iconButton.addTarget(self, action: #selector(onAIChatContextualSheetIconPressed), for: .touchUpInside)
-        configureAIChatChipLongPressMenu()
+        configureAIChatChipMenu()
         fireButton.addTarget(self, action: #selector(onFireButtonPressed), for: .touchUpInside)
         tabSwitcherButton.delegate = self
 
@@ -442,8 +442,17 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
         addTabButton.showsMenuAsPrimaryAction = false
     }
 
-    private func configureAIChatChipLongPressMenu() {
-        let menu = UIMenu(children: [
+    private func configureAIChatChipMenu() {
+        let menu = makeAIChatChipMenu()
+        aiChatChip.textButton.menu = menu
+        aiChatChip.textButton.showsMenuAsPrimaryAction = false
+        aiChatChip.iconButton.menu = menu
+        aiChatChip.iconButton.showsMenuAsPrimaryAction = false
+        aiChatChip.addInteraction(UIContextMenuInteraction(delegate: self))
+    }
+
+    private func makeAIChatChipMenu() -> UIMenu {
+        UIMenu(children: [
             UIDeferredMenuElement.uncached { [weak self] completion in
                 completion([
                     UIAction(title: UserText.actionHideAIChatChromeShortcut) { [weak self] _ in
@@ -456,11 +465,6 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
                 ])
             }
         ])
-
-        aiChatChip.textButton.menu = menu
-        aiChatChip.textButton.showsMenuAsPrimaryAction = false
-        aiChatChip.iconButton.menu = menu
-        aiChatChip.iconButton.showsMenuAsPrimaryAction = false
     }
 
     private func createButton(image: UIImage) -> UIButton {
@@ -473,6 +477,17 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
         super.viewDidLayoutSubviews()
         NotificationCenter.default.post(name: TabsBarViewController.viewDidLayoutNotification, object: self)
     }
+}
+
+extension TabsBarViewController: UIContextMenuInteractionDelegate {
+
+    func contextMenuInteraction(_ interaction: UIContextMenuInteraction,
+                                configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
+        UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
+            self?.makeAIChatChipMenu()
+        }
+    }
+
 }
 
 extension TabsBarViewController: TabSwitcherButtonDelegate {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1215105825199698
Tech Design URL:
CC:

### Description

Adds a `UIContextMenuInteraction` to the iPad Duck.ai chip so secondary-click (Magic Trackpad / Magic Mouse) opens the same *Hide Duck.ai Shortcut* / *Open AI Settings* menu as the long-press gesture from #5142. Menu construction is factored into `makeAIChatChipMenu()` and reused from both the `UIButton.menu` attachment and the `UIContextMenuInteractionDelegate`.

### Testing Steps

1. iPad sim or real iPad with pointer enabled (Magic Trackpad / Magic Mouse, or Mac trackpad via the simulator's pointer mode).
2. Two-finger tap (or right-click) on either half of the Duck.ai chip → same menu with *Hide Duck.ai Shortcut* and *Open AI Settings*.
3. Tap each item and confirm same behavior as long-press (chip hides; Settings opens at AI Chat).
4. Regression: long-press still opens the menu; single tap still opens a new Duck.ai tab / toggles the contextual sheet.

### Impact and Risks

Low. Adds a second presentation path for the existing menu; no new behavior or data.

### Notes to Reviewer

Stacked on #5142 (which is stacked on #5126). GitHub will retarget as each lands.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only second presentation path for an existing menu; no new actions, settings, or data handling.
> 
> **Overview**
> On iPad, the Duck.ai chrome chip now exposes the same **Hide Duck.ai Shortcut** / **Open AI Settings** menu on **secondary click** (trackpad/mouse) as on long-press.
> 
> Menu building is moved into `makeAIChatChipMenu()` and wired from both the existing `UIButton.menu` on the chip halves and a new `UIContextMenuInteraction` on `DuckAIChromeChipView` via `UIContextMenuInteractionDelegate` in `TabsBarViewController`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5498f2781c641495f50ec5e4be5d03023e04dde3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->