### PR TITLE
Add a local PR checks script for LLMs

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageKeys.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageKeys.swift
@@ -35,5 +35,5 @@ public struct DuckAiNativeStorageSettings: StoringKeys {
 public enum DuckAiNativeStorageReservedEntryKeys: String {
     /// Entry holding the JSON array of chat IDs deleted on the native side.
     /// The web app reads it to reconcile deletions it did not itself initiate. Value: `[String]`.
-    case locallyDeletedChatIds = "locallyDeletedChatIds"
+    case locallyDeletedChatIds
 }

--- a/scripts/run-local-pr-checks
+++ b/scripts/run-local-pr-checks
@@ -21,6 +21,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 PLATFORMS=("iOS" "macOS")
 SWIFTLINT_ALL=false
+BASE_REF="origin/${GITHUB_BASE_REF:-main}"
 
 PASS_COUNT=0
 FAIL_COUNT=0
@@ -44,7 +45,8 @@ Options:
   --platform ios|macos   Restrict per-platform checks (pixel + translation) to
                          one platform. Default: both.
   --all                  Run SwiftLint over the whole repo (CI parity) instead
-                         of only files changed vs origin/main.
+                         of only files changed vs the base branch (origin/main,
+                         or origin/$GITHUB_BASE_REF when set).
   -h, --help             Show this help.
 
 Exit code equals the number of failed checks (0 = all green; skips never fail).
@@ -53,16 +55,16 @@ EOF
 
 have() { command -v "$1" >/dev/null 2>&1; }
 
-ORIGIN_MAIN_STATUS=""
-origin_main_available() {
-  if [ -z "$ORIGIN_MAIN_STATUS" ]; then
-    if git -C "$REPO_ROOT" rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
-      ORIGIN_MAIN_STATUS="yes"
+BASE_REF_STATUS=""
+base_ref_available() {
+  if [ -z "$BASE_REF_STATUS" ]; then
+    if git -C "$REPO_ROOT" rev-parse --verify --quiet "$BASE_REF" >/dev/null 2>&1; then
+      BASE_REF_STATUS="yes"
     else
-      ORIGIN_MAIN_STATUS="no"
+      BASE_REF_STATUS="no"
     fi
   fi
-  [ "$ORIGIN_MAIN_STATUS" = "yes" ]
+  [ "$BASE_REF_STATUS" = "yes" ]
 }
 
 pass() { PASS_COUNT=$((PASS_COUNT + 1)); printf '  %sPASS%s  %s\n' "$C_GREEN" "$C_RESET" "$1"; }
@@ -119,13 +121,13 @@ check_swiftlint() {
     return
   fi
 
-  if ! origin_main_available; then
-    skip "swiftlint" "origin/main not available — fetch it, or use --all"
+  if ! base_ref_available; then
+    skip "swiftlint" "$BASE_REF not available — fetch it, or use --all"
     return
   fi
 
   local base
-  base="$(git -C "$REPO_ROOT" merge-base origin/main HEAD)"
+  base="$(git -C "$REPO_ROOT" merge-base "$BASE_REF" HEAD)"
 
   local swift_files=()
   while IFS= read -r f; do
@@ -163,7 +165,7 @@ check_pixels() {
 
 check_translations() {
   if ! have python3; then skip "translation checks" "python3 not installed"; return; fi
-  if ! origin_main_available; then skip "translation checks" "origin/main not available — fetch it"; return; fi
+  if ! base_ref_available; then skip "translation checks" "$BASE_REF not available — fetch it"; return; fi
 
   local scripts=(verify_locale_list verify_string_extraction check_new_string_translations check_marker_consistency check_deleted_string_translations)
   local plat script

--- a/scripts/run-local-pr-checks
+++ b/scripts/run-local-pr-checks
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Runs cheap non-test-suite PR checks.
+#
+# Optional: use as an LLM "fix before finishing" hook (personal, uncommitted).
+# Claude Code and Codex both have a Stop hook where exit 2 + stderr blocks
+# completion and feeds the text back, so the agent fixes issues before stopping.
+# Send this script's output to stderr and map failure to exit 2:
+#
+#   Claude Code — .claude/settings.local.json (gitignored):
+#     { "hooks": { "Stop": [ { "matcher": "", "hooks": [ { "type": "command",
+#       "command": "\"$CLAUDE_PROJECT_DIR/scripts/run-local-pr-checks\" >&2 || exit 2" } ] } ] } }
+#
+#   Codex — ~/.codex/config.toml (outside the repo):
+#     [[hooks.Stop]]
+#     [[hooks.Stop.hooks]]
+#     type = "command"
+#     command = ["bash", "-lc", "scripts/run-local-pr-checks >&2 || exit 2"]
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+PLATFORMS=("iOS" "macOS")
+SWIFTLINT_ALL=false
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+
+if [ -t 1 ]; then
+  C_GREEN=$'\033[32m'; C_RED=$'\033[31m'; C_YELLOW=$'\033[33m'; C_DIM=$'\033[2m'; C_RESET=$'\033[0m'
+else
+  C_GREEN=''; C_RED=''; C_YELLOW=''; C_DIM=''; C_RESET=''
+fi
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/run-local-pr-checks [options]
+
+Runs the cheap static PR checks CI enforces: ActionLint, ShellCheck, SwiftLint,
+pixel lint/validation, and translation/string checks. Each tool is skipped (not
+failed) when it is not installed.
+
+Options:
+  --platform ios|macos   Restrict per-platform checks (pixel + translation) to
+                         one platform. Default: both.
+  --all                  Run SwiftLint over the whole repo (CI parity) instead
+                         of only files changed vs origin/main.
+  -h, --help             Show this help.
+
+Exit code equals the number of failed checks (0 = all green; skips never fail).
+EOF
+}
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+ORIGIN_MAIN_STATUS=""
+origin_main_available() {
+  if [ -z "$ORIGIN_MAIN_STATUS" ]; then
+    if git -C "$REPO_ROOT" rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+      ORIGIN_MAIN_STATUS="yes"
+    else
+      ORIGIN_MAIN_STATUS="no"
+    fi
+  fi
+  [ "$ORIGIN_MAIN_STATUS" = "yes" ]
+}
+
+pass() { PASS_COUNT=$((PASS_COUNT + 1)); printf '  %sPASS%s  %s\n' "$C_GREEN" "$C_RESET" "$1"; }
+skip() { SKIP_COUNT=$((SKIP_COUNT + 1)); printf '  %sSKIP%s  %s %s(%s)%s\n' "$C_YELLOW" "$C_RESET" "$1" "$C_DIM" "$2" "$C_RESET"; }
+
+run_check() {
+  local name="$1" workdir="$2"; shift 2
+  local output status
+  output="$(cd "$workdir" && "$@" 2>&1)"
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    pass "$name"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    printf '  %sFAIL%s  %s\n' "$C_RED" "$C_RESET" "$name"
+    [ -n "$output" ] && printf '%s\n' "$output" | sed 's/^/        /'
+  fi
+}
+
+check_actionlint() {
+  if ! have actionlint; then skip "actionlint" "actionlint not installed"; return; fi
+  run_check "actionlint" "$REPO_ROOT" actionlint -shellcheck=
+}
+
+check_shellcheck() {
+  if ! have shellcheck; then skip "shellcheck" "shellcheck not installed"; return; fi
+
+  local ios_files=()
+  while IFS= read -r f; do ios_files+=("$f"); done \
+    < <(cd "$REPO_ROOT" && find iOS/scripts -type f -name '*.sh' 2>/dev/null | sort)
+  if [ ${#ios_files[@]} -eq 0 ]; then
+    skip "shellcheck (iOS)" "no shell scripts found"
+  else
+    run_check "shellcheck (iOS)" "$REPO_ROOT" shellcheck -x -P iOS/scripts "${ios_files[@]}"
+  fi
+
+  # helpers are excluded from being checked but kept on the source path so that
+  # `source` directives in the other scripts still resolve.
+  local mac_files=()
+  while IFS= read -r f; do mac_files+=("$f"); done \
+    < <(cd "$REPO_ROOT" && find macOS/scripts -type f -name '*.sh' -not -path '*/helpers/*' 2>/dev/null | sort)
+  if [ ${#mac_files[@]} -eq 0 ]; then
+    skip "shellcheck (macOS)" "no shell scripts found"
+  else
+    run_check "shellcheck (macOS)" "$REPO_ROOT" shellcheck -x -P macOS/scripts -P macOS/scripts/helpers "${mac_files[@]}"
+  fi
+}
+
+check_swiftlint() {
+  if ! have mint; then skip "swiftlint" "mint not installed"; return; fi
+
+  if [ "$SWIFTLINT_ALL" = true ]; then
+    run_check "swiftlint (all files)" "$REPO_ROOT" mint run swiftlint lint --strict --quiet
+    return
+  fi
+
+  if ! origin_main_available; then
+    skip "swiftlint" "origin/main not available — fetch it, or use --all"
+    return
+  fi
+
+  local base
+  base="$(git -C "$REPO_ROOT" merge-base origin/main HEAD)"
+
+  local swift_files=()
+  while IFS= read -r f; do
+    [ -n "$f" ] && swift_files+=("$REPO_ROOT/$f")
+  done < <({
+    git -C "$REPO_ROOT" diff --name-only --diff-filter=d "$base" -- '*.swift'
+    git -C "$REPO_ROOT" ls-files --others --exclude-standard -- '*.swift'
+  } | sort -u)
+
+  if [ ${#swift_files[@]} -eq 0 ]; then
+    pass "swiftlint (no changed Swift files)"
+    return
+  fi
+
+  # SwiftLint indexes its working directory even when given explicit files (~50s
+  # on this repo); running from /tmp with --working-directory avoids that scan
+  # while still resolving config and the Mintfile-pinned version from the root.
+  run_check "swiftlint (${#swift_files[@]} changed)" /tmp \
+    mint run --mintfile "$REPO_ROOT/Mintfile" swiftlint lint --strict --quiet \
+    --working-directory "$REPO_ROOT" "${swift_files[@]}"
+}
+
+check_pixels() {
+  if ! have npm; then skip "pixel checks" "npm not installed"; return; fi
+  local plat
+  for plat in "${PLATFORMS[@]}"; do
+    if [ ! -d "$REPO_ROOT/$plat/node_modules" ]; then
+      skip "pixel checks ($plat)" "node_modules missing — run npm ci in $plat"
+      continue
+    fi
+    run_check "pixel-lint ($plat)" "$REPO_ROOT/$plat" npm run pixel-lint
+    run_check "pixel-defs ($plat)" "$REPO_ROOT/$plat" npm run validate-defs-without-formatting
+  done
+}
+
+check_translations() {
+  if ! have python3; then skip "translation checks" "python3 not installed"; return; fi
+  if ! origin_main_available; then skip "translation checks" "origin/main not available — fetch it"; return; fi
+
+  local scripts=(verify_locale_list verify_string_extraction check_new_string_translations check_marker_consistency check_deleted_string_translations)
+  local plat script
+  for plat in "${PLATFORMS[@]}"; do
+    for script in "${scripts[@]}"; do
+      run_check "$script ($plat)" "$REPO_ROOT" python3 "scripts/translation-pr-checks/$script.py" --platform "$plat"
+    done
+  done
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --platform|--platform=*)
+      if [ "$1" = "--platform" ]; then shift; val="${1:-}"; else val="${1#*=}"; fi
+      case "$val" in
+        ios|iOS)     PLATFORMS=("iOS") ;;
+        macos|macOS) PLATFORMS=("macOS") ;;
+        *) printf 'error: --platform expects "ios" or "macos"\n' >&2; exit 2 ;;
+      esac
+      ;;
+    --all) SWIFTLINT_ALL=true ;;
+    -h|--help) usage; exit 0 ;;
+    *) printf 'error: unknown option: %s\n\n' "$1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+check_actionlint
+check_shellcheck
+check_swiftlint
+check_pixels
+check_translations
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  printf '\n%s%s passed, %s failed, %s skipped%s\n' "$C_RED" "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT" "$C_RESET"
+else
+  printf '\n%s%s passed, %s failed, %s skipped%s\n' "$C_GREEN" "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT" "$C_RESET"
+fi
+
+exit "$FAIL_COUNT"


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1215606878661706?focus=true
Tech Design URL:
CC:

### Description

This PR adds a new script that runs a set of quick PR checks locally, so that LLMs can detect and fix them before they get pushed up to GitHub and cause a longer iteration cycle.

When Claude's stop hook runs this script and fails, it will output the following:

```
⏺ Ran 2 stop hooks
  ⎿  Stop hook error: ["$CLAUDE_PROJECT_DIR/scripts/run-local-pr-checks" >&2 || exit 2]:   PASS  actionlint
    PASS  shellcheck (iOS)
    PASS  shellcheck (macOS)
    FAIL  swiftlint (1 changed)
          /Users/samsymons/Code/DuckDuckGo/Monorepo/iOS/DuckDuckGo/AppLifecycle/AppDelegate.swift:28:36: error: Force Cast Violation: Force casts should be avoided (force_cast)
    PASS  pixel-lint (iOS)
    PASS  pixel-defs (iOS)
    PASS  pixel-lint (macOS)
    PASS  pixel-defs (macOS)
    PASS  verify_locale_list (iOS)
    PASS  verify_string_extraction (iOS)
    PASS  check_new_string_translations (iOS)
    PASS  check_marker_consistency (iOS)
    PASS  check_deleted_string_translations (iOS)
    PASS  verify_locale_list (macOS)
    PASS  verify_string_extraction (macOS)
    PASS  check_new_string_translations (macOS)
    PASS  check_marker_consistency (macOS)
    PASS  check_deleted_string_translations (macOS)
```

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check out the branch and ask Claude to add the script to the Stop hook
2. Now ask Claude to introduce a deliberate failure (like a SwiftLint failure due to a force unwrap) - once it does this, the hook should cause the failure to be detected

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-only bash orchestration; no changes to app runtime, auth, or data paths.
> 
> **Overview**
> Adds **`scripts/run-local-pr-checks`**, a bash entry point that runs the same **lightweight static PR checks** CI uses (ActionLint, ShellCheck on iOS/macOS shell scripts, SwiftLint, pixel lint/defs, and the five `scripts/translation-pr-checks/*.py` scripts per platform).
> 
> The script **skips** checks when tools or `origin/main` are missing (or `node_modules` for pixel work), prints **PASS/FAIL/SKIP** with indented tool output on failure, and exits with the **failure count**. **SwiftLint** defaults to changed `.swift` files vs `origin/main`, with **`--all`** for full-repo lint and a **`/tmp` + `--working-directory`** workaround for slow indexing. **`--platform`** limits iOS or macOS pixel/translation runs.
> 
> Header comments document wiring it as a **Claude Code / Codex Stop hook** (stderr + exit 2) so agents can fix issues before finishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b54504c4cf9297408d6fd7e9350e949b2b7885f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->