### PR TITLE
[WIP] Sync V2 pixels

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
@@ -25,7 +25,7 @@ public protocol SyncConnectionControllerDelegate: AnyObject {
 
     func controllerDidReceiveRecoveryKey()
 
-    func controllerDidRecognizeCode(setupSource: SyncSetupSource, codeSource: SyncCodeSource) async
+    func controllerDidRecognizeCode(setupSource: SyncSetupSource, codeSource: SyncCodeSource, codeVersion: SyncSetupCodeVersion) async
 
     func controllerWillPerformServerSyncOperation(setupRole: SyncSetupRole) async -> Bool
     func controllerShouldAllowPairingV2PeerToJoin(peerName: String?, peerKind: PairingV2DeviceKind) async -> Bool
@@ -61,6 +61,9 @@ public enum SyncConnectionError: Error {
 
     case failedToCreateAccount
     case failedToTransmitConnectRecoveryKey
+
+    case accountUpgradeFailed
+    case protocolError
 
     case pollingForRecoveryKeyTimedOut
 }
@@ -263,7 +266,7 @@ public class SyncConnectionController: SyncConnectionControlling {
 
         if let exchangeKey = syncCode.exchangeKey {
             let setupRole: SyncSetupRole = .receiver(.exchange, codeSource)
-            await delegate?.controllerDidRecognizeCode(setupSource: .exchange, codeSource: codeSource)
+            await delegate?.controllerDidRecognizeCode(setupSource: .exchange, codeSource: codeSource, codeVersion: .v1)
             guard await shouldContinueServerSyncOperation(setupRole: setupRole) else {
                 return false
             }
@@ -271,14 +274,14 @@ public class SyncConnectionController: SyncConnectionControlling {
             return await handleExchangeKey(exchangeKey, codeSource: codeSource)
         } else if let connectKey = syncCode.connect {
             let setupRole: SyncSetupRole = .receiver(.connect, codeSource)
-            await delegate?.controllerDidRecognizeCode(setupSource: .connect, codeSource: codeSource)
+            await delegate?.controllerDidRecognizeCode(setupSource: .connect, codeSource: codeSource, codeVersion: .v1)
             guard await shouldContinueServerSyncOperation(setupRole: setupRole) else {
                 return false
             }
             await state.prepareForNewFlow()
             return await handleConnectKey(connectKey, codeSource: codeSource)
         } else {
-            await delegate?.controllerDidRecognizeCode(setupSource: .recovery, codeSource: codeSource)
+            await delegate?.controllerDidRecognizeCode(setupSource: .recovery, codeSource: codeSource, codeVersion: .v1)
             await delegate?.controllerDidError(.unableToRecognizeCode, underlyingError: nil, setupRole: .receiver(.unknown, codeSource))
             return false
         }
@@ -345,7 +348,7 @@ public class SyncConnectionController: SyncConnectionControlling {
     private func handleDecodedSyncCode(_ syncCode: SyncCode, codeSource: SyncCodeSource) async -> Bool {
         if let exchangeKey = syncCode.exchangeKey {
             let setupRole: SyncSetupRole = .receiver(.exchange, codeSource)
-            await delegate?.controllerDidRecognizeCode(setupSource: .exchange, codeSource: codeSource)
+            await delegate?.controllerDidRecognizeCode(setupSource: .exchange, codeSource: codeSource, codeVersion: .v1)
             guard await shouldContinueServerSyncOperation(setupRole: setupRole) else {
                 return false
             }
@@ -355,7 +358,7 @@ public class SyncConnectionController: SyncConnectionControlling {
             return await handleRecoveryCode(recovery, codeSource: codeSource)
         } else if let connectKey = syncCode.connect {
             let setupRole: SyncSetupRole = .receiver(.connect, codeSource)
-            await delegate?.controllerDidRecognizeCode(setupSource: .connect, codeSource: codeSource)
+            await delegate?.controllerDidRecognizeCode(setupSource: .connect, codeSource: codeSource, codeVersion: .v1)
             guard await shouldContinueServerSyncOperation(setupRole: setupRole) else {
                 return false
             }
@@ -393,7 +396,7 @@ public class SyncConnectionController: SyncConnectionControlling {
             await delegate?.controllerDidError(.unableToRecognizeCode, underlyingError: nil, setupRole: setupRole)
             return false
         }
-        await delegate?.controllerDidRecognizeCode(setupSource: .exchange, codeSource: codeSource)
+        await delegate?.controllerDidRecognizeCode(setupSource: .exchange, codeSource: codeSource, codeVersion: .v2)
         guard await shouldContinueServerSyncOperation(setupRole: setupRole) else {
             return false
         }
@@ -656,7 +659,7 @@ public class SyncConnectionController: SyncConnectionControlling {
             return false
         }
 
-        await delegate?.controllerDidRecognizeCode(setupSource: .recovery, codeSource: codeSource)
+        await delegate?.controllerDidRecognizeCode(setupSource: .recovery, codeSource: codeSource, codeVersion: recovery.syncSetupCodeVersion)
         guard await shouldContinueServerSyncOperation(setupRole: setupRole) else {
             return false
         }
@@ -733,6 +736,8 @@ public class SyncConnectionController: SyncConnectionControlling {
             return .failedToTransmitExchangeRecoveryKey
         case .loginFailed:
             return .failedToLogIn
+        case .upgradeFailed:
+            return .accountUpgradeFailed
         case .nativeCredentialAlreadyPresent:
             return .thirdPartyAccountAlreadyUpgraded
         case .recoveryCodeDenied, .recoveryCodeUnavailable:
@@ -741,7 +746,9 @@ public class SyncConnectionController: SyncConnectionControlling {
             return unsupportedVersionConnectionError(for: version, supportedMajor: PairingV2ProtocolVersion.supportedMajor)
         case .v2ScanningDisabled, .unknownCode, .unsupportedFlow:
             return .unableToRecognizeCode
-        case .secondHello, .unexpectedEvent, .pairingSessionNotReady, .relayChannelUnavailable, .relayChannelExpired:
+        case .secondHello, .unexpectedEvent, .pairingSessionNotReady:
+            return .protocolError
+        case .relayChannelUnavailable, .relayChannelExpired:
             return .failedToFetchExchangeRecoveryKey
         case .cancelled:
             return .syncCancelledFromOtherDevice
@@ -765,6 +772,18 @@ public class SyncConnectionController: SyncConnectionControlling {
             return .unableToRecognizeCode
         }
         return .updateRequired
+    }
+}
+
+private extension SyncCode.Recovery {
+
+    var syncSetupCodeVersion: SyncSetupCodeVersion {
+        switch self {
+        case .v1:
+            return .v1
+        case .v2:
+            return .v2
+        }
     }
 }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConstants.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConstants.swift
@@ -21,6 +21,11 @@ public enum SyncSetupRole {
     case sharer
 }
 
+public enum SyncSetupCodeVersion: String {
+    case v1
+    case v2
+}
+
 public enum SyncSetupSource: String {
     case recovery
     case exchange

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/PairingV2/PairingV2Coordinator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/PairingV2/PairingV2Coordinator.swift
@@ -342,7 +342,7 @@ final class PairingV2Coordinator {
                 case .nativeCredentialAlreadyPresent:
                     pairingError = .nativeCredentialAlreadyPresent
                 default:
-                    pairingError = .loginFailed
+                    pairingError = .upgradeFailed
                 }
                 try await execute(stateMachine.handle(.failed(pairingError)))
                 throw pairingError
@@ -350,8 +350,8 @@ final class PairingV2Coordinator {
                 try await execute(stateMachine.handle(.failed(error)))
                 throw error
             } catch {
-                try await execute(stateMachine.handle(.failed(.loginFailed)))
-                throw PairingV2Error.loginFailed
+                try await execute(stateMachine.handle(.failed(.upgradeFailed)))
+                throw PairingV2Error.upgradeFailed
             }
             try await execute(stateMachine.handle(.loginSucceeded))
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/PairingV2/PairingV2StateMachine.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/PairingV2/PairingV2StateMachine.swift
@@ -174,6 +174,7 @@ enum PairingV2Error: Error, Equatable {
     case recoveryCodePreparationFailed
     case recoveryCodeSendFailed
     case loginFailed
+    case upgradeFailed
     case recoveryCodeDenied
     case recoveryCodeUnavailable
     case unsupportedVersion(String)

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/PairingV2/PairingV2CoordinatorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/PairingV2/PairingV2CoordinatorTests.swift
@@ -762,19 +762,19 @@ final class PairingV2CoordinatorTests: XCTestCase {
         XCTAssertEqual(setup.coordinator.state, .failed(.nativeCredentialAlreadyPresent))
     }
 
-    func testWhenThirdPartyUpgradeReportsGenericUpgradeErrorThenPairingFailsWithLoginFailed() async throws {
+    func testWhenThirdPartyUpgradeReportsGenericUpgradeErrorThenPairingFailsWithUpgradeFailed() async throws {
         let setup = try await makeNativeJoinerReadyForThirdPartyUpgrade(upgradeError: ThirdPartyAccountUpgradeError.noUsableThirdPartyProtectedKeys)
 
         do {
             try await setup.coordinator.pollOnce()
             XCTFail("Expected upgrade failure to abort pairing")
-        } catch PairingV2Error.loginFailed {
+        } catch PairingV2Error.upgradeFailed {
         } catch {
             XCTFail("Unexpected error: \(error)")
         }
 
         XCTAssertEqual(setup.upgradeCoordinator.upgradeThirdPartyAccountCalls.map(\.recoveryCode), ["third-party-recovery-code"])
-        XCTAssertEqual(setup.coordinator.state, .failed(.loginFailed))
+        XCTAssertEqual(setup.coordinator.state, .failed(.upgradeFailed))
     }
 
     func testWhenNativeJoinerConfirmationIsDeniedThenDoesNotLoginIfRecoveryCodeArrives() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SyncConnectionControllerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SyncConnectionControllerTests.swift
@@ -79,7 +79,7 @@ final class MockSyncConnectionControllerDelegate: SyncConnectionControllerDelega
         didReceiveRecoveryKeyCalled()
     }
 
-    func controllerDidRecognizeCode(setupSource: SyncSetupSource, codeSource: SyncCodeSource) async {
+    func controllerDidRecognizeCode(setupSource: SyncSetupSource, codeSource: SyncCodeSource, codeVersion: SyncSetupCodeVersion) async {
         didRecognizeScannedCodeCalled()
     }
 

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1115,6 +1115,7 @@ extension Pixel {
         case syncSetupManualCodeEnteredSuccess
         case syncSetupManualCodeEnteredFailed
         case syncSetupEndedAbandoned
+        case syncSetupEndedFailed
         case syncSetupEndedSuccessful
         case syncSetupDeepLinkFlowStarted
         case syncSetupDeepLinkFlowSuccess
@@ -3084,6 +3085,7 @@ extension Pixel.Event {
         case .syncSetupManualCodeEnteredSuccess: return "sync_setup_manual_code_entered_success"
         case .syncSetupManualCodeEnteredFailed: return "sync_setup_manual_code_entered_failed"
         case .syncSetupEndedAbandoned: return "sync_setup_ended_abandoned"
+        case .syncSetupEndedFailed: return "sync_setup_ended_failed"
         case .syncSetupEndedSuccessful: return "sync_setup_ended_successful"
         case .syncSetupDeepLinkFlowStarted: return "sync_setup_deep_link_flow_started"
         case .syncSetupDeepLinkFlowSuccess: return "sync_setup_deep_link_flow_success"

--- a/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -590,6 +590,7 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
     }
 
     private func collectCode(showQRCode: Bool) {
+        pairingV2PeerKind = nil
         guard featureFlagger.isFeatureOn(.exchangeKeysToSyncWithAnotherDevice) else {
             legacyCollectCode(showQRCode: showQRCode)
             return
@@ -623,11 +624,12 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                 stringForQRCode: stringForQRCode,
                 showQRCode: showQRCode,
                 source: source,
-                onPresentPixelInfo: .init(pixel: .syncSetupBarcodeScreenShown, source: source))
+                onPresentPixelInfo: .init(pixel: .syncSetupBarcodeScreenShown, source: source, flowVersion: syncSetupPixelFlowVersion))
         }
     }
 
     private func legacyCollectCode(showQRCode: Bool) {
+        pairingV2PeerKind = nil
         Task {
             let stringForQRCode: String
             let codeForDisplayOrPasting: String
@@ -644,7 +646,7 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                     stringForQRCode = featureFlagger.isFeatureOn(.syncSetupBarcodeIsUrlBased) ? pairingInfo.url.absoluteString : pairingInfo.base64Code
                     codeForDisplayOrPasting = pairingInfo.base64Code
                     source = showQRCode ? .connect : .recovery
-                    onPresentPixelInfo = .init(pixel: .syncSetupBarcodeScreenShown, source: source)
+                    onPresentPixelInfo = .init(pixel: .syncSetupBarcodeScreenShown, source: source, flowVersion: syncSetupPixelFlowVersion)
                 } catch {
                     await handleError(SyncErrorMessage.unableToSyncToServer, error: error, event: .syncLoginError)
                     return
@@ -701,7 +703,12 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
             self.checkCameraPermission(model: model)
             if let onPresentPixelInfo {
                 let pixelSource = self.source ?? onPresentPixelInfo.source.rawValue
-                Pixel.fire(onPresentPixelInfo.pixel, withAdditionalParameters: [PixelParameters.source: pixelSource])
+                var parameters = [
+                    PixelParameters.source: pixelSource,
+                    SyncSetupPixelInfo.Parameter.myKind: SyncSetupPixelInfo.Value.ddg
+                ]
+                parameters[SyncSetupPixelInfo.Parameter.flowVersion] = onPresentPixelInfo.flowVersion
+                Pixel.fire(onPresentPixelInfo.pixel, withAdditionalParameters: parameters)
                 self.syncSetupExperimentPixels.fireBarcodeScreenShown()
             }
         }
@@ -738,6 +745,8 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
         let isConfirmed = await presentPairingV2ConfirmationAlert(message: message)
         if !isConfirmed {
             dismissPairingV2UIAfterDeniedConfirmation()
+        } else {
+            pairingV2PeerKind = peerKind
         }
         return isConfirmed
     }
@@ -892,7 +901,12 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
     }
 
     func codeEntryScreenShown() {
-        Pixel.fire(pixel: .syncSetupManualCodeEntryScreenShown, includedParameters: [.appVersion])
+        Pixel.fire(pixel: .syncSetupManualCodeEntryScreenShown,
+                   withAdditionalParameters: [
+                    SyncSetupPixelInfo.Parameter.myKind: SyncSetupPixelInfo.Value.ddg,
+                    SyncSetupPixelInfo.Parameter.flowVersion: syncSetupPixelFlowVersion
+                   ],
+                   includedParameters: [.appVersion])
         syncSetupExperimentPixels.fireManualCodeEntryScreenShown()
     }
 
@@ -1015,6 +1029,25 @@ private extension CodeCollectionSource {
 }
 
 private struct SyncSetupPixelInfo {
+    enum Parameter {
+        static let flowVersion = "flow_version"
+        static let myKind = "my_kind"
+    }
+
+    enum Value {
+        static let ddg = "ddg"
+        static let v1 = "v1"
+        static let v2 = "v2"
+    }
+
     let pixel: Pixel.Event
     let source: SyncSetupSource
+    let flowVersion: String?
+}
+
+extension SyncSettingsViewController {
+
+    var syncSetupPixelFlowVersion: String {
+        featureFlagger.isFeatureOn(.syncCanUseV2ConnectFlow) ? SyncSetupPixelInfo.Value.v2 : SyncSetupPixelInfo.Value.v1
+    }
 }

--- a/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -732,18 +732,20 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
     }
 
     func controllerShouldAllowPairingV2PeerToJoin(peerName: String?, peerKind: PairingV2DeviceKind) async -> Bool {
-        await confirmPairingV2Peer(peerName: peerName, peerKind: peerKind)
+        await confirmPairingV2Peer(peerName: peerName, peerKind: peerKind, setupRole: .sharer)
     }
 
     func controllerShouldJoinPairingV2Peer(peerName: String?, peerKind: PairingV2DeviceKind) async -> Bool {
-        await confirmPairingV2Peer(peerName: peerName, peerKind: peerKind)
+        // codeSource is unused for the abandonment pixel; only the source/role matter.
+        await confirmPairingV2Peer(peerName: peerName, peerKind: peerKind, setupRole: .receiver(.exchange, .qrCode))
     }
 
-    private func confirmPairingV2Peer(peerName: String?, peerKind: PairingV2DeviceKind) async -> Bool {
+    private func confirmPairingV2Peer(peerName: String?, peerKind: PairingV2DeviceKind, setupRole: SyncSetupRole) async -> Bool {
         let peerName = pairingV2DisplayName(for: peerName)
         let message = UserText.syncPairingV2ConfirmationMessage(peerName, isThirdPartyPeer: peerKind == .thirdParty)
         let isConfirmed = await presentPairingV2ConfirmationAlert(message: message)
         if !isConfirmed {
+            sendSetupEndedAbandonedPixel(setupRole: setupRole, reason: SyncSetupPixelValue.syncConfirmationDenied)
             dismissPairingV2UIAfterDeniedConfirmation()
         } else {
             pairingV2PeerKind = peerKind

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -94,6 +94,7 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsRootView> {
 
     var source: String?
     var pairingInfo: PairingInfo?
+    var pairingV2PeerKind: PairingV2DeviceKind?
     var needsPreservedAccountCleanupBeforeServerOperation = false
     var autoRestorePromptSource: AutoRestorePromptSource?
 
@@ -553,7 +554,8 @@ extension SyncSettingsViewController: ScanOrPasteCodeViewModelDelegate {
         dismissPresentedViewController()
         endConnectMode()
         Pixel.fire(pixel: .syncSetupEndedAbandoned,
-                   withAdditionalParameters: [PixelParameters.source: source.rawValue],
+                   withAdditionalParameters: syncSetupPixelParameters(setupSource: SyncSetupSource(codeCollectionSource: source),
+                                                                      reason: SyncSetupPixelValue.scanningCancelled),
                    includedParameters: [.appVersion])
         syncSetupExperimentPixels.fireSetupEndedAbandoned()
     }
@@ -630,9 +632,14 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
     }
 
     func controllerDidFinishTransmittingRecoveryKey(shouldWaitForDevicesToChange: Bool) {
+        let parameters = syncSetupPixelParameters(setupSource: .exchange,
+                                                  path: SyncSetupPixelValue.pairing,
+                                                  peerKind: pairingV2PeerKind?.syncSetupPeerKind,
+                                                  myRole: SyncSetupPixelValue.host)
         Pixel.fire(pixel: .syncSetupEndedSuccessful,
-                   withAdditionalParameters: [PixelParameters.source: SyncSetupSource.exchange.rawValue],
+                   withAdditionalParameters: parameters,
                    includedParameters: [.appVersion])
+        pairingV2PeerKind = nil
         if shouldWaitForDevicesToChange {
             waitForDevicesToChangeThenPresentSyncing()
         } else {
@@ -646,8 +653,8 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         }
     }
     
-    func controllerDidRecognizeCode(setupSource: SyncSetupSource, codeSource: SyncCodeSource) async {
-        sendCodeRecognisedPixel(setupSource: setupSource, codeSource: codeSource)
+    func controllerDidRecognizeCode(setupSource: SyncSetupSource, codeSource: SyncCodeSource, codeVersion: SyncSetupCodeVersion) async {
+        sendCodeRecognisedPixel(setupSource: setupSource, codeSource: codeSource, codeVersion: codeVersion)
         await dismissPresentedViewController()
         await showPreparingSync()
     }
@@ -679,16 +686,22 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         presentSyncCompletionAfterDelay()
         guard case .receiver(let syncSetupSource, let syncCodeSource) = setupRole else {
             // .sharer reaches here only via the connect flow (exchange-sharer terminates in controllerDidFinishTransmittingRecoveryKey).
+            let parameters = syncSetupPixelParameters(setupSource: .connect,
+                                                      path: SyncSetupPixelValue.pairing,
+                                                      peerKind: pairingV2PeerKind?.syncSetupPeerKind,
+                                                      myRole: SyncSetupPixelValue.joiner)
             Pixel.fire(pixel: .syncSetupEndedSuccessful,
-                       withAdditionalParameters: [PixelParameters.source: SyncSetupSource.connect.rawValue],
+                       withAdditionalParameters: parameters,
                        includedParameters: [.appVersion])
+            pairingV2PeerKind = nil
             return
         }
 
         sendSetupEndedSuccessfullyPixel(setupSource: syncSetupSource, codeSource: syncCodeSource)
     }
 
-    func controllerDidCompletePairingWithAlreadyConnectedAccount(setupRole _: SyncSetupRole) {
+    func controllerDidCompletePairingWithAlreadyConnectedAccount(setupRole: SyncSetupRole) {
+        sendSetupEndedFailedPixel(setupRole: setupRole, reason: SyncSetupPixelValue.alreadyPaired)
         Task { @MainActor in
             await handleError(.alreadyPairedWithAccount, error: nil, event: nil)
         }
@@ -697,24 +710,29 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
     func controllerDidError(_ error: SyncConnectionError, underlyingError: (any Error)?, setupRole: SyncSetupRole) async {
         switch error {
         case .unableToRecognizeCode:
-            sendCodeParsingFailedPixel(setupRole: setupRole)
+            sendCodeParsingFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             await handleError(.unableToRecognizeCode, error: underlyingError, event: nil)
         case .updateRequired:
-            sendCodeParsingFailedPixel(setupRole: setupRole)
+            sendCodeParsingFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             await handleError(.updateRequired, error: nil, event: nil)
         case .unsupportedThirdPartyRecoveryCode:
-            sendCodeParsingFailedPixel(setupRole: setupRole)
+            sendCodeParsingFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             await handleError(.unsupportedThirdPartyRecoveryCode, error: nil, event: nil)
         case .thirdPartyAccountAlreadyUpgraded:
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             await handleError(.thirdPartyAccountAlreadyUpgraded, error: nil, event: nil)
         case .syncCancelledFromOtherDevice:
+            sendSetupEndedAbandonedPixel(setupRole: setupRole, reason: SyncSetupPixelValue.syncConfirmationDenied)
             await handleError(.syncCancelledFromOtherDevice, error: nil, event: nil)
-        case .failedToFetchPublicKey, .failedToTransmitExchangeRecoveryKey, .failedToFetchConnectRecoveryKey, .failedToLogIn, .failedToTransmitExchangeKey, .failedToFetchExchangeRecoveryKey, .failedToTransmitConnectRecoveryKey:
+        case .failedToFetchPublicKey, .failedToTransmitExchangeRecoveryKey, .failedToFetchConnectRecoveryKey, .failedToLogIn, .failedToTransmitExchangeKey, .failedToFetchExchangeRecoveryKey, .failedToTransmitConnectRecoveryKey, .accountUpgradeFailed, .protocolError:
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             fireCodeHandlingFailedExperimentPixel(setupRole: setupRole)
             await handleError(.unableToSyncWithDevice, error: underlyingError, event: .syncLoginError)
         case .failedToCreateAccount:
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             await handleError(.unableToSyncWithDevice, error: underlyingError, event: .syncSignupError)
         case .pollingForRecoveryKeyTimedOut:
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             await dismissPresentedViewController()
             handleRecoveryKeyPollingTimeout(setupRole: setupRole)
         }
@@ -734,9 +752,9 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         }
     }
 
-    private func sendCodeRecognisedPixel(setupSource: SyncSetupSource, codeSource: SyncCodeSource) {
+    private func sendCodeRecognisedPixel(setupSource: SyncSetupSource, codeSource: SyncCodeSource, codeVersion: SyncSetupCodeVersion) {
         guard setupSource != .unknown else { return }
-        let parameters = source.map { [PixelParameters.source: $0] } ?? [PixelParameters.source: setupSource.rawValue]
+        let parameters = syncSetupPixelParameters(setupSource: setupSource, codeType: setupSource.syncSetupCodeType, codeVersion: codeVersion.rawValue)
         switch codeSource {
         case .qrCode:
             Pixel.fire(pixel: .syncSetupBarcodeScannerSuccess, withAdditionalParameters: parameters, includedParameters: [.appVersion])
@@ -749,17 +767,18 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         }
     }
 
-    private func sendCodeParsingFailedPixel(setupRole: SyncSetupRole) {
-        guard case .receiver(_, let codeSource) = setupRole else {
+    private func sendCodeParsingFailedPixel(setupRole: SyncSetupRole, reason: String?) {
+        guard case .receiver(let setupSource, let codeSource) = setupRole else {
             return
         }
+        let parameters = syncSetupPixelParameters(setupSource: setupSource, reason: reason)
 
         switch codeSource {
         case .qrCode:
-            Pixel.fire(pixel: .syncSetupBarcodeScannerFailed, includedParameters: [.appVersion])
+            Pixel.fire(pixel: .syncSetupBarcodeScannerFailed, withAdditionalParameters: parameters, includedParameters: [.appVersion])
             syncSetupExperimentPixels.fireBarcodeScannerFailed()
         case .pastedCode:
-            Pixel.fire(pixel: .syncSetupManualCodeEnteredFailed, includedParameters: [.appVersion])
+            Pixel.fire(pixel: .syncSetupManualCodeEnteredFailed, withAdditionalParameters: parameters, includedParameters: [.appVersion])
             syncSetupExperimentPixels.fireManualCodeEnteredFailed()
         case .deepLink:
             break
@@ -768,14 +787,68 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
 
     private func sendSetupEndedSuccessfullyPixel(setupSource: SyncSetupSource, codeSource: SyncCodeSource) {
         guard setupSource != .unknown else { return }
-        let parameters = source.map { [PixelParameters.source: $0] } ?? [PixelParameters.source: setupSource.rawValue]
+        let parameters = syncSetupPixelParameters(setupSource: setupSource,
+                                                  path: setupSource.syncSetupPath,
+                                                  peerKind: pairingV2PeerKind?.syncSetupPeerKind,
+                                                  myRole: setupSource.syncSetupMyRole)
         switch codeSource {
         case .pastedCode, .qrCode:
             Pixel.fire(pixel: .syncSetupEndedSuccessful, withAdditionalParameters: parameters, includedParameters: [.appVersion])
+            pairingV2PeerKind = nil
         case .deepLink:
             Pixel.fire(pixel: .syncSetupDeepLinkFlowSuccess, includedParameters: [.appVersion])
             syncSetupExperimentPixels.fireDeepLinkFlowSuccess()
         }
+    }
+
+    private func sendSetupEndedFailedPixel(setupRole: SyncSetupRole, reason: String?) {
+        Pixel.fire(pixel: .syncSetupEndedFailed,
+                   withAdditionalParameters: syncSetupPixelParameters(setupRole: setupRole, reason: reason),
+                   includedParameters: [.appVersion])
+        pairingV2PeerKind = nil
+    }
+
+    private func sendSetupEndedAbandonedPixel(setupRole: SyncSetupRole, reason: String?) {
+        Pixel.fire(pixel: .syncSetupEndedAbandoned,
+                   withAdditionalParameters: syncSetupPixelParameters(setupRole: setupRole, reason: reason),
+                   includedParameters: [.appVersion])
+    }
+
+    private func syncSetupPixelParameters(setupRole: SyncSetupRole, reason: String?) -> [String: String] {
+        switch setupRole {
+        case .receiver(let setupSource, _):
+            return syncSetupPixelParameters(setupSource: setupSource,
+                                            path: setupSource.syncSetupPath,
+                                            reason: reason,
+                                            peerKind: pairingV2PeerKind?.syncSetupPeerKind,
+                                            myRole: setupSource.syncSetupMyRole)
+        case .sharer:
+            return syncSetupPixelParameters(setupSource: .exchange,
+                                            path: SyncSetupPixelValue.pairing,
+                                            reason: reason,
+                                            peerKind: pairingV2PeerKind?.syncSetupPeerKind,
+                                            myRole: SyncSetupPixelValue.host)
+        }
+    }
+
+    private func syncSetupPixelParameters(setupSource: SyncSetupSource,
+                                          codeType: String? = nil,
+                                          codeVersion: String? = nil,
+                                          path: String? = nil,
+                                          flowVersion: String? = nil,
+                                          reason: String? = nil,
+                                          peerKind: String? = nil,
+                                          myRole: String? = nil) -> [String: String] {
+        var parameters = source.map { [PixelParameters.source: $0] } ?? [PixelParameters.source: setupSource.rawValue]
+        parameters[SyncSetupPixelParameter.myKind] = SyncSetupPixelValue.ddg
+        parameters[SyncSetupPixelParameter.codeType] = codeType
+        parameters[SyncSetupPixelParameter.codeVersion] = codeVersion
+        parameters[SyncSetupPixelParameter.path] = path
+        parameters[SyncSetupPixelParameter.flowVersion] = flowVersion ?? syncSetupPixelFlowVersion
+        parameters[SyncSetupPixelParameter.reason] = reason
+        parameters[SyncSetupPixelParameter.peerKind] = peerKind
+        parameters[SyncSetupPixelParameter.myRole] = myRole
+        return parameters
     }
 
     func handleSuccessfulSetupOutcome(_ outcome: SyncSetupSuccessOutcome) {
@@ -796,6 +869,14 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
     }
 
     func fireBarcodeCodeCopiedPixel(for code: String) {
+        if URL(string: code)?.absoluteString.contains("code2=") == true {
+            Pixel.fire(pixel: .syncSetupBarcodeCodeCopied,
+                       withAdditionalParameters: syncSetupPixelParameters(setupSource: .exchange,
+                                                                          codeType: SyncSetupPixelValue.linking))
+            syncSetupExperimentPixels.fireBarcodeCodeCopied()
+            return
+        }
+
         guard let decoded = try? SyncCode.decodeBase64String(code) else { return }
         let source: SyncSetupSource
         if decoded.connect != nil {
@@ -806,7 +887,7 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
             return
         }
         Pixel.fire(pixel: .syncSetupBarcodeCodeCopied,
-                   withAdditionalParameters: [PixelParameters.source: source.rawValue])
+                   withAdditionalParameters: syncSetupPixelParameters(setupSource: source, codeType: source.syncSetupCodeType))
         syncSetupExperimentPixels.fireBarcodeCodeCopied()
     }
 
@@ -832,4 +913,126 @@ extension SyncSettingsViewController {
 
     }
 
+}
+
+private enum SyncSetupPixelParameter {
+    static let flowVersion = "flow_version"
+    static let myKind = "my_kind"
+    static let codeType = "code_type"
+    static let codeVersion = "code_version"
+    static let path = "path"
+    static let reason = "reason"
+    static let peerKind = "peer_kind"
+    static let myRole = "my_role"
+}
+
+private enum SyncSetupPixelValue {
+    static let ddg = "ddg"
+    static let recovery = "recovery"
+    static let pairing = "pairing"
+    static let linking = "linking"
+    static let sessionTimeout = "session_timeout"
+    static let transportFailure = "transport_failure"
+    static let needsUpgrade = "needs_upgrade"
+    static let incompatibleCode = "incompatible_code"
+    static let unrecognizedCode = "unrecognized_code"
+    static let scanningCancelled = "scanning_cancelled"
+    static let syncConfirmationDenied = "sync_confirmation_denied"
+    static let invalidCredentials = "invalid_credentials"
+    static let alreadyUpgraded = "already_upgraded"
+    static let alreadyPaired = "already_paired"
+    static let accountCreationFailed = "account_creation_failed"
+    static let accountUpgradeFailed = "account_upgrade_failed"
+    static let protocolError = "protocol_error"
+    static let host = "host"
+    static let joiner = "joiner"
+}
+
+private extension SyncSetupSource {
+
+    init(codeCollectionSource: CodeCollectionSource) {
+        switch codeCollectionSource {
+        case .connect:
+            self = .connect
+        case .exchange:
+            self = .exchange
+        case .recovery:
+            self = .recovery
+        }
+    }
+
+    var syncSetupCodeType: String? {
+        switch self {
+        case .recovery:
+            return SyncSetupPixelValue.recovery
+        case .exchange, .connect:
+            return SyncSetupPixelValue.linking
+        case .unknown:
+            return nil
+        }
+    }
+
+    var syncSetupPath: String? {
+        switch self {
+        case .recovery:
+            return SyncSetupPixelValue.recovery
+        case .exchange, .connect:
+            return SyncSetupPixelValue.pairing
+        case .unknown:
+            return nil
+        }
+    }
+
+    var syncSetupMyRole: String? {
+        switch self {
+        case .connect:
+            return SyncSetupPixelValue.host
+        case .exchange:
+            return SyncSetupPixelValue.joiner
+        case .recovery, .unknown:
+            return nil
+        }
+    }
+}
+
+private extension PairingV2DeviceKind {
+
+    var syncSetupPeerKind: String {
+        rawValue
+    }
+}
+
+private extension SyncConnectionError {
+
+    var syncSetupFailureReason: String? {
+        switch self {
+        case .failedToLogIn:
+            return SyncSetupPixelValue.invalidCredentials
+        case .failedToFetchPublicKey,
+                .failedToTransmitExchangeRecoveryKey,
+                .failedToFetchConnectRecoveryKey,
+                .failedToTransmitExchangeKey,
+                .failedToFetchExchangeRecoveryKey,
+                .failedToTransmitConnectRecoveryKey:
+            return SyncSetupPixelValue.transportFailure
+        case .pollingForRecoveryKeyTimedOut:
+            return SyncSetupPixelValue.sessionTimeout
+        case .updateRequired:
+            return SyncSetupPixelValue.needsUpgrade
+        case .unsupportedThirdPartyRecoveryCode:
+            return SyncSetupPixelValue.incompatibleCode
+        case .thirdPartyAccountAlreadyUpgraded:
+            return SyncSetupPixelValue.alreadyUpgraded
+        case .unableToRecognizeCode:
+            return SyncSetupPixelValue.unrecognizedCode
+        case .failedToCreateAccount:
+            return SyncSetupPixelValue.accountCreationFailed
+        case .accountUpgradeFailed:
+            return SyncSetupPixelValue.accountUpgradeFailed
+        case .protocolError:
+            return SyncSetupPixelValue.protocolError
+        case .syncCancelledFromOtherDevice:
+            return nil
+        }
+    }
 }

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -808,10 +808,18 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         pairingV2PeerKind = nil
     }
 
-    private func sendSetupEndedAbandonedPixel(setupRole: SyncSetupRole, reason: String?) {
+    func sendSetupEndedAbandonedPixel(setupRole: SyncSetupRole, reason: String?) {
+        let parameters: [String: String]
+        switch setupRole {
+        case .receiver(let setupSource, _):
+            parameters = syncSetupPixelParameters(setupSource: setupSource, reason: reason)
+        case .sharer:
+            parameters = syncSetupPixelParameters(setupSource: .exchange, reason: reason)
+        }
         Pixel.fire(pixel: .syncSetupEndedAbandoned,
-                   withAdditionalParameters: syncSetupPixelParameters(setupRole: setupRole, reason: reason),
+                   withAdditionalParameters: parameters,
                    includedParameters: [.appVersion])
+        pairingV2PeerKind = nil
     }
 
     private func syncSetupPixelParameters(setupRole: SyncSetupRole, reason: String?) -> [String: String] {
@@ -887,7 +895,8 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
             return
         }
         Pixel.fire(pixel: .syncSetupBarcodeCodeCopied,
-                   withAdditionalParameters: syncSetupPixelParameters(setupSource: source, codeType: source.syncSetupCodeType))
+                   withAdditionalParameters: syncSetupPixelParameters(setupSource: source,
+                                                                      codeType: source.syncSetupCodeType))
         syncSetupExperimentPixels.fireBarcodeCodeCopied()
     }
 

--- a/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -296,7 +296,16 @@
                 "key": "reason",
                 "type": "string",
                 "description": "The reason Sync setup failed, when it can be mapped safely.",
-                "enum": ["session_timeout", "transport_failure", "invalid_credentials", "already_upgraded", "already_paired", "account_creation_failed", "account_upgrade_failed", "protocol_error"]
+                "enum": [
+                    "session_timeout",
+                    "transport_failure",
+                    "invalid_credentials",
+                    "already_upgraded",
+                    "already_paired",
+                    "account_creation_failed",
+                    "account_upgrade_failed",
+                    "protocol_error"
+                ]
             }
         ]
     },

--- a/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -1,0 +1,347 @@
+{
+    "sync_setup_barcode_screen_shown": {
+        "description": "Fired when the Sync setup QR/code screen is shown.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source or entry surface."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            }
+        ]
+    },
+    "sync_setup_barcode_scanner_success": {
+        "description": "Fired when Sync setup recognizes a scanned code.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source or recognized code source."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            },
+            {
+                "key": "code_type",
+                "type": "string",
+                "description": "The type of Sync setup code recognized.",
+                "enum": ["recovery", "linking"]
+            },
+            {
+                "key": "code_version",
+                "type": "string",
+                "description": "The version of Sync setup code recognized.",
+                "enum": ["v1", "v2"]
+            }
+        ]
+    },
+    "sync_setup_barcode_scanner_failed": {
+        "description": "Fired when Sync setup rejects a scanned code.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source or rejected code source."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            },
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "The reason the scanned code was rejected, when it can be mapped safely.",
+                "enum": ["unrecognized_code", "needs_upgrade", "incompatible_code"]
+            }
+        ]
+    },
+    "sync_setup_barcode_code_copied": {
+        "description": "Fired when the user copies the Sync setup code.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            },
+            {
+                "key": "code_type",
+                "type": "string",
+                "description": "The type of Sync setup code copied.",
+                "enum": ["recovery", "linking"]
+            }
+        ]
+    },
+    "sync_setup_manual_code_entry_screen_shown": {
+        "description": "Fired when the Sync setup manual code-entry screen is shown.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            }
+        ]
+    },
+    "sync_setup_manual_code_entered_success": {
+        "description": "Fired when Sync setup recognizes a manually entered or pasted code.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source or recognized code source."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            },
+            {
+                "key": "code_type",
+                "type": "string",
+                "description": "The type of Sync setup code recognized.",
+                "enum": ["recovery", "linking"]
+            },
+            {
+                "key": "code_version",
+                "type": "string",
+                "description": "The version of Sync setup code recognized.",
+                "enum": ["v1", "v2"]
+            }
+        ]
+    },
+    "sync_setup_manual_code_entered_failed": {
+        "description": "Fired when Sync setup rejects a manually entered or pasted code.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source or rejected code source."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            },
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "The reason the entered code was rejected, when it can be mapped safely.",
+                "enum": ["unrecognized_code", "needs_upgrade", "incompatible_code"]
+            }
+        ]
+    },
+    "sync_setup_ended_abandoned": {
+        "description": "Fired when the user abandons Sync setup before completion.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source or entry surface."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            },
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "The reason Sync setup was abandoned, when it can be mapped safely.",
+                "enum": ["scanning_cancelled", "sync_confirmation_denied"]
+            }
+        ]
+    },
+    "sync_setup_ended_failed": {
+        "description": "Fired when Sync setup started from a recognized code but failed before completion.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source or entry surface."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            },
+            {
+                "key": "path",
+                "type": "string",
+                "description": "Whether the setup flow was recovery or pairing.",
+                "enum": ["recovery", "pairing"]
+            },
+            {
+                "key": "peer_kind",
+                "type": "string",
+                "description": "The kind of the peer client, when known.",
+                "enum": ["ddg", "3party"]
+            },
+            {
+                "key": "my_role",
+                "type": "string",
+                "description": "This client's role in the pairing flow, when applicable.",
+                "enum": ["host", "joiner"]
+            },
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "The reason Sync setup failed, when it can be mapped safely.",
+                "enum": ["session_timeout", "transport_failure", "invalid_credentials", "already_upgraded", "already_paired", "account_creation_failed", "account_upgrade_failed", "protocol_error"]
+            }
+        ]
+    },
+    "sync_setup_ended_successful": {
+        "description": "Fired when Sync setup completes successfully.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source or entry surface."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            },
+            {
+                "key": "path",
+                "type": "string",
+                "description": "Whether the setup flow was recovery or pairing.",
+                "enum": ["recovery", "pairing"]
+            },
+            {
+                "key": "peer_kind",
+                "type": "string",
+                "description": "The kind of the peer client, when known.",
+                "enum": ["ddg", "3party"]
+            },
+            {
+                "key": "my_role",
+                "type": "string",
+                "description": "This client's role in the pairing flow, when applicable.",
+                "enum": ["host", "joiner"]
+            }
+        ]
+    }
+}

