### PR TITLE
Fix recent pixel schema validation failures

### DIFF
--- a/iOS/PixelDefinitions/pixels/definitions/vpn_events.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/vpn_events.json5
@@ -212,7 +212,7 @@
                 "key": "feature.data.ext.trigger",
                 "type": "string",
                 "description": "What caused the leak check cycle to run",
-                "enum": ["tunnel_start", "reassert", "periodic"]
+                "enum": ["tunnel_start", "reassert", "periodic", "rekey"]
             },
             {
                 "key": "feature.data.ext.status_reason",
@@ -231,6 +231,11 @@
                 "type": "string",
                 "description": "Name of the VPN egress server the cycle ran against",
                 "examples": ["yvr2-netp-prod-egress2"]
+            },
+            {
+                "key": "feature.data.ext.os_version",
+                "type": "string",
+                "description": "Operating system major/minor version at the time of the leak check, for example 13.7 or 26.4"
             },
             {
                 "keyPattern": "feature\\.data\\.ext\\.ipv(4|6)\\.leak_ip_type",
@@ -254,6 +259,11 @@
                 "keyPattern": "feature\\.data\\.ext\\.ipv(4|6)\\.(http|https|stun)\\.(error_code|underlying_code)",
                 "type": "integer",
                 "description": "Error code associated with a per-probe error (outer or underlying)"
+            },
+            {
+                "keyPattern": "feature\\.data\\.ext\\.ipv4\\.(http|https|stun)\\.leak_octet[1-4]_matched",
+                "type": "boolean",
+                "description": "Whether the corresponding octet of the observed IPv4 address matched the egress IP, present only when a probe reported a leak"
             }
         ]
     }

--- a/macOS/PixelDefinitions/pixels/definitions/debug_db_value_transformer.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/debug_db_value_transformer.json5
@@ -4,6 +4,14 @@
         "owners": ["samsymons"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
-        "parameters": ["appVersion", "pixelSource", "errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain"]
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "errorCode",
+            "errorDomain",
+            "underlyingErrorCode",
+            "underlyingErrorDomain",
+            "keychainErrorCode"
+        ]
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/subscription.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/subscription.json5
@@ -490,8 +490,7 @@
             {
                 "key": "feature.data.ext.funnel_name",
                 "type": "string",
-                "description": "The funnel that led to the subscription flow",
-                "pattern": "^funnel_"
+                "description": "The funnel that led to the subscription flow"
             }
         ]
     },
@@ -633,7 +632,8 @@
                 "type": "integer",
                 "description": "Bucketed latency for fetch JWKS step (ms)",
                 "enum": [1000, 5000, 10000, 30000, 60000, 300000, 600000]
-            }
+            },
+            "channel"
         ]
     },
     "m_mac_wide_subscription_plan_change": {

--- a/macOS/PixelDefinitions/pixels/definitions/vpn_events.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/vpn_events.json5
@@ -218,7 +218,7 @@
                 "key": "feature.data.ext.trigger",
                 "type": "string",
                 "description": "What caused the leak check cycle to run",
-                "enum": ["tunnel_start", "reassert", "periodic"]
+                "enum": ["tunnel_start", "reassert", "periodic", "rekey"]
             },
             {
                 "key": "feature.data.ext.status_reason",
@@ -237,6 +237,11 @@
                 "type": "string",
                 "description": "Name of the VPN egress server the cycle ran against",
                 "examples": ["yvr2-netp-prod-egress2"]
+            },
+            {
+                "key": "feature.data.ext.os_version",
+                "type": "string",
+                "description": "Operating system major/minor version at the time of the leak check, for example 13.7 or 26.4"
             },
             {
                 "keyPattern": "feature\\.data\\.ext\\.ipv(4|6)\\.leak_ip_type",
@@ -260,6 +265,11 @@
                 "keyPattern": "feature\\.data\\.ext\\.ipv(4|6)\\.(http|https|stun)\\.(error_code|underlying_code)",
                 "type": "integer",
                 "description": "Error code associated with a per-probe error (outer or underlying)"
+            },
+            {
+                "keyPattern": "feature\\.data\\.ext\\.ipv4\\.(http|https|stun)\\.leak_octet[1-4]_matched",
+                "type": "boolean",
+                "description": "Whether the corresponding octet of the observed IPv4 address matched the egress IP, present only when a probe reported a leak"
             }
         ]
     }

--- a/macOS/PixelDefinitions/pixels/params_dictionary.json5
+++ b/macOS/PixelDefinitions/pixels/params_dictionary.json5
@@ -48,6 +48,11 @@
         "type": "number",
         "description": "NSError code"
     },
+    "keychainErrorCode": {
+        "key": "keychain_error_code",
+        "type": "string",
+        "description": "OSStatus code returned by the Keychain when reading or writing the encryption key failed"
+    },
     "fromExtension": {
         "key": "fromExtension",
         "description": "0 when fired from UserScript (web extensions available but autoconsent extension not loaded), 1 when fired from the web extension",


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1215492380697287?focus=true
Tech Design URL:
CC:

### Description

This PR fixes recent validation failures in pixels that I own.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that the changes look correct

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only JSON5 definition changes; no app logic, with slightly broader allowed telemetry shapes for analytics validation.
> 
> **Overview**
> Updates **pixel definition schemas** on iOS and macOS so validation accepts telemetry the apps are already sending, without changing runtime behavior.
> 
> For **`vpn-ip-leak-check`** wide pixels (iOS and macOS), the schema now allows trigger **`rekey`**, adds **`feature.data.ext.os_version`**, and documents per-probe **`leak_octet[1-4]_matched`** booleans for IPv4 HTTP/HTTPS/STUN when a leak is reported.
> 
> On macOS, **`m_mac_debug_db_value_transformer_registration_error`** gains a **`keychainErrorCode`** parameter via a new shared **`keychainErrorCode`** entry in `params_dictionary.json5`. Subscription wide pixels drop the **`^funnel_`** pattern on purchase **`funnel_name`** (free-form funnel strings), and **`m_mac_wide_auth_v2_token_refresh`** explicitly includes the shared **`channel`** parameter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9b9140b3a0c3f89bd1cc6632b39d846084e1dca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->