### PR TITLE
Add channel parameter to Privacy Pro toolbar popover pixel definitions

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/privacy_pro_toolbar_button.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/privacy_pro_toolbar_button.json5
@@ -43,7 +43,7 @@
         "description": "Fired when the Privacy Pro toolbar button popover is displayed to a user",
         "owners": ["jozsef-vesza"],
         "triggers": ["other"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
 
     "m_mac_store_subscription_toolbar_vpn_popover_shown": {
@@ -65,14 +65,14 @@
         "description": "Fired when the dismiss button is clicked in the Privacy Pro toolbar button upsell popover",
         "owners": ["jozsef-vesza"],
         "triggers": ["user_submitted"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
 
     "m_mac_privacy-pro_toolbar_button_popover_proceed_button_clicked": {
         "description": "Fired when the proceed button is clicked in the Privacy Pro toolbar button upsell popover",
         "owners": ["jozsef-vesza"],
         "triggers": ["user_submitted"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
 
     "m_mac_store_subscription_toolbar_vpn_popover_expired_view_shown": {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215712638097451
Tech Design URL:
CC:

### Description

This PR adds the `channel` parameter to:

- `m_mac_privacy-pro_toolbar_button_popover_shown` (flagged)
- `m_mac_privacy-pro_toolbar_button_popover_proceed_button_clicked` (flagged)
- `m_mac_privacy-pro_toolbar_button_popover_dismiss_button_clicked` (same gap, fixed preventively)

### Testing Steps
Green CI 🟢 

### Impact and Risks

None

#### What could go wrong?

N/A

### Notes to Reviewer

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics definition-only change with no runtime behavior; aligns schema with pixels that already send global `channel` via PixelKit.
> 
> **Overview**
> Adds the **`channel`** parameter to three macOS Privacy Pro toolbar **upsell popover** pixel definitions in `privacy_pro_toolbar_button.json5`, matching **`m_mac_privacy-pro_toolbar_button_shown`**, which already declares `channel`.
> 
> Updated events: popover shown, dismiss clicked, and proceed clicked. No app logic changes—only the declared parameter lists for analytics/schema validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad70ab89a39ff5f54bdfb2c9a5137d15704668ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->