### PR TITLE
Apply onboarding search-mode choice to NTP and web homepage

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -537,6 +537,10 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// Group into the app's Application Support directory on iOS. Off keeps the
     /// legacy App Group path.
     case nativeStoragePathMigration
+
+    /// macOS only. When on, the onboarding Search/Duck.ai toggle choice also drives the New Tab Page
+    /// search-mode toggle and seeds the duckduckgo.com homepage. Off keeps the choice address-bar only.
+    case onboardingToggleAffectsNtpAndDdg
 }
 
 public enum HtmlNewTabPageSubfeature: String, Equatable, PrivacySubfeature {

--- a/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
@@ -111,6 +111,7 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
     private let startupPreferences: StartupPreferences
     private let dataImportProvider: DataImportStatusProviding
     private var aiChatPreferencesStorage: AIChatPreferencesStorage
+    private let homepageSearchModeSeedPersistor: HomepageSearchModeSeedPersistor
     private let featureFlagger: FeatureFlagger
     private let onboardingSharedPixelHandler: OnboardingSharedPixelHandling
     private var cancellables = Set<AnyCancellable>()
@@ -207,6 +208,7 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         startupPreferences: StartupPreferences,
         dataImportProvider: DataImportStatusProviding,
         aiChatPreferencesStorage: AIChatPreferencesStorage = DefaultAIChatPreferencesStorage(),
+        homepageSearchModeSeedPersistor: HomepageSearchModeSeedPersistor = HomepageSearchModeSeedUserDefaultsPersistor(),
         featureFlagger: FeatureFlagger,
         onboardingSharedPixelHandler: OnboardingSharedPixelHandling
     ) {
@@ -217,6 +219,7 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         self.startupPreferences = startupPreferences
         self.dataImportProvider = dataImportProvider
         self.aiChatPreferencesStorage = aiChatPreferencesStorage
+        self.homepageSearchModeSeedPersistor = homepageSearchModeSeedPersistor
         self.featureFlagger = featureFlagger
         self.onboardingSharedPixelHandler = onboardingSharedPixelHandler
     }
@@ -291,16 +294,9 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
     }
 
     func setDuckAiInAddressBar(enabled: Bool) {
-        // Mirror the onboarding choice across all surfaces. The address-bar toggle and the native
-        // New Tab Page reflect `enabled` directly...
         aiChatPreferencesStorage.showSearchAndDuckAIToggle = enabled
         aiChatPreferencesStorage.showShortcutOnNewTabPage = enabled
-        // ...and arm a one-shot marker carrying the chosen value (true = show the search-mode toggle).
-        // HomepageSearchModeToggleSeedUserScript applies it to the duckduckgo.com web homepage on
-        // next load and reports back to clear the marker once applied, after which later web changes
-        // are respected. Clearing is tied to the script running (not a navigation event) so it works
-        // regardless of how onboarding finishes and survives the homepage's script-install race.
-        UserDefaults.standard.set(enabled, forKey: HomepageSearchModeToggleSeedUserScript.pendingSeedDefaultsKey)
+        homepageSearchModeSeedPersistor.pendingShowSearchModeToggle = enabled
     }
 
     private func onMainThreadIfNeeded(_ function: @escaping () -> Void) {

--- a/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
@@ -295,6 +295,7 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
 
     func setDuckAiInAddressBar(enabled: Bool) {
         aiChatPreferencesStorage.showSearchAndDuckAIToggle = enabled
+        guard featureFlagger.isFeatureOn(.aiChatOnboardingToggleAffectsNtpAndDdg) else { return }
         aiChatPreferencesStorage.showShortcutOnNewTabPage = enabled
         homepageSearchModeSeedPersistor.pendingShowSearchModeToggle = enabled
     }

--- a/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
@@ -235,6 +235,9 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         tab.navigationDidEndPublisher
             .first()
             .sink { [weak self] _ in
+                // The homepage seed script has applied on this first successful duckduckgo.com load;
+                // consume the one-shot marker so it is no longer injected on subsequent tabs.
+                UserDefaults.standard.removeObject(forKey: HomepageSearchModeToggleSeedUserScript.pendingSeedDefaultsKey)
                 self?.navigation.focusOnAddressBar()
             }
             .store(in: &cancellables)
@@ -295,10 +298,10 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         // New Tab Page reflect `enabled` directly...
         aiChatPreferencesStorage.showSearchAndDuckAIToggle = enabled
         aiChatPreferencesStorage.showShortcutOnNewTabPage = enabled
-        // ...and arm a one-shot marker carrying the chosen value (true = show the search-mode toggle)
-        // so the duckduckgo.com web homepage applies it once on next load
-        // (HomepageSearchModeToggleSeedUserScript consumes the marker), then respects any later
-        // change the user makes via the web "Customize Homepage" UI.
+        // ...and arm a one-shot marker carrying the chosen value (true = show the search-mode toggle).
+        // HomepageSearchModeToggleSeedUserScript applies it to the duckduckgo.com web homepage on
+        // next load; the marker is consumed after the first successful homepage navigation
+        // (see goToAddressBar), after which later web changes are respected.
         UserDefaults.standard.set(enabled, forKey: HomepageSearchModeToggleSeedUserScript.pendingSeedDefaultsKey)
     }
 

