### PR TITLE
iOS: Keep iPad Duck.ai contextual-sheet button visible on NTP and Duck.ai

### DIFF
--- a/iOS/DuckDuckGo/DuckAIChromeChipView.swift
+++ b/iOS/DuckDuckGo/DuckAIChromeChipView.swift
@@ -22,8 +22,7 @@ import DesignResourcesKitIcons
 import DesignResourcesKit
 
 /// iPad Duck.ai chrome split-button. Left half opens a new Duck.ai tab (text);
-/// right half toggles the current tab's contextual sheet (icon). On Duck.ai
-/// pages the icon half (and divider) collapse, leaving the text-only chip.
+/// right half toggles the current tab's contextual sheet (icon).
 final class DuckAIChromeChipView: UIView {
 
     enum SheetState {
@@ -147,7 +146,7 @@ final class DuckAIChromeChipView: UIView {
         iconButton.accessibilityTraits = state == .open ? [.button, .selected] : [.button]
     }
 
-    /// Hides only the icon half + divider when the current tab is Duck.ai. The text half stays.
+    /// Shows or hides the icon half (contextual-sheet toggle) and its divider.
     func setIconVisible(_ visible: Bool) {
         iconContainer.isHidden = !visible
     }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -951,7 +951,7 @@ class MainViewController: UIViewController {
         bindAIChatChromeChipToCurrentTab()
     }
 
-    /// Rebinds chip subscriptions to the current tab's URL + contextual sheet publishers.
+    /// Rebinds the chip's contextual-sheet subscription to the current tab.
     /// Called whenever the active tab changes (transitionTo) or the tabs bar is created.
     func bindAIChatChromeChipToCurrentTab() {
         aiChatChromeChipCancellables.removeAll()
@@ -960,11 +960,6 @@ class MainViewController: UIViewController {
             refreshAIChatChromeChip()
             return
         }
-
-        currentTab.urlPublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in self?.refreshAIChatChromeChip() }
-            .store(in: &aiChatChromeChipCancellables)
 
         currentTab.aiChatContextualSheetCoordinator.$isSheetPresented
             .receive(on: DispatchQueue.main)
@@ -976,16 +971,8 @@ class MainViewController: UIViewController {
 
     private func refreshAIChatChromeChip() {
         guard let tabsBarController else { return }
-        // Read from the Tab model (always available); the VC may not be instantiated yet.
-        let currentTabModel = tabManager.currentTabsModel.currentTab
-        let isAIChat = currentTabModel?.isAITab ?? false
-        let isHome = currentTabModel?.isHomeTab ?? false
         let isSheetPresented = currentTab?.aiChatContextualSheetCoordinator.isSheetPresented ?? false
-        tabsBarController.updateAIChatChipState(
-            isCurrentTabAIChat: isAIChat,
-            isCurrentTabHome: isHome,
-            isContextualSheetPresented: isSheetPresented
-        )
+        tabsBarController.updateAIChatChipState(isContextualSheetPresented: isSheetPresented)
     }
 
     func startAddFavoriteFlow() {

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -227,13 +227,9 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
     }
 
     /// Pushes per-tab state into the chip. Called by `MainViewController` when the
-    /// current tab changes, its URL changes (Duck.ai vs not), or its contextual sheet
-    /// is presented/dismissed.
-    func updateAIChatChipState(isCurrentTabAIChat: Bool, isCurrentTabHome: Bool, isContextualSheetPresented: Bool) {
+    /// current tab changes or its contextual sheet is presented/dismissed.
+    func updateAIChatChipState(isContextualSheetPresented: Bool) {
         aiChatChip.setSheetState(isContextualSheetPresented ? .open : .closed)
-        // The icon half toggles the page-context sheet; hide it where there's no page to attach
-        // — Duck.ai tabs and the New Tab Page.
-        aiChatChip.setIconVisible(!isCurrentTabAIChat && !isCurrentTabHome)
     }
 
     @IBAction func onFireButtonPressed() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215366761782874

### Description

Stops hiding the contextual-sheet (icon) half of the iPad tabs-bar Duck.ai chip on Duck.ai tabs and the New Tab Page, where it used to collapse and resize the pill as you navigated. `updateAIChatChipState` now only carries the sheet open/closed state.

### Testing Steps
1. iPad (sim or device), internal user, `aiChatChromeShortcutIPad` on.
2. On a web page, confirm the chip shows both halves.
3. Switch to a Duck.ai tab and the New Tab Page — the icon half stays visible (it previously disappeared).

### Impact and Risks
Low. iPad-only, behind an internal-only flag; iPhone unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> iPad-only UI wiring behind the existing internal flag; no auth, data, or iPhone behavior changes.
> 
> **Overview**
> The iPad tabs-bar **Duck.ai split chip** no longer collapses to text-only on Duck.ai tabs or the New Tab Page. **`TabsBarViewController.updateAIChatChipState`** now only updates open/closed sheet styling via **`setSheetState`**; it no longer calls **`setIconVisible`** based on tab type.
> 
> **`MainViewController`** drops the current-tab **`urlPublisher`** subscription and **`isAITab` / `isHomeTab`** checks from **`refreshAIChatChromeChip`**, so chip refresh runs when the active tab changes or the contextual sheet is presented/dismissed. Comments on **`DuckAIChromeChipView`** are updated to match the always-visible icon half.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 445fbc2d1d99448116d061e0c531552f06762318. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->