### PR TITLE
Add Maestro E2E tests for autocomplete fill arrow and history delete

### DIFF
--- a/.maestro/release_tests/autocomplete.yaml
+++ b/.maestro/release_tests/autocomplete.yaml
@@ -1,0 +1,82 @@
+# autocomplete.yaml
+#
+# Covers the autocomplete suggestion accessory controls:
+#  * Test 1: the "fill" / tap-ahead arrow on a search-phrase suggestion fills the
+#            suggestion text back into the address bar for further editing instead
+#            of navigating. This regressed once (tapping the arrow did nothing),
+#            so the test taps the arrow and asserts the query actually changes.
+#  * Test 2: the delete button on a history suggestion removes that entry from
+#            history (the row disappears from the suggestions list).
+#
+# Search-phrase suggestions are fetched remotely, so the test waits for them with
+# extendedWaitUntil rather than a fixed delay.
+appId: com.duckduckgo.mobile.ios
+tags:
+    - iphone
+    - release
+name: autocomplete
+
+---
+
+# Set up
+- runFlow:
+    file: ../shared/setup.yaml
+
+# Test 1: tap-ahead / fill arrow fills the phrase into the address bar (no navigation)
+- assertVisible:
+    id: "searchEntry"
+- tapOn:
+    id: "searchEntry"
+- inputText: "weath"
+# The fill arrow is only shown on (remotely fetched) search-phrase suggestions
+- extendedWaitUntil:
+    visible:
+        id: "Autocomplete.Suggestions.ListItem.TapAheadButton"
+    timeout: 15000
+- tapOn:
+    id: "Autocomplete.Suggestions.ListItem.TapAheadButton"
+# Let the address bar update with the chosen phrase
+- runFlow:
+    file: ../shared/delay.yaml
+# The query in the address bar should now be the (longer) suggestion phrase,
+# and we should still be editing rather than having navigated away.
+- copyTextFrom:
+    id: "searchEntry"
+- assertTrue: ${maestro.copiedText != "weath"}
+- assertVisible: "Cancel"
+- tapOn: "Cancel"
+
+# Test 2: delete button on a history suggestion removes the entry from history
+# First create a history entry by visiting a site
+- assertVisible:
+    id: "searchEntry"
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://privacy-test-pages.site"
+- pressKey: Enter
+- extendedWaitUntil:
+    visible: ".*Privacy Test Pages.*"
+    timeout: 20000
+
+# Open a fresh tab and start typing to surface the history suggestion
+- tapOn: "Tab Switcher"
+- tapOn: "New Tab"
+- assertVisible:
+    id: "searchEntry"
+- tapOn:
+    id: "searchEntry"
+- inputText: "privacy-test-pages"
+# History suggestion for the visited site, with its delete button
+- extendedWaitUntil:
+    visible:
+        id: "Autocomplete.Suggestions.ListItem.History-privacy-test-pages.site.*"
+    timeout: 15000
+- assertVisible:
+    id: "Autocomplete.Suggestions.ListItem.DeleteButton"
+- tapOn:
+    id: "Autocomplete.Suggestions.ListItem.DeleteButton"
+# The history suggestion should be gone after deletion
+- extendedWaitUntil:
+    notVisible:
+        id: "Autocomplete.Suggestions.ListItem.History-privacy-test-pages.site.*"
+    timeout: 10000

--- a/iOS/DuckDuckGo/AutocompleteView.swift
+++ b/iOS/DuckDuckGo/AutocompleteView.swift
@@ -179,46 +179,46 @@ private struct SuggestionView: View {
                 SuggestionListItem(icon: Image(uiImage: DesignSystemImages.Glyphs.Size24.findSearchSmall),
                                    title: phrase,
                                    query: query,
+                                   accessibilityIdentifier: "Autocomplete.Suggestions.ListItem.SearchPhrase-\(phrase)",
                                    indicator: tapAheadImage,
                                    onTapIndicator: { autocompleteModel.onTapAhead(model) })
-                .accessibilityIdentifier("Autocomplete.Suggestions.ListItem.SearchPhrase-\(phrase)")
 
             case .website(let url):
                 SuggestionListItem(icon: Image(uiImage: DesignSystemImages.Glyphs.Size24.globe),
-                                   title: url.formattedForSuggestion())
-                .accessibilityIdentifier("Autocomplete.Suggestions.ListItem.Website-\(url.formattedForSuggestion())")
+                                   title: url.formattedForSuggestion(),
+                                   accessibilityIdentifier: "Autocomplete.Suggestions.ListItem.Website-\(url.formattedForSuggestion())")
 
             case .bookmark(let title, let url, let isFavorite, _) where isFavorite:
                 SuggestionListItem(icon: Image(uiImage: DesignSystemImages.Glyphs.Size24.bookmarkFavorite),
                                    title: title,
-                                   subtitle: url.formattedForSuggestion())
-                .accessibilityIdentifier("Autocomplete.Suggestions.ListItem.Favorite-\(url.formattedForSuggestion())")
+                                   subtitle: url.formattedForSuggestion(),
+                                   accessibilityIdentifier: "Autocomplete.Suggestions.ListItem.Favorite-\(url.formattedForSuggestion())")
 
             case .bookmark(let title, let url, _, _):
                 SuggestionListItem(icon: Image(uiImage: DesignSystemImages.Glyphs.Size24.bookmark),
                                    title: title,
-                                   subtitle: url.formattedForSuggestion())
-                .accessibilityIdentifier("Autocomplete.Suggestions.ListItem.Bookmark-\(url.formattedForSuggestion())")
+                                   subtitle: url.formattedForSuggestion(),
+                                   accessibilityIdentifier: "Autocomplete.Suggestions.ListItem.Bookmark-\(url.formattedForSuggestion())")
 
             case .historyEntry(_, let url, _) where url.isDuckDuckGoSearch:
                 SuggestionListItem(icon: Image(uiImage: DesignSystemImages.Glyphs.Size24.history),
                                    title: url.searchQuery ?? "",
                                    subtitle: UserText.autocompleteSearchDuckDuckGo,
+                                   accessibilityIdentifier: "Autocomplete.Suggestions.ListItem.SERPHistory-\(url.searchQuery ?? "")",
                                    onDelete: onDelete)
