### PR TITLE
Fix favicon loading crash on corrupt stored image (APPLE-MACOS-B8H)

### DIFF
--- a/macOS/DuckDuckGo/Favicons/Services/FaviconStore.swift
+++ b/macOS/DuckDuckGo/Favicons/Services/FaviconStore.swift
@@ -235,7 +235,20 @@ fileprivate extension Favicon {
             return nil
         }
 
-        let image = faviconMO.imageEncrypted as? NSImage
+        // Reading `imageEncrypted` makes Core Data unarchive the stored NSImage. If the saved bitmap is corrupt,
+        // AppKit raises an Objective-C `NSInvalidUnarchiveOperationException` ("bad TIFF data") while unarchiving.
+        // Swift's `try`/`try?` cannot catch Objective-C exceptions, so this would otherwise crash the app.
+        // `NSException.catch` bridges it to a Swift error; on failure we use a nil image, which the favicon system
+        // re-fetches on the next visit.
+        let image: NSImage?
+        do {
+            image = try NSException.catch {
+                faviconMO.imageEncrypted as? NSImage
+            }
+        } catch {
+            PixelKit.fire(DebugEvent(GeneralPixel.faviconDecryptionFailedUnique), frequency: .legacyDaily)
+            image = nil
+        }
 
         self.init(identifier: identifier, url: url, image: image, relation: relation, documentUrl: documentUrl, dateCreated: dateCreated)
     }

--- a/macOS/UnitTests/Common/FileSystem/EncryptedValueTransformerTests.swift
+++ b/macOS/UnitTests/Common/FileSystem/EncryptedValueTransformerTests.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import AppKit
 import CryptoKit
 import SharedTestUtilities
 import XCTest
