### PR TITLE
escape hatch hide action ship review feedback

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1488,6 +1488,14 @@ extension Pixel {
         case ntpAfterIdleEscapeHatchAfterInactivitySettingChangedToNewTab
         case ntpAfterIdleEscapeHatchAfterInactivitySettingChangedToLastUsedTab
         case ntpAfterIdleEscapeHatchHiddenFromMenu
+        case ntpAfterIdleEscapeHatchShown
+        case ntpAfterIdleEscapeHatchMenuShown
+        case ntpAfterIdleEscapeHatchReturnToTabTappedFromMenu
+        case ntpAfterIdleEscapeHatchCloseTabTappedFromMenu
+        case ntpAfterIdleEscapeHatchBurnWithConfirmationTappedFromMenu
+        case ntpAfterIdleEscapeHatchBurnImmediatelyTappedFromMenu
+        case ntpAfterIdleEscapeHatchSwipeActionPerformed
+        case ntpAfterIdleEscapeHatchBurnTappedFromButton
         case ntpAfterIdleSettingChangedToNewTab
         case ntpAfterIdleSettingChangedToLastUsedTab
         case ntpAfterIdleSettingIdleIntervalChanged
@@ -3337,6 +3345,14 @@ extension Pixel.Event {
         case .ntpAfterIdleEscapeHatchAfterInactivitySettingChangedToNewTab: return "m_ntp_after_idle_escape_hatch_after_inactivity_setting_changed_to_new_tab"
         case .ntpAfterIdleEscapeHatchAfterInactivitySettingChangedToLastUsedTab: return "m_ntp_after_idle_escape_hatch_after_inactivity_setting_changed_to_last_used_tab"
         case .ntpAfterIdleEscapeHatchHiddenFromMenu: return "m_ntp_after_idle_escape_hatch_hidden_from_menu"
+        case .ntpAfterIdleEscapeHatchShown: return "m_ntp_after_idle_escape_hatch_shown"
+        case .ntpAfterIdleEscapeHatchMenuShown: return "m_ntp_after_idle_escape_hatch_menu_shown"
+        case .ntpAfterIdleEscapeHatchReturnToTabTappedFromMenu: return "m_ntp_after_idle_escape_hatch_return_to_tab_tapped_from_menu"
+        case .ntpAfterIdleEscapeHatchCloseTabTappedFromMenu: return "m_ntp_after_idle_escape_hatch_close_tab_tapped_from_menu"
+        case .ntpAfterIdleEscapeHatchBurnWithConfirmationTappedFromMenu: return "m_ntp_after_idle_escape_hatch_burn_with_confirmation_tapped_from_menu"
+        case .ntpAfterIdleEscapeHatchBurnImmediatelyTappedFromMenu: return "m_ntp_after_idle_escape_hatch_burn_immediately_tapped_from_menu"
+        case .ntpAfterIdleEscapeHatchSwipeActionPerformed: return "m_ntp_after_idle_escape_hatch_swipe_action_performed"
+        case .ntpAfterIdleEscapeHatchBurnTappedFromButton: return "m_ntp_after_idle_escape_hatch_burn_tapped_from_button"
         case .ntpAfterIdleSettingChangedToNewTab: return "m_ntp_after_idle_setting_changed_to_new_tab"
         case .ntpAfterIdleSettingChangedToLastUsedTab: return "m_ntp_after_idle_setting_changed_to_last_used_tab"
         case .ntpAfterIdleSettingIdleIntervalChanged: return "m_ntp_after_idle_setting_idle_interval_changed"

--- a/iOS/DuckDuckGo/AppLifecycle/LastTabShortcutAdapter.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/LastTabShortcutAdapter.swift
@@ -20,8 +20,8 @@
 import Foundation
 import Persistence
 
-/// Owns the "Last Tab Shortcut" preference, shared by the Settings toggle and the escape hatch's
-/// "Don't Show This" action so both stay in sync. Defaults to enabled when nothing is stored.
+/// Owns the "Last Used Tab Shortcut" preference, shared by the Settings toggle and the escape hatch's
+/// "Hide These Shortcuts" action so both stay in sync. Defaults to enabled when nothing is stored.
 final class LastTabShortcutAdapter: ObservableObject {
 
     @Published var isEnabled: Bool

--- a/iOS/DuckDuckGo/AppLifecycle/NTPAfterIdleInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/NTPAfterIdleInstrumentation.swift
@@ -61,7 +61,7 @@ protocol NTPAfterIdleInstrumentation: AnyObject {
     /// The user changed the Opening Screen option from the escape hatch's settings menu.
     func escapeHatchOptionChanged(to option: AfterInactivityOption)
 
-    /// The user hid the "Return to tab" shortcut via the card's "Don't Show This" menu item.
+    /// The user hid the "Return to tab" shortcut via the card's "Hide These Shortcuts" menu item.
     func escapeHatchHiddenFromMenu()
 }
 

--- a/iOS/DuckDuckGo/AppLifecycle/NTPAfterIdleInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/NTPAfterIdleInstrumentation.swift
@@ -63,6 +63,28 @@ protocol NTPAfterIdleInstrumentation: AnyObject {
 
     /// The user hid the "Return to tab" shortcut via the card's "Hide These Shortcuts" menu item.
     func escapeHatchHiddenFromMenu()
+
+    /// The escape hatch "Return to tab" card became visible.
+    func escapeHatchShown()
+
+    /// The user opened the escape hatch card's menu (three-dots or long-press).
+    func escapeHatchMenuShown()
+
+    /// The user selected "Return to Tab" from the escape hatch card's menu.
+    func escapeHatchReturnToTabTappedFromMenu()
+
+    /// The user selected "Close Tab" from the escape hatch card's menu.
+    func escapeHatchCloseTabTappedFromMenu()
+
+    /// The user selected "Delete Tab" from the escape hatch card's menu.
+    /// - Parameter requiredConfirmation: `true` when the burn flow shows the fire confirmation prompt, `false` when the tab is burned immediately.
+    func escapeHatchBurnTappedFromMenu(requiredConfirmation: Bool)
+
+    /// The user performed the primary swipe action on the escape hatch card.
+    func escapeHatchSwipeActionPerformed()
+
+    /// The user tapped the dedicated Fire (delete tab) button on the escape hatch card.
+    func escapeHatchBurnTappedFromButton()
 }
 
 final class DefaultNTPAfterIdleInstrumentation: NTPAfterIdleInstrumentation {
@@ -130,5 +152,33 @@ final class DefaultNTPAfterIdleInstrumentation: NTPAfterIdleInstrumentation {
 
     func escapeHatchHiddenFromMenu() {
         firePixel(.ntpAfterIdleEscapeHatchHiddenFromMenu)
+    }
+
+    func escapeHatchShown() {
+        firePixel(.ntpAfterIdleEscapeHatchShown)
+    }
+
+    func escapeHatchMenuShown() {
+        firePixel(.ntpAfterIdleEscapeHatchMenuShown)
+    }
+
+    func escapeHatchReturnToTabTappedFromMenu() {
+        firePixel(.ntpAfterIdleEscapeHatchReturnToTabTappedFromMenu)
+    }
+
+    func escapeHatchCloseTabTappedFromMenu() {
+        firePixel(.ntpAfterIdleEscapeHatchCloseTabTappedFromMenu)
+    }
+
+    func escapeHatchBurnTappedFromMenu(requiredConfirmation: Bool) {
+        firePixel(requiredConfirmation ? .ntpAfterIdleEscapeHatchBurnWithConfirmationTappedFromMenu : .ntpAfterIdleEscapeHatchBurnImmediatelyTappedFromMenu)
+    }
+
+    func escapeHatchSwipeActionPerformed() {
+        firePixel(.ntpAfterIdleEscapeHatchSwipeActionPerformed)
+    }
+
+    func escapeHatchBurnTappedFromButton() {
+        firePixel(.ntpAfterIdleEscapeHatchBurnTappedFromButton)
     }
 }

--- a/iOS/DuckDuckGo/EscapeHatchModel.swift
+++ b/iOS/DuckDuckGo/EscapeHatchModel.swift
@@ -80,7 +80,7 @@ final class EscapeHatchModel: ObservableObject {
     /// When on, the destructive "delete tab" action is surfaced as a dedicated Fire button on the card
     /// instead of (and removed from) the three-dots menu. Gated by the `escapeHatchFireButton` feature flag.
     let isFireButtonEnabled: Bool
-    /// When on, the "Don't Show This" menu item is surfaced and the card can be hidden, leaving only the tab
+    /// When on, the "Hide These Shortcuts" menu item is surfaced and the card can be hidden, leaving only the tab
     /// switcher pill. Gated by the `escapeHatchHideShortcut` feature flag.
     let isHideShortcutEnabled: Bool
     let onCardTap: () -> Void

--- a/iOS/DuckDuckGo/EscapeHatchModel.swift
+++ b/iOS/DuckDuckGo/EscapeHatchModel.swift
@@ -90,6 +90,8 @@ final class EscapeHatchModel: ObservableObject {
     let onBurnTabImmediately: () -> Void
     let onOpeningScreenOptionChanged: (AfterInactivityOption) -> Void
     let onShortcutHidden: () -> Void
+    /// Fires the menu / impression / swipe telemetry that the router can't attribute (it can't tell which surface triggered an action).
+    private let instrumentation: NTPAfterIdleInstrumentation?
 
     init(title: String,
          subtitle: String,
@@ -109,7 +111,8 @@ final class EscapeHatchModel: ObservableObject {
          onBurnTabWithConfirmation: @escaping (CGRect) -> Void,
          onBurnTabImmediately: @escaping () -> Void,
          onOpeningScreenOptionChanged: @escaping (AfterInactivityOption) -> Void = { _ in },
-         onShortcutHidden: @escaping () -> Void = {}) {
+         onShortcutHidden: @escaping () -> Void = {},
+         instrumentation: NTPAfterIdleInstrumentation? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.tabType = tabType
@@ -128,6 +131,7 @@ final class EscapeHatchModel: ObservableObject {
         self.onBurnTabImmediately = onBurnTabImmediately
         self.onOpeningScreenOptionChanged = onOpeningScreenOptionChanged
         self.onShortcutHidden = onShortcutHidden
+        self.instrumentation = instrumentation
 
         subscribeToTabsSource(tabsSource)
         startForwardingAdapterWillChangeEvents(afterInactivityOptionAdapter)
@@ -136,7 +140,7 @@ final class EscapeHatchModel: ObservableObject {
 
     /// Builds the model with action closures wired to a router. The router is captured weakly so holders of `EscapeHatchModel` don't pin its owner's lifecycle.
     ///
-    convenience init(title: String, subtitle: String, tabType: TabType, domain: String?, targetTab: Tab, tabsSource: some EscapeHatchTabsSource, hasReturnToTabCard: Bool = true, router: EscapeHatchActionRouter, featureFlagger: FeatureFlagger, afterInactivityOptionAdapter: AfterInactivityOptionAdapter, lastTabShortcutAdapter: LastTabShortcutAdapter, onShortcutHidden: @escaping () -> Void = {}) {
+    convenience init(title: String, subtitle: String, tabType: TabType, domain: String?, targetTab: Tab, tabsSource: some EscapeHatchTabsSource, hasReturnToTabCard: Bool = true, router: EscapeHatchActionRouter, featureFlagger: FeatureFlagger, afterInactivityOptionAdapter: AfterInactivityOptionAdapter, lastTabShortcutAdapter: LastTabShortcutAdapter, onShortcutHidden: @escaping () -> Void = {}, instrumentation: NTPAfterIdleInstrumentation? = nil) {
         self.init(
             title: title,
             subtitle: subtitle,
@@ -168,7 +172,8 @@ final class EscapeHatchModel: ObservableObject {
             onOpeningScreenOptionChanged: { [weak router] option in
                 router?.escapeHatchDidChangeOpeningScreenOption(to: option)
             },
-            onShortcutHidden: onShortcutHidden
+            onShortcutHidden: onShortcutHidden,
+            instrumentation: instrumentation
         )
     }
 
@@ -246,6 +251,52 @@ extension EscapeHatchModel {
         isFireTab
             ? SwipeAction(label: UserText.escapeHatchMenuDeleteTab, perform: onBurnTabImmediately)
             : SwipeAction(label: UserText.escapeHatchMenuCloseTab, perform: onCloseTab)
+    }
+
+    // MARK: - Surface-attributed telemetry
+    //
+    // The router fires the generic action pixels (close/burn/return), but it can't tell which surface
+    // triggered the action. These wrappers fire the menu / swipe / impression pixels at the call site —
+    // where the surface is known — then delegate to the same action closure as before.
+
+    /// The card's menu (three-dots or long-press) was opened.
+    func menuDidAppear() {
+        instrumentation?.escapeHatchMenuShown()
+    }
+
+    func returnToTabFromMenu() {
+        instrumentation?.escapeHatchReturnToTabTappedFromMenu()
+        onCardTap()
+    }
+
+    func closeTabFromMenu() {
+        instrumentation?.escapeHatchCloseTabTappedFromMenu()
+        onCloseTab()
+    }
+
+    func burnImmediatelyFromMenu() {
+        instrumentation?.escapeHatchBurnTappedFromMenu(requiredConfirmation: false)
+        onBurnTabImmediately()
+    }
+
+    func burnWithConfirmationFromMenu(_ sourceRect: CGRect) {
+        instrumentation?.escapeHatchBurnTappedFromMenu(requiredConfirmation: true)
+        onBurnTabWithConfirmation(sourceRect)
+    }
+
+    func performPrimarySwipeAction() {
+        instrumentation?.escapeHatchSwipeActionPerformed()
+        primarySwipeAction.perform()
+    }
+
+    /// The dedicated Fire button on the card: fire tabs burn immediately, everything else asks for confirmation.
+    func burnFromButton(_ sourceRect: CGRect) {
+        instrumentation?.escapeHatchBurnTappedFromButton()
+        if isFireTab {
+            onBurnTabImmediately()
+        } else {
+            onBurnTabWithConfirmation(sourceRect)
+        }
     }
 }
 

--- a/iOS/DuckDuckGo/EscapeHatchModelBuilder.swift
+++ b/iOS/DuckDuckGo/EscapeHatchModelBuilder.swift
@@ -111,7 +111,8 @@ struct EscapeHatchModelBuilder {
             featureFlagger: featureFlagger,
             afterInactivityOptionAdapter: afterInactivityOptionAdapter,
             lastTabShortcutAdapter: lastTabShortcutAdapter,
-            onShortcutHidden: { [instrumentation] in instrumentation.escapeHatchHiddenFromMenu() }
+            onShortcutHidden: { [instrumentation] in instrumentation.escapeHatchHiddenFromMenu() },
+            instrumentation: instrumentation
         )
     }
 }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1750,7 +1750,7 @@ class MainViewController: UIViewController {
         // about to shown to the user.
         if presentedViewController == nil || presentedViewController?.isBeingDismissed == true {
             fireNewTabPixels()
-            fireNTPShownInstrumentation(openedAfterIdle: openedAfterIdle)
+            fireNTPShownInstrumentation(openedAfterIdle: openedAfterIdle, hatch: hatch)
         }
 
         // Suppress keyboard-on-new-tab when an NTP onboarding dialog is about to appear:
@@ -1777,8 +1777,14 @@ class MainViewController: UIViewController {
         unifiedToggleInputCoordinator?.setEscapeHatch(hatch)
     }
 
-    private func fireNTPShownInstrumentation(openedAfterIdle: Bool) {
+    private func fireNTPShownInstrumentation(openedAfterIdle: Bool, hatch: EscapeHatchModel?) {
         ntpAfterIdleInstrumentation.ntpShown(afterIdle: openedAfterIdle)
+        // Fire the card impression once per presentation here (not from the card's onAppear): the same hatch
+        // model is mounted in several hosts — NTP, suggestions, AI-chat history — so a view-level hook counts
+        // once per mount.
+        if hatch?.isReturnToTabCardVisible == true {
+            ntpAfterIdleInstrumentation.escapeHatchShown()
+        }
         if openedAfterIdle {
             postIdleSessionInstrumentation.sessionStarted(surface: .ntp)
         }

--- a/iOS/DuckDuckGo/ReturnToTabCard.swift
+++ b/iOS/DuckDuckGo/ReturnToTabCard.swift
@@ -47,7 +47,7 @@ struct ReturnToTabCard: View {
 
     @ViewBuilder
     private func bodyWithActions(width: CGFloat) -> some View {
-        SwipeActionView(onCommit: model.primarySwipeAction.perform) {
+        SwipeActionView(onCommit: model.performPrimarySwipeAction) {
             contentView
         } actions: {
             swipeableActionsView
@@ -140,11 +140,7 @@ struct ReturnToTabCard: View {
     }
 
     private func deleteTab() {
-        if model.isFireTab {
-            model.onBurnTabImmediately()
-        } else {
-            model.onBurnTabWithConfirmation(fireButtonFrameInWindow)
-        }
+        model.burnFromButton(fireButtonFrameInWindow)
     }
 
     private var menuView: some View {
@@ -171,7 +167,7 @@ struct ReturnToTabCard: View {
                 text: UserText.escapeHatchMenuReturnToTab,
                 icon: DesignSystemImages.Glyphs.Size16.goBackCircle,
                 role: .none,
-                action: model.onCardTap
+                action: model.returnToTabFromMenu
             )
             destructiveActionButtons
             if model.isHideShortcutEnabled{
@@ -188,6 +184,7 @@ struct ReturnToTabCard: View {
                 afterInactivityPicker
             }
         }
+        .onAppear { model.menuDidAppear() }
     }
 
     @ViewBuilder
@@ -199,7 +196,7 @@ struct ReturnToTabCard: View {
                     text: UserText.escapeHatchMenuDeleteTab,
                     icon: DesignSystemImages.Glyphs.Size16.fire,
                     role: .destructive,
-                    action: model.onBurnTabImmediately
+                    action: model.burnImmediatelyFromMenu
                 )
             }
         } else {
@@ -207,14 +204,14 @@ struct ReturnToTabCard: View {
                 text: UserText.escapeHatchMenuCloseTab,
                 icon: DesignSystemImages.Glyphs.Size16.closeOutline,
                 role: .destructive,
-                action: model.onCloseTab
+                action: model.closeTabFromMenu
             )
             if !model.isFireButtonEnabled {
                 MenuActionButton(
                     text: UserText.escapeHatchMenuDeleteTab,
                     icon: DesignSystemImages.Glyphs.Size16.fire,
                     role: .destructive,
-                    action: { model.onBurnTabWithConfirmation(menuFrameInWindow) }
+                    action: { model.burnWithConfirmationFromMenu(menuFrameInWindow) }
                 )
             }
         }

--- a/iOS/DuckDuckGo/ReturnToTabCard.swift
+++ b/iOS/DuckDuckGo/ReturnToTabCard.swift
@@ -174,21 +174,17 @@ struct ReturnToTabCard: View {
                 action: model.onCardTap
             )
             destructiveActionButtons
-            if model.isHideShortcutEnabled {
-                MenuActionButton(
-                    text: UserText.escapeHatchMenuDontShowThis,
-                    icon: DesignSystemImages.Glyphs.Size16.eyeClosed,
-                    role: .none,
-                    action: model.hideShortcut
-                )
+            if model.isHideShortcutEnabled{
+                Section {
+                    afterInactivityPicker
+                    MenuActionButton(
+                        text: UserText.escapeHatchMenuHideTheseShortcuts,
+                        icon: DesignSystemImages.Glyphs.Size16.eyeClosed,
+                        role: .none,
+                        action: model.hideShortcut
+                    )
+                }
             } else {
-                afterInactivityPicker
-            }
-        }
-
-        // With the hide shortcut, the After Inactivity option moves to its own section, below a divider.
-        if model.isHideShortcutEnabled {
-            Section {
                 afterInactivityPicker
             }
         }

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -1669,8 +1669,8 @@ public struct UserText {
     public static let settingsAfterInactivityIntervalLabel = NSLocalizedString("settings.afterInactivity.interval.label", value: "Inactivity Timer", comment: "Settings picker label for the inactivity duration before showing New Tab")
     public static let settingsAfterInactivityIdleIntervalNone = NSLocalizedString("settings.afterInactivity.idle.interval.none", value: "None", comment: "Idle interval option meaning the New Tab Page is shown every time the user returns (no inactivity threshold)")
     public static let settingsAfterInactivityFooterNone = NSLocalizedString("settings.afterInactivity.footer.none", value: "Choose what you see when you return to DuckDuckGo.", comment: "Section footer when no inactivity timer is set or the Last Used Tab option is selected")
-    public static let settingsLastTabShortcutLabel = NotLocalizedString("settings.lastTabShortcut.label", value: "Last Tab Shortcut", comment: "Settings toggle label for showing a shortcut back to the last used tab on the New Tab Page after inactivity. Not translated; final copy will land in a follow-up PR.")
-    public static let settingsLastTabShortcutSubtitle = NotLocalizedString("settings.lastTabShortcut.subtitle", value: "Displays a link to quickly revisit the last opened tab when you launch the app after inactivity.", comment: "Settings toggle subtitle describing the Last Tab Shortcut option. Not translated; final copy will land in a follow-up PR.")
+    public static let settingsLastTabShortcutLabel = NotLocalizedString("settings.lastTabShortcut.label", value: "Last Used Tab Shortcut", comment: "Settings toggle label for showing a shortcut back to the last used tab on the New Tab Page after inactivity. Not translated; final copy will land in a follow-up PR.")
+    public static let settingsLastTabShortcutSubtitle = NotLocalizedString("settings.lastTabShortcut.subtitle", value: "Displays a link to return to the last used tab when you launch the app after inactivity.", comment: "Settings toggle subtitle describing the Last Used Tab Shortcut option. Not translated; final copy will land in a follow-up PR.")
 
     // Escape Hatch (Return to Tab Card)
     public static let escapeHatchReturnToLabel = NSLocalizedString("escapeHatch.returnTo.label", value: "Return to…", comment: "Label shown on the escape hatch card above the tab title")
@@ -1682,9 +1682,9 @@ public struct UserText {
     public static let escapeHatchMenuReturnToTab = NSLocalizedString("escapeHatch.menu.returnToTab", value: "Return to Tab", comment: "Menu item that returns the user to the open tab from the escape hatch card")
     public static let escapeHatchMenuCloseTab = NSLocalizedString("escapeHatch.menu.closeTab", value: "Close Tab", comment: "Menu item that closes the open tab referenced by the escape hatch card")
     public static let escapeHatchMenuDeleteTab = NSLocalizedString("escapeHatch.menu.deleteTab", value: "Delete Tab", comment: "Menu item that deletes (closes and clears data for) the tab referenced by the escape hatch card")
-    public static let escapeHatchMenuDontShowThis = NotLocalizedString("escapeHatch.menu.dontShowThis", value: "Don’t Show This", comment: "Menu item that hides the 'Return to tab' shortcut so only the tab switcher is shown after inactivity. Not translated; final copy will land in a follow-up PR.")
+    public static let escapeHatchMenuHideTheseShortcuts = NotLocalizedString("escapeHatch.menu.dontShowThis", value: "Hide These Shortcuts", comment: "Menu item that hides the 'Return to tab' shortcut so only the tab switcher is shown after inactivity. Not translated; final copy will land in a follow-up PR.")
     public static let escapeHatchTabSwitcherPrivateTabsLabel = NSLocalizedString("escapeHatch.tabSwitcher.privateTabs.label", value: "Private Tabs", comment: "Label shown next to the tab count when the escape hatch's tab switcher pill is in its expanded form")
-
+    
     // Subscription Section
     public static let settingsSubscriptionSection = NSLocalizedString("settings.subscription.Section", value: "DuckDuckGo Subscription", comment: "Product name for the subscription bundle")
     public static let settingsPProSectionFooter = NSLocalizedString("settings.ppro.footer", value: "Privacy Policy and Terms of Service", comment: "Title for Link in the Footer of Privacy Pro section")

--- a/iOS/DuckDuckGoTests/EscapeHatchModelTests.swift
+++ b/iOS/DuckDuckGoTests/EscapeHatchModelTests.swift
@@ -48,11 +48,37 @@ struct EscapeHatchModelTests {
         }
     }
 
+    /// Records the surface-attributed events the view fires through the model wrappers; all other protocol methods are no-ops.
+    private final class SpyInstrumentation: NTPAfterIdleInstrumentation {
+        private(set) var firedEvents: [String] = []
+
+        func ntpShown(afterIdle: Bool) {}
+        func returnToPageTapped(afterIdle: Bool) {}
+        func barUsedFromNTP(afterIdle: Bool) {}
+        func toggleUsedFromNTP(afterIdle: Bool) {}
+        func backButtonUsedFromNTP(afterIdle: Bool) {}
+        func appBackgroundedFromNTP(afterIdle: Bool) {}
+        func tabSwitcherSelectedFromNTP(afterIdle: Bool) {}
+        func escapeHatchTabSwitcherTapped() {}
+        func escapeHatchCloseTabTapped() {}
+        func escapeHatchBurnTapped(requiredConfirmation: Bool) {}
+        func escapeHatchOptionChanged(to option: AfterInactivityOption) {}
+        func escapeHatchHiddenFromMenu() {}
+        func escapeHatchShown() { firedEvents.append("shown") }
+        func escapeHatchMenuShown() { firedEvents.append("menuShown") }
+        func escapeHatchReturnToTabTappedFromMenu() { firedEvents.append("returnToTabFromMenu") }
+        func escapeHatchCloseTabTappedFromMenu() { firedEvents.append("closeTabFromMenu") }
+        func escapeHatchBurnTappedFromMenu(requiredConfirmation: Bool) { firedEvents.append(requiredConfirmation ? "burnWithConfirmationFromMenu" : "burnImmediatelyFromMenu") }
+        func escapeHatchSwipeActionPerformed() { firedEvents.append("swipe") }
+        func escapeHatchBurnTappedFromButton() { firedEvents.append("burnFromButton") }
+    }
+
     private func makeSUT(targetTab: Tab,
                          router: EscapeHatchActionRouter,
                          featureFlagger: FeatureFlagger = MockFeatureFlagger(),
                          lastTabShortcutAdapter: LastTabShortcutAdapter = LastTabShortcutAdapter(keyValueStore: MockKeyValueFileStore()),
-                         onShortcutHidden: @escaping () -> Void = {}) -> EscapeHatchModel {
+                         onShortcutHidden: @escaping () -> Void = {},
+                         instrumentation: NTPAfterIdleInstrumentation? = nil) -> EscapeHatchModel {
         EscapeHatchModel(
             title: "title",
             subtitle: "subtitle",
@@ -67,7 +93,8 @@ struct EscapeHatchModelTests {
                 keyValueStore: MockKeyValueFileStore()
             ),
             lastTabShortcutAdapter: lastTabShortcutAdapter,
-            onShortcutHidden: onShortcutHidden
+            onShortcutHidden: onShortcutHidden,
+            instrumentation: instrumentation
         )
     }
 
@@ -192,5 +219,77 @@ struct EscapeHatchModelTests {
 
         #expect(sut.isLastTabShortcutEnabled == true)
         #expect(sut.isReturnToTabCardVisible == true)
+    }
+
+    // MARK: - Surface-attributed telemetry
+
+    @available(iOS 16, *)
+    @Test("menuDidAppear fires the menu shown pixel", .timeLimit(.minutes(1)))
+    func menuDidAppearFiresMenuShown() {
+        let spy = SpyInstrumentation()
+        let sut = makeSUT(targetTab: Tab(uid: "tab"), router: SpyRouter(), instrumentation: spy)
+
+        sut.menuDidAppear()
+
+        #expect(spy.firedEvents == ["menuShown"])
+    }
+
+    @available(iOS 16, *)
+    @Test("closeTabFromMenu fires the menu pixel and delegates to the close action", .timeLimit(.minutes(1)))
+    func closeTabFromMenuFiresPixelAndDelegates() {
+        let targetTab = Tab(uid: "tab")
+        let router = SpyRouter()
+        let spy = SpyInstrumentation()
+        let sut = makeSUT(targetTab: targetTab, router: router, instrumentation: spy)
+
+        sut.closeTabFromMenu()
+
+        #expect(spy.firedEvents == ["closeTabFromMenu"])
+        #expect(router.closeCalls.count == 1)
+        #expect(router.closeCalls.first === targetTab)
+    }
+
+    @available(iOS 16, *)
+    @Test("burnImmediatelyFromMenu fires the menu pixel and delegates to the burn action", .timeLimit(.minutes(1)))
+    func burnImmediatelyFromMenuFiresPixelAndDelegates() {
+        let targetTab = Tab(uid: "tab")
+        let router = SpyRouter()
+        let spy = SpyInstrumentation()
+        let sut = makeSUT(targetTab: targetTab, router: router, instrumentation: spy)
+
+        sut.burnImmediatelyFromMenu()
+
+        #expect(spy.firedEvents == ["burnImmediatelyFromMenu"])
+        #expect(router.burnImmediatelyCalls.count == 1)
+        #expect(router.burnImmediatelyCalls.first === targetTab)
+    }
+
+    @available(iOS 16, *)
+    @Test("performPrimarySwipeAction fires the swipe pixel and delegates to the primary action", .timeLimit(.minutes(1)))
+    func performPrimarySwipeActionFiresPixelAndDelegates() {
+        let targetTab = Tab(uid: "regular-tab")
+        let router = SpyRouter()
+        let spy = SpyInstrumentation()
+        let sut = makeSUT(targetTab: targetTab, router: router, instrumentation: spy)
+
+        sut.performPrimarySwipeAction()
+
+        #expect(spy.firedEvents == ["swipe"])
+        #expect(router.closeCalls.count == 1)
+        #expect(router.closeCalls.first === targetTab)
+    }
+
+    @available(iOS 16, *)
+    @Test("burnFromButton fires the button pixel and delegates with confirmation for a regular tab", .timeLimit(.minutes(1)))
+    func burnFromButtonFiresPixelAndDelegates() {
+        let targetTab = Tab(uid: "regular-tab")
+        let router = SpyRouter()
+        let spy = SpyInstrumentation()
+        let sut = makeSUT(targetTab: targetTab, router: router, instrumentation: spy)
+
+        sut.burnFromButton(.zero)
+
+        #expect(spy.firedEvents == ["burnFromButton"])
+        #expect(router.burnImmediatelyCalls.isEmpty) // regular tab → confirmation flow, not immediate
     }
 }

--- a/iOS/DuckDuckGoTests/NTPAfterIdleInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/NTPAfterIdleInstrumentationTests.swift
@@ -273,6 +273,78 @@ struct NTPAfterIdleInstrumentationTests {
         #expect(collector.firedPixelNames == [Pixel.Event.ntpAfterIdleEscapeHatchAfterInactivitySettingChangedToLastUsedTab.name])
     }
 
+    // MARK: - escapeHatchShown / escapeHatchMenuShown
+
+    @available(iOS 16, *)
+    @Test("When escape hatch shown then fires the shown pixel", .timeLimit(.minutes(1)))
+    func whenEscapeHatchShownThenFiresCorrectPixel() {
+        let (sut, collector) = makeSUT()
+        sut.escapeHatchShown()
+        #expect(collector.firedPixelNames == [Pixel.Event.ntpAfterIdleEscapeHatchShown.name])
+    }
+
+    @available(iOS 16, *)
+    @Test("When escape hatch menu shown then fires the menu_shown pixel", .timeLimit(.minutes(1)))
+    func whenEscapeHatchMenuShownThenFiresCorrectPixel() {
+        let (sut, collector) = makeSUT()
+        sut.escapeHatchMenuShown()
+        #expect(collector.firedPixelNames == [Pixel.Event.ntpAfterIdleEscapeHatchMenuShown.name])
+    }
+
+    // MARK: - Menu-specific actions
+
+    @available(iOS 16, *)
+    @Test("When return to tab tapped from menu then fires the from_menu pixel", .timeLimit(.minutes(1)))
+    func whenReturnToTabTappedFromMenuThenFiresCorrectPixel() {
+        let (sut, collector) = makeSUT()
+        sut.escapeHatchReturnToTabTappedFromMenu()
+        #expect(collector.firedPixelNames == [Pixel.Event.ntpAfterIdleEscapeHatchReturnToTabTappedFromMenu.name])
+    }
+
+    @available(iOS 16, *)
+    @Test("When close tab tapped from menu then fires the from_menu pixel", .timeLimit(.minutes(1)))
+    func whenCloseTabTappedFromMenuThenFiresCorrectPixel() {
+        let (sut, collector) = makeSUT()
+        sut.escapeHatchCloseTabTappedFromMenu()
+        #expect(collector.firedPixelNames == [Pixel.Event.ntpAfterIdleEscapeHatchCloseTabTappedFromMenu.name])
+    }
+
+    @available(iOS 16, *)
+    @Test("When burn tapped from menu with confirmation then fires the with_confirmation_from_menu pixel", .timeLimit(.minutes(1)))
+    func whenBurnTappedFromMenuWithConfirmationThenFiresCorrectPixel() {
+        let (sut, collector) = makeSUT()
+        sut.escapeHatchBurnTappedFromMenu(requiredConfirmation: true)
+        #expect(collector.firedPixelNames == [Pixel.Event.ntpAfterIdleEscapeHatchBurnWithConfirmationTappedFromMenu.name])
+    }
+
+    @available(iOS 16, *)
+    @Test("When burn tapped from menu immediately then fires the immediately_from_menu pixel", .timeLimit(.minutes(1)))
+    func whenBurnTappedFromMenuImmediatelyThenFiresCorrectPixel() {
+        let (sut, collector) = makeSUT()
+        sut.escapeHatchBurnTappedFromMenu(requiredConfirmation: false)
+        #expect(collector.firedPixelNames == [Pixel.Event.ntpAfterIdleEscapeHatchBurnImmediatelyTappedFromMenu.name])
+    }
+
+    // MARK: - escapeHatchSwipeActionPerformed
+
+    @available(iOS 16, *)
+    @Test("When swipe action performed then fires the swipe pixel", .timeLimit(.minutes(1)))
+    func whenSwipeActionPerformedThenFiresCorrectPixel() {
+        let (sut, collector) = makeSUT()
+        sut.escapeHatchSwipeActionPerformed()
+        #expect(collector.firedPixelNames == [Pixel.Event.ntpAfterIdleEscapeHatchSwipeActionPerformed.name])
+    }
+
+    // MARK: - escapeHatchBurnTappedFromButton
+
+    @available(iOS 16, *)
+    @Test("When burn tapped from button then fires the from_button pixel", .timeLimit(.minutes(1)))
+    func whenBurnTappedFromButtonThenFiresCorrectPixel() {
+        let (sut, collector) = makeSUT()
+        sut.escapeHatchBurnTappedFromButton()
+        #expect(collector.firedPixelNames == [Pixel.Event.ntpAfterIdleEscapeHatchBurnTappedFromButton.name])
+    }
+
     // MARK: - Multiple calls accumulate
 
     @Test("When multiple methods called then all pixels are recorded")

--- a/iOS/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
@@ -147,6 +147,62 @@
         "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
+    "m_ntp_after_idle_escape_hatch_shown": {
+        "description": "Fires when the NTP escape hatch 'Return to tab' card becomes visible. Denominator for the menu-engagement funnel (card impression -> menu impression -> action).",
+        "owners": ["SabrinaTardio"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_escape_hatch_menu_shown": {
+        "description": "Fires when the user opens the NTP escape hatch card menu (three-dots button or long-press). Counts a menu impression regardless of which gesture opened it.",
+        "owners": ["SabrinaTardio"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_escape_hatch_return_to_tab_tapped_from_menu": {
+        "description": "Fires when the user selects 'Return to Tab' from the NTP escape hatch card menu. Menu-specific; the generic return_to_page_tapped pixel also fires (it covers taps from any surface).",
+        "owners": ["SabrinaTardio"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_escape_hatch_close_tab_tapped_from_menu": {
+        "description": "Fires when the user selects 'Close Tab' from the NTP escape hatch card menu. Menu-specific; the generic close_tab_tapped pixel also fires (it covers the swipe action too).",
+        "owners": ["SabrinaTardio"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_escape_hatch_burn_with_confirmation_tapped_from_menu": {
+        "description": "Fires when the user selects 'Delete Tab' from the NTP escape hatch card menu and the fire confirmation prompt is shown. Menu-specific; the generic burn_with_confirmation_tapped pixel also fires (it covers the swipe and fire-button surfaces too).",
+        "owners": ["SabrinaTardio"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_escape_hatch_burn_immediately_tapped_from_menu": {
+        "description": "Fires when the user selects 'Delete Tab' from the NTP escape hatch card menu and the tab is burned immediately without confirmation. Menu-specific; the generic burn_immediately_tapped pixel also fires (it covers the swipe and fire-button surfaces too).",
+        "owners": ["SabrinaTardio"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_escape_hatch_swipe_action_performed": {
+        "description": "Fires when the user performs the primary swipe action on the NTP escape hatch card (close for regular tabs, delete for fire tabs). Distinguishes swipe usage from the menu and fire-button surfaces.",
+        "owners": ["SabrinaTardio"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_escape_hatch_burn_tapped_from_button": {
+        "description": "Fires when the user taps the dedicated Fire (delete tab) button on the NTP escape hatch card. Distinguishes the fire-button surface from the menu and swipe; the generic burn_immediately/with_confirmation pixels also fire.",
+        "owners": ["SabrinaTardio"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
     "m_ntp_after_idle_setting_changed_to_new_tab": {
         "description": "Fires when the user changes the after-inactivity setting to New Tab.",
         "owners": ["SabrinaTardio"],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215632126772185?focus=true

### Description
Updates copy and escape hatch menu order

### Testing Steps
1. Trigger the escape hatch and check new copy and order applies 
2. Go to settings general and check copy is updated

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to escape hatch UI copy, menu structure, and additive privacy pixels with tests; tab close/burn behavior stays on existing router paths.
> 
> **Overview**
> Ship-review updates for the NTP **escape hatch** (return-to-tab card): copy is aligned to **“Hide These Shortcuts”** and **“Last Used Tab Shortcut”** in settings and related comments, and when the hide-shortcut flag is on the card menu groups the **after-inactivity picker** with that hide action in one section instead of splitting them.
> 
> The PR also adds **surface-specific analytics** for the escape hatch funnel—card shown, menu opened, menu vs swipe vs Fire-button actions—via new `Pixel.Event` cases, `NTPAfterIdleInstrumentation` hooks, and `EscapeHatchModel` wrappers that fire pixels before delegating to existing router actions. **Card impression** is counted once from `MainViewController` when the return-to-tab card is actually visible (avoiding duplicate `onAppear` across hosts). `ReturnToTabCard` routes interactions through those wrappers; pixel definitions and unit tests cover the new events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07df4ffa512bbc0b97a27b2bbd9fa10c77325f11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->