### PR TITLE
iOS: Keep model chip visible after switching models until submission

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/TabInputState.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/TabInputState.swift
@@ -34,6 +34,9 @@ struct TabInputState: Equatable {
     /// Driven by FE `voiceSessionStarted` / `voiceSessionEnded` user-script messages. Hides the
     /// header chats/compose pill while voice is active; orthogonal to `aiChatInputBoxVisibility`.
     var isVoiceSessionActive: Bool
+    /// Recovery `showModelPicker` pin: keeps the model chip visible mid-chat until prompt submit.
+    /// Used when the user has lost access to the selected model.
+    var isModelPickerForcedVisible: Bool
 
     init(
         text: String = "",
@@ -43,7 +46,8 @@ struct TabInputState: Equatable {
         selectedReasoningMode: AIChatReasoningMode? = nil,
         selectedTool: AIChatRAGTool? = nil,
         aiChatInputBoxVisibility: AIChatInputBoxVisibility = .unknown,
-        isVoiceSessionActive: Bool = false
+        isVoiceSessionActive: Bool = false,
+        isModelPickerForcedVisible: Bool = false
     ) {
         self.text = text
         self.toggleMode = toggleMode
@@ -53,6 +57,7 @@ struct TabInputState: Equatable {
         self.selectedTool = selectedTool
         self.aiChatInputBoxVisibility = aiChatInputBoxVisibility
         self.isVoiceSessionActive = isVoiceSessionActive
+        self.isModelPickerForcedVisible = isModelPickerForcedVisible
     }
 
     static func == (lhs: TabInputState, rhs: TabInputState) -> Bool {
@@ -64,6 +69,7 @@ struct TabInputState: Equatable {
             && lhs.selectedTool == rhs.selectedTool
             && lhs.aiChatInputBoxVisibility == rhs.aiChatInputBoxVisibility
             && lhs.isVoiceSessionActive == rhs.isVoiceSessionActive
+            && lhs.isModelPickerForcedVisible == rhs.isModelPickerForcedVisible
     }
 
     /// Compact, privacy-aware description for debug logs. Reports text length and
@@ -76,6 +82,6 @@ struct TabInputState: Equatable {
         let model = selectedModelID ?? "nil"
         let reasoning = selectedReasoningMode?.rawValue ?? "nil"
         let tool = selectedTool?.rawValue ?? "nil"
-        return "mode=\(mode) text.count=\(textLen) attachments=\(attachments) model=\(model) reasoning=\(reasoning) tool=\(tool) inputBox=\(aiChatInputBoxVisibility.rawValue) voice=\(isVoiceSessionActive)"
+        return "mode=\(mode) text.count=\(textLen) attachments=\(attachments) model=\(model) reasoning=\(reasoning) tool=\(tool) inputBox=\(aiChatInputBoxVisibility.rawValue) voice=\(isVoiceSessionActive) modelPickerPin=\(isModelPickerForcedVisible)"
     }
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -272,9 +272,18 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     private var isContentOverlaySuppressed = false
     private var pendingGatedModelId: String?
     private var pendingGatedReasoningSelection: (modelId: String, mode: AIChatReasoningMode)?
-    /// Forces the model chip visible mid-chat for the FE's `showModelPicker` flow; cleared once a
-    /// supported model is applied or the session resets.
-    private var isModelPickerForcedVisible = false
+    /// Forces the model chip visible mid-chat for the FE's `showModelPicker` flow; cleared on prompt
+    /// submit or session reset.
+    private var isModelPickerForcedVisible: Bool = false {
+        didSet {
+            guard oldValue != isModelPickerForcedVisible else { return }
+            guard !isClearingModelPickerPinWithoutPersist else { return }
+            persistDraftToStore()
+        }
+    }
+    /// Scoped guard for `hide()`: clear the live pin without writing `false` to `TabInputState`
+    /// (the per-tab pin must survive so `activateForTab` can restore the recovery chip).
+    private var isClearingModelPickerPinWithoutPersist = false
 
     private(set) var currentText: String = ""
     var hasActiveChat: Bool { boundUserScript != nil }
@@ -625,6 +634,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
 
         aiChatInputBoxVisibility = state.aiChatInputBoxVisibility
         isVoiceSessionActive = state.isVoiceSessionActive
+        isModelPickerForcedVisible = state.isModelPickerForcedVisible
         setText(state.text)
         syncInputModeFromExternalSource(state.toggleMode)
 
@@ -664,7 +674,8 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             selectedReasoningMode: modelStore.selectedReasoningMode,
             selectedTool: toolsController.selectedTool,
             aiChatInputBoxVisibility: aiChatInputBoxVisibility,
-            isVoiceSessionActive: isVoiceSessionActive
+            isVoiceSessionActive: isVoiceSessionActive,
+            isModelPickerForcedVisible: isModelPickerForcedVisible
         )
     }
 
@@ -767,7 +778,9 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         cancelTopOmnibarKeyboardPresentationFallback()
         isAwaitingTopOmnibarKeyboardPresentation = false
         displayState = .hidden
+        isClearingModelPickerPinWithoutPersist = true
         isModelPickerForcedVisible = false
+        isClearingModelPickerPinWithoutPersist = false
         isSubmitBlockedByRecoveryCard = false
         syncInputBehaviorToHandler()
         isInputVisibleForKeyboard = true
@@ -1160,9 +1173,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             toolsSelected: false,
             attachmentsSelected: false
         )
-        hasSubmittedPrompt = true
-        updateModelChipVisibility()
-        syncHasSubmittedPromptToHandler()
+        markActiveChatPromptSubmitted()
         resetToolsSelection()
         clearStoreEntryAfterSubmission()
         showCollapsed()
@@ -1173,9 +1184,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
 
     func prepareExternalPromptSubmission() -> (modelId: String?, reasoningEffort: AIChatReasoningEffort?) {
         let configuration = promptSubmissionConfiguration
-        hasSubmittedPrompt = true
-        updateModelChipVisibility()
-        syncHasSubmittedPromptToHandler()
+        markActiveChatPromptSubmitted()
         return (configuration.modelId, configuration.reasoningEffort)
     }
 
@@ -1411,9 +1420,6 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         if model.entityHasAccess {
             let isNewSelection = modelId != modelStore.persistedModelId
             pendingGatedModelId = nil
-            if isModelPickerForcedVisible {
-                isModelPickerForcedVisible = false
-            }
             // Supported model picked in the native picker — the recovery card's reason to block
             // submit is gone, so drop the block (no-op when it wasn't set).
             isSubmitBlockedByRecoveryCard = false
@@ -1526,13 +1532,8 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
 
         let isNewSelection = modelId != modelStore.persistedModelId
         pendingGatedModelId = nil
-        // Mirror the direct-selection path: the gated model the recovery-card flow was waiting on
-        // is now accessible (post-purchase), so drop the forced reveal and let the chip re-hide.
-        if isModelPickerForcedVisible {
-            isModelPickerForcedVisible = false
-        }
-        // The gated model the recovery flow waited on is now accessible (post-purchase); it
-        // becomes the active supported model, so lift the recovery-card submit block too.
+        // Mirror the direct-selection path: the gated model in the recovery-card
+        // is now accessible (post-purchase), so drop the recovery-card submit block.
         isSubmitBlockedByRecoveryCard = false
         updateSelectedModel(modelId)
         if isNewSelection {
@@ -1911,9 +1912,7 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
             if isOmnibarNewAIChatPrompt {
                 viewController.prepareToolbarSubmitStyleForDismissal()
             }
-            hasSubmittedPrompt = true
-            updateModelChipVisibility()
-            syncHasSubmittedPromptToHandler()
+            markActiveChatPromptSubmitted()
             if isOmnibarSession {
                 deactivateToOmnibar()
             } else {
@@ -2336,6 +2335,13 @@ private extension UnifiedToggleInputCoordinator {
         updateFloatingReturnKeyState()
     }
 
+    private func markActiveChatPromptSubmitted() {
+        hasSubmittedPrompt = true
+        isModelPickerForcedVisible = false
+        updateModelChipVisibility()
+        syncHasSubmittedPromptToHandler()
+    }
+
     func syncInputBehaviorToHandler() {
         viewController.handler.submitsAIChatOnKeyboardReturn = isOmnibarNewAIChatPrompt
     }
@@ -2345,7 +2351,10 @@ private extension UnifiedToggleInputCoordinator {
         aiChatStatus = .unknown
         attachmentUsage = nil
         hasSubmittedPrompt = false
-        isModelPickerForcedVisible = false
+        // Do not clear the model-picker pin here. It is stored per tab in TabInputState and
+        // restored by applyState during activateForTab. bindToTab calls resetSessionState
+        // immediately after that restore when switching Duck.ai tabs, so resetting the pin
+        // here would undo the value we just loaded for the incoming tab.
         isSubmitBlockedByRecoveryCard = false
         updateModelChipVisibility()
         syncHasSubmittedPromptToHandler()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -687,10 +687,10 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         stateStore.update(snapshotCurrentState(), for: uid)
     }
 
-    /// `hide()` nils `currentTabUID`, so pin clears on submit cannot use `persistDraftToStore`.
-    /// Patch the stored pin directly for the tab we were last on.
-    private func persistModelPickerPinClearedAfterHideIfNeeded(hadPin: Bool) {
-        guard hadPin, currentTabUID == nil, let uid = lastActivatedTabUID else { return }
+    /// `hide()` clears the live pin without updating `TabInputState`, so submit after `hide()`
+    /// (`currentTabUID` nil) must patch the stored pin directly for `lastActivatedTabUID`.
+    private func persistModelPickerPinClearedAfterHideIfNeeded() {
+        guard currentTabUID == nil, let uid = lastActivatedTabUID else { return }
         var state = stateStore.state(for: uid)
         guard state.isModelPickerForcedVisible else { return }
         state.isModelPickerForcedVisible = false
@@ -2347,9 +2347,8 @@ private extension UnifiedToggleInputCoordinator {
 
     private func markActiveChatPromptSubmitted() {
         hasSubmittedPrompt = true
-        let hadPinnedModelPicker = isModelPickerForcedVisible
         isModelPickerForcedVisible = false
-        persistModelPickerPinClearedAfterHideIfNeeded(hadPin: hadPinnedModelPicker)
+        persistModelPickerPinClearedAfterHideIfNeeded()
         updateModelChipVisibility()
         syncHasSubmittedPromptToHandler()
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -687,6 +687,16 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         stateStore.update(snapshotCurrentState(), for: uid)
     }
 
+    /// `hide()` nils `currentTabUID`, so pin clears on submit cannot use `persistDraftToStore`.
+    /// Patch the stored pin directly for the tab we were last on.
+    private func persistModelPickerPinClearedAfterHideIfNeeded(hadPin: Bool) {
+        guard hadPin, currentTabUID == nil, let uid = lastActivatedTabUID else { return }
+        var state = stateStore.state(for: uid)
+        guard state.isModelPickerForcedVisible else { return }
+        state.isModelPickerForcedVisible = false
+        stateStore.update(state, for: uid)
+    }
+
     /// Persists a user-deliberate choice — toggle mode, model, reasoning, tool. These
     /// update the global last-used defaults and write through to the canonical global
     /// preference homes so other components (e.g. NTP omnibar) observe the change.
@@ -2337,7 +2347,9 @@ private extension UnifiedToggleInputCoordinator {
 
     private func markActiveChatPromptSubmitted() {
         hasSubmittedPrompt = true
+        let hadPinnedModelPicker = isModelPickerForcedVisible
         isModelPickerForcedVisible = false
+        persistModelPickerPinClearedAfterHideIfNeeded(hadPin: hadPinnedModelPicker)
         updateModelChipVisibility()
         syncHasSubmittedPromptToHandler()
     }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/TabInputStateTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/TabInputStateTests.swift
@@ -31,6 +31,7 @@ final class TabInputStateTests: XCTestCase {
         XCTAssertNil(sut.selectedModelID)
         XCTAssertNil(sut.selectedReasoningMode)
         XCTAssertNil(sut.selectedTool)
+        XCTAssertFalse(sut.isModelPickerForcedVisible)
     }
 
     func test_equatable_sameValues_areEqual() {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -2929,6 +2929,20 @@ final class UnifiedToggleInputCoordinatorPerTabStateTests: XCTestCase {
         XCTAssertEqual(instrumentation.submissionStartedScopes, [.tab("tab-A")])
     }
 
+    func test_submitAfterHide_clearsPersistedModelPickerPin() {
+        let store = FakeInputStateStore()
+        let sut = makeSUT(stateStore: store)
+        sut.activateForTab("tab-A")
+        _ = sut.prepareExternalPromptSubmission()
+        sut.presentModelPickerForActiveChat()
+        XCTAssertTrue(store.states["tab-A"]?.isModelPickerForcedVisible == true)
+
+        sut.hide()
+        sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "hello", mode: .aiChat)
+
+        XCTAssertEqual(store.states["tab-A"]?.isModelPickerForcedVisible, false)
+    }
+
     // Regression: applyState must always sync the live model store from per-tab
     // state, even when state values are nil. Otherwise the previous tab's reasoning
     // mode (or model id) leaks through preferences, and the next snapshot writes

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -148,7 +148,7 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         XCTAssertFalse(sut.viewController.isModelChipHidden)
     }
 
-    func test_selectingSupportedModel_afterPresentingModelPicker_reHidesModelChip() {
+    func test_selectingSupportedModel_afterPresentingModelPicker_keepsModelChipVisible() {
         _ = sut.prepareExternalPromptSubmission()
         sut.presentModelPickerForActiveChat()
         XCTAssertFalse(sut.viewController.isModelChipHidden)
@@ -157,6 +157,20 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
             AIChatModel(id: "gpt-5", name: "GPT-5", shortName: "G5", provider: .openAI, supportsImageUpload: false, entityHasAccess: true)
         ]
         sut.handleModelSelection("gpt-5")
+
+        XCTAssertFalse(sut.viewController.isModelChipHidden)
+    }
+
+    func test_submittingPrompt_afterPresentingModelPickerAndSelectingModel_hidesModelChip() {
+        _ = sut.prepareExternalPromptSubmission()
+        sut.presentModelPickerForActiveChat()
+        sut.modelStore.models = [
+            AIChatModel(id: "gpt-5", name: "GPT-5", shortName: "G5", provider: .openAI, supportsImageUpload: false, entityHasAccess: true)
+        ]
+        sut.handleModelSelection("gpt-5")
+        XCTAssertFalse(sut.viewController.isModelChipHidden)
+
+        sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "follow-up", mode: .aiChat)
 
         XCTAssertTrue(sut.viewController.isModelChipHidden)
     }
@@ -2772,6 +2786,43 @@ final class UnifiedToggleInputCoordinatorPerTabStateTests: XCTestCase {
         XCTAssertFalse(sut.isVoiceSessionActive)
         sut.activateForTab("tab-A")
         XCTAssertTrue(sut.isVoiceSessionActive)
+    }
+
+    func test_activateForTab_roundTripsModelPickerForcedVisible() {
+        let store = FakeInputStateStore()
+        let sut = makeSUT(stateStore: store)
+        sut.activateForTab("tab-A")
+        _ = sut.prepareExternalPromptSubmission()
+        sut.presentModelPickerForActiveChat()
+        XCTAssertFalse(sut.viewController.isModelChipHidden)
+
+        sut.activateForTab("tab-B")
+        XCTAssertTrue(sut.viewController.isModelChipHidden)
+
+        sut.activateForTab("tab-A")
+        XCTAssertFalse(sut.viewController.isModelChipHidden)
+    }
+
+    func test_bindToTab_afterActivateForTab_preservesModelPickerPin() {
+        let store = FakeInputStateStore()
+        let sut = makeSUT(stateStore: store)
+        let scriptA = makeTestUserScript()
+        let scriptB = makeTestUserScript()
+
+        sut.activateForTab("tab-A")
+        _ = sut.prepareExternalPromptSubmission()
+        sut.presentModelPickerForActiveChat()
+        sut.bindToTab(scriptA, hasExistingChat: true)
+        XCTAssertFalse(sut.viewController.isModelChipHidden)
+
+        sut.activateForTab("tab-B")
+        sut.bindToTab(scriptB, hasExistingChat: true)
+
+        sut.activateForTab("tab-A")
+        sut.bindToTab(scriptA, hasExistingChat: true)
+
+        XCTAssertFalse(sut.viewController.isModelChipHidden,
+                      "bindToTab must not reset the pin applyState restored — mirrors AI-tab → AI-tab switch")
     }
 
     func test_endToEnd_twoTabSwitches_preserveIndependentState() {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210947754188321/task/1215592714384520?focus=true
Tech Design URL:
CC:

### Description
When the FE sends `showModelPicker` (subscription recovery card “Switch Model”), the native model chip now stays visible until the user submits a prompt, not when they pick a model or dismiss the picker. This lets users see and change the selected model before sending.

The recovery pin (`isModelPickerForcedVisible`) is persisted per tab in `TabInputState`, matching the existing `isVoiceSessionActive` pattern.


### Testing Steps
Setup:
- `unifiedToggleInput` enabled
- active subscription

1. Create a chat with either Plus or Pro model. Send at least one prompt on that chat. Remove subscription.
2. Open a paid-model for which subscription expired, model chip should stay hidden until you tap “Switch Model” web button
3. Tap “Switch Model”, UTI expands, model chip appears, picker opens; chip stays visible if you dismiss without choosing.
4. Select a supported model. Chip remains visible, change model again via chip — still visible.
5. Tap on a gated model (Plus or Pro) -> selection still routes to subscription upsell; chip stays visible.
6. Switch to another Duck\.ai tab (free chat) — model chip is hidden; return to paid tab — chip visible again.
7. Switch to non-chat website (i.e. wikipedia\.org) — model chip is hidden; return to paid tab — chip visible again.
8. Submit a prompt on the paid tab — chip hides after submit.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
**Low** — scoped to UTI recovery / `showModelPicker` flow on active Duck\.ai chats. No bridge contract changes.

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
- Pin could leak across tabs if `TabInputState` snapshot/restore regresses — covered by new tab-switch tests.
- `hide()` clears live pin without persisting; returning via `activateForTab` must restore from store — manually verified.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->
- **Edge cases:** Tab switch AI→AI, `hide()` without overriding stored pin, post-purchase gated model apply, submit via keyboard / external / voice paths (DRY via `markActiveChatPromptSubmitted`).

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to UTI Duck.ai recovery UI and per-tab draft state; no bridge contract changes, with new tab-switch and submit-after-hide tests.
> 
> **Overview**
> For the FE **`showModelPicker`** subscription-recovery flow, the native model chip now **stays visible until the user submits a prompt**, not when they pick a supported model or finish a gated purchase.
> 
> **`isModelPickerForcedVisible`** is added to **`TabInputState`** and round-tripped on tab activate/snapshot (same pattern as voice session). The coordinator persists pin changes via **`didSet`**, clears the pin in a shared **`markActiveChatPromptSubmitted()`** for keyboard/voice/external submit paths, and **stops clearing the pin** on model selection or **`resetSessionState`** (so AI-tab switches after **`bindToTab`** don’t drop the recovery chip).
> 
> **`hide()`** clears the in-memory pin without writing **`false`** to the store so returning to the tab restores the chip; submit after hide patches the stored pin via **`persistModelPickerPinClearedAfterHideIfNeeded()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f370e494f62ebdbdcffed76a8702013b8d2d4a24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->