### PR TITLE
iOS: Aggregated dax logo fixes (OM3, hatch overlap, splash anchor)

### DIFF
--- a/iOS/DuckDuckGo/NewTabPageView.swift
+++ b/iOS/DuckDuckGo/NewTabPageView.swift
@@ -174,7 +174,6 @@ private extension NewTabPageView {
     private var shouldShowLogoInEmptyState: Bool {
         guard !viewModel.isLogoHidden else { return false }
         guard messagesModel.homeMessageViewModels.isEmpty && !messagesModel.isFirePromotionVisible else { return false }
-        if viewModel.escapeHatch?.tabType == .aiChat { return false }
         if viewModel.escapeHatch != nil && isLandscapeOrientation { return false }
         if viewModel.escapeHatch != nil && isFocussedState { return false }
         return true

--- a/iOS/DuckDuckGo/NewTabPageView.swift
+++ b/iOS/DuckDuckGo/NewTabPageView.swift
@@ -145,7 +145,12 @@ private extension NewTabPageView {
     private var logoEmptyView: some View {
         GeometryReader { proxy in
             ZStack {
+                // Anchors the Lottie's geometric center to screen.midY - 55, so the visible duck
+                // lands at screen.midY - 72 — the splash storyboard's resting position. The
+                // dynamic offset compensates for the NTP body's centerY shifting based on top vs
+                // bottom omnibar chrome.
                 NewTabPageDaxLogoView()
+                    .offset(y: (UIScreen.main.bounds.midY - 55) - proxy.frame(in: .global).midY)
                     .opacity(shouldShowLogoInEmptyState ? 1 : 0)
                     .allowsHitTesting(false)
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -252,6 +252,7 @@ final class UnifiedInputContentContainerViewController: UIViewController {
     }
 
     func setEscapeHatch(_ model: EscapeHatchModel?) {
+        let hatchPresenceChanged = (escapeHatchModel != nil) != (model != nil)
         escapeHatchModel = model
         // The model self-updates `openTabCount` from `TabManaging.tabsModel(for:).tabsPublisher`, so SwiftUI consumers redraw reactively.
         suggestionTrayManager?.setEscapeHatch(model)
@@ -259,6 +260,11 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         let duckAIHatchModel = switchBarHandler.isFireTab ? nil : model
         duckAISuggestionsCoordinator?.setEscapeHatch(duckAIHatchModel)
         updateEscapeHatchTopInset()
+        // The dax offset depends on hatch presence (`hatchClearance` is added when present),
+        // so refresh visibility when the hatch is added or removed mid-session.
+        if hatchPresenceChanged {
+            updateDaxVisibility()
+        }
     }
 
     private var escapeHatchTopInset: CGFloat {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -697,11 +697,15 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         let isAIDaxVisible = !hasContent && !isShowingDuckAISuggestions && !isDuckAISuggestionsPending
 
         daxLogoManager.updateVisibility(isHomeDaxVisible: isHomeDaxVisible, isAIDaxVisible: isAIDaxVisible)
-        // The toolbar is still in the hierarchy under the unified input, so the keyboard-relative
-        // centering sits visually too high — shift the dax down by this constant to compensate.
-        // The escape hatch sits in the suggestion tray above the logo and doesn't push it down.
-        daxLogoManager.setEscapeHatchBaseOffset(Metrics.toolbarCompensationOffset)
+        daxLogoManager.setEscapeHatchBaseOffset(daxVerticalOffset(hasEscapeHatch: escapeHatchModel != nil))
         updateSectionTitle()
+    }
+
+    /// `toolbarCompensationOffset` shifts the dax down because the toolbar still sits under the
+    /// unified input — without it, the keyboard-relative centering reads visually too high.
+    /// `hatchClearance` adds extra padding when the escape hatch is present so the two don't crowd.
+    private func daxVerticalOffset(hasEscapeHatch: Bool) -> CGFloat {
+        Metrics.toolbarCompensationOffset + (hasEscapeHatch ? Metrics.hatchClearance : 0)
     }
 
     private enum Metrics {
@@ -713,6 +717,7 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         // chain positions the UTI hatch ~10pt below the NTP equivalent.
         static let escapeHatchTrayPullUp: CGFloat = -10
         static let toolbarCompensationOffset: CGFloat = 80
+        static let hatchClearance: CGFloat = 50
         static let suggestionsHorizontalInset: CGFloat = 8
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215045430101949

### Description

Aggregates three dax-logo fixes from the iOS Must-Fix / Ship Review board for the Duck.ai release.

- **OM3 — Idle NTP missing DDG logo when last tab was Duck.ai.** Drops the `tabType == .aiChat` short-circuit in `NewTabPageView.shouldShowLogoInEmptyState`. The suppression was added by #4794 as belt-and-suspenders against a double-stack with the UTI dax, but #4794's other fix (gating UTI `isHomeDaxVisible` on `currentToggleState == .search`) already prevents the stack. The suppression now wrongly hides the NTP logo whenever the idle-return escape hatch points at a Duck.ai tab. Fixes [aggregated subtask OM3](https://app.asana.com/1/137249556945/task/1215056187001445).

- **Anchor NTP dax to splash storyboard position.** `LaunchScreen.storyboard` pins the visible duck at `view.centerY − 72`. The dax Lottie's geometric center sits ~17pt below the visible duck (the wordmark pulls the canvas down), so anchoring the Lottie's centerY to `screen.midY − 55` lands the visible duck at the splash position. The dynamic offset compensates for the NTP body's centerY differing from screen centerY depending on top/bottom omnibar chrome — without it the duck is off by ~14pt in top-omnibar config. No Asana subtask; visible polish improvement.

- **Push UTI dax down to clear escape hatch on Duck.ai focused state.** On compact layouts the UTI's natural keyboard-aware centering places the dax head circle behind the "Return to..." hatch card. Add 50pt of `hatchClearance` to the existing toolbar-compensation offset when the hatch is present so the two elements coexist with proper padding. Fixes [aggregated subtask — Dax/hatch overlap on Duck.ai mode](https://app.asana.com/1/137249556945/task/1214822077298468).

Two subtasks from the aggregated parent remain open and are **not** addressed here:
- [JL5 — Dax logo renders over recent chats during Search→Duck.ai pan](https://app.asana.com/1/137249556945/task/1215043850166977)
- [Polish — Dax Logo Animation Janky On NTP UTI Dismiss Action](https://app.asana.com/1/137249556945/task/1214895994110223) (attempted; needs a structural refactor of the dax view ownership to do well — out of scope for this batch).

### Testing Steps

**OM3 (idle return after Duck.ai)**
1. Settings → Debug → set "Idle Return NTP" to 1 second.
2. Open a Duck.ai chat.
3. Background the app for ≥1 second, then foreground.
4. Verify the NTP is shown with the DuckDuckGo dax logo visible alongside the "Return to..." escape hatch.

**NTP dax positioning**
1. With no favorites and no remote messages, open the app to a clean NTP.
2. Verify the dax visible duck sits at approximately the same vertical position as the splash storyboard's duck (no perceptible jump between splash and NTP).
3. Settings → Address Bar → switch between top and bottom. NTP dax should stay at the same Y position in both configurations.

**Escape hatch padding (focused UTI in Duck.ai mode)**
1. Settings → Debug → set "Idle Return NTP" to 1 second.
2. Visit any website. Background and foreground the app.
3. App opens in UTI expanded state with the "Return to..." escape hatch.
4. Switch to Duck.ai mode.
5. Verify the dax circle does not overlap or crowd the hatch card; clear vertical padding between them.

### Impact and Risks

**Low.** Three small, scoped visual fixes affecting only NTP empty-state and UTI focused-state rendering. No behavior change on web/private-tab paths.

#### What could go wrong?

- **OM3**: removing the `.aiChat` suppression could re-introduce the double-stack #4794 was guarding against. Verified the other fix in #4794 (UTI `isHomeDaxVisible = isSearchMode && …`) is still in place and prevents the stack.
- **NTP positioning**: the `.offset` is computed from `UIScreen.main.bounds.midY` and `proxy.frame(in: .global).midY`. Both are read each render; the offset re-computes if the NTP body shifts (e.g. orientation change). No state, no animation.
- **Escape hatch padding**: only activates when `escapeHatchModel != nil`. For all other UTI states the offset is unchanged from before.

### Quality Considerations

- All changes are SwiftUI/UIKit visual-position adjustments. No new state, no async, no logging.
- Existing tests relevant to the touched code (`DaxLogoManagerTests.test_shouldShowHomeDax_*`, `EscapeHatchModelTests.*`) pass locally.
- No tests added: the changes are pure visual positioning that's easier to verify by reading the source + visual repro than by unit-testing private SwiftUI body properties (per project memory's "skip tests for trivial pure logic" rule).

### Notes to Reviewer

The aggregated parent task has four subtasks — this PR closes two of them (OM3 and the hatch overlap on Duck.ai) plus an unscheduled NTP positional alignment improvement. The other two will be filed as follow-ups.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only layout changes on NTP/UTI empty and focused states; no auth, data, or navigation logic changes.
> 
> **Overview**
> **Three scoped visual fixes** for the NTP empty state and unified input (UTI) dax logo.
> 
> On **NTP**, the empty-state logo is shown again when the idle-return escape hatch targets a Duck.ai tab by removing the `tabType == .aiChat` guard in `shouldShowLogoInEmptyState`. The NTP dax also gets a **dynamic vertical offset** so the visible duck aligns with the splash storyboard position across top vs bottom address bar layouts.
> 
> On **UTI**, dax vertical placement now adds **50pt hatch clearance** on top of the existing toolbar compensation when an escape hatch is present, via `daxVerticalOffset`. **`setEscapeHatch`** triggers **`updateDaxVisibility`** when hatch presence toggles so mid-session add/remove updates the offset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9052c9d7ce362310dbfa2cfd2eebbc0a95d68877. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->