### PR TITLE
[macOS][SERP] Add daily frequency for SERP pixel

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageKeys.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageKeys.swift
@@ -35,5 +35,5 @@ public struct DuckAiNativeStorageSettings: StoringKeys {
 public enum DuckAiNativeStorageReservedEntryKeys: String {
     /// Entry holding the JSON array of chat IDs deleted on the native side.
     /// The web app reads it to reconcile deletions it did not itself initiate. Value: `[String]`.
-    case locallyDeletedChatIds = "locallyDeletedChatIds"
+    case locallyDeletedChatIds
 }

--- a/macOS/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
+++ b/macOS/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
@@ -74,7 +74,7 @@ final class StatisticsLoader {
                         completion()
                     }
                 }
-                PixelKit.fire(GeneralPixel.serp, frequency: .standard)
+                PixelKit.fire(GeneralPixel.serp, frequency: .dailyAndStandard)
                 PixelKit.fire(GeneralPixel.serpInitial, frequency: .uniqueByName)
                 self.fireSearchExperimentPixels()
                 if AppVersion.runType == .normal {

--- a/macOS/PixelDefinitions/pixels/definitions/navigation.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/navigation.json5
@@ -197,5 +197,12 @@
             },
             "channel"
         ]
+    },
+    "m_mac_navigation_search": {
+        "description": "Fires when the user performs a search via the DuckDuckGo SERP.",
+        "owners": ["alessandroboron"],
+        "triggers": ["other"],
+        "suffixes": ["daily_standard"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
     }
 }

--- a/macOS/UnitTests/Statistics/ATB/StatisticsLoaderTests.swift
+++ b/macOS/UnitTests/Statistics/ATB/StatisticsLoaderTests.swift
@@ -95,6 +95,38 @@ class StatisticsLoaderTests: XCTestCase {
         }
     }
 
+    func testRefreshRetentionAtbOnNavigationFiresStandardAndDailySerpPixelWithDailyRateLimited() {
+        // GIVEN
+        let firstExpectation = expectation(description: #function)
+        var firedPixelNames: [String] = []
+        let capturingPixelKit = PixelKit(
+            dryRun: false,
+            appVersion: "1.0.0",
+            defaultHeaders: [:],
+            defaults: UserDefaults(suiteName: "test_\(UUID().uuidString)")!,
+            fireRequest: { name, _, _, _, _, onComplete in
+                firedPixelNames.append(name)
+                onComplete(true, nil)
+            }
+        )
+        PixelKit.setSharedForTesting(pixelKit: capturingPixelKit)
+
+        mockStatisticsStore.atb = "atb"
+        mockStatisticsStore.searchRetentionAtb = "retentionatb"
+        mockStatisticsStore.variant = "test"
+        loadSuccessfulUpdateAtbStub()
+
+        // WHEN
+        testee.refreshRetentionAtbOnNavigation(isSearch: true, isDuckAI: false) {
+            firstExpectation.fulfill()
+        }
+        wait(for: [firstExpectation], timeout: 5)
+
+        // THEN
+        XCTAssertEqual(firedPixelNames.filter { $0 == "m_mac_navigation_search" }.count, 1)
+        XCTAssertEqual(firedPixelNames.filter { $0 == "m_mac_navigation_search_daily" }.count, 1)
+    }
+
     func testRefreshSearchRetentionAtbFiresSearchesOSDistributionPixel() {
         var firedPixelNames: [String] = []
         let capturingPixelKit = PixelKit(dryRun: false,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1214364681236602?focus=true
Tech Design URL:
CC: @samhouts 

### Description

This PR changes the `m_mac_navigation_search` pixel to also send a daily pixel, by switching the existing pixel frequency from `.standard` to `.dailyAndStandard` to measure DAU searches. 

### Testing Steps
1. Launch the app and perform a search via the address bar.
2. Verify that both `m_mac_navigation_search` and `m_mac_navigation_search_daily` pixels fire on the first SERP navigation of the day.
3. Perform another search and verify that only `m_mac_navigation_search` pixel fires again and `m_mac_navigation_search_daily` pixel is skipped.
4. Ensure new unit test pass.

### Impact and Risks
**Low:** Instrumentation only. No change to navigation/search functionality or logic to fire the pixel.

#### What could go wrong?
`m_mac_navigation_search` dashboard consumer affected: mitigated by using `.dailyAndStandard` rather than `.dailyAndCount` (the latter would suffix the base pixel with `_count`, breaking the existing consumer).

### Quality Considerations
- A new unit test in `StatisticsLoaderTests` covers the expected behaviour 

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Instrumentation-only change to pixel firing frequency and definitions; no navigation or search logic changes.
> 
> **Overview**
> **SERP navigation telemetry** now fires both the existing `m_mac_navigation_search` pixel and a once-per-day `m_mac_navigation_search_daily` variant by changing `PixelKit.fire(GeneralPixel.serp, …)` from `.standard` to `.dailyAndStandard` in `StatisticsLoader` when the user hits the SERP (non–Duck.ai search path).
> 
> `navigation.json5` registers **`m_mac_navigation_search`** with a `daily_standard` suffix and standard params. A new **`StatisticsLoaderTests`** case asserts one standard and one `_daily` fire on the first search navigation in a test harness.
> 
> **Duck.ai native storage:** `DuckAiNativeStorageReservedEntryKeys.locallyDeletedChatIds` drops an explicit `= "locallyDeletedChatIds"` raw value; behavior for the web bridge key string is unchanged when using default `String` enum raw values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fe7bf630b2569be5727f1b861b11533967f310a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->