### PR TITLE
[iOS][Onboarding] Implement Unified Toggle Input fixes for Duck.ai tailored flow

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -273,6 +273,9 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214797978179697?focus=true
     case customProductPageDuckAiChat
 
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215151176422651?focus=true
+    case customProductPageDuckAiOnboardingFlow
+
     /// Gate the default-to-NTP-after-idle behavior for existing iPhone users behind a remote flag.
     /// https://app.asana.com/1/137249556945/project/1204186595873227/task/1214830562427843
     case defaultExistingIPhoneUsersToNewTabAfterIdle

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -626,7 +626,7 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(AIChatSubfeature.onboardingDuckAIQueryTrackersDemoExperiment),
                    cohortType: DuckAIQueryExperimentCohort.self)
         case .onboardingDuckAIFlow:
-            Config(source: .disabled, supportsLocalOverriding: true)
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(iOSBrowserConfigSubfeature.customProductPageDuckAiOnboardingFlow))
         case .storeSerpSettings:
             Config(source: .remoteReleasable(SERPSubfeature.storeSerpSettings))
         case .standaloneMigration:

--- a/iOS/DuckDuckGo/AppSettings.swift
+++ b/iOS/DuckDuckGo/AppSettings.swift
@@ -19,6 +19,7 @@
 
 import Bookmarks
 import Foundation
