### PR TITLE
iOS: Fix favorites horizontal shift before autocomplete in UTI

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SuggestionTrayManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SuggestionTrayManager.swift
@@ -164,6 +164,7 @@ final class SuggestionTrayManager: NSObject {
 
         controller.coversFullScreen = true
         controller.deferAutocompleteReveal = deferAutocompleteReveal
+        controller.autocompleteHorizontalInset = autocompleteHorizontalInset
 
         parentViewController.addChild(controller)
         containerView.addSubview(controller.view)
@@ -211,7 +212,7 @@ final class SuggestionTrayManager: NSObject {
         if canShow {
             // Don't set view.isHidden = false here — the tray stays hidden until
             // results arrive. autocompleteDidReloadResults shows it if non-empty.
-            suggestionTray.fill(horizontalInset: autocompleteHorizontalInset)
+            suggestionTray.fill()
             suggestionTray.show(for: .autocomplete(query: query), animated: animated)
         } else {
             suggestionTray.didHide(animated: animated)
@@ -280,19 +281,10 @@ final class SuggestionTrayManager: NSObject {
 
         if canShowSuggestion {
             suggestionTray.view.isHidden = false
-            suggestionTray.fill(horizontalInset: horizontalInset(for: type))
+            suggestionTray.fill()
             suggestionTray.show(for: type, animated: animated)
         } else {
             suggestionTray.didHide(animated: animated)
-        }
-    }
-
-    private func horizontalInset(for type: SuggestionTrayViewController.SuggestionType) -> CGFloat {
-        switch type {
-        case .autocomplete:
-            return autocompleteHorizontalInset
-        case .favorites:
-            return 0
         }
     }
     

--- a/iOS/DuckDuckGo/SuggestionTrayViewController.swift
+++ b/iOS/DuckDuckGo/SuggestionTrayViewController.swift
@@ -96,6 +96,11 @@ class SuggestionTrayViewController: UIViewController {
 
     var coversFullScreen: Bool = false
 
+    /// Horizontal inset applied to the autocomplete content only. Favorites and the shared container stay
+    /// full width, so switching between favorites and autocomplete doesn't resize/recenter the container
+    /// (which would visibly shift the still-mounted favorites view before autocomplete reveals).
+    var autocompleteHorizontalInset: CGFloat = 0
+
     var selectedSuggestion: Suggestion? {
         autocompleteController?.selectedSuggestion
     }
@@ -304,7 +309,7 @@ class SuggestionTrayViewController: UIViewController {
         applyTopConstraintForLayoutMode()
     }
 
-    func fill(bottomOffset: CGFloat = 0.0, horizontalInset: CGFloat = 0.0) {
+    func fill(bottomOffset: CGFloat = 0.0) {
         additionalSafeAreaInsets = .init(top: 0, left: 0, bottom: bottomOffset, right: 0)
 
         containerView.layer.shadowColor = UIColor.clear.cgColor
@@ -317,7 +322,7 @@ class SuggestionTrayViewController: UIViewController {
         backgroundView.backgroundColor = UIColor.clear
 
         fullWidthConstraint.isActive = true
-        fullWidthConstraint.constant = -(horizontalInset * 2)
+        fullWidthConstraint.constant = 0
         fullHeightConstraint.isActive = coversFullScreen
         fullHeightSafeAreaConstraint.isActive = !coversFullScreen
         fullHeightSafeAreaInequalityConstraint.isActive = !coversFullScreen
@@ -435,7 +440,9 @@ class SuggestionTrayViewController: UIViewController {
                                                     featureDiscovery: featureDiscovery,
                                                     productSurfaceTelemetry: productSurfaceTelemetry)
         controller.suggestionFilter = suggestionFilter
-        install(controller: controller, animated: deferAutocompleteReveal ? false : animated)
+        install(controller: controller,
+                animated: deferAutocompleteReveal ? false : animated,
+                additionalInsets: UIEdgeInsets(top: 0, left: autocompleteHorizontalInset, bottom: 0, right: autocompleteHorizontalInset))
         if deferAutocompleteReveal {
             controller.view.isHidden = true
             pendingDeferredAutocompleteReveal = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211767540372501/task/1215335030413361

### Description

- Fix a horizontal shift of the favorites grid in the UTI focused search tray when the user types the first character and autocomplete replaces favorites.
- Root cause: switching to autocomplete called `fill(horizontalInset: 8)`, which narrowed the shared center-anchored `containerView` while favorites was still mounted (autocomplete reveal is deferred until results arrive).
- Keep the tray container full width for both favorites and autocomplete; apply the 8pt horizontal inset only to the autocomplete child view via `additionalInsets`, so favorites no longer relayouts during the transition.
- Non-UTI hosts are unchanged (they pass inset 0).

### Testing Steps

1. Enable the `unifiedToggleInput` feature flag.
2. Ensure the device has favorites configured.
3. Open a new tab and tap the address bar to enter the UTI focused search state (favorites visible).
4. Type the first character to trigger autocomplete.
5. Confirm the favorites grid does **not** shift horizontally before autocomplete appears.
6. Confirm autocomplete suggestions still have the expected 8pt horizontal margin from the screen edges.
7. Repeat with top and bottom address bar positions.
8. Smoke-test legacy omnibar editing path (without UTI) to confirm autocomplete/favorites behavior is unchanged.

### Impact and Risks

**Impact Level: Low**

This is a focused layout fix in the UTI suggestions tray. It only changes how the autocomplete horizontal inset is applied (child view vs shared container). Favorites layout is unchanged; autocomplete keeps its 8pt margin. Non-UTI hosts pass inset 0 and should behave as before.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only change in the suggestion tray; behavior outside UTI is unchanged when inset is 0.
> 
> **Overview**
> Fixes a visible **horizontal jump of the favorites grid** in unified toggle input (UTI) when the first keystroke switches the tray from favorites to autocomplete while reveal is still deferred.
> 
> **Before:** Autocomplete mode called `fill(horizontalInset:)`, which narrowed the center-anchored shared `containerView` while favorites was still mounted, so favorites relayouted before autocomplete appeared.
> 
> **After:** `fill()` always keeps the tray container full width. UTI passes `autocompleteHorizontalInset` (e.g. 8pt) onto `SuggestionTrayViewController`, and that inset is applied only to the autocomplete child via `additionalInsets` when it is installed. Favorites stay full width during the transition; autocomplete keeps the same edge margin. Non-UTI hosts still use inset `0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b5860623715023b005eb94d044c1c6828a664ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->