### PR TITLE
Use PR merge base for localization checks

### DIFF
--- a/scripts/translation-pr-checks/localization_utils.py
+++ b/scripts/translation-pr-checks/localization_utils.py
@@ -10,7 +10,6 @@ Copyright © 2025 DuckDuckGo. All rights reserved.
 Licensed under the Apache License, Version 2.0
 """
 
-import json
 import os
 import plistlib
 import re
@@ -23,18 +22,37 @@ from typing import Dict, FrozenSet, List, Optional, Set
 
 _base_branch_cache: Optional[str] = None
 
+
+def get_merge_base(base_ref: str) -> Optional[str]:
+    """Get the merge base for HEAD and the base branch."""
+    try:
+        result = subprocess.run(
+            ['git', 'merge-base', base_ref, 'HEAD'],
+            capture_output=True, text=True, check=False
+        )
+    except Exception:
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    merge_base = result.stdout.strip()
+    return merge_base if merge_base else None
+
+
 def get_base_branch() -> str:
-    """Get the base branch for comparison (usually main or the PR base)."""
+    """Get the merge-base revision for comparison."""
     global _base_branch_cache
     if _base_branch_cache is not None:
         return _base_branch_cache
 
     base_ref = os.environ.get('GITHUB_BASE_REF')
     if base_ref:
-        _base_branch_cache = f"origin/{base_ref}"
+        base = f"origin/{base_ref}"
     else:
-        _base_branch_cache = "origin/main"
+        base = "origin/main"
 
+    _base_branch_cache = get_merge_base(base) or base
     return _base_branch_cache
 
 def get_files_content_at_base(file_paths: List[str]) -> Dict[str, str]:
@@ -202,4 +220,3 @@ def get_search_paths(platform: str) -> List[str]:
         return ["macOS", "SharedPackages"]
     else:
         return [platform]
-


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1215162688786291?focus=true
Tech Design URL: N/A
CC: N/A

### Description

- Updates the localization PR-check helpers to compare changed files and base file contents against the merge base of `HEAD` and the PR base branch.
- Keeps the existing `origin/<base ref>` fallback if a merge base cannot be resolved.
- Prevents localization marker issues outside the PR diff from being attributed to the PR.
- This specifically addresses the stale marker-mismatch comment seen on #5251, where the reported `Localizable.strings` file was not part of the PR diff.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. This is an edge case that depends on PR/base-branch timing, so it is hard to reproduce consistently with a local command. It can happen when a PR branch is created from `main`, `main` later advances with localization changes, and the localization helper compares the PR against the moving `origin/main` tip instead of the PR branch's merge base.
2. In #5251, that made the marker check attribute an existing German `Localizable.strings` issue to the PR, even though `Localizable.strings` was not in #5251's changed files.

### Impact and Risks

None / Low: CI-only localization tooling. This changes only which base revision the existing translation checks compare against during PR runs.

#### What could go wrong?

If the merge base cannot be resolved, the helper falls back to the existing `origin/<base ref>` behavior. The main risk is therefore unchanged behavior in unusual checkout states, not app runtime impact.

### Quality Considerations

- `GITHUB_BASE_REF` gives the base branch name, which is useful for choosing the branch but not sufficient as a fixed diff endpoint.
- Resolving `git merge-base origin/<base ref> HEAD` gives the same comparison base as a three-dot PR-style diff, avoiding false positives from files outside the PR diff.
- This mirrors the approach used by the existing merge conflict checker (`conflict-watch`), which also compares against the PR branch's merge base to avoid moving-base false positives.
- The original #5251 marker comment was stale/noisy rather than backed by the current PR diff: #5251's changed files did not include `Localizable.strings`, and later checks for its current head were green. The bug is still valid because the workflow could attribute unrelated localization changes to the PR before this fix.

### Notes to Reviewer

This follows up on a stale localization marker comment on #5251 after #5165/#5199 landed. The check result was real for an existing German string, but the PR attribution was wrong because the helper compared against the base branch tip instead of the PR branch's merge base.

--- 
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to which git revision is used for comparisons; fallback preserves prior behavior when merge-base cannot be resolved.
> 
> **Overview**
> Localization PR-check helpers now resolve **`git merge-base`** between `HEAD` and `origin/<base>` (from `GITHUB_BASE_REF`, else `origin/main`) and use that commit for **`get_changed_files`** and **`get_files_content_at_base`**, instead of diffing against the moving base-branch tip.
> 
> That aligns checks with a three-dot PR diff so marker/translation failures on files **outside** the PR's changes are not blamed on the PR. If merge-base lookup fails, behavior stays the same as before by falling back to `origin/<base>`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 993f0164baf3fcb42fc0a6efc930db2cf3549021. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
