### PR TITLE
Dax logo is shown on top of content

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/ChatHistory/AIChatHistoryManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/ChatHistory/AIChatHistoryManager.swift
@@ -55,6 +55,10 @@ final class AIChatHistoryManager {
             .eraseToAnyPublisher()
     }
 
+    func hasSettled(forQuery query: String) -> Bool {
+        lastCompletedFetchQuery.map { $0 == query } ?? false
+    }
+
     private var historyViewController: AIChatHistoryListViewController?
     private let suggestionsReader: AIChatSuggestionsReading
     private let aiChatSettings: AIChatSettingsProvider

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FadeOutContainerViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FadeOutContainerViewController.swift
@@ -224,7 +224,7 @@ final class FadeOutContainerViewController: UIViewController {
         updateTransitionProgress(currentProgress)
     }
 
-    private func updateTransitionProgress(_ progress: CGFloat) {
+    func updateTransitionProgress(_ progress: CGFloat) {
         transitionProgress = progress
         delegate?.fadeOutContainerViewController(self, didUpdateTransitionProgress: progress)
     }

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SwipeContainerManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SwipeContainerManager.swift
@@ -92,7 +92,11 @@ final class SwipeContainerManager: NSObject {
 
     var fadeOutDelegate: FadeOutContainerViewControllerDelegate? {
         get { fadeOutContainerViewController.delegate }
-        set { fadeOutContainerViewController.delegate = newValue }
+        set {
+            fadeOutContainerViewController.delegate = newValue
+            guard usesFadeOutTransition, newValue != nil else { return }
+            fadeOutContainerViewController.updateTransitionProgress(fadeOutContainerViewController.transitionProgress)
+        }
     }
 
     // MARK: - Initialization

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -719,6 +719,10 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
         let shouldDisplayFavoritesOverlay = suggestionTrayManager?.shouldDisplayFavoritesOverlay == true
         let isHorizontallyCompactLayoutEnabled = requiresHorizontallyCompactLayout(for: view.bounds.size)
         let isShowingChatHistory = aiChatHistoryManager?.hasSuggestions == true
+        let isAIChatHistoryPending = aiChatHistoryManager != nil
+            && aiChatHistoryManager?.hasSettled(forQuery: switchBarHandler.currentText) != true
+            && switchBarHandler.currentToggleState == .aiChat
+            && !switchBarHandler.isFireTab
 
         let hasRemoteMessages = suggestionTrayManager?.hasRemoteMessages ?? false
         let hasEscapeHatchWithoutFavoritesOrMessages = escapeHatchModel != nil && !(suggestionTrayManager?.hasFavorites ?? false) && !hasRemoteMessages
@@ -726,16 +730,29 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
 
         let isURLFallbackShowingContent = isShowingURLFallback && (suggestionTrayManager?.isShowingSuggestionTray ?? false)
 
-        let isAIDaxVisible: Bool
-        if switchBarHandler.isUsingFadeOutAnimation {
-            isAIDaxVisible = !isHorizontallyCompactLayoutEnabled && !isShowingChatHistory && !isURLFallbackShowingContent && !shouldDisplaySuggestionTray
-        } else {
-            isAIDaxVisible = !shouldDisplaySuggestionTray && !isHorizontallyCompactLayoutEnabled && !isShowingChatHistory && !isURLFallbackShowingContent
-        }
+        let isAIDaxVisible = Self.isAIDaxVisible(
+            isHorizontallyCompactLayoutEnabled: isHorizontallyCompactLayoutEnabled,
+            isShowingChatHistory: isShowingChatHistory,
+            isURLFallbackShowingContent: isURLFallbackShowingContent,
+            shouldDisplaySuggestionTray: shouldDisplaySuggestionTray,
+            isAIChatHistoryPending: isAIChatHistoryPending
+        )
 
         daxLogoManager.updateVisibility(isHomeDaxVisible: isHomeDaxVisible, isAIDaxVisible: isAIDaxVisible)
         let escapeHatchOffset: CGFloat = (escapeHatchModel != nil && !switchBarHandler.isFireTab) ? Constants.escapeHatchLogoZoneHeight : 0
         daxLogoManager.setEscapeHatchBaseOffset(escapeHatchOffset)
+    }
+
+    static func isAIDaxVisible(isHorizontallyCompactLayoutEnabled: Bool,
+                               isShowingChatHistory: Bool,
+                               isURLFallbackShowingContent: Bool,
+                               shouldDisplaySuggestionTray: Bool,
+                               isAIChatHistoryPending: Bool) -> Bool {
+        !isAIChatHistoryPending
+        && !isHorizontallyCompactLayoutEnabled
+        && !isShowingChatHistory
+        && !isURLFallbackShowingContent
+        && !shouldDisplaySuggestionTray
     }
 
 }

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -410,6 +410,13 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
                     self.view.layoutIfNeeded()
                 }
             }
