### PR TITLE
Surface DDGError description via NSError.localizedDescription

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Common/DDGError.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Common/DDGError.swift
@@ -270,14 +270,23 @@ public extension DDGError /*CustomNSError*/ {
     ///
     /// - Returns: A dictionary suitable for use as NSError userInfo.
     var errorUserInfo: [String: Any] {
+        // `description` is exposed both as the debug description and as the localized description.
+        // Populating `NSLocalizedDescriptionKey` ensures that once the error is bridged to `NSError`
+        // (e.g. when passed to PixelKit or any logging that reads `localizedDescription`), the
+        // meaningful description is surfaced instead of the generic
+        // "The operation couldn’t be completed. (domain error code.)" fallback.
         var result: [String: Any] = [
-            NSDebugDescriptionErrorKey: description
+            NSDebugDescriptionErrorKey: description,
+            NSLocalizedDescriptionKey: description
         ]
         if let underlying = underlyingError {
             result[NSUnderlyingErrorKey] = underlying
         }
         if let localisedError = self as? LocalizedError {
-            result[NSLocalizedDescriptionKey] = localisedError.errorDescription
+            // A more specific localized description takes precedence over `description` when provided.
+            if let errorDescription = localisedError.errorDescription {
+                result[NSLocalizedDescriptionKey] = errorDescription
+            }
             if let failureReason = localisedError.failureReason {
                 result[NSLocalizedFailureErrorKey] = failureReason
             }

--- a/SharedPackages/BrowserServicesKit/Tests/CommonTests/DDGErrorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/CommonTests/DDGErrorTests.swift
@@ -62,6 +62,24 @@ final class DDGErrorTests: XCTestCase {
         let message: String
     }
 
+    enum TestLocalizedError: DDGError, LocalizedError {
+        case withErrorDescription
+        case withoutErrorDescription
+
+        static var errorDomain: String { "TestLocalizedErrorDomain" }
+
+        var errorCode: Int { 300 }
+
+        var description: String { "Debug description" }
+
+        var errorDescription: String? {
+            switch self {
+            case .withErrorDescription: return "Localized description"
+            case .withoutErrorDescription: return nil
+            }
+        }
+    }
+
     // MARK: - DDGError Protocol Tests
 
     func testDDGErrorBasicProperties() {
@@ -169,5 +187,42 @@ final class DDGErrorTests: XCTestCase {
 
         XCTAssertEqual(userInfo[NSDebugDescriptionErrorKey] as? String, "Main error")
         XCTAssertNil(userInfo[NSUnderlyingErrorKey]) // Should not be present when there is no underlying error
+    }
+
+    // MARK: - Localized Description Tests
+
+    func testDDGErrorUserInfoPopulatesLocalizedDescriptionKey() {
+        let error = TestError.simpleError(code: 100, description: "Main error")
+
+        let userInfo = error.errorUserInfo
+
+        XCTAssertEqual(userInfo[NSLocalizedDescriptionKey] as? String, "Main error")
+    }
+
+    func testDDGErrorBridgedToNSErrorSurfacesDescriptionAsLocalizedDescription() {
+        let error = TestError.simpleError(code: 100, description: "Readable description")
+
+        let nsError = error as NSError
+
+        XCTAssertEqual(nsError.localizedDescription, "Readable description")
+    }
+
+    func testLocalizedErrorDescriptionTakesPrecedenceOverDescription() {
+        let error = TestLocalizedError.withErrorDescription
+
+        let userInfo = error.errorUserInfo
+
+        // When a DDGError also conforms to LocalizedError, its errorDescription wins.
+        XCTAssertEqual(userInfo[NSLocalizedDescriptionKey] as? String, "Localized description")
+        XCTAssertEqual(userInfo[NSDebugDescriptionErrorKey] as? String, "Debug description")
+    }
+
+    func testLocalizedErrorFallsBackToDescriptionWhenErrorDescriptionIsNil() {
+        let error = TestLocalizedError.withoutErrorDescription
+
+        let userInfo = error.errorUserInfo
+
+        // errorDescription is nil here, so the debug description is used as the localized fallback.
+        XCTAssertEqual(userInfo[NSLocalizedDescriptionKey] as? String, "Debug description")
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205842942115003/task/1215602205109346
Tech Design URL:
CC:

### Description

When a `DDGError` is bridged to `NSError` — which happens whenever one is passed to PixelKit or logged via `localizedDescription` — its human-readable `description` was stored only under `NSDebugDescriptionErrorKey`. `NSLocalizedDescriptionKey` was left unset (unless the error also conformed to `LocalizedError`), so `NSError.localizedDescription` fell back to the generic `"The operation couldn’t be completed. (domain error code.)"` string and the real message was hidden.

`DDGError.errorUserInfo` now populates `NSLocalizedDescriptionKey` with `description` by default, so the meaningful text is surfaced for every `DDGError`. When an error also conforms to `LocalizedError`, its `errorDescription` still takes precedence — and now falls back to `description` when `errorDescription` is `nil`, instead of leaving the key unset.

Example: `OAuthClientError.invalidTokenRequest(.reused)`, once bridged and logged, now reports **"Invalid token request: Token reuse window expired"** instead of the generic system string.

> Note: this does **not** change pixel parameters on the wire. PixelKit still intentionally omits error descriptions to avoid leaking PII — only `errorCode`/`errorDomain` (and underlying error codes/domains) are sent. This change only affects how a bridged `DDGError` reads back via `localizedDescription` (logging, retry queue, wide events).

### Testing Steps

1. Unit tests run from CI
2. Optional sanity check: bridge any `DDGError` (e.g. `OAuthClientError.invalidTokenRequest(.reused) as NSError`) and confirm `localizedDescription` shows the real message rather than the generic fallback.

---

###### Internal references: [DoD](https://app.asana.com/0/1207634633537039) | [Eng Expectations](https://app.asana.com/0/199064865822552) | [Tech Design Template](https://app.asana.com/0/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small NSError userInfo change for logging and diagnostics; no auth, data, or pixel payload behavior changes described.
> 
> **Overview**
> Bridged **`DDGError`** values now expose their human-readable **`description`** through **`NSError.localizedDescription`** instead of the generic domain/code fallback.
> 
> **`DDGError.errorUserInfo`** always sets **`NSLocalizedDescriptionKey`** to **`description`** (alongside the existing debug key). For types that also conform to **`LocalizedError`**, a non-nil **`errorDescription`** still overrides that value; when **`errorDescription`** is nil, the key keeps the **`description`** fallback rather than being left unset.
> 
> Unit tests cover userInfo, NSError bridging, and **`LocalizedError`** precedence/fallback. Pixel parameters on the wire are unchanged—this only affects how bridged errors read in logging and similar **`localizedDescription`** use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a891e13b2398aa47f615a8db66bf675ca0890f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->