### PR TITLE
[macOS] Add missing channel params to two failing DBP pixel defs

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -12,7 +12,8 @@
                 "description": "Whether the user is internal",
                 "type": "string",
                 "enum": ["true", "false"]
-            }
+            },
+            "channel"
         ]
     },
     "m_mac_dbp_optout_stage_start": {
@@ -451,7 +452,8 @@
                 "key": "broker_version",
                 "description": "The version of the broker JSON file (unknown when not available)",
                 "type": "string"
-            }
+            },
+            "channel"
         ]
     },
     "m_mac_dbp_service_email-confirmation-link_client-received": {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1205591970852438/task/1215263528371490?focus=true
Tech Design URL:
CC:

### Description

Adds missing param

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. CI passes
2.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only analytics definition changes with no app logic or security impact.
> 
> **Overview**
> Adds the shared **`channel`** parameter to two macOS Data Broker Protection pixel definitions that were missing it: **`m_mac_dbp_secure_vault_database_recreated`** and **`m_mac_dbp_service_empty-auth-token`**.
> 
> This aligns those events with the rest of the DBP pixels in `data_broker_protection.json5` (which already declare `channel`) so emitted events pass pixel validation instead of failing on an undeclared param.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba7d2f122fdf0c9f29100ca2384a186f70a871fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->