### PR TITLE
iOS: Fix embedded SERP settings native sync (use tab content-scope in…

### DIFF
--- a/iOS/Core/AppURLs.swift
+++ b/iOS/Core/AppURLs.swift
@@ -44,7 +44,7 @@ public extension URL {
     static let settingsPath = "/settings"
     static let embeddedGeneralSERPSettings = URL(string: "\(base)\(settingsPath)?ko=-1&embedded=1#general")!
     static let embeddedSearchAssistSettings =  URL(string: "\(base)\(settingsPath)?ko=-1&embedded=1&hideduckai=1&highlight=kbe#aifeatures")!
-    static let embeddedHideAIGeneratedImagesSettings =  URL(string: "\(base)\(settingsPath)?ko=-1&embedded=1&hideduckai=1&highlight=kbe#aifeatures")!
+    static let embeddedHideAIGeneratedImagesSettings =  URL(string: "\(base)\(settingsPath)?ko=-1&embedded=1&hideduckai=1&highlight=kbj#aifeatures")!
 
     static let searchSettings = URL(string: AppDeepLinkSchemes.quickLink.appending("\(ddg.host!)\(settingsPath)"))!
     static let assistSettings = URL(string: AppDeepLinkSchemes.quickLink.appending("\(ddg.host!)\(settingsPath)#aifeatures"))!

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -936,6 +936,7 @@
 		85DFEDF924CF3D0E00973FE7 /* TabsBarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85DFEDF824CF3D0E00973FE7 /* TabsBarCell.swift */; };
 		85E242172AB1B54D000F3E28 /* ReturnUserMeasurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85E242162AB1B54D000F3E28 /* ReturnUserMeasurement.swift */; };
 		85E3332D2E8D5D3E0025CF7B /* SERPSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85E3332C2E8D5CEB0025CF7B /* SERPSettingsView.swift */; };
+		BB88557B2FD1D04B007BDE10 /* SERPSettingsWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB88557A2FD1D04B007BDE10 /* SERPSettingsWebView.swift */; };
 		85E8036F2E785BD8008E87CA /* ApplicationShortcutItems.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 85E8036E2E785BD8008E87CA /* ApplicationShortcutItems.xcassets */; };
 		85E803732E786B95008E87CA /* AIChatService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85E803722E786B95008E87CA /* AIChatService.swift */; };
 		85F0E97329952D7A003D5181 /* DuckDuckGo Recovery Document.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 85F0E97229952D7A003D5181 /* DuckDuckGo Recovery Document.pdf */; };
@@ -3480,6 +3481,7 @@
 		85DFEDF824CF3D0E00973FE7 /* TabsBarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsBarCell.swift; sourceTree = "<group>"; };
 		85E242162AB1B54D000F3E28 /* ReturnUserMeasurement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReturnUserMeasurement.swift; sourceTree = "<group>"; };
 		85E3332C2E8D5CEB0025CF7B /* SERPSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SERPSettingsView.swift; sourceTree = "<group>"; };
+		BB88557A2FD1D04B007BDE10 /* SERPSettingsWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SERPSettingsWebView.swift; sourceTree = "<group>"; };
 		85E8036E2E785BD8008E87CA /* ApplicationShortcutItems.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ApplicationShortcutItems.xcassets; sourceTree = "<group>"; };
 		85E803722E786B95008E87CA /* AIChatService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatService.swift; sourceTree = "<group>"; };
 		85F0E97229952D7A003D5181 /* DuckDuckGo Recovery Document.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = "DuckDuckGo Recovery Document.pdf"; sourceTree = "<group>"; };
@@ -10156,6 +10158,7 @@
 			isa = PBXGroup;
 			children = (
 				85E3332C2E8D5CEB0025CF7B /* SERPSettingsView.swift */,
+				BB88557A2FD1D04B007BDE10 /* SERPSettingsWebView.swift */,
 				D6E83C302B1EA309006C8AFB /* SettingsCell.swift */,
 				1DEAADFA2BA71E9A00E25A97 /* SettingsDescriptionView.swift */,
 				D6E83C472B20C812006C8AFB /* SettingsHostingController.swift */,
