### PR TITLE
[CI] Post a comment on PR subtask upon PR review submitted

### DIFF
--- a/.github/workflows/add_asana_comment_on_pr_review.yml
+++ b/.github/workflows/add_asana_comment_on_pr_review.yml
@@ -6,9 +6,9 @@ on:
 
 jobs:
 
-    add-changes-requested-comment:
-        if: ${{ github.event.review.state == 'changes_requested' }}
-        name: "Add 'Changes Requested' comment on PR subtask"
+    add-pr-review-comment:
+        if: ${{ contains(fromJSON('["approved","changes_requested","commented"]'), github.event.review.state) }}
+        name: "Add Asana comment on PR review"
         runs-on: ubuntu-latest
 
         steps:
@@ -39,10 +39,25 @@ jobs:
             echo "::error::No PR review subtask found for @${{ github.event.review.user.login }}. They may not be in the GitHub→Asana mapping. Add them in duckduckgo/native-github-asana-sync and re-run."
             exit 1
 
-        - name: Post changes-requested comment
-          uses: duckduckgo/apple-toolbox/actions/asana-add-changes-requested-comment@alessandro/apple-proposal-comment-on-changes-requested
+        - name: Build comment text
+          id: comment
+          env:
+            STATE: ${{ github.event.review.state }}
+            REVIEWER: ${{ github.event.review.user.login }}
+            REVIEW_URL: ${{ github.event.review.html_url }}
+          run: |
+            case "$STATE" in
+              approved)          prefix="✅ Approved" ;;
+              changes_requested) prefix="🔄 Changes requested" ;;
+              commented)         prefix="💬 Comment" ;;
+            esac
+            echo "text=${prefix} by @${REVIEWER} — see review: ${REVIEW_URL}" >> "$GITHUB_OUTPUT"
+
+        - name: Post review comment
+          uses: duckduckgo/native-github-asana-sync@v1.9
           with:
-            access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
-            task-id: ${{ fromJSON(steps.find-subtask.outputs.subtask-ids)[0] }}
-            github-reviewer-user: ${{ github.event.review.user.login }}
-            github-review-url: ${{ github.event.review.html_url }}
+            action: 'post-comment-asana-task'
+            asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+            asana-task-id: ${{ fromJSON(steps.find-subtask.outputs.subtask-ids)[0] }}
+            asana-task-comment: ${{ steps.comment.outputs.text }}
+            asana-task-comment-pinned: false

--- a/.github/workflows/add_asana_comment_on_pr_review.yml
+++ b/.github/workflows/add_asana_comment_on_pr_review.yml
@@ -24,6 +24,12 @@ jobs:
             )
             echo "task_id=${task_id//[^0-9]/}" >> $GITHUB_OUTPUT
 
+        - name: Fail if no Asana task URL in PR body
+          if: ${{ steps.get-task-id.outputs.task_id == '' }}
+          run: |
+            echo "::error::No Asana task URL found in the PR body. Add a 'Task/Issue URL: https://app.asana.com/...' line to enable PR review subtask comments."
+            exit 1
+
         - name: Find PR review subtask for the reviewer
           id: find-subtask
           uses: duckduckgo/apple-toolbox/actions/asana-fetch-pr-subtasks@alessandro/apple-proposal-comment-on-changes-requested

--- a/.github/workflows/add_asana_comment_on_pr_review.yml
+++ b/.github/workflows/add_asana_comment_on_pr_review.yml
@@ -45,7 +45,7 @@ jobs:
 
         - name: Find PR review subtask for the reviewer
           id: find-subtask
-          uses: duckduckgo/apple-toolbox/actions/asana-fetch-pr-subtasks@alessandro/apple-proposal-comment-on-changes-requested
+          uses: duckduckgo/apple-toolbox/actions/asana-fetch-pr-subtasks@main
           with:
             access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
             asana-task-id: ${{ steps.get-task-id.outputs.task_id }}

--- a/.github/workflows/add_asana_comment_on_pr_review.yml
+++ b/.github/workflows/add_asana_comment_on_pr_review.yml
@@ -7,7 +7,20 @@ on:
 jobs:
 
     add-pr-review-comment:
-        if: ${{ contains(fromJSON('["approved","changes_requested","commented"]'), github.event.review.state) }}
+        # Skip when the review submitter is the PR author themselves.
+        # Catches: self-reviews (author clicks Submit review on own PR) and
+        # AI/automation tools (e.g. Cursor Bugbot) posting reviews via the
+        # author's GitHub token. No subtask exists in either case.
+        #
+        # For 'commented' state also require a non-empty review.body: GitHub
+        # wraps every "Add single comment" inline reply in a review with
+        # state=commented and an empty body. Filtering by body excludes those
+        # noisy inline-reply events while keeping deliberate "Submit review →
+        # Comment" submissions that include a summary.
+        if: |
+            contains(fromJSON('["approved","changes_requested","commented"]'), github.event.review.state)
+            && github.event.review.user.login != github.event.pull_request.user.login
+            && (github.event.review.state != 'commented' || github.event.review.body != '')
         name: "Add Asana comment on PR review"
         runs-on: ubuntu-latest
 

--- a/.github/workflows/add_asana_comment_on_pr_review.yml
+++ b/.github/workflows/add_asana_comment_on_pr_review.yml
@@ -26,7 +26,7 @@ jobs:
 
         - name: Find PR review subtask for the reviewer
           id: find-subtask
-          uses: duckduckgo/apple-toolbox/actions/asana-fetch-pr-subtasks@main
+          uses: duckduckgo/apple-toolbox/actions/asana-fetch-pr-subtasks@alessandro/apple-proposal-comment-on-changes-requested
           with:
             access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
             asana-task-id: ${{ steps.get-task-id.outputs.task_id }}
@@ -40,7 +40,7 @@ jobs:
             exit 1
 
         - name: Post changes-requested comment
-          uses: duckduckgo/apple-toolbox/actions/asana-add-changes-requested-comment@main
+          uses: duckduckgo/apple-toolbox/actions/asana-add-changes-requested-comment@alessandro/apple-proposal-comment-on-changes-requested
           with:
             access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
             task-id: ${{ fromJSON(steps.find-subtask.outputs.subtask-ids)[0] }}

--- a/.github/workflows/add_asana_comment_on_pr_review.yml
+++ b/.github/workflows/add_asana_comment_on_pr_review.yml
@@ -1,0 +1,48 @@
+name: Shared - Add Asana Comment on PR Review
+
+on:
+    pull_request_review:
+        types: [submitted]
+
+jobs:
+
+    add-changes-requested-comment:
+        if: ${{ github.event.review.state == 'changes_requested' }}
+        name: "Add 'Changes Requested' comment on PR subtask"
+        runs-on: ubuntu-latest
+
+        steps:
+        - name: Get Task ID
+          id: get-task-id
+          env:
+            BODY: ${{ github.event.pull_request.body }}
+          run: |
+            task_id=$(grep -i "task/issue url.*https://app.asana.com/" <<< "$BODY" \
+              | perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?|\1|; \
+                s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?|\1|; \
+                s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)(?:\?focus=true)?|\1|'
+            )
+            echo "task_id=${task_id//[^0-9]/}" >> $GITHUB_OUTPUT
+
+        - name: Find PR review subtask for the reviewer
+          id: find-subtask
+          uses: duckduckgo/apple-toolbox/actions/asana-fetch-pr-subtasks@main
+          with:
+            access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
+            asana-task-id: ${{ steps.get-task-id.outputs.task_id }}
+            github-reviewer-user: ${{ github.event.review.user.login }}
+            github-token: ${{ secrets.APPLE_GH_RO_PAT }}
+
+        - name: Fail if reviewer's Asana mapping is missing
+          if: ${{ steps.find-subtask.outputs.subtask-ids == '[]' }}
+          run: |
+            echo "::error::No PR review subtask found for @${{ github.event.review.user.login }}. They may not be in the GitHub→Asana mapping. Add them in duckduckgo/native-github-asana-sync and re-run."
+            exit 1
+
+        - name: Post changes-requested comment
+          uses: duckduckgo/apple-toolbox/actions/asana-add-changes-requested-comment@main
+          with:
+            access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
+            task-id: ${{ fromJSON(steps.find-subtask.outputs.subtask-ids)[0] }}
+            github-reviewer-user: ${{ github.event.review.user.login }}
+            github-review-url: ${{ github.event.review.html_url }}

