### PR TITLE
[iOS] Add "days since installed" to Remote Messaging debug screen

### DIFF
--- a/iOS/DuckDuckGo/RemoteMessagingDebugViewController.swift
+++ b/iOS/DuckDuckGo/RemoteMessagingDebugViewController.swift
@@ -25,6 +25,7 @@ import CoreData
 import Combine
 import Persistence
 import OSLog
+import FoundationExtensions
 
 class RemoteMessagingDebugViewController: UIHostingController<RemoteMessagingDebugRootView> {
 
@@ -42,9 +43,30 @@ struct RemoteMessagingDebugRootView: View {
         self.model = RemoteMessagingDebugViewModel(remoteMessagingDebugHandler: remoteMessagingDebugHandler)
     }
     @State private var shareItem: ShareItem?
+    @State private var isShowingDaysAlert = false
+    @State private var daysInput = ""
 
     var body: some View {
         List {
+            Section {
+                HStack {
+                    Text("Days Since Installed")
+                        .font(.system(size: 15))
+                    Spacer()
+                    Text(model.currentDaysSinceInstalled.map(String.init) ?? "Not set")
+                        .font(.system(size: 15))
+                        .foregroundStyle(Color(baseColor: .gray70))
+                }
+                Button("Set Days Since Installed…") {
+                    daysInput = model.currentDaysSinceInstalled.map(String.init) ?? ""
+                    isShowingDaysAlert = true
+                }
+            } header: {
+                Text("Install Date")
+            } footer: {
+                Text("Sets the install date to N days ago, to test messages gated by daysSinceInstalled. Tap “Refresh Config” afterwards to re-evaluate.")
+            }
+
             Section {
                 if let configInfo = model.configInfo {
                     VStack(alignment: .leading, spacing: 6) {
@@ -139,6 +161,18 @@ struct RemoteMessagingDebugRootView: View {
         .sheet(item: $shareItem) { item in
             ShareSheet(activityItems: [item.fileURL])
         }
+        .alert("Set Days Since Installed", isPresented: $isShowingDaysAlert) {
+            TextField("Days", text: $daysInput)
+                .keyboardType(.numberPad)
+            Button("Cancel", role: .cancel) {}
+            Button("Set") {
+                if let days = Int(daysInput.trimmingCharacters(in: .whitespaces)), days >= 0 {
+                    model.setDaysSinceInstalled(days)
+                }
+            }
+        } message: {
+            Text("Enter a non-negative number of days. The install date will be set to that many days ago.")
+        }
     }
 }
 
@@ -232,6 +266,7 @@ class RemoteMessagingDebugViewModel: ObservableObject {
     @Published var configInfo: ConfigDebugModel?
     @Published var recentLogs: [LogEntry] = []
     @Published var isLoadingLogs: Bool = false
+    @Published var currentDaysSinceInstalled: Int?
 
     let database: CoreDataDatabase
     private let remoteMessagingDebugHandler: RemoteMessagingDebugHandling?
@@ -241,6 +276,7 @@ class RemoteMessagingDebugViewModel: ObservableObject {
         database = Database.shared
         fetchMessages()
         fetchConfigInfo()
+        fetchInstallDateInfo()
         Task {
             await fetchLogs()
         }
@@ -275,6 +311,19 @@ class RemoteMessagingDebugViewModel: ObservableObject {
 
     func refreshConfig() {
         remoteMessagingDebugHandler?.refreshRemoteMessages()
+    }
+
+    func fetchInstallDateInfo() {
+        guard let installDate = StatisticsUserDefaults().installDate else {
+            currentDaysSinceInstalled = nil
+            return
+        }
+        currentDaysSinceInstalled = Calendar.current.numberOfDaysBetween(installDate, and: Date())
+    }
+
+    func setDaysSinceInstalled(_ days: Int) {
+        StatisticsUserDefaults().installDate = Calendar.current.date(byAdding: .day, value: -days, to: Date())
+        fetchInstallDateInfo()
     }
 
     func fetchMessages() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214893957137406
Tech Design URL:
CC:

### Description

Adds a debug utility so Ship Review testers can set "days since installed" to an arbitrary value without waiting real days. This unblocks testing of any RMF gated by `daysSinceInstalled`, like  the delayed PIR Freemium entry-point promo (5-day gate).

### Testing Steps
1. Make sure the production config is used by `RemoteMessagingClient.swift` (in `endpoint`)
2. Run the app, open Settings → Debug → PIR and Force Freemium PIR Eligibility
3. Open Debug → Remote Messaging. "Delete All" and then tap "Refresh Config". At this point, the Freemium PIR remote message should not be matched
4. Set "Days Since Installed" to 5, "Delete All" and then tap "Refresh Config". At this point, Freemium PIR remote message will be matched.

| days since install: 1 | days since install: 5 |
| --- | --- |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-29 at 10 27 31" src="https://github.com/user-attachments/assets/20b9a1cd-e908-4956-abd8-de8a4ed5fcaa" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-29 at 10 27 22" src="https://github.com/user-attachments/assets/30d8e0b5-e09c-4413-9d7e-9125d0ad4b85" />  |

### Impact and Risks

None, debug menu only.

#### What could go wrong?

N/A

### Notes to Reviewer

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Debug-only UI that mutates install date in user defaults for QA; no production user-facing behavior.
> 
> **Overview**
> Adds an **Install Date** section to the Remote Messaging debug screen so testers can read and override **days since installed** without waiting in real time.
> 
> The UI shows the current value (or “Not set”) and a **Set Days Since Installed…** flow that writes `StatisticsUserDefaults().installDate` to *N* days ago, then refreshes the displayed count. Footer text reminds reviewers to use **Refresh Config** after changing the value so RMF rules that use `daysSinceInstalled` (e.g. delayed promos) can be exercised in Ship Review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d554a431faa794a623a9e4f3fa0af08d8bc00f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->