### PR TITLE
iOS: Escape Hatch - Hide Functionality

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -250,6 +250,9 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/1211654189969294/task/1215358250572341?focus=true
     case escapeHatchFireButton
 
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215530020470713?focus=true
+    case escapeHatchHideShortcut
+
     case crashReportOptInStatusResetting
 
     case screenTimeCleaning

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -334,6 +334,9 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211654189969294/task/1215358250572341?focus=true
     case escapeHatchFireButton
 
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215530020470713?focus=true
+    case escapeHatchHideShortcut
+
     /// Test-only feature flag for verifying UI test override mechanism.
     /// Used in Debug > UI Test Overrides screen.
     case uiTestFeatureFlag
@@ -705,6 +708,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.escapeHatchActions))
         case .escapeHatchFireButton:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.escapeHatchFireButton))
+        case .escapeHatchHideShortcut:
+            Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.escapeHatchHideShortcut))
         case .uiTestFeatureFlag:
             Config(source: .disabled)
         case .uiTestExperiment:

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1484,9 +1484,12 @@ extension Pixel {
         case ntpAfterIdleEscapeHatchBurnImmediatelyTapped
         case ntpAfterIdleEscapeHatchAfterInactivitySettingChangedToNewTab
         case ntpAfterIdleEscapeHatchAfterInactivitySettingChangedToLastUsedTab
+        case ntpAfterIdleEscapeHatchHiddenFromMenu
         case ntpAfterIdleSettingChangedToNewTab
         case ntpAfterIdleSettingChangedToLastUsedTab
         case ntpAfterIdleSettingIdleIntervalChanged
+        case ntpAfterIdleLastTabShortcutSettingEnabled
+        case ntpAfterIdleLastTabShortcutSettingDisabled
 
         // MARK: DuckPlayer
 
@@ -3324,9 +3327,12 @@ extension Pixel.Event {
         case .ntpAfterIdleEscapeHatchBurnImmediatelyTapped: return "m_ntp_after_idle_escape_hatch_burn_immediately_tapped"
         case .ntpAfterIdleEscapeHatchAfterInactivitySettingChangedToNewTab: return "m_ntp_after_idle_escape_hatch_after_inactivity_setting_changed_to_new_tab"
         case .ntpAfterIdleEscapeHatchAfterInactivitySettingChangedToLastUsedTab: return "m_ntp_after_idle_escape_hatch_after_inactivity_setting_changed_to_last_used_tab"
+        case .ntpAfterIdleEscapeHatchHiddenFromMenu: return "m_ntp_after_idle_escape_hatch_hidden_from_menu"
         case .ntpAfterIdleSettingChangedToNewTab: return "m_ntp_after_idle_setting_changed_to_new_tab"
         case .ntpAfterIdleSettingChangedToLastUsedTab: return "m_ntp_after_idle_setting_changed_to_last_used_tab"
         case .ntpAfterIdleSettingIdleIntervalChanged: return "m_ntp_after_idle_setting_idle_interval_changed"
+        case .ntpAfterIdleLastTabShortcutSettingEnabled: return "m_ntp_after_idle_last_tab_shortcut_setting_enabled"
+        case .ntpAfterIdleLastTabShortcutSettingDisabled: return "m_ntp_after_idle_last_tab_shortcut_setting_disabled"
 
         // MARK: DuckPlayer
         case .duckPlayerSettingsOpen: return "m_settings_duckplayer_open"

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -2180,6 +2180,7 @@
 		CBAD0F1D2D02EE43006267B8 /* IdleReturnNTPDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAD0F1C2D02EE43006267B8 /* IdleReturnNTPDebugView.swift */; };
 		CBAD0F1F2D02EE45006267B8 /* IdleReturnEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAD0F1E2D02EE45006267B8 /* IdleReturnEvaluatorTests.swift */; };
 		CBAD0F212D02EE46006267B8 /* EscapeHatchModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAD0F202D02EE46006267B8 /* EscapeHatchModel.swift */; };
+		BEC5B10A1F9E4CF5A889BBDC /* EscapeHatchModelBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98109F19E7F142578C327237 /* EscapeHatchModelBuilder.swift */; };
 		CBAD0F232D02EE47006267B8 /* ReturnToTabCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAD0F222D02EE47006267B8 /* ReturnToTabCard.swift */; };
 		CBAD0F252D02EE49006267B8 /* LastBackgroundDateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAD0F242D02EE48006267B8 /* LastBackgroundDateStore.swift */; };
 		CBAD0F272D02EE4B006267B8 /* AfterInactivitySettingStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAD0F262D02EE4A006267B8 /* AfterInactivitySettingStorage.swift */; };
@@ -2486,6 +2487,7 @@
 		F2B8A10736AA100000C0DE01 /* UnifiedToggleInputAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B8A10936AA100000C0DE01 /* UnifiedToggleInputAttachment.swift */; };
 		F2B8A10836AA100000C0DE01 /* UnifiedToggleInputFileEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B8A10A36AA100000C0DE01 /* UnifiedToggleInputFileEncoder.swift */; };
 		F2DE024241BD443BAA7E32E3 /* AfterInactivityOptionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3663DD21563403B96D50EF0 /* AfterInactivityOptionAdapter.swift */; };
+		99E2FD79C4FC4D9F8863DCB8 /* LastTabShortcutAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE843090E1154413AF82C75E /* LastTabShortcutAdapter.swift */; };
 		F40F843728C939760081AE75 /* AutofillLoginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F40F843528C938370081AE75 /* AutofillLoginListViewModelTests.swift */; };
 		F4147354283BF834004AA7A5 /* AutofillContentScopeFeatureToggles.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4147353283BF834004AA7A5 /* AutofillContentScopeFeatureToggles.swift */; };
 		F41C2DA326C1925700F9A760 /* BookmarksAndFolders.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = F41C2DA126C1925600F9A760 /* BookmarksAndFolders.xcdatamodeld */; };
@@ -4881,6 +4883,7 @@
 		CBAD0F1C2D02EE43006267B8 /* IdleReturnNTPDebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleReturnNTPDebugView.swift; sourceTree = "<group>"; };
 		CBAD0F1E2D02EE45006267B8 /* IdleReturnEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleReturnEvaluatorTests.swift; sourceTree = "<group>"; };
 		CBAD0F202D02EE46006267B8 /* EscapeHatchModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EscapeHatchModel.swift; sourceTree = "<group>"; };
+		98109F19E7F142578C327237 /* EscapeHatchModelBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EscapeHatchModelBuilder.swift; sourceTree = "<group>"; };
 		CBAD0F222D02EE47006267B8 /* ReturnToTabCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReturnToTabCard.swift; sourceTree = "<group>"; };
 		CBAD0F242D02EE48006267B8 /* LastBackgroundDateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastBackgroundDateStore.swift; sourceTree = "<group>"; };
 		CBAD0F262D02EE4A006267B8 /* AfterInactivitySettingStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterInactivitySettingStorage.swift; sourceTree = "<group>"; };
@@ -5042,6 +5045,7 @@
 		E1A4A4D42F2A111100AA11BB /* TabViewController+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabViewController+UI.swift"; sourceTree = "<group>"; };
 		E29382A31F7E094527FD807C /* IPadTabChatHistoryCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadTabChatHistoryCoordinator.swift; sourceTree = "<group>"; };
 		E3663DD21563403B96D50EF0 /* AfterInactivityOptionAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterInactivityOptionAdapter.swift; sourceTree = "<group>"; };
+		CE843090E1154413AF82C75E /* LastTabShortcutAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastTabShortcutAdapter.swift; sourceTree = "<group>"; };
 		E44F90E856A0488A976B6AFE /* FileCorruptErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCorruptErrorView.swift; sourceTree = "<group>"; };
 		E7971E90992B46FABF42A908 /* AIChatContextualWebViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualWebViewControllerTests.swift; sourceTree = "<group>"; };
 		EA39B7E1268A1A35000C62CD /* privacy-reference-tests */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = folder; name = "privacy-reference-tests"; path = "../SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Resources/privacy-reference-tests"; sourceTree = SOURCE_ROOT; };
@@ -10059,6 +10063,7 @@
 				CBAD0F262D02EE4A006267B8 /* AfterInactivitySettingStorage.swift */,
 				CBAD0F2A2D02EE4D006267B8 /* AfterInactivityEffectiveOptionResolver.swift */,
 				E3663DD21563403B96D50EF0 /* AfterInactivityOptionAdapter.swift */,
+				CE843090E1154413AF82C75E /* LastTabShortcutAdapter.swift */,
 				CBAD0F3A2D02EE5B006267B8 /* IdleReturnCohort.swift */,
 				CBAD0F2C2D02EE4F006267B8 /* IdleReturnEligibilityManager.swift */,
 				E0742FD8DD5F46AB8243103F /* NTPAfterIdleInstrumentation.swift */,
@@ -10689,6 +10694,7 @@
 				6FE127372C20492500EB5724 /* NewTabPage.swift */,
 				6FD8E51F2C5BA23200345670 /* NewTabPageViewModel.swift */,
 				CBAD0F202D02EE46006267B8 /* EscapeHatchModel.swift */,
