### PR TITLE
Use surface-canvas background for Duck.ai header and toolbar

### DIFF
--- a/iOS/DuckDuckGo/AIChat/AIChatTabChatHeaderView.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatTabChatHeaderView.swift
@@ -378,7 +378,7 @@ final class AIChatTabChatHeaderView: UIView {
     }()
 
     private func setupUI() {
-        backgroundColor = UIColor(designSystemColor: .surface)
+        backgroundColor = UIColor(designSystemColor: .surfaceCanvas)
         addSubview(leftStack)
         addSubview(rightStack)
         addSubview(titleHolder)

--- a/iOS/DuckDuckGo/MainViewCoordinator.swift
+++ b/iOS/DuckDuckGo/MainViewCoordinator.swift
@@ -501,7 +501,7 @@ class MainViewCoordinator {
         case .omnibarEditing, .aiTabSearchChromeHidden:
             UIColor(designSystemColor: .panel)
         case .aiTabChatChromeHidden:
-            UIColor(designSystemColor: .surface)
+            UIColor(designSystemColor: .surfaceCanvas)
         }
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -275,9 +275,9 @@ extension MainViewController {
                 unifiedToggleInputContainerColor = .clear
                 webViewBackgroundColor = rootBackgroundColor
             } else {
-                rootBackgroundColor = UIColor(designSystemColor: .surface)
+                rootBackgroundColor = UIColor(designSystemColor: .surfaceCanvas)
                 navigationBarContainerColor = .clear
-                unifiedToggleInputContainerColor = UIColor(designSystemColor: .surface)
+                unifiedToggleInputContainerColor = UIColor(designSystemColor: .surfaceCanvas)
                 webViewBackgroundColor = UIColor(designSystemColor: .surfaceCanvas)
             }
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215191440522445?focus=true
Tech Design URL:
CC:

### Description
In the Duck.ai chat tab, the header, status-bar strip, root view, and bottom input-toolbar container used `.surface` while the chat web view already used `.surfaceCanvas`, leaving a visible color mismatch. This switches those chrome surfaces to `.surfaceCanvas` so the whole screen reads as one continuous surface. All changes are reachable only when the `unifiedToggleInput` feature flag is on.

### Testing Steps
1. Enable the `unifiedToggleInput` feature flag and open a Duck.ai chat tab.
2. Confirm the header (back/forward, menu, fire button toolbar area) and surrounding chrome now match the chat content background in both light and dark mode.
3. Turn the flag off and confirm normal browser tabs are visually unchanged.

### Impact and Risks
Low — cosmetic color change confined to the flagged Duck.ai chrome.

#### What could go wrong?
A surface could show a seam if a related chrome element still references `.surface`, visible only in the flagged chat state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic design-token swap in flagged Duck.ai chrome only; no logic, auth, or data changes.
> 
> **Overview**
> Aligns Duck.ai chat tab chrome with the chat web view by replacing **`.surface`** with **`.surfaceCanvas`** on the AI chat header, the status-bar background when chat chrome is hidden, and the idle root / bottom unified-toggle input container backgrounds.
> 
> The chat content already used **`.surfaceCanvas`**; header, status strip, and bottom toolbar area had been **`.surface`**, which caused a visible band mismatch in light and dark mode. Behavior is unchanged when the input is focused (contextual sheet background still applies). Scope is the **`unifiedToggleInput`** Duck.ai presentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bab061ab87fb03aa58e53b2907c379f8c6a1650. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->