### PR TITLE
[CI] Clean up PR review task on approve and on PR closed

### DIFF
--- a/.github/workflows/add_asana_comment_on_pr_review.yml
+++ b/.github/workflows/add_asana_comment_on_pr_review.yml
@@ -69,7 +69,7 @@ jobs:
             echo "text=${prefix} by @${REVIEWER} — see review: ${REVIEW_URL}" >> "$GITHUB_OUTPUT"
 
         - name: Post review comment
-          uses: duckduckgo/native-github-asana-sync@v1.9
+          uses: duckduckgo/native-github-asana-sync@v2.4
           with:
             action: 'post-comment-asana-task'
             asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
@@ -79,7 +79,7 @@ jobs:
 
         - name: Mark subtask complete on approve
           if: ${{ github.event.review.state == 'approved' }}
-          uses: duckduckgo/native-github-asana-sync@v1.9
+          uses: duckduckgo/native-github-asana-sync@v2.4
           with:
             action: 'mark-asana-task-complete'
             asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
@@ -90,7 +90,7 @@ jobs:
         # completed) and submits a non-approve review, reopen the subtask.
         - name: Mark subtask incomplete on non-approve review
           if: ${{ github.event.review.state != 'approved' }}
-          uses: duckduckgo/native-github-asana-sync@v1.9
+          uses: duckduckgo/native-github-asana-sync@v2.4
           with:
             action: 'mark-asana-task-complete'
             asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/add_asana_comment_on_pr_review.yml
+++ b/.github/workflows/add_asana_comment_on_pr_review.yml
@@ -91,3 +91,14 @@ jobs:
             asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
             asana-task-id: ${{ fromJSON(steps.find-subtask.outputs.subtask-ids)[0] }}
             is-complete: true
+
+        # If a reviewer returns to a previously approved PR (subtask already
+        # completed) and submits a non-approve review, reopen the subtask.
+        - name: Mark subtask incomplete on non-approve review
+          if: ${{ github.event.review.state != 'approved' }}
+          uses: duckduckgo/native-github-asana-sync@v1.9
+          with:
+            action: 'mark-asana-task-complete'
+            asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+            asana-task-id: ${{ fromJSON(steps.find-subtask.outputs.subtask-ids)[0] }}
+            is-complete: false

--- a/.github/workflows/add_asana_comment_on_pr_review.yml
+++ b/.github/workflows/add_asana_comment_on_pr_review.yml
@@ -82,3 +82,12 @@ jobs:
             asana-task-id: ${{ fromJSON(steps.find-subtask.outputs.subtask-ids)[0] }}
             asana-task-comment: ${{ steps.comment.outputs.text }}
             asana-task-comment-pinned: false
+
+        - name: Mark subtask complete on approve
+          if: ${{ github.event.review.state == 'approved' }}
+          uses: duckduckgo/native-github-asana-sync@v1.9
+          with:
+            action: 'mark-asana-task-complete'
+            asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+            asana-task-id: ${{ fromJSON(steps.find-subtask.outputs.subtask-ids)[0] }}
+            is-complete: true

--- a/.github/workflows/add_asana_comment_on_pr_review.yml
+++ b/.github/workflows/add_asana_comment_on_pr_review.yml
@@ -29,18 +29,12 @@ jobs:
         steps:
         - name: Get Task ID
           id: get-task-id
-          env:
-            BODY: ${{ github.event.pull_request.body }}
-          run: |
-            task_id=$(grep -i "task/issue url.*https://app.asana.com/" <<< "$BODY" \
-              | perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?|\1|; \
-                s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?|\1|; \
-                s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)(?:\?focus=true)?|\1|'
-            )
-            echo "task_id=${task_id//[^0-9]/}" >> $GITHUB_OUTPUT
+          uses: duckduckgo/apple-toolbox/actions/asana-extract-task-id@main
+          with:
+            text: ${{ github.event.pull_request.body }}
 
         - name: Fail if no Asana task URL in PR body
-          if: ${{ steps.get-task-id.outputs.task_id == '' }}
+          if: ${{ steps.get-task-id.outputs.task-id == '' }}
           run: |
             echo "::error::No Asana task URL found in the PR body. Add a 'Task/Issue URL: https://app.asana.com/...' line to enable PR review subtask comments."
             exit 1
@@ -50,7 +44,7 @@ jobs:
           uses: duckduckgo/apple-toolbox/actions/asana-fetch-pr-subtasks@main
           with:
             access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
-            asana-task-id: ${{ steps.get-task-id.outputs.task_id }}
+            asana-task-id: ${{ steps.get-task-id.outputs.task-id }}
             github-reviewer-user: ${{ github.event.review.user.login }}
             github-token: ${{ secrets.APPLE_GH_RO_PAT }}
 

