### PR TITLE
Add debounce frequency to PixelKit

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit.swift
@@ -861,18 +861,25 @@ public final class PixelKit {
         )
     }
 
+    /// Evaluates `within` against the stored last-fire date for `frequency`'s `mapKey`.
+    /// Returns `false` when there's no stored date for that frequency, and fails closed
+    /// (returns `true`, suppressing the pixel) on a storage read error.
+    private func pixelHasBeenFired(_ name: String, frequency: Frequency, within: (Date) -> Bool) -> Bool {
+        do {
+            let map = try migratedLastFireDateMap(forKey: userDefaultsKeyName(forPixelName: name))
+            guard let lastFireDate = map[frequency.mapKey] else { return false }
+            return within(lastFireDate)
+        } catch {
+            return true
+        }
+    }
+
     /// Returns `true` if the pixel was last fired less than `seconds` ago (so it should be suppressed).
     /// The stored fire date is shared across debounce intervals (mapKey `"debounce"`), and the window is
     /// evaluated against the passed `seconds`. Fails closed (suppresses) on a storage read error.
     private func pixelHasBeenFiredWithinDebounceInterval(_ name: String, seconds: TimeInterval) -> Bool {
-        do {
-            let map = try migratedLastFireDateMap(forKey: userDefaultsKeyName(forPixelName: name))
-            if let lastFireDate = map[Frequency.debounce(seconds: seconds).mapKey] {
-                return lastFireDate > dateGenerator().addingTimeInterval(-seconds)
-            }
-            return false
-        } catch {
-            return true
+        pixelHasBeenFired(name, frequency: .debounce(seconds: seconds)) { lastFireDate in
+            lastFireDate > dateGenerator().addingTimeInterval(-seconds)
         }
     }
 
@@ -886,14 +893,8 @@ public final class PixelKit {
             return false
         }
 
-        do {
-            let map = try migratedLastFireDateMap(forKey: userDefaultsKeyName(forPixelName: name))
-            if let lastFireDate = map[Frequency.daily.mapKey] {
-                return pixelCalendar.isDate(dateGenerator(), inSameDayAs: lastFireDate)
-            }
-            return false
-        } catch {
-            return true
+        return pixelHasBeenFired(name, frequency: .daily) { lastFireDate in
+            pixelCalendar.isDate(dateGenerator(), inSameDayAs: lastFireDate)
         }
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit.swift
@@ -74,6 +74,12 @@ public final class PixelKit {
         /// Sent with sampling - only N% of calls result in actual pixel firing
         case sample(percentage: Int)
 
+        /// Sent at most once per `seconds`-long window per pixel name: suppressed if the pixel was fired
+        /// less than `seconds` ago. The window is anchored to the last actual fire (a suppressed call does
+        /// not extend it). `seconds: 0` is an empty window and never suppresses. This is the PixelKit
+        /// equivalent of the legacy `Pixel.fire(debounce:)` parameter.
+        case debounce(seconds: TimeInterval)
+
         fileprivate var description: String {
             switch self {
             case .standard:
@@ -100,6 +106,8 @@ public final class PixelKit {
                 "Legacy Daily No Suffix"
             case .sample(let percentage):
                 "Sample (\(percentage)%)"
+            case .debounce(let seconds):
+                "Debounce (\(seconds)s)"
             }
         }
 
@@ -119,6 +127,7 @@ public final class PixelKit {
             case .legacyDaily: return "legacyDaily"
             case .legacyDailyAndCount: return "legacyDailyAndCount"
             case .sample(let percentage): return "sample(\(percentage))"
+            case .debounce: return "debounce"
             }
         }
     }
@@ -371,6 +380,8 @@ public final class PixelKit {
             handleLegacyDailyNoSuffix(pixelName, headers, newParams, allowedQueryReservedCharacters, onComplete)
         case .sample(let percentage):
             handleSample(pixelName, headers, newParams, allowedQueryReservedCharacters, percentage, onComplete)
+        case .debounce(let seconds):
+            handleDebounce(pixelName, headers, newParams, allowedQueryReservedCharacters, seconds, onComplete)
         }
     }
 
@@ -470,6 +481,28 @@ public final class PixelKit {
             }
         } else {
             printDebugInfo(pixelName: pixelName + "_daily", frequency: .daily, parameters: newParams, skipped: true)
+        }
+    }
+
+    private func handleDebounce(_ pixelName: String,
+                                _ headers: [String: String],
+                                _ newParams: [String: String],
+                                _ allowedQueryReservedCharacters: CharacterSet?,
+                                _ seconds: TimeInterval,
+                                _ onComplete: @escaping CompletionBlock) {
+        let frequency = Frequency.debounce(seconds: seconds)
+        if !pixelHasBeenFiredWithinDebounceInterval(pixelName, seconds: seconds) {
+            do {
+                try updatePixelLastFireDate(pixelName: pixelName, frequency: frequency)
+                fireRequestWrapper(pixelName, headers, newParams, allowedQueryReservedCharacters, true, frequency, onComplete)
+            } catch {
+                fireStorageWriteErrorPixel(suppressedPixelName: pixelName, error: error)
+                printDebugInfo(pixelName: pixelName, frequency: frequency, parameters: newParams, skipped: true)
+                onComplete(false, nil)
+            }
+        } else {
+            printDebugInfo(pixelName: pixelName, frequency: frequency, parameters: newParams, skipped: true)
+            onComplete(false, nil)
         }
     }
 
