### PR TITLE
VPN: bypass orphaned transparent proxy when tunnel is gone

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -588,6 +588,14 @@ public enum NetworkProtectionSubfeature: String, Equatable, PrivacySubfeature {
     /// Risky Domain Protection for VPN
     /// https://app.asana.com/0/1204186595873227/1206489252288889
     case riskyDomainsProtection
+
+    /// Kill switch for the orphaned-proxy detection machinery (tunnel heartbeat + proxy detection loop + pixel).
+    /// Off by default → detection runs; enable remotely to disable it.
+    case orphanProxyDetectionKillSwitch
+
+    /// Kill switch for the orphaned-proxy full-bypass behavior.
+    /// Off by default → bypass engages when an orphaned proxy is detected; enable remotely to disable it.
+    case orphanProxyBypassKillSwitch
 }
 
 public enum SyncSubfeature: String, PrivacySubfeature {

--- a/SharedPackages/VPN/Sources/VPN/Diagnostics/TunnelHeartbeatStore.swift
+++ b/SharedPackages/VPN/Sources/VPN/Diagnostics/TunnelHeartbeatStore.swift
@@ -1,0 +1,53 @@
+//
+//  TunnelHeartbeatStore.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Persistence
+
+/// Records a periodic "alive" timestamp from the packet tunnel so other VPN components
+/// (notably the transparent proxy) can detect when the tunnel is no longer running.
+public final class TunnelHeartbeatStore {
+
+    public enum Keys {
+        static let lastHeartbeatAt = "vpn.tunnel.last-heartbeat-at"
+    }
+
+    private let store: ThrowingKeyValueStoring
+    private let dateGenerator: () -> Date
+
+    public init(store: ThrowingKeyValueStoring, dateGenerator: @escaping () -> Date = Date.init) {
+        self.store = store
+        self.dateGenerator = dateGenerator
+    }
+
+    public func recordHeartbeat() {
+        let timestamp = dateGenerator().timeIntervalSince1970
+        try? store.set(timestamp, forKey: Keys.lastHeartbeatAt)
+    }
+
+    public var lastHeartbeat: Date? {
+        guard let timestamp = (try? store.object(forKey: Keys.lastHeartbeatAt)) as? TimeInterval else {
+            return nil
+        }
+        return Date(timeIntervalSince1970: timestamp)
+    }
+
+    public func clear() {
+        try? store.removeObject(forKey: Keys.lastHeartbeatAt)
+    }
+}

--- a/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
+++ b/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
@@ -404,6 +404,11 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     private let providerEvents: EventMapping<Event>
     public let entitlementCheck: (() async -> Result<Bool, Error>)?
     public let loopDetector: ConnectionFailureLoopDetector
+    private let heartbeatStore: TunnelHeartbeatStore?
+    private var heartbeatTask: Task<Never, Error>? {
+        willSet { heartbeatTask?.cancel() }
+    }
+    private static let heartbeatInterval: TimeInterval = 15
 
     @MainActor
     public init(notificationsPresenter: VPNNotificationsPresenting,
@@ -432,7 +437,8 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 tunnelFailureMonitor: TunnelFailureMonitoring? = nil,
                 failureRecoveryHandler: FailureRecoveryHandling? = nil,
                 entitlementCheck: (() async -> Result<Bool, Error>)?,
-                loopDetector: ConnectionFailureLoopDetector) {
+                loopDetector: ConnectionFailureLoopDetector,
+                heartbeatStore: TunnelHeartbeatStore? = nil) {
         Logger.networkProtectionMemory.log("[+] PacketTunnelProvider")
 
         self.notificationsPresenter = notificationsPresenter
@@ -452,6 +458,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         self.entitlementMonitor = entitlementMonitor
         self.entitlementCheck = entitlementCheck
         self.loopDetector = loopDetector
+        self.heartbeatStore = heartbeatStore
 
         self.wideEvent = wideEvent ?? WideEvent(featureFlagProvider: WideEventFeatureFlagProvider(settings: settings))
 
@@ -849,6 +856,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             providerEvents.fire(.tunnelStartAttempt(.success))
             providerEvents.fire(.reportConnectionAttempt(attempt: .success, source: .start))
             loopDetector.connectionSucceeded()
+            startHeartbeat()
             completeAndCleanupConnectionWideEvent()
         } catch {
             if loopDetector.connectionFailed(isOnDemand: startupOptions.startupMethod == .automaticOnDemand) {
@@ -965,6 +973,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     @MainActor
     open override func stopTunnel(with reason: NEProviderStopReason) async {
         providerEvents.fire(.tunnelStopAttempt(.begin))
+        stopHeartbeat()
 
         Logger.networkProtection.log("🛑 Stopping tunnel with reason \(String(describing: reason), privacy: .public)")
 
@@ -996,6 +1005,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     @MainActor
     func cancelTunnel(with stopError: Error) async {
         providerEvents.fire(.tunnelStopAttempt(.begin))
+        stopHeartbeat()
 
         Logger.networkProtection.error("Stopping tunnel with error \(stopError.localizedDescription, privacy: .public)")
 
@@ -1483,6 +1493,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     @MainActor
     public override func sleep() async {
         Logger.networkProtectionSleep.log("Sleep")
+        stopHeartbeat()
         await stopMonitors()
     }
 
@@ -1505,11 +1516,26 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 try await handleAdapterStarted(startReason: .wake)
                 Logger.networkProtectionConnectionTester.log("🟢 Wake success")
                 providerEvents.fire(.tunnelWakeAttempt(.success))
+                startHeartbeat()
             } catch {
                 Logger.networkProtection.error("🔴 Wake error: \(error.localizedDescription, privacy: .public)")
                 providerEvents.fire(.tunnelWakeAttempt(.failure(error)))
             }
         }
+    }
+
+    // MARK: - Tunnel heartbeat
+
+    private func startHeartbeat() {
+        guard settings.isOrphanProxyDetectionEnabled else { return }
+        guard let heartbeatStore else { return }
+        heartbeatTask = Task.periodic(interval: Self.heartbeatInterval) { [weak heartbeatStore] in
+            heartbeatStore?.recordHeartbeat()
+        }
+    }
+
+    private func stopHeartbeat() {
+        heartbeatTask = nil
     }
 
     // MARK: - Snooze

--- a/SharedPackages/VPN/Sources/VPN/Settings/Extensions/UserDefaults+orphanProxyDetection.swift
+++ b/SharedPackages/VPN/Sources/VPN/Settings/Extensions/UserDefaults+orphanProxyDetection.swift
@@ -1,0 +1,48 @@
+//
+//  UserDefaults+orphanProxyDetection.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import Foundation
+
+extension UserDefaults {
+    private var orphanProxyDetectionEnabledKey: String {
+        "networkProtectionSettingOrphanProxyDetectionEnabled"
+    }
+
+    /// The behavior before the orphan-proxy kill switch existed: detection ran unconditionally.
+    public static let orphanProxyDetectionEnabledDefaultValue = true
+
+    @objc
+    dynamic var networkProtectionSettingOrphanProxyDetectionEnabled: Bool {
+        get {
+            value(forKey: orphanProxyDetectionEnabledKey) as? Bool ?? Self.orphanProxyDetectionEnabledDefaultValue
+        }
+
+        set {
+            set(newValue, forKey: orphanProxyDetectionEnabledKey)
+        }
+    }
+
+    var networkProtectionSettingOrphanProxyDetectionEnabledPublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.networkProtectionSettingOrphanProxyDetectionEnabled).eraseToAnyPublisher()
+    }
+
+    func resetNetworkProtectionSettingOrphanProxyDetectionEnabled() {
+        removeObject(forKey: orphanProxyDetectionEnabledKey)
+    }
+}

