### PR TITLE
Add platform suffix to remote message image-load pixel defs

### DIFF
--- a/iOS/PixelDefinitions/pixels/definitions/remote_messaging_framework.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/remote_messaging_framework.json5
@@ -272,7 +272,7 @@
         "description": "Triggered when a remote message image is successfully loaded and displayed",
         "owners": ["edulpn"],
         "triggers": ["other"],
-        "suffixes": ["form_factor"],
+        "suffixes": ["platform", "form_factor"],
         "parameters": [
             "appVersion",
             {
@@ -286,7 +286,7 @@
         "description": "Triggered when a remote message image fails to load",
         "owners": ["edulpn"],
         "triggers": ["other"],
-        "suffixes": ["form_factor"],
+        "suffixes": ["platform", "form_factor"],
         "parameters": [
             "appVersion",
             {
@@ -300,7 +300,7 @@
         "description": "Triggered when a per-card remote message image is successfully loaded and displayed within a card-style remote message",
         "owners": ["samsymons"],
         "triggers": ["other"],
-        "suffixes": ["form_factor"],
+        "suffixes": ["platform", "form_factor"],
         "parameters": [
             "appVersion",
             {
@@ -319,7 +319,7 @@
         "description": "Triggered when a per-card remote message image fails to load within a card-style remote message",
         "owners": ["samsymons"],
         "triggers": ["other"],
-        "suffixes": ["form_factor"],
+        "suffixes": ["platform", "form_factor"],
         "parameters": [
             "appVersion",
             {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215263528458950
Tech Design URL:
CC:

### Description

Live validation flagged `m_remote_message_image_load_success` with two errors: "Found extra suffix 'phone'" and "Suffix 'ios' must be equal to one of the allowed values".

These pixels fire through the default `Pixel.fire` path, which appends `_ios_<formFactor>` to the name (`Pixel.swift:446`). So the wire name is `..._ios_phone`, carrying a `platform` suffix (`ios`) followed by a `form_factor` suffix (`phone`). The definitions declared only `["form_factor"]`, so the validator read `ios` into the form_factor slot (failing its `phone`/`tablet` enum) and treated `phone` as an undeclared extra.

Fixed by declaring `["platform", "form_factor"]`, matching the other nine pixels in this file. Covers all four image-load variants, since they share the same firing path:

- `m_remote_message_image_load_success` (flagged in the report)
- `m_remote_message_image_load_failed`
- `m_remote_message_card_image_load_success`
- `m_remote_message_card_image_load_failed`

Definitions-only change. No Swift code is modified. The suffixes are already emitted on the wire, this documents them so validation matches.

### Testing Steps

1. Check that PixelDefinitions validation passes.

### Impact and Risks

None. Definitions-only change to bring the schema in line with what is already sent.

#### What could go wrong?

N/A

### Quality Considerations

N/A

### Notes to Reviewer

@samsymons the last two pixels (`m_remote_message_card_image_load_success` / `_failed`) are owned by you. They had the same incomplete suffix declaration and would produce the same validation failure once they fire on a phone, so I included them here. Please confirm the change reads correctly for those two.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSON5 pixel schema only; aligns documentation with suffixes already emitted on the wire.
> 
> **Overview**
> Fixes **PixelDefinitions** validation failures for four remote messaging image-load pixels by declaring **`platform`** and **`form_factor`** suffixes instead of **`form_factor`** only.
> 
> The wire names already include `_ios_<phone|tablet>` from the default **`Pixel.fire`** path; the old schema mis-parsed **`ios`** as form factor and treated **`phone`** as an extra suffix. The update aligns these four events with the other RMF pixels in **`remote_messaging_framework.json5`**: **`m_remote_message_image_load_success`**, **`m_remote_message_image_load_failed`**, **`m_remote_message_card_image_load_success`**, and **`m_remote_message_card_image_load_failed`**.
> 
> Definitions-only; no runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce11a0cf9aa2979c59b0c4a3f1f65fdff3d0a363. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->