+import Onboarding
 
 enum AutoplayBlockingMode: String, CaseIterable, CustomStringConvertible {
     case allowAll
@@ -154,4 +155,7 @@ protocol OnboardingDebugAppSettings {
     /// When `true`, `OnboardingRestorePromptHandler.isEligibleForRestorePrompt()` short-circuits to `true`
     /// in DEBUG/ALPHA builds so the `.restoreData` intro can be reached without a preserved sync account.
     var onboardingForceRestorePromptEligible: Bool { get set }
+
+    /// Sets the `OnboardingFlowType` for  DEBUG/ALPHA builds. Used `OnboardingManager.configureOnboardingFlow(from:)`
+    var onboardingFlowType: OnboardingFlowType? { get set }
 }

--- a/iOS/DuckDuckGo/AppUserDefaults.swift
+++ b/iOS/DuckDuckGo/AppUserDefaults.swift
@@ -20,6 +20,7 @@
 import Foundation
 import Bookmarks
 import Core
+import Onboarding
 import WidgetKit
 
 public class AppUserDefaults: AppSettings {
@@ -109,6 +110,7 @@ public class AppUserDefaults: AppSettings {
         static let contentScopeDebugStateEnabledKey = "com.duckduckgo.ios.debug.contentScopeDebugStateEnabled"
         static let onboardingIsNewUserKey = "com.duckduckgo.ios.debug.onboardingIsNewUser"
         static let onboardingForceRestorePromptEligibleKey = "com.duckduckgo.ios.debug.onboardingForceRestorePromptEligible"
+        static let onboardingFlowTypeKey = "com.duckduckgo.ios.debug.onboardingFlowType"
         static let shakeToOpenDebugMenuEnabledKey = "com.duckduckgo.ios.debug.shakeToOpenDebugMenuEnabled"
     }
 
@@ -618,6 +620,16 @@ public class AppUserDefaults: AppSettings {
         }
         set {
             userDefaults?.set(newValue, forKey: DebugKeys.onboardingForceRestorePromptEligibleKey)
+        }
+    }
+
+    var onboardingFlowType: OnboardingFlowType? {
+        get {
+            guard let rawValue = userDefaults?.string(forKey: DebugKeys.onboardingFlowTypeKey) else { return nil }
+            return OnboardingFlowType(rawValue: rawValue)
+        }
+        set {
+            userDefaults?.set(newValue?.rawValue, forKey: DebugKeys.onboardingFlowTypeKey)
         }
     }
 

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -113,7 +113,8 @@ final class DefaultOmniBarViewController: OmniBarViewController {
 
         let activationDecision = unifiedToggleInputOmnibarActivating?.activateFromOmnibarIfNeeded(
             currentText: extractCurrentTextForEditing(textField),
-            tapped: textFieldTapped)
+            tapped: textFieldTapped,
+            textEntryMode: textEntryMode)
 
         if activationDecision == .intercept {
             return false

--- a/iOS/DuckDuckGo/OnboardingDebugView.swift
+++ b/iOS/DuckDuckGo/OnboardingDebugView.swift
@@ -19,6 +19,7 @@
 
 import SwiftUI
 import Core
+import Onboarding
 import Persistence
 
 struct OnboardingDebugView: View {
@@ -104,6 +105,24 @@ struct OnboardingDebugView: View {
 
             Section {
                 Picker(
+                    selection: $viewModel.forcedOnboardingFlowType,
+                    content: {
+                        Text(verbatim: "Auto-detect (URL evaluator)").tag(Optional<OnboardingFlowType>.none)
+                        Text(verbatim: "Default").tag(OnboardingFlowType.default)
+                        Text(verbatim: "Duck.ai Tailored").tag(OnboardingFlowType.duckAI)
+                    },
+                    label: {
+                        Text(verbatim: "Flow Type:")
+                    }
+                )
+            } header: {
+                Text(verbatim: "Force Onboarding Flow Type")
+            } footer: {
+                Text(verbatim: "Honoured on next launch by OnboardingManager.configureOnboardingFlow when no flow is already configured. Reset Onboarding above and kill+relaunch the app to apply.")
+            }
+
+            Section {
+                Picker(
                     selection: $selectedFlow,
                     content: {
                         ForEach(OnboardingDebugFlow.allCases) { flow in
@@ -146,6 +165,15 @@ final class OnboardingDebugViewModel: ObservableObject {
         }
     }
 
+    /// Debug override for the resolved onboarding flow type on next launch.
+    /// `nil` means "no override — use the real evaluator (URL-based)."
+    /// Honoured by `OnboardingManager.configureOnboardingFlow(from:)` only in DEBUG/ALPHA builds.
+    @Published var forcedOnboardingFlowType: OnboardingFlowType? {
+        didSet {
+            appSettings.onboardingFlowType = forcedOnboardingFlowType
+        }
+    }
+
     private let manager: OnboardingNewUserProviderDebugging
     private var settings: DaxDialogsSettings
     private let tutorialSettings: TutorialSettings
@@ -177,6 +205,7 @@ final class OnboardingDebugViewModel: ObservableObject {
         self.appSettings = appSettings
         onboardingUserType = manager.onboardingUserTypeDebugValue
         forceRestorePromptEligible = appSettings.onboardingForceRestorePromptEligible
+        forcedOnboardingFlowType = appSettings.onboardingFlowType
     }
 
     func resetAllOnboarding() {

--- a/iOS/DuckDuckGo/OnboardingFlow/Manager/OnboardingManager.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/Manager/OnboardingManager.swift
@@ -276,6 +276,36 @@ extension OnboardingManager: OnboardingFlowManaging {
             return
         }
 
+        let resolvedFlow: OnboardingFlowType
+        let onboardingSource: OnboardingSource
+
+#if DEBUG || ALPHA
+        switch appDefaults.onboardingFlowType {
+        case .none:
+            (resolvedFlow, onboardingSource) = resolveOnboardingFromEvaluator(url: url)
+        case .default:
+            Logger.onboarding.debug("Onboarding flow - Debug `.default` flow override active")
+            resolvedFlow = .default
+            onboardingSource = .default
+        case .duckAI:
+            Logger.onboarding.debug("Onboarding flow - Debug `.duckAI` flow override active")
+            resolvedFlow = .duckAI
+            onboardingSource = .duckAICPP
+        }
+#else
+        (resolvedFlow, onboardingSource) = resolveOnboardingFromEvaluator(url: url)
+#endif
+
+        // Clear any stale resume checkpoint persisted before the flow was configured
+        // (e.g. by a previous build that didn't set onboardingFlowType), so we don't
+        // resume into a step that appears at a different point of the flow causing the user to skip important steps.
+        OnboardingResumeCheckpointStore.clearAll(in: onboardingResumeStepStore)
+
+        tutorialSettings.onboardingFlowType = resolvedFlow
+        persistOnboardingPixelContext(flow: resolvedFlow, source: onboardingSource)
+    }
+
+    private func resolveOnboardingFromEvaluator(url: URL?) -> (flow: OnboardingFlowType, source: OnboardingSource) {
         let evaluatedOnboarding = onboardingFlowEvaluator.evaluateOnboardingFlow(from: url)
         Logger.onboarding.debug("Configured onboarding flow: \(evaluatedOnboarding.flow.rawValue, privacy: .public)")
 
@@ -290,14 +320,7 @@ extension OnboardingManager: OnboardingFlowManaging {
         default:
             resolvedFlow = evaluatedOnboarding.flow
         }
-
-        // Clear any stale resume checkpoint persisted before the flow was configured
-        // (e.g. by a previous build that didn't set onboardingFlowType), so we don't
-        // resume into a step that appears at a different point of the flow causing the user to skip important steps.
-        OnboardingResumeCheckpointStore.clearAll(in: onboardingResumeStepStore)
-
-        tutorialSettings.onboardingFlowType = resolvedFlow
-        persistOnboardingPixelContext(flow: resolvedFlow, source: evaluatedOnboarding.source)
+        return (resolvedFlow, evaluatedOnboarding.source)
     }
 
 }

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -874,6 +874,11 @@ extension MainCoordinator: OnboardingPresenting {
         // 1. Configure Onboarding Flow
         onboardingManager.configureOnboardingFlow(from: url)
 
+        // The flow is now known. Duck.ai tailored-flow users need UTI set up before the
+        // Duck.ai interlude runs inside their onboarding; the viewDidLoad call earlier
+        // bailed because the flow wasn't determined yet (defaulted to .default).
+        controller.setUpUnifiedToggleInputIfNeeded()
+
         // 2. Presenting Onboarding Flow if needed
         guard !hasPresentedOnboarding, controller.isStartupOnboardingPending else { return }
         hasPresentedOnboarding = true

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -875,8 +875,7 @@ extension MainCoordinator: OnboardingPresenting {
         onboardingManager.configureOnboardingFlow(from: url)
 
         // The flow is now known. Duck.ai tailored-flow users need UTI set up before the
-        // Duck.ai interlude runs inside their onboarding; the viewDidLoad call earlier
-        // bailed because the flow wasn't determined yet (defaulted to .default).
+        // Duck.ai interlude runs inside their onboarding
         controller.setUpUnifiedToggleInputIfNeeded()
 
         // 2. Presenting Onboarding Flow if needed

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -56,11 +56,16 @@ extension MainViewController {
     }
 
     func setUpUnifiedToggleInputIfNeeded() {
-        // Defer setup until linear onboarding has completed, so that any experiment
-        // cohort enrollment that happens during onboarding is reflected in
-        // `unifiedToggleInputFeature.isAvailable` before we wire up the coordinator.
-        // Returning users (who skip linear onboarding) fall through immediately.
-        guard !needsToShowOnboardingIntro() else { return }
+        // Idempotent: callable from viewDidLoad, MainCoordinator.startOnboardingFlowIfNotSeenBefore,
+        // and onboardingCompleted — first call that passes the gates wins.
+        guard unifiedToggleInputCoordinator == nil else { return }
+        // Defer setup only for default-flow users still in linear onboarding intro: cohort
+        // enrollment for the Duck.ai query experiment happens during their onboarding, and
+        // wiring up the coordinator before that lands would read a stale
+        // `unifiedToggleInputFeature.isAvailable`. Duck.ai tailored-flow users are
+        // pre-enrolled and need UTI active during the Duck.ai interlude that runs inside
+        // their onboarding. Returning users (who skip linear onboarding) fall through immediately.
+        guard !(needsToShowOnboardingIntro() && onboardingManager.currentOnboardingFlow == .default) else { return }
         guard unifiedToggleInputFeature.isAvailable else { return }
 
         let aiChatPreferences = AIChatPreferencesPersistor()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -187,6 +187,26 @@ extension MainViewController {
             viewCoordinator.toolbar.isHidden = true
         } else {
             viewCoordinator.toolbar.isHidden = AppWidthObserver.shared.isLargeWidth || isInMinimalChromeLayout
+            // Self-heal a stale clamp. `updateToolbarConstant` deliberately pushes the
+            // toolbar's constraint off-screen whenever `toolbar.isHidden == true`. This
+            // is required for iPad and minimal-chrome layouts, where the toolbar is
+            // permanently hidden and its off-screen layout slot acts as a spacer.
+            //
+            // The UTI AI-tab phase reuses `isHidden = true` *transiently*. Any
+            // `setBarsVisibility(1)` call during that phase (refreshAITab, BarsAnimator,
+            // applyExperimentDuckAIFireChromeState, etc.) writes the same off-screen
+            // value via the clamp. When `isHidden` flips back to false here, nothing
+            // else recomputes the constant; the toolbar is unhidden but laid out
+            // off-screen. Snap it back to 0.
+            //
+            // `alpha == 1` excludes mid-scroll partial-hides. `BarsAnimator` writes
+            // matching `alpha` and `constant` values together, so they can only
+            // disagree when the clamp suppressed a write.
+            if !viewCoordinator.toolbar.isHidden
+                && viewCoordinator.toolbar.alpha == 1.0
+                && viewCoordinator.constraints.toolbarBottom.constant != 0 {
+                viewCoordinator.constraints.toolbarBottom.constant = 0
+            }
         }
         // `toolbarBottom.constant` is derived from `isHidden`; recompute when it flips.
         if wasHidden != viewCoordinator.toolbar.isHidden {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1078,7 +1078,7 @@ extension MainViewController {
 
 extension MainViewController: UnifiedToggleInputOmnibarActivating {
 
-    func activateFromOmnibarIfNeeded(currentText: String?, tapped: Bool) -> UnifiedToggleInputActivationDecision {
+    func activateFromOmnibarIfNeeded(currentText: String?, tapped: Bool, textEntryMode: TextEntryMode?) -> UnifiedToggleInputActivationDecision {
         guard let coordinator = unifiedToggleInputCoordinator,
               currentTab?.isAITab != true else {
             return .allowDefault
@@ -1087,7 +1087,9 @@ extension MainViewController: UnifiedToggleInputOmnibarActivating {
             onExperimentalAddressBarTapped()
         }
         let position: UnifiedToggleInputCardPosition = appSettings.currentAddressBarPosition == .bottom ? .bottom : .top
-        let inputMode = tabManager.currentTabsModel.currentTab.map { initialOmnibarToggleMode(for: $0) } ?? .search
+        let inputMode = textEntryMode
+            ?? tabManager.currentTabsModel.currentTab.map { initialOmnibarToggleMode(for: $0) }
+            ?? .search
         let isToggleEnabled = isAIChatSearchInputToggleEnabledForCurrentOnboardingState()
         coordinator.updateToggleEnabled(isToggleEnabled)
         coordinator.contentViewController.isSwipeEnabled = coordinator.isToggleVisible

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -59,12 +59,11 @@ extension MainViewController {
         // Idempotent: callable from viewDidLoad, MainCoordinator.startOnboardingFlowIfNotSeenBefore,
         // and onboardingCompleted — first call that passes the gates wins.
         guard unifiedToggleInputCoordinator == nil else { return }
-        // Defer setup only for default-flow users still in linear onboarding intro: cohort
-        // enrollment for the Duck.ai query experiment happens during their onboarding, and
-        // wiring up the coordinator before that lands would read a stale
-        // `unifiedToggleInputFeature.isAvailable`. Duck.ai tailored-flow users are
-        // pre-enrolled and need UTI active during the Duck.ai interlude that runs inside
-        // their onboarding. Returning users (who skip linear onboarding) fall through immediately.
+        // Defer setup until linear onboarding for default flow has completed, so that any experiment
+        // cohort enrollment that happens during onboarding is reflected in
+        // `unifiedToggleInputFeature.isAvailable` before we wire up the coordinator.
+        // Duck.ai tailored-flow users are need UTI during the linear onboarding otherwise they will not see the new UI in the Duck.ai page that is shown during the linear onboarding interlude.
+        // Returning users (who skip linear onboarding) fall through immediately.
         guard !(needsToShowOnboardingIntro() && onboardingManager.currentOnboardingFlow == .default) else { return }
         guard unifiedToggleInputFeature.isAvailable else { return }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1090,6 +1090,7 @@ extension MainViewController: UnifiedToggleInputOmnibarActivating {
         let inputMode = textEntryMode
             ?? tabManager.currentTabsModel.currentTab.map { initialOmnibarToggleMode(for: $0) }
             ?? .search
+        coordinator.updateInputMode(inputMode, animated: false)
         let isToggleEnabled = isAIChatSearchInputToggleEnabledForCurrentOnboardingState()
         coordinator.updateToggleEnabled(isToggleEnabled)
         coordinator.contentViewController.isSwipeEnabled = coordinator.isToggleVisible

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputOmnibarActivating.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputOmnibarActivating.swift
@@ -17,10 +17,11 @@
 //  limitations under the License.
 //
 
+import AIChat
 import Foundation
 
 protocol UnifiedToggleInputOmnibarActivating: AnyObject {
-    func activateFromOmnibarIfNeeded(currentText: String?, tapped: Bool) -> UnifiedToggleInputActivationDecision
+    func activateFromOmnibarIfNeeded(currentText: String?, tapped: Bool, textEntryMode: TextEntryMode?) -> UnifiedToggleInputActivationDecision
 }
 
 enum UnifiedToggleInputActivationDecision {

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Application/AppSettingsMock.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Application/AppSettingsMock.swift
@@ -19,6 +19,7 @@
 
 import Bookmarks
 import Foundation
+import Onboarding
 @testable import DuckDuckGo
 
 class AppSettingsMock: AppSettings {
@@ -107,6 +108,7 @@ class AppSettingsMock: AppSettings {
 
     var onboardingUserType: OnboardingUserType = .notSet
     var onboardingForceRestorePromptEligible: Bool = false
+    var onboardingFlowType: OnboardingFlowType?
 
     var duckPlayerNativeUISERPEnabled: Bool = true
     var duckPlayerNativeYoutubeMode: DuckDuckGo.NativeDuckPlayerYoutubeMode = .allCases.first!


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1214953460655161?focus=true
Tech Design URL:
CC:

### Description
This PR implements:
- Bug fixes in the Unified Toggle Input (UTI) behaviour during the Duck.ai tailored onboarding flow.
- Set the Duck.ai onboarding flow feature flag to internal only.
- Enhance the onboarding Debug view for forcing the flow type.

### Key Changes
- **Show UTI toggle when skipping onboarding**:  UTI setup was deferred until linear onboarding completed, so Duck.ai tailored-flow users never got the toggle wired up. `setUpUnifiedToggleInputIfNeeded()` is now idempotent (first call that passes the gates wins) and only defers for default-flow users still in the intro.
- **Set up UTI when onboarding flow is known** — Duck.ai tailored-flow users need UTI active during the Duck.ai interlude that runs inside their onboarding. MainCoordinator now calls setUpUnifiedToggleInputIfNeeded() immediately after the flow is resolved
- **Preserve input mode when manually pre-set** — `activateFromOmnibarIfNeeded` now accepts a `TextEntryMode?` from the omnibar so a manually pre-set toggle mode (search vs AI) is honored rather than overwritten by the per-tab default.
- **Disable Duck.ai back button when locking controls** — setOnboardingLocked now also disables `backButton` so users can't navigate away from a locked onboarding step.
- **Fix toolbar not appearing when Duck.ai tailored flow completes** — Added a self-healing branch in the toolbar visibility logic to snap `toolbarBottom.constant` back to 0 when a stale UTI off-screen clamp leaves the toolbar unhidden but laid out off-screen.
- **Feature flag** — `onboardingDuckAIFlow` is now internalOnly by default and gated on the new `customProductPageDuckAiOnboardingFlow` privacy subfeature.
- **Debug menu** — Added a "Force Onboarding Flow Type" picker to `OnboardingDebugView` (DEBUG/ALPHA only) with Auto / Default / Duck.ai Tailored options.

### Testing Steps
**Scenario 1 - Duck.ai Onboarding Flow**
1. Ensure that `Internal user` flag is enabled.
2. Enable Unified Toggle Input feature flag. 
3. From debug menu → Onboarding -> Force Onboarding Flow Type → `Duck.ai (Tailored)
4. Tap `Reset All onboarding` and relaunch the app.
3. Follow the onboarding steps and verify that in the the Duck.ai page, the new UI is visible and disabled.
4. Tap back in the Duck.ai chat header and verify it is disabled.
5. Complete Duck.ai onboarding and confirm the bottom toolbar reappears in place when the final dialog is presented.
6. Manually toggle input mode in the omnibar, type a query, verify the mode is preserved to AI chat.

**Scenario 2 - Smoke Test Tracker Demo Experiment**
- Smoke test UTI and Experiment via steps defined in this [PR](https://github.com/duckduckgo/apple-browsers/pull/4668)

*Scenario 3 - Smoke Test Unified Toggle Input**
- Smoke test that Unified Toggle Input behaves as expected outside the onboarding.

### Impact and Risks
Medium. Touches UTI wiring, omnibar input routing, and toolbar visibility.

#### What could go wrong?
- UTI gate regression for default-flow users — mitigated by keeping the needsToShowOnboardingIntro() gate for .default flows only.
- Toolbar self-heal mis-fire — guarded by `!isHidden && alpha == 1.0 && constant != 0` so BarsAnimator mid-scroll partial hides can't trigger it.

### Quality Considerations
- The new TextEntryMode? parameter is optional, so the protocol change is source-compatible.

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes onboarding startup, UTI gating, omnibar routing, and toolbar constraints; default-flow deferral is preserved but regressions could affect first-run UX outside the Duck.ai path.
> 
> **Overview**
> Fixes **Unified Toggle Input (UTI)** during the Duck.ai tailored onboarding path and wires rollout/debug controls for that flow.
> 
> **UTI timing and omnibar:** `setUpUnifiedToggleInputIfNeeded()` is idempotent and only blocks setup while the **default** flow still needs the intro; Duck.ai tailored users get UTI as soon as the flow is resolved via `MainCoordinator.startOnboardingFlowIfNotSeenBefore`. Omnibar activation now takes optional `TextEntryMode?` so a pre-set search vs AI mode is kept instead of being replaced by the tab default. Toolbar visibility adds a self-heal that resets `toolbarBottom.constant` to 0 when UTI left the bar visible but off-screen.
> 
> **Flags and debug:** Adds privacy subfeature `customProductPageDuckAiOnboardingFlow` and maps `onboardingDuckAIFlow` to **internalOnly** with that remote source (replacing a locally disabled config). DEBUG/ALPHA can force **Default** vs **Duck.ai Tailored** via persisted `onboardingFlowType` and a new picker in `OnboardingDebugView`; `OnboardingManager.configureOnboardingFlow` reads the override before the URL evaluator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00a39c6c36723af15729a57f8a4020408d145c30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->