### PR TITLE
[CI] Post a comment on PR subtask when reviewer request changes

### DIFF
--- a/.github/workflows/add_asana_comment_on_pr_review.yml
+++ b/.github/workflows/add_asana_comment_on_pr_review.yml
@@ -6,9 +6,9 @@ on:
 
 jobs:
 
-    add-changes-requested-comment:
-        if: ${{ github.event.review.state == 'changes_requested' }}
-        name: "Add 'Changes Requested' comment on PR subtask"
+    add-pr-review-comment:
+        if: ${{ contains(fromJSON('["approved","changes_requested","commented"]'), github.event.review.state) }}
+        name: "Add Asana comment on PR review"
         runs-on: ubuntu-latest
 
         steps:
@@ -39,10 +39,25 @@ jobs:
             echo "::error::No PR review subtask found for @${{ github.event.review.user.login }}. They may not be in the GitHub→Asana mapping. Add them in duckduckgo/native-github-asana-sync and re-run."
             exit 1
 
-        - name: Post changes-requested comment
-          uses: duckduckgo/apple-toolbox/actions/asana-add-changes-requested-comment@alessandro/apple-proposal-comment-on-changes-requested
+        - name: Build comment text
+          id: comment
+          env:
+            STATE: ${{ github.event.review.state }}
+            REVIEWER: ${{ github.event.review.user.login }}
+            REVIEW_URL: ${{ github.event.review.html_url }}
+          run: |
+            case "$STATE" in
+              approved)          prefix="✅ Approved" ;;
+              changes_requested) prefix="🔄 Changes requested" ;;
+              commented)         prefix="💬 Comment" ;;
+            esac
+            echo "text=${prefix} by @${REVIEWER} — see review: ${REVIEW_URL}" >> "$GITHUB_OUTPUT"
+
+        - name: Post review comment
+          uses: duckduckgo/native-github-asana-sync@v1.9
           with:
-            access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
-            task-id: ${{ fromJSON(steps.find-subtask.outputs.subtask-ids)[0] }}
-            github-reviewer-user: ${{ github.event.review.user.login }}
-            github-review-url: ${{ github.event.review.html_url }}
+            action: 'post-comment-asana-task'
+            asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+            asana-task-id: ${{ fromJSON(steps.find-subtask.outputs.subtask-ids)[0] }}
+            asana-task-comment: ${{ steps.comment.outputs.text }}
+            asana-task-comment-pinned: false

--- a/.github/workflows/add_asana_comment_on_pr_review.yml
+++ b/.github/workflows/add_asana_comment_on_pr_review.yml
@@ -26,7 +26,7 @@ jobs:
 
         - name: Find PR review subtask for the reviewer
           id: find-subtask
-          uses: duckduckgo/apple-toolbox/actions/asana-fetch-pr-subtasks@main
+          uses: duckduckgo/apple-toolbox/actions/asana-fetch-pr-subtasks@alessandro/apple-proposal-comment-on-changes-requested
           with:
             access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
             asana-task-id: ${{ steps.get-task-id.outputs.task_id }}
@@ -40,7 +40,7 @@ jobs:
             exit 1
 
         - name: Post changes-requested comment
-          uses: duckduckgo/apple-toolbox/actions/asana-add-changes-requested-comment@main
+          uses: duckduckgo/apple-toolbox/actions/asana-add-changes-requested-comment@alessandro/apple-proposal-comment-on-changes-requested
           with:
             access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
             task-id: ${{ fromJSON(steps.find-subtask.outputs.subtask-ids)[0] }}

