### PR TITLE
Apply Liquid Glass treatment to feedback dialogs

### DIFF
--- a/macOS/DuckDuckGo/Feedback/New/ReportProblemFormView.swift
+++ b/macOS/DuckDuckGo/Feedback/New/ReportProblemFormView.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import Common
 import SwiftUI
 import SwiftUIExtensions
 import DesignResourcesKit
@@ -25,7 +26,9 @@ final class ReportProblemFormViewController: NSHostingController<ReportProblemFo
 
     enum Constants {
         static let width: CGFloat = 448
-        static let height: CGFloat = 560
+        // Liquid Glass uses taller pill buttons (8/8 padding) and a larger bottom inset, so the
+        // fixed-height categories screen needs extra room to avoid clipping the footer.
+        static var height: CGFloat { AppVersion.isLiquidGlassSupported ? 575 : 571 }
 
         // Constants for the sub-categories screen
         static let detailsFormHeight: CGFloat = 356
@@ -154,7 +157,8 @@ struct ProblemCategoriesView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.top, 20)
-        .padding([.leading, .trailing, .bottom], 24)
+        .padding([.leading, .trailing], AppVersion.isLiquidGlassSupported ? 20 : 24)
+        .padding(.bottom, 24)
     }
 
     @State private var hoveredCategoryId: String?
@@ -213,7 +217,8 @@ struct ProblemCategoriesView: View {
             RoundedRectangle(cornerRadius: 6)
                 .stroke(Color.divider, lineWidth: 1)
         )
-        .padding([.leading, .trailing, .bottom], 24)
+        .padding([.leading, .trailing], AppVersion.isLiquidGlassSupported ? 20 : 24)
+        .padding(.bottom, 24)
     }
 
     private func footer() -> some View {
@@ -226,7 +231,7 @@ struct ProblemCategoriesView: View {
             Text(UserText.feedbackDisclaimer)
                 .caption2()
                 .multilineTextAlignment(.leading)
-                .padding([.leading, .trailing], 24)
+                .padding([.leading, .trailing], AppVersion.isLiquidGlassSupported ? 20 : 24)
 
             Button {
                 onClose()
@@ -234,9 +239,9 @@ struct ProblemCategoriesView: View {
                 Text(UserText.cancel)
                     .frame(maxWidth: .infinity)
             }
-            .buttonStyle(DismissActionButtonStyle())
-            .padding([.leading, .trailing], 24)
-            .padding(.bottom, 16)
+            .buttonStyle(DismissActionButtonStyle(topPadding: 8, bottomPadding: 8, pillShape: true))
+            .padding([.leading, .trailing], AppVersion.isLiquidGlassSupported ? 20 : 24)
+            .padding(.bottom, AppVersion.isLiquidGlassSupported ? 20 : 16)
         }
     }
 }
