### PR TITLE
Update titlebar strip color on system appearance changes

### DIFF
--- a/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
@@ -86,6 +86,7 @@ final class MainWindowController: NSWindowController {
         subscribeToFullScreenToolbarChanges()
         subscribeToKeyWindow()
         subscribeToThemeChanges()
+        subscribeToEffectiveAppearance()
 
         applyThemeStyle()
 
@@ -171,6 +172,21 @@ final class MainWindowController: NSWindowController {
 
     private func subscribeToResolutionChange() {
         NotificationCenter.default.addObserver(self, selector: #selector(didChangeScreenParameters), name: NSApplication.didChangeScreenParametersNotification, object: NSApp)
+    }
+
+    private func subscribeToEffectiveAppearance() {
+        // The titlebarView layer color set in applyThemeStyle is a frozen CGColor that, unlike
+        // window.backgroundColor, does not track the effective appearance. Re-apply the theme when the
+        // appearance changes (e.g. the system switches between light and dark while following the system
+        // setting) so the strip above the tab bar stays in sync. Only relevant on Liquid Glass UI.
+        guard AppVersion.isLiquidGlassSupported else { return }
+        NSApp.publisher(for: \.effectiveAppearance)
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.applyThemeStyle()
+            }
+            .store(in: &cancellables)
     }
 
     private func subscribeToFullScreenToolbarChanges() {
@@ -361,7 +377,9 @@ extension MainWindowController: ThemeUpdateListening {
         // white, so coloring the titlebarView's layer itself is the only way to fill that strip.
         if AppVersion.isLiquidGlassSupported, let titlebarView = window?.titlebarView {
             titlebarView.wantsLayer = true
-            titlebarView.layer?.backgroundColor = theme.colorsProvider.baseBackgroundColor.cgColor
+            titlebarView.effectiveAppearance.performAsCurrentDrawingAppearance {
+                titlebarView.layer?.backgroundColor = theme.colorsProvider.baseBackgroundColor.cgColor
+            }
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1215316158895866?focus=true

### Description
Follow-up to #4962. That fix colors the `titlebarView` layer with `baseBackgroundColor` to hide the 2pt white strip above the tab bar on macOS 26 Liquid Glass UI. However, it assigned `baseBackgroundColor.cgColor` directly to the layer.

`baseBackgroundColor` is a dynamic `NSColor` (created via `NSColor(name:nil, dynamicProvider:)`). When assigned to `window.backgroundColor`, AppKit re-resolves it automatically as the effective appearance changes. But a `CGColor` assigned to a `CALayer` is frozen at assignment time and does not track appearance — and `applyThemeStyle` only ran on explicit theme changes, never when the system switched between light and dark while the app follows the system appearance. As a result the strip kept its stale color and a UI glitch appeared on appearance changes.

This PR:
- Re-applies the theme on `effectiveAppearance` changes via a Combine subscription on `NSApp` (matching the existing pattern in `AddressBarButtonsViewController` / `MouseOverAnimationButton`).
- Resolves the `CGColor` within the `titlebarView`'s effective appearance using `performAsCurrentDrawingAppearance`, so the correct light/dark variant is picked.

### Testing Steps
1. Set the app's appearance to **System** in Settings.
2. Open a browser window and observe the area above the tab bar (both windowed and fullscreen).
3. Switch the macOS system appearance between Light and Dark (System Settings → Appearance), or toggle automatic light/dark.
4. Verify the thin strip above the tab bar updates to match the new appearance immediately, with no stale white/dark line.

### Impact and Risks
Low — a small, self-contained UI fix gated on `AppVersion.isLiquidGlassSupported`. It only affects the titlebar strip color on macOS 26 Liquid Glass UI.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, Liquid-Glass-gated UI color refresh with no security or data impact.
> 
> **Overview**
> Follow-up to the Liquid Glass titlebar strip fix: **`MainWindowController`** now keeps the thin strip above the tab bar in sync when the system or app appearance changes.
> 
> On **macOS 26 Liquid Glass** only (`AppVersion.isLiquidGlassSupported`), a new **`subscribeToEffectiveAppearance()`** Combine subscription on **`NSApp.effectiveAppearance`** re-runs **`applyThemeStyle()`** after the initial value (same pattern as elsewhere in the app). **`applyThemeStyle`** now resolves **`titlebarView.layer?.backgroundColor`** inside **`titlebarView.effectiveAppearance.performAsCurrentDrawingAppearance`**, so dynamic **`baseBackgroundColor`** is not frozen as a stale **`CGColor`** when the user follows system light/dark.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4803d2757ce6a3ccc8ecf62a6263ff939dbedd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->