### PR TITLE
[iOS] Web-scroll-freeze observability (internal-only, feature-flagged)

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -255,6 +255,10 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
 
     case crashReportOptInStatusResetting
 
+    /// Internal-only observability for the hard-to-reproduce "web view scroll frozen, taps still work" bug:
+    /// a passive scroll-failure observer plus a gesture watchdog. Off for the general population by default.
+    case webScrollFreezeObservability
+
     case screenTimeCleaning
 
     case minimalChromeInLandscape

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -311,6 +311,9 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1206488453854252/task/1212289671815991
     case unifiedToggleInput
 
+    /// Internal-only gate for web-scroll-freeze observability (scroll-failure observer + gesture watchdog).
+    case webScrollFreezeObservability
+
     /// Failsafe kill switch for hiding the Search↔Duck.ai toggle on Duck.ai tabs. On by
     /// default; ship a privacy-config entry to roll back. See
     /// `UnifiedToggleInputFeatureProviding.isToggleHiddenOnDuckAITab`.
@@ -696,6 +699,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.showWhatsNewPromptOnDemand))
         case .unifiedToggleInput:
             Config(source: .remoteReleasable(AIChatSubfeature.unifiedToggleInput))
+        case .webScrollFreezeObservability:
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(iOSBrowserConfigSubfeature.webScrollFreezeObservability))
         case .aiChatTabHideToggle:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.aiChatTabHideToggle))
         case .freeTrialConversionWideEvent:

--- a/iOS/Core/Logger+Multiple.swift
+++ b/iOS/Core/Logger+Multiple.swift
@@ -28,4 +28,5 @@ public extension Logger {
     static let launchSource = Logger(subsystem: "LaunchSource", category: "")
     static let addressBarPicker = Logger(subsystem: "AddressBar Picker", category: "")
     static let customProductPage = Logger(subsystem: "Custom Product Page", category: "")
+    static let interaction = Logger(subsystem: "Interaction", category: "")
 }

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -968,6 +968,9 @@ extension Pixel {
 
         case debugWebViewInVisibleTabHidden
 
+        case debugInteractionRepeatedFailedScroll
+        case debugInteractionWedgedRecognizer
+
         case debugPromptCoordinationFailedToSaveLastPresentationDate
         case debugPromptCoordinationFailedToRetrieveLastPresentationDate
 
@@ -2914,6 +2917,9 @@ extension Pixel.Event {
             // MARK: Debug Web View
 
         case .debugWebViewInVisibleTabHidden: return "m_debug_webview_in_visible_tab_hidden"
+
+        case .debugInteractionRepeatedFailedScroll: return "m_debug_interaction_repeated_failed_scroll"
+        case .debugInteractionWedgedRecognizer: return "m_debug_interaction_wedged_recognizer"
 
             // MARK: - Debug Prompt Coordination
 

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -789,6 +789,9 @@
 		8528AE81212F15D600D0BD74 /* AppRatingPrompt.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 8528AE7F212F15D600D0BD74 /* AppRatingPrompt.xcdatamodeld */; };
 		8528AE84212FF9A100D0BD74 /* AppRatingPromptStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8528AE82212FF91A00D0BD74 /* AppRatingPromptStorageTests.swift */; };
 		852BCC4D2EC4AEAC0093C753 /* DataAuditDebugScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 852BCC4C2EC4AEA60093C753 /* DataAuditDebugScreen.swift */; };
+		AC7100D1A6105DEBEEF00006 /* WebScrollObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC7100D1A6105DEBEEF00005 /* WebScrollObserver.swift */; };
+		AC7100D1A6105DEBEEF00004 /* InteractionIntegrityMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC7100D1A6105DEBEEF00003 /* InteractionIntegrityMonitor.swift */; };
+		AC7100D1A6105DEBEEF00002 /* InteractionDiagnosticsDebugScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC7100D1A6105DEBEEF00001 /* InteractionDiagnosticsDebugScreen.swift */; };
 		852E766D2E4638AF00BA92F1 /* AIChatSettingsMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 852E766C2E4638AB00BA92F1 /* AIChatSettingsMigration.swift */; };
 		8531A08E1F9950E6000484F0 /* UnprotectedSitesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8531A08D1F9950E6000484F0 /* UnprotectedSitesViewController.swift */; };
 		853273AE24FEF49600E3C778 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853273AC24FEF49600E3C778 /* Extensions.swift */; };
@@ -3368,6 +3371,9 @@
 		8528AE80212F15D600D0BD74 /* AppRatingPrompt.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = AppRatingPrompt.xcdatamodel; sourceTree = "<group>"; };
 		8528AE82212FF91A00D0BD74 /* AppRatingPromptStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingPromptStorageTests.swift; sourceTree = "<group>"; };
 		852BCC4C2EC4AEA60093C753 /* DataAuditDebugScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataAuditDebugScreen.swift; sourceTree = "<group>"; };
+		AC7100D1A6105DEBEEF00005 /* WebScrollObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebScrollObserver.swift; sourceTree = "<group>"; };
+		AC7100D1A6105DEBEEF00003 /* InteractionIntegrityMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractionIntegrityMonitor.swift; sourceTree = "<group>"; };
+		AC7100D1A6105DEBEEF00001 /* InteractionDiagnosticsDebugScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractionDiagnosticsDebugScreen.swift; sourceTree = "<group>"; };
 		852E766C2E4638AB00BA92F1 /* AIChatSettingsMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSettingsMigration.swift; sourceTree = "<group>"; };
 		8531A08D1F9950E6000484F0 /* UnprotectedSitesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnprotectedSitesViewController.swift; sourceTree = "<group>"; };
 		853273AC24FEF49600E3C778 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
@@ -7708,6 +7714,9 @@
 			isa = PBXGroup;
 			children = (
 				852BCC4C2EC4AEA60093C753 /* DataAuditDebugScreen.swift */,
+				AC7100D1A6105DEBEEF00005 /* WebScrollObserver.swift */,
+				AC7100D1A6105DEBEEF00003 /* InteractionIntegrityMonitor.swift */,
+				AC7100D1A6105DEBEEF00001 /* InteractionDiagnosticsDebugScreen.swift */,
 				36A96A092E6606C0003D4529 /* LocalNotificationsPlaygroundView.swift */,
 				4B67012A2E3BE3660066176A /* LogViewer */,
 				31206F6F2D3804E800A95D76 /* AIChatDebugView.swift */,
