### PR TITLE
iOS: Rename iPad Duck.ai shortcut "Navigation Bar" to "Tab Bar"

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/iOS/PublicAPI/AIChatSettingsProvider.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/iOS/PublicAPI/AIChatSettingsProvider.swift
@@ -58,7 +58,7 @@ public protocol AIChatSettingsProvider {
     var isAIChatTabSwitcherUserSettingsEnabled: Bool { get }
 
     /// The user settings state for the Duck.ai shortcut in the iPad browser chrome (tabs bar).
-    var isAIChatNavigationBarUserSettingsEnabled: Bool { get }
+    var isAIChatTabBarUserSettingsEnabled: Bool { get }
 
     /// The user settings state for automatically attaching page context
     var isAutomaticContextAttachmentEnabled: Bool { get }
@@ -82,7 +82,7 @@ public protocol AIChatSettingsProvider {
     func enableAIChatTabSwitcherUserSettings(enable: Bool)
 
     /// Updates the user settings state for the Duck.ai shortcut in the iPad browser chrome.
-    func enableAIChatNavigationBarUserSettings(enable: Bool)
+    func enableAIChatTabBarUserSettings(enable: Bool)
 
     /// Updates the user settings state for the AI Chat Search Input
     func enableAIChatSearchInputUserSettings(enable: Bool)

--- a/SharedPackages/SERPSettings/Tests/SERPSettingsTests/Mocks/MockSERPSettingsProvider.swift
+++ b/SharedPackages/SERPSettings/Tests/SERPSettingsTests/Mocks/MockSERPSettingsProvider.swift
@@ -88,7 +88,7 @@ final class MockAIChatSettingsProvider: AIChatSettingsProvider {
     var isAIChatBrowsingMenuUserSettingsEnabled: Bool = false
     var isAIChatVoiceSearchUserSettingsEnabled: Bool = false
     var isAIChatTabSwitcherUserSettingsEnabled: Bool = false
-    var isAIChatNavigationBarUserSettingsEnabled: Bool = false
+    var isAIChatTabBarUserSettingsEnabled: Bool = false
     var isAIChatFullModeEnabled: Bool = false
     var isAutomaticContextAttachmentEnabled: Bool = false
     var isChatSuggestionsEnabled: Bool = true
@@ -101,7 +101,7 @@ final class MockAIChatSettingsProvider: AIChatSettingsProvider {
     func enableAIChatAddressBarUserSettings(enable: Bool) {}
     func enableAIChatVoiceSearchUserSettings(enable: Bool) {}
     func enableAIChatTabSwitcherUserSettings(enable: Bool) {}
-    func enableAIChatNavigationBarUserSettings(enable: Bool) {}
+    func enableAIChatTabBarUserSettings(enable: Bool) {}
     func enableAIChatSearchInputUserSettings(enable: Bool) {}
     func enableAIChatFullModeSetting(enable: Bool) {}
     func enableAutomaticContextAttachment(enable: Bool) {}

--- a/iOS/DuckDuckGo/AIChat/AIChatAddressBarExperience.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatAddressBarExperience.swift
@@ -76,7 +76,7 @@ struct AIChatAddressBarExperience: AIChatAddressBarExperienceProviding {
         if isIPadChromeShortcutInPlay {
             return DuckAIChromeShortcutVisibility.isAddressBarButtonVisibleOnIPad(
                 isLargeWidth: largeWidthProvider.isLargeWidth,
-                isAIChatNavigationBarUserSettingsEnabled: aiChatSettings.isAIChatNavigationBarUserSettingsEnabled
+                isAIChatTabBarUserSettingsEnabled: aiChatSettings.isAIChatTabBarUserSettingsEnabled
             )
         }
         return aiChatSettings.isAIChatAddressBarUserSettingsEnabled

--- a/iOS/DuckDuckGo/AIChat/AIChatSettings.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatSettings.swift
@@ -71,15 +71,15 @@ final class AIChatSettings: AIChatSettingsProvider {
     }
 
     /// One-shot: if a user had the legacy Address Bar toggle off, carry that into the
-    /// Navigation Bar toggle so the iPad chrome shortcut doesn't silently re-enable
+    /// Tab Bar toggle so the iPad chrome shortcut doesn't silently re-enable
     /// the surface under a new name.
     private func migrateAddressBarSettingIfNeeded() {
-        guard keyValueStore.object(forKey: .showAIChatNavigationBarKey) == nil,
+        guard keyValueStore.object(forKey: .showAIChatTabBarKey) == nil,
               let legacyAddressBarValue = keyValueStore.object(forKey: .showAIChatAddressBarKey) as? Bool,
               legacyAddressBarValue == false else {
             return
         }
-        keyValueStore.set(false, forKey: .showAIChatNavigationBarKey)
+        keyValueStore.set(false, forKey: .showAIChatTabBarKey)
     }
 
     // MARK: - Public
@@ -136,8 +136,8 @@ final class AIChatSettings: AIChatSettingsProvider {
             && isAIChatEnabled
     }
 
-    var isAIChatNavigationBarUserSettingsEnabled: Bool {
-        keyValueStore.bool(.showAIChatNavigationBarKey, defaultValue: .showAIChatNavigationBarDefaultValue)
+    var isAIChatTabBarUserSettingsEnabled: Bool {
+        keyValueStore.bool(.showAIChatTabBarKey, defaultValue: .showAIChatTabBarDefaultValue)
             && isAIChatEnabled
     }
 
@@ -255,8 +255,8 @@ final class AIChatSettings: AIChatSettingsProvider {
         }
     }
 
-    func enableAIChatNavigationBarUserSettings(enable: Bool) {
-        keyValueStore.set(enable, forKey: .showAIChatNavigationBarKey)
+    func enableAIChatTabBarUserSettings(enable: Bool) {
+        keyValueStore.set(enable, forKey: .showAIChatTabBarKey)
         triggerSettingsChangedNotification()
     }
 
@@ -329,7 +329,7 @@ private extension String {
     static let showAIChatAddressBarKey = "aichat.settings.showAIChatAddressBar"
     static let showAIChatVoiceSearchKey = "aichat.settings.showAIChatVoiceSearch"
     static let showAIChatTabSwitcherKey = "aichat.settings.showAIChatTabSwitcher"
-    static let showAIChatNavigationBarKey = "aichat.settings.showAIChatNavigationBar"
+    static let showAIChatTabBarKey = "aichat.settings.showAIChatTabBar"
     static let showAIChatExperimentalSearchInputKey = "aichat.settings.showAIChatExperimentalSearchInput"
     static let showChatSuggestionsKey = "aichat.settings.showChatSuggestions"
     static let isAIChatAutomaticContextAttachmentEnabledKey = "aichat.settings.isAIChatAutomaticContextAttachmentEnabled"
@@ -343,7 +343,7 @@ enum LegacyAiChatUserDefaultsKeys {
     static let showAIChatAddressBarKey: String = .showAIChatAddressBarKey
     static let showAIChatVoiceSearchKey: String = .showAIChatVoiceSearchKey
     static let showAIChatTabSwitcherKey: String = .showAIChatTabSwitcherKey
-    static let showAIChatNavigationBarKey: String = .showAIChatNavigationBarKey
+    static let showAIChatTabBarKey: String = .showAIChatTabBarKey
     static let showAIChatExperimentalSearchInputKey: String = .showAIChatExperimentalSearchInputKey
     static let defaultOmnibarModeKey: String = .defaultOmnibarModeKey
 
@@ -358,7 +358,7 @@ private extension Bool {
     static let showAIChatAddressBarDefaultValue = true
     static let showAIChatVoiceSearchDefaultValue = true
     static let showAIChatTabSwitcherDefaultValue = true
-    static let showAIChatNavigationBarDefaultValue = true
+    static let showAIChatTabBarDefaultValue = true
     static let showAIChatExperimentalSearchInputDefaultValue = false
     static let showChatSuggestionsDefaultValue = true
 

--- a/iOS/DuckDuckGo/DuckAIChromeChipView.swift
+++ b/iOS/DuckDuckGo/DuckAIChromeChipView.swift
@@ -22,8 +22,7 @@ import DesignResourcesKitIcons
 import DesignResourcesKit
 
 /// iPad Duck.ai chrome split-button. Left half opens a new Duck.ai tab (text);
-/// right half toggles the current tab's contextual sheet (icon). On Duck.ai
-/// pages the icon half (and divider) collapse, leaving the text-only chip.
+/// right half toggles the current tab's contextual sheet (icon).
 final class DuckAIChromeChipView: UIView {
 
     enum SheetState {
@@ -147,7 +146,7 @@ final class DuckAIChromeChipView: UIView {
         iconButton.accessibilityTraits = state == .open ? [.button, .selected] : [.button]
     }
 
-    /// Hides only the icon half + divider when the current tab is Duck.ai. The text half stays.
+    /// Shows or hides the icon half (contextual-sheet toggle) and its divider.
     func setIconVisible(_ visible: Bool) {
         iconContainer.isHidden = !visible
     }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -951,7 +951,7 @@ class MainViewController: UIViewController {
         bindAIChatChromeChipToCurrentTab()
     }
 
-    /// Rebinds chip subscriptions to the current tab's URL + contextual sheet publishers.
+    /// Rebinds the chip's contextual-sheet subscription to the current tab.
     /// Called whenever the active tab changes (transitionTo) or the tabs bar is created.
     func bindAIChatChromeChipToCurrentTab() {
         aiChatChromeChipCancellables.removeAll()
@@ -960,11 +960,6 @@ class MainViewController: UIViewController {
             refreshAIChatChromeChip()
             return
         }
-
-        currentTab.urlPublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in self?.refreshAIChatChromeChip() }
-            .store(in: &aiChatChromeChipCancellables)
 
         currentTab.aiChatContextualSheetCoordinator.$isSheetPresented
             .receive(on: DispatchQueue.main)
@@ -976,16 +971,8 @@ class MainViewController: UIViewController {
 
     private func refreshAIChatChromeChip() {
         guard let tabsBarController else { return }
-        // Read from the Tab model (always available); the VC may not be instantiated yet.
-        let currentTabModel = tabManager.currentTabsModel.currentTab
-        let isAIChat = currentTabModel?.isAITab ?? false
-        let isHome = currentTabModel?.isHomeTab ?? false
         let isSheetPresented = currentTab?.aiChatContextualSheetCoordinator.isSheetPresented ?? false
-        tabsBarController.updateAIChatChipState(
-            isCurrentTabAIChat: isAIChat,
-            isCurrentTabHome: isHome,
-            isContextualSheetPresented: isSheetPresented
-        )
+        tabsBarController.updateAIChatChipState(isContextualSheetPresented: isSheetPresented)
     }
 
     func startAddFavoriteFlow() {

--- a/iOS/DuckDuckGo/SettingsAIChatShortcutsView.swift
+++ b/iOS/DuckDuckGo/SettingsAIChatShortcutsView.swift
@@ -36,7 +36,7 @@ enum DuckAIChromeShortcutVisibility {
         isIPad && featureFlagger.isFeatureOn(.aiChatChromeShortcutIPad)
     }
 
-    /// Address Bar settings row hides whenever the Navigation Bar row is shown — they describe the same surface.
+    /// Address Bar settings row hides whenever the Tab Bar row is shown — they describe the same surface.
     static func isAddressBarRowVisible(isIPad: Bool, featureFlagger: FeatureFlagger) -> Bool {
         !isSettingsRowVisible(isIPad: isIPad, featureFlagger: featureFlagger)
     }
@@ -44,19 +44,19 @@ enum DuckAIChromeShortcutVisibility {
     /// No `isIPad` parameter — the only caller (`TabsBarViewController`) is iPad-only by construction.
     static func isChromeButtonVisible(
         featureFlagger: FeatureFlagger,
-        isAIChatNavigationBarUserSettingsEnabled: Bool
+        isAIChatTabBarUserSettingsEnabled: Bool
     ) -> Bool {
         featureFlagger.isFeatureOn(.aiChatChromeShortcutIPad)
-            && isAIChatNavigationBarUserSettingsEnabled
+            && isAIChatTabBarUserSettingsEnabled
     }
 
     /// On iPad with the chrome shortcut in play, the in-address-bar Duck.ai icon only
     /// shows at narrow widths where the tabs bar (and chrome pill) is hidden.
     static func isAddressBarButtonVisibleOnIPad(
         isLargeWidth: Bool,
-        isAIChatNavigationBarUserSettingsEnabled: Bool
+        isAIChatTabBarUserSettingsEnabled: Bool
     ) -> Bool {
-        !isLargeWidth && isAIChatNavigationBarUserSettingsEnabled
+        !isLargeWidth && isAIChatTabBarUserSettingsEnabled
     }
 }
 
@@ -74,10 +74,10 @@ struct SettingsAIChatShortcutsView: View {
                                      accessory: .toggle(isOn: viewModel.aiChatAddressBarEnabledBinding))
                 }
 
-                if shouldShowNavigationBarShortcut {
-                    SettingsCellView(label: UserText.aiChatSettingsEnableNavigationBarToggle,
-                                     subtitle: UserText.aiChatSettingsEnableNavigationBarSubtitle,
-                                     accessory: .toggle(isOn: viewModel.aiChatNavigationBarEnabledBinding))
+                if shouldShowTabBarShortcut {
+                    SettingsCellView(label: UserText.aiChatSettingsEnableTabBarToggle,
+                                     subtitle: UserText.aiChatSettingsEnableTabBarSubtitle,
+                                     accessory: .toggle(isOn: viewModel.aiChatTabBarEnabledBinding))
                 }
 
                 if viewModel.state.voiceSearchEnabled {
@@ -160,7 +160,7 @@ struct SettingsAIChatShortcutsView: View {
         )
     }
 
-    private var shouldShowNavigationBarShortcut: Bool {
+    private var shouldShowTabBarShortcut: Bool {
         DuckAIChromeShortcutVisibility.isSettingsRowVisible(
             isIPad: UIDevice.current.userInterfaceIdiom == .pad,
             featureFlagger: viewModel.featureFlagger

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -1874,11 +1874,11 @@ extension SettingsViewModel {
         )
     }
 
-    var aiChatNavigationBarEnabledBinding: Binding<Bool> {
+    var aiChatTabBarEnabledBinding: Binding<Bool> {
         Binding<Bool>(
-            get: { self.aiChatSettings.isAIChatNavigationBarUserSettingsEnabled },
+            get: { self.aiChatSettings.isAIChatTabBarUserSettingsEnabled },
             set: { newValue in
-                self.aiChatSettings.enableAIChatNavigationBarUserSettings(enable: newValue)
+                self.aiChatSettings.enableAIChatTabBarUserSettings(enable: newValue)
                 DailyPixel.fireDailyAndCount(pixel: newValue ? .aiChatSettingsNavigationBarTurnedOn : .aiChatSettingsNavigationBarTurnedOff)
             }
         )

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -218,7 +218,7 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
         if let featureFlagger, let aiChatSettings {
             isVisible = DuckAIChromeShortcutVisibility.isChromeButtonVisible(
                 featureFlagger: featureFlagger,
-                isAIChatNavigationBarUserSettingsEnabled: aiChatSettings.isAIChatNavigationBarUserSettingsEnabled
+                isAIChatTabBarUserSettingsEnabled: aiChatSettings.isAIChatTabBarUserSettingsEnabled
             )
         } else {
             isVisible = false
@@ -463,7 +463,7 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
                 completion([
                     UIAction(title: UserText.actionHideAIChatChromeShortcut) { [weak self] _ in
                         DailyPixel.fireDailyAndCount(pixel: .aiChatNavigationBarShortcutMenuHideTapped)
-                        self?.aiChatSettings?.enableAIChatNavigationBarUserSettings(enable: false)
+                        self?.aiChatSettings?.enableAIChatTabBarUserSettings(enable: false)
                     },
                     UIAction(title: UserText.actionOpenAISettings) { [weak self] _ in
                         guard let self else { return }

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -227,13 +227,9 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
     }
 
     /// Pushes per-tab state into the chip. Called by `MainViewController` when the
-    /// current tab changes, its URL changes (Duck.ai vs not), or its contextual sheet
-    /// is presented/dismissed.
-    func updateAIChatChipState(isCurrentTabAIChat: Bool, isCurrentTabHome: Bool, isContextualSheetPresented: Bool) {
+    /// current tab changes or its contextual sheet is presented/dismissed.
+    func updateAIChatChipState(isContextualSheetPresented: Bool) {
         aiChatChip.setSheetState(isContextualSheetPresented ? .open : .closed)
-        // The icon half toggles the page-context sheet; hide it where there's no page to attach
-        // — Duck.ai tabs and the New Tab Page.
-        aiChatChip.setIconVisible(!isCurrentTabAIChat && !isCurrentTabHome)
     }
 
     @IBAction func onFireButtonPressed() {

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -2255,10 +2255,10 @@ public struct UserText {
     public static let aiChatSettingsEnableTabSwitcherToggle = NSLocalizedString("duckai.settings.enable.tab-switcher-toggle", value: "Tabs Screen", comment: "Toggle text to enable/disable Duck.ai in tab manager")
 
     // Held as NotLocalizedString until copy is approved at Ship Review; convert to NSLocalizedString afterwards.
-    public static let aiChatSettingsEnableNavigationBarToggle = NotLocalizedString("duckai.settings.enable.navigation-bar-toggle", value: "Navigation Bar", comment: "Toggle text to enable/disable Duck.ai shortcut in the iPad browser chrome (tabs bar)")
+    public static let aiChatSettingsEnableTabBarToggle = NotLocalizedString("duckai.settings.enable.tab-bar-toggle", value: "Tab Bar", comment: "Toggle text to enable/disable Duck.ai shortcut in the iPad browser chrome (tabs bar)")
 
     // Held as NotLocalizedString until copy is approved at Ship Review; convert to NSLocalizedString afterwards.
-    public static let aiChatSettingsEnableNavigationBarSubtitle = NotLocalizedString("duckai.settings.enable.navigation-bar-subtitle", value: "Show in the browser navigation bar or address bar, depending on window size.", comment: "Subtitle for the Navigation Bar toggle row in Manage Duck.ai Shortcuts settings")
+    public static let aiChatSettingsEnableTabBarSubtitle = NotLocalizedString("duckai.settings.enable.tab-bar-subtitle", value: "Show in the browser tab bar or address bar, depending on window size.", comment: "Subtitle for the Tab Bar toggle row in Manage Duck.ai Shortcuts settings")
     
     public static let aiChatSettingsBrowserShortcutsSectionTitle = NSLocalizedString("duckai.settings.browserShortcuts.section.title", value: "Browser shortcuts", comment: "Title for section that groups shortcuts related to browser")
 

--- a/iOS/DuckDuckGoTests/AIChat/AIChatAddressBarExperienceTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatAddressBarExperienceTests.swift
@@ -158,7 +158,7 @@ final class AIChatAddressBarExperienceTests: XCTestCase {
     func testWhenIPadAndChromeShortcutOnAndLargeWidthThenAddressBarButtonHidden() {
         MockUIDevice.mockUserInterfaceIdiom = .pad
         let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.aiChatChromeShortcutIPad])
-        let aiChatSettings = MockAIChatSettingsProvider(isAIChatNavigationBarUserSettingsEnabled: true)
+        let aiChatSettings = MockAIChatSettingsProvider(isAIChatTabBarUserSettingsEnabled: true)
         let testee = AIChatAddressBarExperience(featureFlagger: featureFlagger,
                                                 aiChatSettings: aiChatSettings,
                                                 largeWidthProvider: MockLargeWidthProvider(isLargeWidth: true))
@@ -169,7 +169,7 @@ final class AIChatAddressBarExperienceTests: XCTestCase {
     func testWhenIPadAndChromeShortcutOnAndNarrowWidthThenAddressBarButtonShown() {
         MockUIDevice.mockUserInterfaceIdiom = .pad
         let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.aiChatChromeShortcutIPad])
-        let aiChatSettings = MockAIChatSettingsProvider(isAIChatNavigationBarUserSettingsEnabled: true)
+        let aiChatSettings = MockAIChatSettingsProvider(isAIChatTabBarUserSettingsEnabled: true)
         let testee = AIChatAddressBarExperience(featureFlagger: featureFlagger,
                                                 aiChatSettings: aiChatSettings,
                                                 largeWidthProvider: MockLargeWidthProvider(isLargeWidth: false))
@@ -177,10 +177,10 @@ final class AIChatAddressBarExperienceTests: XCTestCase {
         XCTAssertTrue(testee.shouldShowDuckAIAddressBarButton)
     }
 
-    func testWhenIPadAndChromeShortcutOnAndNavigationBarOffThenAddressBarButtonHiddenAtAnyWidth() {
+    func testWhenIPadAndChromeShortcutOnAndTabBarOffThenAddressBarButtonHiddenAtAnyWidth() {
         MockUIDevice.mockUserInterfaceIdiom = .pad
         let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.aiChatChromeShortcutIPad])
-        let aiChatSettings = MockAIChatSettingsProvider(isAIChatNavigationBarUserSettingsEnabled: false)
+        let aiChatSettings = MockAIChatSettingsProvider(isAIChatTabBarUserSettingsEnabled: false)
 
         let large = AIChatAddressBarExperience(featureFlagger: featureFlagger,
                                                aiChatSettings: aiChatSettings,
@@ -198,7 +198,7 @@ final class AIChatAddressBarExperienceTests: XCTestCase {
         MockUIDevice.mockUserInterfaceIdiom = .pad
         let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.aiChatChromeShortcutIPad])
         let aiChatSettings = MockAIChatSettingsProvider(isAIChatAddressBarUserSettingsEnabled: true,
-                                                        isAIChatNavigationBarUserSettingsEnabled: false)
+                                                        isAIChatTabBarUserSettingsEnabled: false)
         let testee = AIChatAddressBarExperience(featureFlagger: featureFlagger,
                                                 aiChatSettings: aiChatSettings,
                                                 largeWidthProvider: MockLargeWidthProvider(isLargeWidth: false))
@@ -210,7 +210,7 @@ final class AIChatAddressBarExperienceTests: XCTestCase {
         MockUIDevice.mockUserInterfaceIdiom = .phone
         let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.aiChatChromeShortcutIPad])
         let aiChatSettings = MockAIChatSettingsProvider(isAIChatAddressBarUserSettingsEnabled: false,
-                                                        isAIChatNavigationBarUserSettingsEnabled: true)
+                                                        isAIChatTabBarUserSettingsEnabled: true)
         let testee = AIChatAddressBarExperience(featureFlagger: featureFlagger,
                                                 aiChatSettings: aiChatSettings)
 

--- a/iOS/DuckDuckGoTests/AIChat/AIChatSettingsTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatSettingsTests.swift
@@ -178,60 +178,60 @@ class AIChatSettingsTests: XCTestCase {
         XCTAssertTrue(settings.isAutomaticContextAttachmentEnabled)
     }
 
-    // MARK: - Navigation Bar shortcut (iPad Duck.ai chrome)
+    // MARK: - Tab Bar shortcut (iPad Duck.ai chrome)
 
-    func testIsAIChatNavigationBarUserSettingsEnabled_returnsTrueByDefault_whenAIChatIsEnabled() {
+    func testIsAIChatTabBarUserSettingsEnabled_returnsTrueByDefault_whenAIChatIsEnabled() {
         let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
                                       debugSettings: mockAIChatDebugSettings,
                                       keyValueStore: mockKeyValueStore,
                                       notificationCenter: mockNotificationCenter,
                                       featureFlagger: mockFeatureFlagger)
         // Pin the AI Chat global gate explicitly so the test only depends on
-        // showAIChatNavigationBarDefaultValue, not the isAIChatEnabled default.
+        // showAIChatTabBarDefaultValue, not the isAIChatEnabled default.
         settings.enableAIChat(enable: true)
 
-        XCTAssertTrue(settings.isAIChatNavigationBarUserSettingsEnabled)
+        XCTAssertTrue(settings.isAIChatTabBarUserSettingsEnabled)
     }
 
-    func testEnableAIChatNavigationBarUserSettings_persistsValue() {
+    func testEnableAIChatTabBarUserSettings_persistsValue() {
         let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
                                       debugSettings: mockAIChatDebugSettings,
                                       keyValueStore: mockKeyValueStore,
                                       notificationCenter: mockNotificationCenter,
                                       featureFlagger: mockFeatureFlagger)
 
-        settings.enableAIChatNavigationBarUserSettings(enable: false)
-        XCTAssertFalse(settings.isAIChatNavigationBarUserSettingsEnabled)
+        settings.enableAIChatTabBarUserSettings(enable: false)
+        XCTAssertFalse(settings.isAIChatTabBarUserSettingsEnabled)
 
-        settings.enableAIChatNavigationBarUserSettings(enable: true)
-        XCTAssertTrue(settings.isAIChatNavigationBarUserSettingsEnabled)
+        settings.enableAIChatTabBarUserSettings(enable: true)
+        XCTAssertTrue(settings.isAIChatTabBarUserSettingsEnabled)
     }
 
-    func testIsAIChatNavigationBarUserSettingsEnabled_returnsFalse_whenAIChatGloballyDisabled() {
+    func testIsAIChatTabBarUserSettingsEnabled_returnsFalse_whenAIChatGloballyDisabled() {
         let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
                                       debugSettings: mockAIChatDebugSettings,
                                       keyValueStore: mockKeyValueStore,
                                       notificationCenter: mockNotificationCenter,
                                       featureFlagger: mockFeatureFlagger)
-        settings.enableAIChatNavigationBarUserSettings(enable: true)
+        settings.enableAIChatTabBarUserSettings(enable: true)
         settings.enableAIChat(enable: false)
 
-        XCTAssertFalse(settings.isAIChatNavigationBarUserSettingsEnabled)
+        XCTAssertFalse(settings.isAIChatTabBarUserSettingsEnabled)
     }
 
-    func testEnableAIChatNavigationBarUserSettings_postsNotification() {
+    func testEnableAIChatTabBarUserSettings_postsNotification() {
         let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
                                       debugSettings: mockAIChatDebugSettings,
                                       keyValueStore: mockKeyValueStore,
                                       notificationCenter: mockNotificationCenter,
                                       featureFlagger: mockFeatureFlagger)
 
-        let expectation = self.expectation(description: "Notification posted on Navigation Bar setting change")
+        let expectation = self.expectation(description: "Notification posted on Tab Bar setting change")
         let observer = mockNotificationCenter.addObserver(forName: .aiChatSettingsChanged, object: nil, queue: nil) { _ in
             expectation.fulfill()
         }
 
-        settings.enableAIChatNavigationBarUserSettings(enable: false)
+        settings.enableAIChatTabBarUserSettings(enable: false)
         waitForExpectations(timeout: 1, handler: nil)
         mockNotificationCenter.removeObserver(observer)
     }
@@ -262,7 +262,7 @@ class AIChatSettingsTests: XCTestCase {
         let flagger = MockFeatureFlagger(enabledFeatureFlags: [.aiChatChromeShortcutIPad])
         XCTAssertTrue(DuckAIChromeShortcutVisibility.isChromeButtonVisible(
             featureFlagger: flagger,
-            isAIChatNavigationBarUserSettingsEnabled: true
+            isAIChatTabBarUserSettingsEnabled: true
         ))
     }
 
@@ -270,7 +270,7 @@ class AIChatSettingsTests: XCTestCase {
         let flagger = MockFeatureFlagger(enabledFeatureFlags: [])
         XCTAssertFalse(DuckAIChromeShortcutVisibility.isChromeButtonVisible(
             featureFlagger: flagger,
-            isAIChatNavigationBarUserSettingsEnabled: true
+            isAIChatTabBarUserSettingsEnabled: true
         ))
     }
 
@@ -278,13 +278,13 @@ class AIChatSettingsTests: XCTestCase {
         let flagger = MockFeatureFlagger(enabledFeatureFlags: [.aiChatChromeShortcutIPad])
         XCTAssertFalse(DuckAIChromeShortcutVisibility.isChromeButtonVisible(
             featureFlagger: flagger,
-            isAIChatNavigationBarUserSettingsEnabled: false
+            isAIChatTabBarUserSettingsEnabled: false
         ))
     }
 
     // MARK: - DuckAIChromeShortcutVisibility — Address Bar row / button
 
-    func testDuckAIChromeShortcutVisibility_addressBarRowHidden_whenNavigationBarRowIsShown() {
+    func testDuckAIChromeShortcutVisibility_addressBarRowHidden_whenTabBarRowIsShown() {
         let flagger = MockFeatureFlagger(enabledFeatureFlags: [.aiChatChromeShortcutIPad])
         XCTAssertFalse(DuckAIChromeShortcutVisibility.isAddressBarRowVisible(isIPad: true, featureFlagger: flagger))
     }
@@ -302,27 +302,27 @@ class AIChatSettingsTests: XCTestCase {
     func testDuckAIChromeShortcutVisibility_addressBarButtonHidden_onIPad_atLargeWidth() {
         XCTAssertFalse(DuckAIChromeShortcutVisibility.isAddressBarButtonVisibleOnIPad(
             isLargeWidth: true,
-            isAIChatNavigationBarUserSettingsEnabled: true
+            isAIChatTabBarUserSettingsEnabled: true
         ))
     }
 
     func testDuckAIChromeShortcutVisibility_addressBarButtonVisible_onIPad_atNarrowWidth_whenSettingOn() {
         XCTAssertTrue(DuckAIChromeShortcutVisibility.isAddressBarButtonVisibleOnIPad(
             isLargeWidth: false,
-            isAIChatNavigationBarUserSettingsEnabled: true
+            isAIChatTabBarUserSettingsEnabled: true
         ))
     }
 
     func testDuckAIChromeShortcutVisibility_addressBarButtonHidden_onIPad_atNarrowWidth_whenSettingOff() {
         XCTAssertFalse(DuckAIChromeShortcutVisibility.isAddressBarButtonVisibleOnIPad(
             isLargeWidth: false,
-            isAIChatNavigationBarUserSettingsEnabled: false
+            isAIChatTabBarUserSettingsEnabled: false
         ))
     }
 
-    // MARK: - Address Bar → Navigation Bar migration
+    // MARK: - Address Bar → Tab Bar migration
 
-    func testMigration_preservesAddressBarOff_asNavigationBarOff() {
+    func testMigration_preservesAddressBarOff_asTabBarOff() {
         mockKeyValueStore.set(false, forKey: LegacyAiChatUserDefaultsKeys.showAIChatAddressBarKey)
 
         let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
@@ -332,7 +332,7 @@ class AIChatSettingsTests: XCTestCase {
                                       featureFlagger: mockFeatureFlagger)
         settings.enableAIChat(enable: true)
 
-        XCTAssertFalse(settings.isAIChatNavigationBarUserSettingsEnabled)
+        XCTAssertFalse(settings.isAIChatTabBarUserSettingsEnabled)
     }
 
     func testMigration_doesNothing_whenAddressBarWasOn() {
@@ -346,7 +346,7 @@ class AIChatSettingsTests: XCTestCase {
         settings.enableAIChat(enable: true)
 
         // No prior Nav Bar value, no migration override — falls through to default (true).
-        XCTAssertTrue(settings.isAIChatNavigationBarUserSettingsEnabled)
+        XCTAssertTrue(settings.isAIChatTabBarUserSettingsEnabled)
     }
 
     func testMigration_doesNothing_whenAddressBarValueNeverSet() {
@@ -357,13 +357,13 @@ class AIChatSettingsTests: XCTestCase {
                                       featureFlagger: mockFeatureFlagger)
         settings.enableAIChat(enable: true)
 
-        XCTAssertTrue(settings.isAIChatNavigationBarUserSettingsEnabled)
+        XCTAssertTrue(settings.isAIChatTabBarUserSettingsEnabled)
     }
 
-    func testMigration_doesNotOverrideExplicitNavigationBarValue() {
+    func testMigration_doesNotOverrideExplicitTabBarValue() {
         // User had Address Bar off AND Nav Bar already explicitly set to true — keep Nav Bar.
         mockKeyValueStore.set(false, forKey: LegacyAiChatUserDefaultsKeys.showAIChatAddressBarKey)
-        mockKeyValueStore.set(true, forKey: LegacyAiChatUserDefaultsKeys.showAIChatNavigationBarKey)
+        mockKeyValueStore.set(true, forKey: LegacyAiChatUserDefaultsKeys.showAIChatTabBarKey)
 
         let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
                                       debugSettings: mockAIChatDebugSettings,
@@ -372,10 +372,10 @@ class AIChatSettingsTests: XCTestCase {
                                       featureFlagger: mockFeatureFlagger)
         settings.enableAIChat(enable: true)
 
-        XCTAssertTrue(settings.isAIChatNavigationBarUserSettingsEnabled)
+        XCTAssertTrue(settings.isAIChatTabBarUserSettingsEnabled)
     }
 
-    func testMigration_isOneShot_subsequentAddressBarToggleDoesNotResetNavigationBar() {
+    func testMigration_isOneShot_subsequentAddressBarToggleDoesNotResetTabBar() {
         mockKeyValueStore.set(false, forKey: LegacyAiChatUserDefaultsKeys.showAIChatAddressBarKey)
 
         let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
@@ -384,16 +384,16 @@ class AIChatSettingsTests: XCTestCase {
                                       notificationCenter: mockNotificationCenter,
                                       featureFlagger: mockFeatureFlagger)
         settings.enableAIChat(enable: true)
-        XCTAssertFalse(settings.isAIChatNavigationBarUserSettingsEnabled)
+        XCTAssertFalse(settings.isAIChatTabBarUserSettingsEnabled)
 
         // User then turns Nav Bar back on; a new AIChatSettings instance must not re-migrate.
-        settings.enableAIChatNavigationBarUserSettings(enable: true)
+        settings.enableAIChatTabBarUserSettings(enable: true)
         let secondInstance = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
                                             debugSettings: mockAIChatDebugSettings,
                                             keyValueStore: mockKeyValueStore,
                                             notificationCenter: mockNotificationCenter,
                                             featureFlagger: mockFeatureFlagger)
-        XCTAssertTrue(secondInstance.isAIChatNavigationBarUserSettingsEnabled)
+        XCTAssertTrue(secondInstance.isAIChatTabBarUserSettingsEnabled)
     }
 
 }

--- a/iOS/SharedTestUtils/Mocks/AIChat/MockAIChatSettingsProvider.swift
+++ b/iOS/SharedTestUtils/Mocks/AIChat/MockAIChatSettingsProvider.swift
@@ -29,7 +29,7 @@ public class MockAIChatSettingsProvider: AIChatSettingsProvider {
     public var isAIChatAddressBarShortcutFeatureEnabled: Bool
     public var isAIChatVoiceSearchUserSettingsEnabled: Bool
     public var isAIChatTabSwitcherUserSettingsEnabled: Bool
-    public var isAIChatNavigationBarUserSettingsEnabled: Bool
+    public var isAIChatTabBarUserSettingsEnabled: Bool
     public var sessionTimerInMinutes: Int
     public var isAIChatSearchInputUserSettingsEnabled: Bool
     public var isAIChatSearchInputUserSettingsDisabledByUser: Bool
@@ -45,7 +45,7 @@ public class MockAIChatSettingsProvider: AIChatSettingsProvider {
                 isAIChatAddressBarShortcutFeatureEnabled: Bool = false,
                 isAIChatVoiceSearchUserSettingsEnabled: Bool = false,
                 isAIChatTabSwitcherUserSettingsEnabled: Bool = false,
-                isAIChatNavigationBarUserSettingsEnabled: Bool = false,
+                isAIChatTabBarUserSettingsEnabled: Bool = false,
                 isAIChatSearchInputUserSettingsEnabled: Bool = false,
                 isAIChatSearchInputUserSettingsDisabledByUser: Bool = false,
                 isAutomaticContextAttachmentEnabled: Bool = false,
@@ -60,7 +60,7 @@ public class MockAIChatSettingsProvider: AIChatSettingsProvider {
         self.isAIChatAddressBarShortcutFeatureEnabled = isAIChatAddressBarShortcutFeatureEnabled
         self.isAIChatVoiceSearchUserSettingsEnabled = isAIChatVoiceSearchUserSettingsEnabled
         self.isAIChatTabSwitcherUserSettingsEnabled = isAIChatTabSwitcherUserSettingsEnabled
-        self.isAIChatNavigationBarUserSettingsEnabled = isAIChatNavigationBarUserSettingsEnabled
+        self.isAIChatTabBarUserSettingsEnabled = isAIChatTabBarUserSettingsEnabled
         self.isAIChatSearchInputUserSettingsEnabled = isAIChatSearchInputUserSettingsEnabled
         self.isAIChatSearchInputUserSettingsDisabledByUser = isAIChatSearchInputUserSettingsDisabledByUser
         self.isAutomaticContextAttachmentEnabled = isAutomaticContextAttachmentEnabled
@@ -85,8 +85,8 @@ public class MockAIChatSettingsProvider: AIChatSettingsProvider {
         isAIChatTabSwitcherUserSettingsEnabled = enable
     }
 
-    public func enableAIChatNavigationBarUserSettings(enable: Bool) {
-        isAIChatNavigationBarUserSettingsEnabled = enable
+    public func enableAIChatTabBarUserSettings(enable: Bool) {
+        isAIChatTabBarUserSettingsEnabled = enable
     }
 
     public func enableAIChat(enable: Bool) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1215366761782865

### Description

Renames the iPad Duck.ai shortcut's user-facing Settings label/subtitle and all internal symbols (property, binding, storage key, UserText keys) from `NavigationBar` to `TabBar` — the shortcut lives in the tabs bar, so the old name was a misnomer. No migration needed (internal-only, never shipped); the legacy Address Bar → shortcut migration is preserved. Pixel names stay on `m_aichat_navigation_bar_*` for analytics continuity (no new defs).

### Testing Steps
1. iPad, internal user, `aiChatChromeShortcutIPad` on; Settings → AI Features → Manage Duck.ai Shortcuts.
2. The shortcut toggle now reads "Tab Bar" (was "Navigation Bar"); behavior unchanged.

### Impact and Risks
Low. Rename only (label + internal symbols); pixels unchanged.

### Notes to Reviewer
Stacked on #5259 — review/merge after it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Label and symbol rename with a new UserDefaults key; logic and pixels are preserved, and the feature was described as not yet shipped under the old key.
> 
> **Overview**
> Renames the iPad Duck.ai chrome shortcut from **Navigation Bar** to **Tab Bar** in Settings copy and across internal APIs (`AIChatSettingsProvider`, persistence key `aichat.settings.showAIChatTabBar`, bindings, and `DuckAIChromeShortcutVisibility` parameters). User-facing strings move to `aiChatSettingsEnableTabBarToggle` / subtitle; behavior for the tabs-bar pill, address-bar fallback at narrow width, and hide-from-menu flows is unchanged.
> 
> The one-shot **Address Bar → shortcut** migration now writes the Tab Bar key instead of the old Navigation Bar key so users who disabled the legacy address-bar toggle do not get the shortcut re-enabled under the new name. Analytics pixels remain `m_aichat_navigation_bar_*` for continuity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 478d6c5f0855d72f7fa99ef4de9c95ae8243ce81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->