### PR TITLE
[iOS/macOS] Stop VPN configuration failures from impacting monitoring

### DIFF
--- a/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
+++ b/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
@@ -1077,48 +1077,68 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             providerEvents.fire(.reportConnectionAttempt(attempt: .connecting, source: attemptSource))
         }
 
-        if reassert {
-            await stopMonitors()
+        try await TunnelConfigurationUpdateOperation.run(
+            reassert: reassert,
+            generateTunnelConfiguration: {
+                switch updateMethod {
+                case .selectServer(let serverSelectionMethod):
+                    return try await generateTunnelConfiguration(
+                        serverSelectionMethod: serverSelectionMethod,
+                        dnsSettings: settings.dnsSettings,
+                        regenerateKey: regenerateKey)
+
+                case .useConfiguration(let newTunnelConfiguration):
+                    return newTunnelConfiguration
+                }
+            },
+            stopMonitors: { [weak self] in
+                await self?.stopMonitors()
+            },
+            updateAdapterConfiguration: { [weak self] tunnelConfiguration in
+                guard let self else { throw CancellationError() }
+                try await self.updateAdapterConfiguration(tunnelConfiguration: tunnelConfiguration, reassert: reassert)
+            },
+            handleAdapterStarted: { [weak self] in
+                guard let self else { throw CancellationError() }
+                try await self.handleAdapterStarted(startReason: .reconnected)
+            },
+            handleFailure: { [weak self] error in
+                guard let self else { return false }
+                return await self.handleTunnelConfigurationUpdateFailure(error, attemptSource: attemptSource)
+            },
+            restartMonitorsAfterFailure: { [weak self] in
+                await self?.restartMonitorsAfterFailedReassert()
+            }
+        )
+
+        providerEvents.fire(.tunnelUpdateAttempt(.success))
+        if attemptSource.isConnectionAttempt {
+            providerEvents.fire(.reportConnectionAttempt(attempt: .success, source: attemptSource))
+        }
+    }
+
+    @MainActor
+    private func handleTunnelConfigurationUpdateFailure(_ error: Error, attemptSource: ConnectionAttemptSource) async -> Bool {
+        providerEvents.fire(.tunnelUpdateAttempt(.failure(error)))
+        if attemptSource.isConnectionAttempt {
+            providerEvents.fire(.reportConnectionAttempt(attempt: .failure, source: attemptSource))
         }
 
+        switch error {
+        case WireGuardAdapterError.setWireguardConfig:
+            await cancelTunnel(with: error)
+            return true
+        default:
+            return false
+        }
+    }
+
+    @MainActor
+    private func restartMonitorsAfterFailedReassert() async {
         do {
-            let tunnelConfiguration: TunnelConfiguration
-
-            switch updateMethod {
-            case .selectServer(let serverSelectionMethod):
-                tunnelConfiguration = try await generateTunnelConfiguration(
-                    serverSelectionMethod: serverSelectionMethod,
-                    dnsSettings: settings.dnsSettings,
-                    regenerateKey: regenerateKey)
-
-            case .useConfiguration(let newTunnelConfiguration):
-                tunnelConfiguration = newTunnelConfiguration
-            }
-
-            try await updateAdapterConfiguration(tunnelConfiguration: tunnelConfiguration, reassert: reassert)
-
-            if reassert {
-                try await handleAdapterStarted(startReason: .reconnected)
-            }
-
-            providerEvents.fire(.tunnelUpdateAttempt(.success))
-            if attemptSource.isConnectionAttempt {
-                providerEvents.fire(.reportConnectionAttempt(attempt: .success, source: attemptSource))
-            }
+            try await startMonitors(testImmediately: true)
         } catch {
-            providerEvents.fire(.tunnelUpdateAttempt(.failure(error)))
-            if attemptSource.isConnectionAttempt {
-                providerEvents.fire(.reportConnectionAttempt(attempt: .failure, source: attemptSource))
-            }
-
-            switch error {
-            case WireGuardAdapterError.setWireguardConfig:
-                await cancelTunnel(with: error)
-            default:
-                break
-            }
-
-            throw error
+            Logger.networkProtection.error("Failed to restart monitors after failed reassert update: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/SharedPackages/VPN/Sources/VPN/TunnelConfigurationUpdateOperation.swift
+++ b/SharedPackages/VPN/Sources/VPN/TunnelConfigurationUpdateOperation.swift
@@ -1,0 +1,54 @@
+//
+//  TunnelConfigurationUpdateOperation.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+@MainActor
+enum TunnelConfigurationUpdateOperation {
+
+    static func run(
+        reassert: Bool,
+        generateTunnelConfiguration: () async throws -> TunnelConfiguration,
+        stopMonitors: () async -> Void,
+        updateAdapterConfiguration: (TunnelConfiguration) async throws -> Void,
+        handleAdapterStarted: () async throws -> Void,
+        handleFailure: (Error) async -> Bool,
+        restartMonitorsAfterFailure: () async -> Void
+    ) async throws {
+        var didStopMonitors = false
+
+        do {
+            let tunnelConfiguration = try await generateTunnelConfiguration()
+
+            if reassert {
+                await stopMonitors()
+                didStopMonitors = true
+            }
+
+            try await updateAdapterConfiguration(tunnelConfiguration)
+
+            if reassert {
+                try await handleAdapterStarted()
+            }
+        } catch {
+            let didCancelTunnel = await handleFailure(error)
+            if reassert, didStopMonitors, !didCancelTunnel {
+                await restartMonitorsAfterFailure()
+            }
+            throw error
+        }
+    }
+}

--- a/SharedPackages/VPN/Tests/VPNTests/TunnelConfigurationUpdateOperationTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/TunnelConfigurationUpdateOperationTests.swift
@@ -1,0 +1,252 @@
+//
+//  TunnelConfigurationUpdateOperationTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import VPN
+
+@MainActor
+final class TunnelConfigurationUpdateOperationTests: XCTestCase {
+
+    private enum TestError: Error {
+        case generateConfiguration
+        case updateAdapter
+        case startAdapter
+    }
+
+    func testRun_reassertConfigGenerationFailure_handlesFailureWithoutStoppingOrRestartingMonitors() async {
+        var events: [String] = []
+
+        do {
+            try await TunnelConfigurationUpdateOperation.run(
+                reassert: true,
+                generateTunnelConfiguration: {
+                    events.append("generate")
+                    throw TestError.generateConfiguration
+                },
+                stopMonitors: {
+                    events.append("stop")
+                },
+                updateAdapterConfiguration: { _ in
+                    events.append("update")
+                },
+                handleAdapterStarted: {
+                    events.append("start")
+                },
+                handleFailure: { error in
+                    events.append("failure")
+                    XCTAssertTrue(error is TestError)
+                    return false
+                },
+                restartMonitorsAfterFailure: {
+                    events.append("restart")
+                }
+            )
+            XCTFail("Expected operation to throw")
+        } catch TestError.generateConfiguration {
+            // expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(events, ["generate", "failure"])
+    }
+
+    func testRun_reassertAdapterUpdateFailure_restartsMonitorsAfterFailure() async {
+        var events: [String] = []
+
+        do {
+            try await TunnelConfigurationUpdateOperation.run(
+                reassert: true,
+                generateTunnelConfiguration: {
+                    events.append("generate")
+                    return .make()
+                },
+                stopMonitors: {
+                    events.append("stop")
+                },
+                updateAdapterConfiguration: { _ in
+                    events.append("update")
+                    throw TestError.updateAdapter
+                },
+                handleAdapterStarted: {
+                    events.append("start")
+                },
+                handleFailure: { error in
+                    events.append("failure")
+                    XCTAssertTrue(error is TestError)
+                    return false
+                },
+                restartMonitorsAfterFailure: {
+                    events.append("restart")
+                }
+            )
+            XCTFail("Expected operation to throw")
+        } catch TestError.updateAdapter {
+            // expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(events, ["generate", "stop", "update", "failure", "restart"])
+    }
+
+    func testRun_reassertAdapterUpdateFailure_whenFailureCancelsTunnel_doesNotRestartMonitors() async {
+        var events: [String] = []
+
+        do {
+            try await TunnelConfigurationUpdateOperation.run(
+                reassert: true,
+                generateTunnelConfiguration: {
+                    events.append("generate")
+                    return .make()
+                },
+                stopMonitors: {
+                    events.append("stop")
+                },
+                updateAdapterConfiguration: { _ in
+                    events.append("update")
+                    throw TestError.updateAdapter
+                },
+                handleAdapterStarted: {
+                    events.append("start")
+                },
+                handleFailure: { _ in
+                    events.append("failure")
+                    return true
+                },
+                restartMonitorsAfterFailure: {
+                    events.append("restart")
+                }
+            )
+            XCTFail("Expected operation to throw")
+        } catch TestError.updateAdapter {
+            // expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(events, ["generate", "stop", "update", "failure"])
+    }
+
+    func testRun_reassertAdapterStartedFailure_restartsMonitorsAfterFailure() async {
+        var events: [String] = []
+
+        do {
+            try await TunnelConfigurationUpdateOperation.run(
+                reassert: true,
+                generateTunnelConfiguration: {
+                    events.append("generate")
+                    return .make()
+                },
+                stopMonitors: {
+                    events.append("stop")
+                },
+                updateAdapterConfiguration: { _ in
+                    events.append("update")
+                },
+                handleAdapterStarted: {
+                    events.append("start")
+                    throw TestError.startAdapter
+                },
+                handleFailure: { error in
+                    events.append("failure")
+                    XCTAssertTrue(error is TestError)
+                    return false
+                },
+                restartMonitorsAfterFailure: {
+                    events.append("restart")
+                }
+            )
+            XCTFail("Expected operation to throw")
+        } catch TestError.startAdapter {
+            // expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(events, ["generate", "stop", "update", "start", "failure", "restart"])
+    }
+
+    func testRun_reassertSuccess_stopsMonitorsAfterConfigGenerationAndStartsMonitorsAfterAdapterUpdate() async throws {
+        var events: [String] = []
+
+        try await TunnelConfigurationUpdateOperation.run(
+            reassert: true,
+            generateTunnelConfiguration: {
+                events.append("generate")
+                return .make()
+            },
+            stopMonitors: {
+                events.append("stop")
+            },
+            updateAdapterConfiguration: { _ in
+                events.append("update")
+            },
+            handleAdapterStarted: {
+                events.append("start")
+            },
+            handleFailure: { _ in
+                events.append("failure")
+                return false
+            },
+            restartMonitorsAfterFailure: {
+                events.append("restart")
+            }
+        )
+
+        XCTAssertEqual(events, ["generate", "stop", "update", "start"])
+    }
+
+    func testRun_nonReassertAdapterUpdateFailure_doesNotStopOrRestartMonitors() async {
+        var events: [String] = []
+
+        do {
+            try await TunnelConfigurationUpdateOperation.run(
+                reassert: false,
+                generateTunnelConfiguration: {
+                    events.append("generate")
+                    return .make()
+                },
+                stopMonitors: {
+                    events.append("stop")
+                },
+                updateAdapterConfiguration: { _ in
+                    events.append("update")
+                    throw TestError.updateAdapter
+                },
+                handleAdapterStarted: {
+                    events.append("start")
+                },
+                handleFailure: { _ in
+                    events.append("failure")
+                    return false
+                },
+                restartMonitorsAfterFailure: {
+                    events.append("restart")
+                }
+            )
+            XCTFail("Expected operation to throw")
+        } catch TestError.updateAdapter {
+            // expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(events, ["generate", "update", "failure"])
+    }
+}


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1215471059381430?focus=true
Tech Design URL:
CC:

### Description

This PR fixes a bug where a failed rekeying/tunnel generation attempt could cause monitors to stop and never be restarted.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that connecting and changing location does not impact monitoring - you should still see monitoring logs in the Console

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reassert update ordering and failure recovery in the packet tunnel extension; incorrect monitor restart logic could affect connectivity monitoring or reassert flows, but behavior is covered by new unit tests.
> 
> **Overview**
> Fixes a bug where **failed reassert** tunnel updates (rekey, location change, etc.) could **stop VPN monitors and never bring them back**, leaving health/connectivity monitoring silent while the tunnel might still be up.
> 
> Tunnel update logic is extracted into **`TunnelConfigurationUpdateOperation`**, which owns the reassert sequence: generate config → stop monitors → apply adapter config → restart monitors via `handleAdapterStarted` on success. On failure it still reports attempt pixels through **`handleTunnelConfigurationUpdateFailure`** (including tunnel cancel for `WireGuardAdapterError.setWireguardConfig`), and **restarts monitors** when monitors were stopped but the tunnel was not cancelled.
> 
> **`PacketTunnelProvider.updateTunnelConfiguration`** now delegates to that operation and adds **`restartMonitorsAfterFailedReassert()`** (`startMonitors(testImmediately: true)` with error logging). Unit tests cover success/failure ordering for reassert vs non-reassert paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5cae6e90c8cd43f02fca7772a89839e8a0aff72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->