@@ -826,6 +859,21 @@ public final class PixelKit {
             .standard,
             { _, _ in }
         )
+    }
+
+    /// Returns `true` if the pixel was last fired less than `seconds` ago (so it should be suppressed).
+    /// The stored fire date is shared across debounce intervals (mapKey `"debounce"`), and the window is
+    /// evaluated against the passed `seconds`. Fails closed (suppresses) on a storage read error.
+    private func pixelHasBeenFiredWithinDebounceInterval(_ name: String, seconds: TimeInterval) -> Bool {
+        do {
+            let map = try migratedLastFireDateMap(forKey: userDefaultsKeyName(forPixelName: name))
+            if let lastFireDate = map[Frequency.debounce(seconds: seconds).mapKey] {
+                return lastFireDate > dateGenerator().addingTimeInterval(-seconds)
+            }
+            return false
+        } catch {
+            return true
+        }
     }
 
     private func pixelHasBeenFiredDailyToday(_ name: String) -> Bool {

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKitTestingUtilities/XCTestCase+PixelKit.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKitTestingUtilities/XCTestCase+PixelKit.swift
@@ -193,6 +193,8 @@ public extension XCTestCase {
             expectedPixelNames.append(originalName)
         case .sample(let percentage):
             expectedPixelNames.append(originalName.appending("_sample\(percentage)"))
+        case .debounce:
+            expectedPixelNames.append(originalName)
         }
         return expectedPixelNames
     }

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/PixelKitTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/PixelKitTests.swift
@@ -395,6 +395,66 @@ final class PixelKitTests: XCTestCase {
         XCTAssertNotEqual(map?["daily"], map?["monthly"], "Daily and monthly should track different dates")
     }
 
