### PR TITLE
iOS app rebrand: Update primary accent color to pondwater60

### DIFF
--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalletes/DefaultColorPalette.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalletes/DefaultColorPalette.swift
@@ -204,13 +204,18 @@ struct DefaultColorPalette: ColorPaletteDefinition {
         case .surfaceTertiary: return surfaceTertiary
         case .surfaceCanvas: return surfaceCanvas
 
-        case .accent: return accent
+        case .accent:
+            // Rebranding 2026: the primary accent blue switches to Pondwater. Reuses the rebranding
+            // `accentPrimary` mapping so there's a single source of truth for the new value.
+            return DesignSystemRebrand.isAppRebranded() ? dynamicColor(for: SingleUseColor.Rebranding.accentPrimary) : accent
         case .accentGlowSecondary: return accentGlowSecondary
         case .alertGreen: return alertGreen
         case .alertYellow: return alertYellow
         case .shieldPrivacy: return shieldPrivacy
         case .border: return border
-        case .textLink: return textLink
+        case .textLink:
+            // Rebranding 2026: text links switch to Pondwater, matching the rebranded accent.
+            return DesignSystemRebrand.isAppRebranded() ? dynamicColor(for: SingleUseColor.Rebranding.textLink) : textLink
         case .textPlaceholder: return textPlaceholder
         case .textSecondary: return textSecondary
         case .textTertiary: return textTertiary

--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalletes/DefaultColorPalette.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalletes/DefaultColorPalette.swift
@@ -205,8 +205,6 @@ struct DefaultColorPalette: ColorPaletteDefinition {
         case .surfaceCanvas: return surfaceCanvas
 
         case .accent:
-            // Rebranding 2026: the primary accent blue switches to Pondwater. Reuses the rebranding
-            // `accentPrimary` mapping so there's a single source of truth for the new value.
             return DesignSystemRebrand.isAppRebranded() ? dynamicColor(for: SingleUseColor.Rebranding.accentPrimary) : accent
         case .accentGlowSecondary: return accentGlowSecondary
         case .alertGreen: return alertGreen
@@ -214,7 +212,6 @@ struct DefaultColorPalette: ColorPaletteDefinition {
         case .shieldPrivacy: return shieldPrivacy
         case .border: return border
         case .textLink:
-            // Rebranding 2026: text links switch to Pondwater, matching the rebranded accent.
             return DesignSystemRebrand.isAppRebranded() ? dynamicColor(for: SingleUseColor.Rebranding.textLink) : textLink
         case .textPlaceholder: return textPlaceholder
         case .textSecondary: return textSecondary

--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/DesignSystemRebrand.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/DesignSystemRebrand.swift
@@ -1,0 +1,35 @@
+//
+//  DesignSystemRebrand.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// Global, app-wide app-rebrand state used to switch design-system colors between their legacy and
+/// rebranded values. The host app should override this at launch by setting the closure to a live feature-flag lookup, e.g.:
+///
+/// ```swift
+/// DesignSystemRebrand.isAppRebranded = {
+///     AppDependencyProvider.shared.featureFlagger.isFeatureOn(.appRebranding)
+/// }
+/// ```
+///
+public enum DesignSystemRebrand {
+
+    /// Returns `true` when the app should display rebranded design-system colors; `false` for legacy.
+    /// Set this once at launch from the host app.
+    nonisolated(unsafe) public static var isAppRebranded: () -> Bool = { false }
+}

--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/DesignSystemRebrand.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/DesignSystemRebrand.swift
@@ -18,14 +18,7 @@
 
 import Foundation
 
-/// Global, app-wide app-rebrand state used to switch design-system colors between their legacy and
-/// rebranded values. The host app should override this at launch by setting the closure to a live feature-flag lookup, e.g.:
-///
-/// ```swift
-/// DesignSystemRebrand.isAppRebranded = {
-///     AppDependencyProvider.shared.featureFlagger.isFeatureOn(.appRebranding)
-/// }
-/// ```
+/// Used to switch design-system colors between their legacy and rebranded values.
 ///
 public enum DesignSystemRebrand {
 

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -19,6 +19,7 @@
 
 import AIChat
 import Core
+import DesignResourcesKit
 import DesignResourcesKitIcons
 import DuckAiDataStore
 import Persistence
@@ -70,6 +71,12 @@ struct Launching: LaunchingHandling {
         // Consumed by `DesignSystemImages` accessors and the `Image(rebrandable:)` initializer
         // so call sites don't need to read the flag directly.
         AppRebrand.isAppRebranded = { [featureFlagger] in
+            featureFlagger.isFeatureOn(.appRebranding)
+        }
+
+        // Wire the DesignResourcesKit color rebrand hook to the same feature flag, so design-system
+        // colors (e.g. the primary accent and text links) switch to their Pondwater values.
+        DesignSystemRebrand.isAppRebranded = { [featureFlagger] in
             featureFlagger.isFeatureOn(.appRebranding)
         }
 

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -74,8 +74,7 @@ struct Launching: LaunchingHandling {
             featureFlagger.isFeatureOn(.appRebranding)
         }
 
-        // Wire the DesignResourcesKit color rebrand hook to the same feature flag, so design-system
-        // colors (e.g. the primary accent and text links) switch to their Pondwater values.
+        // Temporary feature flag and wiring during rebrand rollout – used to enable color palette updates.
         DesignSystemRebrand.isAppRebranded = { [featureFlagger] in
             featureFlagger.isFeatureOn(.appRebranding)
         }


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/1211264967278501/task/1215192453454998?focus=true
Tech Design URL:
CC:

### Description

This PR updates the app’s primary accent color to pondwater60 as part of the rebrand. This is also behind the same appRebranding feature flag.

Example:

| Before | After |
|--------|--------|
| <img alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-29 at 15 37 37" src="https://github.com/user-attachments/assets/58b4ca53-a6e5-4405-91fa-e042e94cdfb7" /> | <img alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-29 at 15 37 55" src="https://github.com/user-attachments/assets/a02518c8-e204-43d7-94e7-9e95ffe30f90" /> |

### Testing Steps

- Build and run the iOS app
- With the appRebranding FF OFF, view some key screens / modals / settings screens and verify the primary blue color remains as it is in production.
- With the appRebranding FF ON, view some key screens / modals / settings screens and verify the primary blue color is now updated to pondWater60.


### Impact and Risks

Low: Minor visual changes, small bug fixes, improvement to existing features

Gated behind feature flag, so shouldn’t affect production.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, flag-gated visual palette changes for two semantic color tokens; no auth, data, or business-logic impact.
> 
> **Overview**
> Introduces **`DesignSystemRebrand`**, a launch-time hook (same pattern as **`AppRebrand`**) so design-system **colors** can switch between legacy and rebrand palettes without call sites reading the feature flag.
> 
> When **`appRebranding`** is on, **`DefaultColorPalette`** resolves **`.accent`** and **`.textLink`** to the existing rebranding tokens (**pondwater60** / **pondwater40**) instead of the legacy blue accents. The iOS app wires **`DesignSystemRebrand.isAppRebranded`** in **`Launching`** alongside the existing image rebrand wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 656d8875c623ebf86fade112aa536af158703fb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->