### PR TITLE
iOS: Fix navigation bar stuck hidden on error page

### DIFF
--- a/iOS/DuckDuckGo/BrowserChromeManager.swift
+++ b/iOS/DuckDuckGo/BrowserChromeManager.swift
@@ -22,6 +22,7 @@ import UIKit
 protocol BrowserChromeDelegate: AnyObject {
     
     func setBarsHidden(_ hidden: Bool, animated: Bool, customAnimationDuration: CGFloat?)
+    func resetBars(animated: Bool)
     func setNavigationBarHidden(_ hidden: Bool)
     func setRefreshControlEnabled(_ isEnabled: Bool)
     func setUnifiedInputContentOverlaySuppressed(_ suppressed: Bool)

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3651,6 +3651,10 @@ extension MainViewController: BrowserChromeDelegate {
 
         setBarsVisibility(hidden ? 0 : 1.0, animated: animated, animationDuration: customAnimationDuration)
     }
+
+    func resetBars(animated: Bool) {
+        chromeManager.reset(animated: animated)
+    }
     
     func setBarsVisibility(_ percent: CGFloat, animated: Bool, animationDuration: CGFloat?) {
         if percent < 1 {
@@ -3724,6 +3728,8 @@ extension MainViewController: BrowserChromeDelegate {
     }
 
     var canHideBars: Bool {
+        // Keep bars shown on the error page: the webView is hidden, so scroll can't self-heal a stuck-hidden bar.
+        if currentTab?.isError == true { return false }
         return !daxDialogsManager.shouldShowFireButtonPulse
     }
 

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -1474,7 +1474,8 @@ class TabViewController: UIViewController {
     }
 
     private func showBars(animated: Bool = true) {
-        chromeDelegate?.setBarsHidden(false, animated: animated, customAnimationDuration: nil)
+        // resetBars syncs BarsAnimator's state; setBarsHidden alone leaves it stale and the chrome can stick hidden.
+        chromeDelegate?.resetBars(animated: animated)
     }
 
     private func hideBars(animated: Bool = true) {

--- a/iOS/DuckDuckGoTests/BarsAnimatorTests.swift
+++ b/iOS/DuckDuckGoTests/BarsAnimatorTests.swift
@@ -146,6 +146,49 @@ class BarsAnimatorTests: XCTestCase {
 
         XCTAssertEqual(delegate.receivedMessages, [])
     }
+
+    // Force-revealing must reset the state from .hidden back to .revealed. The error-page reveal
+    // relies on this (routed through chromeManager.reset) so the bars can't get stuck hidden.
+    func testRevealBarsResetsHiddenStateToRevealed() {
+        let (sut, delegate) = makeSUT()
+        let scrollView = mockScrollView()
+
+        scrollView.contentOffset.y = 100
+        sut.didStartScrolling(in: scrollView)
+        scrollView.contentOffset.y = 200
+        sut.didScroll(in: scrollView)
+        scrollView.contentOffset.y = 300
+        sut.didScroll(in: scrollView)
+        XCTAssertEqual(sut.barsState, .hidden)
+
+        sut.revealBars(animated: true)
+
+        XCTAssertEqual(sut.barsState, .revealed)
+        XCTAssertEqual(delegate.receivedMessages.last, .setBarsVisibility(1.0))
+    }
+
+    // After a force-reveal a trailing scroll-end must not re-hide the bars (the stuck "no buttons" bug).
+    func testRevealedBarsAreNotReHiddenByTrailingScrollEnd() {
+        let (sut, delegate) = makeSUT()
+        let scrollView = mockScrollView()
+
+        scrollView.contentOffset.y = 100
+        sut.didStartScrolling(in: scrollView)
+        scrollView.contentOffset.y = 200
+        sut.didScroll(in: scrollView)
+        scrollView.contentOffset.y = 300
+        sut.didScroll(in: scrollView)
+        XCTAssertEqual(sut.barsState, .hidden)
+
+        sut.revealBars(animated: true)
+        XCTAssertEqual(sut.barsState, .revealed)
+
+        scrollView.contentOffset.y = 100
+        sut.didFinishScrolling(in: scrollView, velocity: 0)
+
+        XCTAssertEqual(sut.barsState, .revealed)
+        XCTAssertEqual(delegate.receivedMessages.last, .setBarsVisibility(1.0))
+    }
 }
 
 // MARK: - Helpers
@@ -177,6 +220,7 @@ private class BrowserChromeDelegateMock: BrowserChromeDelegate {
 
     enum Message: Equatable {
         case setBarsHidden(Bool)
+        case resetBars
         case setNavigationBarHidden(Bool)
         case setBarsVisibility(CGFloat)
         case setRefreshControlEnabled(Bool)
@@ -195,6 +239,10 @@ private class BrowserChromeDelegateMock: BrowserChromeDelegate {
 
     func setBarsHidden(_ hidden: Bool, animated: Bool) {
         receivedMessages.append(.setBarsHidden(hidden))
+    }
+
+    func resetBars(animated: Bool) {
+        receivedMessages.append(.resetBars)
     }
 
     func setNavigationBarHidden(_ hidden: Bool) {

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/DuckPlayerMocks.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/DuckPlayerMocks.swift
@@ -582,6 +582,7 @@ final class DuckPlayerBrowserChromeDelegateMock: BrowserChromeDelegate {
 
     enum Message: Equatable {
         case setBarsHidden(Bool)
+        case resetBars
         case setNavigationBarHidden(Bool)
         case setBarsVisibility(CGFloat)
         case setRefreshControlEnabled(Bool)
@@ -591,6 +592,10 @@ final class DuckPlayerBrowserChromeDelegateMock: BrowserChromeDelegate {
 
     func setBarsHidden(_ hidden: Bool, animated: Bool) {
         receivedMessages.append(.setBarsHidden(hidden))
+    }
+
+    func resetBars(animated: Bool) {
+        receivedMessages.append(.resetBars)
     }
 
     func setNavigationBarHidden(_ hidden: Bool) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1211689879271276?focus=true
Tech Design URL:
CC:

### Description
If a page load fails (e.g. no connectivity) while the chrome (address bar plus toolbar buttons) is hiding on scroll, it can get stuck hidden, recoverable only by force quitting or backgrounding the app.

The error path forced the chrome to show via `setBarsHidden(false)`, a reveal that bypasses `BarsAnimator` and leaves its `barsState` stale. A later scroll hid the bars again, and because the error page hides the webView there was no scrollable content left to reveal them.

Fix: route the reveal on the error page through `chromeManager.reset` so `BarsAnimator` state is synced to `.revealed`, and prevent the chrome from hiding on scroll while the error page is shown.

### Testing Steps
The underlying issue is a timing race, so the default repro takes a few tries. To make it reliable, temporarily set `ChromeAnimationConstants.duration` (MainViewController) to `1.5`.

1. Run a search so a scrollable SERP is loaded.
2. Cut the network.
3. Tap refresh, then immediately scroll to hide the chrome and keep scrolling for about 1.5 seconds.
4. Verify the error page appears with the address bar and buttons visible, and that they stay visible.
5. Regression: hiding on scroll then revealing by scrolling up still works, tapping the bottom of the screen reveals the chrome, and the new tab page and Duck Player chrome behaviour are unchanged.

### Impact and Risks
Low. Scoped to revealing the chrome on the error page. The reveal now also syncs `BarsAnimator` state, and every reveal stays routed through the current tab's `chromeDelegate`.

#### What could go wrong?
- The reveal now goes through `chromeManager.reset` (the animator reveal) rather than `setBarsHidden`. Both end at the same `setBarsVisibility(1)`, so the visual result is identical and only the animator state is additionally synced.
- `canHideBars` returns false while an error page is shown. `isError` is read live and clears on the next navigation, so no state keeps the bars permanently visible.
- Background tabs: the reveal routes through `chromeDelegate`, which is nil for tabs that are not current, so a background tab whose load fails does not move the visible chrome.

### Quality Considerations
Other reveals that bypass the animator (new tab page, Duck.ai, Duck Player) still do not sync `BarsAnimator` state, but none pair with the error page condition (a hidden webView), so none produce a user visible bug.

### Notes to Reviewer
`resetBars` is a thin addition to `BrowserChromeDelegate` so `TabViewController` (which only holds `chromeDelegate`) can trigger the reveal routed through the animator, keeping reveal symmetric with hide and scoped to the current tab.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)