### PR TITLE
Fix OS Distribution pixel for searches + duck.ai prompts to be regular always-firing, not monthly firing

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/OSDistributionPixel.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/OSDistributionPixel.swift
@@ -19,7 +19,11 @@
 import Foundation
 import Common
 
-/// Monthly pixels for deciding when to end support for an operating system version.
+/// Pixels for deciding when to end support for an operating system version.
+///
+/// `.client` and `.activeSubscriptions` fire at most once per calendar month (monthly-active
+/// users / subscribers); `.searches` fires on every search or AI query, since the EOL policy's
+/// "low monthly search traffic" metric counts total search + AI-query *traffic*, not active users.
 ///
 /// Tech design: https://app.asana.com/1/137249556945/project/1208546505108826/task/1214950124367783?focus=true
 public struct OSDistributionPixel: PixelKitEvent {
@@ -49,6 +53,15 @@ public struct OSDistributionPixel: PixelKitEvent {
         "os_distribution_\(metric.rawValue)_major_version_\(osMajorVersion)_\(platform.rawValue.lowercased())_\(formFactor)"
     }
 
+    /// Per-metric firing frequency. `.searches` measures total search + AI-query traffic so it fires
+    /// on every event; `.client` and `.activeSubscriptions` measure monthly-active users / subscribers.
+    var frequency: PixelKit.Frequency {
+        switch metric {
+        case .searches: return .standard
+        case .client, .activeSubscriptions: return .monthly
+        }
+    }
+
     // Self-tags the pixel to route through the PETAL (timestamp-randomization) pipeline.
     public var parameters: [String: String]? { ["petal": "randomize"] }
 
@@ -59,10 +72,11 @@ public struct OSDistributionPixel: PixelKitEvent {
 public extension PixelKit {
 
     /// Fires an OS-distribution pixel with the fixed configuration these pixels require:
-    /// `.monthly` frequency, no `appVersion`, no `pixelSource`, and no platform-prefix enforcement.
+    /// the metric's `frequency` (see `OSDistributionPixel.frequency`), no `appVersion`,
+    /// no `pixelSource`, and no platform-prefix enforcement.
     func fireOSDistributionPixel(_ event: OSDistributionPixel) {
         fire(event,
-             frequency: .monthly,
+             frequency: event.frequency,
              includeAppVersionParameter: false,
              doNotEnforcePrefix: true)
     }

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/OSDistributionPixelTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/OSDistributionPixelTests.swift
@@ -71,7 +71,8 @@ final class OSDistributionPixelTests: XCTestCase {
         XCTAssertNil(firedParameters?[PixelKit.Parameters.pixelSource], "pixelSource must not be added")
     }
 
-    /// A second fire within the same calendar month is suppressed (monthly frequency gating).
+    /// A second fire within the same calendar month is suppressed for monthly-frequency metrics
+    /// (`.client` / `.activeSubscriptions`). (`.searches` is per-event — see `testSearchesFiresEveryTime`.)
     func testSecondFireInSameMonthIsSuppressed() {
         var fireCount = 0
         let defaults = InMemoryThrowingKeyValueStore()
@@ -86,11 +87,37 @@ final class OSDistributionPixelTests: XCTestCase {
             }
         }
 
-        let event = OSDistributionPixel(metric: .searches, osMajorVersion: 15, platform: .macOS, formFactor: "desktop")
+        let event = OSDistributionPixel(metric: .client, osMajorVersion: 15, platform: .macOS, formFactor: "desktop")
         makePixelKit().fireOSDistributionPixel(event)
         makePixelKit().fireOSDistributionPixel(event)
 
         XCTAssertEqual(fireCount, 1, "Monthly pixel should only fire once per calendar month")
+    }
+
+    /// `.searches` is a per-event traffic pixel (`.standard` frequency): it fires every time, with no
+    /// monthly dedup — unlike the monthly `.client` / `.activeSubscriptions`.
+    func testSearchesFiresEveryTime() {
+        var firedNames: [String] = []
+        let defaults = InMemoryThrowingKeyValueStore()
+
+        let makePixelKit: () -> PixelKit = {
+            PixelKit(dryRun: false,
+                     appVersion: "1.2.3",
+                     defaultHeaders: [:],
+                     defaults: defaults) { name, _, _, _, _, onComplete in
+                firedNames.append(name)
+                onComplete(true, nil)
+            }
+        }
+
+        let event = OSDistributionPixel(metric: .searches, osMajorVersion: 15, platform: .macOS, formFactor: "desktop")
+        makePixelKit().fireOSDistributionPixel(event)
+        makePixelKit().fireOSDistributionPixel(event)
+
+        XCTAssertEqual(firedNames, [
+            "os_distribution_searches_major_version_15_macos_desktop",
+            "os_distribution_searches_major_version_15_macos_desktop"
+        ], "Searches is per-event: fires every time")
     }
 
     // MARK: - Metric-based firing

--- a/iOS/Core/StatisticsLoader.swift
+++ b/iOS/Core/StatisticsLoader.swift
@@ -198,10 +198,8 @@ public class StatisticsLoader {
             group.enter()
             group.enter()
 
-            // The refreshSearchRetentionAtb call below is what fires the `.searches`
-            // OS-distribution pixel for a Duck.ai prompt, so Duck.ai usage is included in our
-            // search + AI-query traffic count. (refreshDuckAIRetentionAtb deliberately does not
-            // fire it, to avoid double-counting a single prompt.)
+            // The refreshSearchRetentionAtb call below fires the `.searches` OS-distribution pixel
+            // for a Duck.ai prompt, so Duck.ai usage is included in our search + AI-query traffic count.
             self.refreshSearchRetentionAtb {
                 group.leave()
             }
@@ -218,11 +216,6 @@ public class StatisticsLoader {
 
     private func refreshDuckAIRetentionAtb(completion: @escaping Completion = {}) {
         dispatchPrecondition(condition: .onQueue(.main))
-
-        // Intentionally does NOT fire the `.searches` OS-distribution pixel. The Duck.ai prompt
-        // path (refreshRetentionAtbOnDuckAIPromptSubmission) also calls refreshSearchRetentionAtb,
-        // which is the single emit point for `.searches`. Firing here as well would double-count a
-        // single prompt now that `.searches` is a per-event pixel rather than monthly-deduped.
 
         guard !isDuckAIRetentionRequestInProgress else {
             completion()

--- a/iOS/Core/StatisticsLoader.swift
+++ b/iOS/Core/StatisticsLoader.swift
@@ -198,6 +198,10 @@ public class StatisticsLoader {
             group.enter()
             group.enter()
 
+            // The refreshSearchRetentionAtb call below is what fires the `.searches`
+            // OS-distribution pixel for a Duck.ai prompt, so Duck.ai usage is included in our
+            // search + AI-query traffic count. (refreshDuckAIRetentionAtb deliberately does not
+            // fire it, to avoid double-counting a single prompt.)
             self.refreshSearchRetentionAtb {
                 group.leave()
             }
@@ -215,7 +219,10 @@ public class StatisticsLoader {
     private func refreshDuckAIRetentionAtb(completion: @escaping Completion = {}) {
         dispatchPrecondition(condition: .onQueue(.main))
 
-        fireOSDistributionPixel(.searches)
+        // Intentionally does NOT fire the `.searches` OS-distribution pixel. The Duck.ai prompt
+        // path (refreshRetentionAtbOnDuckAIPromptSubmission) also calls refreshSearchRetentionAtb,
+        // which is the single emit point for `.searches`. Firing here as well would double-count a
+        // single prompt now that `.searches` is a per-event pixel rather than monthly-deduped.
 
         guard !isDuckAIRetentionRequestInProgress else {
             completion()

--- a/iOS/DuckDuckGoTests/StatisticsLoaderTests.swift
+++ b/iOS/DuckDuckGoTests/StatisticsLoaderTests.swift
@@ -76,6 +76,26 @@ class StatisticsLoaderTests: XCTestCase {
         XCTAssertFalse(firedOSDistributionMetrics.contains(.client))
     }
 
+    func testRefreshRetentionAtbOnDuckAIPromptSubmissionFiresExactlyOneSearchesOSDistributionPixel() {
+        mockStatisticsStore.atb = "atb"
+        mockStatisticsStore.searchRetentionAtb = "searchretentionatb"
+        mockStatisticsStore.duckAIRetentionAtb = "retentionatb"
+        loadSuccessfulAtbStub()
+        loadSuccessfulExiStub()
+
+        let testExpectation = expectation(description: "refresh complete")
+        testee.refreshRetentionAtbOnDuckAIPromptSubmission {
+            testExpectation.fulfill()
+        }
+        wait(for: [testExpectation], timeout: 10.0)
+
+        // The prompt path calls both refreshSearchRetentionAtb and refreshDuckAIRetentionAtb, but only
+        // the former fires .searches — so a single Duck.ai prompt must count as exactly one search event.
+        XCTAssertEqual(firedOSDistributionMetrics.filter { $0 == .searches }.count, 1,
+                       "A Duck.ai prompt must fire exactly one searches OS-distribution pixel. Fired: \(firedOSDistributionMetrics)")
+        XCTAssertFalse(firedOSDistributionMetrics.contains(.client))
+    }
+
     override func tearDown() {
         HTTPStubs.removeAllStubs()
         PixelFiringMock.tearDown()

--- a/iOS/PixelDefinitions/pixels/definitions/os_distribution_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/os_distribution_pixels.json5
@@ -29,7 +29,7 @@
         "description": "Fires on each search or Duck.ai prompt submission (total search + AI-query traffic).",
         "owners": ["jdjackson"],
         "privacyReview": ["https://app.asana.com/1/137249556945/project/69071770703008/task/1215252656518903?focus=true"],
-        "triggers": ["search_ddg", "user_submitted"],
+        "triggers": ["search_ddg"],
         "parameters": [
             {
                 "key": "petal",

--- a/iOS/PixelDefinitions/pixels/definitions/os_distribution_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/os_distribution_pixels.json5
@@ -26,10 +26,10 @@
         ]
     },
     "os_distribution_searches_major_version": {
-        "description": "Fires at most once per calendar month, on search.",
+        "description": "Fires on each search or Duck.ai prompt submission (total search + AI-query traffic).",
         "owners": ["jdjackson"],
         "privacyReview": ["https://app.asana.com/1/137249556945/project/69071770703008/task/1215252656518903?focus=true"],
-        "triggers": ["scheduled"],
+        "triggers": ["search_ddg", "user_submitted"],
         "parameters": [
             {
                 "key": "petal",
@@ -44,11 +44,7 @@
                 "pattern": "^[0-9]{1,2}$"
             },
             "platform",
-            "form_factor",
-            {
-                "description": "Calendar month frequency marker",
-                "enum": ["monthly"]
-            }
+            "form_factor"
         ]
     },
     "os_distribution_active_subscriptions_major_version": {

--- a/macOS/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
+++ b/macOS/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
@@ -103,6 +103,10 @@ final class StatisticsLoader {
             group.enter()
             group.enter()
 
+            // The refreshSearchRetentionAtb call below is what fires the `.searches`
+            // OS-distribution pixel for a Duck.ai prompt, so Duck.ai usage is included in our
+            // search + AI-query traffic count. (refreshDuckAIRetentionAtb deliberately does not
+            // fire it, to avoid double-counting a single prompt.)
             self.refreshSearchRetentionAtb {
                 group.leave()
             }
@@ -280,7 +284,10 @@ final class StatisticsLoader {
     func refreshDuckAIRetentionAtb(completion: @escaping Completion = {}) {
         dispatchPrecondition(condition: .onQueue(.main))
 
-        PixelKit.fireOSDistributionPixel(metric: .searches)
+        // Intentionally does NOT fire the `.searches` OS-distribution pixel. The Duck.ai prompt
+        // path (refreshRetentionAtbOnDuckAiPromptSubmition) also calls refreshSearchRetentionAtb,
+        // which is the single emit point for `.searches`. Firing here as well would double-count a
+        // single prompt now that `.searches` is a per-event pixel rather than monthly-deduped.
 
         guard !isDuckAIRetentionRequestInProgress else {
             completion()

--- a/macOS/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
+++ b/macOS/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
@@ -103,10 +103,8 @@ final class StatisticsLoader {
             group.enter()
             group.enter()
 
-            // The refreshSearchRetentionAtb call below is what fires the `.searches`
-            // OS-distribution pixel for a Duck.ai prompt, so Duck.ai usage is included in our
-            // search + AI-query traffic count. (refreshDuckAIRetentionAtb deliberately does not
-            // fire it, to avoid double-counting a single prompt.)
+            // The refreshSearchRetentionAtb call below fires the `.searches` OS-distribution pixel
+            // for a Duck.ai prompt, so Duck.ai usage is included in our search + AI-query traffic count.
             self.refreshSearchRetentionAtb {
                 group.leave()
             }
@@ -283,11 +281,6 @@ final class StatisticsLoader {
 
     func refreshDuckAIRetentionAtb(completion: @escaping Completion = {}) {
         dispatchPrecondition(condition: .onQueue(.main))
-
-        // Intentionally does NOT fire the `.searches` OS-distribution pixel. The Duck.ai prompt
-        // path (refreshRetentionAtbOnDuckAiPromptSubmition) also calls refreshSearchRetentionAtb,
-        // which is the single emit point for `.searches`. Firing here as well would double-count a
-        // single prompt now that `.searches` is a per-event pixel rather than monthly-deduped.
 
         guard !isDuckAIRetentionRequestInProgress else {
             completion()

--- a/macOS/PixelDefinitions/pixels/definitions/os_distribution_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/os_distribution_pixels.json5
@@ -30,7 +30,7 @@
         "description": "Fires on each search or Duck.ai prompt submission (total search + AI-query traffic).",
         "owners": ["jdjackson"],
         "privacyReview": ["https://app.asana.com/1/137249556945/project/69071770703008/task/1215252656518903?focus=true"],
-        "triggers": ["search_ddg", "user_submitted"],
+        "triggers": ["search_ddg"],
         "parameters": [
             {
                 "key": "petal",

--- a/macOS/PixelDefinitions/pixels/definitions/os_distribution_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/os_distribution_pixels.json5
@@ -27,10 +27,10 @@
         ]
     },
     "os_distribution_searches_major_version": {
-        "description": "Fires at most once per calendar month, on search.",
+        "description": "Fires on each search or Duck.ai prompt submission (total search + AI-query traffic).",
         "owners": ["jdjackson"],
         "privacyReview": ["https://app.asana.com/1/137249556945/project/69071770703008/task/1215252656518903?focus=true"],
-        "triggers": ["scheduled"],
+        "triggers": ["search_ddg", "user_submitted"],
         "parameters": [
             {
                 "key": "petal",
@@ -46,11 +46,7 @@
                 "pattern": "^[0-9]{1,2}$"
             },
             "platform",
-            "form_factor",
-            {
-                "description": "Calendar month frequency marker",
-                "enum": ["monthly"]
-            }
+            "form_factor"
         ]
     },
     "os_distribution_active_subscriptions_major_version": {

--- a/macOS/UnitTests/Statistics/ATB/StatisticsLoaderTests.swift
+++ b/macOS/UnitTests/Statistics/ATB/StatisticsLoaderTests.swift
@@ -153,7 +153,7 @@ class StatisticsLoaderTests: XCTestCase {
                       "Expected searches OS-distribution pixel. Fired: \(firedPixelNames)")
     }
 
-    func testRefreshDuckAIRetentionAtbFiresSearchesOSDistributionPixel() {
+    func testRefreshDuckAIRetentionAtbDoesNotFireSearchesOSDistributionPixel() {
         var firedPixelNames: [String] = []
         let capturingPixelKit = PixelKit(dryRun: false,
                                          appVersion: "1.0.0",
@@ -175,8 +175,36 @@ class StatisticsLoaderTests: XCTestCase {
         }
         waitForExpectations(timeout: 5)
 
-        XCTAssertTrue(firedPixelNames.contains { $0.hasPrefix("os_distribution_searches_major_version_") },
-                      "Expected searches OS-distribution pixel. Fired: \(firedPixelNames)")
+        // The searches pixel is emitted once via refreshSearchRetentionAtb on the prompt path,
+        // so refreshDuckAIRetentionAtb must NOT also fire it (that would double-count one prompt).
+        XCTAssertFalse(firedPixelNames.contains { $0.hasPrefix("os_distribution_searches_major_version_") },
+                       "refreshDuckAIRetentionAtb must not fire the searches pixel. Fired: \(firedPixelNames)")
+    }
+
+    func testRefreshRetentionAtbOnDuckAiPromptSubmissionFiresExactlyOneSearchesOSDistributionPixel() {
+        var firedPixelNames: [String] = []
+        let capturingPixelKit = PixelKit(dryRun: false,
+                                         appVersion: "1.0.0",
+                                         defaultHeaders: [:],
+                                         defaults: UserDefaults(suiteName: "test_\(UUID().uuidString)")!,
+                                         fireRequest: { name, _, _, _, _, onComplete in
+                                             firedPixelNames.append(name)
+                                             onComplete(true, nil)
+                                         })
+        PixelKit.setSharedForTesting(pixelKit: capturingPixelKit)
+
+        mockStatisticsStore.atb = "atb"
+        mockStatisticsStore.variant = "test"
+        loadSuccessfulUpdateAtbStub()
+
+        let expect = expectation(description: #function)
+        testee.refreshRetentionAtbOnDuckAiPromptSubmition {
+            expect.fulfill()
+        }
+        waitForExpectations(timeout: 5)
+
+        XCTAssertEqual(firedPixelNames.filter { $0.hasPrefix("os_distribution_searches_major_version_") }.count, 1,
+                       "A Duck.ai prompt must fire exactly one searches OS-distribution pixel. Fired: \(firedPixelNames)")
     }
 
     func testWhenSearchRefreshHasSuccessfulUpdateAtbRequestThenSearchRetentionAtbUpdated() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/69071770703008/task/1215643311982508?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/1208546505108826/task/1214950124367783?focus=true (needs update if we move forward with this)
CC: @nshuba @adewes 

Fix OS Distribution pixel for searches + duck.ai prompts to be a "normal" (always fired) pixel, rather than a monthly one, since the metric is not actually a monthly users type metric.


### Description

### Testing Steps
1. Like before, unit tests are the primary testing method here, so ensure those tests make sense
2. Consider manual testing and ensuring the pixel fires on both search and AI queries issued in various ways throughout the apps (macOS and iOS)
3. We will validate arrival via the dashboards as well, though only once this is in internal / public (as is common with testing pixel data)

### Impact and Risks
Risk level: Low (change to how frequently a pixel fires)

#### What could go wrong?
Mistakes here could over- or under-fire a pixel on search or Duck.ai prompt submission.

### Quality Considerations
Double-check my logic around why this should be changed from a monthly pixel to a regular always-fire pixel.  Review the definition of the “low monthly search traffic” metric in our [policy](https://app.asana.com/1/137249556945/project/1202500774821704/task/1214267099184919?focus=true) and think about exactly what we’re trying to measure.

Note: This PR is tagged DO NOT MERGE until we have a chance to discuss and agree that this is a correct change to make.  If we agree, I’d like to merge this to our internal branch as well, so it goes public with the other pixels correctly next week, rather than releasing the mistaken monthly pixel first, and then this change landing a week later.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only pixel frequency and call-site deduping; wrong behavior would over- or under-count search traffic for OS EOL metrics, not affect app security or user data.
> 
> **Overview**
> Aligns the **os_distribution_searches** pixel with total search + Duck.ai **traffic** (not monthly active users): **`.searches`** now uses **`.standard`** frequency in `OSDistributionPixel` / `fireOSDistributionPixel`, while **`.client`** and **`.activeSubscriptions`** stay monthly.
> 
> Pixel definitions on iOS and macOS drop the **`_monthly`** suffix and **`scheduled`** trigger for searches in favor of **`search_ddg`** and per-event firing. On the Duck.ai prompt path, **`refreshDuckAIRetentionAtb`** no longer fires **`.searches`**—only **`refreshSearchRetentionAtb`** does—so one prompt counts once. Tests cover per-event searches firing and single-pixel behavior on Duck.ai submission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a34f714bf2f6f898f4ee4ba1526cb983f35ad859. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->