### PR TITLE
Fix crash on provisional navigation failure before start

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -1160,6 +1160,8 @@
 		376325C22F86964C00B6B0DB /* TabSuspensionDebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376325C02F86964C00B6B0DB /* TabSuspensionDebugMenu.swift */; };
 		37657FC42DB8D564003D749E /* TabCrashRecoveryExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37657FC32DB8D55F003D749E /* TabCrashRecoveryExtensionTests.swift */; };
 		37657FC52DB8D564003D749E /* TabCrashRecoveryExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37657FC32DB8D55F003D749E /* TabCrashRecoveryExtensionTests.swift */; };
+		DBDE0002000000000000BDE0 /* NavigationPixelNavigationResponderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBDE0001000000000000BDE0 /* NavigationPixelNavigationResponderTests.swift */; };
+		DBDE0003000000000000BDE0 /* NavigationPixelNavigationResponderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBDE0001000000000000BDE0 /* NavigationPixelNavigationResponderTests.swift */; };
 		37657FC72DB95140003D749E /* TabCrashIndicatorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37657FC62DB9513B003D749E /* TabCrashIndicatorModel.swift */; };
 		37657FC82DB95140003D749E /* TabCrashIndicatorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37657FC62DB9513B003D749E /* TabCrashIndicatorModel.swift */; };
 		3765CAAC2E4B50AC00A26678 /* PageContextUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3765CAAB2E4B509800A26678 /* PageContextUserScript.swift */; };
@@ -5087,6 +5089,7 @@
 		376113D72B29D0F800E794BB /* SyncE2EUITestsAppStore.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = SyncE2EUITestsAppStore.xcconfig; sourceTree = "<group>"; };
 		376325C02F86964C00B6B0DB /* TabSuspensionDebugMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSuspensionDebugMenu.swift; sourceTree = "<group>"; };
 		37657FC32DB8D55F003D749E /* TabCrashRecoveryExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabCrashRecoveryExtensionTests.swift; sourceTree = "<group>"; };
+		DBDE0001000000000000BDE0 /* NavigationPixelNavigationResponderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationPixelNavigationResponderTests.swift; sourceTree = "<group>"; };
 		37657FC62DB9513B003D749E /* TabCrashIndicatorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabCrashIndicatorModel.swift; sourceTree = "<group>"; };
 		3765CAAB2E4B509800A26678 /* PageContextUserScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageContextUserScript.swift; sourceTree = "<group>"; };
 		3765CAAE2E4B70DC00A26678 /* PageContextTabExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageContextTabExtension.swift; sourceTree = "<group>"; };
@@ -12183,6 +12186,7 @@
 				B626A7632992506A00053070 /* SerpHeadersNavigationResponderTests.swift */,
 				567A23CC2C80CE060010F66C /* SpecialErrorPageUserScriptTests.swift */,
 				37657FC32DB8D55F003D749E /* TabCrashRecoveryExtensionTests.swift */,
+				DBDE0001000000000000BDE0 /* NavigationPixelNavigationResponderTests.swift */,
 				1D8C2FE42B70F4C4005E4BBD /* TabSnapshotExtensionTests.swift */,
 				4620F01533744547AD4AE7FF /* TabSuspensionExtensionTests.swift */,
 			);
@@ -16531,6 +16535,7 @@
 				5650E3742D3FDC8900D41ECF /* PageRefreshMonitorExtensionTests.swift in Sources */,
 				B51A90DB2F044C3E00FB9C0C /* ScriptStyleProviderTests.swift in Sources */,
 				37657FC42DB8D564003D749E /* TabCrashRecoveryExtensionTests.swift in Sources */,
+				DBDE0002000000000000BDE0 /* NavigationPixelNavigationResponderTests.swift in Sources */,
 				9FFBEE702DDEDB3C0058B11A /* MockDefaultBrowserAndDockPromptCoordinator.swift in Sources */,
 				372D43D92DF2573A00A3A10D /* MockFireproofDomains.swift in Sources */,
 				3706FE79293F661700E42796 /* AppearancePreferencesTests.swift in Sources */,
@@ -18796,6 +18801,7 @@
 				9FFBEE742DDEDC650058B11A /* ApplicationBuildTypeMock.swift in Sources */,
 				9FBD84702BB3DD8400220859 /* MockAttributionsPixelHandler.swift in Sources */,
 				37657FC52DB8D564003D749E /* TabCrashRecoveryExtensionTests.swift in Sources */,
+				DBDE0003000000000000BDE0 /* NavigationPixelNavigationResponderTests.swift in Sources */,
 				4B117F7D276C0CB5002F3D8C /* LocalStatisticsStoreTests.swift in Sources */,
 				3783F92329432E1800BCA897 /* WebViewTests.swift in Sources */,
 				EA8AE76A279FBDB20078943E /* ClickToLoadTDSTests.swift in Sources */,

