### PR TITLE
Fix: Popover Clipping on iPad

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/DuckAISuggestionTableViewCell.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/DuckAISuggestionTableViewCell.swift
@@ -30,7 +30,8 @@ final class DuckAISuggestionTableViewCell: UITableViewCell {
     private lazy var accessoryButton: UIButton = {
         let action = UIAction { [weak self] _ in
             guard let self else { return }
-            self.onAccessoryButtonPressed?(self)
+            // Anchor on the image view rather than the (larger, trailing-aligned) button so the popover is positioned over the actual image.
+            self.onAccessoryButtonPressed?(self.accessoryButton.imageView ?? self.accessoryButton)
         }
 
         let button = UIButton(type: .system)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1215610834149983?focus=true
Tech Design URL:
CC:

### Description
This PR fixes a glitch that caused a Popover to clip, on iPad devices, when in Landscape (+ keyboard visible)

### Testing Steps
1. Launch the browser **on iPad** (Simulator is good!)
2. Enable the flat `removeChatHistory`
3. Turn your device into Landscape Mode
4. Make sure the Keyboard is visible
5. Start a Duck.ai Chat, and close the Tab
6. Press on the Address Bar
7. Switch to Duck.ai (Address Bar Switch)
8. Press on the 🔥 Button on your Chat Row

- [ ] Verify the Confirmation Popover doesn't get clipped

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing really!

### Quality Considerations
None

### Notes to Reviewer
Thank you!

### Screenshots

Before | Now
-|-
<img width="300" src="https://github.com/user-attachments/assets/e17d6af9-fba8-4cd6-a32c-3ea958a852c9" /> | <img width="300" src="https://github.com/user-attachments/assets/aa3ca7f6-07a9-46d4-8198-937fad26ca3b" />


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line UI anchoring change for popover presentation; no auth, data, or deletion logic changes.
> 
> **Overview**
> Fixes **iPad popover clipping** when confirming chat deletion from the Duck.ai suggestion row fire button (notably in landscape with the keyboard up).
> 
> `DuckAISuggestionTableViewCell` now passes **`accessoryButton.imageView`** (falling back to the button) into `onAccessoryButtonPressed` instead of the whole cell, so the confirmation popover anchors on the visible icon rather than the larger trailing-aligned 44×44 hit target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0604d30ce0515358d81070759febed235c54bd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->