### PR TITLE
iOS: Fix Duck Player settings Maestro test

### DIFF
--- a/.maestro/duckplayer_native/10_youtube_open_settings.yaml
+++ b/.maestro/duckplayer_native/10_youtube_open_settings.yaml
@@ -41,4 +41,5 @@ tags:
 
 - tapOn: ${output.duckPlayerSettingsId}
 
-- assertVisible: "SettingsDuckPlayerHero"
+- assertVisible:
+    id: "SettingsDuckPlayerHero"

--- a/iOS/DuckDuckGo/SettingsDuckPlayerView.swift
+++ b/iOS/DuckDuckGo/SettingsDuckPlayerView.swift
@@ -50,6 +50,7 @@ struct SettingsDuckPlayerView: View {
             if !viewModel.shouldDisplayDuckPlayerContingencyMessage {
                 VStack(alignment: .center) {
                     Image(rebrandable: "SettingsDuckPlayerHero")
+                        .accessibilityIdentifier("SettingsDuckPlayerHero")
                         .padding(.top, -20) // Adjust for the image padding
 
                     Text(UserText.duckPlayerFeatureName)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1215276166067025?focus=true
Tech Design URL: N/A
CC:

### Description

The `duckplayer_native/10_youtube_open_settings` Maestro flow was failing on its final assertion. It used `assertVisible: "SettingsDuckPlayerHero"`, which matches against an accessibility label/text, but the Duck Player settings hero image exposed no element matching that string.

This change:
- Adds `.accessibilityIdentifier("SettingsDuckPlayerHero")` to the hero `Image` in `SettingsDuckPlayerView`.
- Updates the Maestro assertion to match by `id` (`assertVisible: { id: "SettingsDuckPlayerHero" }`) so it targets the identifier rather than a label.

### Testing Steps
1. Run the `.maestro/duckplayer_native/10_youtube_open_settings.yaml` flow against an iOS simulator build.
2. Confirm the flow reaches and passes the final `assertVisible` step for the Duck Player settings hero.

### Impact and Risks
Low — adds an accessibility identifier to an existing view and adjusts a Maestro test assertion. No user-visible behavior change.

#### What could go wrong?
The identifier could collide with another element, or a future refactor of `SettingsDuckPlayerView` could drop the modifier and break the flow again. Either would surface as a failing Maestro run rather than a user-facing regression.

### Quality Considerations
Accessibility identifiers are not localized, so the assertion is no longer sensitive to copy or localization changes. No performance or privacy impact.

### Notes to Reviewer
Failing-test fix — the production change is limited to a single `accessibilityIdentifier` modifier on the Duck Player settings hero image.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only targeting plus a non-user-facing accessibility identifier; no product behavior change.
> 
> **Overview**
> Repairs the failing **`duckplayer_native/10_youtube_open_settings`** Maestro flow by giving the Duck Player settings hero image a stable UI-test target and aligning the flow with it.
> 
> The hero **`Image`** in **`SettingsDuckPlayerView`** now uses **`.accessibilityIdentifier("SettingsDuckPlayerHero")`**. The flow’s final check switches from a text-based **`assertVisible`** to **`assertVisible` by `id`**, so automation no longer depends on a label that the image never exposed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5076acb97b974795b26c6d7ab2bb13a6426aa93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->