### PR TITLE
iOS: Fire a separate data-clearing pixel for single-tab burns

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -2829,9 +2829,9 @@ extension Pixel.Event {
         case .cookieDeletionTime(let aggregation):
             return "m_debug_cookie-clearing-time-\(aggregation)"
         case .clearDataInDefaultPersistence(let aggregation):
-            return "m_debug_legacy-data-clearing-time-\(aggregation)"
+            return "data-clearing_all-tabs-time-\(aggregation)"
         case .clearDataInDefaultPersistenceSingleTab(let aggregation):
-            return "m_debug_legacy-data-clearing-single-tab-time-\(aggregation)"
+            return "data-clearing_single-tab-time-\(aggregation)"
         case .cookieDeletionLeftovers: return "m_cookie_deletion_leftovers"
 
         case .webkitWarmupStart(let appState):

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -903,6 +903,7 @@ extension Pixel {
         case cookieDeletionTime(_ time: BucketAggregation)
         case cookieDeletionLeftovers
         case clearDataInDefaultPersistence(_ time: BucketAggregation)
+        case clearDataInDefaultPersistenceSingleTab(_ time: BucketAggregation)
 
         case webkitWarmupStart(appState: String)
         case webkitWarmupFinished(appState: String)
@@ -2829,6 +2830,8 @@ extension Pixel.Event {
             return "m_debug_cookie-clearing-time-\(aggregation)"
         case .clearDataInDefaultPersistence(let aggregation):
             return "m_debug_legacy-data-clearing-time-\(aggregation)"
+        case .clearDataInDefaultPersistenceSingleTab(let aggregation):
+            return "m_debug_legacy-data-clearing-single-tab-time-\(aggregation)"
         case .cookieDeletionLeftovers: return "m_cookie_deletion_leftovers"
 
         case .webkitWarmupStart(let appState):

--- a/iOS/Core/WebCacheManager.swift
+++ b/iOS/Core/WebCacheManager.swift
@@ -294,7 +294,7 @@ extension WebCacheManager {
         observationsInterval.complete()
 
         let totalTime = CACurrentMediaTime() - startTime
-        Pixel.fire(pixel: .clearDataInDefaultPersistence(.init(number: totalTime)))
+        fireDataClearingTimePixel(scope: scope, totalTime: totalTime)
 
         return WebsiteDataClearingResult(
             safelyRemovableData: ActionResult(result: safelyRemovableResult, measuredInterval: safelyRemovableInterval),
@@ -303,6 +303,16 @@ extension WebCacheManager {
             observationsData: ActionResult(result: observationsResult, measuredInterval: observationsInterval),
             removeAllContainersAfterDelay: nil
         )
+    }
+
+    // Fire a separate pixel per scope
+    private func fireDataClearingTimePixel(scope: Scope, totalTime: Double) {
+        switch scope {
+        case .all:
+            Pixel.fire(pixel: .clearDataInDefaultPersistence(.init(number: totalTime)))
+        case .limited:
+            Pixel.fire(pixel: .clearDataInDefaultPersistenceSingleTab(.init(number: totalTime)))
+        }
     }
 
     @MainActor

--- a/iOS/PixelDefinitions/pixels/definitions/data_clearing_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/data_clearing_pixels.json5
@@ -45,5 +45,21 @@
                 "enum": ["fireRising", "fireRisingLegacy", "waterSwirl", "airstream", "none"]
             }
         ]
+    },
+
+    "data-clearing_all-tabs-time-": {
+        "description": "Fires when website data clearing completes for an all-tabs (full scope) burn, reporting how long the operation took. Tracked separately from the single-tab timing.",
+        "owners": ["hassaanelgarem"],
+        "triggers": ["other"],
+        "suffixes": ["time_bucket", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+
+    "data-clearing_single-tab-time-": {
+        "description": "Fires when website data clearing completes for a single-tab (limited scope) burn, reporting how long the operation took. Tracked separately from the all-tabs timing because clearing a single tab must enumerate and selectively delete per-domain, making it inherently slower.",
+        "owners": ["hassaanelgarem"],
+        "triggers": ["other"],
+        "suffixes": ["time_bucket", "platform", "form_factor"],
+        "parameters": ["appVersion"]
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
@@ -111,12 +111,5 @@
             }
         ],
         "expires": "2026-07-11"
-    },
-    "m_debug_legacy-data-clearing-single-tab-time-": {
-        "description": "Fires when website data clearing completes for a single-tab (limited scope) burn, reporting how long the operation took. Tracked separately from the burn-all timing because clearing a single tab must enumerate and selectively delete per-domain, making it inherently slower.",
-        "owners": ["hassaanelgarem"],
-        "triggers": ["other"],
-        "suffixes": ["time_bucket", "platform", "form_factor"],
-        "parameters": ["appVersion"]
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
@@ -111,5 +111,12 @@
             }
         ],
         "expires": "2026-07-11"
