### PR TITLE
iOS: Rebind Duck.ai chip when opening a chat in a new tab

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2014,6 +2014,9 @@ class MainViewController: UIViewController {
             refreshControls()
             tabsBarController?.refresh(tabsModel: tabManager.currentTabsModel, scrollToSelected: true)
             swipeTabsCoordinator?.refresh(tabsModel: tabManager.currentTabsModel, scrollToSelected: true)
+            // Rebind the chip to the newly-current tab — this path (e.g. the Duck.ai chip
+            // opening a chat in a new tab) doesn't go through transitionTo.
+            bindAIChatChromeChipToCurrentTab()
         }
 
         if clearInProgress {


### PR DESCRIPTION
Task/Issue URL:
Tech Design URL:
CC:

### Description

Fixes a case where the Duck.ai chip's contextual-sheet icon stayed visible on a Duck.ai tab. Opening Duck.ai from the chip on a web page routes through `loadUrlInNewTab()`, which doesn't go through `transitionTo()` and so never rebound the chip to the newly-current tab — it stayed bound to the previous web tab and never learned the current tab was Duck.ai. Added a `bindAIChatChromeChipToCurrentTab()` call in the `loadUrlInNewTab` worker so every new-tab branch rebinds.

### Testing Steps

1. iPad, Duck.ai chip visible.
2. Open bbc.com — chip shows the Duck.ai text and the contextual-sheet icon.
3. Tap the Duck.ai text button → a new Duck.ai tab opens.
4. The contextual-sheet icon is now hidden (Duck.ai tabs have no page to attach). Before this fix it stayed visible.
5. Regression: switching between a web tab and a Duck.ai tab still toggles the icon correctly; the New Tab Page still hides the icon.

### Impact and Risks

Low. One extra rebind on the new-tab path; idempotent with the existing `transitionTo` rebind.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single idempotent rebind on an existing new-tab flow; same helper already used from transitionTo and other tab paths.
> 
> **Overview**
> Fixes the **Duck.ai** chrome chip staying bound to the previous tab when a chat opens via **`loadUrlInNewTab`** (e.g. tapping the chip on a web page), because that path skips **`transitionTo`**.
> 
> After the new-tab worker refreshes the tab bar, it now calls **`bindAIChatChromeChipToCurrentTab()`** so chip subscriptions follow the newly current tab and the contextual-sheet icon hides on Duck.ai tabs as intended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7b84cdd5d5191ae697f55b39abff0d52fb594d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->