### PR TITLE
iOS: Add pixels for iPad Duck.ai navigation bar shortcut

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1558,6 +1558,12 @@ extension Pixel {
         case openAIChatFromWidgetLockScreenComplication
         case openAIChatFromIconShortcut
         case openAIChatFromTabManager
+        case openAIChatFromNavigationBarShortcut
+
+        case aiChatNavigationBarContextualSheetOpened
+        case aiChatNavigationBarShortcutMenuOpened
+        case aiChatNavigationBarShortcutMenuHideTapped
+        case aiChatNavigationBarShortcutMenuOpenSettingsTapped
 
         case voiceEntryPointTapped
         case voiceSessionStarted
@@ -1572,6 +1578,8 @@ extension Pixel {
         case aiChatSettingsBrowserMenuTurnedOn
         case aiChatSettingsTabManagerTurnedOff
         case aiChatSettingsTabManagerTurnedOn
+        case aiChatSettingsNavigationBarTurnedOff
+        case aiChatSettingsNavigationBarTurnedOn
         case aiChatSettingsChatSuggestionsTurnedOff
         case aiChatSettingsChatSuggestionsTurnedOn
         case aiChatSettingsDisplayed
@@ -3372,6 +3380,11 @@ extension Pixel.Event {
         case .browsingMenuAIChatWebPage: return "m_aichat_menu_webpage"
         case .openAIChatFromIconShortcut: return "m_aichat-icon-shortcut"
         case .openAIChatFromTabManager: return "m_aichat_tabmanager_icon"
+        case .openAIChatFromNavigationBarShortcut: return "m_aichat_navigation_bar_shortcut_open"
+        case .aiChatNavigationBarContextualSheetOpened: return "m_aichat_navigation_bar_contextual_sheet_opened"
+        case .aiChatNavigationBarShortcutMenuOpened: return "m_aichat_navigation_bar_shortcut_menu_opened"
+        case .aiChatNavigationBarShortcutMenuHideTapped: return "m_aichat_navigation_bar_shortcut_menu_hide_tapped"
+        case .aiChatNavigationBarShortcutMenuOpenSettingsTapped: return "m_aichat_navigation_bar_shortcut_menu_open_settings_tapped"
         case .voiceEntryPointTapped: return "m_aichat_voice_entry_point_tapped"
         case .voiceSessionStarted: return "m_aichat_voice_session_started"
         case .aiChatSettingsVoiceTurnedOff: return "m_aichat_settings_voice_turned_off"
@@ -3382,6 +3395,8 @@ extension Pixel.Event {
         case .aiChatSettingsBrowserMenuTurnedOn: return "m_aichat_settings_browser_menu_turned_on"
         case .aiChatSettingsTabManagerTurnedOff: return "m_aichat_settings_tab_manager_turned_off"
         case .aiChatSettingsTabManagerTurnedOn: return "m_aichat_settings_tab_manager_turned_on"
+        case .aiChatSettingsNavigationBarTurnedOff: return "m_aichat_settings_navigation_bar_turned_off"
+        case .aiChatSettingsNavigationBarTurnedOn: return "m_aichat_settings_navigation_bar_turned_on"
         case .aiChatSettingsChatSuggestionsTurnedOff: return "m_aichat_settings_chat_suggestions_turned_off"
         case .aiChatSettingsChatSuggestionsTurnedOn: return "m_aichat_settings_chat_suggestions_turned_on"
         case .aiChatSettingsDisplayed: return "m_aichat_settings_displayed"

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -1879,6 +1879,7 @@ extension SettingsViewModel {
             get: { self.aiChatSettings.isAIChatNavigationBarUserSettingsEnabled },
             set: { newValue in
                 self.aiChatSettings.enableAIChatNavigationBarUserSettings(enable: newValue)
+                DailyPixel.fireDailyAndCount(pixel: newValue ? .aiChatSettingsNavigationBarTurnedOn : .aiChatSettingsNavigationBarTurnedOff)
             }
         )
     }

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -269,10 +269,14 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
     }
 
     @objc private func onAIChatPressed() {
+        DailyPixel.fireDailyAndCount(pixel: .openAIChatFromNavigationBarShortcut)
         delegate?.tabsBarDidRequestAIChat(self)
     }
 
     @objc private func onAIChatContextualSheetIconPressed() {
+        if aiChatChip.sheetState == .closed {
+            DailyPixel.fireDailyAndCount(pixel: .aiChatNavigationBarContextualSheetOpened)
+        }
         delegate?.tabsBarDidRequestToggleAIChatContextualSheet(self)
     }
 
@@ -454,12 +458,15 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
     private func makeAIChatChipMenu() -> UIMenu {
         UIMenu(children: [
             UIDeferredMenuElement.uncached { [weak self] completion in
+                DailyPixel.fireDailyAndCount(pixel: .aiChatNavigationBarShortcutMenuOpened)
                 completion([
                     UIAction(title: UserText.actionHideAIChatChromeShortcut) { [weak self] _ in
+                        DailyPixel.fireDailyAndCount(pixel: .aiChatNavigationBarShortcutMenuHideTapped)
                         self?.aiChatSettings?.enableAIChatNavigationBarUserSettings(enable: false)
                     },
                     UIAction(title: UserText.actionOpenAISettings) { [weak self] _ in
                         guard let self else { return }
+                        DailyPixel.fireDailyAndCount(pixel: .aiChatNavigationBarShortcutMenuOpenSettingsTapped)
                         self.delegate?.tabsBarDidRequestOpenAISettings(self)
                     }
                 ])

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_navigation_bar_shortcut.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_navigation_bar_shortcut.json5
@@ -1,0 +1,38 @@
+// iPad Duck.ai navigation bar shortcut (chrome chip) interaction metrics.
+{
+    "m_aichat_navigation_bar_shortcut_open": {
+        "description": "Fires when the user opens a new Duck.ai tab from the iPad navigation bar shortcut",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_navigation_bar_contextual_sheet_opened": {
+        "description": "Fires when the user opens the Duck.ai contextual sheet from the iPad navigation bar shortcut icon",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_navigation_bar_shortcut_menu_opened": {
+        "description": "Fires when the user opens the options menu on the iPad Duck.ai navigation bar shortcut (long-press / context menu)",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_navigation_bar_shortcut_menu_hide_tapped": {
+        "description": "Fires when the user taps 'Hide Duck.ai Shortcut' in the iPad navigation bar shortcut options menu",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_navigation_bar_shortcut_menu_open_settings_tapped": {
+        "description": "Fires when the user taps 'Open AI Settings' in the iPad navigation bar shortcut options menu",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    }
+}

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_settings.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_settings.json5
@@ -27,6 +27,20 @@
         "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
+    "m_aichat_settings_navigation_bar_turned_on": {
+        "description": "Fired when the user enables the Navigation Bar shortcut in AI Chat settings",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_settings_navigation_bar_turned_off": {
+        "description": "Fired when the user disables the Navigation Bar shortcut in AI Chat settings",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
     "m_aichat_single_delete_successful": {
         "description": "Fired when a single AI chat is deleted successfully",
         "owners": ["hassaanelgarem"],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1215105848409865
Tech Design URL:
CC:

### Description

Adds pixels for the iPad Duck.ai navigation bar shortcut (chrome chip) interactions: opening Duck.ai from the shortcut, opening the contextual sheet from the icon half, opening the long-press options menu, the menu's "Hide Duck.ai Shortcut" and "Open AI Settings" actions, and the Settings navigation-bar toggle (on/off).

### Testing Steps
1. Internal iPad build with the Duck.ai navigation bar shortcut (chrome chip) visible in the tab bar. Filter the Xcode console for `m_aichat_navigation_bar`.
2. Tap the chip's "Duck.ai" text → `m_aichat_navigation_bar_shortcut_open` (fires `_d` + `_c`).
3. On a web page, tap the chip's sheet icon → `m_aichat_navigation_bar_contextual_sheet_opened`.
4. Long-press the chip → `m_aichat_navigation_bar_shortcut_menu_opened`. Tap "Open AI Settings" → `..._menu_open_settings_tapped`; long-press again and tap "Hide Duck.ai Shortcut" → `..._menu_hide_tapped`.
5. Settings → Duck.ai shortcuts, toggle the Navigation Bar shortcut off then on → `m_aichat_settings_navigation_bar_turned_off` / `_on`.

### Impact and Risks
Low. Telemetry only — no behavior change. Pixels fire only where the iPad shortcut is available (internal).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes with no product behavior impact beyond firing metrics at existing UI interaction points.
> 
> **Overview**
> Adds **telemetry only** for the iPad Duck.ai navigation bar shortcut (chrome chip): new `PixelEvent` cases, `DailyPixel.fireDailyAndCount` hooks in `TabsBarViewController` (open chat, contextual sheet when closed, long-press menu and hide/settings actions), and in `SettingsViewModel` for the Navigation Bar shortcut toggle on/off.
> 
> Pixel definitions are added in `ai_chat_navigation_bar_shortcut.json5` and two entries in `ai_chat_settings.json5`. Settings on/off pixels fire from the settings binding, not from `enableAIChatNavigationBarUserSettings`, so hiding via the chip menu stays attributed separately from the settings toggle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a8d2bccfa5511db534ac9764d42deb9b66174fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->