### PR TITLE
[iOS] UTI: favorites on a pre-filled URL, no dismiss flash, long URL single-line

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -545,8 +545,12 @@ class SwitchBarTextEntryView: UIView {
     }
 
     /// https://app.asana.com/1/137249556945/project/392891325557410/task/1210835160047733?focus=true
+    /// A URL stays single-line unless it's an interactive AI-chat composer: search mode, or
+    /// search-only (no toggle, so AI chat is unavailable), or before the user interacts — all
+    /// single-line. Only an interacted AI-chat field (toggle present) lets a long URL expand.
     private func isUnexpandedURL() -> Bool {
-        return !hasBeenInteractedWith && isURL
+        guard isURL else { return false }
+        return currentMode == .search || !handler.isToggleEnabled || !hasBeenInteractedWith
     }
 
     private func updateTextViewHeight() {
@@ -682,7 +686,6 @@ class SwitchBarTextEntryView: UIView {
                     let isNewLineInsertion = text == (self.textView.text ?? "") + "\n"
                     
                     guard !isUserActivelyTyping || isNewLineInsertion else { return }
-                    
                     self.textView.text = text
                     self.updatePlaceholderVisibility()
                     self.updateTextViewHeight()
@@ -877,8 +880,11 @@ extension SwitchBarTextEntryView: UITextViewDelegate {
 
     func textViewDidChangeSelection(_ textView: UITextView) {
         guard canExpandOnSelectionChange else { return }
-        textViewDidChange(textView)
         canExpandOnSelectionChange = false
+        // A selection change (e.g. the select-all on focus) only needs the expandable-height
+        // recompute — it is NOT a text edit, so it must not run the full `textViewDidChange`
+        // (which marks user interaction and would flash suggestions over favorites/logo).
+        updateTextViewHeight()
     }
 
     func textViewDidBeginEditing(_ textView: UITextView) {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/UnifiedSuggestionsInputsMerger.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/UnifiedSuggestionsInputsMerger.swift
@@ -37,11 +37,15 @@ enum UnifiedSuggestionsInputsMerger {
 
     /// `duckAI` is nil when the duck.ai source isn't installed (its lazy lifecycle), which the
     /// resolver treats as no recents and nothing pending.
+    /// A pre-filled, unedited URL stays in the not-typing state (favorites until the user edits),
+    /// mirroring `SuggestionTrayManager.shouldDisplaySuggestionTray`.
     static func merge(mode: TextEntryMode,
                       text: String,
+                      hasUserInteractedWithText: Bool,
                       search: SearchState,
                       duckAI: DuckAIState?) -> UnifiedSuggestionsInputs {
-        let isTyping = !text.isEmpty
+        let isURL = URL.isValidAddressBarURLInput(text)
+        let isTyping = !text.isEmpty && (!isURL || hasUserInteractedWithText)
         switch mode {
         case .search:
             return UnifiedSuggestionsInputs(

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -530,14 +530,17 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         // one). The model notifies after refreshing its array, so the reads below are fresh.
         Publishers.CombineLatest4(
             switchBarHandler.toggleStatePublisher,
-            switchBarHandler.currentTextPublisher,
+            Publishers.CombineLatest(switchBarHandler.currentTextPublisher,
+                                     switchBarHandler.hasUserInteractedWithTextPublisher),
             duckAIStateRelay,
             searchStateChanged.prepend(())
         )
-        .map { mode, text, duckAIState, _ -> UnifiedSuggestionsInputs in
-            UnifiedSuggestionsInputsMerger.merge(
+        .map { mode, textState, duckAIState, _ -> UnifiedSuggestionsInputs in
+            let (text, hasUserInteractedWithText) = textState
+            return UnifiedSuggestionsInputsMerger.merge(
                 mode: mode,
                 text: text,
+                hasUserInteractedWithText: hasUserInteractedWithText,
                 search: .init(hasFavorites: hasFavorites(), hasMessages: hasMessages()),
                 duckAI: duckAIState)
         }
@@ -744,7 +747,12 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         // when it resolves to `.logo`. Resolving both modes keeps the swipe-morph's two empty states
         // available; landscape suppresses both.
         func resolvesToLogo(_ mode: TextEntryMode) -> Bool {
-            let inputs = UnifiedSuggestionsInputsMerger.merge(mode: mode, text: text, search: searchState, duckAI: duckAIState)
+            let inputs = UnifiedSuggestionsInputsMerger.merge(
+                mode: mode,
+                text: text,
+                hasUserInteractedWithText: switchBarHandler.hasUserInteractedWithText,
+                search: searchState,
+                duckAI: duckAIState)
             return UnifiedSuggestionsContentResolver.resolve(inputs, previous: nil) == .logo
         }
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/Suggestions/UnifiedSuggestionsInputsMergerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/Suggestions/UnifiedSuggestionsInputsMergerTests.swift
@@ -27,6 +27,7 @@ final class UnifiedSuggestionsInputsMergerTests: XCTestCase {
     func test_search_blank_withFavorites_resolvesFavoritesInputs() {
         let i = Merger.merge(
             mode: .search, text: "",
+            hasUserInteractedWithText: false,
             search: .init(hasFavorites: true, hasMessages: false),
             duckAI: nil)
         XCTAssertEqual(i, UnifiedSuggestionsInputs(
@@ -38,6 +39,7 @@ final class UnifiedSuggestionsInputsMergerTests: XCTestCase {
     func test_search_typing_isTyping_andNeverHasRecents() {
         let i = Merger.merge(
             mode: .search, text: "abc",
+            hasUserInteractedWithText: true,
             search: .init(hasFavorites: true, hasMessages: true),
             duckAI: .init(hasRecents: true, settled: false))
         XCTAssertTrue(i.isTyping)
@@ -46,9 +48,40 @@ final class UnifiedSuggestionsInputsMergerTests: XCTestCase {
         XCTAssertEqual(i.mode, .search)
     }
 
+    // A typed (non-URL) query shows suggestions immediately — the interaction flag isn't required.
+    func test_search_typedNonURL_isTyping_withoutInteractionFlag() {
+        let i = Merger.merge(
+            mode: .search, text: "cats",
+            hasUserInteractedWithText: false,
+            search: .init(hasFavorites: true, hasMessages: false),
+            duckAI: nil)
+        XCTAssertTrue(i.isTyping)
+    }
+
+    // Pre-filled, unedited URL (omnibar tapped on a loaded page) stays not-typing so favorites show.
+    func test_search_prefilledURL_notInteracted_isNotTyping() {
+        let i = Merger.merge(
+            mode: .search, text: "https://example.com",
+            hasUserInteractedWithText: false,
+            search: .init(hasFavorites: true, hasMessages: false),
+            duckAI: nil)
+        XCTAssertFalse(i.isTyping)
+    }
+
+    // Once the user edits the pre-filled URL, suggestions take over.
+    func test_search_prefilledURL_afterInteraction_isTyping() {
+        let i = Merger.merge(
+            mode: .search, text: "https://example.com",
+            hasUserInteractedWithText: true,
+            search: .init(hasFavorites: true, hasMessages: false),
+            duckAI: nil)
+        XCTAssertTrue(i.isTyping)
+    }
+
     func test_aichat_blank_withRecents_setsHasRecents() {
         let i = Merger.merge(
             mode: .aiChat, text: "",
+            hasUserInteractedWithText: false,
             search: .init(hasFavorites: false, hasMessages: false),
             duckAI: .init(hasRecents: true, settled: true))
         XCTAssertEqual(i.mode, .aiChat)
@@ -60,6 +93,7 @@ final class UnifiedSuggestionsInputsMergerTests: XCTestCase {
     func test_aichat_typing_unsettled_setsResultsPending() {
         let i = Merger.merge(
             mode: .aiChat, text: "foo",
+            hasUserInteractedWithText: true,
             search: .init(hasFavorites: false, hasMessages: false),
             duckAI: .init(hasRecents: false, settled: false))
         XCTAssertTrue(i.isTyping)
@@ -69,6 +103,7 @@ final class UnifiedSuggestionsInputsMergerTests: XCTestCase {
     func test_aichat_typing_settled_clearsResultsPending() {
         let i = Merger.merge(
             mode: .aiChat, text: "foo",
+            hasUserInteractedWithText: true,
             search: .init(hasFavorites: false, hasMessages: false),
             duckAI: .init(hasRecents: false, settled: true))
         XCTAssertTrue(i.isTyping)
@@ -78,6 +113,7 @@ final class UnifiedSuggestionsInputsMergerTests: XCTestCase {
     func test_aichat_withoutDuckAISource_hasNoRecentsOrPending() {
         let i = Merger.merge(
             mode: .aiChat, text: "foo",
+            hasUserInteractedWithText: true,
             search: .init(hasFavorites: true, hasMessages: false),
             duckAI: nil)
         XCTAssertFalse(i.hasRecents)

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -544,6 +544,75 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         assertColor(rimShadowLayer.shadowColor, equals: expectedShadowColor)
     }
 
+    private let longURL = "https://www.cinemark.com/theatres/ca-playa-vista/cinemark-playa-vista-and-xd?showDate=2026-06-12"
+
+    func test_urlDoesNotExpandHeightInSearchModeAfterUserTap() {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.setToggleState(.search)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut)
+        sut.setQueryText(longURL)
+        let singleLineHeight = applyFittingHeight(to: sut)
+
+        sut.hasBeenInteractedWith = true
+        sut.updatePoseForCurrentState()
+        let heightAfterTap = applyFittingHeight(to: sut)
+
+        XCTAssertEqual(heightAfterTap, singleLineHeight, accuracy: 1)
+    }
+
+    func test_urlCanExpandInAIChatModeAfterUserTap() {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.setToggleState(.aiChat)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut)
+        sut.setQueryText(longURL)
+        let singleLineHeight = applyFittingHeight(to: sut)
+
+        sut.hasBeenInteractedWith = true
+        sut.updatePoseForCurrentState()
+        let heightAfterTap = applyFittingHeight(to: sut)
+
+        XCTAssertGreaterThan(heightAfterTap, singleLineHeight)
+    }
+
+    func test_urlCollapsesToSingleLineWhenModeSwitchesFromAIChatToSearch() {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.setToggleState(.aiChat)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut)
+        sut.setQueryText(longURL)
+        sut.hasBeenInteractedWith = true
+        sut.updatePoseForCurrentState()
+        let expandedHeight = applyFittingHeight(to: sut)
+
+        handler.setToggleState(.search)
+        sut.updatePoseForCurrentState()
+        let heightAfterSwitch = applyFittingHeight(to: sut)
+
+        XCTAssertGreaterThan(expandedHeight, heightAfterSwitch)
+    }
+
+    // Search-only: UTI shown without a toggle (AI chat unavailable). Even though the handler's
+    // toggle state may still be its `.aiChat` default, a tapped URL must stay single-line.
+    func test_urlDoesNotExpandHeightInSearchOnlyModeWithoutToggle() {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false, isToggleEnabled: false)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut)
+        sut.setQueryText(longURL)
+        let singleLineHeight = applyFittingHeight(to: sut)
+
+        sut.hasBeenInteractedWith = true
+        sut.updatePoseForCurrentState()
+        let heightAfterTap = applyFittingHeight(to: sut)
+
+        XCTAssertEqual(heightAfterTap, singleLineHeight, accuracy: 1)
+    }
+
     private func flushMainQueue() {
         let expectation = expectation(description: "main queue flushed")
         DispatchQueue.main.async {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1213881875984009/task/1215717889939551

### Description
Three related fixes to the Unified Toggle Input (UTI) omnibar. The UTI is gated by the **unified toggle input** feature flag — this is distinct from the older "experimental input" omnibar, which is a separate feature.

### Testing Steps
Enable the **unified toggle input** feature flag. (Not the "experimental input" omnibar — that's a separate feature.) Use a tab loaded on a page and ≥1 saved favorite.

A — UTI on, toggle enabled:
1. Tap the address bar → favorites show (or the Dax logo if none), NOT search suggestions.
2. Type → suggestions replace favorites; clear to empty → favorites return.
3. Pre-filled URL, don't type, tap back → no suggestion-list flash during the collapse (try a few times — it was intermittent).

B — UTI on, long URL:
4. Load a page with a long URL → tap the address bar → the URL stays on ONE line (no wrap to two).
5. Switch to Duck.ai and edit a long prompt → it can grow to multiple lines (intended; only an interacted AI-chat composer expands).

C — UTI on, toggle disabled:
6. In Settings set AI Chat to "Search only" so the UTI shows with NO toggle; relaunch.
7. Tap the address bar on a long URL → it stays ONE line. Moving the caret without typing keeps favorites; typing shows suggestions.

D — Regression (shared text entry):
8. Turn the unified toggle input flag OFF, restart app → plain omnibar focus / type / dismiss / navigate behaves normally.

### Impact and Risks
Low. UTI-only behaviour, confined to pre-filled-URL focus and dismiss.

#### What could go wrong?
The shared `SwitchBarTextEntryView` edits (`textViewDidChangeSelection` now height-only; `isUnexpandedURL` single-line gating). The shared edit path is untouched, so real typing still marks interaction. The one behavioural delta for the experimental SwitchBar omnibar: a caret-move after select-all no longer counts as interaction (favorites stay until typing) — arguably more correct. Covered by steps 8–9.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are scoped to UTI suggestion merging and shared `SwitchBarTextEntryView` selection/height logic; real typing still marks interaction, with minor shared-component edge-case risk.
> 
> **Overview**
> Three **Unified Toggle Input (UTI)** omnibar fixes: pre-filled URL focus, dismiss animation, and long-URL height.
> 
> **Favorites on focus:** `UnifiedSuggestionsInputsMerger` now treats a pre-filled, unedited URL as *not typing* (`isTyping` requires `!isURL || hasUserInteractedWithText`), wired through `hasUserInteractedWithTextPublisher` in the merged inputs and Dax logo resolution—so tapping the bar on a loaded page shows favorites instead of suggestions.
> 
> **Dismiss flash:** `SwitchBarTextEntryView.textViewDidChangeSelection` no longer forwards to `textViewDidChange` (which marked interaction during dismiss snapshot select-all); it only calls `updateTextViewHeight()`.
> 
> **Long URL single-line:** `isUnexpandedURL()` keeps URLs truncated in search mode, search-only (no toggle), or before interaction; multi-line expansion remains for interacted Duck.ai when the toggle is enabled.
> 
> Unit tests cover merger URL/interaction cases and text-entry height behavior (search vs AI chat, mode switch, search-only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3685558564baead199a3a33f4a35a3499f8f8dfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->