### PR TITLE
iPad: Enable iPadChromeShortcut FF for external users

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -777,7 +777,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .walletPassDownload:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.walletPassDownload))
         case .aiChatChromeShortcutIPad:
-            Config(defaultValue: .disabled, source: .remoteReleasable(AIChatSubfeature.iPadChromeShortcut))
+            Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.iPadChromeShortcut))
         case .floatingUI:
             Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.floatingUI))
         case .removeChatHistory:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215626304400548?focus=true
Tech Design URL:
CC:

### Description
Enables the FF of iPadChromeShortcut to external users.

### Testing Steps
Nothing to test.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing.

### Quality Considerations
Nothing.

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single default-value flip for a UI feature flag; remote config can still disable the shortcut.
> 
> **Overview**
> Turns on the **`aiChatChromeShortcutIPad`** feature flag by default (`.disabled` → `.enabled`) in `FeatureFlag.swift`, while it remains tied to remote releasable config via `AIChatSubfeature.iPadChromeShortcut`.
> 
> For external iPad users, the Duck.ai shortcut in the tabs bar chrome and related Settings / address-bar visibility paths that check this flag will be **on by default** unless remote privacy config disables it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26dbd5ee43438a0a5eff2dd46854157ce4557af9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->