### PR TITLE
Revert "Remove tab switcher long press menu" (#4909) on main

### DIFF
--- a/iOS/DuckDuckGo/BlankSnapshotViewController.swift
+++ b/iOS/DuckDuckGo/BlankSnapshotViewController.swift
@@ -76,7 +76,7 @@ class BlankSnapshotViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        tabSwitcherButton = TabSwitcherStaticButton()
+        tabSwitcherButton = TabSwitcherStaticButton(showMenuOnLongPress: false)
 
         viewCoordinator = MainViewFactory.createViewHierarchy(self,
                                                               aiChatSettings: aiChatSettings,

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -1132,7 +1132,7 @@ extension DefaultOmniBarView {
         setLayoutMode(mode, animated: false)
         tabSwitcherContainerView.subviews.forEach { $0.removeFromSuperview() }
         if mode != .compact {
-            let button = TabSwitcherStaticButton()
+            let button = TabSwitcherStaticButton(showMenuOnLongPress: false)
             button.translatesAutoresizingMaskIntoConstraints = false
             tabSwitcherContainerView.addSubview(button)
             NSLayoutConstraint.activate([

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1421,7 +1421,7 @@ class MainViewController: UIViewController {
     private func initTabButton() {
         assert(tabSwitcherButton == nil)
 
-        tabSwitcherButton = TabSwitcherStaticButton()
+        tabSwitcherButton = TabSwitcherStaticButton(showMenuOnLongPress: fireModeCapability.isFireModeEnabled)
 
         tabSwitcherButton?.delegate = self
         viewCoordinator.toolbarTabSwitcherButton.customView = tabSwitcherButton
@@ -1432,7 +1432,7 @@ class MainViewController: UIViewController {
         viewCoordinator.toolbarTabSwitcherButton.accessibilityTraits = .button
 
         // Omnibar tab switcher button (for iPhone landscape combined bar)
-        let omniBarTabSwitcher = TabSwitcherStaticButton()
+        let omniBarTabSwitcher = TabSwitcherStaticButton(showMenuOnLongPress: fireModeCapability.isFireModeEnabled)
         omniBarTabSwitcher.delegate = self
         omniBarTabSwitcher.translatesAutoresizingMaskIntoConstraints = false
         let container = viewCoordinator.omniBar.barView.tabSwitcherContainerView
@@ -4322,6 +4322,20 @@ extension MainViewController: OmniBarDelegate {
         newTab()
     }
 
+    private func newFireTabLongPressMenuAction() {
+        postIdleSessionInstrumentation.sessionEnded(reason: .tabSwitcherSelected)
+        tabManager.setBrowsingMode(.fire, source: .longPressTabsIcon)
+        performCancel()
+        newTab()
+    }
+
+    private func newNormalTabLongPressMenuAction() {
+        postIdleSessionInstrumentation.sessionEnded(reason: .tabSwitcherSelected)
+        tabManager.setBrowsingMode(.normal, source: .longPressTabsIcon)
+        performCancel()
+        newTab()
+    }
+
     private var isSERPPresented: Bool {
         guard let tabURL = currentTab?.url else { return false }
         return tabURL.isDuckDuckGoSearch
@@ -5698,6 +5712,14 @@ extension MainViewController: TabSwitcherButtonDelegate {
 
     func launchNewTabWithCurrentMode(_ button: TabSwitcherButton) {
         newTabShortcutAction()
+    }
+    
+    func launchNewNormalTab(_ button: any TabSwitcherButton) {
+        newNormalTabLongPressMenuAction()
+    }
+
+    func launchNewFireTab(_ button: TabSwitcherButton) {
+        newFireTabLongPressMenuAction()
     }
 
     func showTabSwitcher(_ button: TabSwitcherButton) {

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -96,12 +96,13 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
     var daxDialogsManager: DaxDialogsManaging?
     var fireModeCapability: FireModeCapable? {
         didSet {
+            configureTabSwitcherLongPressMenu()
             configureAddTabButtonLongPressMenu()
         }
     }
     private weak var tabsModel: TabsModelManaging?
 
-    private lazy var tabSwitcherButton: TabSwitcherStaticButton = TabSwitcherStaticButton()
+    private lazy var tabSwitcherButton: TabSwitcherStaticButton = TabSwitcherStaticButton(showMenuOnLongPress: false)
 
     private let longPressTabGesture = UILongPressGestureRecognizer()
     private var cancellables = Set<AnyCancellable>()
@@ -408,6 +409,10 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
         }
     }
 
+    private func configureTabSwitcherLongPressMenu() {
+        tabSwitcherButton.showMenuOnLongPress = fireModeCapability?.isFireModeEnabled ?? false
+    }
+
     private func configureAddTabButtonLongPressMenu() {
         guard fireModeCapability?.isFireModeEnabled ?? false else {
             addTabButton.menu = nil
@@ -498,6 +503,14 @@ extension TabsBarViewController: TabSwitcherButtonDelegate {
     
     func launchNewTabWithCurrentMode(_ button: any TabSwitcherButton) {
         requestNewTab(type: .currentMode)
+    }
+    
+    func launchNewNormalTab(_ button: TabSwitcherButton) {
+        requestNewTab(type: .normal)
+    }
+
+    func launchNewFireTab(_ button: TabSwitcherButton) {
+        requestNewTab(type: .fire)
     }
 }
 

--- a/iOS/DuckDuckGo/ToolbarButtons/TabSwitcherAnimatedButton.swift
+++ b/iOS/DuckDuckGo/ToolbarButtons/TabSwitcherAnimatedButton.swift
@@ -25,6 +25,8 @@ protocol TabSwitcherButtonDelegate: AnyObject {
     
     func showTabSwitcher(_ button: TabSwitcherButton)
     func launchNewTabWithCurrentMode(_ button: TabSwitcherButton)
+    func launchNewNormalTab(_ button: TabSwitcherButton)
+    func launchNewFireTab(_ button: TabSwitcherButton)
 
 }
 

--- a/iOS/DuckDuckGo/ToolbarButtons/TabSwitcherStaticButton.swift
+++ b/iOS/DuckDuckGo/ToolbarButtons/TabSwitcherStaticButton.swift
@@ -27,6 +27,12 @@ final class TabSwitcherStaticButton: BrowserChromeButton, TabSwitcherButton {
     private var longPressRecognizer: UILongPressGestureRecognizer!
     weak var delegate: TabSwitcherButtonDelegate?
 
+    var showMenuOnLongPress: Bool {
+        didSet {
+            configureLongPressBehavior()
+        }
+    }
+
     var text: String? {
         tabSwitcherView.label.text
     }
@@ -34,7 +40,8 @@ final class TabSwitcherStaticButton: BrowserChromeButton, TabSwitcherButton {
     // Just to satisfy protocol requirement
     let pointer: UIView? = nil
 
-    init() {
+    init(showMenuOnLongPress: Bool) {
+        self.showMenuOnLongPress = showMenuOnLongPress
         super.init()
         self.frame = CGRect(x: 0, y: 0, width: 34, height: 44)
 
@@ -47,7 +54,8 @@ final class TabSwitcherStaticButton: BrowserChromeButton, TabSwitcherButton {
 
         longPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(onNewTabLongPressRecognizer))
         longPressRecognizer.minimumPressDuration = 0.4
-        addGestureRecognizer(longPressRecognizer)
+
+        configureLongPressBehavior()
         setUpSubviews()
         self.isPointerInteractionEnabled = true
     }
@@ -115,6 +123,50 @@ final class TabSwitcherStaticButton: BrowserChromeButton, TabSwitcherButton {
         super.tintColorDidChange()
 
         tabSwitcherView.tintColor = tintColor
+    }
+    
+    private func configureLongPressBehavior() {
+        if showMenuOnLongPress {
+            setLongPressMenu()
+        } else {
+            setLongPressGestureRecognizer()
+        }
+    }
+
+    private func setLongPressMenu() {
+        removeGestureRecognizer(longPressRecognizer)
+        let menu = UIMenu(children: [
+            UIDeferredMenuElement.uncached { [weak self] completion in
+                Pixel.fire(pixel: .tabLongPressMenuDisplayed, withAdditionalParameters: [
+                    PixelParameters.source: "toolbar"
+                ])
+                completion([
+                    UIAction(title: UserText.actionNewFireTab,
+                             image: DesignSystemImages.Glyphs.Size16.fireWindow) { [weak self] _ in
+                                 guard let self else { return }
+                                 Pixel.fire(pixel: .tabLongPressMenuNewFireTab, withAdditionalParameters: [
+                                     PixelParameters.source: "toolbar"
+                                 ])
+                                 delegate?.launchNewFireTab(self)
+                             },
+                    UIAction(title: UserText.actionNewTab,
+                             image: DesignSystemImages.Glyphs.Size16.add) { [weak self] _ in
+                                 guard let self else { return }
+                                 Pixel.fire(pixel: .tabLongPressMenuNewNormalTab, withAdditionalParameters: [
+                                     PixelParameters.source: "toolbar"
+                                 ])
+                                 delegate?.launchNewNormalTab(self)
+                             }
+                ])
+            }
+        ])
+
+        self.menu = menu
+    }
+    
+    private func setLongPressGestureRecognizer() {
+        self.menu = nil
+        addGestureRecognizer(longPressRecognizer)
     }
 
     @objc private func onNewTabLongPressRecognizer(_ recognizer: UILongPressGestureRecognizer) {

--- a/iOS/DuckDuckGoTests/TabSwitcherAnimatedButtonTests.swift
+++ b/iOS/DuckDuckGoTests/TabSwitcherAnimatedButtonTests.swift
@@ -34,7 +34,7 @@ class TabSwitcherAnimatedButtonTests: XCTestCase {
 
     func testStaticButtonInitialState() {
 
-        let button = TabSwitcherStaticButton()
+        let button = TabSwitcherStaticButton(showMenuOnLongPress: false)
         XCTAssertEqual(0, button.tabCount)
         XCTAssertFalse(button.hasUnread)
 

--- a/iOS/DuckDuckGoTests/TabSwitcherStaticButtonTests.swift
+++ b/iOS/DuckDuckGoTests/TabSwitcherStaticButtonTests.swift
@@ -23,21 +23,21 @@ import XCTest
 class TabSwitcherStaticButtonTests: XCTestCase {
 
     func testInitialState() {
-        let button = TabSwitcherStaticButton()
+        let button = TabSwitcherStaticButton(showMenuOnLongPress: false)
         XCTAssertEqual(0, button.tabCount)
         XCTAssertFalse(button.hasUnread)
         XCTAssertNil(button.text)
     }
 
     func testWhenAnimateCalledThenCountIsNotIncremented() {
-        let button = TabSwitcherStaticButton()
+        let button = TabSwitcherStaticButton(showMenuOnLongPress: false)
         button.animateUpdate { }
         XCTAssertEqual(0, button.tabCount)
         XCTAssertNil(button.text)
     }
 
     func testWhenCountSetBackToZeroThenTextIsBlank() {
-        let button = TabSwitcherStaticButton()
+        let button = TabSwitcherStaticButton(showMenuOnLongPress: false)
         button.tabCount = 1
         XCTAssertNotNil(button.text)
         button.tabCount = 0
@@ -45,14 +45,14 @@ class TabSwitcherStaticButtonTests: XCTestCase {
     }
 
     func testWhenExceedsMaxThenLabelIsSetAppropriately() {
-        let button = TabSwitcherStaticButton()
+        let button = TabSwitcherStaticButton(showMenuOnLongPress: false)
         button.tabCount = 100
         XCTAssertEqual("∞", button.text)
     }
 
 
     func testWhenCountIsUpdatedThenLabelIsUpdated() {
-        let button = TabSwitcherStaticButton()
+        let button = TabSwitcherStaticButton(showMenuOnLongPress: false)
         button.tabCount = 99
         XCTAssertEqual("99", button.text)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215279678739770
Tech Design URL:
CC: @dus7

### Description

Ports the revert of #4909 ("Remove tab switcher long press menu") from the `release/ios/7.223.0` branch back to `main`.

The revert was originally merged onto the release branch only via #5203, so `main` still has the long-press menu **removed**. This restores parity by re-applying #5203's change on `main`: long-pressing the Tabs icon (toolbar, omnibar, tabs bar) again presents the Normal / Fire tab choice instead of directly opening a new tab in the current mode.

This is a clean cherry-pick of `052e377` (the #5203 merge commit) onto `main` — it applied with no conflicts, and the resulting diff is byte-for-byte identical in content to the release-branch commit (only line offsets shift). The adaptations Mariusz made for the release branch's divergence (preserving the AI-chat header's `TabSwitcherStaticView` refactor, not resurrecting the `onTouchDown` diagnostic hook) are already baked into that diff and carry over correctly.

### Testing Steps

1. Enable Fire Mode.
2. Open a Normal tab.
3. Long-press the Tabs icon in the browser toolbar — verify the Normal / Fire menu appears.
4. Tap New Fire Tab — verify mode changes and a new tab is created.
5. Long-press the Tabs icon again — verify the menu appears.
6. Tap New Tab — verify mode changes and a new tab is created.
7. Repeat the long-press checks from the omnibar Tabs icon and the iPad tabs bar.

### Impact and Risks

Low — restores previously shipped UI behaviour (the long-press tab-switcher menu). No privacy or data implications.

#### What could go wrong?

The menu could fail to present, or present in the wrong mode context. Covered by the testing steps above across the three entry points (toolbar, omnibar, tabs bar). `TabSwitcherStaticButtonTests` / `TabSwitcherAnimatedButtonTests` are restored by this change.

### Notes to Reviewer

@dus7 — this is a straight port of your #5203 to `main`; flagging you since you made the original adaptation decisions. The cherry-pick was conflict-free and content-identical, but a second look that the same judgment calls hold on `main` (154 commits past #4909) would be worth it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only restoration of previously shipped tab-creation behavior; delegates switch browsing mode before opening tabs, with no auth or data-path changes.
> 
> **Overview**
> Restores the **long-press tab switcher menu** on `main` (parity with the release-branch revert of #4909). When Fire Mode is enabled, long-pressing the Tabs icon on the **toolbar** and **omnibar** shows **New Fire Tab** / **New Tab** instead of only opening a tab in the current mode; the iPad **tabs bar** updates the same behavior when `fireModeCapability` is set.
> 
> `TabSwitcherStaticButton` gains a `showMenuOnLongPress` flag that swaps between a `UIMenu` (with toolbar pixels) and the existing long-press gesture. `TabSwitcherButtonDelegate` adds `launchNewNormalTab` / `launchNewFireTab`, wired in `MainViewController` and `TabsBarViewController` to set browsing mode and open a tab. Snapshot and swipe-template tab buttons keep `showMenuOnLongPress: false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86b58d1ecda1d370da4ceb669250a783f7886b02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->