@@ -12936,6 +12945,9 @@
 				CB6D17C02FB488BE00ECD5AE /* UTIDismissSnapshot.swift in Sources */,
 				9F387DE22EA891E8006861F8 /* NewAddressBarPickerModalPromptProvider.swift in Sources */,
 				852BCC4D2EC4AEAC0093C753 /* DataAuditDebugScreen.swift in Sources */,
+				AC7100D1A6105DEBEEF00006 /* WebScrollObserver.swift in Sources */,
+				AC7100D1A6105DEBEEF00004 /* InteractionIntegrityMonitor.swift in Sources */,
+				AC7100D1A6105DEBEEF00002 /* InteractionDiagnosticsDebugScreen.swift in Sources */,
 				31A968192E4F692200F4305E /* SettingsAIExperimentalPickerView.swift in Sources */,
 				9F23B8032C2BCD0000950875 /* DaxDialogStyles.swift in Sources */,
 				C128BA252DF0847900ADDC5F /* SettingsCompleteSetupView.swift in Sources */,

--- a/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
+++ b/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
@@ -104,6 +104,9 @@ extension DebugScreensViewModel {
             .view(title: "Data Audit", { _ in
                 DataAuditDebugScreen()
             }),
+            .view(title: "Interaction Diagnostics", { d in
+                InteractionDiagnosticsDebugScreen(tabManager: d.tabManager)
+            }),
             .view(title: "Feature Flags", { _ in
                 FeatureFlagsMenuView()
             }),

--- a/iOS/DuckDuckGo/InteractionDiagnosticsDebugScreen.swift
+++ b/iOS/DuckDuckGo/InteractionDiagnosticsDebugScreen.swift
@@ -1,0 +1,327 @@
+//
+//  InteractionDiagnosticsDebugScreen.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+import UIKit
+import OSLog
+import Core
+
+/// Debug screen that captures a root-cause-agnostic snapshot of the current scroll / gesture /
+/// overlay state of the foreground web tab, plus recent `Logger.interaction` entries.
+///
+/// Built to diagnose the hard-to-reproduce "web view can't be scrolled but taps still work" freeze
+/// seen on internal builds: when it happens, open this screen, tap Capture, then Copy and paste the
+/// report into the bug. The report is structural (it walks the live view tree) so it stays valid even
+/// though this screen is presented on top of the frozen tab.
+struct InteractionDiagnosticsDebugScreen: View {
+
+    @StateObject private var model: InteractionDiagnosticsModel
+
+    init(tabManager: TabManager) {
+        _model = StateObject(wrappedValue: InteractionDiagnosticsModel(tabManager: tabManager))
+    }
+
+    var body: some View {
+        List {
+            Section {
+                Button {
+                    model.capture()
+                } label: {
+                    Text(verbatim: "Capture Snapshot")
+                }
+
+                if !model.report.isEmpty {
+                    Button {
+                        model.copy()
+                    } label: {
+                        Text(verbatim: "Copy to Clipboard")
+                    }
+                }
+            } header: {
+                Text(verbatim: "Actions")
+            } footer: {
+                Text(verbatim: "Capture reads the live view tree of the foreground tab. Persistent state "
+                     + "(isScrollEnabled, overlays, which recognizers are enabled) is reliable here. A gesture "
+                     + "recognizer's transient .state may reset when this screen is presented — for that, rely "
+                     + "on the live logs below / the Log Viewer (subsystem: Interaction).")
+            }
+
+            if !model.report.isEmpty {
+                Section {
+                    TextEditor(text: .constant(model.report))
+                        .font(.system(.caption, design: .monospaced))
+                        .frame(minHeight: 360)
+                } header: {
+                    Text(verbatim: "Snapshot")
+                }
+            }
+        }
+        .navigationTitle("Interaction Diagnostics")
+    }
+}
+
+final class InteractionDiagnosticsModel: ObservableObject {
+
+    @Published var report = ""
+
+    private let tabManager: TabManager
+
+    init(tabManager: TabManager) {
+        self.tabManager = tabManager
+    }
+
+    func copy() {
+        UIPasteboard.general.string = report
+    }
+
+    @MainActor
+    func capture() {
+        report = buildSnapshot() + "\n\n## Recent interaction logs (last 5 min)\n" + Self.recentInteractionLogs()
+    }
+
+    // MARK: - Snapshot
+
+    @MainActor
+    private func buildSnapshot() -> String {
+        var out = "# Interaction Diagnostics — \(Date())\n"
+        out += "App: \(Self.appVersion)\n\n"
+        out += featureFlagsSection()
+        out += "\n" + currentTabSection()
+        return out
+    }
+
+    private func featureFlagsSection() -> String {
+        let flagger = AppDependencyProvider.shared.featureFlagger
+        var out = "## Feature flags\n"
+        out += "- unifiedToggleInput: \(flagger.isFeatureOn(.unifiedToggleInput))\n"
+        out += "- experimentalAddressBar: \(flagger.isFeatureOn(.experimentalAddressBar))\n"
+        out += "- showAIChatAddressBarChoiceScreen: \(flagger.isFeatureOn(.showAIChatAddressBarChoiceScreen))\n"
+        return out
+    }
+
+    @MainActor
+    private func currentTabSection() -> String {
+        guard let tab = tabManager.current(createIfNeeded: false) else {
+            return "## Current tab\n- No current TabViewController\n"
+        }
+        guard let webView = tab.webView else {
+            return "## Current tab\n- TabViewController has no webView\n"
+        }
+
+        let scrollView = webView.scrollView
+        var out = "## Current tab\n"
+        out += "- URL host: \(webView.url?.host ?? "nil")\n"
+        out += "- TabViewController: \(Self.typeName(tab))\n"
+        out += "- scroll observer: \(tab.webScrollObserver?.recentStatus ?? "not installed")\n\n"
+
+        out += "## webView.scrollView\n"
+        out += "- isScrollEnabled: \(scrollView.isScrollEnabled)\(scrollView.isScrollEnabled ? "" : "  ⚠️ SCROLL DISABLED")\n"
+        out += "- isUserInteractionEnabled: \(scrollView.isUserInteractionEnabled)\n"
+        out += "- delaysContentTouches: \(scrollView.delaysContentTouches)  canCancelContentTouches: \(scrollView.canCancelContentTouches)\n"
+        out += "- bounces: \(scrollView.bounces)  alwaysBounceVertical: \(scrollView.alwaysBounceVertical)\n"
+        out += "- isDragging: \(scrollView.isDragging)  isDecelerating: \(scrollView.isDecelerating)"
+            + "  isTracking: \(scrollView.isTracking)  isZooming: \(scrollView.isZooming)\n"
+        out += "- contentOffset: \(scrollView.contentOffset)\n"
+        out += "- contentSize: \(scrollView.contentSize)\n"
+        out += "- bounds: \(scrollView.bounds)\n"
+        out += "- adjustedContentInset: \(scrollView.adjustedContentInset)\n"
+        out += "- zoomScale: \(scrollView.zoomScale) (min \(scrollView.minimumZoomScale) / max \(scrollView.maximumZoomScale))\n"
+        out += "- delegate: \(scrollView.delegate.map { Self.typeName($0) } ?? "nil")\n"
+
+        out += "\n" + Self.panGesture(of: scrollView)
+        out += "\n" + Self.gestureChainSection(from: webView)
+        out += "\n" + Self.competingRecognizersSection()
+        out += "\n" + Self.overlaySection(over: webView, boundary: Self.findMainViewController()?.view)
+        out += "\n" + coordinatorSection()
+        return out
+    }
+
+    /// Window-wide scan for the swipe-tabs recognizers. They live on chrome containers (toolbar, UTI
+    /// container, chat header) that are siblings of the web view, so they never appear in the
+    /// webView→window chain above — but a wedge in one is the prime scroll-freeze suspect.
+    private static func competingRecognizersSection() -> String {
+        var out = "## Swipe-tabs recognizers (window-wide)\n"
+        var found = false
+        forEachWindowGestureRecognizer { recognizer in
+            guard recognizer is UnifiedInputSwipeTabsPanGestureRecognizer else { return }
+            found = true
+            let host = recognizer.view.map { typeName($0) } ?? "nil"
+            out += "• on \(host): \(describe(recognizer))\n"
+        }
+        if !found {
+            out += "- (none found)\n"
+        }
+        return out
+    }
+
+    /// The scroll view's own pan recognizer — the one that actually drives web scrolling.
+    private static func panGesture(of scrollView: UIScrollView) -> String {
+        var out = "## webView.scrollView.panGestureRecognizer\n"
+        out += "- \(describe(scrollView.panGestureRecognizer))\n"
+        return out
+    }
+
+    /// Walk webView → window collecting every gesture recognizer on the chain. A recognizer stuck in
+    /// `began`/`changed` on an ancestor, or a stray pan with `cancelsTouchesInView`, is the prime
+    /// scroll-blocking suspect and is flagged inline.
+    private static func gestureChainSection(from start: UIView) -> String {
+        var out = "## Gesture recognizers (webView → window)\n"
+        var view: UIView? = start
+        var found = false
+        while let current = view {
+            if let recognizers = current.gestureRecognizers, !recognizers.isEmpty {
+                found = true
+                out += "• \(typeName(current)) [\(current.frame)]\n"
+                for recognizer in recognizers {
+                    out += "    - \(describe(recognizer))\n"
+                }
+            }
+            view = current.superview
+        }
+        if !found {
+            out += "- (none)\n"
+        }
+        return out
+    }
+
+    /// Structural overlay check (modal-safe — does not use hitTest). Walks webView up to MainViewController's
+    /// view (so the presented debug screen isn't itself reported as a blocker) and flags any sibling drawn
+    /// above our branch that can receive touches and covers any of three sample points down the web view —
+    /// a leftover transition snapshot / scrim / cover left interactive would block pans here.
+    private static func overlaySection(over webView: UIView, boundary: UIView?) -> String {
+        var out = "## Potential blocking overlays over the web view\n"
+        let bounds = webView.bounds
+        let samples = [CGPoint(x: bounds.midX, y: bounds.minY + 20),
+                       CGPoint(x: bounds.midX, y: bounds.midY),
+                       CGPoint(x: bounds.midX, y: bounds.maxY - 20)].map { webView.convert($0, to: nil) }
+        var branch = webView
+        var found = false
+        while branch !== boundary, let container = branch.superview {
+            if let branchIndex = container.subviews.firstIndex(of: branch) {
+                for sibling in container.subviews[(branchIndex + 1)...] where sibling.isUserInteractionEnabled
+                    && !sibling.isHidden && sibling.alpha > 0.01 {
+                    let frameInWindow = sibling.convert(sibling.bounds, to: nil)
+                    if samples.contains(where: { frameInWindow.contains($0) }) {
+                        found = true
+                        out += "- ⚠️ \(typeName(sibling)) above \(typeName(container))"
+                            + " [\(sibling.frame)] alpha \(sibling.alpha)\n"
+                    }
+                }
+            }
+            branch = container
+        }
+        if !found {
+            out += "- (none over the web view)\n"
+        }
+        return out
+    }
+
+    /// Best-effort UTI / swipe-tabs coordinator state, reached by locating MainViewController in the tree.
+    @MainActor
+    private func coordinatorSection() -> String {
+        guard let mainVC = Self.findMainViewController() else {
+            return "## Coordinator state\n- MainViewController not found\n"
+        }
+        var out = "## Coordinator state\n"
+        if let swipe = mainVC.swipeTabsCoordinator {
+            out += "- swipeTabsCoordinator.isEnabled: \(swipe.isEnabled)\n"
+            out += "- swipeTabsCoordinator.state: \(String(describing: swipe.state))\n"
+        } else {
+            out += "- swipeTabsCoordinator: nil\n"
+        }
+        if let uti = mainVC.unifiedToggleInputCoordinator {
+            out += "- unifiedToggleInputCoordinator.displayState: \(String(describing: uti.displayState))\n"
+        } else {
+            out += "- unifiedToggleInputCoordinator: nil\n"
+        }
+        return out
+    }
+
+    // MARK: - Logs
+
+    private static func recentInteractionLogs() -> String {
+        guard let store = try? OSLogStore(scope: .currentProcessIdentifier) else {
+            return "(OSLogStore unavailable)"
+        }
+        let since = store.position(date: Date().addingTimeInterval(-300))
+        let predicate = NSPredicate(format: "subsystem == %@", "Interaction")
+        guard let entries = try? store.getEntries(at: since, matching: predicate) else {
+            return "(failed to read log store)"
+        }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss.SSS"
+        let lines = entries.compactMap { $0 as? OSLogEntryLog }.suffix(300).map {
+            "\(formatter.string(from: $0.date)) \($0.composedMessage)"
+        }
+        return lines.isEmpty ? "(no interaction logs in window)" : lines.joined(separator: "\n")
+    }
+
+    // MARK: - Helpers
+
+    private static var appVersion: String {
+        let short = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
+        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
+        return "\(short) (\(build))"
+    }
+
+    private static func typeName(_ object: Any) -> String {
+        String(describing: type(of: object))
+    }
+
+    private static func describe(_ recognizer: UIGestureRecognizer) -> String {
+        let active = (recognizer.state == .began || recognizer.state == .changed)
+        return "\(typeName(recognizer)) state=\(recognizer.state.diagnosticName)\(active ? " ⚠️ ACTIVE" : "")"
+            + " enabled=\(recognizer.isEnabled) cancelsTouchesInView=\(recognizer.cancelsTouchesInView)"
+            + " delaysTouchesBegan=\(recognizer.delaysTouchesBegan) touches=\(recognizer.numberOfTouches)"
+    }
+
+    private static func findMainViewController() -> MainViewController? {
+        let windows = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+        for window in windows {
+            if let root = window.rootViewController, let match = firstDescendant(MainViewController.self, in: root) {
+                return match
+            }
+        }
+        return nil
+    }
+
+    private static func firstDescendant<T: UIViewController>(_ type: T.Type, in viewController: UIViewController) -> T? {
+        if let match = viewController as? T { return match }
+        for child in viewController.children {
+            if let match = firstDescendant(type, in: child) { return match }
+        }
+        return nil
+    }
+
+    private static func forEachWindowGestureRecognizer(_ body: (UIGestureRecognizer) -> Void) {
+        let windows = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+        for window in windows {
+            walk(window, body)
+        }
+    }
+
+    private static func walk(_ view: UIView, _ body: (UIGestureRecognizer) -> Void) {
+        view.gestureRecognizers?.forEach(body)
+        view.subviews.forEach { walk($0, body) }
+    }
+}

--- a/iOS/DuckDuckGo/InteractionIntegrityMonitor.swift
+++ b/iOS/DuckDuckGo/InteractionIntegrityMonitor.swift
@@ -1,0 +1,108 @@
+//
+//  InteractionIntegrityMonitor.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+import OSLog
+import Core
+
+/// Breadcrumb watchdog over container pans that arbitrate with web scrolling, for the hard-to-reproduce
+/// "web view can't scroll but taps still work" freeze. A healthy pan emits `changed` repeatedly then a
+/// terminal state; if it goes quiet while still active with no touch down (the touch ended without the
+/// recognizer reaching a terminal state), it is wedged — we LOG it (a breadcrumb visible in the in-app
+/// Log Viewer and the Interaction Diagnostics snapshot). It does NOT fire a population pixel: the signal
+/// is too narrow (one gesture) to be a reliable user metric, but it's useful evidence in a captured trace.
+///
+/// Not a singleton: owned as an instance by the controller that feeds it gesture state.
+/// All methods are main-thread only (gesture callbacks run on main).
+@MainActor
+final class InteractionIntegrityMonitor {
+
+    private enum Constant {
+        static let watchdogTimeout: TimeInterval = 4
+    }
+
+    private var watchdog: Timer?
+    private weak var armedRecognizer: UIGestureRecognizer?
+    private var armedLabel: String?
+
+    /// Feed gesture state transitions of any container pan that competes with web scrolling.
+    func noteGestureState(_ recognizer: UIGestureRecognizer, label: String) {
+        switch recognizer.state {
+        case .began:
+            Logger.interaction.debug("\(label, privacy: .public) pan: began")
+            arm(recognizer, label: label)
+        case .changed:
+            arm(recognizer, label: label)
+        case .ended, .cancelled, .failed:
+            Logger.interaction.debug("\(label, privacy: .public) pan: \(recognizer.state.diagnosticName, privacy: .public)")
+            disarm()
+        default:
+            break
+        }
+    }
+
+    // MARK: - Watchdog
+
+    private func arm(_ recognizer: UIGestureRecognizer, label: String) {
+        armedRecognizer = recognizer
+        armedLabel = label
+        watchdog?.invalidate()
+        watchdog = Timer.scheduledTimer(timeInterval: Constant.watchdogTimeout,
+                                        target: self,
+                                        selector: #selector(watchdogFired(_:)),
+                                        userInfo: nil,
+                                        repeats: false)
+    }
+
+    private func disarm() {
+        watchdog?.invalidate()
+        watchdog = nil
+        armedRecognizer = nil
+        armedLabel = nil
+    }
+
+    /// Logs only for a genuine wedge: the armed recognizer is still mid-gesture (`began`/`changed`) but is
+    /// tracking no touches. A finger held still keeps `numberOfTouches >= 1`, so paused drags are excluded.
+    /// Runs synchronously on the main run loop, so a gesture that ended first has already invalidated this.
+    @objc private func watchdogFired(_ timer: Timer) {
+        defer { disarm() }
+        guard let recognizer = armedRecognizer,
+              recognizer.state == .began || recognizer.state == .changed,
+              recognizer.numberOfTouches == 0 else {
+            return
+        }
+        let label = armedLabel ?? "unknown"
+        Logger.interaction.error("Gesture watchdog: \(label, privacy: .public) wedged in \(recognizer.state.diagnosticName, privacy: .public) with no active touch")
+    }
+}
+
+extension UIGestureRecognizer.State {
+
+    var diagnosticName: String {
+        switch self {
+        case .possible: return "possible"
+        case .began: return "began"
+        case .changed: return "changed"
+        case .ended: return "ended"
+        case .cancelled: return "cancelled"
+        case .failed: return "failed"
+        @unknown default: return "unknown(\(rawValue))"
+        }
+    }
+}

--- a/iOS/DuckDuckGo/InteractionIntegrityMonitor.swift
+++ b/iOS/DuckDuckGo/InteractionIntegrityMonitor.swift
@@ -48,7 +48,7 @@ final class InteractionIntegrityMonitor {
             Logger.interaction.debug("\(label, privacy: .public) pan: began")
             arm(recognizer, label: label)
         case .changed:
-            arm(recognizer, label: label)
+            extend(recognizer, label: label)
         case .ended, .cancelled, .failed:
             Logger.interaction.debug("\(label, privacy: .public) pan: \(recognizer.state.diagnosticName, privacy: .public)")
             disarm()
@@ -68,6 +68,18 @@ final class InteractionIntegrityMonitor {
                                         selector: #selector(watchdogFired(_:)),
                                         userInfo: nil,
                                         repeats: false)
+    }
+
+    /// Push the deadline out on each `.changed` rather than recreating the timer, which would churn the
+    /// run loop ~60×/sec during an active pan.
+    private func extend(_ recognizer: UIGestureRecognizer, label: String) {
+        guard let watchdog else {
+            arm(recognizer, label: label)
+            return
+        }
+        armedRecognizer = recognizer
+        armedLabel = label
+        watchdog.fireDate = Date(timeIntervalSinceNow: Constant.watchdogTimeout)
     }
 
     private func disarm() {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -589,6 +589,10 @@ class MainViewController: UIViewController {
     
     var swipeTabsCoordinator: SwipeTabsCoordinator?
 
+    /// Watchdog for container pan gestures that arbitrate with web scrolling. Owned here (not a singleton)
+    /// and fed gesture state from `handleUnifiedInputSwipeTabsPan`.
+    let interactionIntegrityMonitor = InteractionIntegrityMonitor()
+
     /// Overlay used to render tab-swipe transitions. Hosts per-tab full-screen snapshots so
     /// the swipe moves chrome+content as a single visual unit instead of as N separately
     /// translated layers. Hidden when not swiping; populated and made visible by

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -781,6 +781,7 @@ class TabViewController: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
+        webScrollObserver?.reset()
         duckPlayerNavigationHandler.updateDuckPlayerForWebViewDisappearance(self)
 
         unregisterFromResignActive()
@@ -1821,6 +1822,7 @@ extension TabViewController: WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+        webScrollObserver?.reset()
         if let url = webView.url {
             let finalURL = duckPlayerNavigationHandler.getDuckURLFor(url)
             viewModel.captureWebviewDidCommit(finalURL)

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -851,6 +851,8 @@ class TabViewController: UIViewController {
             .assign(to: \.netPConnectionStatus, onWeaklyHeld: self)
     }
 
+    private(set) var webScrollObserver: WebScrollObserver?
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         // The email manager is pulled from the main view controller, so reconnect it now, otherwise, it's nil
@@ -866,6 +868,7 @@ class TabViewController: UIViewController {
         duckPlayerNavigationHandler.updateDuckPlayerForWebViewAppearance(self)
 
         checkWebViewVisibilityConsistency()
+        webScrollObserver?.checkForWedgedRecognizer()
     }
 
     override func buildActivities() -> [UIActivity] {
@@ -968,6 +971,13 @@ class TabViewController: UIViewController {
                                                             onRefresh: { [weak self] in
             self?.handlePullToRefresh()
         })
+
+        if webScrollObserver == nil, featureFlagger.isFeatureOn(.webScrollFreezeObservability) {
+            webScrollObserver = WebScrollObserver(container: webViewContainer,
+                                                  scrollView: { [weak self] in self?.webView?.scrollView },
+                                                  currentURL: { [weak self] in self?.webView?.url })
+            webScrollObserver?.install()
+        }
 
         if isAITab {
             pullToRefreshViewAdapter?.setRefreshControlEnabled(false)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputSwipeTabs.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputSwipeTabs.swift
@@ -41,6 +41,9 @@ extension MainViewController {
     }
 
     @objc func handleUnifiedInputSwipeTabsPan(_ gesture: UnifiedInputSwipeTabsPanGestureRecognizer) {
+        if featureFlagger.isFeatureOn(.webScrollFreezeObservability) {
+            interactionIntegrityMonitor.noteGestureState(gesture, label: "swipe_tabs")
+        }
         swipeTabsCoordinator?.handleExternalPan(gesture)
     }
 

--- a/iOS/DuckDuckGo/WebScrollObserver.swift
+++ b/iOS/DuckDuckGo/WebScrollObserver.swift
@@ -1,0 +1,297 @@
+//
+//  WebScrollObserver.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+import OSLog
+import Core
+
+/// Detects the symptom of the hard-to-reproduce "web page visible, taps work, scroll dead" freeze:
+/// the user drags to scroll a scrollable web page and the content doesn't move, repeatedly.
+///
+/// Owned per `TabViewController`, attached to `webViewContainer` via a passive bystander recognizer that
+/// never interferes with scrolling or taps. Fires three telemetry signals (symptom + two daily liveness
+/// heartbeats) and a separate mechanism signal (`checkForWedgedRecognizer`). Logs every failed attempt as
+/// a breadcrumb so the Interaction Diagnostics snapshot has the recent history even below the pixel
+/// threshold. No Swift concurrency — the post-gesture and wedge re-checks use `asyncAfter` on the main
+/// queue. `firePixel*` closures are injected so the detectors are unit-testable without the static pipeline.
+@MainActor
+final class WebScrollObserver: NSObject {
+
+    private enum Constant {
+        static let minScrollableRange: CGFloat = 64
+        static let minHeadroom: CGFloat = 16
+        static let minVerticalDrag: CGFloat = 48
+        static let verticalDominance: CGFloat = 1.5
+        static let movedThreshold: CGFloat = 3
+        static let postEndRecheck: TimeInterval = 0.2
+        static let streakThreshold = 3
+        static let streakWindow: TimeInterval = 30
+        static let wedgeRecheck: TimeInterval = 1.0
+    }
+
+    private weak var container: UIView?
+    private let scrollViewProvider: () -> UIScrollView?
+    private let currentURL: () -> URL?
+    private let firePixelDailyAndCount: (Pixel.Event, [String: String]) -> Void
+    private let now: () -> Date
+
+    private var recognizer: WebScrollObserverGestureRecognizer?
+    private var dragStartOffsetY: CGFloat = 0
+
+    private var failureStreak = 0
+    private var lastFailureAt: Date?
+    private var streakDirections: Set<String> = []
+    private var highestBucketFired: String?
+
+    private weak var wedgeCandidate: UIGestureRecognizer?
+
+    /// Human-readable last outcome, surfaced in the Interaction Diagnostics snapshot.
+    private(set) var recentStatus = "no scroll attempt observed yet"
+
+    init(container: UIView,
+         scrollView: @escaping () -> UIScrollView?,
+         currentURL: @escaping () -> URL?,
+         firePixelDailyAndCount: @escaping (Pixel.Event, [String: String]) -> Void = {
+            DailyPixel.fireDailyAndCount(pixel: $0, withAdditionalParameters: $1)
+         },
+         now: @escaping () -> Date = { Date() }) {
+        self.container = container
+        self.scrollViewProvider = scrollView
+        self.currentURL = currentURL
+        self.firePixelDailyAndCount = firePixelDailyAndCount
+        self.now = now
+        super.init()
+    }
+
+    func install() {
+        guard recognizer == nil, let container else { return }
+        let recognizer = WebScrollObserverGestureRecognizer(target: nil, action: nil)
+        recognizer.delegate = self
+        recognizer.onBegan = { [weak self] in self?.dragBegan() }
+        recognizer.onEnded = { [weak self] dx, dy in self?.dragEnded(dx: dx, dy: dy) }
+        container.addGestureRecognizer(recognizer)
+        self.recognizer = recognizer
+    }
+
+    /// Reset the failure streak — call on navigation, tab disappearance, or backgrounding.
+    func reset() {
+        failureStreak = 0
+        lastFailureAt = nil
+        streakDirections = []
+        highestBucketFired = nil
+    }
+
+    // MARK: - Symptom detection (C1)
+
+    private func dragBegan() {
+        dragStartOffsetY = scrollViewProvider()?.contentOffset.y ?? 0
+    }
+
+    private func dragEnded(dx: CGFloat, dy: CGFloat) {
+        // Re-sample after a beat so late settling counts as movement.
+        DispatchQueue.main.asyncAfter(deadline: .now() + Constant.postEndRecheck) { [weak self] in
+            self?.classifyDrag(dx: dx, dy: dy)
+        }
+    }
+
+    private func classifyDrag(dx: CGFloat, dy: CGFloat) {
+        guard isEligible(), let scrollView = scrollViewProvider() else { return }
+
+        // Only count vertical-dominant drags long enough to be a real scroll attempt.
+        guard abs(dy) >= Constant.minVerticalDrag, abs(dy) >= abs(dx) * Constant.verticalDominance else {
+            return
+        }
+
+        let metrics = scrollMetrics(scrollView)
+        let fingerUp = dy < 0
+        let hasHeadroom = fingerUp
+            ? dragStartOffsetY < metrics.maxY - Constant.minHeadroom
+            : dragStartOffsetY > metrics.minY + Constant.minHeadroom
+        guard hasHeadroom else {
+            reset()
+            return
+        }
+
+        let moved = abs(scrollView.contentOffset.y - dragStartOffsetY) >= Constant.movedThreshold
+        if moved {
+            reset()
+            recentStatus = "last drag scrolled OK (\(formatted(now())))"
+        } else {
+            registerFailedAttempt(direction: fingerUp ? "up" : "down")
+        }
+    }
+
+    private func registerFailedAttempt(direction: String) {
+        if let last = lastFailureAt, now().timeIntervalSince(last) > Constant.streakWindow {
+            failureStreak = 0
+            streakDirections = []
+            highestBucketFired = nil
+        }
+        failureStreak += 1
+        lastFailureAt = now()
+        streakDirections.insert(direction)
+        recentStatus = "\(failureStreak) failed scroll attempt(s) (\(formatted(now())))"
+        Logger.interaction.error("Web scroll did not move: failed attempt #\(self.failureStreak, privacy: .public), direction \(direction, privacy: .public)")
+
+        guard failureStreak >= Constant.streakThreshold else { return }
+        let bucket = attemptBucket(failureStreak)
+        guard bucket != highestBucketFired else { return }
+        highestBucketFired = bucket
+        firePixelDailyAndCount(.debugInteractionRepeatedFailedScroll, [
+            "attempt_count_bucket": bucket,
+            "direction": streakDirections.count > 1 ? "mixed" : (streakDirections.first ?? "mixed")
+        ])
+    }
+
+    // MARK: - Wedged-recognizer detection (C2)
+
+    /// Look for a non-scroll recognizer stuck active with no touches; confirm with a re-check ~1s later
+    /// (to exclude transient cancellation/reset states) before firing.
+    func checkForWedgedRecognizer() {
+        guard isEligible(), let wedged = Self.firstWedgedRecognizer() else { return }
+        wedgeCandidate = wedged
+        DispatchQueue.main.asyncAfter(deadline: .now() + Constant.wedgeRecheck) { [weak self] in
+            guard let self, let candidate = self.wedgeCandidate, candidate === wedged,
+                  Self.isWedged(candidate) else { return }
+            self.wedgeCandidate = nil
+            Logger.interaction.error("Wedged recognizer detected: \(Self.bucket(for: candidate), privacy: .public)")
+            self.firePixelDailyAndCount(.debugInteractionWedgedRecognizer, [
+                "recognizer": Self.bucket(for: candidate)
+            ])
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func isEligible() -> Bool {
+        guard let scheme = currentURL()?.scheme?.lowercased(), scheme == "http" || scheme == "https",
+              let scrollView = scrollViewProvider() else { return false }
+        let metrics = scrollMetrics(scrollView)
+        return metrics.maxY - metrics.minY > Constant.minScrollableRange
+    }
+
+    private func scrollMetrics(_ scrollView: UIScrollView) -> (minY: CGFloat, maxY: CGFloat) {
+        let minY = -scrollView.adjustedContentInset.top
+        let maxY = scrollView.contentSize.height - scrollView.bounds.height + scrollView.adjustedContentInset.bottom
+        return (minY, max(minY, maxY))
+    }
+
+    private func attemptBucket(_ count: Int) -> String {
+        switch count {
+        case ..<4: return "3"
+        case 4...5: return "4_5"
+        default: return "6_plus"
+        }
+    }
+
+    private func formatted(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter.string(from: date)
+    }
+
+    private static func isWedged(_ recognizer: UIGestureRecognizer) -> Bool {
+        (recognizer.state == .began || recognizer.state == .changed) && recognizer.numberOfTouches == 0
+    }
+
+    private static func firstWedgedRecognizer() -> UIGestureRecognizer? {
+        let windows = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+        for window in windows {
+            if let match = firstWedged(in: window) { return match }
+        }
+        return nil
+    }
+
+    private static func firstWedged(in view: UIView) -> UIGestureRecognizer? {
+        if let wedged = view.gestureRecognizers?.first(where: isWedged) { return wedged }
+        for subview in view.subviews {
+            if let match = firstWedged(in: subview) { return match }
+        }
+        return nil
+    }
+
+    static func bucket(for recognizer: UIGestureRecognizer) -> String {
+        if recognizer is UnifiedInputSwipeTabsPanGestureRecognizer { return "swipe_tabs" }
+        if recognizer is UIScreenEdgePanGestureRecognizer { return "edge_pan" }
+        if recognizer is UITapGestureRecognizer { return "tap" }
+        if recognizer is UILongPressGestureRecognizer { return "long_press" }
+        let typeName = String(describing: type(of: recognizer)).lowercased()
+        if typeName.contains("refresh") || typeName.contains("pullto") { return "pull_to_refresh_pan" }
+        if let scrollView = recognizer.view as? UIScrollView, recognizer === scrollView.panGestureRecognizer {
+            return "web_scroll_pan"
+        }
+        if recognizer is UIPanGestureRecognizer { return "other_pan" }
+        return "other"
+    }
+}
+
+extension WebScrollObserver: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
+                           shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        true
+    }
+}
+
+/// A pure bystander: it observes the touch stream to measure drag distance but never recognizes, cancels,
+/// or blocks any other gesture (so it can't interfere with scrolling or taps).
+final class WebScrollObserverGestureRecognizer: UIGestureRecognizer {
+
+    var onBegan: (() -> Void)?
+    var onEnded: ((CGFloat, CGFloat) -> Void)?
+
+    private var startPoint: CGPoint = .zero
+    private var lastPoint: CGPoint = .zero
+
+    override init(target: Any?, action: Selector?) {
+        super.init(target: target, action: action)
+        cancelsTouchesInView = false
+        delaysTouchesBegan = false
+        delaysTouchesEnded = false
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
+        guard let view, let touch = touches.first else { return }
+        startPoint = touch.location(in: view)
+        lastPoint = startPoint
+        onBegan?()
+    }
+
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
+        guard let view, let touch = touches.first else { return }
+        lastPoint = touch.location(in: view)
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
+        finish()
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent) {
+        finish()
+    }
+
+    private func finish() {
+        onEnded?(lastPoint.x - startPoint.x, lastPoint.y - startPoint.y)
+        state = .failed
+    }
+
+    override func canPrevent(_ preventedGestureRecognizer: UIGestureRecognizer) -> Bool { false }
+    override func canBePrevented(by preventingGestureRecognizer: UIGestureRecognizer) -> Bool { false }
+}

--- a/iOS/DuckDuckGo/WebScrollObserver.swift
+++ b/iOS/DuckDuckGo/WebScrollObserver.swift
@@ -104,13 +104,16 @@ final class WebScrollObserver: NSObject {
     }
 
     private func dragEnded(dx: CGFloat, dy: CGFloat) {
+        // Capture the start offset by value now — a second drag within the recheck window would
+        // otherwise overwrite `dragStartOffsetY` before this closure runs.
+        let startOffsetY = dragStartOffsetY
         // Re-sample after a beat so late settling counts as movement.
         DispatchQueue.main.asyncAfter(deadline: .now() + Constant.postEndRecheck) { [weak self] in
-            self?.classifyDrag(dx: dx, dy: dy)
+            self?.classifyDrag(dx: dx, dy: dy, startOffsetY: startOffsetY)
         }
     }
 
-    private func classifyDrag(dx: CGFloat, dy: CGFloat) {
+    private func classifyDrag(dx: CGFloat, dy: CGFloat, startOffsetY: CGFloat) {
         guard isEligible(), let scrollView = scrollViewProvider() else { return }
 
         // Only count vertical-dominant drags long enough to be a real scroll attempt.
@@ -121,14 +124,12 @@ final class WebScrollObserver: NSObject {
         let metrics = scrollMetrics(scrollView)
         let fingerUp = dy < 0
         let hasHeadroom = fingerUp
-            ? dragStartOffsetY < metrics.maxY - Constant.minHeadroom
-            : dragStartOffsetY > metrics.minY + Constant.minHeadroom
-        guard hasHeadroom else {
-            reset()
-            return
-        }
+            ? startOffsetY < metrics.maxY - Constant.minHeadroom
+            : startOffsetY > metrics.minY + Constant.minHeadroom
+        // At the top/bottom edge there's nothing to scroll in this direction — skip, don't reset the streak.
+        guard hasHeadroom else { return }
 
-        let moved = abs(scrollView.contentOffset.y - dragStartOffsetY) >= Constant.movedThreshold
+        let moved = abs(scrollView.contentOffset.y - startOffsetY) >= Constant.movedThreshold
         if moved {
             reset()
             recentStatus = "last drag scrolled OK (\(formatted(now())))"
@@ -166,8 +167,8 @@ final class WebScrollObserver: NSObject {
     func checkForWedgedRecognizer() {
         guard isEligible(), let wedged = Self.firstWedgedRecognizer() else { return }
         wedgeCandidate = wedged
-        DispatchQueue.main.asyncAfter(deadline: .now() + Constant.wedgeRecheck) { [weak self] in
-            guard let self, let candidate = self.wedgeCandidate, candidate === wedged,
+        DispatchQueue.main.asyncAfter(deadline: .now() + Constant.wedgeRecheck) { [weak self, weak wedged] in
+            guard let self, let wedged, let candidate = self.wedgeCandidate, candidate === wedged,
                   Self.isWedged(candidate) else { return }
             self.wedgeCandidate = nil
             Logger.interaction.error("Wedged recognizer detected: \(Self.bucket(for: candidate), privacy: .public)")
@@ -200,10 +201,14 @@ final class WebScrollObserver: NSObject {
         }
     }
 
-    private func formatted(_ date: Date) -> String {
+    private static let timeFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "HH:mm:ss"
-        return formatter.string(from: date)
+        return formatter
+    }()
+
+    private func formatted(_ date: Date) -> String {
+        Self.timeFormatter.string(from: date)
     }
 
     private static func isWedged(_ recognizer: UIGestureRecognizer) -> Bool {

--- a/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
@@ -94,7 +94,7 @@
                 "enum": ["up", "down", "mixed"]
             }
         ],
-        "expires": "2026-12-31"
+        "expires": "2026-07-11"
     },
     "m_debug_interaction_wedged_recognizer": {
         "description": "Fires when a non-scroll gesture recognizer is found in an active (began/changed) state with no touches down, and is still wedged on a re-check ~1s later, while a web page is shown. Reliable mechanism signal for a recognizer that may be starving the web scroll pan.",
@@ -110,6 +110,6 @@
                 "enum": ["web_scroll_pan", "pull_to_refresh_pan", "swipe_tabs", "edge_pan", "tap", "long_press", "other_pan", "other"]
             }
         ],
-        "expires": "2026-12-31"
+        "expires": "2026-07-11"
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
@@ -73,5 +73,43 @@
                 "description": "The name of the pixel that was suppressed due to the storage write failure"
             }
         ]
+    },
+    "m_debug_interaction_repeated_failed_scroll": {
+        "description": "Fires when the native web scroll view did not move after repeated vertical drags on a scrollable page (3 consecutive failed attempts within 30s). Observability for the 'web page visible, taps work, scroll dead' freeze; this measures the symptom (scroll did not move), NOT a confirmed browser bug.",
+        "owners": ["pikorddg"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "attempt_count_bucket",
+                "description": "Bucketed number of consecutive failed scroll attempts when the streak fired.",
+                "type": "string",
+                "enum": ["3", "4_5", "6_plus"]
+            },
+            {
+                "key": "direction",
+                "description": "Dominant drag direction across the failed attempts.",
+                "type": "string",
+                "enum": ["up", "down", "mixed"]
+            }
+        ],
+        "expires": "2026-12-31"
+    },
+    "m_debug_interaction_wedged_recognizer": {
+        "description": "Fires when a non-scroll gesture recognizer is found in an active (began/changed) state with no touches down, and is still wedged on a re-check ~1s later, while a web page is shown. Reliable mechanism signal for a recognizer that may be starving the web scroll pan.",
+        "owners": ["pikorddg"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "recognizer",
+                "description": "Bucketed class of the wedged recognizer.",
+                "type": "string",
+                "enum": ["web_scroll_pan", "pull_to_refresh_pan", "swipe_tabs", "edge_pan", "tap", "long_press", "other_pan", "other"]
+            }
+        ],
+        "expires": "2026-12-31"
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
@@ -76,7 +76,7 @@
     },
     "m_debug_interaction_repeated_failed_scroll": {
         "description": "Fires when the native web scroll view did not move after repeated vertical drags on a scrollable page (3 consecutive failed attempts within 30s). Observability for the 'web page visible, taps work, scroll dead' freeze; this measures the symptom (scroll did not move), NOT a confirmed browser bug.",
-        "owners": ["pikorddg"],
+        "owners": ["aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": [
@@ -98,7 +98,7 @@
     },
     "m_debug_interaction_wedged_recognizer": {
         "description": "Fires when a non-scroll gesture recognizer is found in an active (began/changed) state with no touches down, and is still wedged on a re-check ~1s later, while a web page is shown. Reliable mechanism signal for a recognizer that may be starving the web scroll pan.",
-        "owners": ["pikorddg"],
+        "owners": ["aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1215573601896252

## What & why
Adds **internal-only, feature-flagged** observability for a hard-to-reproduce freeze: on a regular web page the `WKWebView` won't scroll (drag up/down does nothing) while taps/links, the omnibar, and the toolbar all still work; switching tabs doesn't fix it; only killing the app does. We can't reliably reproduce it, so this ships instrumentation to catch it in the field and diagnose it on a captured device — without touching the normal scroll path.

Everything is gated behind a new flag **`webScrollFreezeObservability`** (`defaultValue: .internalOnly`, remote-releasable). With the flag off (general population) **none of the new code runs** — no gesture recognizer is added, no watchdog. The bug is not confirmed to be UTI; the instrumentation is deliberately cause-agnostic.

### What it adds
- **`WebScrollObserver`** — a passive bystander `UIGestureRecognizer` on `webViewContainer` (never recognizes/cancels/prevents touches) that detects repeated failed scroll attempts on a scrollable page → fires `m_debug_interaction_repeated_failed_scroll`; plus a wedged-recognizer checkpoint → `m_debug_interaction_wedged_recognizer`. **Failure-only pixels** (no heartbeats).
- **`InteractionIntegrityMonitor`** — a swipe-tabs gesture watchdog that logs a `Logger.interaction` breadcrumb when the pan wedges (no pixel).
- **Interaction Diagnostics** debug-menu screen (read-only) — captures a snapshot of scroll-view state, the gesture chain, swipe-tabs recognizers, overlays, coordinator state, and recent logs; copy to clipboard.

## Symptom (NOT reliably reproducible)
Intermittent, internal builds. Seen both when returning to the app on a web page and when loading a page while already in the app. There is no deterministic repro — which is the whole reason for this telemetry.

## How to verify this change (the instrumentation, not the freeze)
1. Internal build — confirm **`webScrollFreezeObservability`** is enabled (internal-only by default; can also toggle via Debug → Feature Flags).
2. Open a regular http/https page tall enough to scroll.
3. **Debug → Interaction Diagnostics → Capture → Copy.** Confirm the report shows scroll-view state, the webView→window gesture chain, the window-wide swipe-tabs recognizers, overlay scan, coordinator state, and a `scroll observer:` line.
4. Scroll the page normally, then re-Capture — `scroll observer:` should read **"last drag scrolled OK"** (confirms the bystander receives touches).
5. Pixels: confirm via the pixel console that `m_debug_interaction_repeated_failed_scroll` fires only after **repeated** drags that don't move a scrollable page, and that normal scrolling/taps/zoom/long-press/text-selection/edge-swipe-back are all unaffected by the bystander.
6. Turn the flag **off** → confirm none of the above runs (no recognizer added; the snapshot shows `scroll observer: not installed`).

## Risk
Low / gated. The only code that touches the live gesture system is the bystander recognizer, and it only attaches for internal users with the flag on. A remote toggle can disable it (takes effect as tabs are recreated). Needs an on-device interaction pass on an internal build to confirm the bystander is fully inert.

### Still open / follow-ups
- The flag gates observer **install**, not ongoing execution — a remote disable only takes effect as affected tabs are recreated (acceptable: internal-only + passive).
- `direction` pixel param uses finger direction (documented; could flip).
- Low: `bucket(for:)` could be `private`; `copy()` Swift-6 `@MainActor`; monitor allocation not flag-gated.
- **No unit test yet** (the injected `firePixelDailyAndCount` + `now` are the hooks) and **not compiled locally** (relying on CI).
- Pixel `owners` placeholder (`pikorddg`) to set; `validate-pixel-defs`/prettier pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> All new gesture/logging/pixel code is gated to internal users via `webScrollFreezeObservability`; the scroll observer is designed as a non-interfering bystander and does not alter scroll handling when disabled.
> 
> **Overview**
> Adds **internal-only** observability (feature flag `webScrollFreezeObservability`, default internal-only) for the intermittent “web page won’t scroll but taps still work” freeze—no behavior change when the flag is off.
> 
> When enabled, each tab gets a **`WebScrollObserver`**: a passive bystander recognizer on `webViewContainer` that logs failed scroll attempts and, after repeated non-moving vertical drags on a scrollable page, fires **`m_debug_interaction_repeated_failed_scroll`**; it also re-checks for wedged recognizers and can fire **`m_debug_interaction_wedged_recognizer`**. **`MainViewController`** feeds swipe-tabs pan state into **`InteractionIntegrityMonitor`** (log-only wedge breadcrumbs). Debug menu adds **Interaction Diagnostics** to capture scroll/gesture/overlay/coordinator state plus recent `Interaction` logs for clipboard export.
> 
> Also wires **`Logger.interaction`**, pixel enum mappings, and pixel definitions (expiring 2026-07-11).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a64e1163801dba09fdeae7dfdf59260018c12ff6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->