### PR TITLE
Add missing channel parameter to two failing pixel definitions

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/aichat_addressbar_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_addressbar_pixels.json5
@@ -229,7 +229,7 @@
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_new_voice_chat_omnibar_native": {
         "description": "Fired when user opens a new Duck.ai voice chat from the native omnibar",

--- a/macOS/PixelDefinitions/pixels/definitions/serp_settings_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/serp_settings_pixels.json5
@@ -26,7 +26,7 @@
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_serp_settings_open_duck_ai_button_click": {
         "description": "Fired when the user taps the Open AI Features Setting button from the SERP",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1215263590993483?focus=true
Tech Design URL:
CC:

### Description

Fixes live-validation failures for `m_mac_aichat_addressbar_reasoning_effort_selected` and `m_mac_aichat_hide_ai_generated_images_button_clicked`, both rejected with "must NOT have additional properties. Found extra property 'channel'". Their definitions declared only `["appVersion", "pixelSource"]`, but PixelKit auto-attaches the global `channel` param on internal (`canary`) and alpha/review (`dev`) builds — the very builds live validation runs against. Adds `channel` to both parameter lists, matching every sibling definition in `aichat_addressbar_pixels.json5` and `serp_settings_pixels.json5`. No code or fire-site change — the pixels were always firing `channel`; the definitions just hadn't declared it.

### Testing Steps
1. From `macOS/`, run `npm run pixel-lint` — prettier passes on the edited json5 files.
2. Confirm `channel` is a defined global in `PixelDefinitions/pixels/params_dictionary.json5`.
3. On next live validation run, the two pixels above no longer report the extra-`channel` error.

### Impact and Risks
Low. Definition-only metadata change; no app behavior or pixel-firing code affected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only JSON5 definition updates; no runtime behavior or pixel emission changes.
> 
> **Overview**
> Declares the global **`channel`** parameter on two macOS pixel definitions that were failing live validation because PixelKit already sends **`channel`** on internal/alpha builds while the schemas only allowed **`appVersion`** and **`pixelSource`**.
> 
> **`m_mac_aichat_addressbar_reasoning_effort_selected`** in `aichat_addressbar_pixels.json5` and **`m_mac_aichat_hide_ai_generated_images_button_clicked`** in `serp_settings_pixels.json5` now list **`channel`** alongside their siblings. No firing logic or app code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 918e32d3fcc8359c86ae66b176192abadce5785b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->