### PR TITLE
[iOS][UTI] Remove duplicate UTI URL expansion tests

### DIFF
--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -311,56 +311,6 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         XCTAssertEqual(handler.currentText, "he\nllo")
     }
 
-    func test_urlDoesNotExpandHeightInSearchModeAfterUserTap() {
-        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
-        handler.setToggleState(.search)
-        let sut = SwitchBarTextEntryView(handler: handler)
-        sut.isExpandable = true
-        prepareForFitting(sut)
-        sut.setQueryText("https://www.cinemark.com/theatres/ca-playa-vista/cinemark-playa-vista-and-xd?showDate=2026-06-12")
-        let singleLineHeight = applyFittingHeight(to: sut)
-
-        sut.hasBeenInteractedWith = true
-        sut.updatePoseForCurrentState()
-        let heightAfterTap = applyFittingHeight(to: sut)
-
-        XCTAssertEqual(heightAfterTap, singleLineHeight, accuracy: 1)
-    }
-
-    func test_urlCanExpandInAIChatModeAfterUserTap() {
-        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
-        handler.setToggleState(.aiChat)
-        let sut = SwitchBarTextEntryView(handler: handler)
-        sut.isExpandable = true
-        prepareForFitting(sut)
-        sut.setQueryText("https://www.cinemark.com/theatres/ca-playa-vista/cinemark-playa-vista-and-xd?showDate=2026-06-12")
-        let singleLineHeight = applyFittingHeight(to: sut)
-
-        sut.hasBeenInteractedWith = true
-        sut.updatePoseForCurrentState()
-        let heightAfterTap = applyFittingHeight(to: sut)
-
-        XCTAssertGreaterThan(heightAfterTap, singleLineHeight)
-    }
-
-    func test_urlCollapsesToSingleLineWhenModeSwitchesFromAIChatToSearch() {
-        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
-        handler.setToggleState(.aiChat)
-        let sut = SwitchBarTextEntryView(handler: handler)
-        sut.isExpandable = true
-        prepareForFitting(sut)
-        sut.setQueryText("https://www.cinemark.com/theatres/ca-playa-vista/cinemark-playa-vista-and-xd?showDate=2026-06-12")
-        sut.hasBeenInteractedWith = true
-        sut.updatePoseForCurrentState()
-        let expandedHeight = applyFittingHeight(to: sut)
-
-        handler.setToggleState(.search)
-        sut.updatePoseForCurrentState()
-        let heightAfterSwitch = applyFittingHeight(to: sut)
-
-        XCTAssertGreaterThan(expandedHeight, heightAfterSwitch)
-    }
-
     func test_topAIChatTextEntryDoesNotGrowOnFirstFloatingReturnNewline() {
         let expectedTopAIChatMinimumHeight: CGFloat = 68
         let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1215787787224969
Tech Design URL:
CC: @aataraxiaa 

### Description

Three tests (`test_urlDoesNotExpandHeightInSearchModeAfterUserTap`, `test_urlCanExpandInAIChatModeAfterUserTap`,
`test_urlCollapsesToSingleLineWhenModeSwitchesFromAIChatToSearch`) ended up declared twice in `UnifiedToggleInputViewTests` after [PR #5429](https://github.com/duckduckgo/apple-browsers/pull/5429/changes#diff-34310428192e95374cff6d9d8e7ebc9c3db01a35236e576fa6bc5d66fece6f6c) added them.
Keep the newer code that uses the shared longURL constant and drop the inline-URL duplicates.

**NOTE** I ensured the code tested the same behaviour of the removed counterpart.

### Testing Steps
1. Verify CI passes

### Impact and Risks
Low: Fixes to main branch

#### What could go wrong?
The removed tests leave the production code untested.

### Quality Considerations
Ensured that the removed tests duplicate the testing behaviour.

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only deduplication with equivalent coverage kept elsewhere in the same file; no runtime behavior changes.
> 
> **Overview**
> Removes three duplicate URL height-expansion tests from `UnifiedToggleInputViewTests` that were left after an earlier merge added the same scenarios twice.
> 
> The deleted copies inlined the long Cinemark URL in each test; the retained suite already covers the same behavior via the shared `longURL` helper and related cases (including search-only mode). **No production or test logic changes**—only duplicate declarations are dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46b2bd320adbfa98fbc1ca71c474e1dd9b0df7b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->