### PR TITLE
Add iPad tabs bar usage baseline pixels

### DIFF
--- a/iOS/Core/Pixel.swift
+++ b/iOS/Core/Pixel.swift
@@ -89,6 +89,7 @@ public struct PixelParameters {
     public static let source = "source"
     public static let shortcut = "shortcut"
     public static let browsingMode = "browsing_mode"
+    public static let tabState = "tab_state"
     public static let authVersion = "authVersion"
     public static let lastUsed = "last_used"
 

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -216,7 +216,13 @@ extension Pixel {
         case bookmarksButtonPressed
         case tabBarBookmarksLongPressed
         case tabBarTabSwitcherOpened
-        
+
+        case tabBarTabSelected
+        case tabBarTabClosed
+        case tabBarNewTab
+        case tabBarOverflowDaily
+        case tabBarOpenTabCountDaily
+
         case homeScreenShown
         case homeScreenEditFavorite
         case homeScreenDeleteFavorite
@@ -2147,6 +2153,11 @@ extension Pixel.Event {
         case .bookmarksButtonPressed: return "mt_bm"
         case .tabBarBookmarksLongPressed: return "mt_bl"
         case .tabBarTabSwitcherOpened: return "m_tab_manager_opened"
+        case .tabBarTabSelected: return "m_tab_bar_tab_selected"
+        case .tabBarTabClosed: return "m_tab_bar_tab_closed"
+        case .tabBarNewTab: return "m_tab_bar_new_tab"
+        case .tabBarOverflowDaily: return "m_tab_bar_overflow_daily"
+        case .tabBarOpenTabCountDaily: return "m_tab_bar_open_tab_count_daily"
 
         case .bookmarkLaunchList: return "m_bookmark_launch_list"
         case .bookmarkLaunchScored: return "m_bookmark_launch_scored"

--- a/iOS/DuckDuckGo/TabSwitcherOpenDailyPixel.swift
+++ b/iOS/DuckDuckGo/TabSwitcherOpenDailyPixel.swift
@@ -38,8 +38,10 @@ struct TabSwitcherOpenDailyPixel {
     }
 
     private func tabCountBucket(for tabs: [Tab]) -> String? {
-        let count = tabs.count
+        Self.tabCountBucket(forCount: tabs.count)
+    }
 
+    static func tabCountBucket(forCount count: Int) -> String? {
         switch count {
         case 0: return nil
         case 1...1: return "1"
@@ -51,7 +53,6 @@ struct TabSwitcherOpenDailyPixel {
         case 61...80: return "61-80"
         default: return "81+"
         }
-
     }
 
     private func bucketForInactiveTabs<Range: RangeExpression>(_ tabs: [Tab], within daysInterval: Range, from referenceDate: Date) -> String? where Range.Bound == Int {

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -323,7 +323,6 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
         guard tabsCount > 0 else { return }
 
         if let tabCountBucket = TabSwitcherOpenDailyPixel.tabCountBucket(forCount: tabsCount) {
-            // Shared "tab_count" bucket param (matches m_tab_manager_opened_daily), not the legacy PixelParameters.tabCount ("tc").
             DailyPixel.fire(pixel: .tabBarOpenTabCountDaily, withAdditionalParameters: ["tab_count": tabCountBucket])
         }
 

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -266,6 +266,7 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
     }
 
     @IBAction func onNewTabPressed() {
+        DailyPixel.fireDailyAndCount(pixel: .tabBarNewTab)
         requestNewTab(type: .currentMode)
     }
 
@@ -290,6 +291,7 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
 
         recomputeItemSize()
         reloadData()
+        fireUsageDailyPixels()
 
         if scrollToSelected {
             DispatchQueue.main.async {
@@ -312,6 +314,23 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
 
         if let flowLayout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
             flowLayout.itemSize = CGSize(width: itemWidth, height: view.frame.size.height)
+        }
+    }
+
+    /// Once-per-day baseline snapshots: open-tab count (bucketed) and whether the strip overflows
+    /// (scroll required). DailyPixel dedupes per day, so these capture the first qualifying state of the day.
+    private func fireUsageDailyPixels() {
+        guard tabsCount > 0 else { return }
+
+        if let tabCountBucket = TabSwitcherOpenDailyPixel.tabCountBucket(forCount: tabsCount) {
+            // Shared "tab_count" bucket param (matches m_tab_manager_opened_daily), not the legacy PixelParameters.tabCount ("tc").
+            DailyPixel.fire(pixel: .tabBarOpenTabCountDaily, withAdditionalParameters: ["tab_count": tabCountBucket])
+        }
+
+        let availableWidth = collectionView.frame.size.width
+        let itemWidth = (collectionView.collectionViewLayout as? UICollectionViewFlowLayout)?.itemSize.width ?? 0
+        if availableWidth > 0, itemWidth > 0, CGFloat(tabsCount) * itemWidth > availableWidth {
+            DailyPixel.fire(pixel: .tabBarOverflowDaily)
         }
     }
 
@@ -524,6 +543,7 @@ extension TabsBarViewController: TabSwitcherButtonDelegate {
 extension TabsBarViewController: UICollectionViewDelegate {
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        DailyPixel.fireDailyAndCount(pixel: .tabBarTabSelected)
         delegate?.tabsBar(self, didSelectTabAtIndex: indexPath.row)
     }
 
@@ -568,6 +588,8 @@ extension TabsBarViewController: UICollectionViewDataSource {
             guard let self = self, let model = model,
                 let tabIndex = self.tabsModel?.indexOf(tab: model)
                 else { return }
+            let tabState = tabIndex == self.currentIndex ? "active" : "inactive"
+            DailyPixel.fireDailyAndCount(pixel: .tabBarTabClosed, withAdditionalParameters: [PixelParameters.tabState: tabState])
             self.delegate?.tabsBar(self, didRemoveTabAtIndex: tabIndex)
         }
         return cell

--- a/iOS/PixelDefinitions/pixels/definitions/ipad_tabs_bar.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ipad_tabs_bar.json5
@@ -1,0 +1,48 @@
+// iPad tabs bar usage baseline pixels.
+{
+    "m_tab_bar_tab_selected": {
+        "description": "User selects (switches to) a tab in the iPad tabs bar.",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "expires": "2026-08-05",
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_tab_bar_tab_closed": {
+        "description": "User closes a tab via the close button in the iPad tabs bar.",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "tab_state",
+                "type": "string",
+                "description": "Whether the closed tab was the active (currently shown) tab or an inactive background tab. Inactive indicates a close-without-switching.",
+                "enum": ["active", "inactive"]
+            }
+        ]
+    },
+    "m_tab_bar_new_tab": {
+        "description": "User opens a new tab via the add-tab button in the iPad tabs bar.",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_tab_bar_overflow_daily": {
+        "description": "Fires once per day when the iPad tabs bar holds more tabs than fit and must scroll horizontally.",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "expires": "2026-08-05",
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_tab_bar_open_tab_count_daily": {
+        "description": "Fires once per day with the bucketed number of open tabs, sampled at the first iPad tabs bar refresh of the day.",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "tabCount"]
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215329485346261?focus=true
Tech Design URL:
CC:

### Description
Adds daily-first baseline telemetry for the iPad tabs bar so we can measure per-user engagement before the tab bar UX changes roll out. All pixels fire unconditionally from `TabsBarViewController` (an iPad-only surface), so they are not gated behind any of the upcoming UX feature flags and establish a true pre-rollout baseline.

Pixels added:
- `m_tab_bar_tab_selected` (daily + count, temporary): user switches to a tab in the strip.
- `m_tab_bar_tab_closed` (daily + count) with `tab_state` = active/inactive: distinguishes closing the active tab (close-after-selection) from an inactive background tab (close-without-switching).
- `m_tab_bar_new_tab` (daily + count): the add-tab button.
- `m_tab_bar_overflow_daily` (daily, temporary): the strip holds more tabs than fit and must scroll.
- `m_tab_bar_open_tab_count_daily` (daily) with bucketed `tab_count`: open-tab distribution, reusing the shared bucket from `TabSwitcherOpenDailyPixel`.

`tab_selected` and `overflow` are temporary (expire 2026-08-05) since they exist to validate the tab sizing rollout. The other three are permanent engagement baselines.

### Testing Steps
1. Run the app - make sure to not clear the console output so that daily pixels in pt. 5 are not cleared.
1. With the tabs bar visible, tap a non-active tab, verify `m_tab_bar_tab_selected_daily` (first time today) and `m_tab_bar_tab_selected_count` fire.
2. Tap the + button, verify `m_tab_bar_new_tab` fires.
3. Close a tab via its close button, verify `m_tab_bar_tab_closed` fires with `tab_state=active`.
4. Open enough tabs that the strip scrolls, then refresh or relaunch, verify `m_tab_bar_overflow_daily` fires once that day and `m_tab_bar_open_tab_count_daily` fires with a bucketed `tab_count`.

### Impact and Risks
Low. Additive telemetry only, no behavior or UI change.

#### What could go wrong?

### Quality Considerations
— 

### Notes to Reviewer
The two daily-only pixels reuse the bucket boundaries from `TabSwitcherOpenDailyPixel` (the bucket helper was made shared).

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive analytics only; no behavior, auth, or data-handling changes.
> 
> **Overview**
> Adds **pre-rollout baseline telemetry** for the iPad tabs bar in `TabsBarViewController`, wired to new `Pixel.Event` cases and documented in `ipad_tabs_bar.json5`.
> 
> **Interaction pixels** use `DailyPixel.fireDailyAndCount` for tab switch, new tab (+), and tab close; close events include `tab_state` (`active` vs `inactive`) via new `PixelParameters.tabState`.
> 
> **Once-per-day snapshots** run from `fireUsageDailyPixels()` on bar refresh: bucketed open-tab count (reusing `TabSwitcherOpenDailyPixel.tabCountBucket(forCount:)`, now shared as a static helper) and overflow when the strip must scroll horizontally.
> 
> No UX or feature-flag gating—telemetry only on an iPad-only surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e756e1eb576e16273ded7fbc9fc5ba422cb0c39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->