### PR TITLE
speed up ios builds by only running the localisation script if needed

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b8d37a0a66887c2d1393a98c71aade977545f9dc8b175523134eb32361591a3b",
+  "originHash" : "254b590324d9707fc05668f89674e1cb3a4499d746f3e43ffb3950d97047ed52",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "0d678e5ea42dd082c22237469599186b5d3a753a",
-        "version" : "14.14.0"
+        "revision" : "512a2657dd2f3b73682babf77561068cccd28c41",
+        "version" : "15.0.0"
       }
     },
     {

--- a/iOS/scripts/README.md
+++ b/iOS/scripts/README.md
@@ -87,6 +87,8 @@ See: https://app.asana.com/0/0/1195919669085073/f for more info.
 
 This script updates localization strings for app targets by running `xcrun extractLocStrings` command on each Swift file in the specified target sub-directories. It then converts the extracted strings to UTF-8 format and moves them to the `en.lproj/Localizable.strings` file for each target.
 
+When `Localizable.strings` already exists for a target, the script first checks whether any `.swift` files are newer than that output file. If no source files are newer, extraction is skipped for that target to keep no-op build phase runs fast.
+
 ### Requirements
 
 No 3rd party software is required to run the script. It uses built-in command line utilities.

--- a/iOS/scripts/loc_update.sh
+++ b/iOS/scripts/loc_update.sh
@@ -23,6 +23,14 @@ update_localizable_strings() {
 	target_strings="${output_dir}/Localizable.strings"
 
 	echo "Processing ${source_dir}"
+	if [ -f "${target_strings}" ]; then
+		newer_source_file=$(find "${source_dir}/" -name "*.swift" -newer "${target_strings}" -print -quit)
+		if [ -z "${newer_source_file}" ]; then
+			echo "  Localizable.strings up to date"
+			return
+		fi
+	fi
+
 	mkdir -p "${tmp_output_dir}"
 	if ! find "${source_dir}/" -name "*.swift" -print0 | xargs -0 xcrun extractLocStrings -o "${tmp_output_dir}"; then
 		echo "error: Failed to extract localization strings from ${source_dir}" >&2

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "bd771ea52b7e4b14f6cb79f3e03909b17fc2a32c12c4feae819b4c371a4c78e0",
+  "originHash" : "20a1b846ca48f5066ca3982fcad5e35db901b43b339d7275d6a0e709fe8a2702",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "0d678e5ea42dd082c22237469599186b5d3a753a",
-        "version" : "14.14.0"
+        "revision" : "512a2657dd2f3b73682babf77561068cccd28c41",
+        "version" : "15.0.0"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "9f542610331815e29cc3821d3b6f488db8715517",
-        "version" : "1.6.0"
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1215330581100913?focus=true
Tech Design URL:
CC:

### Description

### Testing Steps
1. Build the app twice. Second, if not the first, should be about ~10 seconds quicker.
2. Change a string (check across modules, e.g. Sync-UI and the app), and build, should generate the localised strings
3. Under the change, should never the localised strings
4. Build again, should be ~10s faster

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Break localisations

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-script and dependency pin changes only; the main risk is stale `Localizable.strings` if the mtime check misses a string change edge case.
> 
> **Overview**
> **iOS build phase optimization:** `loc_update.sh` now skips `extractLocStrings` for a target when `Localizable.strings` already exists and no `.swift` files under that source tree are newer than that file, logging `Localizable.strings up to date` instead. The README documents this behavior for the “Update Localizable.strings” build phase.
> 
> **Dependency lockfile updates:** iOS and macOS `Package.resolved` bump **content-scope-scripts** from 14.14.0 to **15.0.0**; macOS also bumps **swift-asn1** to 1.7.0 (with updated origin hashes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c1ee3c7295f1ead2140426f8b80dbb8d5a8bd77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->