@@ -45,6 +46,68 @@ final class EncryptedValueTransformerTests: XCTestCase {
 
         XCTAssertTrue(reverseTransformedValue is String)
         XCTAssertEqual(reverseTransformedValue as? String, value)
+    }
+
+    // MARK: - Corrupt favicon image must not crash favicon loading
+
+    /// Builds a valid keyed-archive of an `NSImage`, then corrupts the embedded TIFF magic bytes so that
+    /// `-[NSBitmapImageRep initWithCoder:]` raises an ObjC `NSInvalidUnarchiveOperationException`
+    /// ("Archived bitmap contains bad TIFF data...") on decode – the same failure mode seen in production.
+    private func makeCorruptArchivedImageData() throws -> Data {
+        let rep = NSBitmapImageRep(bitmapDataPlanes: nil, pixelsWide: 4, pixelsHigh: 4,
+                                   bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+                                   colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0)!
+        let image = NSImage(size: NSSize(width: 4, height: 4))
+        image.addRepresentation(rep)
+
+        var data = try NSKeyedArchiver.archivedData(withRootObject: image, requiringSecureCoding: true)
+        let tiffMagics: [[UInt8]] = [[0x49, 0x49, 0x2A, 0x00], [0x4D, 0x4D, 0x00, 0x2A]]
+        var corrupted = false
+        data.withUnsafeMutableBytes { raw in
+            let bytes = raw.bindMemory(to: UInt8.self)
+            guard bytes.count > 4 else { return }
+            for i in 0..<(bytes.count - 4) where !corrupted {
+                for magic in tiffMagics where bytes[i] == magic[0] && bytes[i + 1] == magic[1]
+                    && bytes[i + 2] == magic[2] && bytes[i + 3] == magic[3] {
+                    bytes[i] = 0xFF; bytes[i + 1] = 0xFF; bytes[i + 2] = 0xFF; bytes[i + 3] = 0xFF
+                    corrupted = true
+                }
+            }
+        }
+        XCTAssertTrue(corrupted, "Test setup failed: TIFF magic not found in archived NSImage")
+        return data
+    }
+
+    /// Mirrors the decode performed by `EncryptedValueTransformer<NSImage>` via the
+    /// `NSKeyedUnarchiver+DecodingFailurePolicy` helper.
+    private func decodeImage(from data: Data) throws -> NSImage? {
+        let unarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
+        unarchiver.decodingFailurePolicy = .setErrorAndReturn
+        unarchiver.requiresSecureCoding = true
+        let object = unarchiver.decodeObject(of: NSImage.self, forKey: NSKeyedArchiveRootObjectKey)
+        unarchiver.finishDecoding()
+        return object
+    }
+
+    /// Documents the precondition: corrupt bitmap data raises an ObjC exception that `.setErrorAndReturn`
+    /// and Swift `try?` do NOT catch – so it can only be caught with `NSException.catch`.
+    func testDecodingCorruptArchivedImageRaisesUncatchableObjCException() throws {
+        let data = try makeCorruptArchivedImageData()
+        var raisedObjCException = false
+        do {
+            _ = try NSException.catch { try? self.decodeImage(from: data) }
+        } catch {
+            raisedObjCException = true
+        }
+        XCTAssertTrue(raisedObjCException, "Expected decoding corrupt TIFF data to raise an ObjC NSException")
+    }
+
+    /// Verifies the fix: wrapping the decode in `NSException.catch` (as `FaviconStore` now does) turns the
+    /// crash into a graceful `nil` image.
+    func testFaviconImageDecodingCatchesCorruptDataAndReturnsNilWithoutCrashing() throws {
+        let data = try makeCorruptArchivedImageData()
+        let image = try? NSException.catch { try? self.decodeImage(from: data) }
+        XCTAssertNil(image, "Corrupt favicon image should decode to nil instead of crashing")
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1215620347057957?focus=true

### Description

Fixes the crash **APPLE-MACOS-B8H** (`NSInvalidUnarchiveOperationException` / `Favicon.init`, 51 occurrences / 10 users since 1.193.0).

When `FaviconStore.loadFavicons()` builds a `Favicon` from a `FaviconManagedObject`, accessing `imageEncrypted` fires a Core Data fault that decodes the stored image via `EncryptedValueTransformer<NSImage>`. If the stored bitmap is corrupt, `-[NSBitmapImageRep initWithCoder:]` raises an Objective-C `NSException` ("Archived bitmap contains bad TIFF data, which is a required element. This archive is bad."). `decodingFailurePolicy = .setErrorAndReturn` and Swift `try?` do **not** catch raw `NSException`s, so the exception propagated up through Core Data and crashed the app.

This wraps the image decode in the existing `NSException.catch { }` helper. On corrupt data the favicon now loads with a `nil` image (re-fetched on the next visit) and fires the existing `faviconDecryptionFailedUnique` debug pixel, instead of crashing.

This is a deliberately targeted fix at the call site. The same exception is theoretically possible for any transformable Core Data attribute, so a follow-up may move the catch down into the shared `NSKeyedUnarchiver+DecodingFailurePolicy` helper once this approach is validated in production.

### Testing Steps

The live crash requires an already-corrupted favicon record, which is impractical to produce by normal use. It is covered by two new unit tests in `EncryptedValueTransformerTests` that reproduce the exact failure mode (a valid archived `NSImage` with its embedded TIFF magic bytes corrupted):

1. Run the **Unit Tests** target (scheme *macOS Browser*).
2. `EncryptedValueTransformerTests/testDecodingCorruptArchivedImageRaisesUncatchableObjCException` — confirms the corrupt decode raises an ObjC `NSException` that `try?` cannot catch (the crash precondition).
3. `EncryptedValueTransformerTests/testFaviconImageDecodingCatchesCorruptDataAndReturnsNilWithoutCrashing` — confirms `NSException.catch` returns `nil` without crashing.
4. Both tests pass; the app still launches and loads favicons normally.

### Impact and Risks

**Low.** Behaviour is unchanged for valid favicons; the only change is that a corrupt favicon image now degrades to a missing icon instead of crashing the app. No data is deleted.

#### What could go wrong?

- A favicon with corrupt image data will display without its icon until it is re-fetched on the next visit — an acceptable, self-healing degradation versus a crash.
- The `faviconDecryptionFailedUnique` pixel is reused for this image-decode failure (in addition to its existing decryption-failure use), so its volume may rise slightly; this is intentional and gives visibility into how often corrupt images occur.

### Quality Considerations

- `NSException.catch` is an established pattern already used elsewhere in the app (e.g. `WebView`, `MainMenu`), so no new abstraction is introduced.
- Edge case verified: the catch only triggers on the raised exception; valid images decode exactly as before.
- No performance impact on the common path (single `@try`/`@catch` wrapper around the existing decode).
- Privacy/security unaffected — decryption still occurs identically; only post-decryption unarchiving failures are caught.

### Notes to Reviewer

The fix is intentionally scoped to `FaviconStore` per discussion; see the Description for the potential follow-up to relocate it into the `NSKeyedUnarchiver+DecodingFailurePolicy` helper. The root cause was confirmed by reproducing the exact production exception locally.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted degradation path for corrupt favicon bitmaps only; valid favicons behave the same and no data is deleted.
> 
> **Overview**
> Fixes **APPLE-MACOS-B8H** by hardening favicon load when stored encrypted images fail to unarchive.
> 
> `Favicon.init(faviconMO:)` no longer reads `imageEncrypted` directly. It wraps that Core Data fault in **`NSException.catch`**, because corrupt archived bitmaps can raise an Objective-C **`NSInvalidUnarchiveOperationException`** that Swift `try`/`catch` and `NSKeyedUnarchiver`’s `.setErrorAndReturn` do not handle. On failure it fires **`faviconDecryptionFailedUnique`** and builds the favicon with a **`nil` image** so loading continues and the icon can be re-fetched later.
> 
> **`EncryptedValueTransformerTests`** adds helpers that corrupt TIFF magic in a keyed-archived `NSImage`, plus two tests: one proving the ObjC exception is not catchable without `NSException.catch`, and one proving the wrapped decode returns `nil` without crashing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09481f76bfb192a79513e64c745b7db798f0d0a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->