### PR TITLE
Jjackson/os eol metrics add specific pixels

### DIFF
--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -903,6 +903,7 @@ let package = Package(
                 "SharedObjCTestsUtils",
                 "PixelKit",
                 "PixelKitTestingUtilities",
+                "PersistenceTestingUtils",
             ]
         ),
         .testTarget(

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/OSDistributionPixel.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/OSDistributionPixel.swift
@@ -66,8 +66,6 @@ public extension PixelKit {
              doNotEnforcePrefix: true)
     }
 
-    /// Fires an OS-distribution pixel for the given metric, using the current platform and
-    /// `DevicePlatform.formFactor` (the same form-factor source other pixels use).
     func fireOSDistributionPixel(metric: OSDistributionPixel.Metric) {
         fireOSDistributionPixel(OSDistributionPixel(metric: metric,
                                                     platform: .currentPlatform,

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/OSDistributionPixel.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/OSDistributionPixel.swift
@@ -51,7 +51,7 @@ public struct OSDistributionPixel: PixelKitEvent {
 
     public var parameters: [String: String]? { nil }
 
-    // No standard parameters: these pixels must not carry `pixelSource`.
+    // No standard parameters
     public var standardParameters: [PixelKitStandardParameter]? { [] }
 }
 
@@ -72,10 +72,6 @@ public extension PixelKit {
         fireOSDistributionPixel(OSDistributionPixel(metric: metric,
                                                     platform: .currentPlatform,
                                                     formFactor: DevicePlatform.formFactor))
-    }
-
-    static func fireOSDistributionPixel(_ event: OSDistributionPixel) {
-        shared?.fireOSDistributionPixel(event)
     }
 
     static func fireOSDistributionPixel(metric: OSDistributionPixel.Metric) {

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/OSDistributionPixel.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/OSDistributionPixel.swift
@@ -69,7 +69,6 @@ public extension PixelKit {
 
     /// Fires an OS-distribution pixel with the fixed configuration these pixels require:
     /// `.monthly` frequency, no `appVersion`, no `pixelSource`, and no platform-prefix enforcement.
-    /// (On macOS, `channel` is still added like every other macOS pixel; iOS does not send it.)
     func fireOSDistributionPixel(_ event: OSDistributionPixel) {
         fire(event,
              frequency: .monthly,
@@ -79,21 +78,17 @@ public extension PixelKit {
 
     /// Fires an OS-distribution pixel for the given metric, deriving `platform` and `formFactor`
     /// from the `source` configured at `setUp` (set per-context — app or extension — without UIKit).
-    /// No-ops if the source is unknown/unset, so it is safe to call from any context.
     func fireOSDistributionPixel(metric: OSDistributionPixel.Metric) {
-        let platform: OSDistributionPixel.Platform
-        let formFactor: OSDistributionPixel.FormFactor
         switch source {
         case Source.iOS.rawValue:
-            (platform, formFactor) = (.iOS, .phone)
+            fireOSDistributionPixel(OSDistributionPixel(metric: metric, platform: .iOS, formFactor: .phone))
         case Source.iPadOS.rawValue:
-            (platform, formFactor) = (.iOS, .tablet)
+            fireOSDistributionPixel(OSDistributionPixel(metric: metric, platform: .iOS, formFactor: .tablet))
         case Source.macStore.rawValue, Source.macDMG.rawValue:
-            (platform, formFactor) = (.macOS, .desktop)
+            fireOSDistributionPixel(OSDistributionPixel(metric: metric, platform: .macOS, formFactor: .desktop))
         default:
             return
         }
-        fireOSDistributionPixel(OSDistributionPixel(metric: metric, platform: platform, formFactor: formFactor))
     }
 
     static func fireOSDistributionPixel(_ event: OSDistributionPixel) {

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/OSDistributionPixel.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/OSDistributionPixel.swift
@@ -1,0 +1,106 @@
+//
+//  OSDistributionPixel.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// Monthly pixels for deciding when to end support for an operating system version.
+///
+/// Tech design: https://app.asana.com/1/137249556945/project/1208546505108826/task/1214950124367783?focus=true
+public struct OSDistributionPixel: PixelKitEvent {
+
+    public enum Metric: String {
+        case client
+        case searches
+        case activeSubscriptions = "active_subscriptions"
+    }
+
+    public enum Platform: String {
+        case iOS = "ios"
+        case macOS = "macos"
+    }
+
+    public enum FormFactor: String {
+        case phone
+        case tablet
+        case desktop
+    }
+
+    private let metric: Metric
+    private let osMajorVersion: Int
+    private let platform: Platform
+    private let formFactor: FormFactor
+
+    public init(metric: Metric,
+                osMajorVersion: Int = ProcessInfo.processInfo.operatingSystemVersion.majorVersion,
+                platform: Platform,
+                formFactor: FormFactor) {
+        self.metric = metric
+        self.osMajorVersion = osMajorVersion
+        self.platform = platform
+        self.formFactor = formFactor
+    }
+
+    public var name: String {
+        "os_distribution_\(metric.rawValue)_major_version_\(osMajorVersion)_\(platform.rawValue)_\(formFactor.rawValue)"
+    }
+
+    public var parameters: [String: String]? { nil }
+
+    // No standard parameters: these pixels must not carry `pixelSource`.
+    public var standardParameters: [PixelKitStandardParameter]? { [] }
+}
+
+public extension PixelKit {
+
+    /// Fires an OS-distribution pixel with the fixed configuration these pixels require:
+    /// `.monthly` frequency, no `appVersion`, no `pixelSource`, and no platform-prefix enforcement.
+    /// (On macOS, `channel` is still added like every other macOS pixel; iOS does not send it.)
+    func fireOSDistributionPixel(_ event: OSDistributionPixel) {
+        fire(event,
+             frequency: .monthly,
+             includeAppVersionParameter: false,
+             doNotEnforcePrefix: true)
+    }
+
+    /// Fires an OS-distribution pixel for the given metric, deriving `platform` and `formFactor`
+    /// from the `source` configured at `setUp` (set per-context — app or extension — without UIKit).
+    /// No-ops if the source is unknown/unset, so it is safe to call from any context.
+    func fireOSDistributionPixel(metric: OSDistributionPixel.Metric) {
+        let platform: OSDistributionPixel.Platform
+        let formFactor: OSDistributionPixel.FormFactor
+        switch source {
+        case Source.iOS.rawValue:
+            (platform, formFactor) = (.iOS, .phone)
+        case Source.iPadOS.rawValue:
+            (platform, formFactor) = (.iOS, .tablet)
+        case Source.macStore.rawValue, Source.macDMG.rawValue:
+            (platform, formFactor) = (.macOS, .desktop)
+        default:
+            return
+        }
+        fireOSDistributionPixel(OSDistributionPixel(metric: metric, platform: platform, formFactor: formFactor))
+    }
+
+    static func fireOSDistributionPixel(_ event: OSDistributionPixel) {
+        shared?.fireOSDistributionPixel(event)
+    }
+
+    static func fireOSDistributionPixel(metric: OSDistributionPixel.Metric) {
+        shared?.fireOSDistributionPixel(metric: metric)
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/OSDistributionPixel.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/OSDistributionPixel.swift
@@ -30,19 +30,14 @@ public struct OSDistributionPixel: PixelKitEvent {
         case activeSubscriptions = "active_subscriptions"
     }
 
-    public enum Platform: String {
-        case iOS = "ios"
-        case macOS = "macos"
-    }
-
     private let metric: Metric
     private let osMajorVersion: Int
-    private let platform: Platform
+    private let platform: String
     private let formFactor: String
 
     public init(metric: Metric,
                 osMajorVersion: Int = ProcessInfo.processInfo.operatingSystemVersion.majorVersion,
-                platform: Platform,
+                platform: String,
                 formFactor: String) {
         self.metric = metric
         self.osMajorVersion = osMajorVersion
@@ -51,7 +46,7 @@ public struct OSDistributionPixel: PixelKitEvent {
     }
 
     public var name: String {
-        "os_distribution_\(metric.rawValue)_major_version_\(osMajorVersion)_\(platform.rawValue)_\(formFactor)"
+        "os_distribution_\(metric.rawValue)_major_version_\(osMajorVersion)_\(platform)_\(formFactor)"
     }
 
     public var parameters: [String: String]? { nil }
@@ -74,9 +69,8 @@ public extension PixelKit {
     /// Fires an OS-distribution pixel for the given metric, using the current platform and
     /// `DevicePlatform.formFactor` (the same form-factor source other pixels use).
     func fireOSDistributionPixel(metric: OSDistributionPixel.Metric) {
-        let platform: OSDistributionPixel.Platform = DevicePlatform.isMac ? .macOS : .iOS
         fireOSDistributionPixel(OSDistributionPixel(metric: metric,
-                                                    platform: platform,
+                                                    platform: DevicePlatform.currentPlatform.rawValue.lowercased(),
                                                     formFactor: DevicePlatform.formFactor))
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/OSDistributionPixel.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/OSDistributionPixel.swift
@@ -32,12 +32,12 @@ public struct OSDistributionPixel: PixelKitEvent {
 
     private let metric: Metric
     private let osMajorVersion: Int
-    private let platform: String
+    private let platform: DevicePlatform
     private let formFactor: String
 
     public init(metric: Metric,
                 osMajorVersion: Int = ProcessInfo.processInfo.operatingSystemVersion.majorVersion,
-                platform: String,
+                platform: DevicePlatform,
                 formFactor: String) {
         self.metric = metric
         self.osMajorVersion = osMajorVersion
@@ -46,7 +46,7 @@ public struct OSDistributionPixel: PixelKitEvent {
     }
 
     public var name: String {
-        "os_distribution_\(metric.rawValue)_major_version_\(osMajorVersion)_\(platform)_\(formFactor)"
+        "os_distribution_\(metric.rawValue)_major_version_\(osMajorVersion)_\(platform.rawValue.lowercased())_\(formFactor)"
     }
 
     public var parameters: [String: String]? { nil }
@@ -70,7 +70,7 @@ public extension PixelKit {
     /// `DevicePlatform.formFactor` (the same form-factor source other pixels use).
     func fireOSDistributionPixel(metric: OSDistributionPixel.Metric) {
         fireOSDistributionPixel(OSDistributionPixel(metric: metric,
-                                                    platform: DevicePlatform.currentPlatform.rawValue.lowercased(),
+                                                    platform: .currentPlatform,
                                                     formFactor: DevicePlatform.formFactor))
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/OSDistributionPixel.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/OSDistributionPixel.swift
@@ -66,10 +66,12 @@ public extension PixelKit {
              doNotEnforcePrefix: true)
     }
 
-    func fireOSDistributionPixel(metric: OSDistributionPixel.Metric) {
+    func fireOSDistributionPixel(metric: OSDistributionPixel.Metric,
+                                 platform: DevicePlatform = .currentPlatform,
+                                 formFactor: String = DevicePlatform.formFactor) {
         fireOSDistributionPixel(OSDistributionPixel(metric: metric,
-                                                    platform: .currentPlatform,
-                                                    formFactor: DevicePlatform.formFactor))
+                                                    platform: platform,
+                                                    formFactor: formFactor))
     }
 
     static func fireOSDistributionPixel(metric: OSDistributionPixel.Metric) {

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/OSDistributionPixel.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/OSDistributionPixel.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import Common
 
 /// Monthly pixels for deciding when to end support for an operating system version.
 ///
@@ -34,21 +35,15 @@ public struct OSDistributionPixel: PixelKitEvent {
         case macOS = "macos"
     }
 
-    public enum FormFactor: String {
-        case phone
-        case tablet
-        case desktop
-    }
-
     private let metric: Metric
     private let osMajorVersion: Int
     private let platform: Platform
-    private let formFactor: FormFactor
+    private let formFactor: String
 
     public init(metric: Metric,
                 osMajorVersion: Int = ProcessInfo.processInfo.operatingSystemVersion.majorVersion,
                 platform: Platform,
-                formFactor: FormFactor) {
+                formFactor: String) {
         self.metric = metric
         self.osMajorVersion = osMajorVersion
         self.platform = platform
@@ -56,7 +51,7 @@ public struct OSDistributionPixel: PixelKitEvent {
     }
 
     public var name: String {
-        "os_distribution_\(metric.rawValue)_major_version_\(osMajorVersion)_\(platform.rawValue)_\(formFactor.rawValue)"
+        "os_distribution_\(metric.rawValue)_major_version_\(osMajorVersion)_\(platform.rawValue)_\(formFactor)"
     }
 
     public var parameters: [String: String]? { nil }
@@ -76,19 +71,13 @@ public extension PixelKit {
              doNotEnforcePrefix: true)
     }
 
-    /// Fires an OS-distribution pixel for the given metric, deriving `platform` and `formFactor`
-    /// from the `source` configured at `setUp` (set per-context — app or extension — without UIKit).
+    /// Fires an OS-distribution pixel for the given metric, using the current platform and
+    /// `DevicePlatform.formFactor` (the same form-factor source other pixels use).
     func fireOSDistributionPixel(metric: OSDistributionPixel.Metric) {
-        switch source {
-        case Source.iOS.rawValue:
-            fireOSDistributionPixel(OSDistributionPixel(metric: metric, platform: .iOS, formFactor: .phone))
-        case Source.iPadOS.rawValue:
-            fireOSDistributionPixel(OSDistributionPixel(metric: metric, platform: .iOS, formFactor: .tablet))
-        case Source.macStore.rawValue, Source.macDMG.rawValue:
-            fireOSDistributionPixel(OSDistributionPixel(metric: metric, platform: .macOS, formFactor: .desktop))
-        default:
-            return
-        }
+        let platform: OSDistributionPixel.Platform = DevicePlatform.isMac ? .macOS : .iOS
+        fireOSDistributionPixel(OSDistributionPixel(metric: metric,
+                                                    platform: platform,
+                                                    formFactor: DevicePlatform.formFactor))
     }
 
     static func fireOSDistributionPixel(_ event: OSDistributionPixel) {

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/OSDistributionPixel.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/OSDistributionPixel.swift
@@ -49,7 +49,8 @@ public struct OSDistributionPixel: PixelKitEvent {
         "os_distribution_\(metric.rawValue)_major_version_\(osMajorVersion)_\(platform.rawValue.lowercased())_\(formFactor)"
     }
 
-    public var parameters: [String: String]? { nil }
+    // Self-tags the pixel to route through the PETAL (timestamp-randomization) pipeline.
+    public var parameters: [String: String]? { ["petal": "randomize"] }
 
     // No standard parameters
     public var standardParameters: [PixelKitStandardParameter]? { [] }

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit.swift
@@ -166,7 +166,7 @@ public final class PixelKit {
     private let defaultHeaders: [String: String]
     private let fireRequest: FireRequest
     private var dryRun: Bool
-    let source: String?
+    private let source: String?
     private let channel: String?
     private let pixelCalendar: Calendar
 

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit.swift
@@ -166,7 +166,7 @@ public final class PixelKit {
     private let defaultHeaders: [String: String]
     private let fireRequest: FireRequest
     private var dryRun: Bool
-    private let source: String?
+    let source: String?
     private let channel: String?
     private let pixelCalendar: Calendar
 

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManager.swift
@@ -350,7 +350,7 @@ public final class DefaultSubscriptionManager: SubscriptionManager {
         }
         if cached.isActive {
             pixelHandler.handle(pixel: .subscriptionIsActive)
-            pixelHandler.handle(pixel: .activeSubscriptionOSDistribution)
+            pixelHandler.handle(pixel: .osDistributionActiveSubscription)
         }
         return cached
     }
@@ -424,7 +424,7 @@ public final class DefaultSubscriptionManager: SubscriptionManager {
 
         if subscription.isActive {
             pixelHandler.handle(pixel: .subscriptionIsActive)
-            pixelHandler.handle(pixel: .activeSubscriptionOSDistribution)
+            pixelHandler.handle(pixel: .osDistributionActiveSubscription)
         }
         return subscription
     }

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManager.swift
@@ -348,7 +348,10 @@ public final class DefaultSubscriptionManager: SubscriptionManager {
         guard let cached = await subscriptionCachingService.get() else {
             throw fallbackError
         }
-        if cached.isActive { pixelHandler.handle(pixel: .subscriptionIsActive) }
+        if cached.isActive {
+            pixelHandler.handle(pixel: .subscriptionIsActive)
+            pixelHandler.handle(pixel: .activeSubscriptionOSDistribution)
+        }
         return cached
     }
 
@@ -419,7 +422,10 @@ public final class DefaultSubscriptionManager: SubscriptionManager {
             subscription = finalSubscription
         }
 
-        if subscription.isActive { pixelHandler.handle(pixel: .subscriptionIsActive) }
+        if subscription.isActive {
+            pixelHandler.handle(pixel: .subscriptionIsActive)
+            pixelHandler.handle(pixel: .activeSubscriptionOSDistribution)
+        }
         return subscription
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionPixelType.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionPixelType.swift
@@ -22,7 +22,7 @@ import Networking
 public enum SubscriptionPixelType: Equatable {
     case invalidRefreshToken
     case subscriptionIsActive
-    case activeSubscriptionOSDistribution
+    case osDistributionActiveSubscription
     case getTokensError(AuthTokensCachePolicy, Error)
     case invalidRefreshTokenSignedOut
     case invalidRefreshTokenRecovered
@@ -33,7 +33,7 @@ public enum SubscriptionPixelType: Equatable {
         switch (lhs, rhs) {
         case (.invalidRefreshToken, .invalidRefreshToken),
             (.subscriptionIsActive, .subscriptionIsActive),
-            (.activeSubscriptionOSDistribution, .activeSubscriptionOSDistribution),
+            (.osDistributionActiveSubscription, .osDistributionActiveSubscription),
             (.invalidRefreshTokenSignedOut, .invalidRefreshTokenSignedOut),
             (.invalidRefreshTokenRecovered, .invalidRefreshTokenRecovered),
             (.getTokensError, .getTokensError),

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionPixelType.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionPixelType.swift
@@ -22,6 +22,7 @@ import Networking
 public enum SubscriptionPixelType: Equatable {
     case invalidRefreshToken
     case subscriptionIsActive
+    case activeSubscriptionOSDistribution
     case getTokensError(AuthTokensCachePolicy, Error)
     case invalidRefreshTokenSignedOut
     case invalidRefreshTokenRecovered
@@ -32,6 +33,7 @@ public enum SubscriptionPixelType: Equatable {
         switch (lhs, rhs) {
         case (.invalidRefreshToken, .invalidRefreshToken),
             (.subscriptionIsActive, .subscriptionIsActive),
+            (.activeSubscriptionOSDistribution, .activeSubscriptionOSDistribution),
             (.invalidRefreshTokenSignedOut, .invalidRefreshTokenSignedOut),
             (.invalidRefreshTokenRecovered, .invalidRefreshTokenRecovered),
             (.getTokensError, .getTokensError),

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/OSDistributionPixelTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/OSDistributionPixelTests.swift
@@ -94,21 +94,32 @@ final class OSDistributionPixelTests: XCTestCase {
 
     // MARK: - Metric-based firing
 
-    /// `fireOSDistributionPixel(metric:)` resolves platform and form factor for the running device.
-    /// These tests run on macOS, so it yields the `macos_desktop` segment.
-    func testFiringByMetricUsesCurrentDevicePlatformAndFormFactor() {
-        var firedName: String?
-        let pixelKit = PixelKit(dryRun: false,
-                                appVersion: "1.2.3",
-                                defaultHeaders: [:],
-                                defaults: InMemoryThrowingKeyValueStore()) { name, _, _, _, _, onComplete in
-            firedName = name
-            onComplete(true, nil)
+    /// `fireOSDistributionPixel(metric:)` builds the name from the given platform/form factor
+    /// (defaulting to the current device). Covers every expected OS-name / form-factor combination.
+    func testFiringByMetricCoversAllPlatformAndFormFactorCombinations() {
+        let major = ProcessInfo.processInfo.operatingSystemVersion.majorVersion
+        let combinations: [(platform: DevicePlatform, formFactor: String, expectedSegment: String)] = [
+            (.iOS, "phone", "ios_phone"),
+            (.iOS, "tablet", "ios_tablet"),
+            (.macOS, "desktop", "macos_desktop"),
+        ]
+
+        for combination in combinations {
+            var firedName: String?
+            let pixelKit = PixelKit(dryRun: false,
+                                    appVersion: "1.2.3",
+                                    defaultHeaders: [:],
+                                    defaults: InMemoryThrowingKeyValueStore()) { name, _, _, _, _, onComplete in
+                firedName = name
+                onComplete(true, nil)
+            }
+
+            pixelKit.fireOSDistributionPixel(metric: .client,
+                                             platform: combination.platform,
+                                             formFactor: combination.formFactor)
+
+            XCTAssertEqual(firedName,
+                           "os_distribution_client_major_version_\(major)_\(combination.expectedSegment)_monthly")
         }
-
-        pixelKit.fireOSDistributionPixel(metric: .client)
-
-        XCTAssertEqual(firedName?.hasPrefix("os_distribution_client_major_version_"), true)
-        XCTAssertEqual(firedName?.hasSuffix("_macos_desktop_monthly"), true)
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/OSDistributionPixelTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/OSDistributionPixelTests.swift
@@ -41,9 +41,9 @@ final class OSDistributionPixelTests: XCTestCase {
 
     // MARK: - Firing
 
-    /// Firing appends the `_monthly` suffix (from `.monthly` frequency) and suppresses the default
-    /// `appVersion` and `pixelSource` parameters, even when a source is configured.
-    func testFiringAppendsMonthlySuffixAndSuppressesDefaultParameters() {
+    /// Firing appends the `_monthly` suffix (from `.monthly` frequency), sends `petal=randomize`,
+    /// and suppresses the default `appVersion` and `pixelSource` parameters, even when a source is configured.
+    func testFiringAppendsMonthlySuffixSendsPetalAndSuppressesDefaultParameters() {
         var firedName: String?
         var firedParameters: [String: String]?
         let fired = expectation(description: "pixel fired")
@@ -66,6 +66,7 @@ final class OSDistributionPixelTests: XCTestCase {
         wait(for: [fired], timeout: 1.0)
 
         XCTAssertEqual(firedName, "os_distribution_client_major_version_15_macos_desktop_monthly")
+        XCTAssertEqual(firedParameters?["petal"], "randomize", "petal=randomize must be sent (PETAL pipeline tag)")
         XCTAssertNil(firedParameters?[PixelKit.Parameters.appVersion], "appVersion must be suppressed")
         XCTAssertNil(firedParameters?[PixelKit.Parameters.pixelSource], "pixelSource must not be added")
     }

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/OSDistributionPixelTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/OSDistributionPixelTests.swift
@@ -17,6 +17,7 @@
 //
 
 import XCTest
+import Common
 @testable import PixelKit
 
 final class OSDistributionPixelTests: XCTestCase {
@@ -29,15 +30,15 @@ final class OSDistributionPixelTests: XCTestCase {
 
     func testNameComposition() {
         XCTAssertEqual(
-            OSDistributionPixel(metric: .client, osMajorVersion: 15, platform: "ios", formFactor: "phone").name,
+            OSDistributionPixel(metric: .client, osMajorVersion: 15, platform: .iOS, formFactor: "phone").name,
             "os_distribution_client_major_version_15_ios_phone")
 
         XCTAssertEqual(
-            OSDistributionPixel(metric: .searches, osMajorVersion: 18, platform: "ios", formFactor: "tablet").name,
+            OSDistributionPixel(metric: .searches, osMajorVersion: 18, platform: .iOS, formFactor: "tablet").name,
             "os_distribution_searches_major_version_18_ios_tablet")
 
         XCTAssertEqual(
-            OSDistributionPixel(metric: .activeSubscriptions, osMajorVersion: 26, platform: "macos", formFactor: "desktop").name,
+            OSDistributionPixel(metric: .activeSubscriptions, osMajorVersion: 26, platform: .macOS, formFactor: "desktop").name,
             "os_distribution_active_subscriptions_major_version_26_macos_desktop")
     }
 
@@ -62,7 +63,7 @@ final class OSDistributionPixelTests: XCTestCase {
         }
 
         pixelKit.fireOSDistributionPixel(
-            OSDistributionPixel(metric: .client, osMajorVersion: 15, platform: "macos", formFactor: "desktop")
+            OSDistributionPixel(metric: .client, osMajorVersion: 15, platform: .macOS, formFactor: "desktop")
         )
 
         wait(for: [fired], timeout: 1.0)
@@ -87,7 +88,7 @@ final class OSDistributionPixelTests: XCTestCase {
             }
         }
 
-        let event = OSDistributionPixel(metric: .searches, osMajorVersion: 15, platform: "macos", formFactor: "desktop")
+        let event = OSDistributionPixel(metric: .searches, osMajorVersion: 15, platform: .macOS, formFactor: "desktop")
         makePixelKit().fireOSDistributionPixel(event)
         makePixelKit().fireOSDistributionPixel(event)
 

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/OSDistributionPixelTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/OSDistributionPixelTests.swift
@@ -29,15 +29,15 @@ final class OSDistributionPixelTests: XCTestCase {
 
     func testNameComposition() {
         XCTAssertEqual(
-            OSDistributionPixel(metric: .client, osMajorVersion: 15, platform: .iOS, formFactor: "phone").name,
+            OSDistributionPixel(metric: .client, osMajorVersion: 15, platform: "ios", formFactor: "phone").name,
             "os_distribution_client_major_version_15_ios_phone")
 
         XCTAssertEqual(
-            OSDistributionPixel(metric: .searches, osMajorVersion: 18, platform: .iOS, formFactor: "tablet").name,
+            OSDistributionPixel(metric: .searches, osMajorVersion: 18, platform: "ios", formFactor: "tablet").name,
             "os_distribution_searches_major_version_18_ios_tablet")
 
         XCTAssertEqual(
-            OSDistributionPixel(metric: .activeSubscriptions, osMajorVersion: 26, platform: .macOS, formFactor: "desktop").name,
+            OSDistributionPixel(metric: .activeSubscriptions, osMajorVersion: 26, platform: "macos", formFactor: "desktop").name,
             "os_distribution_active_subscriptions_major_version_26_macos_desktop")
     }
 
@@ -62,7 +62,7 @@ final class OSDistributionPixelTests: XCTestCase {
         }
 
         pixelKit.fireOSDistributionPixel(
-            OSDistributionPixel(metric: .client, osMajorVersion: 15, platform: .macOS, formFactor: "desktop")
+            OSDistributionPixel(metric: .client, osMajorVersion: 15, platform: "macos", formFactor: "desktop")
         )
 
         wait(for: [fired], timeout: 1.0)
@@ -87,7 +87,7 @@ final class OSDistributionPixelTests: XCTestCase {
             }
         }
 
-        let event = OSDistributionPixel(metric: .searches, osMajorVersion: 15, platform: .macOS, formFactor: "desktop")
+        let event = OSDistributionPixel(metric: .searches, osMajorVersion: 15, platform: "macos", formFactor: "desktop")
         makePixelKit().fireOSDistributionPixel(event)
         makePixelKit().fireOSDistributionPixel(event)
 

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/OSDistributionPixelTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/OSDistributionPixelTests.swift
@@ -1,0 +1,124 @@
+//
+//  OSDistributionPixelTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import PixelKit
+
+final class OSDistributionPixelTests: XCTestCase {
+
+    private func userDefaults() -> UserDefaults {
+        UserDefaults(suiteName: "testing_\(UUID().uuidString)")!
+    }
+
+    // MARK: - Name composition (must match the os_distribution pixel definitions)
+
+    func testNameComposition() {
+        XCTAssertEqual(
+            OSDistributionPixel(metric: .client, osMajorVersion: 15, platform: .iOS, formFactor: .phone).name,
+            "os_distribution_client_major_version_15_ios_phone")
+
+        XCTAssertEqual(
+            OSDistributionPixel(metric: .searches, osMajorVersion: 18, platform: .iOS, formFactor: .tablet).name,
+            "os_distribution_searches_major_version_18_ios_tablet")
+
+        XCTAssertEqual(
+            OSDistributionPixel(metric: .activeSubscriptions, osMajorVersion: 26, platform: .macOS, formFactor: .desktop).name,
+            "os_distribution_active_subscriptions_major_version_26_macos_desktop")
+    }
+
+    // MARK: - Firing
+
+    /// Firing appends the `_monthly` suffix (from `.monthly` frequency) and suppresses the default
+    /// `appVersion` and `pixelSource` parameters, even when a source is configured.
+    func testFiringAppendsMonthlySuffixAndSuppressesDefaultParameters() {
+        var firedName: String?
+        var firedParameters: [String: String]?
+        let fired = expectation(description: "pixel fired")
+
+        let pixelKit = PixelKit(dryRun: false,
+                                appVersion: "1.2.3",
+                                source: "test-source",
+                                defaultHeaders: [:],
+                                defaults: userDefaults()) { name, _, parameters, _, _, onComplete in
+            firedName = name
+            firedParameters = parameters
+            onComplete(true, nil)
+            fired.fulfill()
+        }
+
+        pixelKit.fireOSDistributionPixel(
+            OSDistributionPixel(metric: .client, osMajorVersion: 15, platform: .macOS, formFactor: .desktop)
+        )
+
+        wait(for: [fired], timeout: 1.0)
+
+        XCTAssertEqual(firedName, "os_distribution_client_major_version_15_macos_desktop_monthly")
+        XCTAssertNil(firedParameters?[PixelKit.Parameters.appVersion], "appVersion must be suppressed")
+        XCTAssertNil(firedParameters?[PixelKit.Parameters.pixelSource], "pixelSource must not be added")
+    }
+
+    /// A second fire within the same calendar month is suppressed (monthly frequency gating).
+    func testSecondFireInSameMonthIsSuppressed() {
+        var fireCount = 0
+        let defaults = userDefaults()
+
+        let makePixelKit: () -> PixelKit = {
+            PixelKit(dryRun: false,
+                     appVersion: "1.2.3",
+                     defaultHeaders: [:],
+                     defaults: defaults) { _, _, _, _, _, onComplete in
+                fireCount += 1
+                onComplete(true, nil)
+            }
+        }
+
+        let event = OSDistributionPixel(metric: .searches, osMajorVersion: 15, platform: .macOS, formFactor: .desktop)
+        makePixelKit().fireOSDistributionPixel(event)
+        makePixelKit().fireOSDistributionPixel(event)
+
+        XCTAssertEqual(fireCount, 1, "Monthly pixel should only fire once per calendar month")
+    }
+
+    // MARK: - Source-derived platform / form factor
+
+    /// `fireOSDistributionPixel(metric:)` derives platform/formFactor from the configured PixelKit
+    /// `source`, and no-ops for unknown/unset sources.
+    func testFiringByMetricDerivesPlatformAndFormFactorFromSource() {
+        func capturedName(forSource source: String?) -> String? {
+            var pixelName: String?
+            let pixelKit = PixelKit(dryRun: false,
+                                    appVersion: "1.2.3",
+                                    source: source,
+                                    defaultHeaders: [:],
+                                    defaults: userDefaults()) { name, _, _, _, _, onComplete in
+                pixelName = name
+                onComplete(true, nil)
+            }
+            pixelKit.fireOSDistributionPixel(metric: .client)
+            return pixelName
+        }
+
+        XCTAssertEqual(capturedName(forSource: "phone")?.hasSuffix("_ios_phone_monthly"), true)
+        XCTAssertEqual(capturedName(forSource: "tablet")?.hasSuffix("_ios_tablet_monthly"), true)
+        XCTAssertEqual(capturedName(forSource: "browser-dmg")?.hasSuffix("_macos_desktop_monthly"), true)
+        XCTAssertEqual(capturedName(forSource: "browser-appstore")?.hasSuffix("_macos_desktop_monthly"), true)
+        XCTAssertEqual(capturedName(forSource: "phone")?.hasPrefix("os_distribution_client_major_version_"), true)
+        XCTAssertNil(capturedName(forSource: "unknown-source"), "Unknown source must not fire")
+        XCTAssertNil(capturedName(forSource: nil), "Unset source must not fire")
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/OSDistributionPixelTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/OSDistributionPixelTests.swift
@@ -29,15 +29,15 @@ final class OSDistributionPixelTests: XCTestCase {
 
     func testNameComposition() {
         XCTAssertEqual(
-            OSDistributionPixel(metric: .client, osMajorVersion: 15, platform: .iOS, formFactor: .phone).name,
+            OSDistributionPixel(metric: .client, osMajorVersion: 15, platform: .iOS, formFactor: "phone").name,
             "os_distribution_client_major_version_15_ios_phone")
 
         XCTAssertEqual(
-            OSDistributionPixel(metric: .searches, osMajorVersion: 18, platform: .iOS, formFactor: .tablet).name,
+            OSDistributionPixel(metric: .searches, osMajorVersion: 18, platform: .iOS, formFactor: "tablet").name,
             "os_distribution_searches_major_version_18_ios_tablet")
 
         XCTAssertEqual(
-            OSDistributionPixel(metric: .activeSubscriptions, osMajorVersion: 26, platform: .macOS, formFactor: .desktop).name,
+            OSDistributionPixel(metric: .activeSubscriptions, osMajorVersion: 26, platform: .macOS, formFactor: "desktop").name,
             "os_distribution_active_subscriptions_major_version_26_macos_desktop")
     }
 
@@ -62,7 +62,7 @@ final class OSDistributionPixelTests: XCTestCase {
         }
 
         pixelKit.fireOSDistributionPixel(
-            OSDistributionPixel(metric: .client, osMajorVersion: 15, platform: .macOS, formFactor: .desktop)
+            OSDistributionPixel(metric: .client, osMajorVersion: 15, platform: .macOS, formFactor: "desktop")
         )
 
         wait(for: [fired], timeout: 1.0)
@@ -87,38 +87,30 @@ final class OSDistributionPixelTests: XCTestCase {
             }
         }
 
-        let event = OSDistributionPixel(metric: .searches, osMajorVersion: 15, platform: .macOS, formFactor: .desktop)
+        let event = OSDistributionPixel(metric: .searches, osMajorVersion: 15, platform: .macOS, formFactor: "desktop")
         makePixelKit().fireOSDistributionPixel(event)
         makePixelKit().fireOSDistributionPixel(event)
 
         XCTAssertEqual(fireCount, 1, "Monthly pixel should only fire once per calendar month")
     }
 
-    // MARK: - Source-derived platform / form factor
+    // MARK: - Metric-based firing
 
-    /// `fireOSDistributionPixel(metric:)` derives platform/formFactor from the configured PixelKit
-    /// `source`, and no-ops for unknown/unset sources.
-    func testFiringByMetricDerivesPlatformAndFormFactorFromSource() {
-        func capturedName(forSource source: String?) -> String? {
-            var pixelName: String?
-            let pixelKit = PixelKit(dryRun: false,
-                                    appVersion: "1.2.3",
-                                    source: source,
-                                    defaultHeaders: [:],
-                                    defaults: userDefaults()) { name, _, _, _, _, onComplete in
-                pixelName = name
-                onComplete(true, nil)
-            }
-            pixelKit.fireOSDistributionPixel(metric: .client)
-            return pixelName
+    /// `fireOSDistributionPixel(metric:)` resolves platform and form factor for the running device.
+    /// These tests run on macOS, so it yields the `macos_desktop` segment.
+    func testFiringByMetricUsesCurrentDevicePlatformAndFormFactor() {
+        var firedName: String?
+        let pixelKit = PixelKit(dryRun: false,
+                                appVersion: "1.2.3",
+                                defaultHeaders: [:],
+                                defaults: userDefaults()) { name, _, _, _, _, onComplete in
+            firedName = name
+            onComplete(true, nil)
         }
 
-        XCTAssertEqual(capturedName(forSource: "phone")?.hasSuffix("_ios_phone_monthly"), true)
-        XCTAssertEqual(capturedName(forSource: "tablet")?.hasSuffix("_ios_tablet_monthly"), true)
-        XCTAssertEqual(capturedName(forSource: "browser-dmg")?.hasSuffix("_macos_desktop_monthly"), true)
-        XCTAssertEqual(capturedName(forSource: "browser-appstore")?.hasSuffix("_macos_desktop_monthly"), true)
-        XCTAssertEqual(capturedName(forSource: "phone")?.hasPrefix("os_distribution_client_major_version_"), true)
-        XCTAssertNil(capturedName(forSource: "unknown-source"), "Unknown source must not fire")
-        XCTAssertNil(capturedName(forSource: nil), "Unset source must not fire")
+        pixelKit.fireOSDistributionPixel(metric: .client)
+
+        XCTAssertEqual(firedName?.hasPrefix("os_distribution_client_major_version_"), true)
+        XCTAssertEqual(firedName?.hasSuffix("_macos_desktop_monthly"), true)
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/OSDistributionPixelTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/OSDistributionPixelTests.swift
@@ -18,13 +18,10 @@
 
 import XCTest
 import Common
+import PersistenceTestingUtils
 @testable import PixelKit
 
 final class OSDistributionPixelTests: XCTestCase {
-
-    private func userDefaults() -> UserDefaults {
-        UserDefaults(suiteName: "testing_\(UUID().uuidString)")!
-    }
 
     // MARK: - Name composition (must match the os_distribution pixel definitions)
 
@@ -55,7 +52,7 @@ final class OSDistributionPixelTests: XCTestCase {
                                 appVersion: "1.2.3",
                                 source: "test-source",
                                 defaultHeaders: [:],
-                                defaults: userDefaults()) { name, _, parameters, _, _, onComplete in
+                                defaults: InMemoryThrowingKeyValueStore()) { name, _, parameters, _, _, onComplete in
             firedName = name
             firedParameters = parameters
             onComplete(true, nil)
@@ -76,7 +73,7 @@ final class OSDistributionPixelTests: XCTestCase {
     /// A second fire within the same calendar month is suppressed (monthly frequency gating).
     func testSecondFireInSameMonthIsSuppressed() {
         var fireCount = 0
-        let defaults = userDefaults()
+        let defaults = InMemoryThrowingKeyValueStore()
 
         let makePixelKit: () -> PixelKit = {
             PixelKit(dryRun: false,
@@ -104,7 +101,7 @@ final class OSDistributionPixelTests: XCTestCase {
         let pixelKit = PixelKit(dryRun: false,
                                 appVersion: "1.2.3",
                                 defaultHeaders: [:],
-                                defaults: userDefaults()) { name, _, _, _, _, onComplete in
+                                defaults: InMemoryThrowingKeyValueStore()) { name, _, _, _, _, onComplete in
             firedName = name
             onComplete(true, nil)
         }

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerTests.swift
@@ -200,6 +200,8 @@ class SubscriptionManagerTests: XCTestCase {
         let subscription = try await subscriptionManager.getSubscription(forceRefresh: true)
         XCTAssertNotNil(subscription)
         XCTAssertTrue(subscription!.isActive)
+        XCTAssertTrue(mockPixelHandler.handledPixels.contains(.subscriptionIsActive))
+        XCTAssertTrue(mockPixelHandler.handledPixels.contains(.activeSubscriptionOSDistribution))
     }
 
     func testRefreshCachedSubscription_ExpiredSubscription() async throws {
@@ -226,6 +228,8 @@ class SubscriptionManagerTests: XCTestCase {
         XCTAssertNotNil(subscription, "Expired subscription should still be returned")
         XCTAssertFalse(subscription!.isActive, "Expired subscription should not be active")
         XCTAssertEqual(subscription!.status, .expired)
+        XCTAssertFalse(mockPixelHandler.handledPixels.contains(.activeSubscriptionOSDistribution),
+                       "OS-distribution pixel must not fire for an inactive subscription")
     }
 
     func testGetSubscription_NoDataOnBackend_ReturnsNil() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerTests.swift
@@ -201,7 +201,7 @@ class SubscriptionManagerTests: XCTestCase {
         XCTAssertNotNil(subscription)
         XCTAssertTrue(subscription!.isActive)
         XCTAssertTrue(mockPixelHandler.handledPixels.contains(.subscriptionIsActive))
-        XCTAssertTrue(mockPixelHandler.handledPixels.contains(.activeSubscriptionOSDistribution))
+        XCTAssertTrue(mockPixelHandler.handledPixels.contains(.osDistributionActiveSubscription))
     }
 
     func testRefreshCachedSubscription_ExpiredSubscription() async throws {
@@ -228,7 +228,7 @@ class SubscriptionManagerTests: XCTestCase {
         XCTAssertNotNil(subscription, "Expired subscription should still be returned")
         XCTAssertFalse(subscription!.isActive, "Expired subscription should not be active")
         XCTAssertEqual(subscription!.status, .expired)
-        XCTAssertFalse(mockPixelHandler.handledPixels.contains(.activeSubscriptionOSDistribution),
+        XCTAssertFalse(mockPixelHandler.handledPixels.contains(.osDistributionActiveSubscription),
                        "OS-distribution pixel must not fire for an inactive subscription")
     }
 

--- a/iOS/Core/StatisticsLoader.swift
+++ b/iOS/Core/StatisticsLoader.swift
@@ -48,9 +48,7 @@ public class StatisticsLoader {
          usageSegmentation: UsageSegmenting = UsageSegmentation(pixelEvents: UsageSegmentation.pixelEvents),
          fireAppRetentionExperimentPixels: @escaping () -> Void = PixelKit.fireAppRetentionExperimentPixels,
          fireSearchExperimentPixels: @escaping () -> Void = PixelKit.fireSearchExperimentPixels,
-         fireOSDistributionPixel: @escaping (OSDistributionPixel.Metric) -> Void = { metric in
-             PixelKit.fireOSDistributionPixel(metric: metric)
-         },
+         fireOSDistributionPixel: @escaping (OSDistributionPixel.Metric) -> Void = PixelKit.fireOSDistributionPixel(metric:),
          pixelFiring: PixelFiring.Type = Pixel.self,
          isPad: Bool = UIDevice.current.userInterfaceIdiom == .pad) {
         self.statisticsStore = statisticsStore

--- a/iOS/Core/StatisticsLoader.swift
+++ b/iOS/Core/StatisticsLoader.swift
@@ -38,6 +38,7 @@ public class StatisticsLoader {
     private let parser = AtbParser()
     private let fireSearchExperimentPixels: () -> Void
     private let fireAppRetentionExperimentPixels: () -> Void
+    private let fireOSDistributionPixel: (OSDistributionPixel.Metric) -> Void
     private let pixelFiring: PixelFiring.Type
     private var isDuckAIRetentionRequestInProgress = false
     private let isPad: Bool
@@ -47,6 +48,9 @@ public class StatisticsLoader {
          usageSegmentation: UsageSegmenting = UsageSegmentation(pixelEvents: UsageSegmentation.pixelEvents),
          fireAppRetentionExperimentPixels: @escaping () -> Void = PixelKit.fireAppRetentionExperimentPixels,
          fireSearchExperimentPixels: @escaping () -> Void = PixelKit.fireSearchExperimentPixels,
+         fireOSDistributionPixel: @escaping (OSDistributionPixel.Metric) -> Void = { metric in
+             PixelKit.fireOSDistributionPixel(metric: metric)
+         },
          pixelFiring: PixelFiring.Type = Pixel.self,
          isPad: Bool = UIDevice.current.userInterfaceIdiom == .pad) {
         self.statisticsStore = statisticsStore
@@ -54,6 +58,7 @@ public class StatisticsLoader {
         self.usageSegmentation = usageSegmentation
         self.fireSearchExperimentPixels = fireSearchExperimentPixels
         self.fireAppRetentionExperimentPixels = fireAppRetentionExperimentPixels
+        self.fireOSDistributionPixel = fireOSDistributionPixel
         self.pixelFiring = pixelFiring
         self.isPad = isPad
     }
@@ -128,6 +133,7 @@ public class StatisticsLoader {
 
     public func refreshSearchRetentionAtb(completion: @escaping Completion = {}) {
         fireSearchExperimentPixels()
+        fireOSDistributionPixel(.searches)
         guard let url = StatisticsDependentURLFactory(statisticsStore: statisticsStore).makeSearchAtbURL() else {
             requestInstallStatistics {
                 self.updateUsageSegmentationAfterInstall(activityType: .search)
@@ -158,6 +164,7 @@ public class StatisticsLoader {
 
     public func refreshAppRetentionAtb(completion: @escaping Completion = {}) {
         fireAppRetentionExperimentPixels()
+        fireOSDistributionPixel(.client)
         guard let url = StatisticsDependentURLFactory(statisticsStore: statisticsStore).makeAppAtbURL() else {
             requestInstallStatistics {
                 self.updateUsageSegmentationAfterInstall(activityType: .appUse)
@@ -207,6 +214,8 @@ public class StatisticsLoader {
 
     private func refreshDuckAIRetentionAtb(completion: @escaping Completion = {}) {
         dispatchPrecondition(condition: .onQueue(.main))
+
+        fireOSDistributionPixel(.searches)
 
         guard !isDuckAIRetentionRequestInProgress else {
             completion()

--- a/iOS/Core/StatisticsLoader.swift
+++ b/iOS/Core/StatisticsLoader.swift
@@ -132,6 +132,7 @@ public class StatisticsLoader {
     public func refreshSearchRetentionAtb(completion: @escaping Completion = {}) {
         fireSearchExperimentPixels()
         fireOSDistributionPixel(.searches)
+
         guard let url = StatisticsDependentURLFactory(statisticsStore: statisticsStore).makeSearchAtbURL() else {
             requestInstallStatistics {
                 self.updateUsageSegmentationAfterInstall(activityType: .search)
@@ -163,6 +164,7 @@ public class StatisticsLoader {
     public func refreshAppRetentionAtb(completion: @escaping Completion = {}) {
         fireAppRetentionExperimentPixels()
         fireOSDistributionPixel(.client)
+
         guard let url = StatisticsDependentURLFactory(statisticsStore: statisticsStore).makeAppAtbURL() else {
             requestInstallStatistics {
                 self.updateUsageSegmentationAfterInstall(activityType: .appUse)

--- a/iOS/DuckDuckGo/Subscription/Pixels/SubscriptionPixelHandler.swift
+++ b/iOS/DuckDuckGo/Subscription/Pixels/SubscriptionPixelHandler.swift
@@ -44,7 +44,7 @@ public struct SubscriptionPixelHandler: SubscriptionPixelHandling {
             pixelKit?.fire(SubscriptionPixel.subscriptionInvalidRefreshTokenDetected(source), frequency: .dailyAndCount)
         case .subscriptionIsActive:
             pixelKit?.fire(SubscriptionPixel.subscriptionActive, frequency: .legacyDaily)
-        case .activeSubscriptionOSDistribution:
+        case .osDistributionActiveSubscription:
             pixelKit?.fireOSDistributionPixel(metric: .activeSubscriptions)
         case .getTokensError(let policy, let error):
             pixelKit?.fire(SubscriptionPixel.subscriptionAuthV2GetTokensError(policy, source, error), frequency: .dailyAndCount)

--- a/iOS/DuckDuckGo/Subscription/Pixels/SubscriptionPixelHandler.swift
+++ b/iOS/DuckDuckGo/Subscription/Pixels/SubscriptionPixelHandler.swift
@@ -44,6 +44,8 @@ public struct SubscriptionPixelHandler: SubscriptionPixelHandling {
             pixelKit?.fire(SubscriptionPixel.subscriptionInvalidRefreshTokenDetected(source), frequency: .dailyAndCount)
         case .subscriptionIsActive:
             pixelKit?.fire(SubscriptionPixel.subscriptionActive, frequency: .legacyDaily)
+        case .activeSubscriptionOSDistribution:
+            pixelKit?.fireOSDistributionPixel(metric: .activeSubscriptions)
         case .getTokensError(let policy, let error):
             pixelKit?.fire(SubscriptionPixel.subscriptionAuthV2GetTokensError(policy, source, error), frequency: .dailyAndCount)
         case .invalidRefreshTokenSignedOut:

--- a/iOS/DuckDuckGoTests/StatisticsLoaderTests.swift
+++ b/iOS/DuckDuckGoTests/StatisticsLoaderTests.swift
@@ -22,6 +22,7 @@ import OHHTTPStubs
 import OHHTTPStubsSwift
 @testable import Core
 @testable import BrowserServicesKit
+import PixelKit
 
 class StatisticsLoaderTests: XCTestCase {
 
@@ -31,6 +32,7 @@ class StatisticsLoaderTests: XCTestCase {
     var testee: StatisticsLoader!
     private var fireAppRetentionExperimentPixelsCalled = false
     private var fireSearchExperimentPixelsCalled = false
+    private var firedOSDistributionMetrics: [OSDistributionPixel.Metric] = []
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -44,7 +46,34 @@ class StatisticsLoaderTests: XCTestCase {
                                   usageSegmentation: mockUsageSegmentation,
                                   fireAppRetentionExperimentPixels: { self.fireAppRetentionExperimentPixelsCalled = true },
                                   fireSearchExperimentPixels: { self.fireSearchExperimentPixelsCalled = true },
+                                  fireOSDistributionPixel: { self.firedOSDistributionMetrics.append($0) },
                                   pixelFiring: mockPixelFiring)
+    }
+
+    func testRefreshAppRetentionAtbFiresClientOSDistributionPixel() {
+        loadSuccessfulAtbStub()
+        loadSuccessfulExiStub()
+
+        let testExpectation = expectation(description: "refresh complete")
+        testee.refreshAppRetentionAtb {
+            testExpectation.fulfill()
+        }
+        wait(for: [testExpectation], timeout: 10.0)
+        XCTAssertTrue(firedOSDistributionMetrics.contains(.client))
+        XCTAssertFalse(firedOSDistributionMetrics.contains(.searches))
+    }
+
+    func testRefreshSearchRetentionAtbFiresSearchesOSDistributionPixel() {
+        loadSuccessfulAtbStub()
+        loadSuccessfulExiStub()
+
+        let testExpectation = expectation(description: "refresh complete")
+        testee.refreshSearchRetentionAtb {
+            testExpectation.fulfill()
+        }
+        wait(for: [testExpectation], timeout: 10.0)
+        XCTAssertTrue(firedOSDistributionMetrics.contains(.searches))
+        XCTAssertFalse(firedOSDistributionMetrics.contains(.client))
     }
 
     override func tearDown() {

--- a/iOS/DuckDuckGoTests/Subscription/SubscriptionPixelHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/SubscriptionPixelHandlerTests.swift
@@ -107,8 +107,10 @@ final class SubscriptionPixelHandlerTests: XCTestCase {
         let handler = SubscriptionPixelHandler(source: subscriptionSource, pixelKit: pixelKit)
         handler.handle(pixel: .osDistributionActiveSubscription)
 
-        XCTAssertTrue(firedPixels.contains { $0.name.hasPrefix("os_distribution_active_subscriptions_major_version_") && $0.name.hasSuffix("_ios_phone_monthly") },
-                      "Expected active-subscriptions OS-distribution pixel. Fired: \(firedPixels.map(\.name))")
+        let osMajorVersion = ProcessInfo.processInfo.operatingSystemVersion.majorVersion
+        let expectedName = "os_distribution_active_subscriptions_major_version_\(osMajorVersion)_ios_phone_monthly"
+        XCTAssertTrue(firedPixels.contains { $0.name == expectedName },
+                      "Expected \(expectedName). Fired: \(firedPixels.map(\.name))")
     }
 
     func testGetTokensErrorPixel() {

--- a/iOS/DuckDuckGoTests/Subscription/SubscriptionPixelHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/SubscriptionPixelHandlerTests.swift
@@ -103,9 +103,9 @@ final class SubscriptionPixelHandlerTests: XCTestCase {
         )
     }
 
-    func testActiveSubscriptionOSDistributionPixel() {
+    func testOSDistributionActiveSubscription() {
         let handler = SubscriptionPixelHandler(source: subscriptionSource, pixelKit: pixelKit)
-        handler.handle(pixel: .activeSubscriptionOSDistribution)
+        handler.handle(pixel: .osDistributionActiveSubscription)
 
         XCTAssertTrue(firedPixels.contains { $0.name.hasPrefix("os_distribution_active_subscriptions_major_version_") && $0.name.hasSuffix("_ios_phone_monthly") },
                       "Expected active-subscriptions OS-distribution pixel. Fired: \(firedPixels.map(\.name))")

--- a/iOS/DuckDuckGoTests/Subscription/SubscriptionPixelHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/SubscriptionPixelHandlerTests.swift
@@ -103,6 +103,26 @@ final class SubscriptionPixelHandlerTests: XCTestCase {
         )
     }
 
+    func testActiveSubscriptionOSDistributionPixel() {
+        var firedNames: [String] = []
+        let phonePixelKit = PixelKit(
+            dryRun: false,
+            appVersion: "1.0.0",
+            source: PixelKit.Source.iOS.rawValue,
+            defaultHeaders: [:],
+            defaults: UserDefaults(suiteName: "SubscriptionPixelHandlerTests.osdist.\(UUID().uuidString)")!,
+            fireRequest: { pixelName, _, _, _, _, onComplete in
+                firedNames.append(pixelName)
+                onComplete(true, nil)
+            }
+        )
+        let handler = SubscriptionPixelHandler(source: subscriptionSource, pixelKit: phonePixelKit)
+        handler.handle(pixel: .activeSubscriptionOSDistribution)
+
+        XCTAssertTrue(firedNames.contains { $0.hasPrefix("os_distribution_active_subscriptions_major_version_") && $0.hasSuffix("_ios_phone_monthly") },
+                      "Expected active-subscriptions OS-distribution pixel. Fired: \(firedNames)")
+    }
+
     func testGetTokensErrorPixel() {
         let handler = SubscriptionPixelHandler(source: subscriptionSource, pixelKit: pixelKit)
         let error = OAuthClientError.invalidTokenRequest(.reused)

--- a/iOS/DuckDuckGoTests/Subscription/SubscriptionPixelHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/SubscriptionPixelHandlerTests.swift
@@ -104,23 +104,11 @@ final class SubscriptionPixelHandlerTests: XCTestCase {
     }
 
     func testActiveSubscriptionOSDistributionPixel() {
-        var firedNames: [String] = []
-        let phonePixelKit = PixelKit(
-            dryRun: false,
-            appVersion: "1.0.0",
-            source: PixelKit.Source.iOS.rawValue,
-            defaultHeaders: [:],
-            defaults: UserDefaults(suiteName: "SubscriptionPixelHandlerTests.osdist.\(UUID().uuidString)")!,
-            fireRequest: { pixelName, _, _, _, _, onComplete in
-                firedNames.append(pixelName)
-                onComplete(true, nil)
-            }
-        )
-        let handler = SubscriptionPixelHandler(source: subscriptionSource, pixelKit: phonePixelKit)
+        let handler = SubscriptionPixelHandler(source: subscriptionSource, pixelKit: pixelKit)
         handler.handle(pixel: .activeSubscriptionOSDistribution)
 
-        XCTAssertTrue(firedNames.contains { $0.hasPrefix("os_distribution_active_subscriptions_major_version_") && $0.hasSuffix("_ios_phone_monthly") },
-                      "Expected active-subscriptions OS-distribution pixel. Fired: \(firedNames)")
+        XCTAssertTrue(firedPixels.contains { $0.name.hasPrefix("os_distribution_active_subscriptions_major_version_") && $0.name.hasSuffix("_ios_phone_monthly") },
+                      "Expected active-subscriptions OS-distribution pixel. Fired: \(firedPixels.map(\.name))")
     }
 
     func testGetTokensErrorPixel() {

--- a/iOS/PixelDefinitions/pixels/definitions/os_distribution_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/os_distribution_pixels.json5
@@ -4,6 +4,13 @@
         "owners": ["jdjackson"],
         "privacyReview": ["https://app.asana.com/1/137249556945/project/69071770703008/task/1215252656518903?focus=true"],
         "triggers": ["scheduled"],
+        "parameters": [
+            {
+                "key": "petal",
+                "description": "Routes the pixel through the PETAL timestamp-randomization pipeline",
+                "enum": ["randomize"]
+            }
+        ],
         "suffixes": [
             {
                 "description": "OS major version",
@@ -23,6 +30,13 @@
         "owners": ["jdjackson"],
         "privacyReview": ["https://app.asana.com/1/137249556945/project/69071770703008/task/1215252656518903?focus=true"],
         "triggers": ["scheduled"],
+        "parameters": [
+            {
+                "key": "petal",
+                "description": "Routes the pixel through the PETAL timestamp-randomization pipeline",
+                "enum": ["randomize"]
+            }
+        ],
         "suffixes": [
             {
                 "description": "OS major version",
@@ -42,6 +56,13 @@
         "owners": ["jdjackson"],
         "privacyReview": ["https://app.asana.com/1/137249556945/project/69071770703008/task/1215252656518903?focus=true"],
         "triggers": ["scheduled"],
+        "parameters": [
+            {
+                "key": "petal",
+                "description": "Routes the pixel through the PETAL timestamp-randomization pipeline",
+                "enum": ["randomize"]
+            }
+        ],
         "suffixes": [
             {
                 "description": "OS major version",

--- a/macOS/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
+++ b/macOS/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
@@ -68,7 +68,7 @@ final class StatisticsLoader {
         load {
             dispatchPrecondition(condition: .onQueue(.main))
 
-            self.fireOSDistributionPixel(.client)
+            PixelKit.fireOSDistributionPixel(metric: .client)
 
             if isSearch && !isDuckAI {
                 self.refreshSearchRetentionAtb {
@@ -188,7 +188,7 @@ final class StatisticsLoader {
     func refreshSearchRetentionAtb(completion: @escaping Completion = {}) {
         dispatchPrecondition(condition: .onQueue(.main))
 
-        fireOSDistributionPixel(.searches)
+        PixelKit.fireOSDistributionPixel(metric: .searches)
 
         guard !isSearchRetentionRequestInProgress else {
             completion()
@@ -279,7 +279,7 @@ final class StatisticsLoader {
     func refreshDuckAIRetentionAtb(completion: @escaping Completion = {}) {
         dispatchPrecondition(condition: .onQueue(.main))
 
-        fireOSDistributionPixel(.searches)
+        PixelKit.fireOSDistributionPixel(metric: .searches)
 
         guard !isDuckAIRetentionRequestInProgress else {
             completion()
@@ -329,10 +329,6 @@ final class StatisticsLoader {
             statisticsStore.atb = updateVersion
             statisticsStore.variant = nil
         }
-    }
-
-    private func fireOSDistributionPixel(_ metric: OSDistributionPixel.Metric) {
-        PixelKit.fireOSDistributionPixel(metric: metric)
     }
 
     private func fireDailyOsVersionCounterPixel() {

--- a/macOS/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
+++ b/macOS/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
@@ -68,6 +68,8 @@ final class StatisticsLoader {
         load {
             dispatchPrecondition(condition: .onQueue(.main))
 
+            self.fireOSDistributionPixel(.client)
+
             if isSearch && !isDuckAI {
                 self.refreshSearchRetentionAtb {
                     self.refreshRetentionAtbOnNavigation(isSearch: false, isDuckAI: false) {
@@ -186,6 +188,8 @@ final class StatisticsLoader {
     func refreshSearchRetentionAtb(completion: @escaping Completion = {}) {
         dispatchPrecondition(condition: .onQueue(.main))
 
+        fireOSDistributionPixel(.searches)
+
         guard !isSearchRetentionRequestInProgress else {
             completion()
             return
@@ -275,6 +279,8 @@ final class StatisticsLoader {
     func refreshDuckAIRetentionAtb(completion: @escaping Completion = {}) {
         dispatchPrecondition(condition: .onQueue(.main))
 
+        fireOSDistributionPixel(.searches)
+
         guard !isDuckAIRetentionRequestInProgress else {
             completion()
             return
@@ -323,6 +329,10 @@ final class StatisticsLoader {
             statisticsStore.atb = updateVersion
             statisticsStore.variant = nil
         }
+    }
+
+    private func fireOSDistributionPixel(_ metric: OSDistributionPixel.Metric) {
+        PixelKit.fireOSDistributionPixel(metric: metric)
     }
 
     private func fireDailyOsVersionCounterPixel() {

--- a/macOS/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
+++ b/macOS/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
@@ -68,8 +68,6 @@ final class StatisticsLoader {
         load {
             dispatchPrecondition(condition: .onQueue(.main))
 
-            PixelKit.fireOSDistributionPixel(metric: .client)
-
             if isSearch && !isDuckAI {
                 self.refreshSearchRetentionAtb {
                     self.refreshRetentionAtbOnNavigation(isSearch: false, isDuckAI: false) {
@@ -84,6 +82,9 @@ final class StatisticsLoader {
                 }
                 self.fireDockPixel()
             }
+
+            PixelKit.fireOSDistributionPixel(metric: .client)
+
             if !self.statisticsStore.isAppRetentionFiredToday {
                 self.refreshAppRetentionAtb(completion: completion)
                 self.fireAppRetentionExperimentPixels()

--- a/macOS/DuckDuckGo/Subscription/SubscriptionPixelHandler.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionPixelHandler.swift
@@ -51,7 +51,7 @@ public struct SubscriptionPixelHandler: SubscriptionPixelHandling {
             pixelKit?.fire(SubscriptionPixel.subscriptionInvalidRefreshTokenDetected(source), frequency: .dailyAndCount)
         case .subscriptionIsActive:
             pixelKit?.fire(SubscriptionPixel.subscriptionActive(AuthVersion.v2), frequency: .legacyDaily)
-        case .activeSubscriptionOSDistribution:
+        case .osDistributionActiveSubscription:
             pixelKit?.fireOSDistributionPixel(metric: .activeSubscriptions)
         case .getTokensError(let policy, let error):
             pixelKit?.fire(SubscriptionPixel.subscriptionAuthV2GetTokensError(policy, source, error), frequency: .dailyAndCount)

--- a/macOS/DuckDuckGo/Subscription/SubscriptionPixelHandler.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionPixelHandler.swift
@@ -51,6 +51,8 @@ public struct SubscriptionPixelHandler: SubscriptionPixelHandling {
             pixelKit?.fire(SubscriptionPixel.subscriptionInvalidRefreshTokenDetected(source), frequency: .dailyAndCount)
         case .subscriptionIsActive:
             pixelKit?.fire(SubscriptionPixel.subscriptionActive(AuthVersion.v2), frequency: .legacyDaily)
+        case .activeSubscriptionOSDistribution:
+            pixelKit?.fireOSDistributionPixel(metric: .activeSubscriptions)
         case .getTokensError(let policy, let error):
             pixelKit?.fire(SubscriptionPixel.subscriptionAuthV2GetTokensError(policy, source, error), frequency: .dailyAndCount)
         case .invalidRefreshTokenSignedOut:

--- a/macOS/PixelDefinitions/pixels/definitions/os_distribution_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/os_distribution_pixels.json5
@@ -4,6 +4,13 @@
         "owners": ["jdjackson"],
         "privacyReview": ["https://app.asana.com/1/137249556945/project/69071770703008/task/1215252656518903?focus=true"],
         "triggers": ["scheduled"],
+        "parameters": [
+            {
+                "key": "petal",
+                "description": "Routes the pixel through the PETAL timestamp-randomization pipeline",
+                "enum": ["randomize"]
+            }
+        ],
         "suffixes": [
             {
                 "description": "OS major version",
@@ -23,6 +30,13 @@
         "owners": ["jdjackson"],
         "privacyReview": ["https://app.asana.com/1/137249556945/project/69071770703008/task/1215252656518903?focus=true"],
         "triggers": ["scheduled"],
+        "parameters": [
+            {
+                "key": "petal",
+                "description": "Routes the pixel through the PETAL timestamp-randomization pipeline",
+                "enum": ["randomize"]
+            }
+        ],
         "suffixes": [
             {
                 "description": "OS major version",
@@ -42,6 +56,13 @@
         "owners": ["jdjackson"],
         "privacyReview": ["https://app.asana.com/1/137249556945/project/69071770703008/task/1215252656518903?focus=true"],
         "triggers": ["scheduled"],
+        "parameters": [
+            {
+                "key": "petal",
+                "description": "Routes the pixel through the PETAL timestamp-randomization pipeline",
+                "enum": ["randomize"]
+            }
+        ],
         "suffixes": [
             {
                 "description": "OS major version",

--- a/macOS/PixelDefinitions/pixels/definitions/os_distribution_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/os_distribution_pixels.json5
@@ -9,7 +9,8 @@
                 "key": "petal",
                 "description": "Routes the pixel through the PETAL timestamp-randomization pipeline",
                 "enum": ["randomize"]
-            }
+            },
+            "channel"
         ],
         "suffixes": [
             {
@@ -35,7 +36,8 @@
                 "key": "petal",
                 "description": "Routes the pixel through the PETAL timestamp-randomization pipeline",
                 "enum": ["randomize"]
-            }
+            },
+            "channel"
         ],
         "suffixes": [
             {
@@ -61,7 +63,8 @@
                 "key": "petal",
                 "description": "Routes the pixel through the PETAL timestamp-randomization pipeline",
                 "enum": ["randomize"]
-            }
+            },
+            "channel"
         ],
         "suffixes": [
             {

--- a/macOS/UnitTests/Statistics/ATB/StatisticsLoaderTests.swift
+++ b/macOS/UnitTests/Statistics/ATB/StatisticsLoaderTests.swift
@@ -82,9 +82,9 @@ class StatisticsLoaderTests: XCTestCase {
         }
         waitForExpectations(timeout: 5)
 
-        XCTAssertTrue(firedPixelNames.contains { $0.hasPrefix("os_distribution_client_major_version_") && $0.hasSuffix("_macos_desktop_monthly") },
+        XCTAssertTrue(firedPixelNames.contains { $0.hasPrefix("os_distribution_client_major_version_") },
                       "Expected MAU OS-distribution pixel. Fired: \(firedPixelNames)")
-        XCTAssertTrue(firedPixelNames.contains { $0.hasPrefix("os_distribution_searches_major_version_") && $0.hasSuffix("_macos_desktop_monthly") },
+        XCTAssertTrue(firedPixelNames.contains { $0.hasPrefix("os_distribution_searches_major_version_") },
                       "Expected searches OS-distribution pixel. Fired: \(firedPixelNames)")
     }
 
@@ -110,7 +110,7 @@ class StatisticsLoaderTests: XCTestCase {
         }
         waitForExpectations(timeout: 5)
 
-        XCTAssertTrue(firedPixelNames.contains { $0.hasPrefix("os_distribution_searches_major_version_") && $0.hasSuffix("_macos_desktop_monthly") },
+        XCTAssertTrue(firedPixelNames.contains { $0.hasPrefix("os_distribution_searches_major_version_") },
                       "Expected searches OS-distribution pixel. Fired: \(firedPixelNames)")
     }
 

--- a/macOS/UnitTests/Statistics/ATB/StatisticsLoaderTests.swift
+++ b/macOS/UnitTests/Statistics/ATB/StatisticsLoaderTests.swift
@@ -63,7 +63,6 @@ class StatisticsLoaderTests: XCTestCase {
         var firedPixelNames: [String] = []
         let capturingPixelKit = PixelKit(dryRun: false,
                                          appVersion: "1.0.0",
-                                         source: "browser-dmg",
                                          defaultHeaders: [:],
                                          defaults: UserDefaults(suiteName: "test_\(UUID().uuidString)")!,
                                          fireRequest: { name, _, _, _, _, onComplete in
@@ -93,7 +92,6 @@ class StatisticsLoaderTests: XCTestCase {
         var firedPixelNames: [String] = []
         let capturingPixelKit = PixelKit(dryRun: false,
                                          appVersion: "1.0.0",
-                                         source: "browser-dmg",
                                          defaultHeaders: [:],
                                          defaults: UserDefaults(suiteName: "test_\(UUID().uuidString)")!,
                                          fireRequest: { name, _, _, _, _, onComplete in

--- a/macOS/UnitTests/Statistics/ATB/StatisticsLoaderTests.swift
+++ b/macOS/UnitTests/Statistics/ATB/StatisticsLoaderTests.swift
@@ -59,33 +59,40 @@ class StatisticsLoaderTests: XCTestCase {
         pixelKit = nil
     }
 
-    func testRefreshRetentionAtbOnNavigationFiresClientAndSearchesOSDistributionPixels() {
-        var firedPixelNames: [String] = []
-        let capturingPixelKit = PixelKit(dryRun: false,
-                                         appVersion: "1.0.0",
-                                         defaultHeaders: [:],
-                                         defaults: UserDefaults(suiteName: "test_\(UUID().uuidString)")!,
-                                         fireRequest: { name, _, _, _, _, onComplete in
-                                             firedPixelNames.append(name)
-                                             onComplete(true, nil)
-                                         })
-        PixelKit.setSharedForTesting(pixelKit: capturingPixelKit)
+    func testRefreshRetentionAtbOnNavigationFiresClientOSDistributionPixelRegardlessOfInputs() {
+        let configurations: [(isSearch: Bool, isDuckAI: Bool)] = [
+            (isSearch: true, isDuckAI: false),
+            (isSearch: true, isDuckAI: true),
+            (isSearch: false, isDuckAI: true)
+        ]
 
-        mockStatisticsStore.atb = "atb"
-        mockStatisticsStore.searchRetentionAtb = "retentionatb"
-        mockStatisticsStore.variant = "test"
-        loadSuccessfulUpdateAtbStub()
+        for configuration in configurations {
+            var firedPixelNames: [String] = []
+            // Fresh defaults per configuration so the monthly client pixel isn't deduped across iterations.
+            let capturingPixelKit = PixelKit(dryRun: false,
+                                             appVersion: "1.0.0",
+                                             defaultHeaders: [:],
+                                             defaults: UserDefaults(suiteName: "test_\(UUID().uuidString)")!,
+                                             fireRequest: { name, _, _, _, _, onComplete in
+                                                 firedPixelNames.append(name)
+                                                 onComplete(true, nil)
+                                             })
+            PixelKit.setSharedForTesting(pixelKit: capturingPixelKit)
 
-        let expect = expectation(description: #function)
-        testee.refreshRetentionAtbOnNavigation(isSearch: true, isDuckAI: false) {
-            expect.fulfill()
+            mockStatisticsStore.atb = "atb"
+            mockStatisticsStore.searchRetentionAtb = "retentionatb"
+            mockStatisticsStore.variant = "test"
+            loadSuccessfulUpdateAtbStub()
+
+            let expect = expectation(description: "\(#function) isSearch:\(configuration.isSearch) isDuckAI:\(configuration.isDuckAI)")
+            testee.refreshRetentionAtbOnNavigation(isSearch: configuration.isSearch, isDuckAI: configuration.isDuckAI) {
+                expect.fulfill()
+            }
+            waitForExpectations(timeout: 5)
+
+            XCTAssertTrue(firedPixelNames.contains { $0.hasPrefix("os_distribution_client_major_version_") },
+                          "Expected MAU OS-distribution pixel for isSearch:\(configuration.isSearch) isDuckAI:\(configuration.isDuckAI). Fired: \(firedPixelNames)")
         }
-        waitForExpectations(timeout: 5)
-
-        XCTAssertTrue(firedPixelNames.contains { $0.hasPrefix("os_distribution_client_major_version_") },
-                      "Expected MAU OS-distribution pixel. Fired: \(firedPixelNames)")
-        XCTAssertTrue(firedPixelNames.contains { $0.hasPrefix("os_distribution_searches_major_version_") },
-                      "Expected searches OS-distribution pixel. Fired: \(firedPixelNames)")
     }
 
     func testRefreshDuckAIRetentionAtbFiresSearchesOSDistributionPixel() {

--- a/macOS/UnitTests/Statistics/ATB/StatisticsLoaderTests.swift
+++ b/macOS/UnitTests/Statistics/ATB/StatisticsLoaderTests.swift
@@ -59,6 +59,63 @@ class StatisticsLoaderTests: XCTestCase {
         pixelKit = nil
     }
 
+    func testRefreshRetentionAtbOnNavigationFiresClientAndSearchesOSDistributionPixels() {
+        var firedPixelNames: [String] = []
+        let capturingPixelKit = PixelKit(dryRun: false,
+                                         appVersion: "1.0.0",
+                                         source: "browser-dmg",
+                                         defaultHeaders: [:],
+                                         defaults: UserDefaults(suiteName: "test_\(UUID().uuidString)")!,
+                                         fireRequest: { name, _, _, _, _, onComplete in
+                                             firedPixelNames.append(name)
+                                             onComplete(true, nil)
+                                         })
+        PixelKit.setSharedForTesting(pixelKit: capturingPixelKit)
+
+        mockStatisticsStore.atb = "atb"
+        mockStatisticsStore.searchRetentionAtb = "retentionatb"
+        mockStatisticsStore.variant = "test"
+        loadSuccessfulUpdateAtbStub()
+
+        let expect = expectation(description: #function)
+        testee.refreshRetentionAtbOnNavigation(isSearch: true, isDuckAI: false) {
+            expect.fulfill()
+        }
+        waitForExpectations(timeout: 5)
+
+        XCTAssertTrue(firedPixelNames.contains { $0.hasPrefix("os_distribution_client_major_version_") && $0.hasSuffix("_macos_desktop_monthly") },
+                      "Expected MAU OS-distribution pixel. Fired: \(firedPixelNames)")
+        XCTAssertTrue(firedPixelNames.contains { $0.hasPrefix("os_distribution_searches_major_version_") && $0.hasSuffix("_macos_desktop_monthly") },
+                      "Expected searches OS-distribution pixel. Fired: \(firedPixelNames)")
+    }
+
+    func testRefreshDuckAIRetentionAtbFiresSearchesOSDistributionPixel() {
+        var firedPixelNames: [String] = []
+        let capturingPixelKit = PixelKit(dryRun: false,
+                                         appVersion: "1.0.0",
+                                         source: "browser-dmg",
+                                         defaultHeaders: [:],
+                                         defaults: UserDefaults(suiteName: "test_\(UUID().uuidString)")!,
+                                         fireRequest: { name, _, _, _, _, onComplete in
+                                             firedPixelNames.append(name)
+                                             onComplete(true, nil)
+                                         })
+        PixelKit.setSharedForTesting(pixelKit: capturingPixelKit)
+
+        mockStatisticsStore.atb = "atb"
+        mockStatisticsStore.variant = "test"
+        loadSuccessfulUpdateAtbStub()
+
+        let expect = expectation(description: #function)
+        testee.refreshDuckAIRetentionAtb {
+            expect.fulfill()
+        }
+        waitForExpectations(timeout: 5)
+
+        XCTAssertTrue(firedPixelNames.contains { $0.hasPrefix("os_distribution_searches_major_version_") && $0.hasSuffix("_macos_desktop_monthly") },
+                      "Expected searches OS-distribution pixel. Fired: \(firedPixelNames)")
+    }
+
     func testWhenSearchRefreshHasSuccessfulUpdateAtbRequestThenSearchRetentionAtbUpdated() {
 
         mockStatisticsStore.atb = "atb"

--- a/macOS/UnitTests/Statistics/ATB/StatisticsLoaderTests.swift
+++ b/macOS/UnitTests/Statistics/ATB/StatisticsLoaderTests.swift
@@ -95,6 +95,32 @@ class StatisticsLoaderTests: XCTestCase {
         }
     }
 
+    func testRefreshSearchRetentionAtbFiresSearchesOSDistributionPixel() {
+        var firedPixelNames: [String] = []
+        let capturingPixelKit = PixelKit(dryRun: false,
+                                         appVersion: "1.0.0",
+                                         defaultHeaders: [:],
+                                         defaults: UserDefaults(suiteName: "test_\(UUID().uuidString)")!,
+                                         fireRequest: { name, _, _, _, _, onComplete in
+                                             firedPixelNames.append(name)
+                                             onComplete(true, nil)
+                                         })
+        PixelKit.setSharedForTesting(pixelKit: capturingPixelKit)
+
+        mockStatisticsStore.atb = "atb"
+        mockStatisticsStore.variant = "test"
+        loadSuccessfulUpdateAtbStub()
+
+        let expect = expectation(description: #function)
+        testee.refreshSearchRetentionAtb {
+            expect.fulfill()
+        }
+        waitForExpectations(timeout: 5)
+
+        XCTAssertTrue(firedPixelNames.contains { $0.hasPrefix("os_distribution_searches_major_version_") },
+                      "Expected searches OS-distribution pixel. Fired: \(firedPixelNames)")
+    }
+
     func testRefreshDuckAIRetentionAtbFiresSearchesOSDistributionPixel() {
         var firedPixelNames: [String] = []
         let capturingPixelKit = PixelKit(dryRun: false,

--- a/macOS/UnitTests/Subscription/SubscriptionPixelHandlerTests.swift
+++ b/macOS/UnitTests/Subscription/SubscriptionPixelHandlerTests.swift
@@ -99,6 +99,16 @@ final class SubscriptionPixelHandlerTests: XCTestCase {
         )
     }
 
+    func testOSDistributionActiveSubscription() {
+        let handler = SubscriptionPixelHandler(source: subscriptionSource, pixelKit: pixelKit)
+        handler.handle(pixel: .osDistributionActiveSubscription)
+
+        let osMajorVersion = ProcessInfo.processInfo.operatingSystemVersion.majorVersion
+        let expectedName = "os_distribution_active_subscriptions_major_version_\(osMajorVersion)_macos_desktop_monthly"
+        XCTAssertTrue(firedPixels.contains { $0.name == expectedName },
+                      "Expected \(expectedName). Fired: \(firedPixels.map(\.name))")
+    }
+
     func testGetTokensErrorPixel() {
         let handler = SubscriptionPixelHandler(source: subscriptionSource, pixelKit: pixelKit)
         let error = OAuthClientError.invalidTokenRequest(.reused)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1214036592228411?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/1208546505108826/task/1214950124367783?focus=true
CC: @samsymons, @nshuba, @brindy, @THISISDINOSAUR 

### Description

### Testing Steps
1. Automated tests for all pixel use cases are in place, including ensuring that standard parameters (except `channel` on macOS, since it’s only in internal and dev builds, and hard to remove) are omitted.
2. Testing by hand can be done as well if desired, reference the TD for the specific use cases they should fire under.

Note: Next week once this is in internal, I’ll be building dashboards, and will be able to verify the pixels come through end-to-end at that point as well.

### Impact and Risks
Risk: Low

#### What could go wrong?
- Touches subscriptions pixels and statistics loader (atb and related data collection), so mistakes could cause problems with these.  The changes in these files are pretty minimal though, so risk is quite low.
- Pixels are intended to go through PETAL, but we can’t verify that this has been configured properly until this is in an internal build.  I’ll be coordinating with Andreas (see [this task](https://app.asana.com/1/137249556945/project/69071770703008/task/1215252667096758?focus=true)) next week to verify this before anything goes public.

### Quality Considerations
None beyond testing to ensure pixels fire at the appointed times, with the right data in their names, and that parameters are suppressed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly additive analytics with monthly deduping; touch points are StatisticsLoader and subscription pixel side effects, with broad test coverage. PETAL routing cannot be fully verified until internal builds.
> 
> **Overview**
> Adds **monthly OS-distribution pixels** (`client`, `searches`, `active_subscriptions`) keyed by OS major version, platform, and form factor, aimed at understanding OS adoption before ending support.
> 
> **PixelKit** introduces `OSDistributionPixel` and `fireOSDistributionPixel`, which fire with **monthly** gating, **`petal=randomize`**, and **without** default `appVersion` / `pixelSource` (and no platform-prefix enforcement).
> 
> **Wiring:** iOS and macOS **StatisticsLoader** fires `.client` during app retention (macOS also on navigation refresh) and `.searches` during search and Duck.ai retention refreshes. **SubscriptionManager** emits a new `.osDistributionActiveSubscription` pixel alongside the existing active-subscription pixel when a subscription is active; platform **SubscriptionPixelHandler** maps that to the active-subscriptions OS-distribution metric.
> 
> Pixel **definitions** document the `petal` parameter; **tests** cover naming, firing behavior, statistics hooks, and subscription gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9d6377638d8e06aedc60be2c69aec5a630d89db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->