+        manager.onFetchCompleted = { [weak self] _, _ in
+            guard let self else { return }
+            self.scheduleAnimation {
+                self.updateDaxVisibility()
+                self.view.layoutIfNeeded()
+            }
+        }
         aiChatHistoryManager = manager
 
         manager.setEscapeHatch(escapeHatchModel)

--- a/iOS/DuckDuckGoTests/AIChat/DaxLogoManagerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DaxLogoManagerTests.swift
@@ -17,6 +17,7 @@
 //  limitations under the License.
 //
 
+import Combine
 import XCTest
 @testable import DuckDuckGo
 
@@ -113,5 +114,157 @@ final class DaxLogoManagerTests: XCTestCase {
             hasRemoteMessages: false
         )
         XCTAssertTrue(sut.shouldShowHomeDax(inputs))
+    }
+}
+
+final class FadeOutContainerViewControllerTests: XCTestCase {
+
+    func testWhenInitialModeIsAIChatThenDelegateReceivesInitialProgress() {
+        let switchBarHandler = FadeOutSwitchBarHandlerStub(currentToggleState: .aiChat)
+        let sut = SwipeContainerManager(switchBarHandler: switchBarHandler, contentTransition: .crossfade)
+        sut.containerViewController.loadViewIfNeeded()
+        let delegate = RecordingFadeOutContainerDelegate()
+
+        sut.fadeOutDelegate = delegate
+
+        XCTAssertEqual(delegate.progressUpdates, [1])
+        XCTAssertTrue(delegate.transitionedModes.isEmpty)
+    }
+
+    func testWhenInitialModeIsSearchThenDelegateReceivesInitialProgress() {
+        let switchBarHandler = FadeOutSwitchBarHandlerStub(currentToggleState: .search)
+        let sut = SwipeContainerManager(switchBarHandler: switchBarHandler, contentTransition: .crossfade)
+        sut.containerViewController.loadViewIfNeeded()
+        let delegate = RecordingFadeOutContainerDelegate()
+
+        sut.fadeOutDelegate = delegate
+
+        XCTAssertEqual(delegate.progressUpdates, [0])
+        XCTAssertTrue(delegate.transitionedModes.isEmpty)
+    }
+}
+
+final class OmniBarEditingStateViewControllerDaxVisibilityTests: XCTestCase {
+
+    func testWhenAIChatHistoryIsPendingThenAIDaxIsHidden() {
+        let isVisible = OmniBarEditingStateViewController.isAIDaxVisible(
+            isHorizontallyCompactLayoutEnabled: false,
+            isShowingChatHistory: false,
+            isURLFallbackShowingContent: false,
+            shouldDisplaySuggestionTray: false,
+            isAIChatHistoryPending: true
+        )
+
+        XCTAssertFalse(isVisible)
+    }
+
+    func testWhenAIChatHistoryIsSettledAndNoContentThenAIDaxIsVisible() {
+        let isVisible = OmniBarEditingStateViewController.isAIDaxVisible(
+            isHorizontallyCompactLayoutEnabled: false,
+            isShowingChatHistory: false,
+            isURLFallbackShowingContent: false,
+            shouldDisplaySuggestionTray: false,
+            isAIChatHistoryPending: false
+        )
+
+        XCTAssertTrue(isVisible)
+    }
+}
+
+private final class RecordingFadeOutContainerDelegate: FadeOutContainerViewControllerDelegate {
+    private(set) var progressUpdates: [CGFloat] = []
+    private(set) var transitionedModes: [TextEntryMode] = []
+
+    func fadeOutContainerViewController(_ controller: FadeOutContainerViewController, didTransitionToMode mode: TextEntryMode) {
+        transitionedModes.append(mode)
+    }
+
+    func fadeOutContainerViewController(_ controller: FadeOutContainerViewController, didUpdateTransitionProgress progress: CGFloat) {
+        progressUpdates.append(progress)
+    }
+
+    func fadeOutContainerViewControllerIsShowingSuggestions(_ controller: FadeOutContainerViewController) -> Bool {
+        false
+    }
+
+    func fadeOutContainerViewControllerShouldKeepSearchVisible(_ controller: FadeOutContainerViewController) -> Bool {
+        false
+    }
+}
+
+private final class FadeOutSwitchBarHandlerStub: SwitchBarHandling {
+    var currentText = ""
+    var currentToggleState: TextEntryMode
+    var isVoiceSearchEnabled = false
+    var isAIVoiceChatEnabled = false
+    var hasUserInteractedWithText = false
+    var isCurrentTextValidURL = false
+    var buttonState: SwitchBarButtonState = .noButtons
+    var isTopBarPosition = true
+    var isToggleEnabled = true
+    var isFireTab = false
+    var isUsingExpandedBottomBarHeight = false
+    var isUsingFadeOutAnimation = true
+    var shouldDisableAutocorrectOnEmpty = false
+    var hidesVoiceButton = false
+    var hasSubmittedPrompt = false
+    var modeParameters: [String: String] = [:]
+
+    var hasSubmittedPromptPublisher: AnyPublisher<Bool, Never> { Just(false).eraseToAnyPublisher() }
+    var currentTextPublisher: AnyPublisher<String, Never> { currentTextSubject.eraseToAnyPublisher() }
+    var toggleStatePublisher: AnyPublisher<TextEntryMode, Never> { toggleStateSubject.eraseToAnyPublisher() }
+    var textSubmissionPublisher: AnyPublisher<(text: String, mode: TextEntryMode), Never> { textSubmissionSubject.eraseToAnyPublisher() }
+    var microphoneButtonTappedPublisher: AnyPublisher<Void, Never> { microphoneButtonTappedSubject.eraseToAnyPublisher() }
+    var clearButtonTappedPublisher: AnyPublisher<Void, Never> { clearButtonTappedSubject.eraseToAnyPublisher() }
+    var hasUserInteractedWithTextPublisher: AnyPublisher<Bool, Never> { hasUserInteractedWithTextSubject.eraseToAnyPublisher() }
+    var isCurrentTextValidURLPublisher: AnyPublisher<Bool, Never> { isCurrentTextValidURLSubject.eraseToAnyPublisher() }
+    var currentButtonStatePublisher: AnyPublisher<SwitchBarButtonState, Never> { currentButtonStateSubject.eraseToAnyPublisher() }
+
+    private let currentTextSubject = PassthroughSubject<String, Never>()
+    private let toggleStateSubject = PassthroughSubject<TextEntryMode, Never>()
+    private let textSubmissionSubject = PassthroughSubject<(text: String, mode: TextEntryMode), Never>()
+    private let microphoneButtonTappedSubject = PassthroughSubject<Void, Never>()
+    private let clearButtonTappedSubject = PassthroughSubject<Void, Never>()
+    private let hasUserInteractedWithTextSubject = PassthroughSubject<Bool, Never>()
+    private let isCurrentTextValidURLSubject = PassthroughSubject<Bool, Never>()
+    private let currentButtonStateSubject = PassthroughSubject<SwitchBarButtonState, Never>()
+
+    init(currentToggleState: TextEntryMode) {
+        self.currentToggleState = currentToggleState
+    }
+
+    func updateCurrentText(_ text: String) {
+        currentText = text
+        currentTextSubject.send(text)
+    }
+
+    func submitText(_ text: String) {
+        textSubmissionSubject.send((text, currentToggleState))
+    }
+
+    func setToggleState(_ state: TextEntryMode) {
+        currentToggleState = state
+        toggleStateSubject.send(state)
+    }
+
+    func clearText() {
+        updateCurrentText("")
+    }
+
+    func microphoneButtonTapped() {
+        microphoneButtonTappedSubject.send(())
+    }
+
+    func markUserInteraction() {
+        hasUserInteractedWithText = true
+        hasUserInteractedWithTextSubject.send(true)
+    }
+
+    func clearButtonTapped() {
+        clearButtonTappedSubject.send(())
+    }
+
+    func updateBarPosition(isTop: Bool) {
+        isTopBarPosition = isTop
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1215326710230677?focus=true
Tech Design URL:
CC:

### Description
- Fix Dax logo appearing over Duck\.ai recent chats when `unifiedInputToggle` is disabled.
- Sync initial crossfade progress when attaching the fade container delegate.
- Hide legacy Duck\.ai empty-state Dax until chat history settles for the current query.
- Add regression coverage for initial crossfade progress and pending chat-history visibility.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Ensure previous Duck\.ai chats exist.
2. Disable `unifiedInputToggle`.
3. Set Settings > AI Features > Toggle Position > Duck\.ai
4. Open a new empty tab and tap the omnibar.
5. Verify recent chats appear without Dax over the content or flashing during transition.
6. Repeat with no favorites and with favorites present.
7. Enable `unifiedInputToggle` and switch Search <> Duck\.ai from the omnibar.
8. Verify the UTI crossfade and Dax empty states still behave correctly.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
- Dax empty-state visibility could regress during Search/Duck.ai transitions.
- Initial crossfade progress sync could affect UTI mode-switch timing.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->
- Covered legacy Duck\.ai pending-history state.
- Covered initial crossfade progress sync for Search and Duck\.ai.
- No privacy, security, analytics, or performance impact expected.

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

- Focus on legacy omnibar Duck\.ai with previous chats and UTI Search/Duck.ai switching.
---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only omnibar/Dax visibility and crossfade delegate timing; regression risk is limited to Search/Duck.ai transitions and empty-state display.
> 
> **Overview**
> Fixes the **Dax logo drawing on top of Duck.ai recent chats** (and flashing during transitions) in the legacy omnibar path when unified input is off.
> 
> **Pending chat history:** `AIChatHistoryManager` exposes `hasSettled(forQuery:)` so the omnibar can tell when the latest fetch matches the current query. While Duck.ai mode is active and history is still pending, **AI empty-state Dax stays hidden**; visibility refreshes on suggestion updates and on `onFetchCompleted`. Logic is centralized in `OmniBarEditingStateViewController.isAIDaxVisible(...)`, dropping the old fade-animation-specific branch.
> 
> **Crossfade sync:** Assigning `SwipeContainerManager.fadeOutDelegate` now **re-pushes the current transition progress** to the delegate so Dax/toggle state matches Search vs Duck.ai on attach (not only mid-animation).
> 
> **Tests:** Regression coverage for initial progress (0 vs 1) and for pending vs settled history affecting AI Dax visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da9646c6edb14a2540724087b8c503a9c368787a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->