### PR TITLE
[macOS] Update pixel parameters for Next Steps cards

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -4153,6 +4153,8 @@
 		CCF40A722ED7529D00CBF271 /* UserChurnPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF40A702ED7529D00CBF271 /* UserChurnPixel.swift */; };
 		CCF40A782ED76C0600CBF271 /* UserChurnBackgroundActivityScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF40A772ED76C0600CBF271 /* UserChurnBackgroundActivityScheduler.swift */; };
 		CCF40A792ED76C0600CBF271 /* UserChurnBackgroundActivityScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF40A772ED76C0600CBF271 /* UserChurnBackgroundActivityScheduler.swift */; };
+		CCF7761F2FD9641B005C9832 /* NewTabPagePixelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF7761E2FD9641B005C9832 /* NewTabPagePixelTests.swift */; };
+		CCF776202FD9641B005C9832 /* NewTabPagePixelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF7761E2FD9641B005C9832 /* NewTabPagePixelTests.swift */; };
 		CCF78AD62F34996900263097 /* CombineSchedulers in Frameworks */ = {isa = PBXBuildFile; productRef = CCF78AD52F34996900263097 /* CombineSchedulers */; };
 		CCF78AD82F34997400263097 /* CombineSchedulers in Frameworks */ = {isa = PBXBuildFile; productRef = CCF78AD72F34997400263097 /* CombineSchedulers */; };
 		CD2AB5BF2C8222F20019EB49 /* MaliciousSiteProtectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE248A42C821FFE00F9399D /* MaliciousSiteProtectionManager.swift */; };
@@ -6796,6 +6798,7 @@
 		CCF40A6A2ED7434C00CBF271 /* UserChurnServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserChurnServiceTests.swift; sourceTree = "<group>"; };
 		CCF40A702ED7529D00CBF271 /* UserChurnPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserChurnPixel.swift; sourceTree = "<group>"; };
 		CCF40A772ED76C0600CBF271 /* UserChurnBackgroundActivityScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserChurnBackgroundActivityScheduler.swift; sourceTree = "<group>"; };
+		CCF7761E2FD9641B005C9832 /* NewTabPagePixelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPagePixelTests.swift; sourceTree = "<group>"; };
 		CD2AB5C92C8225E70019EB49 /* URLTokenValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLTokenValidator.swift; sourceTree = "<group>"; };
 		CD3301282C887B1C009AA127 /* URLTokenValidatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLTokenValidatorTests.swift; sourceTree = "<group>"; };
 		CD33012B2C89B588009AA127 /* ErrorPageHTMLFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorPageHTMLFactory.swift; sourceTree = "<group>"; };
@@ -12196,6 +12199,7 @@
 				B6DA441D2616C84600DD1EC2 /* PixelStoreMock.swift */,
 				4B117F7C276C0CB5002F3D8C /* LocalStatisticsStoreTests.swift */,
 				B610F2E327A8F37A00FCEBE9 /* CBRCompileTimeReporterTests.swift */,
+				CCF7761E2FD9641B005C9832 /* NewTabPagePixelTests.swift */,
 			);
 			path = Statistics;
 			sourceTree = "<group>";
@@ -16560,6 +16564,7 @@
 				56EA402A2DB7830800B5061E /* LocalizationTests.swift in Sources */,
 				3790E2F52F6D5F70003EACD2 /* TabCollectionViewModelTests.swift in Sources */,
 				7B1522B12DE9CCA900887371 /* MockFeatureGatekeeper.swift in Sources */,
+				CCF776202FD9641B005C9832 /* NewTabPagePixelTests.swift in Sources */,
 				3706FE81293F661700E42796 /* PermissionModelTests.swift in Sources */,
 				5681ED442BDBA5F900F59729 /* SyncBookmarksAdapterTests.swift in Sources */,
 				BB0036652E426EDD0016DDEF /* ReportProblemFormViewModelTests.swift in Sources */,
@@ -18747,6 +18752,7 @@
 				1D4B03D92CA55DDF00224E99 /* BookmarkUrlExtensionTests.swift in Sources */,
 				B6106BB326A7F4AA0013B453 /* GeolocationServiceMock.swift in Sources */,
 				4B8AC93D26B49BE600879451 /* FirefoxLoginReaderTests.swift in Sources */,
+				CCF7761F2FD9641B005C9832 /* NewTabPagePixelTests.swift in Sources */,
 				3714B1E728EDB7FA0056C57A /* DuckPlayerPreferencesTests.swift in Sources */,
 				9F1556822DDC41E600A35DBA /* MockDefaultBrowserAndDockPromptStorage.swift in Sources */,
 				BBD31EAB2E2FB46E0045551C /* VPNUpsellVisibilityManagerTests.swift in Sources */,

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -575,7 +575,6 @@ extension AppDelegate {
         duckPlayer.preferences.duckPlayerMode = .alwaysAsk
         UserDefaultsWrapper<Bool>(key: .homePageContinueSetUpImport, defaultValue: false).clear()
         homePageSetUpDependencies.clearAll()
-        NotificationCenter.default.post(name: .newTabPageWebViewDidAppear, object: nil)
     }
 
     @MainActor

--- a/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsCardsPixelHandler.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsCardsPixelHandler.swift
@@ -18,6 +18,7 @@
 
 import NewTabPage
 import PixelKit
