### PR TITLE
[macOS Release PR] Check for Duck Player interaction when factoring in the rollout flag 

### DIFF
--- a/iOS/DuckDuckGo/AppUserDefaults.swift
+++ b/iOS/DuckDuckGo/AppUserDefaults.swift
@@ -518,7 +518,7 @@ public class AppUserDefaults: AppSettings {
                let mode = DuckPlayerMode(stringValue: value) {
                 return mode
             }
-            return AdBlockingAvailability.areAdBlockingDefaultsActive(featureFlagger: featureFlagger) ? .disabled : .alwaysAsk
+            return AdBlockingAvailability.areAdBlockingDefaultsActive(featureFlagger: featureFlagger) && !duckPlayerAskModeOverlayHidden ? .disabled : .alwaysAsk
         }
         set {
             userDefaults?.set(newValue.stringValue, forKey: Keys.duckPlayerMode)
@@ -583,7 +583,7 @@ public class AppUserDefaults: AppSettings {
                let mode = NativeDuckPlayerYoutubeMode(stringValue: value) {
                 return mode
             }
-            return AdBlockingAvailability.areAdBlockingDefaultsActive(featureFlagger: featureFlagger) ? .never : .ask
+            return AdBlockingAvailability.areAdBlockingDefaultsActive(featureFlagger: featureFlagger) && !(duckPlayerNativeUIWasUsed || duckPlayerWelcomeMessageShown) ? .never : .ask
         }
         set {
             userDefaults?.set(newValue.stringValue, forKey: Keys.duckPlayerNativeYoutubeMode)

--- a/iOS/DuckDuckGoTests/AppUserDefaultsTests.swift
+++ b/iOS/DuckDuckGoTests/AppUserDefaultsTests.swift
@@ -289,6 +289,17 @@ class AppUserDefaultsTests: XCTestCase {
         XCTAssertEqual(appUserDefaults.duckPlayerMode, .disabled)
     }
 
+    func testWhenDuckPlayerModeStorageIsNilAndRolloutOnButOverlayInteractedThenReturnsAlwaysAsk() {
+        // askModeOverlayHidden == true means the user interacted with the web overlay.
+        // Such users keep "Ask" even under the rollout. .alwaysAsk on every OS:
+        // supported+interacted -> Ask (gate), unsupported -> Ask (historical default).
+        let appUserDefaults = AppUserDefaults(groupName: testGroupName)
+        appUserDefaults.featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.adBlockingExtensionEnabledByDefault, .webExtensions])
+        appUserDefaults.duckPlayerAskModeOverlayHidden = true
+
+        XCTAssertEqual(appUserDefaults.duckPlayerMode, .alwaysAsk)
+    }
+
     // MARK: - duckPlayerNativeYoutubeMode rollout-aware default
 
     func testWhenDuckPlayerNativeYoutubeModeStorageIsNilAndRolloutOffThenReturnsAsk() {
@@ -331,6 +342,24 @@ class AppUserDefaultsTests: XCTestCase {
         appUserDefaults.duckPlayerNativeYoutubeMode = .never
 
         XCTAssertEqual(appUserDefaults.duckPlayerNativeYoutubeMode, .never)
+    }
+
+    func testWhenNativeYoutubeModeStorageIsNilAndRolloutOnButNativeUIWasUsedThenReturnsAsk() {
+        let appUserDefaults = AppUserDefaults(groupName: testGroupName)
+        defer { appUserDefaults.duckPlayerNativeUIWasUsed = false }
+        appUserDefaults.featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.adBlockingExtensionEnabledByDefault, .webExtensions])
+        appUserDefaults.duckPlayerNativeUIWasUsed = true
+
+        XCTAssertEqual(appUserDefaults.duckPlayerNativeYoutubeMode, .ask)
+    }
+
+    func testWhenNativeYoutubeModeStorageIsNilAndRolloutOnButWelcomeMessageShownThenReturnsAsk() {
+        let appUserDefaults = AppUserDefaults(groupName: testGroupName)
+        defer { appUserDefaults.duckPlayerWelcomeMessageShown = false }
+        appUserDefaults.featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.adBlockingExtensionEnabledByDefault, .webExtensions])
+        appUserDefaults.duckPlayerWelcomeMessageShown = true
+
+        XCTAssertEqual(appUserDefaults.duckPlayerNativeYoutubeMode, .ask)
     }
 
     // MARK: - Mock Creation