--- a/SharedPackages/VPN/Sources/VPN/Settings/VPNSettings.swift
+++ b/SharedPackages/VPN/Sources/VPN/Settings/VPNSettings.swift
@@ -355,6 +355,21 @@ public final class VPNSettings {
         }
     }
 
+    // MARK: - Orphan Proxy Detection
+
+    /// When `false`, the tunnel stops writing its heartbeat (see `TunnelHeartbeatStore`), which in turn
+    /// disables the transparent proxy's orphan detection. Resolved from a remote kill switch by the app
+    /// and delivered to the tunnel via the startup options snapshot. Defaults to `true`.
+    public var isOrphanProxyDetectionEnabled: Bool {
+        get {
+            defaults.networkProtectionSettingOrphanProxyDetectionEnabled
+        }
+
+        set {
+            defaults.networkProtectionSettingOrphanProxyDetectionEnabled = newValue
+        }
+    }
+
     // MARK: - Exclude APNs
 
     public var excludeAPNsPublisher: AnyPublisher<Bool, Never> {

--- a/SharedPackages/VPN/Sources/VPN/StartupOptions.swift
+++ b/SharedPackages/VPN/Sources/VPN/StartupOptions.swift
@@ -31,6 +31,7 @@ public struct VPNSettingsSnapshot: Codable, Equatable {
     let selectedLocation: VPNSettings.SelectedLocation
     let dnsSettings: NetworkProtectionDNSSettings
     let excludeLocalNetworks: Bool
+    let isOrphanProxyDetectionEnabled: Bool
 
     /// Create a snapshot of the current VPN settings
     public init(from settings: VPNSettings) {
@@ -40,6 +41,7 @@ public struct VPNSettingsSnapshot: Codable, Equatable {
         self.selectedLocation = settings.selectedLocation
         self.dnsSettings = settings.dnsSettings
         self.excludeLocalNetworks = settings.excludeLocalNetworks
+        self.isOrphanProxyDetectionEnabled = settings.isOrphanProxyDetectionEnabled
     }
 
     /// Create a snapshot with explicit values
@@ -48,13 +50,29 @@ public struct VPNSettingsSnapshot: Codable, Equatable {
                 selectedServer: VPNSettings.SelectedServer,
                 selectedLocation: VPNSettings.SelectedLocation,
                 dnsSettings: NetworkProtectionDNSSettings,
-                excludeLocalNetworks: Bool) {
+                excludeLocalNetworks: Bool,
+                isOrphanProxyDetectionEnabled: Bool = UserDefaults.orphanProxyDetectionEnabledDefaultValue) {
         self.registrationKeyValidity = registrationKeyValidity
         self.selectedEnvironment = selectedEnvironment
         self.selectedServer = selectedServer
         self.selectedLocation = selectedLocation
         self.dnsSettings = dnsSettings
         self.excludeLocalNetworks = excludeLocalNetworks
+        self.isOrphanProxyDetectionEnabled = isOrphanProxyDetectionEnabled
+    }
+
+    /// Custom decoding so snapshots persisted by older versions (which lack `isOrphanProxyDetectionEnabled`)
+    /// still decode, falling back to the pre-kill-switch behavior rather than failing the whole snapshot.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        registrationKeyValidity = try container.decode(VPNSettings.RegistrationKeyValidity.self, forKey: .registrationKeyValidity)
+        selectedEnvironment = try container.decode(VPNSettings.SelectedEnvironment.self, forKey: .selectedEnvironment)
+        selectedServer = try container.decode(VPNSettings.SelectedServer.self, forKey: .selectedServer)
+        selectedLocation = try container.decode(VPNSettings.SelectedLocation.self, forKey: .selectedLocation)
+        dnsSettings = try container.decode(NetworkProtectionDNSSettings.self, forKey: .dnsSettings)
+        excludeLocalNetworks = try container.decode(Bool.self, forKey: .excludeLocalNetworks)
+        isOrphanProxyDetectionEnabled = try container.decodeIfPresent(Bool.self, forKey: .isOrphanProxyDetectionEnabled)
+            ?? UserDefaults.orphanProxyDetectionEnabledDefaultValue
     }
 
     /// Apply these settings to a VPNSettings instance
@@ -65,6 +83,7 @@ public struct VPNSettingsSnapshot: Codable, Equatable {
         settings.selectedLocation = selectedLocation
         settings.dnsSettings = dnsSettings
         settings.excludeLocalNetworks = excludeLocalNetworks
+        settings.isOrphanProxyDetectionEnabled = isOrphanProxyDetectionEnabled
     }
 }
 

--- a/SharedPackages/VPN/Tests/VPNTests/StartupOptionTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/StartupOptionTests.swift
@@ -167,6 +167,58 @@ final class StartupOptionsTests: XCTestCase {
         XCTAssertEqual(vpnSettings.excludeLocalNetworks, true)
     }
 
+    func testVPNSettingsSnapshotRoundTripsOrphanProxyDetectionFlag() throws {
+        let snapshot = VPNSettingsSnapshot(
+            registrationKeyValidity: .custom(3600),
+            selectedEnvironment: .production,
+            selectedServer: .automatic,
+            selectedLocation: .nearest,
+            dnsSettings: .ddg(blockRiskyDomains: true),
+            excludeLocalNetworks: false,
+            isOrphanProxyDetectionEnabled: false
+        )
+
+        let decoded = try JSONDecoder().decode(VPNSettingsSnapshot.self, from: JSONEncoder().encode(snapshot))
+
+        XCTAssertFalse(decoded.isOrphanProxyDetectionEnabled)
+    }
+
+    func testVPNSettingsSnapshotDefaultsOrphanProxyDetectionEnabledWhenMissingFromPayload() throws {
+        // Simulate a snapshot persisted by an older version that predates the flag.
+        let snapshot = VPNSettingsSnapshot(
+            registrationKeyValidity: .custom(3600),
+            selectedEnvironment: .production,
+            selectedServer: .automatic,
+            selectedLocation: .nearest,
+            dnsSettings: .ddg(blockRiskyDomains: true),
+            excludeLocalNetworks: false
+        )
+        let encoded = try JSONEncoder().encode(snapshot)
+        var json = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        json.removeValue(forKey: "isOrphanProxyDetectionEnabled")
+        let legacyData = try JSONSerialization.data(withJSONObject: json)
+
+        let decoded = try JSONDecoder().decode(VPNSettingsSnapshot.self, from: legacyData)
+
+        XCTAssertTrue(decoded.isOrphanProxyDetectionEnabled)
+    }
+
+    func testVPNSettingsSnapshotCarriesOrphanProxyDetectionFromSettings() {
+        let sourceDefaults = UserDefaults(suiteName: "orphan-proxy-source-test")!
+        defer { sourceDefaults.removePersistentDomain(forName: "orphan-proxy-source-test") }
+        let vpnSettings = VPNSettings(defaults: sourceDefaults)
+        vpnSettings.isOrphanProxyDetectionEnabled = false
+
+        let snapshot = VPNSettingsSnapshot(from: vpnSettings)
+        XCTAssertFalse(snapshot.isOrphanProxyDetectionEnabled)
+
+        let targetDefaults = UserDefaults(suiteName: "orphan-proxy-apply-test")!
+        defer { targetDefaults.removePersistentDomain(forName: "orphan-proxy-apply-test") }
+        let other = VPNSettings(defaults: targetDefaults)
+        snapshot.applyTo(other)
+        XCTAssertFalse(other.isOrphanProxyDetectionEnabled)
+    }
+
     func testCorruptedVPNSettingsResultInResetOption() {
         let corruptedData = "invalid json data".data(using: .utf8)!
 

--- a/SharedPackages/VPN/Tests/VPNTests/TunnelHeartbeatStoreTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/TunnelHeartbeatStoreTests.swift
@@ -1,0 +1,82 @@
+//
+//  TunnelHeartbeatStoreTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import VPN
+
+final class TunnelHeartbeatStoreTests: XCTestCase {
+
+    private static let suiteName = "TunnelHeartbeatStoreTests"
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: Self.suiteName)!
+        defaults.removePersistentDomain(forName: Self.suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: Self.suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    func testLastHeartbeat_isNilBeforeAnyWrite() {
+        let store = TunnelHeartbeatStore(store: defaults)
+        XCTAssertNil(store.lastHeartbeat)
+    }
+
+    func testRecordHeartbeat_storesGeneratedDate() {
+        let fixed = Date(timeIntervalSince1970: 1_700_000_000)
+        let store = TunnelHeartbeatStore(store: defaults, dateGenerator: { fixed })
+
+        store.recordHeartbeat()
+
+        XCTAssertEqual(store.lastHeartbeat?.timeIntervalSince1970, fixed.timeIntervalSince1970)
+    }
+
+    func testRecordHeartbeat_overwritesPreviousValue() {
+        var now = Date(timeIntervalSince1970: 1_700_000_000)
+        let store = TunnelHeartbeatStore(store: defaults, dateGenerator: { now })
+
+        store.recordHeartbeat()
+        now = Date(timeIntervalSince1970: 1_700_000_060)
+        store.recordHeartbeat()
+
+        XCTAssertEqual(store.lastHeartbeat?.timeIntervalSince1970, 1_700_000_060)
+    }
+
+    func testClear_removesStoredHeartbeat() {
+        let store = TunnelHeartbeatStore(store: defaults)
+        store.recordHeartbeat()
+        XCTAssertNotNil(store.lastHeartbeat)
+
+        store.clear()
+
+        XCTAssertNil(store.lastHeartbeat)
+    }
+
+    func testLastHeartbeat_persistsAcrossInstances() {
+        let fixed = Date(timeIntervalSince1970: 1_700_000_000)
+        let writer = TunnelHeartbeatStore(store: defaults, dateGenerator: { fixed })
+        writer.recordHeartbeat()
+
+        let reader = TunnelHeartbeatStore(store: defaults)
+        XCTAssertEqual(reader.lastHeartbeat?.timeIntervalSince1970, fixed.timeIntervalSince1970)
+    }
+}

--- a/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/MacPacketTunnelProvider.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/MacPacketTunnelProvider.swift
@@ -576,6 +576,7 @@ final class MacPacketTunnelProvider: PacketTunnelProvider {
         // MARK: -
 
         let loopDetector = ConnectionFailureLoopDetector(store: defaults)
+        let heartbeatStore = TunnelHeartbeatStore(store: defaults)
 
         let tunnelHealthStore = NetworkProtectionTunnelHealthStore(notificationCenter: notificationCenter)
         let notificationsPresenter = NetworkProtectionNotificationsPresenterFactory().make(settings: settings, defaults: defaults)
@@ -593,7 +594,8 @@ final class MacPacketTunnelProvider: PacketTunnelProvider {
                    defaults: defaults,
                    wideEvent: wideEvent,
                    entitlementCheck: entitlementsCheck,
-                   loopDetector: loopDetector)
+                   loopDetector: loopDetector,
+                   heartbeatStore: heartbeatStore)
 
         setupPixels()
         Logger.networkProtection.log("[+] MacPacketTunnelProvider Initialised")

--- a/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/MacTransparentProxyProvider.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/MacTransparentProxyProvider.swift
@@ -26,6 +26,7 @@ import NetworkProtectionProxy
 import os.log
 import PixelKit
 import PrivacyConfig
+import VPN
 
 final class MacTransparentProxyProvider: TransparentProxyProvider {
 
@@ -42,30 +43,37 @@ final class MacTransparentProxyProvider: TransparentProxyProvider {
 #endif
         }()
 
-        let settings: TransparentProxySettings = {
+        /// The defaults the tunnel and proxy share inside this extension's process:
+        /// - sysex: tunnel and proxy live in the same binary and share `UserDefaults.standard`
+        /// - appex: tunnel writes to `.netP` via the app group; the proxy reads from the same group
+        let sharedDefaults: UserDefaults = {
 #if NETP_SYSTEM_EXTENSION
-            /// Because our System Extension is running in the system context and doesn't have access
-            /// to shared user defaults, we just make it use the `.standard` defaults.
-            TransparentProxySettings(defaults: .standard)
+            return .standard
 #else
-            /// Because our App Extension is running in the user context and has access
-            /// to shared user defaults, we take advantage of this and use the `.netP` defaults.
-            TransparentProxySettings(defaults: .netP)
+            return .netP
 #endif
         }()
+
+        let settings = TransparentProxySettings(defaults: sharedDefaults)
 
         let configuration = TransparentProxyProvider.Configuration(
             loadSettingsFromProviderConfiguration: loadSettingsFromStartupOptions)
 
-#if !NETP_SYSTEM_EXTENSION
         let internalUserDecider = DefaultInternalUserDecider(store: UserDefaults.appConfiguration)
         let channel = StandardApplicationBuildType().channelName(isInternalUser: internalUserDecider.isInternalUser)
-        PixelKit.setUp(dryRun: PixelKitConfig.isDryRun(isProductionBuild: BuildFlags.isProductionBuild),
-                       appVersion: AppVersion.shared.versionNumber,
-                       source: "vpnProxyExtension",
-                       channel: channel,
-                       defaultHeaders: [:],
-                       defaults: UserDefaults.netP) { (pixelName: String, headers: [String: String], parameters: [String: String], _, _, onComplete: @escaping PixelKit.CompletionBlock) in
+#if NETP_SYSTEM_EXTENSION
+        let pixelSource = "vpnSystemExtensionProxy"
+#else
+        let pixelSource = "vpnProxyExtension"
+#endif
+        let pixelKit = PixelKit(
+            dryRun: PixelKitConfig.isDryRun(isProductionBuild: BuildFlags.isProductionBuild),
+            appVersion: AppVersion.shared.versionNumber,
+            source: pixelSource,
+            channel: channel,
+            defaultHeaders: [:],
+            defaults: sharedDefaults
+        ) { (pixelName: String, headers: [String: String], parameters: [String: String], _, _, onComplete: @escaping PixelKit.CompletionBlock) in
 
             let url = URL.pixelUrl(forPixelNamed: pixelName)
             let apiHeaders = APIRequest.Headers(additionalHeaders: headers)
@@ -76,13 +84,14 @@ final class MacTransparentProxyProvider: TransparentProxyProvider {
                 onComplete(error == nil, error)
             }
         }
-#endif
 
-        let eventHandler = TransparentProxyProviderEventHandler(logger: Self.vpnProxyLogger)
+        let eventHandler = TransparentProxyProviderEventHandler(logger: Self.vpnProxyLogger, pixelKit: pixelKit)
+        let heartbeatStore = TunnelHeartbeatStore(store: sharedDefaults)
 
         super.init(settings: settings,
                    configuration: configuration,
                    logger: Self.vpnProxyLogger,
-                   eventHandler: eventHandler)
+                   eventHandler: eventHandler,
+                   heartbeatStore: heartbeatStore)
     }
 }

--- a/macOS/DuckDuckGoVPN/ConfigurationManager.swift
+++ b/macOS/DuckDuckGoVPN/ConfigurationManager.swift
@@ -27,6 +27,7 @@ import PixelKit
 final class ConfigurationManager: DefaultConfigurationManager {
 
     private let privacyConfigManager: VPNPrivacyConfigurationManager
+    var onPrivacyConfigurationUpdated: (() -> Void)?
 
     init(privacyConfigManager: VPNPrivacyConfigurationManager,
          fetcher: ConfigurationFetching,
@@ -85,6 +86,7 @@ final class ConfigurationManager: DefaultConfigurationManager {
             etag: store.loadEtag(for: .privacyConfiguration),
             data: store.loadData(for: .privacyConfiguration)
         )
+        onPrivacyConfigurationUpdated?()
     }
 }
 

--- a/macOS/DuckDuckGoVPN/DuckDuckGoVPNAppDelegate.swift
+++ b/macOS/DuckDuckGoVPN/DuckDuckGoVPNAppDelegate.swift
@@ -143,6 +143,12 @@ final class DuckDuckGoVPNAppDelegate: NSObject, NSApplicationDelegate {
         self.configurationManager = ConfigurationManager(privacyConfigManager: privacyConfigurationManager, fetcher: ConfigurationFetcher(store: configurationStore, configurationURLProvider: VPNAgentConfigurationURLProvider(), eventMapping: ConfigurationManager.configurationDebugEvents), store: configurationStore)
         super.init()
 
+        configurationManager.onPrivacyConfigurationUpdated = { [weak self] in
+            Task { @MainActor in
+                self?.applyOrphanProxyFeatureFlags()
+            }
+        }
+
         let tokenFound = subscriptionManager.isUserAuthenticated
         if tokenFound {
             Logger.networkProtection.debug("🟢 VPN Agent found")
@@ -484,6 +490,19 @@ final class DuckDuckGoVPNAppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @MainActor
+    /// Resolves the orphan-proxy kill switches into the tunnel and proxy settings.
+    ///
+    /// Both flags are kill switches: enabling the remote subfeature *disables* the corresponding behavior,
+    /// so each setting is the negation of the flag. They default to enabled when the flags are off.
+    private func applyOrphanProxyFeatureFlags() {
+        let detectionEnabled = !featureFlagger.isFeatureOn(.vpnOrphanProxyDetectionKillSwitch)
+        let bypassEnabled = !featureFlagger.isFeatureOn(.vpnOrphanProxyBypassKillSwitch)
+
+        tunnelSettings.isOrphanProxyDetectionEnabled = detectionEnabled
+        proxySettings.isOrphanProxyDetectionEnabled = detectionEnabled
+        proxySettings.isOrphanProxyBypassEnabled = bypassEnabled
+    }
+
     func applicationDidFinishLaunching(_ aNotification: Notification) {
 
         APIRequest.Headers.setUserAgent(UserAgent.duckDuckGoUserAgent())
@@ -499,6 +518,10 @@ final class DuckDuckGoVPNAppDelegate: NSObject, NSApplicationDelegate {
         // It's important for this to be set-up after the privacy configuration is loaded
         // as it relies on it for the remote feature flag.
         TipKitAppEventHandler(featureFlagger: featureFlagger).appDidFinishLaunching()
+
+        // Resolve the orphan-proxy kill switches into settings so the tunnel and proxy pick them up
+        // on their next start. Must run after the privacy configuration is loaded above.
+        applyOrphanProxyFeatureFlags()
 
         setupMenuVisibility()
 

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -47,6 +47,14 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866473771128
     case networkProtectionAppStoreSysexMessage
 
+    /// Kill switch: enable remotely to disable orphaned-proxy detection (tunnel heartbeat + proxy detection loop + pixel).
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215509351454304
+    case vpnOrphanProxyDetectionKillSwitch
+
+    /// Kill switch: enable remotely to disable the orphaned-proxy full-bypass behavior.
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215509351454309
+    case vpnOrphanProxyBypassKillSwitch
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866615719736
     case autoUpdateInDEBUG
 
@@ -431,6 +439,10 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(NetworkProtectionSubfeature.appStoreSystemExtension), category: .vpn)
         case .networkProtectionAppStoreSysexMessage:
             Config(source: .remoteReleasable(NetworkProtectionSubfeature.appStoreSystemExtensionMessage), category: .vpn)
+        case .vpnOrphanProxyDetectionKillSwitch:
+            Config(source: .remoteReleasable(NetworkProtectionSubfeature.orphanProxyDetectionKillSwitch), category: .vpn)
+        case .vpnOrphanProxyBypassKillSwitch:
+            Config(source: .remoteReleasable(NetworkProtectionSubfeature.orphanProxyBypassKillSwitch), category: .vpn)
         case .autoUpdateInDEBUG:
             Config(source: .disabled, category: .updates)
         case .autoUpdateInREVIEW:

--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Provider/OrphanProxyDecision.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Provider/OrphanProxyDecision.swift
@@ -1,0 +1,89 @@
+//
+//  OrphanProxyDecision.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// The detector state the transparent proxy should hold after evaluating one observation.
+struct OrphanProxyDecision: Equatable {
+
+    /// Whether full-bypass mode should be on after this check.
+    let isFullBypassEnabled: Bool
+
+    /// The episode's fire-once latch after this check.
+    let orphanFiredForCurrentEpisode: Bool
+
+    /// Whether the "first orphan detection of this episode" pixel should fire now.
+    let shouldFirePixel: Bool
+}
+
+/// Pure decision logic for the orphaned-proxy detector, extracted from `TransparentProxyProvider`
+/// so it can be unit-tested without standing up a Network Extension provider.
+///
+/// The proxy records when it started and reads the tunnel's heartbeat timestamp; a proxy that has
+/// been up past the age threshold while the heartbeat is stale (or absent) is treated as orphaned —
+/// its tunnel is gone. Bypass engages so traffic falls back to default routing, and lifts again once
+/// a fresh heartbeat shows the tunnel recovered.
+enum OrphanProxyTester {
+
+    /// Decides the next detector state from a single observation.
+    ///
+    /// Returns `nil` when the proxy is younger than `proxyAgeThreshold`, meaning the caller leaves
+    /// all detector state untouched (too early to judge).
+    ///
+    /// - Parameters:
+    ///   - proxyAge: How long the proxy has been running.
+    ///   - heartbeatAge: Age of the tunnel's last heartbeat, or `nil` if none was ever recorded.
+    ///   - bypassEnabled: The bypass kill switch — when `false`, an orphan is reported but bypass never engages.
+    ///   - isFullBypassEnabled: Whether bypass is currently on.
+    ///   - orphanFiredForCurrentEpisode: Whether the pixel already fired for the current orphan episode.
+    ///   - proxyAgeThreshold: Minimum proxy age before we judge orphan status.
+    ///   - heartbeatAgeThreshold: Maximum heartbeat age still considered fresh.
+    static func decision(
+        proxyAge: TimeInterval,
+        heartbeatAge: TimeInterval?,
+        bypassEnabled: Bool,
+        isFullBypassEnabled: Bool,
+        orphanFiredForCurrentEpisode: Bool,
+        proxyAgeThreshold: TimeInterval,
+        heartbeatAgeThreshold: TimeInterval
+    ) -> OrphanProxyDecision? {
+        guard proxyAge >= proxyAgeThreshold else { return nil }
+
+        let heartbeatIsFresh: Bool
+        if let heartbeatAge {
+            heartbeatIsFresh = heartbeatAge < heartbeatAgeThreshold
+        } else {
+            heartbeatIsFresh = false
+        }
+
+        // Fresh heartbeat: the tunnel is alive, so lift any bypass and reset the episode latch.
+        if heartbeatIsFresh {
+            return OrphanProxyDecision(
+                isFullBypassEnabled: false,
+                orphanFiredForCurrentEpisode: false,
+                shouldFirePixel: false)
+        }
+
+        // Stale heartbeat: orphaned. Engage bypass if the kill switch allows it, and fire the pixel
+        // once per episode. The bypass decision is independent of the fire-once latch.
+        return OrphanProxyDecision(
+            isFullBypassEnabled: isFullBypassEnabled || bypassEnabled,
+            orphanFiredForCurrentEpisode: true,
+            shouldFirePixel: !orphanFiredForCurrentEpisode)
+    }
+}

--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Provider/TransparentProxyProvider.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Provider/TransparentProxyProvider.swift
@@ -97,18 +97,41 @@ open class TransparentProxyProvider: NETransparentProxyProvider {
     private let appMessageHandler: TransparentProxyAppMessageHandler
     private let eventHandler: TransparentProxyProviderEventHandler
 
+    // MARK: - Orphan detection
+
+    private let heartbeatStore: TunnelHeartbeatStore?
+    private static let orphanCheckInterval: TimeInterval = 15
+    private static let orphanProxyAgeThreshold: TimeInterval = 60
+    private static let orphanHeartbeatAgeThreshold: TimeInterval = 60
+    private static let postWakeGracePeriod: TimeInterval = 60
+
+    @MainActor private var proxyStartedAt: Date?
+    @MainActor private var orphanFiredForCurrentEpisode = false
+    @MainActor private var orphanCheckTask: Task<Never, Error>? {
+        willSet { orphanCheckTask?.cancel() }
+    }
+
+    /// While true, the proxy returns `false` from `handleNewFlow` for every incoming flow
+    /// so the OS routes traffic as if no proxy were installed. Engaged when we detect the
+    /// orphan-proxy state; disengaged when the tunnel heartbeat reappears.
+    /// Read from non-isolated flow callbacks; mutated only from @MainActor. The race on a
+    /// Bool is benign: at worst, one flow either side of the flip gets the previous value.
+    private var isFullBypassEnabled = false
+
     // MARK: - Init
 
     public init(settings: TransparentProxySettings,
                 configuration: Configuration,
                 logger: Logger,
-                eventHandler: TransparentProxyProviderEventHandler) {
+                eventHandler: TransparentProxyProviderEventHandler,
+                heartbeatStore: TunnelHeartbeatStore? = nil) {
 
         appMessageHandler = TransparentProxyAppMessageHandler(settings: settings, logger: logger)
         self.configuration = configuration
         self.logger = logger
         self.settings = settings
         self.eventHandler = eventHandler
+        self.heartbeatStore = heartbeatStore
 
         appRoutingRulesManager = AppRoutingRulesManager(settings: settings)
 
@@ -219,6 +242,7 @@ open class TransparentProxyProvider: NETransparentProxyProvider {
             }
 
             isRunning = true
+            startOrphanDetection()
             eventHandler.handle(event: .startAttempt(.success))
         } catch {
             eventHandler.handle(event: .startAttempt(.failure(error)))
@@ -229,6 +253,7 @@ open class TransparentProxyProvider: NETransparentProxyProvider {
     @MainActor
     open override func stopProxy(with reason: NEProviderStopReason) async {
         stopMonitoringNetworkInterfaces()
+        stopOrphanDetection()
         isRunning = false
 
         eventHandler.handle(event: .stopped(reason))
@@ -238,6 +263,7 @@ open class TransparentProxyProvider: NETransparentProxyProvider {
     override public func sleep(completionHandler: @escaping () -> Void) {
         eventHandler.handle(event: .sleep)
         stopMonitoringNetworkInterfaces()
+        orphanCheckTask = nil
         completionHandler()
     }
 
@@ -245,6 +271,85 @@ open class TransparentProxyProvider: NETransparentProxyProvider {
     override public func wake() {
         eventHandler.handle(event: .wake)
         startMonitoringNetworkInterfaces()
+        scheduleOrphanCheckAfterWake()
+    }
+
+    // MARK: - Orphan detection
+
+    @MainActor
+    private func startOrphanDetection() {
+        guard settings.isOrphanProxyDetectionEnabled else { return }
+        guard heartbeatStore != nil else { return }
+        proxyStartedAt = Date()
+        orphanFiredForCurrentEpisode = false
+        orphanCheckTask = Task.periodic(
+            delay: Self.orphanCheckInterval,
+            interval: Self.orphanCheckInterval
+        ) { [weak self] in
+            await self?.checkForOrphan()
+        }
+    }
+
+    @MainActor
+    private func stopOrphanDetection() {
+        orphanCheckTask = nil
+        proxyStartedAt = nil
+        orphanFiredForCurrentEpisode = false
+        isFullBypassEnabled = false
+    }
+
+    @MainActor
+    private func scheduleOrphanCheckAfterWake() {
+        guard settings.isOrphanProxyDetectionEnabled else { return }
+        guard heartbeatStore != nil, proxyStartedAt != nil else { return }
+
+        // The grace period defers *engaging* the bypass after wake, so the tunnel has time to write
+        // a post-wake heartbeat before we judge the proxy orphaned. But if we resumed with the bypass
+        // already engaged, there's nothing to defer — a check can only lift it (or keep it), never
+        // falsely engage or re-fire the pixel — so run on the normal cadence to lift it promptly once
+        // the tunnel recovers, instead of holding traffic off the proxy for the full grace window.
+        let delay = isFullBypassEnabled ? Self.orphanCheckInterval : Self.postWakeGracePeriod
+
+        orphanCheckTask = Task.periodic(
+            delay: delay,
+            interval: Self.orphanCheckInterval
+        ) { [weak self] in
+            await self?.checkForOrphan()
+        }
+    }
+
+    @MainActor
+    private func checkForOrphan() {
+        guard let heartbeatStore, let proxyStartedAt else { return }
+
+        let now = Date()
+        let proxyAge = now.timeIntervalSince(proxyStartedAt)
+        let lastHeartbeat = heartbeatStore.lastHeartbeat
+
+        guard let decision = OrphanProxyTester.decision(
+            proxyAge: proxyAge,
+            heartbeatAge: lastHeartbeat.map { now.timeIntervalSince($0) },
+            bypassEnabled: settings.isOrphanProxyBypassEnabled,
+            isFullBypassEnabled: isFullBypassEnabled,
+            orphanFiredForCurrentEpisode: orphanFiredForCurrentEpisode,
+            proxyAgeThreshold: Self.orphanProxyAgeThreshold,
+            heartbeatAgeThreshold: Self.orphanHeartbeatAgeThreshold
+        ) else { return }
+
+        if isFullBypassEnabled, !decision.isFullBypassEnabled {
+            logger.log("🟢 Tunnel heartbeat detected — disabling proxy full-bypass mode")
+        } else if !isFullBypassEnabled, decision.isFullBypassEnabled {
+            logger.log("🟠 Tunnel heartbeat stale — enabling proxy full-bypass mode")
+        }
+
+        isFullBypassEnabled = decision.isFullBypassEnabled
+        orphanFiredForCurrentEpisode = decision.orphanFiredForCurrentEpisode
+
+        guard decision.shouldFirePixel else { return }
+
+        let heartbeatBucket = HeartbeatAgeBucket.bucket(for: lastHeartbeat, now: now)
+        let proxyBucket = ProxyAgeBucket.bucket(for: proxyAge)
+        eventHandler.handle(event: .orphaned(heartbeatAge: heartbeatBucket, proxyAge: proxyBucket))
     }
 
     private func logFlowMessage(_ flow: NEAppProxyFlow, level: OSLogType, message: String) {
@@ -274,6 +379,10 @@ open class TransparentProxyProvider: NETransparentProxyProvider {
     }
 
     override public func handleNewFlow(_ flow: NEAppProxyFlow) -> Bool {
+        if isFullBypassEnabled {
+            return false
+        }
+
         logNewTCPFlow(flow)
 
         guard let flow = flow as? NEAppProxyTCPFlow else {
@@ -331,6 +440,9 @@ open class TransparentProxyProvider: NETransparentProxyProvider {
     }
 
     override public func handleNewUDPFlow(_ flow: NEAppProxyUDPFlow, initialRemoteEndpoint remoteEndpoint: NWEndpoint) -> Bool {
+        if isFullBypassEnabled {
+            return false
+        }
 
         guard let remoteEndpoint = remoteEndpoint as? NWHostEndpoint,
               !isDnsServer(remoteEndpoint) else {
@@ -482,6 +594,59 @@ extension TransparentProxyProvider {
         case stopped(_ reason: NEProviderStopReason)
         case sleep
         case wake
+        case orphaned(heartbeatAge: HeartbeatAgeBucket, proxyAge: ProxyAgeBucket)
+    }
+
+    public enum HeartbeatAgeBucket: String {
+        case missing
+        case under5m = "under_5m"
+        case under30m = "under_30m"
+        case over30m = "over_30m"
+
+        static func bucket(for date: Date?, now: Date) -> Self {
+            guard let date else { return .missing }
+            switch now.timeIntervalSince(date) {
+            case ..<300: return .under5m
+            case ..<1800: return .under30m
+            default: return .over30m
+            }
+        }
+    }
+
+    public enum ProxyAgeBucket: String {
+        case under5m = "under_5m"
+        case under30m = "under_30m"
+        case under2h = "under_2h"
+        case over2h = "over_2h"
+
+        static func bucket(for proxyAge: TimeInterval) -> Self {
+            switch proxyAge {
+            case ..<300: return .under5m
+            case ..<1800: return .under30m
+            case ..<7200: return .under2h
+            default: return .over2h
+            }
+        }
+    }
+
+    public struct OrphanedEvent: PixelKitEvent {
+        public let heartbeatAge: HeartbeatAgeBucket
+        public let proxyAge: ProxyAgeBucket
+
+        public var name: String {
+            "vpn_proxy_orphaned"
+        }
+
+        public var parameters: [String: String]? {
+            [
+                "heartbeat_age": heartbeatAge.rawValue,
+                "proxy_age": proxyAge.rawValue
+            ]
+        }
+
+        public var standardParameters: [PixelKitStandardParameter]? {
+            [.pixelSource]
+        }
     }
 
     public enum StartAttemptStep: PixelKitEvent {

--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Provider/TransparentProxyProviderEventHandler.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Provider/TransparentProxyProviderEventHandler.swift
@@ -60,6 +60,13 @@ public final class TransparentProxyProviderEventHandler: TransparentProxyProvide
             logger.log("Proxy provider: sleep")
         case .wake:
             logger.log("Proxy provider: wake")
+
+        // Orphan detection
+
+        case .orphaned(let heartbeatAge, let proxyAge):
+            logger.log("🟠 Proxy provider orphaned (heartbeat: \(heartbeatAge.rawValue, privacy: .public), proxyAge: \(proxyAge.rawValue, privacy: .public))")
+            let pixel = TransparentProxyProvider.OrphanedEvent(heartbeatAge: heartbeatAge, proxyAge: proxyAge)
+            pixelKit?.fire(pixel, frequency: .dailyAndCount)
         }
     }
 }

--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Settings/TransparentProxySettings.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Settings/TransparentProxySettings.swift
@@ -107,6 +107,33 @@ public final class TransparentProxySettings: TransparentProxySettingsProviding {
         defaults.vpnProxyExcludedDomainsPublisher
     }
 
+    // MARK: - Orphan proxy detection
+
+    /// When `false`, the proxy skips its orphan-detection loop entirely. Resolved from a remote kill
+    /// switch by the app and delivered via the settings snapshot. Defaults to `true`.
+    public var isOrphanProxyDetectionEnabled: Bool {
+        get {
+            defaults.vpnProxyOrphanDetectionEnabled
+        }
+
+        set {
+            defaults.vpnProxyOrphanDetectionEnabled = newValue
+        }
+    }
+
+    /// When `false`, the proxy still detects (and reports) the orphaned state but never engages the
+    /// full-bypass mode. Resolved from a remote kill switch by the app and delivered via the settings
+    /// snapshot. Defaults to `true`.
+    public var isOrphanProxyBypassEnabled: Bool {
+        get {
+            defaults.vpnProxyOrphanBypassEnabled
+        }
+
+        set {
+            defaults.vpnProxyOrphanBypassEnabled = newValue
+        }
+    }
+
     // MARK: - Reset to factory defaults
 
     public func resetAll() {
@@ -173,12 +200,17 @@ public final class TransparentProxySettings: TransparentProxySettingsProviding {
     // MARK: - Snapshot support
 
     public func snapshot() -> TransparentProxySettingsSnapshot {
-        .init(appRoutingRules: appRoutingRules, excludedDomains: excludedDomains)
+        .init(appRoutingRules: appRoutingRules,
+              excludedDomains: excludedDomains,
+              isOrphanProxyDetectionEnabled: isOrphanProxyDetectionEnabled,
+              isOrphanProxyBypassEnabled: isOrphanProxyBypassEnabled)
     }
 
     public func apply(_ snapshot: TransparentProxySettingsSnapshot) {
         appRoutingRules = snapshot.appRoutingRules
         excludedDomains = snapshot.excludedDomains
+        isOrphanProxyDetectionEnabled = snapshot.isOrphanProxyDetectionEnabled
+        isOrphanProxyBypassEnabled = snapshot.isOrphanProxyBypassEnabled
     }
 }
 
@@ -198,4 +230,28 @@ public struct TransparentProxySettingsSnapshot: Codable {
 
     public let appRoutingRules: VPNAppRoutingRules
     public let excludedDomains: [String]
+    public let isOrphanProxyDetectionEnabled: Bool
+    public let isOrphanProxyBypassEnabled: Bool
+
+    public init(appRoutingRules: VPNAppRoutingRules,
+                excludedDomains: [String],
+                isOrphanProxyDetectionEnabled: Bool = UserDefaults.orphanProxyDetectionEnabledDefaultValue,
+                isOrphanProxyBypassEnabled: Bool = UserDefaults.orphanProxyBypassEnabledDefaultValue) {
+        self.appRoutingRules = appRoutingRules
+        self.excludedDomains = excludedDomains
+        self.isOrphanProxyDetectionEnabled = isOrphanProxyDetectionEnabled
+        self.isOrphanProxyBypassEnabled = isOrphanProxyBypassEnabled
+    }
+
+    /// Custom decoding so snapshots persisted by older versions (which lack the orphan-proxy flags) still
+    /// decode, falling back to the pre-kill-switch behavior rather than failing the whole snapshot.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        appRoutingRules = try container.decode(VPNAppRoutingRules.self, forKey: .appRoutingRules)
+        excludedDomains = try container.decode([String].self, forKey: .excludedDomains)
+        isOrphanProxyDetectionEnabled = try container.decodeIfPresent(Bool.self, forKey: .isOrphanProxyDetectionEnabled)
+            ?? UserDefaults.orphanProxyDetectionEnabledDefaultValue
+        isOrphanProxyBypassEnabled = try container.decodeIfPresent(Bool.self, forKey: .isOrphanProxyBypassEnabled)
+            ?? UserDefaults.orphanProxyBypassEnabledDefaultValue
+    }
 }

--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Settings/UserDefaultsExtensions/UserDefaults+orphanProxy.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Settings/UserDefaultsExtensions/UserDefaults+orphanProxy.swift
@@ -1,0 +1,71 @@
+//
+//  UserDefaults+orphanProxy.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import Foundation
+
+extension UserDefaults {
+
+    // MARK: - Orphan proxy detection
+
+    /// The behavior before the orphan-proxy kill switches existed: detection ran unconditionally.
+    public static let orphanProxyDetectionEnabledDefaultValue = true
+
+    private var orphanProxyDetectionEnabledKey: String {
+        "vpnProxyOrphanDetectionEnabled"
+    }
+
+    @objc
+    dynamic var vpnProxyOrphanDetectionEnabled: Bool {
+        get {
+            value(forKey: orphanProxyDetectionEnabledKey) as? Bool ?? Self.orphanProxyDetectionEnabledDefaultValue
+        }
+
+        set {
+            set(newValue, forKey: orphanProxyDetectionEnabledKey)
+        }
+    }
+
+    func resetVPNProxyOrphanDetectionEnabled() {
+        removeObject(forKey: orphanProxyDetectionEnabledKey)
+    }
+
+    // MARK: - Orphan proxy full bypass
+
+    /// The behavior before the orphan-proxy kill switches existed: bypass engaged on detection.
+    public static let orphanProxyBypassEnabledDefaultValue = true
+
+    private var orphanProxyBypassEnabledKey: String {
+        "vpnProxyOrphanBypassEnabled"
+    }
+
+    @objc
+    dynamic var vpnProxyOrphanBypassEnabled: Bool {
+        get {
+            value(forKey: orphanProxyBypassEnabledKey) as? Bool ?? Self.orphanProxyBypassEnabledDefaultValue
+        }
+
+        set {
+            set(newValue, forKey: orphanProxyBypassEnabledKey)
+        }
+    }
+
+    func resetVPNProxyOrphanBypassEnabled() {
+        removeObject(forKey: orphanProxyBypassEnabledKey)
+    }
+}

--- a/macOS/LocalPackages/NetworkProtectionMac/Tests/NetworkProtectionProxyTests/OrphanProxyBucketTests.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Tests/NetworkProtectionProxyTests/OrphanProxyBucketTests.swift
@@ -1,0 +1,48 @@
+//
+//  OrphanProxyBucketTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+@testable import NetworkProtectionProxy
+import XCTest
+
+final class OrphanProxyBucketTests: XCTestCase {
+
+    private let now = Date()
+
+    private func heartbeatBucket(ageSeconds: TimeInterval?) -> TransparentProxyProvider.HeartbeatAgeBucket {
+        let date = ageSeconds.map { now.addingTimeInterval(-$0) }
+        return TransparentProxyProvider.HeartbeatAgeBucket.bucket(for: date, now: now)
+    }
+
+    func testHeartbeatBuckets() {
+        XCTAssertEqual(heartbeatBucket(ageSeconds: nil), .missing)
+        XCTAssertEqual(heartbeatBucket(ageSeconds: 299), .under5m)
+        XCTAssertEqual(heartbeatBucket(ageSeconds: 300), .under30m)
+        XCTAssertEqual(heartbeatBucket(ageSeconds: 1799), .under30m)
+        XCTAssertEqual(heartbeatBucket(ageSeconds: 1800), .over30m)
+    }
+
+    func testProxyBuckets() {
+        XCTAssertEqual(TransparentProxyProvider.ProxyAgeBucket.bucket(for: 299), .under5m)
+        XCTAssertEqual(TransparentProxyProvider.ProxyAgeBucket.bucket(for: 300), .under30m)
+        XCTAssertEqual(TransparentProxyProvider.ProxyAgeBucket.bucket(for: 1799), .under30m)
+        XCTAssertEqual(TransparentProxyProvider.ProxyAgeBucket.bucket(for: 1800), .under2h)
+        XCTAssertEqual(TransparentProxyProvider.ProxyAgeBucket.bucket(for: 7199), .under2h)
+        XCTAssertEqual(TransparentProxyProvider.ProxyAgeBucket.bucket(for: 7200), .over2h)
+    }
+}

--- a/macOS/LocalPackages/NetworkProtectionMac/Tests/NetworkProtectionProxyTests/OrphanProxyDecisionTests.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Tests/NetworkProtectionProxyTests/OrphanProxyDecisionTests.swift
@@ -1,0 +1,116 @@
+//
+//  OrphanProxyDecisionTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+@testable import NetworkProtectionProxy
+import XCTest
+
+final class OrphanProxyDecisionTests: XCTestCase {
+
+    private let proxyAgeThreshold: TimeInterval = 60
+    private let heartbeatAgeThreshold: TimeInterval = 60
+
+    private func decision(
+        proxyAge: TimeInterval = 120,
+        heartbeatAge: TimeInterval? = 120,
+        bypassEnabled: Bool = true,
+        isFullBypassEnabled: Bool = false,
+        orphanFiredForCurrentEpisode: Bool = false
+    ) -> OrphanProxyDecision? {
+        OrphanProxyTester.decision(
+            proxyAge: proxyAge,
+            heartbeatAge: heartbeatAge,
+            bypassEnabled: bypassEnabled,
+            isFullBypassEnabled: isFullBypassEnabled,
+            orphanFiredForCurrentEpisode: orphanFiredForCurrentEpisode,
+            proxyAgeThreshold: proxyAgeThreshold,
+            heartbeatAgeThreshold: heartbeatAgeThreshold)
+    }
+
+    // MARK: - Proxy age gate
+
+    func testReturnsNilWhenProxyTooYoung() {
+        XCTAssertNil(decision(proxyAge: 59, heartbeatAge: nil))
+    }
+
+    func testEvaluatesWhenProxyAgeExactlyAtThreshold() {
+        XCTAssertNotNil(decision(proxyAge: 60, heartbeatAge: nil))
+    }
+
+    // MARK: - Fresh heartbeat (tunnel alive)
+
+    func testFreshHeartbeatLiftsBypassAndResetsLatch() {
+        let result = decision(
+            heartbeatAge: 10,
+            isFullBypassEnabled: true,
+            orphanFiredForCurrentEpisode: true)
+
+        XCTAssertEqual(result, OrphanProxyDecision(
+            isFullBypassEnabled: false,
+            orphanFiredForCurrentEpisode: false,
+            shouldFirePixel: false))
+    }
+
+    func testHeartbeatExactlyAtThresholdIsStale() {
+        // Fresh means strictly under the threshold, so an age equal to it is orphaned.
+        let result = decision(heartbeatAge: heartbeatAgeThreshold)
+        XCTAssertEqual(result?.isFullBypassEnabled, true)
+    }
+
+    // MARK: - Stale heartbeat (orphaned)
+
+    func testStaleHeartbeatEngagesBypassAndFires() {
+        let result = decision(heartbeatAge: 120, isFullBypassEnabled: false)
+
+        XCTAssertEqual(result, OrphanProxyDecision(
+            isFullBypassEnabled: true,
+            orphanFiredForCurrentEpisode: true,
+            shouldFirePixel: true))
+    }
+
+    func testMissingHeartbeatIsTreatedAsOrphaned() {
+        let result = decision(heartbeatAge: nil)
+        XCTAssertEqual(result?.isFullBypassEnabled, true)
+        XCTAssertEqual(result?.shouldFirePixel, true)
+    }
+
+    func testPixelFiresOncePerEpisode() {
+        let result = decision(
+            heartbeatAge: 120,
+            isFullBypassEnabled: true,
+            orphanFiredForCurrentEpisode: true)
+
+        // Still orphaned: bypass stays engaged, but the pixel does not re-fire.
+        XCTAssertEqual(result?.isFullBypassEnabled, true)
+        XCTAssertEqual(result?.shouldFirePixel, false)
+    }
+
+    // MARK: - Bypass kill switch
+
+    func testBypassKillSwitchOffStillFiresPixelButDoesNotEngageBypass() {
+        let result = decision(
+            heartbeatAge: 120,
+            bypassEnabled: false,
+            isFullBypassEnabled: false)
+
+        XCTAssertEqual(result, OrphanProxyDecision(
+            isFullBypassEnabled: false,
+            orphanFiredForCurrentEpisode: true,
+            shouldFirePixel: true))
+    }
+}

--- a/macOS/LocalPackages/NetworkProtectionMac/Tests/NetworkProtectionProxyTests/TransparentProxySettingsSnapshotTests.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Tests/NetworkProtectionProxyTests/TransparentProxySettingsSnapshotTests.swift
@@ -1,0 +1,70 @@
+//
+//  TransparentProxySettingsSnapshotTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+@testable import NetworkProtectionProxy
+import XCTest
+
+final class TransparentProxySettingsSnapshotTests: XCTestCase {
+
+    func testRoundTripsOrphanProxyFlags() throws {
+        let snapshot = TransparentProxySettingsSnapshot(
+            appRoutingRules: [:],
+            excludedDomains: [],
+            isOrphanProxyDetectionEnabled: false,
+            isOrphanProxyBypassEnabled: false)
+
+        let decoded = try JSONDecoder().decode(
+            TransparentProxySettingsSnapshot.self,
+            from: JSONEncoder().encode(snapshot))
+
+        XCTAssertFalse(decoded.isOrphanProxyDetectionEnabled)
+        XCTAssertFalse(decoded.isOrphanProxyBypassEnabled)
+    }
+
+    func testDefaultsOrphanProxyFlagsToEnabledWhenMissingFromPayload() throws {
+        // A snapshot persisted by an older version that predates the flags.
+        let legacyJSON = """
+        {"appRoutingRules":{},"excludedDomains":[]}
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(TransparentProxySettingsSnapshot.self, from: legacyJSON)
+
+        XCTAssertTrue(decoded.isOrphanProxyDetectionEnabled)
+        XCTAssertTrue(decoded.isOrphanProxyBypassEnabled)
+    }
+
+    func testSettingsRoundTripThroughSnapshot() {
+        let defaults = UserDefaults(suiteName: "orphan-proxy-settings-test")!
+        defer { defaults.removePersistentDomain(forName: "orphan-proxy-settings-test") }
+
+        let settings = TransparentProxySettings(defaults: defaults)
+        XCTAssertTrue(settings.isOrphanProxyDetectionEnabled)
+        XCTAssertTrue(settings.isOrphanProxyBypassEnabled)
+
+        settings.isOrphanProxyDetectionEnabled = false
+        settings.isOrphanProxyBypassEnabled = false
+
+        let applied = TransparentProxySettings(defaults: UserDefaults(suiteName: "orphan-proxy-applied-test")!)
+        defer { applied.defaults.removePersistentDomain(forName: "orphan-proxy-applied-test") }
+        applied.apply(settings.snapshot())
+
+        XCTAssertFalse(applied.isOrphanProxyDetectionEnabled)
+        XCTAssertFalse(applied.isOrphanProxyBypassEnabled)
+    }
+}

--- a/macOS/PixelDefinitions/pixels/definitions/vpn_events.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/vpn_events.json5
@@ -262,5 +262,27 @@
                 "description": "Error code associated with a per-probe error (outer or underlying)"
             }
         ]
+    },
+    "m_mac_vpn_proxy_orphaned": {
+        "description": "Fired once per episode when the transparent proxy detects it is orphaned: it has been running past the age threshold while the tunnel's heartbeat is missing or stale, indicating the tunnel is gone",
+        "owners": ["diegoreymendez"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "heartbeat_age",
+                "type": "string",
+                "description": "Bucketed age of the tunnel's last heartbeat at detection time, or 'missing' if no heartbeat was ever recorded",
+                "enum": ["missing", "under_5m", "under_30m", "over_30m"]
+            },
+            {
+                "key": "proxy_age",
+                "type": "string",
+                "description": "Bucketed time the proxy had been running at detection time",
+                "enum": ["under_5m", "under_30m", "under_2h", "over_2h"]
+            }
+        ]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207603085593419/task/1214550570741638?focus=true

## IMPORTANT
Cherry-picks https://github.com/duckduckgo/apple-browsers/pull/4973 into 1.194.0
I opened a PR to get the CI to go green since these are a lot of lines.

### Description

When the VPN login item is disabled and the user stops the VPN from System Settings, the transparent proxy can be left running with no agent left to disable it, silently breaking the user's traffic. The tunnel now writes a periodic heartbeat, and the proxy switches to a full-bypass mode when that heartbeat goes stale, exiting automatically once it returns. A daily pixel fires per user when bypass engages so we can size the problem. The detection machinery and bypass behavior are each gated behind a remote kill switch, both defaulting to enabled.

### Testing Steps

1. Connect the VPN with the login item enabled.
2. Confirm proxied apps route through the VPN as normal.
3. Disable the VPN login item, then stop the VPN from System Settings.
4. Observe that proxied app traffic recovers rather than staying broken.
5. Confirm the `vpn_proxy_orphaned` pixel fires when bypass engages.

### Impact and Risks

Medium. Targets a path where the proxy outlives its agent and breaks the user's network. Both the detection loop and the bypass are individually kill-switchable from privacy config, so either half can be disabled remotely without an app update.

#### What could go wrong?

A false-positive staleness reading could bypass the proxy while the tunnel is still healthy. The staleness thresholds and a post-wake grace period guard against this, and the bypass kill switch is the remote off-ramp if it misbehaves.

### Quality Considerations

The orphan decision logic is extracted into a pure `OrphanProxyDecision` helper with unit tests covering the decision matrix, pixel age buckets, and settings-snapshot defaults, so the thresholds and gating are verified without standing up a Network Extension provider.

### Notes to Reviewer

This is a cherry-pick of the already-merged work onto `release/macos/1.194.0` for inclusion in the 1.194.0 release; it will need a release exception.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macOS VPN routing behavior (proxy full bypass) based on heartbeat heuristics; mitigated by thresholds, post-wake grace, and separate remote kill switches for detection vs bypass.
> 
> **Overview**
> Adds **orphaned transparent-proxy recovery** when the VPN tunnel stops but the macOS app proxy keeps running (e.g. login item off + VPN stopped in System Settings).
> 
> The packet tunnel now writes a **15s heartbeat** to shared storage via `TunnelHeartbeatStore`, started/stopped with connect, cancel, sleep, and wake, and only when `isOrphanProxyDetectionEnabled` is true. That flag flows through `VPNSettings` / `VPNSettingsSnapshot` (with legacy decode defaults).
> 
> The transparent proxy runs a periodic **orphan check** (pure `OrphanProxyTester` logic): if the proxy has been up long enough and the heartbeat is missing or stale, it can enter **full bypass** (`handleNewFlow` returns false so traffic uses normal routing) until a fresh heartbeat returns. A **daily-count** `vpn_proxy_orphaned` pixel reports bucketed heartbeat/proxy ages.
> 
> **Remote kill switches** (privacy config + macOS feature flags) independently disable detection (heartbeat + loop + pixel) or bypass while still allowing detection/metrics. The VPN agent applies negated flag values on launch and when privacy config reloads.
> 
> Also wires heartbeat into `MacPacketTunnelProvider` / `MacTransparentProxyProvider` (shared defaults, PixelKit for system extension proxy) and adds unit tests for store, decisions, buckets, and snapshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e9a948296fe1d6bc30f74cd1b8aac42ee321dec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->