### PR TITLE
[iOS][Tailored Onboarding] Add a pixel to measure reinstallers from Duck.ai CPP who should experience autosync restore flow

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -271,6 +271,7 @@ extension Pixel {
         case onboardingDuckAIExperimentFinalDialogShownUnique
         case onboardingChatPathTryVisitSiteUnique
         case onboardingChatPathTrackersBlockedUnique
+        case onboardingSyncAutoRestoreUserFromDuckAiFlow
 
         case onboardingContextualSearchOptionTappedUnique
         case onboardingContextualSearchCustomUnique
@@ -2201,6 +2202,7 @@ extension Pixel.Event {
         case .onboardingDuckAIExperimentFinalDialogShownUnique: return "m_preonboarding_duckai_final-dialog-impression_unique"
         case .onboardingChatPathTryVisitSiteUnique: return "m_onboarding_chat-path_try-visit-site_unique"
         case .onboardingChatPathTrackersBlockedUnique: return "m_onboarding_chat-path_trackers-blocked_unique"
+        case .onboardingSyncAutoRestoreUserFromDuckAiFlow : return "m_onboarding_duck-ai_sync-auto-restore-user"
 
         case .onboardingContextualSearchOptionTappedUnique: return "m_onboarding_search_option_tapped_unique"
         case .onboardingContextualSiteOptionTappedUnique: return "m_onboarding_visit_site_option_tapped_unique"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -2202,7 +2202,7 @@ extension Pixel.Event {
         case .onboardingDuckAIExperimentFinalDialogShownUnique: return "m_preonboarding_duckai_final-dialog-impression_unique"
         case .onboardingChatPathTryVisitSiteUnique: return "m_onboarding_chat-path_try-visit-site_unique"
         case .onboardingChatPathTrackersBlockedUnique: return "m_onboarding_chat-path_trackers-blocked_unique"
-        case .onboardingSyncAutoRestoreUserFromDuckAiFlow : return "m_onboarding_duck-ai_sync-auto-restore-user"
+        case .onboardingSyncAutoRestoreUserFromDuckAiFlow: return "m_onboarding_duck-ai_sync-auto-restore-user"
 
         case .onboardingContextualSearchOptionTappedUnique: return "m_onboarding_search_option_tapped_unique"
         case .onboardingContextualSiteOptionTappedUnique: return "m_onboarding_visit_site_option_tapped_unique"

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
@@ -584,6 +584,8 @@ private extension OnboardingIntroViewModel {
         }
         // Restore-data prompt is suppressed in the Duck.ai tailored flow.
         guard onboardingManager.currentOnboardingFlow != .duckAI else {
+            // Fire a temporary pixel to measure the volume of re‑installers who previously synced their device and would normally see the restore-data flow but instead experience the CPP onboarding (honouring the CPP install context).
+            DailyPixel.fireDailyAndCount(pixel: .onboardingSyncAutoRestoreUserFromDuckAiFlow)
             return .skipTutorial
         }
         return restorePromptHandler.isEligibleForRestorePrompt() ? .restoreData : .skipTutorial

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
@@ -584,7 +584,8 @@ private extension OnboardingIntroViewModel {
         }
         // Restore-data prompt is suppressed in the Duck.ai tailored flow.
         guard onboardingManager.currentOnboardingFlow != .duckAI else {
-            // Fire a temporary pixel to measure the volume of re‑installers who previously synced their device and would normally see the restore-data flow but instead experience the CPP onboarding (honouring the CPP install context).
+            // Fire a pixel to measure the volume of re‑installers who previously synced their device and would normally see the restore-data flow but instead experience the CPP onboarding (honouring the CPP install context).
+            // Consider deleting this pixel ini the future if the information is no longer needed
             if restorePromptHandler.isEligibleForRestorePrompt() {
                 DailyPixel.fireDailyAndCount(pixel: .onboardingSyncAutoRestoreUserFromDuckAiFlow)
             }

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
@@ -585,7 +585,9 @@ private extension OnboardingIntroViewModel {
         // Restore-data prompt is suppressed in the Duck.ai tailored flow.
         guard onboardingManager.currentOnboardingFlow != .duckAI else {
             // Fire a temporary pixel to measure the volume of re‑installers who previously synced their device and would normally see the restore-data flow but instead experience the CPP onboarding (honouring the CPP install context).
-            DailyPixel.fireDailyAndCount(pixel: .onboardingSyncAutoRestoreUserFromDuckAiFlow)
+            if restorePromptHandler.isEligibleForRestorePrompt() {
+                DailyPixel.fireDailyAndCount(pixel: .onboardingSyncAutoRestoreUserFromDuckAiFlow)
+            }
             return .skipTutorial
         }
         return restorePromptHandler.isEligibleForRestorePrompt() ? .restoreData : .skipTutorial

--- a/iOS/PixelDefinitions/pixels/definitions/onboarding.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/onboarding.json5
@@ -75,5 +75,12 @@
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
+    },
+    "m_onboarding_duck-ai_sync-auto-restore-user": {
+        "description": "Fired when the a reinstaller who previously synced their device goes through the Duck AI onboarding flow. Used to understand the volume of these users.",
+        "owners": ["alessandroboron"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215190155026980
Tech Design URL:
CC:

### Description

This PR adds a pixel (`m_onboarding_duck-ai_sync-auto-restore-user`) that fires when a re-installer who previously synced their device is routed through the Duck.ai tailored onboarding flow instead of the standard restore-data prompt.

Because the Duck.ai tailored flow suppresses the restore-data prompt (to honour the CPP install context), we currently have no visibility into how many sync-eligible re-installers are being diverted away from the restore flow. This pixel measures that volume so we can decide whether a follow-up treatment is needed.

### Testing Steps
1. Install the app fresh and complete onboarding normally and confirm the new pixel does **not** fire.
2. With a synced device, simulate a re-install scenario where `restorePromptHandler.isEligibleForRestorePrompt()` would return `true` AND the active flow is `.duckAI` (Duck.ai tailored onboarding).
3. Launch the app and proceed through onboarding. Verify that `m_onboarding_duck-ai_sync-auto-restore-user` fires.

### Impact and Risks
**Low**: instrumentation-only change. No user-visible behaviour modified; the Duck.ai flow continues to suppress the restore prompt exactly as before.

#### What could go wrong?
- Pixel fires on an unintended path. Mitigated: the fire site is inside the `guard onboardingManager.currentOnboardingFlow != .duckAI else { … }` branch that *only* runs when restore is skipped due to Duck.ai flow.
- Over-firing inflates counts. Mitigated by using `DailyPixel.fireDailyAndCount`.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Instrumentation-only; onboarding routing and restore suppression are unchanged, with firing gated to the existing Duck.ai + restore-eligibility branch.
> 
> **Overview**
> Adds analytics to count **returning users who would have seen sync restore** but are sent through **Duck.ai tailored onboarding** instead (restore prompt still suppressed).
> 
> When `introDialogType` resolves to `.skipTutorial` on the `.duckAI` flow and `restorePromptHandler.isEligibleForRestorePrompt()` is true, the app fires **`m_onboarding_duck-ai_sync-auto-restore-user`** via `DailyPixel.fireDailyAndCount`. The event is wired through `PixelEvent`, pixel definitions (`daily_count`, platform, form factor), and does not change which intro dialog type is shown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7ce3d2d68cb95c3766f963fb936421bdeb4fc72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->