### PR TITLE
[macOS] Fix an additional test suite crash

### DIFF
--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -1109,7 +1109,7 @@ protocol TabDelegate: ContentOverlayUserScriptDelegate {
         case .loadInBackgroundIfNeeded(shouldLoadInBackground: let shouldLoadInBackground):
 #if DEBUG
             switch AppVersion.runType {
-            case .unitTests, .integrationTests: return false
+            case .unitTests, .integrationTests, .xcPreviews: return false
             default: break
             }
 #endif

--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -1108,8 +1108,10 @@ protocol TabDelegate: ContentOverlayUserScriptDelegate {
         // should load on Web View instantiation?
         case .loadInBackgroundIfNeeded(shouldLoadInBackground: let shouldLoadInBackground):
 #if DEBUG
-            // Prevent background auto-loading when running unit tests, as this can stress out the CI runner.
-            guard AppVersion.runType.requiresEnvironment else { return false }
+            switch AppVersion.runType {
+            case .unitTests, .integrationTests: return false
+            default: break
+            }
 #endif
             switch content {
             case .newtab, .bookmarks, .settings:


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1215317994682727?focus=true
Tech Design URL:
CC:

### Description

This PR fixes another test suite crash for macOS.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that CI is green

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> DEBUG-only guard around test/preview run types; production `.normal` behavior is unchanged.
> 
> **Overview**
> In **`Tab.shouldReload`**, DEBUG builds no longer use **`AppVersion.runType.requiresEnvironment`** to decide whether to skip background loads when a tab is created. They now **explicitly skip** auto-load for **`.unitTests`**, **`.integrationTests`**, and **`.xcPreviews`**.
> 
> **Integration tests** previously still allowed background **`WKWebView`** loading because **`requiresEnvironment`** is **true** for that run type. That could spin up real navigations during tab setup and contribute to **macOS test suite / CI crashes**. Unit tests and previews were already covered by the old guard; this change mainly closes the **integration test** gap while keeping the same “no background load” behavior for unit tests and XC previews.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a0ec00155c44caea35c42495073d27fade85e28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->