--- a/.github/workflows/add_asana_comment_on_pr_review.yml
+++ b/.github/workflows/add_asana_comment_on_pr_review.yml
@@ -1,0 +1,48 @@
+name: Shared - Add Asana Comment on PR Review
+
+on:
+    pull_request_review:
+        types: [submitted]
+
+jobs:
+
+    add-changes-requested-comment:
+        if: ${{ github.event.review.state == 'changes_requested' }}
+        name: "Add 'Changes Requested' comment on PR subtask"
+        runs-on: ubuntu-latest
+
+        steps:
+        - name: Get Task ID
+          id: get-task-id
+          env:
+            BODY: ${{ github.event.pull_request.body }}
+          run: |
+            task_id=$(grep -i "task/issue url.*https://app.asana.com/" <<< "$BODY" \
+              | perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?|\1|; \
+                s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?|\1|; \
+                s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)(?:\?focus=true)?|\1|'
+            )
+            echo "task_id=${task_id//[^0-9]/}" >> $GITHUB_OUTPUT
+
+        - name: Find PR review subtask for the reviewer
+          id: find-subtask
+          uses: duckduckgo/apple-toolbox/actions/asana-fetch-pr-subtasks@main
+          with:
+            access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
+            asana-task-id: ${{ steps.get-task-id.outputs.task_id }}
+            github-reviewer-user: ${{ github.event.review.user.login }}
+            github-token: ${{ secrets.APPLE_GH_RO_PAT }}
+
+        - name: Fail if reviewer's Asana mapping is missing
+          if: ${{ steps.find-subtask.outputs.subtask-ids == '[]' }}
+          run: |
+            echo "::error::No PR review subtask found for @${{ github.event.review.user.login }}. They may not be in the GitHub→Asana mapping. Add them in duckduckgo/native-github-asana-sync and re-run."
+            exit 1
+
+        - name: Post changes-requested comment
+          uses: duckduckgo/apple-toolbox/actions/asana-add-changes-requested-comment@main
+          with:
+            access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
+            task-id: ${{ fromJSON(steps.find-subtask.outputs.subtask-ids)[0] }}
+            github-reviewer-user: ${{ github.event.review.user.login }}
+            github-review-url: ${{ github.event.review.html_url }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1215321546485062?focus=true
Tech Design URL:
CC:

### Description

Adds a workflow that posts an Asana comment on the PR review subtask when a reviewer clicks "Request changes." Combined with the stacked 3.1 PR (author-as-follower), the PR author receives an Asana inbox notification.

## New workflow

`.github/workflows/add_asana_comment_on_pr_review.yml`

Triggers on `pull_request_review[submitted]`. Single job (gated on `review.state == 'changes_requested'`):
1. Extract Asana task ID from PR body (regex copied verbatim from `create_asana_pr_subtask.yml` — extracting into a shared action deferred to a follow-up to avoid touching release-critical `shared_asana_pr_task_url.yml` in this PR)
2. Find the matching subtask via `asana-fetch-pr-subtasks` (filtered to the reviewer who submitted)
3. Fail the job (`::error::` + `exit 1`) if no subtask was found — almost always = reviewer missing from the Asana user mapping. Non-blocking (not a required check) but visible red X with an actionable message.
4. Post the comment via `asana-add-changes-requested-comment`

Workflow is named generically (`Shared - Add Asana Comment on PR Review`) so future review-state handlers (`approved` for proposal item 2, `commented` if scope expands) can be added as sibling jobs.

Apple Toolbox PR: https://github.com/duckduckgo/apple-toolbox/pull/19

### Testing Steps
1. Request changes on this PR and check that a comment is posted in the PR subtask

### Impact and Risks
None: Internal tooling

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal automation only; uses existing Asana secrets and fails visibly when reviewer mapping is missing, with no product or runtime impact.
> 
> **Overview**
> Adds a new GitHub Actions workflow that runs when a pull request review is **submitted** (`approved`, **changes requested**, or **commented**).
> 
> It parses the parent Asana task ID from the PR description, resolves the reviewer’s PR review subtask via `asana-fetch-pr-subtasks`, and posts a short status comment (with a link to the GitHub review) on that subtask through `native-github-asana-sync`. If no subtask exists for the reviewer, the job fails with an actionable error about the GitHub→Asana user mapping.
> 
> The workflow name is generic so additional review-state behavior can be added later without renaming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fdeb819bfd6aaa84335ae9de226c44e92866241. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->