--- a/macOS/DuckDuckGo/Preferences/Model/DuckPlayerPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/DuckPlayerPreferences.swift
@@ -151,7 +151,7 @@ final class DuckPlayerPreferences: ObservableObject {
         if let stored = persistor.duckPlayerModeBool {
             duckPlayerMode = .init(stored)
         } else {
-            duckPlayerMode = Self.rolloutDefaultsActive(featureFlagger: featureFlagger) ? .disabled : .alwaysAsk
+            duckPlayerMode = Self.rolloutDefaultsActive(featureFlagger: featureFlagger) && !persistor.youtubeOverlayAnyButtonPressed ? .disabled : .alwaysAsk
         }
         youtubeOverlayInteracted = persistor.youtubeOverlayInteracted
         youtubeOverlayAnyButtonPressed = persistor.youtubeOverlayAnyButtonPressed
@@ -187,7 +187,7 @@ final class DuckPlayerPreferences: ObservableObject {
 
     private func refreshDefaultModeIfNeeded() {
         guard persistor.duckPlayerModeBool == nil else { return }
-        let resolved: DuckPlayerMode = Self.rolloutDefaultsActive(featureFlagger: featureFlagger) ? .disabled : .alwaysAsk
+        let resolved: DuckPlayerMode = Self.rolloutDefaultsActive(featureFlagger: featureFlagger) && !persistor.youtubeOverlayAnyButtonPressed ? .disabled : .alwaysAsk
         guard resolved != duckPlayerMode else { return }
         isApplyingRolloutDefault = true
         duckPlayerMode = resolved

--- a/macOS/UnitTests/Preferences/DuckPlayerPreferencesTests.swift
+++ b/macOS/UnitTests/Preferences/DuckPlayerPreferencesTests.swift
@@ -137,6 +137,22 @@ final class DuckPlayerPreferencesTests: XCTestCase {
         XCTAssertEqual(model.duckPlayerMode, .enabled)
     }
 
+    func testWhenPersistorBoolIsNilAndRolloutOnButOverlayEngagedThenModeIsAlwaysAsk() {
+        // Engaged = pressed a button on the YouTube overlay before. Such users keep "Ask"
+        // even while the rollout is active. Expected value is .alwaysAsk on every OS:
+        // supported+engaged -> Ask (the gate), unsupported -> Ask (historical default).
+        let persistor = DuckPlayerPreferencesPersistorMock(duckPlayerMode: .alwaysAsk,
+                                                           youtubeOverlayAnyButtonPressed: true)
+        let featureFlagger = MockFeatureFlagger(featuresStub: [
+            FeatureFlag.adBlockingExtensionEnabledByDefault.rawValue: true,
+            FeatureFlag.webExtensions.rawValue: true
+        ])
+        let model = DuckPlayerPreferences(persistor: persistor, featureFlagger: featureFlagger)
+
+        XCTAssertEqual(model.duckPlayerMode, .alwaysAsk, "Engaged users must retain Ask under the rollout")
+        XCTAssertNil(persistor.duckPlayerModeBool, "Rollout default must not be persisted")
+    }
+
     // MARK: - refreshDefaultModeIfNeeded (publisher-triggered)
 
     func testPublisherTriggerUpdatesCachedModeForNilPersistorWhenFeatureSupported() {
@@ -186,6 +202,21 @@ final class DuckPlayerPreferencesTests: XCTestCase {
 
         XCTAssertEqual(model.duckPlayerMode, .enabled, "Explicit user choice must be preserved")
         XCTAssertEqual(persistor.duckPlayerModeBool, true)
+    }
+
+    func testPublisherTriggerKeepsAlwaysAskForNilPersistorWhenOverlayEngaged() {
+        let persistor = DuckPlayerPreferencesPersistorMock(duckPlayerMode: .alwaysAsk,
+                                                           youtubeOverlayAnyButtonPressed: true)
+        let featureFlagger = MockFeatureFlagger(featuresStub: [FeatureFlag.webExtensions.rawValue: true])
+        let model = DuckPlayerPreferences(persistor: persistor, featureFlagger: featureFlagger)
+        XCTAssertEqual(model.duckPlayerMode, .alwaysAsk)
+
+        featureFlagger.featuresStub[FeatureFlag.adBlockingExtensionEnabledByDefault.rawValue] = true
+        featureFlagger.triggerUpdate()
+        drainMainQueue()
+
+        XCTAssertEqual(model.duckPlayerMode, .alwaysAsk, "Engaged users must retain Ask after a mid-session rollout flip")
+        XCTAssertNil(persistor.duckPlayerModeBool)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1215645186670029?focus=true
Tech Design URL:
CC:

### Description

This PR fixes an issue where the ad blocking default flag did not check whether the user had interacted with Duck Player before - instead, it only checked whether the user had manually overridden Duck Player settings. For users who knew about Duck Player but decided whether to use it each time, Duck Player became disabled.

This change updates the flag so that now Duck Player is only disabled for users who have not only never overridden any settings, but have also never interacted with the choice modal.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Test that Duck Player is no longer disabled when the feature flag is enabled and you have made a Duck Player choice (but didn't override any settings)

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default Duck Player mode resolution for users without an explicit stored preference during an active rollout; wrong gating could leave too many users on Ask or incorrectly apply Disabled.
> 
> **Overview**
> **Rollout-aware Duck Player defaults** no longer apply the ad-blocking rollout’s stricter defaults when the user has already engaged with Duck Player. Users who interacted with the web overlay or native UI keep **Ask** behavior instead of being defaulted to **Disabled** / **Never**.
> 
> On **iOS**, unset `duckPlayerMode` only resolves to `.disabled` under rollout when `duckPlayerAskModeOverlayHidden` is false; if the overlay was interacted with (`true`), default stays `.alwaysAsk`. Unset `duckPlayerNativeYoutubeMode` similarly skips `.never` when `duckPlayerNativeUIWasUsed` or `duckPlayerWelcomeMessageShown` is set.
> 
> On **macOS**, `DuckPlayerPreferences` init and `refreshDefaultModeIfNeeded()` apply the same gate using `youtubeOverlayAnyButtonPressed` before choosing `.disabled` vs `.alwaysAsk`.
> 
> Unit tests on both platforms cover overlay-engaged and native-interaction cases, including mid-session rollout flag updates on macOS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 599a78d36f63fca5d1c98823d8112f2b9566ae7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->