### PR TITLE
Disable flaky PIR opt-out E2E test

### DIFF
--- a/macOS/DBPE2ETests/DBPEndToEndTests.swift
+++ b/macOS/DBPE2ETests/DBPEndToEndTests.swift
@@ -115,6 +115,10 @@ final class DBPEndToEndTests: XCTestCase {
      When we adopt Swift 6, this can likely be replaced with the new testing macros
      */
     func testWhenProfileIsSaved_ThenEachStepHappensInSequence() async throws {
+        // Disabled while we investigate the opt-out step timing out against the fake broker, which fails broadly across branches and the scheduled main run.
+        // Tracking: https://app.asana.com/1/137249556945/project/1203108348835387/task/1215581159471305
+        try XCTSkipIf(true, "Disabled: opt-out step times out against the fake broker.")
+
         // Given
 
         // Local state set up


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1215581159471305

### Description

Disables failing test `testWhenProfileIsSaved_ThenEachStepHappensInSequence`.

### Testing Steps

Verify CI goes green here.

### Impact and Risks

None. Disables a single E2E test that's already failing, so this PR doesn't introduce additional risk..

#### What could go wrong?

NA

### Quality Considerations

`XCTSkipIf` skip the test.

### Notes to Reviewer

The test fails on the scheduled main run and on multiple unrelated branches.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that skips a single E2E test; no production code paths are modified.
> 
> **Overview**
> **Skips** the macOS PIR end-to-end test `testWhenProfileIsSaved_ThenEachStepHappensInSequence` at the start of the method using `XCTSkipIf(true, …)` so CI no longer fails on opt-out timeouts against the fake broker.
> 
> Comments point to an Asana task for the investigation; the full multi-stage test body is unchanged and will not run until the skip is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5b4d1fa8be91b5f58fc931d933830533d272a58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->