### PR TITLE
Add installType/installAge to Duck.ai native config

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatScriptUserValues.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatScriptUserValues.swift
@@ -17,6 +17,17 @@
 //
 
 import Foundation
+import FoundationExtensions
+
+/// Indicates whether the Duck.ai conversion pixel is being fired by a new or returning install.
+///
+/// `unknown` is reported on platforms/build channels that cannot determine this — e.g. macOS
+/// App Store builds, which have no reliable reinstall signal — so it isn't conflated with `new`.
+public enum AIChatInstallType: String, Codable {
+    case new
+    case returning
+    case unknown
+}
 
 public struct AIChatNativeHandoffData: Codable {
     public let isAIChatHandoffEnabled: Bool
@@ -93,6 +104,12 @@ public struct AIChatNativeConfigValues: Codable {
     /// must suppress its own in-page tooltip and post `voiceChatStartFailed` to native
     /// after `getUserMedia` rejects.
     public let supportsNativeVoicePermissionHandler: Bool
+    /// Whether this is a new or returning (reinstall) install — `unknown` when the platform
+    /// can't tell. Surfaced on the `web.conversion.duckai.prompt` pixel.
+    public let installType: AIChatInstallType
+    /// Bucketed age of the install (days since the ATB install date):
+    /// 0 = same day, 1 = 1–7, 2 = 8–14, 3 = 15–21, 4 = 22–28, 5 = after day 28.
+    public let installAge: Int
 
     public static var defaultValues: AIChatNativeConfigValues {
 #if os(iOS)
@@ -156,7 +173,9 @@ public struct AIChatNativeConfigValues: Codable {
                 supportsMultipleContexts: Bool = false,
                 supportsTabPicker: Bool = false,
                 supportsNativeStorage: Bool = false,
-                supportsNativeVoicePermissionHandler: Bool = false) {
+                supportsNativeVoicePermissionHandler: Bool = false,
+                installType: AIChatInstallType = .new,
+                installAge: Int = 0) {
         self.isAIChatHandoffEnabled = isAIChatHandoffEnabled
         self.platform = Platform.name
         self.supportsClosingAIChat = supportsClosingAIChat
@@ -177,6 +196,26 @@ public struct AIChatNativeConfigValues: Codable {
         self.supportsTabPicker = supportsTabPicker
         self.supportsNativeStorage = supportsNativeStorage
         self.supportsNativeVoicePermissionHandler = supportsNativeVoicePermissionHandler
+        self.installType = installType
+        self.installAge = installAge
+    }
+
+    /// Buckets the days between the install date and `now` into the values expected by the
+    /// `web.conversion.duckai.prompt` pixel. A `nil` install date (ATB round-trip not yet
+    /// completed on a fresh install) maps to `0` (same day), as do future/negative dates.
+    public static func installAgeBucket(installDate: Date?, now: Date = Date()) -> Int {
+        guard let installDate else { return 0 }
+        let days = Calendar.current.numberOfDaysBetween(
+            Calendar.current.startOfDay(for: installDate),
+            and: Calendar.current.startOfDay(for: now)) ?? 0
+        switch days {
+        case ..<1: return 0
+        case 1...7: return 1
+        case 8...14: return 2
+        case 15...21: return 3
+        case 22...28: return 4
+        default: return 5
+        }
     }
 }
 

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatNativeConfigValuesTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatNativeConfigValuesTests.swift
@@ -1,0 +1,84 @@
+//
+//  AIChatNativeConfigValuesTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import AIChat
+
+final class AIChatNativeConfigValuesTests: XCTestCase {
+
+    private let referenceNow = Date(timeIntervalSince1970: 1_700_000_000) // fixed "now"
+
+    private func date(daysBeforeNow days: Int) -> Date {
+        Calendar.current.date(byAdding: .day, value: -days, to: referenceNow)!
+    }
+
+    // MARK: - installAgeBucket
+
+    func testWhenInstallDateIsNilThenBucketIsZero() {
+        XCTAssertEqual(AIChatNativeConfigValues.installAgeBucket(installDate: nil, now: referenceNow), 0)
+    }
+
+    func testInstallAgeBucketBoundaries() {
+        let expectations: [(daysAgo: Int, bucket: Int)] = [
+            (0, 0),   // same day
+            (1, 1), (7, 1),    // 1–7
+            (8, 2), (14, 2),   // 8–14
+            (15, 3), (21, 3),  // 15–21
+            (22, 4), (28, 4),  // 22–28
+            (29, 5), (400, 5)  // after day 28
+        ]
+
+        for expectation in expectations {
+            let bucket = AIChatNativeConfigValues.installAgeBucket(installDate: date(daysBeforeNow: expectation.daysAgo), now: referenceNow)
+            XCTAssertEqual(bucket, expectation.bucket, "Expected bucket \(expectation.bucket) for install \(expectation.daysAgo) days ago, got \(bucket)")
+        }
+    }
+
+    func testWhenInstallDateIsInTheFutureThenBucketIsZero() {
+        let future = Calendar.current.date(byAdding: .day, value: 5, to: referenceNow)!
+        XCTAssertEqual(AIChatNativeConfigValues.installAgeBucket(installDate: future, now: referenceNow), 0)
+    }
+
+    func testSameCalendarDayLaterTimeIsBucketZero() {
+        // Installed earlier the same calendar day -> still "same day" (0), not 1.
+        let installed = Calendar.current.startOfDay(for: referenceNow)
+        XCTAssertEqual(AIChatNativeConfigValues.installAgeBucket(installDate: installed, now: referenceNow), 0)
+    }
+
+    // MARK: - Wire format
+
+    func testInstallTypeEncodesToExpectedStrings() throws {
+        XCTAssertEqual(try encodedRawValue(.new), "new")
+        XCTAssertEqual(try encodedRawValue(.returning), "returning")
+        XCTAssertEqual(try encodedRawValue(.unknown), "unknown")
+    }
+
+    func testConfigValuesEncodeInstallTypeAndInstallAge() throws {
+        let config = AIChatNativeConfigValues.defaultValues
+        let data = try JSONEncoder().encode(config)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertNotNil(json["installType"])
+        XCTAssertNotNil(json["installAge"])
+    }
+
+    private func encodedRawValue(_ type: AIChatInstallType) throws -> String {
+        let data = try JSONEncoder().encode(type)
+        return try XCTUnwrap(String(data: data, encoding: .utf8)).trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+    }
+}

--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -207,6 +207,8 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
     private let keyValueStore: KeyValueStoring
     private let isNativeStorageBridgeAvailable: Bool
     private let aiChatUserScriptErrorEventMapper: EventMapping<AIChatUserScriptErrorEvent>
+    private let installDateProvider: () -> Date?
+    private let installTypeProvider: () -> AIChatInstallType
 
     /// Set externally via `AIChatContentHandler.setup()`.
     var displayMode: AIChatDisplayMode?
@@ -228,7 +230,11 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
          aichatContextualModeFeature: AIChatContextualModeFeatureProviding = AIChatContextualModeFeature(),
          unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature(),
          aiChatUserScriptErrorEventMapper: EventMapping<AIChatUserScriptErrorEvent> = AIChatUserScriptErrorEventMapper(),
-         isNativeStorageBridgeAvailable: Bool = false) {
+         isNativeStorageBridgeAvailable: Bool = false,
+         installDateProvider: @escaping () -> Date? = { StatisticsUserDefaults().installDate },
+         installTypeProvider: @escaping () -> AIChatInstallType = {
+             StatisticsUserDefaults().variant == VariantIOS.returningUser.name ? .returning : .new
+         }) {
         self.experimentalAIChatManager = experimentalAIChatManager
         self.syncHandler = syncHandler
         self.featureFlagger = featureFlagger
@@ -239,6 +245,8 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
         self.unifiedToggleInputFeature = unifiedToggleInputFeature
         self.aiChatUserScriptErrorEventMapper = aiChatUserScriptErrorEventMapper
         self.isNativeStorageBridgeAvailable = isNativeStorageBridgeAvailable
+        self.installDateProvider = installDateProvider
+        self.installTypeProvider = installTypeProvider
         setUpSyncStatusObserver()
     }
 
@@ -388,7 +396,9 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
             supportsOpenAIChatLink: defaults.supportsOpenAIChatLink,
             supportsAIChatSync: featureFlagger.isFeatureOn(.aiChatSync) && !fireMode,
             supportsMultipleContexts: supportsContextualMode && featureFlagger.isFeatureOn(.multiplePageContexts),
-            supportsNativeStorage: featureFlagger.isFeatureOn(.aiChatNativeStorage) && isNativeStorageBridgeAvailable
+            supportsNativeStorage: featureFlagger.isFeatureOn(.aiChatNativeStorage) && isNativeStorageBridgeAvailable,
+            installType: installTypeProvider(),
+            installAge: AIChatNativeConfigValues.installAgeBucket(installDate: installDateProvider())
         )
     }
 

