### PR TITLE
Move tab switcher List/Grid toggle into the menu

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -80,8 +80,9 @@ extension Pixel {
         
         case privacyDashboardReportBrokenSite
         
-        case tabSwitcherListEnabled
-        case tabSwitcherGridEnabled
+        case tabSwitcherViewAsList
+        case tabSwitcherViewAsGrid
+        case tabSwitcherViewAsMenuShown
         case tabSwitcherNewTab
         case tabSwitcherSwitchTabs
         case tabSwitcherClickCloseTab
@@ -2023,8 +2024,9 @@ extension Pixel.Event {
         case .tabsStoreSaveError: return "m_debug_tabs_store_save_error"
         case .tabsStoreReadError: return "m_debug_tabs_store_read_error"
 
-        case .tabSwitcherListEnabled: return "m_ts_l"
-        case .tabSwitcherGridEnabled: return "m_ts_g"
+        case .tabSwitcherViewAsList: return "m_tab_switcher_view_as_list"
+        case .tabSwitcherViewAsGrid: return "m_tab_switcher_view_as_grid"
+        case .tabSwitcherViewAsMenuShown: return "m_tab_switcher_view_as_shown"
         case .tabSwitcherNewTab: return "m_tab_manager_new_tab_click"
         case .tabSwitcherSwitchTabs: return "m_tab_manager_switch_tabs"
         case .tabSwitcherClickCloseTab: return "m_tab_manager_close_tab_click"

--- a/iOS/DuckDuckGo/RemoteMessagingDebugViewController.swift
+++ b/iOS/DuckDuckGo/RemoteMessagingDebugViewController.swift
@@ -50,7 +50,7 @@ struct RemoteMessagingDebugRootView: View {
         List {
             Section {
                 HStack {
-                    Text("Days Since Installed")
+                    Text(verbatim: "Days Since Installed")
                         .font(.system(size: 15))
                     Spacer()
                     Text(model.currentDaysSinceInstalled.map(String.init) ?? "Not set")
@@ -62,9 +62,9 @@ struct RemoteMessagingDebugRootView: View {
                     isShowingDaysAlert = true
                 }
             } header: {
-                Text("Install Date")
+                Text(verbatim: "Install Date")
             } footer: {
-                Text("Sets the install date to N days ago, to test messages gated by daysSinceInstalled. Tap “Refresh Config” afterwards to re-evaluate.")
+                Text(verbatim: "Sets the install date to N days ago, to test messages gated by daysSinceInstalled. Tap “Refresh Config” afterwards to re-evaluate.")
             }
 
             Section {

--- a/iOS/DuckDuckGo/TabSwitcherBarsStateHandler.swift
+++ b/iOS/DuckDuckGo/TabSwitcherBarsStateHandler.swift
@@ -47,7 +47,6 @@ protocol TabSwitcherBarsStateHandling {
     var doneButton: UIBarButtonItem { get }
     var closeTabsButton: UIBarButtonItem { get }
     var menuButton: UIBarButtonItem { get }
-    var tabSwitcherStyleButton: UIBarButtonItem { get }
     var editButton: UIBarButtonItem { get }
     var selectAllButton: UIBarButtonItem { get }
     var deselectAllButton: UIBarButtonItem { get }
@@ -65,7 +64,6 @@ protocol TabSwitcherBarsStateHandling {
     var onFireButtonTapped: (() -> Void)? { get set }
     var onDoneButtonTapped: (() -> Void)? { get set }
     var onEditButtonTapped: (() -> UIMenu?)? { get set }
-    var onTabStyleButtonTapped: (() -> Void)? { get set }
     var onSelectAllTapped: (() -> Void)? { get set }
     var onDeselectAllTapped: (() -> Void)? { get set }
     var onMenuButtonTapped: (() -> UIMenu?)? { get set }
@@ -74,8 +72,7 @@ protocol TabSwitcherBarsStateHandling {
 
     func update(_ state: TabSwitcherToolbarState)
 
-    func configureButtonActions(tabsStyle: TabSwitcherViewController.TabsStyle,
-                                canShowSelectionMenu: Bool)
+    func configureButtonActions(canShowSelectionMenu: Bool)
 
     func configurePlusButtonLongPressMenu(isFireModeEnabled: Bool)
 
@@ -127,15 +124,8 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
         return item
     }()
 
-    lazy var tabSwitcherStyleButton: UIBarButtonItem = {
-        let item = BrowserChromeButton.createToolbarButtonItem(title: "", image: nil) { [weak self] in
-            self?.onTabStyleButtonTapped?()
-        }
-        return item
-    }()
-
     lazy var editButton: UIBarButtonItem = {
-        let item = BrowserChromeButton.createToolbarButtonItem(title: UserText.actionGenericEdit, image: DesignSystemImages.Glyphs.Size24.menuDotsVertical)
+        let item = BrowserChromeButton.createToolbarButtonItem(title: UserText.actionGenericEdit, image: DesignSystemImages.Glyphs.Size24.menuDotsHorizontal)
         return item
     }()
 
@@ -177,7 +167,6 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
     var onFireButtonTapped: (() -> Void)?
     var onDoneButtonTapped: (() -> Void)?
     var onEditButtonTapped: (() -> UIMenu?)?
-    var onTabStyleButtonTapped: (() -> Void)?
     var onSelectAllTapped: (() -> Void)?
     var onDeselectAllTapped: (() -> Void)?
     var onMenuButtonTapped: (() -> UIMenu?)?
@@ -207,13 +196,7 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
         updateTopRightButtons()
     }
 
-    func configureButtonActions(tabsStyle: TabSwitcherViewController.TabsStyle,
-                                canShowSelectionMenu: Bool) {
-        if let button = tabSwitcherStyleButton.customView as? BrowserChromeButton {
-            button.setImage(tabsStyle.image)
-            button.accessibilityLabel = tabsStyle.accessibilityLabel
-        }
-
+    func configureButtonActions(canShowSelectionMenu: Bool) {
         // Configure edit button with menu
         if let button = editButton.customView as? BrowserChromeButton {
             button.menu = onEditButtonTapped?()
@@ -303,10 +286,6 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
         case .regularSize:
 
             newItems = [
-                tabSwitcherStyleButton,
-
-                .flexibleSpace(),
-
                 invisibleBalancingButton(),
 
                 .flexibleSpace(),
@@ -316,8 +295,6 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
                 .flexibleSpace(),
 
                 plusButton,
-
-                .flexibleSpace(),
 
                 editButton,
             ].compactMap { $0 }
@@ -377,7 +354,6 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
         case .largeSize:
             topBarLeftButtons = [
                 editButton,
-                tabSwitcherStyleButton,
             ].views()
 
         case .editingRegularSize:

--- a/iOS/DuckDuckGo/TabSwitcherBarsStateHandler.swift
+++ b/iOS/DuckDuckGo/TabSwitcherBarsStateHandler.swift
@@ -258,7 +258,8 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
         configureAccessibility(deselectAllButton, label: UserText.deselectAllTabs)
         configureAccessibility(menuButton, label: "More Menu")
 
-        setEnabled(editButton, params.totalCount > 1 || params.containsWebPages)
+        // Always enabled so the "View As" layout menu stays reachable with no tabs.
+        setEnabled(editButton, true)
         setEnabled(closeTabsButton, params.selectedCount > 0)
         let doneEnabled = params.canDismissOnEmpty || params.totalCount > 0
         setEnabled(doneIconButton, doneEnabled)

--- a/iOS/DuckDuckGo/TabSwitcherMenuBuilder.swift
+++ b/iOS/DuckDuckGo/TabSwitcherMenuBuilder.swift
@@ -82,9 +82,15 @@ struct TabSwitcherLongPressMenuActions {
     var onCloseOther: () -> Void
 }
 
+struct TabSwitcherEditMenuState {
+    let isGridViewEnabled: Bool
+}
+
 struct TabSwitcherEditMenuActions {
     var onEnterSelectMode: () -> Void
     var onCloseAll: () -> Void
+    var onSelectGridView: () -> Void
+    var onSelectListView: () -> Void
 }
 
 // MARK: - Protocol
@@ -92,7 +98,8 @@ struct TabSwitcherEditMenuActions {
 protocol TabSwitcherMenuBuilding {
     func multiSelectionMenu(state: TabSwitcherMultiSelectMenuState,
                             actions: TabSwitcherMultiSelectMenuActions) -> UIMenu
-    func editMenu(actions: TabSwitcherEditMenuActions) -> UIMenu
+    func editMenu(state: TabSwitcherEditMenuState,
+                  actions: TabSwitcherEditMenuActions) -> UIMenu
     func longPressMenu(state: TabSwitcherLongPressMenuState,
                        actions: TabSwitcherLongPressMenuActions) -> UIMenu
 }
@@ -111,8 +118,9 @@ class DefaultTabSwitcherMenuBuilder: TabSwitcherMenuBuilding {
         return UIMenu(title: "", children: [deferredElement])
     }
 
-    func editMenu(actions: TabSwitcherEditMenuActions) -> UIMenu {
-        let items = editMenuItems(actions: actions)
+    func editMenu(state: TabSwitcherEditMenuState,
+                  actions: TabSwitcherEditMenuActions) -> UIMenu {
+        let items = editMenuItems(state: state, actions: actions)
         let deferredElement = UIDeferredMenuElement.uncached { completion in
             Pixel.fire(pixel: .tabSwitcherEditMenuClicked)
             completion(items)
@@ -169,8 +177,11 @@ class DefaultTabSwitcherMenuBuilder: TabSwitcherMenuBuilding {
         ]
     }
 
-    func editMenuItems(actions: TabSwitcherEditMenuActions) -> [UIMenuElement] {
+    func editMenuItems(state: TabSwitcherEditMenuState,
+                       actions: TabSwitcherEditMenuActions) -> [UIMenuElement] {
         return [
+            viewAsMenu(isGridViewEnabled: state.isGridViewEnabled, actions: actions),
+
             // Force plural version - this really means "switch to select tabs mode"
             action(UserText.tabSwitcherSelectTabs(withCount: 2),
                    DesignSystemImages.Glyphs.Size16.checkCircle,
@@ -182,6 +193,23 @@ class DefaultTabSwitcherMenuBuilder: TabSwitcherMenuBuilding {
                             actions.onCloseAll),
             ]),
         ]
+    }
+
+    /// Nested "View As" submenu to switch between grid and list layouts.
+    /// The active layout carries a checkmark.
+    private func viewAsMenu(isGridViewEnabled: Bool,
+                            actions: TabSwitcherEditMenuActions) -> UIMenu {
+        let grid = UIAction(title: UserText.tabSwitcherViewAsGrid,
+                            image: DesignSystemImages.Glyphs.Size16.viewGrid,
+                            state: isGridViewEnabled ? .on : .off) { _ in actions.onSelectGridView() }
+        let list = UIAction(title: UserText.tabSwitcherViewAsList,
+                            image: DesignSystemImages.Glyphs.Size16.viewList,
+                            state: isGridViewEnabled ? .off : .on) { _ in actions.onSelectListView() }
+        return UIMenu(title: UserText.tabSwitcherViewAs,
+                      image: isGridViewEnabled
+                        ? DesignSystemImages.Glyphs.Size16.viewGrid
+                        : DesignSystemImages.Glyphs.Size16.viewList,
+                      children: [grid, list])
     }
 
     func longPressMenuItems(state: TabSwitcherLongPressMenuState,

--- a/iOS/DuckDuckGo/TabSwitcherMenuBuilder.swift
+++ b/iOS/DuckDuckGo/TabSwitcherMenuBuilder.swift
@@ -199,17 +199,27 @@ class DefaultTabSwitcherMenuBuilder: TabSwitcherMenuBuilding {
     /// The active layout carries a checkmark.
     private func viewAsMenu(isGridViewEnabled: Bool,
                             actions: TabSwitcherEditMenuActions) -> UIMenu {
+        let items = viewAsItems(isGridViewEnabled: isGridViewEnabled, actions: actions)
+        let deferredElement = UIDeferredMenuElement.uncached { completion in
+            Pixel.fire(pixel: .tabSwitcherViewAsMenuShown)
+            completion(items)
+        }
+        return UIMenu(title: UserText.tabSwitcherViewAs,
+                      image: isGridViewEnabled
+                        ? DesignSystemImages.Glyphs.Size16.viewGrid
+                        : DesignSystemImages.Glyphs.Size16.viewList,
+                      children: [deferredElement])
+    }
+
+    func viewAsItems(isGridViewEnabled: Bool,
+                     actions: TabSwitcherEditMenuActions) -> [UIAction] {
         let grid = UIAction(title: UserText.tabSwitcherViewAsGrid,
                             image: DesignSystemImages.Glyphs.Size16.viewGrid,
                             state: isGridViewEnabled ? .on : .off) { _ in actions.onSelectGridView() }
         let list = UIAction(title: UserText.tabSwitcherViewAsList,
                             image: DesignSystemImages.Glyphs.Size16.viewList,
                             state: isGridViewEnabled ? .off : .on) { _ in actions.onSelectListView() }
-        return UIMenu(title: UserText.tabSwitcherViewAs,
-                      image: isGridViewEnabled
-                        ? DesignSystemImages.Glyphs.Size16.viewGrid
-                        : DesignSystemImages.Glyphs.Size16.viewList,
-                      children: [grid, list])
+        return [grid, list]
     }
 
     func longPressMenuItems(state: TabSwitcherLongPressMenuState,

--- a/iOS/DuckDuckGo/TabSwitcherMenuBuilder.swift
+++ b/iOS/DuckDuckGo/TabSwitcherMenuBuilder.swift
@@ -84,6 +84,7 @@ struct TabSwitcherLongPressMenuActions {
 
 struct TabSwitcherEditMenuState {
     let isGridViewEnabled: Bool
+    let canEditTabs: Bool
 }
 
 struct TabSwitcherEditMenuActions {
@@ -185,18 +186,18 @@ class DefaultTabSwitcherMenuBuilder: TabSwitcherMenuBuilding {
             // Force plural version - this really means "switch to select tabs mode"
             action(UserText.tabSwitcherSelectTabs(withCount: 2),
                    DesignSystemImages.Glyphs.Size16.checkCircle,
+                   enabled: state.canEditTabs,
                    actions.onEnterSelectMode),
 
             UIMenu(title: "", options: [.displayInline], children: [
                 destructive(UserText.closeAllTabs,
                             DesignSystemImages.Glyphs.Size16.tabCloseAlt,
+                            enabled: state.canEditTabs,
                             actions.onCloseAll),
             ]),
         ]
     }
 
-    /// Nested "View As" submenu to switch between grid and list layouts.
-    /// The active layout carries a checkmark.
     private func viewAsMenu(isGridViewEnabled: Bool,
                             actions: TabSwitcherEditMenuActions) -> UIMenu {
         let items = viewAsItems(isGridViewEnabled: isGridViewEnabled, actions: actions)
@@ -258,11 +259,15 @@ class DefaultTabSwitcherMenuBuilder: TabSwitcherMenuBuilding {
             DesignSystemImages.Glyphs.Size16.tabCloseAlt
     }
 
-    private func action(_ title: String, _ image: UIImage? = nil, _ handler: @escaping () -> Void) -> UIAction {
-        return UIAction(title: title, image: image) { _ in handler() }
+    private func action(_ title: String, _ image: UIImage? = nil, enabled: Bool = true, _ handler: @escaping () -> Void) -> UIAction {
+        let action = UIAction(title: title, image: image) { _ in handler() }
+        if !enabled { action.attributes.insert(.disabled) }
+        return action
     }
 
-    private func destructive(_ title: String, _ image: UIImage, _ handler: @escaping () -> Void) -> UIAction {
-        return UIAction(title: title, image: image, attributes: .destructive) { _ in handler() }
+    private func destructive(_ title: String, _ image: UIImage, enabled: Bool = true, _ handler: @escaping () -> Void) -> UIAction {
+        let action = UIAction(title: title, image: image, attributes: .destructive) { _ in handler() }
+        if !enabled { action.attributes.insert(.disabled) }
+        return action
     }
 }

--- a/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
@@ -65,8 +65,9 @@ extension TabSwitcherViewController {
         })
     }
 
-    func onTabStyleChange() {
+    func setGridView(_ enabled: Bool) {
         guard isProcessingUpdates == false else { return }
+        guard tabSwitcherSettings.isGridViewEnabled != enabled else { return }
 
         isProcessingUpdates = true
         // Idea is here to wait for any pending processing of reconfigureItems on a cells,
@@ -77,15 +78,13 @@ extension TabSwitcherViewController {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
             guard let self else { return }
 
-            tabSwitcherSettings.isGridViewEnabled = !tabSwitcherSettings.isGridViewEnabled
+            tabSwitcherSettings.isGridViewEnabled = enabled
 
             if tabSwitcherSettings.isGridViewEnabled {
                 Pixel.fire(pixel: .tabSwitcherGridEnabled)
             } else {
                 Pixel.fire(pixel: .tabSwitcherListEnabled)
             }
-
-            self.refreshDisplayModeButton()
 
             UIView.transition(with: view,
                               duration: 0.3,
@@ -278,7 +277,7 @@ extension TabSwitcherViewController {
         }
 
         barsHandler.update(state)
-        barsHandler.configureButtonActions(tabsStyle: tabsStyle, canShowSelectionMenu: canShowSelectionMenu)
+        barsHandler.configureButtonActions(canShowSelectionMenu: canShowSelectionMenu)
 
         titleBarView.setCenterView(isEditing ? nil : segmentedPickerHostingController?.view)
         titleBarView.setLeadingButtons(barsHandler.topBarLeftButtons)
@@ -310,10 +309,14 @@ extension TabSwitcherViewController {
     }
 
     func createEditMenu() -> UIMenu {
-        return menuBuilder.editMenu(actions: TabSwitcherEditMenuActions(
-            onEnterSelectMode: { [weak self] in self?.editMenuEnterSelectMode() },
-            onCloseAll: { [weak self] in self?.editMenuCloseAllTabs() }
-        ))
+        return menuBuilder.editMenu(
+            state: TabSwitcherEditMenuState(isGridViewEnabled: tabSwitcherSettings.isGridViewEnabled),
+            actions: TabSwitcherEditMenuActions(
+                onEnterSelectMode: { [weak self] in self?.editMenuEnterSelectMode() },
+                onCloseAll: { [weak self] in self?.editMenuCloseAllTabs() },
+                onSelectGridView: { [weak self] in self?.setGridView(true) },
+                onSelectListView: { [weak self] in self?.setGridView(false) }
+            ))
     }
 
     /// Takes indexes of tabs to create long menu for.  Internally creates tab array for those

--- a/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
@@ -259,7 +259,6 @@ extension TabSwitcherViewController {
         }
 
         let showAIChatButton = aiChatSettings.isAIChatTabSwitcherUserSettingsEnabled
-        let containsWebPages = tabsModel.tabs.contains(where: { $0.link != nil })
 
         let state: TabSwitcherToolbarState
         if isEditing {
@@ -309,8 +308,10 @@ extension TabSwitcherViewController {
     }
 
     func createEditMenu() -> UIMenu {
+        let canEditTabs = tabsModel.count > 1 || containsWebPages
         return menuBuilder.editMenu(
-            state: TabSwitcherEditMenuState(isGridViewEnabled: tabSwitcherSettings.isGridViewEnabled),
+            state: TabSwitcherEditMenuState(isGridViewEnabled: tabSwitcherSettings.isGridViewEnabled,
+                                            canEditTabs: canEditTabs),
             actions: TabSwitcherEditMenuActions(
                 onEnterSelectMode: { [weak self] in self?.editMenuEnterSelectMode() },
                 onCloseAll: { [weak self] in self?.editMenuCloseAllTabs() },

--- a/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
@@ -81,9 +81,9 @@ extension TabSwitcherViewController {
             tabSwitcherSettings.isGridViewEnabled = enabled
 
             if tabSwitcherSettings.isGridViewEnabled {
-                Pixel.fire(pixel: .tabSwitcherGridEnabled)
+                Pixel.fire(pixel: .tabSwitcherViewAsGrid)
             } else {
-                Pixel.fire(pixel: .tabSwitcherListEnabled)
+                Pixel.fire(pixel: .tabSwitcherViewAsList)
             }
 
             UIView.transition(with: view,

--- a/iOS/DuckDuckGo/TabSwitcherViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController.swift
@@ -69,29 +69,6 @@ class TabSwitcherViewController: UIViewController {
 
     }
 
-    enum TabsStyle: String {
-
-        case list = "tabsToggleList"
-        case grid = "tabsToggleGrid"
-
-        var accessibilityLabel: String {
-            switch self {
-            case .list: "Switch to grid view"
-            case .grid: "Switch to list view"
-            }
-        }
-
-        var image: UIImage {
-            switch self {
-            case .list:
-                return DesignSystemImages.Glyphs.Size24.viewList
-            case .grid:
-                return DesignSystemImages.Glyphs.Size24.viewGrid
-            }
-        }
-
-    }
-
     lazy var borderView = StyledTopBottomBorderView()
 
     let titleBarView = TabSwitcherTitleBarView()
@@ -142,7 +119,6 @@ class TabSwitcherViewController: UIViewController {
 
     let favicons: FaviconManaging
 
-    var tabsStyle: TabsStyle = .list
     var interfaceMode: InterfaceMode = .regularSize
     var canShowSelectionMenu = false
     var menuBuilder: TabSwitcherMenuBuilding = DefaultTabSwitcherMenuBuilder()
@@ -551,10 +527,6 @@ class TabSwitcherViewController: UIViewController {
             return self?.createEditMenu()
         }
 
-        barsHandler.onTabStyleButtonTapped = { [weak self] in
-            self?.onTabStyleChange()
-        }
-
         barsHandler.onSelectAllTapped = { [weak self] in
             self?.selectAllTabs()
         }
@@ -591,10 +563,6 @@ class TabSwitcherViewController: UIViewController {
     private func showFireButtonPulseIfNeeded() {
         guard daxDialogsManager.isShowingFireDialog, let window = view.window else { return }
         ViewHighlighter.showIn(window, focussedOnButton: barsHandler.fireButton)
-    }
-
-    func refreshDisplayModeButton() {
-        tabsStyle = tabSwitcherSettings.isGridViewEnabled ? .grid : .list
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -817,9 +785,7 @@ extension TabSwitcherViewController {
     private func decorate() {
         let theme = ThemeManager.shared.currentTheme
         view.backgroundColor = theme.backgroundColor
-        
-        refreshDisplayModeButton()
-        
+
         titleBarView.tintColor = theme.barTintColor
 
         toolbar.barTintColor = theme.barBackgroundColor
@@ -899,7 +865,7 @@ extension TabSwitcherViewController: TabSwitcherPageDelegate {
 
     func page(_ page: TabSwitcherPageViewController, didReorderTabs: Void) {
         if isEditing {
-            barsHandler.configureButtonActions(tabsStyle: tabsStyle, canShowSelectionMenu: canShowSelectionMenu)
+            barsHandler.configureButtonActions(canShowSelectionMenu: canShowSelectionMenu)
         }
         delegate.tabSwitcherDidReorderTabs(tabSwitcher: self)
     }

--- a/iOS/DuckDuckGo/TabSwitcherViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController.swift
@@ -138,7 +138,11 @@ class TabSwitcherViewController: UIViewController {
     var canDismissOnEmpty: Bool {
         !tabsModel.allowsEmpty
     }
-    
+
+    var containsWebPages: Bool {
+        tabsModel.tabs.contains(where: { $0.link != nil })
+    }
+
     var barsHandler: TabSwitcherBarsStateHandling = DefaultTabSwitcherBarsStateHandler()
 
     private let appSettings: AppSettings

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -408,6 +408,12 @@ public struct UserText {
 
     public static let tabSwitcherBookmarkAllTabs = NSLocalizedString("tab.switcher.bookmarkAll", value: "Bookmark All Tabs", comment: "Bookmark all tabs menu item")
 
+    public static let tabSwitcherViewAs = NSLocalizedString("tab.switcher.viewAs", value: "View As", comment: "Title for the menu item that lets the user choose between grid and list tab layouts")
+
+    public static let tabSwitcherViewAsGrid = NSLocalizedString("tab.switcher.viewAs.grid", value: "Grid", comment: "Menu item to show tabs in a grid layout")
+
+    public static let tabSwitcherViewAsList = NSLocalizedString("tab.switcher.viewAs.list", value: "List", comment: "Menu item to show tabs in a list layout")
+
     public static func tabSwitcherSelectTabs(withCount count: Int) -> String {
         let format = Bundle.main.localizedString(forKey: "tab.switcher.select-tabs.withCount", value: nil, table: nil)
         return String.localizedStringWithFormat(format, count)

--- a/iOS/DuckDuckGo/en.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/en.lproj/Localizable.strings
@@ -4402,6 +4402,15 @@ Take back control of your personal information with the browser designed for dat
 /* Do not translate - stringsdict entry */
 "tab.switcher.tracker.count.title" = "tab.switcher.tracker.count.title";
 
+/* Title for the menu item that lets the user choose between grid and list tab layouts */
+"tab.switcher.viewAs" = "View As";
+
+/* Menu item to show tabs in a grid layout */
+"tab.switcher.viewAs.grid" = "Grid";
+
+/* Menu item to show tabs in a list layout */
+"tab.switcher.viewAs.list" = "List";
+
 /* Description text for the text size adjustment setting */
 "textSize.description" = "Increase or decrease text size across all sites.";
 

--- a/iOS/DuckDuckGoTests/TabSwitcherBarsStateHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/TabSwitcherBarsStateHandlerTests.swift
@@ -40,11 +40,10 @@ class TabSwitcherBarsStateHandlerTests: XCTestCase {
         stateHandler.update(.regularSize(selectedCount: 0, totalCount: 1, containsWebPages: false, showAIChat: true, canDismissOnEmpty: true))
 
         let items = stateHandler.bottomBarItems
-        XCTAssertEqual(items.count, 9)
-        XCTAssertEqual(items[0], stateHandler.tabSwitcherStyleButton)
-        XCTAssertEqual(items[4], stateHandler.fireButton)
-        XCTAssertEqual(items[6], stateHandler.plusButton)
-        XCTAssertEqual(items[8], stateHandler.editButton)
+        XCTAssertEqual(items.count, 6)
+        XCTAssertEqual(items[2], stateHandler.fireButton)
+        XCTAssertEqual(items[4], stateHandler.plusButton)
+        XCTAssertEqual(items[5], stateHandler.editButton)
 
         XCTAssertFalse(stateHandler.isBottomBarHidden)
         XCTAssertFalse(stateHandler.editButton.isEnabled)
@@ -55,11 +54,10 @@ class TabSwitcherBarsStateHandlerTests: XCTestCase {
 
         // Check that the expected items are present in the correct order
         let items = stateHandler.bottomBarItems
-        XCTAssertEqual(items.count, 9)
-        XCTAssertEqual(items[0], stateHandler.tabSwitcherStyleButton)
-        XCTAssertEqual(items[4], stateHandler.fireButton)
-        XCTAssertEqual(items[6], stateHandler.plusButton)
-        XCTAssertEqual(items[8], stateHandler.editButton)
+        XCTAssertEqual(items.count, 6)
+        XCTAssertEqual(items[2], stateHandler.fireButton)
+        XCTAssertEqual(items[4], stateHandler.plusButton)
+        XCTAssertEqual(items[5], stateHandler.editButton)
 
         XCTAssertFalse(stateHandler.isBottomBarHidden)
         XCTAssertTrue(stateHandler.editButton.isEnabled)
@@ -158,17 +156,15 @@ class TabSwitcherBarsStateHandlerTests: XCTestCase {
     func testWhenInterfaceModeIsLargeSizeThenTopLeftButtonsAreSetCorrectly() {
         stateHandler.update(.largeSize(selectedCount: 0, totalCount: 2, containsWebPages: false, showAIChat: false, canDismissOnEmpty: true))
 
-        XCTAssertEqual(stateHandler.topBarLeftButtons.count, 2)
+        XCTAssertEqual(stateHandler.topBarLeftButtons.count, 1)
         XCTAssertTrue(stateHandler.topBarLeftButtons.contains(stateHandler.editButton.customView!))
-        XCTAssertTrue(stateHandler.topBarLeftButtons.contains(stateHandler.tabSwitcherStyleButton.customView!))
     }
 
     func testWhenInterfaceModeIsLargeSizeAndCannotShowEditButtonThenTopLeftButtonsAreSetCorrectly() {
         stateHandler.update(.largeSize(selectedCount: 0, totalCount: 0, containsWebPages: false, showAIChat: false, canDismissOnEmpty: true))
 
-        XCTAssertEqual(stateHandler.topBarLeftButtons.count, 2)
+        XCTAssertEqual(stateHandler.topBarLeftButtons.count, 1)
         XCTAssertTrue(stateHandler.topBarLeftButtons.contains(stateHandler.editButton.customView!))
-        XCTAssertTrue(stateHandler.topBarLeftButtons.contains(stateHandler.tabSwitcherStyleButton.customView!))
     }
 
     func testWhenInterfaceModeIsLargeSizeThenTopRightButtonsAreSetCorrectly() {

--- a/iOS/DuckDuckGoTests/TabSwitcherBarsStateHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/TabSwitcherBarsStateHandlerTests.swift
@@ -36,7 +36,7 @@ class TabSwitcherBarsStateHandlerTests: XCTestCase {
         super.tearDown()
     }
 
-    func testWhenNoPagesThenEditButtonVisibleButDisabled() {
+    func testWhenNoPagesThenEditButtonVisibleAndEnabled() {
         stateHandler.update(.regularSize(selectedCount: 0, totalCount: 1, containsWebPages: false, showAIChat: true, canDismissOnEmpty: true))
 
         let items = stateHandler.bottomBarItems
@@ -46,7 +46,8 @@ class TabSwitcherBarsStateHandlerTests: XCTestCase {
         XCTAssertEqual(items[5], stateHandler.editButton)
 
         XCTAssertFalse(stateHandler.isBottomBarHidden)
-        XCTAssertFalse(stateHandler.editButton.isEnabled)
+        // Stays enabled so the "View As" menu is reachable even with a single empty tab.
+        XCTAssertTrue(stateHandler.editButton.isEnabled)
     }
 
     func testWhenDuckChatEnabledThenBottomBarItemsAreSetCorrectly() {

--- a/iOS/DuckDuckGoTests/TabSwitcherMenuBuilderTests.swift
+++ b/iOS/DuckDuckGoTests/TabSwitcherMenuBuilderTests.swift
@@ -36,7 +36,8 @@ class DefaultTabSwitcherMenuBuilderTests: XCTestCase {
             onDeselectAll: {}, onSelectAll: {}, onShare: {},
             onBookmarkSelected: {}, onCloseOther: {}, onCloseSelected: {}, onBookmarkAll: {}
         )
-        noopEditActions = TabSwitcherEditMenuActions(onEnterSelectMode: {}, onCloseAll: {})
+        noopEditActions = TabSwitcherEditMenuActions(onEnterSelectMode: {}, onCloseAll: {},
+                                                     onSelectGridView: {}, onSelectListView: {})
         noopLongPressActions = TabSwitcherLongPressMenuActions(
             onShare: {}, onBookmark: {}, onSelect: {}, onClose: {}, onCloseOther: {}
         )
@@ -147,7 +148,7 @@ class DefaultTabSwitcherMenuBuilderTests: XCTestCase {
     // MARK: - Edit Menu
 
     func testEditMenu_alwaysContainsSelectTabsAndCloseAll() {
-        let items = builder.editMenuItems(actions: noopEditActions)
+        let items = builder.editMenuItems(state: .init(isGridViewEnabled: true), actions: noopEditActions)
         let actions = flatActions(items)
 
         XCTAssertTrue(actions.contains(title: UserText.tabSwitcherSelectTabs(withCount: 2)))
@@ -155,11 +156,32 @@ class DefaultTabSwitcherMenuBuilderTests: XCTestCase {
     }
 
     func testEditMenu_closeAllIsDestructive() {
-        let items = builder.editMenuItems(actions: noopEditActions)
+        let items = builder.editMenuItems(state: .init(isGridViewEnabled: true), actions: noopEditActions)
         let closeAllAction = flatActions(items).first(withTitle: UserText.closeAllTabs)
 
         XCTAssertNotNil(closeAllAction)
         XCTAssertTrue(closeAllAction!.attributes.contains(.destructive))
+    }
+
+    func testViewAsMenu_containsGridAndList() {
+        let actions = builder.viewAsItems(isGridViewEnabled: true, actions: noopEditActions)
+
+        XCTAssertTrue(actions.contains(title: UserText.tabSwitcherViewAsGrid))
+        XCTAssertTrue(actions.contains(title: UserText.tabSwitcherViewAsList))
+    }
+
+    func testViewAsMenu_checksGridWhenGridEnabled() {
+        let actions = builder.viewAsItems(isGridViewEnabled: true, actions: noopEditActions)
+
+        XCTAssertEqual(actions.first(withTitle: UserText.tabSwitcherViewAsGrid)?.state, .on)
+        XCTAssertEqual(actions.first(withTitle: UserText.tabSwitcherViewAsList)?.state, .off)
+    }
+
+    func testViewAsMenu_checksListWhenGridDisabled() {
+        let actions = builder.viewAsItems(isGridViewEnabled: false, actions: noopEditActions)
+
+        XCTAssertEqual(actions.first(withTitle: UserText.tabSwitcherViewAsGrid)?.state, .off)
+        XCTAssertEqual(actions.first(withTitle: UserText.tabSwitcherViewAsList)?.state, .on)
     }
 
     // MARK: - Long Press Menu

--- a/iOS/DuckDuckGoTests/TabSwitcherMenuBuilderTests.swift
+++ b/iOS/DuckDuckGoTests/TabSwitcherMenuBuilderTests.swift
@@ -147,16 +147,32 @@ class DefaultTabSwitcherMenuBuilderTests: XCTestCase {
 
     // MARK: - Edit Menu
 
-    func testEditMenu_alwaysContainsSelectTabsAndCloseAll() {
-        let items = builder.editMenuItems(state: .init(isGridViewEnabled: true), actions: noopEditActions)
+    func testEditMenu_whenCanEditTabsSelectTabsAndCloseAllAreEnabled() {
+        let items = builder.editMenuItems(state: .init(isGridViewEnabled: true, canEditTabs: true), actions: noopEditActions)
         let actions = flatActions(items)
+        let select = actions.first(withTitle: UserText.tabSwitcherSelectTabs(withCount: 2))
+        let closeAll = actions.first(withTitle: UserText.closeAllTabs)
 
-        XCTAssertTrue(actions.contains(title: UserText.tabSwitcherSelectTabs(withCount: 2)))
-        XCTAssertTrue(actions.contains(title: UserText.closeAllTabs))
+        XCTAssertNotNil(select)
+        XCTAssertNotNil(closeAll)
+        XCTAssertFalse(select!.attributes.contains(.disabled))
+        XCTAssertFalse(closeAll!.attributes.contains(.disabled))
+    }
+
+    func testEditMenu_whenCannotEditTabsSelectTabsAndCloseAllAreDisabled() {
+        let items = builder.editMenuItems(state: .init(isGridViewEnabled: true, canEditTabs: false), actions: noopEditActions)
+        let actions = flatActions(items)
+        let select = actions.first(withTitle: UserText.tabSwitcherSelectTabs(withCount: 2))
+        let closeAll = actions.first(withTitle: UserText.closeAllTabs)
+
+        XCTAssertNotNil(select)
+        XCTAssertNotNil(closeAll)
+        XCTAssertTrue(select!.attributes.contains(.disabled))
+        XCTAssertTrue(closeAll!.attributes.contains(.disabled))
     }
 
     func testEditMenu_closeAllIsDestructive() {
-        let items = builder.editMenuItems(state: .init(isGridViewEnabled: true), actions: noopEditActions)
+        let items = builder.editMenuItems(state: .init(isGridViewEnabled: true, canEditTabs: true), actions: noopEditActions)
         let closeAllAction = flatActions(items).first(withTitle: UserText.closeAllTabs)
 
         XCTAssertNotNil(closeAllAction)

--- a/iOS/PixelDefinitions/pixels/definitions/tab_switcher_view_as.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/tab_switcher_view_as.json5
@@ -1,0 +1,27 @@
+// Tab switcher "View As" (grid/list layout) pixels.
+{
+    "m_tab_switcher_view_as_grid": {
+        "description": "User switched the tab manager layout to Grid via the View As menu.",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"],
+        "expires": "2026-07-15"
+    },
+    "m_tab_switcher_view_as_list": {
+        "description": "User switched the tab manager layout to List via the View As menu.",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"],
+        "expires": "2026-07-15"
+    },
+    "m_tab_switcher_view_as_shown": {
+        "description": "User opened the View As submenu (change layout) from the tab manager more menu.",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"],
+        "expires": "2026-07-15"
+    }
+}

--- a/iOS/PixelDefinitions/pixels/definitions/tab_switcher_view_as.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/tab_switcher_view_as.json5
@@ -5,16 +5,14 @@
         "owners": ["dus7"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
-        "parameters": ["appVersion"],
-        "expires": "2026-07-15"
+        "parameters": ["appVersion"]
     },
     "m_tab_switcher_view_as_list": {
         "description": "User switched the tab manager layout to List via the View As menu.",
         "owners": ["dus7"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
-        "parameters": ["appVersion"],
-        "expires": "2026-07-15"
+        "parameters": ["appVersion"]
     },
     "m_tab_switcher_view_as_shown": {
         "description": "User opened the View As submenu (change layout) from the tab manager more menu.",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212844028524981
Tech Design URL:
CC:

### Description
Remove the standalone List/Grid layout toggle button from the tab switcher and move it into the existing "more" menu as a "View As" submenu, on both iPhone and iPad.

### Testing Steps
1. Open TabSwitcher on an iPhone.
2. Confirm there is no separate List/Grid toggle button in the toolbar, and the bottom bar shows Fire (centred), New Tab, and the “..." menu.
3. Tap the “..." menu, then View As, and switch between Grid and List. Confirm the layout changes and the checkmark moves to the selected option and there’s no icon shift between main screen toolbar and tab switcher.
4. Confirm pixels fire when View As, Grid and List are pressed.
5. Confirm Select Tabs and Close All Tabs are still present in the same menu.
6. With a single empty tab open (no loaded web page), open the “..." menu and confirm View As is enabled and switches layout, while Select Tabs and Close All Tabs are visible but disabled.
7. Repeat on an iPad
8. Confirm the chosen layout persists after closing and reopening the tab switcher.

### Impact and Risks
Low. UI relocation of an existing control plus a pixel rename.

#### What could go wrong?
- iPhone bottom toolbar balance: the toggle button was previously part of the layout, so the invisible balancing item is retained to keep Fire centered.

### Quality Considerations
— 

### Notes to Reviewer
Because layout switching now lives in the "..." menu, that menu button is kept enabled even when there is a single tab with no loaded web page (previously it was disabled in that state, which would have made View As unreachable). In that state Select Tabs and Close All Tabs are shown but disabled, while View As stays enabled.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI relocation of an existing preference with no auth or data changes; main risk is toolbar layout balance on iPhone, which the PR retains an invisible balancing item to address.
> 
> **Overview**
> Removes the dedicated tab switcher **List/Grid** toolbar control and exposes layout switching from the existing **"..." edit menu** via a new **View As** submenu (Grid/List with checkmarks). The edit button icon switches to horizontal dots; bottom and large-width top bars no longer include the style toggle, with toolbar tests updated for the slimmer item layout.
> 
> Layout changes go through **\`setGridView(_:)\`** (no-op when already selected) instead of toggling from a toolbar button. Analytics pixels are renamed/added: **\`m_tab_switcher_view_as_grid\`**, **\`m_tab_switcher_view_as_list\`**, and **\`m_tab_switcher_view_as_shown\`** (replacing the old list/grid enabled events), with matching **\`PixelEvent\`** cases and a new pixel definitions file.
> 
> Also adds localized **View As** strings and uses **\`Text(verbatim:)\`** on a few Remote Messaging debug labels (unrelated UI copy fix).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 460cf2e0b9390d3e06e93af76c0edbd512e2283c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->