### PR TITLE
iOS: Remove haptic feedback from the unified toggle input toggle

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToggleView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToggleView.swift
@@ -47,7 +47,6 @@ final class UnifiedToggleInputToggleView: UIView {
 
     // MARK: - Drag State
 
-    private let selectionFeedback = UISelectionFeedbackGenerator()
     private var dragStartMode: TextEntryMode = .aiChat
     /// Resting leading-x of the indicator for each mode, in this view's coordinate space,
     /// captured at drag start so the gesture stays correct across resize / rotation / Dynamic Type.
@@ -222,7 +221,6 @@ final class UnifiedToggleInputToggleView: UIView {
         guard mode != selectedMode else { return }
         selectedMode = mode
         updateIndicator(animated: true)
-        selectionFeedback.selectionChanged()
         updateButtonAppearance()
         onModeChanged?(mode)
     }
@@ -243,7 +241,6 @@ final class UnifiedToggleInputToggleView: UIView {
     }
 
     private func beginDrag() {
-        selectionFeedback.prepare()
         dragStartMode = selectedMode
         // Indicator rest positions equal the buttons' leading edges (see the indicator constraints).
         dragSearchRestX = convert(searchButton.bounds, from: searchButton).minX
@@ -286,7 +283,6 @@ final class UnifiedToggleInputToggleView: UIView {
         selectedMode = target
         updateIndicator(animated: true)
         guard modeChanged else { return }
-        selectionFeedback.selectionChanged()
         updateButtonAppearance()
         onModeChanged?(target)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1215415293172121?focus=true
Tech Design URL:
CC:

### Description
Removes the selection haptic feedback that was added to the unified toggle input Search ⇄ Duck.ai pill (iPhone, `unifiedToggleInput`). The drag gesture, flick/snap behaviour, and tap-to-switch all remain unchanged — only the `UISelectionFeedbackGenerator` and its three call sites are gone.

### Testing Steps
1. On an iPhone build with `unifiedToggleInput` enabled, focus the address bar so the Search/Duck.ai toggle appears.
2. Tap each segment and drag the pill between sides — confirm mode switching still works.
3. Confirm no haptic buzz fires on tap or on drag-release commit.

### Impact and Risks
Low

#### What could go wrong?
Nothing functional — purely removes a tactile side effect from a feature-flagged iPhone-only control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Feature-flagged UI-only change with no logic or data impact; only removes haptic side effects.
> 
> **Overview**
> Removes **selection haptics** from the unified address-bar Search ⇄ Duck.ai pill in `UnifiedToggleInputToggleView`. The `UISelectionFeedbackGenerator` property and all `prepare()` / `selectionChanged()` calls on segment tap and drag commit are deleted.
> 
> **Tap, drag, flick/snap, and `onModeChanged` behavior are unchanged** — only the tactile feedback on mode switch is gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7269977d174e3cc7e25a00e77d392ca5597aeb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->