### PR TITLE
iOS: Fade attachments strip during UTI dismiss collapse

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -943,6 +943,8 @@ final class UnifiedToggleInputView: UIView {
         toolbarBottomConstraint.constant = 0
         toolbarHeightConstraint.constant = 0
         toolsToolbar.alpha = 0
+        attachmentsStripHeightConstraint.constant = 0
+        attachmentsStrip.alpha = 0
         textEntryView.isExpandable = false
     }
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -54,6 +54,24 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         XCTAssertFalse(sut.isToolbarSubmitEnabled)
     }
 
+    func test_dismissPoseFadesAttachmentsStripOutSoItAnimatesWithTheCollapse() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        let sut = UnifiedToggleInputView(handler: handler)
+
+        sut.applyCardLayout(.expanded(showsToggle: true, showsToolbar: true), animated: false)
+        sut.addAttachment(makeFileAttachment())
+        flushMainQueue()
+
+        let strip = try XCTUnwrap(firstDescendant(of: UnifiedToggleInputAttachmentsStripView.self, in: sut))
+        XCTAssertEqual(strip.alpha, 1, accuracy: 0.001)
+
+        // The top + toggle-on dismiss pose. Without fading the strip here it stays fully opaque
+        // through the collapse and then blinks out when the container is hidden.
+        sut.applyToggleHideChanges()
+
+        XCTAssertEqual(strip.alpha, 0, accuracy: 0.001)
+    }
+
     func test_attachmentStripScrollsToTrailingEdgeAfterAttachmentLayoutChange() throws {
         let sut = UnifiedToggleInputAttachmentsStripView()
         sut.frame = .zero


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1215059077913311?focus=true
Tech Design URL:
CC:

### Description
With the `unifiedToggleInput` flag on, dismissing the duck.ai address bar via the back arrow collapsed the input but the attachments strip stayed fully opaque and then blinked out, because the top-bar + toggle-enabled dismiss pose (`applyToggleHideChanges`) never touched the strip. This collapses the strip's height and alpha there too, so attached images fade with the surrounding collapse animation, mirroring the show path in `applyToggleRevealChanges`.

### Testing Steps
1. Enable the `unifiedToggleInput` feature flag and open the address bar in Duck.ai mode (top bar).
2. Attach one or more images, then tap the back arrow to dismiss.
3. Confirm the images section fades out smoothly with the collapse instead of blinking and disappearing.

### Impact and Risks
Low

#### What could go wrong?
The strip could fail to reappear on re-focus, but the show path (`applyToggleRevealChanges`) restores it independently and a unit test guards the dismiss-pose alpha.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change to dismiss animation layout; show path still restores the strip via existing layout helpers, guarded by a new unit test.
> 
> **Overview**
> Fixes a **visual glitch** when dismissing the Duck.ai unified toggle input (top bar + toggle on): attached images stayed **fully opaque** during the collapse and then **vanished abruptly**, because `applyToggleHideChanges` already hid the toggle and toolbar but left the attachments strip alone.
> 
> The dismiss pose now **zeros the strip height** and **fades alpha to 0** in the same animation block as the rest of the collapse, matching how the reveal path drives the strip via `updateAttachmentsStripLayout`. A unit test asserts the strip’s alpha is 0 after `applyToggleHideChanges`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa58fff264ab9404b595407546279ccc148a93bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->