### PR TITLE
Add Duck.ai direct-navigation pixel for search-only mode

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1766,6 +1766,7 @@ extension Pixel {
         case unifiedToggleInputSubscriptionUpsellTriggered
         case unifiedToggleInputChatHeaderUpgradeTapped
         case unifiedToggleInputPromptSubmitted
+        case unifiedToggleInputDuckAIDirectNavigation
 
         // MARK: Unified Toggle Input - Duck.ai autocomplete suggestion clicks
         case autocompleteDuckAIClickWebsite
@@ -3589,6 +3590,7 @@ extension Pixel.Event {
         case .unifiedToggleInputSubscriptionUpsellTriggered: return "m_aichat_unified_input_subscription_upsell_triggered"
         case .unifiedToggleInputChatHeaderUpgradeTapped: return "m_aichat_unified_input_chat_header_upgrade_tapped"
         case .unifiedToggleInputPromptSubmitted: return "m_aichat_unified_input_prompt_submitted"
+        case .unifiedToggleInputDuckAIDirectNavigation: return "m_aichat_unified_input_duck_ai_direct_navigation"
 
         case .autocompleteDuckAIClickWebsite: return "m_autocomplete_duckai_click_website"
         case .autocompleteDuckAIClickBookmark: return "m_autocomplete_duckai_click_bookmark"

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1134,7 +1134,22 @@ extension MainViewController {
     }
 
     func handleUnifiedToggleInputSearchSubmission(_ query: String) {
+        fireDirectDuckAINavigationPixelIfNeeded(for: query)
         loadQuery(query)
+    }
+
+    /// Fires when Duck.ai is disabled under AI Features settings yet the user still reaches Duck.ai by
+    /// typing its address into the UTI. Counts those direct navigations to gauge residual Duck.ai
+    /// demand among users who have turned it off. (Disabling Duck.ai also forces the Search↔Duck.ai
+    /// toggle off, so the `isAIChatEnabled` check is sufficient.) Mirrors `loadQuery`'s URL resolution
+    /// so detection matches what actually gets navigated.
+    private func fireDirectDuckAINavigationPixelIfNeeded(for query: String) {
+        guard !aiChatSettings.isAIChatEnabled,
+              let url = URL.makeSearchURL(query: query,
+                                          useUnifiedLogic: isUnifiedURLPredictionEnabled,
+                                          queryContext: currentTab?.url),
+              url.isDuckAIURL else { return }
+        DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputDuckAIDirectNavigation)
     }
 
 }

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
@@ -287,5 +287,12 @@
                 "type": "boolean"
             }
         ]
+    },
+    "m_aichat_unified_input_duck_ai_direct_navigation": {
+        "description": "Fires when Duck.ai is disabled under AI Features settings yet the user navigates directly to Duck.ai by typing its address into the Unified Toggle Input and submitting. Does not fire for the in-input Duck.ai shortcut button or other Duck.ai entry points.",
+        "owners": ["aataraxiaa"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1215321415119177?focus=true

### Description

Adds a daily+count pixel (`m_aichat_unified_input_duck_ai_direct_navigation`) that fires when **Duck.ai is disabled** under AI Features settings (`isAIChatEnabled == false`) yet the user still navigates directly to Duck.ai by typing its address into the Unified Toggle Input and submitting. This gauges residual Duck.ai demand among users who have turned it off.

It fires from `handleUnifiedToggleInputSearchSubmission` (the UTI search-submission path) only when `isAIChatEnabled` is false and the typed text resolves to a Duck.ai URL (`URL.isDuckAIURL`), mirroring `loadQuery`'s URL resolution so detection matches the actual navigation. (Disabling Duck.ai also forces the Search↔Duck.ai toggle off, so checking `isAIChatEnabled` alone is sufficient.)

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
Prerequisite: the `unifiedToggleInput` feature flag is ON except where step 1 says otherwise. Watch the pixel firing in the pixel debug screen / console.

1. **UTI disabled → no pixel.** With `unifiedToggleInput` OFF, type `duck.ai` in the address bar and submit. → `m_aichat_unified_input_duck_ai_direct_navigation` does **not** fire.
2. **Duck.ai enabled, toggle ON (Search & Duck.ai) → no pixel.** type `duck.ai` and submit. → pixel does **not** fire.
3. **Duck.ai enabled, toggle OFF (Search only) → no pixel.** type `duck.ai` and submit. → pixel does **not** fire.
4. **Duck.ai disabled in settings → pixel fires.** With **Duck.ai turned OFF** under Settings → AI Features, type `duck.ai` and submit. → `..._daily` and `..._count` fire.
5. **Duck.ai disabled in settings, non-Duck.ai URL → no pixel.** With Duck.ai OFF, type a regular URL (e.g. `example.com`) and submit. → pixel does **not** fire.

### Impact and Risks
Low — telemetry-only addition, gated to the search-input UTI submission path; no change to navigation behavior.

#### What could go wrong?
- Detection drifting from the actual navigation: avoided by resolving the URL with the same `URL.makeSearchURL(...)` call `loadQuery` uses.

### Notes to Reviewer
- The query is resolved twice (pixel check + `loadQuery`); `makeSearchURL`/`Classifier` are pure, so it's a cheap, side-effect-free trade-off versus restructuring the load path.
- `isDuckAIURL` also counts `duckduckgo.com?ia=chat` / AI-bang submissions as Duck.ai (app-wide semantics); swap to `isStandaloneDuckAIURL` if only the literal `duck.ai` host should count.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only on the existing UTI search submission path; navigation behavior is unchanged.
> 
> **Overview**
> Adds telemetry for **direct Duck.ai navigations from the Unified Toggle Input** when Duck.ai is turned off in AI Features settings.
> 
> On UTI search submit, **`handleUnifiedToggleInputSearchSubmission`** now calls **`fireDirectDuckAINavigationPixelIfNeeded`** before **`loadQuery`**. That helper fires **`m_aichat_unified_input_duck_ai_direct_navigation`** (daily + count) only when **`!aiChatSettings.isAIChatEnabled`** and the submitted text resolves to a Duck.ai URL via the same **`URL.makeSearchURL`** / **`isDuckAIURL`** logic used for navigation.
> 
> Wires the new case through **`PixelEvent.swift`** and **`ai_chat_unified_input.json5`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a31ffdeae2bcbee5568209e56ed80d9daf140a87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->