### PR TITLE
Ensure keyboard is dismissed when opening Duck.ai from a suggestion

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3821,6 +3821,9 @@ extension MainViewController: BrowserChromeDelegate {
             loadUrlInNewTab(url, reuseExisting: tabId.map(ExistingTabReusePolicy.tabWithId) ?? .any, inheritedAttribution: .noAttribution)
 
         case .askAIChat(let value):
+            // We intentionally don't forward the resolved model config: the suggestion is offered
+            // from Search mode where the model chip is hidden and the user hasn't chosen a model.
+            _ = unifiedToggleInputCoordinator?.prepareExternalPromptSubmission()
             openAIChat(value, autoSend: true)
 
         case .unknown(value: let value), .internalPage(title: let value, url: _, _):


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215056187001442

### Description

- Fixes the top-omnibar "Ask Duck.ai" suggestion opening a Duck.ai tab with the keyboard still up, while a direct prompt submission correctly opens with the keyboard down.
- On the `.askAIChat` suggestion path, set the coordinator's submitted-prompt flag (via `prepareExternalPromptSubmission()`) so the freshly-opened Duck.ai tab stays collapsed instead of auto-expanding the unified input after refresh.
- Intentionally does not forward the resolved model config: the suggestion is offered from Search mode where the model chip is hidden and the user hasn't picked a model, so the chat opens with the frontend's default model (preserving prior behavior).

### Testing Steps

1. Enable Unified Input. From the top-omnibar unified input, keep **Search** selected.
2. Type a search query until autocomplete suggestions appear.
3. Tap the **Ask Duck.ai** suggestion.
4. Verify a Duck.ai tab opens with the query submitted and the **keyboard is down**.
5. Verify the chat uses your default Duck.ai model (not forced to a different one).
6. For comparison, submit a prompt directly (without a suggestion) and confirm the keyboard is also down — behavior should match.

### Impact and Risks

**Impact Level: Low**

#### What could go wrong?

- The legacy (non-unified) omnibar shares `handleSuggestionSelected`, but there `unifiedToggleInputCoordinator` is nil, so the optional call is a no-op and behavior is unchanged.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single optional coordinator call on one suggestion branch; nil on legacy omnibar, no auth or data changes.
> 
> **Overview**
> Fixes **Ask Duck.ai** autocomplete opening Duck.ai with the keyboard still visible by mirroring the direct prompt path in `handleSuggestionSelected`.
> 
> On `.askAIChat`, the handler now calls `unifiedToggleInputCoordinator?.prepareExternalPromptSubmission()` before `openAIChat(..., autoSend: true)`. That sets the coordinator’s submitted-prompt state so the new Duck.ai tab keeps unified input **collapsed** after refresh instead of re-expanding and refocusing the field. The returned model/reasoning config is **not** passed through—Search-mode suggestions don’t reflect a user-chosen model, so chat still uses the default frontend model.
> 
> Legacy omnibar is unchanged: `unifiedToggleInputCoordinator` is nil, so the call is a no-op.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7f4c7e1c776ffee16fb62f6437d3bf51661dd5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->