### PR TITLE
Use standard fire glyph on the escape-hatch Return-to card button

### DIFF
--- a/iOS/DuckDuckGo/ReturnToTabCard.swift
+++ b/iOS/DuckDuckGo/ReturnToTabCard.swift
@@ -127,7 +127,7 @@ struct ReturnToTabCard: View {
     /// fire tabs burn immediately, everything else asks for confirmation (anchored to this button on iPad).
     private var fireButton: some View {
         Button(action: deleteTab) {
-            Image(uiImage: DesignSystemImages.Glyphs.Size24.fireTabs)
+            Image(uiImage: DesignSystemImages.Glyphs.Size24.fire)
                 .foregroundColor(Color(designSystemColor: .icons))
                 .padding(.horizontal, Metrics.actionIconPadding)
                 .frame(maxHeight: .infinity)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211654189969294/task/1215358250572341?focus=true
Tech Design URL:
CC:

### Description

Follow-up to #5255. Swaps the escape-hatch "Return to…" card Fire button icon from the `fireTabs` glyph to the **standard** `Size24.fire` glyph, per the updated [Figma design](https://www.figma.com/design/QUTLfN2oPR6ivG1Jwsw3Mg/?node-id=12009-72157) (plain flame, no "tab" box).

One-line change in `ReturnToTabCard.swift`; no behaviour change. The button stays gated behind the `escapeHatchFireButton` feature flag.

### Testing Steps
1. Open a site, then open a new tab so the "Return to…" card appears on the NTP.
2. Confirm the button to the left of the ⋯ menu now shows the **standard fire** glyph (a plain flame, no rounded-rectangle tab underneath).
3. Tapping it still performs the delete-tab action (immediate burn for fire tabs; confirmation otherwise).

### Impact and Risks

**Low** — purely a glyph swap to another existing design-system icon; no logic, layout, or flag changes.

#### What could go wrong?
- Nothing functional. Visual-only change; both glyphs are the same 24pt size so layout is unaffected.

### Notes to Reviewer
- No new asset is added — `Size24.fire` already ships in DesignResourcesKitIcons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-image swap using an existing design-system asset; no logic, layout, or feature-flag changes.
> 
> **Overview**
> Updates the **Return to…** escape-hatch card so the trailing **Delete tab** control uses the design-system **`Size24.fire`** glyph (plain flame) instead of **`Size24.fireTabs`**, matching the revised Figma spec and follow-up to the escape-hatch fire button work.
> 
> **Behaviour is unchanged**: the control still sits behind `escapeHatchFireButton`, keeps the same accessibility label and identifiers, and still runs immediate burn vs confirmation flows via `deleteTab`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36c4cd4da6fa0f60767d24708694468b4b953400. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->