### PR TITLE
[iOS] [test] Wire JS Bridge Playground to the 3 new bridge methods

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -625,6 +625,7 @@ public enum PrivacyProSubfeature: String, Equatable, PrivacySubfeature {
     case allowProTierPurchase
     case freeTrialConversionWideEvent
     case subscriptionPromoForReinstallers
+    case subscriptionExpirationReminderNotification
 }
 
 public enum DuckPlayerSubfeature: String, PrivacySubfeature {

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -140,7 +140,7 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213569392605475
     case subscriptionPromoForReinstallers
 
-    /// https://app.asana.com/1/137249556945/task/1215310117152165
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215316109166260?focus=true
     case subscriptionExpirationReminderNotification
 
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866464085187

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -140,6 +140,9 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213569392605475
     case subscriptionPromoForReinstallers
 
+    /// https://app.asana.com/1/137249556945/task/1215310117152165
+    case subscriptionExpirationReminderNotification
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866464085187
     case syncSetupBarcodeIsUrlBased
 
@@ -559,6 +562,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(PrivacyProSubfeature.privacyProOnboardingPromotion))
         case .subscriptionPromoForReinstallers:
             Config(defaultValue: .enabled, source: .remoteReleasable(PrivacyProSubfeature.subscriptionPromoForReinstallers))
+        case .subscriptionExpirationReminderNotification:
+            Config(source: .remoteReleasable(PrivacyProSubfeature.subscriptionExpirationReminderNotification))
         case .syncSetupBarcodeIsUrlBased:
             Config(source: .remoteReleasable(SyncSubfeature.syncSetupBarcodeIsUrlBased))
         case .canScanUrlBasedSyncSetupBarcodes:

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -433,6 +433,7 @@
 		569B072A2DD7378700E0719A /* ThreatProtectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569B07292DD7378700E0719A /* ThreatProtectionView.swift */; };
 		56A0FE0D2DF7A44800486632 /* SubscriptionFeatureAvailabilityMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A0FE0C2DF7A44800486632 /* SubscriptionFeatureAvailabilityMock.swift */; };
 		56A0FE0E2DF7A52F00486632 /* SubscriptionFeatureAvailabilityMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A0FE0C2DF7A44800486632 /* SubscriptionFeatureAvailabilityMock.swift */; };
+		7B12B1A32C100A0100AABBCC /* SubscriptionExpirationReminderSchedulerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B12B1A22C100A0100AABBCC /* SubscriptionExpirationReminderSchedulerMock.swift */; };
 		56A625232ED623FB00803E31 /* SubscriptionPageFeatureFlagAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A625222ED623FB00803E31 /* SubscriptionPageFeatureFlagAdapter.swift */; };
 		56A625252ED62AEF00803E31 /* SubscriptionPageFeatureFlagAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A625242ED62AEF00803E31 /* SubscriptionPageFeatureFlagAdapterTests.swift */; };
 		56B3310F2E0E92B200D4D3BA /* SubscriptionURLNavigationHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B3310E2E0E92B200D4D3BA /* SubscriptionURLNavigationHandlerTests.swift */; };
@@ -2276,6 +2277,7 @@
 		D668D9272B6937D2008E2FF2 /* SubscriptionITPViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D668D9262B6937D2008E2FF2 /* SubscriptionITPViewModel.swift */; };
 		D668D9292B69681C008E2FF2 /* IdentityTheftRestorationPagesUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = D668D9282B69681C008E2FF2 /* IdentityTheftRestorationPagesUserScript.swift */; };
 		D668D92B2B696840008E2FF2 /* IdentityTheftRestorationPagesFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D668D92A2B696840008E2FF2 /* IdentityTheftRestorationPagesFeature.swift */; };
+		7B12A1B92C100A0100AABBCC /* SubscriptionExpirationReminderScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B12A1B82C100A0100AABBCC /* SubscriptionExpirationReminderScheduler.swift */; };
 		D66F683D2BB333C100AE93E2 /* SubscriptionContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66F683C2BB333C100AE93E2 /* SubscriptionContainerView.swift */; };
 		D670E5BB2BB6A75300941A42 /* SubscriptionNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D670E5BA2BB6A75200941A42 /* SubscriptionNavigationCoordinator.swift */; };
 		D67969112BC84CE700BA8B34 /* SubscriptionContainerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67969102BC84CE700BA8B34 /* SubscriptionContainerViewModel.swift */; };
@@ -3018,6 +3020,7 @@
 		569437352BE5160600C0881B /* SyncSettingsViewControllerErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncSettingsViewControllerErrorTests.swift; sourceTree = "<group>"; };
 		569B07292DD7378700E0719A /* ThreatProtectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreatProtectionView.swift; sourceTree = "<group>"; };
 		56A0FE0C2DF7A44800486632 /* SubscriptionFeatureAvailabilityMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionFeatureAvailabilityMock.swift; sourceTree = "<group>"; };
+		7B12B1A22C100A0100AABBCC /* SubscriptionExpirationReminderSchedulerMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionExpirationReminderSchedulerMock.swift; sourceTree = "<group>"; };
 		56A625222ED623FB00803E31 /* SubscriptionPageFeatureFlagAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPageFeatureFlagAdapter.swift; sourceTree = "<group>"; };
 		56A625242ED62AEF00803E31 /* SubscriptionPageFeatureFlagAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPageFeatureFlagAdapterTests.swift; sourceTree = "<group>"; };
 		56B3310E2E0E92B200D4D3BA /* SubscriptionURLNavigationHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionURLNavigationHandlerTests.swift; sourceTree = "<group>"; };
@@ -4958,6 +4961,7 @@
 		D668D9262B6937D2008E2FF2 /* SubscriptionITPViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionITPViewModel.swift; sourceTree = "<group>"; };
 		D668D9282B69681C008E2FF2 /* IdentityTheftRestorationPagesUserScript.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentityTheftRestorationPagesUserScript.swift; sourceTree = "<group>"; };
 		D668D92A2B696840008E2FF2 /* IdentityTheftRestorationPagesFeature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentityTheftRestorationPagesFeature.swift; sourceTree = "<group>"; };
+		7B12A1B82C100A0100AABBCC /* SubscriptionExpirationReminderScheduler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionExpirationReminderScheduler.swift; sourceTree = "<group>"; };
 		D66F683C2BB333C100AE93E2 /* SubscriptionContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionContainerView.swift; sourceTree = "<group>"; };
 		D670E5BA2BB6A75200941A42 /* SubscriptionNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionNavigationCoordinator.swift; sourceTree = "<group>"; };
 		D67969102BC84CE700BA8B34 /* SubscriptionContainerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionContainerViewModel.swift; sourceTree = "<group>"; };
@@ -6697,6 +6701,7 @@
 				56A0FE0C2DF7A44800486632 /* SubscriptionFeatureAvailabilityMock.swift */,
 				56C23F642E0AD93600FD63C6 /* MockFeedbackSender.swift */,
 				56C23F682E0AD97300FD63C6 /* MockUnifiedMetadataCollector.swift */,
+				7B12B1A22C100A0100AABBCC /* SubscriptionExpirationReminderSchedulerMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -10185,6 +10190,7 @@
 				D668D9282B69681C008E2FF2 /* IdentityTheftRestorationPagesUserScript.swift */,
 				D668D92A2B696840008E2FF2 /* IdentityTheftRestorationPagesFeature.swift */,
 				565AC7452EDE090600639D35 /* SubscriptionTierEventReporter.swift */,
+				7B12A1B82C100A0100AABBCC /* SubscriptionExpirationReminderScheduler.swift */,
 			);
 			path = UserScripts;
 			sourceTree = "<group>";
@@ -12907,6 +12913,7 @@
 				65D091262D47DF2A00226164 /* DuckPlayerView.swift in Sources */,
 				851B12CC22369931004781BC /* AtbAndVariantCleanup.swift in Sources */,
 				D668D92B2B696840008E2FF2 /* IdentityTheftRestorationPagesFeature.swift in Sources */,
+				7B12A1B92C100A0100AABBCC /* SubscriptionExpirationReminderScheduler.swift in Sources */,
 				85F2FFCF2211F8E5006BB258 /* TabSwitcherViewController+KeyCommands.swift in Sources */,
 				3157B43327F497E90042D3D7 /* SaveLoginView.swift in Sources */,
 				31A7B00227F497E90042D3D8 /* SaveLoginDebugView.swift in Sources */,
@@ -14037,6 +14044,7 @@
 				85D2187424BF25CD004373D2 /* FaviconsTests.swift in Sources */,
 				80437D6D2EFB3BDA00D3E896 /* AutoClearSettingsViewModelTests.swift in Sources */,
 				56A0FE0D2DF7A44800486632 /* SubscriptionFeatureAvailabilityMock.swift in Sources */,
+				7B12B1A32C100A0100AABBCC /* SubscriptionExpirationReminderSchedulerMock.swift in Sources */,
 				9F254ACB2CF5CDC60063B308 /* SpecialErrorPageNavigationHandlerTests.swift in Sources */,
 				98E564372DE8B6BF00E6E75F /* PrivacyConfigurationManagerMock.swift in Sources */,
 				9F3361BA2F2B24B800E0C21A /* ContextualDaxDialogsProviderTests.swift in Sources */,

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -252,6 +252,8 @@
 		362AB8382F69A33700E3F222 /* ActionResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 362AB8372F69A33700E3F222 /* ActionResult.swift */; };
 		365E900B2E566C2300BDB0E8 /* AIChatIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 365E900A2E566C2300BDB0E8 /* AIChatIntent.swift */; };
 		365E90132E5673DF00BDB0E8 /* SearchInAppIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 365E90122E5673DF00BDB0E8 /* SearchInAppIntent.swift */; };
+		366A93042FCE0E0B00211BA8 /* SubscriptionExpirationReminderScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 366A93032FCE0E0B00211BA8 /* SubscriptionExpirationReminderScheduler.swift */; };
+		366A93062FCE0E3700211BA8 /* SubscriptionExpirationReminderSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 366A93052FCE0E3700211BA8 /* SubscriptionExpirationReminderSchedulerTests.swift */; };
 		369809BF2E5635E7007FE895 /* AppShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 369809BE2E5635E1007FE895 /* AppShortcuts.swift */; };
 		369E69282E5F4B9600F98A8F /* InactivityNotificationSchedulerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 369E69272E5F4B8500F98A8F /* InactivityNotificationSchedulerService.swift */; };
 		369E692A2E5F579B00F98A8F /* NotificationServiceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 369E69292E5F579500F98A8F /* NotificationServiceManager.swift */; };
@@ -433,7 +435,6 @@
 		569B072A2DD7378700E0719A /* ThreatProtectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569B07292DD7378700E0719A /* ThreatProtectionView.swift */; };
 		56A0FE0D2DF7A44800486632 /* SubscriptionFeatureAvailabilityMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A0FE0C2DF7A44800486632 /* SubscriptionFeatureAvailabilityMock.swift */; };
 		56A0FE0E2DF7A52F00486632 /* SubscriptionFeatureAvailabilityMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A0FE0C2DF7A44800486632 /* SubscriptionFeatureAvailabilityMock.swift */; };
-		7B12B1A32C100A0100AABBCC /* SubscriptionExpirationReminderSchedulerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B12B1A22C100A0100AABBCC /* SubscriptionExpirationReminderSchedulerMock.swift */; };
 		56A625232ED623FB00803E31 /* SubscriptionPageFeatureFlagAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A625222ED623FB00803E31 /* SubscriptionPageFeatureFlagAdapter.swift */; };
 		56A625252ED62AEF00803E31 /* SubscriptionPageFeatureFlagAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A625242ED62AEF00803E31 /* SubscriptionPageFeatureFlagAdapterTests.swift */; };
 		56B3310F2E0E92B200D4D3BA /* SubscriptionURLNavigationHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B3310E2E0E92B200D4D3BA /* SubscriptionURLNavigationHandlerTests.swift */; };
@@ -615,6 +616,7 @@
 		7B0752D92F21BFDB00ACA559 /* AutomationServer in Frameworks */ = {isa = PBXBuildFile; productRef = 7B0752D82F21BFDB00ACA559 /* AutomationServer */; };
 		7B10FF242D11A56300F36BF2 /* ControlWidgetVPNIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B10FF232D11A56300F36BF2 /* ControlWidgetVPNIntents.swift */; };
 		7B10FF252D11A56300F36BF2 /* ControlWidgetVPNIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B10FF232D11A56300F36BF2 /* ControlWidgetVPNIntents.swift */; };
+		7B12B1A32C100A0100AABBCC /* SubscriptionExpirationReminderSchedulerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B12B1A22C100A0100AABBCC /* SubscriptionExpirationReminderSchedulerMock.swift */; };
 		7B1604E82CB685B400A44EC6 /* Logger+TipKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1604E72CB685B400A44EC6 /* Logger+TipKit.swift */; };
 		7B1604EC2CB68BDA00A44EC6 /* TipKitController+ConvenienceInitializers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1604EB2CB68BDA00A44EC6 /* TipKitController+ConvenienceInitializers.swift */; };
 		7B1604EE2CB68D2600A44EC6 /* TipKitDebugOptionsUIActionHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1604ED2CB68D2600A44EC6 /* TipKitDebugOptionsUIActionHandling.swift */; };
@@ -2277,7 +2279,6 @@
 		D668D9272B6937D2008E2FF2 /* SubscriptionITPViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D668D9262B6937D2008E2FF2 /* SubscriptionITPViewModel.swift */; };
 		D668D9292B69681C008E2FF2 /* IdentityTheftRestorationPagesUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = D668D9282B69681C008E2FF2 /* IdentityTheftRestorationPagesUserScript.swift */; };
 		D668D92B2B696840008E2FF2 /* IdentityTheftRestorationPagesFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D668D92A2B696840008E2FF2 /* IdentityTheftRestorationPagesFeature.swift */; };
-		7B12A1B92C100A0100AABBCC /* SubscriptionExpirationReminderScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B12A1B82C100A0100AABBCC /* SubscriptionExpirationReminderScheduler.swift */; };
 		D66F683D2BB333C100AE93E2 /* SubscriptionContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66F683C2BB333C100AE93E2 /* SubscriptionContainerView.swift */; };
 		D670E5BB2BB6A75300941A42 /* SubscriptionNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D670E5BA2BB6A75200941A42 /* SubscriptionNavigationCoordinator.swift */; };
 		D67969112BC84CE700BA8B34 /* SubscriptionContainerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67969102BC84CE700BA8B34 /* SubscriptionContainerViewModel.swift */; };
@@ -2896,6 +2897,8 @@
 		362AB8372F69A33700E3F222 /* ActionResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionResult.swift; sourceTree = "<group>"; };
 		365E900A2E566C2300BDB0E8 /* AIChatIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatIntent.swift; sourceTree = "<group>"; };
 		365E90122E5673DF00BDB0E8 /* SearchInAppIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchInAppIntent.swift; sourceTree = "<group>"; };
+		366A93032FCE0E0B00211BA8 /* SubscriptionExpirationReminderScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionExpirationReminderScheduler.swift; sourceTree = "<group>"; };
+		366A93052FCE0E3700211BA8 /* SubscriptionExpirationReminderSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionExpirationReminderSchedulerTests.swift; sourceTree = "<group>"; };
 		369809BE2E5635E1007FE895 /* AppShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppShortcuts.swift; sourceTree = "<group>"; };
 		369E69272E5F4B8500F98A8F /* InactivityNotificationSchedulerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactivityNotificationSchedulerService.swift; sourceTree = "<group>"; };
 		369E69292E5F579500F98A8F /* NotificationServiceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceManager.swift; sourceTree = "<group>"; };
@@ -3020,7 +3023,6 @@
 		569437352BE5160600C0881B /* SyncSettingsViewControllerErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncSettingsViewControllerErrorTests.swift; sourceTree = "<group>"; };
 		569B07292DD7378700E0719A /* ThreatProtectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreatProtectionView.swift; sourceTree = "<group>"; };
 		56A0FE0C2DF7A44800486632 /* SubscriptionFeatureAvailabilityMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionFeatureAvailabilityMock.swift; sourceTree = "<group>"; };
-		7B12B1A22C100A0100AABBCC /* SubscriptionExpirationReminderSchedulerMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionExpirationReminderSchedulerMock.swift; sourceTree = "<group>"; };
 		56A625222ED623FB00803E31 /* SubscriptionPageFeatureFlagAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPageFeatureFlagAdapter.swift; sourceTree = "<group>"; };
 		56A625242ED62AEF00803E31 /* SubscriptionPageFeatureFlagAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPageFeatureFlagAdapterTests.swift; sourceTree = "<group>"; };
 		56B3310E2E0E92B200D4D3BA /* SubscriptionURLNavigationHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionURLNavigationHandlerTests.swift; sourceTree = "<group>"; };
@@ -3194,6 +3196,7 @@
 		7B059F132D03881000371ED0 /* ControlCenterWidgetEducationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlCenterWidgetEducationView.swift; sourceTree = "<group>"; };
 		7B10FF232D11A56300F36BF2 /* ControlWidgetVPNIntents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlWidgetVPNIntents.swift; sourceTree = "<group>"; };
 		7B10FF282D11AA0D00F36BF2 /* VPNiOS */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = VPNiOS; sourceTree = "<group>"; };
