### PR TITLE
[MacOS][Pixels][Auth V2] Enrich invalid refresh token telemetry with token status, source, and error description

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManager.swift
@@ -606,15 +606,15 @@ public final class DefaultSubscriptionManager: SubscriptionManager {
                 await signOut(notifyUI: true, userInitiated: false)
                 throw SubscriptionManagerError.noTokenAvailable
 
-            case OAuthClientError.invalidTokenRequest:
-                pixelHandler.handle(pixel: .invalidRefreshToken)
+            case OAuthClientError.invalidTokenRequest(let tokenStatus):
+                pixelHandler.handle(pixel: .invalidRefreshToken(tokenStatus: tokenStatus))
                 do {
                     let recoveredTokenContainer = try await attemptTokenRecovery()
                     pixelHandler.handle(pixel: .invalidRefreshTokenRecovered)
                     return recoveredTokenContainer
                 } catch {
                     await signOut(notifyUI: false, userInitiated: false)
-                    pixelHandler.handle(pixel: .invalidRefreshTokenSignedOut)
+                    pixelHandler.handle(pixel: .invalidRefreshTokenSignedOut(tokenStatus: tokenStatus))
                     throw SubscriptionManagerError.noTokenAvailable
                 }
 

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionPixelType.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionPixelType.swift
@@ -20,11 +20,11 @@ import Foundation
 import Networking
 
 public enum SubscriptionPixelType: Equatable {
-    case invalidRefreshToken
+    case invalidRefreshToken(tokenStatus: OAuthRequest.TokenStatus?)
     case subscriptionIsActive
     case osDistributionActiveSubscription
     case getTokensError(AuthTokensCachePolicy, Error)
-    case invalidRefreshTokenSignedOut
+    case invalidRefreshTokenSignedOut(tokenStatus: OAuthRequest.TokenStatus?)
     case invalidRefreshTokenRecovered
     case purchaseSuccessAfterPendingTransaction
     case pendingTransactionApproved

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/WideEvents/AuthV2TokenRefreshWideEventData.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/WideEvents/AuthV2TokenRefreshWideEventData.swift
@@ -148,7 +148,7 @@ extension AuthV2TokenRefreshWideEventData {
                 }
             case .tokenRefreshFailed(let refreshID, let error):
                 if let data = wideEvent.getFlowData(AuthV2TokenRefreshWideEventData.self, globalID: refreshID) {
-                    data.errorData = WideEventErrorData(error: error)
+                    data.errorData = WideEventErrorData(error: error, description: (error as? any DDGError)?.description)
                     wideEvent.updateFlow(data)
                     wideEvent.completeFlow(data, status: .failure, onComplete: { _, _ in })
                 }

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerTests.swift
@@ -122,7 +122,7 @@ class SubscriptionManagerTests: XCTestCase {
         }
 
         assertGetTokensErrorPixel(policy: .localValid)
-        XCTAssertFalse(mockPixelHandler.handledPixels.contains(.invalidRefreshToken))
+        XCTAssertFalse(mockPixelHandler.handledPixels.contains(.invalidRefreshToken(tokenStatus: nil)))
     }
 
     func testGetTokenContainer_InvalidTokenRequest_RecoverySuccess_Pixels() async throws {
@@ -134,9 +134,9 @@ class SubscriptionManagerTests: XCTestCase {
         XCTAssertEqual(result, recoveredTokenContainer)
 
         assertGetTokensErrorPixel(policy: .localValid)
-        XCTAssertTrue(mockPixelHandler.handledPixels.contains(.invalidRefreshToken))
+        XCTAssertTrue(mockPixelHandler.handledPixels.contains(.invalidRefreshToken(tokenStatus: nil)))
         XCTAssertTrue(mockPixelHandler.handledPixels.contains(.invalidRefreshTokenRecovered))
-        XCTAssertFalse(mockPixelHandler.handledPixels.contains(.invalidRefreshTokenSignedOut))
+        XCTAssertFalse(mockPixelHandler.handledPixels.contains(.invalidRefreshTokenSignedOut(tokenStatus: nil)))
     }
 
     func testGetTokenContainer_InvalidTokenRequest_RecoveryFailure_Pixels() async throws {
@@ -153,8 +153,8 @@ class SubscriptionManagerTests: XCTestCase {
         }
 
         assertGetTokensErrorPixel(policy: .localValid)
-        XCTAssertTrue(mockPixelHandler.handledPixels.contains(.invalidRefreshToken))
-        XCTAssertTrue(mockPixelHandler.handledPixels.contains(.invalidRefreshTokenSignedOut))
+        XCTAssertTrue(mockPixelHandler.handledPixels.contains(.invalidRefreshToken(tokenStatus: nil)))
+        XCTAssertTrue(mockPixelHandler.handledPixels.contains(.invalidRefreshTokenSignedOut(tokenStatus: nil)))
         XCTAssertFalse(mockPixelHandler.handledPixels.contains(.invalidRefreshTokenRecovered))
     }
 
@@ -172,7 +172,7 @@ class SubscriptionManagerTests: XCTestCase {
         }
 
         assertGetTokensErrorPixel(policy: .localValid)
-        XCTAssertFalse(mockPixelHandler.handledPixels.contains(.invalidRefreshToken))
+        XCTAssertFalse(mockPixelHandler.handledPixels.contains(.invalidRefreshToken(tokenStatus: nil)))
     }
 
     // MARK: - Subscription Status Tests

--- a/iOS/DuckDuckGoTests/Subscription/SubscriptionPixelHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/SubscriptionPixelHandlerTests.swift
@@ -78,7 +78,7 @@ final class SubscriptionPixelHandlerTests: XCTestCase {
 
     func testInvalidRefreshTokenDetectedPixel() {
         let handler = SubscriptionPixelHandler(source: subscriptionSource, pixelKit: pixelKit)
-        handler.handle(pixel: .invalidRefreshToken)
+        handler.handle(pixel: .invalidRefreshToken(tokenStatus: nil))
 
         assertDailyAndCountPixel(
             baseName: SubscriptionPixel.subscriptionInvalidRefreshTokenDetected(subscriptionSource).name,
@@ -135,7 +135,7 @@ final class SubscriptionPixelHandlerTests: XCTestCase {
 
     func testInvalidRefreshTokenSignedOutPixel() {
         let handler = SubscriptionPixelHandler(source: subscriptionSource, pixelKit: pixelKit)
-        handler.handle(pixel: .invalidRefreshTokenSignedOut)
+        handler.handle(pixel: .invalidRefreshTokenSignedOut(tokenStatus: nil))
 
         assertDailyAndCountPixel(
             baseName: SubscriptionPixel.subscriptionInvalidRefreshTokenSignedOut.name,

--- a/macOS/DuckDuckGo/Statistics/SubscriptionPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/SubscriptionPixel.swift
@@ -85,8 +85,8 @@ enum SubscriptionPixel: PixelKitEvent {
     case subscriptionUpgradeClick
     case subscriptionCancelPendingDowngradeClick
     // Auth
-    case subscriptionInvalidRefreshTokenDetected(SubscriptionPixelHandler.Source)
-    case subscriptionInvalidRefreshTokenSignedOut
+    case subscriptionInvalidRefreshTokenDetected(SubscriptionPixelHandler.Source, tokenStatus: OAuthRequest.TokenStatus?)
+    case subscriptionInvalidRefreshTokenSignedOut(SubscriptionPixelHandler.Source, tokenStatus: OAuthRequest.TokenStatus?)
     case subscriptionInvalidRefreshTokenRecovered
     case subscriptionAuthV2GetTokensError(AuthTokensCachePolicy, SubscriptionPixelHandler.Source, Error)
     // Pending Transaction
@@ -266,6 +266,7 @@ enum SubscriptionPixel: PixelKitEvent {
     private struct SubscriptionPixelsDefaults {
         static let policyCacheKey = "policycache"
         static let sourceKey = "source"
+        static let tokenStatusKey = "token_status"
         static let platformKey = "platform"
         static let activationDayKey = "activation_day"
         static let statusKey = "status"
@@ -273,8 +274,11 @@ enum SubscriptionPixel: PixelKitEvent {
 
     var parameters: [String: String]? {
         switch self {
-        case .subscriptionInvalidRefreshTokenDetected(let source),
-                .subscriptionPurchaseSuccessAfterPendingTransaction(let source),
+        case .subscriptionInvalidRefreshTokenDetected(let source, let tokenStatus),
+                .subscriptionInvalidRefreshTokenSignedOut(let source, let tokenStatus):
+            return [SubscriptionPixelsDefaults.sourceKey: source.description,
+                    SubscriptionPixelsDefaults.tokenStatusKey: tokenStatus?.subscriptionPixelValue ?? "unknown"]
+        case .subscriptionPurchaseSuccessAfterPendingTransaction(let source),
                 .subscriptionPendingTransactionApproved(let source),
                 .subscriptionKeychainManagerDataAddedToTheBacklog(let source),
                 .subscriptionKeychainManagerDeallocatedWithBacklog(let source),
@@ -435,4 +439,17 @@ enum SubscriptionErrorPixel: PixelKitEvent {
         }
     }
 
+}
+
+private extension OAuthRequest.TokenStatus {
+    /// Stable string value reported in the `token_status` pixel parameter.
+    var subscriptionPixelValue: String {
+        switch self {
+        case .invalid: return "invalid"
+        case .expired: return "expired"
+        case .reused: return "reused"
+        case .loggedOut: return "logged_out"
+        case .fraudDetected: return "fraud_detected"
+        }
+    }
 }

--- a/macOS/DuckDuckGo/Subscription/SubscriptionPixelHandler.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionPixelHandler.swift
@@ -47,16 +47,16 @@ public struct SubscriptionPixelHandler: SubscriptionPixelHandling {
 
     public func handle(pixel: Subscription.SubscriptionPixelType) {
         switch pixel {
-        case .invalidRefreshToken:
-            pixelKit?.fire(SubscriptionPixel.subscriptionInvalidRefreshTokenDetected(source), frequency: .dailyAndCount)
+        case .invalidRefreshToken(let tokenStatus):
+            pixelKit?.fire(SubscriptionPixel.subscriptionInvalidRefreshTokenDetected(source, tokenStatus: tokenStatus), frequency: .dailyAndCount)
         case .subscriptionIsActive:
             pixelKit?.fire(SubscriptionPixel.subscriptionActive(AuthVersion.v2), frequency: .legacyDaily)
         case .osDistributionActiveSubscription:
             pixelKit?.fireOSDistributionPixel(metric: .activeSubscriptions)
         case .getTokensError(let policy, let error):
             pixelKit?.fire(SubscriptionPixel.subscriptionAuthV2GetTokensError(policy, source, error), frequency: .dailyAndCount)
-        case .invalidRefreshTokenSignedOut:
-            pixelKit?.fire(SubscriptionPixel.subscriptionInvalidRefreshTokenSignedOut, frequency: .dailyAndCount)
+        case .invalidRefreshTokenSignedOut(let tokenStatus):
+            pixelKit?.fire(SubscriptionPixel.subscriptionInvalidRefreshTokenSignedOut(source, tokenStatus: tokenStatus), frequency: .dailyAndCount)
         case .invalidRefreshTokenRecovered:
             pixelKit?.fire(SubscriptionPixel.subscriptionInvalidRefreshTokenRecovered, frequency: .dailyAndCount)
         case .purchaseSuccessAfterPendingTransaction:

--- a/macOS/PixelDefinitions/pixels/definitions/subscription.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/subscription.json5
@@ -907,5 +907,89 @@
                 "enum": ["d1", "d2_to_d7"]
             }
         ]
+    },
+    "m_mac_direct_privacy-pro_auth_invalid_refresh_token_detected": {
+        "description": "Fired when the server rejects the stored refresh token (OAuthClientError.invalidTokenRequest), before recovery is attempted. Direct distribution.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "source",
+                "description": "The app component where the rejection was detected, like MainApp, SysExt, VPNApp or DBP",
+                "type": "string"
+            },
+            {
+                "key": "token_status",
+                "description": "The TokenStatus the server reported for the rejected refresh token",
+                "type": "string",
+                "enum": ["invalid", "expired", "reused", "logged_out", "fraud_detected", "unknown"]
+            }
+        ]
+    },
+    "m_mac_store_privacy-pro_auth_invalid_refresh_token_detected": {
+        "description": "Fired when the server rejects the stored refresh token (OAuthClientError.invalidTokenRequest), before recovery is attempted. App Store distribution.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "source",
+                "description": "The app component where the rejection was detected, like MainApp, SysExt, VPNApp or DBP",
+                "type": "string"
+            },
+            {
+                "key": "token_status",
+                "description": "The TokenStatus the server reported for the rejected refresh token",
+                "type": "string",
+                "enum": ["invalid", "expired", "reused", "logged_out", "fraud_detected", "unknown"]
+            }
+        ]
+    },
+    "m_mac_direct_privacy-pro_auth_invalid_refresh_token_signed_out": {
+        "description": "Fired when the user is signed out because the rejected refresh token could not be recovered. Direct distribution.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "source",
+                "description": "The app component where the sign-out happened, like MainApp, SysExt, VPNApp or DBP",
+                "type": "string"
+            },
+            {
+                "key": "token_status",
+                "description": "The TokenStatus the server reported for the rejected refresh token",
+                "type": "string",
+                "enum": ["invalid", "expired", "reused", "logged_out", "fraud_detected", "unknown"]
+            }
+        ]
+    },
+    "m_mac_store_privacy-pro_auth_invalid_refresh_token_signed_out": {
+        "description": "Fired when the user is signed out because the rejected refresh token could not be recovered. App Store distribution.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "source",
+                "description": "The app component where the sign-out happened, like MainApp, SysExt, VPNApp or DBP",
+                "type": "string"
+            },
+            {
+                "key": "token_status",
+                "description": "The TokenStatus the server reported for the rejected refresh token",
+                "type": "string",
+                "enum": ["invalid", "expired", "reused", "logged_out", "fraud_detected", "unknown"]
+            }
+        ]
     }
 }

--- a/macOS/UnitTests/Subscription/SubscriptionPixelHandlerTests.swift
+++ b/macOS/UnitTests/Subscription/SubscriptionPixelHandlerTests.swift
@@ -73,12 +73,13 @@ final class SubscriptionPixelHandlerTests: XCTestCase {
 
     func testInvalidRefreshTokenDetectedPixel() {
         let handler = SubscriptionPixelHandler(source: subscriptionSource, pixelKit: pixelKit)
-        handler.handle(pixel: .invalidRefreshToken)
+        handler.handle(pixel: .invalidRefreshToken(tokenStatus: nil))
 
         assertDailyAndCountPixel(
-            baseName: SubscriptionPixel.subscriptionInvalidRefreshTokenDetected(subscriptionSource).name,
+            baseName: SubscriptionPixel.subscriptionInvalidRefreshTokenDetected(subscriptionSource, tokenStatus: nil).name,
             expectedParameters: [
                 "source": subscriptionSource.description,
+                "token_status": "unknown",
                 PixelKit.Parameters.pixelSource: pixelSource,
                 PixelKit.Parameters.appVersion: "1.0.0"
             ]
@@ -131,11 +132,13 @@ final class SubscriptionPixelHandlerTests: XCTestCase {
 
     func testInvalidRefreshTokenSignedOutPixel() {
         let handler = SubscriptionPixelHandler(source: subscriptionSource, pixelKit: pixelKit)
-        handler.handle(pixel: .invalidRefreshTokenSignedOut)
+        handler.handle(pixel: .invalidRefreshTokenSignedOut(tokenStatus: nil))
 
         assertDailyAndCountPixel(
-            baseName: SubscriptionPixel.subscriptionInvalidRefreshTokenSignedOut.name,
+            baseName: SubscriptionPixel.subscriptionInvalidRefreshTokenSignedOut(subscriptionSource, tokenStatus: nil).name,
             expectedParameters: [
+                "source": subscriptionSource.description,
+                "token_status": "unknown",
                 PixelKit.Parameters.pixelSource: pixelSource,
                 PixelKit.Parameters.appVersion: "1.0.0"
             ]


### PR DESCRIPTION
Task/Issue URL:
Tech Design URL:
CC:

### Description

Enriches Privacy Pro AuthV2 invalid-refresh-token telemetry so subscription sign-outs can be attributed to a process and a cause.

- Adds `OAuthRequest.TokenStatus` to the `invalidRefreshToken` (detected) and `invalidRefreshTokenSignedOut` pixels, emitted as a `token_status` parameter (`invalid` / `expired` / `reused` / `logged_out` / `fraud_detected`). This distinguishes a refresh-token reuse-window race (`reused`) from benign 30-day TTL expiry (`expired`).
- Adds `source` to the signed-out pixel (previously only the detected pixel carried it), so sign-outs can be attributed to the firing process (MainApp / SysExt / VPNApp / DBP).
- Updates the subscription pixel definitions for the new parameters.
- Populates `error_description` on the `auth_v2_token_refresh` wide event failure. The field is already declared in the shared error schema (`props_dictionary.json` `errorParameters`), so no schema change or version bump is required — it was previously sent as `nil`.

### Testing Steps
1. Trigger an invalid refresh token sign-out (e.g. invalidate the stored refresh token so the next refresh is rejected by the server).
2. Confirm the `m_mac_<dist>_privacy-pro_auth_invalid_refresh_token_detected` and `..._signed_out` pixels now carry both `source` and `token_status` parameters.
3. Confirm the `auth_v2_token_refresh` wide event failure carries `feature.data.ext.error.error_description` with the human-readable error text.

### Impact and Risks

**Low** — telemetry/instrumentation only. No change to authentication, token-refresh, or sign-out control flow; only the parameters attached to existing pixels and the wide event are extended.

#### What could go wrong?
- A `nil` token status is handled explicitly (reported as `unknown`), so the new parameter is always present.
- No new wide-event field is introduced (`error_description` already exists in the shared schema), so there is no schema/ingestion mismatch and no version bump.

### Quality Considerations
- This change is itself monitoring: it adds the dimensions (`token_status`, `source`, error description) needed to diagnose the subscription-disconnect investigation.
- Edge cases: missing/unknown token status maps to `unknown`; non-`DDGError` refresh failures leave `error_description` empty while domain/code are still captured.
- Pixel definitions (`subscription.json5`) updated to keep the definition in sync with the emitted parameters.

### Notes to Reviewer
- Most of the diff is the sign-out pixel enrichment (token status + source). The single one-line change in `AuthV2TokenRefreshWideEventData.swift` is the wide-event `error_description` population.
- Build and full test suite have not been run yet from this branch — recommend a CI pass before un-drafting.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