+import Foundation
 
 protocol NewTabPageNextStepsCardsPixelHandling {
 
@@ -50,9 +51,21 @@ protocol NewTabPageNextStepsCardsPixelHandling {
 
 final class NewTabPageNextStepsCardsPixelHandler: NewTabPageNextStepsCardsPixelHandling {
     private let pixelHandler: (PixelKitEvent, PixelKit.Frequency, Bool) -> Void
+    private let persistor: NewTabPageNextStepsCardsPersisting
+    private let appearancePreferences: AppearancePreferences
+    private let daysSinceInstallProvider: () -> Int?
 
-    init(pixelHandler: @escaping (PixelKitEvent, PixelKit.Frequency, Bool) -> Void = { PixelKit.fire($0, frequency: $1, includeAppVersionParameter: $2) }) {
+    init(persistor: NewTabPageNextStepsCardsPersisting,
+         appearancePreferences: AppearancePreferences,
+         installDateProvider: @escaping () -> Date?,
+         pixelHandler: @escaping (PixelKitEvent, PixelKit.Frequency, Bool) -> Void = { PixelKit.fire($0, frequency: $1, includeAppVersionParameter: $2) }) {
         self.pixelHandler = pixelHandler
+        self.persistor = persistor
+        self.appearancePreferences = appearancePreferences
+        self.daysSinceInstallProvider = {
+            guard let installDate = installDateProvider() else { return nil }
+            return Calendar.current.numberOfDaysBetween(installDate, and: Date())
+        }
     }
 
     func fireAddToDockPresentedPixelIfNeeded(_ cards: [NewTabPageDataModel.CardID]) {
@@ -70,11 +83,21 @@ final class NewTabPageNextStepsCardsPixelHandler: NewTabPageNextStepsCardsPixelH
     }
 
     func fireNextStepsCardClickedPixel(_ card: NewTabPage.NewTabPageDataModel.CardID) {
-        pixelHandler(NewTabPagePixel.nextStepsCardClicked(card.rawValue), .standard, true)
+        let clickedEvent = NewTabPagePixel.nextStepsCardClicked(card.rawValue,
+                                                                cardImpressionCount: persistor.timesShown(for: card),
+                                                                ntpImpressionCount: persistor.ntpImpressionCount,
+                                                                daysSinceInstall: daysSinceInstallProvider(),
+                                                                activeUsageDays: appearancePreferences.nextStepsCardsDemonstrationDays)
+        pixelHandler(clickedEvent, .standard, true)
     }
 
     func fireNextStepsCardDismissedPixel(_ card: NewTabPage.NewTabPageDataModel.CardID) {
-        pixelHandler(NewTabPagePixel.nextStepsCardDismissed(card.rawValue), .standard, true)
+        let dismissedEvent = NewTabPagePixel.nextStepsCardDismissed(card.rawValue,
+                                                                    cardImpressionCount: persistor.timesShown(for: card),
+                                                                    ntpImpressionCount: persistor.ntpImpressionCount,
+                                                                    daysSinceInstall: daysSinceInstallProvider(),
+                                                                    activeUsageDays: appearancePreferences.nextStepsCardsDemonstrationDays)
+        pixelHandler(dismissedEvent, .standard, true)
     }
 
     func fireAddedToDockPixel() {

--- a/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsPersistor.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsPersistor.swift
@@ -24,6 +24,7 @@ protocol NewTabPageNextStepsCardsPersisting {
     var orderedCardIDs: [NewTabPageDataModel.CardID]? { get set }
     var firstCardLevel: NewTabPageDataModel.CardLevel { get set }
     var isFirstSession: Bool { get set }
+    var ntpImpressionCount: Int { get set }
 
     func timesShown(for card: NewTabPageDataModel.CardID) -> Int
     func setTimesShown(_ value: Int, for card: NewTabPageDataModel.CardID)
@@ -45,10 +46,20 @@ final class NewTabPageNextStepsCardsPersistor: NewTabPageNextStepsCardsPersistin
         static let cardOrder = "new.tab.page.next.steps.card.order"
         static let firstCardLevel = "new.tab.page.next.steps.first.card.level"
         static let isFirstSession = "new.tab.page.next.steps.is.first.session"
+        static let ntpImpressionCount = "new.tab.page.next.steps.ntp.impression.count"
     }
 
     init(keyValueStore: ThrowingKeyValueStoring) {
         self.keyValueStore = keyValueStore
+    }
+
+    var ntpImpressionCount: Int {
+        get {
+            return (try? keyValueStore.object(forKey: Keys.ntpImpressionCount) as? Int) ?? 0
+        }
+        set {
+            try? keyValueStore.set(newValue, forKey: Keys.ntpImpressionCount)
+        }
     }
 
     var orderedCardIDs: [NewTabPageDataModel.CardID]? {
@@ -169,6 +180,7 @@ final class NewTabPageNextStepsCardsPersistor: NewTabPageNextStepsCardsPersistin
         try? keyValueStore.removeObject(forKey: Keys.cardOrder)
         try? keyValueStore.removeObject(forKey: Keys.firstCardLevel)
         try? keyValueStore.removeObject(forKey: Keys.isFirstSession)
+        try? keyValueStore.removeObject(forKey: Keys.ntpImpressionCount)
     }
 
     private func shownKey(for card: NewTabPageDataModel.CardID) -> String {

--- a/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
@@ -270,11 +270,11 @@ private extension NewTabPageNextStepsSingleCardProvider {
 
         // Check if the first visible card has been shown 10+ times, and move it to the end of the list
         if let firstVisibleCard = orderedCards.first(where: shouldShowCard),
-           persistor.timesShown(for: firstVisibleCard) >= Constants.maxTimesCardShown,
+           persistor.timesShown(for: firstVisibleCard) > 0,
+           persistor.timesShown(for: firstVisibleCard) % Constants.maxTimesCardShown == 0,
            let index = orderedCards.firstIndex(where: { $0 == firstVisibleCard }) {
             let card = orderedCards.remove(at: index)
             orderedCards.append(card)
-            persistor.setTimesShown(0, for: card)
         }
 
         // Swap the order of levels if needed.

--- a/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
@@ -238,7 +238,6 @@ final class NewTabPageNextStepsSingleCardProvider: NewTabPageNextStepsCardsProvi
         if let card = cards.first {
             pixelHandler.fireNextStepsCardShownPixels([card])
             pixelHandler.fireAddToDockPresentedPixelIfNeeded([card])
-            persistor.incrementTimesShown(for: card)
         }
     }
 }
@@ -395,6 +394,10 @@ private extension NewTabPageNextStepsSingleCardProvider {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else { return }
+                if let card = cards.first {
+                    persistor.incrementTimesShown(for: card)
+                }
+
                 let buildType = StandardApplicationBuildType()
                 if buildType.isDebugBuild || buildType.isReviewBuild || buildType.isAlphaBuild {
                     // Reset standard card list and mark first session as complete for debug menu reset action, if needed

--- a/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
@@ -251,7 +251,17 @@ private extension NewTabPageNextStepsSingleCardProvider {
         if cards.isEmpty {
             appearancePreferences.continueSetUpCardsClosed = true
         }
+        // Record a new card impression if the first card in the list has changed:
+        // after a card is dismissed, no longer eligible to be shown, or the cards are shuffled/re-ordered.
+        if let initialVisibleCard = self.cards.first, cards.first != initialVisibleCard {
+            recordImpression(for: cards.first)
+        }
         cardList = cards
+    }
+
+    func recordImpression(for card: NewTabPageDataModel.CardID?) {
+        guard let card else { return }
+        persistor.incrementTimesShown(for: card)
     }
 
     /// If this is not the first session, sorts `standardCards` with the `defaultApp` card first, and the remaining cards in random order.
@@ -394,9 +404,7 @@ private extension NewTabPageNextStepsSingleCardProvider {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else { return }
-                if let card = cards.first {
-                    persistor.incrementTimesShown(for: card)
-                }
+                recordImpression(for: cards.first)
 
                 let buildType = StandardApplicationBuildType()
                 if buildType.isDebugBuild || buildType.isReviewBuild || buildType.isAlphaBuild {

--- a/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
@@ -282,12 +282,14 @@ private extension NewTabPageNextStepsSingleCardProvider {
         var orderedCards = persistor.orderedCardIDs ?? defaultAdvancedCards.map { $0.cardID }
 
         // Check if the first visible card has been shown 10+ times, and move it to the end of the list
-        if let firstVisibleCard = orderedCards.first(where: shouldShowCard),
-           persistor.timesShown(for: firstVisibleCard) > 0,
-           persistor.timesShown(for: firstVisibleCard) % Constants.maxTimesCardShown == 0,
-           let index = orderedCards.firstIndex(where: { $0 == firstVisibleCard }) {
-            let card = orderedCards.remove(at: index)
-            orderedCards.append(card)
+        if let firstVisibleCard = orderedCards.first(where: shouldShowCard) {
+            let cardImpressions = persistor.timesShown(for: firstVisibleCard)
+            if cardImpressions > 0,
+               cardImpressions % Constants.maxTimesCardShown == 0,
+               let index = orderedCards.firstIndex(where: { $0 == firstVisibleCard }) {
+                let card = orderedCards.remove(at: index)
+                orderedCards.append(card)
+            }
         }
 
         // Swap the order of levels if needed.

--- a/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
@@ -135,10 +135,14 @@ final class NewTabPageNextStepsSingleCardProvider: NewTabPageNextStepsCardsProvi
 
     @Published private var cardList: [NewTabPageDataModel.CardID] = []
 
+    var isNextStepsCardsComplete: Bool {
+        appearancePreferences.isContinueSetUpCardsViewOutdated || appearancePreferences.continueSetUpCardsClosed
+    }
+
     /// Returns the list of cards to be displayed, or an empty list if the continue set up cards view is considered outdated or was previously closed.
     /// The widget only shows the first card in the list, but we provide the full list of available cards so it can show a progress indicator.
     var cards: [NewTabPageDataModel.CardID] {
-        guard !appearancePreferences.isContinueSetUpCardsViewOutdated, !appearancePreferences.continueSetUpCardsClosed else {
+        guard !isNextStepsCardsComplete else {
             return []
         }
         return cardList
@@ -260,7 +264,7 @@ private extension NewTabPageNextStepsSingleCardProvider {
     }
 
     func recordImpression(for card: NewTabPageDataModel.CardID?) {
-        guard let card else { return }
+        guard !isNextStepsCardsComplete, let card else { return }
         persistor.incrementTimesShown(for: card)
     }
 
@@ -404,7 +408,10 @@ private extension NewTabPageNextStepsSingleCardProvider {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else { return }
-                recordImpression(for: cards.first)
+                if !isNextStepsCardsComplete {
+                    recordImpression(for: cards.first)
+                    persistor.ntpImpressionCount += 1
+                }
 
                 let buildType = StandardApplicationBuildType()
                 if buildType.isDebugBuild || buildType.isReviewBuild || buildType.isAlphaBuild {

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageActionsManagerExtension.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageActionsManagerExtension.swift
@@ -145,7 +145,11 @@ extension NewTabPageActionsManager {
             featureFlagger: featureFlagger
         )
         let dataImportProvider = BookmarksAndPasswordsImportStatusProvider(bookmarkManager: bookmarkManager, pinningManager: pinningManager)
-        let nextStepsPixelHandler = NewTabPageNextStepsCardsPixelHandler()
+        let nextStepsPixelHandler = NewTabPageNextStepsCardsPixelHandler(
+            persistor: nextStepsCardsPersistor,
+            appearancePreferences: appearancePreferences,
+            installDateProvider: { LocalStatisticsStore().installDate }
+        )
         let nextStepsCardsFacade = NewTabPageNextStepsCardsProviderFacade(
             featureFlagger: featureFlagger,
             dataImportProvider: dataImportProvider,

--- a/macOS/DuckDuckGo/Statistics/NewTabPagePixel.swift
+++ b/macOS/DuckDuckGo/Statistics/NewTabPagePixel.swift
@@ -165,8 +165,8 @@ enum NewTabPagePixel: PixelKitEvent {
     case newTabPageLoadingTime(duration: TimeInterval, osMajorVersion: Int)
 
     // See macOS/PixelDefinitions/pixels/new_tab_page_pixels.json5
-    case nextStepsCardClicked(_ card: String)
-    case nextStepsCardDismissed(_ card: String)
+    case nextStepsCardClicked(_ card: String, cardImpressionCount: Int, ntpImpressionCount: Int, daysSinceInstall: Int?, activeUsageDays: Int)
+    case nextStepsCardDismissed(_ card: String, cardImpressionCount: Int, ntpImpressionCount: Int, daysSinceInstall: Int?, activeUsageDays: Int)
     case nextStepsCardShown(_ card: String)
 
     // MARK: -
@@ -200,8 +200,8 @@ enum NewTabPagePixel: PixelKitEvent {
         case .aiChatRecentChatSelectedMouse: return "new-tab-page_aichat_recent_chat_selected_mouse"
         case .aiChatRecentChatSelectedKeyboard: return "new-tab-page_aichat_recent_chat_selected_keyboard"
         case .newTabPageLoadingTime: return "new-tab-page_loading_time"
-        case .nextStepsCardClicked(let card): return "new-tab-page_next-steps_\(card)_clicked"
-        case .nextStepsCardDismissed(let card): return "new-tab-page_next-steps_\(card)_dismissed"
+        case .nextStepsCardClicked(let card, _, _, _, _): return "new-tab-page_next-steps_\(card)_clicked"
+        case .nextStepsCardDismissed(let card, _, _, _, _): return "new-tab-page_next-steps_\(card)_dismissed"
         case .nextStepsCardShown(let card): return "new-tab-page_next-steps_\(card)_shown"
         }
     }
@@ -228,6 +228,20 @@ enum NewTabPagePixel: PixelKitEvent {
                 "loadingTime": String(Int(duration * 1000)),
                 "osMajorVersion": "\(osMajorVersion)"
             ]
+        case let .nextStepsCardClicked(_, cardImpressionCount, ntpImpressionCount, daysSinceInstall, activeUsageDays),
+            let .nextStepsCardDismissed(_, cardImpressionCount, ntpImpressionCount, daysSinceInstall, activeUsageDays):
+            var parameters = [
+                "cardImpressionCount": String(NextStepsCards.cardImpressions(cardImpressionCount)),
+                "ntpImpressionCount": String(NextStepsCards.newTabPageImpressions(ntpImpressionCount)),
+                "daysSinceInstall": String(NextStepsCards.daysSinceInstall(daysSinceInstall ?? 0)),
+                "nextStepsActiveUsageDays": String(NextStepsCards.activeUsageDays(activeUsageDays))
+            ]
+
+            if let daysSinceInstall {
+                parameters["daysSinceInstall"] = String(NextStepsCards.daysSinceInstall(daysSinceInstall))
+            }
+
+            return parameters
         case .favoriteSectionHidden,
                 .protectionsSectionHidden,
                 .blockedTrackingAttemptsShowLess,
@@ -245,8 +259,6 @@ enum NewTabPagePixel: PixelKitEvent {
                 .aiChatRecentChatSelectedPinnedKeyboard,
                 .aiChatRecentChatSelectedMouse,
                 .aiChatRecentChatSelectedKeyboard,
-                .nextStepsCardClicked,
-                .nextStepsCardDismissed,
                 .nextStepsCardShown:
             return nil
         }
@@ -255,6 +267,52 @@ enum NewTabPagePixel: PixelKitEvent {
     enum OmnibarMode: String {
         case search
         case duckAI = "duck_ai"
+    }
+
+    enum NextStepsCards {
+        static func daysSinceInstall(_ days: Int) -> Int {
+            switch days {
+            case 0: return 0
+            case 1: return 1
+            case 2...3: return 2
+            default: return 4
+            }
+        }
+
+        static func activeUsageDays(_ days: Int) -> Int {
+            switch days {
+            case 0: return 0
+            case 1: return 1
+            case 2: return 2
+            case 3: return 3
+            case 4...5: return 4
+            case 6...8: return 6
+            case 9...13: return 9
+            default: return 14
+            }
+        }
+
+        static func newTabPageImpressions(_ impressions: Int) -> Int {
+            switch impressions {
+            case 0...1: return 1
+            case 2: return 2
+            case 3: return 3
+            case 4: return 4
+            case 5: return 5
+            case 6: return 6
+            case 7: return 7
+            case 8...9: return 8
+            case 10...14: return 10
+            case 15...24: return 15
+            case 25...49: return 25
+            default: return 50
+            }
+        }
+
+        static func cardImpressions(_ impressions: Int) -> Int {
+            let maximum = 10
+            return impressions < maximum ? impressions : maximum
+        }
     }
 
     var standardParameters: [PixelKitStandardParameter]? {

--- a/macOS/UnitTests/NewTabPage/MockNewTabPageNextStepsCardsPersistor.swift
+++ b/macOS/UnitTests/NewTabPage/MockNewTabPageNextStepsCardsPersistor.swift
@@ -60,5 +60,6 @@ final class MockNewTabPageNextStepsCardsPersistor: NewTabPageNextStepsCardsPersi
         orderedCardIDs = nil
         firstCardLevel = .level1
         isFirstSession = true
+        ntpImpressionCount = 0
     }
 }

--- a/macOS/UnitTests/NewTabPage/MockNewTabPageNextStepsCardsPersistor.swift
+++ b/macOS/UnitTests/NewTabPage/MockNewTabPageNextStepsCardsPersistor.swift
@@ -27,6 +27,7 @@ final class MockNewTabPageNextStepsCardsPersistor: NewTabPageNextStepsCardsPersi
     var orderedCardIDs: [NewTabPageDataModel.CardID]?
     var firstCardLevel: NewTabPageDataModel.CardLevel = .level1
     var isFirstSession: Bool = true
+    var ntpImpressionCount: Int = 0
 
     func timesShown(for card: NewTabPageDataModel.CardID) -> Int {
         timesShownStorage[card] ?? 0

--- a/macOS/UnitTests/NewTabPage/NewTabPageNextStepsCardsPersistorTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageNextStepsCardsPersistorTests.swift
@@ -305,4 +305,31 @@ final class NewTabPageNextStepsCardsPersistorTests: XCTestCase {
         let stored = try? keyValueStore.object(forKey: "new.tab.page.next.steps.first.card.level") as? NewTabPageDataModel.CardLevel
         XCTAssertNil(stored)
     }
+
+    func testWhenClearIsCalledThenNtpImpressionCountIsRemoved() throws {
+        persistor.ntpImpressionCount = 5
+        XCTAssertEqual(persistor.ntpImpressionCount, 5)
+
+        persistor.clear()
+
+        XCTAssertEqual(persistor.ntpImpressionCount, 0)
+        let stored = try? keyValueStore.object(forKey: "new.tab.page.next.steps.ntp.impression.count") as? Int
+        XCTAssertNil(stored)
+    }
+
+    // MARK: - New Tab Page Impression Count Tests
+
+    func testNtpImpressionCountReturnsZeroByDefault() {
+        XCTAssertTrue(persistor.ntpImpressionCount == 0)
+    }
+
+    func testNtpImpressionCountIsSetThenValueIsStored() throws {
+        persistor.ntpImpressionCount = 5
+        XCTAssertEqual(try keyValueStore.object(forKey: "new.tab.page.next.steps.ntp.impression.count") as? Int, 5)
+    }
+
+    func testWhenNtpImpressionCountIsRetrievedThenStoredValueIsReturned() throws {
+        try keyValueStore.set(3, forKey: "new.tab.page.next.steps.ntp.impression.count")
+        XCTAssertEqual(persistor.ntpImpressionCount, 3)
+    }
 }

--- a/macOS/UnitTests/NewTabPage/NewTabPageNextStepsCardsPixelHandlerTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageNextStepsCardsPixelHandlerTests.swift
@@ -18,23 +18,48 @@
 
 import NewTabPage
 import PixelKit
+import PrivacyConfig
+import PrivacyConfigTestsUtils
 import XCTest
 @testable import DuckDuckGo_Privacy_Browser
 
 final class NewTabPageNextStepsCardsPixelHandlerTests: XCTestCase {
     private var pixelHandler: NewTabPageNextStepsCardsPixelHandler!
     private var firedPixels: [(event: PixelKitEvent, frequency: PixelKit.Frequency, includesAppVersionParameter: Bool)] = []
+    private var persistor: MockNewTabPageNextStepsCardsPersistor!
+    private var appearancePrefsPersistor: MockAppearancePreferencesPersistor!
+
+    // Test values
+    private let expectedDaysSinceInstall = 0
+    private let expectedNextStepsActiveUsageDays = 1
+    private let expectedCardImpressions = 2
+    private let expectedNTPImpressions = 3
 
     override func setUp() async throws {
         firedPixels = []
-        pixelHandler = NewTabPageNextStepsCardsPixelHandler { event, frequency, includesAppVersionParameter in
+        persistor = MockNewTabPageNextStepsCardsPersistor()
+        persistor.ntpImpressionCount = expectedNTPImpressions
+        appearancePrefsPersistor = MockAppearancePreferencesPersistor(continueSetUpCardsNumberOfDaysDemonstrated: expectedNextStepsActiveUsageDays)
+        let appearancePreferences = AppearancePreferences(
+            persistor: appearancePrefsPersistor,
+            privacyConfigurationManager: MockPrivacyConfigurationManager(),
+            featureFlagger: MockFeatureFlagger(),
+            aiChatMenuConfig: MockAIChatConfig()
+        )
+        let installDate = Date()
+        pixelHandler = NewTabPageNextStepsCardsPixelHandler(persistor: persistor,
+                                                            appearancePreferences: appearancePreferences,
+                                                            installDateProvider: { installDate },
+                                                            pixelHandler:  { event, frequency, includesAppVersionParameter in
             self.firedPixels.append((event, frequency, includesAppVersionParameter))
-        }
+        })
     }
 
     override func tearDown() {
         pixelHandler = nil
         firedPixels = []
+        persistor = nil
+        appearancePrefsPersistor = nil
     }
 
     // MARK: - Shown pixels
@@ -151,14 +176,18 @@ final class NewTabPageNextStepsCardsPixelHandlerTests: XCTestCase {
         XCTAssertEqual(firedPixels.first?.includesAppVersionParameter, true)
     }
 
-    func testWhenFireNextStepsCardClickedCalled_ForDefaultApp_ThenItFiresPixel() {
+    func testWhenFireNextStepsCardClickedCalled_ForDefaultApp_ThenItFiresPixel() throws {
+        // GIVEN
+        let card = NewTabPageDataModel.CardID.defaultApp
+        let expectedEvent = setUpExpectedClickedEvent(for: card)
+
         // WHEN
-        pixelHandler.fireNextStepsCardClickedPixel(.defaultApp)
+        pixelHandler.fireNextStepsCardClickedPixel(card)
 
         // THEN
         XCTAssertEqual(firedPixels.count, 1)
-        let expectedEvent = NewTabPagePixel.nextStepsCardClicked(NewTabPageDataModel.CardID.defaultApp.rawValue)
         XCTAssertEqual(firedPixels.first?.event.name, expectedEvent.name)
+        XCTAssertEqual(firedPixels.first?.event.parameters, expectedEvent.parameters)
         XCTAssertEqual(firedPixels.first?.frequency, .standard)
         XCTAssertEqual(firedPixels.first?.includesAppVersionParameter, true)
     }
@@ -176,47 +205,63 @@ final class NewTabPageNextStepsCardsPixelHandlerTests: XCTestCase {
     }
 
     func testWhenFireNextStepsCardClickedCalled_ForAddToDock_ThenItFiresPixel() {
+        // GIVEN
+        let card = NewTabPageDataModel.CardID.addAppToDockMac
+        let expectedEvent = setUpExpectedClickedEvent(for: card)
+
         // WHEN
-        pixelHandler.fireNextStepsCardClickedPixel(.addAppToDockMac)
+        pixelHandler.fireNextStepsCardClickedPixel(card)
 
         // THEN
         XCTAssertEqual(firedPixels.count, 1)
-        let expectedEvent = NewTabPagePixel.nextStepsCardClicked(NewTabPageDataModel.CardID.addAppToDockMac.rawValue)
         XCTAssertEqual(firedPixels.first?.event.name, expectedEvent.name)
+        XCTAssertEqual(firedPixels.first?.event.parameters, expectedEvent.parameters)
         XCTAssertEqual(firedPixels.first?.frequency, .standard)
         XCTAssertEqual(firedPixels.first?.includesAppVersionParameter, true)
     }
 
     func testWhenFireNextStepsCardClickedCalled_ForDuckplayer_ThenItFiresPixel() {
+        // GIVEN
+        let card = NewTabPageDataModel.CardID.duckplayer
+        let expectedEvent = setUpExpectedClickedEvent(for: card)
+
         // WHEN
-        pixelHandler.fireNextStepsCardClickedPixel(.duckplayer)
+        pixelHandler.fireNextStepsCardClickedPixel(card)
 
         // THEN
         XCTAssertEqual(firedPixels.count, 1)
-        let expectedPixel = NewTabPagePixel.nextStepsCardClicked(NewTabPageDataModel.CardID.duckplayer.rawValue)
-        XCTAssertEqual(firedPixels.first?.event.name, expectedPixel.name)
+        XCTAssertEqual(firedPixels.first?.event.name, expectedEvent.name)
+        XCTAssertEqual(firedPixels.first?.event.parameters, expectedEvent.parameters)
         XCTAssertEqual(firedPixels.first?.includesAppVersionParameter, true)
     }
 
     func testWhenFireNextStepsCardClickedCalled_ForEmailProtection_ThenItFiresPixel() {
+        // GIVEN
+        let card = NewTabPageDataModel.CardID.emailProtection
+        let expectedEvent = setUpExpectedClickedEvent(for: card)
+
         // WHEN
-        pixelHandler.fireNextStepsCardClickedPixel(.emailProtection)
+        pixelHandler.fireNextStepsCardClickedPixel(card)
 
         // THEN
         XCTAssertEqual(firedPixels.count, 1)
-        let expectedPixel = NewTabPagePixel.nextStepsCardClicked(NewTabPageDataModel.CardID.emailProtection.rawValue)
-        XCTAssertEqual(firedPixels.first?.event.name, expectedPixel.name)
+        XCTAssertEqual(firedPixels.first?.event.name, expectedEvent.name)
+        XCTAssertEqual(firedPixels.first?.event.parameters, expectedEvent.parameters)
         XCTAssertEqual(firedPixels.first?.includesAppVersionParameter, true)
     }
 
     func testWhenFireNextStepsCardClickedCalled_ForBringStuff_ThenItFiresPixel() {
+        // GIVEN
+        let card = NewTabPageDataModel.CardID.bringStuff
+        let expectedEvent = setUpExpectedClickedEvent(for: card)
+
         // WHEN
-        pixelHandler.fireNextStepsCardClickedPixel(.bringStuff)
+        pixelHandler.fireNextStepsCardClickedPixel(card)
 
         // THEN
         XCTAssertEqual(firedPixels.count, 1)
-        let expectedPixel = NewTabPagePixel.nextStepsCardClicked(NewTabPageDataModel.CardID.bringStuff.rawValue)
-        XCTAssertEqual(firedPixels.first?.event.name, expectedPixel.name)
+        XCTAssertEqual(firedPixels.first?.event.name, expectedEvent.name)
+        XCTAssertEqual(firedPixels.first?.event.parameters, expectedEvent.parameters)
         XCTAssertEqual(firedPixels.first?.includesAppVersionParameter, true)
     }
 
@@ -233,13 +278,17 @@ final class NewTabPageNextStepsCardsPixelHandlerTests: XCTestCase {
     }
 
     func testWhenFireNextStepsCardClickedCalled_ForSubscription_ThenItFiresPixel() {
+        // GIVEN
+        let card = NewTabPageDataModel.CardID.subscription
+        let expectedEvent = setUpExpectedClickedEvent(for: card)
+
         // WHEN
-        pixelHandler.fireNextStepsCardClickedPixel(.subscription)
+        pixelHandler.fireNextStepsCardClickedPixel(card)
 
         // THEN
         XCTAssertEqual(firedPixels.count, 1)
-        let expectedEvent = NewTabPagePixel.nextStepsCardClicked(NewTabPageDataModel.CardID.subscription.rawValue)
         XCTAssertEqual(firedPixels.first?.event.name, expectedEvent.name)
+        XCTAssertEqual(firedPixels.first?.event.parameters, expectedEvent.parameters)
         XCTAssertEqual(firedPixels.first?.frequency, .standard)
         XCTAssertEqual(firedPixels.first?.includesAppVersionParameter, true)
     }
@@ -247,61 +296,81 @@ final class NewTabPageNextStepsCardsPixelHandlerTests: XCTestCase {
     // MARK: - Dismissed pixels
 
     func testWhenFireNextStepsCardDismissedPixelCalled_ForDefaultApp_ThenItFiresPixel() {
+        // GIVEN
+        let card = NewTabPageDataModel.CardID.defaultApp
+        let expectedEvent = setUpExpectedDismissedEvent(for: card)
+
         // WHEN
-        pixelHandler.fireNextStepsCardDismissedPixel(.defaultApp)
+        pixelHandler.fireNextStepsCardDismissedPixel(card)
 
         // THEN
         XCTAssertEqual(firedPixels.count, 1)
-        let expectedEvent = NewTabPagePixel.nextStepsCardDismissed(NewTabPageDataModel.CardID.defaultApp.rawValue)
         XCTAssertEqual(firedPixels.first?.event.name, expectedEvent.name)
+        XCTAssertEqual(firedPixels.first?.event.parameters, expectedEvent.parameters)
         XCTAssertEqual(firedPixels.first?.frequency, .standard)
         XCTAssertEqual(firedPixels.first?.includesAppVersionParameter, true)
     }
 
     func testWhenFireNextStepsCardDismissedPixelCalled_ForAddToDock_ThenItFiresPixel() {
+        // GIVEN
+        let card = NewTabPageDataModel.CardID.addAppToDockMac
+        let expectedEvent = setUpExpectedDismissedEvent(for: card)
+
         // WHEN
-        pixelHandler.fireNextStepsCardDismissedPixel(.addAppToDockMac)
+        pixelHandler.fireNextStepsCardDismissedPixel(card)
 
         // THEN
         XCTAssertEqual(firedPixels.count, 1)
-        let expectedEvent = NewTabPagePixel.nextStepsCardDismissed(NewTabPageDataModel.CardID.addAppToDockMac.rawValue)
         XCTAssertEqual(firedPixels.first?.event.name, expectedEvent.name)
+        XCTAssertEqual(firedPixels.first?.event.parameters, expectedEvent.parameters)
         XCTAssertEqual(firedPixels.first?.frequency, .standard)
         XCTAssertEqual(firedPixels.first?.includesAppVersionParameter, true)
     }
 
     func testWhenFireNextStepsCardDismissedPixelCalled_ForDuckplayer_ThenItFiresPixel() {
+        // GIVEN
+        let card = NewTabPageDataModel.CardID.duckplayer
+        let expectedEvent = setUpExpectedDismissedEvent(for: card)
+
         // WHEN
-        pixelHandler.fireNextStepsCardDismissedPixel(.duckplayer)
+        pixelHandler.fireNextStepsCardDismissedPixel(card)
 
         // THEN
         XCTAssertEqual(firedPixels.count, 1)
-        let expectedEvent = NewTabPagePixel.nextStepsCardDismissed(NewTabPageDataModel.CardID.duckplayer.rawValue)
         XCTAssertEqual(firedPixels.first?.event.name, expectedEvent.name)
+        XCTAssertEqual(firedPixels.first?.event.parameters, expectedEvent.parameters)
         XCTAssertEqual(firedPixels.first?.frequency, .standard)
         XCTAssertEqual(firedPixels.first?.includesAppVersionParameter, true)
     }
 
     func testWhenFireNextStepsCardDismissedPixelCalled_ForEmailProtection_ThenItFiresPixel() {
+        // GIVEN
+        let card = NewTabPageDataModel.CardID.emailProtection
+        let expectedEvent = setUpExpectedDismissedEvent(for: card)
+
         // WHEN
-        pixelHandler.fireNextStepsCardDismissedPixel(.emailProtection)
+        pixelHandler.fireNextStepsCardDismissedPixel(card)
 
         // THEN
         XCTAssertEqual(firedPixels.count, 1)
-        let expectedEvent = NewTabPagePixel.nextStepsCardDismissed(NewTabPageDataModel.CardID.emailProtection.rawValue)
         XCTAssertEqual(firedPixels.first?.event.name, expectedEvent.name)
+        XCTAssertEqual(firedPixels.first?.event.parameters, expectedEvent.parameters)
         XCTAssertEqual(firedPixels.first?.frequency, .standard)
         XCTAssertEqual(firedPixels.first?.includesAppVersionParameter, true)
     }
 
     func testWhenFireNextStepsCardDismissedPixelCalled_ForBringStuff_ThenItFiresPixel() {
+        // GIVEN
+        let card = NewTabPageDataModel.CardID.bringStuff
+        let expectedEvent = setUpExpectedDismissedEvent(for: card)
+
         // WHEN
-        pixelHandler.fireNextStepsCardDismissedPixel(.bringStuff)
+        pixelHandler.fireNextStepsCardDismissedPixel(card)
 
         // THEN
         XCTAssertEqual(firedPixels.count, 1)
-        let expectedEvent = NewTabPagePixel.nextStepsCardDismissed(NewTabPageDataModel.CardID.bringStuff.rawValue)
         XCTAssertEqual(firedPixels.first?.event.name, expectedEvent.name)
+        XCTAssertEqual(firedPixels.first?.event.parameters, expectedEvent.parameters)
         XCTAssertEqual(firedPixels.first?.frequency, .standard)
         XCTAssertEqual(firedPixels.first?.includesAppVersionParameter, true)
     }
@@ -319,15 +388,39 @@ final class NewTabPageNextStepsCardsPixelHandlerTests: XCTestCase {
     }
 
     func testWhenFireNextStepsCardDismissedPixelCalled_ForSubscription_ThenItFiresPixel() {
+        // GIVEN
+        let card = NewTabPageDataModel.CardID.subscription
+        let expectedEvent = setUpExpectedDismissedEvent(for: card)
+
         // WHEN
-        pixelHandler.fireNextStepsCardDismissedPixel(.subscription)
+        pixelHandler.fireNextStepsCardDismissedPixel(card)
 
         // THEN
         XCTAssertEqual(firedPixels.count, 1)
-        let expectedEvent = NewTabPagePixel.nextStepsCardDismissed(NewTabPageDataModel.CardID.subscription.rawValue)
         XCTAssertEqual(firedPixels.first?.event.name, expectedEvent.name)
+        XCTAssertEqual(firedPixels.first?.event.parameters, expectedEvent.parameters)
         XCTAssertEqual(firedPixels.first?.frequency, .standard)
         XCTAssertEqual(firedPixels.first?.includesAppVersionParameter, true)
     }
 
+}
+
+private extension NewTabPageNextStepsCardsPixelHandlerTests {
+    func setUpExpectedClickedEvent(for card: NewTabPageDataModel.CardID) -> PixelKitEvent {
+        persistor.setTimesShown(expectedCardImpressions, for: card)
+        return NewTabPagePixel.nextStepsCardClicked(card.rawValue,
+                                                    cardImpressionCount: expectedCardImpressions,
+                                                    ntpImpressionCount: expectedNTPImpressions,
+                                                    daysSinceInstall: expectedDaysSinceInstall,
+                                                    activeUsageDays: expectedNextStepsActiveUsageDays)
+    }
+
+    func setUpExpectedDismissedEvent(for card: NewTabPageDataModel.CardID) -> PixelKitEvent {
+        persistor.setTimesShown(expectedCardImpressions, for: card)
+        return NewTabPagePixel.nextStepsCardDismissed(card.rawValue,
+                                                      cardImpressionCount: expectedCardImpressions,
+                                                      ntpImpressionCount: expectedNTPImpressions,
+                                                      daysSinceInstall: expectedDaysSinceInstall,
+                                                      activeUsageDays: expectedNextStepsActiveUsageDays)
+    }
 }

--- a/macOS/UnitTests/NewTabPage/NewTabPageNextStepsCardsPixelHandlerTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageNextStepsCardsPixelHandlerTests.swift
@@ -50,7 +50,7 @@ final class NewTabPageNextStepsCardsPixelHandlerTests: XCTestCase {
         pixelHandler = NewTabPageNextStepsCardsPixelHandler(persistor: persistor,
                                                             appearancePreferences: appearancePreferences,
                                                             installDateProvider: { installDate },
-                                                            pixelHandler:  { event, frequency, includesAppVersionParameter in
+                                                            pixelHandler: { event, frequency, includesAppVersionParameter in
             self.firedPixels.append((event, frequency, includesAppVersionParameter))
         })
     }

--- a/macOS/UnitTests/NewTabPage/NewTabPageNextStepsSingleCardProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageNextStepsSingleCardProviderTests.swift
@@ -327,6 +327,51 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
         XCTAssertEqual(persistor.timesShown(for: secondCard), 0)
     }
 
+    @MainActor
+    func testWhenNewTabPageWebViewAppearsThenNtpImpressionCountIsIncremented() {
+        // GIVEN
+        persistor.ntpImpressionCount = 0
+        let testProvider = createProvider()
+
+        let expectation = XCTestExpectation(description: "Cards publisher emits card list")
+        let cancellable = testProvider.cardsPublisher
+            .sink { cards in
+                expectation.fulfill()
+            }
+
+        // WHEN - Trigger card list refresh
+        NotificationCenter.default.post(name: .newTabPageWebViewDidAppear, object: nil)
+
+        wait(for: [expectation], timeout: 1.0)
+        cancellable.cancel()
+
+        // THEN
+        XCTAssertEqual(persistor.ntpImpressionCount, 1)
+    }
+
+    @MainActor
+    func testWhenNewTabPageWebViewAppearsThenNtpImpressionCountIsNotIncrementedIfNextStepsCardsComplete() {
+        // GIVEN
+        persistor.ntpImpressionCount = 0
+        appearancePreferences.isContinueSetUpCardsViewOutdated = true
+        let testProvider = createProvider()
+
+        let expectation = XCTestExpectation(description: "Cards publisher emits card list")
+        let cancellable = testProvider.cardsPublisher
+            .sink { cards in
+                expectation.fulfill()
+            }
+
+        // WHEN - Trigger card list refresh
+        NotificationCenter.default.post(name: .newTabPageWebViewDidAppear, object: nil)
+
+        wait(for: [expectation], timeout: 1.0)
+        cancellable.cancel()
+
+        // THEN
+        XCTAssertEqual(persistor.ntpImpressionCount, 0)
+    }
+
     func testWhenNewTabPageWebViewAppearsThenCardListRefreshes() {
         appearancePreferences.isContinueSetUpCardsViewOutdated = false
         let testProvider = createProvider()

--- a/macOS/UnitTests/NewTabPage/NewTabPageNextStepsSingleCardProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageNextStepsSingleCardProviderTests.swift
@@ -300,6 +300,33 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
         XCTAssertFalse(cardsEvents.isEmpty)
     }
 
+    @MainActor
+    func testWhenNewTabPageWebViewAppearsThenTimesShownIsIncrementedForFirstCard() {
+        // GIVEN
+        let firstCard = NewTabPageNextStepsSingleCardProvider.defaultStandardCards[0]
+        let secondCard = NewTabPageNextStepsSingleCardProvider.defaultStandardCards[1]
+        persistor.setTimesShown(0, for: firstCard)
+        persistor.setTimesShown(0, for: secondCard)
+        let testProvider = createProvider()
+
+        let expectation = XCTestExpectation(description: "Cards publisher emits card list")
+        let cancellable = testProvider.cardsPublisher
+            .sink { cards in
+                expectation.fulfill()
+            }
+
+        // WHEN - Trigger card list refresh
+        NotificationCenter.default.post(name: .newTabPageWebViewDidAppear, object: nil)
+
+        wait(for: [expectation], timeout: 1.0)
+        cancellable.cancel()
+
+        // THEN
+        XCTAssertEqual(persistor.timesShown(for: firstCard), 1)
+        // Second card should not be incremented
+        XCTAssertEqual(persistor.timesShown(for: secondCard), 0)
+    }
+
     func testWhenNewTabPageWebViewAppearsThenCardListRefreshes() {
         appearancePreferences.isContinueSetUpCardsViewOutdated = false
         let testProvider = createProvider()
@@ -598,19 +625,6 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
 
         XCTAssertEqual(pixelHandler.fireNextStepsCardShownPixelsCalledWith, [.addAppToDockMac])
         XCTAssertEqual(pixelHandler.fireAddToDockPresentedPixelIfNeededCalledWith, [.addAppToDockMac])
-    }
-
-    @MainActor
-    func testWhenWillDisplayCardsIsCalledThenTimesShownIsIncrementedForFirstCard() {
-        let testProvider = createProvider()
-        let cards: [NewTabPageDataModel.CardID] = [.defaultApp, .emailProtection]
-        let initialTimesShown = persistor.timesShown(for: .defaultApp)
-
-        testProvider.willDisplayCards(cards)
-
-        XCTAssertEqual(persistor.timesShown(for: .defaultApp), initialTimesShown + 1)
-        // Email protection should not be incremented (only first card)
-        XCTAssertEqual(persistor.timesShown(for: .emailProtection), 0)
     }
 
     // MARK: - Edge Cases

--- a/macOS/UnitTests/NewTabPage/NewTabPageNextStepsSingleCardProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageNextStepsSingleCardProviderTests.swift
@@ -873,6 +873,31 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
         XCTAssertEqual(updatedCards.last, .personalizeBrowser, "Card should move to back of list after multiple of max times shown is reached")
     }
 
+    @MainActor
+    func testWhenCardsAreRefreshedWithNewFirstCardThenTimesShownIsIncrementedForFirstCard() {
+        // GIVEN
+        let testFeatureFlagger = MockFeatureFlagger()
+        testFeatureFlagger.enabledFeatureFlags = [.nextStepsListAdvancedCardOrdering]
+        let testPersistor = MockNewTabPageNextStepsCardsPersistor()
+        testPersistor.orderedCardIDs = [.personalizeBrowser, .sync, .emailProtection]
+        let testProvider = createProvider(persistor: testPersistor, featureFlagger: testFeatureFlagger)
+
+        var cardList = [NewTabPageDataModel.CardID]()
+        let cancellable = testProvider.cardsPublisher
+            .sink { cards in
+                cardList = cards
+            }
+
+        // Trigger card list refresh by dismissing card
+        testProvider.dismiss(.personalizeBrowser)
+
+        cancellable.cancel()
+
+        // THEN
+        XCTAssertEqual(cardList.first, .sync, "Next card should be first after dismissing the first card")
+        XCTAssertEqual(testPersistor.timesShown(for: .sync), 1)
+    }
+
     // MARK: - Card Ordering Tests (nextStepsListAdvancedCardOrdering disabled)
 
     @MainActor

--- a/macOS/UnitTests/NewTabPage/NewTabPageNextStepsSingleCardProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageNextStepsSingleCardProviderTests.swift
@@ -797,11 +797,26 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
     }
 
     @MainActor
+    func testWhenCardShownFewerThanMaxTimes_WithAdvancedOrderingEnabled_ThenCardOrderRemainsTheSame() throws {
+        let testFeatureFlagger = MockFeatureFlagger()
+        testFeatureFlagger.enabledFeatureFlags = [.nextStepsListAdvancedCardOrdering]
+        let testPersistor = MockNewTabPageNextStepsCardsPersistor()
+        let timesShown = NewTabPageNextStepsSingleCardProvider.Constants.maxTimesCardShown - 1
+        testPersistor.setTimesShown(timesShown, for: .personalizeBrowser)
+        testPersistor.orderedCardIDs = [.personalizeBrowser, .sync, .emailProtection]
+        let testProvider = createProvider(persistor: testPersistor, featureFlagger: testFeatureFlagger)
+
+        let cards = testProvider.cards
+
+        XCTAssertEqual(cards.first, .personalizeBrowser, "Card should remain in the same position until max times shown is reached")
+    }
+
+    @MainActor
     func testWhenCardShownMaxTimes_WithAdvancedOrderingEnabled_ThenCardMovesToBack() throws {
         let testFeatureFlagger = MockFeatureFlagger()
         testFeatureFlagger.enabledFeatureFlags = [.nextStepsListAdvancedCardOrdering]
         let testPersistor = MockNewTabPageNextStepsCardsPersistor()
-        testPersistor.setTimesShown(10, for: .personalizeBrowser)
+        testPersistor.setTimesShown(NewTabPageNextStepsSingleCardProvider.Constants.maxTimesCardShown, for: .personalizeBrowser)
         testPersistor.orderedCardIDs = [.personalizeBrowser, .sync, .emailProtection]
         let testProvider = createProvider(persistor: testPersistor, featureFlagger: testFeatureFlagger)
 
@@ -812,17 +827,36 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
     }
 
     @MainActor
-    func testWhenCardShownMaxTimes_WithAdvancedOrderingEnabled_ThenTimesShownResets() {
+    func testWhenCardShownMoreThanMaxTimes_WithAdvancedOrderingEnabled_ThenCardOrderOnlyUpdatesOnMultiplesOfMaxTimesShown() throws {
         let testFeatureFlagger = MockFeatureFlagger()
         testFeatureFlagger.enabledFeatureFlags = [.nextStepsListAdvancedCardOrdering]
         let testPersistor = MockNewTabPageNextStepsCardsPersistor()
-        testPersistor.setTimesShown(10, for: .personalizeBrowser)
+        testPersistor.setTimesShown(NewTabPageNextStepsSingleCardProvider.Constants.maxTimesCardShown + 1, for: .personalizeBrowser)
         testPersistor.orderedCardIDs = [.personalizeBrowser, .sync, .emailProtection]
         let testProvider = createProvider(persistor: testPersistor, featureFlagger: testFeatureFlagger)
 
-        _ = testProvider.cards
+        // Card order is unchanged
+        let cards = testProvider.cards
+        XCTAssertEqual(cards.first, .personalizeBrowser, "Card should remain in the same position until multiple of max times shown is reached")
 
-        XCTAssertEqual(testPersistor.timesShown(for: .personalizeBrowser), 0, "Times shown should reset to 0")
+        // Simulate more views and trigger card list refresh
+        var cardsEvents = [[NewTabPageDataModel.CardID]]()
+        let expectation = XCTestExpectation(description: "Cards publisher emits card list")
+        let cancellable = testProvider.cardsPublisher
+            .sink { cards in
+                cardsEvents.append(cards)
+                expectation.fulfill()
+            }
+
+        testPersistor.setTimesShown(2 * NewTabPageNextStepsSingleCardProvider.Constants.maxTimesCardShown, for: .personalizeBrowser)
+        NotificationCenter.default.post(name: .newTabPageWebViewDidAppear, object: nil)
+
+        wait(for: [expectation], timeout: 1.0)
+        cancellable.cancel()
+
+        // Card order is updated
+        let updatedCards = testProvider.cards
+        XCTAssertEqual(updatedCards.last, .personalizeBrowser, "Card should move to back of list after multiple of max times shown is reached")
     }
 
     // MARK: - Card Ordering Tests (nextStepsListAdvancedCardOrdering disabled)

--- a/macOS/UnitTests/Statistics/NewTabPagePixelTests.swift
+++ b/macOS/UnitTests/Statistics/NewTabPagePixelTests.swift
@@ -1,0 +1,75 @@
+//
+//  NewTabPagePixelTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo_Privacy_Browser
+
+final class NewTabPagePixelTests: XCTestCase {
+
+    func testNextStepsCards_daysSinceInstall_buckets() {
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.daysSinceInstall(0), 0)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.daysSinceInstall(1), 1)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.daysSinceInstall(2), 2)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.daysSinceInstall(3), 2)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.daysSinceInstall(4), 4)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.daysSinceInstall(5), 4)
+    }
+
+    func testNextStepsCards_activeUsageDays_buckets() {
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.activeUsageDays(0), 0)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.activeUsageDays(1), 1)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.activeUsageDays(2), 2)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.activeUsageDays(3), 3)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.activeUsageDays(4), 4)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.activeUsageDays(5), 4)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.activeUsageDays(6), 6)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.activeUsageDays(8), 6)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.activeUsageDays(9), 9)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.activeUsageDays(13), 9)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.activeUsageDays(14), 14)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.activeUsageDays(15), 14)
+    }
+
+    func testNextStepsCards_newTabPageImpressions_buckets() {
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.newTabPageImpressions(0), 1)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.newTabPageImpressions(1), 1)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.newTabPageImpressions(2), 2)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.newTabPageImpressions(3), 3)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.newTabPageImpressions(4), 4)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.newTabPageImpressions(5), 5)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.newTabPageImpressions(6), 6)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.newTabPageImpressions(7), 7)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.newTabPageImpressions(8), 8)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.newTabPageImpressions(9), 8)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.newTabPageImpressions(10), 10)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.newTabPageImpressions(14), 10)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.newTabPageImpressions(15), 15)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.newTabPageImpressions(24), 15)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.newTabPageImpressions(25), 25)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.newTabPageImpressions(49), 25)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.newTabPageImpressions(50), 50)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.newTabPageImpressions(51), 50)
+    }
+
+    func testNextStepsCards_cardImpressions_maximum() {
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.cardImpressions(9), 9)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.cardImpressions(10), 10)
+        XCTAssertEqual(NewTabPagePixel.NextStepsCards.cardImpressions(11), 10)
+    }
+
+}


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1215454466673264?focus=true
Tech Design URL:
CC:

