### PR TITLE
iOS Rebranding: Further metrics tweaks and omnibar animation fix

### DIFF
--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -994,10 +994,10 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
     private struct Metrics {
         static let itemSize: CGFloat = 44
         static let height: CGFloat = 60
-        static var cornerRadius: CGFloat { AppRebrand.isAppRebranded() ? 22 : 16 }
+        static var cornerRadius: CGFloat { OmniBarMetrics.cornerRadius }
 
         /// Sits 2pt outside `cornerRadius` so the active outline stays concentric with the field.
-        static var activeBorderRadius: CGFloat { AppRebrand.isAppRebranded() ? 24 : 18 }
+        static var activeBorderRadius: CGFloat { OmniBarMetrics.cornerRadius + 2 }
         static let activeBorderWidth: CGFloat = 2
 
         static let textAreaHorizontalPadding: CGFloat = 16

--- a/iOS/DuckDuckGo/FireMode/FireModeEmptyStateView.swift
+++ b/iOS/DuckDuckGo/FireMode/FireModeEmptyStateView.swift
@@ -21,6 +21,7 @@ import SwiftUI
 import DesignResourcesKit
 import DesignResourcesKitIcons
 import DuckUI
+import MetricBuilder
 
 struct FireModeEmptyStateView: View {
     
@@ -108,7 +109,7 @@ struct FireModeEmptyStateView: View {
         }
         .padding(Constants.cardPadding)
         .background(Color(designSystemColor: .surface))
-        .clipShape(RoundedRectangle(cornerRadius: Constants.cardCornerRadius))
+        .clipShape(RoundedRectangle(cornerRadius: ContainerMetrics.cornerRadius))
     }
 
     // MARK: - Bullet Points
@@ -202,7 +203,6 @@ struct FireModeEmptyStateView: View {
 
         static let cardContentSpacing: CGFloat = 24
         static let cardPadding: CGFloat = 24
-        static let cardCornerRadius: CGFloat = 16
 
         static let bulletSpacing: CGFloat = 12
         static let iconTextSpacing: CGFloat = 8

--- a/iOS/DuckDuckGo/ImportPromotion/ImportPromotionHeaderView.swift
+++ b/iOS/DuckDuckGo/ImportPromotion/ImportPromotionHeaderView.swift
@@ -22,6 +22,7 @@ import DesignResourcesKit
 import DesignResourcesKitIcons
 import DuckUI
 import Lottie
+import MetricBuilder
 
 struct ImportPromotionHeaderView: View {
     var primaryButtonAction: (() -> Void)?
@@ -86,7 +87,7 @@ struct ImportPromotionHeaderView: View {
                 dimension[.top]
             }
         }
-        .background(RoundedRectangle(cornerRadius: 8.0)
+        .background(RoundedRectangle(cornerRadius: ContainerMetrics.cornerRadius)
             .foregroundColor(Color(designSystemColor: .surface))
         )
         .onAppear {

--- a/iOS/DuckDuckGo/OmniBarView.swift
+++ b/iOS/DuckDuckGo/OmniBarView.swift
@@ -18,6 +18,11 @@
 //
 
 import UIKit
+import DesignResourcesKitIcons
+
+enum OmniBarMetrics {
+    static var cornerRadius: CGFloat { AppRebrand.isAppRebranded() ? 22 : 16 }
+}
 
 enum OmniBarLayoutMode {
     /// No external buttons visible, full-width search bar (iPhone portrait, iPad compact, editing)

--- a/iOS/DuckDuckGo/Subscription/Views/SubscriptionRestoreView.swift
+++ b/iOS/DuckDuckGo/Subscription/Views/SubscriptionRestoreView.swift
@@ -23,6 +23,7 @@ import DesignResourcesKit
 import DesignResourcesKitIcons
 import Core
 import PrivacyConfig
+import MetricBuilder
 
 struct SubscriptionRestoreView: View {
 
@@ -232,7 +233,6 @@ struct SubscriptionRestoreView: View {
 private struct RoundedCardView: View {
 
     private enum Constants {
-        static let cornerRadius = 12.0
         static let cardPadding = EdgeInsets(top: 16,
                                             leading: 16,
                                             bottom: 16,
@@ -297,6 +297,6 @@ private struct RoundedCardView: View {
         .padding(Constants.cardPadding)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color(designSystemColor: .surface))
-        .cornerRadius(Constants.cornerRadius)
+        .cornerRadius(ContainerMetrics.cornerRadius)
     }
 }

--- a/iOS/DuckDuckGo/SyncPromoView.swift
+++ b/iOS/DuckDuckGo/SyncPromoView.swift
@@ -21,6 +21,7 @@ import SwiftUI
 import DesignResourcesKit
 import DesignResourcesKitIcons
 import DuckUI
+import MetricBuilder
 
 struct SyncPromoView: View {
 
@@ -43,15 +44,14 @@ struct SyncPromoView: View {
                         .daxSubheadRegular()
                         .frame(maxWidth: .infinity)
                 }
-                .padding(.horizontal, 12)
 
-                HStack {
+                HStack(spacing: ButtonStackMetrics.interButtonSpacing) {
                     Button {
                         viewModel.dismissButtonAction?()
                     } label: {
                         Text(viewModel.secondaryButtonTitle)
                     }
-                    .buttonStyle(SecondaryFillButtonStyle(compact: true, fullWidth: false))
+                    .buttonStyle(SecondaryFillButtonStyle(compact: true, fullWidth: true))
                     .accessibilityLabel(viewModel.secondaryButtonTitle)
 
                     Button {
@@ -59,16 +59,16 @@ struct SyncPromoView: View {
                     } label: {
                         Text(viewModel.primaryButtonTitle)
                     }
-                    .buttonStyle(PrimaryButtonStyle(compact: true, fullWidth: false))
+                    .buttonStyle(PrimaryButtonStyle(compact: true, fullWidth: true))
                     .accessibilityLabel(viewModel.primaryButtonTitle)
 
                 }
                 .padding(.top, 12)
-                .padding(.horizontal, 8)
             }
             .multilineTextAlignment(.center)
-            .padding(.vertical)
-            .padding(.horizontal, 8)
+            .padding(.top)
+            .padding(.bottom, ButtonStackMetrics.containerPadding)
+            .padding(.horizontal, ButtonStackMetrics.containerPadding)
 
             VStack {
                 HStack {
@@ -90,7 +90,7 @@ struct SyncPromoView: View {
             .accessibilityHidden(true)
         }
         .background(
-            RoundedRectangle(cornerRadius: 8)
+            RoundedRectangle(cornerRadius: ContainerMetrics.cornerRadius)
                 .foregroundColor(Color(designSystemColor: .surface))
         )
         .padding(.horizontal, 20)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -74,7 +74,7 @@ final class UnifiedToggleInputView: UIView {
         // `.collapsed` layout — UTI mimics the regular omnibar pill so the snap between the two
         // surfaces reads as one continuous element.
         static let collapsedCardHeight: CGFloat = 44
-        static let cardCornerRadiusCollapsed: CGFloat = 16
+        static var cardCornerRadiusCollapsed: CGFloat { OmniBarMetrics.cornerRadius }
         static let collapsedCardTopMargin: CGFloat = 10
         static let collapsedCardBottomMargin: CGFloat = 6
         // `.flanked` layout — 48pt capsule sized to match the fire/voice accessory height.

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/PlatformLinksView.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/PlatformLinksView.swift
@@ -54,13 +54,6 @@ public struct PlatformLinksView: View {
         .navigationTitle(UserText.syncGetOtherDevicesScreenTitle)
     }
 
-    private var isiOS26: Bool {
-        if #available(iOS 26, *) {
-            return true
-        }
-        return false
-    }
-
     private var content: some View {
         VStack(alignment: .center, spacing: 0) {
 

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/PlatformLinksView.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/PlatformLinksView.swift
@@ -21,6 +21,7 @@ import SwiftUI
 import DesignResourcesKit
 import DesignResourcesKitIcons
 import DuckUI
+import MetricBuilder
 
 public struct PlatformLinksView: View {
 
@@ -117,12 +118,11 @@ public struct PlatformLinksView: View {
                 }
             }
             .padding(.horizontal, 24)
-            .padding(.bottom, 8)
 
         }
         .padding(.vertical, 24)
         .background(
-            RoundedRectangle(cornerRadius: isiOS26 ? 24 : 12)
+            RoundedRectangle(cornerRadius: ContainerMetrics.cornerRadius)
                 .fill(Color(designSystemColor: .surface))
         )
         .onAppear {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211264967278501/task/1215516761990383?focus=true
Tech Design URL:
CC:

### Description

This PR fixes an issue with the corner radiuses of the omnibar during animations, and applies the new corner radius and spacing metrics to additional surfaces.

This video shows the issue with the omnibar corners – they animate to the wrong radius then pop to the correct one once the animation completes:


https://github.com/user-attachments/assets/21835753-68bb-4d7e-a083-b79e11c6eef9


### Testing Steps

1. With the feature flag both on and off test focusing and unfocusing the omnibar to expand and contract it. Check there’s no ‘pop in’ of the corner radiuses and that they animate smoothly.
2. Verify each of the areas with new corner radiuses spacing to check they look good with old and new appearances:
  - Fire mode empty tab panel
  - Settings > I Have a subscription screen
  - Promos in Passwords screen (you may need to reset these in debug settings)
  - Settings > Sync > Get Desktop App screen


### Impact and Risks

Low: Minor visual changes, small bug fixes, improvement to existing features

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and layout-token refactors only; no auth, data, or business-logic changes. Main risk is minor UI regressions on promos and omnibar focus animations.
> 
> **Overview**
> Centralizes **omnibar corner radius** in a shared `OmniBarMetrics` type (rebrand-aware 22 vs 16) and wires `DefaultOmniBarView` and collapsed **Unified Toggle Input** to use it, with the active outline radius derived as `cornerRadius + 2`. That replaces duplicated `AppRebrand` checks so radius values stay aligned during focus/expand animations and should remove the corner “pop.”
> 
> Several **promo and settings surfaces** now pull layout from **MetricBuilder**: card corners use `ContainerMetrics.cornerRadius` (Fire mode empty state, import promo, subscription restore cards, sync promo, sync “get desktop app”), and **Sync promo** adopts `ButtonStackMetrics` for padding/spacing plus full-width compact primary/secondary buttons. **PlatformLinksView** drops the iOS 26–specific corner-radius branch in favor of the same container metric.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5ea031232563edfa305f091a3a2c79b5ffd3637. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->