### PR TITLE
[CI][PR Subtask] Add PR author as collaborator to PR subtask 

### DIFF
--- a/.github/workflows/create_asana_pr_subtask.yml
+++ b/.github/workflows/create_asana_pr_subtask.yml
@@ -31,4 +31,5 @@ jobs:
             asana-task-id: ${{ steps.get-task-id.outputs.task_id }}
             github-reviewer-user: ${{ github.event.requested_reviewer.login }}
             github-pr-author-user: ${{ github.event.pull_request.user.login }}
+            github-pr-author-type: ${{ github.event.pull_request.user.type }}
             github-token: ${{ secrets.APPLE_GH_RO_PAT }}

--- a/.github/workflows/create_asana_pr_subtask.yml
+++ b/.github/workflows/create_asana_pr_subtask.yml
@@ -30,4 +30,5 @@ jobs:
             access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
             asana-task-id: ${{ steps.get-task-id.outputs.task_id }}
             github-reviewer-user: ${{ github.event.requested_reviewer.login }}
+            github-pr-author-user: ${{ github.event.pull_request.user.login }}
             github-token: ${{ secrets.APPLE_GH_RO_PAT }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1215310281455434?focus=true
Tech Design URL:
CC:

### Description

This PR adds the PR author as a collaborator to each PR review task, so that comments/updates in the PR review task are automatically surfaced in their inbox.

This PR depends on Apple Toolbox PR https://github.com/duckduckgo/apple-toolbox/pull/18

### Testing Steps
1. Ensure that the author of this PR (me) gets added to the PR task URL.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal CI wiring only; no app or user-facing runtime changes, though subtask collaborator assignment depends on the external apple-toolbox release.
> 
> **Overview**
> When a reviewer is requested on a PR, the **Create or Update PR Subtask** step in `create_asana_pr_subtask.yml` now passes the pull request author's GitHub **login** and **user type** into `duckduckgo/apple-toolbox`’s `asana-create-pr-subtask` action (alongside the existing reviewer mapping). That lets the toolbox action add the PR author as a collaborator on the Asana PR review subtask so task comments and updates show up in their inbox.
> 
> Behavior still runs only on `review_requested` and still depends on the companion change in **apple-toolbox** for the new inputs to take effect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc92420eb9b3b0692a2522012623da10133ccbf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->