### PR TITLE
Update LLM local PR check script

### DIFF
--- a/scripts/run-local-pr-checks
+++ b/scripts/run-local-pr-checks
@@ -100,11 +100,10 @@ emit_hook_guidance_header() {
   cat <<'EOF'
 [local PR checks] Finishing is blocked: static checks failed (see below).
 
-This gate lints your UNCOMMITTED working-tree changes (SwiftLint is scoped to
-the files you changed). Those changes being uncommitted is expected and correct
-- the gate runs before you commit, not because you forgot to. To clear it, fix
-the violations listed below directly in the working tree, then finish again. Do
-NOT stage or commit anything to satisfy this hook.
+This gate lints the changes on your branch, committed or not (SwiftLint is
+scoped to the files you changed). It is blocking on the violations listed below,
+not on your commit state - committing or staging will not clear it. To clear it,
+fix the violations directly in the code, then finish again.
 
 EOF
 }
@@ -282,7 +281,7 @@ fi
 # In hook mode, failure must exit 2 - the code that blocks the agent and feeds
 # stderr back. Outside hook mode keep the documented contract: exit = failures.
 if [ "$HOOK_MODE" = true ] && [ "$FAIL_COUNT" -gt 0 ]; then
-  printf '\nTo finish: fix the FAIL items above in the working tree, then stop again. Leave the changes uncommitted.\n'
+  printf '\nTo finish: fix the FAIL items above, then stop again. Committing will not clear this gate; fixing the violations will.\n'
   exit 2
 fi
 exit "$FAIL_COUNT"

