### PR TITLE
iOS: End post-idle session as bar_used on direct address-bar search

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3923,6 +3923,12 @@ extension MainViewController: OmniBarDelegate {
         // and resolves to .dismissed, not .suspended.
         hideSuggestionTray()
         omniBar.cancel()
+        // A direct address-bar submission is a terminal `.barUsed` action, same as
+        // selecting a suggestion (`handleSuggestionSelected`). Ending the post-idle
+        // session here keeps direct searches in parity with the suggestion path;
+        // without it, a typed search left the session open to later complete as
+        // `app_backgrounded`, undercounting `bar_used`.
+        postIdleSessionInstrumentation.sessionEnded(reason: .barUsed)
         loadQuery(query)
         hideNotificationBarIfBrokenSitePromptShown()
         showHomeRowReminder()

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3923,11 +3923,6 @@ extension MainViewController: OmniBarDelegate {
         // and resolves to .dismissed, not .suspended.
         hideSuggestionTray()
         omniBar.cancel()
-        // A direct address-bar submission is a terminal `.barUsed` action, same as
-        // selecting a suggestion (`handleSuggestionSelected`). Ending the post-idle
-        // session here keeps direct searches in parity with the suggestion path;
-        // without it, a typed search left the session open to later complete as
-        // `app_backgrounded`, undercounting `bar_used`.
         postIdleSessionInstrumentation.sessionEnded(reason: .barUsed)
         loadQuery(query)
         hideNotificationBarIfBrokenSitePromptShown()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1093,6 +1093,7 @@ extension MainViewController {
     }
 
     func handleUnifiedToggleInputSearchSubmission(_ query: String) {
+        postIdleSessionInstrumentation.sessionEnded(reason: .barUsed)
         loadQuery(query)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1215446349371630?focus=true

### Description

The post-idle wide-event pixel `m_ios_wide_post_idle_session` (`post_idle_session`) tracks what a user does after returning from idle on the NTP/LUT, and is meant to complete with a terminal `StatusReason` such as `bar_used`.

A **direct address-bar query submission** (typing a query and hitting enter) never ended the session: `onOmniQuerySubmitted` → `loadQuery` → `loadUrlRespectingAIBoundary` → `loadUrl`/`loadUrlInNewTab`, none of which call `postIdleSessionInstrumentation.sessionEnded`. As a result the session stayed open and was typically completed later as `app_backgrounded` when the app was backgrounded — undercounting `bar_used` and inflating `app_backgrounded`.

The other "bar used" entry points already end the session as `.barUsed`:
- `handleSuggestionSelected` (tapping an autocomplete suggestion) — `MainViewController.swift:3792`
- The Duck.ai `load(...)` path — `MainViewController.swift:2101` / `:3528`

This change adds the matching `sessionEnded(reason: .barUsed)` call in `onOmniQuerySubmitted` so direct searches are in parity. `sessionEnded` is a no-op when no post-idle session is active (it guards on `activeSessionID`), so this has no effect outside an active post-idle session.

### Testing Steps
1. Set the After Inactivity / Opening Screen option so returning from idle shows the NTP (or last-used tab).
2. Background the app long enough to cross the idle threshold, then foreground it (this starts a post-idle session).
3. Type a query directly into the address bar and press enter (do **not** tap an autocomplete suggestion).
4. Confirm `m_ios_wide_post_idle_session` fires with `feature.data.ext.status_reason = bar_used` (rather than the session staying open and later firing `app_backgrounded`).
5. Regression: repeat but tap a suggestion / favorite / tab switcher / return-to-page and confirm those still report their respective reasons (no double-fire — `sessionEnded` is idempotent).

### Impact and Risks
Low. Analytics-only change to one wide-event pixel; no user-facing behaviour changes. Shifts a slice of `post_idle_session` completions from `app_backgrounded` to `bar_used`, which is the intended classification.

#### What could go wrong?
- Double-completion: not possible — `sessionEnded` guards on `activeSessionID` and clears it, so a second call is a no-op.
- Misattribution: `loadQuery` builds a search URL (not a Duck.ai URL), so `loadUrlRespectingAIBoundary` routes to `loadUrl`/`loadUrlInNewTab`, never the Duck.ai `load(...)` path that also fires `.barUsed`. No double counting.

### Notes to Reviewer
- The same direct-search path also skips `ntpAfterIdleInstrumentation.barUsedFromNTP(afterIdle:)`, which the suggestion and Duck.ai paths fire alongside `sessionEnded`. That is a separate pixel and out of scope here — happy to follow up separately if we want that in parity too.
- Wiring-level calls for the sibling `.barUsed` sites (`handleSuggestionSelected`, Duck.ai `load`) are not unit-tested at the `MainViewController` level, so no test is added here for consistency; the instrumentation itself is covered by `PostIdleSessionInstrumentationTests`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only wiring for one wide-event pixel; guarded idempotent `sessionEnded` with no user-facing behavior change.
> 
> **Overview**
> Direct **address-bar search** (Enter without picking a suggestion) now ends an active post-idle session with **`status_reason = bar_used`**, matching autocomplete suggestions and Duck.ai bar paths that already call `postIdleSessionInstrumentation.sessionEnded(reason: .barUsed)`.
> 
> The call is added in **`onOmniQuerySubmitted`** and **`handleUnifiedToggleInputSearchSubmission`** immediately before **`loadQuery`**, so sessions no longer linger until **`app_backgrounded`**. **`sessionEnded`** is a no-op when no session is active, so behavior outside post-idle is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 152d933bcc0211037662f79eb8e3f269c1e03617. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->