### PR TITLE
[iOS] Defensive [weak self] in chrome animation closures

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2538,7 +2538,8 @@ class MainViewController: UIViewController {
 
         updateNewTabPageLayoutForCurrentChromeMode()
 
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
             // Do this async otherwise the toolbar buttons skew to the right
             if self.viewCoordinator.constraints.navigationBarContainerTop.constant >= 0,
                !self.isInMinimalChromeLayout,
@@ -2548,7 +2549,7 @@ class MainViewController: UIViewController {
             // If tabs have been udpated, do this async to make sure size calcs are current
             self.tabsBarController?.refresh(tabsModel: self.tabManager.currentTabsModel)
             self.swipeTabsCoordinator?.refresh(tabsModel: self.tabManager.currentTabsModel)
-            
+
             // Do this on the next UI thread pass so we definitely have the right width
             self.applyWidthToTrayController()
         }
@@ -3618,7 +3619,8 @@ extension MainViewController: BrowserChromeDelegate {
             showMenuHighlighterIfNeeded()
         }
 
-        let updateBlock = {
+        let updateBlock = { [weak self] in
+            guard let self else { return }
             self.updateToolbarConstant(percent)
             self.updateNavBarConstant(percent)
             self.currentTab?.updateWebViewBottomAnchor(for: percent)
@@ -3626,7 +3628,7 @@ extension MainViewController: BrowserChromeDelegate {
             self.viewCoordinator.navigationBarContainer.alpha = percent
             self.viewCoordinator.tabBarContainer.alpha = percent
             self.viewCoordinator.toolbar.alpha = percent
-            
+
             // Post notification only when bars are fully shown or hidden
             if percent == 0 || percent == 1 {
                 NotificationCenter.default.post(
@@ -3636,12 +3638,12 @@ extension MainViewController: BrowserChromeDelegate {
                 )
             }
         }
-           
+
         if animated {
             self.view.layoutIfNeeded()
-            UIView.animate(withDuration: animationDuration ?? ChromeAnimationConstants.duration) {
+            UIView.animate(withDuration: animationDuration ?? ChromeAnimationConstants.duration) { [weak self] in
                 updateBlock()
-                self.view.layoutIfNeeded()
+                self?.view.layoutIfNeeded()
             }
         } else {
             updateBlock()
@@ -5227,16 +5229,17 @@ extension MainViewController: TabDelegate {
         tab.aiChatContextualSheetCoordinator.dismissSheet()
         if openedByPage {
             showBars()
-            newTabAnimation {
+            newTabAnimation { [weak self] in
+                guard let self else { return }
                 self.loadUrlInNewTab(url, inheritedAttribution: attribution)
                 self.currentTab?.openedByPage = true
                 self.currentTab?.openingTab = tab
             }
-            tabSwitcherButton?.animateUpdate {
-                self.tabSwitcherButton?.tabCount += 1
+            tabSwitcherButton?.animateUpdate { [weak self] in
+                self?.tabSwitcherButton?.tabCount += 1
             }
-            omniBarTabSwitcherButton?.animateUpdate {
-                self.omniBarTabSwitcherButton?.tabCount += 1
+            omniBarTabSwitcherButton?.animateUpdate { [weak self] in
+                self?.omniBarTabSwitcherButton?.tabCount += 1
             }
         } else {
             loadUrlInNewTab(url, inheritedAttribution: attribution)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1200194497630846/task/1215224247451374?focus=true
Tech Design URL:
CC:

### Description
This PR adds weak `self` captures to some of the chrome animation closures. This is a tentative fix to address some animation related to long tail crashes detected on Sentry. This is a speculative defensive patch, there is no local repro.

### Testing Steps
1. Ci stays 🟢 
2. General smoke test of the related closures:
    - `setBarsVisibility`: Scroll up/down on a long web page. Tap URL bar to edit. Open/close fire confirmation sheet.
        - Bars should hide on scroll-down, show on scroll-up. Animation smooth.
    - `applyWidth`: Rotate iPhone portrait <-> landscape. On iPad, split-view in/out.
        - Toolbar buttons end up positioned correctly, tabs bar refreshes.
    - `newTabAnimation`: On a page with a link that opens in a new tab then tap the tab.
        - New tab loads, tab counter increments on both toolbar buttons.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
- Site 3 (`newTabAnimation` closure in `tab(_:didRequestNewTabForUrl:openedByPage:)`) wraps `self.loadUrlInNewTab(url, ...)` in a `[weak self]` + guard. If `MainViewController` were deallocated between scheduling the animation and the closure firing, the new tab would silently fail to load. In practice, `MainViewController` is the app's root VC and does not deallocate mid-newTab, so the edge is theoretical.
- Sites 1 and 2 (`setBarsVisibility` updateBlock + UIView.animate, and `applyWidth` `DispatchQueue.main.async`) previously kept `self` alive through their lifetimes via strong capture. With weak captures, the work becomes a no-op if `self` is gone. No realistic path where `MainViewController` deallocates while these closures are pending.
 
### Quality Considerations
N/A

### Notes to Reviewer
- Precedent in the codebase: `cancelInFlightLayoutAnimations`, `reset(animated: false)` on the same subsystem.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow defensive capture changes with no new logic paths under normal app lifetime; theoretical no-op if root VC were gone before an async animation fired.
> 
> **Overview**
> Adds **`[weak self]`** captures (with early `guard`) to deferred chrome UI work in **`MainViewController`**, matching existing patterns elsewhere in the same file.
> 
> **`applyWidth`**’s `DispatchQueue.main.async` block now weakly captures before refreshing the tabs bar, swipe tabs, and tray width. **`setBarsVisibility`** uses weak `self` in both the layout update closure and the nested **`UIView.animate`** block (optional chaining on `layoutIfNeeded`). **`tab(_:didRequestNewTabForUrl:openedByPage:)`** weakly captures in **`newTabAnimation`** and the tab switcher **`animateUpdate`** callbacks so tab count updates don’t retain the root VC through animation completion handlers.
> 
> Behavior is unchanged when `MainViewController` is still alive; the intent is to break retain cycles / use-after-deallocation seen in production crash reports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a7a7e5bc12138edc1249245d2a30b16c89b1a29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->