--- a/.github/workflows/create_asana_pr_subtask.yml
+++ b/.github/workflows/create_asana_pr_subtask.yml
@@ -25,7 +25,7 @@ jobs:
             echo "task_id=${task_id//[^0-9]/}" >> $GITHUB_OUTPUT
 
         - name: Create or Update PR Subtask
-          uses: duckduckgo/apple-toolbox/actions/asana-create-pr-subtask@alessandro/apple-proposal-comment-on-changes-requested
+          uses: duckduckgo/apple-toolbox/actions/asana-create-pr-subtask@main
           with:
             access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
             asana-task-id: ${{ steps.get-task-id.outputs.task_id }}

--- a/.github/workflows/create_asana_pr_subtask.yml
+++ b/.github/workflows/create_asana_pr_subtask.yml
@@ -25,7 +25,7 @@ jobs:
             echo "task_id=${task_id//[^0-9]/}" >> $GITHUB_OUTPUT
 
         - name: Create or Update PR Subtask
-          uses: duckduckgo/apple-toolbox/actions/asana-create-pr-subtask@main
+          uses: duckduckgo/apple-toolbox/actions/asana-create-pr-subtask@alessandro/apple-proposal-comment-on-changes-requested
           with:
             access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
             asana-task-id: ${{ steps.get-task-id.outputs.task_id }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1215321546485075?focus=true
Tech Design URL:
CC:

### Description

Adds a workflow that posts an Asana comment upon PR review submitted (approved, comment, request changes).

## New workflow

`.github/workflows/add_asana_comment_on_pr_review.yml`

Triggers on `pull_request_review[submitted]`. Single job gated on `review.state ∈ {approved, changes_requested, commented}`, with these steps:

1. **Extract Asana task ID** from PR body (inline regex copy — kept inline for now to limit PR scope; extraction into a shared action deferred to a follow-up)
2. **Find the matching subtask** via `asana-fetch-pr-subtasks` (filtered to the reviewer who submitted)
3. **Fail loudly** (`::error::` + `exit 1`) if no subtask was found — almost always means the reviewer is missing from the Asana user mapping.
4. **Build comment text** based on `review.state` — emoji + verb per state (`✅ Approved`, `🔄 Changes requested`, `💬 Comment`)
5. **Post comment** via `duckduckgo/native-github-asana-sync@v1.9` action `post-comment-asana-task`

Unified single-job design (vs three sibling jobs) — the steps are identical across all three states; only the comment prefix differs.

This PR depends on its apple-toolbox counterparts: https://github.com/duckduckgo/apple-toolbox/pull/20

### Testing Steps
1. Request changes on this PR and check that a comment is posted in the PR subtask.
2. Change PR review to ‘Comment' and verify that a comment is posted in the PR subtask.
3. Change PR review to ‘Approved’ and verify that a comment is posted in the PR subtask
4. Verify that normal comments do not generate a comment on the PR.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal CI only; failures are explicit when PR body or GitHub→Asana mapping is missing, with no app or user-data impact.
> 
> **Overview**
> Adds **`.github/workflows/add_asana_comment_on_pr_review.yml`**, a shared workflow that runs on **`pull_request_review` submitted** and posts a short comment to the reviewer’s **PR review subtask** in Asana.
> 
> The job only runs for **approved**, **changes_requested**, or **commented** reviews from someone other than the PR author, and for **commented** it requires a **non-empty review body** so inline single-comment replies are ignored. It **parses the Asana task ID from the PR body**, resolves the reviewer’s subtask via **`asana-fetch-pr-subtasks`**, **fails the run** if the task URL or mapping is missing, then posts state-specific text (emoji + reviewer + review link) with **`native-github-asana-sync`** **`post-comment-asana-task`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d43c13e01b72eb4a3f1fbc6ad0798463b4a57123. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->