+		7B12B1A22C100A0100AABBCC /* SubscriptionExpirationReminderSchedulerMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionExpirationReminderSchedulerMock.swift; sourceTree = "<group>"; };
 		7B1604E72CB685B400A44EC6 /* Logger+TipKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+TipKit.swift"; sourceTree = "<group>"; };
 		7B1604EB2CB68BDA00A44EC6 /* TipKitController+ConvenienceInitializers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TipKitController+ConvenienceInitializers.swift"; sourceTree = "<group>"; };
 		7B1604ED2CB68D2600A44EC6 /* TipKitDebugOptionsUIActionHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipKitDebugOptionsUIActionHandling.swift; sourceTree = "<group>"; };
@@ -4961,7 +4964,6 @@
 		D668D9262B6937D2008E2FF2 /* SubscriptionITPViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionITPViewModel.swift; sourceTree = "<group>"; };
 		D668D9282B69681C008E2FF2 /* IdentityTheftRestorationPagesUserScript.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentityTheftRestorationPagesUserScript.swift; sourceTree = "<group>"; };
 		D668D92A2B696840008E2FF2 /* IdentityTheftRestorationPagesFeature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentityTheftRestorationPagesFeature.swift; sourceTree = "<group>"; };
-		7B12A1B82C100A0100AABBCC /* SubscriptionExpirationReminderScheduler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionExpirationReminderScheduler.swift; sourceTree = "<group>"; };
 		D66F683C2BB333C100AE93E2 /* SubscriptionContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionContainerView.swift; sourceTree = "<group>"; };
 		D670E5BA2BB6A75200941A42 /* SubscriptionNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionNavigationCoordinator.swift; sourceTree = "<group>"; };
 		D67969102BC84CE700BA8B34 /* SubscriptionContainerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionContainerViewModel.swift; sourceTree = "<group>"; };
@@ -10185,12 +10187,12 @@
 		D664C7B02B289AA000CBFA76 /* UserScripts */ = {
 			isa = PBXGroup;
 			children = (
+				366A93032FCE0E0B00211BA8 /* SubscriptionExpirationReminderScheduler.swift */,
 				D664C7B32B289AA000CBFA76 /* SubscriptionPagesUserScript.swift */,
 				D664C7B52B289AA000CBFA76 /* SubscriptionPagesUseSubscriptionFeature.swift */,
 				D668D9282B69681C008E2FF2 /* IdentityTheftRestorationPagesUserScript.swift */,
 				D668D92A2B696840008E2FF2 /* IdentityTheftRestorationPagesFeature.swift */,
 				565AC7452EDE090600639D35 /* SubscriptionTierEventReporter.swift */,
-				7B12A1B82C100A0100AABBCC /* SubscriptionExpirationReminderScheduler.swift */,
 			);
 			path = UserScripts;
 			sourceTree = "<group>";
@@ -11033,6 +11035,7 @@
 		F1BDDBFC2C340D9C00459306 /* Subscription */ = {
 			isa = PBXGroup;
 			children = (
+				366A93052FCE0E3700211BA8 /* SubscriptionExpirationReminderSchedulerTests.swift */,
 				F14B81412F32615B00C39E26 /* SubscriptionPixelHandlerTests.swift */,
 				BBFA343E2F19286D0003CB58 /* SubscriptionPagesUseSubscriptionFeatureTests.swift */,
 				BBFA343F2F19286D0003CB58 /* SubscriptionSettingsViewModelTests.swift */,
@@ -12644,6 +12647,7 @@
 				CB6D179F2FA38FAD00ECD5AE /* UnifiedToggleInputHost.swift in Sources */,
 				C13C36702F4B5B3A008E7D08 /* SyncAutoRestoreHandler.swift in Sources */,
 				3157B43527F497F50042D3D7 /* SaveLoginViewController.swift in Sources */,
+				366A93042FCE0E0B00211BA8 /* SubscriptionExpirationReminderScheduler.swift in Sources */,
 				317A247F2D8336650033A0D6 /* DownloadsDirectoryHandling.swift in Sources */,
 				853807922D6E638000CE1455 /* AlertPlaygroundView.swift in Sources */,
 				C14D43012B45D6CD00ACA4DC /* AutofillDebugViewController.swift in Sources */,
@@ -12913,7 +12917,6 @@
 				65D091262D47DF2A00226164 /* DuckPlayerView.swift in Sources */,
 				851B12CC22369931004781BC /* AtbAndVariantCleanup.swift in Sources */,
 				D668D92B2B696840008E2FF2 /* IdentityTheftRestorationPagesFeature.swift in Sources */,
-				7B12A1B92C100A0100AABBCC /* SubscriptionExpirationReminderScheduler.swift in Sources */,
 				85F2FFCF2211F8E5006BB258 /* TabSwitcherViewController+KeyCommands.swift in Sources */,
 				3157B43327F497E90042D3D7 /* SaveLoginView.swift in Sources */,
 				31A7B00227F497E90042D3D8 /* SaveLoginDebugView.swift in Sources */,
@@ -13731,6 +13734,7 @@
 				B6AD9E3828D4512E0019CDE9 /* EmbeddedTrackerDataTests.swift in Sources */,
 				56A625252ED62AEF00803E31 /* SubscriptionPageFeatureFlagAdapterTests.swift in Sources */,
 				5B4F88C42F465B76003999E2 /* TabExternalLaunchTests.swift in Sources */,
+				366A93062FCE0E3700211BA8 /* SubscriptionExpirationReminderSchedulerTests.swift in Sources */,
 				5B4F88C72F466017003999E2 /* TabManagerExternalLaunchTests.swift in Sources */,
 				9876DF2D2DEEE21700E30713 /* MockThemeManager.swift in Sources */,
 				84EFBCC92D81796000706739 /* AutocompleteSuggestionsDataSourceTests.swift in Sources */,

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -804,6 +804,8 @@
 		85371D242121B9D500920548 /* new_tab.json in Resources */ = {isa = PBXBuildFile; fileRef = 85371D232121B9D400920548 /* new_tab.json */; };
 		85372447220DD103009D09CD /* UIKeyCommandExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85372446220DD103009D09CD /* UIKeyCommandExtension.swift */; };
 		853807922D6E638000CE1455 /* AlertPlaygroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853807912D6E638000CE1455 /* AlertPlaygroundView.swift */; };
+		86CFB2CDD7994EA2BDE8B9C9 /* JSBridgePlayground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3547B661FE5E43D481720B23 /* JSBridgePlayground.swift */; };
+		4981777E82734C27BC55EFFA /* SubscriptionBridgePlaygroundFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825F1E60DD344C7AAD838D0 /* SubscriptionBridgePlaygroundFeature.swift */; };
 		853A717620F62FE800FE60BC /* Pixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853A717520F62FE800FE60BC /* Pixel.swift */; };
 		853A717820F645FB00FE60BC /* PixelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853A717720F645FB00FE60BC /* PixelTests.swift */; };
 		853C5F6121C277C7001F7A05 /* global.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853C5F6021C277C7001F7A05 /* global.swift */; };
@@ -3368,6 +3370,9 @@
 		85371D232121B9D400920548 /* new_tab.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = new_tab.json; sourceTree = "<group>"; };
 		85372446220DD103009D09CD /* UIKeyCommandExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKeyCommandExtension.swift; sourceTree = "<group>"; };
 		853807912D6E638000CE1455 /* AlertPlaygroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertPlaygroundView.swift; sourceTree = "<group>"; };
+		3547B661FE5E43D481720B23 /* JSBridgePlayground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSBridgePlayground.swift; sourceTree = "<group>"; };
+		4825F1E60DD344C7AAD838D0 /* SubscriptionBridgePlaygroundFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionBridgePlaygroundFeature.swift; sourceTree = "<group>"; };
+		9915A189A9C64BD28067CBFA /* JSBridgePlaygroundAddingFeatures.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = JSBridgePlaygroundAddingFeatures.md; sourceTree = "<group>"; };
 		853A717520F62FE800FE60BC /* Pixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pixel.swift; sourceTree = "<group>"; };
 		853A717720F645FB00FE60BC /* PixelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelTests.swift; sourceTree = "<group>"; };
 		853C5F6021C277C7001F7A05 /* global.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = global.swift; sourceTree = "<group>"; };
@@ -7683,6 +7688,9 @@
 				4B67012A2E3BE3660066176A /* LogViewer */,
 				31206F6F2D3804E800A95D76 /* AIChatDebugView.swift */,
 				853807912D6E638000CE1455 /* AlertPlaygroundView.swift */,
+				3547B661FE5E43D481720B23 /* JSBridgePlayground.swift */,
+				4825F1E60DD344C7AAD838D0 /* SubscriptionBridgePlaygroundFeature.swift */,
+				9915A189A9C64BD28067CBFA /* JSBridgePlaygroundAddingFeatures.md */,
 				C1047CA32CA59BDC00B916FD /* Autofill */,
 				98A860EE2C4682E00077FE4D /* BookmarksDebugViewController.swift */,
 				857917E12D806C1900E23CDC /* BulkGeneratorView.swift */,
@@ -12650,6 +12658,8 @@
 				366A93042FCE0E0B00211BA8 /* SubscriptionExpirationReminderScheduler.swift in Sources */,
 				317A247F2D8336650033A0D6 /* DownloadsDirectoryHandling.swift in Sources */,
 				853807922D6E638000CE1455 /* AlertPlaygroundView.swift in Sources */,
+				86CFB2CDD7994EA2BDE8B9C9 /* JSBridgePlayground.swift in Sources */,
+				4981777E82734C27BC55EFFA /* SubscriptionBridgePlaygroundFeature.swift in Sources */,
 				C14D43012B45D6CD00ACA4DC /* AutofillDebugViewController.swift in Sources */,
 				5608B5132F2125CC00ABC3F4 /* UITestOverridesDebugView.swift in Sources */,
 				856F28D72D3EC5FA00A88211 /* TabSwitcherViewController+MultiSelect.swift in Sources */,

--- a/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
@@ -62,6 +62,7 @@ protocol DependencyProvider {
     var freeTrialConversionService: FreeTrialConversionInstrumentationService { get }
     var subscriptionManager: any SubscriptionManager { get }
     var tokenHandlerProvider: any SubscriptionTokenHandling { get }
+    var subscriptionExpirationReminderScheduler: SubscriptionExpirationReminderScheduling { get }
     var dbpSettings: DataBrokerProtectionSettings { get }
     var syncAutoRestoreDecisionManager: SyncAutoRestoreDecisionManaging { get }
 }
