### PR TITLE
iPad: Defer UTI nav-bar recompute off scene-snapshot transaction

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2503,7 +2503,13 @@ class MainViewController: UIViewController {
             }
 
             ViewHighlighter.updatePositions()
-            self.recomputeNavigationBarContainerHeightIfNeeded()
+            /// Defer off this block: iPad multitasking resize (Split View / Stage Manager) drives
+            /// _sceneBoundsDidChange, which flushes this completion synchronously inside UIKit's
+            /// scene-snapshot transaction — the relayout there risks a watchdog SIGKILL.
+            /// https://app.asana.com/1/137249556945/project/1214294661819890/task/1214959863673211?focus=true
+            DispatchQueue.main.async { [weak self] in
+                self?.recomputeNavigationBarContainerHeightIfNeeded()
+            }
         }
 
         hideNotificationBarIfBrokenSitePromptShown()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214960074346518?focus=true
Tech Design URL:
CC:

### Description
On iPad, multitasking resize (Split View / Stage Manager) drives `_sceneBoundsDidChange`, which flushes the `viewWillTransition` completion synchronously inside UIKit's scene-snapshot transaction; running `recomputeNavigationBarContainerHeightIfNeeded`'s synchronous relayout there risks a scene-update watchdog SIGKILL (APPLE-IOS-DPKD). This hops the recompute to the next runloop so the completion returns and the snapshot can ack, while keeping the layout synchronous (its inset math depends on a completed layout pass). The other three callers stay synchronous and are unchanged.

### Testing Steps
1. On iPad, open a Duck.ai/omnibar editing session (UTI input focused/expanded).
2. While editing, repeatedly resize the app via Split View / Stage Manager (drag the divider).
3. Confirm the nav-bar height/insets still settle correctly and the app does not get killed.

### Impact and Risks
Low — the recompute is idempotent and only its timing changes (one runloop later), at the one call site that runs inside the scene-snapshot transaction.

#### What could go wrong?
A one-frame stale nav-bar height after an iPad resize while editing, which the deferred recompute corrects on the next runloop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Timing-only change at one call site; recompute is idempotent with a possible one-frame stale nav-bar height before correction.
> 
> **Overview**
> On iPad, multitasking resize can run the **`$viewWillTransition$` animation **completion** synchronously inside UIKit’s scene-snapshot transaction. Calling `$recomputeNavigationBarContainerHeightIfNeeded()$` there triggers synchronous relayout and has been linked to scene-update watchdog kills.
> 
> This PR **only** changes that completion handler in `$MainViewController$`: the nav-bar height recompute is scheduled with `$DispatchQueue.main.async$` so the completion returns before relayout. Comments document the Asana task and the `_sceneBoundsDidChange` path. Other callers of `$recomputeNavigationBarContainerHeightIfNeeded()$` (UTI height changes, omnibar visibility) stay synchronous.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fdcd977d9709452cb8ebb9c94a96183cbbe3445. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->