### PR TITLE
Validate URL schemes and double extensions on file import

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Bookmarks/BookmarkletExtensions.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Bookmarks/BookmarkletExtensions.swift
@@ -25,6 +25,14 @@ public extension String {
         return self.lowercased().hasPrefix("javascript:")
     }
 
+    /// URL schemes that are unsafe to import as a bookmark target, because activating the
+    /// bookmark would execute embedded content rather than navigate to a page. Used to drop
+    /// such bookmarks during third-party import (e.g. `javascript:`, `data:`).
+    func hasUnsafeBookmarkImportScheme() -> Bool {
+        let value = trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return value.hasPrefix("javascript:") || value.hasPrefix("data:")
+    }
+
     func toDecodedBookmarklet() -> String? {
         guard self.isBookmarklet(),
               let result = self.dropping(prefix: "javascript:").removingPercentEncoding,

--- a/SharedPackages/BrowserServicesKit/Sources/Bookmarks/ImportExport/BookmarkOrFolder.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Bookmarks/ImportExport/BookmarkOrFolder.swift
@@ -41,11 +41,14 @@ public class BookmarkOrFolder {
         return nil
     }
 
-    // There's no guarantee that imported bookmarks will have a URL, this is used to filter them out during import
+    // There's no guarantee that imported bookmarks will have a URL, this is used to filter them out during import.
+    // We also drop bookmarks whose URL uses an unsafe scheme (e.g. javascript:/data:), which would execute content
+    // rather than navigate if the bookmark were later activated.
     public var isInvalidBookmark: Bool {
         switch type {
         case .bookmark, .favorite:
-            return urlString == nil
+            guard let urlString else { return true }
+            return urlString.hasUnsafeBookmarkImportScheme()
         default:
             return false
         }

--- a/SharedPackages/BrowserServicesKit/Sources/Common/Extensions/String+FileExtensions.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Common/Extensions/String+FileExtensions.swift
@@ -1,0 +1,31 @@
+//
+//  String+FileExtensions.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public extension String {
+
+    /// `true` when the path's last component contains more than one dot, e.g. `foo.swift.html`.
+    ///
+    /// Used to reject disguising double extensions in imported archive entries: a file whose
+    /// real type is masked behind an allowed extension (such as `.html`/`.csv`/`.json`).
+    var hasMultipleFileExtensions: Bool {
+        let name = (self as NSString).lastPathComponent
+        return name.filter { $0 == "." }.count > 1
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Sources/Common/Extensions/String+FileExtensions.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Common/Extensions/String+FileExtensions.swift
@@ -1,7 +1,7 @@
 //
 //  String+FileExtensions.swift
 //
-//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/SharedPackages/BrowserServicesKit/Tests/BookmarksTests/BookmarkImportSchemeValidationTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BookmarksTests/BookmarkImportSchemeValidationTests.swift
@@ -1,0 +1,75 @@
+//
+//  BookmarkImportSchemeValidationTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Bookmarks
+import Testing
+
+struct BookmarkImportSchemeValidationTests {
+
+    @Test("Unsafe schemes are detected", arguments: [
+        "javascript:alert(1)",
+        "JavaScript:alert(1)",
+        "  javascript:alert(1)",
+        "data:text/html,<script>alert(1)</script>",
+        "DATA:text/html;base64,AAAA"
+    ])
+    func unsafeSchemesDetected(urlString: String) {
+        #expect(urlString.hasUnsafeBookmarkImportScheme() == true)
+    }
+
+    @Test("Safe URLs are not flagged", arguments: [
+        "https://duckduckgo.com",
+        "http://example.com",
+        "ftp://files.example.com",
+        "about:blank",
+        "https://example.com?q=javascript:foo" // scheme is https, not javascript
+    ])
+    func safeURLsAllowed(urlString: String) {
+        #expect(urlString.hasUnsafeBookmarkImportScheme() == false)
+    }
+
+    @Test("Bookmark or favorite with an unsafe scheme is invalid")
+    func unsafeSchemeBookmarkIsInvalid() {
+        let jsBookmark = BookmarkOrFolder(name: "x", type: .bookmark, urlString: "javascript:alert(1)", children: nil)
+        let dataFavorite = BookmarkOrFolder(name: "x", type: .favorite, urlString: "data:text/html,x", children: nil)
+
+        #expect(jsBookmark.isInvalidBookmark)
+        #expect(dataFavorite.isInvalidBookmark)
+    }
+
+    @Test("Bookmark with a safe scheme is valid")
+    func safeSchemeBookmarkIsValid() {
+        let bookmark = BookmarkOrFolder(name: "x", type: .bookmark, urlString: "https://duckduckgo.com", children: nil)
+
+        #expect(bookmark.isInvalidBookmark == false)
+    }
+
+    @Test("Bookmark with no URL is invalid")
+    func bookmarkWithoutURLIsInvalid() {
+        let bookmark = BookmarkOrFolder(name: "x", type: .bookmark, urlString: nil, children: nil)
+
+        #expect(bookmark.isInvalidBookmark)
+    }
+
+    @Test("Folder is never invalidated by the scheme check")
+    func folderIsValid() {
+        let folder = BookmarkOrFolder(name: "f", type: .folder, urlString: nil, children: [])
+
+        #expect(folder.isInvalidBookmark == false)
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Tests/BookmarksTests/BookmarkImportSchemeValidationTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BookmarksTests/BookmarkImportSchemeValidationTests.swift
@@ -21,7 +21,8 @@ import Testing
 
 struct BookmarkImportSchemeValidationTests {
 
-    @Test("Unsafe schemes are detected", arguments: [
+    @available(iOS 16, macOS 13, *)
+    @Test("Unsafe schemes are detected", .timeLimit(.minutes(1)), arguments: [
         "javascript:alert(1)",
         "JavaScript:alert(1)",
         "  javascript:alert(1)",
@@ -32,7 +33,8 @@ struct BookmarkImportSchemeValidationTests {
         #expect(urlString.hasUnsafeBookmarkImportScheme() == true)
     }
 
-    @Test("Safe URLs are not flagged", arguments: [
+    @available(iOS 16, macOS 13, *)
+    @Test("Safe URLs are not flagged", .timeLimit(.minutes(1)), arguments: [
         "https://duckduckgo.com",
         "http://example.com",
         "ftp://files.example.com",
@@ -43,7 +45,8 @@ struct BookmarkImportSchemeValidationTests {
         #expect(urlString.hasUnsafeBookmarkImportScheme() == false)
     }
 
-    @Test("Bookmark or favorite with an unsafe scheme is invalid")
+    @available(iOS 16, macOS 13, *)
+    @Test("Bookmark or favorite with an unsafe scheme is invalid", .timeLimit(.minutes(1)))
     func unsafeSchemeBookmarkIsInvalid() {
         let jsBookmark = BookmarkOrFolder(name: "x", type: .bookmark, urlString: "javascript:alert(1)", children: nil)
         let dataFavorite = BookmarkOrFolder(name: "x", type: .favorite, urlString: "data:text/html,x", children: nil)
@@ -52,21 +55,24 @@ struct BookmarkImportSchemeValidationTests {
         #expect(dataFavorite.isInvalidBookmark)
     }
 
-    @Test("Bookmark with a safe scheme is valid")
+    @available(iOS 16, macOS 13, *)
+    @Test("Bookmark with a safe scheme is valid", .timeLimit(.minutes(1)))
     func safeSchemeBookmarkIsValid() {
         let bookmark = BookmarkOrFolder(name: "x", type: .bookmark, urlString: "https://duckduckgo.com", children: nil)
 
         #expect(bookmark.isInvalidBookmark == false)
     }
 
-    @Test("Bookmark with no URL is invalid")
+    @available(iOS 16, macOS 13, *)
+    @Test("Bookmark with no URL is invalid", .timeLimit(.minutes(1)))
     func bookmarkWithoutURLIsInvalid() {
         let bookmark = BookmarkOrFolder(name: "x", type: .bookmark, urlString: nil, children: nil)
 
         #expect(bookmark.isInvalidBookmark)
     }
 
-    @Test("Folder is never invalidated by the scheme check")
+    @available(iOS 16, macOS 13, *)
+    @Test("Folder is never invalidated by the scheme check", .timeLimit(.minutes(1)))
     func folderIsValid() {
         let folder = BookmarkOrFolder(name: "f", type: .folder, urlString: nil, children: [])
 

--- a/SharedPackages/BrowserServicesKit/Tests/BookmarksTests/BookmarkImportSchemeValidationTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BookmarksTests/BookmarkImportSchemeValidationTests.swift
@@ -1,7 +1,7 @@
 //
 //  BookmarkImportSchemeValidationTests.swift
 //
-//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/SharedPackages/BrowserServicesKit/Tests/CommonTests/Extensions/StringFileExtensionsTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/CommonTests/Extensions/StringFileExtensionsTests.swift
@@ -1,7 +1,7 @@
 //
 //  StringFileExtensionsTests.swift
 //
-//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/SharedPackages/BrowserServicesKit/Tests/CommonTests/Extensions/StringFileExtensionsTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/CommonTests/Extensions/StringFileExtensionsTests.swift
@@ -21,7 +21,8 @@ import Testing
 
 struct StringFileExtensionsTests {
 
-    @Test("Single extension is allowed", arguments: [
+    @available(iOS 16, macOS 13, *)
+    @Test("Single extension is allowed", .timeLimit(.minutes(1)), arguments: [
         "bookmarks.html",
         "passwords.csv",
         "cards.json",
@@ -34,7 +35,8 @@ struct StringFileExtensionsTests {
         #expect(path.hasMultipleFileExtensions == false)
     }
 
-    @Test("Double extension is rejected", arguments: [
+    @available(iOS 16, macOS 13, *)
+    @Test("Double extension is rejected", .timeLimit(.minutes(1)), arguments: [
         "foo.swift.html",
         "a/b.exe.csv",
         "x.html.html",
@@ -45,7 +47,8 @@ struct StringFileExtensionsTests {
         #expect(path.hasMultipleFileExtensions == true)
     }
 
-    @Test("Dots in directory components are ignored")
+    @available(iOS 16, macOS 13, *)
+    @Test("Dots in directory components are ignored", .timeLimit(.minutes(1)))
     func dotsInDirectoryComponentsAreIgnored() {
         // Only the last path component is considered.
         #expect("a.b.c/bookmarks.html".hasMultipleFileExtensions == false)

--- a/SharedPackages/BrowserServicesKit/Tests/CommonTests/Extensions/StringFileExtensionsTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/CommonTests/Extensions/StringFileExtensionsTests.swift
@@ -1,0 +1,53 @@
+//
+//  StringFileExtensionsTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Common
+import Testing
+
+struct StringFileExtensionsTests {
+
+    @Test("Single extension is allowed", arguments: [
+        "bookmarks.html",
+        "passwords.csv",
+        "cards.json",
+        "dir/passwords.csv",
+        "nested/dir/bookmarks.html",
+        "no-extension",
+        ".dotfile"
+    ])
+    func singleExtensionIsNotFlagged(path: String) {
+        #expect(path.hasMultipleFileExtensions == false)
+    }
+
+    @Test("Double extension is rejected", arguments: [
+        "foo.swift.html",
+        "a/b.exe.csv",
+        "x.html.html",
+        "nested/dir/evil.swift.html",
+        "report.tar.gz"
+    ])
+    func doubleExtensionIsFlagged(path: String) {
+        #expect(path.hasMultipleFileExtensions == true)
+    }
+
+    @Test("Dots in directory components are ignored")
+    func dotsInDirectoryComponentsAreIgnored() {
+        // Only the last path component is considered.
+        #expect("a.b.c/bookmarks.html".hasMultipleFileExtensions == false)
+    }
+}

--- a/iOS/Core/DataImportManager.swift
+++ b/iOS/Core/DataImportManager.swift
@@ -103,6 +103,13 @@ public final class DataImportManager: DataImportManaging {
     public func importFile(at url: URL, for fileType: DataImportFileType) async throws -> DataImportSummary? {
         defer { cleanupImporters() }
 
+        // Reject a directly-selected file with a disguising double extension (e.g. foo.swift.html).
+        // Archive entries are validated separately inside ImportArchiveReader.
+        guard !url.lastPathComponent.hasMultipleFileExtensions else {
+            Logger.autofill.debug("Rejected import file with multiple extensions: \(url.lastPathComponent)")
+            return nil
+        }
+
         switch fileType {
         case .csv:
             csvImporter = createCSVImporter(url: url)

--- a/iOS/Core/ImportArchiveReader.swift
+++ b/iOS/Core/ImportArchiveReader.swift
@@ -21,6 +21,7 @@ import Foundation
 import ZIPFoundation
 import os.log
 import PrivacyConfig
+import Common
 
 public protocol ImportArchiveReading {
     func readContents(from archiveURL: URL, featureFlagger: FeatureFlagger) throws -> ImportArchiveContents
@@ -78,6 +79,9 @@ public struct ImportArchiveReader: ImportArchiveReading {
 
         for entry in archive {
             let lowercasedPath = entry.path.lowercased()
+
+            // Reject entries with a disguising double extension (e.g. foo.swift.html).
+            guard !entry.path.hasMultipleFileExtensions else { continue }
 
             if lowercasedPath.hasSuffix(Constants.csvExtension),
                let content = extractFileContent(from: entry, in: archive) {

--- a/iOS/DuckDuckGoTests/DataImport/DataImportManagerTests.swift
+++ b/iOS/DuckDuckGoTests/DataImport/DataImportManagerTests.swift
@@ -109,6 +109,16 @@ final class DataImportManagerTests: XCTestCase {
         XCTAssertEqual(summary, expectedSummary)
     }
 
+    func testWhenImportHtmlFileHasDoubleExtensionThenItIsRejected() async throws {
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("bookmarks.evil.html")
+        try "<html>bookmark data</html>".write(to: tempURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let result = try await dataImportManager.importFile(at: tempURL, for: .html)
+
+        XCTAssertNil(result)
+    }
+
     // MARK: - JSON Import Tests
 
     func testWhenImportingJSONFileThenCreditCardsSuccessfullyImported() async throws {

--- a/iOS/DuckDuckGoTests/DataImport/ImportArchiveReaderTests.swift
+++ b/iOS/DuckDuckGoTests/DataImport/ImportArchiveReaderTests.swift
@@ -229,6 +229,23 @@ final class ImportArchiveReaderTests: XCTestCase {
         XCTAssertEqual(contents.type, .none)
     }
 
+    func testWhenArchiveContainsDoubleExtensionEntryThenItIsSkippedButValidFileIsRead() throws {
+        let archiveURL = try createTestArchive(
+            files: [
+                "evil.swift.html": "<html>disguised</html>",
+                "subfolder/payload.exe.csv": "user,pass",
+                "bookmarks.html": "<html>bookmark data</html>"
+            ]
+        )
+
+        let contents = try reader.readContents(from: archiveURL, featureFlagger: mockFeatureFlagger)
+
+        XCTAssertEqual(contents.bookmarks, ["<html>bookmark data</html>"])
+        XCTAssertTrue(contents.passwords.isEmpty)
+        XCTAssertTrue(contents.creditCards.isEmpty)
+        XCTAssertEqual(contents.type, .bookmarksOnly)
+    }
+
     func testWhenArchiveContainsPasswordsWithInvalidContentsThenNoPasswordsRead() throws {
         let invalidData = Data([0xFF, 0xFE, 0xFD]) // Invalid UTF-8
         let archiveURL = try createTestArchive(

--- a/macOS/DuckDuckGo/Bookmarks/Services/LocalBookmarkStore.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Services/LocalBookmarkStore.swift
@@ -832,6 +832,13 @@ final class LocalBookmarkStore: BookmarkStore {
 
         for bookmarkOrFolder in bookmarks {
 
+            // Drop bookmarks whose URL uses an unsafe scheme (e.g. javascript:/data:), which would
+            // execute content rather than navigate if the bookmark were later activated.
+            if bookmarkOrFolder.urlString?.hasUnsafeBookmarkImportScheme() == true {
+                total.failed += 1
+                continue
+            }
+
             let bookmarkManagedObject: BookmarkEntity
             if bookmarkOrFolder.isFolder {
                 bookmarkManagedObject = BookmarkEntity.makeFolder(title: bookmarkOrFolder.name,

--- a/macOS/DuckDuckGo/Bookmarks/Services/LocalBookmarkStore.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Services/LocalBookmarkStore.swift
@@ -832,9 +832,11 @@ final class LocalBookmarkStore: BookmarkStore {
 
         for bookmarkOrFolder in bookmarks {
 
-            // Drop bookmarks whose URL uses an unsafe scheme (e.g. javascript:/data:), which would
-            // execute content rather than navigate if the bookmark were later activated.
-            if bookmarkOrFolder.urlString?.hasUnsafeBookmarkImportScheme() == true {
+            // Drop bookmarks/favorites whose URL uses an unsafe scheme (e.g. javascript:/data:), which
+            // would execute content rather than navigate if the bookmark were later activated. Folders
+            // are exempt (mirrors iOS BookmarkOrFolder.isInvalidBookmark) so a folder is never dropped
+            // along with its children even if it carries a stray URL string.
+            if !bookmarkOrFolder.isFolder, bookmarkOrFolder.urlString?.hasUnsafeBookmarkImportScheme() == true {
                 total.failed += 1
                 continue
             }

--- a/macOS/DuckDuckGo/DataImport/ImportArchiveReader.swift
+++ b/macOS/DuckDuckGo/DataImport/ImportArchiveReader.swift
@@ -20,6 +20,7 @@ import Foundation
 import ZIPFoundation
 import os.log
 import BrowserServicesKit
+import Common
 
 public protocol ImportArchiveReading {
     func readContents(from archiveURL: URL) throws -> ImportArchiveContents
@@ -81,6 +82,9 @@ public struct ImportArchiveReader: ImportArchiveReading {
 
         for entry in archive {
             let lowercasedPath = entry.path.lowercased()
+
+            // Reject entries with a disguising double extension (e.g. foo.swift.html).
+            guard !entry.path.hasMultipleFileExtensions else { continue }
 
             if lowercasedPath.hasSuffix(Constants.csvExtension),
                let content = extractFileContent(from: entry, in: archive) {

--- a/macOS/DuckDuckGo/DataImport/SafariArchiveImporter.swift
+++ b/macOS/DuckDuckGo/DataImport/SafariArchiveImporter.swift
@@ -276,6 +276,13 @@ final class SafariArchiveImporter: DataImporter {
     // MARK: - Private
 
     private func readContentsForSelectedFile() throws -> ImportArchiveContents {
+        // Reject a directly-selected file with a disguising double extension (e.g. foo.swift.html).
+        // Archives are exempt here (their own name is irrelevant); their entries are validated
+        // individually inside ImportArchiveReader.
+        if sourceFileType != .archive, archiveURL.lastPathComponent.hasMultipleFileExtensions {
+            return ImportArchiveReader.Contents(passwords: [], bookmarks: [], creditCards: [])
+        }
+
         switch sourceFileType {
         case .archive:
             return try archiveReader.readContents(from: archiveURL)

--- a/macOS/UnitTests/Bookmarks/Services/LocalBookmarkStoreTests.swift
+++ b/macOS/UnitTests/Bookmarks/Services/LocalBookmarkStoreTests.swift
@@ -1490,6 +1490,38 @@ final class LocalBookmarkStoreTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
+    func testWhenBookmarksAreImported_AndURLUsesUnsafeScheme_ThenBookmarkIsDroppedAndCountedAsFailed() {
+        let context = container.viewContext
+        let bookmarkStore = LocalBookmarkStore(context: context)
+
+        let javascriptBookmark = ImportedBookmarks.BookmarkOrFolder(name: "JS", type: .bookmark, urlString: "javascript:alert(1)", children: nil)
+        let dataBookmark = ImportedBookmarks.BookmarkOrFolder(name: "Data", type: .bookmark, urlString: "data:text/html,<script>alert(1)</script>", children: nil)
+        let safeBookmark = ImportedBookmarks.BookmarkOrFolder(name: "DuckDuckGo", type: .bookmark, urlString: "https://duckduckgo.com", children: nil)
+        let bookmarkBar = ImportedBookmarks.BookmarkOrFolder(name: "Bookmark Bar", type: .folder, urlString: nil, children: [javascriptBookmark, dataBookmark, safeBookmark])
+        let otherBookmarks = ImportedBookmarks.BookmarkOrFolder(name: "Other Bookmarks", type: .folder, urlString: nil, children: [])
+
+        let topLevelFolders = ImportedBookmarks.TopLevelFolders(bookmarkBar: bookmarkBar, otherBookmarks: otherBookmarks, syncedBookmarks: nil)
+        let importedBookmarks = ImportedBookmarks(topLevelFolders: topLevelFolders)
+
+        let result = bookmarkStore.importBookmarks(importedBookmarks, source: .thirdPartyBrowser(.safari))
+
+        XCTAssertEqual(result.successful, 1)
+        XCTAssertEqual(result.failed, 2)
+
+        let loadingExpectation = self.expectation(description: "Loading")
+
+        bookmarkStore.loadAll(type: .bookmarks) { bookmarks, error in
+            XCTAssertNotNil(bookmarks)
+            XCTAssertNil(error)
+            // Only the safe bookmark should be persisted; the unsafe-scheme ones are dropped.
+            XCTAssert(bookmarks?.count == 1)
+
+            loadingExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
     @MainActor
     func testWhenBookmarksAreImported_AndDuplicatesExist_ThenBookmarksAreStillImported() async throws {
         let context = container.viewContext

--- a/macOS/UnitTests/Bookmarks/Services/LocalBookmarkStoreTests.swift
+++ b/macOS/UnitTests/Bookmarks/Services/LocalBookmarkStoreTests.swift
@@ -1522,6 +1522,36 @@ final class LocalBookmarkStoreTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
+    func testWhenImportedFolderCarriesUnsafeSchemeURLThenFolderAndChildrenAreStillImported() {
+        let context = container.viewContext
+        let bookmarkStore = LocalBookmarkStore(context: context)
+
+        let child = ImportedBookmarks.BookmarkOrFolder(name: "DuckDuckGo", type: .bookmark, urlString: "https://duckduckgo.com", children: nil)
+        // Malformed input: a folder carrying a javascript: URL string. The folder (and its children)
+        // must NOT be dropped — the unsafe-scheme check applies to bookmarks/favorites only.
+        let folder = ImportedBookmarks.BookmarkOrFolder(name: "Folder", type: .folder, urlString: "javascript:alert(1)", children: [child])
+        let bookmarkBar = ImportedBookmarks.BookmarkOrFolder(name: "Bookmark Bar", type: .folder, urlString: nil, children: [folder])
+        let otherBookmarks = ImportedBookmarks.BookmarkOrFolder(name: "Other Bookmarks", type: .folder, urlString: nil, children: [])
+
+        let topLevelFolders = ImportedBookmarks.TopLevelFolders(bookmarkBar: bookmarkBar, otherBookmarks: otherBookmarks, syncedBookmarks: nil)
+        let importedBookmarks = ImportedBookmarks(topLevelFolders: topLevelFolders)
+
+        _ = bookmarkStore.importBookmarks(importedBookmarks, source: .thirdPartyBrowser(.safari))
+
+        let loadingExpectation = self.expectation(description: "Loading")
+
+        bookmarkStore.loadAll(type: .bookmarks) { bookmarks, error in
+            XCTAssertNotNil(bookmarks)
+            XCTAssertNil(error)
+            // The safe child survived: the folder was not dropped. Without the folder exemption this would be 0.
+            XCTAssert(bookmarks?.count == 1)
+
+            loadingExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
     @MainActor
     func testWhenBookmarksAreImported_AndDuplicatesExist_ThenBookmarksAreStillImported() async throws {
         let context = container.viewContext

--- a/macOS/UnitTests/DataImport/SafariArchiveImporterTests.swift
+++ b/macOS/UnitTests/DataImport/SafariArchiveImporterTests.swift
@@ -225,6 +225,22 @@ final class SafariArchiveImporterTests: XCTestCase {
 
         return archiveURL
     }
+
+    // MARK: - ImportArchiveReader double-extension validation
+
+    func testWhenArchiveContainsDoubleExtensionEntryThenItIsSkippedButValidFileIsRead() throws {
+        let archiveURL = try createZipArchive(files: [
+            "evil.swift.html": "<html>disguised</html>",
+            "subfolder/payload.exe.csv": "user,pass",
+            "bookmarks.html": "<html>bookmark data</html>"
+        ])
+
+        let contents = try ImportArchiveReader().readContents(from: archiveURL)
+
+        XCTAssertEqual(contents.bookmarks, ["<html>bookmark data</html>"])
+        XCTAssertTrue(contents.passwords.isEmpty)
+        XCTAssertTrue(contents.creditCards.isEmpty)
+    }
 }
 
 // MARK: - Helpers

--- a/macOS/UnitTests/DataImport/SafariArchiveImporterTests.swift
+++ b/macOS/UnitTests/DataImport/SafariArchiveImporterTests.swift
@@ -226,6 +226,19 @@ final class SafariArchiveImporterTests: XCTestCase {
         return archiveURL
     }
 
+    func testWhenDirectlySelectedFileHasDoubleExtensionThenItIsRejected() async throws {
+        // A standalone (non-archive) file with a disguising double extension is rejected:
+        // no content is read, so the import yields a failure rather than importing it.
+        let url = try writeTempFile(named: "bookmarks.evil.html", contents: "<html>bookmark data</html>")
+        let importer = makeImporter(fileURL: url)
+
+        let summary = await importer.importData(types: [.bookmarks]).task.value
+
+        guard case .failure? = summary[.bookmarks] else {
+            return XCTFail("Expected the double-extension file to be rejected")
+        }
+    }
+
     // MARK: - ImportArchiveReader double-extension validation
 
     func testWhenArchiveContainsDoubleExtensionEntryThenItIsSkippedButValidFileIsRead() throws {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214200115953388/task/1210880241624727?focus=true

### Description
Hardens the third-party file/zip import path (security-audit follow-up):
- Drops bookmarks whose URL uses a `javascript:`/`data:` scheme — activating such a bookmark would execute embedded content instead of navigating.
- Rejects files and zip entries with a disguising double extension (e.g. `foo.swift.html`).

Both rules live once in BrowserServicesKit (`String.hasUnsafeBookmarkImportScheme()` / `String.hasMultipleFileExtensions`) and are invoked from each platform's import paths — the scheme check at the shared bookmark-save chokepoint (iOS `BookmarkOrFolder.isInvalidBookmark`, macOS `LocalBookmarkStore`), and the double-extension check at both the archive readers (`ImportArchiveReader`) and the direct-file entry points (iOS `DataImportManager.importFile`, macOS `SafariArchiveImporter.readContentsForSelectedFile`). Archives themselves are exempt — their entries are validated individually; folders carrying a stray unsafe URL are kept so their children still import.

### Testing Steps
A manual smoke-test kit is attached to the linked Asana task and also here. 
[file-import-validation-tests.zip](https://github.com/user-attachments/files/28568569/file-import-validation-tests.zip)
Import each on a **clean profile** (clear bookmarks **and** passwords) on iOS and macOS, comparing a build **before** vs **after** this change.

1. **`bookmarks.html`** (import as bookmarks HTML) — safe + `javascript:` + `data:` + `<script>`/`onload`/`<img onload>` + unclosed tag.
   - **Before: 6 bookmarks → After: 4.** The `javascript:` and `data:` rows are dropped (shown as "Failed to import 2" on iOS). Safe / onload / img / unclosed are kept (handlers ignored, no JS runs); a bare `<script>` never imports.
2. **`import.zip`** (import as zip) — `bookmarks.swift.html` (double-ext bookmark), `passwords.csv`, `passwords.exe.csv` (double-ext login), `cards.json`, junk `.js`.
   - **Bookmarks 1 → 0** (both platforms): the `.swift.html` double-extension entry no longer slips past the `.html` gate.
   - **Passwords 2 → 1 on macOS** (the double-extension `passwords.exe.csv` is skipped); **iOS stays 1** (it reads only the first CSV, so the decoy never imported there).
   - Credit cards need the `autofillCreditCards` flag (off by default on iOS → 0).
3. **Regression:** a normal Safari/Chrome export still imports all valid bookmarks/passwords/cards.

✅ Verified manually on **iOS and macOS** (before/after) in addition to the unit tests.


### Impact and Risks
Low–Medium — changes which imported bookmarks/files are accepted (privacy/security hardening; no change to existing stored data).

#### What could go wrong?
A legitimate item could be dropped. Mitigations: the scheme check is limited to `javascript:`/`data:` and is bookmarks-only (passwords/cards unaffected). The double-extension rule is intentionally strict (any filename with >1 dot) — an accepted trade-off agreed in the kick-off — so a legitimately double-dotted archive entry is skipped, and a directly-selected file with that shape is rejected outright (the import fails). The strictness was a deliberate decision over false-positive risk.

### Quality Considerations
- Validation centralized in BSK and reused at every per-platform import sink, so a future import source inherits both checks.
- Unit tests added in BSK (`StringFileExtensionsTests`, `BookmarkImportSchemeValidationTests`), iOS (`ImportArchiveReaderTests`, `DataImportManagerTests`), and macOS (`LocalBookmarkStoreTests`, `SafariArchiveImporterTests`), plus manual before/after smoke verification on both platforms.
- **Observability / pixels:** no new telemetry was added. The new rejections ride the import flow's existing patterns — unexpected zip entries are already skipped silently (allowlist), and invalid bookmarks already count into `failed` — so observability is unchanged from the current baseline rather than regressed. Dedicated rejection pixels were consciously skipped given the low expected frequency (P3, no demonstrated exploit) and out-of-kickoff-scope; pixel/security owners can revisit if monitoring of rejection frequency is later desired.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-focused import filtering can drop legitimate bookmarks (unsafe schemes) or archive entries with multiple dots in the filename; behavior is intentional but may surprise users with unusual exports.
> 
> **Overview**
> **Hardens third-party data import** so malicious or disguised payloads are rejected before they reach bookmarks or archive parsing.
> 
> Imported **bookmarks/favorites** with `javascript:` or `data:` URLs are now treated as invalid and dropped (counted as failed on macOS via `LocalBookmarkStore`; filtered via `BookmarkOrFolder.isInvalidBookmark` on iOS). **Folders** are not dropped when they carry a stray unsafe URL, so child bookmarks still import.
> 
> **Double-extension filenames** (more than one dot in the last path component, e.g. `foo.swift.html`) are rejected for **direct file picks** (iOS `DataImportManager.importFile`, macOS `SafariArchiveImporter` for non-archive files) and **skipped inside zip entries** (iOS/macOS `ImportArchiveReader`).
> 
> Shared helpers live in BrowserServicesKit: `String.hasUnsafeBookmarkImportScheme()` and `String.hasMultipleFileExtensions`. Unit tests cover BSK, iOS, and macOS import paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8958d5206e9897ffdebcc9d1de80f11c45b1c80c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


