### PR TITLE
Flaky test disabled

### DIFF
--- a/macOS/IntegrationTests/Tab/ErrorPageTests.swift
+++ b/macOS/IntegrationTests/Tab/ErrorPageTests.swift
@@ -268,6 +268,8 @@ class ErrorPageTests: XCTestCase {
 
     @MainActor
     func testWhenTabWithConnectionLostErrorActivatedAndReloadFailsAgain_errorPageIsShownOnce() async throws {
+        throw XCTSkip("Flaky test")
+
         // open 2 Tabs with newtab page
         // navigate to a failing url right away
         schemeHandler.middleware = [{ _ in


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1208324840822237?focus=true
Tech Design URL:
CC: @mallexxx @alessandroboron 

### Description

Flaky `testWhenTabWithConnectionLostErrorActivatedAndReloadFailsAgain_errorPageIsShownOnce` disabled waiting for replacement

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production impact; coverage for connection-lost tab reactivation error-page behavior is temporarily reduced.
> 
> **Overview**
> Skips the macOS integration test **`testWhenTabWithConnectionLostErrorActivatedAndReloadFailsAgain_errorPageIsShownOnce`** in `ErrorPageTests` by adding **`throw XCTSkip("Flaky test")`** at the start of the method, so CI no longer runs the unstable scenario (tab with connection-lost error, reactivation, failed reload, single error page). The test body is unchanged and intended to be replaced later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 906b5858dd8d4a97f5df8c5c9cdd401c08997b47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->