### PR TITLE
Add channel parameter to AI chat menu pixel definitions

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/aichat_main_menu_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_main_menu_pixels.json5
@@ -11,7 +11,7 @@
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_new_voice_chat_main_menu": {
         "description": "Fired when user opens a new Duck.ai voice chat from the main menu",
@@ -25,14 +25,14 @@
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_recent_chat_selected_main_menu": {
         "description": "Fired when user selects a recent Duck.ai chat from the main menu",
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_delete_all_chats_main_menu": {
         "description": "Fired when user confirms Delete All Chats from the main menu",
@@ -60,21 +60,21 @@
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_new_image_chat_more_options_menu": {
         "description": "Fired when user opens a new Duck.ai image chat from the more options menu",
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_recent_chat_selected_more_options_menu": {
         "description": "Fired when user selects a recent Duck.ai chat from the more options menu",
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_delete_all_chats_more_options_menu": {
         "description": "Fired when user confirms Delete All Chats from the more options menu",
@@ -88,13 +88,13 @@
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_view_all_chats_more_options_menu": {
         "description": "Fired when user taps View All Chats... from the more options menu",
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1215471586943994?focus=true
Tech Design URL:
CC:

### Description

Adds the `channel` parameter to eight AI chat menu pixel definitions in `aichat_main_menu_pixels.json5`. PixelKit injects `channel` (canary/dev) into every pixel on internal and alpha builds, so each definition must declare it. Five pixels failed live validation for the missing property; the three sibling menu pixels in the same file had the same latent omission and are fixed too.

### Testing Steps
1. From `macOS/`, run `npm run validate-pixel-defs` — passes, no "additional property 'channel'" errors.

### Impact and Risks
Low. Pixel-definition metadata only; no code or runtime behavior changes.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only pixel schema updates with no application or runtime behavior changes.
> 
> **Overview**
> Adds **`channel`** to the `parameters` list on **eight** Duck.ai main-menu / more-options menu pixels in `aichat_main_menu_pixels.json5`, bringing them in line with siblings that already declared `appVersion`, `pixelSource`, and `channel`.
> 
> This fixes pixel-definition validation when PixelKit injects `channel` (e.g. canary/dev) on internal and alpha builds—five pixels were failing live validation for the missing property; three related definitions had the same gap and are updated in the same change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45a9762cce9ea73cf58996f93e45703c575f368c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->