### PR TITLE
[iOS] Add JS Bridge Playground debug screen

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -801,6 +801,8 @@
 		85371D242121B9D500920548 /* new_tab.json in Resources */ = {isa = PBXBuildFile; fileRef = 85371D232121B9D400920548 /* new_tab.json */; };
 		85372447220DD103009D09CD /* UIKeyCommandExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85372446220DD103009D09CD /* UIKeyCommandExtension.swift */; };
 		853807922D6E638000CE1455 /* AlertPlaygroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853807912D6E638000CE1455 /* AlertPlaygroundView.swift */; };
+		86CFB2CDD7994EA2BDE8B9C9 /* JSBridgePlayground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3547B661FE5E43D481720B23 /* JSBridgePlayground.swift */; };
+		4981777E82734C27BC55EFFA /* SubscriptionBridgePlaygroundFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825F1E60DD344C7AAD838D0 /* SubscriptionBridgePlaygroundFeature.swift */; };
 		853A717620F62FE800FE60BC /* Pixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853A717520F62FE800FE60BC /* Pixel.swift */; };
 		853A717820F645FB00FE60BC /* PixelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853A717720F645FB00FE60BC /* PixelTests.swift */; };
 		853C5F6121C277C7001F7A05 /* global.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853C5F6021C277C7001F7A05 /* global.swift */; };
@@ -3362,6 +3364,9 @@
 		85371D232121B9D400920548 /* new_tab.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = new_tab.json; sourceTree = "<group>"; };
 		85372446220DD103009D09CD /* UIKeyCommandExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKeyCommandExtension.swift; sourceTree = "<group>"; };
 		853807912D6E638000CE1455 /* AlertPlaygroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertPlaygroundView.swift; sourceTree = "<group>"; };
+		3547B661FE5E43D481720B23 /* JSBridgePlayground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSBridgePlayground.swift; sourceTree = "<group>"; };
+		4825F1E60DD344C7AAD838D0 /* SubscriptionBridgePlaygroundFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionBridgePlaygroundFeature.swift; sourceTree = "<group>"; };
+		9915A189A9C64BD28067CBFA /* JSBridgePlaygroundAddingFeatures.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = JSBridgePlaygroundAddingFeatures.md; sourceTree = "<group>"; };
 		853A717520F62FE800FE60BC /* Pixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pixel.swift; sourceTree = "<group>"; };
 		853A717720F645FB00FE60BC /* PixelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelTests.swift; sourceTree = "<group>"; };
 		853C5F6021C277C7001F7A05 /* global.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = global.swift; sourceTree = "<group>"; };
@@ -7676,6 +7681,9 @@
 				4B67012A2E3BE3660066176A /* LogViewer */,
 				31206F6F2D3804E800A95D76 /* AIChatDebugView.swift */,
 				853807912D6E638000CE1455 /* AlertPlaygroundView.swift */,
+				3547B661FE5E43D481720B23 /* JSBridgePlayground.swift */,
+				4825F1E60DD344C7AAD838D0 /* SubscriptionBridgePlaygroundFeature.swift */,
+				9915A189A9C64BD28067CBFA /* JSBridgePlaygroundAddingFeatures.md */,
 				C1047CA32CA59BDC00B916FD /* Autofill */,
 				98A860EE2C4682E00077FE4D /* BookmarksDebugViewController.swift */,
 				857917E12D806C1900E23CDC /* BulkGeneratorView.swift */,
@@ -12640,6 +12648,8 @@
 				3157B43527F497F50042D3D7 /* SaveLoginViewController.swift in Sources */,
 				317A247F2D8336650033A0D6 /* DownloadsDirectoryHandling.swift in Sources */,
 				853807922D6E638000CE1455 /* AlertPlaygroundView.swift in Sources */,
+				86CFB2CDD7994EA2BDE8B9C9 /* JSBridgePlayground.swift in Sources */,
+				4981777E82734C27BC55EFFA /* SubscriptionBridgePlaygroundFeature.swift in Sources */,
 				C14D43012B45D6CD00ACA4DC /* AutofillDebugViewController.swift in Sources */,
 				5608B5132F2125CC00ABC3F4 /* UITestOverridesDebugView.swift in Sources */,
 				856F28D72D3EC5FA00A88211 /* TabSwitcherViewController+MultiSelect.swift in Sources */,

