### PR TITLE
macOS Updates: Verify we always keep 1.193.1 in appcast (last Big Sur version)

### DIFF
--- a/macOS/scripts/appcast_manager/appcastManager.swift
+++ b/macOS/scripts/appcast_manager/appcastManager.swift
@@ -20,7 +20,7 @@ let specificDir = tmpDirURL.appendingPathComponent("sparkle-updates")
 let appcastFilePath = specificDir.appendingPathComponent("appcast2.xml")
 let backupAppcastFilePath = "\(tmpDir)/appcast.xml.backup"
 let backupFileURL = URL(fileURLWithPath: backupAppcastFilePath)
-let lastCatalinaBuildVersion = "1.55.0"
+let lastBigSurBuildVersion = "736" // 1.193.1 – last build shipped with minimumSystemVersion 11.4 (Big Sur)
 
 // MARK: - Arguments
 
@@ -874,8 +874,8 @@ func runGenerateAppcast(with versionNumber: String, channel: String? = nil, roll
     print("✅ generate_appcast command executed successfully.")
 
     // Verify presense of old builds
-    if !verifyAppcastContainsBuild(lastCatalinaBuildVersion, in: appcastFilePath) {
-        print("❌ Error: Appcast does not contain the build (\(lastCatalinaBuildVersion)).")
+    if !verifyAppcastContainsBuild(lastBigSurBuildVersion, in: appcastFilePath) {
+        print("❌ Error: Appcast does not contain the build (\(lastBigSurBuildVersion)).")
         exit(1)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210094913833251?focus=true

### Description

Add checks to ensure we validate our last Big Sur supporting version (1.193.1) is present in appcast.xml.

Drop the same checks for Catalina.

### Testing Steps

1. Verify the CI is green.

### Impact and Risks

None. Internal release tooling only; no user-facing or app-runtime code is affected.

#### What could go wrong?

The guard only reads the generated appcast and aborts on a missing build, so the worst case is a release operator seeing a generation failure — which is the intended signal, not a regression.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal release scripting only; worst case is an intentional abort when the pinned build is absent from the generated appcast.
> 
> **Overview**
> Updates the macOS **appcast manager** post-generation guard so it requires the last **Big Sur**–compatible release instead of the old **Catalina** pin.
> 
> The constant is renamed to `lastBigSurBuildVersion` and set to Sparkle build **`736`** (1.193.1, noted as the last build with `minimumSystemVersion` 11.4). After `generate_appcast` runs, the script still calls `verifyAppcastContainsBuild` and fails the release flow if that build is missing from `appcast2.xml`; the Catalina check (`1.55.0`) is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88e9c02e4b971bc8976843fb31fb170ba990c55b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->