--- a/.github/workflows/close_asana_pr_subtasks.yml
+++ b/.github/workflows/close_asana_pr_subtasks.yml
@@ -46,7 +46,7 @@ jobs:
 
         steps:
         - name: Mark PR review subtask as complete
-          uses: duckduckgo/native-github-asana-sync@v1.9
+          uses: duckduckgo/native-github-asana-sync@v2.4
           with:
             action: 'mark-asana-task-complete'
             asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/close_asana_pr_subtasks.yml
+++ b/.github/workflows/close_asana_pr_subtasks.yml
@@ -17,28 +17,22 @@ jobs:
         steps:
         - name: Get Task ID
           id: get-task-id
-          env:
-            BODY: ${{ github.event.pull_request.body }}
-          run: |
-            task_id=$(grep -i "task/issue url.*https://app.asana.com/" <<< "$BODY" \
-              | perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?|\1|; \
-                s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?|\1|; \
-                s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)(?:\?focus=true)?|\1|'
-            )
-            echo "task_id=${task_id//[^0-9]/}" >> $GITHUB_OUTPUT
+          uses: duckduckgo/apple-toolbox/actions/asana-extract-task-id@main
+          with:
+            text: ${{ github.event.pull_request.body }}
 
         - name: Skip if no Asana task URL in PR body
-          if: ${{ steps.get-task-id.outputs.task_id == '' }}
+          if: ${{ steps.get-task-id.outputs.task-id == '' }}
           run: |
             echo "::notice::No Asana task URL found in the PR body — nothing to clean up."
 
         - name: Find incomplete PR review subtasks
           id: find-subtasks
-          if: ${{ steps.get-task-id.outputs.task_id != '' }}
+          if: ${{ steps.get-task-id.outputs.task-id != '' }}
           uses: duckduckgo/apple-toolbox/actions/asana-fetch-pr-subtasks@main
           with:
             access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
-            asana-task-id: ${{ steps.get-task-id.outputs.task_id }}
+            asana-task-id: ${{ steps.get-task-id.outputs.task-id }}
             complete: 'false'
 
     close-pr-review-subtask:

--- a/.github/workflows/close_asana_pr_subtasks.yml
+++ b/.github/workflows/close_asana_pr_subtasks.yml
@@ -1,0 +1,60 @@
+# Mark PR task complete when the PR is merged or closed without merging.
+
+name: Shared - Close Asana PR Review Subtasks on PR Closed
+
+on:
+    pull_request:
+        types: [closed]
+
+jobs:
+
+    resolve-pr-review-subtasks:
+        name: "Resolve PR review subtasks"
+        runs-on: ubuntu-latest
+        outputs:
+            subtask-ids: ${{ steps.find-subtasks.outputs.subtask-ids }}
+
+        steps:
+        - name: Get Task ID
+          id: get-task-id
+          env:
+            BODY: ${{ github.event.pull_request.body }}
+          run: |
+            task_id=$(grep -i "task/issue url.*https://app.asana.com/" <<< "$BODY" \
+              | perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?|\1|; \
+                s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?|\1|; \
+                s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)(?:\?focus=true)?|\1|'
+            )
+            echo "task_id=${task_id//[^0-9]/}" >> $GITHUB_OUTPUT
+
+        - name: Skip if no Asana task URL in PR body
+          if: ${{ steps.get-task-id.outputs.task_id == '' }}
+          run: |
+            echo "::notice::No Asana task URL found in the PR body — nothing to clean up."
+
+        - name: Find incomplete PR review subtasks
+          id: find-subtasks
+          if: ${{ steps.get-task-id.outputs.task_id != '' }}
+          uses: duckduckgo/apple-toolbox/actions/asana-fetch-pr-subtasks@main
+          with:
+            access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
+            asana-task-id: ${{ steps.get-task-id.outputs.task_id }}
+            complete: 'false'
+
+    close-pr-review-subtask:
+        name: "Close PR review subtask in Asana"
+        needs: resolve-pr-review-subtasks
+        if: ${{ needs.resolve-pr-review-subtasks.outputs.subtask-ids != '' && needs.resolve-pr-review-subtasks.outputs.subtask-ids != '[]' }}
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                subtask-id: ${{ fromJSON(needs.resolve-pr-review-subtasks.outputs.subtask-ids) }}
+
+        steps:
+        - name: Mark PR review subtask as complete
+          uses: duckduckgo/native-github-asana-sync@v1.9
+          with:
+            action: 'mark-asana-task-complete'
+            asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+            asana-task-id: ${{ matrix.subtask-id }}
+            is-complete: 'true'

