### PR TITLE
iOS: Fix iPad duck.ai panel showing favicon/title on quick re-tap

### DIFF
--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -246,6 +246,29 @@ final class DefaultOmniBarViewController: OmniBarViewController {
         ])
     }
 
+    override func refreshText(forUrl url: URL?, forceFullURL: Bool) {
+        /// Skip while the expanded duck.ai panel is open — otherwise the page title bleeds
+        /// through the transparent aiChatTextView. https://app.asana.com/1/137249556945/project/1201011656765697/task/1215084286493408?focus=true
+        if omniBarView.isSearchAreaExpanded {
+            return
+        }
+        super.refreshText(forUrl: url, forceFullURL: forceFullURL)
+    }
+
+    override func enterAIChatMode() {
+        /// Skip while the user is editing — would reveal the favicon over the open panel.
+        ///  https://app.asana.com/1/137249556945/project/1201011656765697/task/1215084286493408?focus=true
+        if omniBarView.isSearchAreaExpanded || omniBarView.textField.isEditing {
+            return
+        }
+        super.enterAIChatMode()
+
+        if dependencies.aiChatAddressBarExperience.isIPadAIToggleExperienceEnabled,
+           state is SmallOmniBarState.AIChatModeState {
+            refreshState(SmallOmniBarState.AIChatTabModeState(dependencies: dependencies, isLoading: state.isLoading))
+        }
+    }
+
     override func updateInterface(from oldState: any OmniBarState, to state: any OmniBarState) {
         super.updateInterface(from: oldState, to: state)
 
@@ -406,6 +429,11 @@ extension DefaultOmniBarViewController {
                 omniDelegate?.onOmniQuerySubmitted(query)
             } else {
                 DailyPixel.fireDailyAndCount(pixel: .aiChatIPadTogglePromptSubmitted)
+                /// Collapse and resign instantly so a quick re-tap doesn't race the post-submit
+                /// collapse animation.
+                /// https://app.asana.com/1/137249556945/project/1201011656765697/task/1215084286493408?focus=true
+                omniBarView.setSearchAreaExpanded(false, animated: false)
+                omniBarView.aiChatTextView.resignFirstResponder()
                 omniDelegate?.onPromptSubmitted(query, tools: nil)
             }
         } else {

--- a/iOS/DuckDuckGo/OmniBarViewController.swift
+++ b/iOS/DuckDuckGo/OmniBarViewController.swift
@@ -398,6 +398,11 @@ class OmniBarViewController: UIViewController, OmniBar {
         // Overridden in DefaultOmniBarViewController for the experimental editing state.
     }
 
+    /// Enters AI Chat full mode, showing AI Chat-specific UI in the omnibar
+    func enterAIChatMode() {
+        refreshState(state.onEnterAIChatState)
+    }
+
     func refreshText(forUrl url: URL?, forceFullURL: Bool) {
         guard !textField.isEditing else { return }
         guard let url = url else {
@@ -1113,14 +1118,6 @@ extension OmniBarViewController: UITextFieldDelegate {
     /// Shows the logo after full-screen transition completes.
     func showLogoAfterTransition() {
         barView.privacyInfoContainer.privacyIcon.showLogoAfterTransition()
-    }
-}
-
-extension OmniBarViewController {
-
-    /// Enters AI Chat full mode, showing AI Chat-specific UI in the omnibar
-    func enterAIChatMode() {
-        refreshState(state.onEnterAIChatState)
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1215084286493408?focus=true
Tech Design URL:
CC:

### Description
On iPad, a `refreshOmniBar` triggered mid-edit (e.g. by a navigation finishing) was writing the page title into the textField behind the expanded duck.ai panel and transitioning state to `AIChatModeState` (which un-hides the favicon). Guard `refreshText` and `enterAIChatMode` against the editing/expanded state, and collapse instantly on prompt submit so a quick re-tap can't race the collapse animation. Also redirect compact-width iPad-with-toggle to `AIChatTabModeState` so the favicon renders instead of falling into the iPhone branding state that's gated off here.

### Testing Steps
1. On an iPad (regular width), open the duck.ai panel, send a prompt, immediately re-tap the address bar — the favicon and "Duck.ai" title should no longer bleed through the expanded panel.
2. While the panel is open and a duck.ai page is loading, confirm the favicon does not appear over the input.
3. Resize the app to a narrow/compact window on a duck.ai tab — the favicon should now appear next to "Duck.ai" in the address bar.

### Impact and Risks
Low

#### What could go wrong?
The state redirect to `AIChatTabModeState` runs only on iPad-with-toggle compact width, but a regression there could leave the address bar in an unexpected state for AI tabs at small width.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only omnibar guards and a narrow iPad compact-width state redirect; main regression risk is unexpected address bar state on small-width AI tabs with the toggle enabled.
> 
> **Overview**
> Fixes **iPad duck.ai** address bar glitches where **page title and favicon** could show through or over the **expanded duck.ai panel** when navigation or omnibar refresh ran during edit, or when users **re-tapped** the bar right after sending a prompt.
> 
> **`DefaultOmniBarViewController`** now **skips** `refreshText` while the search area is expanded and **skips** `enterAIChatMode` while expanded or the text field is editing; after entering AI chat mode on iPad with the toggle, it can **redirect** compact-width state from `AIChatModeState` to **`AIChatTabModeState`** so the favicon shows instead of the wrong branding path. On duck.ai **prompt submit**, it **collapses** the panel and **resigns** the AI text view **without animation** to avoid racing the collapse animation.
> 
> **`enterAIChatMode`** is moved onto the base **`OmniBarViewController`** (same behavior, no longer only in an extension).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5f2cb7de4e620ef6417c7f302503ad2cd87cff6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->