### PR TITLE
[CI] Skip PR review comment job when reviewer is a Bot

### DIFF
--- a/.github/workflows/add_asana_comment_on_pr_review.yml
+++ b/.github/workflows/add_asana_comment_on_pr_review.yml
@@ -7,19 +7,21 @@ on:
 jobs:
 
     add-pr-review-comment:
-        # Skip when the review submitter is the PR author themselves.
-        # Catches: self-reviews (author clicks Submit review on own PR) and
-        # AI/automation tools (e.g. Cursor Bugbot) posting reviews via the
-        # author's GitHub token. No subtask exists in either case.
-        #
-        # For 'commented' state also require a non-empty review.body: GitHub
-        # wraps every "Add single comment" inline reply in a review with
-        # state=commented and an empty body. Filtering by body excludes those
-        # noisy inline-reply events while keeping deliberate "Submit review →
-        # Comment" submissions that include a summary.
+        # Skip this job when:
+        #   - The review submitter is the PR author themselves (self-review,
+        #     or AI/automation tools posting via the author's GitHub token).
+        #   - The review submitter is a Bot account (e.g. cursor[bot],
+        #     dependabot[bot]) posting under its own [bot] identity. No
+        #     Asana subtask exists for bots.
+        #   - The review state is 'commented' with an empty body. GitHub
+        #     wraps every "Add single comment" inline reply in a review with
+        #     state=commented and an empty body; filtering by body excludes
+        #     those noisy inline-reply events while keeping deliberate
+        #     "Submit review → Comment" submissions that include a summary.
         if: |
             contains(fromJSON('["approved","changes_requested","commented"]'), github.event.review.state)
             && github.event.review.user.login != github.event.pull_request.user.login
+            && github.event.review.user.type != 'Bot'
             && (github.event.review.state != 'commented' || github.event.review.body != '')
         name: "Add Asana comment on PR review"
         runs-on: ubuntu-latest


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1215353333611713?focus=true
Tech Design URL:
CC:

### Description

This PR excludes prevents `add-pr-review-comment` job to run if the PR review is submitted by a bot.

### Testing Steps
1. Wait for Cursor[bot] to submit a review and verify that Post PR Comment workflow does not fail

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal CI guard only; narrows when a workflow runs and does not change product code or data paths.
> 
> **Overview**
> The **Add Asana Comment on PR Review** workflow now **skips** the `add-pr-review-comment` job when the submitted review comes from a **GitHub Bot** (`github.event.review.user.type == 'Bot'`), in addition to existing skips for self-reviews and empty `commented` reviews.
> 
> Inline comments were **rewritten** to list all three skip reasons together (author, bot identity such as `cursor[bot]` / `dependabot[bot]`, and empty inline-reply noise).
> 
> This avoids the job running—and failing on missing Asana subtask mapping—when automation posts reviews under a `[bot]` account.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e1e31c4a94246d29ff5a07d8f2021974f9c1854. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->