### PR TITLE
iOS: Suggestions/autocomplete background flash on first keystroke (search mode, light mode, dark mode)

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SuggestionTrayManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SuggestionTrayManager.swift
@@ -136,8 +136,16 @@ final class SuggestionTrayManager: NSObject {
         suggestionTrayViewController?.additionalTopInset = inset
     }
 
-    /// Installs the suggestion tray in the provided container view
-    func installInContainerView(_ containerView: UIView, parentViewController: UIViewController, escapeHatchModel: EscapeHatchModel? = nil) {
+    /// Installs the suggestion tray in the provided container view.
+    ///
+    /// - Parameter deferAutocompleteReveal: When `true`, the autocomplete surface stays hidden until
+    ///   its first results arrive, so the underlying content (favorites NTP / Dax) isn't briefly
+    ///   covered by an empty surface flashing in. Only the unified toggle input surface opts in;
+    ///   other hosts (legacy omnibar editing, iPad chat history, swipe container) keep the default (false).
+    func installInContainerView(_ containerView: UIView,
+                                parentViewController: UIViewController,
+                                escapeHatchModel: EscapeHatchModel? = nil,
+                                deferAutocompleteReveal: Bool = false) {
         guard suggestionTrayViewController == nil else { return }
         
 
@@ -155,6 +163,7 @@ final class SuggestionTrayManager: NSObject {
             hideBorder: true)
 
         controller.coversFullScreen = true
+        controller.deferAutocompleteReveal = deferAutocompleteReveal
 
         parentViewController.addChild(controller)
         containerView.addSubview(controller.view)

--- a/iOS/DuckDuckGo/SuggestionTrayViewController.swift
+++ b/iOS/DuckDuckGo/SuggestionTrayViewController.swift
@@ -76,6 +76,11 @@ class SuggestionTrayViewController: UIViewController {
     private var autocompleteController: AutocompleteViewController?
     private var newTabPage: NewTabPageViewController?
     private var willRemoveAutocomplete = false
+
+    /// Allows to defer autocomplete presentation to avoid short UI glitch (blink) when presenting
+    /// autocomplete suggestions when unifiedToggleInput flag is on.
+    var deferAutocompleteReveal = false
+    private var pendingDeferredAutocompleteReveal = false
     private var pendingEscapeHatchModel: EscapeHatchModel?
     private var pendingSuggestionsSectionTitle: String?
     private var pendingFavoritesSectionTitle: String?
@@ -430,7 +435,11 @@ class SuggestionTrayViewController: UIViewController {
                                                     featureDiscovery: featureDiscovery,
                                                     productSurfaceTelemetry: productSurfaceTelemetry)
         controller.suggestionFilter = suggestionFilter
-        install(controller: controller, animated: animated)
+        install(controller: controller, animated: deferAutocompleteReveal ? false : animated)
+        if deferAutocompleteReveal {
+            controller.view.isHidden = true
+            pendingDeferredAutocompleteReveal = true
+        }
         controller.delegate = autocompleteDelegate
         controller.presentationDelegate = self
         autocompleteController = controller
@@ -441,8 +450,9 @@ class SuggestionTrayViewController: UIViewController {
 
     private func removeAutocomplete(animated: Bool) {
         guard let controller = autocompleteController else { return }
-        removeController(controller, animated: animated)
+        removeController(controller, animated: deferAutocompleteReveal ? false : animated)
         autocompleteController = nil
+        pendingDeferredAutocompleteReveal = false
     }
 
     private func removeNewTabPage(animated: Bool) {
@@ -511,9 +521,15 @@ extension SuggestionTrayViewController: AutocompleteViewControllerPresentationDe
     }
 
     func autocompleteDidReloadResults(_ controller: AutocompleteViewController) {
-        guard controller.suggestionFilter == .urlsOnly else { return }
-        view.isHidden = controller.isEmpty
-        onURLFallbackVisibilityChanged?()
+        if controller.suggestionFilter == .urlsOnly {
+            view.isHidden = controller.isEmpty
+            onURLFallbackVisibilityChanged?()
+            return
+        }
+        if pendingDeferredAutocompleteReveal, controller === autocompleteController {
+            pendingDeferredAutocompleteReveal = false
+            controller.view.isHidden = false
+        }
     }
 
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -444,7 +444,10 @@ final class UnifiedInputContentContainerViewController: UIViewController {
             autocompleteHorizontalInset: Metrics.suggestionsHorizontalInset)
         manager.delegate = self
         let trayEscapeHatchModel = switchBarHandler.isFireTab ? nil : escapeHatchModel
-        manager.installInContainerView(searchContainer, parentViewController: containerViewController, escapeHatchModel: trayEscapeHatchModel)
+        manager.installInContainerView(searchContainer,
+                                       parentViewController: containerViewController,
+                                       escapeHatchModel: trayEscapeHatchModel,
+                                       deferAutocompleteReveal: true)
         suggestionTrayManager = manager
     }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210947754188321/task/1215238064166656?focus=true
Tech Design URL:
CC:

### Description
With `unifiedToggleInput` flag ON, in Search mode, typing the **first** character of a query (and deleting it) produced a brief flash of the background color, visible on device in both light and dark mode.

**Root cause:** The autocomplete surface (an opaque `UIHostingController<AutocompleteView>`) is created and faded in on the first keystroke while the favourites NewTabPage stays mounted underneath. Since results arrive ~100–300ms later (debounce + network), the opaque surface covers the underlying content while still empty — the flash. Subsequent keystrokes reuse the already-visible controller, so they don't flash.

**Fix:** Add an opt-in `deferAutocompleteReveal` mode to `SuggestionTrayViewController` that installs the autocomplete hidden (no fade) and reveals it only once its first results arrive — keeping the previous content on screen until suggestions are ready. Mirrors the existing `urlsOnly` deferral already in this file. The parameter defaults to `false` and is opted into **only** by the UTI surface (`UnifiedInputContentContainerViewController`); all other `installInContainerView` callers (legacy omnibar editing, iPad chat history, swipe container) are unchanged.


### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
Note: see the flash on latest Alpha build to know what to look for.

1. Enable the `unifiedToggleInput` feature flag.
2. Ensure at least one favourite is saved (so the NewTabPage shows underneath the input).
3. Open the Unified Toggle Input, set the toggle to **Search**, and focus the empty input.
4. Type the first character of a query that returns suggestions (e.g. `d`) — verify there is **no** background-colour flash before the suggestions appear. Test in **both light and dark mode**, on a **physical device** (the flash is hard to see on the simulator).
5. Delete that first character — verify there is no flash when returning to the empty/favourites state.
6. Type several characters in a row — verify suggestions update normally.
7. Regression check: with `unifiedToggleInput` **off**, use the legacy omnibar editing / suggestions and confirm behaviour is unchanged.
<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
**Low.** This is a UI-timing change gated to the UTI surface only. The new parameter defaults to `false`, leaving every other suggestion-tray host untouched. Worst case is a visual timing regression confined to UTI Search.

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
A timing or visibility issue would be limited to the UTI Search path. All non-UTI hosts use the default `false` and retain the original animated install/removal behaviour, so they cannot be affected.


### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->
- **Edge case:** Unlike the `urlsOnly` path (which hides when results are empty), the deferred `.all` Search path reveals unconditionally on the first results callback. For a query that returns no suggestions, the UTI would briefly show an empty autocomplete instead of staying on favourites. This is rare for Search and is an accepted trade-off.
- **Performance / privacy:** No impact — the change is purely view visibility and animation timing.
- **Pattern reuse:** Reuses the existing `urlsOnly` deferral pattern already present in `SuggestionTrayViewController`, rather than introducing a new mechanism.

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->
- `deferAutocompleteReveal` defaults to `false`; only `UnifiedInputContentContainerViewController` opts in.
- The reveal happens in the `autocompleteDidReloadResults` branch (`pendingDeferredAutocompleteReveal` + identity check on the current controller).
- In defer mode both install and removal are non-animated (the `animated:` argument is overridden to `false`), which is the intended part of the fix.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI visibility/timing only, gated to UTI via a default-false flag; no auth, data, or network behavior changes.
> 
> **Overview**
> Fixes a brief **background flash** on the first keystroke in Unified Toggle Input (UTI) **Search** mode when `unifiedToggleInput` is on: the opaque autocomplete layer was appearing before debounced/network results arrived, covering favorites/Dax underneath.
> 
> Adds an opt-in **`deferAutocompleteReveal`** path on `SuggestionTrayViewController` / `SuggestionTrayManager.installInContainerView`: autocomplete installs **hidden** with **no fade**, then becomes visible in `autocompleteDidReloadResults` after the first non–`urlsOnly` results callback. **`UnifiedInputContentContainerViewController`** is the only caller that passes `true`; legacy omnibar and other hosts keep the default `false`.
> 
> **Trade-off:** empty-result queries may briefly show an empty autocomplete instead of staying on favorites (accepted for Search).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e829ae5e062ba511cc6e208f0d99f7776a5b8a99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->