### PR TITLE
iOS: Fix UTI card height expanding to fit long URL on omnibar tap

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -549,7 +549,7 @@ class SwitchBarTextEntryView: UIView {
         guard isURL else { return false }
         // In search mode the address bar is always single-line; the interaction flag is irrelevant.
         // In AI chat mode, URLs can expand once the user has actively started interacting.
-        return currentMode != .aiChat || !hasBeenInteractedWith
+        return currentMode == .search || !hasBeenInteractedWith
     }
 
     private func updateTextViewHeight() {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -546,7 +546,10 @@ class SwitchBarTextEntryView: UIView {
 
     /// https://app.asana.com/1/137249556945/project/392891325557410/task/1210835160047733?focus=true
     private func isUnexpandedURL() -> Bool {
-        return !hasBeenInteractedWith && isURL
+        guard isURL else { return false }
+        // In search mode the address bar is always single-line; the interaction flag is irrelevant.
+        // In AI chat mode, URLs can expand once the user has actively started interacting.
+        return currentMode != .aiChat || !hasBeenInteractedWith
     }
 
     private func updateTextViewHeight() {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -311,6 +311,38 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         XCTAssertEqual(handler.currentText, "he\nllo")
     }
 
+    func test_urlDoesNotExpandHeightInSearchModeAfterUserTap() {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.setToggleState(.search)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut)
+        sut.setQueryText("https://www.cinemark.com/theatres/ca-playa-vista/cinemark-playa-vista-and-xd?showDate=2026-06-12")
+        let singleLineHeight = applyFittingHeight(to: sut)
+
+        sut.hasBeenInteractedWith = true
+        sut.updatePoseForCurrentState()
+        let heightAfterTap = applyFittingHeight(to: sut)
+
+        XCTAssertEqual(heightAfterTap, singleLineHeight, accuracy: 1)
+    }
+
+    func test_urlCanExpandInAIChatModeAfterUserTap() {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.setToggleState(.aiChat)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut)
+        sut.setQueryText("https://www.cinemark.com/theatres/ca-playa-vista/cinemark-playa-vista-and-xd?showDate=2026-06-12")
+        let singleLineHeight = applyFittingHeight(to: sut)
+
+        sut.hasBeenInteractedWith = true
+        sut.updatePoseForCurrentState()
+        let heightAfterTap = applyFittingHeight(to: sut)
+
+        XCTAssertGreaterThan(heightAfterTap, singleLineHeight)
+    }
+
     func test_topAIChatTextEntryDoesNotGrowOnFirstFloatingReturnNewline() {
         let expectedTopAIChatMinimumHeight: CGFloat = 68
         let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -343,6 +343,24 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         XCTAssertGreaterThan(heightAfterTap, singleLineHeight)
     }
 
+    func test_urlCollapsesToSingleLineWhenModeSwitchesFromAIChatToSearch() {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.setToggleState(.aiChat)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut)
+        sut.setQueryText("https://www.cinemark.com/theatres/ca-playa-vista/cinemark-playa-vista-and-xd?showDate=2026-06-12")
+        sut.hasBeenInteractedWith = true
+        sut.updatePoseForCurrentState()
+        let expandedHeight = applyFittingHeight(to: sut)
+
+        handler.setToggleState(.search)
+        sut.updatePoseForCurrentState()
+        let heightAfterSwitch = applyFittingHeight(to: sut)
+
+        XCTAssertGreaterThan(expandedHeight, heightAfterSwitch)
+    }
+
     func test_topAIChatTextEntryDoesNotGrowOnFirstFloatingReturnNewline() {
         let expectedTopAIChatMinimumHeight: CGFloat = 68
         let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1210835160047733?focus=true

### Description

When the UTI was in expanded mode (toggle disabled or search-only) and the user tapped the omnibar on a page with a long URL, the card grew to fit the multi-line URL text. `isUnexpandedURL()` only protected against height expansion before the user had interacted with the field — once `hasBeenInteractedWith` became true on tap, the URL fell into the expandable path and the card grew unbounded.

Fix: make `isUnexpandedURL()` mode-aware. In search mode the address bar is always single-line regardless of interaction state. In AI chat mode the original expand-after-interaction behaviour is preserved.

### Testing Steps

1. Go to **Settings → AI Features** and set the omnibar to **Search only**
2. Navigate to a page with a long URL (e.g. `www.cinemark.com/theatres/ca-playa-vista/cinemark-playa-vista-and-xd?showDate=2026-06-12`)
3. Tap the omnibar
4. Verify the UTI card stays at its normal single-line height — the URL should be truncated, not wrapped across multiple lines
5. Repeat with **Toggle between Search and Duck.ai** enabled and the toggle in Search mode — same result expected
6. Toggle to duck.ai and input expands to show full URL
7. Disable the UTI and smoke test with the old toggle

### Impact and Risks

**Low** — minor visual bug fix. The change is isolated to a single private method on `SwitchBarTextEntryView` and only affects how URL height is computed after the user taps the omnibar.

#### What could go wrong?

In AI chat mode, a URL pasted as the entire message text will no longer expand the field before the user has interacted — this is unchanged. After interaction, AI chat mode still allows expansion. No other paths affected.

### Quality Considerations

Three unit tests cover the fix: search mode stays single-line after tap, AI chat mode is free to expand after tap, and switching from AI chat to search collapses the height.

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Low Risk**
> Isolated layout logic in one private helper on the switch bar text entry; only URL height behavior after interaction changes, with regression tests.
> 
> **Overview**
> Fixes the unified toggle input (UTI) card growing when the user taps the omnibar on a page with a long URL in **search** mode.
> 
> `isUnexpandedURL()` on `SwitchBarTextEntryView` is now **mode-aware**: search keeps URLs on the single-line, truncated path even after `hasBeenInteractedWith` is set on tap; **AI chat** still allows multi-line URL height once the user has interacted. Switching from AI chat back to search collapses height again.
> 
> Three unit tests lock in search-after-tap, AI chat expansion, and mode-switch collapse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7003a9d6fad3f623bd68b20e90df70ed92aef518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>