### PR TITLE
iOS: Add drag gesture to the unified toggle input Search/Duck.ai toggle

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1735,6 +1735,7 @@
 		AABB0001000100010001000D /* UTIModelStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0001000100010001000E /* UTIModelStoreTests.swift */; };
 		AABB0001000100010001000F /* UTIToolsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB00010001000100010010 /* UTIToolsController.swift */; };
 		AABB00010001000100010101 /* UnifiedToggleInputViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB00010001000100010100 /* UnifiedToggleInputViewTests.swift */; };
+		AABB00010001000100010201 /* UnifiedToggleInputToggleViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB00010001000100010200 /* UnifiedToggleInputToggleViewTests.swift */; };
 		AAE51CD3558F68CEF6919A73 /* DBPIOSContentBlocking.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8EF7D71865351940816E1A0 /* DBPIOSContentBlocking.swift */; };
 		AB98765432109876543210BA /* ProductionSubscriptionPurchaseDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12345678901234567890AB /* ProductionSubscriptionPurchaseDebugView.swift */; };
 		ABA18ED2F9373DE1F5B57B66 /* RebrandedOnboardingAddressBarPositionPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392856D96DBE03E4E18EFCF8 /* RebrandedOnboardingAddressBarPositionPicker.swift */; };
@@ -4393,6 +4394,7 @@
 		AABB0001000100010001000E /* UTIModelStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIModelStoreTests.swift; sourceTree = "<group>"; };
 		AABB00010001000100010010 /* UTIToolsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIToolsController.swift; sourceTree = "<group>"; };
 		AABB00010001000100010100 /* UnifiedToggleInputViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputViewTests.swift; sourceTree = "<group>"; };
+		AABB00010001000100010200 /* UnifiedToggleInputToggleViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputToggleViewTests.swift; sourceTree = "<group>"; };
 		AB12345678901234567890AB /* ProductionSubscriptionPurchaseDebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductionSubscriptionPurchaseDebugView.swift; sourceTree = "<group>"; };
 		AC7D7E5EB7B04D2385E0E48E /* AfterInactivityOptionAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterInactivityOptionAdapterTests.swift; sourceTree = "<group>"; };
 		AD8CF8E4B152CDB3A4ACB14C /* StartupOnboardingCover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupOnboardingCover.swift; sourceTree = "<group>"; };
@@ -9462,6 +9464,7 @@
 				9AD3EE389CF6162AB1F6B023 /* UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift */,
 				AABB0001000100010001000A /* UTIAttachmentPolicyTests.swift */,
 				AABB00010001000100010100 /* UnifiedToggleInputViewTests.swift */,
+				AABB00010001000100010200 /* UnifiedToggleInputToggleViewTests.swift */,
 				AABB0001000100010001000E /* UTIModelStoreTests.swift */,
 				AABB00010001000100010004 /* UTIRenderStateTests.swift */,
 				33CC9145E578E99B3052757F /* UnifiedToggleInputModelMenuTests.swift */,
@@ -13964,6 +13967,7 @@
 				F101D53CD31E95F9C9FE2AC1 /* UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift in Sources */,
 				AABB00010001000100010009 /* UTIAttachmentPolicyTests.swift in Sources */,
 				AABB00010001000100010101 /* UnifiedToggleInputViewTests.swift in Sources */,
+				AABB00010001000100010201 /* UnifiedToggleInputToggleViewTests.swift in Sources */,
 				AABB0001000100010001000D /* UTIModelStoreTests.swift in Sources */,
 				AABB00010001000100010003 /* UTIRenderStateTests.swift in Sources */,
 				275A9E842551836ECC9E6873 /* UnifiedToggleInputModelMenuTests.swift in Sources */,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToggleView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToggleView.swift
@@ -34,6 +34,9 @@ final class UnifiedToggleInputToggleView: UIView {
         static let iconTextSpacing: CGFloat = 4
         static let horizontalPadding: CGFloat = 2
         static let animationDuration: TimeInterval = 0.25
+        /// Horizontal drag speed (pt/s) above which a release commits in the flick direction,
+        /// regardless of whether the pill has crossed the midpoint.
+        static let flickVelocityThreshold: CGFloat = 300
     }
 
     // MARK: - Properties
