### PR TITLE
[macOS] Delay showing onboarding-related Next Steps cards (feature-flagged)

### DIFF
--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -1638,14 +1638,14 @@ extension MainViewController {
         let debugPersistor = NewTabPageNextStepsCardsDebugPersistor()
         guard let card = debugPersistor.debugVisibleCards.first else { return }
         persistor.setTimesShown(10, for: card)
-        NotificationCenter.default.post(name: .newTabPageWebViewDidAppear, object: nil)
+        NotificationCenter.default.post(name: NSWindow.didBecomeKeyNotification, object: nil)
     }
 
     @objc func debugShiftNewTabOpeningDate(_ sender: Any?) {
         let persistor = AppearancePreferencesUserDefaultsPersistor(keyValueStore: NSApp.delegateTyped.keyValueStore)
         persistor.continueSetUpCardsLastDemonstrated = (persistor.continueSetUpCardsLastDemonstrated ?? Date()).addingTimeInterval(-.day)
         NSApp.delegateTyped.appearancePreferences.continueSetUpCardsViewDidAppear()
-        NotificationCenter.default.post(name: .newTabPageWebViewDidAppear, object: nil)
+        NotificationCenter.default.post(name: NSWindow.didBecomeKeyNotification, object: nil)
     }
 
     @objc func debugShiftNewTabOpeningDateNtimes(_ sender: Any?) {

--- a/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
@@ -62,6 +62,12 @@ final class NewTabPageNextStepsSingleCardProvider: NewTabPageNextStepsCardsProvi
         NewTabPageNextStepsCardsDebugPersistor()
     }()
 
