### PR TITLE
Fix toggle-drag conflicting with content swipe in Unified Toggle Input

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1878,6 +1878,13 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
         updateInputMode(mode, animated: true)
     }
 
+    func unifiedToggleInputVC(_ vc: UnifiedToggleInputViewController, isDraggingToggle isDragging: Bool) {
+        // While the toggle pill is in flight, suppress the content swipe-between-modes gesture so the
+        // two animations can't run concurrently and glitch each other. On release, restore swipe to
+        // whatever toggle visibility dictates (the single source of truth for the gesture).
+        contentViewController.isSwipeEnabled = isDragging ? false : isToggleVisible
+    }
+
     func unifiedToggleInputVCDidClearSelectedTool(_ vc: UnifiedToggleInputViewController) {
         let previousTool = toolsController.selectedTool
         clearSelectedTool()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToggleView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToggleView.swift
@@ -45,6 +45,11 @@ final class UnifiedToggleInputToggleView: UIView {
 
     var onModeChanged: ((TextEntryMode) -> Void)?
 
+    /// Fires `true` when the user starts dragging the pill and `false` when the drag ends
+    /// (released, cancelled or failed). The content container observes this to suppress its own
+    /// swipe-between-modes gesture while the pill is in flight, so the two animations don't fight.
+    var onDragStateChanged: ((Bool) -> Void)?
+
     // MARK: - Drag State
 
     private var dragStartMode: TextEntryMode = .aiChat
@@ -231,10 +236,12 @@ final class UnifiedToggleInputToggleView: UIView {
         switch gesture.state {
         case .began:
             beginDrag()
+            onDragStateChanged?(true)
         case .changed:
             updateDrag(translationX: gesture.translation(in: self).x)
         case .ended, .cancelled, .failed:
             endDrag(velocityX: gesture.velocity(in: self).x)
+            onDragStateChanged?(false)
         default:
             break
         }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -33,6 +33,7 @@ protocol UnifiedToggleInputViewDelegate: AnyObject {
     func unifiedToggleInputViewDidSubmitText(_ view: UnifiedToggleInputView, text: String, mode: TextEntryMode)
     func unifiedToggleInputViewDidChangeText(_ view: UnifiedToggleInputView, text: String)
     func unifiedToggleInputViewDidChangeMode(_ view: UnifiedToggleInputView, mode: TextEntryMode)
+    func unifiedToggleInputView(_ view: UnifiedToggleInputView, isDraggingToggle isDragging: Bool)
     func unifiedToggleInputViewDidClearSelectedTool(_ view: UnifiedToggleInputView)
     func unifiedToggleInputViewDidTapFire(_ view: UnifiedToggleInputView)
     func unifiedToggleInputViewDidTapAppMenu(_ view: UnifiedToggleInputView)
@@ -1250,6 +1251,10 @@ private extension UnifiedToggleInputView {
             if self.isExpanded {
                 self.textEntryView.becomeFirstResponder()
             }
+        }
+        toggleView.onDragStateChanged = { [weak self] isDragging in
+            guard let self else { return }
+            self.delegate?.unifiedToggleInputView(self, isDraggingToggle: isDragging)
         }
         addSubview(toggleView)
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
@@ -32,6 +32,7 @@ protocol UnifiedToggleInputViewControllerDelegate: AnyObject {
     func unifiedToggleInputVC(_ vc: UnifiedToggleInputViewController, didSubmitText text: String, mode: TextEntryMode)
     func unifiedToggleInputVC(_ vc: UnifiedToggleInputViewController, didChangeText text: String)
     func unifiedToggleInputVC(_ vc: UnifiedToggleInputViewController, didChangeMode mode: TextEntryMode)
+    func unifiedToggleInputVC(_ vc: UnifiedToggleInputViewController, isDraggingToggle isDragging: Bool)
     func unifiedToggleInputVCDidClearSelectedTool(_ vc: UnifiedToggleInputViewController)
     func unifiedToggleInputVC(_ vc: UnifiedToggleInputViewController, didRemoveAttachment id: UUID, attachment: UnifiedToggleInputAttachment, isUserInitiated: Bool)
     func unifiedToggleInputVCDidChangeAttachments(_ vc: UnifiedToggleInputViewController)
@@ -429,6 +430,10 @@ extension UnifiedToggleInputViewController: UnifiedToggleInputViewDelegate {
 
     func unifiedToggleInputViewDidChangeMode(_ view: UnifiedToggleInputView, mode: TextEntryMode) {
         delegate?.unifiedToggleInputVC(self, didChangeMode: mode)
+    }
+
+    func unifiedToggleInputView(_ view: UnifiedToggleInputView, isDraggingToggle isDragging: Bool) {
+        delegate?.unifiedToggleInputVC(self, isDraggingToggle: isDragging)
     }
 
     func unifiedToggleInputViewDidClearSelectedTool(_ view: UnifiedToggleInputView) {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -2457,6 +2457,55 @@ final class UnifiedToggleInputToolbarViewTests: XCTestCase {
         XCTAssertTrue(coord.isToggleVisible, "Kill-switch only applies on Duck.ai tabs — non-AI tabs follow the user setting")
     }
 
+    // MARK: - Content swipe suppression while the toggle pill is being dragged
+
+    func test_draggingToggle_disablesContentSwipe_soTheTwoGesturesDoNotGlitchEachOther() {
+        let coord = UnifiedToggleInputCoordinator(
+            host: .omnibar,
+            isToggleEnabled: true,
+            hidesToggleOnDuckAITab: false,
+            preferences: MockAIChatPreferences()
+        )
+        coord.showExpanded(inputMode: .aiChat)
+        XCTAssertTrue(coord.contentViewController.isSwipeEnabled, "Precondition: content swipe is enabled when the toggle is visible")
+
+        coord.unifiedToggleInputVC(coord.viewController, isDraggingToggle: true)
+
+        XCTAssertFalse(coord.contentViewController.isSwipeEnabled, "Content swipe must be suppressed while the toggle pill is being dragged")
+    }
+
+    func test_endingToggleDrag_restoresContentSwipeToToggleVisibility() {
+        let coord = UnifiedToggleInputCoordinator(
+            host: .omnibar,
+            isToggleEnabled: true,
+            hidesToggleOnDuckAITab: false,
+            preferences: MockAIChatPreferences()
+        )
+        coord.showExpanded(inputMode: .aiChat)
+
+        coord.unifiedToggleInputVC(coord.viewController, isDraggingToggle: true)
+        coord.unifiedToggleInputVC(coord.viewController, isDraggingToggle: false)
+
+        XCTAssertEqual(coord.contentViewController.isSwipeEnabled, coord.isToggleVisible, "Once the drag ends, content swipe must return to following toggle visibility")
+        XCTAssertTrue(coord.contentViewController.isSwipeEnabled)
+    }
+
+    func test_endingToggleDrag_keepsContentSwipeDisabled_whenToggleIsNotVisible() {
+        let coord = UnifiedToggleInputCoordinator(
+            host: .omnibar,
+            isToggleEnabled: false,
+            hidesToggleOnDuckAITab: false,
+            preferences: MockAIChatPreferences()
+        )
+        coord.showExpanded(inputMode: .aiChat)
+        XCTAssertFalse(coord.isToggleVisible)
+
+        coord.unifiedToggleInputVC(coord.viewController, isDraggingToggle: true)
+        coord.unifiedToggleInputVC(coord.viewController, isDraggingToggle: false)
+
+        XCTAssertFalse(coord.contentViewController.isSwipeEnabled, "Restoring after a drag must not enable swipe when the toggle is hidden")
+    }
+
     /// Mirrors `test_syncInputModeFromExternalSource_toggleDisabled_forcesAIChatInAITabSession`
     /// for the kill-switch path: the toggle row is hidden by the remote flag (not by the user
     /// setting), so the user has no way to flip back — `effectiveInputMode` must clamp.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1215448085230405?focus=true
Tech Design URL:
CC:

### Description
While dragging the search/Duck.ai toggle pill, the content swipe-between-modes gesture could run at the same time and glitch the animation. The toggle view now reports its drag state up the delegate chain so the coordinator suppresses the content swipe for the duration of the drag, restoring it to toggle visibility on release.

### Testing Steps
1. Enable the `unifiedToggleInput` feature flag and open the input bar with the toggle visible.
2. Start dragging the toggle pill between Search and Duck.ai, and while still dragging, attempt to swipe the body/content view underneath.
3. Confirm the content no longer swipes mid-drag and the toggle animation stays smooth; releasing the pill restores normal content swiping.

### Impact and Risks
Low — gesture coordination is scoped to the active drag and reuses the existing swipe-enable gate.

#### What could go wrong?
Content swipe could be left disabled if a drag-end event were missed, but the gesture's cancelled/failed states are handled alongside ended.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped gesture coordination during an active pan; drag end handles ended/cancelled/failed, with tests for restore behavior when the toggle is visible or hidden.
> 
> **Overview**
> Fixes a gesture conflict where **swiping the content** to switch Search/Duck.ai could run **while dragging the toggle pill**, causing glitchy animations.
> 
> The toggle pill now reports **drag begin/end** (including cancelled/failed) via a new `onDragStateChanged` callback propagated through the view → view controller → **coordinator**. While dragging, the coordinator sets **`contentViewController.isSwipeEnabled` to `false`**; on release it restores swipe to **`isToggleVisible`** (same gate used elsewhere for content swipe).
> 
> **Coordinator tests** cover swipe disabled during drag, restored when the toggle is visible, and left disabled when the toggle is hidden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35db378b7f6aba02a636fb52b018741c57417752. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->