### PR TITLE
Defensive fix for TabsBarViewController out-of-bounds crash

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -923,6 +923,7 @@ extension Pixel {
 
         case debugTabSwitcherDidChangeInvalidState
         case debugTabsModelCrossModeMismatch
+        case debugTabsBarCellIndexOutOfRange
 
         case debugBookmarksInitialStructureQueryFailed
         case debugBookmarksStructureLost
@@ -2727,6 +2728,7 @@ extension Pixel.Event {
 
         case .debugTabSwitcherDidChangeInvalidState: return "m_debug_tabswitcher_didchange_invalidstate"
         case .debugTabsModelCrossModeMismatch: return "m_debug_tabs-model_cross-mode-mismatch"
+        case .debugTabsBarCellIndexOutOfRange: return "m_debug_tabs-bar_cell-index-out-of-range"
 
         case .debugBookmarksMigratedMoreThanOnce: return "m_debug_bookmarks_migrated-more-than-once"
             

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -2728,7 +2728,7 @@ extension Pixel.Event {
 
         case .debugTabSwitcherDidChangeInvalidState: return "m_debug_tabswitcher_didchange_invalidstate"
         case .debugTabsModelCrossModeMismatch: return "m_debug_tabs-model_cross-mode-mismatch"
-        case .debugTabsBarCellIndexOutOfRange: return "m_debug_tabs-bar_cell-index-out-of-range"
+        case .debugTabsBarCellIndexOutOfRange: return "debug_tabs-bar_cell-index-out-of-range"
 
         case .debugBookmarksMigratedMoreThanOnce: return "m_debug_bookmarks_migrated-more-than-once"
             

--- a/iOS/DuckDuckGo/TabsBarCell.swift
+++ b/iOS/DuckDuckGo/TabsBarCell.swift
@@ -107,7 +107,31 @@ class TabsBarCell: UICollectionViewCell {
         
         applyModel(model)
     }
-    
+
+    /// Configures the cell to render without a backing `Tab`.
+    ///
+    /// Used as a defensive fallback when the collection view requests a cell for an index that no
+    /// longer exists in the tabs model (e.g. during a desync between the layout and the model). The
+    /// cell is left visually empty and non-interactive; a subsequent refresh replaces it.
+    func configurePlaceholder(withTheme theme: Theme) {
+        self.model?.removeObserver(self)
+        self.model = nil
+        onRemove = nil
+
+        label.primaryColor = theme.barTintColor
+        label.text = nil
+        label.accessibilityLabel = nil
+        faviconImage.image = nil
+
+        topBackgroundView.backgroundColor = .clear
+        bottomBackgroundView.backgroundColor = .clear
+        separatorView.backgroundColor = theme.tabsBarSeparatorColor
+
+        labelRemoveButtonConstraint.isActive = false
+        separatorView.isHidden = true
+        removeButton.isHidden = true
+    }
+
     private func applyModel(_ model: Tab) {
 
         if model.link == nil {

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -538,7 +538,10 @@ extension TabsBarViewController: UICollectionViewDataSource {
         }
         
         guard let model = tabsModel?.get(tabAt: indexPath.row) else {
-            fatalError("Failed to load tab at \(indexPath.row)")
+            assertionFailure("TabsBarViewController: failed to load tab at \(indexPath.row) of \(tabsCount)")
+            DailyPixel.fireDailyAndCount(pixel: .debugTabsBarCellIndexOutOfRange)
+            cell.configurePlaceholder(withTheme: ThemeManager.shared.currentTheme)
+            return cell
         }
         let isCurrent = indexPath.row == currentIndex
         let isNextCurrent = indexPath.row + 1 == currentIndex

--- a/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
@@ -49,7 +49,7 @@
             }
         ]
     },
-    "m_debug_tabs-bar_cell-index-out-of-range": {
+    "debug_tabs-bar_cell-index-out-of-range": {
         "description": "Fires when the iPad tabs bar collection view requests a cell for an index that no longer exists in the tabs model (a desync between the layout and the model). The view now renders a placeholder instead of crashing. Expecting minimal numbers of these pixels - ideally zero.",
         "owners": ["hassaanelgarem"],
         "triggers": ["other"],

--- a/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
@@ -49,6 +49,13 @@
             }
         ]
     },
+    "m_debug_tabs-bar_cell-index-out-of-range": {
+        "description": "Fires when the iPad tabs bar collection view requests a cell for an index that no longer exists in the tabs model (a desync between the layout and the model). The view now renders a placeholder instead of crashing. Expecting minimal numbers of these pixels - ideally zero.",
+        "owners": ["hassaanelgarem"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
     "m_pixel_fire_suppressed_storage_error": {
         "description": "Fired when a daily or unique pixel is suppressed because the storage write for its last-fire date failed. Indicates a broken pixel store that would otherwise cause repeated firing.",
         "owners": ["samsymons"],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211767540372501/task/1215437898996660?focus=true

### Description

- Replace the `fatalError` in `TabsBarViewController.collectionView(_:cellForItemAt:)` with a graceful fallback: when the tabs model has no tab at the requested index, the cell is rendered as a placeholder instead of crashing. This stops the high-volume iPad crash (Sentry APPLE-IOS-CQYR).
- Add `TabsBarCell.configurePlaceholder(withTheme:)` which renders an empty, non-interactive cell without a backing `Tab` (observer detached, remove button hidden).
- Keep an `assertionFailure` on this path so the layout/model desync is still surfaced loudly in debug/QA builds.
- Add a `debugTabsBarCellIndexOutOfRange` daily + count pixel so we can measure how often this desync actually happens in the wild.

This is **defensive code only** — it stops the crash but does not address the underlying layout/model desync that causes the collection view to request a stale index. A follow-up PR with potential root-cause fixes is to follow.

### Testing Steps

The crash itself is hard to reproduce on demand, so testing focuses on confirming no regressions to the tabs bar on iPad:

1. On an iPad, open several tabs so the tabs bar is populated.
2. Switch between tabs — confirm the correct tab is highlighted and titles/favicons are correct.
3. Close individual tabs via the tab bar's close button — confirm the bar updates correctly.
4. Bulk-close tabs from the tab switcher (e.g. "Close all tabs") — confirm the tabs bar updates without visual glitches or crashes.
5. Open/close tabs rapidly and rotate the device — confirm no crash and the bar stays consistent.
6. To exercise the placeholder path directly: temporarily change `numberOfItemsInSection` in `TabsBarViewController` to return `tabsCount + 1` and comment out the `assertionFailure` in `cellForItemAt`. Confirm the extra cell renders as an empty, non-interactive placeholder and the tabs bar UI is not broken. Revert both changes after verifying.

### Impact and Risks

**Impact Level: Low**

#### What could go wrong?

- The placeholder path only executes on a code path that previously crashed, so the worst realistic outcome is a momentary empty cell that is corrected on the next refresh.
- `assertionFailure` will trap in debug builds if the desync occurs; this is intentional to keep the underlying issue visible while the root cause is investigated.

### Notes to Reviewer

This is a targeted crash-stopper. The real fix for the layout/model desync will come in a separate PR; this one is intentionally minimal and low-risk so it can ship quickly to halt the crash volume.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive UI-only change on a path that previously crashed; worst case is a brief empty tab cell until reload.
> 
> **Overview**
> Replaces the **fatalError** in iPad **TabsBarViewController** when `cellForItemAt` cannot resolve a tab for the requested index with a **defensive fallback**: **`assertionFailure`** in debug, a new **`debugTabsBarCellIndexOutOfRange`** daily/count pixel, and an empty **`TabsBarCell.configurePlaceholder(withTheme:)`** cell instead of crashing.
> 
> This targets the high-volume Sentry crash from collection view / tabs model desync; it does **not** fix the underlying sync issue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d95eebacd085efa12c39c9e5e29aae1c60434c0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->