+    private static let onboardingCardIDs: Set<NewTabPageDataModel.CardID> = [
+        .defaultApp,
+        .addAppToDockMac,
+        .bringStuff
+    ]
+
     enum Constants {
         /// Maximum times a card can be dismissed before it is permanently hidden.
         ///
@@ -252,7 +258,7 @@ private extension NewTabPageNextStepsSingleCardProvider {
 
     func refreshCardList() {
         let cards = shouldUseAdvancedCardOrdering ? getOrderedCardsWithAdvancedOrdering() : standardCards.filter(shouldShowCard)
-        if cards.isEmpty {
+        if cards.isEmpty && !hasPendingOnboardingCards() {
             appearancePreferences.continueSetUpCardsClosed = true
         }
         // Record a new card impression if the first card in the list has changed:
@@ -326,7 +332,16 @@ private extension NewTabPageNextStepsSingleCardProvider {
         guard !isCardPermanentlyDismissed(card) else {
             return false
         }
+        guard isCardEligible(card) else {
+            return false
+        }
+        if Self.onboardingCardIDs.contains(card) {
+            return appearancePreferences.isOnboardingNextStepsCardsDelayMet
+        }
+        return true
+    }
 
+    func isCardEligible(_ card: NewTabPageDataModel.CardID) -> Bool {
         switch card {
         case .defaultApp:
             return !defaultBrowserProvider.isDefault
@@ -346,6 +361,15 @@ private extension NewTabPageNextStepsSingleCardProvider {
             return syncService?.featureFlags.contains(.all) == true && syncService?.authState == .inactive
         case .youtubeAdBlocking:
             return adBlockingAvailability.isEnabled
+        }
+    }
+
+    func hasPendingOnboardingCards() -> Bool {
+        guard !appearancePreferences.isOnboardingNextStepsCardsDelayMet else {
+            return false
+        }
+        return Self.onboardingCardIDs.contains { card in
+            isCardEligible(card) && !isCardPermanentlyDismissed(card)
         }
     }
 

--- a/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
@@ -84,6 +84,11 @@ final class NewTabPageNextStepsSingleCardProvider: NewTabPageNextStepsCardsProvi
     /// Whether to use standard or advanced ordering for the card list.
     private var shouldUseAdvancedCardOrdering: Bool
 
+    /// Whether the day-0 delay for onboarding-related cards is active.
+    private var isOnboardingCardDelayEnabled: Bool {
+        shouldUseAdvancedCardOrdering
+    }
+
     /// Which card level to show first in the list of cards.
     /// This is used to swap the card order after `cardLevel1DemonstrationDays` have passed.
     private var firstCardLevel: NewTabPageDataModel.CardLevel {
@@ -327,10 +332,10 @@ private extension NewTabPageNextStepsSingleCardProvider {
     }
 
     /// Returns whether the card should be shown in the list of visible cards.
-    /// This checks to following conditions:
+    /// This checks the following conditions:
     /// - Whether the card has been permanently dismissed
     /// - Whether the card's specific visibility conditions are met.
-    /// - For onboarding cards, whether the delay has passed to start showing them.
+    /// - For onboarding cards when `nextStepsListAdvancedCardOrdering` is enabled, whether the delay has passed to start showing them.
     func shouldShowCard(_ card: NewTabPageDataModel.CardID) -> Bool {
         guard !isCardPermanentlyDismissed(card) else {
             return false
@@ -338,7 +343,7 @@ private extension NewTabPageNextStepsSingleCardProvider {
         guard isCardEligible(card) else {
             return false
         }
-        if Self.onboardingCardIDs.contains(card) {
+        if isOnboardingCardDelayEnabled && Self.onboardingCardIDs.contains(card) {
             return appearancePreferences.isOnboardingNextStepsCardsDelayMet
         }
         return true
@@ -368,6 +373,9 @@ private extension NewTabPageNextStepsSingleCardProvider {
     }
 
     func hasPendingOnboardingCards() -> Bool {
+        guard isOnboardingCardDelayEnabled else {
+            return false
+        }
         guard !appearancePreferences.isOnboardingNextStepsCardsDelayMet else {
             return false
         }

--- a/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
@@ -222,7 +222,7 @@ final class NewTabPageNextStepsSingleCardProvider: NewTabPageNextStepsCardsProvi
         }
 
         shuffleStandardCardsIfNeeded()
-        refreshCardList()
+        refreshCardList(recordNewCardImpression: false)
         observeCardVisibilityChanges()
         observeKeyWindowChanges()
         observeNewTabPageWebViewDidAppear()
@@ -261,19 +261,46 @@ final class NewTabPageNextStepsSingleCardProvider: NewTabPageNextStepsCardsProvi
 
 private extension NewTabPageNextStepsSingleCardProvider {
 
-    func refreshCardList() {
-        let cards = shouldUseAdvancedCardOrdering ? getOrderedCardsWithAdvancedOrdering() : standardCards.filter(shouldShowCard)
+    /// Refreshes the card list based on card visibility conditions and ordering logic.
+    ///
+    /// - Parameters:
+    ///   - updateOrder: Whether to update the card order. Set to false to check if cards are still eligible to be shown, for example after returning to the app or changing a setting that impacts card visibility, without affecting card order. Defaults to true.
+    ///   - recordNewCardImpression: Whether to record an impression for the newly visible card if the first card in the list has changed after the refresh. Defaults to true.
+    func refreshCardList(updateOrder: Bool = true, recordNewCardImpression: Bool = true) {
+        let cards = visibleCards(updateOrder: updateOrder)
         if cards.isEmpty && !hasPendingOnboardingCards() {
             appearancePreferences.continueSetUpCardsClosed = true
         }
-        // Record a new card impression if the first card in the list has changed:
-        // after a card is dismissed, no longer eligible to be shown, or the cards are shuffled/re-ordered.
-        if let initialVisibleCard = self.cards.first, cards.first != initialVisibleCard {
-            recordImpression(for: cards.first)
+
+        if recordNewCardImpression, let newVisibleCard = cards.first, newVisibleCard != self.cards.first {
+            recordImpression(for: newVisibleCard)
         }
+
         cardList = cards
     }
 
+    func visibleCards(updateOrder: Bool) -> [NewTabPageDataModel.CardID] {
+        guard shouldUseAdvancedCardOrdering else {
+            return standardCards.filter(shouldShowCard)
+        }
+
+        var ordered = persistor.orderedCardIDs ?? defaultAdvancedCards.map(\.cardID)
+        if updateOrder {
+            ordered = applyAdvancedCardOrdering(to: ordered)
+        }
+        let orderedVisibleCards = ordered.filter(shouldShowCard)
+
+        let buildType = StandardApplicationBuildType()
+        if buildType.isDebugBuild || buildType.isReviewBuild || buildType.isAlphaBuild {
+            // Persist visible cards for debug menu actions
+            // Otherwise, we don't need to persist this because we want to check card visibility each time cards are shown
+            debugPersistor.debugVisibleCards = orderedVisibleCards
+        }
+
+        return orderedVisibleCards
+    }
+
+    /// Records an impression for the provided card.
     func recordImpression(for card: NewTabPageDataModel.CardID?) {
         guard !isNextStepsCardsComplete, let card else { return }
         persistor.incrementTimesShown(for: card)
@@ -286,11 +313,9 @@ private extension NewTabPageNextStepsSingleCardProvider {
         standardCards = [.defaultApp] + shuffledCards
     }
 
-    /// Gets a list of cards, sorted by card level and persisted card order.
-    /// Returns only the visible cards (filtered by shouldShowCard).
-    func getOrderedCardsWithAdvancedOrdering() -> [NewTabPageDataModel.CardID] {
-        // Get the card list based on persisted or default order
-        var orderedCards = persistor.orderedCardIDs ?? defaultAdvancedCards.map { $0.cardID }
+    /// Returns the card list sorted by card level and persisted card order.
+    func applyAdvancedCardOrdering(to cards: [NewTabPageDataModel.CardID]) -> [NewTabPageDataModel.CardID] {
+        var orderedCards = cards
 
         // Check if the first visible card has been shown 10+ times, and move it to the end of the list
         if let firstVisibleCard = orderedCards.first(where: shouldShowCard) {
@@ -318,17 +343,7 @@ private extension NewTabPageNextStepsSingleCardProvider {
             persistor.orderedCardIDs = orderedCards
         }
 
-        let orderedVisibleCards = orderedCards.filter(shouldShowCard)
-
-        let buildType = StandardApplicationBuildType()
-        if buildType.isDebugBuild || buildType.isReviewBuild || buildType.isAlphaBuild {
-            // Persist visible cards for debug menu actions
-            // Otherwise, we don't need to persist this because we want to check card visibility each time cards are shown
-            debugPersistor.debugVisibleCards = orderedVisibleCards
-        }
-
-        // Return only the visible cards
-        return orderedVisibleCards
+        return orderedCards
     }
 
     /// Returns whether the card should be shown in the list of visible cards.
@@ -419,7 +434,8 @@ private extension NewTabPageNextStepsSingleCardProvider {
             .combineLatest(appearancePreferences.$didChangeAnyNewTabPageCustomizationSetting.removeDuplicates())
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.refreshCardList()
+                // Only refresh the list based on card visibility changes.
+                self?.refreshCardList(updateOrder: false)
             }
             .store(in: &cancellables)
     }
@@ -432,7 +448,8 @@ private extension NewTabPageNextStepsSingleCardProvider {
         NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)
             .sink { _ in
                 DispatchQueue.main.async { [weak self] in
-                    self?.refreshCardList()
+                    // Only refresh the list based on card visibility changes, e.g. if the default browser setting has changed.
+                    self?.refreshCardList(updateOrder: false)
                 }
             }
             .store(in: &cancellables)
@@ -445,10 +462,6 @@ private extension NewTabPageNextStepsSingleCardProvider {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else { return }
-                if !isNextStepsCardsComplete {
-                    recordImpression(for: cards.first)
-                    persistor.ntpImpressionCount += 1
-                }
 
                 let buildType = StandardApplicationBuildType()
                 if buildType.isDebugBuild || buildType.isReviewBuild || buildType.isAlphaBuild {
@@ -458,7 +471,13 @@ private extension NewTabPageNextStepsSingleCardProvider {
                         standardCards = defaultStandardCards
                     }
                 }
-                refreshCardList()
+                // We record an impression for the visible card unconditionally when the New Tab Page is opened,
+                // not only when a new card is visible due to the card list refresh.
+                refreshCardList(recordNewCardImpression: false)
+                if !isNextStepsCardsComplete {
+                    recordImpression(for: cards.first)
+                    persistor.ntpImpressionCount += 1
+                }
             }
             .store(in: &cancellables)
     }

--- a/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
@@ -327,7 +327,10 @@ private extension NewTabPageNextStepsSingleCardProvider {
     }
 
     /// Returns whether the card should be shown in the list of visible cards.
-    /// This checks both if the card has been permanently dismissed and if the card's specific visibility conditions are met.
+    /// This checks to following conditions:
+    /// - Whether the card has been permanently dismissed
+    /// - Whether the card's specific visibility conditions are met.
+    /// - For onboarding cards, whether the delay has passed to start showing them.
     func shouldShowCard(_ card: NewTabPageDataModel.CardID) -> Bool {
         guard !isCardPermanentlyDismissed(card) else {
             return false

--- a/macOS/DuckDuckGo/Preferences/Model/AppearancePreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AppearancePreferences.swift
@@ -335,12 +335,7 @@ final class AppearancePreferences: ObservableObject {
         persistor.continueSetUpCardsNumberOfDaysDemonstrated
     }
 
-    /// Date Next Steps cards were last demonstrated (also the first demonstration date while `nextStepsCardsDemonstrationDays == 0`).
-    var continueSetUpCardsLastDemonstrated: Date? {
-        persistor.continueSetUpCardsLastDemonstrated
-    }
-
-    /// Whether onboarding-related Next Steps cards (default browser, dock, import) may be shown.
+    /// Whether onboarding-related Next Steps cards may be shown.
     ///
     /// Onboarding cards are suppressed on the user's first calendar day of seeing Next Steps.
     /// They become eligible when the demonstration-day counter reaches 1, or when the calendar
@@ -354,11 +349,7 @@ final class AppearancePreferences: ObservableObject {
             return false
         }
 
-        let daysSinceFirstDemonstration = Calendar.current.dateComponents(
-            [.day],
-            from: lastDemonstrated,
-            to: dateTimeProvider()
-        ).day ?? 0
+        let daysSinceFirstDemonstration = Calendar.current.dateComponents([.day], from: lastDemonstrated, to: dateTimeProvider()).day ?? 0
 
         return daysSinceFirstDemonstration > 0
     }

--- a/macOS/DuckDuckGo/Preferences/Model/AppearancePreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AppearancePreferences.swift
@@ -335,6 +335,34 @@ final class AppearancePreferences: ObservableObject {
         persistor.continueSetUpCardsNumberOfDaysDemonstrated
     }
 
+    /// Date Next Steps cards were last demonstrated (also the first demonstration date while `nextStepsCardsDemonstrationDays == 0`).
+    var continueSetUpCardsLastDemonstrated: Date? {
+        persistor.continueSetUpCardsLastDemonstrated
+    }
+
+    /// Whether onboarding-related Next Steps cards (default browser, dock, import) may be shown.
+    ///
+    /// Onboarding cards are suppressed on the user's first calendar day of seeing Next Steps.
+    /// They become eligible when the demonstration-day counter reaches 1, or when the calendar
+    /// rolls past the first demonstration while the counter is still 0.
+    var isOnboardingNextStepsCardsDelayMet: Bool {
+        if nextStepsCardsDemonstrationDays >= 1 {
+            return true
+        }
+
+        guard let lastDemonstrated = persistor.continueSetUpCardsLastDemonstrated else {
+            return false
+        }
+
+        let daysSinceFirstDemonstration = Calendar.current.dateComponents(
+            [.day],
+            from: lastDemonstrated,
+            to: dateTimeProvider()
+        ).day ?? 0
+
+        return daysSinceFirstDemonstration > 0
+    }
+
     private var shouldHideNextStepsCards: Bool {
        persistor.continueSetUpCardsNumberOfDaysDemonstrated >= maxNextStepsCardsDemonstrationDays
     }

--- a/macOS/UnitTests/NewTabPage/NewTabPageNextStepsSingleCardProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageNextStepsSingleCardProviderTests.swift
@@ -307,17 +307,8 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
         persistor.setTimesShown(0, for: secondCard)
         let testProvider = createProvider()
 
-        let expectation = XCTestExpectation(description: "Cards publisher emits card list")
-        let cancellable = testProvider.cardsPublisher
-            .sink { cards in
-                expectation.fulfill()
-            }
-
-        // WHEN - Trigger card list refresh
-        NotificationCenter.default.post(name: .newTabPageWebViewDidAppear, object: nil)
-
-        wait(for: [expectation], timeout: 1.0)
-        cancellable.cancel()
+        // WHEN
+        triggerNewTabPageView(on: testProvider)
 
         // THEN
         XCTAssertEqual(persistor.timesShown(for: firstCard), 1)
@@ -331,17 +322,8 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
         persistor.ntpImpressionCount = 0
         let testProvider = createProvider()
 
-        let expectation = XCTestExpectation(description: "Cards publisher emits card list")
-        let cancellable = testProvider.cardsPublisher
-            .sink { cards in
-                expectation.fulfill()
-            }
-
-        // WHEN - Trigger card list refresh
-        NotificationCenter.default.post(name: .newTabPageWebViewDidAppear, object: nil)
-
-        wait(for: [expectation], timeout: 1.0)
-        cancellable.cancel()
+        // WHEN
+        triggerNewTabPageView(on: testProvider)
 
         // THEN
         XCTAssertEqual(persistor.ntpImpressionCount, 1)
@@ -354,17 +336,8 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
         appearancePreferences.isContinueSetUpCardsViewOutdated = true
         let testProvider = createProvider()
 
-        let expectation = XCTestExpectation(description: "Cards publisher emits card list")
-        let cancellable = testProvider.cardsPublisher
-            .sink { cards in
-                expectation.fulfill()
-            }
-
-        // WHEN - Trigger card list refresh
-        NotificationCenter.default.post(name: .newTabPageWebViewDidAppear, object: nil)
-
-        wait(for: [expectation], timeout: 1.0)
-        cancellable.cancel()
+        // WHEN
+        triggerNewTabPageView(on: testProvider)
 
         // THEN
         XCTAssertEqual(persistor.ntpImpressionCount, 0)
@@ -1154,6 +1127,51 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
         XCTAssertFalse(appearancePrefs.continueSetUpCardsClosed)
     }
 
+    @MainActor
+    func testWhenOnboardingDelayMetAfterEmptyListThenTimesShownIsIncrementedForFirstOnboardingCard() {
+        // GIVEN
+        var now = Date()
+        let appearancePersistor = MockAppearancePreferencesPersistor(
+            continueSetUpCardsLastDemonstrated: now,
+            continueSetUpCardsNumberOfDaysDemonstrated: 0
+        )
+        let appearancePrefs = AppearancePreferences(
+            persistor: appearancePersistor,
+            privacyConfigurationManager: MockPrivacyConfigurationManager(),
+            dateTimeProvider: { now },
+            featureFlagger: MockFeatureFlagger(),
+            aiChatMenuConfig: MockAIChatConfig()
+        )
+        let testFeatureFlagger = MockFeatureFlagger()
+        testFeatureFlagger.enabledFeatureFlags = [.nextStepsListAdvancedCardOrdering]
+        let testPersistor = MockNewTabPageNextStepsCardsPersistor()
+        for card in NewTabPageDataModel.CardID.allCases where card != .defaultApp && card != .addAppToDockMac && card != .bringStuff {
+            testPersistor.setTimesDismissed(NewTabPageNextStepsSingleCardProvider.Constants.maxTimesCardDismissed, for: card)
+        }
+        let testProvider = createProvider(
+            defaultBrowserIsDefault: false,
+            appearancePreferences: appearancePrefs,
+            persistor: testPersistor,
+            featureFlagger: testFeatureFlagger,
+            isAppStoreBuild: false
+        )
+
+        // WHEN - simulate opening the New Tab Page with delay not yet met
+        triggerNewTabPageView(on: testProvider)
+
+        // THEN
+        XCTAssertTrue(testProvider.cards.isEmpty)
+        XCTAssertEqual(testPersistor.timesShown(for: .defaultApp), 0)
+
+        // WHEN - simulate time passing to meet onboarding delay requirement
+        now = now.addingTimeInterval(.day)
+        triggerNewTabPageView(on: testProvider)
+
+        // THEN
+        XCTAssertEqual(testProvider.cards.first, .defaultApp)
+        XCTAssertEqual(testPersistor.timesShown(for: .defaultApp), 1)
+    }
+
     func testWhenNonOnboardingCardsExhaustedAndOnboardingIneligibleThenContinueSetUpCardsClosed() {
         let now = Date()
         let appearancePrefs = createAppearancePrefs(
@@ -1344,6 +1362,19 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
             featureFlagger: MockFeatureFlagger(),
             aiChatMenuConfig: MockAIChatConfig()
         )
+    }
+
+    private func triggerNewTabPageView(on testProvider: NewTabPageNextStepsSingleCardProvider) {
+        let expectation = XCTestExpectation(description: "Cards publisher emits card list")
+        let cancellable = testProvider.cardsPublisher
+            .sink { cards in
+                expectation.fulfill()
+            }
+
+        NotificationCenter.default.post(name: .newTabPageWebViewDidAppear, object: nil)
+
+        wait(for: [expectation], timeout: 1.0)
+        cancellable.cancel()
     }
 }
 

--- a/macOS/UnitTests/NewTabPage/NewTabPageNextStepsSingleCardProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageNextStepsSingleCardProviderTests.swift
@@ -1071,11 +1071,14 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
             lastDemonstrated: now,
             now: now
         )
+        let testFeatureFlagger = MockFeatureFlagger()
+        testFeatureFlagger.enabledFeatureFlags = [.nextStepsListAdvancedCardOrdering]
         let testProvider = createProvider(
             defaultBrowserIsDefault: false,
             dataImportDidImport: false,
             dockStatus: false,
             appearancePreferences: appearancePrefs,
+            featureFlagger: testFeatureFlagger,
             isAppStoreBuild: false
         )
 
@@ -1091,9 +1094,12 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
             demonstrationDays: 1,
             lastDemonstrated: Date()
         )
+        let testFeatureFlagger = MockFeatureFlagger()
+        testFeatureFlagger.enabledFeatureFlags = [.nextStepsListAdvancedCardOrdering]
         let testProvider = createProvider(
             defaultBrowserIsDefault: false,
             appearancePreferences: appearancePrefs,
+            featureFlagger: testFeatureFlagger,
             isAppStoreBuild: false
         )
 
@@ -1110,9 +1116,12 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
             lastDemonstrated: yesterday,
             now: now
         )
+        let testFeatureFlagger = MockFeatureFlagger()
+        testFeatureFlagger.enabledFeatureFlags = [.nextStepsListAdvancedCardOrdering]
         let testProvider = createProvider(
             defaultBrowserIsDefault: false,
             appearancePreferences: appearancePrefs,
+            featureFlagger: testFeatureFlagger,
             isAppStoreBuild: false
         )
 
@@ -1127,6 +1136,8 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
             lastDemonstrated: now,
             now: now
         )
+        let testFeatureFlagger = MockFeatureFlagger()
+        testFeatureFlagger.enabledFeatureFlags = [.nextStepsListAdvancedCardOrdering]
         let testPersistor = MockNewTabPageNextStepsCardsPersistor()
         for card in NewTabPageDataModel.CardID.allCases where card != .defaultApp && card != .addAppToDockMac && card != .bringStuff {
             testPersistor.setTimesDismissed(NewTabPageNextStepsSingleCardProvider.Constants.maxTimesCardDismissed, for: card)
@@ -1135,6 +1146,7 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
             defaultBrowserIsDefault: false,
             appearancePreferences: appearancePrefs,
             persistor: testPersistor,
+            featureFlagger: testFeatureFlagger,
             isAppStoreBuild: false
         )
 
@@ -1150,6 +1162,8 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
             lastDemonstrated: now,
             now: now
         )
+        let testFeatureFlagger = MockFeatureFlagger()
+        testFeatureFlagger.enabledFeatureFlags = [.nextStepsListAdvancedCardOrdering]
         let testProvider = createProvider(
             defaultBrowserIsDefault: true,
             dataImportDidImport: true,
@@ -1158,11 +1172,34 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
             subscriptionCardShouldShow: false,
             syncConnected: true,
             appearancePreferences: appearancePrefs,
+            featureFlagger: testFeatureFlagger,
             isAppStoreBuild: true
         )
 
         XCTAssertTrue(testProvider.cards.isEmpty)
         XCTAssertTrue(appearancePrefs.continueSetUpCardsClosed)
+    }
+
+    func testWhenOnboardingDelayNotMetAndAdvancedOrderingDisabledThenOnboardingCardsAreIncluded() {
+        let now = Date()
+        let appearancePrefs = createAppearancePrefs(
+            demonstrationDays: 0,
+            lastDemonstrated: now,
+            now: now
+        )
+        let testFeatureFlagger = MockFeatureFlagger()
+        testFeatureFlagger.enabledFeatureFlags = []
+        let testProvider = createProvider(
+            defaultBrowserIsDefault: false,
+            appearancePreferences: appearancePrefs,
+            featureFlagger: testFeatureFlagger,
+            isAppStoreBuild: false
+        )
+
+        let cards = testProvider.cards
+        XCTAssertTrue(cards.contains(.defaultApp))
+        XCTAssertTrue(cards.contains(.addAppToDockMac))
+        XCTAssertTrue(cards.contains(.bringStuff))
     }
 
     // MARK: - Helper Functions

--- a/macOS/UnitTests/NewTabPage/NewTabPageNextStepsSingleCardProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageNextStepsSingleCardProviderTests.swift
@@ -58,11 +58,9 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
         legacyPersistor = MockHomePageContinueSetUpModelPersisting()
         legacySubscriptionCardPersistor = MockHomePageSubscriptionCardPersisting()
 
-        appearancePreferences = AppearancePreferences(
-            persistor: MockAppearancePreferencesPersistor(),
-            privacyConfigurationManager: MockPrivacyConfigurationManager(),
-            featureFlagger: MockFeatureFlagger(),
-            aiChatMenuConfig: MockAIChatConfig()
+        appearancePreferences = createAppearancePrefs(
+            demonstrationDays: 1,
+            lastDemonstrated: Date()
         )
 
         defaultBrowserProvider = CapturingDefaultBrowserProvider()
@@ -1064,6 +1062,109 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
         XCTAssertFalse(testProvider.cards.contains(.youtubeAdBlocking))
     }
 
+    // MARK: - Onboarding cards day-0 delay
+
+    func testWhenOnboardingDelayNotMetThenOnboardingCardsAreExcluded() {
+        let now = Date()
+        let appearancePrefs = createAppearancePrefs(
+            demonstrationDays: 0,
+            lastDemonstrated: now,
+            now: now
+        )
+        let testProvider = createProvider(
+            defaultBrowserIsDefault: false,
+            dataImportDidImport: false,
+            dockStatus: false,
+            appearancePreferences: appearancePrefs,
+            isAppStoreBuild: false
+        )
+
+        let cards = testProvider.cards
+        XCTAssertFalse(cards.contains(.defaultApp))
+        XCTAssertFalse(cards.contains(.addAppToDockMac))
+        XCTAssertFalse(cards.contains(.bringStuff))
+        XCTAssertFalse(cards.isEmpty)
+    }
+
+    func testWhenOnboardingDelayMetViaDemonstrationDaysThenOnboardingCardsAreIncluded() {
+        let appearancePrefs = createAppearancePrefs(
+            demonstrationDays: 1,
+            lastDemonstrated: Date()
+        )
+        let testProvider = createProvider(
+            defaultBrowserIsDefault: false,
+            appearancePreferences: appearancePrefs,
+            isAppStoreBuild: false
+        )
+
+        let cards = testProvider.cards
+        XCTAssertTrue(cards.contains(.defaultApp))
+        XCTAssertTrue(cards.contains(.bringStuff))
+    }
+
+    func testWhenOnboardingDelayMetViaCalendarRollThenOnboardingCardsAreIncluded() {
+        let now = Date()
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: now)!
+        let appearancePrefs = createAppearancePrefs(
+            demonstrationDays: 0,
+            lastDemonstrated: yesterday,
+            now: now
+        )
+        let testProvider = createProvider(
+            defaultBrowserIsDefault: false,
+            appearancePreferences: appearancePrefs,
+            isAppStoreBuild: false
+        )
+
+        let cards = testProvider.cards
+        XCTAssertTrue(cards.contains(.defaultApp))
+    }
+
+    func testWhenNonOnboardingCardsExhaustedButOnboardingPendingThenContinueSetUpCardsNotClosed() {
+        let now = Date()
+        let appearancePrefs = createAppearancePrefs(
+            demonstrationDays: 0,
+            lastDemonstrated: now,
+            now: now
+        )
+        let testPersistor = MockNewTabPageNextStepsCardsPersistor()
+        for card in NewTabPageDataModel.CardID.allCases where card != .defaultApp && card != .addAppToDockMac && card != .bringStuff {
+            testPersistor.setTimesDismissed(NewTabPageNextStepsSingleCardProvider.Constants.maxTimesCardDismissed, for: card)
+        }
+        let testProvider = createProvider(
+            defaultBrowserIsDefault: false,
+            appearancePreferences: appearancePrefs,
+            persistor: testPersistor,
+            isAppStoreBuild: false
+        )
+
+        XCTAssertTrue(testProvider.cards.isEmpty)
+        XCTAssertFalse(appearancePrefs.continueSetUpCardsClosed)
+    }
+
+    func testWhenNonOnboardingCardsExhaustedAndOnboardingIneligibleThenContinueSetUpCardsClosed() {
+        let now = Date()
+        let appearancePrefs = createAppearancePrefs(
+            didChangeAnyCustomizationSetting: true,
+            demonstrationDays: 0,
+            lastDemonstrated: now,
+            now: now
+        )
+        let testProvider = createProvider(
+            defaultBrowserIsDefault: true,
+            dataImportDidImport: true,
+            dockStatus: true,
+            emailManagerSignedIn: true,
+            subscriptionCardShouldShow: false,
+            syncConnected: true,
+            appearancePreferences: appearancePrefs,
+            isAppStoreBuild: true
+        )
+
+        XCTAssertTrue(testProvider.cards.isEmpty)
+        XCTAssertTrue(appearancePrefs.continueSetUpCardsClosed)
+    }
+
     // MARK: - Helper Functions
 
     private func createProvider(
@@ -1191,14 +1292,18 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
     }
 
     private func createAppearancePrefs(didChangeAnyCustomizationSetting: Bool = false,
-                                       demonstrationDays: Int = 0) -> AppearancePreferences {
+                                       demonstrationDays: Int = 0,
+                                       lastDemonstrated: Date? = nil,
+                                       now: Date = Date()) -> AppearancePreferences {
         let persistor = MockAppearancePreferencesPersistor(
+            continueSetUpCardsLastDemonstrated: lastDemonstrated,
             continueSetUpCardsNumberOfDaysDemonstrated: demonstrationDays,
             didChangeAnyNewTabPageCustomizationSetting: didChangeAnyCustomizationSetting
         )
         return AppearancePreferences(
             persistor: persistor,
             privacyConfigurationManager: MockPrivacyConfigurationManager(),
+            dateTimeProvider: { now },
             featureFlagger: MockFeatureFlagger(),
             aiChatMenuConfig: MockAIChatConfig()
         )

--- a/macOS/UnitTests/Preferences/AppearancePreferencesTests.swift
+++ b/macOS/UnitTests/Preferences/AppearancePreferencesTests.swift
@@ -220,6 +220,73 @@ final class AppearancePreferencesTests: XCTestCase {
         XCTAssertEqual(model.nextStepsCardsDemonstrationDays, 5)
     }
 
+    // MARK: - Onboarding Next Steps cards delay
+
+    func testWhenOnboardingNextStepsCardsDelayMetAndDemonstrationDaysIsOneOrMoreThenReturnsTrue() {
+        let persistor = AppearancePreferencesPersistorMock(
+            continueSetUpCardsLastDemonstrated: Date(),
+            continueSetUpCardsNumberOfDaysDemonstrated: 1
+        )
+        let model = AppearancePreferences(
+            persistor: persistor,
+            privacyConfigurationManager: MockPrivacyConfigurationManager(),
+            featureFlagger: MockFeatureFlagger(),
+            aiChatMenuConfig: MockAIChatConfig()
+        )
+
+        XCTAssertTrue(model.isOnboardingNextStepsCardsDelayMet)
+    }
+
+    func testWhenOnboardingNextStepsCardsDelayMetAndCardsNeverShownThenReturnsFalse() {
+        let persistor = AppearancePreferencesPersistorMock(
+            continueSetUpCardsLastDemonstrated: nil,
+            continueSetUpCardsNumberOfDaysDemonstrated: 0
+        )
+        let model = AppearancePreferences(
+            persistor: persistor,
+            privacyConfigurationManager: MockPrivacyConfigurationManager(),
+            featureFlagger: MockFeatureFlagger(),
+            aiChatMenuConfig: MockAIChatConfig()
+        )
+
+        XCTAssertFalse(model.isOnboardingNextStepsCardsDelayMet)
+    }
+
+    func testWhenOnboardingNextStepsCardsDelayMetAndSameCalendarDayAsFirstDemonstrationThenReturnsFalse() {
+        let now = Date()
+        let persistor = AppearancePreferencesPersistorMock(
+            continueSetUpCardsLastDemonstrated: now,
+            continueSetUpCardsNumberOfDaysDemonstrated: 0
+        )
+        let model = AppearancePreferences(
+            persistor: persistor,
+            privacyConfigurationManager: MockPrivacyConfigurationManager(),
+            dateTimeProvider: { now },
+            featureFlagger: MockFeatureFlagger(),
+            aiChatMenuConfig: MockAIChatConfig()
+        )
+
+        XCTAssertFalse(model.isOnboardingNextStepsCardsDelayMet)
+    }
+
+    func testWhenOnboardingNextStepsCardsDelayMetAndDemonstrationDaysStillZeroButCalendarDayRolledThenReturnsTrue() {
+        let now = Date()
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: now)!
+        let persistor = AppearancePreferencesPersistorMock(
+            continueSetUpCardsLastDemonstrated: yesterday,
+            continueSetUpCardsNumberOfDaysDemonstrated: 0
+        )
+        let model = AppearancePreferences(
+            persistor: persistor,
+            privacyConfigurationManager: MockPrivacyConfigurationManager(),
+            dateTimeProvider: { now },
+            featureFlagger: MockFeatureFlagger(),
+            aiChatMenuConfig: MockAIChatConfig()
+        )
+
+        XCTAssertTrue(model.isOnboardingNextStepsCardsDelayMet)
+    }
+
     func testContinueSetUpIsNotDismissedAfterSeveralDemonstrationsWithinSeveralDays() {
         // 1. app installed and launched
         var now = Date()


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1215531524368920?focus=true
Tech Design URL:
CC:

### Description

This updates the Next Steps cards behavior when the feature flag `nextStepsListAdvancedCardOrdering` is enabled, to delay showing onboarding-related cards:
* Cards with calls to action that are also part of onboarding (Set as Default, Add to Dock, Import) are not shown on day 0, i.e. the first day Next Steps cards are shown.
* After a day, the onboarding cards are added to the Next Steps stack.
* Next Steps is only closed if all eligible cards have been actioned, with no pending onboarding cards. In other words, if all cards on day 0 are actioned, it's still possible for onboarding cards to be shown the next day.

This change makes it possible to go from an empty card list to showing cards again (when onboarding cards are shown). To account for that scenario, the logic for refreshing the card list has been updated:
* Card refreshing explicitly handles when new card impressions are counted. This allows new cards to be counted when the list was previously empty, except during init (in that case the impression will be counted when the New Tab Page is opened).
* When the card list is refreshed due to card visibility changes, the list updates what cards are shown without changing any card ordering.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Build and run the app.
2. **Debug** -> **New Tab Page** -> **Reset Next Steps**
3. Relaunch the app.
4. Go through each Next Steps card (dismissing each card) and confirm the onboarding cards are included in the stack. (Note: If you have completed those actions, i.e. the app is your default browser, it is in the Dock, or you previously imported data, you won't be eligible to see them and those cards won't be included.)
5. **Debug** -> **New Tab Page** -> **Reset Next Steps**
6. **Debug** -> **Feature Flag Overrides** -> **Other** -> enable `nextStepsListAdvancedCardOrdering`
7. Go through each Next Steps card and confirm the onboarding cards are **not** included in the stack.
8. Confirm the onboarding cards appear on the New Tab Page.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
10. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Medium: Could disrupt specific features or user flows

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
* Delay could be applied to non-feature-flagged UX. Mitigation: Unit and manual tests confirm delay only applies when feature flag is enabled.
* Feature flag and testing mitigate risks around incorrect card logic, e.g. onboarding cards showing up too early, not showing up when delay has passed, or not showing up after non-onboarding cards are all dismissed.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->
Scenarios considered:
- All non-onboarding cards are dismissed on day 0; onboarding cards still appear after day 0.
- Some non-onboarding cards are still in stack after day 0; onboarding cards are added to stack after day 0.
- User is not eligible for any onboarding cards (e.g. all steps completed during onboarding); Next Steps is closed after non-onboarding cards are actioned.

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes New Tab onboarding card visibility and when Next Steps auto-closes; gated by a feature flag with broad unit test coverage, but incorrect timing could confuse new users.
> 
> **Overview**
> When **`nextStepsListAdvancedCardOrdering`** is on, macOS New Tab **Next Steps** hides onboarding-aligned cards (**Set as Default**, **Add to Dock**, **Import**) on the user’s first day of seeing the stack, then shows them once the delay is met.
> 
> **`AppearancePreferences`** adds **`isOnboardingNextStepsCardsDelayMet`**, true when demonstration days ≥ 1 or the calendar has moved past the first demonstration day (using existing persisted dates).
> 
> **`NewTabPageNextStepsSingleCardProvider`** gates those card IDs through that flag, splits eligibility into **`isCardEligible`**, and uses **`hasPendingOnboardingCards()`** so an empty visible list on day 0 does **not** set **`continueSetUpCardsClosed`** while eligible onboarding cards are still waiting. Behavior without the flag is unchanged.
> 
> Unit tests cover delay timing, auto-close vs pending onboarding, and flag-off paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bbeb2d712706766ad6f57cf28300c72a6a9039d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->