### PR TITLE
Update pixel definitions

### DIFF
--- a/iOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -1,14 +1,14 @@
 {
     "m_ios_dbp_optout_stage_start": {
         "description": "Fired at the start stage of an opt-out attempt.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource", "dbpDataBroker", "dbpParentBroker", "dbpAttemptId"]
     },
     "m_ios_dbp_optout_stage_email-generate": {
         "description": "Fired at the email generation stage of an opt-out attempt.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -25,7 +25,7 @@
     },
     "m_ios_dbp_optout_stage_captcha-parse": {
         "description": "Fired at the captcha parse stage of an opt-out attempt.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -42,7 +42,7 @@
     },
     "m_ios_dbp_optout_stage_captcha-send": {
         "description": "Fired at the captcha send stage of an opt-out attempt.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -59,7 +59,7 @@
     },
     "m_ios_dbp_optout_stage_captcha-solve": {
         "description": "Fired at the captcha solve stage of an opt-out attempt.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -76,7 +76,7 @@
     },
     "m_ios_dbp_optout_stage_submit": {
         "description": "Fired at the submit stage of an opt-out attempt.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -110,7 +110,7 @@
     },
     "m_ios_dbp_optout_stage_email-receive": {
         "description": "Fired at the email receive stage of an opt-out attempt.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -127,7 +127,7 @@
     },
     "m_ios_dbp_optout_stage_email-confirm": {
         "description": "Fired at the email confirmation stage of an opt-out attempt.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -161,7 +161,7 @@
     },
     "m_ios_dbp_optout_stage_validate": {
         "description": "Fired at the validation stage of an opt-out attempt.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -178,7 +178,7 @@
     },
     "m_ios_dbp_optout_stage_fill-form": {
         "description": "Fired at the fill-form stage of an opt-out attempt.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -195,7 +195,7 @@
     },
     "m_ios_dbp_optout_stage_finish": {
         "description": "Fired at the finish stage of an opt-out attempt.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -213,7 +213,7 @@
     },
     "m_ios_dbp_optout_process_submit-success": {
         "description": "Fired when an opt-out submission succeeds.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -248,7 +248,7 @@
     },
     "m_ios_dbp_optout_process_success": {
         "description": "Fired when an opt-out attempt completes successfully.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -279,7 +279,7 @@
     },
     "m_ios_dbp_optout_process_failure": {
         "description": "Fired when an opt-out attempt fails.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -1218,21 +1218,21 @@
     },
     "m_ios_dbp_event_scanning-events_new-match": {
         "description": "Fired when a new matching profile is found during a scan",
-        "owners": ["quanganhdo", "edulpn"],
+        "owners": ["quanganhdo"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource", "dbpDataBroker"]
     },
     "m_ios_dbp_event_scanning-events_re-appearance": {
         "description": "Fired when a previously removed profile re-appears on a data broker during a scan",
-        "owners": ["quanganhdo", "edulpn"],
+        "owners": ["quanganhdo"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource", "dbpDataBroker"]
     },
     "m_ios_dbp_databroker_custom_stats_optoutsubmit": {
         "description": "Fired daily with per-broker opt-out submission success rate stats.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["scheduled"],
         "suffixes": [],
         "parameters": [
@@ -1248,7 +1248,7 @@
     },
     "m_ios_dbp_custom_stats_optoutsubmit": {
         "description": "Fired daily with global opt-out submission success rate stats.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["scheduled"],
         "suffixes": [],
         "parameters": [

--- a/iOS/PixelDefinitions/pixels/definitions/ics_calendar_links.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ics_calendar_links.json5
@@ -1,7 +1,7 @@
 {
     "m_ics_calendar_editor_presented": {
         "description": "Fired when EKEventEditViewController is presented for a downloaded .ics file containing a single VEVENT",
-        "owners": ["edulpn"],
+        "owners": ["samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
@@ -9,7 +9,7 @@
 
     "m_ics_calendar_editor_saved": {
         "description": "Fired when the user taps Add in the EKEventEditViewController shown for a downloaded .ics file",
-        "owners": ["edulpn"],
+        "owners": ["samsymons"],
         "triggers": ["user_submitted"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
@@ -17,7 +17,7 @@
 
     "m_ics_calendar_editor_cancelled": {
         "description": "Fired when the user taps Cancel or Delete in the EKEventEditViewController shown for a downloaded .ics file",
-        "owners": ["edulpn"],
+        "owners": ["samsymons"],
         "triggers": ["user_submitted"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
@@ -25,7 +25,7 @@
 
     "m_ics_calendar_fallback_multiple_events": {
         "description": "Fired when an .ics file contains more than one VEVENT and we fall back to QuickLook with a toast",
-        "owners": ["edulpn"],
+        "owners": ["samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
@@ -33,7 +33,7 @@
 
     "m_ics_calendar_fallback_unrecognized_time_zone": {
         "description": "Fired when an .ics file references a TZID we can't resolve and we fall back to QuickLook with a toast",
-        "owners": ["edulpn"],
+        "owners": ["samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
@@ -41,7 +41,7 @@
 
     "m_ics_calendar_fallback_parse_failure": {
         "description": "Fired when an .ics file fails to parse (malformed content) and we fall back to QuickLook with a toast",
-        "owners": ["edulpn"],
+        "owners": ["samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
@@ -49,7 +49,7 @@
 
     "m_ics_calendar_routed_by_extension": {
         "description": "Fired when a downloaded file is routed through the .ics handler based on its file extension because the MIME type wasn't text/calendar",
-        "owners": ["edulpn"],
+        "owners": ["samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
@@ -57,7 +57,7 @@
 
     "m_ics_calendar_unsupported_rrule": {
         "description": "Fired when an .ics RRULE contains parts the parser ignores (BYSETPOS, BYWEEKNO, BYYEARDAY, BYHOUR, BYMINUTE, BYSECOND, WKST)",
-        "owners": ["edulpn"],
+        "owners": ["samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]

--- a/iOS/PixelDefinitions/pixels/definitions/remote_messaging_framework.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/remote_messaging_framework.json5
@@ -270,7 +270,7 @@
     },
     "m_remote_message_image_load_success": {
         "description": "Triggered when a remote message image is successfully loaded and displayed",
-        "owners": ["edulpn"],
+        "owners": ["samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": [
@@ -284,7 +284,7 @@
     },
     "m_remote_message_image_load_failed": {
         "description": "Triggered when a remote message image fails to load",
-        "owners": ["edulpn"],
+        "owners": ["samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": [

--- a/iOS/PixelDefinitions/pixels/definitions/settings.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/settings.json5
@@ -42,14 +42,14 @@
     },
     "m_settings_autoplay_open": {
         "description": "Fires when the user opens the Autoplay settings screen",
-        "owners": ["edulpn"],
+        "owners": ["samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "m_settings_autoplay_changed": {
         "description": "Fires when the user changes the autoplay blocking mode setting",
-        "owners": ["edulpn"],
+        "owners": ["samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": [

--- a/iOS/PixelDefinitions/pixels/definitions/wallet_pass_preview.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/wallet_pass_preview.json5
@@ -1,7 +1,7 @@
 {
     "wallet_pass_preview_requested": {
         "description": "Fired when the navigation policy routes an Apple Wallet pass (.pkpass or .pkpasses) into the auto-preview path. Counted on both the legacy URLSession path and the modern WKDownload-continuation path so the success rate can be derived against wallet_pass_preview_failed.",
-        "owners": ["edulpn"],
+        "owners": ["samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
@@ -9,7 +9,7 @@
 
     "wallet_pass_preview_failed": {
         "description": "Fired when PassKit rejects the downloaded pass bytes before the system Add to Wallet UI can present. The reason parameter captures the categorised failure mode.",
-        "owners": ["edulpn"],
+        "owners": ["samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": [

--- a/iOS/PixelDefinitions/pixels/definitions/widget_quick_actions.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/widget_quick_actions.json5
@@ -1,7 +1,7 @@
 {
     "m_widget_medium_launch": {
         "description": "Fires daily and counts when the user taps any shortcut in the medium quick-actions widget. The shortcut parameter identifies which shortcut was tapped, allowing per-shortcut analysis and inference of customisation usage.",
-        "owners": ["edulpn"],
+        "owners": ["samsymons"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": [

--- a/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -35,14 +35,14 @@
     },
     "m_mac_dbp_optout_stage_start": {
         "description": "Fired at the start stage of an opt-out attempt.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource", "dbpDataBroker", "dbpParentBroker", "dbpAttemptId", "channel"]
     },
     "m_mac_dbp_optout_stage_email-generate": {
         "description": "Fired at the email generation stage of an opt-out attempt.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -60,7 +60,7 @@
     },
     "m_mac_dbp_optout_stage_captcha-parse": {
         "description": "Fired at the captcha parse stage of an opt-out attempt.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -78,7 +78,7 @@
     },
     "m_mac_dbp_optout_stage_captcha-send": {
         "description": "Fired at the captcha send stage of an opt-out attempt.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -96,7 +96,7 @@
     },
     "m_mac_dbp_optout_stage_captcha-solve": {
         "description": "Fired at the captcha solve stage of an opt-out attempt.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -114,7 +114,7 @@
     },
     "m_mac_dbp_optout_stage_submit": {
         "description": "Fired at the submit stage of an opt-out attempt.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -131,7 +131,7 @@
     },
     "m_mac_dbp_optout_stage_email-receive": {
         "description": "Fired at the email receive stage of an opt-out attempt.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -148,7 +148,7 @@
     },
     "m_mac_dbp_optout_stage_email-confirm": {
         "description": "Fired at the email confirmation stage of an opt-out attempt.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -182,7 +182,7 @@
     },
     "m_mac_dbp_optout_stage_validate": {
         "description": "Fired at the validation stage of an opt-out attempt.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -200,7 +200,7 @@
     },
     "m_mac_dbp_optout_stage_fill-form": {
         "description": "Fired at the fill-form stage of an opt-out attempt.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -218,7 +218,7 @@
     },
     "m_mac_dbp_optout_stage_finish": {
         "description": "Fired at the finish stage of an opt-out attempt.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -237,7 +237,7 @@
     },
     "m_mac_dbp_optout_process_submit-success": {
         "description": "Fired when an opt-out submission succeeds.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -273,7 +273,7 @@
     },
     "m_mac_dbp_optout_process_success": {
         "description": "Fired when an opt-out attempt completes successfully.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -305,7 +305,7 @@
     },
     "m_mac_dbp_optout_process_failure": {
         "description": "Fired when an opt-out attempt fails.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -609,7 +609,7 @@
     },
     "m_mac_dbp_update_databrokers_success": {
         "description": "Fired when a data broker JSON is updated successfuly.",
-        "owners": ["edulpn", "jozsef-vesza"],
+        "owners": ["quanganhdo", "jozsef-vesza"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": [
@@ -631,7 +631,7 @@
     },
     "m_mac_dbp_update_databrokers_failure": {
         "description": "Fired when a data broker JSON update has failed.",
-        "owners": ["edulpn", "jozsef-vesza"],
+        "owners": ["quanganhdo", "jozsef-vesza"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count"],
         "parameters": [
@@ -1230,21 +1230,21 @@
     },
     "m_mac_dbp_event_scanning-events_new-match": {
         "description": "Fired when a new matching profile is found during a scan",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource", "dbpDataBroker", "channel"]
     },
     "m_mac_dbp_event_scanning-events_re-appearance": {
         "description": "Fired when a previously removed profile re-appears on a data broker during a scan",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource", "dbpDataBroker", "channel"]
     },
     "m_mac_dbp_databroker_custom_stats_optoutsubmit": {
         "description": "Fired daily with per-broker opt-out submission success rate stats.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["scheduled"],
         "suffixes": [],
         "parameters": [
@@ -1260,7 +1260,7 @@
     },
     "m_mac_dbp_custom_stats_optoutsubmit": {
         "description": "Fired daily with global opt-out submission success rate stats.",
-        "owners": ["quanganhdo", "edulpn", "THISISDINOSAUR"],
+        "owners": ["quanganhdo", "THISISDINOSAUR"],
         "triggers": ["scheduled"],
         "suffixes": [],
         "parameters": [


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1215742732392262?focus=true
Tech Design URL:
CC:

### Description

This PR updates pixel definitions.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that pixel validation succeeds

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only owner list edits with no runtime or schema changes beyond validation of existing definitions.
> 
> **Overview**
> Updates **ownership metadata only** in pixel definition JSON5 files; pixel names, parameters, triggers, and firing behavior are unchanged.
> 
> On **iOS**, **Data Broker Protection** opt-out stage/process, scanning-event, and opt-out submit stats pixels drop **`edulpn`** from `owners` (typically leaving **`quanganhdo`** and **`THISISDINOSAUR`**, or **`quanganhdo`** alone on scan match/re-appearance). **`edulpn`** is replaced with **`samsymons`** on ICS calendar link, remote message image load, autoplay settings, wallet pass preview, and medium widget quick-action pixels.
> 
> On **macOS**, the same **DBP** owner cleanup applies for opt-out and scanning pixels. **`m_mac_dbp_update_databrokers_success`** and **`_failure`** change from **`edulpn`** to **`quanganhdo`** (still paired with **`jozsef-vesza`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c023202841d058b89a6b0aab13f5bf47e33deb01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->