-                .accessibilityIdentifier("Autocomplete.Suggestions.ListItem.SERPHistory-\(url.searchQuery ?? "")")
 
             case .historyEntry(let title, let url, _):
                 SuggestionListItem(icon: Image(uiImage: DesignSystemImages.Glyphs.Size24.history),
                                    title: title ?? "",
                                    subtitle: url.formattedForSuggestion(),
+                                   accessibilityIdentifier: "Autocomplete.Suggestions.ListItem.History-\(url.formattedForSuggestion())",
                                    onDelete: onDelete)
-                .accessibilityIdentifier("Autocomplete.Suggestions.ListItem.History-\(url.formattedForSuggestion())")
 
             case .openTab(title: let title, url: let url, _, _):
                 SuggestionListItem(icon: Image(uiImage: DesignSystemImages.Glyphs.Size24.tabsMobile),
                                    title: title,
-                                   subtitle: "\(UserText.autocompleteSwitchToTab) · \(url.formattedForSuggestion())")
-                .accessibilityIdentifier("Autocomplete.Suggestions.ListItem.OpenTab-\(url.formattedForSuggestion())")
+                                   subtitle: "\(UserText.autocompleteSwitchToTab) · \(url.formattedForSuggestion())",
+                                   accessibilityIdentifier: "Autocomplete.Suggestions.ListItem.OpenTab-\(url.formattedForSuggestion())")
 
             case .internalPage, .unknown:
                 FailedAssertionView("Unknown or unsupported suggestion type")
@@ -226,8 +226,8 @@ private struct SuggestionView: View {
             case .askAIChat(value: let value):
                 SuggestionListItem(icon: Image(uiImage: DesignSystemImages.Glyphs.Size24.aiChat),
                                    title: value,
-                                   subtitle: UserText.autocompleteAskAIChat)
-                .accessibilityIdentifier("Autocomplete.Suggestions.ListItem.AskAIChat-\(value)")
+                                   subtitle: UserText.autocompleteAskAIChat,
+                                   accessibilityIdentifier: "Autocomplete.Suggestions.ListItem.AskAIChat-\(value)")
 
             }
 
