### PR TITLE
Marker check: don't compare .xcstrings variation leaves against the source top-level

### DIFF
--- a/scripts/translation-pr-checks/check_marker_consistency.py
+++ b/scripts/translation-pr-checks/check_marker_consistency.py
@@ -208,7 +208,11 @@ def check_xcstrings_data(new_data: Dict, path: str, old_data: Dict = None) -> Li
             for sub_path, loc_value in new_leaves.items():
                 if old_data is not None and not source_changed and old_leaves.get(sub_path) == loc_value:
                     continue
-                source_value = source_leaves.get(sub_path, source_leaves.get(""))
+                # Only compare leaves the source has at the same subpath. No
+                # top-level fallback: a locale plural category the source lacks
+                # (e.g. Russian "many" vs English "one/other") would otherwise be
+                # compared against the source's top-level unit and falsely flagged.
+                source_value = source_leaves.get(sub_path)
                 if source_value is None:
                     continue
                 issues = marker_issues(source_value, loc_value)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215162688786291

### Description

Follow-up to #5165 (markdown bold-marker validation). Fixes a false-positive risk in `check_marker_consistency.py` flagged in post-merge review.

In `check_xcstrings_data`, the source lookup fell back to the source's **top-level** `stringUnit` (`source_leaves.get("")`) whenever a locale leaf's subpath had no match in the source. A locale plural category the English source lacks — e.g. Russian `one/few/many/other` vs English `one/other` — would then be compared against the unrelated top-level value, and if their `**` counts differed it would be **falsely flagged**. Because the check is blocking, that's a spurious CI failure on an otherwise-unrelated PR (low likelihood — gated by `--changed-only` + `source_changed` — but it's the one spot that can manufacture a block).

Fix: drop the fallback — only compare leaves the source has at the **same subpath**; the existing `if source_value is None: continue` skips the rest, matching how mismatched plural categories were already handled. Simple strings still match on the `""` subpath, so no real comparison is lost (a locale pluralizing a non-plural source isn't a real String Catalog shape).

### Testing Steps

1. A `ru` string with `few`/`many` plural categories the English source lacks → **no findings** (previously a false `DROPPED`/`EXTRA`).
2. A genuinely broken plural leaf (source `**bold**`, locale dropped it) → still flagged `[DROPPED]`.
3. `--all` audits unchanged (macOS 4, iOS 12) — no regression.

### Impact and Risks

**None / Low** — CI-only localization tooling, no app code. Strictly removes a false-positive path; real detections are unaffected.

### Notes to Reviewer

- Thanks to the post-merge review that caught this (the `source_leaves.get("")` fallback at the variation-leaf comparison).
- The separate "re-posts a PR comment per push" nit is intentionally left as-is — it matches the existing `orphaned-translations` pattern in the same job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only localization script change that removes false positives; genuine marker mismatches on matched subpaths are still enforced.
> 
> **Overview**
> Fixes a false-positive path in the CI **markdown `**` marker** check for `.xcstrings` String Catalogs.
> 
> In `check_xcstrings_data`, locale variation leaves (e.g. Russian plural `few`/`many` that English does not define) were compared to the English source using a fallback to the source’s top-level `stringUnit` when the subpath did not exist. That could spuriously flag **DROPPED**/**EXTRA** and fail blocking PR checks. The change only compares leaves where the source has the **same subpath**; missing source leaves are skipped via the existing `source_value is None` guard. Real mismatches on shared leaves are unchanged; simple strings still align on the `""` subpath.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a05dd45e2ec21d14eea236613b6692379f5d2093. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->