+    /// `.debounce(seconds:)` suppresses re-firing the same pixel within the window, anchored to the
+    /// last *actual* fire (a suppressed call must not extend the window), and fires again once at least
+    /// `seconds` have elapsed since the last fire.
+    func testDebounceSuppressesWithinWindowAndFiresAfterWindow() {
+        let appVersion = "1.0.5"
+        let event = TestEventV2.testEventWithoutParameters
+        let userDefaults = userDefaults()
+        let timeMachine = TimeMachine()
+
+        let fireCallbackCalled = expectation(description: "Expect the pixel firing callback to be called")
+        fireCallbackCalled.expectedFulfillmentCount = 2
+        fireCallbackCalled.assertForOverFulfill = true
+
+        let pixelKit = PixelKit(dryRun: false,
+                                appVersion: appVersion,
+                                source: PixelKit.Source.macDMG.rawValue,
+                                defaultHeaders: [:],
+                                pixelCalendar: nil,
+                                dateGenerator: timeMachine.now,
+                                defaults: userDefaults) { _, _, _, _, _, _ in
+            fireCallbackCalled.fulfill()
+        }
+
+        pixelKit.fire(event, frequency: .debounce(seconds: 5))   // t0 — Fired
+        timeMachine.travel(by: .second, value: 2)
+        pixelKit.fire(event, frequency: .debounce(seconds: 5))   // t0+2 — Skipped (within window)
+        timeMachine.travel(by: .second, value: 4)
+        pixelKit.fire(event, frequency: .debounce(seconds: 5))   // t0+6 — Fired (window elapsed since t0)
+
+        wait(for: [fireCallbackCalled], timeout: 0.5)
+    }
+
+    /// `.debounce(seconds: 0)` is an empty window, so it never suppresses and fires every time.
+    func testDebounceWithZeroSecondsAlwaysFires() {
+        let appVersion = "1.0.5"
+        let event = TestEventV2.testEventWithoutParameters
+        let userDefaults = userDefaults()
+        let timeMachine = TimeMachine()
+
+        let fireCallbackCalled = expectation(description: "Expect the pixel firing callback to be called")
+        fireCallbackCalled.expectedFulfillmentCount = 3
+        fireCallbackCalled.assertForOverFulfill = true
+
+        let pixelKit = PixelKit(dryRun: false,
+                                appVersion: appVersion,
+                                source: PixelKit.Source.macDMG.rawValue,
+                                defaultHeaders: [:],
+                                pixelCalendar: nil,
+                                dateGenerator: timeMachine.now,
+                                defaults: userDefaults) { _, _, _, _, _, _ in
+            fireCallbackCalled.fulfill()
+        }
+
+        pixelKit.fire(event, frequency: .debounce(seconds: 0))
+        pixelKit.fire(event, frequency: .debounce(seconds: 0))
+        pixelKit.fire(event, frequency: .debounce(seconds: 0))
+
+        wait(for: [fireCallbackCalled], timeout: 0.5)
+    }
+
     /// A pixel whose last-fire date was previously stored as a raw `Date` (legacy format)
     /// should still be recognized as fired today AND have its storage migrated to a
     /// `[frequency.mapKey: Date]` map on the next `pixelHasBeenFiredDailyToday` check.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205842942115003/task/1213797000731646?focus=true
Tech Design URL:
CC:

### Description

Adds debounce support to PixelKit, the equivalent of the legacy Pixel.fire(debounce:) parameter, so callers migrating off the legacy API keep the same rapid-repeat de-duplication.

Debounce is expressed as a new Frequency case (.debounce(seconds:)) rather than a separate parameter, reusing PixelKit's existing per-pixel last-fire-date storage (no new storage and no change to the fire API). A pixel fired with this frequency is suppressed if it already fired less than that many seconds ago, with the window anchored to the last actual fire (a suppressed call does not extend it). A window of 0 seconds never suppresses.

This is the capability only; migrating the legacy call sites is follow-up work.

### Testing Steps

1. Run the PixelKit unit tests in the BrowserServicesKit package and confirm they pass.

### Impact and Risks

#### What could go wrong?

- Additive change: a new Frequency case plus its handler. Existing frequencies, call sites, and storage are unchanged; the only non-test edit outside PixelKit is one exhaustive-switch update in the test utilities.
- Debounce reuses the existing per-pixel storage under its own independent key, so it cannot interfere with daily/monthly/unique tracking on the same pixel.

### Quality Considerations

Unit tests added for in-window suppression (anchored to the last actual fire and firing again once the window elapses) and the zero-second no-op case. The full PixelKit suite passes.

---

###### Internal references: [DoD](https://app.asana.com/0/1207634633537039) | [Eng Expectations](https://app.asana.com/0/199064865822552) | [Tech Design Template](https://app.asana.com/0/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive analytics API with isolated storage key; daily logic is a small refactor to a shared helper with the same fail-closed semantics.
> 
> **Overview**
> Adds **`Frequency.debounce(seconds:)`** to PixelKit so callers can throttle repeat fires the same way as legacy `Pixel.fire(debounce:)`, without a separate API or new storage keys beyond the existing per-pixel last-fire map (`mapKey` `"debounce"`).
> 
> A fire is **skipped** if the same pixel name fired less than `seconds` ago; the window is tied to the **last successful fire** (suppressed calls do not reset the timer). **`seconds: 0`** never suppresses. Storage read failures **fail closed** (suppress). Daily “fired today” checks are refactored to share a new **`pixelHasBeenFired`** helper with the debounce path.
> 
> Test utilities gain an exhaustive-switch case for debounce; unit tests cover in-window suppression, post-window refire, and the zero-second case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 313f97c76a0f6ddecd99a1b4a351b26550d251cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->