### PR TITLE
Fix Duck.ai native-storage error pixel validation failures

### DIFF
--- a/iOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
@@ -63,8 +63,11 @@
         "description": "Fires when DuckAiNativeStorageProvider init fails (DB or directory creation)",
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["daily_standard", "platform", "form_factor"],
-        "parameters": ["appVersion", "errorDomain", "errorCode"]
+        "suffixes": [
+            ["daily", "platform", "form_factor"],
+            ["platform", "form_factor"]
+        ],
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_duck-ai_native-storage_migration_started": {
         "description": "Fires when the web layer calls markMigrationDone (migration was attempted)",
@@ -85,7 +88,7 @@
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
-        "parameters": ["appVersion", "errorDomain", "errorCode"]
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_duck-ai_native-storage_container-migration_not-needed_default": {
         "description": "Fires once when no app-group default container directory exists on launch (fresh install or already migrated previously)",
@@ -217,84 +220,120 @@
         "description": "Fires when putEntry (Settings) fails",
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["daily_standard", "platform", "form_factor"],
-        "parameters": ["appVersion", "errorDomain", "errorCode"]
+        "suffixes": [
+            ["daily", "platform", "form_factor"],
+            ["platform", "form_factor"]
+        ],
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_duck-ai_native-storage_settings-get_error": {
         "description": "Fires when getEntry or getAllEntries (Settings) fails",
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["daily_standard", "platform", "form_factor"],
-        "parameters": ["appVersion", "errorDomain", "errorCode"]
+        "suffixes": [
+            ["daily", "platform", "form_factor"],
+            ["platform", "form_factor"]
+        ],
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_duck-ai_native-storage_settings-delete_error": {
         "description": "Fires when deleteEntry, deleteAllEntries, or replaceAllEntries (Settings) fails",
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["daily_standard", "platform", "form_factor"],
-        "parameters": ["appVersion", "errorDomain", "errorCode"]
+        "suffixes": [
+            ["daily", "platform", "form_factor"],
+            ["platform", "form_factor"]
+        ],
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_duck-ai_native-storage_chat-put_error": {
         "description": "Fires when putChat or putChats fails",
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["daily_standard", "platform", "form_factor"],
-        "parameters": ["appVersion", "errorDomain", "errorCode"]
+        "suffixes": [
+            ["daily", "platform", "form_factor"],
+            ["platform", "form_factor"]
+        ],
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_duck-ai_native-storage_chat-get_error": {
         "description": "Fires when getChat or getAllChats fails",
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["daily_standard", "platform", "form_factor"],
-        "parameters": ["appVersion", "errorDomain", "errorCode"]
+        "suffixes": [
+            ["daily", "platform", "form_factor"],
+            ["platform", "form_factor"]
+        ],
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_duck-ai_native-storage_chat-delete_error": {
         "description": "Fires when deleteChat or deleteAllChats fails",
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["daily_standard", "platform", "form_factor"],
-        "parameters": ["appVersion", "errorDomain", "errorCode"]
+        "suffixes": [
+            ["daily", "platform", "form_factor"],
+            ["platform", "form_factor"]
+        ],
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_duck-ai_native-storage_file-put_error": {
         "description": "Fires when putFile fails",
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["daily_standard", "platform", "form_factor"],
-        "parameters": ["appVersion", "errorDomain", "errorCode"]
+        "suffixes": [
+            ["daily", "platform", "form_factor"],
+            ["platform", "form_factor"]
+        ],
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_duck-ai_native-storage_file-get_error": {
         "description": "Fires when getFile fails",
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["daily_standard", "platform", "form_factor"],
-        "parameters": ["appVersion", "errorDomain", "errorCode"]
+        "suffixes": [
+            ["daily", "platform", "form_factor"],
+            ["platform", "form_factor"]
+        ],
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_duck-ai_native-storage_file-list_error": {
         "description": "Fires when listFiles fails",
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["daily_standard", "platform", "form_factor"],
-        "parameters": ["appVersion", "errorDomain", "errorCode"]
+        "suffixes": [
+            ["daily", "platform", "form_factor"],
+            ["platform", "form_factor"]
+        ],
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_duck-ai_native-storage_file-delete_error": {
         "description": "Fires when deleteFile, deleteFiles (by chatId), or deleteAllFiles fails",
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["daily_standard", "platform", "form_factor"],
-        "parameters": ["appVersion", "errorDomain", "errorCode"]
+        "suffixes": [
+            ["daily", "platform", "form_factor"],
+            ["platform", "form_factor"]
+        ],
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_duck-ai_native-storage_last-used-model-parse_error": {
         "description": "Fires when decoding the persisted chat JSON to read the last-used model fails",
         "owners": ["Bunn", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["daily_standard", "platform", "form_factor"],
-        "parameters": ["appVersion", "errorDomain", "errorCode"]
+        "suffixes": [
+            ["daily", "platform", "form_factor"],
+            ["platform", "form_factor"]
+        ],
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_duck-ai_native-storage_last-used-reasoning-mode-parse_error": {
         "description": "Fires when decoding the persisted chat JSON to read the last-used reasoning mode fails",
         "owners": ["pikorddg", "samsymons"],
         "triggers": ["other"],
-        "suffixes": ["daily_standard", "platform", "form_factor"],
-        "parameters": ["appVersion", "errorDomain", "errorCode"]
+        "suffixes": [
+            ["daily", "platform", "form_factor"],
+            ["platform", "form_factor"]
+        ],
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1215709112012831?focus=true
Tech Design URL:
CC:

### Description
Fixes live validation failures for the Duck.ai native-storage error pixels. These pixels fire via `DailyPixel.fireDailyAndCount` with `dailyAndStandardSuffixes` (emitting both a `_daily` and a no-suffix variant), so the positional `daily_standard` suffix broke validation; they also emit underlying-error params (`ud`/`ue`/`ud2`/`ue2`) that weren't declared. Switched to the array-of-arrays suffix form and added `underlyingErrorCode`/`underlyingErrorDomain` parameters, matching the existing `web_extensions.json5` pattern.

### Testing Steps
1. From `iOS/`, run `npm run validate-pixel-defs` and confirm `aichat_native_storage_pixels.json5` validates with no errors and passes the prettier check.
2. Confirm the definitions now cover both emitted suffix shapes (`..._error_daily_ios_phone` and `..._error_ios_phone`) and the `ud`/`ue`/`ud2`/`ue2` underlying-error params.

### Impact and Risks
Low — telemetry-definition metadata only; no app behavior or pixel-firing code changes.

#### What could go wrong?
A pixel could fire with a suffix/parameter combination still not covered by the definitions, which would surface as another validation report.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry metadata only in JSON5 pixel definitions; no runtime firing or storage behavior changes.
> 
> **Overview**
> Fixes **pixel definition validation** for Duck.ai native-storage **error** events in `aichat_native_storage_pixels.json5` so definitions match what the app actually emits.
> 
> For error pixels fired via **`DailyPixel.fireDailyAndCount`** / **`dailyAndStandardSuffixes`**, **`daily_standard`** was replaced with an **array-of-arrays** suffix list: `["daily", "platform", "form_factor"]` and `["platform", "form_factor"]`, covering both `_daily_…` and non-daily suffix shapes.
> 
> **`underlyingErrorCode`** and **`underlyingErrorDomain`** were added to the affected error pixel parameter lists (including **`migration_error`**, which only gained params). Init, settings, chat, file, and parse error pixels got both suffix and parameter updates where applicable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7576cbf5df93ec070c63db542e9f2dcb4e76c4f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->