### PR TITLE
Fix hard-to-tap buttons in the Duck.ai AI chat header

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/SiteLoadingPixel.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/SiteLoadingPixel.swift
@@ -200,4 +200,3 @@ public enum SiteLoadingPixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
         }
     }
 }
-

--- a/iOS/DuckDuckGo/AIChat/AIChatTabChatHeaderView.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatTabChatHeaderView.swift
@@ -37,7 +37,7 @@ final class AIChatTabChatHeaderView: UIView {
 
     private enum Constants {
         static let headerHeight: CGFloat = 60
-        static let buttonSize: CGFloat = 48
+        static let buttonSize: CGFloat = 44
         static let horizontalPadding: CGFloat = 16
         static let buttonSpacing: CGFloat = 12
         static let titleEdgeSpacing: CGFloat = 12
@@ -45,9 +45,9 @@ final class AIChatTabChatHeaderView: UIView {
         static let titleVerticalPadding: CGFloat = 2
         static let chevronSize: CGFloat = 12
         static let chevronSpacing: CGFloat = 4
-        static let pillInnerHorizontalPadding: CGFloat = 6
-        static let pillInnerIconSpacing: CGFloat = 20
-        static let pillButtonSize: CGFloat = 36
+        /// Gap between the two icons in the shared right pill: two `buttonSize` targets + this = the 104pt group.
+        static let pillInnerIconSpacing: CGFloat = 16
+        static let tabBadgeSize: CGFloat = 36
         static let paidIconSize: CGFloat = 16
         static let paidIconTitleSpacing: CGFloat = 6
         static let titleMinimumScaleFactor: CGFloat = 0.7
@@ -118,14 +118,15 @@ final class AIChatTabChatHeaderView: UIView {
         button.accessibilityLabel = UserText.tabSwitcherAccessibilityLabel
         button.addTarget(self, action: #selector(tabSwitcherTapped), for: .touchUpInside)
         button.addSubview(tabSwitcherView)
+        // Pin the badge to its own footprint, centred, so the bigger tap target doesn't stretch it.
         NSLayoutConstraint.activate([
-            tabSwitcherView.topAnchor.constraint(equalTo: button.topAnchor),
-            tabSwitcherView.leadingAnchor.constraint(equalTo: button.leadingAnchor),
-            tabSwitcherView.trailingAnchor.constraint(equalTo: button.trailingAnchor),
-            tabSwitcherView.bottomAnchor.constraint(equalTo: button.bottomAnchor),
+            tabSwitcherView.centerXAnchor.constraint(equalTo: button.centerXAnchor),
+            tabSwitcherView.centerYAnchor.constraint(equalTo: button.centerYAnchor),
+            tabSwitcherView.widthAnchor.constraint(equalToConstant: Constants.tabBadgeSize),
+            tabSwitcherView.heightAnchor.constraint(equalToConstant: Constants.tabBadgeSize),
         ])
         // Capsule-clip the button so the adjacent Plus menu dismissal can't flash a rectangle highlight.
-        button.layer.cornerRadius = Constants.pillButtonSize / 2
+        button.layer.cornerRadius = Constants.buttonSize / 2
         button.clipsToBounds = true
         return button
     }()
@@ -150,7 +151,7 @@ final class AIChatTabChatHeaderView: UIView {
         button.showsMenuAsPrimaryAction = true
         // Clip the button itself to the pill shape — without this, UIKit's transient
         // highlight on menu dismiss renders as a rectangle against the surrounding pill.
-        button.layer.cornerRadius = Constants.pillButtonSize / 2
+        button.layer.cornerRadius = Constants.buttonSize / 2
         button.clipsToBounds = true
         return button
     }()
@@ -412,8 +413,9 @@ final class AIChatTabChatHeaderView: UIView {
         rightStack.addArrangedSubview(rightPairPill)
         pillContentSuperview(for: rightPairPill).addSubview(rightPairStack)
 
-        for control in [closeButton, chatListButton, newChatButton, tabSwitcherButton] as [UIControl] {
-            control.addGestureRecognizer(StrictBoundsTouchObserver())
+        // Only the shared right-pair pill can cross-fire between icons, so only those two are guarded.
+        for control in [newChatButton, tabSwitcherButton] as [UIControl] {
+            control.addGestureRecognizer(SiblingTouchGuard())
         }
 
         titleContainer.addSubview(freeTitleStack)
@@ -435,17 +437,17 @@ final class AIChatTabChatHeaderView: UIView {
             titleContainer.trailingAnchor.constraint(equalTo: titleHolder.trailingAnchor),
             titleContainer.bottomAnchor.constraint(equalTo: titleHolder.bottomAnchor),
 
-            closeButton.widthAnchor.constraint(equalToConstant: Constants.pillButtonSize),
-            closeButton.heightAnchor.constraint(equalToConstant: Constants.pillButtonSize),
+            closeButton.widthAnchor.constraint(equalToConstant: Constants.buttonSize),
+            closeButton.heightAnchor.constraint(equalToConstant: Constants.buttonSize),
 
-            chatListButton.widthAnchor.constraint(equalToConstant: Constants.pillButtonSize),
-            chatListButton.heightAnchor.constraint(equalToConstant: Constants.pillButtonSize),
+            chatListButton.widthAnchor.constraint(equalToConstant: Constants.buttonSize),
+            chatListButton.heightAnchor.constraint(equalToConstant: Constants.buttonSize),
 
-            newChatButton.widthAnchor.constraint(equalToConstant: Constants.pillButtonSize),
-            newChatButton.heightAnchor.constraint(equalToConstant: Constants.pillButtonSize),
+            newChatButton.widthAnchor.constraint(equalToConstant: Constants.buttonSize),
+            newChatButton.heightAnchor.constraint(equalToConstant: Constants.buttonSize),
 
-            tabSwitcherButton.widthAnchor.constraint(equalToConstant: Constants.pillButtonSize),
-            tabSwitcherButton.heightAnchor.constraint(equalToConstant: Constants.pillButtonSize),
+            tabSwitcherButton.widthAnchor.constraint(equalToConstant: Constants.buttonSize),
+            tabSwitcherButton.heightAnchor.constraint(equalToConstant: Constants.buttonSize),
 
             closeButtonPill.widthAnchor.constraint(equalToConstant: Constants.buttonSize),
             closeButtonPill.heightAnchor.constraint(equalToConstant: Constants.buttonSize),
@@ -458,8 +460,8 @@ final class AIChatTabChatHeaderView: UIView {
             chatListButton.centerYAnchor.constraint(equalTo: chatListButtonPill.centerYAnchor),
 
             rightPairPill.heightAnchor.constraint(equalToConstant: Constants.buttonSize),
-            rightPairStack.leadingAnchor.constraint(equalTo: rightPairPill.leadingAnchor, constant: Constants.pillInnerHorizontalPadding),
-            rightPairStack.trailingAnchor.constraint(equalTo: rightPairPill.trailingAnchor, constant: -Constants.pillInnerHorizontalPadding),
+            rightPairStack.leadingAnchor.constraint(equalTo: rightPairPill.leadingAnchor),
+            rightPairStack.trailingAnchor.constraint(equalTo: rightPairPill.trailingAnchor),
             rightPairStack.topAnchor.constraint(equalTo: rightPairPill.topAnchor),
             rightPairStack.bottomAnchor.constraint(equalTo: rightPairPill.bottomAnchor),
 
@@ -656,12 +658,10 @@ private final class HighlightableContainerView: UIControl {
     }
 }
 
-/// Cancels the host UIControl's touch follow-through the moment the touch leaves the visible
-/// bounds. UIControl tolerates ~70pt of slack by default — fine for an isolated button, but
-/// inside our shared glass pill it lets the originally-tapped icon fire when the finger is
-/// released over a sibling icon. The flags below keep the recognizer purely observational so
-/// the control's own taps, long-press, and menus still flow normally.
-private final class StrictBoundsTouchObserver: UIGestureRecognizer {
+/// Cancels the host control's tracking once the finger moves onto a sibling control, so a tap on one
+/// icon in the shared pill can't fire when released over its neighbour. Observational only; with no
+/// siblings it never cancels, leaving the control's taps, long-press, and menus normal.
+private final class SiblingTouchGuard: UIGestureRecognizer {
     override init(target: Any?, action: Selector?) {
         super.init(target: target, action: action)
         delaysTouchesBegan = false
@@ -671,9 +671,14 @@ private final class StrictBoundsTouchObserver: UIGestureRecognizer {
 
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
         super.touchesMoved(touches, with: event)
-        guard let control = view as? UIControl, let touch = touches.first else { return }
-        if !control.bounds.contains(touch.location(in: control)) {
+        guard let control = view as? UIControl,
+              let touch = touches.first,
+              let container = control.superview else { return }
+        let location = touch.location(in: container)
+        for case let sibling as UIControl in container.subviews
+        where sibling !== control && sibling.isUserInteractionEnabled && sibling.isEnabled && !sibling.isHidden && sibling.frame.contains(location) {
             control.cancelTracking(with: event)
+            return
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1215513005598430
Tech Design URL:
CC:

### Description

The close (✕, top-left) and new-chat (+, top-right) buttons in the Duck.ai AI chat header were hard to tap — sometimes needing several attempts. Two causes:

- A `StrictBoundsTouchObserver` gesture recognizer was attached to **all four** header buttons and cancelled a tap the instant the finger drifted outside the button's own bounds, discarding the ~70pt of touch slack iOS normally gives a control. It existed to stop cross-fire between the two icons that share the right-hand pill, but on the standalone close/chat-list buttons it stripped tolerance for no benefit.
- The tap targets were only 36pt — below the 44pt HIG minimum.

Changes (all in `AIChatTabChatHeaderView.swift`):

- Replaced `StrictBoundsTouchObserver` with `SiblingTouchGuard`, which cancels tracking only when the finger moves **onto a neighbouring control**, and attached it only to the shared right-pair pill (`+` / tab-count). This restores iOS's natural touch slack everywhere while still preventing cross-fire in the shared pill. It also ignores disabled/hidden siblings (e.g. during onboarding lock).
- Sized every header tap target to **44pt** (HIG minimum), per the design: the close and chat-list icons fill their pills, and the grouped `+` / tab-count icons are 44pt each within the 104pt pill (`44 + 16 gap + 44`). The icon glyphs are unchanged; the tab-count badge keeps its own footprint so it isn't stretched.

### Testing Steps
1. Open a Duck.ai AI chat tab.
2. Tap the close (top-left) and + (top-right) buttons, including near the edges — they should respond on the first tap.
3. Confirm the header renders correctly in light and dark (glyphs unchanged; tap targets are 44pt per the design).
4. Confirm the + menu still opens (New Chat / New Voice Chat / New Tab / New Search / New Fire Tab) and the tab-count button still opens the tab switcher.

### Impact and Risks
Low — a hit-area / touch-handling change confined to the AI chat header, bringing tap targets to the 44pt HIG minimum.

#### What could go wrong?
The cross-fire guard for the shared `+` / tab-count pill could regress if it stopped firing (a tap on `+` released over the tab icon would fire `+`). Mitigated: the guard keys off direct sibling controls in the shared `UIStackView` (arranged subviews are direct subviews — verified in review), and the two targets keep a 16pt gap so touch-down is unambiguous.

### Notes to Reviewer
- No automated test covers the gesture guard or tap-target sizes; validated manually on the simulator in light and dark (clean build; close dismisses, `+` menu opens, tab switcher opens; glyphs render unchanged).
- `tabSwitcherButton`'s inner badge view is pinned to a fixed footprint (centred) rather than the button's edges, so the 44pt tap target doesn't stretch the count/unread rendering.
- **Second commit is an unrelated one-line lint unblock:** `SiteLoadingPixel.swift` was added with a double trailing newline in #5301 and is failing SwiftLint `--strict` on every open PR. Removing the stray newline here unblocks the lint job; happy to split it into a standalone main hotfix if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to AI chat header UI and a cosmetic SwiftLint fix; main regression risk is +/tab cross-fire in the shared pill, mitigated by sibling-only cancellation.
> 
> **Overview**
> Improves **Duck.ai AI chat header** tap reliability by enlarging controls to **44pt** (HIG minimum) and fixing touch handling so close and **+** respond on the first tap.
> 
> **Touch handling:** `StrictBoundsTouchObserver` (cancelled tracking when the finger left the button bounds) is replaced by **`SiblingTouchGuard`**, attached only to the shared **+** / tab-count pill. Close and chat-list buttons no longer lose iOS’s normal touch slack; cross-fire between the two right-pill icons is still blocked when the finger moves onto a sibling control (disabled/hidden siblings ignored).
> 
> **Layout:** Header buttons use `buttonSize` 44pt instead of 36pt; the tab badge stays **36pt** and centered inside the larger tab switcher target. Right-pill inner padding constants are dropped so the **104pt** group is **44 + 16 gap + 44**.
> 
> **Lint:** Removes a trailing blank line at the end of `SiteLoadingPixel.swift` to satisfy SwiftLint `--strict`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 768fe045adc1ec2ed5d43a89188d1c17fb6a4252. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->