@@ -13483,6 +13486,7 @@
 				BD10B8AA2C7629740033115D /* Logger+Subscription.swift in Sources */,
 				D6E0C1892B7A2E0D00D5E1E9 /* DesktopDownloadViewModel.swift in Sources */,
 				85E3332D2E8D5D3E0025CF7B /* SERPSettingsView.swift in Sources */,
+				BB88557B2FD1D04B007BDE10 /* SERPSettingsWebView.swift in Sources */,
 				31CE145C2D5505520027F11D /* OmnibarDependencyProvider.swift in Sources */,
 				6F45B70F2F1E616600883A86 /* BrowsingMenuSheetViewController.swift in Sources */,
 				9F23B8012C2BC94400950875 /* OnboardingBackground.swift in Sources */,

--- a/iOS/DuckDuckGo/MainViewController+Segues.swift
+++ b/iOS/DuckDuckGo/MainViewController+Segues.swift
@@ -475,6 +475,7 @@ extension MainViewController {
                                                   experimentalAIChatManager: ExperimentalAIChatManager(featureFlagger: featureFlagger),
                                                   privacyConfigurationManager: privacyConfigurationManager,
                                                   keyValueStore: keyValueStore,
+                                                  contentBlockingAssetsPublisher: contentBlockingAssetsPublisher,
                                                   idleReturnEligibilityManager: idleReturnEligibilityManager,
                                                   afterInactivityOptionAdapter: afterInactivityOptionAdapter,
                                                   systemSettingsPiPTutorialManager: systemSettingsPiPTutorialManager,

--- a/iOS/DuckDuckGo/PrivateSearchView.swift
+++ b/iOS/DuckDuckGo/PrivateSearchView.swift
@@ -67,7 +67,9 @@ struct PrivateSearchViewSettings: View {
 
         Section {
             // More Search Settings
-            NavigationLink(destination: SERPSettingsView(page: .general, featureFlagger: viewModel.featureFlagger)) {
+            NavigationLink(destination: SERPSettingsView(page: .general,
+                                                         contentBlockingAssetsPublisher: viewModel.contentBlockingAssetsPublisher,
+                                                         keyValueStore: viewModel.keyValueStore)) {
                 SettingsCellView(label: UserText.moreSearchSettings,
                                  subtitle: UserText.moreSearchSettingsExplanation)
             }

--- a/iOS/DuckDuckGo/SERPSettingsView.swift
+++ b/iOS/DuckDuckGo/SERPSettingsView.swift
@@ -22,29 +22,22 @@ import Core
 import SwiftUI
 import DesignResourcesKit
 import PrivacyConfig
+import Combine
+import Persistence
 
 struct SERPSettingsView: View {
 
     /// Used to show the right settings screen on SERP
     let page: Page
-    
-    let webViewModel: AsyncHeadlessWebViewViewModel
-
-    init(page: Page, featureFlagger: FeatureFlagger) {
-        self.page = page
-        self.webViewModel = AsyncHeadlessWebViewViewModel(
-            settings: AsyncHeadlessWebViewSettings(bounces: false,
-                                                   userScriptsDependencies: nil,
-                                                   featureFlagger: featureFlagger))
-    }
+    let contentBlockingAssetsPublisher: AnyPublisher<ContentBlockingUpdating.NewContent, Never>
+    let keyValueStore: ThrowingKeyValueStoring
 
     var body: some View {
-        AsyncHeadlessWebView(viewModel: webViewModel)
+        SERPSettingsWebView(url: page.url,
+                            contentBlockingAssetsPublisher: contentBlockingAssetsPublisher,
+                            keyValueStore: keyValueStore)
             .ignoresSafeArea(edges: .bottom)
             .background()
-            .onAppear {
-                webViewModel.navigationCoordinator.navigateTo(url: page.url)
-            }
     }
 
     enum Page {

--- a/iOS/DuckDuckGo/SERPSettingsWebView.swift
+++ b/iOS/DuckDuckGo/SERPSettingsWebView.swift
@@ -1,0 +1,133 @@
+//
+//  SERPSettingsWebView.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+import UIKit
+import WebKit
+import Combine
+import Core
+import BrowserServicesKit
+import PrivacyConfig
+import Persistence
+import UserScript
+
+struct SERPSettingsWebView: UIViewRepresentable {
+
+    let url: URL
+    let contentBlockingAssetsPublisher: AnyPublisher<ContentBlockingUpdating.NewContent, Never>
+    let keyValueStore: ThrowingKeyValueStoring
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(url: url, keyValueStore: keyValueStore)
+    }
+
+    func makeUIView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.dataDetectorTypes = []
+        let userContentController = UserContentController(assetsPublisher: contentBlockingAssetsPublisher,
+                                                          privacyConfigurationManager: ContentBlocking.shared.privacyConfigurationManager)
+        configuration.userContentController = userContentController
+        userContentController.delegate = context.coordinator
+
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.navigationDelegate = context.coordinator
+        webView.uiDelegate = context.coordinator
+        webView.scrollView.bounces = false
+        webView.preventFlashOnLoad()
+#if DEBUG
+        if #available(iOS 16.4, *) {
+            webView.isInspectable = true
+        }
+#endif
+        context.coordinator.webView = webView
+        return webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {}
+
+    static func dismantleUIView(_ uiView: WKWebView, coordinator: Coordinator) {
+        uiView.stopLoading()
+        uiView.navigationDelegate = nil
+        uiView.uiDelegate = nil
+        (uiView.configuration.userContentController as? UserContentController)?.cleanUpBeforeClosing()
+        coordinator.webView = nil
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, UserContentControllerDelegate, WKNavigationDelegate, WKUIDelegate {
+
+        private let url: URL
+        private let keyValueStore: ThrowingKeyValueStoring
+        weak var webView: WKWebView?
+        private var didLoad = false
+
+        init(url: URL, keyValueStore: ThrowingKeyValueStoring) {
+            self.url = url
+            self.keyValueStore = keyValueStore
+        }
+
+        func userContentController(_ userContentController: UserContentController,
+                                   didInstallContentRuleLists contentRuleLists: [String: WKContentRuleList],
+                                   userScripts: UserScriptsProvider,
+                                   updateEvent: ContentBlockerRulesManager.UpdateEvent) {
+            guard let userScripts = userScripts as? UserScripts else { return }
+            userScripts.serpSettingsUserScript.setStore(keyValueStore)
+            userScripts.serpSettingsUserScript.webView = webView
+
+            guard !didLoad, let webView else { return }
+            didLoad = true
+            webView.load(URLRequest(url: url))
+        }
+
+        func webView(_ webView: WKWebView,
+                     decidePolicyFor navigationAction: WKNavigationAction,
+                     decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+            guard let url = navigationAction.request.url, let scheme = url.scheme?.lowercased() else {
+                decisionHandler(.cancel)
+                return
+            }
+
+            guard scheme == "http" || scheme == "https" else {
+                openExternally(url)
+                decisionHandler(.cancel)
+                return
+            }
+
+            if url.isPart(ofDomain: "duckduckgo.com") {
+                decisionHandler(.allow)
+            } else {
+                openExternally(url)
+                decisionHandler(.cancel)
+            }
+        }
+
+        func webView(_ webView: WKWebView,
+                     createWebViewWith configuration: WKWebViewConfiguration,
+                     for navigationAction: WKNavigationAction,
+                     windowFeatures: WKWindowFeatures) -> WKWebView? {
+            webView.load(navigationAction.request)
+            return nil
+        }
+
+        private func openExternally(_ url: URL) {
+            guard UIApplication.shared.canOpenURL(url) else { return }
+            UIApplication.shared.open(url)
+        }
+    }
+}

--- a/iOS/DuckDuckGo/SettingsAIFeaturesView.swift
+++ b/iOS/DuckDuckGo/SettingsAIFeaturesView.swift
@@ -122,25 +122,27 @@ struct SettingsAIFeaturesView: View {
 
             if !viewModel.openedFromSERPSettingsButton {
                 Section {
-                    NavigationLink(destination: SERPSettingsView(page: .searchAssist, featureFlagger: viewModel.featureFlagger)) {
+                    NavigationLink(destination: SERPSettingsView(page: .searchAssist,
+                                                                 contentBlockingAssetsPublisher: viewModel.contentBlockingAssetsPublisher,
+                                                                 keyValueStore: viewModel.keyValueStore)) {
                         SettingsCellView(label: UserText.settingsAiFeaturesSearchAssist,
                                          subtitle: UserText.settingsAiFeaturesSearchAssistSubtitle,
                                          image: Image(uiImage: DesignSystemImages.Glyphs.Size24.assist))
                     }
                     .listRowBackground(Color(designSystemColor: .surface))
 
-                    if viewModel.shouldShowHideAIGeneratedImagesSection {
-                        NavigationLink(destination: SERPSettingsView(page: .hideAIGeneratedImages, featureFlagger: viewModel.featureFlagger)
-                                .onAppear {
-                                    PixelKit.fire(SERPSettingsPixel.hideAIGeneratedImagesButtonClicked, frequency: .dailyAndStandard)
-                                }
-                        ) {
-                            SettingsCellView(label: UserText.settingsAiFeaturesHideAIGeneratedImages,
-                                             subtitle: UserText.settingsAiFeaturesHideAIGeneratedImagesSubtitle,
-                                             image: Image(uiImage: DesignSystemImages.Glyphs.Size24.imageAIHide))
-                        }
-                        .listRowBackground(Color(designSystemColor: .surface))
+                    NavigationLink(destination: SERPSettingsView(page: .hideAIGeneratedImages,
+                                                                 contentBlockingAssetsPublisher: viewModel.contentBlockingAssetsPublisher,
+                                                                 keyValueStore: viewModel.keyValueStore)
+                            .onAppear {
+                                PixelKit.fire(SERPSettingsPixel.hideAIGeneratedImagesButtonClicked, frequency: .dailyAndStandard)
+                            }
+                    ) {
+                        SettingsCellView(label: UserText.settingsAiFeaturesHideAIGeneratedImages,
+                                         subtitle: UserText.settingsAiFeaturesHideAIGeneratedImagesSubtitle,
+                                         image: Image(uiImage: DesignSystemImages.Glyphs.Size24.imageAIHide))
                     }
+                    .listRowBackground(Color(designSystemColor: .surface))
                 }
             }
         }.applySettingsListModifiers(title: UserText.settingsAiFeatures,

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -147,7 +147,8 @@ final class SettingsViewModel: ObservableObject {
     private var aiChatSettingsObserver: Any?
 
     private let privacyConfigurationManager: PrivacyConfigurationManaging
-    private let keyValueStore: ThrowingKeyValueStoring
+    let keyValueStore: ThrowingKeyValueStoring
+    let contentBlockingAssetsPublisher: AnyPublisher<ContentBlockingUpdating.NewContent, Never>
     private let systemSettingsPiPTutorialManager: SystemSettingsPiPTutorialManaging
 
     // Closures to interact with legacy view controllers through the container
@@ -952,6 +953,7 @@ final class SettingsViewModel: ObservableObject {
          urlOpener: URLOpener = UIApplication.shared,
          privacyConfigurationManager: PrivacyConfigurationManaging,
          keyValueStore: ThrowingKeyValueStoring,
+         contentBlockingAssetsPublisher: AnyPublisher<ContentBlockingUpdating.NewContent, Never>,
          idleReturnEligibilityManager: IdleReturnEligibilityManaging,
          afterInactivityOptionAdapter: AfterInactivityOptionAdapter,
          systemSettingsPiPTutorialManager: SystemSettingsPiPTutorialManaging,
@@ -992,6 +994,7 @@ final class SettingsViewModel: ObservableObject {
         self.urlOpener = urlOpener
         self.privacyConfigurationManager = privacyConfigurationManager
         self.keyValueStore = keyValueStore
+        self.contentBlockingAssetsPublisher = contentBlockingAssetsPublisher
         self.idleReturnEligibilityManager = idleReturnEligibilityManager
         self.afterInactivityOptionAdapter = afterInactivityOptionAdapter
         self.afterInactivityIdleInterval = AfterInactivityIdleInterval(rawValue: idleReturnEligibilityManager.idleThresholdSeconds()) ?? .default

--- a/iOS/DuckDuckGoTests/SERPSettingsViewPageTests.swift
+++ b/iOS/DuckDuckGoTests/SERPSettingsViewPageTests.swift
@@ -26,6 +26,7 @@ final class SERPSettingsViewPageTests: XCTestCase {
     func testAppURLsAreConstructedCorrectly() {
         XCTAssertEqual(SERPSettingsView.Page.general.url.absoluteString, "https://duckduckgo.com/settings?ko=-1&embedded=1#general")
         XCTAssertEqual(SERPSettingsView.Page.searchAssist.url.absoluteString, "https://duckduckgo.com/settings?ko=-1&embedded=1&hideduckai=1&highlight=kbe#aifeatures")
+        XCTAssertEqual(SERPSettingsView.Page.hideAIGeneratedImages.url.absoluteString, "https://duckduckgo.com/settings?ko=-1&embedded=1&hideduckai=1&highlight=kbj#aifeatures")
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204649612742120/task/1215395615844707?focus=true
Tech Design URL:
CC:

### Description

Fixes the embedded SERP settings webview (Search Assist / Hide AI Images / Private Search → More Search Settings) not syncing: it used a bare `WKUserContentController` that injects the content-scope script but never initialises the `messageBridge` runtime the SERP needs, so `getNativeSettings`/`updateNativeSettings` were never called. New `SERPSettingsWebView` backs it with the same `UserContentController` + `UserScripts` pipeline a browser tab uses (navigation contained to duckduckgo.com, torn down on dismiss). Also fixes the Hide-AI-Images highlight anchor (`kbe`→`kbj`).

### Testing Steps
1. Settings → AI Features → Search Assist: change a toggle, reopen — it persists.
2. Settings → AI Features → Hide AI-Generated Images: same.
3. Settings → Private Search → More Search Settings: same.
4. Change the settings from Settings> AI Features (both Hide AI-Generated Images and More Search Settings), then open a new tab and go to SERP; make sure that those are set up correctly there.

### Impact and Risks
Low. Restores settings sync in the embedded SERP settings webview using the same content-scope pipeline as a browser tab.

### Notes to Reviewer
The webview loads only after content-scope scripts install (in the `UserContentControllerDelegate` callback), mirroring how a tab gates on content-blocking assets — otherwise the messaging bridge isn't present at document start.

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Low Risk**
> Scoped to embedded settings webviews and dependency plumbing; behavior aligns with existing tab setup and restores sync rather than changing auth or data models.
> 
> **Overview**
> **Embedded SERP settings** (Search Assist, Hide AI Images, More Search Settings) no longer use `AsyncHeadlessWebView`; they now load through a new **`SERPSettingsWebView`** that mirrors a browser tab’s **`UserContentController`** + content-blocking assets pipeline. The page load is deferred until content rule lists and user scripts (including **`serpSettingsUserScript`**) are installed, then the script gets **`keyValueStore`** and the web view so **`getNativeSettings` / `updateNativeSettings`** can run.
> 
> **Settings wiring:** `SettingsViewModel` and settings launch from **`MainViewController`** now pass **`contentBlockingAssetsPublisher`** and expose **`keyValueStore`** to all **`SERPSettingsView`** entry points. **`SERPSettingsView`** takes those dependencies instead of building a headless web view from **`FeatureFlagger`**.
> 
> **Other:** Hide AI Generated Images deep link **`highlight`** changes from **`kbe`** to **`kbj`**. The Hide AI Generated Images row in AI Features is always shown (feature-flag gate removed). URL construction test updated for the new anchor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b62bd45a8fe1fe04594b0c64e46cbe33b7d57e44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>