### PR TITLE
iOS: Fix missing device image in Set Default Browser prompt

### DIFF
--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Prompts/DefaultBrowserPromptActiveUserView.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Prompts/DefaultBrowserPromptActiveUserView.swift
@@ -88,7 +88,7 @@ private extension DefaultBrowserPromptActiveUserView {
             let imageSize = Metrics.Content.imageSize.build(v: verticalSizeClass, h: horizontalSizeClass)
 
             VStack(spacing: Metrics.Content.itemsVerticalSpacing.build(v: verticalSizeClass, h: horizontalSizeClass)) {
-                Image(rebrandable: "device-mobile-default-128")
+                Image(rebrandable: "device-mobile-default-128", bundle: .module)
                     .resizable()
                     .scaledToFit()
                     .frame(width: imageSize.width, height: imageSize.height)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1215452560697524?focus=true
Tech Design URL:
CC:

### Description
The `device-mobile-default-128` artwork ships inside the `SetDefaultBrowserUI` Swift package's own asset catalog, which compiles into that package's `Bundle.module`. The `Image(rebrandable:)` call in the active-user prompt omitted the `bundle:` argument, so it defaulted to `nil` and resolved to the main app bundle. The asset is not in the main bundle, so the image (and its `-legacy` fallback) failed to load.

This was the only broken Image(rebrandable:) call site in the repo because it's the only one whose asset lives in an SPM package's own catalog 

This passes `bundle: .module` at the call site so both the rebranded and legacy lookups target the package bundle, matching how the same package already loads its localized strings from `Bundle.module`.

### Testing Steps
- Debug menu > Default browser prompt > Reset prompt and today's date
- Kill the app
- Relaunch the app

---

###### Internal references: [DoD](https://app.asana.com/0/1207634633537039) | [Eng Expectations](https://app.asana.com/0/199064865822552) | [Tech Design Template](https://app.asana.com/0/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single call-site bundle fix for UI asset loading; no auth, data, or business-logic changes.
> 
> **Overview**
> Fixes a **missing device illustration** on the active-user Set Default Browser prompt by passing **`bundle: .module`** to `Image(rebrandable: "device-mobile-default-128", …)` in `DefaultBrowserPromptActiveUserView`.
> 
> That artwork lives in the **SetDefaultBrowserUI** package asset catalog, not the main app bundle. Without an explicit bundle, `Image(rebrandable:)` looked in the app bundle and failed to load both the rebranded asset and its `-legacy` fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c83e3c2122943c5bf524029cd040772960281553. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->