### PR TITLE
[macOS][Burn On Exit] Add pixels to instrument burn on exit feature

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -1568,6 +1568,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         fireDailyFireWindowConfigurationPixels()
         fireDailyAIChatEnabledPixel()
         fireDailyAdBlockingPixel()
+        fireDailyAutoClearOnExitEnabledPixel()
 
         fireAutoconsentDailyPixel()
         fireThemeDailyPixel()
@@ -1616,6 +1617,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func fireDailyAIChatEnabledPixel() {
         PixelKit.fire(AIChatPixel.aiChatIsEnabled(isEnabled: aiChatPreferences.isAIFeaturesEnabled), frequency: .daily)
+    }
+
+    private func fireDailyAutoClearOnExitEnabledPixel() {
+        guard dataClearingPreferences.isAutoClearEnabled else { return }
+        PixelKit.fire(GeneralPixel.dailyAutoClearOnExitEnabled, frequency: .daily, doNotEnforcePrefix: true)
     }
 
     private func fireDailyAdBlockingPixel() {

--- a/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -49,6 +49,7 @@ enum GeneralPixel: PixelKitEvent {
     case dailyFireWindowConfigurationStartupFireWindowEnabled(startupFireWindow: Bool)
     case dailyFireWindowConfigurationOpenFireWindowByDefaultEnabled(openFireWindowByDefault: Bool)
     case dailyFireWindowConfigurationFireAnimationEnabled(fireAnimationEnabled: Bool)
+    case dailyAutoClearOnExitEnabled
 
     case navigation(NavigationKind)
     case navigationToExternalURL
@@ -666,6 +667,9 @@ enum GeneralPixel: PixelKitEvent {
 
         case .dailyFireWindowConfigurationFireAnimationEnabled(fireAnimationEnabled: let fireAnimationEnabled):
             return "m_mac_fire_window_configuration_fire-animation_\(fireAnimationEnabled ? "enabled" : "disabled")"
+
+        case .dailyAutoClearOnExitEnabled:
+            return "m_mac_settings_auto-clear_on"
 
         case .navigation:
             return "m_mac_navigation"
@@ -1587,6 +1591,7 @@ enum GeneralPixel: PixelKitEvent {
                 .dailyFireWindowConfigurationFireAnimationEnabled,
                 .fireWindowOpenedAny,
                 .fireWindowOpened,
+                .dailyAutoClearOnExitEnabled,
                 .navigation,
                 .navigationToExternalURL,
                 .serp,

--- a/macOS/PixelDefinitions/pixels/definitions/app_settings_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/app_settings_pixels.json5
@@ -55,5 +55,12 @@
         "triggers": ["other"],
         "suffixes": ["daily"],
         "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_settings_auto-clear_on": {
+        "description": "Fires once per day when the user has the Burn-On-Exit (auto-clear data on quit) setting enabled.",
+        "owners": ["alessandroboron"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1214246575566493?focus=true
Tech Design URL:
CC: @samhouts 

### Description

This PR adds pixel instrumentation for the Burn-On-Exit feature and settings:
  - **State pixel:**
    - `m_mac_settings_auto-clear_on` fires once per user per day when the user has "Automatically delete tabs and browsing data when DuckDuckGo quits" enabled.
 
### Testing Steps

**Scenario 1 - Burn on Exit Setting Pixel**:
1. Ensure that ‘Settings' → 'Data Clearing' → "Automatically delete tabs and browsing data when DuckDuckGo quits” is checked.
2. Re-launch the app and expect `m_mac_settings_auto-clear_on_daily` is fired. 
3. Untoggle the check and re-launch the app.
4. Verify that the pixel is not fired.

### Impact and Risks
**Low:** Instrumentation only.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Low Risk**
> Analytics-only changes at existing burn entry points; clearing logic is unchanged aside from pixel calls.
> 
> **Overview**
> Adds **macOS pixel instrumentation** for Burn-on-Exit and data clearing without changing burn behavior.
> 
> A **daily state pixel** (`m_mac_settings_auto-clear_on`) fires when auto-clear on quit is enabled. **Burn-started analytics** introduce `BurnType` and fire an aggregate daily pixel plus path-specific pixels for manual fire (**in-session**), quit-time auto-clear (**on-exit**), and recovery burns on launch (**on-startup**). `DataClearingPixelsReporter` is exposed behind `DataClearingPixelsReporting` and wired from `FireCoordinator`, `AutoClearHandler` (injectable for tests), and daily active-user firing in `AppDelegate`.
> 
> **SERP navigation** now uses `dailyAndStandard` for `GeneralPixel.serp` (with JSON definition and a unit test). Pixel definition JSON and reporter/handler tests cover the new events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 786e56627dfdde5dd2835f04efcf119efc4d1860. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only instrumentation gated on an existing preference flag; no change to auto-clear or burn behavior in this diff.
> 
> **Overview**
> Adds a **daily state pixel** for Burn-on-Exit (auto-clear on quit): **`m_mac_settings_auto-clear_on`**, fired when the user has “Automatically delete tabs and browsing data when DuckDuckGo quits” enabled.
> 
> Wiring matches other daily configuration pixels: a new **`GeneralPixel.dailyAutoClearOnExitEnabled`** case maps to that name, is included in standard **`pixelSource`** parameters, and **`AppDelegate`** calls **`fireDailyAutoClearOnExitEnabledPixel()`** from **`applicationDidBecomeActive`** (with the other daily pixels). The helper **no-ops unless** **`dataClearingPreferences.isAutoClearEnabled`**, then fires once per day via **`PixelKit`** with **`doNotEnforcePrefix: true`**.
> 
> **`app_settings_pixels.json5`** documents the event (daily suffix, owners, parameters).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db885765d9269bdb359c8098d00756daa615e097. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->