### PR TITLE
Fix Duck.ai bubble tap target in search widget

### DIFF
--- a/iOS/Widgets/Views/ResponsiveSearchFieldView.swift
+++ b/iOS/Widgets/Views/ResponsiveSearchFieldView.swift
@@ -37,60 +37,65 @@ struct ResponsiveSearchFieldView: View {
         widgetFamily == .systemSmall ? UserText.quickActionsSearch : UserText.searchDuckDuckGo
     }
 
+    private var showsAIChatIcon: Bool {
+        isRightIconEnabled && isAIChatEnabled && widgetFamily != .systemSmall
+    }
+
     var body: some View {
-        Link(destination: DeepLinks.newSearch) {
-            ZStack {
-                RoundedRectangle(cornerRadius: 16)
-                    .renderAwareBackgroundFill()
-                    .frame(minHeight: fieldHeight, maxHeight: fieldHeight)
-                    .shadow(color: Color(designSystemColor: .shadowSecondary), radius: 12, x: 0, y: 8)
-                    .makeAccentable()
+        ZStack {
+            RoundedRectangle(cornerRadius: 16)
+                .renderAwareBackgroundFill()
+                .frame(minHeight: fieldHeight, maxHeight: fieldHeight)
+                .shadow(color: Color(designSystemColor: .shadowSecondary), radius: 12, x: 0, y: 8)
+                .makeAccentable()
 
-                HStack(spacing: 0) {
+            HStack(spacing: 0) {
+                Link(destination: DeepLinks.newSearch) {
+                    HStack(spacing: 0) {
 
-                    if showLogo {
-                        ResizableTintableImage(fullColor: UIImage(resource: .widgetDaxLogo),
-                                      tintable: UIImage(resource: .widgetDaxLogoTinted))
-                                      .frame(width: 24, height: 24, alignment: .leading)
-                                      .padding(.leading, 12)
-                    }
+                        if showLogo {
+                            ResizableTintableImage(fullColor: UIImage(resource: .widgetDaxLogo),
+                                          tintable: UIImage(resource: .widgetDaxLogoTinted))
+                                          .frame(width: 24, height: 24, alignment: .leading)
+                                          .padding(.leading, 12)
+                        }
 
-                    Text(prompt)
-                        .daxBodyRegular()
-                        .foregroundStyle(Color(designSystemColor: .textSecondary))
-                        .padding(.leading, showLogo ? 8 : 12)
-                        .makeAccentable()
+                        Text(prompt)
+                            .daxBodyRegular()
+                            .foregroundStyle(Color(designSystemColor: .textSecondary))
+                            .padding(.leading, showLogo ? 8 : 12)
+                            .makeAccentable()
 
-                    Spacer()
+                        Spacer()
 
-                    Group {
-                        if isRightIconEnabled {
-                            if isAIChatEnabled && widgetFamily != .systemSmall {
-                                Link(destination: DeepLinks.openAIChat.appendingParameter(name: WidgetSourceType.sourceKey, value: WidgetSourceType.favorite.rawValue)) {
-                                    Image(uiImage: DesignSystemImages.Glyphs.Size24.aiChat)
-                                        .resizable()
-                                        .makeAccentable()
-                                        .frame(width: 24, height: 24, alignment: .leading)
-                                        .foregroundStyle(Color(designSystemColor: .icons))
-                                }
-                            } else {
-                                Image(.widgetSearchLoupe)
-                                    .resizable()
-                                    .makeAccentable()
-                                    .frame(width: 24, height: 24, alignment: .leading)
-                                    .foregroundStyle(Color(designSystemColor: .icons))
-                            }
-                        } else {
-                            EmptyView()
+                        if isRightIconEnabled && !showsAIChatIcon {
+                            Image(.widgetSearchLoupe)
+                                .resizable()
+                                .makeAccentable()
+                                .frame(width: 24, height: 24, alignment: .leading)
+                                .foregroundStyle(Color(designSystemColor: .icons))
+                                .padding(.trailing, 12)
                         }
                     }
-                    .padding(.trailing, 12)
-
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .contentShape(Rectangle())
                 }
-
+                if showsAIChatIcon {
+                    Link(destination: DeepLinks.openAIChat.appendingParameter(name: WidgetSourceType.sourceKey, value: WidgetSourceType.favorite.rawValue)) {
+                        Image(uiImage: DesignSystemImages.Glyphs.Size24.aiChat)
+                            .resizable()
+                            .makeAccentable()
+                            .frame(width: 24, height: 24, alignment: .leading)
+                            .foregroundStyle(Color(designSystemColor: .icons))
+                            .padding(.horizontal, 12)
+                            .frame(maxHeight: .infinity)
+                            .contentShape(Rectangle())
+                    }
+                }
             }
-            .unredacted()
         }
+        .frame(height: fieldHeight)
+        .unredacted()
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1214486607140303?focus=true
Tech Design URL:
CC:

### Description
The Duck.ai bubble in the medium/large search (Favorites) widget was a `Link` nested inside the search-field `Link` with only a 24x24pt hit area, so off-centre taps fell through to the enclosing search `Link` and opened search instead of Duck.ai. This replaces the nested `Link`s with two sibling `Link`s that partition the field and expands the Duck.ai tap target to the full field height (~48x46pt, above the 44pt HIG minimum), keeping the glyph visually 24x24. The field is pinned to its fixed height so the un-nesting doesn't shift the search field's vertical position.

### Testing Steps
1. Add the medium or large Favorites widget to the home screen with Duck.ai enabled, so the speech-bubble icon shows on the right of the search field.
2. Tap the Duck.ai bubble — including its edges and the area just above/below it — and confirm it reliably opens Duck.ai rather than search.
3. Tap elsewhere on the search field and confirm it still opens search, and that the field is not visually pushed down.

### Impact and Risks
Low

#### What could go wrong?
A layout regression in the widget search field across widget families or tinting modes, mitigated by pinning the field to its fixed height.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Widget-only SwiftUI layout and tap routing; no auth, data, or core app logic changes.
> 
> **Overview**
> Fixes unreliable Duck.ai opens from the medium/large **Favorites** widget search field when users tapped near the bubble instead of dead center.
> 
> **`ResponsiveSearchFieldView`** no longer nests the Duck.ai `Link` inside the search `Link`. The field is a shared chrome `ZStack` with two sibling links: one for **search** (logo, prompt, loupe when AI chat is off) and a separate **Duck.ai** link when `showsAIChatIcon` is true. Each link uses `contentShape(Rectangle())` and full field height so the AI control’s hit area is much larger than the 24×24 glyph while the icon stays the same size.
> 
> A fixed `.frame(height: fieldHeight)` on the container keeps the search row from shifting after un-nesting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a56463cc16460655ec911558dc80520bdc05eca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->