@@ -323,7 +328,8 @@ struct ProblemDetailFormView: View {
     private enum ComponentHeights {
         static let header: CGFloat = 72  // 24 padding + ~24 button/text + 24 padding
         static let textInputSection: CGFloat = 159  // Calculated from original height difference (515 - 356 = 159)
-        static let footer: CGFloat = 122  // 16 spacing + 1 divider + ~10 disclaimer + 16 spacing + ~32 buttons + 16 bottom padding + ~31 button spacing
+        // 16 spacing + 1 divider + ~10 disclaimer + 16 spacing + ~43 pill buttons (8/8 padding) + bottom padding + ~31 button spacing
+        static var footer: CGFloat { AppVersion.isLiquidGlassSupported ? 137 : 133 }
     }
 
     private func calculateTotalHeight() -> CGFloat {
@@ -366,11 +372,12 @@ struct ProblemDetailFormView: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(24)
+        .padding([.leading, .trailing], AppVersion.isLiquidGlassSupported ? 20 : 24)
+        .padding(.vertical, 24)
     }
 
     private func optionsPills() -> some View {
-        let horizontalPadding: CGFloat = 24
+        let horizontalPadding: CGFloat = AppVersion.isLiquidGlassSupported ? 20 : 24
         return FlexibleView(
             availableWidth: ReportProblemFormViewController.Constants.width - (horizontalPadding * 2),
             data: viewModel.availableOptions,
@@ -410,7 +417,7 @@ struct ProblemDetailFormView: View {
             AdaptiveTextEditor(text: $viewModel.customText)
                 .textEditorStyling(isEmpty: viewModel.customText.isEmpty)
         }
-        .padding([.leading, .trailing], 24)
+        .padding([.leading, .trailing], AppVersion.isLiquidGlassSupported ? 20 : 24)
         .padding(.bottom, 8)
     }
 
@@ -424,7 +431,7 @@ struct ProblemDetailFormView: View {
             Text(UserText.feedbackDisclaimer)
                 .caption2()
                 .multilineTextAlignment(.leading)
-                .padding([.leading, .trailing], 24)
+                .padding([.leading, .trailing], AppVersion.isLiquidGlassSupported ? 20 : 24)
 
             HStack(spacing: 10) {
                 Button {
@@ -433,7 +440,7 @@ struct ProblemDetailFormView: View {
                     Text(UserText.cancel)
                         .frame(maxWidth: .infinity)
                 }
-                .buttonStyle(DismissActionButtonStyle())
+                .buttonStyle(DismissActionButtonStyle(topPadding: 8, bottomPadding: 8, pillShape: true))
 
                 Button {
                     viewModel.submitFeedback()
@@ -442,10 +449,10 @@ struct ProblemDetailFormView: View {
                         .frame(maxWidth: .infinity)
                 }
                 .disabled(!viewModel.shouldEnableSubmit)
-                .buttonStyle(DefaultActionButtonStyle(enabled: viewModel.shouldEnableSubmit))
+                .buttonStyle(DefaultActionButtonStyle(enabled: viewModel.shouldEnableSubmit, topPadding: 8, bottomPadding: 8, pillShape: true))
             }
-            .padding([.leading, .trailing], 24)
-            .padding(.bottom, 16)
+            .padding([.leading, .trailing], AppVersion.isLiquidGlassSupported ? 20 : 24)
+            .padding(.bottom, AppVersion.isLiquidGlassSupported ? 20 : 16)
         }
     }
 }

--- a/macOS/DuckDuckGo/Feedback/New/RequestNewFeatureFormView.swift
+++ b/macOS/DuckDuckGo/Feedback/New/RequestNewFeatureFormView.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import Common
 import SwiftUI
 import SwiftUIExtensions
 import DesignResourcesKit
@@ -123,7 +124,8 @@ struct RequestNewFeatureFormView: View {
     private enum ComponentHeights {
         static let header: CGFloat = 72  // 24 padding + ~24 button/text + 24 padding
         static let textInputSection: CGFloat = 159  // Same as problem form
-        static let footer: CGFloat = 122  // Same as problem form structure
+        // Same as problem form structure; taller on Liquid Glass to fit the pill buttons (8/8 padding) + larger bottom inset
+        static var footer: CGFloat { AppVersion.isLiquidGlassSupported ? 137 : 133 }
     }
 
     private func calculateTotalHeight() -> CGFloat {
@@ -163,11 +165,12 @@ struct RequestNewFeatureFormView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.top, 20)
-        .padding([.leading, .trailing, .bottom], 24)
+        .padding([.leading, .trailing], AppVersion.isLiquidGlassSupported ? 20 : 24)
+        .padding(.bottom, 24)
     }
 
     private func featurePills() -> some View {
-        let horizontalPadding: CGFloat = 24
+        let horizontalPadding: CGFloat = AppVersion.isLiquidGlassSupported ? 20 : 24
         return FlexibleView(
             availableWidth: RequestNewFeatureFormViewController.Constants.width - (horizontalPadding * 2),
             data: viewModel.availableFeatures,
@@ -203,7 +206,7 @@ struct RequestNewFeatureFormView: View {
 
     private func incognitoInfoSection() -> some View {
         IncognitoInfoBox()
-            .padding([.leading, .trailing], 24)
+            .padding([.leading, .trailing], AppVersion.isLiquidGlassSupported ? 20 : 24)
             .padding(.bottom, 16)
             .transition(.opacity)
             .background(
@@ -256,7 +259,7 @@ struct RequestNewFeatureFormView: View {
                     }
                 )
         }
-        .padding([.leading, .trailing], 24)
+        .padding([.leading, .trailing], AppVersion.isLiquidGlassSupported ? 20 : 24)
         .padding(.bottom, 8)
     }
 
@@ -270,7 +273,7 @@ struct RequestNewFeatureFormView: View {
             Text(UserText.feedbackDisclaimer)
                 .caption2()
                 .multilineTextAlignment(.leading)
-                .padding([.leading, .trailing], 24)
+                .padding([.leading, .trailing], AppVersion.isLiquidGlassSupported ? 20 : 24)
 
             HStack(spacing: 10) {
                 Button {
@@ -279,7 +282,7 @@ struct RequestNewFeatureFormView: View {
                     Text(UserText.cancel)
                         .frame(maxWidth: .infinity)
                 }
-                .buttonStyle(DismissActionButtonStyle())
+                .buttonStyle(DismissActionButtonStyle(topPadding: 8, bottomPadding: 8, pillShape: true))
 
                 Button {
                     viewModel.submitFeedback()
@@ -289,10 +292,10 @@ struct RequestNewFeatureFormView: View {
                         .frame(maxWidth: .infinity)
                 }
                 .disabled(!viewModel.shouldEnableSubmit)
-                .buttonStyle(DefaultActionButtonStyle(enabled: viewModel.shouldEnableSubmit))
+                .buttonStyle(DefaultActionButtonStyle(enabled: viewModel.shouldEnableSubmit, topPadding: 8, bottomPadding: 8, pillShape: true))
             }
-            .padding([.leading, .trailing], 24)
-            .padding(.bottom, 16)
+            .padding([.leading, .trailing], AppVersion.isLiquidGlassSupported ? 20 : 24)
+            .padding(.bottom, AppVersion.isLiquidGlassSupported ? 20 : 16)
         }
     }
 }

--- a/macOS/DuckDuckGo/Feedback/New/ThankYouView.swift
+++ b/macOS/DuckDuckGo/Feedback/New/ThankYouView.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import Common
 import DesignResourcesKit
 import DesignResourcesKitIcons
 import Lottie
@@ -40,7 +41,7 @@ struct ThankYouView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.top, 20)
-            .padding([.leading, .trailing], 24)
+            .padding([.leading, .trailing], AppVersion.isLiquidGlassSupported ? 20 : 24)
 
             // Link section
             VStack(alignment: .leading, spacing: 16) {
@@ -48,7 +49,7 @@ struct ThankYouView: View {
                     .systemLabel(color: .textSecondary)
                     .multilineText()
                     .multilineTextAlignment(.leading)
-                    .padding([.leading, .trailing], 24)
+                    .padding([.leading, .trailing], AppVersion.isLiquidGlassSupported ? 20 : 24)
 
                 Button {
                     onSeeWhatsNew()
@@ -62,7 +63,7 @@ struct ThankYouView: View {
                     }
                 }
                 .buttonStyle(.plain)
-                .padding([.leading, .trailing], 24)
+                .padding([.leading, .trailing], AppVersion.isLiquidGlassSupported ? 20 : 24)
 
                 Spacer()
 
@@ -78,9 +79,9 @@ struct ThankYouView: View {
                     Text(UserText.feedbackFormClose)
                         .frame(maxWidth: .infinity)
                 }
-                .buttonStyle(DismissActionButtonStyle())
-                .padding([.leading, .trailing], 24)
-                .padding(.bottom, 16)
+                .buttonStyle(DismissActionButtonStyle(topPadding: 8, bottomPadding: 8, pillShape: true))
+                .padding([.leading, .trailing], AppVersion.isLiquidGlassSupported ? 20 : 24)
+                .padding(.bottom, AppVersion.isLiquidGlassSupported ? 20 : 16)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215218721778304?focus=true

### Description

Applies the Liquid Glass design treatment to the **Report a Browser Problem** and **Request a New Feature** modal dialogs, matching the pattern already used in `QuitSurveyView`:

- Action buttons (Cancel / Submit / Close) now use `pillShape: true` with `topPadding/bottomPadding: 8`, so they render as Liquid Glass capsules on supported OS versions and fall back to the existing rounded-rect style otherwise.
- Outer horizontal content insets switch to `20pt` under Liquid Glass (`24pt` otherwise) across all screens — headers, category list, pills, disclaimer, text editor, and button rows.
- Bottom insets follow the same `isLiquidGlassSupported ? 20 : 16` rule.
- Window/footer height calculations are adjusted to fit the taller pill buttons: the categories screen's fixed height becomes `575/571`, and the detail/feature form computed `footer` height becomes `137/133` (was `122`), preventing the disclaimer text from being clipped.

All changes are gated behind `AppVersion.isLiquidGlassSupported`; pre–Liquid-Glass OS versions are visually unchanged.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Disable Internal User State (otherwise you'd see the internal feedback form everywhere).
2. Open the main menu → **Help → Report a Problem** (or More Options Menu -> **Send Feedback** -> ...).
3. Verify the **categories** screen: rounded/pill Cancel button with proper bottom breathing room, ~20pt content insets, bordered category list correctly inset.
4. Select a category to reach the **detail form**: confirm Cancel/Submit are pill-shaped and the "Reports sent to DuckDuckGo are 100% anonymous…" disclaimer is fully visible (not truncated).
5. Submit to reach the **Thank You** screen: confirm the Close button styling and insets.
6. Open **Request a New Feature** and repeat the detail-form and thank-you checks.
7. On a pre–Liquid-Glass macOS (you can add `UIDesignRequiresCompatibility: YES` to the `Info.plist`), confirm the dialogs look unchanged from before (rounded-rect buttons, 24pt insets).

### Impact and Risks
Low — purely visual styling changes to two feedback dialogs, gated behind `isLiquidGlassSupported` with a preserved fallback path. No behavioral or data changes.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only SwiftUI layout and button styling behind `isLiquidGlassSupported`; no auth, data, or submission logic changes. Residual risk is minor footer clipping or extra whitespace if hardcoded height constants are slightly off.
> 
> **Overview**
> Applies **Liquid Glass** styling to the macOS **Report a Problem**, **Request a New Feature**, and shared **Thank You** feedback modals, aligned with other dialogs that gate on `AppVersion.isLiquidGlassSupported`.
> 
> When Liquid Glass is supported, **Cancel / Submit / Close** use pill capsule button styles (`pillShape: true`, 8pt vertical padding); otherwise behavior and rounded-rect styling stay as before. **Horizontal content insets** drop from 24pt to 20pt (headers, lists, pills, disclaimer, text fields, buttons), and **bottom insets** use 20pt instead of 16pt on those screens.
> 
> **Window height** is bumped so footers are not clipped: the problem **categories** screen fixed height becomes **575 / 571** (was 560), and dynamically sized detail/feature forms use a taller computed **footer** height (**137 / 133** vs **122**). `FlexibleView` pill layout width is updated to match the narrower horizontal padding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4deb1967719cddfa42aeb2e9f2565ae93c6d3d47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->