### PR TITLE
Fix: Fire Confirmation Clipping

### DIFF
--- a/iOS/DuckDuckGo/Fire/FireConfirmationPresenter.swift
+++ b/iOS/DuckDuckGo/Fire/FireConfirmationPresenter.swift
@@ -90,13 +90,14 @@ struct FireConfirmationPresenter {
         if case .duckAIOnboarding = fireContext {
             hostingController.isModalInPresentation = true
         }
-            let presentingWidth = viewController.view.frame.width
-            configurePresentation(for: hostingController,
-                                  source: source,
-                                  sourceRect: sourceRect,
-                                  presentingWidth: presentingWidth)
-            viewController.present(hostingController, animated: true)
-        }
+
+        let presentingWidth = viewController.view.frame.width
+        configurePresentation(for: hostingController,
+                              source: source,
+                              sourceRect: sourceRect,
+                              presentingWidth: presentingWidth)
+        viewController.present(hostingController, animated: true)
+    }
     
     // MARK: - Shared Presentation Helpers
         
@@ -117,7 +118,12 @@ struct FireConfirmationPresenter {
             
             let sheetHeight = calculateSheetHeight(for: hostingController, width: Constants.iPadSheetWidth)
             hostingController.preferredContentSize = CGSize(width: Constants.iPadSheetWidth, height: sheetHeight)
-            
+
+            if #available(iOS 16.4, *) {
+                /// Keyboard Safe Area Insets are interfering may interfere when presented as a popover
+                hostingController.safeAreaRegions = [.container]
+            }
+
             configureSheetDetents(popoverController.adaptiveSheetPresentationController,
                                  hostingController: hostingController,
                                  presentingWidth: presentingWidth)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1215641514839499?focus=true
Tech Design URL:
CC:

### Description
This PR fixes a glitch affecting the Fire Confirmation when presented as a Popover, where the Keyboard Insets were pushing all of the Popover contents upwards.

### Testing Steps
1. Launch the browser on an iPad device
2. Enable the `removeChatHistory` Feature Flag
3. Make sure you have at least one Chat in the history
4. Press on the Address Bar and switch to **Duck.ai**
5. Press on the 🔥 button, next to the Chat

- [ ] Verify the Popover isn't pushed upwards

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing I could think of

### Quality Considerations
None

### Notes to Reviewer
Thank you!!

### Screenshots

Before | Now
-|-
<img width="300" src="https://github.com/user-attachments/assets/a9c10b80-ba19-472b-827d-2d93c343cf2d" /> | <img width="300" src="https://github.com/user-attachments/assets/ea228b9a-cce8-4ee2-98d1-b6bf1465cbdc" />



---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized iPad popover presentation tweak in Fire confirmation with no auth, data, or business-logic changes.
> 
> **Overview**
> Fixes **Fire Confirmation** layout on **iPad popovers** when the keyboard is visible (e.g. Duck.ai address bar): content was being shifted up by keyboard safe-area insets.
> 
> For popover presentation in `configurePresentation`, on **iOS 16.4+** the hosting controller now sets `safeAreaRegions` to **`.container`** only, so keyboard-driven safe areas no longer reposition the popover. Presentation wiring is unchanged aside from minor formatting/indentation in `presentScopeConfirmationSheet`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96b8956479f30840de0bd9af1d8ab351fa397081. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->