--- a/iOS/DuckDuckGoTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -73,7 +73,9 @@ class AIChatUserScriptHandlerTests: XCTestCase {
     }
 
     private func makeAIChatUserScriptHandler(isNativeStorageBridgeAvailable: Bool = false,
-                                             aiChatUserScriptErrorEventMapper: EventMapping<AIChatUserScriptErrorEvent>? = nil) -> AIChatUserScriptHandler {
+                                             aiChatUserScriptErrorEventMapper: EventMapping<AIChatUserScriptErrorEvent>? = nil,
+                                             installDateProvider: @escaping () -> Date? = { nil },
+                                             installTypeProvider: @escaping () -> AIChatInstallType = { .new }) -> AIChatUserScriptHandler {
         let experimentalAIChatManager = ExperimentalAIChatManager(featureFlagger: mockFeatureFlagger, userDefaults: mockUserDefaults)
         return AIChatUserScriptHandler(
             experimentalAIChatManager: experimentalAIChatManager,
@@ -83,8 +85,44 @@ class AIChatUserScriptHandlerTests: XCTestCase {
             aichatFullModeFeature: mockAIChatFullModeFeature,
             aichatContextualModeFeature: mockAIChatContextualModeFeature,
             aiChatUserScriptErrorEventMapper: aiChatUserScriptErrorEventMapper ?? AIChatUserScriptErrorEventMapper(),
-            isNativeStorageBridgeAvailable: isNativeStorageBridgeAvailable
+            isNativeStorageBridgeAvailable: isNativeStorageBridgeAvailable,
+            installDateProvider: installDateProvider,
+            installTypeProvider: installTypeProvider
         )
+    }
+
+    func testWhenReturningUserThenInstallTypeIsReturning() {
+        aiChatUserScriptHandler = makeAIChatUserScriptHandler(installTypeProvider: { .returning })
+
+        let configValues = aiChatUserScriptHandler.getAIChatNativeConfigValues(params: [], message: MockUserScriptMessage(name: "test", body: [:])) as? AIChatNativeConfigValues
+
+        XCTAssertEqual(configValues?.installType, .returning)
+    }
+
+    func testWhenNewUserThenInstallTypeIsNew() {
+        aiChatUserScriptHandler = makeAIChatUserScriptHandler(installTypeProvider: { .new })
+
+        let configValues = aiChatUserScriptHandler.getAIChatNativeConfigValues(params: [], message: MockUserScriptMessage(name: "test", body: [:])) as? AIChatNativeConfigValues
+
+        XCTAssertEqual(configValues?.installType, .new)
+    }
+
+    func testInstallAgeIsBucketedFromInstallDate() {
+        // Installed 10 days ago -> bucket 2 (8–14).
+        let tenDaysAgo = Calendar.current.date(byAdding: .day, value: -10, to: Date())
+        aiChatUserScriptHandler = makeAIChatUserScriptHandler(installDateProvider: { tenDaysAgo })
+
+        let configValues = aiChatUserScriptHandler.getAIChatNativeConfigValues(params: [], message: MockUserScriptMessage(name: "test", body: [:])) as? AIChatNativeConfigValues
+
+        XCTAssertEqual(configValues?.installAge, 2)
+    }
+
+    func testWhenInstallDateIsNilThenInstallAgeIsZero() {
+        aiChatUserScriptHandler = makeAIChatUserScriptHandler(installDateProvider: { nil })
+
+        let configValues = aiChatUserScriptHandler.getAIChatNativeConfigValues(params: [], message: MockUserScriptMessage(name: "test", body: [:])) as? AIChatNativeConfigValues
+
+        XCTAssertEqual(configValues?.installAge, 0)
     }
 
     func testGetAIChatNativeConfigValues() {

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatMessageHandler.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatMessageHandler.swift
@@ -18,6 +18,7 @@
 
 import AIChat
 import Common
+import Foundation
 import FoundationExtensions
 import PrivacyConfig
 import UserScript
@@ -42,19 +43,31 @@ final class AIChatMessageHandler: AIChatMessageHandling {
     private let chatRestorationDataHandler: AIChatRestorationDataHandler
     private let pageContextHandler: AIChatPageContextHandler
     private let isNativeStorageBridgeAvailable: Bool
+    private let installDateProvider: () -> Date?
+    private let installTypeProvider: () -> AIChatInstallType
 
     init(featureFlagger: FeatureFlagger = Application.appDelegate.featureFlagger,
          promptHandler: any AIChatConsumableDataHandling = AIChatPromptHandler.shared,
          payloadHandler: AIChatPayloadHandler = AIChatPayloadHandler(),
          chatRestorationDataHandler: AIChatRestorationDataHandler = AIChatRestorationDataHandler(),
          pageContextHandler: AIChatPageContextHandler = AIChatPageContextHandler(),
-         isNativeStorageBridgeAvailable: Bool = false) {
+         isNativeStorageBridgeAvailable: Bool = false,
+         installDateProvider: @escaping () -> Date? = { LocalStatisticsStore().installDate },
+         installTypeProvider: @escaping () -> AIChatInstallType = {
+             // App Store builds can't detect reinstalls, so report `.unknown` rather than misreporting `.new`.
+             guard StandardApplicationBuildType().isSparkleBuild else { return .unknown }
+             let isReturning = DefaultReinstallUserDetection(
+                keyValueStore: Application.appDelegate.keyValueStore).isReinstallingUser
+             return isReturning ? .returning : .new
+         }) {
         self.featureFlagger = featureFlagger
         self.promptHandler = promptHandler
         self.payloadHandler = payloadHandler
         self.chatRestorationDataHandler = chatRestorationDataHandler
         self.pageContextHandler = pageContextHandler
         self.isNativeStorageBridgeAvailable = isNativeStorageBridgeAvailable
+        self.installDateProvider = installDateProvider
+        self.installTypeProvider = installTypeProvider
     }
 
     func getDataForMessageType(_ type: AIChatMessageType) -> Encodable? {
@@ -108,7 +121,9 @@ extension AIChatMessageHandler {
             supportsMultipleContexts: featureFlagger.isFeatureOn(.aiChatPageContext) && featureFlagger.isFeatureOn(.aiChatMultiplePageContexts),
             supportsTabPicker: featureFlagger.isFeatureOn(.aiChatPageContext) && featureFlagger.isFeatureOn(.aiChatSidebarAttachMoreTabs),
             supportsNativeStorage: featureFlagger.isFeatureOn(.aiChatNativeStorage) && isNativeStorageBridgeAvailable,
-            supportsNativeVoicePermissionHandler: featureFlagger.isFeatureOn(.aiChatNativeVoicePermissionFlow)
+            supportsNativeVoicePermissionHandler: featureFlagger.isFeatureOn(.aiChatNativeVoicePermissionFlow),
+            installType: installTypeProvider(),
+            installAge: AIChatNativeConfigValues.installAgeBucket(installDate: installDateProvider())
         )
     }
 

--- a/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -1094,7 +1094,7 @@ struct AIChatMessageHandlerInstallInfoTests {
         )
     }
 
-    @Test("installType is propagated to the native config")
+    @Test("installType is propagated to the native config", .timeLimit(.minutes(1)))
     func testInstallTypeIsPropagated() {
         for type in [AIChatInstallType.new, .returning, .unknown] {
             let config = makeHandler(installDate: nil, installType: type).getNativeConfigValues(isFireWindow: false)
@@ -1102,14 +1102,14 @@ struct AIChatMessageHandlerInstallInfoTests {
         }
     }
 
-    @Test("installAge is bucketed from the install date")
+    @Test("installAge is bucketed from the install date", .timeLimit(.minutes(1)))
     func testInstallAgeIsBucketed() {
         let twentyFourDaysAgo = Calendar.current.date(byAdding: .day, value: -24, to: Date())
         let config = makeHandler(installDate: twentyFourDaysAgo, installType: .new).getNativeConfigValues(isFireWindow: false)
         #expect(config.installAge == 4) // 22–28 -> bucket 4
     }
 
-    @Test("nil install date buckets to same-day (0)")
+    @Test("nil install date buckets to same-day (0)", .timeLimit(.minutes(1)))
     func testNilInstallDateBucketsToZero() {
         let config = makeHandler(installDate: nil, installType: .new).getNativeConfigValues(isFireWindow: false)
         #expect(config.installAge == 0)

--- a/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -900,7 +900,9 @@ struct AIChatUserScriptHandlerTests {
     func testWhenAIChatSyncEnabledAndNotFireWindowThenSupportsAIChatSyncIsTrue() {
         let featureFlagger = makeFeatureFlagger(aiChatSyncEnabled: true)
         let handler = AIChatMessageHandler(featureFlagger: featureFlagger,
-                                           promptHandler: AIChatPromptHandler.shared)
+                                           promptHandler: AIChatPromptHandler.shared,
+                                           installDateProvider: { nil },
+                                           installTypeProvider: { .new })
 
         let config = handler.getNativeConfigValues(isFireWindow: false)
 
@@ -912,7 +914,9 @@ struct AIChatUserScriptHandlerTests {
     func testWhenAIChatSyncEnabledAndFireWindowThenSupportsAIChatSyncIsFalse() {
         let featureFlagger = makeFeatureFlagger(aiChatSyncEnabled: true)
         let handler = AIChatMessageHandler(featureFlagger: featureFlagger,
-                                           promptHandler: AIChatPromptHandler.shared)
+                                           promptHandler: AIChatPromptHandler.shared,
+                                           installDateProvider: { nil },
+                                           installTypeProvider: { .new })
 
         let config = handler.getNativeConfigValues(isFireWindow: true)
 
@@ -924,7 +928,9 @@ struct AIChatUserScriptHandlerTests {
     func testWhenAIChatSyncDisabledThenSupportsAIChatSyncIsFalse() {
         let featureFlagger = makeFeatureFlagger(aiChatSyncEnabled: false)
         let handler = AIChatMessageHandler(featureFlagger: featureFlagger,
-                                           promptHandler: AIChatPromptHandler.shared)
+                                           promptHandler: AIChatPromptHandler.shared,
+                                           installDateProvider: { nil },
+                                           installTypeProvider: { .new })
 
         #expect(handler.getNativeConfigValues(isFireWindow: false).supportsAIChatSync == false)
         #expect(handler.getNativeConfigValues(isFireWindow: true).supportsAIChatSync == false)
@@ -936,7 +942,9 @@ struct AIChatUserScriptHandlerTests {
         let featureFlagger = makeFeatureFlagger(aiChatNativeStorageEnabled: true)
         let handler = AIChatMessageHandler(featureFlagger: featureFlagger,
                                            promptHandler: AIChatPromptHandler.shared,
-                                           isNativeStorageBridgeAvailable: true)
+                                           isNativeStorageBridgeAvailable: true,
+                                           installDateProvider: { nil },
+                                           installTypeProvider: { .new })
 
         #expect(handler.getNativeConfigValues(isFireWindow: false).supportsNativeStorage == true)
     }
@@ -947,7 +955,9 @@ struct AIChatUserScriptHandlerTests {
         let featureFlagger = makeFeatureFlagger(aiChatNativeStorageEnabled: true)
         let handler = AIChatMessageHandler(featureFlagger: featureFlagger,
                                            promptHandler: AIChatPromptHandler.shared,
-                                           isNativeStorageBridgeAvailable: true)
+                                           isNativeStorageBridgeAvailable: true,
+                                           installDateProvider: { nil },
+                                           installTypeProvider: { .new })
 
         #expect(handler.getNativeConfigValues(isFireWindow: true).supportsNativeStorage == true)
     }
@@ -957,7 +967,9 @@ struct AIChatUserScriptHandlerTests {
     func testWhenAIChatNativeStorageEnabledAndBridgeUnavailableThenSupportsNativeStorageIsFalse() {
         let featureFlagger = makeFeatureFlagger(aiChatNativeStorageEnabled: true)
         let handler = AIChatMessageHandler(featureFlagger: featureFlagger,
-                                           promptHandler: AIChatPromptHandler.shared)
+                                           promptHandler: AIChatPromptHandler.shared,
+                                           installDateProvider: { nil },
+                                           installTypeProvider: { .new })
 
         #expect(handler.getNativeConfigValues(isFireWindow: false).supportsNativeStorage == false)
     }
@@ -968,7 +980,9 @@ struct AIChatUserScriptHandlerTests {
         let featureFlagger = makeFeatureFlagger(aiChatNativeStorageEnabled: false)
         let handler = AIChatMessageHandler(featureFlagger: featureFlagger,
                                            promptHandler: AIChatPromptHandler.shared,
-                                           isNativeStorageBridgeAvailable: true)
+                                           isNativeStorageBridgeAvailable: true,
+                                           installDateProvider: { nil },
+                                           installTypeProvider: { .new })
 
         #expect(handler.getNativeConfigValues(isFireWindow: false).supportsNativeStorage == false)
     }
@@ -978,7 +992,9 @@ struct AIChatUserScriptHandlerTests {
     func testWhenAIChatNativeVoicePermissionFlowEnabledThenSupportsNativeVoicePermissionHandlerIsTrue() {
         let featureFlagger = makeFeatureFlagger(aiChatNativeVoicePermissionFlowEnabled: true)
         let handler = AIChatMessageHandler(featureFlagger: featureFlagger,
-                                           promptHandler: AIChatPromptHandler.shared)
+                                           promptHandler: AIChatPromptHandler.shared,
+                                           installDateProvider: { nil },
+                                           installTypeProvider: { .new })
 
         #expect(handler.getNativeConfigValues(isFireWindow: false).supportsNativeVoicePermissionHandler == true)
     }
@@ -988,7 +1004,9 @@ struct AIChatUserScriptHandlerTests {
     func testWhenAIChatNativeVoicePermissionFlowDisabledThenSupportsNativeVoicePermissionHandlerIsFalse() {
         let featureFlagger = makeFeatureFlagger(aiChatNativeVoicePermissionFlowEnabled: false)
         let handler = AIChatMessageHandler(featureFlagger: featureFlagger,
-                                           promptHandler: AIChatPromptHandler.shared)
+                                           promptHandler: AIChatPromptHandler.shared,
+                                           installDateProvider: { nil },
+                                           installTypeProvider: { .new })
 
         #expect(handler.getNativeConfigValues(isFireWindow: false).supportsNativeVoicePermissionHandler == false)
     }

--- a/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -1094,6 +1094,7 @@ struct AIChatMessageHandlerInstallInfoTests {
         )
     }
 
+    @available(iOS 16, macOS 13, *)
     @Test("installType is propagated to the native config", .timeLimit(.minutes(1)))
     func testInstallTypeIsPropagated() {
         for type in [AIChatInstallType.new, .returning, .unknown] {
@@ -1102,6 +1103,7 @@ struct AIChatMessageHandlerInstallInfoTests {
         }
     }
 
+    @available(iOS 16, macOS 13, *)
     @Test("installAge is bucketed from the install date", .timeLimit(.minutes(1)))
     func testInstallAgeIsBucketed() {
         let twentyFourDaysAgo = Calendar.current.date(byAdding: .day, value: -24, to: Date())
@@ -1109,6 +1111,7 @@ struct AIChatMessageHandlerInstallInfoTests {
         #expect(config.installAge == 4) // 22–28 -> bucket 4
     }
 
+    @available(iOS 16, macOS 13, *)
     @Test("nil install date buckets to same-day (0)", .timeLimit(.minutes(1)))
     func testNilInstallDateBucketsToZero() {
         let config = makeHandler(installDate: nil, installType: .new).getNativeConfigValues(isFireWindow: false)

--- a/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -1080,3 +1080,38 @@ private final class CapturingAIChatUserScriptErrorEventMapper: EventMapping<AICh
     }
 }
 // swiftlint:enable inclusive_language
+
+/// Covers the install-type / install-age values that `AIChatMessageHandler` adds to the
+/// native config for the `web.conversion.duckai.prompt` pixel. The providers are injected so
+/// the test doesn't depend on the real ATB store or build channel.
+struct AIChatMessageHandlerInstallInfoTests {
+
+    private func makeHandler(installDate: Date?, installType: AIChatInstallType) -> AIChatMessageHandler {
+        AIChatMessageHandler(
+            featureFlagger: MockFeatureFlagger(),
+            installDateProvider: { installDate },
+            installTypeProvider: { installType }
+        )
+    }
+
+    @Test("installType is propagated to the native config")
+    func testInstallTypeIsPropagated() {
+        for type in [AIChatInstallType.new, .returning, .unknown] {
+            let config = makeHandler(installDate: nil, installType: type).getNativeConfigValues(isFireWindow: false)
+            #expect(config.installType == type)
+        }
+    }
+
+    @Test("installAge is bucketed from the install date")
+    func testInstallAgeIsBucketed() {
+        let twentyFourDaysAgo = Calendar.current.date(byAdding: .day, value: -24, to: Date())
+        let config = makeHandler(installDate: twentyFourDaysAgo, installType: .new).getNativeConfigValues(isFireWindow: false)
+        #expect(config.installAge == 4) // 22–28 -> bucket 4
+    }
+
+    @Test("nil install date buckets to same-day (0)")
+    func testNilInstallDateBucketsToZero() {
+        let config = makeHandler(installDate: nil, installType: .new).getNativeConfigValues(isFireWindow: false)
+        #expect(config.installAge == 0)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1215106436913172?focus=true

### Description

Adds two fields to the `getAIChatNativeConfigValues` response so the Duck.ai web frontend can attach them to the `web.conversion.duckai.prompt` pixel (FE side: duckduckgo/ddg#45919). This lets the campaign split first prompts by new-vs-returning install and by install age.

- **Shared** (`AIChatNativeConfigValues`): new `installType` (`new` / `returning` / `unknown`) and `installAge` (`0`–`5`). A single `installAgeBucket(installDate:now:)` helper buckets days-since-install identically on both platforms (0 = same day, 1 = 1–7, 2 = 8–14, 3 = 15–21, 4 = 22–28, 5 = after day 28). New init params default to `.new`/`0`, so existing call sites and `defaultValues` are unchanged.
- **iOS**: `installAge` from `StatisticsUserDefaults().installDate` (ATB install date); `installType` from the returning-user variant (`ru`) — the same signal `StatisticsLoader` already uses for the install pixel's `reinstall` param.
- **macOS**: `installAge` from `LocalStatisticsStore().installDate`; `installType` from `ReinstallingUserDetecting` on Sparkle builds. App Store builds have no reliable reinstall signal, so they report `unknown` rather than misclassifying a reinstall as `new`.
- Providers are injected as closures so the values are stubbable in tests.

### Testing Steps


**macOS DMG, new user**
1. Remove app data to ensure clean state (including `~/Library/Application Support/DuckAiNativeStorage`)
2. Run the app and visit duck.ai
3. Open web inspector → Network and add `improving.duckduckgo.com` into the filter
4. Submit a prompt
5. Find and select the `web_conversion_duckai_prompt` pixel request
6. In the Headers tab, verify the request contains `installType=new&installAge=0`

**macOS DMG, returning user**
1. Remove app data to ensure clean state (including `~/Library/Application Support/DuckAiNativeStorage`)
2. Run the app
3. Make sure Debug → Reinstall Detection → Is Reinstalling User is **NO**
4. Quit the app
5. Clean the build folder (make sure the `.app` was removed)
6. Build the app again and run it
7. Make sure Debug → Reinstall Detection → Is Reinstalling User is **YES**
8. Visit duck.ai
9. Open web inspector → Network and add `improving.duckduckgo.com` into the filter
10. Submit a prompt
11. Find and select the `web_conversion_duckai_prompt` pixel request
12. In the Headers tab, verify the request contains `installType=returning&installAge=0`

**macOS App Store, unknown**
1. Remove app data to ensure clean state
2. Select the **macOS Browser App Store** scheme, build and run it
3. Confirm Debug → Reinstall Detection shows **Build: App Store (detection disabled)**
4. Visit duck.ai
5. Open web inspector → Network and add `improving.duckduckgo.com` into the filter
6. Submit a prompt
7. Find and select the `web_conversion_duckai_prompt` pixel request
8. In the Headers tab, verify the request contains `installType=unknown&installAge=0`

**iOS, new user**
1. Erase the simulator (Device → Erase All Content and Settings) or delete the app to ensure clean state
2. Run the app and visit duck.ai
3. Attach the web inspector (Safari → Develop → [Simulator] → duck.ai), open Network and add `improving.duckduckgo.com` into the filter
4. Submit a prompt
5. Find and select the `web_conversion_duckai_prompt` pixel request
6. In the Headers tab, verify the request contains `installType=new&installAge=0`
7. Quit the app
8. Delete the app from the homescreen

**iOS, returning user**
1. Build and install the app again
5. Visit duck.ai
6. Attach the web inspector (Safari → Develop → [Simulator] → duck.ai), open Network and add `improving.duckduckgo.com` into the filter
9. Submit a prompt
10. In the Headers tab, verify the `web_conversion_duckai_prompt` request contains `installType=returning&installAge=0`

### Impact and Risks

Low — additive, telemetry-only fields with safe defaults; no behavioural change to existing config values.

#### What could go wrong?

- The FE types `installType` as `new | returning` and forwards it verbatim; macOS App Store builds send `unknown`. It passes through as a string (no crash), but is outside the FE's declared type — see note below.

### Notes to Reviewer

- The FE (duckduckgo/ddg#45919) already reads these fields and stringifies `installAge` (preserving `0`); it omits them when native supplies neither.
- **Open question for metrics/FE owner:** is `installType: "unknown"` (macOS App Store) acceptable, or should App Store builds omit `installType` entirely? The FE handles omission cleanly, so either works — flagging since `unknown` isn't in the FE's current type.