### PR TITLE
Fix UTI bug where stale suggestions flash for new query

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/SearchSuggestionsLoader.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/SearchSuggestionsLoader.swift
@@ -83,6 +83,16 @@ final class SearchSuggestionsLoader {
         }
     }
 
+    /// Clears state for a fresh editing session so the long-lived loader never renders a previous
+    /// session's suggestions for the new query.
+    func reset() {
+        loader = nil
+        latestDispatchedQuery = nil
+        lastCompletedFetchQuery = nil
+        // Unconditional (no `!= .appEmpty` guard) to force `sectionsPublisher` to recompute
+        result = .appEmpty
+    }
+
     func tearDown() { cancellables.removeAll() }
 }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -200,6 +200,9 @@ final class UnifiedInputContentContainerViewController: UIViewController {
     /// long-lived data source reflects add/remove since the last editing session. Called on each
     /// omnibar-editing show — legacy got this for free by building a fresh data source per session.
     func refreshSuggestionsCaches() {
+        // Drop the persistent Search loader's stale results so they don't flash for the new query
+        // (e.g. after burning all tabs). The Duck.ai surface is rebuilt per session, so it needs none.
+        searchLoader?.reset()
         searchDataSource?.refreshCaches()
         duckAISurface?.refreshCaches()
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1215744232839104?focus=true

### Description

- Fix stale autocomplete suggestions briefly flashing the previous query's results when typing in the address bar with Unified Toggle Input (UTI) enabled in Search mode (e.g. after burning all tabs via the Fire button).
- Add a `reset()` method to the long-lived `SearchSuggestionsLoader` that clears in-flight loader and query tracking, and unconditionally re-publishes `.appEmpty` to force the sections to recompute and drop stale rows.
- Call `searchLoader?.reset()` from `refreshSuggestionsCaches()` so the clear happens at each editing-session boundary (before the user can type), not per keystroke.

### Testing Steps

1. Enable the Unified Toggle Input (UTI) feature flag and ensure the AI Chat toggle is **disabled** (Search mode).
2. In the address bar, type a query with no real matches — e.g. a long unique URL like `https://privacy-test-pages.site` (only the "Search DuckDuckGo for …" and "Ask Duck.ai …" default rows should appear).
3. Visit the URL.
4. Tap the Fire button → burn all tabs. A new empty tab opens and auto-focuses the address bar.
5. Type one character (e.g. `h`).
6. **Verify:** the suggestions list does **not** flash the previous query's rows. It shows an empty list briefly, then the correct new-query suggestions.
7. **Regression — normal typing:** within a single session, type continuously and confirm suggestions do not flicker or collapse to the 2-row fallback between keystrokes.
8. **Regression — re-tap omnibar:** on a loaded page with a prefilled URL, tap the address bar and confirm suggestions reflect the prefilled text, not a prior query.
9. **Regression — Duck.ai mode:** enable the AI Chat toggle and confirm Duck.ai suggestions behave as before (unaffected).

### Impact and Risks

**Impact Level: Low**

- Scoped to the UTI Search suggestions path only; Duck.ai mode is rebuilt per session and is unaffected.
- The reset runs at editing-session boundaries (when the live query is empty), so it doesn't interfere with mid-session typing.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to UTI Search suggestions at session boundaries; Duck.ai path is untouched and mid-session typing behavior is unchanged.
> 
> **Overview**
> Fixes a brief flash of the **previous query’s** autocomplete rows when starting a new address-bar session in Unified Toggle Input Search mode (e.g. after burning all tabs and typing again).
> 
> Adds **`SearchSuggestionsLoader.reset()`**, which drops the in-flight loader, clears query tracking, and **unconditionally** sets `result` to `.appEmpty` so `sectionsPublisher` recomputes instead of reusing stale rows. **`refreshSuggestionsCaches()`** now calls **`searchLoader?.reset()`** at each omnibar-editing boundary (alongside bookmark cache refresh), before the user types—not on every keystroke. Duck.ai suggestions are unchanged (rebuilt per session).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a7c6ca4d21b16e5fb5f9b94bca32f5d85ac2946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->