### PR TITLE
iOS: Remove minimalChromeInLandscape feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -258,8 +258,6 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
 
     case screenTimeCleaning
 
-    case minimalChromeInLandscape
-
     /// https://app.asana.com/1/137249556945/project/1206329551987282/task/1211806114021630?focus=true
     case onboardingRebranding
 

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -386,9 +386,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213763338305579?focus=true
     case aiChatContextualFireButton
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213809475913723?focus=true
-    case minimalChromeInLandscape
-
     case aiChatNativeStorage
 
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215106459483563?focus=true
@@ -709,8 +706,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.screenTimeCleaning))
         case .aiChatContextualFireButton:
             Config(source: .remoteReleasable(AIChatSubfeature.contextualFireButton))
-        case .minimalChromeInLandscape:
-            Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.minimalChromeInLandscape))
         case .aiChatNativeStorage:
             Config(source: .remoteReleasable(AIChatSubfeature.nativeStorage))
         case .duckAINativeStoragePathMigration:

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2433,7 +2433,7 @@ class MainViewController: UIViewController {
         super.viewWillTransition(to: size, with: coordinator)
 
         let isKeyboardShowing = omniBar.isTextFieldEditing
-        if isKeyboardShowing && !AppWidthObserver.shared.isPad && minimalChromeSettings.isFeatureEnabled {
+        if isKeyboardShowing && !AppWidthObserver.shared.isPad {
             omniBar.barView.textField.suppressResignFirstResponder = true
         }
 
@@ -2450,7 +2450,6 @@ class MainViewController: UIViewController {
         }()
 
         let needsWidthUpdate = AppWidthObserver.shared.willResize(toWidth: size.width)
-            && (AppWidthObserver.shared.isPad || isInMinimalChromeLayout || minimalChromeSettings.isFeatureEnabled)
         if needsWidthUpdate {
             applyWidth(for: size)
         }

--- a/iOS/DuckDuckGo/MinimalChromeSettings.swift
+++ b/iOS/DuckDuckGo/MinimalChromeSettings.swift
@@ -18,31 +18,21 @@
 //
 
 import Foundation
-import PrivacyConfig
 
 protocol MinimalChromeSettingsProviding {
 
-    var isFeatureEnabled: Bool { get }
     func shouldApplyMinimalChrome(isCurrentTabAITab: Bool) -> Bool
 }
 
 struct MinimalChromeSettings: MinimalChromeSettingsProviding {
 
-    private let featureFlagger: FeatureFlagger
     private let unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding
 
-    init(featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
-         unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature()) {
-        self.featureFlagger = featureFlagger
+    init(unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature()) {
         self.unifiedToggleInputFeature = unifiedToggleInputFeature
     }
 
-    var isFeatureEnabled: Bool {
-        featureFlagger.isFeatureOn(.minimalChromeInLandscape)
-    }
-
     func shouldApplyMinimalChrome(isCurrentTabAITab: Bool) -> Bool {
-        guard isFeatureEnabled else { return false }
         if isCurrentTabAITab && unifiedToggleInputFeature.isAvailable { return false }
         return true
     }

--- a/iOS/DuckDuckGo/UICoordination/OverlayWindowManager.swift
+++ b/iOS/DuckDuckGo/UICoordination/OverlayWindowManager.swift
@@ -78,7 +78,6 @@ final class OverlayWindowManager: OverlayWindowManaging {
                                                                       appSettings: appSettings,
                                                                       mobileCustomization: mobileCustomization)
         let isMinimalChrome = !AppWidthObserver.shared.isPad
-            && featureFlagger.isFeatureOn(.minimalChromeInLandscape)
             && window.bounds.width > window.bounds.height
         blankSnapshotViewController.useMinimalChromeLayout = AppWidthObserver.shared.isLargeWidth || isMinimalChrome
         blankSnapshotViewController.delegate = self


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215195605176787

Tech Design URL:
CC:

### Description
Removes the `minimalChromeInLandscape` iOS feature flag now that the feature is fully rolled out. The flag's default value was `.enabled`, so removing it makes the minimal-chrome-in-landscape behavior permanent.

Removed the flag case and config from `FeatureFlag`, the `minimalChromeInLandscape` subfeature case from `iOSBrowserConfigSubfeature`, and cleaned up the now-dead branches at every call site. `MinimalChromeSettings` no longer needs a `FeatureFlagger` dependency or the `isFeatureEnabled` accessor; `shouldApplyMinimalChrome` keeps only the AI-tab guard. The always-true flag checks in `MainViewController.viewWillTransition` and `OverlayWindowManager` were folded out, preserving current shipped behavior (flag-on).

### Testing Steps
1. On an iPhone (not iPad), open a web page and rotate to landscape, verify the chrome collapses to the minimal layout (tab bar and toolbar hidden, omnibar in expanded phone state).
2. Rotate back to portrait, verify the full chrome (toolbar, tab bar) is restored.
3. With bottom address bar enabled, repeat steps 1-2 and verify the address bar tracks the keyboard correctly in landscape.
4. Background the app while in landscape minimal chrome, verify the blank snapshot overlay matches the minimal layout.
5. On an iPad, rotate between orientations and verify layout is unaffected by this change.

### Impact and Risks
Low. Pure flag removal with the feature already defaulting to enabled. No behavior change versus current production state.

#### What could go wrong?
The collapsed conditions in `viewWillTransition` and `OverlayWindowManager` relied on the flag being permanently on. Since the flag's default was `.enabled` and it is fully rolled out, the reduced expressions are logically equivalent to the live behavior. Covered by the testing steps above.

### Quality Considerations
The embedded `ios-config.json` still contains the remote subfeature entry; it is a synced artifact and is harmlessly ignored once the enum case is gone. No new edge cases introduced.

### Notes to Reviewer
Main thing to confirm: the boolean reductions at `MainViewController.swift` (viewWillTransition) and `OverlayWindowManager.swift`. With `isFeatureEnabled` permanently true, `(isPad || isInMinimalChromeLayout || isFeatureEnabled)` collapses to `true`, so the whole clause was dropped.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)