@@ -41,6 +44,16 @@ final class UnifiedToggleInputToggleView: UIView {
     private(set) var selectedMode: TextEntryMode = .aiChat
 
     var onModeChanged: ((TextEntryMode) -> Void)?
+
+    // MARK: - Drag State
+
+    private let selectionFeedback = UISelectionFeedbackGenerator()
+    private var dragStartMode: TextEntryMode = .aiChat
+    /// Resting leading-x of the indicator for each mode, in this view's coordinate space,
+    /// captured at drag start so the gesture stays correct across resize / rotation / Dynamic Type.
+    private var dragSearchRestX: CGFloat = 0
+    private var dragDuckAIRestX: CGFloat = 0
+    private var dragIndicatorWidth: CGFloat = 0
 
     // MARK: - UI Components
 
@@ -172,6 +185,9 @@ final class UnifiedToggleInputToggleView: UIView {
             indicator.widthAnchor.constraint(equalTo: searchButton.widthAnchor),
         ])
 
+        let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
+        addGestureRecognizer(panGesture)
+
         updateButtonAppearance()
     }
 
@@ -210,6 +226,70 @@ final class UnifiedToggleInputToggleView: UIView {
         onModeChanged?(mode)
     }
 
+    // MARK: - Drag
+
+    @objc private func handlePan(_ gesture: UIPanGestureRecognizer) {
+        switch gesture.state {
+        case .began:
+            beginDrag()
+        case .changed:
+            updateDrag(translationX: gesture.translation(in: self).x)
+        case .ended, .cancelled, .failed:
+            endDrag(velocityX: gesture.velocity(in: self).x)
+        default:
+            break
+        }
+    }
+
+    private func beginDrag() {
+        selectionFeedback.prepare()
+        dragStartMode = selectedMode
+        // Indicator rest positions equal the buttons' leading edges (see the indicator constraints).
+        dragSearchRestX = convert(searchButton.bounds, from: searchButton).minX
+        dragDuckAIRestX = convert(duckAIButton.bounds, from: duckAIButton).minX
+        dragIndicatorWidth = indicator.bounds.width
+    }
+
+    private func updateDrag(translationX: CGFloat) {
+        let travel = dragDuckAIRestX - dragSearchRestX
+        // Anchored at the drag-start side and clamped to the track, so the pill can reach the
+        // far end but never overshoot past either segment.
+        let clamped: CGFloat
+        if dragStartMode == .search {
+            clamped = min(max(translationX, 0), travel)
+        } else {
+            clamped = max(min(translationX, 0), -travel)
+        }
+        indicator.transform = CGAffineTransform(translationX: clamped, y: 0)
+    }
+
+    private func endDrag(velocityX: CGFloat) {
+        let anchorRestX = dragStartMode == .search ? dragSearchRestX : dragDuckAIRestX
+        let indicatorCenterX = anchorRestX + indicator.transform.tx + dragIndicatorWidth / 2
+        let midpointX = (dragSearchRestX + dragDuckAIRestX) / 2 + dragIndicatorWidth / 2
+        let target = resolveTargetMode(indicatorCenterX: indicatorCenterX, midpointX: midpointX, velocityX: velocityX)
+        commitDrag(to: target)
+    }
+
+    /// Decides which side the pill should settle on when the drag is released.
+    /// A fast flick wins outright; otherwise the nearer side (relative to the midpoint) is chosen.
+    func resolveTargetMode(indicatorCenterX: CGFloat, midpointX: CGFloat, velocityX: CGFloat) -> TextEntryMode {
+        if abs(velocityX) >= Constants.flickVelocityThreshold {
+            return velocityX > 0 ? .aiChat : .search
+        }
+        return indicatorCenterX < midpointX ? .search : .aiChat
+    }
+
+    private func commitDrag(to target: TextEntryMode) {
+        let modeChanged = target != selectedMode
+        selectedMode = target
+        updateIndicator(animated: true)
+        guard modeChanged else { return }
+        selectionFeedback.selectionChanged()
+        updateButtonAppearance()
+        onModeChanged?(target)
+    }
+
     // MARK: - Updates
 
     private func updateIndicator(animated: Bool) {
@@ -218,11 +298,13 @@ final class UnifiedToggleInputToggleView: UIView {
         indicatorToDuckAI.isActive = !isSearch
 
         guard animated else {
+            indicator.transform = .identity
             layoutIfNeeded()
             return
         }
 
         UIView.animate(withDuration: Constants.animationDuration, delay: 0, options: .curveEaseInOut) {
+            self.indicator.transform = .identity
             self.layoutIfNeeded()
         }
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToggleView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToggleView.swift
@@ -222,6 +222,7 @@ final class UnifiedToggleInputToggleView: UIView {
         guard mode != selectedMode else { return }
         selectedMode = mode
         updateIndicator(animated: true)
+        selectionFeedback.selectionChanged()
         updateButtonAppearance()
         onModeChanged?(mode)
     }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputToggleViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputToggleViewTests.swift
@@ -1,0 +1,74 @@
+//
+//  UnifiedToggleInputToggleViewTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import UIKit
+@testable import DuckDuckGo
+
+final class UnifiedToggleInputToggleViewTests: XCTestCase {
+
+    // Track layout for the cases below: search rest-center at 50, Duck.ai rest-center at 150,
+    // so the midpoint sits at 100. Velocities are pt/s.
+    private let searchCenterX: CGFloat = 50
+    private let duckAICenterX: CGFloat = 150
+    private let midpointX: CGFloat = 100
+
+    func testWhenDraggedPastMidpointWithoutFlickThenSnapsToFarSide() {
+        let sut = UnifiedToggleInputToggleView()
+
+        let target = sut.resolveTargetMode(indicatorCenterX: 130, midpointX: midpointX, velocityX: 0)
+
+        XCTAssertEqual(target, .aiChat)
+    }
+
+    func testWhenDraggedShortOfMidpointWithoutFlickThenSnapsBackToNearSide() {
+        let sut = UnifiedToggleInputToggleView()
+
+        let target = sut.resolveTargetMode(indicatorCenterX: 70, midpointX: midpointX, velocityX: 0)
+
+        XCTAssertEqual(target, .search)
+    }
+
+    func testWhenFlickedRightFastThenCommitsToAIChatEvenWhenLeftOfMidpoint() {
+        let sut = UnifiedToggleInputToggleView()
+
+        // Indicator still on the search side, but a fast rightward flick should win.
+        let target = sut.resolveTargetMode(indicatorCenterX: 60, midpointX: midpointX, velocityX: 1500)
+
+        XCTAssertEqual(target, .aiChat)
+    }
+
+    func testWhenFlickedLeftFastThenCommitsToSearchEvenWhenRightOfMidpoint() {
+        let sut = UnifiedToggleInputToggleView()
+
+        // Indicator already on the Duck.ai side, but a fast leftward flick should win.
+        let target = sut.resolveTargetMode(indicatorCenterX: 140, midpointX: midpointX, velocityX: -1500)
+
+        XCTAssertEqual(target, .search)
+    }
+
+    func testWhenFlickVelocityBelowThresholdThenUsesPositionOnly() {
+        let sut = UnifiedToggleInputToggleView()
+
+        // Right of midpoint with only a gentle leftward drift: position decides → aiChat.
+        let target = sut.resolveTargetMode(indicatorCenterX: 130, midpointX: midpointX, velocityX: -50)
+
+        XCTAssertEqual(target, .aiChat)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1214960121177994?focus=true
Tech Design URL:
CC:

### Description
The Search ⇄ Duck.ai pill in the unified toggle input (iPhone, `unifiedToggleInput`) is now draggable: the indicator tracks the finger 1:1, clamped to the track, and snaps to the nearest side on release with a flick-velocity assist. Tap behaviour is unchanged; the mode commit and a selection haptic fire only when the mode actually changes (a drag released on the same side springs back with no change).

### Testing Steps
1. On an iPhone build with `unifiedToggleInput` enabled, focus the address bar so the Search/Duck.ai toggle appears.
2. Drag the pill left/right — it should follow your finger, snap to the nearer side on release, and a quick flick should commit in the flick direction even before crossing the midpoint.
3. Confirm tapping each segment still switches modes, and that dragging back to the same side does not switch (or re-fire) the mode.

### Impact and Risks
Low — additive gesture on an existing iPhone-only, feature-flagged control; tap path and constraint-driven layout are untouched.

#### What could go wrong?
The pan recognizer could interfere with an enclosing horizontal swipe gesture, or the snap could misbehave under unusual layout widths (Dynamic Type / narrow toggle).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive UI gesture on a feature-flagged control; main risk is pan recognizer competing with parent horizontal swipes or odd layouts at narrow widths.
> 
> **Overview**
> Adds **horizontal pan dragging** to the Search ⇄ Duck.ai pill in `UnifiedToggleInputToggleView`, so the selection indicator follows the finger along a clamped track and snaps on release.
> 
> Release behavior uses a **midpoint snap** plus a **flick assist** (300 pt/s threshold via `resolveTargetMode`); `onModeChanged` and selection haptics run only when the mode actually changes, matching tap. Animated indicator updates now reset `transform` so drag offsets don’t stick after snap-back.
> 
> Adds **`UnifiedToggleInputToggleViewTests`** for snap/flick logic and wires the test target in the Xcode project. Tap-to-segment behavior is unchanged aside from haptics on successful taps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5841532ba11a3256c4b5e2c278a9fad16a26d01c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->