+				98109F19E7F142578C327237 /* EscapeHatchModelBuilder.swift */,
 				B5E5F7422FB6362D00A318E7 /* EscapeHatchModel+Previews.swift */,
 				CBAD0F222D02EE47006267B8 /* ReturnToTabCard.swift */,
 				6F5041C82CC11A5100989E48 /* NewTabPageView.swift */,
@@ -12623,6 +12629,7 @@
 				CBAD0F272D02EE4B006267B8 /* AfterInactivitySettingStorage.swift in Sources */,
 				CBAD0F2B2D02EE4E006267B8 /* AfterInactivityEffectiveOptionResolver.swift in Sources */,
 				F2DE024241BD443BAA7E32E3 /* AfterInactivityOptionAdapter.swift in Sources */,
+				99E2FD79C4FC4D9F8863DCB8 /* LastTabShortcutAdapter.swift in Sources */,
 				5B6D651A2FB4BB8000BDCF4D /* ICSFileReader.swift in Sources */,
 				CBAD0F3B2D02EE5B006267B8 /* IdleReturnCohort.swift in Sources */,
 				80A09D522F6B854400AACDEE /* URLCacheFireWorker.swift in Sources */,
@@ -12785,6 +12792,7 @@
 				F4D9C4FA25117A0F00814B71 /* HomeMessageStorage.swift in Sources */,
 				6F5041C92CC11A5100989E48 /* NewTabPageView.swift in Sources */,
 				CBAD0F212D02EE46006267B8 /* EscapeHatchModel.swift in Sources */,
+				BEC5B10A1F9E4CF5A889BBDC /* EscapeHatchModelBuilder.swift in Sources */,
 				CBAD0F232D02EE47006267B8 /* ReturnToTabCard.swift in Sources */,
 				BFA000022F90000000FEEE01 /* FreemiumPIREligibility.swift in Sources */,
 				D69FBF762B28BE3600B505F1 /* SettingsSubscriptionView.swift in Sources */,

--- a/iOS/DuckDuckGo/AppLifecycle/AfterInactivitySettingStorage.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AfterInactivitySettingStorage.swift
@@ -25,6 +25,7 @@ enum AfterInactivityStorageKeys: String, StorageKeyDescribing {
     case afterInactivityOption = "idle-return-after-inactivity-option"
     case idleReturnNewUser = "idle-return-new-user"
     case idleReturnIntervalSeconds = "idle-return-interval-seconds"
+    case lastTabShortcutEnabled = "idle-return-last-tab-shortcut-enabled"
 }
 
 /// StoringKeys for after-inactivity setting.
@@ -32,4 +33,5 @@ struct AfterInactivitySettingKeys: StoringKeys {
     let afterInactivityOption = StorageKey<String>(AfterInactivityStorageKeys.afterInactivityOption)
     let idleReturnNewUser = StorageKey<Bool>(AfterInactivityStorageKeys.idleReturnNewUser)
     let idleReturnIntervalSeconds = StorageKey<Int>(AfterInactivityStorageKeys.idleReturnIntervalSeconds)
+    let lastTabShortcutEnabled = StorageKey<Bool>(AfterInactivityStorageKeys.lastTabShortcutEnabled)
 }

--- a/iOS/DuckDuckGo/AppLifecycle/LastTabShortcutAdapter.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/LastTabShortcutAdapter.swift
@@ -1,0 +1,40 @@
+//
+//  LastTabShortcutAdapter.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Persistence
+
+/// Owns the "Last Tab Shortcut" preference, shared by the Settings toggle and the escape hatch's
+/// "Don't Show This" action so both stay in sync. Defaults to enabled when nothing is stored.
+final class LastTabShortcutAdapter: ObservableObject {
+
+    @Published var isEnabled: Bool
+    private let storage: any ThrowingKeyedStoring<AfterInactivitySettingKeys>
+
+    init(keyValueStore: ThrowingKeyValueStoring) {
+        let storage: any ThrowingKeyedStoring<AfterInactivitySettingKeys> = keyValueStore.throwingKeyedStoring()
+        self.storage = storage
+        self.isEnabled = (try? storage.lastTabShortcutEnabled) ?? true
+    }
+
+    func setEnabled(_ newValue: Bool) {
+        isEnabled = newValue
+        try? storage.set(newValue, for: \AfterInactivitySettingKeys.lastTabShortcutEnabled)
+    }
+}