--- a/.github/workflows/create_asana_pr_subtask.yml
+++ b/.github/workflows/create_asana_pr_subtask.yml
@@ -14,21 +14,15 @@ jobs:
         steps:
         - name: Get Task ID
           id: get-task-id
-          env:
-            BODY: ${{ github.event.pull_request.body }}
-          run: |
-            task_id=$(grep -i "task/issue url.*https://app.asana.com/" <<< "$BODY" \
-              | perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?|\1|; \
-                s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?|\1|; \
-                s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)(?:\?focus=true)?|\1|'
-            )
-            echo "task_id=${task_id//[^0-9]/}" >> $GITHUB_OUTPUT
+          uses: duckduckgo/apple-toolbox/actions/asana-extract-task-id@main
+          with:
+            text: ${{ github.event.pull_request.body }}
 
         - name: Create or Update PR Subtask
           uses: duckduckgo/apple-toolbox/actions/asana-create-pr-subtask@main
           with:
             access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
-            asana-task-id: ${{ steps.get-task-id.outputs.task_id }}
+            asana-task-id: ${{ steps.get-task-id.outputs.task-id }}
             github-reviewer-user: ${{ github.event.requested_reviewer.login }}
             github-pr-author-user: ${{ github.event.pull_request.user.login }}
             github-pr-author-type: ${{ github.event.pull_request.user.type }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215321546485065
Tech Design URL:
CC:

### Description

This PR implements automatic PR subtask completion when a PR is approved and also when a PR is merged or closed.

This PR depends on `apple-toolbox` [PR](https://github.com/duckduckgo/apple-toolbox/pull/21)

### Key Changes:

- **On approve, the reviewer's subtask is marked complete:** New step in the existing comment workflow.
- **On a non-approve review (Changes requested or Comment), the subtask is marked incomplete:** Handles the case where a reviewer revisits a PR they already approved and submits another review.
- **New `close_asana_pr_subtasks.yml` workflow:** Runs on PR closed (merged or not) and completes any subtasks still open. This is the fallback for PRs that don't go through the normal approve flow (closed without merging, etc.).
- **Shared task-id extraction action.** The grep+perl regex for pulling the Asana task gid out of the PR body was inlined across three workflows; now they all use a single composite action in apple-toolbox.

### Testing Steps
1. Approve the PR. Confirm a "✅ Approved" comment lands on the subtask and the subtask is marked complete.
2. Switch the review to Request changes. Confirm a "🔄 Changes requested" comment is added and the subtask is reopened.
3. Switch the review to Comment (with a non-empty body). Confirm a "💬 Comment" comment is added and the subtask is reopened if it was completed by a prior approve.
4. Submit an inline-only comment via "Add single comment" instead of "Submit review". Confirm nothing happens.
5. Close the PR without merging while at least one subtask is still incomplete (e.g. another reviewer didn't approve). Confirm the close workflow runs and marks the remaining subtask complete.
6. Re-open, approve, merge. Confirm the close workflow runs but is a no-op since the subtask was already completed by the approve flow.

### Impact and Risks
Low. CI tooling only, no app or user-visible impact. Workflow failures surface in GitHub Actions and don't block the PR.

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Notes to Reviewer
- The "mark complete" / "mark incomplete" steps in the comment workflow fire unconditionally based on review state. The "mark incomplete" call is idempotent on already-open subtasks. Picked this over an extra fetch-then-check, since the API call is cheap and the code stays simpler.
- The close workflow uses a matrix to fan out one job per remaining incomplete subtask. The job-level `if:` skips the matrix entirely when there are none (the common case after approvals auto-close them), so the runner overhead is only paid in edge cases.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only GitHub Actions and Asana sync; failures show in Actions and do not block merges or affect the app.
> 
> **Overview**
> **Automates Asana PR review subtask lifecycle** so reviewer subtasks stay in sync with GitHub review state and PR closure, without manual cleanup.
> 
> The **PR review comment workflow** now bumps `native-github-asana-sync` to **v2.4**, replaces inline grep/perl task-ID parsing with **`apple-toolbox/actions/asana-extract-task-id`**, and renames outputs to **`task-id`**. After posting the review comment, it **marks the reviewer’s subtask complete on approve** and **marks it incomplete on any non-approve review** (changes requested or comment) so re-reviews reopen work that was already closed.
> 
> A **new workflow** runs on **`pull_request` closed**: it finds **incomplete** PR review subtasks for the linked Asana task and **marks each complete** via a matrix job (fallback when PRs close without every reviewer approving).
> 
> The **create subtask workflow** uses the same shared **extract task ID** action and **`task-id`** output for consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce9df756163b0ff6c1c3761e8c08f4c9885e7c3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->