--- a/macOS/DuckDuckGo/Preferences/Model/LegacySyncPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/LegacySyncPreferences.swift
@@ -552,6 +552,7 @@ final class LegacySyncPreferences: ObservableObject, SyncUI_macOS.ManagementView
     private var connector: RemoteConnecting?
     private let userAuthenticator: UserAuthenticating
     private var syncPromoSource: String?
+    private var pairingV2PeerKind: PairingV2DeviceKind?
 }
 
 extension LegacySyncPreferences: ManagementDialogModelDelegate {
@@ -657,6 +658,7 @@ extension LegacySyncPreferences: ManagementDialogModelDelegate {
     }
 
     private func newStartPollingForRecoveryKey(isRecovery: Bool) {
+        pairingV2PeerKind = nil
         Task { @MainActor in
             do {
                 let pairingInfo = try await connectionController.startConnectMode()
@@ -669,7 +671,7 @@ extension LegacySyncPreferences: ManagementDialogModelDelegate {
                 } else {
                     self.presentDialog(for: .syncWithAnotherDevice(codeForDisplayOrPasting: codeForDisplayOrPasting, stringForQRCode: stringForQR))
                 }
-                PixelKit.fire(SyncSetupPixelKitEvent.syncSetupBarcodeScreenShown(.connect), doNotEnforcePrefix: true)
+                PixelKit.fire(SyncSetupPixelKitEvent.syncSetupBarcodeScreenShown(.connect, flowVersion: syncSetupFlowVersion), doNotEnforcePrefix: true)
             } catch {
                 if syncService.account == nil {
                     if isRecovery {
@@ -871,15 +873,11 @@ extension LegacySyncPreferences: ManagementDialogModelDelegate {
     func userPressedCancel(from dialog: ManagementDialogKind) {
         switch dialog {
         case .syncWithAnotherDevice(_, let stringForQRCode), .enterRecoveryCode(let stringForQRCode):
-            guard let url = URL(string: stringForQRCode),
-                  let pairingInfo = PairingInfo(url: url),
-                  let syncCode = try? SyncCode.decodeBase64String(pairingInfo.base64Code) else {
-                return
-            }
-            if syncCode.connect != nil {
-                PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedAbandoned(.connect), doNotEnforcePrefix: true)
-            } else if syncCode.exchangeKey != nil {
-                PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedAbandoned(.exchange), doNotEnforcePrefix: true)
+            if let source = syncSetupSource(for: stringForQRCode, dialog: dialog) {
+                PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedAbandoned(source,
+                                                                             flowVersion: syncSetupFlowVersion,
+                                                                             reason: SyncSetupPixelKitEvent.ParameterValue.scanningCancelled),
+                              doNotEnforcePrefix: true)
             }
         default:
             break
@@ -891,7 +889,7 @@ extension LegacySyncPreferences: ManagementDialogModelDelegate {
     }
 
     func enterCodeViewDidAppear() {
-        PixelKit.fire(SyncSetupPixelKitEvent.syncSetupManualCodeEntryScreenShown, doNotEnforcePrefix: true)
+        PixelKit.fire(SyncSetupPixelKitEvent.syncSetupManualCodeEntryScreenShown(flowVersion: syncSetupFlowVersion), doNotEnforcePrefix: true)
     }
 
     private func startExchangeOrRecovery() {
@@ -912,6 +910,7 @@ extension LegacySyncPreferences: ManagementDialogModelDelegate {
     }
 
     private func startPollingForPublicKey() {
+        pairingV2PeerKind = nil
         Task { @MainActor in
             do {
                 let pairingInfo = try await connectionController.startExchangeMode()
@@ -920,7 +919,7 @@ extension LegacySyncPreferences: ManagementDialogModelDelegate {
                 self.codeForDisplayOrPasting = codeForDisplayOrPasting
                 self.stringForQR = stringForQR
                 self.presentDialog(for: .syncWithAnotherDevice(codeForDisplayOrPasting: codeForDisplayOrPasting, stringForQRCode: stringForQR))
-                PixelKit.fire(SyncSetupPixelKitEvent.syncSetupBarcodeScreenShown(.exchange), doNotEnforcePrefix: true)
+                PixelKit.fire(SyncSetupPixelKitEvent.syncSetupBarcodeScreenShown(.exchange, flowVersion: syncSetupFlowVersion), doNotEnforcePrefix: true)
             } catch {
                 managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unableToSyncToOtherDevice, description: error.localizedDescription)
                 PixelKit.fire(DebugEvent(GeneralPixel.syncLoginError(error: error)))
@@ -949,11 +948,16 @@ extension LegacySyncPreferences: ManagementDialogModelDelegate {
     }
 
     private func fireCodeCopiedPixel(code: String) {
+        if URL(string: code)?.absoluteString.contains("code2=") == true {
+            PixelKit.fire(SyncSetupPixelKitEvent.syncSetupBarcodeCodeCopied(.exchange, flowVersion: syncSetupFlowVersion), doNotEnforcePrefix: true)
+            return
+        }
+
         guard let syncCode = try? SyncCode.decodeBase64String(code) else { return }
         if syncCode.exchangeKey != nil {
-            PixelKit.fire(SyncSetupPixelKitEvent.syncSetupBarcodeCodeCopied(.exchange), doNotEnforcePrefix: true)
+            PixelKit.fire(SyncSetupPixelKitEvent.syncSetupBarcodeCodeCopied(.exchange, flowVersion: syncSetupFlowVersion), doNotEnforcePrefix: true)
         } else if syncCode.connect != nil {
-            PixelKit.fire(SyncSetupPixelKitEvent.syncSetupBarcodeCodeCopied(.connect), doNotEnforcePrefix: true)
+            PixelKit.fire(SyncSetupPixelKitEvent.syncSetupBarcodeCodeCopied(.connect, flowVersion: syncSetupFlowVersion), doNotEnforcePrefix: true)
         }
     }
 }
@@ -966,6 +970,12 @@ extension LegacySyncPreferences: SyncConnectionControllerDelegate {
     }
 
     func controllerDidFinishTransmittingRecoveryKey(shouldWaitForDevicesToChange: Bool) {
+        PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedSuccessful(.exchange,
+                                                                      flowVersion: syncSetupFlowVersion,
+                                                                      peerKind: pairingV2PeerKind?.syncSetupPeerKind,
+                                                                      myRole: SyncSetupPixelKitEvent.ParameterValue.host),
+                      doNotEnforcePrefix: true)
+        pairingV2PeerKind = nil
         // Temporary handling as devices don't update when 3p device added to account
         if shouldWaitForDevicesToChange {
             waitForDevicesToChangeThenPresentSyncing()
@@ -978,8 +988,8 @@ extension LegacySyncPreferences: SyncConnectionControllerDelegate {
         presentDialog(for: .prepareToSync)
     }
 
-    func controllerDidRecognizeCode(setupSource: SyncSetupSource, codeSource: SyncCodeSource) async {
-        sendCodeRecognisedPixel(setupSource: setupSource, codeSource: codeSource)
+    func controllerDidRecognizeCode(setupSource: SyncSetupSource, codeSource: SyncCodeSource, codeVersion: SyncSetupCodeVersion) async {
+        sendCodeRecognisedPixel(setupSource: setupSource, codeSource: codeSource, codeVersion: codeVersion)
         presentDialog(for: .prepareToSync)
     }
 
@@ -997,6 +1007,8 @@ extension LegacySyncPreferences: SyncConnectionControllerDelegate {
         let isConfirmed = await showPairingV2Confirmation(message: message)
         if !isConfirmed {
             managementDialogModel.endFlow()
+        } else {
+            pairingV2PeerKind = peerKind
         }
         return isConfirmed
     }
@@ -1044,13 +1056,20 @@ extension LegacySyncPreferences: SyncConnectionControllerDelegate {
             self.stopPollingForRecoveryKey()
         }
         guard case .receiver(let syncSetupSource, let syncCodeSource) = setupRole else {
+            PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedSuccessful(.connect,
+                                                                          flowVersion: syncSetupFlowVersion,
+                                                                          peerKind: pairingV2PeerKind?.syncSetupPeerKind,
+                                                                          myRole: SyncSetupPixelKitEvent.ParameterValue.joiner),
+                          doNotEnforcePrefix: true)
+            pairingV2PeerKind = nil
             return
         }
         sendSetupEndedSuccessfullyPixel(setupSource: syncSetupSource, codeSource: syncCodeSource)
     }
 
-    func controllerDidCompletePairingWithAlreadyConnectedAccount(setupRole _: SyncSetupRole) {
+    func controllerDidCompletePairingWithAlreadyConnectedAccount(setupRole: SyncSetupRole) {
         managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .alreadyPairedWithAccount)
+        sendSetupEndedFailedPixel(setupRole: setupRole, reason: SyncSetupPixelKitEvent.ParameterValue.alreadyPaired)
     }
 
     func controllerDidFindTwoAccountsDuringRecovery(_ recoveryKey: SyncCode.RecoveryKey,
@@ -1063,40 +1082,77 @@ extension LegacySyncPreferences: SyncConnectionControllerDelegate {
         switch error {
         case .unableToRecognizeCode:
             handleError(.unableToRecognizeCode, error: underlyingError, pixelEvent: nil)
-            sendCodeParsingFailedPixel(setupRole: setupRole)
+            sendCodeParsingFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
         case .updateRequired:
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .updateRequired)
-            sendCodeParsingFailedPixel(setupRole: setupRole)
+            sendCodeParsingFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
         case .unsupportedThirdPartyRecoveryCode:
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unsupportedThirdPartyRecoveryCode)
-            sendCodeParsingFailedPixel(setupRole: setupRole)
+            sendCodeParsingFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
         case .thirdPartyAccountAlreadyUpgraded:
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .thirdPartyAccountAlreadyUpgraded)
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
         case .syncCancelledFromOtherDevice:
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .syncCancelledFromOtherDevice)
-        case .failedToFetchPublicKey, .failedToTransmitExchangeRecoveryKey, .failedToFetchConnectRecoveryKey, .failedToLogIn, .failedToTransmitExchangeKey, .failedToFetchExchangeRecoveryKey, .failedToTransmitConnectRecoveryKey:
+            sendSetupEndedAbandonedPixel(setupRole: setupRole, reason: SyncSetupPixelKitEvent.ParameterValue.syncConfirmationDenied)
+        case .failedToFetchPublicKey, .failedToTransmitExchangeRecoveryKey, .failedToFetchConnectRecoveryKey, .failedToLogIn, .failedToTransmitExchangeKey, .failedToFetchExchangeRecoveryKey, .failedToTransmitConnectRecoveryKey, .accountUpgradeFailed, .protocolError:
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             handleError(.unableToSyncToOtherDevice, error: underlyingError, pixelEvent: GeneralPixel.syncLoginError(error: underlyingError ?? error))
         case .failedToCreateAccount:
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             handleError(.unableToSyncToOtherDevice, error: underlyingError, pixelEvent: GeneralPixel.syncSignupError(error: underlyingError ?? error))
         case .pollingForRecoveryKeyTimedOut:
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             managementDialogModel.endFlow()
         }
     }
 
-    private func sendCodeRecognisedPixel(setupSource: SyncSetupSource, codeSource: SyncCodeSource) {
+    private func sendCodeRecognisedPixel(setupSource: SyncSetupSource, codeSource: SyncCodeSource, codeVersion: SyncSetupCodeVersion) {
         guard case .pastedCode = codeSource else {
             // Others not supported by macOS
             return
         }
-        guard setupSource != .recovery, setupSource != .unknown else { return }
-        PixelKit.fire(SyncSetupPixelKitEvent.syncSetupManualCodeEnteredSuccess(setupSource), doNotEnforcePrefix: true)
+        guard setupSource != .unknown else { return }
+        PixelKit.fire(SyncSetupPixelKitEvent.syncSetupManualCodeEnteredSuccess(setupSource,
+                                                                               flowVersion: syncSetupFlowVersion,
+                                                                               codeVersion: codeVersion.rawValue),
+                      doNotEnforcePrefix: true)
     }
 
-    private func sendCodeParsingFailedPixel(setupRole: SyncSetupRole) {
-        guard case .receiver(_, let codeSource) = setupRole, case .pastedCode = codeSource else {
+    private func sendCodeParsingFailedPixel(setupRole: SyncSetupRole, reason: String?) {
+        guard case .receiver(let setupSource, let codeSource) = setupRole, case .pastedCode = codeSource else {
             return
         }
-        PixelKit.fire(SyncSetupPixelKitEvent.syncSetupManualCodeEnteredFailed, doNotEnforcePrefix: true)
+        PixelKit.fire(SyncSetupPixelKitEvent.syncSetupManualCodeEnteredFailed(setupSource, flowVersion: syncSetupFlowVersion, reason: reason), doNotEnforcePrefix: true)
+    }
+
+    private func sendSetupEndedFailedPixel(setupRole: SyncSetupRole, reason: String?) {
+        switch setupRole {
+        case .receiver(let setupSource, _):
+            PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedFailed(setupSource,
+                                                                      flowVersion: syncSetupFlowVersion,
+                                                                      peerKind: pairingV2PeerKind?.syncSetupPeerKind,
+                                                                      myRole: setupSource.syncSetupMyRole,
+                                                                      reason: reason),
+                          doNotEnforcePrefix: true)
+        case .sharer:
+            PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedFailed(.exchange,
+                                                                      flowVersion: syncSetupFlowVersion,
+                                                                      peerKind: pairingV2PeerKind?.syncSetupPeerKind,
+                                                                      myRole: SyncSetupPixelKitEvent.ParameterValue.host,
+                                                                      reason: reason),
+                          doNotEnforcePrefix: true)
+        }
+        pairingV2PeerKind = nil
+    }
+
+    private func sendSetupEndedAbandonedPixel(setupRole: SyncSetupRole, reason: String?) {
+        switch setupRole {
+        case .receiver(let setupSource, _):
+            PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedAbandoned(setupSource, flowVersion: syncSetupFlowVersion, reason: reason), doNotEnforcePrefix: true)
+        case .sharer:
+            PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedAbandoned(.exchange, flowVersion: syncSetupFlowVersion, reason: reason), doNotEnforcePrefix: true)
+        }
     }
 
     private func sendSetupEndedSuccessfullyPixel(setupSource: SyncSetupSource, codeSource: SyncCodeSource) {
@@ -1104,8 +1160,49 @@ extension LegacySyncPreferences: SyncConnectionControllerDelegate {
             // Others not supported by macOS
             return
         }
-        guard setupSource != .recovery, setupSource != .unknown else { return }
-        PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedSuccessful(setupSource), doNotEnforcePrefix: true)
+        guard setupSource != .unknown else { return }
+        PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedSuccessful(setupSource,
+                                                                      flowVersion: syncSetupFlowVersion,
+                                                                      peerKind: pairingV2PeerKind?.syncSetupPeerKind,
+                                                                      myRole: setupSource.syncSetupMyRole),
+                      doNotEnforcePrefix: true)
+        pairingV2PeerKind = nil
+    }
+
+    private var syncSetupFlowVersion: String {
+        featureFlagger.isFeatureOn(.syncCanUseV2ConnectFlow) ? SyncSetupPixelKitEvent.ParameterValue.v2 : SyncSetupPixelKitEvent.ParameterValue.v1
+    }
+
+    private func syncSetupSource(for code: String, dialog: ManagementDialogKind) -> SyncSetupSource? {
+        let decodedCode: SyncCode?
+        if URL(string: code)?.absoluteString.contains("code2=") == true {
+            return .exchange
+        } else if let url = URL(string: code), let pairingInfo = PairingInfo(url: url) {
+            decodedCode = try? SyncCode.decodeBase64String(pairingInfo.base64Code)
+        } else {
+            decodedCode = try? SyncCode.decodeBase64String(code)
+        }
+
+        guard let decodedCode else {
+            return nil
+        }
+        if decodedCode.connect != nil {
+            return .connect
+        }
+        if decodedCode.exchangeKey != nil {
+            return .exchange
+        }
+        if decodedCode.recovery != nil {
+            switch dialog {
+            case .syncWithAnotherDevice:
+                return .exchange
+            case .enterRecoveryCode:
+                return .recovery
+            default:
+                return nil
+            }
+        }
+        return nil
     }
 
     private func showPairingV2Confirmation(message: String) async -> Bool {

--- a/macOS/DuckDuckGo/Preferences/Model/LegacySyncPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/LegacySyncPreferences.swift
@@ -994,18 +994,20 @@ extension LegacySyncPreferences: SyncConnectionControllerDelegate {
     }
 
     func controllerShouldAllowPairingV2PeerToJoin(peerName: String?, peerKind: PairingV2DeviceKind) async -> Bool {
-        await confirmPairingV2Peer(peerName: peerName, peerKind: peerKind)
+        await confirmPairingV2Peer(peerName: peerName, peerKind: peerKind, setupRole: .sharer)
     }
 
     func controllerShouldJoinPairingV2Peer(peerName: String?, peerKind: PairingV2DeviceKind) async -> Bool {
-        await confirmPairingV2Peer(peerName: peerName, peerKind: peerKind)
+        // codeSource is unused for the abandonment pixel; only the source/role matter.
+        await confirmPairingV2Peer(peerName: peerName, peerKind: peerKind, setupRole: .receiver(.exchange, .qrCode))
     }
 
-    private func confirmPairingV2Peer(peerName: String?, peerKind: PairingV2DeviceKind) async -> Bool {
+    private func confirmPairingV2Peer(peerName: String?, peerKind: PairingV2DeviceKind, setupRole: SyncSetupRole) async -> Bool {
         let peerName = pairingV2DisplayName(for: peerName)
         let message = UserText.syncPairingV2ConfirmationMessage(peerName, isThirdPartyPeer: peerKind == .thirdParty)
         let isConfirmed = await showPairingV2Confirmation(message: message)
         if !isConfirmed {
+            sendSetupEndedAbandonedPixel(setupRole: setupRole, reason: SyncSetupPixelKitEvent.ParameterValue.syncConfirmationDenied)
             managementDialogModel.endFlow()
         } else {
             pairingV2PeerKind = peerKind
@@ -1153,6 +1155,7 @@ extension LegacySyncPreferences: SyncConnectionControllerDelegate {
         case .sharer:
             PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedAbandoned(.exchange, flowVersion: syncSetupFlowVersion, reason: reason), doNotEnforcePrefix: true)
         }
+        pairingV2PeerKind = nil
     }
 
     private func sendSetupEndedSuccessfullyPixel(setupSource: SyncSetupSource, codeSource: SyncCodeSource) {

--- a/macOS/DuckDuckGo/Preferences/Model/SyncDialogController.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/SyncDialogController.swift
@@ -89,6 +89,7 @@ final class SyncDialogController {
 
     private var cancellables = Set<AnyCancellable>()
     private var syncPromoSource: String?
+    private var pairingV2PeerKind: PairingV2DeviceKind?
 
     @Published var stringForQR: String?
     @Published var codeForDisplayOrPasting: String?
@@ -214,6 +215,7 @@ final class SyncDialogController {
     }
 
     private func startPollingForRecoveryKey(isRecovery: Bool) {
+        pairingV2PeerKind = nil
         Task { @MainActor in
             do {
                 let pairingInfo = try await connectionController.startConnectMode()
@@ -226,7 +228,7 @@ final class SyncDialogController {
                 } else {
                     self.presentDialog(for: .syncWithAnotherDevice(codeForDisplayOrPasting: codeForDisplayOrPasting, stringForQRCode: stringForQR))
                 }
-                PixelKit.fire(SyncSetupPixelKitEvent.syncSetupBarcodeScreenShown(.connect), doNotEnforcePrefix: true)
+                PixelKit.fire(SyncSetupPixelKitEvent.syncSetupBarcodeScreenShown(.connect, flowVersion: syncSetupFlowVersion), doNotEnforcePrefix: true)
             } catch {
                 if syncService.account == nil {
                     if isRecovery {
@@ -264,11 +266,16 @@ final class SyncDialogController {
     }
 
     private func fireCodeCopiedPixel(code: String) {
+        if URL(string: code)?.absoluteString.contains("code2=") == true {
+            PixelKit.fire(SyncSetupPixelKitEvent.syncSetupBarcodeCodeCopied(.exchange, flowVersion: syncSetupFlowVersion), doNotEnforcePrefix: true)
+            return
+        }
+
         guard let syncCode = try? SyncCode.decodeBase64String(code) else { return }
         if syncCode.exchangeKey != nil {
-            PixelKit.fire(SyncSetupPixelKitEvent.syncSetupBarcodeCodeCopied(.exchange), doNotEnforcePrefix: true)
+            PixelKit.fire(SyncSetupPixelKitEvent.syncSetupBarcodeCodeCopied(.exchange, flowVersion: syncSetupFlowVersion), doNotEnforcePrefix: true)
         } else if syncCode.connect != nil {
-            PixelKit.fire(SyncSetupPixelKitEvent.syncSetupBarcodeCodeCopied(.connect), doNotEnforcePrefix: true)
+            PixelKit.fire(SyncSetupPixelKitEvent.syncSetupBarcodeCodeCopied(.connect, flowVersion: syncSetupFlowVersion), doNotEnforcePrefix: true)
         }
     }
 
@@ -302,6 +309,7 @@ final class SyncDialogController {
     }
 
     private func startPollingForPublicKey() {
+        pairingV2PeerKind = nil
         Task { @MainActor in
             do {
                 let pairingInfo = try await connectionController.startExchangeMode()
@@ -310,7 +318,7 @@ final class SyncDialogController {
                 self.codeForDisplayOrPasting = codeForDisplayOrPasting
                 self.stringForQR = stringForQR
                 self.presentDialog(for: .syncWithAnotherDevice(codeForDisplayOrPasting: codeForDisplayOrPasting, stringForQRCode: stringForQR))
-                PixelKit.fire(SyncSetupPixelKitEvent.syncSetupBarcodeScreenShown(.exchange), doNotEnforcePrefix: true)
+                PixelKit.fire(SyncSetupPixelKitEvent.syncSetupBarcodeScreenShown(.exchange, flowVersion: syncSetupFlowVersion), doNotEnforcePrefix: true)
             } catch {
                 managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unableToSyncToOtherDevice, description: error.localizedDescription)
                 PixelKit.fire(DebugEvent(GeneralPixel.syncLoginError(error: error)))
@@ -507,15 +515,11 @@ extension SyncDialogController: ManagementDialogModelDelegate {
     func userPressedCancel(from dialog: ManagementDialogKind) {
         switch dialog {
         case .syncWithAnotherDevice(_, let stringForQRCode), .enterRecoveryCode(let stringForQRCode):
-            guard let url = URL(string: stringForQRCode),
-                  let pairingInfo = PairingInfo(url: url),
-                  let syncCode = try? SyncCode.decodeBase64String(pairingInfo.base64Code) else {
-                return
-            }
-            if syncCode.connect != nil {
-                PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedAbandoned(.connect), doNotEnforcePrefix: true)
-            } else if syncCode.exchangeKey != nil {
-                PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedAbandoned(.exchange), doNotEnforcePrefix: true)
+            if let source = syncSetupSource(for: stringForQRCode, dialog: dialog) {
+                PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedAbandoned(source,
+                                                                             flowVersion: syncSetupFlowVersion,
+                                                                             reason: SyncSetupPixelKitEvent.ParameterValue.scanningCancelled),
+                              doNotEnforcePrefix: true)
             }
         default:
             break
@@ -527,7 +531,7 @@ extension SyncDialogController: ManagementDialogModelDelegate {
     }
 
     func enterCodeViewDidAppear() {
-        PixelKit.fire(SyncSetupPixelKitEvent.syncSetupManualCodeEntryScreenShown, doNotEnforcePrefix: true)
+        PixelKit.fire(SyncSetupPixelKitEvent.syncSetupManualCodeEntryScreenShown(flowVersion: syncSetupFlowVersion), doNotEnforcePrefix: true)
     }
 
     func didEndFlow() {
@@ -603,6 +607,12 @@ extension SyncDialogController: SyncConnectionControllerDelegate {
     }
 
     func controllerDidFinishTransmittingRecoveryKey(shouldWaitForDevicesToChange: Bool) {
+        PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedSuccessful(.exchange,
+                                                                      flowVersion: syncSetupFlowVersion,
+                                                                      peerKind: pairingV2PeerKind?.syncSetupPeerKind,
+                                                                      myRole: SyncSetupPixelKitEvent.ParameterValue.host),
+                      doNotEnforcePrefix: true)
+        pairingV2PeerKind = nil
         // Temporary handling as devices don't update when 3p device added to account
         if shouldWaitForDevicesToChange {
             waitForDevicesToChangeThenPresentSyncing()
@@ -615,8 +625,8 @@ extension SyncDialogController: SyncConnectionControllerDelegate {
         presentDialog(for: .prepareToSync)
     }
 
-    func controllerDidRecognizeCode(setupSource: SyncSetupSource, codeSource: SyncCodeSource) async {
-        sendCodeRecognisedPixel(setupSource: setupSource, codeSource: codeSource)
+    func controllerDidRecognizeCode(setupSource: SyncSetupSource, codeSource: SyncCodeSource, codeVersion: SyncSetupCodeVersion) async {
+        sendCodeRecognisedPixel(setupSource: setupSource, codeSource: codeSource, codeVersion: codeVersion)
         presentDialog(for: .prepareToSync)
     }
 
@@ -634,6 +644,8 @@ extension SyncDialogController: SyncConnectionControllerDelegate {
         let isConfirmed = await showPairingV2Confirmation(message: message)
         if !isConfirmed {
             managementDialogModel.endFlow()
+        } else {
+            pairingV2PeerKind = peerKind
         }
         return isConfirmed
     }
@@ -674,13 +686,20 @@ extension SyncDialogController: SyncConnectionControllerDelegate {
             self.presentDialog(for: .saveRecoveryCode(self.recoveryCode ?? ""))
         }
         guard case .receiver(let syncSetupSource, let syncCodeSource) = setupRole else {
+            PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedSuccessful(.connect,
+                                                                          flowVersion: syncSetupFlowVersion,
+                                                                          peerKind: pairingV2PeerKind?.syncSetupPeerKind,
+                                                                          myRole: SyncSetupPixelKitEvent.ParameterValue.joiner),
+                          doNotEnforcePrefix: true)
+            pairingV2PeerKind = nil
             return
         }
         sendSetupEndedSuccessfullyPixel(setupSource: syncSetupSource, codeSource: syncCodeSource)
     }
 
-    func controllerDidCompletePairingWithAlreadyConnectedAccount(setupRole _: SyncSetupRole) {
+    func controllerDidCompletePairingWithAlreadyConnectedAccount(setupRole: SyncSetupRole) {
         managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .alreadyPairedWithAccount)
+        sendSetupEndedFailedPixel(setupRole: setupRole, reason: SyncSetupPixelKitEvent.ParameterValue.alreadyPaired)
     }
 
     func controllerDidFindTwoAccountsDuringRecovery(_ recoveryKey: SyncCode.RecoveryKey,
@@ -693,24 +712,29 @@ extension SyncDialogController: SyncConnectionControllerDelegate {
         switch error {
         case .unableToRecognizeCode:
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unableToRecognizeCode)
-            sendCodeParsingFailedPixel(setupRole: setupRole)
+            sendCodeParsingFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
         case .updateRequired:
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .updateRequired)
-            sendCodeParsingFailedPixel(setupRole: setupRole)
+            sendCodeParsingFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
         case .unsupportedThirdPartyRecoveryCode:
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unsupportedThirdPartyRecoveryCode)
-            sendCodeParsingFailedPixel(setupRole: setupRole)
+            sendCodeParsingFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
         case .thirdPartyAccountAlreadyUpgraded:
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .thirdPartyAccountAlreadyUpgraded)
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
         case .syncCancelledFromOtherDevice:
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .syncCancelledFromOtherDevice)
-        case .failedToFetchPublicKey, .failedToTransmitExchangeRecoveryKey, .failedToFetchConnectRecoveryKey, .failedToLogIn, .failedToTransmitExchangeKey, .failedToFetchExchangeRecoveryKey, .failedToTransmitConnectRecoveryKey:
+            sendSetupEndedAbandonedPixel(setupRole: setupRole, reason: SyncSetupPixelKitEvent.ParameterValue.syncConfirmationDenied)
+        case .failedToFetchPublicKey, .failedToTransmitExchangeRecoveryKey, .failedToFetchConnectRecoveryKey, .failedToLogIn, .failedToTransmitExchangeKey, .failedToFetchExchangeRecoveryKey, .failedToTransmitConnectRecoveryKey, .accountUpgradeFailed, .protocolError:
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unableToSyncToOtherDevice, description: underlyingError?.localizedDescription)
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             PixelKit.fire(DebugEvent(GeneralPixel.syncLoginError(error: underlyingError ?? error)))
         case .failedToCreateAccount:
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unableToSyncToOtherDevice, description: underlyingError?.localizedDescription)
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             PixelKit.fire(DebugEvent(GeneralPixel.syncSignupError(error: underlyingError ?? error)))
         case .pollingForRecoveryKeyTimedOut:
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             managementDialogModel.endFlow()
         }
     }
@@ -727,20 +751,52 @@ extension SyncDialogController: SyncConnectionControllerDelegate {
         PixelKit.fire(DebugEvent(GeneralPixel.syncLoginExistingAccountError(error: SyncError.accountAlreadyExists)))
     }
 
-    private func sendCodeRecognisedPixel(setupSource: SyncSetupSource, codeSource: SyncCodeSource) {
+    private func sendCodeRecognisedPixel(setupSource: SyncSetupSource, codeSource: SyncCodeSource, codeVersion: SyncSetupCodeVersion) {
         guard case .pastedCode = codeSource else {
             // Others not supported by macOS
             return
         }
-        guard setupSource != .recovery, setupSource != .unknown else { return }
-        PixelKit.fire(SyncSetupPixelKitEvent.syncSetupManualCodeEnteredSuccess(setupSource), doNotEnforcePrefix: true)
+        guard setupSource != .unknown else { return }
+        PixelKit.fire(SyncSetupPixelKitEvent.syncSetupManualCodeEnteredSuccess(setupSource,
+                                                                               flowVersion: syncSetupFlowVersion,
+                                                                               codeVersion: codeVersion.rawValue),
+                      doNotEnforcePrefix: true)
     }
 
-    private func sendCodeParsingFailedPixel(setupRole: SyncSetupRole) {
-        guard case .receiver(_, let codeSource) = setupRole, case .pastedCode = codeSource else {
+    private func sendCodeParsingFailedPixel(setupRole: SyncSetupRole, reason: String?) {
+        guard case .receiver(let setupSource, let codeSource) = setupRole, case .pastedCode = codeSource else {
             return
         }
-        PixelKit.fire(SyncSetupPixelKitEvent.syncSetupManualCodeEnteredFailed, doNotEnforcePrefix: true)
+        PixelKit.fire(SyncSetupPixelKitEvent.syncSetupManualCodeEnteredFailed(setupSource, flowVersion: syncSetupFlowVersion, reason: reason), doNotEnforcePrefix: true)
+    }
+
+    private func sendSetupEndedFailedPixel(setupRole: SyncSetupRole, reason: String?) {
+        switch setupRole {
+        case .receiver(let setupSource, _):
+            PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedFailed(setupSource,
+                                                                      flowVersion: syncSetupFlowVersion,
+                                                                      peerKind: pairingV2PeerKind?.syncSetupPeerKind,
+                                                                      myRole: setupSource.syncSetupMyRole,
+                                                                      reason: reason),
+                          doNotEnforcePrefix: true)
+        case .sharer:
+            PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedFailed(.exchange,
+                                                                      flowVersion: syncSetupFlowVersion,
+                                                                      peerKind: pairingV2PeerKind?.syncSetupPeerKind,
+                                                                      myRole: SyncSetupPixelKitEvent.ParameterValue.host,
+                                                                      reason: reason),
+                          doNotEnforcePrefix: true)
+        }
+        pairingV2PeerKind = nil
+    }
+
+    private func sendSetupEndedAbandonedPixel(setupRole: SyncSetupRole, reason: String?) {
+        switch setupRole {
+        case .receiver(let setupSource, _):
+            PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedAbandoned(setupSource, flowVersion: syncSetupFlowVersion, reason: reason), doNotEnforcePrefix: true)
+        case .sharer:
+            PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedAbandoned(.exchange, flowVersion: syncSetupFlowVersion, reason: reason), doNotEnforcePrefix: true)
+        }
     }
 
     private func sendSetupEndedSuccessfullyPixel(setupSource: SyncSetupSource, codeSource: SyncCodeSource) {
@@ -748,8 +804,49 @@ extension SyncDialogController: SyncConnectionControllerDelegate {
             // Others not supported by macOS
             return
         }
-        guard setupSource != .recovery, setupSource != .unknown else { return }
-        PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedSuccessful(setupSource), doNotEnforcePrefix: true)
+        guard setupSource != .unknown else { return }
+        PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedSuccessful(setupSource,
+                                                                      flowVersion: syncSetupFlowVersion,
+                                                                      peerKind: pairingV2PeerKind?.syncSetupPeerKind,
+                                                                      myRole: setupSource.syncSetupMyRole),
+                      doNotEnforcePrefix: true)
+        pairingV2PeerKind = nil
+    }
+
+    private var syncSetupFlowVersion: String {
+        featureFlagger.isFeatureOn(.syncCanUseV2ConnectFlow) ? SyncSetupPixelKitEvent.ParameterValue.v2 : SyncSetupPixelKitEvent.ParameterValue.v1
+    }
+
+    private func syncSetupSource(for code: String, dialog: ManagementDialogKind) -> SyncSetupSource? {
+        let decodedCode: SyncCode?
+        if URL(string: code)?.absoluteString.contains("code2=") == true {
+            return .exchange
+        } else if let url = URL(string: code), let pairingInfo = PairingInfo(url: url) {
+            decodedCode = try? SyncCode.decodeBase64String(pairingInfo.base64Code)
+        } else {
+            decodedCode = try? SyncCode.decodeBase64String(code)
+        }
+
+        guard let decodedCode else {
+            return nil
+        }
+        if decodedCode.connect != nil {
+            return .connect
+        }
+        if decodedCode.exchangeKey != nil {
+            return .exchange
+        }
+        if decodedCode.recovery != nil {
+            switch dialog {
+            case .syncWithAnotherDevice:
+                return .exchange
+            case .enterRecoveryCode:
+                return .recovery
+            default:
+                return nil
+            }
+        }
+        return nil
     }
 
     private func showPairingV2Confirmation(message: String) async -> Bool {

--- a/macOS/DuckDuckGo/Preferences/Model/SyncDialogController.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/SyncDialogController.swift
@@ -631,18 +631,20 @@ extension SyncDialogController: SyncConnectionControllerDelegate {
     }
 
     func controllerShouldAllowPairingV2PeerToJoin(peerName: String?, peerKind: PairingV2DeviceKind) async -> Bool {
-        await confirmPairingV2Peer(peerName: peerName, peerKind: peerKind)
+        await confirmPairingV2Peer(peerName: peerName, peerKind: peerKind, setupRole: .sharer)
     }
 
     func controllerShouldJoinPairingV2Peer(peerName: String?, peerKind: PairingV2DeviceKind) async -> Bool {
-        await confirmPairingV2Peer(peerName: peerName, peerKind: peerKind)
+        // codeSource is unused for the abandonment pixel; only the source/role matter.
+        await confirmPairingV2Peer(peerName: peerName, peerKind: peerKind, setupRole: .receiver(.exchange, .qrCode))
     }
 
-    private func confirmPairingV2Peer(peerName: String?, peerKind: PairingV2DeviceKind) async -> Bool {
+    private func confirmPairingV2Peer(peerName: String?, peerKind: PairingV2DeviceKind, setupRole: SyncSetupRole) async -> Bool {
         let peerName = pairingV2DisplayName(for: peerName)
         let message = UserText.syncPairingV2ConfirmationMessage(peerName, isThirdPartyPeer: peerKind == .thirdParty)
         let isConfirmed = await showPairingV2Confirmation(message: message)
         if !isConfirmed {
+            sendSetupEndedAbandonedPixel(setupRole: setupRole, reason: SyncSetupPixelKitEvent.ParameterValue.syncConfirmationDenied)
             managementDialogModel.endFlow()
         } else {
             pairingV2PeerKind = peerKind
@@ -797,6 +799,7 @@ extension SyncDialogController: SyncConnectionControllerDelegate {
         case .sharer:
             PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedAbandoned(.exchange, flowVersion: syncSetupFlowVersion, reason: reason), doNotEnforcePrefix: true)
         }
+        pairingV2PeerKind = nil
     }
 
     private func sendSetupEndedSuccessfullyPixel(setupSource: SyncSetupSource, codeSource: SyncCodeSource) {

--- a/macOS/DuckDuckGo/Sync/SyncPixels.swift
+++ b/macOS/DuckDuckGo/Sync/SyncPixels.swift
@@ -92,15 +92,48 @@ enum SyncSetupPixelKitEvent: PixelKitEvent {
 
     enum ParameterKey {
         static let source = "source"
+        static let flowVersion = "flow_version"
+        static let myKind = "my_kind"
+        static let codeType = "code_type"
+        static let codeVersion = "code_version"
+        static let path = "path"
+        static let reason = "reason"
+        static let peerKind = "peer_kind"
+        static let myRole = "my_role"
     }
 
-    case syncSetupBarcodeScreenShown(SyncSetupSource)
-    case syncSetupBarcodeCodeCopied(SyncSetupSource)
-    case syncSetupManualCodeEntryScreenShown
-    case syncSetupManualCodeEnteredSuccess(SyncSetupSource)
-    case syncSetupManualCodeEnteredFailed
-    case syncSetupEndedAbandoned(SyncSetupSource)
-    case syncSetupEndedSuccessful(SyncSetupSource)
+    enum ParameterValue {
+        static let ddg = "ddg"
+        static let recovery = "recovery"
+        static let pairing = "pairing"
+        static let linking = "linking"
+        static let v1 = "v1"
+        static let v2 = "v2"
+        static let alreadyPaired = "already_paired"
+        static let accountCreationFailed = "account_creation_failed"
+        static let accountUpgradeFailed = "account_upgrade_failed"
+        static let protocolError = "protocol_error"
+        static let invalidCredentials = "invalid_credentials"
+        static let transportFailure = "transport_failure"
+        static let sessionTimeout = "session_timeout"
+        static let needsUpgrade = "needs_upgrade"
+        static let incompatibleCode = "incompatible_code"
+        static let alreadyUpgraded = "already_upgraded"
+        static let unrecognizedCode = "unrecognized_code"
+        static let scanningCancelled = "scanning_cancelled"
+        static let syncConfirmationDenied = "sync_confirmation_denied"
+        static let host = "host"
+        static let joiner = "joiner"
+    }
+
+    case syncSetupBarcodeScreenShown(SyncSetupSource, flowVersion: String?)
+    case syncSetupBarcodeCodeCopied(SyncSetupSource, flowVersion: String?)
+    case syncSetupManualCodeEntryScreenShown(flowVersion: String?)
+    case syncSetupManualCodeEnteredSuccess(SyncSetupSource, flowVersion: String?, codeVersion: String?)
+    case syncSetupManualCodeEnteredFailed(SyncSetupSource?, flowVersion: String?, reason: String?)
+    case syncSetupEndedAbandoned(SyncSetupSource, flowVersion: String?, reason: String? = nil)
+    case syncSetupEndedFailed(SyncSetupSource?, flowVersion: String?, peerKind: String?, myRole: String?, reason: String?)
+    case syncSetupEndedSuccessful(SyncSetupSource, flowVersion: String?, peerKind: String?, myRole: String?)
 
     var name: String {
         switch self {
@@ -110,27 +143,113 @@ enum SyncSetupPixelKitEvent: PixelKitEvent {
         case .syncSetupManualCodeEnteredSuccess: return "sync_setup_manual_code_entered_success"
         case .syncSetupManualCodeEnteredFailed: return "sync_setup_manual_code_entered_failed"
         case .syncSetupEndedAbandoned: return "sync_setup_ended_abandoned"
+        case .syncSetupEndedFailed: return "sync_setup_ended_failed"
         case .syncSetupEndedSuccessful: return "sync_setup_ended_successful"
         }
     }
 
     var parameters: [String: String]? {
-        guard let source else { return nil }
-        return [ParameterKey.source: source.rawValue]
+        var parameters = [ParameterKey.myKind: ParameterValue.ddg]
+        parameters[ParameterKey.source] = source?.rawValue
+        parameters[ParameterKey.flowVersion] = flowVersion
+        parameters[ParameterKey.codeType] = codeType
+        parameters[ParameterKey.codeVersion] = codeVersion
+        parameters[ParameterKey.path] = path
+        parameters[ParameterKey.reason] = reason
+        parameters[ParameterKey.peerKind] = peerKind
+        parameters[ParameterKey.myRole] = myRole
+        return parameters
     }
 
     private var source: SyncSetupSource? {
         switch self {
         case
-            .syncSetupBarcodeScreenShown(let source),
-            .syncSetupBarcodeCodeCopied(let source),
-            .syncSetupManualCodeEnteredSuccess(let source),
-            .syncSetupEndedAbandoned(let source),
-            .syncSetupEndedSuccessful(let source):
+            .syncSetupBarcodeScreenShown(let source, _),
+            .syncSetupBarcodeCodeCopied(let source, _),
+            .syncSetupManualCodeEnteredSuccess(let source, _, _),
+            .syncSetupEndedAbandoned(let source, _, _),
+            .syncSetupEndedSuccessful(let source, _, _, _):
             return source
         case
-            .syncSetupManualCodeEntryScreenShown,
-            .syncSetupManualCodeEnteredFailed:
+            .syncSetupManualCodeEnteredFailed(let source, _, _),
+            .syncSetupEndedFailed(let source, _, _, _, _):
+            return source
+        case
+            .syncSetupManualCodeEntryScreenShown:
+            return nil
+        }
+    }
+
+    private var flowVersion: String? {
+        switch self {
+        case .syncSetupBarcodeScreenShown(_, let flowVersion),
+                .syncSetupBarcodeCodeCopied(_, let flowVersion),
+                .syncSetupManualCodeEntryScreenShown(let flowVersion),
+                .syncSetupManualCodeEnteredSuccess(_, let flowVersion, _),
+                .syncSetupManualCodeEnteredFailed(_, let flowVersion, _),
+                .syncSetupEndedAbandoned(_, let flowVersion, _),
+                .syncSetupEndedFailed(_, let flowVersion, _, _, _),
+                .syncSetupEndedSuccessful(_, let flowVersion, _, _):
+            return flowVersion
+        }
+    }
+
+    private var codeType: String? {
+        switch self {
+        case .syncSetupManualCodeEnteredSuccess(let source, _, _):
+            return source.syncSetupCodeType
+        default:
+            return nil
+        }
+    }
+
+    private var codeVersion: String? {
+        switch self {
+        case .syncSetupManualCodeEnteredSuccess(_, _, let codeVersion):
+            return codeVersion
+        default:
+            return nil
+        }
+    }
+
+    private var path: String? {
+        switch self {
+        case .syncSetupEndedSuccessful(let source, _, _, _):
+            return source.syncSetupPath
+        case .syncSetupEndedFailed(let source, _, _, _, _):
+            return source?.syncSetupPath
+        default:
+            return nil
+        }
+    }
+
+    private var reason: String? {
+        switch self {
+        case .syncSetupManualCodeEnteredFailed(_, _, let reason),
+                .syncSetupEndedAbandoned(_, _, let reason),
+                .syncSetupEndedFailed(_, _, _, _, let reason):
+            return reason
+        default:
+            return nil
+        }
+    }
+
+    private var peerKind: String? {
+        switch self {
+        case .syncSetupEndedSuccessful(_, _, let peerKind, _),
+                .syncSetupEndedFailed(_, _, let peerKind, _, _):
+            return peerKind
+        default:
+            return nil
+        }
+    }
+
+    private var myRole: String? {
+        switch self {
+        case .syncSetupEndedSuccessful(_, _, _, let myRole),
+                .syncSetupEndedFailed(_, _, _, let myRole, _):
+            return myRole
+        default:
             return nil
         }
     }
@@ -143,8 +262,91 @@ enum SyncSetupPixelKitEvent: PixelKitEvent {
                 .syncSetupManualCodeEnteredSuccess,
                 .syncSetupManualCodeEnteredFailed,
                 .syncSetupEndedAbandoned,
+                .syncSetupEndedFailed,
                 .syncSetupEndedSuccessful:
             return [.pixelSource]
+        }
+    }
+}
+
+private extension SyncSetupSource {
+
+    var syncSetupCodeType: String? {
+        switch self {
+        case .recovery:
+            return SyncSetupPixelKitEvent.ParameterValue.recovery
+        case .exchange, .connect:
+            return SyncSetupPixelKitEvent.ParameterValue.linking
+        case .unknown:
+            return nil
+        }
+    }
+
+    var syncSetupPath: String? {
+        switch self {
+        case .recovery:
+            return SyncSetupPixelKitEvent.ParameterValue.recovery
+        case .exchange, .connect:
+            return SyncSetupPixelKitEvent.ParameterValue.pairing
+        case .unknown:
+            return nil
+        }
+    }
+
+}
+
+extension SyncSetupSource {
+
+    var syncSetupMyRole: String? {
+        switch self {
+        case .connect:
+            return SyncSetupPixelKitEvent.ParameterValue.host
+        case .exchange:
+            return SyncSetupPixelKitEvent.ParameterValue.joiner
+        case .recovery, .unknown:
+            return nil
+        }
+    }
+}
+
+extension PairingV2DeviceKind {
+
+    var syncSetupPeerKind: String {
+        rawValue
+    }
+}
+
+extension SyncConnectionError {
+
+    var syncSetupFailureReason: String? {
+        switch self {
+        case .failedToLogIn:
+            return SyncSetupPixelKitEvent.ParameterValue.invalidCredentials
+        case .failedToFetchPublicKey,
+                .failedToTransmitExchangeRecoveryKey,
+                .failedToFetchConnectRecoveryKey,
+                .failedToTransmitExchangeKey,
+                .failedToFetchExchangeRecoveryKey,
+                .failedToTransmitConnectRecoveryKey:
+            return SyncSetupPixelKitEvent.ParameterValue.transportFailure
+        case .pollingForRecoveryKeyTimedOut:
+            return SyncSetupPixelKitEvent.ParameterValue.sessionTimeout
+        case .updateRequired:
+            return SyncSetupPixelKitEvent.ParameterValue.needsUpgrade
+        case .unsupportedThirdPartyRecoveryCode:
+            return SyncSetupPixelKitEvent.ParameterValue.incompatibleCode
+        case .thirdPartyAccountAlreadyUpgraded:
+            return SyncSetupPixelKitEvent.ParameterValue.alreadyUpgraded
+        case .unableToRecognizeCode:
+            return SyncSetupPixelKitEvent.ParameterValue.unrecognizedCode
+        case .failedToCreateAccount:
+            return SyncSetupPixelKitEvent.ParameterValue.accountCreationFailed
+        case .accountUpgradeFailed:
+            return SyncSetupPixelKitEvent.ParameterValue.accountUpgradeFailed
+        case .protocolError:
+            return SyncSetupPixelKitEvent.ParameterValue.protocolError
+        case .syncCancelledFromOtherDevice:
+            return nil
         }
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -220,7 +220,16 @@
                 "key": "reason",
                 "type": "string",
                 "description": "The reason Sync setup failed, when it can be mapped safely.",
-                "enum": ["session_timeout", "transport_failure", "invalid_credentials", "already_upgraded", "already_paired", "account_creation_failed", "account_upgrade_failed", "protocol_error"]
+                "enum": [
+                    "session_timeout",
+                    "transport_failure",
+                    "invalid_credentials",
+                    "already_upgraded",
+                    "already_paired",
+                    "account_creation_failed",
+                    "account_upgrade_failed",
+                    "protocol_error"
+                ]
             }
         ]
     },

--- a/macOS/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -1,0 +1,271 @@
+{
+    "sync_setup_barcode_screen_shown": {
+        "description": "Fired when the Sync setup QR/code screen is shown.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            }
+        ]
+    },
+    "sync_setup_barcode_code_copied": {
+        "description": "Fired when the user copies the Sync setup code.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            }
+        ]
+    },
+    "sync_setup_manual_code_entry_screen_shown": {
+        "description": "Fired when the Sync setup manual code-entry screen is shown.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            }
+        ]
+    },
+    "sync_setup_manual_code_entered_success": {
+        "description": "Fired when Sync setup recognizes a manually entered or pasted code.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source or recognized code source."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            },
+            {
+                "key": "code_type",
+                "type": "string",
+                "description": "The type of Sync setup code recognized.",
+                "enum": ["recovery", "linking"]
+            },
+            {
+                "key": "code_version",
+                "type": "string",
+                "description": "The version of Sync setup code recognized.",
+                "enum": ["v1", "v2"]
+            }
+        ]
+    },
+    "sync_setup_manual_code_entered_failed": {
+        "description": "Fired when Sync setup rejects a manually entered or pasted code.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source or rejected code source."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            },
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "The reason the entered code was rejected, when it can be mapped safely.",
+                "enum": ["unrecognized_code", "needs_upgrade", "incompatible_code"]
+            }
+        ]
+    },
+    "sync_setup_ended_abandoned": {
+        "description": "Fired when the user abandons Sync setup before completion.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            },
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "The reason Sync setup was abandoned, when it can be mapped safely.",
+                "enum": ["scanning_cancelled", "sync_confirmation_denied"]
+            }
+        ]
+    },
+    "sync_setup_ended_failed": {
+        "description": "Fired when Sync setup started from a recognized code but failed before completion.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            },
+            {
+                "key": "path",
+                "type": "string",
+                "description": "Whether the setup flow was recovery or pairing.",
+                "enum": ["recovery", "pairing"]
+            },
+            {
+                "key": "peer_kind",
+                "type": "string",
+                "description": "The kind of the peer client, when known.",
+                "enum": ["ddg", "3party"]
+            },
+            {
+                "key": "my_role",
+                "type": "string",
+                "description": "This client's role in the pairing flow, when applicable.",
+                "enum": ["host", "joiner"]
+            },
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "The reason Sync setup failed, when it can be mapped safely.",
+                "enum": ["session_timeout", "transport_failure", "invalid_credentials", "already_upgraded", "already_paired", "account_creation_failed", "account_upgrade_failed", "protocol_error"]
+            }
+        ]
+    },
+    "sync_setup_ended_successful": {
+        "description": "Fired when Sync setup completes successfully.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            },
+            {
+                "key": "path",
+                "type": "string",
+                "description": "Whether the setup flow was recovery or pairing.",
+                "enum": ["recovery", "pairing"]
+            },
+            {
+                "key": "peer_kind",
+                "type": "string",
+                "description": "The kind of the peer client, when known.",
+                "enum": ["ddg", "3party"]
+            },
+            {
+                "key": "my_role",
+                "type": "string",
+                "description": "This client's role in the pairing flow, when applicable.",
+                "enum": ["host", "joiner"]
+            }
+        ]
+    }
+}

