### PR TITLE
Make system extension requests cancellation-safe

### DIFF
--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
@@ -549,11 +549,15 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
                 NetworkProtectionPixelEvent.networkProtectionSystemExtensionActivationSuccess,
                 frequency: .dailyAndCount,
                 includeAppVersionParameter: true)
+        } catch is CancellationError {
+            throw StartError.cancelled
         } catch {
             switch error {
             case OSSystemExtensionError.requestSuperseded:
                 // Even if the installation request is superseded we want to show the message that tells the user
                 // to go to System Settings to allow the extension
+                controllerErrorStore.lastErrorMessage = UserText.networkProtectionSystemSettings
+            case SystemExtensionRequestError.requestTimedOut:
                 controllerErrorStore.lastErrorMessage = UserText.networkProtectionSystemSettings
             case SystemExtensionRequestError.unknownRequestResult:
                 controllerErrorStore.lastErrorMessage = UserText.networkProtectionUnknownActivationError
@@ -686,18 +690,21 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
             VPNOperationErrorRecorder().recordControllerStartFailure(error)
             knownFailureStore.lastKnownFailure = KnownFailure(error)
 
+            let isCancelled: Bool
             if case StartError.cancelled = error {
+                isCancelled = true
                 PixelKit.fire(
                     NetworkProtectionPixelEvent.networkProtectionControllerStartCancelled, frequency: .legacyDailyAndCount, includeAppVersionParameter: true
                 )
             } else {
+                isCancelled = false
                 PixelKit.fire(
                     NetworkProtectionPixelEvent.networkProtectionControllerStartFailure(error), frequency: .legacyDailyAndCount, includeAppVersionParameter: true
                 )
             }
 
             // Always keep the first error message shown, as it's the more actionable one.
-            if controllerErrorStore.lastErrorMessage == nil {
+            if controllerErrorStore.lastErrorMessage == nil && !isCancelled {
                 controllerErrorStore.lastErrorMessage = error.localizedDescription
             }
 

--- a/macOS/LocalPackages/SystemExtensionManager/Sources/SystemExtensionManager/SystemExtensionManager.swift
+++ b/macOS/LocalPackages/SystemExtensionManager/Sources/SystemExtensionManager/SystemExtensionManager.swift
@@ -22,9 +22,27 @@ import Combine
 import os.log
 import SystemExtensions
 
-public enum SystemExtensionRequestError: Error {
+protocol SystemExtensionRequestManaging: AnyObject {
+    func submitRequest(_ request: OSSystemExtensionRequest)
+}
+
+extension OSSystemExtensionManager: SystemExtensionRequestManaging {}
+
+public enum SystemExtensionRequestError: Error, Equatable, LocalizedError {
     case unknownRequestResult
     case willActivateAfterReboot
+    case requestTimedOut
+
+    public var errorDescription: String? {
+        switch self {
+        case .unknownRequestResult:
+            return "System extension request returned an unknown result."
+        case .willActivateAfterReboot:
+            return "System extension request will complete after reboot."
+        case .requestTimedOut:
+            return "System extension request timed out."
+        }
+    }
 }
 
 public enum SystemExtensionActivationState: Equatable {
@@ -50,26 +68,46 @@ public struct SystemExtensionPropertiesSnapshot: Equatable {
 
 public struct SystemExtensionManager {
 
-    private static var systemSettingsSecurityURL: String {
+    private static let defaultRequestTimeout: TimeInterval = 120
+    private static let networkExtensionSettingsExtensionPointIdentifier = "com.apple.system_extension.network_extension.extension-point"
+
+    static func systemSettingsURLString(forExtensionWithIdentifier extensionBundleID: String) -> String {
         if #available(macOS 15, *) {
-            return "x-apple.systempreferences:com.apple.LoginItems-Settings.extension?ExtensionItems"
+            let extensionPointIdentifier = percentEncodedQueryValue(networkExtensionSettingsExtensionPointIdentifier)
+            let extensionIdentifier = percentEncodedQueryValue(extensionBundleID)
+            return "x-apple.systempreferences:com.apple.ExtensionsPreferences?extensionPointIdentifier=\(extensionPointIdentifier)&extensionIdentifier=\(extensionIdentifier)"
         } else {
             return "x-apple.systempreferences:com.apple.preference.security?Security"
         }
     }
 
     private let extensionBundleID: String
-    private let manager: OSSystemExtensionManager
+    private let manager: any SystemExtensionRequestManaging
     private let workspace: NSWorkspace
+    private let requestTimeout: TimeInterval
 
     public init(
         extensionBundleID: String,
         manager: OSSystemExtensionManager = .shared,
         workspace: NSWorkspace = .shared) {
 
+        self.init(
+            extensionBundleID: extensionBundleID,
+            manager: manager as any SystemExtensionRequestManaging,
+            workspace: workspace,
+            requestTimeout: Self.defaultRequestTimeout)
+    }
+
+    init(
+        extensionBundleID: String,
+        manager: any SystemExtensionRequestManaging,
+        workspace: NSWorkspace = .shared,
+        requestTimeout: TimeInterval = Self.defaultRequestTimeout) {
+
         self.extensionBundleID = extensionBundleID
         self.manager = manager
         self.workspace = workspace
+        self.requestTimeout = requestTimeout
     }
 
     /// - Returns: The system extension version when it's updated, otherwise `nil`.
@@ -81,7 +119,8 @@ public struct SystemExtensionManager {
         let activationRequest = SystemExtensionRequest.activationRequest(
             forExtensionWithIdentifier: extensionBundleID,
             manager: manager,
-            waitingForUserApproval: waitingForUserApproval)
+            waitingForUserApproval: waitingForUserApproval,
+            requestTimeout: requestTimeout)
 
         try await activationRequest.submit()
 
@@ -121,7 +160,8 @@ public struct SystemExtensionManager {
     public func deactivate() async throws {
         try await SystemExtensionRequest.deactivationRequest(
             forExtensionWithIdentifier: extensionBundleID,
-            manager: manager)
+            manager: manager,
+            requestTimeout: requestTimeout)
         .submit()
     }
 
@@ -133,7 +173,8 @@ public struct SystemExtensionManager {
         do {
             let properties = try await SystemExtensionPropertiesRequest.properties(
                 forExtensionWithIdentifier: extensionBundleID,
-                manager: manager
+                manager: manager,
+                requestTimeout: requestTimeout
             )
             let snapshots = properties.map {
                 SystemExtensionPropertiesSnapshot(
@@ -143,6 +184,8 @@ public struct SystemExtensionManager {
                 )
             }
             return Self.activationState(from: snapshots)
+        } catch is CancellationError {
+            return .unknown
         } catch {
             Logger.systemExtensionManager.error("""
             Failed to query system extension state
@@ -205,27 +248,43 @@ public struct SystemExtensionManager {
     }
 
     private func openSystemSettingsSecurity() {
-        let url = URL(string: Self.systemSettingsSecurityURL)!
+        let url = URL(string: Self.systemSettingsURLString(forExtensionWithIdentifier: extensionBundleID))!
         workspace.open(url)
+    }
+
+    private static func percentEncodedQueryValue(_ value: String) -> String {
+        var allowedCharacters = CharacterSet.urlQueryAllowed
+        allowedCharacters.remove(charactersIn: "&=?")
+        return value.addingPercentEncoding(withAllowedCharacters: allowedCharacters) ?? value
     }
 }
 
 private final class SystemExtensionPropertiesRequest: NSObject {
 
     private let request: OSSystemExtensionRequest
-    private let manager: OSSystemExtensionManager
+    private let manager: any SystemExtensionRequestManaging
+    private let requestTimeout: TimeInterval
+    private let lock = NSLock()
     private var continuation: CheckedContinuation<[OSSystemExtensionProperties], Error>?
+    private var timeoutTask: Task<Void, Never>?
+    private var cancellationWasRequested = false
 
-    private init(request: OSSystemExtensionRequest, manager: OSSystemExtensionManager) {
+    private init(request: OSSystemExtensionRequest,
+                 manager: any SystemExtensionRequestManaging,
+                 requestTimeout: TimeInterval) {
         self.request = request
         self.manager = manager
+        self.requestTimeout = requestTimeout
         super.init()
     }
 
-    static func properties(forExtensionWithIdentifier bundleId: String, manager: OSSystemExtensionManager) async throws -> [OSSystemExtensionProperties] {
+    static func properties(forExtensionWithIdentifier bundleId: String,
+                           manager: any SystemExtensionRequestManaging,
+                           requestTimeout: TimeInterval) async throws -> [OSSystemExtensionProperties] {
         let query = SystemExtensionPropertiesRequest(
             request: .propertiesRequest(forExtensionWithIdentifier: bundleId, queue: .global()),
-            manager: manager
+            manager: manager,
+            requestTimeout: requestTimeout
         )
         // OSSystemExtensionRequest.delegate is weak. Without an explicit lifetime extension,
         // the compiler may release `query` during the await, niling the delegate before the
@@ -235,26 +294,66 @@ private final class SystemExtensionPropertiesRequest: NSObject {
     }
 
     private func submit() async throws -> [OSSystemExtensionProperties] {
-        try await withCheckedThrowingContinuation { continuation in
-            self.continuation = continuation
-            request.delegate = self
-            manager.submitRequest(request)
+        try Task.checkCancellation()
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                submit(with: continuation)
+            }
+        } onCancel: {
+            complete(with: .failure(CancellationError()))
+        }
+    }
+
+    private func submit(with continuation: CheckedContinuation<[OSSystemExtensionProperties], Error>) {
+        lock.lock()
+        assert(self.continuation == nil, "Request can only be submitted once")
+        guard !cancellationWasRequested else {
+            lock.unlock()
+            continuation.resume(throwing: CancellationError())
+            return
+        }
+
+        self.continuation = continuation
+        timeoutTask = makeTimeoutTask()
+        lock.unlock()
+
+        request.delegate = self
+
+        guard !Task.isCancelled else {
+            complete(with: .failure(CancellationError()))
+            return
+        }
+
+        manager.submitRequest(request)
+    }
+
+    private func makeTimeoutTask() -> Task<Void, Never> {
+        let requestTimeout = max(0, requestTimeout)
+
+        return Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(requestTimeout * Double(NSEC_PER_SEC)))
+            guard !Task.isCancelled else {
+                return
+            }
+
+            self?.complete(with: .failure(SystemExtensionRequestError.requestTimedOut))
         }
     }
 
     private func complete(with result: Result<[OSSystemExtensionProperties], Error>) {
-        guard let continuation else {
-            return
+        lock.lock()
+        let pendingContinuation = continuation
+        continuation = nil
+        let pendingTimeoutTask = timeoutTask
+        timeoutTask = nil
+        if case .failure(let error) = result, error is CancellationError {
+            cancellationWasRequested = true
         }
+        lock.unlock()
 
-        self.continuation = nil
-
-        switch result {
-        case .success(let properties):
-            continuation.resume(returning: properties)
-        case .failure(let error):
-            continuation.resume(throwing: error)
-        }
+        pendingTimeoutTask?.cancel()
+        pendingContinuation?.resume(with: result)
     }
 }
 
@@ -350,39 +449,111 @@ extension SystemExtensionActivationStateObserver: OSSystemExtensionsWorkspaceObs
 final class SystemExtensionRequest: NSObject {
 
     private let request: OSSystemExtensionRequest
-    private let manager: OSSystemExtensionManager
+    private let manager: any SystemExtensionRequestManaging
     private let waitingForUserApproval: (() -> Void)?
+    private let requestTimeout: TimeInterval
     private(set) var version: String?
 
+    private let lock = NSLock()
     private var continuation: CheckedContinuation<Void, Error>?
+    private var timeoutTask: Task<Void, Never>?
+    private var cancellationWasRequested = false
 
-    private init(request: OSSystemExtensionRequest, manager: OSSystemExtensionManager, waitingForUserApproval: (() -> Void)? = nil) {
+    private init(request: OSSystemExtensionRequest,
+                 manager: any SystemExtensionRequestManaging,
+                 waitingForUserApproval: (() -> Void)? = nil,
+                 requestTimeout: TimeInterval) {
         self.manager = manager
         self.request = request
         self.waitingForUserApproval = waitingForUserApproval
+        self.requestTimeout = requestTimeout
 
         super.init()
     }
 
-    static func activationRequest(forExtensionWithIdentifier bundleId: String, manager: OSSystemExtensionManager, waitingForUserApproval: (() -> Void)?) -> Self {
-        self.init(request: .activationRequest(forExtensionWithIdentifier: bundleId, queue: .global()), manager: manager, waitingForUserApproval: waitingForUserApproval)
+    static func activationRequest(forExtensionWithIdentifier bundleId: String,
+                                  manager: any SystemExtensionRequestManaging,
+                                  waitingForUserApproval: (() -> Void)?,
+                                  requestTimeout: TimeInterval) -> Self {
+        self.init(
+            request: .activationRequest(forExtensionWithIdentifier: bundleId, queue: .global()),
+            manager: manager,
+            waitingForUserApproval: waitingForUserApproval,
+            requestTimeout: requestTimeout)
     }
 
-    static func deactivationRequest(forExtensionWithIdentifier bundleId: String, manager: OSSystemExtensionManager) -> Self {
-        self.init(request: .deactivationRequest(forExtensionWithIdentifier: bundleId, queue: .global()), manager: manager)
+    static func deactivationRequest(forExtensionWithIdentifier bundleId: String,
+                                    manager: any SystemExtensionRequestManaging,
+                                    requestTimeout: TimeInterval) -> Self {
+        self.init(
+            request: .deactivationRequest(forExtensionWithIdentifier: bundleId, queue: .global()),
+            manager: manager,
+            requestTimeout: requestTimeout)
     }
 
     /// Submit the request
     ///
     func submit() async throws {
-        assert(continuation == nil, "Request can only be submitted once")
+        try Task.checkCancellation()
 
-        try await withCheckedThrowingContinuation { continuation in
-            self.continuation = continuation
-
-            request.delegate = self
-            manager.submitRequest(request)
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                submit(with: continuation)
+            }
+        } onCancel: {
+            complete(with: .failure(CancellationError()))
         }
+    }
+
+    private func submit(with continuation: CheckedContinuation<Void, Error>) {
+        lock.lock()
+        assert(self.continuation == nil, "Request can only be submitted once")
+        guard !cancellationWasRequested else {
+            lock.unlock()
+            continuation.resume(throwing: CancellationError())
+            return
+        }
+
+        self.continuation = continuation
+        timeoutTask = makeTimeoutTask()
+        lock.unlock()
+
+        request.delegate = self
+
+        guard !Task.isCancelled else {
+            complete(with: .failure(CancellationError()))
+            return
+        }
+
+        manager.submitRequest(request)
+    }
+
+    private func makeTimeoutTask() -> Task<Void, Never> {
+        let requestTimeout = max(0, requestTimeout)
+
+        return Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(requestTimeout * Double(NSEC_PER_SEC)))
+            guard !Task.isCancelled else {
+                return
+            }
+
+            self?.complete(with: .failure(SystemExtensionRequestError.requestTimedOut))
+        }
+    }
+
+    private func complete(with result: Result<Void, Error>) {
+        lock.lock()
+        let pendingContinuation = continuation
+        continuation = nil
+        let pendingTimeoutTask = timeoutTask
+        timeoutTask = nil
+        if case .failure(let error) = result, error is CancellationError {
+            cancellationWasRequested = true
+        }
+        lock.unlock()
+
+        pendingTimeoutTask?.cancel()
+        pendingContinuation?.resume(with: result)
     }
 
     private func updateVersion(to version: String) {
@@ -419,27 +590,23 @@ extension SystemExtensionRequest: OSSystemExtensionRequestDelegate {
         switch result {
         case .completed:
             updateVersionNumberIfMissing()
-            continuation?.resume()
-            continuation = nil
+            complete(with: .success(()))
         case .willCompleteAfterReboot:
             Logger.systemExtensionManager.notice("System extension request will complete after reboot: \(request.identifier, privacy: .public)")
-            continuation?.resume(throwing: SystemExtensionRequestError.willActivateAfterReboot)
-            continuation = nil
+            complete(with: .failure(SystemExtensionRequestError.willActivateAfterReboot))
             return
         @unknown default:
             // Not much we can do about this, so we just let the owning app decide
             // what to do about this.
             Logger.systemExtensionManager.error("System extension request returned unknown result \(result.rawValue, privacy: .public) for \(request.identifier, privacy: .public)")
-            continuation?.resume(throwing: SystemExtensionRequestError.unknownRequestResult)
-            continuation = nil
+            complete(with: .failure(SystemExtensionRequestError.unknownRequestResult))
             return
         }
     }
 
     func request(_ request: OSSystemExtensionRequest, didFailWithError error: Error) {
         Self.logRequestFailure(error: error, request: request)
-        continuation?.resume(throwing: error)
-        continuation = nil
+        complete(with: .failure(error))
     }
 
     private static func logRequestFailure(error: Error, request: OSSystemExtensionRequest) {

--- a/macOS/LocalPackages/SystemExtensionManager/Sources/SystemExtensionManager/SystemExtensionManager.swift
+++ b/macOS/LocalPackages/SystemExtensionManager/Sources/SystemExtensionManager/SystemExtensionManager.swift
@@ -28,21 +28,10 @@ protocol SystemExtensionRequestManaging: AnyObject {
 
 extension OSSystemExtensionManager: SystemExtensionRequestManaging {}
 
-public enum SystemExtensionRequestError: Error, Equatable, LocalizedError {
+public enum SystemExtensionRequestError: Error, Equatable {
     case unknownRequestResult
     case willActivateAfterReboot
     case requestTimedOut
-
-    public var errorDescription: String? {
-        switch self {
-        case .unknownRequestResult:
-            return "System extension request returned an unknown result."
-        case .willActivateAfterReboot:
-            return "System extension request will complete after reboot."
-        case .requestTimedOut:
-            return "System extension request timed out."
-        }
-    }
 }
 
 public enum SystemExtensionActivationState: Equatable {

--- a/macOS/LocalPackages/SystemExtensionManager/Tests/SystemExtensionManagerTests/SystemExtensionManagerTests.swift
+++ b/macOS/LocalPackages/SystemExtensionManager/Tests/SystemExtensionManagerTests/SystemExtensionManagerTests.swift
@@ -17,6 +17,7 @@
 //
 
 import XCTest
+import SystemExtensions
 @testable import SystemExtensionManager
 
 final class SystemExtensionManagerTests: XCTestCase {
@@ -69,5 +70,140 @@ final class SystemExtensionManagerTests: XCTestCase {
         ])
 
         XCTAssertEqual(result, .enabled)
+    }
+
+    func testSystemSettingsURLStringTargetsNetworkExtensionOnSequoia() throws {
+        guard #available(macOS 15, *) else {
+            throw XCTSkip("Specific ExtensionsPreferences URL is only used on macOS 15 and above")
+        }
+
+        let result = SystemExtensionManager.systemSettingsURLString(
+            forExtensionWithIdentifier: "com.duckduckgo.test.extension"
+        )
+
+        XCTAssertEqual(
+            result,
+            "x-apple.systempreferences:com.apple.ExtensionsPreferences?extensionPointIdentifier=com.apple.system_extension.network_extension.extension-point&extensionIdentifier=com.duckduckgo.test.extension"
+        )
+    }
+
+    func testSystemSettingsURLStringEscapesExtensionIdentifier() throws {
+        guard #available(macOS 15, *) else {
+            throw XCTSkip("Specific ExtensionsPreferences URL is only used on macOS 15 and above")
+        }
+
+        let result = SystemExtensionManager.systemSettingsURLString(
+            forExtensionWithIdentifier: "com.duckduckgo.test.extension&debug=true"
+        )
+
+        XCTAssertTrue(result.contains("extensionIdentifier=com.duckduckgo.test.extension%26debug%3Dtrue"))
+    }
+
+    func testRequestTimesOutWhenNoDelegateCallbackIsReceived() async {
+        let manager = CapturingSystemExtensionRequestManager()
+        let request = SystemExtensionRequest.activationRequest(
+            forExtensionWithIdentifier: "com.duckduckgo.test.extension",
+            manager: manager,
+            waitingForUserApproval: nil,
+            requestTimeout: 0.01
+        )
+
+        do {
+            try await request.submit()
+            XCTFail("Expected request to time out")
+        } catch {
+            XCTAssertEqual(error as? SystemExtensionRequestError, .requestTimedOut)
+        }
+
+        XCTAssertEqual(manager.submittedRequests.count, 1)
+    }
+
+    func testRequestCancellationResumesAwaitingSubmit() async {
+        let manager = CapturingSystemExtensionRequestManager()
+        let requestSubmitted = expectation(description: "Request submitted")
+        manager.onSubmit = { _ in
+            requestSubmitted.fulfill()
+        }
+
+        let request = SystemExtensionRequest.activationRequest(
+            forExtensionWithIdentifier: "com.duckduckgo.test.extension",
+            manager: manager,
+            waitingForUserApproval: nil,
+            requestTimeout: 10
+        )
+
+        let task = Task {
+            try await request.submit()
+        }
+
+        await fulfillment(of: [requestSubmitted], timeout: 1)
+        task.cancel()
+
+        do {
+            try await task.value
+            XCTFail("Expected request to be cancelled")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+    }
+
+    func testActivationStateReturnsUnknownWhenPropertiesRequestTimesOut() async {
+        let manager = CapturingSystemExtensionRequestManager()
+        let systemExtensionManager = SystemExtensionManager(
+            extensionBundleID: "com.duckduckgo.test.extension",
+            manager: manager,
+            requestTimeout: 0.01
+        )
+
+        let result = await systemExtensionManager.activationState()
+
+        XCTAssertEqual(result, .unknown)
+        XCTAssertEqual(manager.submittedRequests.count, 1)
+    }
+
+    func testActivationStateReturnsUnknownWhenPropertiesRequestIsCancelled() async {
+        let manager = CapturingSystemExtensionRequestManager()
+        let requestSubmitted = expectation(description: "Request submitted")
+        manager.onSubmit = { _ in
+            requestSubmitted.fulfill()
+        }
+        let systemExtensionManager = SystemExtensionManager(
+            extensionBundleID: "com.duckduckgo.test.extension",
+            manager: manager,
+            requestTimeout: 10
+        )
+
+        let task = Task {
+            await systemExtensionManager.activationState()
+        }
+
+        await fulfillment(of: [requestSubmitted], timeout: 1)
+        task.cancel()
+
+        let result = await task.value
+        XCTAssertEqual(result, .unknown)
+    }
+}
+
+private final class CapturingSystemExtensionRequestManager: SystemExtensionRequestManaging {
+
+    var onSubmit: ((OSSystemExtensionRequest) -> Void)?
+
+    var submittedRequests: [OSSystemExtensionRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+
+        return _submittedRequests
+    }
+
+    private let lock = NSLock()
+    private var _submittedRequests: [OSSystemExtensionRequest] = []
+
+    func submitRequest(_ request: OSSystemExtensionRequest) {
+        lock.lock()
+        _submittedRequests.append(request)
+        lock.unlock()
+
+        onSubmit?(request)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213765876683715

### Description

Three changes:
1. Fixed the URL that's opened when trying to install the VPN extension when a request exists.  This will take the user directly to the screen where they can allow the extension.
2. Added sysex request cancellation locally so only a single thread is allowed at the same time.
3. Added sysex request timeout so we won't hang the connection request indefinitely.

### Testing Steps

1. Start the VPN multiple times without allowing the extension and ensure the flow works fine.
2. Eventually allow it and see the VPN starts fine.
3. Try once to let the sysex request to time out (wait 120 seconds), and try to start the VPN again afterwards.

### Impact and Risks

Medium. The changes sit on the VPN start path, which is core functionality. All request outcomes (delegate callback, timeout, cancellation) are funneled through a single lock-guarded completion so the underlying continuation resumes exactly once, and the behavior is covered by unit tests.

#### What could go wrong?

1. A flaw in the completion handling.
2. The activation timeout runs for its full duration even while the user is approving the extension in System Settings, so a slow approval can surface a timeout. In that case the user sees guidance to open System Settings and the next start succeeds once the extension is allowed.

### Quality Considerations

Requests carry a default 120-second timeout. Cancellation is honored both before submission and while a request is in flight. Unit tests were added for the timeout and cancellation paths on activation and properties requests.

### Notes to Reviewer

Worth a look: whether the activation timeout should pause once `requestNeedsUserApproval` fires, rather than running flat through the user-approval wait. Current behavior is deliberate but debatable.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sit on the VPN start path and system extension activation; incorrect single-resume completion or timeout during slow user approval in Settings could fail starts or show misleading errors, though behavior is lock-guarded and unit-tested.
> 
> **Overview**
> Makes macOS VPN **system extension** activation and state queries **cancellation-safe** and **time-bounded**, and improves where users land in System Settings when approval is needed.
> 
> **SystemExtensionManager** now routes activation, deactivation, and properties requests through lock-guarded completion so the async continuation resumes **once** (delegate success/failure, **120s default timeout** → `requestTimedOut`, or **task cancellation**). A `SystemExtensionRequestManaging` protocol enables tests with a capturing manager. On **macOS 15+**, opening settings uses **ExtensionsPreferences** deep links scoped to the **network extension** point and bundle ID (with query escaping); timeouts and cancellations during properties queries yield **`.unknown`** activation state.
> 
> **NetworkProtectionTunnelController** maps `CancellationError` from activation to **`StartError.cancelled`**, treats **`requestTimedOut`** like other “go to System Settings” cases, skips surfacing a user error message on cancelled starts, and keeps the existing cancelled-start pixel path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fab67bc3d86f063c6b8e9527a9df7a483610b170. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->