### PR TITLE
Add channel parameter to macOS pixel definitions missing it

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/debug_sparkle.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/debug_sparkle.json5
@@ -12,7 +12,7 @@
         "owners": ["diegoreymendez", "quanganhdo"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_debug_updater_did_find_update": {
         "description": "Fired when Sparkle reports that a valid update is available.",

--- a/macOS/PixelDefinitions/pixels/definitions/navigation.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/navigation.json5
@@ -182,7 +182,8 @@
                 "type": "string",
                 "enum": ["none", "few", "moderate", "many"],
                 "description": "Redirect count bucket to prevent fingerprinting"
-            }
+            },
+            "channel"
         ]
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/update_flow_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/update_flow_pixels.json5
@@ -297,7 +297,8 @@
                 "description": "macOS version"
             },
             "appVersion",
-            "pixelSource"
+            "pixelSource",
+            "channel"
         ]
     },
     "m_mac_update_configuration": {

--- a/macOS/PixelDefinitions/pixels/definitions/vpn_events.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/vpn_events.json5
@@ -25,28 +25,28 @@
         "owners": ["diegoreymendez", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["legacy_daily_count"],
-        "parameters": ["appVersion", "pixelSource", "connectionAttemptSource"]
+        "parameters": ["appVersion", "pixelSource", "connectionAttemptSource", "channel"]
     },
     "m_mac_netp_ev_enable_attempt_success": {
         "description": "Fired when a VPN connection attempt succeeds",
         "owners": ["diegoreymendez", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["legacy_daily_count"],
-        "parameters": ["appVersion", "pixelSource", "connectionAttemptSource"]
+        "parameters": ["appVersion", "pixelSource", "connectionAttemptSource", "channel"]
     },
     "m_mac_netp_ev_enable_attempt_failure": {
         "description": "Fired when a VPN connection attempt fails",
         "owners": ["diegoreymendez", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["legacy_daily_count"],
-        "parameters": ["appVersion", "pixelSource", "connectionAttemptSource"]
+        "parameters": ["appVersion", "pixelSource", "connectionAttemptSource", "channel"]
     },
     "m_mac_netp_tunnel_start_attempt_on_demand_without_access_token": {
         "description": "Fired when an on-demand VPN start attempt fails before reaching the actual tunnel start, due to a prerequisite failure such as a missing or unfetchable subscription token, missing settings, or other startup errors. Error parameters identify the underlying cause.",
         "owners": ["diegoreymendez", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["legacy_daily_count"],
-        "parameters": ["appVersion", "pixelSource", "errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain"]
+        "parameters": ["appVersion", "pixelSource", "channel", "errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     // Defined in https://app.asana.com/1/137249556945/project/72649045549333/task/1211597559231997
     "m_mac_wide_vpn_connection": {

--- a/macOS/PixelDefinitions/pixels/definitions/vpn_latency.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/vpn_latency.json5
@@ -4,34 +4,34 @@
         "owners": ["diegoreymendez", "samsymons"],
         "triggers": ["scheduled"],
         "suffixes": ["legacy_daily_count"],
-        "parameters": ["appVersion", "vpnLatencyLocation", "pixelSource"]
+        "parameters": ["appVersion", "vpnLatencyLocation", "pixelSource", "channel"]
     },
     "m_mac_netp_ev_poor_latency": {
         "description": "Sent as part of a regular latency check in the macOS VPN",
         "owners": ["diegoreymendez", "samsymons"],
         "triggers": ["scheduled"],
         "suffixes": ["legacy_daily_count"],
-        "parameters": ["appVersion", "vpnLatencyLocation", "pixelSource"]
+        "parameters": ["appVersion", "vpnLatencyLocation", "pixelSource", "channel"]
     },
     "m_mac_netp_ev_moderate_latency": {
         "description": "Sent as part of a regular latency check in the macOS VPN",
         "owners": ["diegoreymendez", "samsymons"],
         "triggers": ["scheduled"],
         "suffixes": ["legacy_daily_count"],
-        "parameters": ["appVersion", "vpnLatencyLocation", "pixelSource"]
+        "parameters": ["appVersion", "vpnLatencyLocation", "pixelSource", "channel"]
     },
     "m_mac_netp_ev_good_latency": {
         "description": "Sent as part of a regular latency check in the macOS VPN",
         "owners": ["diegoreymendez", "samsymons"],
         "triggers": ["scheduled"],
         "suffixes": ["legacy_daily_count"],
-        "parameters": ["appVersion", "vpnLatencyLocation", "pixelSource"]
+        "parameters": ["appVersion", "vpnLatencyLocation", "pixelSource", "channel"]
     },
     "m_mac_netp_ev_excellent_latency": {
         "description": "Sent as part of a regular latency check in the macOS VPN",
         "owners": ["diegoreymendez", "samsymons"],
         "triggers": ["scheduled"],
         "suffixes": ["legacy_daily_count"],
-        "parameters": ["appVersion", "vpnLatencyLocation", "pixelSource"]
+        "parameters": ["appVersion", "vpnLatencyLocation", "pixelSource", "channel"]
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/vpn_sub_access_revoked_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/vpn_sub_access_revoked_pixels.json5
@@ -5,13 +5,13 @@
         "owners": ["diegoreymendez"],
         "triggers": ["other"],
         "suffixes": ["legacy_daily_count"],
-        "parameters": ["appVersion", "pixelSource", "errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain"]
+        "parameters": ["appVersion", "pixelSource", "channel", "errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_mac_vpn_access_unmanaged_error": {
         "description": "The subscription library has communicated to the VPN there has been a recoverable error when trying to retrieve the token.",
         "owners": ["diegoreymendez"],
         "triggers": ["other"],
         "suffixes": ["legacy_daily_count"],
-        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode"]
+        "parameters": ["appVersion", "pixelSource", "channel", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode"]
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/vpn_sub_client_check_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/vpn_sub_client_check_pixels.json5
@@ -5,21 +5,21 @@
         "owners": ["diegoreymendez"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count"],
-        "parameters": ["vpnSubscriptionActive", "appVersion", "pixelSource"]
+        "parameters": ["vpnSubscriptionActive", "appVersion", "pixelSource", "channel"]
     },
     "m_mac_vpn_subs_client_check_signed_out": {
         "description": "The VPN learns from checking the subscription state that the user has signed out",
         "owners": ["diegoreymendez"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count"],
-        "parameters": ["vpnSubscriptionActive", "appVersion", "pixelSource"]
+        "parameters": ["vpnSubscriptionActive", "appVersion", "pixelSource", "channel"]
     },
     "m_mac_vpn_subs_client_check_vpn_feature_enabled": {
         "description": "The VPN learns from checking the subscription state that the VPN feature is enabled",
         "owners": ["diegoreymendez"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count"],
-        "parameters": ["vpnSubscriptionActive", "appVersion", "pixelSource"]
+        "parameters": ["vpnSubscriptionActive", "appVersion", "pixelSource", "channel"]
     },
     "m_mac_vpn_subs_client_check_vpn_feature_disabled": {
         "description": "The VPN learns from checking the subscription state that the VPN feature is disabled",
@@ -37,6 +37,7 @@
             "vpnSubscriptionActive",
             "appVersion",
             "pixelSource",
+            "channel",
             "errorDomain",
             "errorCode",
             "underlyingErrorDomain",
@@ -48,14 +49,14 @@
         "owners": ["diegoreymendez"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count"],
-        "parameters": ["vpnSubscriptionActive", "appVersion", "pixelSource"]
+        "parameters": ["vpnSubscriptionActive", "appVersion", "pixelSource", "channel"]
     },
     "m_mac_vpn_subs_client_check_on_wake_vpn_feature_disabled": {
         "description": "Fired when the device wakes, if PPro is disabled",
         "owners": ["diegoreymendez"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count"],
-        "parameters": ["vpnSubscriptionActive", "appVersion", "pixelSource"]
+        "parameters": ["vpnSubscriptionActive", "appVersion", "pixelSource", "channel"]
     },
     "m_mac_vpn_subs_client_check_on_foreground_failed": {
         "description": "When doing a client-check on device wake",
@@ -66,6 +67,7 @@
             "vpnSubscriptionActive",
             "appVersion",
             "pixelSource",
+            "channel",
             "errorDomain",
             "errorCode",
             "underlyingErrorDomain",

--- a/macOS/PixelDefinitions/pixels/definitions/web_notification_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/web_notification_pixels.json5
@@ -12,7 +12,7 @@
         "owners": ["diegoreymendez"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_web_notification_system_authorization_requested": {
         "description": "Fired right before showing the macOS system notification authorization prompt",
@@ -36,6 +36,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "channel",
             "errorDomain",
             "errorCode",
             {

--- a/macOS/PixelDefinitions/pixels/definitions/webkit_termination_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/webkit_termination_pixels.json5
@@ -41,6 +41,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "channel",
             {
                 "key": "tab_count",
                 "description": "Number of tab crashes that occurred in the burst (within 100ms window)",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1215471586944052?focus=true

### Description

On internal and alpha/review builds, PixelKit adds a `channel` query parameter to every pixel it fires. Several macOS pixel definitions did not declare `channel` among their allowed parameters, so they failed validation when fired from those builds.

This declares `channel` on the affected pixels. It becomes an allowed parameter, not a required one, so production pixels (which omit `channel`) are unaffected.

### Testing Steps

1. From `macOS/`, run `npm run validate-pixel-defs`.
2. Confirm validation passes with no `channel` additional-property errors.

### Impact and Risks

None. This changes pixel definition metadata only; there is no app code change. A mistyped pixel name or parameter would fail validation in CI before merge.

### Notes to Reviewer

`channel` is only sent on canary (internal) and dev (alpha/review) builds; production builds omit it.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only pixel schema updates with no runtime app changes; production pixels that omit `channel` remain valid.
> 
> **Overview**
> Adds the shared **`channel`** parameter to macOS pixel definitions that did not list it, so PixelKit validation accepts the extra query param on **internal/alpha/review** builds where **`channel`** is always attached.
> 
> Touched definition files span **Sparkle debug updater**, **site loading performance** (`m_mac_site_loading_performance`), **update application failure**, **VPN** (enable attempts, on-demand tunnel start, latency buckets, subscription client-check and access-revoked), **web notifications**, and **WebKit burst termination** pixels. **`channel`** is optional in the schema; production traffic without it is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a087e6faf50836714d667ccb5ba5782d998fa5d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->