--- a/macOS/UnitTests/Sync/SyncDialogControllerTests.swift
+++ b/macOS/UnitTests/Sync/SyncDialogControllerTests.swift
@@ -843,7 +843,7 @@ final class SyncDialogControllerTests: XCTestCase {
     }
 
     func testControllerDidRecognizeCode_presentsPrepareDialog() async {
-        await syncDialogController.controllerDidRecognizeCode(setupSource: .exchange, codeSource: .pastedCode)
+        await syncDialogController.controllerDidRecognizeCode(setupSource: .exchange, codeSource: .pastedCode, codeVersion: .v1)
 
         XCTAssertEqual(managementDialogModel.currentDialog, .prepareToSync)
     }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL:
Tech Design URL:
CC:

### Description

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1.
2.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync pairing/setup flows and delegate APIs across iOS, macOS, and DDGSync; behavior is mostly telemetry and error classification, but mis-fired pixels or wrong failure reasons could skew V2 rollout metrics.
> 
> **Overview**
> **Sync setup pixels** on iOS and macOS now attach shared context (`flow_version` from the V2 connect flag, `my_kind`, `code_type`/`code_version`, `path`, `peer_kind`, `my_role`, and `reason`) across barcode, manual entry, success, abandon, and the new **`sync_setup_ended_failed`** event. Pairing V2 peer kind is captured after the user confirms joining; denial and cancel paths fire abandoned pixels with explicit reasons.
> 
> **Shared kit changes:** `controllerDidRecognizeCode` now includes **`SyncSetupCodeVersion`** (v1 vs v2). **`SyncConnectionError`** gains **`accountUpgradeFailed`** and **`protocolError`**; Pairing V2 third-party upgrade failures map to **`upgradeFailed`** instead of login failures, with matching connection-layer mapping and tests.
> 
> **Schema:** New **`sync_setup.json5`** pixel definitions document the expanded parameter enums on both platforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeba5997ba079a1e1fe55b058bc017b20ce529fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->