### PR TITLE
iOS: Fix after-idle pixels — direct search, UTI toggle, voice, UTI back

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3463,6 +3463,10 @@ class MainViewController: UIViewController {
 
     func onDuckAIVoiceModeRequested() {
         Pixel.fire(pixel: .voiceEntryPointTapped, withAdditionalParameters: [PixelParameters.source: VoiceEntryPointSource.ntp.rawValue])
+        if let tab = tabManager.currentTabsModel.currentTab, tab.link == nil {
+            ntpAfterIdleInstrumentation.barUsedFromNTP(afterIdle: tab.openedAfterIdle)
+        }
+        postIdleSessionInstrumentation.sessionEnded(reason: .barUsed)
         openAIChatInVoiceMode()
     }
 
@@ -3958,6 +3962,10 @@ extension MainViewController: OmniBarDelegate {
         // and resolves to .dismissed, not .suspended.
         hideSuggestionTray()
         omniBar.cancel()
+        if let tab = tabManager.currentTabsModel.currentTab, tab.link == nil {
+            ntpAfterIdleInstrumentation.barUsedFromNTP(afterIdle: tab.openedAfterIdle)
+        }
+        postIdleSessionInstrumentation.sessionEnded(reason: .barUsed)
         loadQuery(query)
         hideNotificationBarIfBrokenSitePromptShown()
         showHomeRowReminder()
@@ -6418,11 +6426,19 @@ extension MainViewController: VoiceSearchViewControllerDelegate {
         switch target {
         case .SERP:
             Pixel.fire(pixel: .voiceSearchSERPDone)
+            if let tab = tabManager.currentTabsModel.currentTab, tab.link == nil {
+                ntpAfterIdleInstrumentation.barUsedFromNTP(afterIdle: tab.openedAfterIdle)
+            }
+            postIdleSessionInstrumentation.sessionEnded(reason: .barUsed)
             loadQuery(query)
 
         case .AIChat:
             Pixel.fire(pixel: .voiceSearchAIChatDone)
             if let coordinator = unifiedToggleInputCoordinator, coordinator.isAITabState, coordinator.hasBoundUserScript {
+                if let tab = tabManager.currentTabsModel.currentTab, tab.link == nil {
+                    ntpAfterIdleInstrumentation.barUsedFromNTP(afterIdle: tab.openedAfterIdle)
+                }
+                postIdleSessionInstrumentation.sessionEnded(reason: .barUsed)
                 coordinator.submitVoicePrompt(query)
             } else {
                 performCancel()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -512,6 +512,11 @@ private extension MainViewController {
     func handleModeChange(_ mode: TextEntryMode) {
         guard let coordinator = unifiedToggleInputCoordinator else { return }
 
+        if let tab = tabManager.currentTabsModel.currentTab, tab.link == nil {
+            ntpAfterIdleInstrumentation.toggleUsedFromNTP(afterIdle: tab.openedAfterIdle)
+        }
+        postIdleSessionInstrumentation.toggleUsed()
+
         if coordinator.isOmnibarSession {
             handleOmnibarModeChange(mode, coordinator: coordinator)
         } else if coordinator.isAITabExpanded {
@@ -911,6 +916,10 @@ extension MainViewController {
         contentVC.onDismissRequested = { [weak self] in
             guard let self, let coordinator = self.unifiedToggleInputCoordinator else { return }
             if coordinator.isOmnibarSession {
+                if let tab = self.tabManager.currentTabsModel.currentTab, tab.link == nil {
+                    self.ntpAfterIdleInstrumentation.backButtonUsedFromNTP(afterIdle: tab.openedAfterIdle)
+                }
+                self.postIdleSessionInstrumentation.backPressed()
                 self.dismissUnifiedToggleInputOmnibarSession(coordinator: coordinator)
             } else if coordinator.isAITabExpanded {
                 coordinator.showCollapsed()
@@ -1134,6 +1143,10 @@ extension MainViewController {
     }
 
     func handleUnifiedToggleInputSearchSubmission(_ query: String) {
+        if let tab = tabManager.currentTabsModel.currentTab, tab.link == nil {
+            ntpAfterIdleInstrumentation.barUsedFromNTP(afterIdle: tab.openedAfterIdle)
+        }
+        postIdleSessionInstrumentation.sessionEnded(reason: .barUsed)
         loadQuery(query)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1215538810600372?focus=true

### Description

Fixes after-idle pixels (`m_ios_wide_post_idle_session` + `m_ntp_after_idle_*`) so bar-initiated actions that previously left the session to expire as `app_backgrounded` are now recorded correctly — across both the legacy omnibar and Unified Toggle Input (UTI). Covers typed search & voice (`bar_used`), the UTI toggle (`toggle_used`), and the UTI back button (`back_button_used` / `backPressed`).

### Testing Steps

**Setup**
1. Internal debug menu → enable feature flag `showNTPAfterIdleReturn`. Run the suite twice: once with the Unified Toggle Input flag **on** (UTI), once **off** (legacy).
2. Settings → General → **After Inactivity** → set the surface (`New Tab` for NTP runs, `Last Used Tab` for LUT runs) and **idle interval = 1 minute**.
3. To start an after-idle session: background the app for **> 1 min**, then reopen.
4. Observe via debugger breakpoints:
   - `PostIdleSessionInstrumentation.swift` → `sessionEnded(reason:)` (inspect `reason` + `surface`), `sessionCancelledByBackground()`, `toggleUsed()`, `backPressed()`
   - `NTPAfterIdleInstrumentation.swift` → `barUsedFromNTP` / `toggleUsedFromNTP` / `backButtonUsedFromNTP`
   (or watch the pixel requests directly.)

**A. NTP surface (Settings = New Tab) — idle-return, then each action**
| Action | Wide `reason` (`surface = ntp`) | Daily pixel |
|---|---|---|
| Type a query + Enter | `bar_used` | `m_ntp_after_idle_bar_used_from_ntp_after_idle` |
| Tap an autocomplete suggestion | `bar_used` | `…bar_used…after_idle` |
| Voice search (mic → speak, search mode) | `bar_used` | `…bar_used…after_idle` |
| Voice prompt / start AI voice chat | `bar_used` | `…bar_used…after_idle` |
| Toggle search ↔ Duck.ai | *(stays open)* `toggleUsed` set | `m_ntp_after_idle_toggle_used_from_ntp_after_idle` |
| Tap a favorite | `favorite_selected` | — |
| Tap "Return to page" escape hatch | `return_to_page_tapped` | `…return_to_page…` |
| Open tab switcher | `tab_switcher_selected` | `…tab_switcher…` |
| UTI back / dismiss button | *(stays open)* `backPressed` | `…back_button_used…after_idle` |
| Do nothing → background | `app_backgrounded` (cancelled) | `…app_backgrounded…` |

**B. Last Used Tab surface (Settings = Last Used Tab) — idle-return lands on a web page**
The wide pixel uses the **same terminal reasons** as NTP (they're surface-independent), just with `surface = lut`. The `m_ntp_after_idle_*` daily pixels do **not** fire on LUT (New-Tab-only). The only NTP actions that don't apply are the escape-hatch ones (`return_to_page_tapped`, close/burn/opening-screen) — there's no escape-hatch card when you land straight on the page.
| Action | Wide `reason` (`surface = lut`) | Daily pixel |
|---|---|---|
| Type a query + Enter | `bar_used` | — |
| Tap an autocomplete suggestion | `bar_used` | — |
| Voice search / voice prompt / AI voice chat | `bar_used` | — |
| Toggle search ↔ Duck.ai | *(stays open)* `toggleUsed` set | — |
| Tap a favorite (from omnibar editing) | `favorite_selected` | — |
| Open tab switcher | `tab_switcher_selected` | — |
| UTI back / dismiss button | *(stays open)* `backPressed` | — |
| Do nothing → background | `app_backgrounded` (cancelled) | — |

**C. No false positives (UTI)**
1. Focus the input without toggling → **no** `toggle_used`.
2. A real toggle fires `toggle_used` exactly **once** (no double-count).

### Impact and Risks
Low — analytics only, no user-facing change. Reclassifies a slice of `post_idle_session` from `app_backgrounded` to the correct terminal/interaction signals.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only instrumentation with the same NTP gating and idempotent session guards as existing paths; no user-facing behavior changes.
> 
> **Overview**
> Fixes **after-idle analytics** so bar-driven actions on legacy omnibar and **Unified Toggle Input (UTI)** report the same signals as suggestion/Duck.ai paths, instead of leaving `m_ios_wide_post_idle_session` open until `app_backgrounded`.
> 
> Adds the existing **NTP gate** (`tab.link == nil`) plus wide/daily hooks at previously uncovered entry points: **typed search** (`onOmniQuerySubmitted`, `handleUnifiedToggleInputSearchSubmission`) → `bar_used`; **UTI Search↔Duck.ai toggle** (`handleModeChange`) → `toggle_used`; **voice** (AI voice mode, voice SERP, voice→AI-chat submit) → `bar_used`; **UTI omnibar back/dismiss** (`onDismissRequested`) → `back_button_used` / `backPressed`, aligned with legacy `onCancelPressed` and `onToggleModeSwitched`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62b34c19e912bcf65e86abf8cb5e14d6c59ee90c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

