### PR TITLE
Add Fire button to the escape-hatch Return-to card

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -242,6 +242,10 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214749215529034?focus=true
     case escapeHatchActions
 
+    /// Surfaces the escape-hatch "delete tab" action as a dedicated Fire button on the card and removes it from the menu.
+    /// https://app.asana.com/1/137249556945/project/1211654189969294/task/1215358250572341?focus=true
+    case escapeHatchFireButton
+
     case crashReportOptInStatusResetting
 
     case screenTimeCleaning

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -330,6 +330,10 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1208671677432066/task/1213821747548995?focus=true
     case escapeHatchActions
 
+    /// Surfaces the escape-hatch "delete tab" action as a dedicated Fire button on the card and removes it from the menu.
+    /// https://app.asana.com/1/137249556945/project/1211654189969294/task/1215358250572341?focus=true
+    case escapeHatchFireButton
+
     /// Test-only feature flag for verifying UI test override mechanism.
     /// Used in Debug > UI Test Overrides screen.
     case uiTestFeatureFlag
@@ -680,6 +684,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.showNTPAfterIdleReturn))
         case .escapeHatchActions:
             Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.escapeHatchActions))
+        case .escapeHatchFireButton:
+            Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.escapeHatchFireButton))
         case .uiTestFeatureFlag:
             Config(source: .disabled)
         case .uiTestExperiment:

