### PR TITLE
Sample site_loading_timing pixel at 20%

### DIFF
--- a/macOS/DuckDuckGo/Tab/TabExtensions/NavigationPixelNavigationResponder.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/NavigationPixelNavigationResponder.swift
@@ -181,6 +181,6 @@ extension NavigationPixelNavigationResponder: NavigationResponder {
             firstMeaningfulPaintMs: firstMeaningfulPaintMs,
             documentCompleteMs: documentCompleteMs,
             allResourcesCompleteMs: allResourcesCompleteMs
-        ), frequency: .standard, withAdditionalParameters: additionalParams)
+        ), frequency: .sample(percentage: SiteLoadingPixel.samplePercentage), withAdditionalParameters: additionalParams)
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/navigation.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/navigation.json5
@@ -80,6 +80,12 @@
         "description": "Fired when WKPageLoadTiming data is available for a site loading navigation. Provides detailed performance timing metrics.",
         "owners": ["diegoreymendez"],
         "triggers": ["page_load"],
+        "suffixes": [
+            {
+                "description": "Sampling percentage (between 1 and 100 inclusive)",
+                "pattern": "^sample(?:100|0?[1-9]|[1-9][0-9])$"
+            }
+        ],
         "parameters": [
             "appVersion",
             "pixelSource",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1215579583844197?focus=true

### Description

The `site_loading_timing` pixel fired on every page load while the other site-loading pixels (success, failure, performance) are all sampled at 20%. This brings it in line by sampling it at 20% too, cutting its volume without losing signal.

### Testing Steps

1. Build and run the macOS app.
2. Browse to several sites and let them finish loading.
3. Verify the `m_mac_site_loading_timing` pixel fires with a `_sample20` suffix and only on a fraction of loads.

### Impact and Risks

Low. Reduces the firing rate of an internal performance-monitoring pixel.

#### What could go wrong?

Sampling lowers the absolute count of timing data points. The 20% rate matches the sibling pixels and remains sufficient for trend analysis.

### Quality Considerations

The pixel definition needs the `sampleNN` suffix pattern declared, or the sampled name fails pixel validation. That suffix block was added to match the other sampled definitions in the same file.

### Notes to Reviewer

No automated tests cover this responder's firing frequency, so the change is verified by definition validation and manual observation.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