@@ -91,6 +92,7 @@ final class AppDependencyProvider: DependencyProvider {
     // Subscription
     var subscriptionManager: any SubscriptionManager
     var tokenHandlerProvider: any SubscriptionTokenHandling
+    let subscriptionExpirationReminderScheduler: SubscriptionExpirationReminderScheduling
     static let deadTokenRecoverer = DeadTokenRecoverer()
 
     let vpnFeatureVisibility: DefaultNetworkProtectionVisibility
@@ -273,6 +275,10 @@ final class AppDependencyProvider: DependencyProvider {
         self.subscriptionManager = subscriptionManager
         tokenHandler = subscriptionManager
         authenticationStateProvider = subscriptionManager
+        self.subscriptionExpirationReminderScheduler = DefaultSubscriptionExpirationReminderScheduler(
+            subscriptionManager: subscriptionManager,
+            isFeatureEnabled: { featureFlagger.isFeatureOn(.subscriptionExpirationReminderNotification) }
+        )
         self.freeTrialConversionService = DefaultFreeTrialConversionInstrumentationService(
             wideEvent: wideEvent,
             pixelHandler: FreeTrialPixelHandler(),

--- a/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
+++ b/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
@@ -240,6 +240,9 @@ extension DebugScreensViewModel {
                     SubscriptionDebugViewController(coder: coder, subscriptionDataReporter: dependencies.subscriptionDataReporter)
                 }
             }),
+            .controller(title: "JS Bridge Playground", { _ in
+                return JSBridgePlaygroundViewController(feature: SubscriptionBridgePlaygroundFeature())
+            }),
             .controller(title: "Configuration URLs", { _ in
                 return self.debugStoryboard.instantiateViewController(identifier: "ConfigurationURLDebugViewController") { coder in
                     let viewController = ConfigurationURLDebugViewController(coder: coder)

--- a/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
+++ b/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
@@ -240,7 +240,7 @@ extension DebugScreensViewModel {
                     SubscriptionDebugViewController(coder: coder, subscriptionDataReporter: dependencies.subscriptionDataReporter)
                 }
             }),
-            .controller(title: "JS Bridge Playground", { _ in
+            .controller(title: "JS Bridge: Subscription Expiration Notification", { _ in
                 return JSBridgePlaygroundViewController(feature: SubscriptionBridgePlaygroundFeature())
             }),
             .controller(title: "Configuration URLs", { _ in

--- a/iOS/DuckDuckGo/JSBridgePlayground.swift
+++ b/iOS/DuckDuckGo/JSBridgePlayground.swift
@@ -1,0 +1,294 @@
+//
+//  JSBridgePlayground.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import UIKit
+import UserScript
+import WebKit
+
+/// Describes a feature whose JS bridge can be exercised inside the in-app playground.
+///
+/// See `JSBridgePlaygroundAddingFeatures.md` for the registration recipe.
+protocol JSBridgePlaygroundFeature {
+
+    /// Human-readable name shown in the debug menu (e.g. "Subscription").
+    var displayName: String { get }
+
+    /// The `WKScriptMessageHandler` name JS calls via `window.webkit.messageHandlers.<name>`.
+    var messageHandlerName: String { get }
+
+    /// The `context` field in the postMessage payload sent to native.
+    var messageContext: String { get }
+
+    /// The `featureName` field in the postMessage payload sent to native.
+    var featureName: String { get }
+
+    /// Origin used as the `baseURL` for `loadHTMLString`. Must satisfy the subfeature's `messageOriginPolicy`.
+    var baseURL: URL { get }
+
+    /// Methods to surface as quick-fill chips on the page. `sampleParamsJSON` is optional pre-filled params.
+    var knownMethods: [JSBridgePlaygroundMethod] { get }
+
+    /// Returns user scripts that already have their subfeatures registered. Called once per playground session.
+    @MainActor
+    func makeUserScripts() -> [UserScript]
+}
+
+struct JSBridgePlaygroundMethod {
+    let name: String
+    let sampleParamsJSON: String?
+}
+
+final class JSBridgePlaygroundViewController: UIViewController {
+
+    private let feature: JSBridgePlaygroundFeature
+    private var webView: WKWebView!
+    private var userScripts: [UserScript] = []
+
+    init(feature: JSBridgePlaygroundFeature) {
+        self.feature = feature
+        super.init(nibName: nil, bundle: nil)
+        title = "JS Bridge: \(feature.displayName)"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        setupWebView()
+        loadPlaygroundPage()
+    }
+
+    @MainActor
+    private func setupWebView() {
+        let contentController = WKUserContentController()
+        userScripts = feature.makeUserScripts()
+        for userScript in userScripts {
+            contentController.addUserScript(userScript.makeWKUserScriptSync())
+            contentController.addHandler(userScript)
+        }
+
+        let configuration = WKWebViewConfiguration()
+        configuration.userContentController = contentController
+        configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
+
+        webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.translatesAutoresizingMaskIntoConstraints = false
+#if DEBUG
+        if #available(iOS 16.4, *) {
+            webView.isInspectable = true
+        }
+#endif
+
+        view.addSubview(webView)
+        NSLayoutConstraint.activate([
+            webView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            webView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    @MainActor
+    private func loadPlaygroundPage() {
+        let html = JSBridgePlaygroundHTML.render(for: feature)
+        webView.loadHTMLString(html, baseURL: feature.baseURL)
+    }
+}
+
+enum JSBridgePlaygroundHTML {
+
+    static func render(for feature: JSBridgePlaygroundFeature) -> String {
+        let chips = feature.knownMethods.map { method -> String in
+            let nameHtml = htmlEscape(method.name)
+            return #"<span class="method-chip" data-method="\#(nameHtml)">\#(nameHtml)</span>"#
+        }.joined()
+
+        let samplesDictEntries = feature.knownMethods.map { method -> String in
+            let key = jsStringLiteral(method.name)
+            let value = method.sampleParamsJSON.map { jsStringLiteral($0) } ?? "\"\""
+            return "\(key): \(value)"
+        }.joined(separator: ", ")
+
+        let defaultMethod = feature.knownMethods.first?.name ?? ""
+        let defaultParams = feature.knownMethods.first?.sampleParamsJSON ?? "{}"
+
+        return template
+            .replacingOccurrences(of: "{{HANDLER}}", with: htmlEscape(feature.messageHandlerName))
+            .replacingOccurrences(of: "{{CONTEXT}}", with: htmlEscape(feature.messageContext))
+            .replacingOccurrences(of: "{{FEATURE}}", with: htmlEscape(feature.featureName))
+            .replacingOccurrences(of: "{{HANDLER_JS}}", with: jsStringLiteral(feature.messageHandlerName))
+            .replacingOccurrences(of: "{{CONTEXT_JS}}", with: jsStringLiteral(feature.messageContext))
+            .replacingOccurrences(of: "{{FEATURE_JS}}", with: jsStringLiteral(feature.featureName))
+            .replacingOccurrences(of: "{{METHOD_CHIPS}}", with: chips)
+            .replacingOccurrences(of: "{{METHOD_SAMPLES}}", with: "{\(samplesDictEntries)}")
+            .replacingOccurrences(of: "{{DEFAULT_METHOD}}", with: htmlEscape(defaultMethod))
+            .replacingOccurrences(of: "{{DEFAULT_PARAMS}}", with: htmlEscape(defaultParams))
+    }
+
+    private static func htmlEscape(_ s: String) -> String {
+        s
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
+    }
+
+    private static func jsStringLiteral(_ s: String) -> String {
+        let data = try? JSONSerialization.data(withJSONObject: s, options: .fragmentsAllowed)
+        return data.flatMap { String(data: $0, encoding: .utf8) } ?? "\"\""
+    }
+
+    private static let template = #"""
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+<style>
+:root { color-scheme: light dark; }
+body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; margin: 12px; font-size: 14px; }
+h2 { margin: 12px 0 6px; font-size: 16px; }
+label { font-weight: 600; display: block; margin: 10px 0 4px; }
+input, textarea { font-family: inherit; font-size: 14px; padding: 8px; border: 1px solid #c8c8c8; border-radius: 6px; width: 100%; box-sizing: border-box; }
+textarea { min-height: 100px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12px; }
+.row-buttons { display: flex; gap: 8px; margin-top: 10px; }
+button { font-family: inherit; font-size: 14px; padding: 10px 14px; border: none; border-radius: 6px; font-weight: 600; cursor: pointer; flex: 1; }
+button.primary { background: #de5833; color: #fff; }
+button.secondary { background: #ccc; color: #000; }
+button:active { opacity: 0.65; }
+.methods { display: flex; flex-wrap: wrap; gap: 6px; margin: 4px 0; }
+.method-chip { padding: 5px 10px; background: rgba(127,127,127,0.18); border-radius: 14px; font-size: 12px; cursor: pointer; }
+.method-chip:active { background: rgba(127,127,127,0.35); }
+.meta { color: #888; font-size: 12px; margin-bottom: 4px; line-height: 1.5; }
+.meta code { background: rgba(127,127,127,0.18); padding: 1px 4px; border-radius: 3px; }
+#log { background: #111; color: #eee; padding: 10px; border-radius: 6px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px; white-space: pre-wrap; word-break: break-all; min-height: 200px; max-height: 55vh; overflow-y: auto; }
+.row-out { color: #7aa2f7; }
+.row-in { color: #9ece6a; }
+.row-err { color: #f7768e; }
+.row-time { color: #888; }
+</style>
+</head>
+<body>
+<h2>JS Bridge Playground</h2>
+<div class="meta">
+Handler <code>{{HANDLER}}</code> · Context <code>{{CONTEXT}}</code> · Feature <code>{{FEATURE}}</code>
+</div>
+
+<label>Quick fill</label>
+<div class="methods">{{METHOD_CHIPS}}</div>
+
+<label for="method">Method</label>
+<input id="method" type="text" autocapitalize="off" autocorrect="off" spellcheck="false" value="{{DEFAULT_METHOD}}">
+
+<label for="params">Params (JSON)</label>
+<textarea id="params" autocapitalize="off" autocorrect="off" spellcheck="false">{{DEFAULT_PARAMS}}</textarea>
+
+<div class="row-buttons">
+<button class="primary" onclick="send()">Send</button>
+<button class="secondary" onclick="clearLog()">Clear log</button>
+</div>
+
+<h2>Response log</h2>
+<div id="log"></div>
+
+<script>
+const HANDLER = {{HANDLER_JS}};
+const CONTEXT = {{CONTEXT_JS}};
+const FEATURE = {{FEATURE_JS}};
+const SAMPLES = {{METHOD_SAMPLES}};
+
+function fillMethod(name) {
+    document.getElementById('method').value = name;
+    if (SAMPLES[name]) {
+        document.getElementById('params').value = SAMPLES[name];
+    }
+}
+
+document.querySelectorAll('.method-chip').forEach(function(chip) {
+    chip.addEventListener('click', function() {
+        fillMethod(chip.getAttribute('data-method'));
+    });
+});
+
+document.getElementById('method').addEventListener('input', function() {
+    var name = this.value.trim();
+    if (SAMPLES[name]) {
+        document.getElementById('params').value = SAMPLES[name];
+    }
+});
+
+function clearLog() { document.getElementById('log').textContent = ''; }
+
+function append(text, cls) {
+    const log = document.getElementById('log');
+    const line = document.createElement('div');
+    if (cls) line.className = cls;
+    const ts = document.createElement('span');
+    ts.className = 'row-time';
+    ts.textContent = '[' + new Date().toLocaleTimeString() + '] ';
+    line.appendChild(ts);
+    line.appendChild(document.createTextNode(text));
+    log.appendChild(line);
+    log.scrollTop = log.scrollHeight;
+}
+
+async function send() {
+    const method = document.getElementById('method').value.trim();
+    const raw = document.getElementById('params').value.trim();
+    if (!method) { append('Method required', 'row-err'); return; }
+    let params;
+    try { params = raw ? JSON.parse(raw) : {}; }
+    catch (e) { append('Params is not valid JSON: ' + e.message, 'row-err'); return; }
+
+    append('-> ' + method + ' ' + JSON.stringify(params), 'row-out');
+
+    const handlerObj = window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers[HANDLER];
+    if (!handlerObj) { append('No JS handler attached: ' + HANDLER, 'row-err'); return; }
+
+    try {
+        const response = await handlerObj.postMessage({
+            context: CONTEXT,
+            featureName: FEATURE,
+            method: method,
+            params: params,
+            id: 'playground-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8)
+        });
+        if (response === undefined || response === null) {
+            append('<- (no value)', 'row-in');
+        } else {
+            var display = response;
+            if (typeof response === 'string') {
+                try { display = JSON.parse(response); } catch (_) { /* keep as string */ }
+            }
+            append('<- ' + JSON.stringify(display, null, 2), 'row-in');
+        }
+    } catch (e) {
+        append('x ' + (e && e.message ? e.message : String(e)), 'row-err');
+    }
+}
+</script>
+</body>
+</html>
+"""#
+}

--- a/iOS/DuckDuckGo/JSBridgePlayground.swift
+++ b/iOS/DuckDuckGo/JSBridgePlayground.swift
@@ -19,6 +19,7 @@
 
 import Foundation
 import UIKit
+import UserNotifications
 import UserScript
 import WebKit
 
@@ -86,6 +87,8 @@ final class JSBridgePlaygroundViewController: UIViewController {
             contentController.addUserScript(userScript.makeWKUserScriptSync())
             contentController.addHandler(userScript)
         }
+        contentController.addScriptMessageHandler(self, contentWorld: .page, name: "__playgroundNotifications")
+        contentController.addScriptMessageHandler(self, contentWorld: .page, name: "__playgroundSchedulerDiagnostics")
 
         let configuration = WKWebViewConfiguration()
         configuration.userContentController = contentController
@@ -113,6 +116,94 @@ final class JSBridgePlaygroundViewController: UIViewController {
         let html = JSBridgePlaygroundHTML.render(for: feature)
         webView.loadHTMLString(html, baseURL: feature.baseURL)
     }
+}
+
+extension JSBridgePlaygroundViewController: WKScriptMessageHandlerWithReply {
+
+    func userContentController(_ userContentController: WKUserContentController,
+                               didReceive message: WKScriptMessage,
+                               replyHandler: @escaping (Any?, String?) -> Void) {
+        switch message.name {
+        case "__playgroundNotifications":
+            Task { @MainActor in
+                let requests = await UNUserNotificationCenter.current().pendingNotificationRequests()
+                let payload = requests.map { request -> [String: Any] in
+                    [
+                        "identifier": request.identifier,
+                        "title": request.content.title,
+                        "body": request.content.body,
+                        "categoryIdentifier": request.content.categoryIdentifier,
+                        "trigger": Self.describe(trigger: request.trigger)
+                    ]
+                }
+                replyHandler(payload, nil)
+            }
+        case "__playgroundSchedulerDiagnostics":
+            Task { @MainActor in
+                let featureFlagEnabled = AppDependencyProvider.shared.featureFlagger.isFeatureOn(.subscriptionExpirationReminderNotification)
+                let authStatus = await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
+
+                var subscriptionDescription: String
+                var subscriptionWarrantsReminder: Bool = false
+                do {
+                    if let sub = try await AppDependencyProvider.shared.subscriptionManager.getSubscription(forceRefresh: false) {
+                        subscriptionDescription = "\(sub.status) (expires \(Self.dateFormatter.string(from: sub.expiresOrRenewsAt)))"
+                        switch sub.status {
+                        case .autoRenewable, .notAutoRenewable, .gracePeriod:
+                            subscriptionWarrantsReminder = true
+                        default:
+                            subscriptionWarrantsReminder = false
+                        }
+                    } else {
+                        subscriptionDescription = "(no subscription)"
+                    }
+                } catch {
+                    subscriptionDescription = "(error: \(error.localizedDescription))"
+                }
+
+                replyHandler([
+                    "featureFlagEnabled": featureFlagEnabled,
+                    "authorizationStatus": Self.describe(authStatus: authStatus),
+                    "subscription": subscriptionDescription,
+                    "subscriptionWarrantsReminder": subscriptionWarrantsReminder
+                ], nil)
+            }
+        default:
+            replyHandler(nil, "Unknown handler: \(message.name)")
+        }
+    }
+
+    private static func describe(authStatus: UNAuthorizationStatus) -> String {
+        switch authStatus {
+        case .notDetermined: return "notDetermined"
+        case .denied: return "denied"
+        case .authorized: return "authorized"
+        case .provisional: return "provisional"
+        case .ephemeral: return "ephemeral"
+        @unknown default: return "unknown(\(authStatus.rawValue))"
+        }
+    }
+
+    private static func describe(trigger: UNNotificationTrigger?) -> String {
+        switch trigger {
+        case let trigger as UNTimeIntervalNotificationTrigger:
+            let fires = Date().addingTimeInterval(trigger.timeInterval)
+            return "TimeInterval(\(Int(trigger.timeInterval))s -> ~\(Self.dateFormatter.string(from: fires)), repeats: \(trigger.repeats))"
+        case let trigger as UNCalendarNotificationTrigger:
+            return "Calendar(\(trigger.dateComponents), repeats: \(trigger.repeats))"
+        case let trigger?:
+            return "\(type(of: trigger))"
+        case nil:
+            return "(no trigger — delivers immediately)"
+        }
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .short
+        f.timeStyle = .medium
+        return f
+    }()
 }
 
 enum JSBridgePlaygroundHTML {
@@ -187,6 +278,16 @@ button:active { opacity: 0.65; }
 .row-in { color: #9ece6a; }
 .row-err { color: #f7768e; }
 .row-time { color: #888; }
+#pending { margin-top: 8px; font-size: 13px; }
+.pending-item { padding: 8px; margin-top: 6px; background: rgba(127,127,127,0.1); border-radius: 6px; }
+.pending-id { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px; color: #888; word-break: break-all; margin-bottom: 2px; }
+.pending-meta { color: #888; font-size: 11px; margin-top: 2px; }
+.diagnostic-note { background: rgba(127,127,127,0.08); border-left: 3px solid #f7c948; padding: 8px 10px; border-radius: 4px; font-size: 12px; margin-top: 4px; }
+.diagnostic-title { font-weight: 600; color: #888; font-size: 11px; margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.5px; }
+.diagnostic-row { display: flex; gap: 8px; padding: 2px 0; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px; }
+.diagnostic-pass { color: #5cb85c; min-width: 18px; }
+.diagnostic-fail { color: #d9534f; min-width: 18px; }
+.diagnostic-label { color: #888; min-width: 110px; }
 </style>
 </head>
 <body>
@@ -211,6 +312,13 @@ Handler <code>{{HANDLER}}</code> · Context <code>{{CONTEXT}}</code> · Feature 
 
 <h2>Response log</h2>
 <div id="log"></div>
+
+<h2>Pending notifications <button class="secondary" style="flex:none;padding:4px 10px;font-size:12px;margin-left:6px" onclick="refreshPending()">Refresh</button></h2>
+<div class="diagnostic-note">
+<div class="diagnostic-title">Scheduler guards (all must pass for a notification to actually be added):</div>
+<div id="diagnostics">(tap Refresh)</div>
+</div>
+<div id="pending">(tap Refresh)</div>
 
 <script>
 const HANDLER = {{HANDLER_JS}};
@@ -237,6 +345,62 @@ document.getElementById('method').addEventListener('input', function() {
         document.getElementById('params').value = SAMPLES[name];
     }
 });
+
+function diagnosticRow(label, value, passing) {
+    var row = document.createElement('div');
+    row.className = 'diagnostic-row';
+    var icon = document.createElement('span');
+    icon.className = passing ? 'diagnostic-pass' : 'diagnostic-fail';
+    icon.textContent = passing ? '✓' : '✗';
+    var lbl = document.createElement('span'); lbl.className = 'diagnostic-label'; lbl.textContent = label;
+    var val = document.createElement('span'); val.textContent = value;
+    row.appendChild(icon); row.appendChild(lbl); row.appendChild(val);
+    return row;
+}
+
+async function refreshDiagnostics() {
+    var handler = window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.__playgroundSchedulerDiagnostics;
+    var el = document.getElementById('diagnostics');
+    if (!handler) { el.textContent = '(handler not available)'; return; }
+    el.textContent = '(loading...)';
+    try {
+        var d = await handler.postMessage(null);
+        el.innerHTML = '';
+        el.appendChild(diagnosticRow('feature flag', String(d.featureFlagEnabled), d.featureFlagEnabled === true));
+        el.appendChild(diagnosticRow('auth status', d.authorizationStatus, d.authorizationStatus === 'authorized'));
+        el.appendChild(diagnosticRow('subscription', d.subscription, d.subscriptionWarrantsReminder === true));
+    } catch (e) {
+        el.textContent = 'Error: ' + (e && e.message ? e.message : String(e));
+    }
+}
+
+async function refreshPending() {
+    refreshDiagnostics();
+    var handler = window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.__playgroundNotifications;
+    var el = document.getElementById('pending');
+    if (!handler) { el.textContent = '(handler not available)'; return; }
+    el.textContent = '(loading...)';
+    try {
+        var list = await handler.postMessage(null);
+        el.innerHTML = '';
+        if (!list || list.length === 0) {
+            el.textContent = '(none scheduled)';
+            return;
+        }
+        list.forEach(function(n) {
+            var item = document.createElement('div');
+            item.className = 'pending-item';
+            var id = document.createElement('div'); id.className = 'pending-id'; id.textContent = n.identifier; item.appendChild(id);
+            if (n.title) { var t = document.createElement('div'); t.textContent = n.title; t.style.fontWeight = '600'; item.appendChild(t); }
+            if (n.body) { var b = document.createElement('div'); b.textContent = n.body; item.appendChild(b); }
+            if (n.categoryIdentifier) { var c = document.createElement('div'); c.className = 'pending-meta'; c.textContent = 'category: ' + n.categoryIdentifier; item.appendChild(c); }
+            if (n.trigger) { var tr = document.createElement('div'); tr.className = 'pending-meta'; tr.textContent = n.trigger; item.appendChild(tr); }
+            el.appendChild(item);
+        });
+    } catch (e) {
+        el.textContent = 'Error: ' + (e && e.message ? e.message : String(e));
+    }
+}
 
 function clearLog() { document.getElementById('log').textContent = ''; }
 

--- a/iOS/DuckDuckGo/JSBridgePlaygroundAddingFeatures.md
+++ b/iOS/DuckDuckGo/JSBridgePlaygroundAddingFeatures.md
@@ -1,0 +1,102 @@
+# Adding a feature to the JS Bridge Playground
+
+This debug tool exercises a feature's JS bridge inside an in-app WKWebView. Only Subscription is wired up today. Adding another feature is one new type plus one line in the debug menu.
+
+## How it works
+
+The playground attaches a feature's `UserScript`(s) to a fresh `WKWebView` and loads an HTML harness via `loadHTMLString(_:baseURL:)`. The `baseURL` is set to the feature's expected origin so each subfeature's `messageOriginPolicy` accepts the page. The page exposes a method field, a JSON params field, a Send button, and a response log.
+
+The native side never inspects the response — JS captures it directly from the `Promise` returned by `window.webkit.messageHandlers.<handler>.postMessage(...)` and renders it in the log. No log scraping is needed.
+
+## The minimum recipe
+
+Implement `JSBridgePlaygroundFeature` and surface it from `DebugScreensViewModel+Screens.swift`.
+
+```swift
+struct MyFeaturePlaygroundFeature: JSBridgePlaygroundFeature {
+
+    let displayName = "MyFeature"
+
+    // window.webkit.messageHandlers.<messageHandlerName>
+    let messageHandlerName = MyFeatureUserScript.context
+
+    // payload.context — usually the same as messageHandlerName
+    let messageContext = MyFeatureUserScript.context
+
+    // payload.featureName — the subfeature constant declared by the feature
+    let featureName = MyFeatureSubfeatureConstants.featureName
+
+    // Origin used as baseURL for loadHTMLString. Must satisfy the subfeature's
+    // messageOriginPolicy (typically a HostnameMatchingRule.makeExactRule).
+    var baseURL: URL {
+        URL(string: "https://duckduckgo.com/myfeature")!
+    }
+
+    // Quick-fill chips on the page. sampleParamsJSON pre-populates the params field.
+    var knownMethods: [JSBridgePlaygroundMethod] {
+        [
+            JSBridgePlaygroundMethod(name: "doSomething", sampleParamsJSON: "{}"),
+            JSBridgePlaygroundMethod(name: "doSomethingElse", sampleParamsJSON: #"{"foo": "bar"}"#)
+        ]
+    }
+
+    @MainActor
+    func makeUserScripts() -> [UserScript] {
+        let userScript = MyFeatureUserScript()
+        let subFeature = MyFeatureSubfeature(/* real dependencies */)
+        userScript.registerSubfeature(delegate: subFeature)
+        return [userScript]
+    }
+}
+```
+
+Then in `DebugScreensViewModel+Screens.swift`:
+
+```swift
+.controller(title: "JS Bridge Playground (MyFeature)", { _ in
+    return JSBridgePlaygroundViewController(feature: MyFeaturePlaygroundFeature())
+}),
+```
+
+## Things to get right
+
+### `baseURL` must satisfy the origin policy
+
+Subfeatures gate inbound messages with `messageOriginPolicy`. Most use `HostnameMatchingRule.makeExactRule(for:)` against a base URL. Set the playground feature's `baseURL` to a URL whose scheme + host (and where relevant, port) match the subfeature's expected origin. `WKWebView.loadHTMLString(_:baseURL:)` reports that URL as the page origin to the script.
+
+If the page's `window.webkit.messageHandlers.<handler>` is `undefined`, the user script is not attaching — either the handler name is wrong, or the script registration failed at construction time. If `postMessage` rejects with an origin error, the `baseURL` doesn't match the policy.
+
+### Dependency wiring
+
+Each subfeature has its own constructor. Mirror the production wiring as closely as possible — the playground exists to test the bridge layer against real handlers, so injecting real dependencies (where safe in a debug surface) gives the most faithful behavior. `SubscriptionBridgePlaygroundFeature.swift` (alongside this doc) is a worked example of a heavy-dependency case.
+
+### Make the user-script instances retained
+
+`JSBridgePlaygroundViewController` already stores the returned `[UserScript]` in a `private var` so the wrapper objects (and the broker → subfeature retention chain) outlive `makeUserScripts()`. If you add an alternative entry point, mirror this — `WKUserContentController.addUserScript(_:)` retains the underlying `WKUserScript`, but not the Swift `UserScript` wrapper.
+
+## Push-style messages (native -> JS)
+
+This UI is one-shot request/response. Methods like `pushPurchaseUpdate` are fire-and-forget native -> JS dispatches against a live webview and aren't surfaced by the current UI. Exercising them needs a JS-side listener registered on the page plus a native trigger; add it as a separate code path if you need it.
+
+## Features still to plumb
+
+These all expose JS bridges and are candidates for follow-up registrations:
+
+- `AIChat` — `iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift`
+- `AIChatSuggestions` — `SharedPackages/AIChat/.../AIChatSuggestionsUserScript.swift`
+- `DuckAiNativeStorage` — `SharedPackages/AIChat/.../DuckAiNativeStorageUserScript.swift`
+- `AIChatDataClearing` — `SharedPackages/AIChat/.../AIChatDataClearingUserScript.swift`
+- `PageContext` — `iOS/DuckDuckGo/AIChat/UserScript/PageContextUserScript.swift`
+- `DuckPlayer (player + youtube variants)` — `DuckPlayerUserScriptPlayer.swift`, `DuckPlayerUserScriptYouTube.swift`, `YoutubeOverlayUserScript.swift`, `YoutubePlayerUserScript.swift`
+- `IdentityTheftRestoration` — `iOS/DuckDuckGo/Subscription/UserScripts/IdentityTheftRestorationPagesFeature.swift`
+- `SERPSettings` — `SharedPackages/SERPSettings/.../SERPSettingsUserScript.swift`
+- `DBP` — `SharedPackages/DataBrokerProtectionCore/.../DBPUICommunicationLayer.swift`
+- `SpecialErrorPages` — `SharedPackages/BrowserServicesKit/.../SpecialErrorPageUserScript.swift`
+- `BrokenSiteReporting` — `SharedPackages/BrowserServicesKit/.../BreakageReportingSubfeature.swift`
+- `WebTelemetry` — `SharedPackages/BrowserServicesKit/.../WebTelemetryUserScript.swift`
+
+## Caveats
+
+- **State is real.** Calls hit the real `SubscriptionManager`, real network, real keychain, etc. Don't fire destructive methods against a signed-in tester account.
+- **Tab-coupled features.** Anything that relies on a `Tab` or surrounding navigation chain may need a stub or simplified factory for the playground surface.
+- **Internal-only.** Don't surface this outside debug builds.

--- a/iOS/DuckDuckGo/NotificationServiceManager.swift
+++ b/iOS/DuckDuckGo/NotificationServiceManager.swift
@@ -27,14 +27,14 @@ import DataBrokerProtection_iOS
 protocol NotificationServiceManaging: UNUserNotificationCenterDelegate {}
 
 final class NotificationServiceManager: NSObject, NotificationServiceManaging {
-    
+
     private let mainCoordinator: MainCoordinator
-    
+
     init(mainCoordinator: MainCoordinator) {
         self.mainCoordinator = mainCoordinator
         super.init()
     }
-    
+
     /// https://stackoverflow.com/questions/73750724/how-can-usernotificationcenter-didreceive-cause-a-crash-even-with-nothing-in
     /// TL;DR: The async UNUserNotificationCenterDelegate methods (`willPresent`, `didReceive`) can be invoked off the main thread, leading to occasional crashes during app activation.
     /// Marking this delegate @MainActor ensures they always run on the main thread. This appears to be an iOS bug.
@@ -43,17 +43,19 @@ final class NotificationServiceManager: NSObject, NotificationServiceManaging {
                                 willPresent notification: UNNotification) async -> UNNotificationPresentationOptions {
         return [.banner, .list]
     }
-    
+
     @MainActor
     func userNotificationCenter(_ center: UNUserNotificationCenter,
                                 didReceive response: UNNotificationResponse) async {
-        
+
         guard response.actionIdentifier == UNNotificationDefaultActionIdentifier else { return }
-        
+
         let id = response.notification.request.identifier
         switch id {
         case InactivityNotificationSchedulerService.Constants.notificationIdentifier:
             handleInactivityNotification(for: response)
+        case DefaultSubscriptionExpirationReminderScheduler.notificationIdentifier:
+            handleSubscriptionExpirationReminder()
         case let raw where NetworkProtectionNotificationIdentifier(rawValue: raw) != nil:
             handleVPNNotification()
         case let raw where DataBrokerProtectionNotificationIdentifier(rawValue: raw) != nil:
@@ -80,6 +82,11 @@ private extension NotificationServiceManager {
     @MainActor
     func handleVPNNotification() {
         mainCoordinator.presentNetworkProtectionStatusSettingsModal()
+    }
+
+    @MainActor
+    func handleSubscriptionExpirationReminder() {
+        mainCoordinator.segueToDuckDuckGoSubscription()
     }
 
     @MainActor

--- a/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionExpirationReminderScheduler.swift
+++ b/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionExpirationReminderScheduler.swift
@@ -96,8 +96,7 @@ final class DefaultSubscriptionExpirationReminderScheduler: SubscriptionExpirati
         content.body = "Tap to review your subscription and stay protected."
         content.categoryIdentifier = Self.notificationIdentifier
 
-        let components = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: fireDate)
-        let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: false)
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: fireDate.timeIntervalSince(dateProvider()), repeats: false)
         let request = UNNotificationRequest(identifier: Self.notificationIdentifier, content: content, trigger: trigger)
 
         do {

--- a/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionExpirationReminderScheduler.swift
+++ b/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionExpirationReminderScheduler.swift
@@ -1,0 +1,139 @@
+//
+//  SubscriptionExpirationReminderScheduler.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import Foundation
+import UIKit
+import UserNotifications
+import os.log
+import Subscription
+
+protocol SubscriptionExpirationReminderScheduling: AnyObject {
+    /// Schedules a single local reminder firing `daysBeforeCancel` days before the active subscription's expiry/renewal date.
+    /// Silently skips when the feature flag is off, permission is unavailable, `daysBeforeCancel <= 0`, the subscription has no expiry, or the computed fire date is in the past.
+    /// Cancels any previously scheduled reminder with the same identifier before scheduling the new one.
+    func scheduleReminder(daysBeforeCancel: Int) async
+}
+
+final class DefaultSubscriptionExpirationReminderScheduler: SubscriptionExpirationReminderScheduling {
+
+    static let notificationIdentifier = "com.duckduckgo.subscriptions.expiration.reminder"
+
+    private let subscriptionManager: SubscriptionManager
+    private let isFeatureEnabled: () -> Bool
+    private let notificationCenter: UNUserNotificationCenterRepresentable
+    private let dateProvider: () -> Date
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(subscriptionManager: SubscriptionManager,
+         isFeatureEnabled: @escaping () -> Bool,
+         notificationCenter: UNUserNotificationCenterRepresentable = UNUserNotificationCenter.current(),
+         dateProvider: @escaping () -> Date = Date.init,
+         notificationCenterObserver: NotificationCenter = .default) {
+        self.subscriptionManager = subscriptionManager
+        self.isFeatureEnabled = isFeatureEnabled
+        self.notificationCenter = notificationCenter
+        self.dateProvider = dateProvider
+
+        // In-app subscription operations post .subscriptionDidChange after updating the cache;
+        // we can trust the cache and skip the network call.
+        notificationCenterObserver.publisher(for: .subscriptionDidChange)
+            .sink { [weak self] _ in
+                Task { [weak self] in await self?.cancelReminderIfInactive(forceRefresh: false) }
+            }
+            .store(in: &cancellables)
+
+        // External changes (App Store cancellation, billing failure) happen without our knowledge,
+        // so re-read from the backend on every foreground.
+        notificationCenterObserver.publisher(for: UIApplication.didBecomeActiveNotification)
+            .sink { [weak self] _ in
+                Task { [weak self] in await self?.cancelReminderIfInactive(forceRefresh: true) }
+            }
+            .store(in: &cancellables)
+    }
+
+    func scheduleReminder(daysBeforeCancel: Int) async {
+        guard isFeatureEnabled() else {
+            Logger.subscription.log("Expiration reminder skipped: feature flag off")
+            return
+        }
+
+        guard daysBeforeCancel > 0 else {
+            Logger.subscription.log("Expiration reminder skipped: non-positive daysBeforeCancel \(daysBeforeCancel, privacy: .public)")
+            return
+        }
+
+        // Only schedule when the user has explicitly tapped Allow. .provisional silently routes to
+        // Notification Center with no banner, and .ephemeral is an App Clip state — neither would
+        // produce the visible reminder the user opted in for.
+        guard await notificationCenter.authorizationStatus() == .authorized else {
+            Logger.subscription.log("Expiration reminder skipped: notifications not explicitly authorized")
+            return
+        }
+
+        guard let subscription = try? await subscriptionManager.getSubscription(forceRefresh: false), subscription.isActive else {
+            Logger.subscription.log("Expiration reminder skipped: no active subscription available")
+            return
+        }
+
+        guard let fireDate = Calendar.current.date(byAdding: .day, value: -daysBeforeCancel, to: subscription.expiresOrRenewsAt),
+              fireDate > dateProvider() else {
+            Logger.subscription.log("Expiration reminder skipped: invalid or past fire date")
+            return
+        }
+
+        notificationCenter.removePendingNotificationRequests(withIdentifiers: [Self.notificationIdentifier])
+
+        // Copy taken from the tech spec; subject to product/copy review before launch and likely to be localized.
+        let content = UNMutableNotificationContent()
+        content.title = "Your Privacy Pro subscription is ending soon"
+        content.body = "Tap to review your subscription and stay protected."
+        content.categoryIdentifier = Self.notificationIdentifier
+
+        let components = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: fireDate)
+        let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: false)
+        let request = UNNotificationRequest(identifier: Self.notificationIdentifier, content: content, trigger: trigger)
+
+        do {
+            try await notificationCenter.add(request)
+            Logger.subscription.log("Expiration reminder scheduled for \(fireDate, privacy: .public)")
+        } catch {
+            Logger.subscription.error("Failed to schedule expiration reminder: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Cancels the pending reminder when the subscription is no longer in a state that warrants a reminder.
+    /// Skips work entirely when no reminder is queued — most users will never opt in.
+    /// Per spec, `.autoRenewable`, `.notAutoRenewable`, and `.gracePeriod` are the only statuses considered active for this purpose.
+    private func cancelReminderIfInactive(forceRefresh: Bool) async {
+        let pending = await notificationCenter.pendingNotificationRequests()
+        guard pending.contains(where: { $0.identifier == Self.notificationIdentifier }) else { return }
+
+        let subscription = try? await subscriptionManager.getSubscription(forceRefresh: forceRefresh)
+        if let status = subscription?.status {
+            switch status {
+            case .autoRenewable, .notAutoRenewable, .gracePeriod:
+                return
+            case .inactive, .expired, .unknown:
+                break
+            }
+        }
+        notificationCenter.removePendingNotificationRequests(withIdentifiers: [Self.notificationIdentifier])
+    }
+}

--- a/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionExpirationReminderScheduler.swift
+++ b/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionExpirationReminderScheduler.swift
@@ -90,7 +90,7 @@ final class DefaultSubscriptionExpirationReminderScheduler: SubscriptionExpirati
 
         notificationCenter.removePendingNotificationRequests(withIdentifiers: [Self.notificationIdentifier])
 
-        // Copy taken from the tech spec; subject to product/copy review before launch and likely to be localized.
+        // TODO: Revisit after copy finalized
         let content = UNMutableNotificationContent()
         content.title = "Your Privacy Pro subscription is ending soon"
         content.body = "Tap to review your subscription and stay protected."

--- a/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionExpirationReminderScheduler.swift
+++ b/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionExpirationReminderScheduler.swift
@@ -25,10 +25,10 @@ import os.log
 import Subscription
 
 protocol SubscriptionExpirationReminderScheduling: AnyObject {
-    /// Schedules a single local reminder firing `daysBeforeCancel` days before the active subscription's expiry/renewal date.
-    /// Silently skips when the feature flag is off, permission is unavailable, `daysBeforeCancel <= 0`, the subscription has no expiry, or the computed fire date is in the past.
+    /// Schedules a single local reminder firing `timeBeforeCancel` seconds before the active subscription's expiry/renewal date.
+    /// Silently skips when the feature flag is off, permission is unavailable, `timeBeforeCancel <= 0`, the subscription has no expiry, or the computed fire date is in the past.
     /// Cancels any previously scheduled reminder with the same identifier before scheduling the new one.
-    func scheduleReminder(daysBeforeCancel: Int) async
+    func scheduleReminder(timeBeforeCancel: TimeInterval) async
 }
 
 final class DefaultSubscriptionExpirationReminderScheduler: SubscriptionExpirationReminderScheduling {
@@ -51,8 +51,7 @@ final class DefaultSubscriptionExpirationReminderScheduler: SubscriptionExpirati
         self.notificationCenter = notificationCenter
         self.dateProvider = dateProvider
 
-        // In-app subscription operations post .subscriptionDidChange after updating the cache;
-        // we can trust the cache and skip the network call.
+        // In-app subscription operations post .subscriptionDidChange after updating the cache.
         notificationCenterObserver.publisher(for: .subscriptionDidChange)
             .sink { [weak self] _ in
                 Task { [weak self] in await self?.cancelReminderIfInactive(forceRefresh: false) }
@@ -68,20 +67,10 @@ final class DefaultSubscriptionExpirationReminderScheduler: SubscriptionExpirati
             .store(in: &cancellables)
     }
 
-    func scheduleReminder(daysBeforeCancel: Int) async {
-        guard isFeatureEnabled() else {
-            Logger.subscription.log("Expiration reminder skipped: feature flag off")
-            return
-        }
+    func scheduleReminder(timeBeforeCancel: TimeInterval) async {
+        guard isFeatureEnabled() else { return }
+        guard timeBeforeCancel > 0 else { return }
 
-        guard daysBeforeCancel > 0 else {
-            Logger.subscription.log("Expiration reminder skipped: non-positive daysBeforeCancel \(daysBeforeCancel, privacy: .public)")
-            return
-        }
-
-        // Only schedule when the user has explicitly tapped Allow. .provisional silently routes to
-        // Notification Center with no banner, and .ephemeral is an App Clip state — neither would
-        // produce the visible reminder the user opted in for.
         guard await notificationCenter.authorizationStatus() == .authorized else {
             Logger.subscription.log("Expiration reminder skipped: notifications not explicitly authorized")
             return
@@ -93,9 +82,9 @@ final class DefaultSubscriptionExpirationReminderScheduler: SubscriptionExpirati
             return
         }
 
-        guard let fireDate = Calendar.current.date(byAdding: .day, value: -daysBeforeCancel, to: subscription.expiresOrRenewsAt),
-              fireDate > dateProvider() else {
-            Logger.subscription.log("Expiration reminder skipped: invalid or past fire date")
+        let fireDate = subscription.expiresOrRenewsAt.addingTimeInterval(-timeBeforeCancel)
+        guard fireDate > dateProvider() else {
+            Logger.subscription.log("Expiration reminder skipped: past fire date")
             return
         }
 

--- a/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionExpirationReminderScheduler.swift
+++ b/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionExpirationReminderScheduler.swift
@@ -87,8 +87,9 @@ final class DefaultSubscriptionExpirationReminderScheduler: SubscriptionExpirati
             return
         }
 
-        guard let subscription = try? await subscriptionManager.getSubscription(forceRefresh: false), subscription.isActive else {
-            Logger.subscription.log("Expiration reminder skipped: no active subscription available")
+        guard let subscription = try? await subscriptionManager.getSubscription(forceRefresh: false),
+              Self.statusWarrantsReminder(subscription.status) else {
+            Logger.subscription.log("Expiration reminder skipped: subscription not in an active state for reminders")
             return
         }
 
@@ -118,22 +119,31 @@ final class DefaultSubscriptionExpirationReminderScheduler: SubscriptionExpirati
         }
     }
 
-    /// Cancels the pending reminder when the subscription is no longer in a state that warrants a reminder.
-    /// Skips work entirely when no reminder is queued — most users will never opt in.
-    /// Per spec, `.autoRenewable`, `.notAutoRenewable`, and `.gracePeriod` are the only statuses considered active for this purpose.
+    /// Cancels the pending reminder unless the subscription is in an active state.
+    /// A thrown error (e.g. transient network failure) leaves the reminder alone; a confirmed inactive/missing subscription cancels it.
+    @MainActor
     private func cancelReminderIfInactive(forceRefresh: Bool) async {
         let pending = await notificationCenter.pendingNotificationRequests()
         guard pending.contains(where: { $0.identifier == Self.notificationIdentifier }) else { return }
 
-        let subscription = try? await subscriptionManager.getSubscription(forceRefresh: forceRefresh)
-        if let status = subscription?.status {
-            switch status {
-            case .autoRenewable, .notAutoRenewable, .gracePeriod:
-                return
-            case .inactive, .expired, .unknown:
-                break
-            }
+        let subscription: DuckDuckGoSubscription?
+        do {
+            subscription = try await subscriptionManager.getSubscription(forceRefresh: forceRefresh)
+        } catch {
+            Logger.subscription.log("Skipping expiration-reminder check: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+
+        if let status = subscription?.status, Self.statusWarrantsReminder(status) {
+            return
         }
         notificationCenter.removePendingNotificationRequests(withIdentifiers: [Self.notificationIdentifier])
+    }
+
+    private static func statusWarrantsReminder(_ status: DuckDuckGoSubscription.Status) -> Bool {
+        switch status {
+        case .autoRenewable, .notAutoRenewable, .gracePeriod: return true
+        case .inactive, .expired, .unknown: return false
+        }
     }
 }

--- a/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
@@ -32,6 +32,7 @@ import PixelKit
 import PrivacyConfig
 import DataBrokerProtectionCore
 import DataBrokerProtection_iOS
+import UserNotifications
 
 struct SubscriptionPagesUseSubscriptionFeatureConstants {
     static let featureName = "useSubscription"
@@ -60,6 +61,9 @@ private struct Handlers {
     static let subscriptionChangeSelected = "subscriptionChangeSelected"
     static let activateSubscription = "activateSubscription"
     static let featureSelected = "featureSelected"
+    // Notification permission & scheduling (expiration reminder experiment)
+    static let getUserSettings = "getUserSettings"
+    static let requestNotificationsPermission = "requestNotificationsPermission"
     // Pixels related events
     static let subscriptionsMonthlyPriceClicked = "subscriptionsMonthlyPriceClicked"
     static let subscriptionsYearlyPriceClicked = "subscriptionsYearlyPriceClicked"
@@ -137,6 +141,9 @@ protocol SubscriptionPagesUseSubscriptionFeature: Subfeature, ObservableObject {
     func subscriptionsWelcomeAddEmailClicked(params: Any, original: WKScriptMessage) async -> Encodable?
     func subscriptionsWelcomeFaqClicked(params: Any, original: WKScriptMessage) async -> Encodable?
 
+    func getUserSettings(params: Any, original: WKScriptMessage) async -> Encodable?
+    func requestNotificationsPermission(params: Any, original: WKScriptMessage) async -> Encodable?
+
     func pushPurchaseUpdate(originalMessage: WKScriptMessage, purchaseUpdate: PurchaseUpdate) async
     func restoreAccountFromAppStorePurchase() async throws
     func cleanup()
@@ -161,6 +168,9 @@ final class DefaultSubscriptionPagesUseSubscriptionFeature: SubscriptionPagesUse
     private var planChangeWideEventData: SubscriptionPlanChangeWideEventData?
     private var subscriptionPlatform: SubscriptionEnvironment.PurchasePlatform { subscriptionManager.currentEnvironment.purchasePlatform }
     private let requestValidator: any ScriptRequestValidator
+    private let userNotificationCenter: UNUserNotificationCenterRepresentable
+    private let expirationReminderScheduler: SubscriptionExpirationReminderScheduling?
+    private var pendingScheduleNotification: ScheduleNotificationPreference?
 
     init(subscriptionManager: SubscriptionManager,
          subscriptionFeatureAvailability: SubscriptionFeatureAvailability,
@@ -178,7 +188,9 @@ final class DefaultSubscriptionPagesUseSubscriptionFeature: SubscriptionPagesUse
             userDefaults: .dbp,
             isUserAuthenticated: { false },
             isFreemiumEnabled: { true }
-         )) {
+         ),
+         userNotificationCenter: UNUserNotificationCenterRepresentable = UNUserNotificationCenter.current(),
+         expirationReminderScheduler: SubscriptionExpirationReminderScheduling? = nil) {
         self.subscriptionManager = subscriptionManager
         self.subscriptionFeatureAvailability = subscriptionFeatureAvailability
         self.appStorePurchaseFlow = appStorePurchaseFlow
@@ -192,6 +204,8 @@ final class DefaultSubscriptionPagesUseSubscriptionFeature: SubscriptionPagesUse
         self.subscriptionFlowsExecuter = subscriptionFlowsExecuter
         self.requestValidator = requestValidator
         self.freemiumDBPUserStateManager = freemiumDBPUserStateManager
+        self.userNotificationCenter = userNotificationCenter
+        self.expirationReminderScheduler = expirationReminderScheduler
     }
 
     // Transaction Status and errors are observed from ViewModels to handle errors in the UI
@@ -247,6 +261,8 @@ final class DefaultSubscriptionPagesUseSubscriptionFeature: SubscriptionPagesUse
         case Handlers.subscriptionsWelcomeAddEmailClicked: return subscriptionsWelcomeAddEmailClicked
         case Handlers.subscriptionsWelcomeFaqClicked: return subscriptionsWelcomeFaqClicked
         case Handlers.getAccessToken: return getAccessToken
+        case Handlers.getUserSettings: return getUserSettings
+        case Handlers.requestNotificationsPermission: return requestNotificationsPermission
         default:
             Logger.subscription.error("Unhandled web message: \(methodName)")
             return nil
@@ -415,6 +431,10 @@ final class DefaultSubscriptionPagesUseSubscriptionFeature: SubscriptionPagesUse
         setTransactionStatus(.purchasing)
         resetSubscriptionFlow()
 
+        // The reminder preference only lives for the duration of one purchase attempt.
+        // Clearing on exit covers cancellation, failure, and post-success paths uniformly.
+        defer { pendingScheduleNotification = nil }
+
         struct SubscriptionSelection: Decodable {
             struct Experiment: Codable {
                 let name: String
@@ -430,6 +450,7 @@ final class DefaultSubscriptionPagesUseSubscriptionFeature: SubscriptionPagesUse
 
             let id: String
             let experiment: Experiment?
+            let scheduleNotification: ScheduleNotificationPreference?
         }
 
         // 1: Parse subscription selection from message object
@@ -440,6 +461,9 @@ final class DefaultSubscriptionPagesUseSubscriptionFeature: SubscriptionPagesUse
             setTransactionStatus(.idle)
             return nil
         }
+
+        // Hold the reminder preference for the duration of the purchase flow. Discarded if the purchase doesn't succeed.
+        pendingScheduleNotification = subscriptionSelection.scheduleNotification
 
         // 2: Check for active subscriptions
         if await subscriptionManager.storePurchaseManager().hasActiveSubscription() {
@@ -569,6 +593,10 @@ final class DefaultSubscriptionPagesUseSubscriptionFeature: SubscriptionPagesUse
                 purchaseWideEventData.activateAccountDuration?.complete()
                 wideEvent.updateFlow(purchaseWideEventData)
                 wideEvent.completeFlow(purchaseWideEventData, status: .success(reason: nil), onComplete: { _, _ in })
+            }
+
+            if let preference = pendingScheduleNotification, let scheduler = expirationReminderScheduler {
+                await scheduler.scheduleReminder(daysBeforeCancel: preference.daysBeforeCancel)
             }
 
         case .failure(let error):
@@ -865,6 +893,58 @@ final class DefaultSubscriptionPagesUseSubscriptionFeature: SubscriptionPagesUse
     private func fireFreemiumUpsellPixel() {
         guard freemiumDBPUserStateManager.didActivate, let pixelKit = PixelKit.shared else { return }
         DataBrokerProtectionSharedPixelsHandler(pixelKit: pixelKit, platform: .iOS).fire(.freemiumUpsell)
+    }
+}
+
+// MARK: - Notification permission (expiration reminder experiment)
+
+extension DefaultSubscriptionPagesUseSubscriptionFeature {
+
+    enum NotificationsPermissionStatus: String, Encodable {
+        case granted, denied, notDetermined
+    }
+
+    struct UserSettingsResponse: Encodable {
+        let notificationsPermission: NotificationsPermissionStatus
+    }
+
+    struct NotificationsPermissionResponse: Encodable {
+        let granted: Bool
+    }
+
+    struct ScheduleNotificationPreference: Decodable, Equatable {
+        let daysBeforeCancel: Int
+    }
+
+    func getUserSettings(params: Any, original: WKScriptMessage) async -> Encodable? {
+        let status = await userNotificationCenter.authorizationStatus()
+        return UserSettingsResponse(notificationsPermission: Self.permissionStatus(from: status))
+    }
+
+    func requestNotificationsPermission(params: Any, original: WKScriptMessage) async -> Encodable? {
+        let status = await userNotificationCenter.authorizationStatus()
+        switch status {
+        case .authorized, .provisional, .ephemeral:
+            return NotificationsPermissionResponse(granted: true)
+        case .denied:
+            // The OS will not display the prompt in this state; report the cached state immediately
+            // so FE can direct the user to Settings.
+            return NotificationsPermissionResponse(granted: false)
+        case .notDetermined:
+            let granted = (try? await userNotificationCenter.requestAuthorization(options: [.alert, .sound])) ?? false
+            return NotificationsPermissionResponse(granted: granted)
+        @unknown default:
+            return NotificationsPermissionResponse(granted: false)
+        }
+    }
+
+    private static func permissionStatus(from status: UNAuthorizationStatus) -> NotificationsPermissionStatus {
+        switch status {
+        case .authorized, .provisional, .ephemeral: return .granted
+        case .notDetermined: return .notDetermined
+        case .denied: return .denied
+        @unknown default: return .denied
+        }
     }
 }
 

--- a/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
@@ -920,9 +920,11 @@ extension DefaultSubscriptionPagesUseSubscriptionFeature {
     func requestNotificationsPermission(params: Any, original: WKScriptMessage) async -> Encodable? {
         let status = await userNotificationCenter.authorizationStatus()
         switch status {
-        case .authorized, .provisional, .ephemeral:
+        case .authorized, .ephemeral:
             return NotificationsPermissionResponse(granted: true)
-        case .denied:
+        case .denied, .provisional:
+            // OS won't show a prompt in either state — `.denied` is blocked, and `.provisional` has
+            // no programmatic upgrade path (only Settings can raise it to `.authorized`).
             return NotificationsPermissionResponse(granted: false)
         case .notDetermined:
             let granted = (try? await userNotificationCenter.requestAuthorization(options: [.alert, .sound])) ?? false
@@ -932,11 +934,14 @@ extension DefaultSubscriptionPagesUseSubscriptionFeature {
         }
     }
 
+    /// Any status that requires a Settings change to become `.authorized` is reported as `.denied`.
+    /// `.provisional` is bucketed with `.denied` because there's no programmatic upgrade path —
+    /// iOS won't show a prompt from `requestAuthorization` when state is `.provisional`.
     private static func permissionStatus(from status: UNAuthorizationStatus) -> NotificationsPermissionStatus {
         switch status {
-        case .authorized, .provisional, .ephemeral: return .granted
+        case .authorized, .ephemeral: return .granted
         case .notDetermined: return .notDetermined
-        case .denied: return .denied
+        case .denied, .provisional: return .denied
         @unknown default: return .denied
         }
     }

--- a/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
@@ -170,7 +170,6 @@ final class DefaultSubscriptionPagesUseSubscriptionFeature: SubscriptionPagesUse
     private let requestValidator: any ScriptRequestValidator
     private let userNotificationCenter: UNUserNotificationCenterRepresentable
     private let expirationReminderScheduler: SubscriptionExpirationReminderScheduling?
-    private var pendingScheduleNotification: ScheduleNotificationPreference?
 
     init(subscriptionManager: SubscriptionManager,
          subscriptionFeatureAvailability: SubscriptionFeatureAvailability,
@@ -431,10 +430,6 @@ final class DefaultSubscriptionPagesUseSubscriptionFeature: SubscriptionPagesUse
         setTransactionStatus(.purchasing)
         resetSubscriptionFlow()
 
-        // The reminder preference only lives for the duration of one purchase attempt.
-        // Clearing on exit covers cancellation, failure, and post-success paths uniformly.
-        defer { pendingScheduleNotification = nil }
-
         struct SubscriptionSelection: Decodable {
             struct Experiment: Codable {
                 let name: String
@@ -462,8 +457,7 @@ final class DefaultSubscriptionPagesUseSubscriptionFeature: SubscriptionPagesUse
             return nil
         }
 
-        // Hold the reminder preference for the duration of the purchase flow. Discarded if the purchase doesn't succeed.
-        pendingScheduleNotification = subscriptionSelection.scheduleNotification
+        let pendingScheduleNotification = subscriptionSelection.scheduleNotification
 
         // 2: Check for active subscriptions
         if await subscriptionManager.storePurchaseManager().hasActiveSubscription() {

--- a/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
@@ -295,6 +295,7 @@ final class DefaultSubscriptionPagesUseSubscriptionFeature: SubscriptionPagesUse
 
     /// If the FE never redirects after we push Stripe redirect (e.g. mobile), the back button stays hidden. Reset to idle after this delay so the user can go back.
     private static let stripeRedirectSafetyTimeoutSeconds: UInt64 = 8
+    private static let secondsPerDay: TimeInterval = 24 * 60 * 60
 
     private enum StripeRedirectSafetyTimeoutError: Error {
         case couldNotRedirect
@@ -590,7 +591,8 @@ final class DefaultSubscriptionPagesUseSubscriptionFeature: SubscriptionPagesUse
             }
 
             if let preference = pendingScheduleNotification, let scheduler = expirationReminderScheduler {
-                await scheduler.scheduleReminder(daysBeforeCancel: preference.daysBeforeCancel)
+                let seconds = TimeInterval(preference.daysBeforeCancel) * Self.secondsPerDay
+                await scheduler.scheduleReminder(timeBeforeCancel: seconds)
             }
 
         case .failure(let error):
@@ -921,8 +923,6 @@ extension DefaultSubscriptionPagesUseSubscriptionFeature {
         case .authorized, .provisional, .ephemeral:
             return NotificationsPermissionResponse(granted: true)
         case .denied:
-            // The OS will not display the prompt in this state; report the cached state immediately
-            // so FE can direct the user to Settings.
             return NotificationsPermissionResponse(granted: false)
         case .notDetermined:
             let granted = (try? await userNotificationCenter.requestAuthorization(options: [.alert, .sound])) ?? false

--- a/iOS/DuckDuckGo/Subscription/Views/SubscriptionContainerViewFactory.swift
+++ b/iOS/DuckDuckGo/Subscription/Views/SubscriptionContainerViewFactory.swift
@@ -27,7 +27,7 @@ import DataBrokerProtection_iOS
 import PixelKit
 
 enum SubscriptionContainerViewFactory {
-    
+
     private static var subscriptionUserDefaults: UserDefaults {
         let subscriptionAppGroup = Bundle.main.appGroup(bundle: .subs)
         return UserDefaults(suiteName: subscriptionAppGroup)!
@@ -104,7 +104,8 @@ enum SubscriptionContainerViewFactory {
                                                                        wideEvent: wideEvent,
                                                                        pendingTransactionHandler: pendingTransactionHandler,
                                                                        subscriptionFlowsExecuter: subscriptionFlowsExecuter,
-                                                                       requestValidator: DefaultScriptRequestValidator(subscriptionManager: subscriptionManager)),
+                                                                       requestValidator: DefaultScriptRequestValidator(subscriptionManager: subscriptionManager),
+                                                                       expirationReminderScheduler: AppDependencyProvider.shared.subscriptionExpirationReminderScheduler),
             dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider
         )
         viewModel.email.setEmailFlowMode(.restoreFlow)
@@ -146,7 +147,8 @@ enum SubscriptionContainerViewFactory {
                                                                                                      wideEvent: wideEvent,
                                                                                                      pendingTransactionHandler: pendingTransactionHandler,
                                                                                                      subscriptionFlowsExecuter: subscriptionFlowsExecuter,
-                                                                                                     requestValidator: DefaultScriptRequestValidator(subscriptionManager: subscriptionManager))
+                                                                                                     requestValidator: DefaultScriptRequestValidator(subscriptionManager: subscriptionManager),
+                                                                                                     expirationReminderScheduler: AppDependencyProvider.shared.subscriptionExpirationReminderScheduler)
 
         let viewModel = SubscriptionContainerViewModel(subscriptionManager: subscriptionManager,
                                                        isInternalUser: internalUserDecider.isInternalUser,
@@ -214,7 +216,8 @@ enum SubscriptionContainerViewFactory {
                                                                        wideEvent: wideEvent,
                                                                        pendingTransactionHandler: pendingTransactionHandler,
                                                                        subscriptionFlowsExecuter: subscriptionFlowsExecuter,
-                                                                       requestValidator: DefaultScriptRequestValidator(subscriptionManager: subscriptionManager)),
+                                                                       requestValidator: DefaultScriptRequestValidator(subscriptionManager: subscriptionManager),
+                                                                       expirationReminderScheduler: AppDependencyProvider.shared.subscriptionExpirationReminderScheduler),
             dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider
         )
         return SubscriptionContainerView(currentView: .subscribe, viewModel: viewModel, featureFlagger: featureFlagger)
@@ -260,7 +263,8 @@ enum SubscriptionContainerViewFactory {
                                                                        wideEvent: wideEvent,
                                                                        pendingTransactionHandler: pendingTransactionHandler,
                                                                        subscriptionFlowsExecuter: subscriptionFlowsExecuter,
-                                                                       requestValidator: DefaultScriptRequestValidator(subscriptionManager: subscriptionManager)),
+                                                                       requestValidator: DefaultScriptRequestValidator(subscriptionManager: subscriptionManager),
+                                                                       expirationReminderScheduler: AppDependencyProvider.shared.subscriptionExpirationReminderScheduler),
             dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider
         )
 

--- a/iOS/DuckDuckGo/SubscriptionBridgePlaygroundFeature.swift
+++ b/iOS/DuckDuckGo/SubscriptionBridgePlaygroundFeature.swift
@@ -26,7 +26,7 @@ import UserScript
 
 struct SubscriptionBridgePlaygroundFeature: JSBridgePlaygroundFeature {
 
-    let displayName = "Subscription"
+    let displayName = "Subscription Expiration Notification"
     let messageHandlerName = SubscriptionPagesUserScript.context
     let messageContext = SubscriptionPagesUserScript.context
     let featureName = SubscriptionPagesUseSubscriptionFeatureConstants.featureName
@@ -61,13 +61,7 @@ struct SubscriptionBridgePlaygroundFeature: JSBridgePlaygroundFeature {
             storePurchaseManager: subscriptionManager.storePurchaseManager(),
             pendingTransactionHandler: pendingTransactionHandler
         )
-        let appStorePurchaseFlow = DefaultAppStorePurchaseFlow(
-            subscriptionManager: subscriptionManager,
-            storePurchaseManager: subscriptionManager.storePurchaseManager(),
-            appStoreRestoreFlow: appStoreRestoreFlow,
-            wideEvent: AppDependencyProvider.shared.wideEvent,
-            pendingTransactionHandler: pendingTransactionHandler
-        )
+        let appStorePurchaseFlow = PlaygroundMockAppStorePurchaseFlow()
         let subscriptionFeatureAvailability = BrowserServicesKit.DefaultSubscriptionFeatureAvailability(
             privacyConfigurationManager: ContentBlocking.shared.privacyConfigurationManager,
             purchasePlatform: .appStore,
@@ -89,7 +83,8 @@ struct SubscriptionBridgePlaygroundFeature: JSBridgePlaygroundFeature {
             wideEvent: AppDependencyProvider.shared.wideEvent,
             pendingTransactionHandler: pendingTransactionHandler,
             subscriptionFlowsExecuter: subscriptionFlowsExecuter,
-            requestValidator: DefaultScriptRequestValidator(subscriptionManager: subscriptionManager)
+            requestValidator: DefaultScriptRequestValidator(subscriptionManager: subscriptionManager),
+            expirationReminderScheduler: AppDependencyProvider.shared.subscriptionExpirationReminderScheduler
         )
 
         let userScript = SubscriptionPagesUserScript()
@@ -97,3 +92,21 @@ struct SubscriptionBridgePlaygroundFeature: JSBridgePlaygroundFeature {
         return [userScript]
     }
 }
+
+/// Mock that drives the production purchase handler down the success path so the
+/// scheduler integration can be exercised without StoreKit.
+private final class PlaygroundMockAppStorePurchaseFlow: AppStorePurchaseFlow {
+
+    func purchaseSubscription(with subscriptionIdentifier: String, includeProTier: Bool) async -> Result<PurchaseResult, AppStorePurchaseFlowError> {
+        .success((transactionJWS: "playground-mock-jws", accountCreationDuration: nil))
+    }
+
+    func completeSubscriptionPurchase(with transactionJWS: TransactionJWS, additionalParams: [String: String]?) async -> Result<PurchaseUpdate, AppStorePurchaseFlowError> {
+        .success(PurchaseUpdate.completed)
+    }
+
+    func changeTier(to subscriptionIdentifier: String) async -> Result<TransactionJWS, AppStorePurchaseFlowError> {
+        .success("playground-mock-jws")
+    }
+}
+

--- a/iOS/DuckDuckGo/SubscriptionBridgePlaygroundFeature.swift
+++ b/iOS/DuckDuckGo/SubscriptionBridgePlaygroundFeature.swift
@@ -35,21 +35,14 @@ struct SubscriptionBridgePlaygroundFeature: JSBridgePlaygroundFeature {
         AppDependencyProvider.shared.subscriptionManager.url(for: .baseURL)
     }
 
-    // Side-effecting handlers (subscriptionSelected starts an Apple purchase sheet, backToSettings
-    // and featureSelected navigate away from the playground) are still safe to expose — sending is
-    // a deliberate action. Samples are filled in automatically when a chip is clicked or the method
-    // name is typed.
     var knownMethods: [JSBridgePlaygroundMethod] {
         [
-            JSBridgePlaygroundMethod(name: "getAccessToken", sampleParamsJSON: "{}"),
-            JSBridgePlaygroundMethod(name: "getAuthAccessToken", sampleParamsJSON: "{}"),
-            JSBridgePlaygroundMethod(name: "getFeatureConfig", sampleParamsJSON: "{}"),
-            JSBridgePlaygroundMethod(name: "getSubscriptionTierOptions", sampleParamsJSON: "{}"),
-            JSBridgePlaygroundMethod(name: "subscriptionsMonthlyPriceClicked", sampleParamsJSON: "{}"),
-            JSBridgePlaygroundMethod(name: "featureSelected",
-                                     sampleParamsJSON: #"{"productFeature": "networkProtection"}"#),
-            JSBridgePlaygroundMethod(name: "subscriptionSelected",
-                                     sampleParamsJSON: #"{"id": "ddg.privacy.pro.monthly.renews.us"}"#)
+            JSBridgePlaygroundMethod(name: "getUserSettings", sampleParamsJSON: "{}"),
+            JSBridgePlaygroundMethod(name: "requestNotificationsPermission", sampleParamsJSON: "{}"),
+            JSBridgePlaygroundMethod(
+                name: "subscriptionSelected",
+                sampleParamsJSON: #"{"id": "ddg.privacy.pro.monthly.renews.us", "scheduleNotification": {"daysBeforeCancel": 3}}"#
+            )
         ]
     }
 

--- a/iOS/DuckDuckGo/SubscriptionBridgePlaygroundFeature.swift
+++ b/iOS/DuckDuckGo/SubscriptionBridgePlaygroundFeature.swift
@@ -1,0 +1,106 @@
+//
+//  SubscriptionBridgePlaygroundFeature.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import BrowserServicesKit
+import Core
+import Foundation
+import PixelKit
+import Subscription
+import UserScript
+
+struct SubscriptionBridgePlaygroundFeature: JSBridgePlaygroundFeature {
+
+    let displayName = "Subscription"
+    let messageHandlerName = SubscriptionPagesUserScript.context
+    let messageContext = SubscriptionPagesUserScript.context
+    let featureName = SubscriptionPagesUseSubscriptionFeatureConstants.featureName
+
+    var baseURL: URL {
+        AppDependencyProvider.shared.subscriptionManager.url(for: .baseURL)
+    }
+
+    // Side-effecting handlers (subscriptionSelected starts an Apple purchase sheet, backToSettings
+    // and featureSelected navigate away from the playground) are still safe to expose — sending is
+    // a deliberate action. Samples are filled in automatically when a chip is clicked or the method
+    // name is typed.
+    var knownMethods: [JSBridgePlaygroundMethod] {
+        [
+            JSBridgePlaygroundMethod(name: "getAccessToken", sampleParamsJSON: "{}"),
+            JSBridgePlaygroundMethod(name: "getAuthAccessToken", sampleParamsJSON: "{}"),
+            JSBridgePlaygroundMethod(name: "getFeatureConfig", sampleParamsJSON: "{}"),
+            JSBridgePlaygroundMethod(name: "getSubscriptionTierOptions", sampleParamsJSON: "{}"),
+            JSBridgePlaygroundMethod(name: "subscriptionsMonthlyPriceClicked", sampleParamsJSON: "{}"),
+            JSBridgePlaygroundMethod(name: "featureSelected",
+                                     sampleParamsJSON: #"{"productFeature": "networkProtection"}"#),
+            JSBridgePlaygroundMethod(name: "subscriptionSelected",
+                                     sampleParamsJSON: #"{"id": "ddg.privacy.pro.monthly.renews.us"}"#)
+        ]
+    }
+
+    @MainActor
+    func makeUserScripts() -> [UserScript] {
+        let subscriptionManager = AppDependencyProvider.shared.subscriptionManager
+        let subscriptionAppGroup = Bundle.main.appGroup(bundle: .subs)
+        let subscriptionUserDefaults = UserDefaults(suiteName: subscriptionAppGroup)!
+
+        let pendingTransactionHandler = DefaultPendingTransactionHandler(
+            userDefaults: subscriptionUserDefaults,
+            pixelHandler: SubscriptionPixelHandler(source: .mainApp, pixelKit: nil)
+        )
+        let appStoreRestoreFlow = DefaultAppStoreRestoreFlow(
+            subscriptionManager: subscriptionManager,
+            storePurchaseManager: subscriptionManager.storePurchaseManager(),
+            pendingTransactionHandler: pendingTransactionHandler
+        )
+        let appStorePurchaseFlow = DefaultAppStorePurchaseFlow(
+            subscriptionManager: subscriptionManager,
+            storePurchaseManager: subscriptionManager.storePurchaseManager(),
+            appStoreRestoreFlow: appStoreRestoreFlow,
+            wideEvent: AppDependencyProvider.shared.wideEvent,
+            pendingTransactionHandler: pendingTransactionHandler
+        )
+        let subscriptionFeatureAvailability = BrowserServicesKit.DefaultSubscriptionFeatureAvailability(
+            privacyConfigurationManager: ContentBlocking.shared.privacyConfigurationManager,
+            purchasePlatform: .appStore,
+            featureFlagProvider: SubscriptionPageFeatureFlagAdapter(featureFlagger: AppDependencyProvider.shared.featureFlagger)
+        )
+        let subscriptionFlowsExecuter = DefaultSubscriptionFlowsExecuter(
+            subscriptionManager: subscriptionManager,
+            appStorePurchaseFlow: appStorePurchaseFlow,
+            wideEvent: AppDependencyProvider.shared.wideEvent,
+            pendingTransactionHandler: pendingTransactionHandler
+        )
+        let subFeature = DefaultSubscriptionPagesUseSubscriptionFeature(
+            subscriptionManager: subscriptionManager,
+            subscriptionFeatureAvailability: subscriptionFeatureAvailability,
+            subscriptionAttributionOrigin: nil,
+            appStorePurchaseFlow: appStorePurchaseFlow,
+            appStoreRestoreFlow: appStoreRestoreFlow,
+            internalUserDecider: AppDependencyProvider.shared.internalUserDecider,
+            wideEvent: AppDependencyProvider.shared.wideEvent,
+            pendingTransactionHandler: pendingTransactionHandler,
+            subscriptionFlowsExecuter: subscriptionFlowsExecuter,
+            requestValidator: DefaultScriptRequestValidator(subscriptionManager: subscriptionManager)
+        )
+
+        let userScript = SubscriptionPagesUserScript()
+        userScript.registerSubfeature(delegate: subFeature)
+        return [userScript]
+    }
+}

--- a/iOS/DuckDuckGo/SubscriptionDebugViewController.swift
+++ b/iOS/DuckDuckGo/SubscriptionDebugViewController.swift
@@ -119,9 +119,12 @@ final class SubscriptionDebugViewController: UITableViewController {
     }
 
     enum ExpirationReminderRows: Int, CaseIterable {
+        case currentStatus
         case triggerMockNotification
-        case cancelPendingReminder
     }
+
+    private var notificationAuthStatusText: String = "Loading"
+    private var subscriptionStatusText: String = "Loading"
     
 
     private var storefrontID = "Loading"
@@ -134,6 +137,12 @@ final class SubscriptionDebugViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         loadStoreKitMetadata()
+        loadExpirationReminderStatus()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        loadExpirationReminderStatus()
     }
 
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
@@ -247,10 +256,15 @@ final class SubscriptionDebugViewController: UITableViewController {
 
         case .expirationReminder:
             switch ExpirationReminderRows(rawValue: indexPath.row) {
+            case .currentStatus:
+                cell.textLabel?.attributedText = Self.makeStatusAttributedText(
+                    notifications: notificationAuthStatusText,
+                    subscription: subscriptionStatusText
+                )
+                cell.textLabel?.numberOfLines = 0
+                cell.selectionStyle = .none
             case .triggerMockNotification:
-                cell.textLabel?.text = "Trigger Mock Notification (5s)"
-            case .cancelPendingReminder:
-                cell.textLabel?.text = "Cancel Pending Reminder"
+                cell.textLabel?.text = "Trigger Mock Notification…"
             case .none:
                 break
             }
@@ -358,7 +372,6 @@ final class SubscriptionDebugViewController: UITableViewController {
         case .expirationReminder:
             switch ExpirationReminderRows(rawValue: indexPath.row) {
             case .triggerMockNotification: triggerMockExpirationReminder()
-            case .cancelPendingReminder: cancelPendingExpirationReminder()
             default: break
             }
         case .none:
@@ -645,9 +658,33 @@ final class SubscriptionDebugViewController: UITableViewController {
 
     // MARK: - Expiration reminder (debug)
 
-    /// Schedules a local notification 5 seconds out using the same identifier and content as the production reminder.
-    /// Exercises the NotificationServiceManager tap-routing path without waiting for an active subscription's expiry.
+    /// Prompts for a delay in seconds, then schedules a local notification using the same identifier
+    /// and content as the production reminder so the NotificationServiceManager tap-routing path can be exercised.
+    /// Note: shares the production identifier, so this will overwrite any real pending reminder.
     private func triggerMockExpirationReminder() {
+        let alert = UIAlertController(title: "Trigger Mock Reminder",
+                                      message: "Fire after how many seconds?",
+                                      preferredStyle: .alert)
+        weak var secondsTextField: UITextField?
+        alert.addTextField { field in
+            field.keyboardType = .numberPad
+            field.placeholder = "Seconds"
+            field.text = "5"
+            secondsTextField = field
+        }
+        alert.addAction(UIAlertAction(title: "Schedule", style: .default) { [weak self] _ in
+            guard let raw = secondsTextField?.text,
+                  let seconds = TimeInterval(raw), seconds > 0 else {
+                self?.showAlert(title: "Invalid value", message: "Enter a positive number of seconds.")
+                return
+            }
+            self?.scheduleMockExpirationReminder(afterSeconds: seconds)
+        })
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        present(alert, animated: true)
+    }
+
+    private func scheduleMockExpirationReminder(afterSeconds seconds: TimeInterval) {
         let center = UNUserNotificationCenter.current()
         Task { @MainActor in
             let status = await center.authorizationStatus()
@@ -668,23 +705,49 @@ final class SubscriptionDebugViewController: UITableViewController {
             content.body = "Tap to review your subscription and stay protected."
             content.categoryIdentifier = identifier
 
-            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 5, repeats: false)
+            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: seconds, repeats: false)
             let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
 
             do {
                 try await center.add(request)
-                showAlert(title: "Mock reminder scheduled", message: "Will fire in 5 seconds. Background the app or wait to see it.")
+                showAlert(title: "Mock reminder scheduled", message: "Will fire in \(Int(seconds)) seconds.")
             } catch {
                 showAlert(title: "Failed to schedule", message: error.localizedDescription)
             }
         }
     }
 
-    private func cancelPendingExpirationReminder() {
-        UNUserNotificationCenter.current().removePendingNotificationRequests(
-            withIdentifiers: [DefaultSubscriptionExpirationReminderScheduler.notificationIdentifier]
-        )
-        showAlert(title: "Pending reminder cancelled")
+    /// Builds a two-line attributed string with each label in `.footnote` + secondary color
+    /// and each value in `.body` + primary color, so labels and values are visually distinguishable.
+    private static func makeStatusAttributedText(notifications: String, subscription: String) -> NSAttributedString {
+        let labelAttrs: [NSAttributedString.Key: Any] = [
+            .font: UIFont.preferredFont(forTextStyle: .footnote),
+            .foregroundColor: UIColor.secondaryLabel
+        ]
+        let valueAttrs: [NSAttributedString.Key: Any] = [
+            .font: UIFont.preferredFont(forTextStyle: .body),
+            .foregroundColor: UIColor.label
+        ]
+        let attributed = NSMutableAttributedString()
+        attributed.append(NSAttributedString(string: "Notifications: ", attributes: labelAttrs))
+        attributed.append(NSAttributedString(string: notifications, attributes: valueAttrs))
+        attributed.append(NSAttributedString(string: "\nSubscription: ", attributes: labelAttrs))
+        attributed.append(NSAttributedString(string: subscription, attributes: valueAttrs))
+        return attributed
+    }
+
+    private func loadExpirationReminderStatus() {
+        Task { @MainActor in
+            let authStatus = await UNUserNotificationCenter.current().authorizationStatus()
+            notificationAuthStatusText = authStatus.stringValue
+
+            if let subscription = try? await subscriptionManager.getSubscription(forceRefresh: false) {
+                subscriptionStatusText = subscription.status.rawValue
+            } else {
+                subscriptionStatusText = "No subscription"
+            }
+            tableView.reloadSections(IndexSet(integer: Sections.expirationReminder.rawValue), with: .none)
+        }
     }
 
     private func showBuyProductionSubscriptions() {

--- a/iOS/DuckDuckGo/SubscriptionDebugViewController.swift
+++ b/iOS/DuckDuckGo/SubscriptionDebugViewController.swift
@@ -658,63 +658,57 @@ final class SubscriptionDebugViewController: UITableViewController {
 
     // MARK: - Expiration reminder (debug)
 
-    /// Prompts for a delay in seconds, then schedules a local notification using the same identifier
-    /// and content as the production reminder so the NotificationServiceManager tap-routing path can be exercised.
-    /// Note: shares the production identifier, so this will overwrite any real pending reminder.
+    /// Prompts for a delay relative to now, then runs the production scheduler with a `timeBeforeCancel`
+    /// derived from the current subscription's expiry so the notification fires N seconds from now.
     private func triggerMockExpirationReminder() {
-        let alert = UIAlertController(title: "Trigger Mock Reminder",
-                                      message: "Fire after how many seconds?",
+        let alert = UIAlertController(title: "Trigger Expiration Reminder",
+                                      message: "Fire how many seconds from now?",
                                       preferredStyle: .alert)
         weak var secondsTextField: UITextField?
         alert.addTextField { field in
             field.keyboardType = .numberPad
-            field.placeholder = "Seconds"
+            field.placeholder = "Seconds from now"
             field.text = "5"
             secondsTextField = field
         }
         alert.addAction(UIAlertAction(title: "Schedule", style: .default) { [weak self] _ in
-            guard let raw = secondsTextField?.text,
-                  let seconds = TimeInterval(raw), seconds > 0 else {
+            guard let raw = secondsTextField?.text, let secondsFromNow = TimeInterval(raw), secondsFromNow > 0 else {
                 self?.showAlert(title: "Invalid value", message: "Enter a positive number of seconds.")
                 return
             }
-            self?.scheduleMockExpirationReminder(afterSeconds: seconds)
+            Task { @MainActor in
+                guard let self else { return }
+                let subscription: DuckDuckGoSubscription?
+                do {
+                    subscription = try await self.subscriptionManager.getSubscription(forceRefresh: true)
+                } catch {
+                    self.showAlert(title: "Failed to load subscription", message: error.localizedDescription)
+                    return
+                }
+                guard let subscription else {
+                    self.showAlert(title: "No active subscription", message: "Sign in with an active subscription before triggering the reminder.")
+                    return
+                }
+                let remaining = subscription.expiresOrRenewsAt.timeIntervalSinceNow
+                guard remaining > 0 else {
+                    self.showAlert(title: "Subscription already expired",
+                                   message: "expiresOrRenewsAt is in the past.")
+                    return
+                }
+                let timeBeforeCancel = remaining - secondsFromNow
+                guard timeBeforeCancel > 0 else {
+                    self.showAlert(title: "Cannot schedule",
+                                   message: "Subscription expires in \(Int(remaining))s — pick a smaller delay.")
+                    return
+                }
+                await AppDependencyProvider.shared.subscriptionExpirationReminderScheduler
+                    .scheduleReminder(timeBeforeCancel: timeBeforeCancel)
+                self.showAlert(title: "Scheduler invoked",
+                               message: "Reminder will fire in ~\(Int(secondsFromNow))s if all production guards pass.")
+            }
         })
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
         present(alert, animated: true)
-    }
-
-    private func scheduleMockExpirationReminder(afterSeconds seconds: TimeInterval) {
-        let center = UNUserNotificationCenter.current()
-        Task { @MainActor in
-            let status = await center.authorizationStatus()
-            if status == .notDetermined {
-                _ = try? await center.requestAuthorization(options: [.alert, .sound])
-            }
-            let refreshedStatus = await center.authorizationStatus()
-            guard refreshedStatus == .authorized || refreshedStatus == .provisional || refreshedStatus == .ephemeral else {
-                showAlert(title: "Notifications not authorized", message: "Enable notifications in Settings to test the reminder.")
-                return
-            }
-
-            let identifier = DefaultSubscriptionExpirationReminderScheduler.notificationIdentifier
-            center.removePendingNotificationRequests(withIdentifiers: [identifier])
-
-            let content = UNMutableNotificationContent()
-            content.title = "Your Privacy Pro subscription is ending soon"
-            content.body = "Tap to review your subscription and stay protected."
-            content.categoryIdentifier = identifier
-
-            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: seconds, repeats: false)
-            let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
-
-            do {
-                try await center.add(request)
-                showAlert(title: "Mock reminder scheduled", message: "Will fire in \(Int(seconds)) seconds.")
-            } catch {
-                showAlert(title: "Failed to schedule", message: error.localizedDescription)
-            }
-        }
     }
 
     /// Builds a two-line attributed string with each label in `.footnote` + secondary color
@@ -741,10 +735,11 @@ final class SubscriptionDebugViewController: UITableViewController {
             let authStatus = await UNUserNotificationCenter.current().authorizationStatus()
             notificationAuthStatusText = authStatus.stringValue
 
-            if let subscription = try? await subscriptionManager.getSubscription(forceRefresh: false) {
-                subscriptionStatusText = subscription.status.rawValue
-            } else {
-                subscriptionStatusText = "No subscription"
+            do {
+                let subscription = try await subscriptionManager.getSubscription(forceRefresh: true)
+                subscriptionStatusText = subscription?.status.rawValue ?? "No subscription"
+            } catch {
+                subscriptionStatusText = "Error: \(error.localizedDescription)"
             }
             tableView.reloadSections(IndexSet(integer: Sections.expirationReminder.rawValue), with: .none)
         }

--- a/iOS/DuckDuckGo/SubscriptionDebugViewController.swift
+++ b/iOS/DuckDuckGo/SubscriptionDebugViewController.swift
@@ -27,6 +27,7 @@ import VPN
 import StoreKit
 import PrivacyConfig
 import Networking
+import UserNotifications
 
 final class SubscriptionDebugViewController: UITableViewController {
 
@@ -62,6 +63,7 @@ final class SubscriptionDebugViewController: UITableViewController {
         Sections.pixels: "Promo Pixel Parameters",
         Sections.metadata: "StoreKit Metadata",
         Sections.regionOverride: "Region override for App Store Sandbox",
+        Sections.expirationReminder: "Expiration Reminder Notification",
     ]
 
     enum Sections: Int, CaseIterable {
@@ -73,6 +75,7 @@ final class SubscriptionDebugViewController: UITableViewController {
         case pixels
         case metadata
         case regionOverride
+        case expirationReminder
     }
 
     enum AuthorizationRows: Int, CaseIterable {
@@ -113,6 +116,11 @@ final class SubscriptionDebugViewController: UITableViewController {
 
     enum RegionOverrideRows: Int, CaseIterable {
         case currentRegionOverride
+    }
+
+    enum ExpirationReminderRows: Int, CaseIterable {
+        case triggerMockNotification
+        case cancelPendingReminder
     }
     
 
@@ -237,6 +245,16 @@ final class SubscriptionDebugViewController: UITableViewController {
                 break
             }
 
+        case .expirationReminder:
+            switch ExpirationReminderRows(rawValue: indexPath.row) {
+            case .triggerMockNotification:
+                cell.textLabel?.text = "Trigger Mock Notification (5s)"
+            case .cancelPendingReminder:
+                cell.textLabel?.text = "Cancel Pending Reminder"
+            case .none:
+                break
+            }
+
         case .regionOverride:
             switch RegionOverrideRows(rawValue: indexPath.row) {
             case .currentRegionOverride:
@@ -293,6 +311,7 @@ final class SubscriptionDebugViewController: UITableViewController {
         case .pixels: return PixelsRows.allCases.count
         case .metadata: return MetadataRows.allCases.count
         case .regionOverride: return RegionOverrideRows.allCases.count
+        case .expirationReminder: return ExpirationReminderRows.allCases.count
         case .none: return 0
         }
     }
@@ -336,6 +355,12 @@ final class SubscriptionDebugViewController: UITableViewController {
             break
         case .regionOverride:
             break
+        case .expirationReminder:
+            switch ExpirationReminderRows(rawValue: indexPath.row) {
+            case .triggerMockNotification: triggerMockExpirationReminder()
+            case .cancelPendingReminder: cancelPendingExpirationReminder()
+            default: break
+            }
         case .none:
             break
         }
@@ -616,6 +641,50 @@ final class SubscriptionDebugViewController: UITableViewController {
             self.storefrontCountryCode = storefront?.countryCode ?? "nil"
             self.tableView.reloadData()
         }
+    }
+
+    // MARK: - Expiration reminder (debug)
+
+    /// Schedules a local notification 5 seconds out using the same identifier and content as the production reminder.
+    /// Exercises the NotificationServiceManager tap-routing path without waiting for an active subscription's expiry.
+    private func triggerMockExpirationReminder() {
+        let center = UNUserNotificationCenter.current()
+        Task { @MainActor in
+            let status = await center.authorizationStatus()
+            if status == .notDetermined {
+                _ = try? await center.requestAuthorization(options: [.alert, .sound])
+            }
+            let refreshedStatus = await center.authorizationStatus()
+            guard refreshedStatus == .authorized || refreshedStatus == .provisional || refreshedStatus == .ephemeral else {
+                showAlert(title: "Notifications not authorized", message: "Enable notifications in Settings to test the reminder.")
+                return
+            }
+
+            let identifier = DefaultSubscriptionExpirationReminderScheduler.notificationIdentifier
+            center.removePendingNotificationRequests(withIdentifiers: [identifier])
+
+            let content = UNMutableNotificationContent()
+            content.title = "Your Privacy Pro subscription is ending soon"
+            content.body = "Tap to review your subscription and stay protected."
+            content.categoryIdentifier = identifier
+
+            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 5, repeats: false)
+            let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+
+            do {
+                try await center.add(request)
+                showAlert(title: "Mock reminder scheduled", message: "Will fire in 5 seconds. Background the app or wait to see it.")
+            } catch {
+                showAlert(title: "Failed to schedule", message: error.localizedDescription)
+            }
+        }
+    }
+
+    private func cancelPendingExpirationReminder() {
+        UNUserNotificationCenter.current().removePendingNotificationRequests(
+            withIdentifiers: [DefaultSubscriptionExpirationReminderScheduler.notificationIdentifier]
+        )
+        showAlert(title: "Pending reminder cancelled")
     }
 
     private func showBuyProductionSubscriptions() {

--- a/iOS/DuckDuckGo/UNUserNotificationCenterRepresentable.swift
+++ b/iOS/DuckDuckGo/UNUserNotificationCenterRepresentable.swift
@@ -34,6 +34,7 @@ protocol UNUserNotificationCenterRepresentable: AnyObject {
     func authorizationStatus() async -> UNAuthorizationStatus
     func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool
     func add(_ request: UNNotificationRequest) async throws
+    func pendingNotificationRequests() async -> [UNNotificationRequest]
     func removePendingNotificationRequests(withIdentifiers identifiers: [String])
 }
 

--- a/iOS/DuckDuckGoTests/Subscription/Mocks/SubscriptionExpirationReminderSchedulerMock.swift
+++ b/iOS/DuckDuckGoTests/Subscription/Mocks/SubscriptionExpirationReminderSchedulerMock.swift
@@ -1,0 +1,30 @@
+//
+//  SubscriptionExpirationReminderSchedulerMock.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+@testable import DuckDuckGo
+
+final class SubscriptionExpirationReminderSchedulerMock: SubscriptionExpirationReminderScheduling {
+
+    private(set) var scheduledDaysBeforeCancel: [Int] = []
+
+    func scheduleReminder(daysBeforeCancel: Int) async {
+        scheduledDaysBeforeCancel.append(daysBeforeCancel)
+    }
+}

--- a/iOS/DuckDuckGoTests/Subscription/Mocks/SubscriptionExpirationReminderSchedulerMock.swift
+++ b/iOS/DuckDuckGoTests/Subscription/Mocks/SubscriptionExpirationReminderSchedulerMock.swift
@@ -22,9 +22,9 @@ import Foundation
 
 final class SubscriptionExpirationReminderSchedulerMock: SubscriptionExpirationReminderScheduling {
 
-    private(set) var scheduledDaysBeforeCancel: [Int] = []
+    private(set) var scheduledTimeBeforeCancel: [TimeInterval] = []
 
-    func scheduleReminder(daysBeforeCancel: Int) async {
-        scheduledDaysBeforeCancel.append(daysBeforeCancel)
+    func scheduleReminder(timeBeforeCancel: TimeInterval) async {
+        scheduledTimeBeforeCancel.append(timeBeforeCancel)
     }
 }

--- a/iOS/DuckDuckGoTests/Subscription/SubscriptionExpirationReminderSchedulerTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/SubscriptionExpirationReminderSchedulerTests.swift
@@ -160,7 +160,9 @@ final class SubscriptionExpirationReminderSchedulerTests: XCTestCase {
         XCTAssertEqual(request.identifier, identifier)
         XCTAssertEqual(request.content.title, "Your Privacy Pro subscription is ending soon")
         XCTAssertEqual(request.content.categoryIdentifier, identifier)
-        XCTAssertTrue(request.trigger is UNCalendarNotificationTrigger)
+        let trigger = try XCTUnwrap(request.trigger as? UNTimeIntervalNotificationTrigger)
+        XCTAssertEqual(trigger.timeInterval, days(23), accuracy: 5)
+        XCTAssertFalse(trigger.repeats)
     }
 
     func test_scheduleReminder_removesPreviouslyScheduledReminderBeforeAdding() async {

--- a/iOS/DuckDuckGoTests/Subscription/SubscriptionExpirationReminderSchedulerTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/SubscriptionExpirationReminderSchedulerTests.swift
@@ -63,29 +63,33 @@ final class SubscriptionExpirationReminderSchedulerTests: XCTestCase {
         subscriptionManager.resultSubscription = .success(SubscriptionMockFactory.subscription(status: status))
     }
 
+    private func days(_ count: Int) -> TimeInterval {
+        TimeInterval(count) * 24 * 60 * 60
+    }
+
     // MARK: - scheduleReminder skip paths
 
     func test_scheduleReminder_whenFeatureFlagOff_doesNotAddRequest() async {
         featureFlagEnabled = false
         setSubscription(status: .autoRenewable)
 
-        await sut.scheduleReminder(daysBeforeCancel: 7)
+        await sut.scheduleReminder(timeBeforeCancel: days(7))
 
         XCTAssertTrue(notificationCenter.addedRequests.isEmpty)
     }
 
-    func test_scheduleReminder_whenDaysBeforeCancelIsZero_doesNotAddRequest() async {
+    func test_scheduleReminder_whenTimeBeforeCancelIsZero_doesNotAddRequest() async {
         setSubscription(status: .autoRenewable)
 
-        await sut.scheduleReminder(daysBeforeCancel: 0)
+        await sut.scheduleReminder(timeBeforeCancel: 0)
 
         XCTAssertTrue(notificationCenter.addedRequests.isEmpty)
     }
 
-    func test_scheduleReminder_whenDaysBeforeCancelIsNegative_doesNotAddRequest() async {
+    func test_scheduleReminder_whenTimeBeforeCancelIsNegative_doesNotAddRequest() async {
         setSubscription(status: .autoRenewable)
 
-        await sut.scheduleReminder(daysBeforeCancel: -3)
+        await sut.scheduleReminder(timeBeforeCancel: -days(3))
 
         XCTAssertTrue(notificationCenter.addedRequests.isEmpty)
     }
@@ -94,7 +98,7 @@ final class SubscriptionExpirationReminderSchedulerTests: XCTestCase {
         notificationCenter.authorizationStatus = .denied
         setSubscription(status: .autoRenewable)
 
-        await sut.scheduleReminder(daysBeforeCancel: 7)
+        await sut.scheduleReminder(timeBeforeCancel: days(7))
 
         XCTAssertTrue(notificationCenter.addedRequests.isEmpty)
     }
@@ -103,7 +107,7 @@ final class SubscriptionExpirationReminderSchedulerTests: XCTestCase {
         notificationCenter.authorizationStatus = .provisional
         setSubscription(status: .autoRenewable)
 
-        await sut.scheduleReminder(daysBeforeCancel: 7)
+        await sut.scheduleReminder(timeBeforeCancel: days(7))
 
         XCTAssertTrue(notificationCenter.addedRequests.isEmpty,
                       "Provisional notifications deliver silently — the user would not see the reminder")
@@ -113,7 +117,7 @@ final class SubscriptionExpirationReminderSchedulerTests: XCTestCase {
         notificationCenter.authorizationStatus = .notDetermined
         setSubscription(status: .autoRenewable)
 
-        await sut.scheduleReminder(daysBeforeCancel: 7)
+        await sut.scheduleReminder(timeBeforeCancel: days(7))
 
         XCTAssertTrue(notificationCenter.addedRequests.isEmpty)
     }
@@ -121,7 +125,7 @@ final class SubscriptionExpirationReminderSchedulerTests: XCTestCase {
     func test_scheduleReminder_whenNoSubscription_doesNotAddRequest() async {
         subscriptionManager.resultSubscription = nil
 
-        await sut.scheduleReminder(daysBeforeCancel: 7)
+        await sut.scheduleReminder(timeBeforeCancel: days(7))
 
         XCTAssertTrue(notificationCenter.addedRequests.isEmpty)
     }
@@ -129,17 +133,17 @@ final class SubscriptionExpirationReminderSchedulerTests: XCTestCase {
     func test_scheduleReminder_whenSubscriptionStatusIsExpired_doesNotAddRequest() async {
         setSubscription(status: .expired)
 
-        await sut.scheduleReminder(daysBeforeCancel: 7)
+        await sut.scheduleReminder(timeBeforeCancel: days(7))
 
         XCTAssertTrue(notificationCenter.addedRequests.isEmpty)
     }
 
     func test_scheduleReminder_whenFireDateInThePast_doesNotAddRequest() async {
         // Depends on SubscriptionMockFactory.subscription(status:) hardcoding a +30-day expiry.
-        // daysBeforeCancel = 365 puts the computed fire date ~335 days in the past.
+        // 365 days puts the computed fire date ~335 days in the past.
         setSubscription(status: .autoRenewable)
 
-        await sut.scheduleReminder(daysBeforeCancel: 365)
+        await sut.scheduleReminder(timeBeforeCancel: days(365))
 
         XCTAssertTrue(notificationCenter.addedRequests.isEmpty)
     }
@@ -149,7 +153,7 @@ final class SubscriptionExpirationReminderSchedulerTests: XCTestCase {
     func test_scheduleReminder_withValidInputs_addsRequestWithCorrectIdentifierAndTrigger() async throws {
         setSubscription(status: .autoRenewable)
 
-        await sut.scheduleReminder(daysBeforeCancel: 7)
+        await sut.scheduleReminder(timeBeforeCancel: days(7))
 
         XCTAssertEqual(notificationCenter.addedRequests.count, 1)
         let request = try XCTUnwrap(notificationCenter.addedRequests.first)
@@ -162,7 +166,7 @@ final class SubscriptionExpirationReminderSchedulerTests: XCTestCase {
     func test_scheduleReminder_removesPreviouslyScheduledReminderBeforeAdding() async {
         setSubscription(status: .autoRenewable)
 
-        await sut.scheduleReminder(daysBeforeCancel: 7)
+        await sut.scheduleReminder(timeBeforeCancel: days(7))
 
         XCTAssertEqual(notificationCenter.removedIdentifiers.count, 1)
         XCTAssertEqual(notificationCenter.removedIdentifiers.first, [identifier])
@@ -172,7 +176,7 @@ final class SubscriptionExpirationReminderSchedulerTests: XCTestCase {
 
     func test_subscriptionDidChange_whenStatusBecomesExpired_cancelsPendingReminder() async {
         setSubscription(status: .autoRenewable)
-        await sut.scheduleReminder(daysBeforeCancel: 7)
+        await sut.scheduleReminder(timeBeforeCancel: days(7))
         let priorRemovalCount = notificationCenter.removedIdentifiers.count
 
         setSubscription(status: .expired)
@@ -186,7 +190,7 @@ final class SubscriptionExpirationReminderSchedulerTests: XCTestCase {
 
     func test_subscriptionDidChange_whenStatusStillActive_doesNotCancel() async {
         setSubscription(status: .autoRenewable)
-        await sut.scheduleReminder(daysBeforeCancel: 7)
+        await sut.scheduleReminder(timeBeforeCancel: days(7))
         let priorRemovalCount = notificationCenter.removedIdentifiers.count
 
         observerNotificationCenter.post(name: .subscriptionDidChange, object: nil)
@@ -211,7 +215,7 @@ final class SubscriptionExpirationReminderSchedulerTests: XCTestCase {
 
     func test_didBecomeActive_whenPendingAndStatusInactive_cancelsReminder() async {
         setSubscription(status: .autoRenewable)
-        await sut.scheduleReminder(daysBeforeCancel: 7)
+        await sut.scheduleReminder(timeBeforeCancel: days(7))
         let priorRemovalCount = notificationCenter.removedIdentifiers.count
 
         setSubscription(status: .inactive)
@@ -225,7 +229,7 @@ final class SubscriptionExpirationReminderSchedulerTests: XCTestCase {
 
     func test_didBecomeActive_whenPendingAndStatusActive_doesNotCancel() async {
         setSubscription(status: .autoRenewable)
-        await sut.scheduleReminder(daysBeforeCancel: 7)
+        await sut.scheduleReminder(timeBeforeCancel: days(7))
         let priorRemovalCount = notificationCenter.removedIdentifiers.count
 
         observerNotificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)

--- a/iOS/DuckDuckGoTests/Subscription/SubscriptionExpirationReminderSchedulerTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/SubscriptionExpirationReminderSchedulerTests.swift
@@ -1,0 +1,255 @@
+//
+//  SubscriptionExpirationReminderSchedulerTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import UIKit
+import UserNotifications
+@testable import DuckDuckGo
+import Subscription
+import SubscriptionTestingUtilities
+
+final class SubscriptionExpirationReminderSchedulerTests: XCTestCase {
+
+    private var subscriptionManager: SubscriptionManagerMock!
+    private var notificationCenter: MockUNUserNotificationCenter!
+    private var observerNotificationCenter: NotificationCenter!
+    private var featureFlagEnabled: Bool = true
+    private var sut: DefaultSubscriptionExpirationReminderScheduler!
+
+    private let identifier = DefaultSubscriptionExpirationReminderScheduler.notificationIdentifier
+
+    override func setUp() {
+        super.setUp()
+        subscriptionManager = SubscriptionManagerMock()
+        notificationCenter = MockUNUserNotificationCenter()
+        notificationCenter.authorizationStatus = .authorized
+        observerNotificationCenter = NotificationCenter()
+        featureFlagEnabled = true
+        sut = DefaultSubscriptionExpirationReminderScheduler(
+            subscriptionManager: subscriptionManager,
+            isFeatureEnabled: { [weak self] in self?.featureFlagEnabled ?? false },
+            notificationCenter: notificationCenter,
+            notificationCenterObserver: observerNotificationCenter
+        )
+    }
+
+    override func tearDown() {
+        sut = nil
+        subscriptionManager = nil
+        notificationCenter = nil
+        observerNotificationCenter = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func setSubscription(status: DuckDuckGoSubscription.Status) {
+        subscriptionManager.resultSubscription = .success(SubscriptionMockFactory.subscription(status: status))
+    }
+
+    // MARK: - scheduleReminder skip paths
+
+    func test_scheduleReminder_whenFeatureFlagOff_doesNotAddRequest() async {
+        featureFlagEnabled = false
+        setSubscription(status: .autoRenewable)
+
+        await sut.scheduleReminder(daysBeforeCancel: 7)
+
+        XCTAssertTrue(notificationCenter.addedRequests.isEmpty)
+    }
+
+    func test_scheduleReminder_whenDaysBeforeCancelIsZero_doesNotAddRequest() async {
+        setSubscription(status: .autoRenewable)
+
+        await sut.scheduleReminder(daysBeforeCancel: 0)
+
+        XCTAssertTrue(notificationCenter.addedRequests.isEmpty)
+    }
+
+    func test_scheduleReminder_whenDaysBeforeCancelIsNegative_doesNotAddRequest() async {
+        setSubscription(status: .autoRenewable)
+
+        await sut.scheduleReminder(daysBeforeCancel: -3)
+
+        XCTAssertTrue(notificationCenter.addedRequests.isEmpty)
+    }
+
+    func test_scheduleReminder_whenAuthorizationStatusIsDenied_doesNotAddRequest() async {
+        notificationCenter.authorizationStatus = .denied
+        setSubscription(status: .autoRenewable)
+
+        await sut.scheduleReminder(daysBeforeCancel: 7)
+
+        XCTAssertTrue(notificationCenter.addedRequests.isEmpty)
+    }
+
+    func test_scheduleReminder_whenAuthorizationStatusIsProvisional_doesNotAddRequest() async {
+        notificationCenter.authorizationStatus = .provisional
+        setSubscription(status: .autoRenewable)
+
+        await sut.scheduleReminder(daysBeforeCancel: 7)
+
+        XCTAssertTrue(notificationCenter.addedRequests.isEmpty,
+                      "Provisional notifications deliver silently — the user would not see the reminder")
+    }
+
+    func test_scheduleReminder_whenAuthorizationStatusIsNotDetermined_doesNotAddRequest() async {
+        notificationCenter.authorizationStatus = .notDetermined
+        setSubscription(status: .autoRenewable)
+
+        await sut.scheduleReminder(daysBeforeCancel: 7)
+
+        XCTAssertTrue(notificationCenter.addedRequests.isEmpty)
+    }
+
+    func test_scheduleReminder_whenNoSubscription_doesNotAddRequest() async {
+        subscriptionManager.resultSubscription = nil
+
+        await sut.scheduleReminder(daysBeforeCancel: 7)
+
+        XCTAssertTrue(notificationCenter.addedRequests.isEmpty)
+    }
+
+    func test_scheduleReminder_whenSubscriptionStatusIsExpired_doesNotAddRequest() async {
+        setSubscription(status: .expired)
+
+        await sut.scheduleReminder(daysBeforeCancel: 7)
+
+        XCTAssertTrue(notificationCenter.addedRequests.isEmpty)
+    }
+
+    func test_scheduleReminder_whenFireDateInThePast_doesNotAddRequest() async {
+        // Depends on SubscriptionMockFactory.subscription(status:) hardcoding a +30-day expiry.
+        // daysBeforeCancel = 365 puts the computed fire date ~335 days in the past.
+        setSubscription(status: .autoRenewable)
+
+        await sut.scheduleReminder(daysBeforeCancel: 365)
+
+        XCTAssertTrue(notificationCenter.addedRequests.isEmpty)
+    }
+
+    // MARK: - scheduleReminder success path
+
+    func test_scheduleReminder_withValidInputs_addsRequestWithCorrectIdentifierAndTrigger() async throws {
+        setSubscription(status: .autoRenewable)
+
+        await sut.scheduleReminder(daysBeforeCancel: 7)
+
+        XCTAssertEqual(notificationCenter.addedRequests.count, 1)
+        let request = try XCTUnwrap(notificationCenter.addedRequests.first)
+        XCTAssertEqual(request.identifier, identifier)
+        XCTAssertEqual(request.content.title, "Your Privacy Pro subscription is ending soon")
+        XCTAssertEqual(request.content.categoryIdentifier, identifier)
+        XCTAssertTrue(request.trigger is UNCalendarNotificationTrigger)
+    }
+
+    func test_scheduleReminder_removesPreviouslyScheduledReminderBeforeAdding() async {
+        setSubscription(status: .autoRenewable)
+
+        await sut.scheduleReminder(daysBeforeCancel: 7)
+
+        XCTAssertEqual(notificationCenter.removedIdentifiers.count, 1)
+        XCTAssertEqual(notificationCenter.removedIdentifiers.first, [identifier])
+    }
+
+    // MARK: - Observer: .subscriptionDidChange
+
+    func test_subscriptionDidChange_whenStatusBecomesExpired_cancelsPendingReminder() async {
+        setSubscription(status: .autoRenewable)
+        await sut.scheduleReminder(daysBeforeCancel: 7)
+        let priorRemovalCount = notificationCenter.removedIdentifiers.count
+
+        setSubscription(status: .expired)
+        observerNotificationCenter.post(name: .subscriptionDidChange, object: nil)
+
+        await waitUntil("reminder cancelled after subscriptionDidChange") {
+            self.notificationCenter.removedIdentifiers.count > priorRemovalCount
+        }
+        XCTAssertEqual(notificationCenter.removedIdentifiers.last, [identifier])
+    }
+
+    func test_subscriptionDidChange_whenStatusStillActive_doesNotCancel() async {
+        setSubscription(status: .autoRenewable)
+        await sut.scheduleReminder(daysBeforeCancel: 7)
+        let priorRemovalCount = notificationCenter.removedIdentifiers.count
+
+        observerNotificationCenter.post(name: .subscriptionDidChange, object: nil)
+
+        await assertNoActionWithinShortDelay()
+        XCTAssertEqual(notificationCenter.removedIdentifiers.count, priorRemovalCount)
+    }
+
+    // MARK: - Observer: UIApplication.didBecomeActiveNotification
+
+    func test_didBecomeActive_whenNoPendingReminder_doesNotCancel() async {
+        // No call to scheduleReminder, so no pending notification queued.
+        // Subscription is inactive — if the foreground observer didn't early-exit on the pending check,
+        // it would proceed to the cancel branch. Verify the absence of cancellation.
+        setSubscription(status: .inactive)
+        observerNotificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        await assertNoActionWithinShortDelay()
+        XCTAssertTrue(notificationCenter.removedIdentifiers.isEmpty,
+                      "Foreground observer should early-exit when no reminder is queued, without reaching the cancel branch")
+    }
+
+    func test_didBecomeActive_whenPendingAndStatusInactive_cancelsReminder() async {
+        setSubscription(status: .autoRenewable)
+        await sut.scheduleReminder(daysBeforeCancel: 7)
+        let priorRemovalCount = notificationCenter.removedIdentifiers.count
+
+        setSubscription(status: .inactive)
+        observerNotificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        await waitUntil("reminder cancelled after didBecomeActive") {
+            self.notificationCenter.removedIdentifiers.count > priorRemovalCount
+        }
+        XCTAssertEqual(notificationCenter.removedIdentifiers.last, [identifier])
+    }
+
+    func test_didBecomeActive_whenPendingAndStatusActive_doesNotCancel() async {
+        setSubscription(status: .autoRenewable)
+        await sut.scheduleReminder(daysBeforeCancel: 7)
+        let priorRemovalCount = notificationCenter.removedIdentifiers.count
+
+        observerNotificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        await assertNoActionWithinShortDelay()
+        XCTAssertEqual(notificationCenter.removedIdentifiers.count, priorRemovalCount)
+    }
+
+    // MARK: - Async test helpers
+
+    private func waitUntil(_ description: String,
+                           timeout: TimeInterval = 1.0,
+                           predicate: @escaping () -> Bool,
+                           file: StaticString = #file,
+                           line: UInt = #line) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if predicate() { return }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Timed out waiting: \(description)", file: file, line: line)
+    }
+
+    private func assertNoActionWithinShortDelay() async {
+        try? await Task.sleep(nanoseconds: 100_000_000)
+    }
+}

--- a/iOS/DuckDuckGoTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
@@ -1314,15 +1314,29 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
         XCTAssertFalse(center.didRequestAuthorization)
     }
 
-    func testRequestNotificationsPermission_WhenNotDetermined_PromptsUserAndReturnsResult() async throws {
+    func testRequestNotificationsPermission_WhenNotDeterminedAndUserAllows_PromptsAndReturnsTrue() async throws {
         let center = MockUNUserNotificationCenter()
         center.authorizationStatus = .notDetermined
+        center.requestAuthorizationResult = true
         let sut = makeFeature(notificationCenter: center)
 
         let response = await sut.requestNotificationsPermission(params: "", original: WKScriptMessage.mock())
         let result = try XCTUnwrap(response as? DefaultSubscriptionPagesUseSubscriptionFeature.NotificationsPermissionResponse)
 
         XCTAssertTrue(result.granted)
+        XCTAssertTrue(center.didRequestAuthorization)
+    }
+
+    func testRequestNotificationsPermission_WhenNotDeterminedAndUserDenies_PromptsAndReturnsFalse() async throws {
+        let center = MockUNUserNotificationCenter()
+        center.authorizationStatus = .notDetermined
+        center.requestAuthorizationResult = false
+        let sut = makeFeature(notificationCenter: center)
+
+        let response = await sut.requestNotificationsPermission(params: "", original: WKScriptMessage.mock())
+        let result = try XCTUnwrap(response as? DefaultSubscriptionPagesUseSubscriptionFeature.NotificationsPermissionResponse)
+
+        XCTAssertFalse(result.granted)
         XCTAssertTrue(center.didRequestAuthorization)
     }
 

--- a/iOS/DuckDuckGoTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
@@ -1256,7 +1256,7 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
         XCTAssertEqual(result.notificationsPermission, .granted)
     }
 
-    func testGetUserSettings_WhenProvisional_ReturnsGranted() async throws {
+    func testGetUserSettings_WhenProvisional_ReturnsDenied() async throws {
         let center = MockUNUserNotificationCenter()
         center.authorizationStatus = .provisional
         let sut = makeFeature(notificationCenter: center)
@@ -1264,7 +1264,9 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
         let response = await sut.getUserSettings(params: "", original: WKScriptMessage.mock())
         let result = try XCTUnwrap(response as? DefaultSubscriptionPagesUseSubscriptionFeature.UserSettingsResponse)
 
-        XCTAssertEqual(result.notificationsPermission, .granted)
+        // .provisional has no programmatic upgrade path — only Settings can raise it to .authorized.
+        // Bucketing it with .denied gives FE a clear "needs Settings change" signal.
+        XCTAssertEqual(result.notificationsPermission, .denied)
     }
 
     func testGetUserSettings_WhenDenied_ReturnsDenied() async throws {

--- a/iOS/DuckDuckGoTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
@@ -1415,6 +1415,50 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
         XCTAssertTrue(scheduler.scheduledTimeBeforeCancel.isEmpty,
                       "Scheduler must not be invoked when the purchase did not complete successfully")
     }
+
+    // MARK: - Bridge result payloads
+    //
+    // These tests pin the JSON shape of the `result` payloads our handlers produce.
+    // The broker's envelope wrapping (context / featureName / id) is covered by
+    // `UserScriptMessagingTests.testDelegateRespondsWithResult` in BrowserServicesKit.
+    // Renaming a key here is a breaking change to the FE↔Native contract.
+
+    func testUserSettingsResponse_encodesGranted() throws {
+        let response = DefaultSubscriptionPagesUseSubscriptionFeature.UserSettingsResponse(notificationsPermission: .granted)
+        XCTAssertEqual(try jsonString(response), "{\"notificationsPermission\":\"granted\"}")
+    }
+
+    func testUserSettingsResponse_encodesDenied() throws {
+        let response = DefaultSubscriptionPagesUseSubscriptionFeature.UserSettingsResponse(notificationsPermission: .denied)
+        XCTAssertEqual(try jsonString(response), "{\"notificationsPermission\":\"denied\"}")
+    }
+
+    func testUserSettingsResponse_encodesNotDetermined() throws {
+        let response = DefaultSubscriptionPagesUseSubscriptionFeature.UserSettingsResponse(notificationsPermission: .notDetermined)
+        XCTAssertEqual(try jsonString(response), "{\"notificationsPermission\":\"notDetermined\"}")
+    }
+
+    func testNotificationsPermissionResponse_encodesGrantedTrue() throws {
+        let response = DefaultSubscriptionPagesUseSubscriptionFeature.NotificationsPermissionResponse(granted: true)
+        XCTAssertEqual(try jsonString(response), "{\"granted\":true}")
+    }
+
+    func testNotificationsPermissionResponse_encodesGrantedFalse() throws {
+        let response = DefaultSubscriptionPagesUseSubscriptionFeature.NotificationsPermissionResponse(granted: false)
+        XCTAssertEqual(try jsonString(response), "{\"granted\":false}")
+    }
+
+    func testScheduleNotificationPreference_decodesFromExpectedShape() throws {
+        let raw = "{\"daysBeforeCancel\":7}"
+        let preference = try JSONDecoder().decode(DefaultSubscriptionPagesUseSubscriptionFeature.ScheduleNotificationPreference.self,
+                                                  from: Data(raw.utf8))
+        XCTAssertEqual(preference.daysBeforeCancel, 7)
+    }
+
+    private func jsonString<T: Encodable>(_ value: T) throws -> String {
+        let data = try JSONEncoder().encode(value)
+        return try XCTUnwrap(String(data: data, encoding: .utf8))
+    }
 }
 
 final class MockURLWebView: WKWebView {

--- a/iOS/DuckDuckGoTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
@@ -21,6 +21,7 @@ import XCTest
 import WebKit
 import PixelKit
 import PrivacyConfig
+import UserNotifications
 @testable import DuckDuckGo
 @testable import Common
 @testable import UserScript
@@ -1212,6 +1213,193 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
         XCTAssertFalse(mockAppStorePurchaseFlow.changeTierCalled, "Unknown platform must not call performTierChange")
         XCTAssertEqual(sut.transactionStatus, .idle)
         XCTAssertEqual(sut.transactionError, .otherRestoreError)
+    }
+
+    // MARK: - Notification permission & expiration reminder
+
+    private func makeFeature(notificationCenter: MockUNUserNotificationCenter,
+                             scheduler: SubscriptionExpirationReminderSchedulerMock? = nil,
+                             appStorePurchaseFlow: AppStorePurchaseFlowMock? = nil) -> DefaultSubscriptionPagesUseSubscriptionFeature {
+        let purchaseFlow = appStorePurchaseFlow ?? mockAppStorePurchaseFlow!
+        let executer = DefaultSubscriptionFlowsExecuter(
+            subscriptionManager: mockSubscriptionManager,
+            appStorePurchaseFlow: purchaseFlow,
+            wideEvent: mockWideEvent,
+            pendingTransactionHandler: MockPendingTransactionHandler()
+        )
+        return DefaultSubscriptionPagesUseSubscriptionFeature(
+            subscriptionManager: mockSubscriptionManager,
+            subscriptionFeatureAvailability: mockSubscriptionFeatureAvailability,
+            subscriptionAttributionOrigin: "",
+            appStorePurchaseFlow: purchaseFlow,
+            appStoreRestoreFlow: AppStoreRestoreFlowMock(),
+            subscriptionDataReporter: nil,
+            internalUserDecider: mockInternalUserDecider,
+            wideEvent: mockWideEvent,
+            tierEventReporter: mockTierEventReporter,
+            pendingTransactionHandler: MockPendingTransactionHandler(),
+            subscriptionFlowsExecuter: executer,
+            requestValidator: mockRequestValidator,
+            userNotificationCenter: notificationCenter,
+            expirationReminderScheduler: scheduler
+        )
+    }
+
+    func testGetUserSettings_WhenAuthorized_ReturnsGranted() async throws {
+        let center = MockUNUserNotificationCenter()
+        center.authorizationStatus = .authorized
+        let sut = makeFeature(notificationCenter: center)
+
+        let response = await sut.getUserSettings(params: "", original: WKScriptMessage.mock())
+        let result = try XCTUnwrap(response as? DefaultSubscriptionPagesUseSubscriptionFeature.UserSettingsResponse)
+
+        XCTAssertEqual(result.notificationsPermission, .granted)
+    }
+
+    func testGetUserSettings_WhenProvisional_ReturnsGranted() async throws {
+        let center = MockUNUserNotificationCenter()
+        center.authorizationStatus = .provisional
+        let sut = makeFeature(notificationCenter: center)
+
+        let response = await sut.getUserSettings(params: "", original: WKScriptMessage.mock())
+        let result = try XCTUnwrap(response as? DefaultSubscriptionPagesUseSubscriptionFeature.UserSettingsResponse)
+
+        XCTAssertEqual(result.notificationsPermission, .granted)
+    }
+
+    func testGetUserSettings_WhenDenied_ReturnsDenied() async throws {
+        let center = MockUNUserNotificationCenter()
+        center.authorizationStatus = .denied
+        let sut = makeFeature(notificationCenter: center)
+
+        let response = await sut.getUserSettings(params: "", original: WKScriptMessage.mock())
+        let result = try XCTUnwrap(response as? DefaultSubscriptionPagesUseSubscriptionFeature.UserSettingsResponse)
+
+        XCTAssertEqual(result.notificationsPermission, .denied)
+    }
+
+    func testGetUserSettings_WhenNotDetermined_ReturnsNotDetermined() async throws {
+        let center = MockUNUserNotificationCenter()
+        center.authorizationStatus = .notDetermined
+        let sut = makeFeature(notificationCenter: center)
+
+        let response = await sut.getUserSettings(params: "", original: WKScriptMessage.mock())
+        let result = try XCTUnwrap(response as? DefaultSubscriptionPagesUseSubscriptionFeature.UserSettingsResponse)
+
+        XCTAssertEqual(result.notificationsPermission, .notDetermined)
+    }
+
+    func testRequestNotificationsPermission_WhenPreviouslyDenied_ReturnsFalseWithoutPrompting() async throws {
+        let center = MockUNUserNotificationCenter()
+        center.authorizationStatus = .denied
+        let sut = makeFeature(notificationCenter: center)
+
+        let response = await sut.requestNotificationsPermission(params: "", original: WKScriptMessage.mock())
+        let result = try XCTUnwrap(response as? DefaultSubscriptionPagesUseSubscriptionFeature.NotificationsPermissionResponse)
+
+        XCTAssertFalse(result.granted)
+        XCTAssertFalse(center.didRequestAuthorization,
+                       "iOS must not invoke requestAuthorization when status is .denied — the OS would not surface a prompt")
+    }
+
+    func testRequestNotificationsPermission_WhenAuthorized_ReturnsTrueWithoutPrompting() async throws {
+        let center = MockUNUserNotificationCenter()
+        center.authorizationStatus = .authorized
+        let sut = makeFeature(notificationCenter: center)
+
+        let response = await sut.requestNotificationsPermission(params: "", original: WKScriptMessage.mock())
+        let result = try XCTUnwrap(response as? DefaultSubscriptionPagesUseSubscriptionFeature.NotificationsPermissionResponse)
+
+        XCTAssertTrue(result.granted)
+        XCTAssertFalse(center.didRequestAuthorization)
+    }
+
+    func testRequestNotificationsPermission_WhenNotDetermined_PromptsUserAndReturnsResult() async throws {
+        let center = MockUNUserNotificationCenter()
+        center.authorizationStatus = .notDetermined
+        let sut = makeFeature(notificationCenter: center)
+
+        let response = await sut.requestNotificationsPermission(params: "", original: WKScriptMessage.mock())
+        let result = try XCTUnwrap(response as? DefaultSubscriptionPagesUseSubscriptionFeature.NotificationsPermissionResponse)
+
+        XCTAssertTrue(result.granted)
+        XCTAssertTrue(center.didRequestAuthorization)
+    }
+
+    @MainActor
+    func testSubscriptionSelected_WhenScheduleNotificationProvidedAndPurchaseSucceeds_CallsSchedulerWithDays() async throws {
+        let center = MockUNUserNotificationCenter()
+        let scheduler = SubscriptionExpirationReminderSchedulerMock()
+
+        let storeManager = StorePurchaseManagerMock()
+        mockSubscriptionManager.resultStorePurchaseManager = storeManager
+        let purchaseFlow = AppStorePurchaseFlowMock()
+        purchaseFlow.purchaseSubscriptionResult = .success((transactionJWS: "jws", accountCreationDuration: nil))
+        purchaseFlow.completeSubscriptionPurchaseResult = .success(.completed)
+
+        let sut = makeFeature(notificationCenter: center, scheduler: scheduler, appStorePurchaseFlow: purchaseFlow)
+
+        let originURL = URL(string: "https://duckduckgo.com/subscriptions")!
+        let webView = MockURLWebView(url: originURL)
+        let message = WKScriptMessage.mock(name: "subscriptionSelected", body: "", webView: webView)
+
+        let params: [String: Any] = [
+            "id": "yearly",
+            "scheduleNotification": ["daysBeforeCancel": 7]
+        ]
+        _ = await sut.subscriptionSelected(params: params, original: message)
+
+        XCTAssertEqual(scheduler.scheduledDaysBeforeCancel, [7],
+                       "Scheduler must be invoked once with the value parsed from scheduleNotification.daysBeforeCancel")
+    }
+
+    @MainActor
+    func testSubscriptionSelected_WhenScheduleNotificationOmitted_DoesNotCallScheduler() async throws {
+        let center = MockUNUserNotificationCenter()
+        let scheduler = SubscriptionExpirationReminderSchedulerMock()
+
+        let storeManager = StorePurchaseManagerMock()
+        mockSubscriptionManager.resultStorePurchaseManager = storeManager
+        let purchaseFlow = AppStorePurchaseFlowMock()
+        purchaseFlow.purchaseSubscriptionResult = .success((transactionJWS: "jws", accountCreationDuration: nil))
+        purchaseFlow.completeSubscriptionPurchaseResult = .success(.completed)
+
+        let sut = makeFeature(notificationCenter: center, scheduler: scheduler, appStorePurchaseFlow: purchaseFlow)
+
+        let originURL = URL(string: "https://duckduckgo.com/subscriptions")!
+        let webView = MockURLWebView(url: originURL)
+        let message = WKScriptMessage.mock(name: "subscriptionSelected", body: "", webView: webView)
+
+        _ = await sut.subscriptionSelected(params: ["id": "yearly"], original: message)
+
+        XCTAssertTrue(scheduler.scheduledDaysBeforeCancel.isEmpty,
+                      "Scheduler must not be invoked when scheduleNotification is absent from the payload")
+    }
+
+    @MainActor
+    func testSubscriptionSelected_WhenScheduleNotificationProvidedButPurchaseFails_DoesNotCallScheduler() async throws {
+        let center = MockUNUserNotificationCenter()
+        let scheduler = SubscriptionExpirationReminderSchedulerMock()
+
+        let storeManager = StorePurchaseManagerMock()
+        mockSubscriptionManager.resultStorePurchaseManager = storeManager
+        let purchaseFlow = AppStorePurchaseFlowMock()
+        purchaseFlow.purchaseSubscriptionResult = .failure(.cancelledByUser)
+
+        let sut = makeFeature(notificationCenter: center, scheduler: scheduler, appStorePurchaseFlow: purchaseFlow)
+
+        let originURL = URL(string: "https://duckduckgo.com/subscriptions")!
+        let webView = MockURLWebView(url: originURL)
+        let message = WKScriptMessage.mock(name: "subscriptionSelected", body: "", webView: webView)
+
+        let params: [String: Any] = [
+            "id": "yearly",
+            "scheduleNotification": ["daysBeforeCancel": 7]
+        ]
+        _ = await sut.subscriptionSelected(params: params, original: message)
+
+        XCTAssertTrue(scheduler.scheduledDaysBeforeCancel.isEmpty,
+                      "Scheduler must not be invoked when the purchase did not complete successfully")
     }
 }
 

--- a/iOS/DuckDuckGoTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
@@ -1363,8 +1363,8 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
         ]
         _ = await sut.subscriptionSelected(params: params, original: message)
 
-        XCTAssertEqual(scheduler.scheduledDaysBeforeCancel, [7],
-                       "Scheduler must be invoked once with the value parsed from scheduleNotification.daysBeforeCancel")
+        XCTAssertEqual(scheduler.scheduledTimeBeforeCancel, [7 * 24 * 60 * 60],
+                       "Scheduler must be invoked once with the daysBeforeCancel value converted to seconds")
     }
 
     @MainActor
@@ -1386,7 +1386,7 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
 
         _ = await sut.subscriptionSelected(params: ["id": "yearly"], original: message)
 
-        XCTAssertTrue(scheduler.scheduledDaysBeforeCancel.isEmpty,
+        XCTAssertTrue(scheduler.scheduledTimeBeforeCancel.isEmpty,
                       "Scheduler must not be invoked when scheduleNotification is absent from the payload")
     }
 
@@ -1412,7 +1412,7 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
         ]
         _ = await sut.subscriptionSelected(params: params, original: message)
 
-        XCTAssertTrue(scheduler.scheduledDaysBeforeCancel.isEmpty,
+        XCTAssertTrue(scheduler.scheduledTimeBeforeCancel.isEmpty,
                       "Scheduler must not be invoked when the purchase did not complete successfully")
     }
 }

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Application/MockUNUserNotificationCenter.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Application/MockUNUserNotificationCenter.swift
@@ -59,6 +59,10 @@ final class MockUNUserNotificationCenter: UNUserNotificationCenterRepresentable 
         addedRequests.append(request)
     }
 
+    func pendingNotificationRequests() async -> [UNNotificationRequest] {
+        addedRequests
+    }
+
     func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {
         removedIdentifiers.append(identifiers)
         let set = Set(identifiers)

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Application/MockUNUserNotificationCenter.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Application/MockUNUserNotificationCenter.swift
@@ -31,6 +31,7 @@ final class MockUNUserNotificationCenter: UNUserNotificationCenterRepresentable 
     var authorizationStatus: UNAuthorizationStatus = .notDetermined
     var addRequestError: MockPushNotificationError?
     var requestAuthError: MockPushNotificationError?
+    var requestAuthorizationResult: Bool = true
     
     // Spies
     private(set) var addedRequests: [UNNotificationRequest] = []
@@ -51,7 +52,7 @@ final class MockUNUserNotificationCenter: UNUserNotificationCenterRepresentable 
         if options.contains(.provisional) {
             authorizationStatus = .provisional
         }
-        return true
+        return requestAuthorizationResult
     }
 
     func add(_ request: UNNotificationRequest) async throws {


### PR DESCRIPTION
**Not for merge.** Test branch that test #5212](https://github.com/duckduckgo/apple-browsers/pull/5212) — the 3 new bridge methods (`getUserSettings`, `requestNotificationsPermission`, extended `subscriptionSelected` with `scheduleNotification.daysBeforeCancel`)

…so the new methods can be exercised manually through the playground while the FE catches up.

### How to use

1. Build this branch.
2. Settings > Debug > **JS Bridge Playground**.
3. Tap one of the three chips, optionally edit the params, hit **Send**.
4. Inspect the response log (and pending-notifications screen for `subscriptionSelected` success path).

### Notes

- `subscriptionSelected` always returns `nil` (fire-and-forget by design), so the response log will show `"could not access encodable result"` — that's the broker mapping the `nil` return to an error response. Side effects (purchase flow, scheduler call on success) still happen.
- `requestNotificationsPermission` will trigger the system prompt if status is `.notDetermined`.
- The scheduler is only invoked on **purchase success** — to exercise that path you need a signed-in App Store sandbox tester.

Base is the scheduler branch ([#5212](https://github.com/duckduckgo/apple-browsers/pull/5212)) — the diff here shows what the playground adds on top.