### PR TITLE
[macOS] Clean up duplicate pixel definition

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/vpn_events.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/vpn_events.json5
@@ -294,27 +294,5 @@
                 "enum": ["under_5m", "under_30m", "under_2h", "over_2h"]
             }
         ]
-    },
-    "m_mac_vpn_proxy_orphaned": {
-        "description": "Fired once per episode when the transparent proxy detects it is orphaned: it has been running past the age threshold while the tunnel's heartbeat is missing or stale, indicating the tunnel is gone",
-        "owners": ["diegoreymendez"],
-        "triggers": ["other"],
-        "suffixes": ["daily_count"],
-        "parameters": [
-            "appVersion",
-            "pixelSource",
-            {
-                "key": "heartbeat_age",
-                "type": "string",
-                "description": "Bucketed age of the tunnel's last heartbeat at detection time, or 'missing' if no heartbeat was ever recorded",
-                "enum": ["missing", "under_5m", "under_30m", "over_30m"]
-            },
-            {
-                "key": "proxy_age",
-                "type": "string",
-                "description": "Bucketed time the proxy had been running at detection time",
-                "enum": ["under_5m", "under_30m", "under_2h", "over_2h"]
-            }
-        ]
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215572316394291?focus=true
Tech Design URL:
CC:

### Description

We have duplicate definitions for `m_mac_vpn_proxy_orphaned`, which seem to have appeared due to a bad merge.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that there is still a `m_mac_vpn_proxy_orphaned` definition on the branch - only one of the two instances should be removed

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only pixel schema cleanup with no runtime or telemetry behavior change beyond fixing a duplicate key in the definitions file.
> 
> **Overview**
> Removes a **duplicate** `m_mac_vpn_proxy_orphaned` entry from `vpn_events.json5` that duplicated the same pixel (description, owners, `heartbeat_age` / `proxy_age` parameters) after a bad merge.
> 
> The surviving definition is unchanged; this only restores valid JSON5 with a single key for that event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 392b46cf6850283759216db5f28d76198c1ad584. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->