### PR TITLE
macOS: Discard startup metrics when the Move to Applications prompt blocks launch

### DIFF
--- a/macOS/DuckDuckGo/AppHealth/StartupProfiler.swift
+++ b/macOS/DuckDuckGo/AppHealth/StartupProfiler.swift
@@ -32,6 +32,7 @@ final class StartupProfiler: @unchecked Sendable {
 
     private let lock = NSLock()
     private var metrics = StartupMetrics()
+    private var isInterrupted = false
     private let logger: Logger
     weak var delegate: StartupProfilerDelegate?
 
@@ -74,6 +75,15 @@ final class StartupProfiler: @unchecked Sendable {
             metrics
         }
     }
+
+    /// Marks the current launch as interrupted by an event that invalidates startup timings
+    /// (e.g. a modal prompt blocking the launch). The completion callback — and therefore the
+    /// startup metrics pixel — is suppressed for this launch.
+    func markStartupInterrupted() {
+        lock.withLock {
+            isInterrupted = true
+        }
+    }
 }
 
 // MARK: - Private Helpers
@@ -108,6 +118,11 @@ private extension StartupProfiler {
 
     func notifyCompletionIfNeeded(metrics: StartupMetrics?) {
         guard let delegate, let metrics, metrics.isComplete else {
+            return
+        }
+
+        guard !lock.withLock({ isInterrupted }) else {
+            logger.log(level: .debug, "🏁 [Startup Metrics] discarded — launch was interrupted")
             return
         }
 

--- a/macOS/DuckDuckGo/AppHealth/StartupProfiler.swift
+++ b/macOS/DuckDuckGo/AppHealth/StartupProfiler.swift
@@ -32,7 +32,7 @@ final class StartupProfiler: @unchecked Sendable {
 
     private let lock = NSLock()
     private var metrics = StartupMetrics()
-    private var isInterrupted = false
+    private var isInvalid = false
     private let logger: Logger
     weak var delegate: StartupProfilerDelegate?
 
@@ -76,12 +76,13 @@ final class StartupProfiler: @unchecked Sendable {
         }
     }
 
-    /// Marks the current launch as interrupted by an event that invalidates startup timings
-    /// (e.g. a modal prompt blocking the launch). The completion callback — and therefore the
-    /// startup metrics pixel — is suppressed for this launch.
-    func markStartupInterrupted() {
+    /// Invalidates the current startup measurement so its metrics are discarded. The completion
+    /// callback — and therefore the startup metrics pixel — is suppressed for this launch.
+    /// Used when something contaminates the timings, such as the Move to Applications Folder
+    /// prompt blocking the launch before the measured sequence begins.
+    func invalidate() {
         lock.withLock {
-            isInterrupted = true
+            isInvalid = true
         }
     }
 }
@@ -121,8 +122,8 @@ private extension StartupProfiler {
             return
         }
 
-        guard !lock.withLock({ isInterrupted }) else {
-            logger.log(level: .debug, "🏁 [Startup Metrics] discarded — launch was interrupted")
+        guard !lock.withLock({ isInvalid }) else {
+            logger.log(level: .debug, "🏁 [Startup Metrics] discarded — measurement invalidated")
             return
         }
 

--- a/macOS/DuckDuckGo/Application/Application.swift
+++ b/macOS/DuckDuckGo/Application/Application.swift
@@ -109,7 +109,7 @@ final class Application: NSApplication, WarnBeforeQuitManagerDelegate {
             // which would inflate startup timings by arbitrary user think-time. Flag the
             // measurement as invalid up-front so the startup pixel is discarded for this launch.
             if PFMoveToApplicationsFolderWillPrompt(/*allowAlertSilencing:*/ true) {
-                Application.appDelegate.startupProfiler.markStartupInterrupted()
+                Application.appDelegate.startupProfiler.invalidate()
             }
             PFMoveToApplicationsFolderIfNecessary(/*allowAlertSilencing:*/ true)
         }

--- a/macOS/DuckDuckGo/Application/Application.swift
+++ b/macOS/DuckDuckGo/Application/Application.swift
@@ -105,6 +105,12 @@ final class Application: NSApplication, WarnBeforeQuitManagerDelegate {
     override func run() {
         let buildType = StandardApplicationBuildType()
         if !buildType.isAppStoreBuild && !buildType.isDebugBuild {
+            // The prompt is modal and blocks the launch for as long as it stays unanswered,
+            // which would inflate startup timings by arbitrary user think-time. Flag the
+            // measurement as invalid up-front so the startup pixel is discarded for this launch.
+            if PFMoveToApplicationsFolderWillPrompt(/*allowAlertSilencing:*/ true) {
+                Application.appDelegate.startupProfiler.markStartupInterrupted()
+            }
             PFMoveToApplicationsFolderIfNecessary(/*allowAlertSilencing:*/ true)
         }
 

--- a/macOS/LocalPackages/LetsMove/Sources/LetsMove/PFMoveApplication.m
+++ b/macOS/LocalPackages/LetsMove/Sources/LetsMove/PFMoveApplication.m
@@ -68,18 +68,15 @@ void PFMoveToApplicationsFolderIfNecessary(BOOL allowAlertSilencing) {     
 		return;
 	}
 
-	// Skip if user suppressed the alert before
-	if (allowAlertSilencing && [[NSUserDefaults standardUserDefaults] boolForKey:AlertSuppressKey]) return;
+	// Skip when the prompt isn't needed (suppressed by the user, or already in an Applications
+	// folder and not nested inside another app's bundle).
+	if (!PFMoveToApplicationsFolderWillPrompt(allowAlertSilencing)) return;
 
 	// Path of the bundle
 	NSString *bundlePath = [[NSBundle mainBundle] bundlePath];
 
 	// Check if the bundle is embedded in another application
 	BOOL isNestedApplication = IsApplicationAtPathNested(bundlePath);
-
-	// Skip if the application is already in some Applications folder,
-	// unless it's inside another app's bundle.
-	if (IsInApplicationsFolder(bundlePath) && !isNestedApplication) return;
 
 	// OK, looks like we'll need to do a move - set the status variable appropriately
 	MoveInProgress = YES;

--- a/macOS/LocalPackages/LetsMove/Sources/LetsMove/PFMoveApplication.m
+++ b/macOS/LocalPackages/LetsMove/Sources/LetsMove/PFMoveApplication.m
@@ -57,7 +57,7 @@ static NSString *ShellQuotedString(NSString *string);
 static void Relaunch(NSString *destinationPath);
 
 // Main worker function
-void PFMoveToApplicationsFolderIfNecessary(BOOL allowAlertSilencing) {
+void PFMoveToApplicationsFolderIfNecessary(BOOL allowAlertSilencing) {     
 
 	// Make sure to do our work on the main thread.
 	// Apparently Electron apps need this for things to work properly.
@@ -217,6 +217,22 @@ fail:
 
 BOOL PFMoveIsInProgress(void) {
     return MoveInProgress;
+}
+
+BOOL PFMoveToApplicationsFolderWillPrompt(BOOL allowAlertSilencing) {
+	// Mirrors the early-return conditions in PFMoveToApplicationsFolderIfNecessary that decide
+	// whether the prompt is shown, without presenting any UI.
+
+	// Suppressed by the user before
+	if (allowAlertSilencing && [[NSUserDefaults standardUserDefaults] boolForKey:AlertSuppressKey]) return NO;
+
+	NSString *bundlePath = [[NSBundle mainBundle] bundlePath];
+	BOOL isNestedApplication = IsApplicationAtPathNested(bundlePath);
+
+	// Already in some Applications folder, unless nested inside another app's bundle
+	if (IsInApplicationsFolder(bundlePath) && !isNestedApplication) return NO;
+
+	return YES;
 }
 
 #pragma mark -

--- a/macOS/LocalPackages/LetsMove/Sources/LetsMove/PFMoveApplication.m
+++ b/macOS/LocalPackages/LetsMove/Sources/LetsMove/PFMoveApplication.m
@@ -57,7 +57,7 @@ static NSString *ShellQuotedString(NSString *string);
 static void Relaunch(NSString *destinationPath);
 
 // Main worker function
-void PFMoveToApplicationsFolderIfNecessary(BOOL allowAlertSilencing) {     
+void PFMoveToApplicationsFolderIfNecessary(BOOL allowAlertSilencing) {
 
 	// Make sure to do our work on the main thread.
 	// Apparently Electron apps need this for things to work properly.

--- a/macOS/LocalPackages/LetsMove/Sources/LetsMove/include/PFMoveApplication.h
+++ b/macOS/LocalPackages/LetsMove/Sources/LetsMove/include/PFMoveApplication.h
@@ -27,6 +27,13 @@ void PFMoveToApplicationsFolderIfNecessary(BOOL allowAlertSilencing);
  See https://github.com/potionfactory/LetsMove/issues/64 for details. */
 BOOL PFMoveIsInProgress(void);
 
+/**
+ Returns YES if a subsequent call to \c PFMoveToApplicationsFolderIfNecessary with the same
+ \c allowAlertSilencing value would present the "Move to Applications Folder" prompt, or NO otherwise.
+ Evaluates the same conditions as that function (suppression preference and Applications-folder
+ location) without showing any UI, so callers can detect launches that will be blocked by the prompt. */
+BOOL PFMoveToApplicationsFolderWillPrompt(BOOL allowAlertSilencing);
+
 #ifdef __cplusplus
 }
 #endif

--- a/macOS/UnitTests/AppHealth/StartupProfilerTests.swift
+++ b/macOS/UnitTests/AppHealth/StartupProfilerTests.swift
@@ -167,6 +167,25 @@ final class StartupProfilerTests: XCTestCase {
         XCTAssertFalse(delegate.didComplete)
     }
 
+    @MainActor
+    func testDelegateNotCalledWhenInvalidatedEvenIfAllStepsRecorded() async {
+        let profiler = StartupProfiler()
+        let delegate = MockStartupProfilerDelegate()
+        profiler.delegate = delegate
+
+        profiler.invalidate()
+
+        for step in StartupStep.allCases {
+            let token = profiler.startMeasuring(step)
+            token.stop()
+        }
+
+        await Task.yield()
+
+        XCTAssertFalse(delegate.didComplete)
+        XCTAssertNil(delegate.receivedMetrics)
+    }
+
     // MARK: - StartupProfilerToken
 
     func testTokenStopOnlyCallsClosureOnce() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1215443703087738?focus=true

### Description

The "Move to Applications Folder" prompt blocks launch before the measured sequence begins, so the user's think-time is counted as startup time and inflates the startup performance pixel. This discards the pixel for launches where that prompt appears.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/04302152-c20e-4ab4-a06f-b3853ec24ca6" />

### Testing Steps

The Move-to-Applications path is gated to non-App-Store, non-Debug builds, so disable that guard to test in Debug. The prompt appears because a Debug build runs from outside /Applications. The profiler logs whether it fired or was discarded, so watch it in Console.

1. Open Console.app, select your Mac, start streaming, and filter on `Startup Metrics` (enable Action ▸ Include Debug Messages so the profiler's debug logs appear).
2. In `Application.swift` line 107, change the build-type guard condition to `if true`.
3. Build and run the app in Debug.
   - The "Move to Applications Folder" prompt appears.
4. Click "Do Not Move".
   - Console shows `🏁 [Startup Metrics] discarded — measurement invalidated`, and no `m_mac_startup_performance_metrics` pixel is sent.
5. Build and run the app again.
   - The prompt appears again.
6. Click "Move to Applications Folder".
   - The app relaunches from /Applications without re-showing the prompt, and Console shows `🏁 [Startup Metrics]` with step durations and `m_mac_startup_performance_metrics` firing.
7. Quit the app, delete the copy from /Applications, and revert the change from step 2.

### Impact and Risks

Low. The change affects only a telemetry pixel; there is no user-facing behavior change, and the prompt itself is untouched.

#### What could go wrong?

The predicate could misjudge whether the prompt will appear and drop (or keep) the wrong launches. It reuses LetsMove's own decision logic — the same suppression and Applications-folder checks — so it stays in sync with what the prompt actually does. Worst case is a small number of startup samples dropped or kept incorrectly, with no user-facing effect.

### Quality Considerations

Clicking "Move" relaunches from /Applications and terminates this process, so no pixel would fire there regardless. The already-in-/Applications and user-suppressed cases are detected and left to report normally. The predicate runs only lightweight path checks at launch and collects no new data.

### Notes to Reviewer

`PFMoveToApplicationsFolderIfNecessary` defers to `PFMoveToApplicationsFolderWillPrompt` for its skip/proceed decision, so the predicate and the prompt share a single gate and can't diverge.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only change with no user-facing behavior; worst case is mis-detecting prompt eligibility and dropping or keeping a few startup samples.
> 
> **Overview**
> Adds a way to **invalidate** macOS startup profiling so the **`m_mac_startup_performance_metrics`** pixel is not sent when launch timing would be misleading.
> 
> **StartupProfiler** gains **`invalidate()`** and an **`isInvalid`** flag; when metrics would otherwise complete, the delegate callback (and thus the pixel) is skipped and a debug log notes the discard.
> 
> Before showing the LetsMove dialog on non–App Store, non-Debug builds, **`Application.run()`** calls **`PFMoveToApplicationsFolderWillPrompt`** and invalidates the profiler when the modal “Move to Applications Folder” prompt would appear, since user think-time would inflate measured startup.
> 
> **LetsMove** exposes **`PFMoveToApplicationsFolderWillPrompt`**, mirroring the same suppression and Applications-folder checks as **`PFMoveToApplicationsFolderIfNecessary`** without UI; the move helper now early-returns via that predicate so prompt logic stays in one place.
> 
> Unit test covers that the delegate is not invoked after invalidation even when all startup steps are recorded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 983baa19a75dca47c2fa6e28e60d6d3544ffa89f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->