### PR TITLE
[macOS] Permanently enable Add to Dock instructions for App Store version

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -193,8 +193,6 @@ public enum MacOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// Enables lazy reload for the more options menu
     case lazyMenuRebuild
 
-    case addToDockAppStore
-
     case screenTimeCleaning
 
     /// Enables the custom NSPanel-based bookmarks bar menu (replacing NSPopover) with NSGlassEffectView on macOS 26

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -922,7 +922,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             keyValueStore: UserDefaults.standard
         )
         dockPreferences = DockPreferencesModel(
-            featureFlagger: featureFlagger,
             dockCustomizer: dockCustomization,
             pixelFiring: PixelKit.shared
         )

--- a/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
@@ -112,7 +112,6 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
     private let dataImportProvider: DataImportStatusProviding
     private var aiChatPreferencesStorage: AIChatPreferencesStorage
     private let featureFlagger: FeatureFlagger
-    private let applicationBuildType: ApplicationBuildType
     private let onboardingSharedPixelHandler: OnboardingSharedPixelHandling
     private var cancellables = Set<AnyCancellable>()
 
@@ -123,14 +122,14 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         let systemSettings: SystemSettings
         let order = featureFlagger.isFeatureOn(.onboardingRebranding) ? "v4" : "v3"
         let platform = OnboardingPlatform(name: "macos")
-        if applicationBuildType.isAppStoreBuild {
+        if dockCustomization.supportsAddingToDock {
             systemSettings = SystemSettings(rows: [
-                OnboardingRow.dockInstructions.rawValue,
+                OnboardingRow.dock.rawValue,
                 OnboardingRow.dataImport.rawValue,
             ])
         } else {
             systemSettings = SystemSettings(rows: [
-                OnboardingRow.dock.rawValue,
+                OnboardingRow.dockInstructions.rawValue,
                 OnboardingRow.dataImport.rawValue
             ])
         }
@@ -209,7 +208,6 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         dataImportProvider: DataImportStatusProviding,
         aiChatPreferencesStorage: AIChatPreferencesStorage = DefaultAIChatPreferencesStorage(),
         featureFlagger: FeatureFlagger,
-        applicationBuildType: ApplicationBuildType = StandardApplicationBuildType(),
         onboardingSharedPixelHandler: OnboardingSharedPixelHandling
     ) {
         self.navigation = navigationDelegate
@@ -220,7 +218,6 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         self.dataImportProvider = dataImportProvider
         self.aiChatPreferencesStorage = aiChatPreferencesStorage
         self.featureFlagger = featureFlagger
-        self.applicationBuildType = applicationBuildType
         self.onboardingSharedPixelHandler = onboardingSharedPixelHandler
     }
 