--- a/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
@@ -291,7 +291,15 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
     }
 
     func setDuckAiInAddressBar(enabled: Bool) {
+        // Mirror the onboarding choice across all surfaces. The address-bar toggle and the native
+        // New Tab Page reflect `enabled` directly...
         aiChatPreferencesStorage.showSearchAndDuckAIToggle = enabled
+        aiChatPreferencesStorage.showShortcutOnNewTabPage = enabled
+        // ...and arm a one-shot marker carrying the chosen value (true = show the search-mode toggle)
+        // so the duckduckgo.com web homepage applies it once on next load
+        // (HomepageSearchModeToggleSeedUserScript consumes the marker), then respects any later
+        // change the user makes via the web "Customize Homepage" UI.
+        UserDefaults.standard.set(enabled, forKey: HomepageSearchModeToggleSeedUserScript.pendingSeedDefaultsKey)
     }
 
     private func onMainThreadIfNeeded(_ function: @escaping () -> Void) {

--- a/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
@@ -235,9 +235,6 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         tab.navigationDidEndPublisher
             .first()
             .sink { [weak self] _ in
-                // The homepage seed script has applied on this first successful duckduckgo.com load;
-                // consume the one-shot marker so it is no longer injected on subsequent tabs.
-                UserDefaults.standard.removeObject(forKey: HomepageSearchModeToggleSeedUserScript.pendingSeedDefaultsKey)
                 self?.navigation.focusOnAddressBar()
             }
             .store(in: &cancellables)
@@ -300,8 +297,9 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         aiChatPreferencesStorage.showShortcutOnNewTabPage = enabled
         // ...and arm a one-shot marker carrying the chosen value (true = show the search-mode toggle).
         // HomepageSearchModeToggleSeedUserScript applies it to the duckduckgo.com web homepage on
-        // next load; the marker is consumed after the first successful homepage navigation
-        // (see goToAddressBar), after which later web changes are respected.
+        // next load and reports back to clear the marker once applied, after which later web changes
+        // are respected. Clearing is tied to the script running (not a navigation event) so it works
+        // regardless of how onboarding finishes and survives the homepage's script-install race.
         UserDefaults.standard.set(enabled, forKey: HomepageSearchModeToggleSeedUserScript.pendingSeedDefaultsKey)
     }
 

