### PR TITLE
Fix failing pixel validation for Duck.ai native storage and recent chat pixels

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/aichat_addressbar_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_addressbar_pixels.json5
@@ -243,21 +243,21 @@
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_recent_chat_delete_confirmed": {
         "description": "Fired when user confirms deletion of a recent chat suggestion in the address bar",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_recent_chat_delete_cancelled": {
         "description": "Fired when user cancels deletion of a recent chat suggestion in the address bar",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_view_all_chats_clicked": {
         "description": "Fired when user taps 'View all chats' from the native address bar omnibar",

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
@@ -64,7 +64,7 @@
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode", "channel"]
     },
     "m_mac_duck-ai_native-storage_migration_started": {
         "description": "Fires when the web layer calls markMigrationDone (migration was attempted)",
@@ -85,76 +85,76 @@
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode", "channel"]
     },
     "m_mac_duck-ai_native-storage_settings-put_error": {
         "description": "Fires when putEntry (Settings) fails",
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode", "channel"]
     },
     "m_mac_duck-ai_native-storage_settings-get_error": {
         "description": "Fires when getEntry or getAllEntries (Settings) fails",
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode", "channel"]
     },
     "m_mac_duck-ai_native-storage_settings-delete_error": {
         "description": "Fires when deleteEntry, deleteAllEntries, or replaceAllEntries (Settings) fails",
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode", "channel"]
     },
     "m_mac_duck-ai_native-storage_chat-put_error": {
         "description": "Fires when putChat or putChats fails",
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode", "channel"]
     },
     "m_mac_duck-ai_native-storage_chat-get_error": {
         "description": "Fires when getChat or getAllChats fails",
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode", "channel"]
     },
     "m_mac_duck-ai_native-storage_chat-delete_error": {
         "description": "Fires when deleteChat or deleteAllChats fails",
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode", "channel"]
     },
     "m_mac_duck-ai_native-storage_file-put_error": {
         "description": "Fires when putFile fails",
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode", "channel"]
     },
     "m_mac_duck-ai_native-storage_file-get_error": {
         "description": "Fires when getFile fails",
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode", "channel"]
     },
     "m_mac_duck-ai_native-storage_file-list_error": {
         "description": "Fires when listFiles fails",
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode", "channel"]
     },
     "m_mac_duck-ai_native-storage_file-delete_error": {
         "description": "Fires when deleteFile, deleteFiles (by chatId), or deleteAllFiles fails",
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode", "channel"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215471443841744?focus=true
Tech Design URL:
CC:

### Description
Live pixel validation flagged Duck.ai native-storage error pixels and address-bar recent-chat-delete pixels for sending parameters not declared in their definitions. PixelKit auto-attaches `channel` on non-production builds and `ud`/`ue`/`ud2` for nested underlying errors, so the definitions are updated to declare `channel`, `underlyingErrorDomain`, and `underlyingErrorCode` as appropriate. Only pixels owned by `Bunn` were changed.

### Testing Steps
1. From `macOS/`, run `npm run validate-pixel-defs` and confirm `aichat_native_storage_pixels.json5` and `aichat_addressbar_pixels.json5` report no errors.
2. Confirm `npx prettier PixelDefinitions --check` passes for both files.

### Impact and Risks
None — pixel definition metadata only; no app behavior changes.

#### What could go wrong?
A declared parameter could be misnamed, but the validator confirms each key matches the shared params dictionary keys/keyPatterns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Definition-only metadata updates; no app behavior or telemetry emission changes beyond satisfying the validator.
> 
> **Overview**
> Updates macOS pixel definition JSON5 so live validation passes for pixels that **PixelKit already sends** but the schemas did not declare.
> 
> In **`aichat_addressbar_pixels.json5`**, the three address-bar recent-chat delete events (`delete_button_clicked`, `delete_confirmed`, `delete_cancelled`) now include **`channel`** alongside `appVersion` and `pixelSource`, matching other omnibar pixels.
> 
> In **`aichat_native_storage_pixels.json5`**, every Duck.ai native-storage **error** pixel gains **`underlyingErrorDomain`**, **`underlyingErrorCode`**, and **`channel`** in addition to the existing `errorDomain` / `errorCode` fields—aligned with auto-attached nested-error and non-production build parameters. No runtime or firing logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4e083094af2ad8a237b3f1c0e4ea39e343fc93f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->