--- a/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
@@ -124,11 +124,10 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         let order = featureFlagger.isFeatureOn(.onboardingRebranding) ? "v4" : "v3"
         let platform = OnboardingPlatform(name: "macos")
         if applicationBuildType.isAppStoreBuild {
-            let rows = [
-                featureFlagger.isFeatureOn(.addToDockAppStore) ? OnboardingRow.dockInstructions.rawValue : nil,
+            systemSettings = SystemSettings(rows: [
+                OnboardingRow.dockInstructions.rawValue,
                 OnboardingRow.dataImport.rawValue,
-            ].compactMap { $0 }
-            systemSettings = SystemSettings(rows: rows)
+            ])
         } else {
             systemSettings = SystemSettings(rows: [
                 OnboardingRow.dock.rawValue,

--- a/macOS/DuckDuckGo/Preferences/Model/DockPreferencesModel.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/DockPreferencesModel.swift
@@ -35,11 +35,6 @@ final class DockPreferencesModel: ObservableObject {
         dockCustomizer.supportsAddingToDock
     }
 
-    /// Whether instructions can be shown for how to add the app to the dock manually.
-    var canShowDockInstructions: Bool {
-        !canAddToDock
-    }
-
     /// Whether the app is being added to the dock.
     /// Used to optimistically update settings when adding the app to the dock.
     @Published private var isBeingAddedToDock = false

--- a/macOS/DuckDuckGo/Preferences/Model/DockPreferencesModel.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/DockPreferencesModel.swift
@@ -19,10 +19,8 @@
 import ContentScopeScripts
 import Foundation
 import PixelKit
-import PrivacyConfig
 
 final class DockPreferencesModel: ObservableObject {
-    private let featureFlagger: FeatureFlagger
     private let dockCustomizer: DockCustomization
     private let pixelFiring: PixelFiring?
 
@@ -39,7 +37,7 @@ final class DockPreferencesModel: ObservableObject {
 
     /// Whether instructions can be shown for how to add the app to the dock manually.
     var canShowDockInstructions: Bool {
-        featureFlagger.isFeatureOn(.addToDockAppStore)
+        !canAddToDock
     }
 
     /// Whether the app is being added to the dock.
@@ -50,10 +48,8 @@ final class DockPreferencesModel: ObservableObject {
         isBeingAddedToDock || dockCustomizer.isAddedToDock
     }
 
-    init(featureFlagger: FeatureFlagger,
-         dockCustomizer: DockCustomization,
+    init(dockCustomizer: DockCustomization,
          pixelFiring: PixelFiring?) {
-        self.featureFlagger = featureFlagger
         self.dockCustomizer = dockCustomizer
         self.pixelFiring = pixelFiring
     }

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesDefaultBrowserView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesDefaultBrowserView.swift
@@ -107,7 +107,7 @@ extension Preferences {
                         .onAppear {
                             dockModel.refresh()
                         }
-                    } else if dockModel.canShowDockInstructions {
+                    } else {
                         PreferencePaneSection(UserText.shortcuts, spacing: 4) {
                             PreferencePaneSubSection {
                                 HStack(alignment: .top) {

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesGeneralView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesGeneralView.swift
@@ -102,7 +102,7 @@ extension Preferences {
                     .onAppear {
                         dockModel.refresh()
                     }
-                } else if dockModel.canShowDockInstructions {
+                } else {
                     PreferencePaneSection(UserText.shortcuts, spacing: 4) {
                         PreferencePaneSubSection {
                             HStack(alignment: .top) {

--- a/macOS/IntegrationTests/Onboarding/BrowserTabViewControllerOnboardingTests.swift
+++ b/macOS/IntegrationTests/Onboarding/BrowserTabViewControllerOnboardingTests.swift
@@ -189,8 +189,7 @@ final class BrowserTabViewControllerOnboardingTests: XCTestCase {
                     featureFlagger: MockFeatureFlagger()
                 ),
                 aboutPreferences: AboutPreferences(internalUserDecider: featureFlagger.internalUserDecider, featureFlagger: featureFlagger, windowControllersManager: windowControllersManager, keyValueStore: InMemoryThrowingKeyValueStore()),
-                dockPreferences: DockPreferencesModel(featureFlagger: featureFlagger,
-                                                      dockCustomizer: DockCustomizerMock(),
+                dockPreferences: DockPreferencesModel(dockCustomizer: DockCustomizerMock(),
                                                       pixelFiring: nil),
                 accessibilityPreferences: AccessibilityPreferences(),
                 duckPlayer: DuckPlayer(

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -338,10 +338,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Defers menu population to NSMenuDelegate.menuNeedsUpdate(_:) to avoid expensive eager rebuilds
     case lazyMenuRebuild
 
-    /// Enables the "Add to dock" onboarding step and setting for App Store builds
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213725466401987?focus=true
-    case addToDockAppStore
-
     /// Enables removing individual AI chat suggestions from the omnibar
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213761882751264?focus=true
     case aiChatRemoveSuggestion
@@ -628,8 +624,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.tabAnimations))
         case .lazyMenuRebuild:
             Config(defaultValue: .enabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.lazyMenuRebuild))
-        case .addToDockAppStore:
-            Config(defaultValue: .enabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.addToDockAppStore))
         case .aiChatRemoveSuggestion:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.removeSuggestion), category: .duckAI)
         case .screenTimeCleaning:

--- a/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
+++ b/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
@@ -111,7 +111,7 @@ class OnboardingManagerTests: XCTestCase {
         XCTAssertEqual(manager.configuration, expectedConfig)
     }
 
-    func testReturnsExpectedOnboardingConfig_WhenAppStoreBuild_DoesNotShowDockRow() {
+    func testReturnsExpectedOnboardingConfig_WhenAppStoreBuild_IncludesDockInstructionsRow() {
         // Given
         applicationBuildType.isAppStoreBuild = true
         let appStoreManager = OnboardingActionsManager(
@@ -125,7 +125,7 @@ class OnboardingManagerTests: XCTestCase {
             applicationBuildType: applicationBuildType,
             onboardingSharedPixelHandler: onboardingSharedPixelHandler
         )
-        let stepDefinitions = StepDefinitions(systemSettings: SystemSettings(rows: ["import"]))
+        let stepDefinitions = StepDefinitions(systemSettings: SystemSettings(rows: ["dock-instructions", "import"]))
         let expectedConfig = OnboardingConfiguration(
             stepDefinitions: stepDefinitions,
             exclude: [OnboardingExcludedStep.duckPlayerSingle.rawValue, OnboardingExcludedStep.addressBarMode.rawValue],

--- a/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
+++ b/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
@@ -40,7 +40,6 @@ class OnboardingManagerTests: XCTestCase {
     var dataClearingPreferences: DataClearingPreferences!
     var startupPersistor: StartupPreferencesUserDefaultsPersistor!
     var importProvider: CapturingDataImportProvider!
-    var applicationBuildType: MockApplicationBuildType!
     private var onboardingSharedPixelHandler: MockOnboardingSharedPixelHandler!
 
     @MainActor override func setUp() {
@@ -64,7 +63,6 @@ class OnboardingManagerTests: XCTestCase {
         )
         startupPreferences = StartupPreferences(pinningManager: MockPinningManager(), persistor: startupPersistor, appearancePreferences: appearancePreferences)
         importProvider = CapturingDataImportProvider()
-        applicationBuildType = MockApplicationBuildType()
         onboardingSharedPixelHandler = MockOnboardingSharedPixelHandler()
         manager = OnboardingActionsManager(
             navigationDelegate: navigationDelegate,
@@ -74,7 +72,6 @@ class OnboardingManagerTests: XCTestCase {
             startupPreferences: startupPreferences,
             dataImportProvider: importProvider,
             featureFlagger: MockFeatureFlagger(),
-            applicationBuildType: applicationBuildType,
             onboardingSharedPixelHandler: onboardingSharedPixelHandler
         )
     }
@@ -90,7 +87,6 @@ class OnboardingManagerTests: XCTestCase {
         dataClearingPreferences = nil
         fireButtonPreferencesPersistor = nil
         importProvider = nil
-        applicationBuildType = nil
         onboardingSharedPixelHandler = nil
     }
 
@@ -111,9 +107,9 @@ class OnboardingManagerTests: XCTestCase {
         XCTAssertEqual(manager.configuration, expectedConfig)
     }
 
-    func testReturnsExpectedOnboardingConfig_WhenAppStoreBuild_IncludesDockInstructionsRow() {
+    func testReturnsExpectedOnboardingConfig_WhenDockCustomization_DoesNotSupportAddingToDock() {
         // Given
-        applicationBuildType.isAppStoreBuild = true
+        dockCustomization.supportsAddingToDock = false
         let appStoreManager = OnboardingActionsManager(
             navigationDelegate: navigationDelegate,
             dockCustomization: dockCustomization,
@@ -122,7 +118,6 @@ class OnboardingManagerTests: XCTestCase {
             startupPreferences: startupPreferences,
             dataImportProvider: importProvider,
             featureFlagger: MockFeatureFlagger(),
-            applicationBuildType: applicationBuildType,
             onboardingSharedPixelHandler: onboardingSharedPixelHandler
         )
         let stepDefinitions = StepDefinitions(systemSettings: SystemSettings(rows: ["dock-instructions", "import"]))
@@ -151,7 +146,6 @@ class OnboardingManagerTests: XCTestCase {
             startupPreferences: startupPreferences,
             dataImportProvider: importProvider,
             featureFlagger: featureFlagger,
-            applicationBuildType: applicationBuildType,
             onboardingSharedPixelHandler: onboardingSharedPixelHandler
         )
 
@@ -182,7 +176,6 @@ class OnboardingManagerTests: XCTestCase {
             startupPreferences: startupPreferences,
             dataImportProvider: importProvider,
             featureFlagger: featureFlagger,
-            applicationBuildType: applicationBuildType,
             onboardingSharedPixelHandler: onboardingSharedPixelHandler
         )
 
@@ -213,7 +206,6 @@ class OnboardingManagerTests: XCTestCase {
             startupPreferences: startupPreferences,
             dataImportProvider: importProvider,
             featureFlagger: featureFlagger,
-            applicationBuildType: applicationBuildType,
             onboardingSharedPixelHandler: onboardingSharedPixelHandler
         )
 
@@ -547,7 +539,6 @@ class OnboardingManagerTests: XCTestCase {
             startupPreferences: startupPreferences,
             dataImportProvider: importProvider,
             featureFlagger: featureFlagger,
-            applicationBuildType: applicationBuildType,
             onboardingSharedPixelHandler: onboardingSharedPixelHandler
         )
 
@@ -574,7 +565,6 @@ class OnboardingManagerTests: XCTestCase {
             startupPreferences: startupPreferences,
             dataImportProvider: importProvider,
             featureFlagger: featureFlagger,
-            applicationBuildType: applicationBuildType,
             onboardingSharedPixelHandler: onboardingSharedPixelHandler
         )
 

--- a/macOS/UnitTests/Preferences/DockPreferencesModelTests.swift
+++ b/macOS/UnitTests/Preferences/DockPreferencesModelTests.swift
@@ -60,25 +60,7 @@ final class DockPreferencesModelTests: XCTestCase {
         XCTAssertFalse(model.canAddToDock)
     }
 
-    // MARK: - canShowDockInstructions
-
-    func testWhenSupportsAddingToDockIsFalseThenCanShowDockInstructionsIsTrue() {
-        mockDockCustomizer.supportsAddingToDock = false
-        let model = DockPreferencesModel(
-            dockCustomizer: mockDockCustomizer,
-            pixelFiring: nil
-        )
-        XCTAssertTrue(model.canShowDockInstructions)
-    }
-
-    func testWhenSupportsAddingToDockIsTrueThenCanShowDockInstructionsIsFalse() {
-        mockDockCustomizer.supportsAddingToDock = true
-        let model = DockPreferencesModel(
-            dockCustomizer: mockDockCustomizer,
-            pixelFiring: nil
-        )
-        XCTAssertFalse(model.canShowDockInstructions)
-    }
+    // MARK: - Add to Dock Instructions
 
     func testDockInstructionsVideoAssetIsNotNil() {
         XCTAssertNotNil(DockPreferencesModel.demoVideoURL)

--- a/macOS/UnitTests/Preferences/DockPreferencesModelTests.swift
+++ b/macOS/UnitTests/Preferences/DockPreferencesModelTests.swift
@@ -17,29 +17,24 @@
 //
 
 import Combine
-import FeatureFlags
 import PixelKitTestingUtilities
-import PrivacyConfig
 import XCTest
 @testable import DuckDuckGo_Privacy_Browser
 
 @MainActor
 final class DockPreferencesModelTests: XCTestCase {
 
-    private var mockFeatureFlagger: MockFeatureFlagger!
     private var mockDockCustomizer: MockDockCustomization!
     private var mockPixelFiring: PixelKitMock!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        mockFeatureFlagger = MockFeatureFlagger()
         mockDockCustomizer = MockDockCustomization()
         mockDockCustomizer.supportsAddingToDock = true
         mockPixelFiring = PixelKitMock()
     }
 
     override func tearDown() {
-        mockFeatureFlagger = nil
         mockDockCustomizer = nil
         mockPixelFiring = nil
         super.tearDown()
@@ -50,7 +45,6 @@ final class DockPreferencesModelTests: XCTestCase {
     func testWhenSupportsAddingToDockIsTrueThenCanAddToDockIsTrue() {
         mockDockCustomizer.supportsAddingToDock = true
         let model = DockPreferencesModel(
-            featureFlagger: mockFeatureFlagger,
             dockCustomizer: mockDockCustomizer,
             pixelFiring: nil
         )
@@ -60,7 +54,6 @@ final class DockPreferencesModelTests: XCTestCase {
     func testWhenSupportsAddingToDockIsFalseThenCanAddToDockIsFalse() {
         mockDockCustomizer.supportsAddingToDock = false
         let model = DockPreferencesModel(
-            featureFlagger: mockFeatureFlagger,
             dockCustomizer: mockDockCustomizer,
             pixelFiring: nil
         )
@@ -69,20 +62,18 @@ final class DockPreferencesModelTests: XCTestCase {
 
     // MARK: - canShowDockInstructions
 
-    func testWhenAddToDockAppStoreFeatureIsOnThenCanShowDockInstructionsIsTrue() {
-        mockFeatureFlagger.enabledFeatureFlags = [.addToDockAppStore]
+    func testWhenSupportsAddingToDockIsFalseThenCanShowDockInstructionsIsTrue() {
+        mockDockCustomizer.supportsAddingToDock = false
         let model = DockPreferencesModel(
-            featureFlagger: mockFeatureFlagger,
             dockCustomizer: mockDockCustomizer,
             pixelFiring: nil
         )
         XCTAssertTrue(model.canShowDockInstructions)
     }
 
-    func testWhenAddToDockAppStoreFeatureIsOffThenCanShowDockInstructionsIsFalse() {
-        mockFeatureFlagger.enabledFeatureFlags = []
+    func testWhenSupportsAddingToDockIsTrueThenCanShowDockInstructionsIsFalse() {
+        mockDockCustomizer.supportsAddingToDock = true
         let model = DockPreferencesModel(
-            featureFlagger: mockFeatureFlagger,
             dockCustomizer: mockDockCustomizer,
             pixelFiring: nil
         )
@@ -98,7 +89,6 @@ final class DockPreferencesModelTests: XCTestCase {
     func testWhenNotAddedToDockAndCustomizerReportsFalseThenIsAddedToDockIsFalse() {
         mockDockCustomizer.isAddedToDock = false
         let model = DockPreferencesModel(
-            featureFlagger: mockFeatureFlagger,
             dockCustomizer: mockDockCustomizer,
             pixelFiring: nil
         )
@@ -108,7 +98,6 @@ final class DockPreferencesModelTests: XCTestCase {
     func testWhenCustomizerReportsTrueThenIsAddedToDockIsTrue() {
         mockDockCustomizer.isAddedToDock = true
         let model = DockPreferencesModel(
-            featureFlagger: mockFeatureFlagger,
             dockCustomizer: mockDockCustomizer,
             pixelFiring: nil
         )
@@ -117,7 +106,6 @@ final class DockPreferencesModelTests: XCTestCase {
 
     func testWhenAddToDockCalledThenIsAddedToDockIsTrue() {
         let model = DockPreferencesModel(
-            featureFlagger: mockFeatureFlagger,
             dockCustomizer: mockDockCustomizer,
             pixelFiring: nil
         )
@@ -130,7 +118,6 @@ final class DockPreferencesModelTests: XCTestCase {
 
     func testWhenAddToDockCalledFromDefaultBrowserThenDockCustomizerAddToDockIsCalled() {
         let model = DockPreferencesModel(
-            featureFlagger: mockFeatureFlagger,
             dockCustomizer: mockDockCustomizer,
             pixelFiring: nil
         )
@@ -141,7 +128,6 @@ final class DockPreferencesModelTests: XCTestCase {
 
     func testWhenAddToDockCalledFromGeneralThenDockCustomizerAddToDockIsCalled() {
         let model = DockPreferencesModel(
-            featureFlagger: mockFeatureFlagger,
             dockCustomizer: mockDockCustomizer,
             pixelFiring: nil
         )
@@ -153,7 +139,6 @@ final class DockPreferencesModelTests: XCTestCase {
     func testWhenSupportsAddingToDockIsFalseThenAddToDockDoesNothing() {
         mockDockCustomizer.supportsAddingToDock = false
         let model = DockPreferencesModel(
-            featureFlagger: mockFeatureFlagger,
             dockCustomizer: mockDockCustomizer,
             pixelFiring: nil
         )
@@ -171,7 +156,6 @@ final class DockPreferencesModelTests: XCTestCase {
                              includeAppVersionParameter: false)
         ]
         let model = DockPreferencesModel(
-            featureFlagger: mockFeatureFlagger,
             dockCustomizer: mockDockCustomizer,
             pixelFiring: mockPixelFiring
         )
@@ -186,7 +170,6 @@ final class DockPreferencesModelTests: XCTestCase {
                              includeAppVersionParameter: false)
         ]
         let model = DockPreferencesModel(
-            featureFlagger: mockFeatureFlagger,
             dockCustomizer: mockDockCustomizer,
             pixelFiring: mockPixelFiring
         )
@@ -197,7 +180,6 @@ final class DockPreferencesModelTests: XCTestCase {
     func testWhenShowMeHowClickedThenExpectedPixelIsFiredAndSheetFlagIsSet() {
         mockPixelFiring.expectedFireCalls = [ExpectedFireCall(pixel: GeneralPixel.settingsAddToDockShowMeHowClicked, frequency: .dailyAndCount)]
         let model = DockPreferencesModel(
-            featureFlagger: mockFeatureFlagger,
             dockCustomizer: mockDockCustomizer,
             pixelFiring: mockPixelFiring
         )

--- a/macOS/UnitTests/Preferences/PreferencesSidebarModelTests.swift
+++ b/macOS/UnitTests/Preferences/PreferencesSidebarModelTests.swift
@@ -119,8 +119,7 @@ final class PreferencesSidebarModelTests: XCTestCase {
             cookiePopupProtectionPreferences: CookiePopupProtectionPreferences(persistor: MockCookiePopupProtectionPreferencesPersistor(), windowControllersManager: windowControllersManager),
             aiChatPreferences: mockAIChatPreferences,
             aboutPreferences: AboutPreferences(internalUserDecider: mockFeatureFlagger.internalUserDecider, featureFlagger: mockFeatureFlagger, windowControllersManager: windowControllersManager, keyValueStore: InMemoryThrowingKeyValueStore()),
-            dockPreferences: DockPreferencesModel(featureFlagger: mockFeatureFlagger,
-                                                  dockCustomizer: DockCustomizerMock(),
+            dockPreferences: DockPreferencesModel(dockCustomizer: DockCustomizerMock(),
                                                   pixelFiring: nil),
             accessibilityPreferences: AccessibilityPreferences(),
             duckPlayerPreferences: {
@@ -162,8 +161,7 @@ final class PreferencesSidebarModelTests: XCTestCase {
             cookiePopupProtectionPreferences: CookiePopupProtectionPreferences(persistor: MockCookiePopupProtectionPreferencesPersistor(), windowControllersManager: windowControllersManager),
             aiChatPreferences: mockAIChatPreferences,
             aboutPreferences: AboutPreferences(internalUserDecider: mockFeatureFlagger.internalUserDecider, featureFlagger: mockFeatureFlagger, windowControllersManager: windowControllersManager, keyValueStore: InMemoryThrowingKeyValueStore()),
-            dockPreferences: DockPreferencesModel(featureFlagger: mockFeatureFlagger,
-                                                  dockCustomizer: DockCustomizerMock(),
+            dockPreferences: DockPreferencesModel(dockCustomizer: DockCustomizerMock(),
                                                   pixelFiring: nil),
             accessibilityPreferences: AccessibilityPreferences(),
             duckPlayerPreferences: {
@@ -216,8 +214,7 @@ final class PreferencesSidebarModelTests: XCTestCase {
             cookiePopupProtectionPreferences: CookiePopupProtectionPreferences(persistor: MockCookiePopupProtectionPreferencesPersistor(), windowControllersManager: windowControllersManager),
             aiChatPreferences: mockAIChatPreferences,
             aboutPreferences: AboutPreferences(internalUserDecider: mockFeatureFlagger.internalUserDecider, featureFlagger: mockFeatureFlagger, windowControllersManager: windowControllersManager, keyValueStore: InMemoryThrowingKeyValueStore()),
-            dockPreferences: DockPreferencesModel(featureFlagger: mockFeatureFlagger,
-                                                  dockCustomizer: DockCustomizerMock(),
+            dockPreferences: DockPreferencesModel(dockCustomizer: DockCustomizerMock(),
                                                   pixelFiring: nil),
             accessibilityPreferences: AccessibilityPreferences(),
             duckPlayerPreferences: {

--- a/macOS/UnitTests/Preferences/RootViewV2Tests.swift
+++ b/macOS/UnitTests/Preferences/RootViewV2Tests.swift
@@ -71,8 +71,7 @@ final class RootViewV2Tests: XCTestCase {
                 featureFlagger: MockFeatureFlagger()
             ),
             aboutPreferences: AboutPreferences(internalUserDecider: featureFlagger.internalUserDecider, featureFlagger: featureFlagger, windowControllersManager: windowControllersManager, keyValueStore: InMemoryThrowingKeyValueStore()),
-            dockPreferences: DockPreferencesModel(featureFlagger: featureFlagger,
-                                                  dockCustomizer: DockCustomizerMock(),
+            dockPreferences: DockPreferencesModel(dockCustomizer: DockCustomizerMock(),
                                                   pixelFiring: nil),
             accessibilityPreferences: AccessibilityPreferences(),
             duckPlayerPreferences: sharedDuckPlayerPreferences,


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1213725466401987?focus=true
Tech Design URL:
CC: @ayoy 

### Description

Removes `addToDockAppStore` feature flag to permanently enable the Add to Dock instructions in the App Store version in onboarding and settings. The DMG version of the app (which supports programmatically adding the app to the Dock) still offers a one-click option to Add to Dock.

Also includes a small improvement in `OnboardingActionsManager` to determine which dock step to show based on `dockCustomization.supportsAddingToDock` (whether the app can be added programmatically to the Dock) rather than checking the build type directly.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
App Store version:
1. Build and run the App Store version of the app.
2. Debug menu → Reset Data → Reset Onboarding
3. Restart the app.
4. Proceed in onboarding to the "Let's get you set up!" screen and confirm the "Keep DuckDuckGo in your Dock" step appears with a "Show Me How" button.
6. Debug menu → Skip Onboarding
7. Go to Settings → Default Browser → Shortcuts and confirm you see instructions for adding the app to the Dock with a "Show Me How" link.
8. Go to Settings → General → Shortcuts and confirm the same instructions and "Show Me How" link appear.

DMG version:
1. Build and run the non-App Store (DMG) version of the app.
2. Debug menu → Reset Data → Reset Onboarding
3. Restart the app.
4. Proceed in onboarding to the "Let's get you set up!" screen and confirm the "Keep DuckDuckGo in your Dock" step appears with a "Keep in Dock" button.
6. Debug menu → Skip Onboarding
7. Go to Settings → Default Browser → Shortcuts and confirm the setting reflects your app dock settings, e.g. if the app is not in the Dock: "DuckDuckGo is not added to the Dock" with an "Add to Dock" button.
8. Go to Settings → General → Shortcuts and confirm the setting reflects your app dock settings, e.g. if the app is not in the Dock: "DuckDuckGo is not added to the Dock" with an "Add to Dock" button.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
10. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Medium: Could disrupt specific features or user flows

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
* Wrong "Add to Dock" onboarding step or setting could be shown in App Store or DMG version. Mitigations:
   * Using `dockCustomization.supportsAddingToDock` ensures the programmatic "Add to Dock" option is only shown when it is supported by the current build.
   * Unit tests cover the expected configurations.
   * Manual testing confirmed the expected behavior.

### Notes to Reviewer

This flag was previously enabled for all users (fallback feature flag enabled by default; no remote config setting). This PR has no behavioral changes; it just removes the feature flag to make the already enabled change permanent.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wrong dock step or settings UI for App Store vs DMG could confuse users; behavior now depends on supportsAddingToDock, which unit tests cover but manual verification across build types is important.
> 
> **Overview**
> Removes the **`addToDockAppStore`** feature flag so manual “Add to Dock” instructions are always available on builds that cannot add the app programmatically (e.g. App Store), in **onboarding** and **Settings** (General and Default Browser).
> 
> **Onboarding** now picks the dock step from **`dockCustomization.supportsAddingToDock`**: programmatic **dock** row when supported, **`dock-instructions`** otherwise—no **`ApplicationBuildType`** injection on **`OnboardingActionsManager`**.
> 
> **`DockPreferencesModel`** drops **`FeatureFlagger`** and **`canShowDockInstructions`**; settings use **`canAddToDock`** only, with an **`else`** branch for instructions when one-click add is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 364fb34d86c6f0a58c7d67f76712d1c70778ab62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->