### PR TITLE
macOS: Control fill colors for Duck.ai voice-mode submit button

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -418,7 +418,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         NSAppearance.withAppAppearance {
             if enabled {
                 if submitButtonMode == .voice {
-                    submitButton.normalTintColor = NSColor(designSystemColor: .accentAltContentPrimary)
+                    submitButton.normalTintColor = NSColor(designSystemColor: .iconsPrimary)
                 } else {
                     submitButton.normalTintColor = NSColor(designSystemColor: .accentContentPrimary)
                 }
@@ -446,11 +446,11 @@ final class AIChatOmnibarContainerViewController: NSViewController {
             designSystemColor = nil
         } else if submitButtonMode == .voice {
             if submitButton.isMouseDown {
-                designSystemColor = .accentAltTertiary
+                designSystemColor = .controlsFillTertiary
             } else if submitButton.isMouseOver {
-                designSystemColor = .accentAltSecondary
+                designSystemColor = .controlsFillSecondary
             } else {
-                designSystemColor = .accentAltPrimary
+                designSystemColor = .controlsFillPrimary
             }
         } else {
             if submitButton.isMouseDown {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1215231576932673?focus=true

### Description

The native address-bar Duck.ai omnibar submit button toggles between **submit mode** (blue accent arrow) and **voice mode** (empty input, waveform glyph). Voice mode reused the `accentAlt*` palette, so it rendered as a second saturated accent. Design wants it to read as a neutral control surface instead.

- Voice-mode fill: `accentAlt{Primary,Secondary,Tertiary}` → `controlsFill{Primary,Secondary,Tertiary}` for idle / hover / press.
- Voice-mode glyph tint: `accentAltContentPrimary` → `iconsPrimary`, so it stays legible on the lighter fill.
- Submit mode (`accentPrimary/Secondary/Tertiary`) and the disabled / no-fill state are unchanged.

Scope is the native omnibar only. The New Tab Page omnibar is a separate web component (content-scope-scripts) and is not affected.

### Testing Steps
1. Click the address bar and switch to Duck.ai mode; leave the input empty (voice mode).
2. Confirm the button shows a subtle gray fill with a dark charcoal waveform glyph; hover darkens the fill, mouse-down darkens it further, glyph tint stays constant.
3. Type text → button switches to the unchanged blue submit arrow; clear text → returns to the gray voice styling.
4. Toggle Light/Dark mode and confirm fill and glyph stay legible.

### Impact and Risks
Low — view-layer color change to a single button, behind existing design tokens.

#### What could go wrong?
Wrong token contrast in one appearance. Verified in both Light and Dark mode against dynamic tokens.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> View-only design token swap on one button state; submit mode and behavior are untouched.
> 
> **Overview**
> Updates **Duck.ai omnibar voice-mode** styling on the native macOS address bar so the empty-input submit control reads as a neutral control, not a second blue accent.
> 
> When `submitButtonMode` is **voice**, the waveform button now uses **`controlsFillPrimary` / `Secondary` / `Tertiary`** for idle, hover, and press fills (replacing **`accentAlt*`**), and **`iconsPrimary`** for the glyph tint (replacing **`accentAltContentPrimary`**). **Submit mode** still uses the **`accent*`** fill palette and **`accentContentPrimary`** icon; disabled / no-fill behavior is unchanged.
> 
> Scope is **`AIChatOmnibarContainerViewController`** only; no logic or interaction changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71815f6145769f08546f492d8ead116d9313f6b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->