### PR TITLE
[macOS] [Subscription] Remove subscriptionPromoFireWindow feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -628,7 +628,6 @@ public enum PrivacyProSubfeature: String, Equatable, PrivacySubfeature {
     case allowProTierPurchase
     case freeTrialConversionWideEvent
     case subscriptionPromoForReinstallers
-    case subscriptionPromoFireWindow
 }
 
 public enum DuckPlayerSubfeature: String, PrivacySubfeature {

--- a/macOS/DuckDuckGo/HomePage/View/BurnerHomePageViewController.swift
+++ b/macOS/DuckDuckGo/HomePage/View/BurnerHomePageViewController.swift
@@ -37,14 +37,12 @@ final class BurnerHomePageViewController: NSViewController {
     init(appearancePreferences: AppearancePreferences? = nil,
          themeManager: ThemeManager? = nil,
          subscriptionManager: any SubscriptionManager,
-         featureFlagger: FeatureFlagger,
          promoDelegate: FireWindowSubscriptionPromoDelegate?,
          dateProvider: @escaping () -> Date = Date.init) {
         self.appearancePreferences = appearancePreferences ?? NSApp.delegateTyped.appearancePreferences
         self.themeManager = themeManager ?? NSApp.delegateTyped.themeManager
         self.subscriptionPromoViewModel = SubscriptionPromoViewModel(
             subscriptionManager: subscriptionManager,
-            featureFlagger: featureFlagger,
             dateProvider: dateProvider,
             promoDelegate: promoDelegate
         )

--- a/macOS/DuckDuckGo/HomePage/View/VPNSubscriptionPromo/SubscriptionPromoViewModel.swift
+++ b/macOS/DuckDuckGo/HomePage/View/VPNSubscriptionPromo/SubscriptionPromoViewModel.swift
@@ -19,7 +19,6 @@
 import Combine
 import Common
 import FoundationExtensions
-import FeatureFlags
 import Foundation
 import Persistence
 import PixelKit
@@ -98,7 +97,6 @@ enum SubscriptionPromoConstants {
 final class SubscriptionPromoViewModel: ObservableObject {
 
     private let subscriptionManager: any SubscriptionManager
-    private let featureFlagger: FeatureFlagger
     private let pixelFiring: PixelFiring?
     private var persistor: SubscriptionPromoPersisting
     private let locale: Locale
@@ -122,23 +120,19 @@ final class SubscriptionPromoViewModel: ObservableObject {
     var onPromoDismissed: (() -> Void)?
 
     init(subscriptionManager: any SubscriptionManager,
-         featureFlagger: FeatureFlagger,
          pixelFiring: PixelFiring? = PixelKit.shared,
          persistor: SubscriptionPromoPersisting? = nil,
          locale: Locale = .current,
          dateProvider: @escaping () -> Date = Date.init,
          promoDelegate: FireWindowSubscriptionPromoDelegate? = nil) {
         self.subscriptionManager = subscriptionManager
-        self.featureFlagger = featureFlagger
         self.pixelFiring = pixelFiring
         self.persistor = persistor ?? SubscriptionPromoUserDefaultsPersistor(keyValueStore: UserDefaults.standard)
         self.locale = locale
         self.dateProvider = dateProvider
         self.promoDelegate = promoDelegate
 
-        if featureFlagger.isFeatureOn(.subscriptionPromoFireWindow) {
-            checkPurchaseEligibility()
-        }
+        checkPurchaseEligibility()
     }
 
     deinit {
@@ -188,7 +182,7 @@ final class SubscriptionPromoViewModel: ObservableObject {
         }
     }
 
-    /// Display conditions (feature flag and purchase eligibility are checked before evaluation in `updateForTab`):
+    /// Display conditions (purchase eligibility is checked before evaluation in `updateForTab`):
     /// - en_US locale only
     /// - Non-subscriber only
     /// - Fire Tab visited >= 3 times

--- a/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -1256,7 +1256,6 @@ final class BrowserTabViewController: NSViewController {
             }
             let burnerHomePageViewController = BurnerHomePageViewController(
                 subscriptionManager: subscriptionManager,
-                featureFlagger: featureFlagger,
                 promoDelegate: subscriptionPromoDelegate,
                 dateProvider: dateProvider
             )

--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
@@ -446,7 +446,7 @@ final class TabCollectionViewModel: NSObject {
         tabCollection.append(tab: tab)
         if tab.content == .newtab {
             NotificationCenter.default.post(name: HomePage.Models.newHomePageTabOpen, object: nil)
-            if isBurner, featureFlagger.isFeatureOn(.subscriptionPromoFireWindow) {
+            if isBurner {
                 var persistor = SubscriptionPromoUserDefaultsPersistor(keyValueStore: UserDefaults.standard)
                 if persistor.fireTabVisitCount < SubscriptionPromoConstants.requiredVisitCount {
                     persistor.fireTabVisitCount += 1

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -362,10 +362,6 @@ public enum FeatureFlag: String, CaseIterable {
 
     case aiChatNativeStorage
 
-    /// Enables the VPN subscription promo card on the Fire Window home page
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213996219850960?focus=true
-    case subscriptionPromoFireWindow
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214025222413375
     case aiChatNativeDataAccess
 
@@ -634,8 +630,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                    category: .duckAI)
         case .aiChatNativeStorage:
             Config(source: .remoteReleasable(AIChatSubfeature.nativeStorage), category: .duckAI)
-        case .subscriptionPromoFireWindow:
-            Config(defaultValue: .disabled, source: .remoteReleasable(PrivacyProSubfeature.subscriptionPromoFireWindow), supportsLocalOverriding: true, category: .subscription)
         case .aiChatNativeDataAccess:
             Config(source: .remoteReleasable(AIChatSubfeature.nativeDataAccess), category: .duckAI)
         case .aiChatNativeVoicePermissionFlow:

--- a/macOS/UnitTests/HomePage/SubscriptionPromoViewModelTests.swift
+++ b/macOS/UnitTests/HomePage/SubscriptionPromoViewModelTests.swift
@@ -19,7 +19,6 @@
 import XCTest
 import PrivacyConfig
 import SubscriptionTestingUtilities
-@testable import FeatureFlags
 @testable import Subscription
 @testable import DuckDuckGo_Privacy_Browser
 
@@ -29,22 +28,18 @@ final class SubscriptionPromoViewModelTests: XCTestCase {
     var sut: SubscriptionPromoViewModel!
     var subscriptionManager: SubscriptionManagerMock!
     var persistor: MockSubscriptionPromoPersisting!
-    var featureFlagger: MockFeatureFlagger!
 
     override func setUp() {
         super.setUp()
         subscriptionManager = SubscriptionManagerMock()
         subscriptionManager.resultSubscription = .failure(SubscriptionManagerError.noTokenAvailable)
         persistor = MockSubscriptionPromoPersisting()
-        featureFlagger = MockFeatureFlagger()
-        featureFlagger.enableFeatures([.subscriptionPromoFireWindow])
     }
 
     override func tearDown() {
         sut = nil
         subscriptionManager = nil
         persistor = nil
-        featureFlagger = nil
         super.tearDown()
     }
 
@@ -313,18 +308,6 @@ final class SubscriptionPromoViewModelTests: XCTestCase {
         XCTAssertFalse(delegate.isVisible)
     }
 
-    // MARK: - Feature Flag
-
-    func testWhenFeatureFlagDisabled_ThenDoesNotShowPromo() {
-        persistor.fireTabVisitCount = 3
-        featureFlagger.enabledFeatureFlags = []
-        sut = makeSUT()
-
-        sut.updateForTab(.notEvaluated)
-
-        XCTAssertFalse(sut.shouldShowPromo)
-    }
-
     // MARK: - Date Provider
 
     func testWhenDateProviderOverridesPastCooldown_ThenShowsPromo() {
@@ -409,7 +392,6 @@ final class SubscriptionPromoViewModelTests: XCTestCase {
         subscriptionManager.currentEnvironment = .init(serviceEnvironment: .staging, purchasePlatform: purchasePlatform)
         return SubscriptionPromoViewModel(
             subscriptionManager: subscriptionManager,
-            featureFlagger: featureFlagger,
             persistor: persistor,
             locale: locale,
             dateProvider: dateProvider,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1213996219850960

### Description

The Fire Window VPN subscription promo has been stable in product for 2 weeks. Removes the `subscriptionPromoFireWindow` feature flag along with all of its checks.

- Removed the `FeatureFlag` case and its `FeatureFlagDescribing` config mapping.
- Removed the `subscriptionPromoFireWindow` `PrivacyProSubfeature`.
- `SubscriptionPromoViewModel` now runs `checkPurchaseEligibility()` unconditionally; the now-unused `featureFlagger` dependency (property, init param, assignment, import) was dropped.
- Removed the now-unused `featureFlagger` parameter from `BurnerHomePageViewController.init` and its `BrowserTabViewController` call site.
- `TabCollectionViewModel` increments the fire-tab visit count gated only on `isBurner`.
- Removed the obsolete feature-flag-disabled unit test (the path it exercised no longer exists).

### Testing Steps
1. Launch a Fire Window and open new tabs until the fire-tab visit count reaches the required threshold (3).
2. With an en-US locale and a non-subscriber account, confirm the VPN subscription promo card appears on the Fire Window home page exactly as it did with the flag enabled.
3. Switch to a non-US locale (e.g. en-GB) and confirm the promo does not appear.
4. Run `SubscriptionPromoViewModelTests` and confirm all tests pass.

### Impact and Risks

Low. The feature was already remotely enabled for the en-US audience; this change hardcodes the released behavior. Display remains gated by the view model's independent `isENUSLocale` check, so there is no locale expansion.

#### What could go wrong?

Removing the flag removes the ability to remotely disable the promo without an app update (loss of kill switch). This is the expected trade-off for a fully released feature. The en-US targeting previously enforced via remote config is preserved by the view model's own `isENUSLocale` gate, so no users outside en-US will newly see the promo.

### Quality Considerations

- The `FeatureFlag` enum case and its `FeatureFlagDescribing` switch arm were removed together, preserving switch exhaustiveness.
- The stale doc comment referencing the feature flag in `SubscriptionPromoViewModel` was updated.
- No new tests are warranted for an always-on graduation; existing display-condition tests continue to cover the behavior.

### Notes to Reviewer

`BurnerHomePageViewController` still has no remaining `FeatureFlagger` reference after the parameter removal, and `BrowserTabViewController` continues to use `featureFlagger` elsewhere, so nothing is orphaned upstream.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior was already enabled remotely for en-US; this hardcodes that path while preserving view-model locale and eligibility gates, with only the loss of a remote off switch.
> 
> **Overview**
> Graduates the **Fire Window VPN subscription promo** by removing the `subscriptionPromoFireWindow` flag from macOS `FeatureFlag`, `PrivacyProSubfeature`, and remote config wiring.
> 
> **`SubscriptionPromoViewModel`** always runs `checkPurchaseEligibility()` on init and no longer takes `FeatureFlagger`; **`BurnerHomePageViewController`** and **`BrowserTabViewController`** drop the matching init parameter. **`TabCollectionViewModel`** increments fire-tab visit counts for new tabs whenever the window is a burner, without a flag check. The feature-flag-disabled unit test and related test mocks/imports are removed; existing locale, visit-count, and purchase-eligibility tests still cover behavior.
> 
> **en-US** targeting remains enforced in the view model (`isENUSLocale`), not via remote config. Remote kill-switch for this promo is gone until a future app change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 011988214fa2ba2cd25916689877da4853044502. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->