### PR TITLE
[iOS] UTI: favorites on a pre-filled URL, no dismiss flash, long URL …

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -545,8 +545,12 @@ class SwitchBarTextEntryView: UIView {
     }
 
     /// https://app.asana.com/1/137249556945/project/392891325557410/task/1210835160047733?focus=true
+    /// A URL stays single-line unless it's an interactive AI-chat composer: search mode, or
+    /// search-only (no toggle, so AI chat is unavailable), or before the user interacts — all
+    /// single-line. Only an interacted AI-chat field (toggle present) lets a long URL expand.
     private func isUnexpandedURL() -> Bool {
-        return !hasBeenInteractedWith && isURL
+        guard isURL else { return false }
+        return currentMode == .search || !handler.isToggleEnabled || !hasBeenInteractedWith
     }
 
     private func updateTextViewHeight() {
@@ -682,7 +686,6 @@ class SwitchBarTextEntryView: UIView {
                     let isNewLineInsertion = text == (self.textView.text ?? "") + "\n"
                     
                     guard !isUserActivelyTyping || isNewLineInsertion else { return }
-                    
                     self.textView.text = text
                     self.updatePlaceholderVisibility()
                     self.updateTextViewHeight()
@@ -877,8 +880,11 @@ extension SwitchBarTextEntryView: UITextViewDelegate {
 
     func textViewDidChangeSelection(_ textView: UITextView) {
         guard canExpandOnSelectionChange else { return }
-        textViewDidChange(textView)
         canExpandOnSelectionChange = false
+        // A selection change (e.g. the select-all on focus) only needs the expandable-height
+        // recompute — it is NOT a text edit, so it must not run the full `textViewDidChange`
+        // (which marks user interaction and would flash suggestions over favorites/logo).
+        updateTextViewHeight()
     }
 
     func textViewDidBeginEditing(_ textView: UITextView) {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/UnifiedSuggestionsInputsMerger.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/UnifiedSuggestionsInputsMerger.swift
@@ -37,11 +37,15 @@ enum UnifiedSuggestionsInputsMerger {
 
     /// `duckAI` is nil when the duck.ai source isn't installed (its lazy lifecycle), which the
     /// resolver treats as no recents and nothing pending.
+    /// A pre-filled, unedited URL stays in the not-typing state (favorites until the user edits),
+    /// mirroring `SuggestionTrayManager.shouldDisplaySuggestionTray`.
     static func merge(mode: TextEntryMode,
                       text: String,
+                      hasUserInteractedWithText: Bool,
                       search: SearchState,
                       duckAI: DuckAIState?) -> UnifiedSuggestionsInputs {
-        let isTyping = !text.isEmpty
+        let isURL = URL.isValidAddressBarURLInput(text)
+        let isTyping = !text.isEmpty && (!isURL || hasUserInteractedWithText)
         switch mode {
         case .search:
             return UnifiedSuggestionsInputs(

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -530,14 +530,17 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         // one). The model notifies after refreshing its array, so the reads below are fresh.
         Publishers.CombineLatest4(
             switchBarHandler.toggleStatePublisher,
-            switchBarHandler.currentTextPublisher,
+            Publishers.CombineLatest(switchBarHandler.currentTextPublisher,
+                                     switchBarHandler.hasUserInteractedWithTextPublisher),
             duckAIStateRelay,
             searchStateChanged.prepend(())
         )
-        .map { mode, text, duckAIState, _ -> UnifiedSuggestionsInputs in
-            UnifiedSuggestionsInputsMerger.merge(
+        .map { mode, textState, duckAIState, _ -> UnifiedSuggestionsInputs in
+            let (text, hasUserInteractedWithText) = textState
+            return UnifiedSuggestionsInputsMerger.merge(
                 mode: mode,
                 text: text,
+                hasUserInteractedWithText: hasUserInteractedWithText,
                 search: .init(hasFavorites: hasFavorites(), hasMessages: hasMessages()),
                 duckAI: duckAIState)
         }
@@ -744,7 +747,12 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         // when it resolves to `.logo`. Resolving both modes keeps the swipe-morph's two empty states
         // available; landscape suppresses both.
         func resolvesToLogo(_ mode: TextEntryMode) -> Bool {
-            let inputs = UnifiedSuggestionsInputsMerger.merge(mode: mode, text: text, search: searchState, duckAI: duckAIState)
+            let inputs = UnifiedSuggestionsInputsMerger.merge(
+                mode: mode,
+                text: text,
+                hasUserInteractedWithText: switchBarHandler.hasUserInteractedWithText,
+                search: searchState,
+                duckAI: duckAIState)
             return UnifiedSuggestionsContentResolver.resolve(inputs, previous: nil) == .logo
         }
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/Suggestions/UnifiedSuggestionsInputsMergerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/Suggestions/UnifiedSuggestionsInputsMergerTests.swift
@@ -27,6 +27,7 @@ final class UnifiedSuggestionsInputsMergerTests: XCTestCase {
     func test_search_blank_withFavorites_resolvesFavoritesInputs() {
         let i = Merger.merge(
             mode: .search, text: "",
+            hasUserInteractedWithText: false,
             search: .init(hasFavorites: true, hasMessages: false),
             duckAI: nil)
         XCTAssertEqual(i, UnifiedSuggestionsInputs(
@@ -38,6 +39,7 @@ final class UnifiedSuggestionsInputsMergerTests: XCTestCase {
     func test_search_typing_isTyping_andNeverHasRecents() {
         let i = Merger.merge(
             mode: .search, text: "abc",
+            hasUserInteractedWithText: true,
             search: .init(hasFavorites: true, hasMessages: true),
             duckAI: .init(hasRecents: true, settled: false))
         XCTAssertTrue(i.isTyping)
@@ -46,9 +48,40 @@ final class UnifiedSuggestionsInputsMergerTests: XCTestCase {
         XCTAssertEqual(i.mode, .search)
     }
 
+    // A typed (non-URL) query shows suggestions immediately — the interaction flag isn't required.
+    func test_search_typedNonURL_isTyping_withoutInteractionFlag() {
+        let i = Merger.merge(
+            mode: .search, text: "cats",
+            hasUserInteractedWithText: false,
+            search: .init(hasFavorites: true, hasMessages: false),
+            duckAI: nil)
+        XCTAssertTrue(i.isTyping)
+    }
+
+    // Pre-filled, unedited URL (omnibar tapped on a loaded page) stays not-typing so favorites show.
+    func test_search_prefilledURL_notInteracted_isNotTyping() {
+        let i = Merger.merge(
+            mode: .search, text: "https://example.com",
+            hasUserInteractedWithText: false,
+            search: .init(hasFavorites: true, hasMessages: false),
+            duckAI: nil)
+        XCTAssertFalse(i.isTyping)
+    }
+
+    // Once the user edits the pre-filled URL, suggestions take over.
+    func test_search_prefilledURL_afterInteraction_isTyping() {
+        let i = Merger.merge(
+            mode: .search, text: "https://example.com",
+            hasUserInteractedWithText: true,
+            search: .init(hasFavorites: true, hasMessages: false),
+            duckAI: nil)
+        XCTAssertTrue(i.isTyping)
+    }
+
     func test_aichat_blank_withRecents_setsHasRecents() {
         let i = Merger.merge(
             mode: .aiChat, text: "",
+            hasUserInteractedWithText: false,
             search: .init(hasFavorites: false, hasMessages: false),
             duckAI: .init(hasRecents: true, settled: true))
         XCTAssertEqual(i.mode, .aiChat)
@@ -60,6 +93,7 @@ final class UnifiedSuggestionsInputsMergerTests: XCTestCase {
     func test_aichat_typing_unsettled_setsResultsPending() {
         let i = Merger.merge(
             mode: .aiChat, text: "foo",
+            hasUserInteractedWithText: true,
             search: .init(hasFavorites: false, hasMessages: false),
             duckAI: .init(hasRecents: false, settled: false))
         XCTAssertTrue(i.isTyping)
@@ -69,6 +103,7 @@ final class UnifiedSuggestionsInputsMergerTests: XCTestCase {
     func test_aichat_typing_settled_clearsResultsPending() {
         let i = Merger.merge(
             mode: .aiChat, text: "foo",
+            hasUserInteractedWithText: true,
             search: .init(hasFavorites: false, hasMessages: false),
             duckAI: .init(hasRecents: false, settled: true))
         XCTAssertTrue(i.isTyping)
@@ -78,6 +113,7 @@ final class UnifiedSuggestionsInputsMergerTests: XCTestCase {
     func test_aichat_withoutDuckAISource_hasNoRecentsOrPending() {
         let i = Merger.merge(
             mode: .aiChat, text: "foo",
+            hasUserInteractedWithText: true,
             search: .init(hasFavorites: true, hasMessages: false),
             duckAI: nil)
         XCTAssertFalse(i.hasRecents)

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -544,6 +544,75 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         assertColor(rimShadowLayer.shadowColor, equals: expectedShadowColor)
     }
 
+    private let longURL = "https://www.cinemark.com/theatres/ca-playa-vista/cinemark-playa-vista-and-xd?showDate=2026-06-12"
+
+    func test_urlDoesNotExpandHeightInSearchModeAfterUserTap() {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.setToggleState(.search)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut)
+        sut.setQueryText(longURL)
+        let singleLineHeight = applyFittingHeight(to: sut)
+
+        sut.hasBeenInteractedWith = true
+        sut.updatePoseForCurrentState()
+        let heightAfterTap = applyFittingHeight(to: sut)
+
+        XCTAssertEqual(heightAfterTap, singleLineHeight, accuracy: 1)
+    }
+
+    func test_urlCanExpandInAIChatModeAfterUserTap() {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.setToggleState(.aiChat)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut)
+        sut.setQueryText(longURL)
+        let singleLineHeight = applyFittingHeight(to: sut)
+
+        sut.hasBeenInteractedWith = true
+        sut.updatePoseForCurrentState()
+        let heightAfterTap = applyFittingHeight(to: sut)
+
+        XCTAssertGreaterThan(heightAfterTap, singleLineHeight)
+    }
+
+    func test_urlCollapsesToSingleLineWhenModeSwitchesFromAIChatToSearch() {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        handler.setToggleState(.aiChat)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut)
+        sut.setQueryText(longURL)
+        sut.hasBeenInteractedWith = true
+        sut.updatePoseForCurrentState()
+        let expandedHeight = applyFittingHeight(to: sut)
+
+        handler.setToggleState(.search)
+        sut.updatePoseForCurrentState()
+        let heightAfterSwitch = applyFittingHeight(to: sut)
+
+        XCTAssertGreaterThan(expandedHeight, heightAfterSwitch)
+    }
+
+    // Search-only: UTI shown without a toggle (AI chat unavailable). Even though the handler's
+    // toggle state may still be its `.aiChat` default, a tapped URL must stay single-line.
+    func test_urlDoesNotExpandHeightInSearchOnlyModeWithoutToggle() {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false, isToggleEnabled: false)
+        let sut = SwitchBarTextEntryView(handler: handler)
+        sut.isExpandable = true
+        prepareForFitting(sut)
+        sut.setQueryText(longURL)
+        let singleLineHeight = applyFittingHeight(to: sut)
+
+        sut.hasBeenInteractedWith = true
+        sut.updatePoseForCurrentState()
+        let heightAfterTap = applyFittingHeight(to: sut)
+
+        XCTAssertEqual(heightAfterTap, singleLineHeight, accuracy: 1)
+    }
+
     private func flushMainQueue() {
         let expectation = expectation(description: "main queue flushed")
         DispatchQueue.main.async {


### PR DESCRIPTION
…stays single-line

Favorites: the suggestions merger gated isTyping on `!text.isEmpty`, so tapping the omnibar on a loaded page (URL pre-filled, not yet edited) showed search suggestions instead of favorites. isTyping now also requires `!isURL || hasUserInteractedWithText` (isURL derived from the text), mirroring SuggestionTrayManager.shouldDisplaySuggestionTray.

Dismiss flash: the dismiss-morph snapshot wrote textView.text, moving the selection and — while canExpandOnSelectionChange was armed from the focus select-all — routing a selection change through textViewDidChange -> markUserInteraction(), flashing the suggestion list for a frame. textViewDidChangeSelection now only recomputes height (its actual job); a selection change isn't a text edit.

Long URL single-line: isUnexpandedURL() keeps a URL single-line in search mode, in search-only (no toggle, AI chat unavailable), and before interaction — only an interacted AI-chat composer expands. Brings the #5373 fix to the release branch and covers the search-only case it missed.

UTI-only behaviour change; the shared SwitchBarTextEntryView text-edit path is unchanged.

<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL:
Tech Design URL:
CC:

### Description

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1.
2.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UTI suggestion/height behavior with matching unit tests; no auth or data-path changes, though URL detection and interaction timing could still affect edge cases in omnibar editing.
> 
> **Overview**
> Fixes three **Unified Toggle Input (UTI)** omnibar/editing UX issues without changing the shared text-edit path for non-UTI flows.
> 
> **Favorites vs suggestions:** `UnifiedSuggestionsInputsMerger` no longer treats any non-empty field as “typing.” For address-bar URLs, `isTyping` now requires user interaction (`hasUserInteractedWithText`), aligned with legacy `SuggestionTrayManager.shouldDisplaySuggestionTray`. The merged inputs publisher and Dax logo resolution in `UnifiedInputContentContainerViewController` pass that flag through from `hasUserInteractedWithTextPublisher`.
> 
> **Dismiss flash:** On focus select-all, `textViewDidChangeSelection` only recomputes height instead of calling `textViewDidChange`, so dismiss-morph selection changes do not call `markUserInteraction()` and briefly show suggestions over favorites/logo.
> 
> **Long URL height:** `isUnexpandedURL()` keeps URLs single-line in search mode, when the toggle is off (search-only), or before interaction; multi-line expansion is limited to an interacted **AI chat** composer. Mode switches from AI chat back to search collapse height again.
> 
> Unit tests cover merger URL/interaction cases and URL height rules across search, AI chat, and search-only modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f6b217169184e9af18fa1e645fbb9f9f1813927. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->