--- a/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
+++ b/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
@@ -240,6 +240,9 @@ extension DebugScreensViewModel {
                     SubscriptionDebugViewController(coder: coder, subscriptionDataReporter: dependencies.subscriptionDataReporter)
                 }
             }),
+            .controller(title: "JS Bridge Playground", { _ in
+                return JSBridgePlaygroundViewController(feature: SubscriptionBridgePlaygroundFeature())
+            }),
             .controller(title: "Configuration URLs", { _ in
                 return self.debugStoryboard.instantiateViewController(identifier: "ConfigurationURLDebugViewController") { coder in
                     let viewController = ConfigurationURLDebugViewController(coder: coder)

--- a/iOS/DuckDuckGo/JSBridgePlayground.swift
+++ b/iOS/DuckDuckGo/JSBridgePlayground.swift
@@ -1,0 +1,294 @@
+//
+//  JSBridgePlayground.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import UIKit
+import UserScript
+import WebKit
+
+/// Describes a feature whose JS bridge can be exercised inside the in-app playground.
+///
+/// See `JSBridgePlaygroundAddingFeatures.md` for the registration recipe.
+protocol JSBridgePlaygroundFeature {
+
+    /// Human-readable name shown in the debug menu (e.g. "Subscription").
+    var displayName: String { get }
+
+    /// The `WKScriptMessageHandler` name JS calls via `window.webkit.messageHandlers.<name>`.
+    var messageHandlerName: String { get }
+
+    /// The `context` field in the postMessage payload sent to native.
+    var messageContext: String { get }
+
+    /// The `featureName` field in the postMessage payload sent to native.
+    var featureName: String { get }
+
+    /// Origin used as the `baseURL` for `loadHTMLString`. Must satisfy the subfeature's `messageOriginPolicy`.
+    var baseURL: URL { get }
+
+    /// Methods to surface as quick-fill chips on the page. `sampleParamsJSON` is optional pre-filled params.
+    var knownMethods: [JSBridgePlaygroundMethod] { get }
+
+    /// Returns user scripts that already have their subfeatures registered. Called once per playground session.
+    @MainActor
+    func makeUserScripts() -> [UserScript]
+}
+
+struct JSBridgePlaygroundMethod {
+    let name: String
+    let sampleParamsJSON: String?
+}
+
+final class JSBridgePlaygroundViewController: UIViewController {
+
+    private let feature: JSBridgePlaygroundFeature
+    private var webView: WKWebView!
+    private var userScripts: [UserScript] = []
+
+    init(feature: JSBridgePlaygroundFeature) {
+        self.feature = feature
+        super.init(nibName: nil, bundle: nil)
+        title = "JS Bridge: \(feature.displayName)"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        setupWebView()
+        loadPlaygroundPage()
+    }
+
+    @MainActor
+    private func setupWebView() {
+        let contentController = WKUserContentController()
+        userScripts = feature.makeUserScripts()
+        for userScript in userScripts {
+            contentController.addUserScript(userScript.makeWKUserScriptSync())
+            contentController.addHandler(userScript)
+        }
+
+        let configuration = WKWebViewConfiguration()
+        configuration.userContentController = contentController
+        configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
+
+        webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.translatesAutoresizingMaskIntoConstraints = false
+#if DEBUG
+        if #available(iOS 16.4, *) {
+            webView.isInspectable = true
+        }
+#endif
+
+        view.addSubview(webView)
+        NSLayoutConstraint.activate([
+            webView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            webView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    @MainActor
+    private func loadPlaygroundPage() {
+        let html = JSBridgePlaygroundHTML.render(for: feature)
+        webView.loadHTMLString(html, baseURL: feature.baseURL)
+    }
+}
+
+enum JSBridgePlaygroundHTML {
+
+    static func render(for feature: JSBridgePlaygroundFeature) -> String {
+        let chips = feature.knownMethods.map { method -> String in
+            let nameHtml = htmlEscape(method.name)
+            return #"<span class="method-chip" data-method="\#(nameHtml)">\#(nameHtml)</span>"#
+        }.joined()
+
+        let samplesDictEntries = feature.knownMethods.map { method -> String in
+            let key = jsStringLiteral(method.name)
+            let value = method.sampleParamsJSON.map { jsStringLiteral($0) } ?? "\"\""
+            return "\(key): \(value)"
+        }.joined(separator: ", ")
+
+        let defaultMethod = feature.knownMethods.first?.name ?? ""
+        let defaultParams = feature.knownMethods.first?.sampleParamsJSON ?? "{}"
+
+        return template
+            .replacingOccurrences(of: "{{HANDLER}}", with: htmlEscape(feature.messageHandlerName))
+            .replacingOccurrences(of: "{{CONTEXT}}", with: htmlEscape(feature.messageContext))
+            .replacingOccurrences(of: "{{FEATURE}}", with: htmlEscape(feature.featureName))
+            .replacingOccurrences(of: "{{HANDLER_JS}}", with: jsStringLiteral(feature.messageHandlerName))
+            .replacingOccurrences(of: "{{CONTEXT_JS}}", with: jsStringLiteral(feature.messageContext))
+            .replacingOccurrences(of: "{{FEATURE_JS}}", with: jsStringLiteral(feature.featureName))
+            .replacingOccurrences(of: "{{METHOD_CHIPS}}", with: chips)
+            .replacingOccurrences(of: "{{METHOD_SAMPLES}}", with: "{\(samplesDictEntries)}")
+            .replacingOccurrences(of: "{{DEFAULT_METHOD}}", with: htmlEscape(defaultMethod))
+            .replacingOccurrences(of: "{{DEFAULT_PARAMS}}", with: htmlEscape(defaultParams))
+    }
+
+    private static func htmlEscape(_ s: String) -> String {
+        s
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
+    }
+
+    private static func jsStringLiteral(_ s: String) -> String {
+        let data = try? JSONSerialization.data(withJSONObject: s, options: .fragmentsAllowed)
+        return data.flatMap { String(data: $0, encoding: .utf8) } ?? "\"\""
+    }
+
+    private static let template = #"""
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+<style>
+:root { color-scheme: light dark; }
+body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; margin: 12px; font-size: 14px; }
+h2 { margin: 12px 0 6px; font-size: 16px; }
+label { font-weight: 600; display: block; margin: 10px 0 4px; }
+input, textarea { font-family: inherit; font-size: 14px; padding: 8px; border: 1px solid #c8c8c8; border-radius: 6px; width: 100%; box-sizing: border-box; }
+textarea { min-height: 100px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12px; }
+.row-buttons { display: flex; gap: 8px; margin-top: 10px; }
+button { font-family: inherit; font-size: 14px; padding: 10px 14px; border: none; border-radius: 6px; font-weight: 600; cursor: pointer; flex: 1; }
+button.primary { background: #de5833; color: #fff; }
+button.secondary { background: #ccc; color: #000; }
+button:active { opacity: 0.65; }
+.methods { display: flex; flex-wrap: wrap; gap: 6px; margin: 4px 0; }
+.method-chip { padding: 5px 10px; background: rgba(127,127,127,0.18); border-radius: 14px; font-size: 12px; cursor: pointer; }
+.method-chip:active { background: rgba(127,127,127,0.35); }
+.meta { color: #888; font-size: 12px; margin-bottom: 4px; line-height: 1.5; }
+.meta code { background: rgba(127,127,127,0.18); padding: 1px 4px; border-radius: 3px; }
+#log { background: #111; color: #eee; padding: 10px; border-radius: 6px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px; white-space: pre-wrap; word-break: break-all; min-height: 200px; max-height: 55vh; overflow-y: auto; }
+.row-out { color: #7aa2f7; }
+.row-in { color: #9ece6a; }
+.row-err { color: #f7768e; }
+.row-time { color: #888; }
+</style>
+</head>
+<body>
+<h2>JS Bridge Playground</h2>
+<div class="meta">
+Handler <code>{{HANDLER}}</code> · Context <code>{{CONTEXT}}</code> · Feature <code>{{FEATURE}}</code>
+</div>
+
+<label>Quick fill</label>
+<div class="methods">{{METHOD_CHIPS}}</div>
+
+<label for="method">Method</label>
+<input id="method" type="text" autocapitalize="off" autocorrect="off" spellcheck="false" value="{{DEFAULT_METHOD}}">
+
+<label for="params">Params (JSON)</label>
+<textarea id="params" autocapitalize="off" autocorrect="off" spellcheck="false">{{DEFAULT_PARAMS}}</textarea>
+
+<div class="row-buttons">
+<button class="primary" onclick="send()">Send</button>
+<button class="secondary" onclick="clearLog()">Clear log</button>
+</div>
+
+<h2>Response log</h2>
+<div id="log"></div>
+
+<script>
+const HANDLER = {{HANDLER_JS}};
+const CONTEXT = {{CONTEXT_JS}};
+const FEATURE = {{FEATURE_JS}};
+const SAMPLES = {{METHOD_SAMPLES}};
+
+function fillMethod(name) {
+    document.getElementById('method').value = name;
+    if (SAMPLES[name]) {
+        document.getElementById('params').value = SAMPLES[name];
+    }
+}
+
+document.querySelectorAll('.method-chip').forEach(function(chip) {
+    chip.addEventListener('click', function() {
+        fillMethod(chip.getAttribute('data-method'));
+    });
+});
+
+document.getElementById('method').addEventListener('input', function() {
+    var name = this.value.trim();
+    if (SAMPLES[name]) {
+        document.getElementById('params').value = SAMPLES[name];
+    }
+});
+
+function clearLog() { document.getElementById('log').textContent = ''; }
+
+function append(text, cls) {
+    const log = document.getElementById('log');
+    const line = document.createElement('div');
+    if (cls) line.className = cls;
+    const ts = document.createElement('span');
+    ts.className = 'row-time';
+    ts.textContent = '[' + new Date().toLocaleTimeString() + '] ';
+    line.appendChild(ts);
+    line.appendChild(document.createTextNode(text));
+    log.appendChild(line);
+    log.scrollTop = log.scrollHeight;
+}
+
+async function send() {
+    const method = document.getElementById('method').value.trim();
+    const raw = document.getElementById('params').value.trim();
+    if (!method) { append('Method required', 'row-err'); return; }
+    let params;
+    try { params = raw ? JSON.parse(raw) : {}; }
+    catch (e) { append('Params is not valid JSON: ' + e.message, 'row-err'); return; }
+
+    append('-> ' + method + ' ' + JSON.stringify(params), 'row-out');
+
+    const handlerObj = window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers[HANDLER];
+    if (!handlerObj) { append('No JS handler attached: ' + HANDLER, 'row-err'); return; }
+
+    try {
+        const response = await handlerObj.postMessage({
+            context: CONTEXT,
+            featureName: FEATURE,
+            method: method,
+            params: params,
+            id: 'playground-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8)
+        });
+        if (response === undefined || response === null) {
+            append('<- (no value)', 'row-in');
+        } else {
+            var display = response;
+            if (typeof response === 'string') {
+                try { display = JSON.parse(response); } catch (_) { /* keep as string */ }
+            }
+            append('<- ' + JSON.stringify(display, null, 2), 'row-in');
+        }
+    } catch (e) {
+        append('x ' + (e && e.message ? e.message : String(e)), 'row-err');
+    }
+}
+</script>
+</body>
+</html>
+"""#
+}

--- a/iOS/DuckDuckGo/JSBridgePlaygroundAddingFeatures.md
+++ b/iOS/DuckDuckGo/JSBridgePlaygroundAddingFeatures.md
@@ -1,0 +1,102 @@
+# Adding a feature to the JS Bridge Playground
+
+This debug tool exercises a feature's JS bridge inside an in-app WKWebView. Only Subscription is wired up today. Adding another feature is one new type plus one line in the debug menu.
+
+## How it works
+
+The playground attaches a feature's `UserScript`(s) to a fresh `WKWebView` and loads an HTML harness via `loadHTMLString(_:baseURL:)`. The `baseURL` is set to the feature's expected origin so each subfeature's `messageOriginPolicy` accepts the page. The page exposes a method field, a JSON params field, a Send button, and a response log.
+
+The native side never inspects the response — JS captures it directly from the `Promise` returned by `window.webkit.messageHandlers.<handler>.postMessage(...)` and renders it in the log. No log scraping is needed.
+
+## The minimum recipe
+
+Implement `JSBridgePlaygroundFeature` and surface it from `DebugScreensViewModel+Screens.swift`.
+
+```swift
+struct MyFeaturePlaygroundFeature: JSBridgePlaygroundFeature {
+
+    let displayName = "MyFeature"
+
+    // window.webkit.messageHandlers.<messageHandlerName>
+    let messageHandlerName = MyFeatureUserScript.context
+
+    // payload.context — usually the same as messageHandlerName
+    let messageContext = MyFeatureUserScript.context
+
+    // payload.featureName — the subfeature constant declared by the feature
+    let featureName = MyFeatureSubfeatureConstants.featureName
+
+    // Origin used as baseURL for loadHTMLString. Must satisfy the subfeature's
+    // messageOriginPolicy (typically a HostnameMatchingRule.makeExactRule).
+    var baseURL: URL {
+        URL(string: "https://duckduckgo.com/myfeature")!
+    }
+
+    // Quick-fill chips on the page. sampleParamsJSON pre-populates the params field.
+    var knownMethods: [JSBridgePlaygroundMethod] {
+        [
+            JSBridgePlaygroundMethod(name: "doSomething", sampleParamsJSON: "{}"),
+            JSBridgePlaygroundMethod(name: "doSomethingElse", sampleParamsJSON: #"{"foo": "bar"}"#)
+        ]
+    }
+
+    @MainActor
+    func makeUserScripts() -> [UserScript] {
+        let userScript = MyFeatureUserScript()
+        let subFeature = MyFeatureSubfeature(/* real dependencies */)
+        userScript.registerSubfeature(delegate: subFeature)
+        return [userScript]
+    }
+}
+```
+
+Then in `DebugScreensViewModel+Screens.swift`:
+
+```swift
+.controller(title: "JS Bridge Playground (MyFeature)", { _ in
+    return JSBridgePlaygroundViewController(feature: MyFeaturePlaygroundFeature())
+}),
+```
+
+## Things to get right
+
+### `baseURL` must satisfy the origin policy
+
+Subfeatures gate inbound messages with `messageOriginPolicy`. Most use `HostnameMatchingRule.makeExactRule(for:)` against a base URL. Set the playground feature's `baseURL` to a URL whose scheme + host (and where relevant, port) match the subfeature's expected origin. `WKWebView.loadHTMLString(_:baseURL:)` reports that URL as the page origin to the script.
+
+If the page's `window.webkit.messageHandlers.<handler>` is `undefined`, the user script is not attaching — either the handler name is wrong, or the script registration failed at construction time. If `postMessage` rejects with an origin error, the `baseURL` doesn't match the policy.
+
+### Dependency wiring
+
+Each subfeature has its own constructor. Mirror the production wiring as closely as possible — the playground exists to test the bridge layer against real handlers, so injecting real dependencies (where safe in a debug surface) gives the most faithful behavior. `SubscriptionBridgePlaygroundFeature.swift` (alongside this doc) is a worked example of a heavy-dependency case.
+
+### Make the user-script instances retained
+
+`JSBridgePlaygroundViewController` already stores the returned `[UserScript]` in a `private var` so the wrapper objects (and the broker → subfeature retention chain) outlive `makeUserScripts()`. If you add an alternative entry point, mirror this — `WKUserContentController.addUserScript(_:)` retains the underlying `WKUserScript`, but not the Swift `UserScript` wrapper.
+
+## Push-style messages (native -> JS)
+
+This UI is one-shot request/response. Methods like `pushPurchaseUpdate` are fire-and-forget native -> JS dispatches against a live webview and aren't surfaced by the current UI. Exercising them needs a JS-side listener registered on the page plus a native trigger; add it as a separate code path if you need it.
+
+## Features still to plumb
+
+These all expose JS bridges and are candidates for follow-up registrations:
+
+- `AIChat` — `iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift`
+- `AIChatSuggestions` — `SharedPackages/AIChat/.../AIChatSuggestionsUserScript.swift`
+- `DuckAiNativeStorage` — `SharedPackages/AIChat/.../DuckAiNativeStorageUserScript.swift`
+- `AIChatDataClearing` — `SharedPackages/AIChat/.../AIChatDataClearingUserScript.swift`
+- `PageContext` — `iOS/DuckDuckGo/AIChat/UserScript/PageContextUserScript.swift`
+- `DuckPlayer (player + youtube variants)` — `DuckPlayerUserScriptPlayer.swift`, `DuckPlayerUserScriptYouTube.swift`, `YoutubeOverlayUserScript.swift`, `YoutubePlayerUserScript.swift`
+- `IdentityTheftRestoration` — `iOS/DuckDuckGo/Subscription/UserScripts/IdentityTheftRestorationPagesFeature.swift`
+- `SERPSettings` — `SharedPackages/SERPSettings/.../SERPSettingsUserScript.swift`
+- `DBP` — `SharedPackages/DataBrokerProtectionCore/.../DBPUICommunicationLayer.swift`
+- `SpecialErrorPages` — `SharedPackages/BrowserServicesKit/.../SpecialErrorPageUserScript.swift`
+- `BrokenSiteReporting` — `SharedPackages/BrowserServicesKit/.../BreakageReportingSubfeature.swift`
+- `WebTelemetry` — `SharedPackages/BrowserServicesKit/.../WebTelemetryUserScript.swift`
+
+## Caveats
+
+- **State is real.** Calls hit the real `SubscriptionManager`, real network, real keychain, etc. Don't fire destructive methods against a signed-in tester account.
+- **Tab-coupled features.** Anything that relies on a `Tab` or surrounding navigation chain may need a stub or simplified factory for the playground surface.
+- **Internal-only.** Don't surface this outside debug builds.

--- a/iOS/DuckDuckGo/SubscriptionBridgePlaygroundFeature.swift
+++ b/iOS/DuckDuckGo/SubscriptionBridgePlaygroundFeature.swift
@@ -1,0 +1,106 @@
+//
+//  SubscriptionBridgePlaygroundFeature.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import BrowserServicesKit
+import Core
+import Foundation
+import PixelKit
+import Subscription
+import UserScript
+
+struct SubscriptionBridgePlaygroundFeature: JSBridgePlaygroundFeature {
+
+    let displayName = "Subscription"
+    let messageHandlerName = SubscriptionPagesUserScript.context
+    let messageContext = SubscriptionPagesUserScript.context
+    let featureName = SubscriptionPagesUseSubscriptionFeatureConstants.featureName
+
+    var baseURL: URL {
+        AppDependencyProvider.shared.subscriptionManager.url(for: .baseURL)
+    }
+
+    // Side-effecting handlers (subscriptionSelected starts an Apple purchase sheet, backToSettings
+    // and featureSelected navigate away from the playground) are still safe to expose — sending is
+    // a deliberate action. Samples are filled in automatically when a chip is clicked or the method
+    // name is typed.
+    var knownMethods: [JSBridgePlaygroundMethod] {
+        [
+            JSBridgePlaygroundMethod(name: "getAccessToken", sampleParamsJSON: "{}"),
+            JSBridgePlaygroundMethod(name: "getAuthAccessToken", sampleParamsJSON: "{}"),
+            JSBridgePlaygroundMethod(name: "getFeatureConfig", sampleParamsJSON: "{}"),
+            JSBridgePlaygroundMethod(name: "getSubscriptionTierOptions", sampleParamsJSON: "{}"),
+            JSBridgePlaygroundMethod(name: "subscriptionsMonthlyPriceClicked", sampleParamsJSON: "{}"),
+            JSBridgePlaygroundMethod(name: "featureSelected",
+                                     sampleParamsJSON: #"{"productFeature": "networkProtection"}"#),
+            JSBridgePlaygroundMethod(name: "subscriptionSelected",
+                                     sampleParamsJSON: #"{"id": "ddg.privacy.pro.monthly.renews.us"}"#)
+        ]
+    }
+
+    @MainActor
+    func makeUserScripts() -> [UserScript] {
+        let subscriptionManager = AppDependencyProvider.shared.subscriptionManager
+        let subscriptionAppGroup = Bundle.main.appGroup(bundle: .subs)
+        let subscriptionUserDefaults = UserDefaults(suiteName: subscriptionAppGroup)!
+
+        let pendingTransactionHandler = DefaultPendingTransactionHandler(
+            userDefaults: subscriptionUserDefaults,
+            pixelHandler: SubscriptionPixelHandler(source: .mainApp, pixelKit: nil)
+        )
+        let appStoreRestoreFlow = DefaultAppStoreRestoreFlow(
+            subscriptionManager: subscriptionManager,
+            storePurchaseManager: subscriptionManager.storePurchaseManager(),
+            pendingTransactionHandler: pendingTransactionHandler
+        )
+        let appStorePurchaseFlow = DefaultAppStorePurchaseFlow(
+            subscriptionManager: subscriptionManager,
+            storePurchaseManager: subscriptionManager.storePurchaseManager(),
+            appStoreRestoreFlow: appStoreRestoreFlow,
+            wideEvent: AppDependencyProvider.shared.wideEvent,
+            pendingTransactionHandler: pendingTransactionHandler
+        )
+        let subscriptionFeatureAvailability = BrowserServicesKit.DefaultSubscriptionFeatureAvailability(
+            privacyConfigurationManager: ContentBlocking.shared.privacyConfigurationManager,
+            purchasePlatform: .appStore,
+            featureFlagProvider: SubscriptionPageFeatureFlagAdapter(featureFlagger: AppDependencyProvider.shared.featureFlagger)
+        )
+        let subscriptionFlowsExecuter = DefaultSubscriptionFlowsExecuter(
+            subscriptionManager: subscriptionManager,
+            appStorePurchaseFlow: appStorePurchaseFlow,
+            wideEvent: AppDependencyProvider.shared.wideEvent,
+            pendingTransactionHandler: pendingTransactionHandler
+        )
+        let subFeature = DefaultSubscriptionPagesUseSubscriptionFeature(
+            subscriptionManager: subscriptionManager,
+            subscriptionFeatureAvailability: subscriptionFeatureAvailability,
+            subscriptionAttributionOrigin: nil,
+            appStorePurchaseFlow: appStorePurchaseFlow,
+            appStoreRestoreFlow: appStoreRestoreFlow,
+            internalUserDecider: AppDependencyProvider.shared.internalUserDecider,
+            wideEvent: AppDependencyProvider.shared.wideEvent,
+            pendingTransactionHandler: pendingTransactionHandler,
+            subscriptionFlowsExecuter: subscriptionFlowsExecuter,
+            requestValidator: DefaultScriptRequestValidator(subscriptionManager: subscriptionManager)
+        )
+
+        let userScript = SubscriptionPagesUserScript()
+        userScript.registerSubfeature(delegate: subFeature)
+        return [userScript]
+    }
+}


### PR DESCRIPTION
Task/Issue URL: N/A — internal debug tooling
Tech Design URL:
CC:

### Description

Adds a feature-agnostic JS bridge harness to **Settings > Debug > "JS Bridge Playground"**. Picks a registered feature, attaches its `UserScript` to a debug `WKWebView`, and loads a small embedded HTML page that lets you craft `method` / `params`, send a `postMessage`, and inspect the native response (the real `MessageResponse` envelope from the broker).

**Architecture:**
- `JSBridgePlaygroundFeature` protocol — open extension point. Each feature provides `displayName`, `messageHandlerName`, `messageContext`, `featureName`, `baseURL`, `knownMethods` (quick-fill chips with sample params), and `makeUserScripts()`.
- `JSBridgePlaygroundViewController` — UIKit VC, instantiates the user scripts, configures the `WKUserContentController`, calls `loadHTMLString(_:baseURL:)` so the page's origin satisfies the feature's `messageOriginPolicy`.
- `SubscriptionBridgePlaygroundFeature` — the only registration today. Mirrors the production dependency wiring (same pattern as `SubscriptionContainerViewFactory`/`SubscriptionDebugViewController`).
- `JSBridgePlaygroundAddingFeatures.md` — sits next to the Swift files; explains the protocol contract, origin-policy gotcha, dependency wiring, push-message limitations, and lists the candidates not yet plumbed (AIChat, DuckPlayer, DBP, etc.).

**Bridge protocol details surfaced by building this:**
- The JS payload must include an `id` field — without it, the broker treats the call as fire-and-forget and returns the literal `"{}"` regardless of handler return value (`UserScriptMessaging.swift:220-246`).
- The broker returns a JSON `String` (not an object). JS must `JSON.parse` it before pretty-printing.
- The page's `baseURL` must satisfy `HostnameMatchingRule.makeExactRule(for: subscriptionManager.url(for: .baseURL))` — `loadHTMLString(_:baseURL:)` reports the baseURL as the document origin, which is enough.

### Testing Steps

1. Settings > Debug > **JS Bridge Playground**.
2. Tap a quick-fill chip — `getFeatureConfig` is the cleanest demo (no auth, no side effects). The method + sample params populate.
3. Tap **Send**. The response log should show a `MessageResponse` envelope with `context`, `featureName`, `id`, and a `result` containing the actual handler return:
   ```json
   { "context": "subscriptionPages", "featureName": "useSubscription", "id": "playground-…", "result": { "usePaidDuckAi": false, "useAlternateStripePaymentFlow": false } }
   ```
4. Try `getAccessToken` / `getAuthAccessToken` — when signed out you'll see `result: {}` (auth-gated handler returned an empty dict, which is expected and proves the round-trip works).
5. Edit the params JSON manually to test malformed input — invalid JSON shows a red error line; missing-handler methods come back with the broker's "no handler" error message.
6. (Optional) Web Inspector: with the app attached, you can confirm `window.webkit.messageHandlers.subscriptionPages` is defined and the user script attached.

### Impact and Risks

**None.** Debug-only screen, unreachable from any user-facing flow. No production code path is altered.

#### What could go wrong?

- **Side-effecting chips.** `subscriptionSelected` will pop a real Apple purchase sheet if a tester taps Send. `featureSelected` will navigate away (e.g. to VPN). These are deliberately kept as chips because they're useful for verifying payload shape; the doc and inline comment call them out. Mitigation: clear distinction between read-only and side-effecting handlers in the chip list.
- **Real handler dependencies.** The Subscription feature is constructed with real `subscriptionManager`, `appStorePurchaseFlow`, etc. (mirrored from `SubscriptionContainerViewFactory`). Pixel fires from production code (e.g. `m.subscription.tier-options.failure` when StoreKit products aren't loaded) are real side effects. Acceptable for an internal-only debug surface.

### Quality Considerations

- **Edge cases:** unknown methods → broker error response; bad JSON params → JS-side error; not signed in → handler-specific empty/null results (visible in log).
- **Performance:** N/A — debug screen, lazily instantiated.
- **Documentation:** `JSBridgePlaygroundAddingFeatures.md` lives next to the Swift files and lists the candidate features for follow-up.
- **Privacy/security:** No new data flows; the playground just exercises existing handlers under the existing `messageOriginPolicy`. The page is loaded via `loadHTMLString` with a `nonPersistent` data store.

### Notes to Reviewer

- The chip list intentionally only includes methods that are actually wired in the production switch at `SubscriptionPagesUseSubscriptionFeature.swift:232-249`. `getSubscription`/`setSubscription` are declared in the protocol but not routed on this branch, so they're excluded.
- `SubscriptionBridgePlaygroundFeature.makeUserScripts()` duplicates the dependency wiring already present in `SubscriptionContainerViewFactory.swift` (4 copies) and `SubscriptionDebugViewController.swift`. Extracting a shared builder is a worthwhile follow-up but not in scope here.
- pbxproj entries were added by hand (UUIDs generated via `uuidgen | tr -d '-' | cut -c1-24 | tr 'a-z' 'A-Z'`). `plutil -lint` passes; UUID collision check confirms no duplicates.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)