### PR TITLE
macOS: Fix Duck Player UI tests and disable flaky YouTube ad-block tests

### DIFF
--- a/macOS/UITests/DuckPlayerTests.swift
+++ b/macOS/UITests/DuckPlayerTests.swift
@@ -37,7 +37,11 @@ class DuckPlayerTests: UITestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         continueAfterFailure = false
-        app = XCUIApplication.setUp(featureFlags: ["adBlockingExtension": false])
+
+        guard #available(macOS 15.4, *) else {
+            throw XCTSkip("Duck Player settings are reached via the YouTube Ad Blocking pane, which requires macOS 15.4+")
+        }
+        app = XCUIApplication.setUp(featureFlags: ["webExtensions": true, "adBlockingExtension": false])
         addressBarTextField = app.addressBar
         app.enforceSingleWindow()
     }
@@ -173,12 +177,6 @@ class DuckPlayerTests: UITestCase {
     // MARK: - Tests
 
     func test_DuckPlayer_AlwaysEnabled_Opens_FromSERPOrganic() throws {
-        // Skip this test on macOS 13
-        let version = ProcessInfo.processInfo.operatingSystemVersion
-        if version.majorVersion == 13 {
-            throw XCTSkip("Test disabled on macOS 13")
-        }
-
         // Settings
         openYouTubeAdBlockingSettings()
         selectAlwaysOpenInDuckPlayer()
@@ -198,12 +196,6 @@ class DuckPlayerTests: UITestCase {
     }
 
     func test_DuckPlayer_AlwaysEnabled_Opens_FromSERPVideos() throws {
-        // Skip this test on macOS 13
-        let version = ProcessInfo.processInfo.operatingSystemVersion
-        if version.majorVersion == 13 {
-            throw XCTSkip("Test disabled on macOS 13")
-        }
-
         // Settings
         openYouTubeAdBlockingSettings()
         selectAlwaysOpenInDuckPlayer()

--- a/macOS/UITests/YouTubeAdBlockingUITests.swift
+++ b/macOS/UITests/YouTubeAdBlockingUITests.swift
@@ -102,6 +102,7 @@ final class YouTubeAdBlockingUITests: UITestCase {
     private let youTubeAdBlockButtonIdentifier = "AddressBarButtonsViewController.youTubeAdBlockButton"
 
     func testYouTubeAdBlockButtonAndPillAppear_onYouTubeVideo_whenEnabled() throws {
+        try skipFlakyTest()
         try skipIfUnsupported()
         try clearYouTubeAdBlockingEnabledDefault()
         app = XCUIApplication.setUp(featureFlags: [
@@ -156,6 +157,7 @@ final class YouTubeAdBlockingUITests: UITestCase {
     // MARK: - Popover items
 
     func testPopoverShowsExpectedItems_whenYouTubeAdBlockButtonTapped() throws {
+        try skipFlakyTest()
         try skipIfUnsupported()
         try clearYouTubeAdBlockingEnabledDefault()
         app = XCUIApplication.setUp(featureFlags: [
@@ -215,5 +217,11 @@ final class YouTubeAdBlockingUITests: UITestCase {
         guard #available(macOS 15.4, *) else {
             throw XCTSkip("YouTube ad blocking requires macOS 15.4+")
         }
+    }
+
+    // Temporarily disabled: these assertions depend on live YouTube navigation and the animated
+    // ad-block "on" pill appearing within a timeout, which is flaky on CI. Re-enable once stabilised.
+    private func skipFlakyTest() throws {
+        throw XCTSkip("Flaky: relies on live YouTube navigation and ad-block pill animation timing, currently failing in CI")
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1215402938907867?focus=true
Tech Design URL:
CC:

### Description

This PR attempts to fix failing Duck Player UI tests, following the release of Youtube Ad Blocking, and disables a couple of other flaky tests.

### Testing Steps

1. Ensure a UI test run passes!

### Impact and Risks

None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to macOS UI test configuration and XCTSkip helpers; no production app behavior is modified.
> 
> **Overview**
> **Duck Player UI tests** are updated so setup matches how Duck Player settings are reached after YouTube Ad Blocking: the suite skips below **macOS 15.4** in `setUpWithError`, launches with **`webExtensions: true`** alongside **`adBlockingExtension: false`**, and drops redundant **macOS 13** skips from the two “always enabled from SERP” cases.
> 
> **YouTube ad-blocking UI tests** that depend on live YouTube loads and the animated address-bar “ad block on” pill now call a shared **`skipFlakyTest()`** helper at the start of **`testYouTubeAdBlockButtonAndPillAppear_onYouTubeVideo_whenEnabled`** and **`testPopoverShowsExpectedItems_whenYouTubeAdBlockButtonTapped`**, so CI skips them until timing/navigation is stabilized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6496cad043d4644cf4d4d7c142fa44cfd42503a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->