### PR TITLE
Address memory leak in DataBrokerProtectionSharedPixelsHandler

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionSharedPixels.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionSharedPixels.swift
@@ -745,32 +745,29 @@ public class DataBrokerProtectionSharedPixelsHandler: EventMapping<DataBrokerPro
     public init(pixelKit: PixelKit, platform: Platform) {
         self.pixelKit = pixelKit
         self.platform = platform
-        super.init { _, _, _, _ in
-        }
-
-        self.eventMapper = { event, _, parameters, _ in
+        super.init { event, _, parameters, _ in
             switch event {
             case .generateEmailHTTPErrorDaily:
-                self.pixelKit.fire(event, frequency: .legacyDaily, withNamePrefix: platform.pixelNamePrefix)
+                pixelKit.fire(event, frequency: .legacyDaily, withNamePrefix: platform.pixelNamePrefix)
             case .emptyAccessTokenDaily:
-                self.pixelKit.fire(event, frequency: .legacyDaily, withNamePrefix: platform.pixelNamePrefix)
+                pixelKit.fire(event, frequency: .legacyDaily, withNamePrefix: platform.pixelNamePrefix)
             case .secureVaultDatabaseRecreated:
-                self.pixelKit.fire(event, frequency: .dailyAndCount, withAdditionalParameters: parameters, withNamePrefix: platform.pixelNamePrefix)
+                pixelKit.fire(event, frequency: .dailyAndCount, withAdditionalParameters: parameters, withNamePrefix: platform.pixelNamePrefix)
             case .httpError(let error, _, _, _, _),
                     .actionFailedError(let error, _, _, _, _, _, _, _),
                     .otherError(let error, _, _, _):
-                self.pixelKit.fire(DebugEvent(event, error: error), frequency: .dailyAndCount, withNamePrefix: platform.pixelNamePrefix)
+                pixelKit.fire(DebugEvent(event, error: error), frequency: .dailyAndCount, withNamePrefix: platform.pixelNamePrefix)
             case .databaseError(let error, _),
                     .cocoaError(let error, _),
                     .miscError(let error, _),
                     .userScriptLoadJSFailed(_, let error):
-                self.pixelKit.fire(DebugEvent(event, error: error), frequency: .dailyAndCount, withNamePrefix: platform.pixelNamePrefix)
+                pixelKit.fire(DebugEvent(event, error: error), frequency: .dailyAndCount, withNamePrefix: platform.pixelNamePrefix)
             case .secureVaultInitError(let error),
                     .secureVaultError(let error),
                     .secureVaultKeyStoreReadError(let error, _, _),
                     .secureVaultKeyStoreUpdateError(let error),
                     .failedToOpenDatabase(let error):
-                self.pixelKit.fire(DebugEvent(event, error: error), frequency: .dailyAndStandard, withNamePrefix: platform.pixelNamePrefix)
+                pixelKit.fire(DebugEvent(event, error: error), frequency: .dailyAndStandard, withNamePrefix: platform.pixelNamePrefix)
             case .parentChildMatches,
                     .optOutStart,
                     .optOutEmailGenerate,
@@ -830,14 +827,14 @@ public class DataBrokerProtectionSharedPixelsHandler: EventMapping<DataBrokerPro
                     .serviceEmailConfirmationJobSuccess,
                     .updateDataBrokersSuccess:
 
-                self.pixelKit.fire(event, withNamePrefix: platform.pixelNamePrefix)
+                pixelKit.fire(event, withNamePrefix: platform.pixelNamePrefix)
             case .firstScan, .freemiumUpsell:
-                self.pixelKit.fire(event, frequency: .uniqueByName, withNamePrefix: platform.pixelNamePrefix)
+                pixelKit.fire(event, frequency: .uniqueByName, withNamePrefix: platform.pixelNamePrefix)
             case .updateDataBrokersFailure(_, _, _, let error):
-                self.pixelKit.fire(DebugEvent(event, error: error), frequency: .dailyAndCount, withNamePrefix: platform.pixelNamePrefix)
+                pixelKit.fire(DebugEvent(event, error: error), frequency: .dailyAndCount, withNamePrefix: platform.pixelNamePrefix)
 #if os(iOS)
             case .scanStarted:
-                self.pixelKit.fire(event, withNamePrefix: platform.pixelNamePrefix)
+                pixelKit.fire(event, withNamePrefix: platform.pixelNamePrefix)
 #endif
 
             }

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/Notifications/DataBrokerProtectionNotificationPixel.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/Notifications/DataBrokerProtectionNotificationPixel.swift
@@ -69,11 +69,8 @@ public class DataBrokerProtectionNotificationPixelHandler: EventMapping<DataBrok
     public init(pixelKit: PixelKit) {
         self.pixelKit = pixelKit
 
-        super.init { _, _, _, _ in
-        }
-
-        self.eventMapper = { event, _, _, _ in
-            self.pixelKit.fire(event)
+        super.init { event, _, _, _ in
+            pixelKit.fire(event)
         }
     }
 

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/Pixels/IOSPixels.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/Pixels/IOSPixels.swift
@@ -75,17 +75,14 @@ public class IOSPixelsHandler: EventMapping<IOSPixels> {
     public init(pixelKit: PixelKit) {
         self.pixelKit = pixelKit
 
-        super.init { _, _, _, _ in
-        }
-
-        self.eventMapper = { event, _, _, _ in
+        super.init { event, _, _, _ in
             switch event {
             case .backgroundTaskStarted,
                     .backgroundTaskExpired,
                     .backgroundTaskEndedHavingCompletedAllJobs:
-                self.pixelKit.fire(event)
+                pixelKit.fire(event)
             case .backgroundTaskSchedulingFailed(let error):
-                self.pixelKit.fire(DebugEvent(event, error: error))
+                pixelKit.fire(DebugEvent(event, error: error))
             }
         }
     }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1215181163850319?focus=true
Tech Design URL:
CC:

### Description

Changes how DataBrokerProtectionSharedPixelsHandler is initialized.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Smoke test PIR to make sure pixels are fired
2. Debug Memory Graph after opening/closing a few windows and make sure the retain cycles go away

<img width="453" height="346" alt="Screenshot 2026-05-29 at 10 01 05 AM" src="https://github.com/user-attachments/assets/411eab64-6e8e-4b28-96f8-46ce1351a9f8" />
<img width="374" height="244" alt="Screenshot 2026-05-29 at 10 18 01 AM" src="https://github.com/user-attachments/assets/9553d376-10a2-4678-b4db-7e19465518fb" />

<!— 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
4. **If the Class Does Not Exist:**
   - Add a new entry
—>

### Impact and Risks
<!— 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
—>

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only initialization change with no new pixel logic; risk is low if smoke tests confirm pixels still fire as before.
> 
> **Overview**
> Fixes a **memory leak** in Data Broker Protection pixel handlers by changing how `EventMapping` subclasses wire their event closures.
> 
> Previously, handlers called `super.init` with an empty mapping, then set `eventMapper` in a second step that referenced **`self.pixelKit`** (and **`self.platform`** where applicable). That post-init closure **strongly retained the handler**, creating a retain cycle with the stored `eventMapper`.
> 
> The PR passes the real mapping **directly into `super.init`**, using the **`pixelKit`** / **`platform`** values captured from initialization instead of `self`. Behavior is unchanged: the same events still fire through `pixelKit` with the same frequencies and prefixes.
> 
> Touched types: **`DataBrokerProtectionSharedPixelsHandler`** (shared core), **`DataBrokerProtectionNotificationPixelHandler`**, and **`IOSPixelsHandler`** (iOS).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f49223533f0fe11070896cd8993975dc106f3fb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->