### PR TITLE
iOS: Fix duck.ai "You've got this" completion dialog persistence and dismissal in UTI mode

### DIFF
--- a/iOS/DuckDuckGo/NewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPageViewController.swift
@@ -147,17 +147,16 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        // Dismiss the UTI completion dialog first — sets the seen flag and handles the promo
-        // chain. Must run before the hostingController parent-check below so that check does
-        // not zero isShowingDuckAICompletionDialog before the seen flag is recorded.
-        dismissDuckAICompletionDialogIfNeededOnEditingEnd()
         // In UTI mode the visit-site dialog's hostingController is parented to MainViewController
-        // (not to self).  When navigation replaces this NTP the container can reappear and show
-        // the stale dialog.  Clean it up here; dismissHostingController nils hostingController,
-        // so this guard only fires when the completion-dialog path did NOT already clean up.
+        // (not to self) so it lives in unifiedInputContentContainer.  When navigation replaces
+        // this NTP with a web view or a fresh NTP, the container can reappear later and show the
+        // stale dialog.  Clean it up here before this NTP leaves the screen.
         if let hc = hostingController, hc.parent !== self {
             dismissHostingController(didFinishNTPOnboarding: false)
         }
+        // Dismiss the UTI completion dialog when the NTP leaves the screen (tab switch,
+        // navigation). The dialog is marked as seen so the subscription promo surfaces cleanly.
+        dismissDuckAICompletionDialogIfNeededOnEditingEnd()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -709,7 +708,6 @@ extension NewTabPageViewController {
         hostingController?.willMove(toParent: nil)
         hostingController?.view.removeFromSuperview()
         hostingController?.removeFromParent()
-        hostingController = nil
         if updateUnifiedInputContentOverlaySuppression {
             chromeDelegate?.setUnifiedInputContentOverlaySuppressed(false)
         }

--- a/iOS/DuckDuckGo/NewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPageViewController.swift
@@ -147,16 +147,13 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        // In UTI mode the visit-site dialog's hostingController is parented to MainViewController
-        // (not to self) so it lives in unifiedInputContentContainer.  When navigation replaces
-        // this NTP with a web view or a fresh NTP, the container can reappear later and show the
-        // stale dialog.  Clean it up here before this NTP leaves the screen.
+        // Must run before the parent-check below, which would zero isShowingDuckAICompletionDialog
+        // and prevent the seen flag from being set (e.g. on a tab switch without editing ending).
+        dismissDuckAICompletionDialogIfNeededOnEditingEnd()
+        // Clean up any stale hosting controller parented to mainVC before this NTP leaves.
         if let hc = hostingController, hc.parent !== self {
             dismissHostingController(didFinishNTPOnboarding: false)
         }
-        // Dismiss the UTI completion dialog when the NTP leaves the screen (tab switch,
-        // navigation). The dialog is marked as seen so the subscription promo surfaces cleanly.
-        dismissDuckAICompletionDialogIfNeededOnEditingEnd()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -708,6 +705,7 @@ extension NewTabPageViewController {
         hostingController?.willMove(toParent: nil)
         hostingController?.view.removeFromSuperview()
         hostingController?.removeFromParent()
+        hostingController = nil
         if updateUnifiedInputContentOverlaySuppression {
             chromeDelegate?.setUnifiedInputContentOverlaySuppressed(false)
         }

--- a/iOS/DuckDuckGo/NewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPageViewController.swift
@@ -147,16 +147,17 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        // Dismiss the UTI completion dialog first — sets the seen flag and handles the promo
+        // chain. Must run before the hostingController parent-check below so that check does
+        // not zero isShowingDuckAICompletionDialog before the seen flag is recorded.
+        dismissDuckAICompletionDialogIfNeededOnEditingEnd()
         // In UTI mode the visit-site dialog's hostingController is parented to MainViewController
-        // (not to self) so it lives in unifiedInputContentContainer.  When navigation replaces
-        // this NTP with a web view or a fresh NTP, the container can reappear later and show the
-        // stale dialog.  Clean it up here before this NTP leaves the screen.
+        // (not to self).  When navigation replaces this NTP the container can reappear and show
+        // the stale dialog.  Clean it up here; dismissHostingController nils hostingController,
+        // so this guard only fires when the completion-dialog path did NOT already clean up.
         if let hc = hostingController, hc.parent !== self {
             dismissHostingController(didFinishNTPOnboarding: false)
         }
-        // Dismiss the UTI completion dialog when the NTP leaves the screen (tab switch,
-        // navigation). The dialog is marked as seen so the subscription promo surfaces cleanly.
-        dismissDuckAICompletionDialogIfNeededOnEditingEnd()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -708,6 +709,7 @@ extension NewTabPageViewController {
         hostingController?.willMove(toParent: nil)
         hostingController?.view.removeFromSuperview()
         hostingController?.removeFromParent()
+        hostingController = nil
         if updateUnifiedInputContentOverlaySuppression {
             chromeDelegate?.setUnifiedInputContentOverlaySuppressed(false)
         }

--- a/iOS/DuckDuckGo/NewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPageViewController.swift
@@ -154,6 +154,9 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
         if let hc = hostingController, hc.parent !== self {
             dismissHostingController(didFinishNTPOnboarding: false)
         }
+        // Dismiss the UTI completion dialog when the NTP leaves the screen (tab switch,
+        // navigation). The dialog is marked as seen so the subscription promo surfaces cleanly.
+        dismissDuckAICompletionDialogIfNeededOnEditingEnd()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -483,8 +486,14 @@ extension NewTabPageViewController {
     }
 
     // Mirrors showDuckAIOnboardingCompletionDialog for UTI mode where no editing-state VC exists.
-    // The completion dialog is embedded directly in unifiedInputContentContainer below the UTI bar,
-    // and the onDismiss closure mirrors the legacy path's subscription-promo check.
+    // Uses the same overlay-suppression mechanism as showNextDaxDialogNew:
+    //   • setUnifiedInputContentOverlaySuppressed(true) hides unifiedInputContentContainer so
+    //     the NTP (contentContainer) shows through, keeping the dialog visible while the address
+    //     bar is active.  dismissHostingController re-enables the overlay on teardown.
+    //   • A single copy in self.view.superview (contentContainer's plain UIView) avoids the
+    //     nested-UIHostingController warning from adding _UIHostingView into another HC's view.
+    // viewWillDisappear ensures cleanup on any navigation or tab switch.
+    // The onDismiss closure mirrors the legacy path's subscription-promo check.
     private func showDuckAIOnboardingCompletionDialogInUTI(
         mainVC: MainViewController,
         coordinator: UnifiedToggleInputCoordinator,
@@ -500,6 +509,10 @@ extension NewTabPageViewController {
         setLogoHidden(true)
         coordinator.contentViewController.setLogoHidden(true)
         view.alpha = 1
+        // Mirror showNextDaxDialogNew: suppress the UTI content overlay so the NTP
+        // (contentContainer) remains visible while the address bar is active.
+        // dismissHostingController re-enables the overlay when the dialog is torn down.
+        chromeDelegate?.setUnifiedInputContentOverlaySuppressed(true)
 
         let onDismiss = { [weak self, weak mainVC, weak coordinator] in
             guard let self else { return }
@@ -567,36 +580,26 @@ extension NewTabPageViewController {
             }
         }
 
-        let root = newTabDialogFactory.createExperimentCompletionDialog(message: message, onDismiss: onDismiss)
-        let hostingController = UIHostingController(rootView: root)
-        hostingController.view.backgroundColor = UIColor.clear
-        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
-
-        guard let container = mainVC.viewCoordinator.unifiedInputContentContainer else {
-            assertionFailure("unifiedInputContentContainer is nil in UTI completion dialog path")
-            isShowingDuckAICompletionDialog = false
-            setLogoHidden(false)
-            coordinator.contentViewController.setLogoHidden(false)
-            return
-        }
-        self.hostingController = hostingController
-        mainVC.addChild(hostingController)
-        container.addSubview(hostingController.view)
-        // In top-bar mode the UTI bar is above the content area: pin the dialog below the bar.
-        // In bottom-bar mode the UTI bar is at the bottom: pin the dialog above the bar so it
-        // fills the visible content area instead of collapsing to zero height.
-        let isBottomBar = coordinator.cardPosition.isBottom
+        // NTP copy — overlays the NTP view, visible after the omnibar closes.
+        // Parented to mainVC (not self) because self is UIHostingController<NewTabPageView>:
+        // adding one _UIHostingView as a subview of another UIHostingController.view is
+        // unsupported and triggers a UIKit warning. self.view.superview is the plain UIView
+        // of UnifiedInputContentContainerViewController, so it is safe to host into.
+        let ntpRoot = newTabDialogFactory.createExperimentCompletionDialog(message: message, onDismiss: onDismiss)
+        let ntpHC = UIHostingController(rootView: ntpRoot)
+        ntpHC.view.backgroundColor = .clear
+        ntpHC.view.translatesAutoresizingMaskIntoConstraints = false
+        self.hostingController = ntpHC
+        let ntpContainer: UIView = view.superview ?? mainVC.view
+        mainVC.addChild(ntpHC)
+        ntpContainer.addSubview(ntpHC.view)
         NSLayoutConstraint.activate([
-            isBottomBar
-                ? hostingController.view.topAnchor.constraint(equalTo: container.topAnchor)
-                : hostingController.view.topAnchor.constraint(equalTo: coordinator.viewController.view.bottomAnchor),
-            hostingController.view.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-            hostingController.view.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-            isBottomBar
-                ? hostingController.view.bottomAnchor.constraint(equalTo: coordinator.viewController.view.topAnchor)
-                : hostingController.view.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            ntpHC.view.topAnchor.constraint(equalTo: view.topAnchor),
+            ntpHC.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            ntpHC.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            ntpHC.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
-        hostingController.didMove(toParent: mainVC)
+        ntpHC.didMove(toParent: mainVC)
     }
 
     func showNextDaxDialogNew(dialogProvider: NewTabDialogSpecProvider, factory: any NewTabDaxDialogProviding) {
@@ -726,6 +729,9 @@ extension NewTabPageViewController {
 
     func dismissDuckAICompletionDialogIfNeededOnEditingEnd() {
         guard isShowingDuckAICompletionDialog else { return }
+        // Mark EOJ seen before peeking subscriptionPromotionPending — the promo requires
+        // finalDaxDialogSeen == true, so checking before this call always returns false.
+        daxDialogsManager.setFinalOnboardingDialogSeen()
         let promoPending = daxDialogsManager.subscriptionPromotionPending
         dismissHostingController(didFinishNTPOnboarding: true)
         if !promoPending {
@@ -739,6 +745,13 @@ extension NewTabPageViewController {
     private func notifyDuckAICompletionDismissedIfNeeded() {
         guard isShowingDuckAICompletionDialog else { return }
         isShowingDuckAICompletionDialog = false
+        // Mirror dismissDuckAICompletionDialogIfNeededOnEditingEnd: mark EOJ seen and
+        // dismiss the dialog system so the subscription promo state is consistent
+        // regardless of whether the user tapped dismiss or navigated away.
+        daxDialogsManager.setFinalOnboardingDialogSeen()
+        if !daxDialogsManager.subscriptionPromotionPending {
+            daxDialogsManager.dismiss()
+        }
         view.alpha = 1
         delegate?.newTabPageDidDismissDuckAIExperimentCompletion(self)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202406491309510/task/1215009192158950
Tech Design URL: N/A
CC: N/A

### Description

- Persist the "You've got this!" completion dialog when the UTI address bar activates or deactivates

### Testing Steps

**Prerequisites**
1. In `iOS/Core/FeatureFlag.swift` change `.unifiedToggleInput` from:
   `Config(source: .remoteReleasable(AIChatSubfeature.unifiedToggleInput))`
   to:
   `Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.unifiedToggleInput))`
2. In `iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift` in `resolveDuckAIQueryExperimentCohortID()` add `return .treatmentB` as the first line to force Treatment B enrollment
3. Reset iOS simulator (`Device` → `Erase all content and settings…`)
4. In the iOS scheme set `App Language` → `English` and `App Region` → `United States`

**Reaching the completion dialog**
5. Fresh install. Go through onboarding to the "Search experience" screen.
6. Toggle to "Search + Duck.ai" → "Next".
7. Select Duck.ai and choose a suggested query option.
8. Complete the onboarding until the "You've got this!" dialog appears with the address bar active.

**Address bar activate/deactivate**
9. While the dialog is visible, activate and deactivate the address bar multiple times — confirm the dialog remains visible throughout

**High-five → Subscription upsell**
10. Tap "High five" — confirm the dialog dismisses and the subscription upsell appears

**Navigate away while address bar is active → upsell on next new tab**
11. Reach the dialog again (steps 5–8), activate the address bar, type a URL and navigate to a page — confirm the dialog is dismissed, then open a new tab and verify the subscription upsell appears

**Burn all → upsell on next new tab**
12. Reach the dialog again, trigger "Burn all" — confirm the dialog is dismissed and the subscription upsell appears on the next new tab

**Open duck.ai → upsell on next new tab**
13. Reach the dialog again, open the duck.ai chat — confirm the dialog is dismissed and the subscription upsell appears on the next new tab

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- `dismissDuckAICompletionDialogIfNeededOnEditingEnd` is now also called from `viewWillDisappear`. It is idempotent (guarded by `isShowingDuckAICompletionDialog`), so double-calls from overlapping triggers are safe.
- `setUnifiedInputContentOverlaySuppressed(true)` is now called during UTI completion dialog setup. `dismissHostingController` already calls `setUnifiedInputContentOverlaySuppressed(false)` on all teardown paths, so the suppression state is always restored.

### Quality Considerations
- All dismissal paths now consistently call `setFinalOnboardingDialogSeen()` before checking `subscriptionPromotionPending`, ensuring the subscription promo state machine behaves the same regardless of how the completion dialog exits.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding-only UI and Dax state machine changes with idempotent guards and existing overlay restore on teardown; no auth or data handling impact.
> 
> **Overview**
> Fixes the Duck.ai **"You've got this!"** completion dialog in **Unified Toggle Input (UTI)** mode so it stays visible while the address bar toggles and tears down cleanly on navigation or tab switches.
> 
> **UTI presentation** now matches other NTP Dax flows: it suppresses the UTI content overlay so the NTP shows through with the bar active, and hosts a single SwiftUI dialog over the NTP (parented to a plain container view) instead of embedding it in `unifiedInputContentContainer`, avoiding nested `UIHostingController` warnings and stale dialogs reappearing.
> 
> **Lifecycle:** `viewWillDisappear` calls `dismissDuckAICompletionDialogIfNeededOnEditingEnd()` before other cleanup so end-of-journey is marked even when editing never ends (e.g. tab switch). `dismissHostingController` nils out the hosting controller after removal.
> 
> **Subscription promo:** All exit paths (`dismissDuckAICompletionDialogIfNeededOnEditingEnd`, `notifyDuckAICompletionDismissedIfNeeded`) call `setFinalOnboardingDialogSeen()` before reading `subscriptionPromotionPending`, so the upsell can surface on the next new tab after navigate-away, burn, or similar dismissals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa969d0781814b7056dcfd875522fcdce8fad429. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->