### PR TITLE
Avoid running workflows when Cursor makes an edit to the PR description

### DIFF
--- a/.github/workflows/should_run_pr_checks.yml
+++ b/.github/workflows/should_run_pr_checks.yml
@@ -51,6 +51,9 @@ jobs:
           if [[ "${{ github.event_name }}" != "pull_request" ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
             echo "Non-PR event, running checks"
+          elif [[ "${{ github.event.action }}" == "edited" && "${{ github.event.sender.type }}" == "Bot" ]]; then
+            echo "should_run=false" >> $GITHUB_OUTPUT
+            echo "PR edited by a bot (${{ github.event.sender.login }}), skipping checks"
           elif [[ "${{ github.event.action }}" == "ready_for_review" ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
             echo "PR was unmarked as draft, running checks"


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1215220346934150?focus=true
Tech Design URL:
CC:

### Description

This PR stops edits from Cursor from triggering workflows. This was done to reduce GitHub API hits that were caused by Cursor editing the PR frequently - these were contributing significantly to recent rate limiting.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that the change looks fine and shouldn't cause any legitimate Danger usage to be interfered with - for example, I was concerned that a real Danger failure could then be masked by a skipped Cursor edit afterwards, but I'm not sure whether it's a legitimate issue.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
3. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
4. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow gating only; any other bot `edited` event would also skip checks until a human-triggered event runs CI again.
> 
> **Overview**
> The reusable **`should_run_pr_checks`** workflow now sets **`should_run=false`** when a pull request **`edited`** event is sent by a **Bot** (e.g. Cursor updating the PR description), so downstream jobs that depend on that output skip CI for those updates.
> 
> Non-PR events, **`ready_for_review`**, and normal open PR behavior are unchanged. The intent is to cut GitHub API usage from repeated bot-driven description edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b3f37cac2a0acf4f0c57b52a6fff65489417a2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->