### PR TITLE
Revert "Remove tab switcher long press menu" (#4909)

### DIFF
--- a/iOS/DuckDuckGo/BlankSnapshotViewController.swift
+++ b/iOS/DuckDuckGo/BlankSnapshotViewController.swift
@@ -76,7 +76,7 @@ class BlankSnapshotViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        tabSwitcherButton = TabSwitcherStaticButton()
+        tabSwitcherButton = TabSwitcherStaticButton(showMenuOnLongPress: false)
 
         viewCoordinator = MainViewFactory.createViewHierarchy(self,
                                                               aiChatSettings: aiChatSettings,

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -1132,7 +1132,7 @@ extension DefaultOmniBarView {
         setLayoutMode(mode, animated: false)
         tabSwitcherContainerView.subviews.forEach { $0.removeFromSuperview() }
         if mode != .compact {
-            let button = TabSwitcherStaticButton()
+            let button = TabSwitcherStaticButton(showMenuOnLongPress: false)
             button.translatesAutoresizingMaskIntoConstraints = false
             tabSwitcherContainerView.addSubview(button)
             NSLayoutConstraint.activate([

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1421,7 +1421,7 @@ class MainViewController: UIViewController {
     private func initTabButton() {
         assert(tabSwitcherButton == nil)
 
-        tabSwitcherButton = TabSwitcherStaticButton()
+        tabSwitcherButton = TabSwitcherStaticButton(showMenuOnLongPress: fireModeCapability.isFireModeEnabled)
 
         tabSwitcherButton?.delegate = self
         viewCoordinator.toolbarTabSwitcherButton.customView = tabSwitcherButton
@@ -1432,7 +1432,7 @@ class MainViewController: UIViewController {
         viewCoordinator.toolbarTabSwitcherButton.accessibilityTraits = .button
 
         // Omnibar tab switcher button (for iPhone landscape combined bar)
-        let omniBarTabSwitcher = TabSwitcherStaticButton()
+        let omniBarTabSwitcher = TabSwitcherStaticButton(showMenuOnLongPress: fireModeCapability.isFireModeEnabled)
         omniBarTabSwitcher.delegate = self
         omniBarTabSwitcher.translatesAutoresizingMaskIntoConstraints = false
         let container = viewCoordinator.omniBar.barView.tabSwitcherContainerView
@@ -4319,6 +4319,20 @@ extension MainViewController: OmniBarDelegate {
         newTab()
     }
 
+    private func newFireTabLongPressMenuAction() {
+        postIdleSessionInstrumentation.sessionEnded(reason: .tabSwitcherSelected)
+        tabManager.setBrowsingMode(.fire, source: .longPressTabsIcon)
+        performCancel()
+        newTab()
+    }
+
+    private func newNormalTabLongPressMenuAction() {
+        postIdleSessionInstrumentation.sessionEnded(reason: .tabSwitcherSelected)
+        tabManager.setBrowsingMode(.normal, source: .longPressTabsIcon)
+        performCancel()
+        newTab()
+    }
+
     private var isSERPPresented: Bool {
         guard let tabURL = currentTab?.url else { return false }
         return tabURL.isDuckDuckGoSearch
@@ -5695,6 +5709,14 @@ extension MainViewController: TabSwitcherButtonDelegate {
 
     func launchNewTabWithCurrentMode(_ button: TabSwitcherButton) {
         newTabShortcutAction()
+    }
+    
+    func launchNewNormalTab(_ button: any TabSwitcherButton) {
+        newNormalTabLongPressMenuAction()
+    }
+
+    func launchNewFireTab(_ button: TabSwitcherButton) {
+        newFireTabLongPressMenuAction()
     }
 
     func showTabSwitcher(_ button: TabSwitcherButton) {

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -96,12 +96,13 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
     var daxDialogsManager: DaxDialogsManaging?
     var fireModeCapability: FireModeCapable? {
         didSet {
+            configureTabSwitcherLongPressMenu()
             configureAddTabButtonLongPressMenu()
         }
     }
     private weak var tabsModel: TabsModelManaging?
 
-    private lazy var tabSwitcherButton: TabSwitcherStaticButton = TabSwitcherStaticButton()
+    private lazy var tabSwitcherButton: TabSwitcherStaticButton = TabSwitcherStaticButton(showMenuOnLongPress: false)
 
     private let longPressTabGesture = UILongPressGestureRecognizer()
     private var cancellables = Set<AnyCancellable>()
@@ -408,6 +409,10 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
         }
     }
 
+    private func configureTabSwitcherLongPressMenu() {
+        tabSwitcherButton.showMenuOnLongPress = fireModeCapability?.isFireModeEnabled ?? false
+    }
+
     private func configureAddTabButtonLongPressMenu() {
         guard fireModeCapability?.isFireModeEnabled ?? false else {
             addTabButton.menu = nil
@@ -498,6 +503,14 @@ extension TabsBarViewController: TabSwitcherButtonDelegate {
     
     func launchNewTabWithCurrentMode(_ button: any TabSwitcherButton) {
         requestNewTab(type: .currentMode)
+    }
+    
+    func launchNewNormalTab(_ button: TabSwitcherButton) {
+        requestNewTab(type: .normal)
+    }
+
+    func launchNewFireTab(_ button: TabSwitcherButton) {
+        requestNewTab(type: .fire)
     }
 }
 

--- a/iOS/DuckDuckGo/ToolbarButtons/TabSwitcherAnimatedButton.swift
+++ b/iOS/DuckDuckGo/ToolbarButtons/TabSwitcherAnimatedButton.swift
@@ -25,6 +25,8 @@ protocol TabSwitcherButtonDelegate: AnyObject {
     
     func showTabSwitcher(_ button: TabSwitcherButton)
     func launchNewTabWithCurrentMode(_ button: TabSwitcherButton)
+    func launchNewNormalTab(_ button: TabSwitcherButton)
+    func launchNewFireTab(_ button: TabSwitcherButton)
 
 }
 

--- a/iOS/DuckDuckGo/ToolbarButtons/TabSwitcherStaticButton.swift
+++ b/iOS/DuckDuckGo/ToolbarButtons/TabSwitcherStaticButton.swift
@@ -27,6 +27,12 @@ final class TabSwitcherStaticButton: BrowserChromeButton, TabSwitcherButton {
     private var longPressRecognizer: UILongPressGestureRecognizer!
     weak var delegate: TabSwitcherButtonDelegate?
 
+    var showMenuOnLongPress: Bool {
+        didSet {
+            configureLongPressBehavior()
+        }
+    }
+
     var text: String? {
         tabSwitcherView.label.text
     }
@@ -34,7 +40,8 @@ final class TabSwitcherStaticButton: BrowserChromeButton, TabSwitcherButton {
     // Just to satisfy protocol requirement
     let pointer: UIView? = nil
 
-    init() {
+    init(showMenuOnLongPress: Bool) {
+        self.showMenuOnLongPress = showMenuOnLongPress
         super.init()
         self.frame = CGRect(x: 0, y: 0, width: 34, height: 44)
 
@@ -47,7 +54,8 @@ final class TabSwitcherStaticButton: BrowserChromeButton, TabSwitcherButton {
 
         longPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(onNewTabLongPressRecognizer))
         longPressRecognizer.minimumPressDuration = 0.4
-        addGestureRecognizer(longPressRecognizer)
+
+        configureLongPressBehavior()
         setUpSubviews()
         self.isPointerInteractionEnabled = true
     }
@@ -115,6 +123,50 @@ final class TabSwitcherStaticButton: BrowserChromeButton, TabSwitcherButton {
         super.tintColorDidChange()
 
         tabSwitcherView.tintColor = tintColor
+    }
+    
+    private func configureLongPressBehavior() {
+        if showMenuOnLongPress {
+            setLongPressMenu()
+        } else {
+            setLongPressGestureRecognizer()
+        }
+    }
+
+    private func setLongPressMenu() {
+        removeGestureRecognizer(longPressRecognizer)
+        let menu = UIMenu(children: [
+            UIDeferredMenuElement.uncached { [weak self] completion in
+                Pixel.fire(pixel: .tabLongPressMenuDisplayed, withAdditionalParameters: [
+                    PixelParameters.source: "toolbar"
+                ])
+                completion([
+                    UIAction(title: UserText.actionNewFireTab,
+                             image: DesignSystemImages.Glyphs.Size16.fireWindow) { [weak self] _ in
+                                 guard let self else { return }
+                                 Pixel.fire(pixel: .tabLongPressMenuNewFireTab, withAdditionalParameters: [
+                                     PixelParameters.source: "toolbar"
+                                 ])
+                                 delegate?.launchNewFireTab(self)
+                             },
+                    UIAction(title: UserText.actionNewTab,
+                             image: DesignSystemImages.Glyphs.Size16.add) { [weak self] _ in
+                                 guard let self else { return }
+                                 Pixel.fire(pixel: .tabLongPressMenuNewNormalTab, withAdditionalParameters: [
+                                     PixelParameters.source: "toolbar"
+                                 ])
+                                 delegate?.launchNewNormalTab(self)
+                             }
+                ])
+            }
+        ])
+
+        self.menu = menu
+    }
+    
+    private func setLongPressGestureRecognizer() {
+        self.menu = nil
+        addGestureRecognizer(longPressRecognizer)
     }
 
     @objc private func onNewTabLongPressRecognizer(_ recognizer: UILongPressGestureRecognizer) {

--- a/iOS/DuckDuckGoTests/TabSwitcherAnimatedButtonTests.swift
+++ b/iOS/DuckDuckGoTests/TabSwitcherAnimatedButtonTests.swift
@@ -34,7 +34,7 @@ class TabSwitcherAnimatedButtonTests: XCTestCase {
 
     func testStaticButtonInitialState() {
 
-        let button = TabSwitcherStaticButton()
+        let button = TabSwitcherStaticButton(showMenuOnLongPress: false)
         XCTAssertEqual(0, button.tabCount)
         XCTAssertFalse(button.hasUnread)
 

--- a/iOS/DuckDuckGoTests/TabSwitcherStaticButtonTests.swift
+++ b/iOS/DuckDuckGoTests/TabSwitcherStaticButtonTests.swift
@@ -23,21 +23,21 @@ import XCTest
 class TabSwitcherStaticButtonTests: XCTestCase {
 
     func testInitialState() {
-        let button = TabSwitcherStaticButton()
+        let button = TabSwitcherStaticButton(showMenuOnLongPress: false)
         XCTAssertEqual(0, button.tabCount)
         XCTAssertFalse(button.hasUnread)
         XCTAssertNil(button.text)
     }
 
     func testWhenAnimateCalledThenCountIsNotIncremented() {
-        let button = TabSwitcherStaticButton()
+        let button = TabSwitcherStaticButton(showMenuOnLongPress: false)
         button.animateUpdate { }
         XCTAssertEqual(0, button.tabCount)
         XCTAssertNil(button.text)
     }
 
     func testWhenCountSetBackToZeroThenTextIsBlank() {
-        let button = TabSwitcherStaticButton()
+        let button = TabSwitcherStaticButton(showMenuOnLongPress: false)
         button.tabCount = 1
         XCTAssertNotNil(button.text)
         button.tabCount = 0
@@ -45,14 +45,14 @@ class TabSwitcherStaticButtonTests: XCTestCase {
     }
 
     func testWhenExceedsMaxThenLabelIsSetAppropriately() {
-        let button = TabSwitcherStaticButton()
+        let button = TabSwitcherStaticButton(showMenuOnLongPress: false)
         button.tabCount = 100
         XCTAssertEqual("∞", button.text)
     }
 
 
     func testWhenCountIsUpdatedThenLabelIsUpdated() {
-        let button = TabSwitcherStaticButton()
+        let button = TabSwitcherStaticButton(showMenuOnLongPress: false)
         button.tabCount = 99
         XCTAssertEqual("99", button.text)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215279678739770?focus=true
Tech Design URL:
CC: @hassaanelgarem @jaceklyp 

### Description

Reverts #4909 ("Remove tab switcher long press menu") on top of `release/ios/7.223.0`. Restores the Fire Mode long-press menu on the Tabs icon (toolbar, omnibar, tabs bar): long-pressing the Tabs icon again presents the Normal / Fire tab choice instead of directly opening a new tab in the current mode.

The revert was adapted to the divergence between the PR's base and the current release branch. Two regions were resolved to keep 7.223.0's later work rather than mechanically reverting:

- The AI-chat header's tab button was refactored after #4909 to a plain `UIButton` backed by `TabSwitcherStaticView` (no long-press menu there). That refactor is preserved, so the header is unchanged by this revert. The header used `showMenuOnLongPress: false` before, so no behavior is lost.
- The `onTouchDown` diagnostic hook on `TabSwitcherStaticButton` (added later for the unresponsive-tab-switcher overlay) was removed on 7.223.0 independently of #4909, so it is not resurrected here.

### Testing Steps

1. Enable Fire Mode.
2. Open a Normal tab.
3. Long-press the Tabs icon in the browser toolbar, verify the Normal / Fire menu appears.
4. Press New Fire Tab, verify mode is changed and new tab is created.
5. Long-press the Tabs icon, verify the menu appears.
6. Press New Tab, verify mode is changed and new tab is created.
7. Enabled Unified Input
8. Confirm the AI-chat tab header still renders its tab switcher correctly (plain button, no long-press menu).
9. Open the Tabs Manager and long-press the `+` button, verify the Normal / Fire menu is still available there.

### Impact and Risks

Low. Localized iOS interaction change on the Tabs icon, restoring previously shipped behavior. Limited to the long-press path on the tabs switcher button.

#### What could go wrong?

The long-press menu and direct gesture share the same button. The revert routes long-press through `configureLongPressBehavior`, which toggles between the deferred `UIMenu` and the gesture recognizer based on `showMenuOnLongPress`.

### Quality Considerations

`onTouchDown` is intentionally not restored (removed separately on 7.223.0); no call site references it. The AI-chat header refactor is intentionally preserved. Tab-switcher button unit tests were reverted alongside the source.

### Notes to Reviewer

This is not a clean mechanical revert because `release/ios/7.223.0` diverged from #4909's base. Focus review on the two conflict-resolution decisions described above: keeping the AI-chat header `UIButton` refactor, and not resurrecting `onTouchDown`.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized iOS chrome interaction restoring prior shipped behavior; menu vs gesture is toggled explicitly and non–Fire Mode paths keep the direct long-press shortcut.
> 
> **Overview**
> Restores the **Fire Mode long-press menu** on the tabs switcher when Fire Mode is enabled: long-pressing the tabs icon can again offer **New Tab** vs **New Fire Tab** instead of only opening a tab in the current mode.
> 
> `TabSwitcherStaticButton` now takes **`showMenuOnLongPress`** and switches between a deferred **`UIMenu`** (with toolbar pixels) and the existing long-press gesture. **Main** toolbar and omnibar tab buttons use `fireModeCapability.isFireModeEnabled`; snapshot overlay and swipe-template omnibar stay **`false`**. **`TabsBarViewController`** turns the menu on when Fire Mode is available and wires new **`TabSwitcherButtonDelegate`** methods through to browsing-mode changes (`longPressTabsIcon`) and a new tab.
> 
> Unit tests pass the new initializer flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e74ff134c2f6eab0049e6bc7372698049f84bc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->