### PR TITLE
Fix off-main WKHTTPCookieStore access crashing AI Chat models fetch

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatModelsService.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatModelsService.swift
@@ -34,7 +34,6 @@ public struct WKHTTPCookieStoreProvider: AIChatCookieProviding {
     }
 
     public func cookies(for url: URL) async -> [HTTPCookie] {
-        // `allCookies()` is `@MainActor`; reading the store off-main (e.g. via `getAllCookies`) traps.
         let cookies = await cookieStore.allCookies()
         let domain = url.host ?? ""
         return cookies.filter { cookie in

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatModelsService.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatModelsService.swift
@@ -34,11 +34,7 @@ public struct WKHTTPCookieStoreProvider: AIChatCookieProviding {
     }
 
     public func cookies(for url: URL) async -> [HTTPCookie] {
-        // `WKHTTPCookieStore` is `@MainActor`-isolated and asserts it is accessed on the main
-        // thread. The async `allCookies()` performs that hop for us; the previous
-        // `withCheckedContinuation` + `getAllCookies` invoked the store synchronously on whatever
-        // (often background) executor this nonisolated function was resumed on, tripping the
-        // assertion (SIGTRAP). Filtering stays off the main actor since it only reads value data.
+        // `allCookies()` is `@MainActor`; reading the store off-main (e.g. via `getAllCookies`) traps.
         let cookies = await cookieStore.allCookies()
         let domain = url.host ?? ""
         return cookies.filter { cookie in

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatModelsService.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatModelsService.swift
@@ -34,15 +34,16 @@ public struct WKHTTPCookieStoreProvider: AIChatCookieProviding {
     }
 
     public func cookies(for url: URL) async -> [HTTPCookie] {
-        await withCheckedContinuation { continuation in
-            cookieStore.getAllCookies { cookies in
-                let domain = url.host ?? ""
-                let relevant = cookies.filter { cookie in
-                    let cookieDomain = cookie.domain.hasPrefix(".") ? String(cookie.domain.dropFirst()) : cookie.domain
-                    return domain.hasSuffix(cookieDomain)
-                }
-                continuation.resume(returning: relevant)
-            }
+        // `WKHTTPCookieStore` is `@MainActor`-isolated and asserts it is accessed on the main
+        // thread. The async `allCookies()` performs that hop for us; the previous
+        // `withCheckedContinuation` + `getAllCookies` invoked the store synchronously on whatever
+        // (often background) executor this nonisolated function was resumed on, tripping the
+        // assertion (SIGTRAP). Filtering stays off the main actor since it only reads value data.
+        let cookies = await cookieStore.allCookies()
+        let domain = url.host ?? ""
+        return cookies.filter { cookie in
+            let cookieDomain = cookie.domain.hasPrefix(".") ? String(cookie.domain.dropFirst()) : cookie.domain
+            return domain.hasSuffix(cookieDomain)
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1215495892917926?focus=true

### Description

Fixes Sentry `APPLE-MACOS-C6N` (`EXC_BREAKPOINT` / SIGTRAP, culprit `WKHTTPCookieStoreProvider.cookies`).

- `WKHTTPCookieStore` is `@MainActor`-isolated and asserts it is accessed on the main thread (`WK_SWIFT_UI_ACTOR` in the WebKit SDK).
- `WKHTTPCookieStoreProvider.cookies(for:)` is nonisolated and wrapped `getAllCookies` in `withCheckedContinuation`. `AIChatModelsService` is a non-`@MainActor` class, so awaiting its `fetchModels()` from the omnibar's `Task` drops execution off the main actor — the continuation then invoked `getAllCookies` on a background thread, tripping the assertion → SIGTRAP.
- Fix: read cookies via the `@MainActor` async `allCookies()` API so the `await` performs the main-thread hop. Domain filtering is byte-for-byte unchanged and stays off the main actor (pure value reads). Matches the existing pattern in `WebsiteDataStore.removeCookies`.

### Testing Steps
1. Run the macOS Browser Debug build.
2. Activate the AI Chat omnibar (repro path: `onOmnibarActivated → fetchModels → cookies(for:)`).
3. Confirm there is no crash and Duck.ai models are fetched as expected

### Impact and Risks
Low — single call-site isolation fix; cookie filtering and the `/models` request are otherwise unchanged.

#### What could go wrong?
The cookie read now hops to the main actor (intended). Filtering logic is identical, so callers see no behavior change.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single call-site threading fix; cookie selection and `/models` request behavior are unchanged aside from reading cookies on the main actor.
> 
> **Overview**
> Fixes a **SIGTRAP** when AI Chat fetches models from a background `Task` (e.g. omnibar activation): `WKHTTPCookieStore` must be used on the main actor, but `WKHTTPCookieStoreProvider.cookies(for:)` previously called `getAllCookies` inside a `withCheckedContinuation`, so the callback could run off the main thread.
> 
> **`cookies(for:)`** now uses `await cookieStore.allCookies()` so the `await` performs the main-actor hop. **Domain filtering** (host suffix match against cookie domains) is unchanged and still runs after the cookie list is returned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5745c0c9d8af0581b4e3891ffa77b5e244cbb88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->