### PR TITLE
Refresh UTI Duck.ai chat suggestions when the list becomes visible

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/ChatHistory/AIChatHistoryManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/ChatHistory/AIChatHistoryManager.swift
@@ -157,6 +157,10 @@ final class AIChatHistoryManager {
             .store(in: &cancellables)
     }
 
+    func refreshSuggestions(query: String) {
+        fetchSuggestionsIfNeeded(query: query)
+    }
+
     /// Fetches suggestions from the API with cancellation support
     /// - Parameter query: The search query to filter results
     private func fetchSuggestionsIfNeeded(query: String) {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/DuckAISuggestionsCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/DuckAISuggestionsCoordinator.swift
@@ -113,6 +113,11 @@ final class DuckAISuggestionsCoordinator {
         )
         vc.delegate = self
 
+        vc.onBecameVisible = { [weak self] in
+            guard let self else { return }
+            self.chatManager.refreshSuggestions(query: self.queryProvider())
+        }
+
         // Hide the hatch the moment the user starts typing; restore on backspace-to-empty (mirrors Search-side autocomplete covering NTP).
         textPublisher
             .map { !$0.isEmpty }

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/DuckAISuggestionsViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/DuckAISuggestionsViewController.swift
@@ -140,6 +140,9 @@ final class DuckAISuggestionsViewController: UIViewController {
     private var syncPromoHostingController: UIHostingController<AIChatSyncPromoView>?
     private var isVisibleContent = false
 
+    /// Fired when the list transitions from hidden to visible. 
+    var onBecameVisible: (() -> Void)?
+
     init(chatViewModel: AIChatSuggestionsViewModel,
          urlLoader: DuckAIURLSuggestionsLoader,
          queryProvider: @escaping () -> String,
@@ -264,6 +267,9 @@ final class DuckAISuggestionsViewController: UIViewController {
         guard visible != isVisibleContent else { return }
         isVisibleContent = visible
         recordSyncPromoImpressionIfNeeded()
+        if visible {
+            onBecameVisible?()
+        }
     }
 
     // MARK: - Header (escape hatch + sync promo)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1215295953438894?focus=true
Tech Design URL:
CC:

### Description
The UTI Duck.ai chat-history suggestions list is fetched only on initial install and on text changes, and the owning view model persists for the whole session, so a chat created since the last fetch never showed up until the app was relaunched. This refetches the suggestions on the list's hidden→visible transition, so re-expanding the unified input in Duck.ai mode picks up newly created chats. The transition is detected by the view controller's existing visibility guard, which avoids redundant refetches when the same visible state is re-asserted.

### Testing Steps
1. Enable the unifiedToggleInput feature, expand the unified input in Duck.ai mode, and note the chat-history suggestions.
2. Type a prompt to start a new chat, then open a new empty tab and expand the unified input in Duck.ai mode again.
3. Confirm the newly created chat now appears in the suggestions list without killing/relaunching the app.

### Impact and Risks
Low — adds a fetch on an existing visibility transition that reuses the current fetch pipeline; behaviour is unchanged when the feature is off.

#### What could go wrong?
A brief stale-then-updated flash if the refetch is slow, matching the existing text-change fetch behaviour.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reuses the existing suggestion fetch path on an already-tracked visibility transition; no auth or data-model changes, with at most an extra API call when re-showing the list.
> 
> **Overview**
> Fixes **stale Duck.ai chat-history suggestions** in unified toggle input when chats are created mid-session: the list used to load only on first install and on text changes, while the view model lived for the whole session.
> 
> Adds a **`refreshSuggestions(query:)`** entry point on `AIChatHistoryManager` that reuses the existing cancellable fetch pipeline. **`DuckAISuggestionsViewController`** exposes an **`onBecameVisible`** hook, invoked only on a **hidden→visible** transition in `setIsVisibleContent` (same guard that already drives sync promo impressions). **`DuckAISuggestionsCoordinator`** wires that hook to refetch chats for the **current input query** when the user re-expands Duck.ai mode—e.g. after starting a chat in another tab—without relaunching the app.
> 
> Possible **brief stale-then-update** UI if the refetch is slow, consistent with existing text-driven fetches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc002b96bf2c6f84b4369140bd19f83d99f2f939. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->