### PR TITLE
iOS: Shrink AI tab header title to fit on narrow screens

### DIFF
--- a/iOS/DuckDuckGo/AIChat/AIChatTabChatHeaderView.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatTabChatHeaderView.swift
@@ -50,6 +50,7 @@ final class AIChatTabChatHeaderView: UIView {
         static let pillButtonSize: CGFloat = 36
         static let paidIconSize: CGFloat = 16
         static let paidIconTitleSpacing: CGFloat = 6
+        static let titleMinimumScaleFactor: CGFloat = 0.7
     }
 
     weak var delegate: AIChatTabChatHeaderViewDelegate?
@@ -220,6 +221,8 @@ final class AIChatTabChatHeaderView: UIView {
         label.textColor = UIColor(designSystemColor: .textPrimary)
         label.textAlignment = .center
         label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = Constants.titleMinimumScaleFactor
         return label
     }()
 
@@ -239,6 +242,8 @@ final class AIChatTabChatHeaderView: UIView {
         label.textColor = UIColor(designSystemColor: .textSecondary)
         label.textAlignment = .center
         label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = Constants.titleMinimumScaleFactor
         return label
     }()
 
@@ -250,6 +255,8 @@ final class AIChatTabChatHeaderView: UIView {
         label.textColor = UIColor(designSystemColor: .textPrimary)
         label.textAlignment = .center
         label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = Constants.titleMinimumScaleFactor
         return label
     }()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214995870352483?focus=true
Tech Design URL:
CC:

### Description
When `unifiedToggleInput` is on and the user is on Duck.ai, the navigation header title ("Free Plan" / "Duck.ai" / "Upgrade") now uses `adjustsFontSizeToFitWidth` with a `minimumScaleFactor` of 0.7. The title shrinks only when the gap between the button pills is too narrow (e.g. iPhone mini or large Dynamic Type), and stays at full size when it fits.

### Testing Steps
1. Enable `unifiedToggleInput` and open the Duck.ai tab on an iPhone mini simulator (or a small device + large Dynamic Type).
2. Confirm the header title shrinks to fit between the buttons instead of truncating or overflowing.
3. Repeat on a regular-size iPhone and confirm the title renders at full size.

### Impact and Risks
Low — purely a layout/typography tweak on the AI tab header title labels.

#### What could go wrong?
The title could scale down more than expected on very constrained widths, but it is floored at 70% before truncating.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only typography on the AI tab header; no logic, networking, or data changes.
> 
> **Overview**
> The Duck.ai tab header center titles (**Free Plan**, **Upgrade**, and paid **Duck.ai**) now shrink when horizontal space between the side pill buttons is tight, instead of truncating or clipping.
> 
> A shared **`titleMinimumScaleFactor` of 0.7** is applied with **`adjustsFontSizeToFitWidth`** on the three title `UILabel`s in `AIChatTabChatHeaderView`. Text stays at full size when it fits; it scales down only as needed, down to 70% of the nominal font size.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 064e56f157f729f7a7004bcc8920b880a7b3420b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->