### PR TITLE
Fix Voice Search Control Center shortcut title

### DIFF
--- a/iOS/Widgets/Definitions/ControlWidgetConfigurable.swift
+++ b/iOS/Widgets/Definitions/ControlWidgetConfigurable.swift
@@ -153,7 +153,7 @@ struct VoiceSearchControlWidget: ControlWidgetConfigurable {
     let intent = OpenVoiceSearchIntent()
 
     struct OpenVoiceSearchIntent: AppIntent {
-        static var title: LocalizedStringResource = "Favorites"
+        static var title: LocalizedStringResource = "Voice Search"
         static var description: LocalizedStringResource = "Start a new voice search from the Control Center."
         static var openAppWhenRun: Bool = true
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1215515407914631?focus=true
Tech Design URL:
CC:

### Description
The Voice Search Control Center shortcut's `AppIntent` title was a copy-paste leftover reading "Favorites" while its description and surrounding widget were about voice search. Changed the `OpenVoiceSearchIntent` title to "Voice Search" so the shortcut name matches its action.

### Testing Steps
1. Build and run the app on an iOS 18+ device/simulator.
2. Add the DuckDuckGo Voice Search control to Control Center (or open the Shortcuts/Controls picker).
3. Confirm the action is named "Voice Search" (not "Favorites") with the description "Start a new voice search from the Control Center."

### Impact and Risks
Low

#### What could go wrong?
The only change is a user-facing string label, so behavior is unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single localized display string change with no logic or deep-link behavior changes.
> 
> **Overview**
> Fixes a copy-paste mistake where the Voice Search Control Center `AppIntent` title was **"Favorites"** while the widget label and description already referred to voice search.
> 
> Updates `OpenVoiceSearchIntent.title` to **"Voice Search"**, aligning it with `displayName`/`labelText` and the same title/description pattern used by other controls in `ControlWidgetConfigurable.swift`. Runtime behavior is unchanged—only the shortcut name shown in Control Center / Shortcuts pickers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1791961c001632b54a4bcfe95d3ec5556efc500c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->