### PR TITLE
[iOS/macOS] Reduce VPN rekeying failure pixel noise

### DIFF
--- a/SharedPackages/VPN/Sources/VPN/Diagnostics/KeyExpirationTester.swift
+++ b/SharedPackages/VPN/Sources/VPN/Diagnostics/KeyExpirationTester.swift
@@ -33,6 +33,7 @@ final actor KeyExpirationTester: KeyExpirationTesting {
     /// The interval of time between the start of each TCP connection test.
     ///
     private let intervalBetweenTests: TimeInterval = .seconds(15)
+
     private let rekeyFailureBackoffIntervals: [TimeInterval] = [
         .seconds(15),
         .seconds(30),
@@ -49,6 +50,10 @@ final actor KeyExpirationTester: KeyExpirationTesting {
     private var isTestingExpiration = false
     private var consecutiveFailedRekeyCount = 0
     private var nextRekeyAttemptDate: Date?
+
+    /// Bumped on every `stop()`. A rekey attempt captures this before it suspends so it can tell,
+    /// once it resumes, whether a `stop()` interleaved while it was awaiting.
+    private var stopGeneration = 0
     private let keyStore: NetworkProtectionKeyStore
     private let rekey: @MainActor () async throws -> Void
     private let settings: VPNSettings
@@ -95,6 +100,7 @@ final actor KeyExpirationTester: KeyExpirationTesting {
         Logger.networkProtectionKeyManagement.log("🔴 Stopping rekey timer")
         stopScheduledTimer()
         resetRekeyFailureBackoff()
+        stopGeneration &+= 1
         isRunning = false
     }
 
@@ -141,6 +147,12 @@ final actor KeyExpirationTester: KeyExpirationTesting {
             isTestingExpiration = false
         }
 
+        // Remember the stop generation before we start awaiting. `rekeyIfExpired()` suspends at the
+        // `await`s below, during which `stop()` can run on the actor and clear the failure backoff.
+        // If that happens, recording a failure afterwards would restore the very backoff `stop()`
+        // just cleared, causing a fresh `start()` to honor a stale delay.
+        let stopGenerationAtStart = stopGeneration
+
         guard await canRekey() else {
             Logger.networkProtectionKeyManagement.log("Can't rekey right now as some preconditions aren't met.")
             return
@@ -165,6 +177,11 @@ final actor KeyExpirationTester: KeyExpirationTesting {
             resetRekeyFailureBackoff()
             Logger.networkProtectionKeyManagement.log("Rekeying completed.")
         } catch {
+            guard stopGenerationAtStart == stopGeneration else {
+                Logger.networkProtectionKeyManagement.log("Rekey failed after the tester was stopped; not recording a failure backoff.")
+                return
+            }
+
             recordRekeyFailure()
             Logger.networkProtectionKeyManagement.error("Rekeying failed with error: \(error, privacy: .public).")
         }

--- a/SharedPackages/VPN/Sources/VPN/Diagnostics/KeyExpirationTester.swift
+++ b/SharedPackages/VPN/Sources/VPN/Diagnostics/KeyExpirationTester.swift
@@ -33,6 +33,13 @@ final actor KeyExpirationTester: KeyExpirationTesting {
     /// The interval of time between the start of each TCP connection test.
     ///
     private let intervalBetweenTests: TimeInterval = .seconds(15)
+    private let rekeyFailureBackoffIntervals: [TimeInterval] = [
+        .seconds(15),
+        .seconds(30),
+        .seconds(60),
+        .seconds(120),
+        .seconds(300)
+    ]
 
     /// Provides a simple mechanism to synchronize an `isRunning` flag for the tester to know if it needs to interrupt its operation.
     /// The reason why this is necessary is that the tester may be stopped while the connection tests are already executing, in a bit
@@ -40,15 +47,19 @@ final actor KeyExpirationTester: KeyExpirationTesting {
     ///
     private(set) var isRunning = false
     private var isTestingExpiration = false
+    private var consecutiveFailedRekeyCount = 0
+    private var nextRekeyAttemptDate: Date?
     private let keyStore: NetworkProtectionKeyStore
     private let rekey: @MainActor () async throws -> Void
     private let settings: VPNSettings
     private var task: Task<Never, Error>?
+    private let currentDate: @Sendable () -> Date
 
     // MARK: - Init & deinit
 
     init(keyStore: NetworkProtectionKeyStore,
          settings: VPNSettings,
+         currentDate: @escaping @Sendable () -> Date = { Date() },
          canRekey: @escaping @MainActor () async -> Bool,
          rekey: @escaping @MainActor () async throws -> Void) {
 
@@ -56,6 +67,7 @@ final actor KeyExpirationTester: KeyExpirationTesting {
         self.rekey = rekey
         self.canRekey = canRekey
         self.settings = settings
+        self.currentDate = currentDate
 
         Logger.networkProtectionMemory.debug("[+] \(String(describing: self), privacy: .public)")
     }
@@ -82,6 +94,7 @@ final actor KeyExpirationTester: KeyExpirationTesting {
     func stop() {
         Logger.networkProtectionKeyManagement.log("🔴 Stopping rekey timer")
         stopScheduledTimer()
+        resetRekeyFailureBackoff()
         isRunning = false
     }
 
@@ -111,7 +124,7 @@ final actor KeyExpirationTester: KeyExpirationTesting {
             return true
         }
 
-        return currentExpirationDate <= Date()
+        return currentExpirationDate <= currentDate()
     }
 
     // MARK: - Expiration check
@@ -137,16 +150,35 @@ final actor KeyExpirationTester: KeyExpirationTesting {
 
         guard isKeyExpired else {
             Logger.networkProtectionKeyManagement.log("The key is not expired")
+            resetRekeyFailureBackoff()
+            return
+        }
+
+        if let nextRekeyAttemptDate, currentDate() < nextRekeyAttemptDate {
+            Logger.networkProtectionKeyManagement.log("Rekeying is delayed after a previous failure.")
             return
         }
 
         Logger.networkProtectionKeyManagement.log("Rekeying now.")
         do {
             try await rekey()
+            resetRekeyFailureBackoff()
             Logger.networkProtectionKeyManagement.log("Rekeying completed.")
         } catch {
+            recordRekeyFailure()
             Logger.networkProtectionKeyManagement.error("Rekeying failed with error: \(error, privacy: .public).")
         }
+    }
+
+    private func recordRekeyFailure() {
+        consecutiveFailedRekeyCount += 1
+        let backoffIndex = min(consecutiveFailedRekeyCount - 1, rekeyFailureBackoffIntervals.count - 1)
+        nextRekeyAttemptDate = currentDate().addingTimeInterval(rekeyFailureBackoffIntervals[backoffIndex])
+    }
+
+    private func resetRekeyFailureBackoff() {
+        consecutiveFailedRekeyCount = 0
+        nextRekeyAttemptDate = nil
     }
 
     // MARK: - Key Validity

--- a/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
+++ b/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
@@ -107,9 +107,11 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         /// Whether attempts from this source should be recorded in the connection-attempt SLO.
         public var isConnectionAttempt: Bool {
             switch self {
-            case .start, .rekey, .serverChange, .locationChange,
+            case .start, .serverChange, .locationChange,
                  .adapterRestart, .failureRecovery, .serverMigration:
                 return true
+            case .rekey:
+                return false
             }
         }
     }

--- a/SharedPackages/VPN/Tests/VPNTests/ConnectionAttemptSourceTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/ConnectionAttemptSourceTests.swift
@@ -1,0 +1,42 @@
+//
+//  ConnectionAttemptSourceTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import VPN
+
+final class ConnectionAttemptSourceTests: XCTestCase {
+
+    func testRekeyIsNotConnectionAttempt() {
+        XCTAssertFalse(PacketTunnelProvider.ConnectionAttemptSource.rekey.isConnectionAttempt)
+    }
+
+    func testUserVisibleReconfigurationSourcesAreConnectionAttempts() {
+        let sources: [PacketTunnelProvider.ConnectionAttemptSource] = [
+            .start,
+            .serverChange,
+            .locationChange,
+            .adapterRestart,
+            .failureRecovery,
+            .serverMigration
+        ]
+
+        for source in sources {
+            XCTAssertTrue(source.isConnectionAttempt, "\(source) should remain in the connection-attempt SLO")
+        }
+    }
+}

--- a/SharedPackages/VPN/Tests/VPNTests/KeyExpirationTesterTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/KeyExpirationTesterTests.swift
@@ -25,11 +25,30 @@ private final class RekeyRecorder {
     var callCount = 0
     var shouldThrow = true
 
+    /// When `true`, `call()` suspends until `resume()` is invoked, letting a test interleave other
+    /// work (e.g. `stop()`) while a rekey is in flight. `onPaused` fires once the suspension begins.
+    var shouldPause = false
+    var onPaused: (() -> Void)?
+    private var pauseContinuation: CheckedContinuation<Void, Never>?
+
     func call() async throws {
         callCount += 1
+
+        if shouldPause {
+            await withCheckedContinuation { continuation in
+                pauseContinuation = continuation
+                onPaused?()
+            }
+        }
+
         if shouldThrow {
             throw RekeyError.failure
         }
+    }
+
+    func resume() {
+        pauseContinuation?.resume()
+        pauseContinuation = nil
     }
 }
 
@@ -155,6 +174,33 @@ final class KeyExpirationTesterTests: XCTestCase {
         XCTAssertEqual(rekeyRecorder.callCount, 1)
 
         await tester.stop()
+        await tester.rekeyIfExpired()
+
+        XCTAssertEqual(rekeyRecorder.callCount, 2)
+    }
+
+    func testStop_whenRekeyFailsAfterStopping_doesNotRestoreFailureBackoff() async {
+        let tester = makeTester()
+
+        // Pause inside `rekey()` so we can stop the tester while a rekey is still in flight.
+        rekeyRecorder.shouldPause = true
+        let paused = expectation(description: "rekey paused mid-flight")
+        rekeyRecorder.onPaused = { paused.fulfill() }
+
+        let inFlightRekey = Task { await tester.rekeyIfExpired() }
+        await fulfillment(of: [paused], timeout: 1.0)
+        XCTAssertEqual(rekeyRecorder.callCount, 1)
+
+        // Stop clears the failure backoff while the rekey is suspended at `await rekey()`.
+        await tester.stop()
+
+        // Let the in-flight rekey resume and throw. Its failure must not restore the backoff
+        // that `stop()` just cleared.
+        rekeyRecorder.resume()
+        await inFlightRekey.value
+
+        // With no stale backoff date, an immediate rekey should run rather than be delayed.
+        rekeyRecorder.shouldPause = false
         await tester.rekeyIfExpired()
 
         XCTAssertEqual(rekeyRecorder.callCount, 2)

--- a/SharedPackages/VPN/Tests/VPNTests/KeyExpirationTesterTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/KeyExpirationTesterTests.swift
@@ -1,0 +1,190 @@
+//
+//  KeyExpirationTesterTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import XCTest
+@testable import VPN
+
+@MainActor
+private final class RekeyRecorder {
+    var callCount = 0
+    var shouldThrow = true
+
+    func call() async throws {
+        callCount += 1
+        if shouldThrow {
+            throw RekeyError.failure
+        }
+    }
+}
+
+private enum RekeyError: Error {
+    case failure
+}
+
+private final class TestDateProvider: @unchecked Sendable {
+    private let lock = NSLock()
+    private var internalDate: Date
+
+    init(date: Date) {
+        self.internalDate = date
+    }
+
+    var date: Date {
+        lock.lock()
+        defer { lock.unlock() }
+        return internalDate
+    }
+
+    func advance(by interval: TimeInterval) {
+        lock.lock()
+        defer { lock.unlock() }
+        internalDate = internalDate.addingTimeInterval(interval)
+    }
+}
+
+@MainActor
+final class KeyExpirationTesterTests: XCTestCase {
+
+    private var keyStore: NetworkProtectionKeyStoreMock!
+    private var settings: VPNSettings!
+    private var rekeyRecorder: RekeyRecorder!
+    private var dateProvider: TestDateProvider!
+
+    override func setUp() {
+        super.setUp()
+
+        keyStore = NetworkProtectionKeyStoreMock()
+        settings = VPNSettings(defaults: .standard)
+        rekeyRecorder = RekeyRecorder()
+        dateProvider = TestDateProvider(date: Date(timeIntervalSince1970: 0))
+        keyStore.currentExpirationDate = dateProvider.date.addingTimeInterval(-1)
+    }
+
+    override func tearDown() {
+        rekeyRecorder = nil
+        settings = nil
+        keyStore = nil
+        dateProvider = nil
+        super.tearDown()
+    }
+
+    func testRekeyIfExpired_whenPreviousFailureIsInBackoff_skipsImmediateRetry() async {
+        let tester = makeTester()
+
+        await tester.rekeyIfExpired()
+        await tester.rekeyIfExpired()
+
+        XCTAssertEqual(rekeyRecorder.callCount, 1)
+    }
+
+    func testRekeyIfExpired_whenRekeyKeepsFailing_backsOffUpToFiveMinutes() async {
+        let tester = makeTester()
+
+        await tester.rekeyIfExpired()
+        XCTAssertEqual(rekeyRecorder.callCount, 1)
+
+        dateProvider.advance(by: .seconds(14))
+        await tester.rekeyIfExpired()
+        XCTAssertEqual(rekeyRecorder.callCount, 1)
+
+        dateProvider.advance(by: .seconds(1))
+        await tester.rekeyIfExpired()
+        XCTAssertEqual(rekeyRecorder.callCount, 2)
+
+        dateProvider.advance(by: .seconds(29))
+        await tester.rekeyIfExpired()
+        XCTAssertEqual(rekeyRecorder.callCount, 2)
+
+        dateProvider.advance(by: .seconds(1))
+        await tester.rekeyIfExpired()
+        XCTAssertEqual(rekeyRecorder.callCount, 3)
+
+        dateProvider.advance(by: .seconds(59))
+        await tester.rekeyIfExpired()
+        XCTAssertEqual(rekeyRecorder.callCount, 3)
+
+        dateProvider.advance(by: .seconds(1))
+        await tester.rekeyIfExpired()
+        XCTAssertEqual(rekeyRecorder.callCount, 4)
+
+        dateProvider.advance(by: .seconds(119))
+        await tester.rekeyIfExpired()
+        XCTAssertEqual(rekeyRecorder.callCount, 4)
+
+        dateProvider.advance(by: .seconds(1))
+        await tester.rekeyIfExpired()
+        XCTAssertEqual(rekeyRecorder.callCount, 5)
+
+        dateProvider.advance(by: .seconds(299))
+        await tester.rekeyIfExpired()
+        XCTAssertEqual(rekeyRecorder.callCount, 5)
+
+        dateProvider.advance(by: .seconds(1))
+        await tester.rekeyIfExpired()
+        XCTAssertEqual(rekeyRecorder.callCount, 6)
+
+        dateProvider.advance(by: .seconds(299))
+        await tester.rekeyIfExpired()
+        XCTAssertEqual(rekeyRecorder.callCount, 6)
+
+        dateProvider.advance(by: .seconds(1))
+        await tester.rekeyIfExpired()
+        XCTAssertEqual(rekeyRecorder.callCount, 7)
+    }
+
+    func testStop_resetsFailureBackoff() async {
+        let tester = makeTester()
+
+        await tester.rekeyIfExpired()
+        XCTAssertEqual(rekeyRecorder.callCount, 1)
+
+        await tester.stop()
+        await tester.rekeyIfExpired()
+
+        XCTAssertEqual(rekeyRecorder.callCount, 2)
+    }
+
+    func testRekeyIfExpired_usesCurrentDateProviderToDetermineExpiration() async {
+        keyStore.currentExpirationDate = dateProvider.date.addingTimeInterval(.seconds(1))
+        let tester = makeTester()
+
+        await tester.rekeyIfExpired()
+        XCTAssertEqual(rekeyRecorder.callCount, 0)
+
+        dateProvider.advance(by: .seconds(2))
+        await tester.rekeyIfExpired()
+        XCTAssertEqual(rekeyRecorder.callCount, 1)
+    }
+
+    private func makeTester(canRekey: Bool = true) -> KeyExpirationTester {
+        KeyExpirationTester(
+            keyStore: keyStore,
+            settings: settings,
+            currentDate: { [dateProvider] in
+                dateProvider?.date ?? Date()
+            },
+            canRekey: {
+                canRekey
+            },
+            rekey: { [rekeyRecorder] in
+                try await rekeyRecorder?.call()
+            }
+        )
+    }
+}


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1215466159186807?focus=true
Tech Design URL:
CC:

### Description

This PR reduces a couple situations where a rekeying failure loop would flood us with failure pixels. Rekeying also now backs off when failing, going from trying every 15 seconds up to every 5 minutes.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that pixels work as expected when rekeying occurs

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VPN key rotation timing and SLO/metrics classification; backoff or race-handling bugs could delay rekeys or skew connection metrics, but behavior is well covered by tests and production defaults stay the same for date injection.
> 
> **Overview**
> Reduces **rekey failure pixel noise** by throttling retries and stopping rekey-driven tunnel updates from counting as user connection attempts in the SLO.
> 
> **`KeyExpirationTester`** now applies **exponential backoff** after failed rekeys (15s → 30s → 60s → 120s → 300s), skips retries until `nextRekeyAttemptDate`, and clears backoff on success or when the key is not expired. **`stop()`** resets backoff and bumps **`stopGeneration`** so a failure that finishes after stop does not re-apply a stale delay. Expiration checks use an injectable **`currentDate`** (defaults to `Date()`).
> 
> **`ConnectionAttemptSource.rekey`** is no longer treated as a connection attempt, so **`updateTunnelConfiguration`** with source `.rekey` no longer fires **`reportConnectionAttempt`** pixels. User-visible sources (start, server/location change, adapter restart, failure recovery, migration) are unchanged.
> 
> New unit tests cover backoff timing, stop/reset behavior, the stop-vs-in-flight-rekey race, and SLO classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bd775d07bf95a8ee343aa9dc2cd27f144101014. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->