### PR TITLE
Prevent VPN server status monitor retain cycle

### DIFF
--- a/SharedPackages/VPN/Sources/VPN/Diagnostics/NetworkProtectionServerStatusMonitor.swift
+++ b/SharedPackages/VPN/Sources/VPN/Diagnostics/NetworkProtectionServerStatusMonitor.swift
@@ -73,7 +73,8 @@ public actor NetworkProtectionServerStatusMonitor: ServerStatusMonitoring {
     public func start(serverName: String, callback: @escaping (ServerStatusResult) -> Void) {
         Logger.networkProtectionServerStatusMonitor.log("⚫️ Starting server status monitor for \(serverName, privacy: .public)")
 
-        task = Task.periodic(delay: Self.monitoringInterval, interval: Self.monitoringInterval) {
+        task = Task.periodic(delay: Self.monitoringInterval, interval: Self.monitoringInterval) { [weak self] in
+            guard let self else { return }
             let result = await self.checkServerStatus(for: serverName)
 
             switch result {

--- a/SharedPackages/VPN/Tests/VPNTests/NetworkProtectionServerStatusMonitorTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/NetworkProtectionServerStatusMonitorTests.swift
@@ -1,0 +1,46 @@
+//
+//  NetworkProtectionServerStatusMonitorTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import VPNTestUtils
+@testable import VPN
+
+final class NetworkProtectionServerStatusMonitorTests: XCTestCase {
+
+    /// The monitor's periodic task must not retain the monitor, otherwise the monitor leaks
+    /// for the lifetime of the (forever-repeating) task whenever its owner is released without
+    /// first calling `stop()`. Deallocating the owner should be enough to tear it down.
+    func testStartDoesNotRetainMonitor() async {
+        weak var weakMonitor: NetworkProtectionServerStatusMonitor?
+
+        // Allocate and start the monitor in a nested scope so its strong reference is gone
+        // by the time we assert. Deliberately never call stop(): the monitor must still
+        // deallocate once the local strong reference goes away.
+        func startMonitorInScope() async {
+            let monitor = NetworkProtectionServerStatusMonitor(
+                networkClient: MockNetworkProtectionClient(),
+                tokenHandler: SubscriptionTokenHandlingMock()
+            )
+            weakMonitor = monitor
+            await monitor.start(serverName: "test-server") { _ in }
+        }
+        await startMonitorInScope()
+
+        XCTAssertNil(weakMonitor, "Monitor leaked — its periodic task is retaining self strongly")
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207603085593419/task/1215509351454326?focus=true

### Description

I don't think this is impacting users but the periodic task should not hold a strong reference to self.

### Testing Steps
1. Run the `VPN` package tests.
2. Confirm `NetworkProtectionServerStatusMonitorTests.testStartDoesNotRetainMonitor` passes.

### Impact and Risks

Low. Memory-leak fix in the VPN tunnel extension; no behavior change to monitoring itself.

#### What could go wrong?

The weak capture returns early once the monitor is deallocated, ending the periodic task — which is the desired teardown. No functional path depends on the task outliving its owner.

### Quality Considerations

Covered by a new leak test that fails before the change and passes after. The fix brings this monitor in line with the existing `[weak self]` pattern used by the latency, connection, tunnel-failure and key-expiration monitors.

### Notes to Reviewer

One-line capture-list change plus its regression test.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single capture-list change in VPN diagnostics with no intended behavior change; teardown when the monitor is released is the desired effect.
> 
> **Overview**
> Fixes a **memory leak** in `NetworkProtectionServerStatusMonitor` where the repeating `Task.periodic` closure captured `self` strongly, so the monitor could stay alive for the life of the task if its owner was released without calling `stop()`.
> 
> The periodic handler now uses **`[weak self]`** with an early return when the monitor is gone, matching the other VPN diagnostic monitors. Monitoring behavior is unchanged while the task is still owned.
> 
> Adds **`NetworkProtectionServerStatusMonitorTests.testStartDoesNotRetainMonitor`**, which starts a monitor without `stop()` and asserts it deallocates once the last strong reference is dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b686bc3a3baf97861a170d40e57e2d2876d8dda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->