--- a/scripts/run-local-pr-checks
+++ b/scripts/run-local-pr-checks
@@ -87,6 +87,28 @@ base_ref_available() {
 pass() { PASS_COUNT=$((PASS_COUNT + 1)); [ "$HOOK_MODE" = true ] && return; printf '  %sPASS%s  %s\n' "$C_GREEN" "$C_RESET" "$1"; }
 skip() { SKIP_COUNT=$((SKIP_COUNT + 1)); [ "$HOOK_MODE" = true ] && return; printf '  %sSKIP%s  %s %s(%s)%s\n' "$C_YELLOW" "$C_RESET" "$1" "$C_DIM" "$2" "$C_RESET"; }
 
+# Printed once, the first time a check fails in hook mode, to frame the block for
+# the agent. The fed-back stderr is the only thing the agent sees, so without
+# this it reads a bare lint dump at "finish" time and misdiagnoses it as "I
+# forgot to commit", then tries to commit/stage instead of fixing the
+# violation. Costs a few lines of context, but only on failure.
+HOOK_HEADER_PRINTED=false
+emit_hook_guidance_header() {
+  [ "$HOOK_MODE" = true ] || return
+  [ "$HOOK_HEADER_PRINTED" = true ] && return
+  HOOK_HEADER_PRINTED=true
+  cat <<'EOF'
+[local PR checks] Finishing is blocked: static checks failed (see below).
+
+This gate lints your UNCOMMITTED working-tree changes (SwiftLint is scoped to
+the files you changed). Those changes being uncommitted is expected and correct
+- the gate runs before you commit, not because you forgot to. To clear it, fix
+the violations listed below directly in the working tree, then finish again. Do
+NOT stage or commit anything to satisfy this hook.
+
+EOF
+}
+
 run_check() {
   local name="$1" workdir="$2"; shift 2
   local output status
@@ -96,6 +118,7 @@ run_check() {
     pass "$name"
   else
     FAIL_COUNT=$((FAIL_COUNT + 1))
+    emit_hook_guidance_header
     printf '  %sFAIL%s  %s\n' "$C_RED" "$C_RESET" "$name"
     [ -n "$output" ] && printf '%s\n' "$output" | sed 's/^/        /'
   fi
@@ -259,6 +282,7 @@ fi
 # In hook mode, failure must exit 2 - the code that blocks the agent and feeds
 # stderr back. Outside hook mode keep the documented contract: exit = failures.
 if [ "$HOOK_MODE" = true ] && [ "$FAIL_COUNT" -gt 0 ]; then
+  printf '\nTo finish: fix the FAIL items above in the working tree, then stop again. Leave the changes uncommitted.\n'
   exit 2
 fi
 exit "$FAIL_COUNT"

--- a/scripts/run-local-pr-checks
+++ b/scripts/run-local-pr-checks
@@ -1,20 +1,31 @@
 #!/usr/bin/env bash
 # Runs cheap non-test-suite PR checks.
 #
-# Optional: use as an LLM "fix before finishing" hook (personal, uncommitted).
-# Claude Code and Codex both have a Stop hook where exit 2 + stderr blocks
-# completion and feeds the text back, so the agent fixes issues before stopping.
-# Send this script's output to stderr and map failure to exit 2:
+# Optional: use as an LLM "fix before finishing" Stop hook (personal,
+# uncommitted). Claude Code and Codex run a Stop hook when the agent tries to
+# finish; exit 2 with output on stderr blocks completion and feeds the text
+# back so the agent fixes the issues first.
+#
+# When invoked as a Stop hook the script detects the hook's JSON on stdin and
+# owns the hook contract itself, so the configured command is just the script
+# path - no ">&2 || exit 2" wrapper needed. In hook mode it:
+#   - routes output to stderr and exits 2 on failure (blocks + feeds back);
+#   - stays completely silent on success, to spend zero agent context;
+#   - exits 0 without re-running when the agent is only re-invoking us because
+#     our own previous run blocked (stop_hook_active=true), so pre-existing
+#     failures can't trap the agent in an endless re-check loop.
+# A normal terminal or CI run (no hook JSON on stdin) is unaffected: full live
+# output, exit code = number of failed checks.
 #
 #   Claude Code — .claude/settings.local.json (gitignored):
 #     { "hooks": { "Stop": [ { "matcher": "", "hooks": [ { "type": "command",
-#       "command": "\"$CLAUDE_PROJECT_DIR/scripts/run-local-pr-checks\" >&2 || exit 2" } ] } ] } }
+#       "command": "\"$CLAUDE_PROJECT_DIR/scripts/run-local-pr-checks\"" } ] } ] } }
 #
 #   Codex — ~/.codex/config.toml (outside the repo):
 #     [[hooks.Stop]]
 #     [[hooks.Stop.hooks]]
 #     type = "command"
-#     command = ["bash", "-lc", "scripts/run-local-pr-checks >&2 || exit 2"]
+#     command = ["bash", "-lc", "scripts/run-local-pr-checks"]
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -26,6 +37,10 @@ BASE_REF="origin/${GITHUB_BASE_REF:-main}"
 PASS_COUNT=0
 FAIL_COUNT=0
 SKIP_COUNT=0
+
+# Set by detect_hook_context when stdin carries an agent Stop-hook payload.
+HOOK_MODE=false
+STOP_HOOK_ACTIVE=false
 
 if [ -t 1 ]; then
   C_GREEN=$'\033[32m'; C_RED=$'\033[31m'; C_YELLOW=$'\033[33m'; C_DIM=$'\033[2m'; C_RESET=$'\033[0m'
@@ -67,8 +82,10 @@ base_ref_available() {
   [ "$BASE_REF_STATUS" = "yes" ]
 }
 
-pass() { PASS_COUNT=$((PASS_COUNT + 1)); printf '  %sPASS%s  %s\n' "$C_GREEN" "$C_RESET" "$1"; }
-skip() { SKIP_COUNT=$((SKIP_COUNT + 1)); printf '  %sSKIP%s  %s %s(%s)%s\n' "$C_YELLOW" "$C_RESET" "$1" "$C_DIM" "$2" "$C_RESET"; }
+# In hook mode pass/skip still count but print nothing: a successful run must
+# emit no output, and on failure we only want the failing checks fed back.
+pass() { PASS_COUNT=$((PASS_COUNT + 1)); [ "$HOOK_MODE" = true ] && return; printf '  %sPASS%s  %s\n' "$C_GREEN" "$C_RESET" "$1"; }
+skip() { SKIP_COUNT=$((SKIP_COUNT + 1)); [ "$HOOK_MODE" = true ] && return; printf '  %sSKIP%s  %s %s(%s)%s\n' "$C_YELLOW" "$C_RESET" "$1" "$C_DIM" "$2" "$C_RESET"; }
 
 run_check() {
   local name="$1" workdir="$2"; shift 2
@@ -176,6 +193,26 @@ check_translations() {
   done
 }
 
+# Detect being run as an agent (Claude Code / Codex) Stop hook by inspecting
+# stdin: those harnesses pipe a JSON object describing the event. A terminal or
+# CI run leaves stdin a TTY or empty, so it never trips this. No jq dependency -
+# we only need to spot a JSON object and one boolean flag. The per-read timeout
+# guarantees we never block if stdin is an idle open pipe.
+detect_hook_context() {
+  [ -t 0 ] && return
+  local input="" line=""
+  while IFS= read -r -t 1 line || [ -n "$line" ]; do
+    input+="$line"$'\n'
+    line=""
+  done
+  printf '%s' "$input" | grep -q '^[[:space:]]*{' || return
+  HOOK_MODE=true
+  # stop_hook_active=true => the agent is only re-invoking us because our own
+  # previous run blocked; let it finish instead of looping on the same failures.
+  printf '%s' "$input" | grep -Eq '"stop_hook_active"[[:space:]]*:[[:space:]]*true' && STOP_HOOK_ACTIVE=true
+  return 0
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --platform|--platform=*)
@@ -193,16 +230,35 @@ while [ $# -gt 0 ]; do
   shift
 done
 
+detect_hook_context
+if [ "$HOOK_MODE" = true ]; then
+  # A re-invocation triggered by our own previous block: exit cleanly so the
+  # agent can finish, otherwise pre-existing failures loop forever.
+  [ "$STOP_HOOK_ACTIVE" = true ] && exit 0
+  # Stop hooks read the blocked command's stderr; route everything there. Combined
+  # with the silent pass/skip above, a clean run now emits nothing at all.
+  exec 1>&2
+fi
+
 check_actionlint
 check_shellcheck
 check_swiftlint
 check_pixels
 check_translations
 
-if [ "$FAIL_COUNT" -gt 0 ]; then
-  printf '\n%s%s passed, %s failed, %s skipped%s\n' "$C_RED" "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT" "$C_RESET"
-else
-  printf '\n%s%s passed, %s failed, %s skipped%s\n' "$C_GREEN" "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT" "$C_RESET"
+# Summary line: shown for any terminal/CI run, and for a hook run that failed
+# (gives the agent the counts). Suppressed only when a hook run fully passes.
+if ! { [ "$HOOK_MODE" = true ] && [ "$FAIL_COUNT" -eq 0 ]; }; then
+  if [ "$FAIL_COUNT" -gt 0 ]; then
+    printf '\n%s%s passed, %s failed, %s skipped%s\n' "$C_RED" "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT" "$C_RESET"
+  else
+    printf '\n%s%s passed, %s failed, %s skipped%s\n' "$C_GREEN" "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT" "$C_RESET"
+  fi
 fi
 
+# In hook mode, failure must exit 2 - the code that blocks the agent and feeds
+# stderr back. Outside hook mode keep the documented contract: exit = failures.
+if [ "$HOOK_MODE" = true ] && [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 2
+fi
 exit "$FAIL_COUNT"


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1215677596171212?focus=true
Tech Design URL:
CC:

### Description

This PR updates the local PR check script to be aware of the Stop hook, and avoid getting into loops.

This means that when the Stop hook runs the first time, the script will output any failures it sees, but in a subsequent run the script does not block the Stop from occurring. This will allow Claude to take one pass at resolving the failures, but will not keep trying and trying if it has issues.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that the script runs as expected when invoked locally

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal developer tooling only; normal local/CI behavior is preserved when stdin is not hook JSON.
> 
> **Overview**
> `scripts/run-local-pr-checks` now **detects Claude Code / Codex Stop-hook invocations** by reading JSON from stdin, so hook config can call the script directly without a `>&2 || exit 2` wrapper.
> 
> In **hook mode**, the script **redirects stdout to stderr**, **stays silent on success**, **exits 2 on failures** (with a one-time guidance header plus a footer that violations—not commits—must be fixed), and **exits 0 without re-running checks** when `stop_hook_active` is true so the agent is not stuck in a re-check loop after the first block. **Terminal/CI runs** keep the same visible pass/fail output and exit code equal to the failure count.
> 
> Header comments and example **Claude/Codex hook commands** are updated to match the simpler invocation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 712d99f9731641b16fb14a8778a9c81a7f172c19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->