### Description

Updates pixels fired when a Next Steps card is clicked/dismissed to include the parameters defined in https://github.com/duckduckgo/apple-browsers/pull/5300.

#### Changes:
* Updates how card impressions are counted:
   * Persists a total count for card impressions, i.e. how many times a card has been seen (previously this count was only used to rotate cards in the stack, so it was reset when the card was re-ordered).
   * Increments the impression count each time the New Tab Page is viewed (when the view appears, not just on page load) and when the card appears at the top of the stack (when the card above it is removed).
   * Note that there's no immediate user-facing change; the related behavior is under a disabled feature flag.
* Persists a count of New Tab Page views (until Next Steps cards are complete, i.e. will not be shown again).
* Adds the new parameters when each card's `clicked` or `dismissed` pixel is fired:
   * `cardImpressionCount` - Total card impressions (max 10)
   * `ntpImpressionCount` - Number of New Tab Page (bucketed, starting with 1)
   * `daysSinceInstall` - Number of days since app install (bucketed, starting with 0)
   * `nextStepsActiveUsageDays` - Number of days the New Tab Page has been viewed with Next Steps cards (bucketed, starting with 0)

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Build and run the app.
2. **Debug** -> **New Tab Page** -> **Reset Next Steps**
3. Relaunch the app. (This is required for accurate impression counts.)
4. Open the New Tab Page and confirm you see a Next Steps card.
5. Click the card's call to action and confirm a `clicked` pixel is fired including the following parameters:
   * "cardImpressionCount": "1"
   * "daysSinceInstall" (value depends on when you installed the app, maximum reported is "4")
   * "nextStepsActiveUsageDays": "0"
   * "ntpImpressionCount": "1"
