### PR TITLE
Fix data race in NewTabPageOmnibarModelsProvider causing EXC_BAD_ACCESS

### DIFF
--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarModelsProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarModelsProvider.swift
@@ -23,6 +23,7 @@ import Subscription
 
 /// Fetches AI models from the duck.ai API and builds sectioned model lists
 /// using the shared section builder for the NTP dropdown.
+@MainActor
 final class NewTabPageOmnibarModelsProvider: NewTabPageOmnibarModelsProviding {
 
     private(set) var lastFetchedSections: [NewTabPageDataModel.AIModelSection]?

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarModelsProviding.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarModelsProviding.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+@MainActor
 public protocol NewTabPageOmnibarModelsProviding {
     var lastFetchedSections: [NewTabPageDataModel.AIModelSection]? { get }
     func fetchAIModelSections() async -> [NewTabPageDataModel.AIModelSection]

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
@@ -20,6 +20,7 @@ import AIChat
 import XCTest
 @testable import NewTabPage
 
+@MainActor
 final class NewTabPageOmnibarClientTests: XCTestCase {
 
     private var suggestionsProvider: MockNewTabPageOmnibarSuggestionsProvider!
@@ -528,6 +529,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
 
 }
 
+@MainActor
 private final class StubNewTabPageOmnibarModelsProvider: NewTabPageOmnibarModelsProviding {
     var lastFetchedSections: [NewTabPageDataModel.AIModelSection]?
 

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarModelsProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarModelsProviderTests.swift
@@ -23,6 +23,7 @@ import NewTabPage
 import SubscriptionTestingUtilities
 @testable import DuckDuckGo_Privacy_Browser
 
+@MainActor
 final class NewTabPageOmnibarModelsProviderTests: XCTestCase {
 
     private var mockModelsService: MockModelsService!
@@ -206,6 +207,47 @@ final class NewTabPageOmnibarModelsProviderTests: XCTestCase {
         let premiumItem = sections.flatMap(\.items).first(where: { $0.id == "premium-model" })
 
         XCTAssertTrue(premiumItem?.isEnabled == false)
+    }
+
+    // MARK: - Concurrency
+
+    /// Overlapping callers (`NewTabPageOmnibarClient.getConfig` and `refreshModelsAndNotify`) must
+    /// not corrupt the cached sections. `@MainActor` isolation serializes these accesses on the main
+    /// actor; before isolation the provider was non-isolated, so concurrent writes to
+    /// `lastFetchedSections` raced on the array's ARC refcount and double-freed its backing storage
+    /// (EXC_BAD_ACCESS in `swift_arrayDestroy`, Sentry APPLE-MACOS-C4H/C6Q/C72). Hammering the
+    /// provider from many overlapping tasks must complete with a well-formed cache; most effective
+    /// under the Thread Sanitizer.
+    func testWhenFetchedConcurrentlyThenCachedSectionsAreNotCorrupted() async {
+        mockModelsService.modelsToReturn = [
+            makeRemoteModel(id: "free-model", accessTier: ["free"]),
+            makeRemoteModel(id: "premium-model", accessTier: ["plus", "pro"]),
+        ]
+        let provider = self.provider!
+
+        // Child tasks only return values; assertions run in this `@MainActor` parent so XCTest
+        // failure recording is never invoked concurrently from background executors.
+        let fetchedIDs = await withTaskGroup(of: [String]?.self) { group -> [[String]] in
+            for _ in 0..<500 {
+                group.addTask {
+                    await provider.fetchAIModelSections().flatMap(\.items).map(\.id)
+                }
+                // Interleave concurrent reads of the cached property with the in-flight writes.
+                group.addTask {
+                    _ = await provider.lastFetchedSections
+                    return nil
+                }
+            }
+            return await group.reduce(into: [[String]]()) { result, ids in
+                if let ids { result.append(ids) }
+            }
+        }
+
+        for ids in fetchedIDs {
+            XCTAssertEqual(Set(ids), ["free-model", "premium-model"])
+        }
+        XCTAssertEqual(Set(provider.lastFetchedSections?.flatMap(\.items).map(\.id) ?? []),
+                       ["free-model", "premium-model"])
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205842942115003/task/1215443431654845
Tech Design URL:
CC:

### Description

Fixes an `EXC_BAD_ACCESS` crash reported via Sentry (`APPLE-MACOS-C4H`, `APPLE-MACOS-C6Q`, `APPLE-MACOS-C72`). The crashing thread tears down an array inside `NewTabPageOmnibarModelsProvider.fetchAIModelSections`, called from `NewTabPageOmnibarClient.getConfig`, with the top frames showing nested `_ContiguousArrayStorage.__deallocating_deinit` → `swift_arrayDestroy` → `_swift_release_dealloc` (a double free).

**Root cause:** `NewTabPageOmnibarModelsProvider` was a non-isolated `final class`. Its `fetchAIModelSections()` is `async` and ran off the main actor, and `NewTabPageOmnibarClient` invokes it from two independent entry points (`getConfig` and `refreshModelsAndNotify`) while also reading `lastFetchedSections` from several main-actor call sites (`setConfig`, `notifyConfigUpdated`, `reasoningEffortForSubmission`). Two overlapping invocations write `lastFetchedSections` concurrently from the cooperative pool; the unsynchronised assignment races on the array's ARC refcount, over-releases the backing storage, and double-frees it on teardown.

**Fix:** Isolate `NewTabPageOmnibarModelsProviding` and `NewTabPageOmnibarModelsProvider` to `@MainActor`, so access to `lastFetchedSections` serialises on the main actor and concurrent writes can no longer race. Every consumer already runs on the main actor, so no production call-site changes were required. `@MainActor` is cascaded onto the two test conformers, and a concurrency regression test (`testWhenFetchedConcurrentlyThenCachedSectionsAreNotCorrupted`) is added.

### Testing Steps
- CI tests

### Impact and Risks
Medium. Touches a shared NTP omnibar component and adds main-actor isolation to a public protocol in the NewTabPage package.

#### What could go wrong?
- The `@MainActor` isolation cascades onto the public `NewTabPageOmnibarModelsProviding` protocol and its test conformers. All production consumers were already `@MainActor`, so no call-site changes were needed, but CI / a local build is the source of truth for the cascade (see Notes).
- Building the model sections now runs on the main actor. The work is a small map over a handful of models; the network awaits (`fetchModels`, `getSubscription`) still release the main actor during I/O.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes isolation on a public NewTabPage protocol and moves post-fetch section building onto the main actor; network awaits still suspend off the actor, but overlapping NTP config paths now depend on main-actor serialization.
> 
> **Overview**
> Fixes a production **EXC_BAD_ACCESS** crash from concurrent access to `lastFetchedSections` when overlapping NTP omnibar paths (`getConfig` and model refresh) both ran `fetchAIModelSections()` off the main actor.
> 
> **`NewTabPageOmnibarModelsProviding`** and **`NewTabPageOmnibarModelsProvider`** are now **`@MainActor`**, so reads/writes to the cached AI model sections serialize on the main actor instead of racing on the array’s refcount. Production call sites were already main-actor; the change is isolation plus matching **`@MainActor`** on test stubs/cases.
> 
> A new **`testWhenFetchedConcurrentlyThenCachedSectionsAreNotCorrupted`** hammers hundreds of overlapping fetches and cache reads to guard against the prior double-free regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bfecc8238760a0dc53f830a62ea734a0afa7465. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->