### PR TITLE
[iOS] Hide stop-generating button during duck.ai fire onboarding

### DIFF
--- a/iOS/DuckDuckGo/NewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPageViewController.swift
@@ -55,7 +55,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
     private let associatedTab: Tab
 
     private var hostingController: UIHostingController<AnyView>?
-    private var isShowingDuckAICompletionDialog = false
+    private(set) var isShowingDuckAICompletionDialog = false
     private var isBorderSuppressedForChromeLayout = false
     private var didHideBarsForChatPathVisitSiteDialog = false
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
@@ -61,6 +61,14 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
         }
     }
 
+    /// When true, the stop-generating button is suppressed regardless of generating state.
+    var isOnboardingLocked: Bool = false {
+        didSet {
+            guard isOnboardingLocked != oldValue else { return }
+            updateButtonState()
+        }
+    }
+
     var isExpanded: Bool = false {
         didSet {
             guard isExpanded != oldValue else { return }
@@ -240,7 +248,7 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
         let voiceAvailable = !hidesVoiceButton && (isVoiceSearchEnabled || aiVoiceChatAvailable)
         let nextButtonState: SwitchBarButtonState
 
-        if isGenerating && !isExpanded && currentToggleState == .aiChat {
+        if isGenerating && !isExpanded && currentToggleState == .aiChat && !isOnboardingLocked {
             nextButtonState = .stopGeneratingOnly
         } else if !currentText.isEmpty && !isToggleEnabled && currentToggleState == .search && isAIChatShortcutAvailable {
             nextButtonState = .clearAndAIChatShortcut

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -538,6 +538,8 @@ final class UnifiedToggleInputView: UIView {
         aiTabCollapsedVoiceButton.isEnabled = !dimmed
         // Block the text view from directly becoming first responder when the user taps the pill.
         textEntryView.isUserInteractionEnabled = !dimmed
+        // Suppress the stop-generating button during onboarding — its red color is distracting even when dimmed.
+        handler.isOnboardingLocked = dimmed
     }
 
     // MARK: - Fire Mode


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202406491309510/task/1215009192158954
Tech Design URL: N/A
CC: N/A

### Description
- Adds `isOnboardingLocked` to `UnifiedToggleInputHandler` to suppress the `.stopGeneratingOnly` button state while the duck.ai fire onboarding is active, preventing the stop-generating button from appearing while the input bar is dimmed
- Wires `handler.isOnboardingLocked = dimmed` from `UnifiedToggleInputView.setOnboardingDimmed(_:)` so the lock is applied whenever the onboarding dims the input bar
- Makes `isShowingDuckAICompletionDialog` `private(set)` in `NewTabPageViewController` so it can be read externally without being mutated from outside

### Testing Steps
1. In `FeatureFlag.swift`, enable the UTI feature flag locally:
   ```swift
   case .unifiedToggleInput:
       Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.unifiedToggleInput))
   ```
2. In `OnboardingIntroViewModel.swift`, force Treatment B:
   ```swift
   func resolveDuckAIQueryExperimentCohortID() -> ... {
       return .treatmentB
       ...
   }
   ```
3. Clear app data / use a fresh install to trigger onboarding. Proceed through the onboarding steps until the "Ask AI" option appears and select it.
4. When the duck.ai query-selection screen appears, tap one of the suggested query chips — duck.ai opens and begins generating a response.
5. Verify that the stop-generating button does **not** appear in the input bar while the fire onboarding step is active (the bar should remain dimmed with only the fire button highlighted).
6. Complete the fire onboarding step (tap the fire button and confirm deletion).
7. Verify normal duck.ai behaviour is restored: the stop-generating button appears correctly when the AI is generating after onboarding is complete.

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- The stop button could remain hidden after onboarding completes if `isOnboardingLocked` is not reset to `false`. The reset path goes through `setExperimentFireControlsLocked(false)` → `setOnboardingControlsLocked(false)` → `setOnboardingDimmed(false)` → `handler.isOnboardingLocked = false`, which is already exercised by the existing completion flow.

### Quality Considerations
- No new public API; `isOnboardingLocked` is an internal property scoped to the UTI layer.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding-only UI gating on the UTI switch bar; unlock follows the existing dim/lock teardown when fire onboarding completes.
> 
> **Overview**
> During duck.ai **fire onboarding**, the unified toggle input bar stays dimmed while AI may still be generating; this change keeps the **stop-generating** control from appearing in that state.
> 
> **`UnifiedToggleInputHandler`** gains **`isOnboardingLocked`**, which blocks the **`.stopGeneratingOnly`** switch-bar button state even when **`isGenerating`** is true. **`UnifiedToggleInputView.setOnboardingDimmed(_:)`** sets **`handler.isOnboardingLocked`** to match dimming, so the lock clears with the existing **`setOnboardingControlsLocked(false)`** path.
> 
> **`NewTabPageViewController.isShowingDuckAICompletionDialog`** is **`private(set)`** so callers can observe completion-dialog visibility without mutating it from outside.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f06a1be347ba64492f140665ab891d17a0a671c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->