### PR TITLE
[iOS] Add provisional notification to Notification Center when scan finishes in foreground.

### DIFF
--- a/iOS/DuckDuckGo/NotificationServiceManager.swift
+++ b/iOS/DuckDuckGo/NotificationServiceManager.swift
@@ -41,7 +41,7 @@ final class NotificationServiceManager: NSObject, NotificationServiceManaging {
     @MainActor
     func userNotificationCenter(_ center: UNUserNotificationCenter,
                                 willPresent notification: UNNotification) async -> UNNotificationPresentationOptions {
-        return .banner
+        return [.banner, .list]
     }
     
     @MainActor


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1214738378921899
Tech Design URL:
CC:

### Description

Adds `.list` to the `willPresent` presentation options in `NotificationServiceManager`. With this, provisional notifications (e.g. PIR scan-completion) land in Notification Center even when the app is foregrounded at the time the notification fires (previously these were dropped entirely).

### Testing Steps

1. Reset PIR notification user defaults so the freemium first-scan notification can re-arm.
2. Trigger a freemium scan with the app in the foreground.
3. When the scan completes, confirm:
   - No banner is presented (existing behavior for provisional notification)
   - The notification is present in Notification Center

### Impact and Risks

None.

#### What could go wrong?

N/A

### Quality Considerations

N/A

### Notes to Reviewer

N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to UNUserNotificationCenter presentation options; no auth, data, or routing logic touched.
> 
> **Overview**
> Foreground notifications delivered while the app is open are no longer limited to in-app presentation only: `NotificationServiceManager`’s `willPresent` handler now returns **`.banner` and `.list`**, so eligible notifications (e.g. PIR scan completion) are also recorded in **Notification Center** instead of being dropped when the user is already in the app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06bf2dbb0acfdc1c4455d8dbb285c49efeb9a636. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->