### PR TITLE
macOS: Fix Duck.ai omnibar clicks falling through to the bookmarks bar

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -209,10 +209,14 @@ final class AIChatOmnibarController {
     /// in the same window if one is active; otherwise opens a new selected Duck.ai tab and hands
     /// off `mode: voice-mode` via the prompt handler.
     func openNewVoiceChat() {
-        aiChatTabOpener.openVoiceSession(
-            inSourceCollection: tabCollectionViewModel,
-            behavior: .newTab(selected: true)
-        )
+        // Defer the tab open: synchronously it tears the panel down mid-click, so the click falls through to the bookmarks bar behind.
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.aiChatTabOpener.openVoiceSession(
+                inSourceCollection: self.tabCollectionViewModel,
+                behavior: .newTab(selected: true)
+            )
+        }
         PixelKit.fire(AIChatPixel.aiChatNewVoiceChatOmnibarNative, frequency: .dailyAndStandard, includeAppVersionParameter: true)
     }
 

--- a/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
@@ -228,6 +228,12 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         // When
         controller.openNewVoiceChat()
 
+        // `openNewVoiceChat` defers the open to the next main-queue turn; enqueue our wait behind it
+        // so FIFO ordering guarantees the deferred open has run by the time this fulfills.
+        let expectation = expectation(description: "deferred voice session open")
+        DispatchQueue.main.async { expectation.fulfill() }
+        waitForExpectations(timeout: 1)
+
         // Then — controller hands off to `openVoiceSession`, which encapsulates the
         // "focus existing voice tab in the same window if active, otherwise open new" decision.
         XCTAssertTrue(mockTabOpener.openVoiceSessionCalled)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211654189969294/task/1215516584717033
Tech Design URL:
CC:

### Description

A Duck.ai omnibar control overlapping the bookmarks bar (e.g. the voice-chat button) also opened the bookmark behind it. The panel's decorative `ShadowView` captured hit-tests, so `MouseBlockingBackgroundView` passed the click through, and it grabbed first responder for the control mid-click, tearing the panel down. Makes the shadow hit-transparent so the MBBV consumes the click, stops it focusing `NSControl`s on click (keeping hover working), and consumes clicks over the shadow-only strip above the tools row.

### Testing Steps
1. macOS with the Duck.ai omnibar + voice-chat access flags on, bookmarks bar visible.
2. New tab → focus the empty Duck.ai omnibar so the voice button shows over a bookmark.
3. Click the voice button — it opens voice chat only (no bookmark), and button hover still works.

### Impact and Risks
Low. Confined to the Duck.ai omnibar's click handling; the `ShadowView` change is opt-in (only the omnibar sets `isHitTransparent`).

### Notes to Reviewer
`MouseBlockingBackgroundView` now passes `mouseMoved` through (previously consumed) so the omnibar buttons' tracking-area hover keeps firing; clicks are still consumed, so nothing behind the panel becomes clickable.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small timing change in omnibar voice-chat only; behavior and tab-opener arguments are unchanged aside from deferral.
> 
> **Overview**
> Fixes voice-chat clicks on the Duck.ai omnibar also activating bookmarks underneath when the panel overlaps the bookmarks bar.
> 
> **`openNewVoiceChat`** no longer calls `openVoiceSession` synchronously from the button action. It schedules the same tab open on the next main-queue turn so the click can finish before UI teardown from opening a tab collapses the omnibar panel.
> 
> Analytics for the omnibar voice action still fire immediately; only the tab open is deferred. The unit test waits on a trailing main-queue block so assertions run after the deferred open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61a866d0b76e8dd274ac4e8b5dd720298c536d7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->