### PR TITLE
iOS: Fix transparent input-accessory gap with Unified Toggle Input

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -268,7 +268,7 @@ extension MainViewController {
         case .standardChrome:
             statusBackgroundPresentation = .standard
             rootBackgroundColor = ThemeManager.shared.currentTheme.mainViewBackgroundColor
-            navigationBarContainerColor = nil
+            navigationBarContainerColor = ThemeManager.shared.currentTheme.barBackgroundColor
             inputContentContainerColor = .clear
             unifiedToggleInputContainerColor = .clear
             webViewBackgroundColor = nil


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1215524884874158
Tech Design URL:
CC:

### Description

With Unified Toggle Input (UTI) enabled and the bottom address bar, the area between the omnibar and the keyboard — behind the web form-assistant accessory (up/down arrows + checkmark) when a website text field is focused — rendered **transparent**, so the page showed through. With UTI off it's opaque, which is the correct look.

**Cause:** `applyUnifiedInputChromeBackground(.standardChrome)` set the navigation bar container's background to `nil` (transparent). Standard chrome's proper colour is the opaque bar background — `decorate()` already uses it — and transparency is only intended for the AI-chat (Duck.ai) surface.

**Fix:** restore the proper opaque colour in `.standardChrome` (`navigationBarContainerColor = theme.barBackgroundColor`). One line, no feature/web-tab special-casing — it's simply the standard chrome's correct colour; the AI-chat states keep their own transparent handling.

### Testing Steps
1. Enable Unified Toggle Input; bottom address bar (iPhone).
2. Open a website with a text field (e.g. `duckduckgo.com`) and focus its on-page search box.
3. ✅ The area between the omnibar and the keyboard (behind the up/down/checkmark accessory) is **opaque** — the page does not show through. Check light and dark mode.
4. Omnibar editing (Search / Duck.ai) and Duck.ai chat tabs are unchanged.
5. Smoke test bottom/top omnibar and UTI FF disabled.

### Impact and Risks
**Low** — restores the standard chrome's intended opaque colour. AI-chat states are untouched.

### Quality Considerations
- Validated on simulator: the standard-chrome nav container is now opaque (confirmed via the live view hierarchy — it previously carried no background at all); collapsed browsing, omnibar/Duck.ai editing, and the Duck.ai chat tab are all unchanged. The opaque `.panel` colour was separately confirmed to render the band solid in light + dark.
- No new logic to unit-test (a single colour assignment).

### Notes to Reviewer
An earlier iteration gated this on keyboard/web-field state with a helper + tests; per review that was unnecessary — standard chrome simply shouldn't be transparent in the first place. The change is now a one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Low Risk**
> Single theme color assignment for standard chrome only; no auth, data, or AI-tab chrome logic changes.
> 
> **Overview**
> Fixes a **transparent band** between the omnibar and keyboard when Unified Toggle Input is on and a web text field shows the form-assistant accessory (bottom address bar).
> 
> In `applyUnifiedInputChromeBackground`, **`.standardChrome`** now sets **`navigationBarContainerColor`** to **`theme.barBackgroundColor`** instead of **`nil`**, matching normal bar decoration and keeping that strip opaque. Duck.ai chrome states are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 245bd8d5e46be5b96accb16d8145b35991912a29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>