--- a/iOS/DuckDuckGo/AppLifecycle/NTPAfterIdleInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/NTPAfterIdleInstrumentation.swift
@@ -60,6 +60,9 @@ protocol NTPAfterIdleInstrumentation: AnyObject {
 
     /// The user changed the Opening Screen option from the escape hatch's settings menu.
     func escapeHatchOptionChanged(to option: AfterInactivityOption)
+
+    /// The user hid the "Return to tab" shortcut via the card's "Don't Show This" menu item.
+    func escapeHatchHiddenFromMenu()
 }
 
 final class DefaultNTPAfterIdleInstrumentation: NTPAfterIdleInstrumentation {
@@ -123,5 +126,9 @@ final class DefaultNTPAfterIdleInstrumentation: NTPAfterIdleInstrumentation {
 
     func escapeHatchOptionChanged(to option: AfterInactivityOption) {
         firePixel(option == .newTab ? .ntpAfterIdleEscapeHatchAfterInactivitySettingChangedToNewTab : .ntpAfterIdleEscapeHatchAfterInactivitySettingChangedToLastUsedTab)
+    }
+
+    func escapeHatchHiddenFromMenu() {
+        firePixel(.ntpAfterIdleEscapeHatchHiddenFromMenu)
     }
 }

--- a/iOS/DuckDuckGo/EscapeHatchModel+Previews.swift
+++ b/iOS/DuckDuckGo/EscapeHatchModel+Previews.swift
@@ -45,7 +45,7 @@ extension EscapeHatchTabsSource where Self == StaticEscapeHatchTabsSource {
 
 extension EscapeHatchModel {
     /// Factory for #Preview / test code: stubs action closures as no-ops so call sites stay readable.
-    static func preview(title: String, subtitle: String, tabType: TabType, domain: String?, targetTab: Tab, tabCount: Int, isActionsEnabled: Bool = true, isFireButtonEnabled: Bool = false, afterInactivityOption: AfterInactivityOption = .lastUsedTab, keyValueStore: ThrowingKeyValueStoring = UserDefaults.standard) -> EscapeHatchModel {
+    static func preview(title: String, subtitle: String, tabType: TabType, domain: String?, targetTab: Tab, tabCount: Int, isActionsEnabled: Bool = true, isFireButtonEnabled: Bool = false, isHideShortcutEnabled: Bool = false, afterInactivityOption: AfterInactivityOption = .lastUsedTab, keyValueStore: ThrowingKeyValueStoring = UserDefaults.standard) -> EscapeHatchModel {
         EscapeHatchModel(
             title: title,
             subtitle: subtitle,
@@ -55,10 +55,12 @@ extension EscapeHatchModel {
             tabsSource: .staticTabsSource(count: tabCount, includes: targetTab),
             isActionsEnabled: isActionsEnabled,
             isFireButtonEnabled: isFireButtonEnabled,
+            isHideShortcutEnabled: isHideShortcutEnabled,
             afterInactivityOptionAdapter: AfterInactivityOptionAdapter(
                 initialOption: afterInactivityOption,
                 keyValueStore: keyValueStore
             ),
+            lastTabShortcutAdapter: LastTabShortcutAdapter(keyValueStore: keyValueStore),
             onCardTap: {},
             onTabSwitcherTap: {},
             onCloseTab: {},

--- a/iOS/DuckDuckGo/EscapeHatchModel.swift
+++ b/iOS/DuckDuckGo/EscapeHatchModel.swift
@@ -66,6 +66,7 @@ final class EscapeHatchModel: ObservableObject {
     @Published private(set) var openTabCount: Int = 0
     @Published private(set) var isTargetTabPresent: Bool = true
     private let afterInactivityOptionAdapter: AfterInactivityOptionAdapter
+    private let lastTabShortcutAdapter: LastTabShortcutAdapter
     private var cancellables = [AnyCancellable]()
 
     let title: String
@@ -73,16 +74,22 @@ final class EscapeHatchModel: ObservableObject {
     let tabType: TabType
     let domain: String?
     let targetTab: Tab
+    /// `false` for tab-switcher-only hatches, so the card never appears (it would be empty: no tab to return to).
+    let hasReturnToTabCard: Bool
     let isActionsEnabled: Bool
     /// When on, the destructive "delete tab" action is surfaced as a dedicated Fire button on the card
     /// instead of (and removed from) the three-dots menu. Gated by the `escapeHatchFireButton` feature flag.
     let isFireButtonEnabled: Bool
+    /// When on, the "Don't Show This" menu item is surfaced and the card can be hidden, leaving only the tab
+    /// switcher pill. Gated by the `escapeHatchHideShortcut` feature flag.
+    let isHideShortcutEnabled: Bool
     let onCardTap: () -> Void
     let onTabSwitcherTap: () -> Void
     let onCloseTab: () -> Void
     let onBurnTabWithConfirmation: (CGRect) -> Void
     let onBurnTabImmediately: () -> Void
     let onOpeningScreenOptionChanged: (AfterInactivityOption) -> Void
+    let onShortcutHidden: () -> Void
 
     init(title: String,
          subtitle: String,
@@ -92,35 +99,44 @@ final class EscapeHatchModel: ObservableObject {
          tabsSource: some EscapeHatchTabsSource,
          isActionsEnabled: Bool,
          isFireButtonEnabled: Bool = false,
+         isHideShortcutEnabled: Bool = false,
+         hasReturnToTabCard: Bool = true,
          afterInactivityOptionAdapter: AfterInactivityOptionAdapter,
+         lastTabShortcutAdapter: LastTabShortcutAdapter,
          onCardTap: @escaping () -> Void,
          onTabSwitcherTap: @escaping () -> Void,
          onCloseTab: @escaping () -> Void,
          onBurnTabWithConfirmation: @escaping (CGRect) -> Void,
          onBurnTabImmediately: @escaping () -> Void,
-         onOpeningScreenOptionChanged: @escaping (AfterInactivityOption) -> Void = { _ in }) {
+         onOpeningScreenOptionChanged: @escaping (AfterInactivityOption) -> Void = { _ in },
+         onShortcutHidden: @escaping () -> Void = {}) {
         self.title = title
         self.subtitle = subtitle
         self.tabType = tabType
         self.domain = domain
         self.targetTab = targetTab
+        self.hasReturnToTabCard = hasReturnToTabCard
         self.isActionsEnabled = isActionsEnabled
         self.isFireButtonEnabled = isFireButtonEnabled
+        self.isHideShortcutEnabled = isHideShortcutEnabled
         self.afterInactivityOptionAdapter = afterInactivityOptionAdapter
+        self.lastTabShortcutAdapter = lastTabShortcutAdapter
         self.onCardTap = onCardTap
         self.onTabSwitcherTap = onTabSwitcherTap
         self.onCloseTab = onCloseTab
         self.onBurnTabWithConfirmation = onBurnTabWithConfirmation
         self.onBurnTabImmediately = onBurnTabImmediately
         self.onOpeningScreenOptionChanged = onOpeningScreenOptionChanged
+        self.onShortcutHidden = onShortcutHidden
 
         subscribeToTabsSource(tabsSource)
         startForwardingAdapterWillChangeEvents(afterInactivityOptionAdapter)
+        startForwardingAdapterWillChangeEvents(lastTabShortcutAdapter)
     }
 
     /// Builds the model with action closures wired to a router. The router is captured weakly so holders of `EscapeHatchModel` don't pin its owner's lifecycle.
     ///
-    convenience init(title: String, subtitle: String, tabType: TabType, domain: String?, targetTab: Tab, tabsSource: some EscapeHatchTabsSource, router: EscapeHatchActionRouter, featureFlagger: FeatureFlagger, afterInactivityOptionAdapter: AfterInactivityOptionAdapter) {
+    convenience init(title: String, subtitle: String, tabType: TabType, domain: String?, targetTab: Tab, tabsSource: some EscapeHatchTabsSource, hasReturnToTabCard: Bool = true, router: EscapeHatchActionRouter, featureFlagger: FeatureFlagger, afterInactivityOptionAdapter: AfterInactivityOptionAdapter, lastTabShortcutAdapter: LastTabShortcutAdapter, onShortcutHidden: @escaping () -> Void = {}) {
         self.init(
             title: title,
             subtitle: subtitle,
@@ -130,7 +146,10 @@ final class EscapeHatchModel: ObservableObject {
             tabsSource: tabsSource,
             isActionsEnabled: featureFlagger.isFeatureOn(.escapeHatchActions),
             isFireButtonEnabled: featureFlagger.isFeatureOn(.escapeHatchFireButton),
+            isHideShortcutEnabled: featureFlagger.isFeatureOn(.escapeHatchHideShortcut),
+            hasReturnToTabCard: hasReturnToTabCard,
             afterInactivityOptionAdapter: afterInactivityOptionAdapter,
+            lastTabShortcutAdapter: lastTabShortcutAdapter,
             onCardTap: { [weak router] in
                 router?.escapeHatchDidRequestSwitch(to: targetTab)
             },
@@ -148,7 +167,30 @@ final class EscapeHatchModel: ObservableObject {
             },
             onOpeningScreenOptionChanged: { [weak router] option in
                 router?.escapeHatchDidChangeOpeningScreenOption(to: option)
-            }
+            },
+            onShortcutHidden: onShortcutHidden
+        )
+    }
+
+    /// A tab-switcher-only hatch: no card (`hasReturnToTabCard` is false); `targetTab` only seeds the tab count.
+    convenience init(tabSwitcherOnlyTargetTab targetTab: Tab,
+                     tabsSource: some EscapeHatchTabsSource,
+                     router: EscapeHatchActionRouter,
+                     featureFlagger: FeatureFlagger,
+                     afterInactivityOptionAdapter: AfterInactivityOptionAdapter,
+                     lastTabShortcutAdapter: LastTabShortcutAdapter) {
+        self.init(
+            title: "",
+            subtitle: "",
+            tabType: .regular,
+            domain: nil,
+            targetTab: targetTab,
+            tabsSource: tabsSource,
+            hasReturnToTabCard: false,
+            router: router,
+            featureFlagger: featureFlagger,
+            afterInactivityOptionAdapter: afterInactivityOptionAdapter,
+            lastTabShortcutAdapter: lastTabShortcutAdapter
         )
     }
 }
@@ -179,6 +221,23 @@ extension EscapeHatchModel {
 
     var isFireTab: Bool {
         targetTab.mode == .fire
+    }
+
+    /// Flips the setting off and reports the action for telemetry.
+    func hideShortcut() {
+        lastTabShortcutAdapter.setEnabled(false)
+        onShortcutHidden()
+    }
+
+    /// Enabled unless the hide feature is on and the user has turned the shortcut off.
+    var isLastTabShortcutEnabled: Bool {
+        isHideShortcutEnabled ? lastTabShortcutAdapter.isEnabled : true
+    }
+
+    /// The card shows only while its target tab is open and the user hasn't hidden the shortcut; otherwise
+    /// the view collapses the card and expands the tab-switcher pill.
+    var isReturnToTabCardVisible: Bool {
+        hasReturnToTabCard && isTargetTabPresent && isLastTabShortcutEnabled
     }
 
     /// Fire tabs have no soft-close semantics, so swipe defaults to burn-immediately.
@@ -221,10 +280,9 @@ private extension EscapeHatchModel {
         }
     }
 
-    /// Forward `AfterInactivityOptionAdapter.objectWillChange` Events:
-    /// This causes `model.afterInactivityOptionBinding` to react to `AfterInactivityOptionAdapter` changes
-    ///
-    func startForwardingAdapterWillChangeEvents(_ adapter: AfterInactivityOptionAdapter) {
+    /// Forward an adapter's `objectWillChange` events so derived values (e.g. `afterInactivityOptionBinding`,
+    /// `isReturnToTabCardVisible`) react to changes the adapter makes to the shared settings storage.
+    func startForwardingAdapterWillChangeEvents(_ adapter: some ObservableObject) {
         adapter.objectWillChange
             .sink { [weak self] _ in
                 self?.objectWillChange.send()

--- a/iOS/DuckDuckGo/EscapeHatchModelBuilder.swift
+++ b/iOS/DuckDuckGo/EscapeHatchModelBuilder.swift
@@ -1,0 +1,117 @@
+//
+//  EscapeHatchModelBuilder.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Core
+import PrivacyConfig
+
+/// Builds the after-idle `EscapeHatchModel`, keeping the construction logic out of `MainViewController`.
+/// The owning view controller passes itself as the `EscapeHatchActionRouter`.
+struct EscapeHatchModelBuilder {
+
+    let tabManager: TabManager
+    let lastActiveTabStore: LastActiveTabStoring
+    let idleReturnEligibilityManager: IdleReturnEligibilityManaging
+    let featureFlagger: FeatureFlagger
+    let afterInactivityOptionAdapter: AfterInactivityOptionAdapter
+    let lastTabShortcutAdapter: LastTabShortcutAdapter
+    let instrumentation: NTPAfterIdleInstrumentation
+
+    /// The hatch to show on an after-idle New Tab Page, or `nil` when none applies.
+    func makeAfterIdleHatch(router: EscapeHatchActionRouter) -> EscapeHatchModel? {
+        guard idleReturnEligibilityManager.isEligibleForNTPAfterIdle() else { return nil }
+
+        let currentTab = tabManager.currentTabsModel.currentTab
+        if currentTab?.fireTab == true {
+            // Avoid showing a hatch on fire tabs.
+            return nil
+        }
+
+        // Prefer the full model whenever there's a distinct tab to return to; the card shows/hides reactively with the setting.
+        if let lastUID = lastActiveTabStore.lastActiveNonEmptyTabUID,
+           let targetTab = tabManager.allTabsModel.tabs.first(where: { $0.uid == lastUID }),
+           targetTab !== currentTab,
+           let model = makeCardModel(targetTab: targetTab, router: router) {
+            return model
+        }
+
+        // No tab to return to. When the shortcut is hidden, still show the expanded pill (even with one tab).
+        if featureFlagger.isFeatureOn(.escapeHatchHideShortcut), !lastTabShortcutAdapter.isEnabled, let currentTab {
+            return makeTabSwitcherOnly(targetTab: currentTab, router: router)
+        }
+
+        return nil
+    }
+
+    /// Tab-switcher-only hatch (no Return-to-tab card) for when the shortcut is hidden and there's no
+    /// distinct tab to return to.
+    func makeTabSwitcherOnly(targetTab: Tab, router: EscapeHatchActionRouter) -> EscapeHatchModel {
+        EscapeHatchModel(
+            tabSwitcherOnlyTargetTab: targetTab,
+            tabsSource: tabManager,
+            router: router,
+            featureFlagger: featureFlagger,
+            afterInactivityOptionAdapter: afterInactivityOptionAdapter,
+            lastTabShortcutAdapter: lastTabShortcutAdapter
+        )
+    }
+
+    private func makeCardModel(targetTab: Tab, router: EscapeHatchActionRouter) -> EscapeHatchModel? {
+        if targetTab.fireTab {
+            guard targetTab.link != nil || targetTab.isAITab else { return nil }
+            return makeModel(title: UserText.escapeHatchFireTabTitle, subtitle: "", tabType: .fire, domain: nil, targetTab: targetTab, router: router)
+        }
+        if targetTab.isAITab {
+            return makeModel(
+                title: targetTab.aiChatConversationTitle ?? UserText.omnibarFullAIChatModeDisplayTitle,
+                subtitle: UserText.omnibarFullAIChatModeDisplayTitle,
+                tabType: .aiChat,
+                domain: nil,
+                targetTab: targetTab,
+                router: router
+            )
+        }
+        if let link = targetTab.link {
+            let subtitle = link.url.host?.droppingWwwPrefix() ?? link.url.absoluteString
+            return makeModel(title: link.displayTitle, subtitle: subtitle, tabType: .regular, domain: link.url.host, targetTab: targetTab, router: router)
+        }
+        return nil
+    }
+
+    private func makeModel(title: String,
+                           subtitle: String,
+                           tabType: EscapeHatchModel.TabType,
+                           domain: String?,
+                           targetTab: Tab,
+                           router: EscapeHatchActionRouter) -> EscapeHatchModel {
+        EscapeHatchModel(
+            title: title,
+            subtitle: subtitle,
+            tabType: tabType,
+            domain: domain,
+            targetTab: targetTab,
+            tabsSource: tabManager,
+            router: router,
+            featureFlagger: featureFlagger,
+            afterInactivityOptionAdapter: afterInactivityOptionAdapter,
+            lastTabShortcutAdapter: lastTabShortcutAdapter,
+            onShortcutHidden: { [instrumentation] in instrumentation.escapeHatchHiddenFromMenu() }
+        )
+    }
+}

--- a/iOS/DuckDuckGo/EscapeHatchView.swift
+++ b/iOS/DuckDuckGo/EscapeHatchView.swift
@@ -24,20 +24,21 @@ struct EscapeHatchView: View {
     @ObservedObject var model: EscapeHatchModel
 
     var body: some View {
-        HStack(spacing: model.isTargetTabPresent ? Metrics.spacing : 0) {
+        HStack(spacing: model.isReturnToTabCardVisible ? Metrics.spacing : 0) {
             ReturnToTabCard(model: model)
-                .frame(maxWidth: model.isTargetTabPresent ? .infinity : 0)
+                .frame(maxWidth: model.isReturnToTabCardVisible ? .infinity : 0)
                 .clipped()
-                .opacity(model.isTargetTabPresent ? 1 : 0)
-                .allowsHitTesting(model.isTargetTabPresent)
+                .opacity(model.isReturnToTabCardVisible ? 1 : 0)
+                .allowsHitTesting(model.isReturnToTabCardVisible)
 
             TabSwitcherPill(count: model.openTabCount,
-                            isExpanded: !model.isTargetTabPresent,
+                            isExpanded: !model.isReturnToTabCardVisible,
+                            showsEndArrow: !model.isHideShortcutEnabled,
                             onTap: model.onTabSwitcherTap)
-                .frame(maxWidth: model.isTargetTabPresent ? TabSwitcherPill.compactSize : .infinity)
+                .frame(maxWidth: model.isReturnToTabCardVisible ? TabSwitcherPill.compactSize : .infinity)
                 .frame(height: TabSwitcherPill.compactSize)
         }
-        .animation(.easeInOut(duration: Metrics.collapseDuration), value: model.isTargetTabPresent)
+        .animation(.easeInOut(duration: Metrics.collapseDuration), value: model.isReturnToTabCardVisible)
         .frame(height: TabSwitcherPill.compactSize)
         .id(model.targetTab.uid)
     }

--- a/iOS/DuckDuckGo/MainViewController+Segues.swift
+++ b/iOS/DuckDuckGo/MainViewController+Segues.swift
@@ -483,6 +483,7 @@ extension MainViewController {
                                                   contentBlockingAssetsPublisher: contentBlockingAssetsPublisher,
                                                   idleReturnEligibilityManager: idleReturnEligibilityManager,
                                                   afterInactivityOptionAdapter: afterInactivityOptionAdapter,
+                                                  lastTabShortcutAdapter: lastTabShortcutAdapter,
                                                   systemSettingsPiPTutorialManager: systemSettingsPiPTutorialManager,
                                                   runPrerequisitesDelegate: dbpIOSPublicInterface,
                                                   dataBrokerProtectionViewControllerProvider: dbpIOSPublicInterface,

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -189,6 +189,7 @@ class MainViewController: UIViewController {
     private let longPressBarMenuBuilder = LongPressBarMenuBuilder()
     let idleReturnEligibilityManager: IdleReturnEligibilityManaging
     let afterInactivityOptionAdapter: AfterInactivityOptionAdapter
+    let lastTabShortcutAdapter: LastTabShortcutAdapter
     let ntpAfterIdleInstrumentation: NTPAfterIdleInstrumentation
     let idleReturnTabCountInstrumentation: IdleReturnTabCountInstrumentation
     let postIdleSessionInstrumentation: PostIdleSessionInstrumentation
@@ -417,6 +418,7 @@ class MainViewController: UIViewController {
         featureFlagger: FeatureFlagger,
         idleReturnEligibilityManager: IdleReturnEligibilityManaging,
         afterInactivityOptionAdapter: AfterInactivityOptionAdapter,
+        lastTabShortcutAdapter: LastTabShortcutAdapter,
         lastActiveTabStore: LastActiveTabStoring = LastActiveTabStore(),
         syncAutoRestoreHandler: SyncAutoRestoreHandling,
         contentScopeExperimentsManager: ContentScopeExperimentsManaging,
@@ -499,6 +501,7 @@ class MainViewController: UIViewController {
         self.featureFlagger = featureFlagger
         self.idleReturnEligibilityManager = idleReturnEligibilityManager
         self.afterInactivityOptionAdapter = afterInactivityOptionAdapter
+        self.lastTabShortcutAdapter = lastTabShortcutAdapter
         self.lastActiveTabStore = lastActiveTabStore
         self.ntpAfterIdleInstrumentation = DefaultNTPAfterIdleInstrumentation(eligibilityManager: idleReturnEligibilityManager)
         self.idleReturnTabCountInstrumentation = DefaultIdleReturnTabCountInstrumentation(eligibilityManager: idleReturnEligibilityManager)
@@ -1585,70 +1588,57 @@ class MainViewController: UIViewController {
         viewCoordinator.omniBar.omniDelegate = self
     }
     
-    private func makeEscapeHatchModel(targetTab: Tab) -> EscapeHatchModel? {
-        if targetTab.fireTab {
-            if targetTab.link != nil || targetTab.isAITab {
-                return EscapeHatchModel(
-                    title: UserText.escapeHatchFireTabTitle,
-                    subtitle: "",
-                    tabType: .fire,
-                    domain: nil,
-                    targetTab: targetTab,
-                    tabsSource: tabManager,
-                    router: self,
-                    featureFlagger: featureFlagger,
-                    afterInactivityOptionAdapter: afterInactivityOptionAdapter
-                )
-            }
-            return nil
+    private lazy var escapeHatchModelBuilder = EscapeHatchModelBuilder(
+        tabManager: tabManager,
+        lastActiveTabStore: lastActiveTabStore,
+        idleReturnEligibilityManager: idleReturnEligibilityManager,
+        featureFlagger: featureFlagger,
+        afterInactivityOptionAdapter: afterInactivityOptionAdapter,
+        lastTabShortcutAdapter: lastTabShortcutAdapter,
+        instrumentation: ntpAfterIdleInstrumentation
+    )
+
+    /// Re-presents the tab switcher after a burn. No-op when the feature is off or the user has left the NTP.
+    private func restoreTabSwitcherOnlyHatchAfterBurn() {
+        guard featureFlagger.isFeatureOn(.escapeHatchHideShortcut),
+              let controller = newTabPageViewController,
+              let currentTab = tabManager.currentTabsModel.currentTab,
+              currentTab.fireTab == false else {
+            return
         }
-        if targetTab.isAITab {
-            return EscapeHatchModel(
-                title: targetTab.aiChatConversationTitle ?? UserText.omnibarFullAIChatModeDisplayTitle,
-                subtitle: UserText.omnibarFullAIChatModeDisplayTitle,
-                tabType: .aiChat,
-                domain: nil,
-                targetTab: targetTab,
-                tabsSource: tabManager,
-                router: self,
-                featureFlagger: featureFlagger,
-                afterInactivityOptionAdapter: afterInactivityOptionAdapter
-            )
+        let model = escapeHatchModelBuilder.makeTabSwitcherOnly(targetTab: currentTab, router: self)
+        controller.setEscapeHatch(model)
+        currentNTPEscapeHatch = model
+        configureUnifiedInputEscapeHatch(model)
+    }
+
+    /// True when an escape hatch action runs in focus mode (reads the persistent omnibar-session state, which
+    /// survives the card tap that dismisses the keyboard).
+    private var isEscapeHatchInFocusMode: Bool {
+        omniBar.isTextFieldEditing || unifiedToggleInputCoordinator?.isOmnibarSession == true
+    }
+
+    /// Restores the keyboard after an escape-hatch burn that started in focus mode, using the unified-input
+    /// session when active (symmetric with `dismissOmniBar`) and the legacy omnibar otherwise.
+    private func restoreFocusModeAfterBurnIfNeeded(wasInFocusMode: Bool) {
+        guard wasInFocusMode else { return }
+        if let coordinator = unifiedToggleInputCoordinator, coordinator.isOmnibarSession {
+            coordinator.activateInput()
+        } else {
+            enterSearch()
         }
-        if let link = targetTab.link {
-            let subtitle = link.url.host?.droppingWwwPrefix() ?? link.url.absoluteString
-            return EscapeHatchModel(
-                title: link.displayTitle,
-                subtitle: subtitle,
-                tabType: .regular,
-                domain: link.url.host,
-                targetTab: targetTab,
-                tabsSource: tabManager,
-                router: self,
-                featureFlagger: featureFlagger,
-                afterInactivityOptionAdapter: afterInactivityOptionAdapter
-            )
-        }
-        return nil
+    }
+
+    /// True for escape-hatch burns while the hide feature is on — these handle focus themselves in
+    /// `restoreFocusModeAfterBurnIfNeeded`, so the generic post-fire keyboard fallback is skipped for them.
+    /// With the feature off, escape-hatch burns keep the original fire behaviour.
+    private func isEscapeHatchHideBurn(_ request: FireRequest) -> Bool {
+        request.source == .escapeHatch && featureFlagger.isFeatureOn(.escapeHatchHideShortcut)
     }
 
     private func buildEscapeHatch(openedAfterIdle: Bool) -> EscapeHatchModel? {
-        guard openedAfterIdle,
-              idleReturnEligibilityManager.isEligibleForNTPAfterIdle() else {
-            return nil
-        }
-        let currentTab = tabManager.currentTabsModel.currentTab
-        if currentTab?.fireTab == true {
-            // Avoid showing a hatch on fire tabs
-            return nil
-        }
-        guard let lastUID = lastActiveTabStore.lastActiveNonEmptyTabUID,
-              let targetTab = tabManager.allTabsModel.tabs.first(where: { $0.uid == lastUID }),
-              targetTab !== currentTab else {
-            // Couldn't find the last active tab
-            return nil
-        }
-        return makeEscapeHatchModel(targetTab: targetTab)
+        guard openedAfterIdle else { return nil }
+        return escapeHatchModelBuilder.makeAfterIdleHatch(router: self)
     }
 
     fileprivate func attachHomeScreen(isNewTab: Bool = false, allowingKeyboard: Bool = false, previousTab: TabViewController? = nil, openedAfterIdle: Bool = false) {
@@ -4924,6 +4914,12 @@ extension MainViewController: EscapeHatchActionRouter {
             return
         }
 
+        // Keep the hatch (and the current focus state) so the card collapses to the expanded pill,
+        // consistent with the delete flow which also preserves focus.
+        if featureFlagger.isFeatureOn(.escapeHatchHideShortcut) {
+            return
+        }
+
         /// # TODO: Invoking `closeTab` removes the Escape Hatch from screen
         clearEscapeHatch()
         dismissOmniBar()
@@ -4936,6 +4932,8 @@ extension MainViewController: EscapeHatchActionRouter {
             return
         }
 
+        // Captured before the confirmation dialog steals focus, so we can restore the keyboard afterwards.
+        let wasInFocusMode = isEscapeHatchInFocusMode
         let tabViewModel = tabManager.viewModel(for: tab)
         let presenter = FireConfirmationPresenter()
         presenter.presentFireConfirmation(
@@ -4946,8 +4944,15 @@ extension MainViewController: EscapeHatchActionRouter {
             fireContext: .singleTab,
             browsingMode: tab.mode,
             onConfirm: { [weak self] fireRequest in
-                self?.forgetAllWithAnimation(request: fireRequest) {}
-                self?.clearEscapeHatch()
+                if self?.featureFlagger.isFeatureOn(.escapeHatchHideShortcut) == true {
+                    self?.forgetAllWithAnimation(request: fireRequest) { [weak self] in
+                        self?.restoreTabSwitcherOnlyHatchAfterBurn()
+                        self?.restoreFocusModeAfterBurnIfNeeded(wasInFocusMode: wasInFocusMode)
+                    }
+                } else {
+                    self?.forgetAllWithAnimation(request: fireRequest) {}
+                    self?.clearEscapeHatch()
+                }
                 self?.postIdleSessionInstrumentation.burnTabTapped()
             },
             onCancel: { }
@@ -4963,6 +4968,7 @@ extension MainViewController: EscapeHatchActionRouter {
             return
         }
 
+        let wasInFocusMode = isEscapeHatchInFocusMode
         let tabViewModel = tabManager.viewModel(for: tab)
         let request = FireRequest(
             options: .all,
@@ -4971,8 +4977,15 @@ extension MainViewController: EscapeHatchActionRouter {
             source: .escapeHatch
         )
 
-        forgetAllWithAnimation(request: request) {}
-        clearEscapeHatch()
+        if featureFlagger.isFeatureOn(.escapeHatchHideShortcut) {
+            forgetAllWithAnimation(request: request) { [weak self] in
+                self?.restoreTabSwitcherOnlyHatchAfterBurn()
+                self?.restoreFocusModeAfterBurnIfNeeded(wasInFocusMode: wasInFocusMode)
+            }
+        } else {
+            forgetAllWithAnimation(request: request) {}
+            clearEscapeHatch()
+        }
         ntpAfterIdleInstrumentation.escapeHatchBurnTapped(requiredConfirmation: false)
         postIdleSessionInstrumentation.burnTabTapped()
     }
@@ -4986,6 +4999,7 @@ extension MainViewController: EscapeHatchActionRouter {
         ntpAfterIdleInstrumentation.escapeHatchOptionChanged(to: option)
         postIdleSessionInstrumentation.openingScreenChanged()
     }
+
 }
 
 extension MainViewController: NewTabPageControllerDelegate {
@@ -5913,7 +5927,7 @@ extension MainViewController {
             Instruments.shared.endTimedEvent(for: spid)
             self.daxDialogsManager.resumeRegularFlow()
         } onTransitionCompleted: { [weak self] in
-            self?.presentPostBurnMessage(tabsCount: tabsCount)
+            self?.presentPostBurnMessage(tabsCount: tabsCount, request: request)
             transitionCompletion?()
         } completion: {
             self.subscriptionDataReporter.saveFireCount()
@@ -5921,7 +5935,8 @@ extension MainViewController {
             // Ideally this should happen once data clearing has finished AND the animation is finished
             if showNextDaxDialog {
                 self.newTabPageViewController?.showNextDaxDialog()
-            } else if request.options.contains(.tabs) && KeyboardSettings().onNewTab {
+            } else if request.options.contains(.tabs) && KeyboardSettings().onNewTab && !self.isEscapeHatchHideBurn(request) {
+                // With the hide feature on, escape-hatch burns restore focus in `restoreFocusModeAfterBurnIfNeeded`.
                 let showKeyboardAfterFireButton = DispatchWorkItem {
                     if !self.aiChatSettings.isAIChatSearchInputUserSettingsEnabled {
                         self.enterSearch()
@@ -5949,10 +5964,13 @@ extension MainViewController {
     }
     
     @MainActor
-    private func presentPostBurnMessage(tabsCount: Int) {
+    private func presentPostBurnMessage(tabsCount: Int, request: FireRequest) {
         let message = UserText.scopedFireConfirmationTabsDeletedToast(tabCount: tabsCount)
-        ActionMessageView.present(message: message,
-                                  presentationLocation: .withBottomBar(andAddressBarBottom: self.appSettings.currentAddressBarPosition.isBottom))
+        // Escape-hatch-hide burns restore the keyboard, which would cover a bottom toast — show it at the top.
+        let location: ActionMessageView.PresentationLocation = isEscapeHatchHideBurn(request)
+            ? .top
+            : .withBottomBar(andAddressBarBottom: self.appSettings.currentAddressBarPosition.isBottom)
+        ActionMessageView.present(message: message, presentationLocation: location)
     }
     
     private func refreshUIAfterClear() {

--- a/iOS/DuckDuckGo/ReturnToTabCard.swift
+++ b/iOS/DuckDuckGo/ReturnToTabCard.swift
@@ -173,50 +173,73 @@ struct ReturnToTabCard: View {
                 role: .none,
                 action: model.onCardTap
             )
-            if model.isFireTab {
-                // When the Fire button is enabled, deleting a fire tab is handled by that button instead.
-                if !model.isFireButtonEnabled {
-                    MenuActionButton(
-                        text: UserText.escapeHatchMenuDeleteTab,
-                        icon: DesignSystemImages.Glyphs.Size16.fire,
-                        role: .destructive,
-                        action: model.onBurnTabImmediately
-                    )
-                }
-            } else {
+            destructiveActionButtons
+            if model.isHideShortcutEnabled {
                 MenuActionButton(
-                    text: UserText.escapeHatchMenuCloseTab,
-                    icon: DesignSystemImages.Glyphs.Size16.closeOutline,
-                    role: .destructive,
-                    action: model.onCloseTab
+                    text: UserText.escapeHatchMenuDontShowThis,
+                    icon: DesignSystemImages.Glyphs.Size16.eyeClosed,
+                    role: .none,
+                    action: model.hideShortcut
                 )
-                // When the Fire button is enabled, deleting the tab is handled by that button instead.
-                if !model.isFireButtonEnabled {
-                    MenuActionButton(
-                        text: UserText.escapeHatchMenuDeleteTab,
-                        icon: DesignSystemImages.Glyphs.Size16.fire,
-                        role: .destructive,
-                        action: { model.onBurnTabWithConfirmation(menuFrameInWindow) }
-                    )
-                }
+            } else {
+                afterInactivityPicker
             }
-            Picker(selection: model.afterInactivityOptionBinding) {
-                ForEach(AfterInactivityOption.allCases, id: \.self) { option in
-                    Text(option.description)
-                        .tag(option)
-                }
-            } label: {
-                Text(UserText.settingsAfterInactivityLabel)
-                Text(model.afterInactivityOptionBinding.wrappedValue.description)
-                    .foregroundColor(.secondary)
-                    .font(.subheadline)
-
-                Image(uiImage: DesignSystemImages.Glyphs.Size16.settings)
-                    .foregroundColor(Color(designSystemColor: .icons))
-
-            }
-            .pickerStyle(.menu)
         }
+
+        // With the hide shortcut, the After Inactivity option moves to its own section, below a divider.
+        if model.isHideShortcutEnabled {
+            Section {
+                afterInactivityPicker
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var destructiveActionButtons: some View {
+        if model.isFireTab {
+            // When the Fire button is enabled, deleting is handled by that button instead of the menu.
+            if !model.isFireButtonEnabled {
+                MenuActionButton(
+                    text: UserText.escapeHatchMenuDeleteTab,
+                    icon: DesignSystemImages.Glyphs.Size16.fire,
+                    role: .destructive,
+                    action: model.onBurnTabImmediately
+                )
+            }
+        } else {
+            MenuActionButton(
+                text: UserText.escapeHatchMenuCloseTab,
+                icon: DesignSystemImages.Glyphs.Size16.closeOutline,
+                role: .destructive,
+                action: model.onCloseTab
+            )
+            if !model.isFireButtonEnabled {
+                MenuActionButton(
+                    text: UserText.escapeHatchMenuDeleteTab,
+                    icon: DesignSystemImages.Glyphs.Size16.fire,
+                    role: .destructive,
+                    action: { model.onBurnTabWithConfirmation(menuFrameInWindow) }
+                )
+            }
+        }
+    }
+
+    private var afterInactivityPicker: some View {
+        Picker(selection: model.afterInactivityOptionBinding) {
+            ForEach(AfterInactivityOption.allCases, id: \.self) { option in
+                Text(option.description)
+                    .tag(option)
+            }
+        } label: {
+            Text(UserText.settingsAfterInactivityLabel)
+            Text(model.afterInactivityOptionBinding.wrappedValue.description)
+                .foregroundColor(.secondary)
+                .font(.subheadline)
+
+            Image(uiImage: DesignSystemImages.Glyphs.Size16.settings)
+                .foregroundColor(Color(designSystemColor: .icons))
+        }
+        .pickerStyle(.menu)
     }
 
     private var swipeableActionsView: some View {

--- a/iOS/DuckDuckGo/SettingsGeneralView.swift
+++ b/iOS/DuckDuckGo/SettingsGeneralView.swift
@@ -83,6 +83,12 @@ struct SettingsGeneralView: View {
                         SettingsPickerCellView(label: UserText.settingsAfterInactivityIntervalLabel,
                                                options: AfterInactivityIdleInterval.allCases,
                                                selectedOption: viewModel.afterInactivityIdleIntervalBinding)
+
+                        if viewModel.shouldShowLastTabShortcutSetting {
+                            SettingsCellView(label: UserText.settingsLastTabShortcutLabel,
+                                             subtitle: UserText.settingsLastTabShortcutSubtitle,
+                                             accessory: .toggle(isOn: viewModel.lastTabShortcutEnabledBinding))
+                        }
                     }
                 }
             }

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -109,6 +109,7 @@ final class SettingsViewModel: ObservableObject {
 
     private let idleReturnEligibilityManager: IdleReturnEligibilityManaging
     private let afterInactivityOptionAdapter: AfterInactivityOptionAdapter
+    private let lastTabShortcutAdapter: LastTabShortcutAdapter
 
     // What's New Dependencies
     private let whatsNewCoordinator: ModalPromptProvider & OnDemandModalPromptProvider
@@ -392,6 +393,22 @@ final class SettingsViewModel: ObservableObject {
 
     var shouldShowNTPAfterIdleSetting: Bool {
         featureFlagger.isFeatureOn(.showNTPAfterIdleReturn)
+    }
+
+    var shouldShowLastTabShortcutSetting: Bool {
+        featureFlagger.isFeatureOn(.escapeHatchHideShortcut)
+    }
+
+    var lastTabShortcutEnabledBinding: Binding<Bool> {
+        Binding<Bool>(
+            get: { self.lastTabShortcutAdapter.isEnabled },
+            set: { newValue in
+                self.lastTabShortcutAdapter.setEnabled(newValue)
+                DailyPixel.fireDailyAndCount(
+                    pixel: newValue ? .ntpAfterIdleLastTabShortcutSettingEnabled : .ntpAfterIdleLastTabShortcutSettingDisabled
+                )
+            }
+        )
     }
 
     var idleTimeInterval: String {
@@ -954,6 +971,7 @@ final class SettingsViewModel: ObservableObject {
          contentBlockingAssetsPublisher: AnyPublisher<ContentBlockingUpdating.NewContent, Never>,
          idleReturnEligibilityManager: IdleReturnEligibilityManaging,
          afterInactivityOptionAdapter: AfterInactivityOptionAdapter,
+         lastTabShortcutAdapter: LastTabShortcutAdapter,
          systemSettingsPiPTutorialManager: SystemSettingsPiPTutorialManaging,
          runPrerequisitesDelegate: DBPIOSInterface.RunPrerequisitesDelegate?,
          dataBrokerProtectionViewControllerProvider: DBPIOSInterface.DataBrokerProtectionViewControllerProvider?,
@@ -995,6 +1013,7 @@ final class SettingsViewModel: ObservableObject {
         self.contentBlockingAssetsPublisher = contentBlockingAssetsPublisher
         self.idleReturnEligibilityManager = idleReturnEligibilityManager
         self.afterInactivityOptionAdapter = afterInactivityOptionAdapter
+        self.lastTabShortcutAdapter = lastTabShortcutAdapter
         self.afterInactivityIdleInterval = AfterInactivityIdleInterval(rawValue: idleReturnEligibilityManager.idleThresholdSeconds()) ?? .default
         self.systemSettingsPiPTutorialManager = systemSettingsPiPTutorialManager
         self.runPrerequisitesDelegate = runPrerequisitesDelegate
@@ -1012,6 +1031,7 @@ final class SettingsViewModel: ObservableObject {
         setupNotificationObservers()
         updateRecentlyVisitedSitesVisibility()
         startForwardingAdapterWillChangeEvents(afterInactivityOptionAdapter)
+        startForwardingAdapterWillChangeEvents(lastTabShortcutAdapter)
     }
 
     deinit {
@@ -1153,10 +1173,9 @@ extension SettingsViewModel {
         Task { await setupSubscriptionEnvironment() }
     }
 
-    /// Forward `AfterInactivityOptionAdapter.objectWillChange` Events:
-    /// This causes `model.afterInactivityOption` to react to `AfterInactivityOptionAdapter` changes
-    ///
-    private func startForwardingAdapterWillChangeEvents(_ adapter: AfterInactivityOptionAdapter) {
+    /// Forward an adapter's `objectWillChange` events so derived values (e.g. `afterInactivityOption`,
+    /// `lastTabShortcutEnabledBinding`) react to changes the adapter makes to the shared settings storage.
+    private func startForwardingAdapterWillChangeEvents(_ adapter: some ObservableObject) {
         adapter.objectWillChange
             .sink { [weak self] _ in
                 self?.objectWillChange.send()

--- a/iOS/DuckDuckGo/TabSwitcherPill.swift
+++ b/iOS/DuckDuckGo/TabSwitcherPill.swift
@@ -28,13 +28,15 @@ struct TabSwitcherPill: View {
 
     let count: Int
     let isExpanded: Bool
+    let showsEndArrow: Bool
     let onTap: () -> Void
 
     @StateObject private var tabCountModel: TabCountModel
 
-    init(count: Int, isExpanded: Bool = false, onTap: @escaping () -> Void) {
+    init(count: Int, isExpanded: Bool = false, showsEndArrow: Bool = true, onTap: @escaping () -> Void) {
         self.count = count
         self.isExpanded = isExpanded
+        self.showsEndArrow = showsEndArrow
         self.onTap = onTap
         // Seed the model with the correct count up front so the badge
         // renders with the number on the first frame instead of flashing empty.
@@ -82,9 +84,11 @@ struct TabSwitcherPill: View {
 
         Spacer(minLength: 0)
 
-        Image(uiImage: DesignSystemImages.Glyphs.Size24.arrowRight)
-            .foregroundColor(Color(designSystemColor: .icons))
-            .transition(.move(edge: .trailing).combined(with: .opacity))
+        if showsEndArrow {
+            Image(uiImage: DesignSystemImages.Glyphs.Size24.arrowRight)
+                .foregroundColor(Color(designSystemColor: .icons))
+                .transition(.move(edge: .trailing).combined(with: .opacity))
+        }
     }
 
     private enum Metrics {

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -253,6 +253,7 @@ final class MainCoordinator {
             keyValueStore: keyValueStore,
             idleReturnEligibilityManager: idleReturnEligibilityManager
         )
+        let lastTabShortcutAdapter = LastTabShortcutAdapter(keyValueStore: keyValueStore)
         controller = MainViewController(privacyConfigurationManager: privacyConfigurationManager,
                                         bookmarksDatabase: bookmarksDatabase,
                                         historyManager: historyManager,
@@ -275,6 +276,7 @@ final class MainCoordinator {
                                         featureFlagger: featureFlagger,
                                         idleReturnEligibilityManager: idleReturnEligibilityManager,
                                         afterInactivityOptionAdapter: afterInactivityOptionAdapter,
+                                        lastTabShortcutAdapter: lastTabShortcutAdapter,
                                         syncAutoRestoreHandler: syncAutoRestoreHandler,
                                         contentScopeExperimentsManager: contentScopeExperimentManager,
                                         fireproofing: fireproofing,

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -1637,6 +1637,8 @@ public struct UserText {
     public static let settingsAfterInactivityIntervalLabel = NSLocalizedString("settings.afterInactivity.interval.label", value: "Inactivity Timer", comment: "Settings picker label for the inactivity duration before showing New Tab")
     public static let settingsAfterInactivityIdleIntervalNone = NSLocalizedString("settings.afterInactivity.idle.interval.none", value: "None", comment: "Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold)")
     public static let settingsAfterInactivityFooterNone = NSLocalizedString("settings.afterInactivity.footer.none", value: "Choose what you see when you return to DuckDuckGo.", comment: "Section footer when no inactivity timer is set or the Last Used Tab option is selected")
+    public static let settingsLastTabShortcutLabel = NotLocalizedString("settings.lastTabShortcut.label", value: "Last Tab Shortcut", comment: "Settings toggle label for showing a shortcut back to the last used tab on the New Tab Page after inactivity. Not translated; final copy will land in a follow-up PR.")
+    public static let settingsLastTabShortcutSubtitle = NotLocalizedString("settings.lastTabShortcut.subtitle", value: "Displays a link to quickly revisit the last opened tab when you launch the app after inactivity.", comment: "Settings toggle subtitle describing the Last Tab Shortcut option. Not translated; final copy will land in a follow-up PR.")
 
     // Escape Hatch (Return to Tab Card)
     public static let escapeHatchReturnToLabel = NSLocalizedString("escapeHatch.returnTo.label", value: "Return to…", comment: "Label shown on the escape hatch card above the tab title")
@@ -1648,6 +1650,7 @@ public struct UserText {
     public static let escapeHatchMenuReturnToTab = NSLocalizedString("escapeHatch.menu.returnToTab", value: "Return to Tab", comment: "Menu item that returns the user to the open tab from the escape hatch card")
     public static let escapeHatchMenuCloseTab = NSLocalizedString("escapeHatch.menu.closeTab", value: "Close Tab", comment: "Menu item that closes the open tab referenced by the escape hatch card")
     public static let escapeHatchMenuDeleteTab = NSLocalizedString("escapeHatch.menu.deleteTab", value: "Delete Tab", comment: "Menu item that deletes (closes and clears data for) the tab referenced by the escape hatch card")
+    public static let escapeHatchMenuDontShowThis = NotLocalizedString("escapeHatch.menu.dontShowThis", value: "Don’t Show This", comment: "Menu item that hides the 'Return to tab' shortcut so only the tab switcher is shown after inactivity. Not translated; final copy will land in a follow-up PR.")
     public static let escapeHatchTabSwitcherPrivateTabsLabel = NSLocalizedString("escapeHatch.tabSwitcher.privateTabs.label", value: "Private Tabs", comment: "Label shown next to the tab count when the escape hatch's tab switcher pill is in its expanded form")
 
     // Subscription Section

--- a/iOS/DuckDuckGoTests/EscapeHatchModelTests.swift
+++ b/iOS/DuckDuckGoTests/EscapeHatchModelTests.swift
@@ -48,7 +48,11 @@ struct EscapeHatchModelTests {
         }
     }
 
-    private func makeSUT(targetTab: Tab, router: EscapeHatchActionRouter, featureFlagger: FeatureFlagger = MockFeatureFlagger()) -> EscapeHatchModel {
+    private func makeSUT(targetTab: Tab,
+                         router: EscapeHatchActionRouter,
+                         featureFlagger: FeatureFlagger = MockFeatureFlagger(),
+                         lastTabShortcutAdapter: LastTabShortcutAdapter = LastTabShortcutAdapter(keyValueStore: MockKeyValueFileStore()),
+                         onShortcutHidden: @escaping () -> Void = {}) -> EscapeHatchModel {
         EscapeHatchModel(
             title: "title",
             subtitle: "subtitle",
@@ -61,7 +65,9 @@ struct EscapeHatchModelTests {
             afterInactivityOptionAdapter: AfterInactivityOptionAdapter(
                 initialOption: .lastUsedTab,
                 keyValueStore: MockKeyValueFileStore()
-            )
+            ),
+            lastTabShortcutAdapter: lastTabShortcutAdapter,
+            onShortcutHidden: onShortcutHidden
         )
     }
 
@@ -127,5 +133,64 @@ struct EscapeHatchModelTests {
                           featureFlagger: flagger)
 
         #expect(sut.isFireButtonEnabled == true)
+    }
+
+    @available(iOS 16, *)
+    @Test("isHideShortcutEnabled tracks the escapeHatchHideShortcut flag", .timeLimit(.minutes(1)))
+    func hideShortcutEnabledTracksFlag() {
+        let off = makeSUT(targetTab: Tab(uid: "tab"), router: SpyRouter(), featureFlagger: MockFeatureFlagger())
+        #expect(off.isHideShortcutEnabled == false)
+
+        let on = makeSUT(targetTab: Tab(uid: "tab"),
+                         router: SpyRouter(),
+                         featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.escapeHatchHideShortcut]))
+        #expect(on.isHideShortcutEnabled == true)
+    }
+
+    @available(iOS 16, *)
+    @Test("hideShortcut disables the setting and reports telemetry", .timeLimit(.minutes(1)))
+    func hideShortcutDisablesAndReports() {
+        let adapter = LastTabShortcutAdapter(keyValueStore: MockKeyValueFileStore())
+        var hiddenReports = 0
+        let sut = makeSUT(targetTab: Tab(uid: "tab"),
+                          router: SpyRouter(),
+                          featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.escapeHatchHideShortcut]),
+                          lastTabShortcutAdapter: adapter,
+                          onShortcutHidden: { hiddenReports += 1 })
+
+        sut.hideShortcut()
+
+        #expect(adapter.isEnabled == false)
+        #expect(hiddenReports == 1)
+    }
+
+    @available(iOS 16, *)
+    @Test("Card is hidden when the shortcut is disabled and the hide feature is available", .timeLimit(.minutes(1)))
+    func cardHiddenWhenShortcutDisabled() {
+        let adapter = LastTabShortcutAdapter(keyValueStore: MockKeyValueFileStore())
+        let sut = makeSUT(targetTab: Tab(uid: "tab"),
+                          router: SpyRouter(),
+                          featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.escapeHatchHideShortcut]),
+                          lastTabShortcutAdapter: adapter)
+
+        // Target tab is present, so the card is visible while the shortcut is enabled.
+        #expect(sut.isReturnToTabCardVisible == true)
+
+        adapter.setEnabled(false)
+        #expect(sut.isReturnToTabCardVisible == false)
+    }
+
+    @available(iOS 16, *)
+    @Test("Shortcut is always considered enabled when the hide feature is unavailable", .timeLimit(.minutes(1)))
+    func shortcutAlwaysEnabledWhenFeatureUnavailable() {
+        let adapter = LastTabShortcutAdapter(keyValueStore: MockKeyValueFileStore())
+        adapter.setEnabled(false)
+        let sut = makeSUT(targetTab: Tab(uid: "tab"),
+                          router: SpyRouter(),
+                          featureFlagger: MockFeatureFlagger(),
+                          lastTabShortcutAdapter: adapter)
+
+        #expect(sut.isLastTabShortcutEnabled == true)
+        #expect(sut.isReturnToTabCardVisible == true)
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
@@ -140,6 +140,13 @@
         "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
+    "m_ntp_after_idle_escape_hatch_hidden_from_menu": {
+        "description": "Fires when the user hides the Return-to-tab shortcut via the 'Don't Show This' item in the NTP escape hatch card menu.",
+        "owners": ["SabrinaTardio"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
     "m_ntp_after_idle_setting_changed_to_new_tab": {
         "description": "Fires when the user changes the after-inactivity setting to New Tab.",
         "owners": ["SabrinaTardio"],
@@ -149,6 +156,20 @@
     },
     "m_ntp_after_idle_setting_changed_to_last_used_tab": {
         "description": "Fires when the user changes the after-inactivity setting to Last Used Tab.",
+        "owners": ["SabrinaTardio"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_last_tab_shortcut_setting_enabled": {
+        "description": "Fires when the user enables the Last Tab Shortcut from the General settings toggle.",
+        "owners": ["SabrinaTardio"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_last_tab_shortcut_setting_disabled": {
+        "description": "Fires when the user disables the Last Tab Shortcut from the General settings toggle.",
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "platform", "form_factor"],

--- a/iOS/SharedStateTests/OnboardingDaxFavouritesTests.swift
+++ b/iOS/SharedStateTests/OnboardingDaxFavouritesTests.swift
@@ -182,6 +182,7 @@ private final class MockIdleReturnEligibilityManagerForMainVC: IdleReturnEligibi
             featureFlagger: featureFlagger,
             idleReturnEligibilityManager: MockIdleReturnEligibilityManagerForMainVC(),
             afterInactivityOptionAdapter: AfterInactivityOptionAdapter(initialOption: .lastUsedTab, keyValueStore: keyValueStore),
+            lastTabShortcutAdapter: LastTabShortcutAdapter(keyValueStore: keyValueStore),
             syncAutoRestoreHandler: syncAutoRestoreHandler,
             contentScopeExperimentsManager: MockContentScopeExperimentManager(),
             fireproofing: fireproofing,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1215446306854273
Tech Design URL:
CC:

### Description

Adds a way to hide the after-idle "Return to tab" escape hatch, behind the `escapeHatchHideShortcut` flag (default on). Flag off ⇒ existing escape hatch unchanged.

- **Settings → "Last Tab Shortcut"** toggle and a **"Don't Show This"** card-menu action — shared + persisted.
- When hidden, after idle only the **expanded tab switcher** shows (even with one tab); it drops the trailing arrow and left-aligns its label whenever the flag is on.
- The tab switcher is kept after closing/deleting the hatch's tab, and focus mode (keyboard) is restored on delete-while-editing.
- FF registry: https://app.asana.com/1/137249556945/project/1211834678943996/task/1215530020470713

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->

**Terminology:** the escape hatch = the **Return to Tab card** plus the **tab switcher** beside it. The tab switcher has two states — **collapsed** (small, showing the tab count, sits next to the card) and **expanded** (full-width, showing the count + "Private Tabs" label).

**Setup**
1. Debug → Feature Flags: enable `showNTPAfterIdleReturn`, `escapeHatchActions`, `escapeHatchHideShortcut`.
2. Settings → General → **After Inactivity = New Tab**, and **Inactivity Timer = None** (shows the after-idle NTP on every return, so no waiting).
3. To trigger the hatch: open a website in a tab → background the app → reopen → you land on a New Tab Page with the escape hatch. Keep ≥2 tabs for the card cases.

**Core feature (flag on)**
4. After idle, the hatch shows the **Return to Tab card + collapsed tab switcher**.
5. Settings → General shows a **"Last Tab Shortcut"** toggle (with subtitle), **on** by default, in the After-Inactivity group.
6. Card ⋯ menu order: Return to Tab → Close/Delete → **Don't Show This** (eye-slash), then a **divider**, then **After Inactivity**.
7. Tap **Don't Show This** → the card collapses away, the **tab switcher expands** to fill the row, and the Settings toggle is now **off**.
8. The **expanded tab switcher** has **no trailing arrow** and shows **`[count] Private Tabs` left-aligned**.
9. Re-enable **Last Tab Shortcut** → after idle the **real Return to Tab card returns** (title + favicon), not an empty card.
10. Tap the **tab switcher** → opens the tab switcher screen. The **After Inactivity** submenu still switches New Tab / Last Used Tab.

**Edge cases (flag on)**
11. **Single tab + shortcut hidden:** with the toggle off and only the NTP tab open, after idle the **expanded tab switcher still shows**.
12. **Tab switcher stays after Close:** Close Tab from the card → the card collapses and the **tab switcher stays**.
13. **Tab switcher stays after Delete/burn:** tap the fire icon (or Delete Tab) → after the fire animation the **tab switcher stays**.
14. **Keyboard restore on delete in focus mode:** focus the address bar → delete the hatch's tab via the fire icon → after the animation the **keyboard returns** and the tab switcher is shown.
15. **Toggle on while the expanded tab switcher is showing:** flip Last Tab Shortcut back on → no empty card flashes.

**Regression (flag off — disable `escapeHatchHideShortcut`)**
16. After idle, when the card collapses the **expanded tab switcher shows the arrow** again.
17. Card ⋯ menu has **no "Don't Show This"** and **no divider** before After Inactivity (single section); **no "Last Tab Shortcut"** toggle in Settings.
18. Closing/deleting the tab from the hatch tears the hatch down as before (no lingering tab switcher).

### Impact and Risks

Low. All new behavior is behind `escapeHatchHideShortcut` (ships default-on, remotely controllable). With the flag off the existing escape hatch experience is unchanged.

#### What could go wrong?
- The post-burn home-screen refresh could tear the tab switcher down — mitigated by re-presenting it in the burn transition-completion callback.
- Re-enabling the shortcut could surface an empty card — mitigated by building a tab-switcher-only model (`hasReturnToTabCard == false`) when there's no tab to return to.

### Notes to Reviewer
- The feature flag ships **default-on** (intentional).
- New pixels (declared in `ntp_after_idle.json5`): `…escape_hatch_hidden_from_menu`, `…last_tab_shortcut_setting_enabled/disabled`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is gated by a remote flag (default on) with the legacy path unchanged when off; main risk is NTP/keyboard/fire interaction edge cases around the new post-burn hatch restore.
> 
> **Overview**
> Adds **`escapeHatchHideShortcut`** (remote, default on) so users can hide the after-idle **Return to tab** card while keeping the tab switcher.
> 
> A shared **`LastTabShortcutAdapter`** persists the preference (defaults on). **Settings → General** gets a **Last Tab Shortcut** toggle when After Inactivity is New Tab; the card menu adds **Don't Show This**, which turns the setting off and collapses the card. Visibility is driven by **`isReturnToTabCardVisible`** instead of only whether the target tab exists.
> 
> When the shortcut is hidden, **`EscapeHatchModelBuilder`** can show a **tab-switcher-only** hatch (`hasReturnToTabCard == false`), including with a single tab. The expanded pill drops the trailing arrow while the flag is on. **Close/delete/burn** from the hatch no longer tears down the UI when the flag is on; burns **re-present** the tab-switcher hatch, **restore focus mode** after delete, skip the generic post-fire keyboard path, and show the burn toast at the **top** so it isn’t covered by the keyboard.
> 
> Escape hatch construction moves out of **`MainViewController`** into **`EscapeHatchModelBuilder`**. New NTP-after-idle pixels cover hiding from the menu and toggling the setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1791ce3bed3e46e2576606e861c08e2d48cec1e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->