--- a/iOS/DuckDuckGo/EscapeHatchModel+Previews.swift
+++ b/iOS/DuckDuckGo/EscapeHatchModel+Previews.swift
@@ -45,7 +45,7 @@ extension EscapeHatchTabsSource where Self == StaticEscapeHatchTabsSource {
 
 extension EscapeHatchModel {
     /// Factory for #Preview / test code: stubs action closures as no-ops so call sites stay readable.
-    static func preview(title: String, subtitle: String, tabType: TabType, domain: String?, targetTab: Tab, tabCount: Int, isActionsEnabled: Bool = true, afterInactivityOption: AfterInactivityOption = .lastUsedTab, keyValueStore: ThrowingKeyValueStoring = UserDefaults.standard) -> EscapeHatchModel {
+    static func preview(title: String, subtitle: String, tabType: TabType, domain: String?, targetTab: Tab, tabCount: Int, isActionsEnabled: Bool = true, isFireButtonEnabled: Bool = false, afterInactivityOption: AfterInactivityOption = .lastUsedTab, keyValueStore: ThrowingKeyValueStoring = UserDefaults.standard) -> EscapeHatchModel {
         EscapeHatchModel(
             title: title,
             subtitle: subtitle,
@@ -54,6 +54,7 @@ extension EscapeHatchModel {
             targetTab: targetTab,
             tabsSource: .staticTabsSource(count: tabCount, includes: targetTab),
             isActionsEnabled: isActionsEnabled,
+            isFireButtonEnabled: isFireButtonEnabled,
             afterInactivityOptionAdapter: AfterInactivityOptionAdapter(
                 initialOption: afterInactivityOption,
                 keyValueStore: keyValueStore

--- a/iOS/DuckDuckGo/EscapeHatchModel.swift
+++ b/iOS/DuckDuckGo/EscapeHatchModel.swift
@@ -74,6 +74,9 @@ final class EscapeHatchModel: ObservableObject {
     let domain: String?
     let targetTab: Tab
     let isActionsEnabled: Bool
+    /// When on, the destructive "delete tab" action is surfaced as a dedicated Fire button on the card
+    /// instead of (and removed from) the three-dots menu. Gated by the `escapeHatchFireButton` feature flag.
+    let isFireButtonEnabled: Bool
     let onCardTap: () -> Void
     let onTabSwitcherTap: () -> Void
     let onCloseTab: () -> Void
@@ -88,6 +91,7 @@ final class EscapeHatchModel: ObservableObject {
          targetTab: Tab,
          tabsSource: some EscapeHatchTabsSource,
          isActionsEnabled: Bool,
+         isFireButtonEnabled: Bool = false,
          afterInactivityOptionAdapter: AfterInactivityOptionAdapter,
          onCardTap: @escaping () -> Void,
          onTabSwitcherTap: @escaping () -> Void,
@@ -101,6 +105,7 @@ final class EscapeHatchModel: ObservableObject {
         self.domain = domain
         self.targetTab = targetTab
         self.isActionsEnabled = isActionsEnabled
+        self.isFireButtonEnabled = isFireButtonEnabled
         self.afterInactivityOptionAdapter = afterInactivityOptionAdapter
         self.onCardTap = onCardTap
         self.onTabSwitcherTap = onTabSwitcherTap
@@ -124,6 +129,7 @@ final class EscapeHatchModel: ObservableObject {
             targetTab: targetTab,
             tabsSource: tabsSource,
             isActionsEnabled: featureFlagger.isFeatureOn(.escapeHatchActions),
+            isFireButtonEnabled: featureFlagger.isFeatureOn(.escapeHatchFireButton),
             afterInactivityOptionAdapter: afterInactivityOptionAdapter,
             onCardTap: { [weak router] in
                 router?.escapeHatchDidRequestSwitch(to: targetTab)

--- a/iOS/DuckDuckGo/ReturnToTabCard.swift
+++ b/iOS/DuckDuckGo/ReturnToTabCard.swift
@@ -27,9 +27,11 @@ struct ReturnToTabCard: View {
 
     @ObservedObject var model: EscapeHatchModel
 
-    /// Frame of the three-dots menu button in the key window's coordinate space.
-    /// Used as the popover anchor when burning a tab on iPad — the FireConfirmationPresenter
-    /// expects window-space coordinates because it attaches the popover to the key window.
+    /// Frames of the Fire button and the three-dots menu button in the key window's coordinate space.
+    /// Used as the popover anchor when burning a tab on iPad — the FireConfirmationPresenter expects
+    /// window-space coordinates because it attaches the popover to the key window. The Fire button is the
+    /// anchor when the Fire-button flag is on; the menu button is the anchor for the legacy in-menu action.
+    @State private var fireButtonFrameInWindow: CGRect = .zero
     @State private var menuFrameInWindow: CGRect = .zero
 
     var body: some View {
@@ -67,7 +69,7 @@ struct ReturnToTabCard: View {
         HStack(spacing: Metrics.innerSpacing) {
             mainView
             if model.isActionsEnabled {
-                menuView
+                actionButtonsView
             }
         }
         .padding(contentPaddingEdges, Metrics.horizontalPadding)
@@ -111,13 +113,49 @@ struct ReturnToTabCard: View {
         .accessibilityIdentifier("NTP.escapeHatch.card")
     }
 
+    /// Trailing controls: when enabled, the Fire (delete tab) button sits to the left of the three-dots menu.
+    private var actionButtonsView: some View {
+        HStack(spacing: 0) {
+            if model.isFireButtonEnabled {
+                fireButton
+            }
+            menuView
+        }
+    }
+
+    /// Deletes the tab directly from the card. Mirrors the old "Delete Tab" menu item:
+    /// fire tabs burn immediately, everything else asks for confirmation (anchored to this button on iPad).
+    private var fireButton: some View {
+        Button(action: deleteTab) {
+            Image(uiImage: DesignSystemImages.Glyphs.Size24.fireTabs)
+                .foregroundColor(Color(designSystemColor: .icons))
+                .padding(.horizontal, Metrics.actionIconPadding)
+                .frame(maxHeight: .infinity)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Text(UserText.escapeHatchMenuDeleteTab))
+        .accessibilityIdentifier("NTP.escapeHatch.fireButton")
+        .onFrameUpdate(in: .global, using: FireButtonFrameInWindowKey.self) { fireButtonFrameInWindow = $0 }
+    }
+
+    private func deleteTab() {
+        if model.isFireTab {
+            model.onBurnTabImmediately()
+        } else {
+            model.onBurnTabWithConfirmation(fireButtonFrameInWindow)
+        }
+    }
+
     private var menuView: some View {
         Menu {
             menuContentView
         } label: {
             Image(uiImage: DesignSystemImages.Glyphs.Size24.menuDotsHorizontal)
                 .foregroundColor(Color(designSystemColor: .icons))
-                .padding(.horizontal, Metrics.horizontalPadding)
+                // Tighten the leading gap to the Fire button when it's present; otherwise keep the original padding.
+                .padding(.leading, model.isFireButtonEnabled ? Metrics.actionIconPadding : Metrics.horizontalPadding)
+                .padding(.trailing, Metrics.horizontalPadding)
                 .frame(maxHeight: .infinity)
                 .contentShape(Rectangle())
         }
@@ -136,12 +174,15 @@ struct ReturnToTabCard: View {
                 action: model.onCardTap
             )
             if model.isFireTab {
-                MenuActionButton(
-                    text: UserText.escapeHatchMenuDeleteTab,
-                    icon: DesignSystemImages.Glyphs.Size16.fire,
-                    role: .destructive,
-                    action: model.onBurnTabImmediately
-                )
+                // When the Fire button is enabled, deleting a fire tab is handled by that button instead.
+                if !model.isFireButtonEnabled {
+                    MenuActionButton(
+                        text: UserText.escapeHatchMenuDeleteTab,
+                        icon: DesignSystemImages.Glyphs.Size16.fire,
+                        role: .destructive,
+                        action: model.onBurnTabImmediately
+                    )
+                }
             } else {
                 MenuActionButton(
                     text: UserText.escapeHatchMenuCloseTab,
@@ -149,12 +190,15 @@ struct ReturnToTabCard: View {
                     role: .destructive,
                     action: model.onCloseTab
                 )
-                MenuActionButton(
-                    text: UserText.escapeHatchMenuDeleteTab,
-                    icon: DesignSystemImages.Glyphs.Size16.fire,
-                    role: .destructive,
-                    action: { model.onBurnTabWithConfirmation(menuFrameInWindow) }
-                )
+                // When the Fire button is enabled, deleting the tab is handled by that button instead.
+                if !model.isFireButtonEnabled {
+                    MenuActionButton(
+                        text: UserText.escapeHatchMenuDeleteTab,
+                        icon: DesignSystemImages.Glyphs.Size16.fire,
+                        role: .destructive,
+                        action: { model.onBurnTabWithConfirmation(menuFrameInWindow) }
+                    )
+                }
             }
             Picker(selection: model.afterInactivityOptionBinding) {
                 ForEach(AfterInactivityOption.allCases, id: \.self) { option in
@@ -292,9 +336,18 @@ private struct MenuFrameInWindowKey: PreferenceKey {
     }
 }
 
+private struct FireButtonFrameInWindowKey: PreferenceKey {
+    static var defaultValue: CGRect = .zero
+    static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
+        value = nextValue()
+    }
+}
+
 private enum Metrics {
     static let height: CGFloat = 56
     static let horizontalPadding: CGFloat = 16
+    /// Padding around the Fire / menu glyphs so the two trailing buttons sit ~16pt apart, matching the design.
+    static let actionIconPadding: CGFloat = 8
     static let innerSpacing: CGFloat = 8
     static let titleToSubtitleSpacing: CGFloat = 0
     static let textRowHeight: CGFloat = 20
@@ -354,6 +407,19 @@ private enum Metrics {
                                     targetTab: target,
                                     tabCount: 9,
                                     afterInactivityOption: .newTab))
+        .padding()
+        .frame(width: 360)
+}
+
+#Preview("Return to tab — Fire button") {
+    let target = Tab(fireTab: false)
+    ReturnToTabCard(model: .preview(title: "Tokamak - Wikipedia",
+                                    subtitle: "en.wikipedia.org/wiki/Tokamak",
+                                    tabType: .regular,
+                                    domain: "en.wikipedia.org",
+                                    targetTab: target,
+                                    tabCount: 9,
+                                    isFireButtonEnabled: true))
         .padding()
         .frame(width: 360)
 }

--- a/iOS/DuckDuckGoTests/EscapeHatchModelTests.swift
+++ b/iOS/DuckDuckGoTests/EscapeHatchModelTests.swift
@@ -20,6 +20,8 @@
 import Foundation
 import CoreGraphics
 import Testing
+import Core
+import PrivacyConfig
 import PersistenceTestingUtils
 @testable import DuckDuckGo
 
@@ -46,7 +48,7 @@ struct EscapeHatchModelTests {
         }
     }
 
-    private func makeSUT(targetTab: Tab, router: EscapeHatchActionRouter) -> EscapeHatchModel {
+    private func makeSUT(targetTab: Tab, router: EscapeHatchActionRouter, featureFlagger: FeatureFlagger = MockFeatureFlagger()) -> EscapeHatchModel {
         EscapeHatchModel(
             title: "title",
             subtitle: "subtitle",
@@ -55,7 +57,7 @@ struct EscapeHatchModelTests {
             targetTab: targetTab,
             tabsSource: StaticEscapeHatchTabsSource(tabs: [targetTab]),
             router: router,
-            featureFlagger: MockFeatureFlagger(),
+            featureFlagger: featureFlagger,
             afterInactivityOptionAdapter: AfterInactivityOptionAdapter(
                 initialOption: .lastUsedTab,
                 keyValueStore: MockKeyValueFileStore()
@@ -104,5 +106,26 @@ struct EscapeHatchModelTests {
         #expect(router.closeCalls.count == 1)
         #expect(router.closeCalls.first === targetTab)
         #expect(router.burnImmediatelyCalls.isEmpty)
+    }
+
+    @available(iOS 16, *)
+    @Test("isFireButtonEnabled is false when the escapeHatchFireButton flag is off", .timeLimit(.minutes(1)))
+    func fireButtonDisabledWhenFlagOff() {
+        let sut = makeSUT(targetTab: Tab(uid: "tab"),
+                          router: SpyRouter(),
+                          featureFlagger: MockFeatureFlagger())
+
+        #expect(sut.isFireButtonEnabled == false)
+    }
+
+    @available(iOS 16, *)
+    @Test("isFireButtonEnabled is true when the escapeHatchFireButton flag is on", .timeLimit(.minutes(1)))
+    func fireButtonEnabledWhenFlagOn() {
+        let flagger = MockFeatureFlagger(featuresStub: [FeatureFlag.escapeHatchFireButton.rawValue: true])
+        let sut = makeSUT(targetTab: Tab(uid: "tab"),
+                          router: SpyRouter(),
+                          featureFlagger: flagger)
+
+        #expect(sut.isFireButtonEnabled == true)
     }
 }

--- a/iOS/DuckDuckGoTests/EscapeHatchModelTests.swift
+++ b/iOS/DuckDuckGoTests/EscapeHatchModelTests.swift
@@ -121,7 +121,7 @@ struct EscapeHatchModelTests {
     @available(iOS 16, *)
     @Test("isFireButtonEnabled is true when the escapeHatchFireButton flag is on", .timeLimit(.minutes(1)))
     func fireButtonEnabledWhenFlagOn() {
-        let flagger = MockFeatureFlagger(featuresStub: [FeatureFlag.escapeHatchFireButton.rawValue: true])
+        let flagger = MockFeatureFlagger(enabledFeatureFlags: [.escapeHatchFireButton])
         let sut = makeSUT(targetTab: Tab(uid: "tab"),
                           router: SpyRouter(),
                           featureFlagger: flagger)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211654189969294/task/1215358250572341?focus=true
Tech Design URL:
CC:

### Description

Adds a dedicated **Fire button** to the escape-hatch "Return to…" card, to the left of the three-dots menu, matching the [Figma design](https://www.figma.com/design/QUTLfN2oPR6ivG1Jwsw3Mg/?node-id=13257-116406). The button performs the existing "delete tab” action. The "Delete Tab" item is removed from the menu so the action lives in a single, more discoverable place.

All of this is gated behind a new `escapeHatchFireButton` feature flag

### Testing Steps
1. Go to general settings select NTP after idle with idle time none
2. Open a site, then open a new tab so the "Return to…" card appears on the NTP.
3. Confirm a 🔥 **Fire** glyph appears to the left of the ⋯ menu on the card.
4. Tap the Fire button on a **regular tab** → confirmation flow appears (on iPad, the popover is anchored to the Fire button).
5. Tap the Fire button on a **Fire tab** → the tab burns immediately (no confirmation).
6. Open the ⋯ menu → "Delete Tab" is **no longer present**; "Return to Tab", "Close Tab" (non-fire tabs only) and the after-inactivity picker remain.
7. Disable the `escapeHatchFireButton` flag → the Fire button disappears and "Delete Tab" returns to the menu (control behaviour).
8. Test on NTP with and without favorite, focussed state on both side (search and chat with and without favorites/chat suggestions), test with unified input mode on.

### Impact and Risks

**Low** — UI-only change on an existing, flagged surface. The destructive action wiring is unchanged (same `onBurnTabImmediately` / `onBurnTabWithConfirmation` closures); only its entry point moves from the menu to a button.

#### What could go wrong?
- The iPad burn-confirmation popover could mis-anchor. Mitigated by tracking the Fire button's window frame and passing it to the existing `FireConfirmationPresenter`; the legacy menu-anchored path is preserved for the flag-off case.
- A fire tab could be left with no destructive action if the button failed to render. Mitigated by gating both the button and the menu-item removal on the same flag, so exactly one delete affordance is always present.

### Quality Considerations
- Flag-off path is unchanged (conditional menu padding + retained menu-frame anchor), so existing behaviour is preserved for staged rollout / rollback.
- Added unit tests covering the `escapeHatchFireButton` flag wiring on `EscapeHatchModel`, and a SwiftUI preview exercising the Fire-button layout.

### Notes to Reviewer
- The long-press context menu shares `menuContentView`, so when the flag is on, "Delete Tab" is removed there too (consistent with moving the action to the Fire button).
- No new asset is committed — the provided `Fire-Tabs-24.svg` matches the existing `fireTabs` design-system glyph (only sub-pixel export rounding differed), so the change reuses the shipped asset rather than drifting from the Figma-synced source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Low Risk**
> UI-only, feature-flagged change on the escape-hatch card; burn/close routing reuses existing model closures with an updated iPad popover anchor when the flag is on.
> 
> **Overview**
> Introduces remote-releasable **`escapeHatchFireButton`** (default **on**) and threads **`isFireButtonEnabled`** through **`EscapeHatchModel`** from the feature flagger.
> 
> When the flag is on, **`ReturnToTabCard`** shows a dedicated **Fire** control beside the ⋯ menu for the existing delete-tab flow (immediate burn for fire tabs, confirmation anchored to the Fire button on iPad for others). **Delete Tab** is omitted from the menu and shared context menu; when the flag is off, layout and menu behavior stay as before.
> 
> Adds unit tests for flag wiring and a SwiftUI preview for the Fire-button layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51356a8569aea4ff746942cd469862270ffc197f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only, feature-flagged change on the escape-hatch card; destructive actions still use the same model closures, with an updated iPad popover anchor when the flag is on.
> 
> **Overview**
> Adds remote-releasable **`escapeHatchFireButton`** (default **on**) and exposes **`isFireButtonEnabled`** on **`EscapeHatchModel`** from the feature flagger.
> 
> When the flag is on, **`ReturnToTabCard`** shows a dedicated **Fire** control beside the ⋯ menu for the existing delete-tab flow (immediate burn for fire tabs; confirmation for others, with iPad popover anchored to the Fire button). **Delete Tab** is omitted from the ⋯ menu and the shared context menu; with the flag off, behavior and menu anchoring stay unchanged.
> 
> Adds unit tests for flag wiring and a SwiftUI preview for the Fire-button layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84b05a3b5346dab89053df6d7566cc7e9a6ac87d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->