### PR TITLE
[iOS] fix view port glitch on ios 26 when bottom bar enabled

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -252,6 +252,9 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
 
     case minimalChromeInLandscape
 
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215448831345663?focus=true
+    case bottomBarViewportFixedElementsWorkaround
+
     /// https://app.asana.com/1/137249556945/project/1206329551987282/task/1211806114021630?focus=true
     case onboardingRebranding
 

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -399,6 +399,9 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213809475913723?focus=true
     case minimalChromeInLandscape
 
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215448831345663?focus=true
+    case bottomBarViewportFixedElementsWorkaround
+
     case aiChatNativeStorage
 
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215106459483563?focus=true
@@ -728,6 +731,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(AIChatSubfeature.contextualFireButton))
         case .minimalChromeInLandscape:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.minimalChromeInLandscape))
+        case .bottomBarViewportFixedElementsWorkaround:
+            Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.bottomBarViewportFixedElementsWorkaround))
         case .aiChatNativeStorage:
             Config(source: .remoteReleasable(AIChatSubfeature.nativeStorage))
         case .duckAINativeStoragePathMigration:

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -814,9 +814,17 @@ class TabViewController: UIViewController {
             /// When address bar is at bottom on iPhone, offset webview to make room for the bars.
             /// AI tabs skip this inset only when unifiedToggleInput is active — that feature
             /// manages its own native bottom layout via the UnifiedToggleInput container.
-
             let targetHeight = chromeDelegate?.barsMaxHeight ?? 0.0
-            webViewBottomAnchorConstraint?.constant = -targetHeight * barsVisibilityPercent
+            let effectiveBarsVisibilityPercent: CGFloat
+            if #available(iOS 26, *) {
+                /// iOS 26 regressed fixed-bottom webpage elements when the browser continuously
+                /// resizes the webview's bottom inset while chrome hides/shows. Keep the inset
+                /// stable in bottom-address-bar mode to avoid pushing page-fixed footers offscreen.
+                effectiveBarsVisibilityPercent = 1.0
+            } else {
+                effectiveBarsVisibilityPercent = barsVisibilityPercent
+            }
+            webViewBottomAnchorConstraint?.constant = -targetHeight * effectiveBarsVisibilityPercent
         } else {
             webViewBottomAnchorConstraint?.constant = 0
         }

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -816,7 +816,8 @@ class TabViewController: UIViewController {
             /// manages its own native bottom layout via the UnifiedToggleInput container.
             let targetHeight = chromeDelegate?.barsMaxHeight ?? 0.0
             let effectiveBarsVisibilityPercent: CGFloat
-            if #available(iOS 26, *) {
+            if #available(iOS 26, *),
+               featureFlagger.isFeatureOn(.bottomBarViewportFixedElementsWorkaround) {
                 /// iOS 26 regressed fixed-bottom webpage elements when the browser continuously
                 /// resizes the webview's bottom inset while chrome hides/shows. Keep the inset
                 /// stable in bottom-address-bar mode to avoid pushing page-fixed footers offscreen.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/715106103902962/task/1215318080803934?focus=true
Tech Design URL:
CC:

### Description
See title

### Testing Steps
1.  Visit https://privacy-test-pages.site/viewport/bottom-pinned.html 
2. With bar in both positions scroll the page and ensure pinned element stays at bottom
3. If you have a Linked In account login and ensure that toolbar stays at the bottom with bar in both positions
4. Smoke test a few other sites and back/forward navigation
5. Ensure no regression with AI off and new UTI feature on
6. Ensure no regression on iPad when scrolling (but bottom bar not available there)

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Could break hiding bars or make view port glitch worse


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized layout change for bottom-bar mode on iOS 26 only, with a remote kill switch; main regression risk is chrome hide/show no longer shrinking the webview inset when the workaround is on.
> 
> **Overview**
> Fixes **iOS 26 viewport glitches** when the address bar is at the bottom: page-fixed footers (e.g. test pages, LinkedIn toolbars) were jumping off-screen because the webview bottom inset tracked chrome show/hide.
> 
> Introduces remote flag **`bottomBarViewportFixedElementsWorkaround`** (privacy config + `FeatureFlag`, default **enabled**). In `TabViewController.updateWebViewBottomAnchor`, on **iOS 26+** with the flag on, the bottom inset stays at full bar height instead of scaling with `barsVisibilityPercent`; older OS versions and flag-off behavior are unchanged. Border chrome fading still follows scroll visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d95819aeaba5f043db24afc53c4ce9800d424e3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->