--- a/macOS/DuckDuckGo/Tab/TabExtensions/NavigationPixelNavigationResponder.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/NavigationPixelNavigationResponder.swift
@@ -171,8 +171,12 @@ extension NavigationPixelNavigationResponder: NavigationResponder {
     }
 
     func navigation(_ navigation: Navigation, didFailWith error: WKError) {
-        guard navigation.navigationAction.isForMainFrame,
-              let startTime = navigation.siteLoadingStartTime else {
+        // Check `siteLoadingStartTime` first: `navigation.navigationAction` crashes (force-unwrap) when the
+        // navigation has no recorded actions, e.g. a provisional load that failed before it ever started.
+        // `siteLoadingStartTime` is nil for exactly those navigations, so checking it first lets us bail out
+        // before reading `navigationAction`.
+        guard let startTime = navigation.siteLoadingStartTime,
+              navigation.navigationAction.isForMainFrame else {
             return
         }
 

--- a/macOS/UnitTests/TabExtensionsTests/NavigationPixelNavigationResponderTests.swift
+++ b/macOS/UnitTests/TabExtensionsTests/NavigationPixelNavigationResponderTests.swift
@@ -1,0 +1,56 @@
+//
+//  NavigationPixelNavigationResponderTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Navigation
+import PixelKit
+import PixelKitTestingUtilities
+import PrivacyConfig
+import WebKit
+import XCTest
+
+@testable import DuckDuckGo_Privacy_Browser
+
+final class NavigationPixelNavigationResponderTests: XCTestCase {
+
+    /// Regression test for APPLE-MACOS-BDE.
+    ///
+    /// A navigation that fails provisionally before it ever starts has an empty `navigationActions`
+    /// array. `Navigation.navigationAction` force-unwraps `navigationActions.last`, so reading it in
+    /// `navigation(_:didFailWith:)` used to trap (EXC_BREAKPOINT). Since `siteLoadingStartTime` is only
+    /// set in `didStart` (after a navigation action exists), the responder must short-circuit on it
+    /// *before* touching `navigationAction`.
+    @MainActor
+    func testWhenNavigationFailsWithNoNavigationActions_thenItDoesNotCrashAndNoPixelIsFired() {
+        let pixelMock = PixelKitMock(expecting: [])
+        let responder = NavigationPixelNavigationResponder(pixelFiring: pixelMock, featureFlagger: MockFeatureFlagger())
+
+        // A navigation that never received a navigation action (empty `navigationActions`),
+        // e.g. a provisional load that failed before `didStart`.
+        let navigation = Navigation(identity: NavigationIdentity(nil),
+                                    responders: ResponderChain(responderRefs: []),
+                                    state: .expected(nil),
+                                    redirectHistory: nil,
+                                    isCurrent: false)
+
+        // Previously trapped on `navigationActions.last!` while evaluating the guard.
+        responder.navigation(navigation, didFailWith: WKError(.webContentProcessTerminated))
+
+        // No pixel should be fired for a navigation that never started loading.
+        pixelMock.verifyExpectations(file: #file, line: #line)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1215620561014173?focus=true

### Description

Fixes the `EXC_BREAKPOINT` crash **APPLE-MACOS-BDE** (169 events / 85 users on 1.193.0).

`NavigationPixelNavigationResponder.navigation(_:didFailWith:)` evaluated `navigation.navigationAction` first in its guard. `Navigation.navigationAction` returns `navigationActions.last!` (a force-unwrap). When a provisional navigation fails *before it ever starts*, `navigationActions` is empty, so the force-unwrap traps at `Navigation.swift:44`.

The fix reorders the guard so the `siteLoadingStartTime` nil-check short-circuits first. `siteLoadingStartTime` is set only in `didStart` (after a navigation action has been recorded) and `navigationActions` is append-only, so `siteLoadingStartTime != nil` implies `navigationActions` is non-empty — the responder now bails out on never-started navigations without ever touching `navigationAction`. Behaviour is otherwise unchanged.

### Testing Steps
1. Run the added unit test `NavigationPixelNavigationResponderTests.testWhenNavigationFailsWithNoNavigationActions_thenItDoesNotCrashAndNoPixelIsFired`. It passes with the fix; reverting the guard reorder makes it crash with `Navigation/Navigation.swift:44: Fatal error: Unexpectedly found nil while unwrapping an Optional value` (the exact APPLE-MACOS-BDE signature).
2. Smoke check: browse normally and trigger failed loads (e.g. navigate to a nonexistent domain, or drop the network mid-load); the app should not crash and normal navigation pixels are unaffected.

### Impact and Risks
Low. The change is a guard-clause reorder in pixel-firing code with no behavioural change for navigations that actually started. It eliminates a crash affecting ~85 users.

#### What could go wrong?
The reorder relies on `siteLoadingStartTime` being nil exactly for navigations with an empty `navigationActions`. Verified against the code: `siteLoadingStartTime` is assigned in a single place (`didStart`, which only runs after a navigation action exists) and `navigationActions` is only ever appended to, never emptied after the first action. Worst case is that a `siteLoadingFailure` pixel is not fired for a navigation that never began loading — which is the correct outcome.

### Quality Considerations
- The empty-`navigationActions` edge case is now covered by a regression test wired into both the `Unit Tests` and `Unit Tests App Store` targets.
- No performance impact (pure read reorder); no privacy/security impact (pixel content unchanged).
- The sibling `navigationDidFinish` uses the same guard pattern but cannot reach the empty state (a finished navigation always has a recorded action), so it is intentionally left unchanged.

### Notes to Reviewer
- Targeted directly at `release/macos/1.194.0` as a crash fix.
- The underlying force-unwrap in the `Navigation` package (`Navigation.swift:44`) is a long-standing latent invariant. This PR fixes the only reachable trigger (the responder) rather than changing the shared public API on a release branch.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Guard reorder only in analytics/pixel code; behavior is unchanged for navigations that actually started loading.
> 
> **Overview**
> Fixes **APPLE-MACOS-BDE** by changing how `NavigationPixelNavigationResponder` handles `navigation(_:didFailWith:)`. The guard now checks **`siteLoadingStartTime` before `navigation.navigationAction`**, so provisional failures with no recorded navigation actions return early instead of force-unwrapping an empty `navigationActions` list.
> 
> Adds **`NavigationPixelNavigationResponderTests`** with a regression test that a never-started navigation does not crash and does not fire a site-loading failure pixel, and wires that file into both unit-test targets in the Xcode project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7076066f9955e4ceffc4b2e2491669a0b1fd569e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->