@@ -245,6 +245,7 @@ private struct SuggestionListItem: View {
     let title: String
     let subtitle: String?
     let query: String?
+    let accessibilityIdentifier: String
     let indicator: Image?
     let onTapIndicator: (() -> Void)?
     let onDelete: (() -> Void)?
@@ -253,6 +254,7 @@ private struct SuggestionListItem: View {
          title: String,
          subtitle: String? = nil,
          query: String? = nil,
+         accessibilityIdentifier: String,
          indicator: Image? = nil,
          onTapIndicator: ( () -> Void)? = nil,
          onDelete: (() -> Void)? = nil) {
@@ -261,6 +263,7 @@ private struct SuggestionListItem: View {
         self.title = title
         self.subtitle = subtitle
         self.query = query
+        self.accessibilityIdentifier = accessibilityIdentifier
         self.indicator = indicator
         self.onTapIndicator = onTapIndicator
         self.onDelete = onDelete
@@ -268,40 +271,49 @@ private struct SuggestionListItem: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            icon
-                .resizable()
-                .frame(width: Metrics.iconSize, height: Metrics.iconSize)
-                .tintIfAvailable(Color(designSystemColor: .icons))
+            // Combine the icon + title/subtitle (the row's "select" target) into a single
+            // accessibility element carrying the row identifier. The row is wrapped in a
+            // Button, whose accessibility element would otherwise absorb the trailing
+            // button identifiers; isolating the identifier here keeps the tap-ahead /
+            // delete buttons addressable by their own identifiers.
+            HStack(spacing: 0) {
+                icon
+                    .resizable()
+                    .frame(width: Metrics.iconSize, height: Metrics.iconSize)
+                    .tintIfAvailable(Color(designSystemColor: .icons))
 
-            VStack(alignment: .leading, spacing: 0) {
+                VStack(alignment: .leading, spacing: 0) {
 
-                Group {
-                    // Can't use dax modifiers because they are not typed for Text
-                    if let query, title.hasPrefix(query) {
-                        Text(query)
-                            .font(Font(uiFont: UIFont.daxBodyRegular()))
-                            .foregroundColor(Color(designSystemColor: .textPrimary))
-                        +
-                        Text(title.dropping(prefix: query))
-                            .font(Font(uiFont: UIFont.daxBodyBold()))
-                            .foregroundColor(Color(designSystemColor: .textPrimary))
-                    } else {
-                        Text(title)
-                            .font(Font(uiFont: UIFont.daxBodyRegular()))
+                    Group {
+                        // Can't use dax modifiers because they are not typed for Text
+                        if let query, title.hasPrefix(query) {
+                            Text(query)
+                                .font(Font(uiFont: UIFont.daxBodyRegular()))
                                 .foregroundColor(Color(designSystemColor: .textPrimary))
+                            +
+                            Text(title.dropping(prefix: query))
+                                .font(Font(uiFont: UIFont.daxBodyBold()))
+                                .foregroundColor(Color(designSystemColor: .textPrimary))
+                        } else {
+                            Text(title)
+                                .font(Font(uiFont: UIFont.daxBodyRegular()))
+                                    .foregroundColor(Color(designSystemColor: .textPrimary))
+                        }
+                    }
+                    .lineLimit(1)
+
+                    if let subtitle {
+                        Text(subtitle)
+                            .daxFootnoteRegular()
+                            .foregroundColor(Color(designSystemColor: .textSecondary))
+                            .lineLimit(1)
+                            .frame(minHeight: Metrics.subtitleMinHeight)
                     }
                 }
-                .lineLimit(1)
-
-                if let subtitle {
-                    Text(subtitle)
-                        .daxFootnoteRegular()
-                        .foregroundColor(Color(designSystemColor: .textSecondary))
-                        .lineLimit(1)
-                        .frame(minHeight: Metrics.subtitleMinHeight)
-                }
+                .padding(.leading, Metrics.verticalSpacing)
             }
-            .padding(.leading, Metrics.verticalSpacing)
+            .accessibilityElement(children: .combine)
+            .accessibilityIdentifier(accessibilityIdentifier)
 
             if indicator == nil && onDelete == nil {
                 // No trailing accessory means we want to preserve the room for icon,
@@ -318,6 +330,7 @@ private struct SuggestionListItem: View {
                     })
                     .tintIfAvailable(Color.init(designSystemColor: .iconsSecondary))
                     .padding(.leading, Metrics.indicatorLeadingPadding)
+                    .accessibilityIdentifier("Autocomplete.Suggestions.ListItem.TapAheadButton")
             } else if let onDelete {
                 Image(uiImage: DesignSystemImages.Glyphs.Size16.clear)
                     .highPriorityGesture(TapGesture().onEnded {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1214603625531199
Tech Design URL:
CC:

### Description
Adds a Maestro flow covering the autocomplete suggestion accessory controls: the tap-ahead "fill" arrow on a search-phrase suggestion, and the delete button on a history suggestion. The fill arrow regressed previously (tapping did nothing), so the test taps it and asserts the address-bar query changes without navigating.

To make both controls addressable by Maestro, the suggestion row now isolates its accessibility identifiers. The row is wrapped in a `Button`, whose accessibility element would otherwise absorb the trailing buttons and propagate the row identifier onto every child, so the icon and title are combined into a single element that carries the row identifier, leaving the tap-ahead and delete buttons as separate siblings with their own identifiers.

### Testing Steps
1. Run `.maestro/release_tests/autocomplete.yaml` and verify it passes.
2. Verify the autocomplete rows design is unchanged and works as expected.

### Impact and Risks
Medium. The change is an accessibility-identifier reorganization on the autocomplete row plus a new test; UI needed some adjustments to allow this to work.

#### What could go wrong?
View modification was required to add an accessibility id for nested items in a button. UI may be off or not functional.

### Quality Considerations
N/A

### Notes to Reviewer


—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Restructures SwiftUI accessibility on autocomplete rows inside a `Button` wrapper; low logic change but possible UI/tap or VoiceOver regressions on suggestion accessories.
> 
> **Overview**
> Adds a **release Maestro flow** (`autocomplete.yaml`) that exercises autocomplete accessory actions: the search-phrase **tap-ahead** control must expand the address-bar query without leaving edit mode, and the **history delete** control must remove the matching suggestion row.
> 
> In **`AutocompleteView`**, suggestion rows now pass **`accessibilityIdentifier`** into `SuggestionListItem` and apply it to a **combined** icon/title accessibility element so the enclosing list `Button` no longer collapses identifiers onto the trailing controls. Dedicated IDs are set on **`Autocomplete.Suggestions.ListItem.TapAheadButton`** and **`DeleteButton`** so automation can target those accessories separately from the row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e07a93292a5b9bbe5622f4ffaa69b3c08906d60c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->