6. Select **Debug** -> **New Tab Page** -> **Shift New Tab daily impression** to simulate opening the New Tab Page again a day later.
7. Dismiss a card and confirm a `dismissed` pixel is fired with the same parameters as above, and the expected corresponding values:
   * "nextStepsActiveUsageDays": "1" (or as many times as you repeat step 6)
   * "ntpImpressionCount" will increase each time the New Tab Page is opened (e.g. in a new tab or window)
   * "cardImpressionCount" will increase each time that card is seen (when the New Tab Page is opened again with that card visible or when another card is removed to reveal it)

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
9. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
None: Internal tooling, documentation

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
* Card logic that depends on persisted card impression counts is feature-flagged (currently disabled). It is unit-tested and will be reviewed again before release.
* Other changes only affect pixels, so no direct user-facing impact if there are errors.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->
* Pixel changes were reviewed and approved via https://github.com/duckduckgo/apple-browsers/pull/5300.

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly analytics and persisted counters; advanced card rotation remains behind a disabled feature flag with expanded tests.
> 
> **Overview**
> Enriches **Next Steps** `clicked` and `dismissed` pixels with bucketed analytics parameters: per-card impressions (capped at 10), NTP view count, days since install, and active Next Steps usage days.
> 
> **Impression accounting** is reworked: a persisted `ntpImpressionCount` increments on each NTP appear (until cards are complete), and per-card `timesShown` increments when the NTP appears with that card on top or when the top card changes after dismiss/re-order. Card rotation under advanced ordering now moves cards at multiples of 10 impressions **without** resetting the counter. Impression bumps are removed from `willDisplayCards`.
> 
> `NewTabPageNextStepsCardsPixelHandler` is wired with persistor, appearance prefs, and install date at composition time. Debug **Reset Next Steps** no longer posts `newTabPageWebViewDidAppear`. Unit tests cover bucketing, persistence, and the new counting behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40f7dc12ca30b7c30b1c635b5c4ce400e0643b6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->