--- a/macOS/DuckDuckGo/Tab/TabExtensions/ContentBlockingTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/ContentBlockingTabExtension.swift
@@ -57,6 +57,7 @@ final class ContentBlockingTabExtension: NSObject {
     private let fbBlockingEnabledProvider: FbBlockingEnabledProvider
     private let tld: TLD
     private let contentBlockingManager: ContentBlockerRulesManagerProtocol
+    private let homepageSearchModeSeedPersistor: HomepageSearchModeSeedPersistor = HomepageSearchModeSeedUserDefaultsPersistor()
 
     private var cachedMapper: TrackerProtectionEventMapper?
     private var cachedMapperVendor: String?
@@ -160,7 +161,9 @@ extension ContentBlockingTabExtension: NavigationResponder {
             // ContentScopeUserScript needs to be loaded for https://duckduckgo.com/identity-theft-restoration
             || navigationAction.url.absoluteString.hasPrefix(SubscriptionURL.identityTheftRestoration.subscriptionURL(environment: .production).absoluteString)
             // ContentScopeUserScript needs to be loaded for Duck.ai
-            || navigationAction.url.isDuckAIURL {
+            || navigationAction.url.isDuckAIURL
+            // HomepageSearchModeToggleSeedUserScript must install before the homepage reads its settings
+            || (navigationAction.url.isDuckDuckGo && homepageSearchModeSeedPersistor.pendingShowSearchModeToggle != nil) {
             await prepareForContentBlocking()
         }
 

--- a/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
@@ -297,15 +297,12 @@ final class UserScripts: UserScriptsProvider, ReleaseNotesUserScriptProvider {
         identityTheftRestorationPagesUserScript.registerSubfeature(delegate: identityTheftRestorationPagesFeature)
         userScripts.append(identityTheftRestorationPagesUserScript)
 
-        // One-shot: an onboarding choice arms a native marker whose value is the chosen
-        // "show search-mode toggle" state (presence of the key == a seed is pending). On the first
-        // duckduckgo.com load the seed script applies it and posts back to clear the marker, so it
-        // runs once per choice and later web changes are respected.
-        let homepageSeedKey = HomepageSearchModeToggleSeedUserScript.pendingSeedDefaultsKey
-        if UserDefaults.standard.object(forKey: homepageSeedKey) != nil {
-            let showSearchModeToggle = UserDefaults.standard.bool(forKey: homepageSeedKey)
-            userScripts.append(HomepageSearchModeToggleSeedUserScript(showSearchModeToggle: showSearchModeToggle, onApplied: {
-                UserDefaults.standard.removeObject(forKey: homepageSeedKey)
+        let homepageSeedPersistor = HomepageSearchModeSeedUserDefaultsPersistor()
+        if let pendingShowSearchModeToggle = homepageSeedPersistor.pendingShowSearchModeToggle {
+            userScripts.append(HomepageSearchModeToggleSeedUserScript(showSearchModeToggle: pendingShowSearchModeToggle, onApplied: { applied in
+                if homepageSeedPersistor.pendingShowSearchModeToggle == applied {
+                    homepageSeedPersistor.pendingShowSearchModeToggle = nil
+                }
             }))
         }
     }
@@ -335,58 +332,73 @@ final class UserScripts: UserScriptsProvider, ReleaseNotesUserScriptProvider {
 
 }
 
-/// Applies the duckduckgo.com web homepage "search mode toggle" preference into the page's own
-/// localStorage to mirror the user's onboarding choice ("Search & Duck.ai" shows the toggle,
-/// "Search Only" hides it). A one-shot native marker gates injection; after the script applies the
-/// value it posts `homepageSearchModeSeedApplied` back to native, whose handler clears the marker
-/// (`onApplied`). Consumption is tied to the script actually running — not a navigation event — so
-/// it works regardless of how onboarding finishes and self-heals if the homepage's first load
-/// happens before the user scripts finish installing (the homepage does not await them).
-///
-/// Runs at document-start in the *page content world* so the SERP's own startup read sees the value
-/// with no flash, and host-gated to duckduckgo.com so no other site's storage is touched. It
-/// *overwrites* the existing value (the homepage may already have `homepageSettings` persisted from
-/// earlier visits), but only when the chosen value differs from what was last applied (tracked in
-/// `__ddgSearchModeSeedApplied`). That way a value the user later sets on the web is respected on
-/// reload, while a *changed* onboarding choice still takes effect.
+/// Document-start, page-content-world script that mirrors the onboarding search-mode choice onto the
+/// duckduckgo.com homepage by writing `homepageSettings.showSearchModeToggle` in its localStorage,
+/// then reports the applied value so the one-shot marker is cleared and later web changes are kept.
 final class HomepageSearchModeToggleSeedUserScript: NSObject, UserScript {
-    static let pendingSeedDefaultsKey = "aichat.pendingHomepageSearchModeSeed"
+    private static let messageName = "homepageSearchModeSeedApplied"
 
-    let messageNames: [String] = ["homepageSearchModeSeedApplied"]
+    var messageNames: [String] { [Self.messageName] }
     let injectionTime: WKUserScriptInjectionTime = .atDocumentStart
     let forMainFrameOnly: Bool = true
     let requiresRunInPageContentWorld: Bool = true
 
     private let showSearchModeToggle: Bool
+    private let onApplied: (Bool?) -> Void
 
     var source: String {
         """
         const host = (window.location && window.location.hostname) || "";
         if (host !== "duckduckgo.com" && !host.endsWith(".duckduckgo.com")) { return; }
+        const desired = \(showSearchModeToggle);
         try {
             const appliedKey = "__ddgSearchModeSeedApplied";
-            const desired = \(showSearchModeToggle);
-            if (window.localStorage.getItem(appliedKey) === String(desired)) { return; }
-            const key = "homepageSettings";
-            const settings = JSON.parse(window.localStorage.getItem(key) || "{}");
-            settings.showSearchModeToggle = desired;
-            window.localStorage.setItem(key, JSON.stringify(settings));
-            window.localStorage.setItem(appliedKey, String(desired));
-            window.webkit.messageHandlers.homepageSearchModeSeedApplied.postMessage({});
+            if (window.localStorage.getItem(appliedKey) !== String(desired)) {
+                let settings = {};
+                try { settings = JSON.parse(window.localStorage.getItem("homepageSettings") || "{}") || {}; } catch (e) {}
+                settings.showSearchModeToggle = desired;
+                window.localStorage.setItem("homepageSettings", JSON.stringify(settings));
+                window.localStorage.setItem(appliedKey, String(desired));
+            }
         } catch (e) {}
+        try { window.webkit.messageHandlers.\(Self.messageName).postMessage({ showSearchModeToggle: desired }); } catch (e) {}
         """
     }
 
-    private let onApplied: () -> Void
-
-    init(showSearchModeToggle: Bool, onApplied: @escaping () -> Void) {
+    init(showSearchModeToggle: Bool, onApplied: @escaping (Bool?) -> Void) {
         self.showSearchModeToggle = showSearchModeToggle
         self.onApplied = onApplied
         super.init()
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        guard message.name == "homepageSearchModeSeedApplied" else { return }
-        onApplied()
+        onApplied((message.body as? [String: Any])?["showSearchModeToggle"] as? Bool)
+    }
+}
+
+protocol HomepageSearchModeSeedPersistor {
+    var pendingShowSearchModeToggle: Bool? { get nonmutating set }
+}
+
+struct HomepageSearchModeSeedUserDefaultsPersistor: HomepageSearchModeSeedPersistor {
+    enum Key: String {
+        case pendingShowSearchModeToggle = "aichat.homepage-search-mode-seed.pending"
+    }
+
+    private let keyValueStore: KeyValueStoring
+
+    init(keyValueStore: KeyValueStoring = UserDefaults.standard) {
+        self.keyValueStore = keyValueStore
+    }
+
+    var pendingShowSearchModeToggle: Bool? {
+        get { try? keyValueStore.object(forKey: Key.pendingShowSearchModeToggle.rawValue) as? Bool }
+        nonmutating set {
+            if let newValue {
+                try? keyValueStore.set(newValue, forKey: Key.pendingShowSearchModeToggle.rawValue)
+            } else {
+                try? keyValueStore.removeObject(forKey: Key.pendingShowSearchModeToggle.rawValue)
+            }
+        }
     }
 }

--- a/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
@@ -296,6 +296,18 @@ final class UserScripts: UserScriptsProvider, ReleaseNotesUserScriptProvider {
         let identityTheftRestorationPagesFeature = IdentityTheftRestorationPagesFeature(subscriptionManager: Application.appDelegate.subscriptionManager)
         identityTheftRestorationPagesUserScript.registerSubfeature(delegate: identityTheftRestorationPagesFeature)
         userScripts.append(identityTheftRestorationPagesUserScript)
+
+        // One-shot: an onboarding choice arms a native marker whose value is the chosen
+        // "show search-mode toggle" state (presence of the key == a seed is pending). On the first
+        // duckduckgo.com load the seed script applies it and posts back to clear the marker, so it
+        // runs once per choice and later web changes are respected.
+        let homepageSeedKey = HomepageSearchModeToggleSeedUserScript.pendingSeedDefaultsKey
+        if UserDefaults.standard.object(forKey: homepageSeedKey) != nil {
+            let showSearchModeToggle = UserDefaults.standard.bool(forKey: homepageSeedKey)
+            userScripts.append(HomepageSearchModeToggleSeedUserScript(showSearchModeToggle: showSearchModeToggle, onApplied: {
+                UserDefaults.standard.removeObject(forKey: homepageSeedKey)
+            }))
+        }
     }
 
     lazy var userScripts: [UserScript] = [
@@ -321,4 +333,56 @@ final class UserScripts: UserScriptsProvider, ReleaseNotesUserScriptProvider {
         }
     }
 
+}
+
+/// Applies the duckduckgo.com web homepage "search mode toggle" preference into the page's own
+/// localStorage to mirror the user's onboarding choice ("Search & Duck.ai" shows the toggle,
+/// "Search Only" hides it), then consumes a one-shot native marker so it runs once per choice.
+///
+/// Injected at document-start and host-gated to duckduckgo.com so no other site's storage is
+/// touched. It *overwrites* the existing value (the homepage may already have `homepageSettings`
+/// persisted from earlier visits), but only when the chosen value differs from what was last
+/// applied (tracked in `__ddgSearchModeSeedApplied`). That way a value the user later sets on the
+/// web is respected on reload, while a *changed* onboarding choice still takes effect. After
+/// writing it posts `homepageSearchModeSeedApplied` to native, whose handler clears the marker
+/// (`onApplied`) so the script is no longer injected on subsequent loads.
+final class HomepageSearchModeToggleSeedUserScript: NSObject, UserScript {
+    static let pendingSeedDefaultsKey = "aichat.pendingHomepageSearchModeSeed"
+
+    let messageNames: [String] = ["homepageSearchModeSeedApplied"]
+    let injectionTime: WKUserScriptInjectionTime = .atDocumentStart
+    let forMainFrameOnly: Bool = true
+
+    private let showSearchModeToggle: Bool
+
+    var source: String {
+        """
+        const host = (window.location && window.location.hostname) || "";
+        if (host !== "duckduckgo.com" && !host.endsWith(".duckduckgo.com")) { return; }
+        try {
+            const appliedKey = "__ddgSearchModeSeedApplied";
+            const desired = \(showSearchModeToggle);
+            if (window.localStorage.getItem(appliedKey) === String(desired)) { return; }
+            const key = "homepageSettings";
+            const settings = JSON.parse(window.localStorage.getItem(key) || "{}");
+            settings.showSearchModeToggle = desired;
+            window.localStorage.setItem(key, JSON.stringify(settings));
+            window.localStorage.setItem(appliedKey, String(desired));
+            window.webkit.messageHandlers.homepageSearchModeSeedApplied.postMessage({});
+        } catch (e) {}
+        """
+    }
+
+    private let onApplied: () -> Void
+
+    init(showSearchModeToggle: Bool, onApplied: @escaping () -> Void) {
+        self.showSearchModeToggle = showSearchModeToggle
+        self.onApplied = onApplied
+        super.init()
+    }
+
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard message.name == "homepageSearchModeSeedApplied" else { return }
+        onApplied()
+    }
 }

--- a/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
@@ -304,7 +304,9 @@ final class UserScripts: UserScriptsProvider, ReleaseNotesUserScriptProvider {
         let homepageSeedKey = HomepageSearchModeToggleSeedUserScript.pendingSeedDefaultsKey
         if UserDefaults.standard.object(forKey: homepageSeedKey) != nil {
             let showSearchModeToggle = UserDefaults.standard.bool(forKey: homepageSeedKey)
-            userScripts.append(HomepageSearchModeToggleSeedUserScript(showSearchModeToggle: showSearchModeToggle))
+            userScripts.append(HomepageSearchModeToggleSeedUserScript(showSearchModeToggle: showSearchModeToggle, onApplied: {
+                UserDefaults.standard.removeObject(forKey: homepageSeedKey)
+            }))
         }
     }
 
@@ -335,8 +337,11 @@ final class UserScripts: UserScriptsProvider, ReleaseNotesUserScriptProvider {
 
 /// Applies the duckduckgo.com web homepage "search mode toggle" preference into the page's own
 /// localStorage to mirror the user's onboarding choice ("Search & Duck.ai" shows the toggle,
-/// "Search Only" hides it). A one-shot native marker gates injection and is consumed natively after
-/// the first successful homepage navigation (see `OnboardingActionsManager.goToAddressBar`).
+/// "Search Only" hides it). A one-shot native marker gates injection; after the script applies the
+/// value it posts `homepageSearchModeSeedApplied` back to native, whose handler clears the marker
+/// (`onApplied`). Consumption is tied to the script actually running — not a navigation event — so
+/// it works regardless of how onboarding finishes and self-heals if the homepage's first load
+/// happens before the user scripts finish installing (the homepage does not await them).
 ///
 /// Runs at document-start in the *page content world* so the SERP's own startup read sees the value
 /// with no flash, and host-gated to duckduckgo.com so no other site's storage is touched. It
@@ -347,7 +352,7 @@ final class UserScripts: UserScriptsProvider, ReleaseNotesUserScriptProvider {
 final class HomepageSearchModeToggleSeedUserScript: NSObject, UserScript {
     static let pendingSeedDefaultsKey = "aichat.pendingHomepageSearchModeSeed"
 
-    let messageNames: [String] = []
+    let messageNames: [String] = ["homepageSearchModeSeedApplied"]
     let injectionTime: WKUserScriptInjectionTime = .atDocumentStart
     let forMainFrameOnly: Bool = true
     let requiresRunInPageContentWorld: Bool = true
@@ -367,14 +372,21 @@ final class HomepageSearchModeToggleSeedUserScript: NSObject, UserScript {
             settings.showSearchModeToggle = desired;
             window.localStorage.setItem(key, JSON.stringify(settings));
             window.localStorage.setItem(appliedKey, String(desired));
+            window.webkit.messageHandlers.homepageSearchModeSeedApplied.postMessage({});
         } catch (e) {}
         """
     }
 
-    init(showSearchModeToggle: Bool) {
+    private let onApplied: () -> Void
+
+    init(showSearchModeToggle: Bool, onApplied: @escaping () -> Void) {
         self.showSearchModeToggle = showSearchModeToggle
+        self.onApplied = onApplied
         super.init()
     }
 
-    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {}
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard message.name == "homepageSearchModeSeedApplied" else { return }
+        onApplied()
+    }
 }

--- a/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
@@ -373,7 +373,8 @@ final class HomepageSearchModeToggleSeedUserScript: NSObject, UserScript {
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        onApplied((message.body as? [String: Any])?["showSearchModeToggle"] as? Bool)
+        let value = (message.body as? [String: Any])?["showSearchModeToggle"]
+        onApplied((value as? Bool) ?? (value as? NSNumber)?.boolValue)
     }
 }
 

--- a/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
@@ -298,7 +298,8 @@ final class UserScripts: UserScriptsProvider, ReleaseNotesUserScriptProvider {
         userScripts.append(identityTheftRestorationPagesUserScript)
 
         let homepageSeedPersistor = HomepageSearchModeSeedUserDefaultsPersistor()
-        if let pendingShowSearchModeToggle = homepageSeedPersistor.pendingShowSearchModeToggle {
+        if sourceProvider.featureFlagger.isFeatureOn(.aiChatOnboardingToggleAffectsNtpAndDdg),
+           let pendingShowSearchModeToggle = homepageSeedPersistor.pendingShowSearchModeToggle {
             userScripts.append(HomepageSearchModeToggleSeedUserScript(showSearchModeToggle: pendingShowSearchModeToggle, onApplied: { applied in
                 if homepageSeedPersistor.pendingShowSearchModeToggle == applied {
                     homepageSeedPersistor.pendingShowSearchModeToggle = nil

--- a/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
@@ -304,9 +304,7 @@ final class UserScripts: UserScriptsProvider, ReleaseNotesUserScriptProvider {
         let homepageSeedKey = HomepageSearchModeToggleSeedUserScript.pendingSeedDefaultsKey
         if UserDefaults.standard.object(forKey: homepageSeedKey) != nil {
             let showSearchModeToggle = UserDefaults.standard.bool(forKey: homepageSeedKey)
-            userScripts.append(HomepageSearchModeToggleSeedUserScript(showSearchModeToggle: showSearchModeToggle, onApplied: {
-                UserDefaults.standard.removeObject(forKey: homepageSeedKey)
-            }))
+            userScripts.append(HomepageSearchModeToggleSeedUserScript(showSearchModeToggle: showSearchModeToggle))
         }
     }
 
@@ -337,21 +335,22 @@ final class UserScripts: UserScriptsProvider, ReleaseNotesUserScriptProvider {
 
 /// Applies the duckduckgo.com web homepage "search mode toggle" preference into the page's own
 /// localStorage to mirror the user's onboarding choice ("Search & Duck.ai" shows the toggle,
-/// "Search Only" hides it), then consumes a one-shot native marker so it runs once per choice.
+/// "Search Only" hides it). A one-shot native marker gates injection and is consumed natively after
+/// the first successful homepage navigation (see `OnboardingActionsManager.goToAddressBar`).
 ///
-/// Injected at document-start and host-gated to duckduckgo.com so no other site's storage is
-/// touched. It *overwrites* the existing value (the homepage may already have `homepageSettings`
-/// persisted from earlier visits), but only when the chosen value differs from what was last
-/// applied (tracked in `__ddgSearchModeSeedApplied`). That way a value the user later sets on the
-/// web is respected on reload, while a *changed* onboarding choice still takes effect. After
-/// writing it posts `homepageSearchModeSeedApplied` to native, whose handler clears the marker
-/// (`onApplied`) so the script is no longer injected on subsequent loads.
+/// Runs at document-start in the *page content world* so the SERP's own startup read sees the value
+/// with no flash, and host-gated to duckduckgo.com so no other site's storage is touched. It
+/// *overwrites* the existing value (the homepage may already have `homepageSettings` persisted from
+/// earlier visits), but only when the chosen value differs from what was last applied (tracked in
+/// `__ddgSearchModeSeedApplied`). That way a value the user later sets on the web is respected on
+/// reload, while a *changed* onboarding choice still takes effect.
 final class HomepageSearchModeToggleSeedUserScript: NSObject, UserScript {
     static let pendingSeedDefaultsKey = "aichat.pendingHomepageSearchModeSeed"
 
-    let messageNames: [String] = ["homepageSearchModeSeedApplied"]
+    let messageNames: [String] = []
     let injectionTime: WKUserScriptInjectionTime = .atDocumentStart
     let forMainFrameOnly: Bool = true
+    let requiresRunInPageContentWorld: Bool = true
 
     private let showSearchModeToggle: Bool
 
@@ -368,21 +367,14 @@ final class HomepageSearchModeToggleSeedUserScript: NSObject, UserScript {
             settings.showSearchModeToggle = desired;
             window.localStorage.setItem(key, JSON.stringify(settings));
             window.localStorage.setItem(appliedKey, String(desired));
-            window.webkit.messageHandlers.homepageSearchModeSeedApplied.postMessage({});
         } catch (e) {}
         """
     }
 
-    private let onApplied: () -> Void
-
-    init(showSearchModeToggle: Bool, onApplied: @escaping () -> Void) {
+    init(showSearchModeToggle: Bool) {
         self.showSearchModeToggle = showSearchModeToggle
-        self.onApplied = onApplied
         super.init()
     }
 
-    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        guard message.name == "homepageSearchModeSeedApplied" else { return }
-        onApplied()
-    }
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {}
 }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -125,6 +125,10 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212710873113687
     case aiChatOmnibarOnboarding
 
+    /// macOS only, on by default. Gates whether the onboarding Search/Duck.ai toggle choice also
+    /// affects the New Tab Page search-mode toggle and the duckduckgo.com homepage.
+    case aiChatOnboardingToggleAffectsNtpAndDdg
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866476152134
     case osSupportForceUnsupportedMessage
 
@@ -483,6 +487,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(AIChatSubfeature.omnibarTools), category: .duckAI)
         case .aiChatOmnibarOnboarding:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.omnibarOnboarding), category: .duckAI)
+        case .aiChatOnboardingToggleAffectsNtpAndDdg:
+            Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.onboardingToggleAffectsNtpAndDdg), category: .duckAI)
         case .osSupportForceUnsupportedMessage:
             Config(source: .disabled, category: .osSupportWarnings)
         case .osSupportWarning:

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -125,8 +125,7 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212710873113687
     case aiChatOmnibarOnboarding
 
-    /// macOS only, on by default. Gates whether the onboarding Search/Duck.ai toggle choice also
-    /// affects the New Tab Page search-mode toggle and the duckduckgo.com homepage.
+    /// https://app.asana.com/1/137249556945/project/1204006570077678/task/1215385527516382?focus=true
     case aiChatOnboardingToggleAffectsNtpAndDdg
 
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866476152134

--- a/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
+++ b/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
@@ -16,6 +16,8 @@
 //  limitations under the License.
 //
 
+import AIChat
+import FeatureFlags
 import Onboarding
 import Persistence
 import PersistenceTestingUtils
@@ -574,6 +576,68 @@ class OnboardingManagerTests: XCTestCase {
 
         // Then
         XCTAssertEqual(onboardingSharedPixelHandler.eventsReceived, [.searchExperience(.clicked(.searchOnly))])
+    }
+
+    // MARK: setDuckAiInAddressBar — NTP + homepage (aiChatOnboardingToggleAffectsNtpAndDdg)
+
+    @MainActor
+    func testSetDuckAiInAddressBar_WhenFlagOnAndSearchOnly_HidesNtpToggleAndArmsHomepageSeedOff() {
+        let storage = MockAIChatPreferencesStorage()
+        let seedPersistor = HomepageSearchModeSeedUserDefaultsPersistor(keyValueStore: MockKeyValueStore())
+        let manager = makeManager(enabledFlags: [.aiChatOnboardingToggleAffectsNtpAndDdg], aiChatPreferencesStorage: storage, homepageSearchModeSeedPersistor: seedPersistor)
+
+        manager.setDuckAiInAddressBar(enabled: false)
+
+        XCTAssertFalse(storage.showSearchAndDuckAIToggle)
+        XCTAssertFalse(storage.showShortcutOnNewTabPage)
+        XCTAssertEqual(seedPersistor.pendingShowSearchModeToggle, false)
+    }
+
+    @MainActor
+    func testSetDuckAiInAddressBar_WhenFlagOnAndSearchAndDuckAi_ShowsNtpToggleAndArmsHomepageSeedOn() {
+        let storage = MockAIChatPreferencesStorage()
+        let seedPersistor = HomepageSearchModeSeedUserDefaultsPersistor(keyValueStore: MockKeyValueStore())
+        let manager = makeManager(enabledFlags: [.aiChatOnboardingToggleAffectsNtpAndDdg], aiChatPreferencesStorage: storage, homepageSearchModeSeedPersistor: seedPersistor)
+
+        manager.setDuckAiInAddressBar(enabled: true)
+
+        XCTAssertTrue(storage.showSearchAndDuckAIToggle)
+        XCTAssertTrue(storage.showShortcutOnNewTabPage)
+        XCTAssertEqual(seedPersistor.pendingShowSearchModeToggle, true)
+    }
+
+    @MainActor
+    func testSetDuckAiInAddressBar_WhenFlagOff_OnlySetsAddressBarToggle() {
+        let storage = MockAIChatPreferencesStorage()
+        storage.showShortcutOnNewTabPage = true
+        let seedPersistor = HomepageSearchModeSeedUserDefaultsPersistor(keyValueStore: MockKeyValueStore())
+        let manager = makeManager(enabledFlags: [], aiChatPreferencesStorage: storage, homepageSearchModeSeedPersistor: seedPersistor)
+
+        manager.setDuckAiInAddressBar(enabled: false)
+
+        XCTAssertFalse(storage.showSearchAndDuckAIToggle)
+        XCTAssertTrue(storage.showShortcutOnNewTabPage)
+        XCTAssertNil(seedPersistor.pendingShowSearchModeToggle)
+    }
+
+    @MainActor
+    private func makeManager(enabledFlags: [FeatureFlag],
+                             aiChatPreferencesStorage: AIChatPreferencesStorage,
+                             homepageSearchModeSeedPersistor: HomepageSearchModeSeedPersistor) -> OnboardingActionsManager {
+        let featureFlagger = MockFeatureFlagger()
+        featureFlagger.enabledFeatureFlags = enabledFlags
+        return OnboardingActionsManager(
+            navigationDelegate: navigationDelegate,
+            dockCustomization: dockCustomization,
+            defaultBrowserProvider: defaultBrowserProvider,
+            appearancePreferences: appearancePreferences,
+            startupPreferences: startupPreferences,
+            dataImportProvider: importProvider,
+            aiChatPreferencesStorage: aiChatPreferencesStorage,
+            homepageSearchModeSeedPersistor: homepageSearchModeSeedPersistor,
+            featureFlagger: featureFlagger,
+            onboardingSharedPixelHandler: onboardingSharedPixelHandler
+        )
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1215385527516382?focus=true
Tech Design URL:
CC:

### Description

The onboarding Search ↔ Duck.ai choice now also drives the native New Tab Page toggle (`showShortcutOnNewTabPage`) and the duckduckgo.com web homepage. The homepage is updated by a one-shot, page-content-world document-start script (`HomepageSearchModeToggleSeedUserScript`) that writes `homepageSettings.showSearchModeToggle` into the page's localStorage, armed by a native marker at onboarding and consumed after the first successful homepage load.

### Testing Steps
1. Complete onboarding choosing "Search Only"
2. New Tab Page search box: the Search/Duck.ai toggle is hidden.
3. duckduckgo.com: search-only box; `homepageSettings.showSearchModeToggle` is `false` in localStorage.
4. Repeat choosing "Search & Duck.ai": the toggle shows on both surfaces.

### Impact and Risks
Low. Reached only via the onboarding address-bar-mode step (internal flags); the web write is host-gated to duckduckgo.com and one-shot.

#### What could go wrong?
- If the page-world localStorage write isn't picked up by the SERP on first paint, the homepage could briefly show the wrong toggle until the next load.

### Notes to Reviewer
The per-origin `__ddgSearchModeSeedApplied` guard is intentionally separate from the native marker: the document-start script stays installed and re-runs on reload, so the guard is what preserves a later change the user makes via the web Customize Homepage UI.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to onboarding and a remote kill switch; homepage writes are duckduckgo.com-only and one-shot, with minor risk of a wrong toggle on first paint if localStorage seed races SERP init.
> 
> **Overview**
> When remote flag **`aiChatOnboardingToggleAffectsNtpAndDdg`** is on, the onboarding Search ↔ Duck.ai step no longer only updates the address-bar toggle—it also sets **`showShortcutOnNewTabPage`** for the native New Tab Page and stores a one-shot **`pendingShowSearchModeToggle`** marker.
> 
> On the first **duckduckgo.com** load after onboarding, **`HomepageSearchModeToggleSeedUserScript`** runs at document start in the page content world, writes **`homepageSettings.showSearchModeToggle`** into localStorage (host-gated), then clears the native pending flag via a WK message handler. **`ContentBlockingTabExtension`** forces content-blocking assets (and thus user scripts) to install early when that pending marker is set so the seed runs before the homepage reads settings. A separate in-page **`__ddgSearchModeSeedApplied`** guard limits re-seeding so later Customize Homepage changes are not overwritten on reload.
> 
> Flag off keeps prior behavior: only **`showSearchAndDuckAIToggle`** is updated. Privacy config and macOS feature-flag wiring add **`onboardingToggleAffectsNtpAndDdg`**; unit tests cover flag on/off for NTP and homepage seed arming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 204ab7e9138f3f64b4023adc15db3464961cd805. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->