### PR TITLE
macOS: Fix Duck.ai voice-chat microphone popover position and arrow tint

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -1840,17 +1840,29 @@ final class AddressBarButtonsViewController: NSViewController {
     private func showSystemDisabledInfoPopover(for domain: String, permissionType: PermissionType) {
         guard permissionCenterButton.isVisible else { return }
 
-        let view = SystemDisabledPermissionInfoView(domain: domain, permissionType: permissionType)
-        let controller = NSHostingController(rootView: view)
-        controller.preferredContentSize = controller.view.fittingSize
+        // Auto-layout-pinned NSHostingView (like PermissionCenterViewController) so NSPopover reads a stable
+        // fitting size; a bare NSHostingController left contentSize at the 320×320 default and mis-positioned it.
+        let swiftUIView = SystemDisabledPermissionInfoView(domain: domain, permissionType: permissionType)
+        let hostingView = NSHostingView(rootView: swiftUIView)
+        hostingView.translatesAutoresizingMaskIntoConstraints = false
+        let controller = NSViewController()
+        controller.view = NSView()
+        controller.view.addSubview(hostingView)
+        NSLayoutConstraint.activate([
+            hostingView.topAnchor.constraint(equalTo: controller.view.topAnchor),
+            hostingView.leadingAnchor.constraint(equalTo: controller.view.leadingAnchor),
+            hostingView.trailingAnchor.constraint(equalTo: controller.view.trailingAnchor),
+            hostingView.bottomAnchor.constraint(equalTo: controller.view.bottomAnchor)
+        ])
 
         let popover = NSPopover()
         systemDisabledInfoPopover = popover
         popover.contentViewController = controller
         popover.behavior = .transient  // Click outside to dismiss
-        popover.show(relativeTo: permissionCenterButton.bounds,
-                     of: permissionCenterButton,
-                     preferredEdge: .maxY)
+        // Tint the whole popover including the arrow to match the theme (default leaves the arrow untinted).
+        popover.backgroundColor = themeManager.theme.colorsProvider.popoverBackgroundColor
+        popover.show(positionedBelow: permissionCenterButton.bounds.insetFromLineOfDeath(flipped: permissionCenterButton.isFlipped),
+                     in: permissionCenterButton)
     }
 
     func openPrivacyDashboard() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1215366389624139?focus=true
Tech Design URL:
CC:

### Description

The Duck.ai voice-chat "microphone access" popover rendered ~200pt below the address-bar shield, with an untinted arrow. A bare `NSHostingController` left `NSPopover.contentSize` at AppKit's 320×320 default (it positioned for 320pt then shrank), so this switches to the `NSHostingView` + auto-layout pattern the other address-bar popovers use, and sets `popover.backgroundColor` so the arrow is tinted with the theme.

### Testing Steps
1. Deny microphone access to the browser in System Settings → Privacy → Microphone.
2. Open Duck.ai with the `aiChatNativeVoicePermissionFlow` flag on.
3. Click New Voice Chat — the popover anchors directly under the address-bar shield, arrow tinted to match the body.

### Impact and Risks
Low. UI-only fix to an existing popover surfaced by the voice-permission flow.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to one popover presentation path in the address bar; no permission logic or data handling changes.
> 
> **Overview**
> Fixes **system-disabled permission info** popover (e.g. Duck.ai voice chat when macOS mic access is denied) so it anchors under the address-bar permission shield and matches other address-bar popovers visually.
> 
> **Hosting:** Replaces a bare `NSHostingController` with an **auto-layout–pinned `NSHostingView`** inside a plain `NSViewController`, matching the permission center pattern. That gives `NSPopover` a stable content size instead of AppKit’s default 320×320, which had caused the popover to appear far below the shield.
> 
> **Presentation:** Sets **`popover.backgroundColor`** from the theme so the arrow is tinted with the popover body, and switches to **`show(positionedBelow:insetFromLineOfDeath:)`** on the permission center button—the same anchoring helper used for authorization, permission center, and YouTube ad-block popovers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 132a02645f14785ee56801c3119d2291dcda0e81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->