+    },
+    "m_debug_legacy-data-clearing-single-tab-time-": {
+        "description": "Fires when website data clearing completes for a single-tab (limited scope) burn, reporting how long the operation took. Tracked separately from the burn-all timing because clearing a single tab must enumerate and selectively delete per-domain, making it inherently slower.",
+        "owners": ["hassaanelgarem"],
+        "triggers": ["other"],
+        "suffixes": ["time_bucket", "platform", "form_factor"],
+        "parameters": ["appVersion"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215736704194450?focus=true

### Description

- Fire a distinct debug pixel for each data-clearing scope so single-tab (limited) burns are no longer conflated with burn-all in the timing metric. Single-tab burns must enumerate and selectively delete per-domain, making them inherently slower; mixing them into one pixel made the burn-all timing look like a regression in anomaly reports.
- `.all` scope continues firing `m_debug_legacy-data-clearing-time-<bucket>`; `.limited` scope now fires the new `m_debug_legacy-data-clearing-single-tab-time-<bucket>`.
- Added the `m_debug_legacy-data-clearing-single-tab-time-` pixel definition to `debug_pixels.json5`.

### Testing Steps

Since these are debug pixels, verification is primarily via pixel logs:
1. Run the app with pixel debugging/logging enabled.
2. Open several tabs and browse a number of sites.
3. Burn a single tab (single-tab burn) and confirm a `m_debug_legacy-data-clearing-single-tab-time-<bucket>` pixel fires (and that `m_debug_legacy-data-clearing-time-<bucket>` does **not**).
4. Trigger a full burn (Fire button → clear everything) and confirm `m_debug_legacy-data-clearing-time-<bucket>` fires (and the single-tab variant does **not**).
5. Confirm normal data clearing still works correctly in both cases.

### Impact and Risks

**Impact Level: Low**

This only renames the single-tab data-clearing debug pixel without changing any clearing behaviour.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only change to pixel firing and naming; no changes to website data clearing behavior.
> 
> **Overview**
> **Data-clearing duration is now reported on separate pixels for full burns vs single-tab burns**, so slower per-domain single-tab clears no longer skew all-tabs timing in anomaly reports.
> 
> After default-persistence clearing finishes, `WebCacheManager` calls a new `fireDataClearingTimePixel(scope:totalTime:)` helper: **`.all`** still fires the existing case but its event name changes from `m_debug_legacy-data-clearing-time-<bucket>` to **`data-clearing_all-tabs-time-<bucket>`**; **`.limited`** fires a new **`clearDataInDefaultPersistenceSingleTab`** pixel mapped to **`data-clearing_single-tab-time-<bucket>`**. Matching entries were added in `data_clearing_pixels.json5`. Clearing logic is unchanged—only which pixel fires and naming/definitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a6b5037b2072f1ca5569b7b8567e09e7c13aa58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->