### PR TITLE
[macOS] Sync V2 device list support updated to include 3rd parties

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncModels.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncModels.swift
@@ -117,11 +117,17 @@ public struct SyncAccount: Codable, Sendable {
 }
 
 public struct RegisteredDevice: Codable, Sendable {
-
     public let id: String
     public let name: String
     public let type: String
+    public let credentialId: String?
 
+    public init(id: String, name: String, type: String, credentialId: String? = nil) {
+        self.id = id
+        self.name = name
+        self.type = type
+        self.credentialId = credentialId
+    }
 }
 
 public struct AccountCreationKeys {
@@ -233,9 +239,9 @@ public struct PairingInfo {
 
 // MARK: - Scoped Access Credentials
 
-enum SyncCredentialID {
-    static let defaultCredential = "ddg"
-    static let thirdParty = "3party"
+public enum SyncCredentialID {
+    public static let defaultCredential = "ddg"
+    public static let thirdParty = "3party"
 }
 
 // AccessCredential is decoded from API responses using JSONDecoder.snakeCaseKeys. The server key

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
@@ -19,7 +19,6 @@
 import Foundation
 import DDGSyncCrypto
 import Networking
-import os.log
 
 struct AccountManager: AccountManaging {
 
@@ -28,7 +27,21 @@ struct AccountManager: AccountManaging {
     let endpoints: Endpoints
     let api: RemoteAPIRequestCreating
     let crypter: CryptingInternal
+    let registeredDeviceMapper: any RegisteredDeviceMapping
     let isScopedAccessCredentialsEnabled: () -> Bool
+
+    init(endpoints: Endpoints,
+         api: RemoteAPIRequestCreating,
+         crypter: CryptingInternal,
+         registeredDeviceMapper: (any RegisteredDeviceMapping)? = nil,
+         isScopedAccessCredentialsEnabled: @escaping () -> Bool) {
+        self.endpoints = endpoints
+        self.api = api
+        self.crypter = crypter
+        self.registeredDeviceMapper = registeredDeviceMapper ?? RegisteredDeviceMapper(crypter: crypter,
+                                                                                       isScopedAccessCredentialsEnabled: isScopedAccessCredentialsEnabled)
+        self.isScopedAccessCredentialsEnabled = isScopedAccessCredentialsEnabled
+    }
 
     func createAccount(deviceName: String, deviceType: String) async throws -> SyncAccount {
         let deviceId = UUID().uuidString
@@ -128,15 +141,25 @@ struct AccountManager: AccountManaging {
             throw SyncError.unableToDecodeResponse("Failed to decode devices")
         }
 
-        var devices = [RegisteredDevice]()
+        // Scoped access enabled: never auto-logout. Prefer entries_v2; otherwise map legacy entries with
+        // decrypt-or-generic-fallback (undecryptable native -> "Unknown", undecryptable 3party -> "Browser").
+        if isScopedAccessCredentialsEnabled() {
+            let entries: [RegisteredDeviceEntry]
+            if let entriesV2 = result.devices?.entriesV2, !entriesV2.isEmpty {
+                entries = entriesV2
+            } else {
+                entries = result.devices?.entries ?? []
+            }
+            return await registeredDeviceMapper.registeredDevices(from: entries, account: account)
+        }
+
+        // Legacy behaviour (scoped access disabled): invalid native devices are automatically logged out.
+        var devices: [RegisteredDevice] = []
         if let entries = result.devices?.entries {
             for device in entries {
-                do {
-                    let name = try crypter.base64DecodeAndDecrypt(device.name, using: account.primaryKey)
-                    let type = try crypter.base64DecodeAndDecrypt(device.type, using: account.primaryKey)
-                    devices.append(RegisteredDevice(id: device.id, name: name, type: type))
-                } catch {
-                    // Invalid devices should be automatically logged out
+                if let registeredDevice = registeredDeviceMapper.registeredDevice(fromLegacyEntry: device, account: account) {
+                    devices.append(registeredDevice)
+                } else {
                     try await logout(deviceId: device.id, token: token)
                 }
             }
@@ -219,14 +242,10 @@ struct AccountManager: AccountManaging {
                 state: .addingNewDevice
             ),
             devices: result.devices.compactMap { device in
-                // Prevent devices with `null` type from blocking login while the V2 device payload is in flux.
-                guard let encryptedType = device.type,
-                      let name = try? crypter.base64DecodeAndDecrypt(device.name, using: info.primaryKey),
-                      let type = try? crypter.base64DecodeAndDecrypt(encryptedType, using: info.primaryKey) else {
-                    return nil
-                }
-
-                return RegisteredDevice(id: device.id, name: name, type: type)
+                registeredDeviceMapper.registeredDevice(fromDefaultCredentialLoginEntryWithID: device.id,
+                                                        encryptedName: device.name,
+                                                        encryptedType: device.type,
+                                                        primaryKey: info.primaryKey)
             },
             keys: result.keys,
             accessCredentials: result.accessCredentials
@@ -293,7 +312,8 @@ struct AccountManager: AccountManaging {
     struct FetchDevicesResult: Decodable {
         struct DeviceWrapper: Decodable {
             var lastModified: String?
-            var entries: [RegisteredDevice]
+            var entries: [RegisteredDeviceEntry]?
+            var entriesV2: [RegisteredDeviceEntry]?
         }
 
         var devices: DeviceWrapper?

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
@@ -84,8 +84,17 @@ struct ProductionDependencies: SyncDependencies {
         payloadCompressor = SyncGzipPayloadCompressor()
 
         crypter = Crypter(secureStore: secureStore)
-        account = AccountManager(endpoints: endpoints, api: api, crypter: crypter, isScopedAccessCredentialsEnabled: { syncFeatureFlags.isScopedAccessCredentialsEnabled() })
-        scopedAccess = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: crypter)
+        let scopedAccess = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: crypter)
+        let registeredDeviceMapper = RegisteredDeviceMapper(crypter: crypter,
+                                                            scopedAccess: scopedAccess,
+                                                            cachedScopedPassword: secureStore.scopedPassword,
+                                                            isScopedAccessCredentialsEnabled: { syncFeatureFlags.isScopedAccessCredentialsEnabled() })
+        account = AccountManager(endpoints: endpoints,
+                                 api: api,
+                                 crypter: crypter,
+                                 registeredDeviceMapper: registeredDeviceMapper,
+                                 isScopedAccessCredentialsEnabled: { syncFeatureFlags.isScopedAccessCredentialsEnabled() })
+        self.scopedAccess = scopedAccess
         scheduler = SyncScheduler()
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
@@ -1,0 +1,230 @@
+//
+//  RegisteredDeviceMapper.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import os.log
+
+protocol RegisteredDeviceMapping {
+    func registeredDevices(from entries: [RegisteredDeviceEntry], account: SyncAccount) async -> [RegisteredDevice]
+    func registeredDevice(fromLegacyEntry entry: RegisteredDeviceEntry, account: SyncAccount) -> RegisteredDevice?
+    func registeredDevice(fromDefaultCredentialLoginEntryWithID id: String,
+                          encryptedName: String,
+                          encryptedType: String?,
+                          primaryKey: Data) -> RegisteredDevice?
+    func registeredDevice(fromThirdPartyLoginEntryWithID id: String, encodedName: String, encodedType: String?) -> RegisteredDevice
+}
+
+/// Maps raw Sync device payloads into app-facing devices without hiding entries that cannot be decrypted locally.
+struct RegisteredDeviceMapper: RegisteredDeviceMapping {
+
+    private static let undecryptableThirdPartyDeviceName = "Browser"
+    private static let undecryptableDeviceName = "Unknown"
+    private static let undecryptableDeviceType = "unknown"
+
+    let crypter: CryptingInternal
+    let scopedAccess: ScopedAccessCredentialManaging?
+    let cachedScopedPassword: () throws -> Data?
+    let isScopedAccessCredentialsEnabled: () -> Bool
+    private let jweCompactCodec: JWECompactCodec
+
+    init(crypter: CryptingInternal,
+         scopedAccess: ScopedAccessCredentialManaging? = nil,
+         cachedScopedPassword: @escaping () throws -> Data? = { nil },
+         isScopedAccessCredentialsEnabled: @escaping () -> Bool,
+         jweCompactCodec: JWECompactCodec = JWECompactCodec()) {
+        self.crypter = crypter
+        self.scopedAccess = scopedAccess
+        self.cachedScopedPassword = cachedScopedPassword
+        self.isScopedAccessCredentialsEnabled = isScopedAccessCredentialsEnabled
+        self.jweCompactCodec = jweCompactCodec
+    }
+
+    func registeredDevices(from entries: [RegisteredDeviceEntry], account: SyncAccount) async -> [RegisteredDevice] {
+        let thirdPartyMainKey = await thirdPartyMainKeyIfNeeded(for: entries, account: account)
+        return entries.map { registeredDevice(from: $0, account: account, thirdPartyMainKey: thirdPartyMainKey) }
+    }
+
+    func registeredDevice(fromLegacyEntry entry: RegisteredDeviceEntry, account: SyncAccount) -> RegisteredDevice? {
+        decryptedDefaultCredentialRegisteredDevice(id: entry.id,
+                                                   encryptedName: entry.name,
+                                                   encryptedType: entry.type,
+                                                   primaryKey: account.primaryKey,
+                                                   credentialId: SyncCredentialID.defaultCredential)
+    }
+
+    func registeredDevice(fromDefaultCredentialLoginEntryWithID id: String,
+                          encryptedName: String,
+                          encryptedType: String?,
+                          primaryKey: Data) -> RegisteredDevice? {
+        guard let encryptedType else {
+            return nil
+        }
+
+        return decryptedDefaultCredentialRegisteredDevice(id: id,
+                                                         encryptedName: encryptedName,
+                                                         encryptedType: encryptedType,
+                                                         primaryKey: primaryKey,
+                                                         credentialId: SyncCredentialID.defaultCredential)
+    }
+
+    func registeredDevice(fromThirdPartyLoginEntryWithID id: String, encodedName: String, encodedType: String?) -> RegisteredDevice {
+        // Login-response 3party fields are base64-encoded plaintext (not a JWE like device-list entries); fall back to the raw value if it isn't base64.
+        RegisteredDevice(id: id,
+                         name: Self.utf8String(fromBase64EncodedString: encodedName) ?? encodedName,
+                         type: encodedType.flatMap { Self.utf8String(fromBase64EncodedString: $0) } ?? encodedType ?? "",
+                         credentialId: SyncCredentialID.thirdParty)
+    }
+
+    private func registeredDevice(from entry: RegisteredDeviceEntry, account: SyncAccount, thirdPartyMainKey: Data?) -> RegisteredDevice {
+        // Keep every server entry visible even if one encrypted field is malformed or uses a key we cannot recover.
+        decryptedRegisteredDevice(from: entry, account: account, thirdPartyMainKey: thirdPartyMainKey) ?? fallbackRegisteredDevice(from: entry)
+    }
+
+    private func decryptedRegisteredDevice(from entry: RegisteredDeviceEntry, account: SyncAccount, thirdPartyMainKey: Data?) -> RegisteredDevice? {
+        switch entry.credentialId {
+        case SyncCredentialID.thirdParty:
+            return decryptedThirdPartyRegisteredDevice(from: entry, thirdPartyMainKey: thirdPartyMainKey)
+        case SyncCredentialID.defaultCredential, nil:
+            // A nil credentialId is a legacy native entry; treat it as the default (ddg) credential.
+            return decryptedDefaultCredentialRegisteredDevice(id: entry.id,
+                                                             encryptedName: entry.name,
+                                                             encryptedType: entry.type,
+                                                             primaryKey: account.primaryKey,
+                                                             credentialId: SyncCredentialID.defaultCredential)
+        default:
+            // Unknown credential kind (e.g. a future type): fall back rather than guess at decryption.
+            return nil
+        }
+    }
+
+    private func decryptedDefaultCredentialRegisteredDevice(id: String,
+                                                           encryptedName: String?,
+                                                           encryptedType: String?,
+                                                           primaryKey: Data,
+                                                           credentialId: String?) -> RegisteredDevice? {
+        guard let encryptedName,
+              let encryptedType,
+              let name = try? crypter.base64DecodeAndDecrypt(encryptedName, using: primaryKey),
+              let type = try? crypter.base64DecodeAndDecrypt(encryptedType, using: primaryKey) else {
+            return nil
+        }
+
+        return RegisteredDevice(id: id, name: name, type: type, credentialId: credentialId)
+    }
+
+    private func decryptedThirdPartyRegisteredDevice(from entry: RegisteredDeviceEntry, thirdPartyMainKey: Data?) -> RegisteredDevice? {
+        guard let thirdPartyMainKey,
+              let name = decryptThirdPartyDeviceField(entry.name, using: thirdPartyMainKey),
+              let type = decryptThirdPartyDeviceField(entry.type, using: thirdPartyMainKey) else {
+            return nil
+        }
+
+        return RegisteredDevice(id: entry.id, name: name, type: type, credentialId: entry.credentialId)
+    }
+
+    private func decryptThirdPartyDeviceField(_ value: String?, using thirdPartyMainKey: Data) -> String? {
+        guard let value,
+              let plaintext = try? jweCompactCodec.decryptDirect(token: value, contentEncryptionKey: thirdPartyMainKey) else {
+            return nil
+        }
+
+        // 3party device fields are direct JWE plaintext strings, not base64-wrapped values.
+        return String(data: plaintext, encoding: .utf8)
+    }
+
+    private func thirdPartyMainKeyIfNeeded(for entries: [RegisteredDeviceEntry], account: SyncAccount) async -> Data? {
+        guard entries.contains(where: { $0.credentialId == SyncCredentialID.thirdParty }) else {
+            return nil
+        }
+        guard isScopedAccessCredentialsEnabled() else {
+            return nil
+        }
+
+        if let cachedMainKey = cachedThirdPartyMainKey(for: entries, account: account) {
+            return cachedMainKey
+        }
+
+        return await recoveredScopedPassword(for: account)
+            .map { ScopedAccessKeyDerivation.mainKey(from: $0, userID: account.userId) }
+    }
+
+    private func cachedThirdPartyMainKey(for entries: [RegisteredDeviceEntry], account: SyncAccount) -> Data? {
+        guard let scopedPassword = try? cachedScopedPassword(), !scopedPassword.isEmpty else {
+            return nil
+        }
+
+        let mainKey = ScopedAccessKeyDerivation.mainKey(from: scopedPassword, userID: account.userId)
+        let thirdPartyEntries = entries.filter { $0.credentialId == SyncCredentialID.thirdParty }
+        // A cached scoped password is only trusted if it can decrypt the 3party fields in this response.
+        guard thirdPartyEntries.allSatisfy({ canDecryptThirdPartyDeviceEntry($0, using: mainKey) }) else {
+            return nil
+        }
+
+        return mainKey
+    }
+
+    private func canDecryptThirdPartyDeviceEntry(_ entry: RegisteredDeviceEntry, using thirdPartyMainKey: Data) -> Bool {
+        // Probe with `type` only: a decryptable type is the signal that this 3party key matches the entry.
+        decryptThirdPartyDeviceField(entry.type, using: thirdPartyMainKey) != nil
+    }
+
+    private func recoveredScopedPassword(for account: SyncAccount) async -> Data? {
+        guard let scopedAccess else {
+            return nil
+        }
+
+        do {
+            let accessCredentials = try await scopedAccess.fetchAccessCredentials(account)
+            guard let scopedPassword = try scopedAccess.recoverScopedPassword(from: accessCredentials,
+                                                                              primaryKey: account.primaryKey,
+                                                                              userID: account.userId) else {
+                return nil
+            }
+            return scopedPassword
+        } catch {
+            Logger.sync.debug("Unable to recover 3party scoped password for device list: \(String(reflecting: error))")
+            return nil
+        }
+    }
+
+    private func fallbackRegisteredDevice(from entry: RegisteredDeviceEntry) -> RegisteredDevice {
+        let credentialId = entry.credentialId ?? SyncCredentialID.defaultCredential
+        // Preserve undecryptable entries so a bad encrypted field cannot hide a device from the list.
+        let name = credentialId == SyncCredentialID.thirdParty
+            ? Self.undecryptableThirdPartyDeviceName
+            : Self.undecryptableDeviceName
+        return RegisteredDevice(id: entry.id,
+                                name: name,
+                                type: Self.undecryptableDeviceType,
+                                credentialId: credentialId)
+    }
+
+    private static func utf8String(fromBase64EncodedString value: String) -> String? {
+        guard let data = Data(base64Encoded: value) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+}
+
+struct RegisteredDeviceEntry: Decodable {
+    let id: String
+    let name: String?
+    let type: String?
+    let credentialId: String?
+}

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
@@ -113,10 +113,10 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
     }
 
     private func decryptedDefaultCredentialRegisteredDevice(id: String,
-                                                           encryptedName: String?,
-                                                           encryptedType: String?,
-                                                           primaryKey: Data,
-                                                           credentialId: String?) -> RegisteredDevice? {
+                                                            encryptedName: String?,
+                                                            encryptedType: String?,
+                                                            primaryKey: Data,
+                                                            credentialId: String?) -> RegisteredDevice? {
         guard let encryptedName,
               let encryptedType,
               let name = try? crypter.base64DecodeAndDecrypt(encryptedName, using: primaryKey),

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
@@ -26,7 +26,6 @@ protocol RegisteredDeviceMapping {
                           encryptedName: String,
                           encryptedType: String?,
                           primaryKey: Data) -> RegisteredDevice?
-    func registeredDevice(fromThirdPartyLoginEntryWithID id: String, encodedName: String, encodedType: String?) -> RegisteredDevice
 }
 
 /// Maps raw Sync device payloads into app-facing devices without hiding entries that cannot be decrypted locally.
@@ -80,14 +79,6 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
                                                          encryptedType: encryptedType,
                                                          primaryKey: primaryKey,
                                                          credentialId: SyncCredentialID.defaultCredential)
-    }
-
-    func registeredDevice(fromThirdPartyLoginEntryWithID id: String, encodedName: String, encodedType: String?) -> RegisteredDevice {
-        // Login-response 3party fields are base64-encoded plaintext (not a JWE like device-list entries); fall back to the raw value if it isn't base64.
-        RegisteredDevice(id: id,
-                         name: Self.utf8String(fromBase64EncodedString: encodedName) ?? encodedName,
-                         type: encodedType.flatMap { Self.utf8String(fromBase64EncodedString: $0) } ?? encodedType ?? "",
-                         credentialId: SyncCredentialID.thirdParty)
     }
 
     private func registeredDevice(from entry: RegisteredDeviceEntry, account: SyncAccount, thirdPartyMainKey: Data?) -> RegisteredDevice {
@@ -214,12 +205,6 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
                                 credentialId: credentialId)
     }
 
-    private static func utf8String(fromBase64EncodedString value: String) -> String? {
-        guard let data = Data(base64Encoded: value) else {
-            return nil
-        }
-        return String(data: data, encoding: .utf8)
-    }
 }
 
 struct RegisteredDeviceEntry: Decodable {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
@@ -593,10 +593,4 @@ private final class RegisteredDeviceMappingMock: RegisteredDeviceMapping {
                          credentialId: SyncCredentialID.defaultCredential)
     }
 
-    func registeredDevice(fromThirdPartyLoginEntryWithID id: String, encodedName: String, encodedType: String?) -> RegisteredDevice {
-        RegisteredDevice(id: id,
-                         name: encodedName,
-                         type: encodedType ?? "",
-                         credentialId: SyncCredentialID.thirdParty)
-    }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
@@ -383,6 +383,152 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertNil(result.accessCredentials)
     }
 
+    func testWhenFetchingDevicesWithScopedAccessEnabledThenPrefersEntriesV2OverLegacyEntries() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let mapper = RegisteredDeviceMappingMock()
+        let accountManager = AccountManager(endpoints: endpoints,
+                                            api: api,
+                                            crypter: CryptingMock(),
+                                            registeredDeviceMapper: mapper,
+                                            isScopedAccessCredentialsEnabled: { true })
+        api.fakeRequests[devicesURL(for: endpoints)] = makeJSONRequest("""
+        {
+            "devices": {
+                "entries": [
+                    {
+                        "id": "legacy-device",
+                        "name": "encrypted_Legacy",
+                        "type": "encrypted_desktop"
+                    }
+                ],
+                "entries_v2": [
+                    {
+                        "id": "v2-device",
+                        "name": "encrypted_V2",
+                        "type": "encrypted_browser",
+                        "credential_id": "3party"
+                    }
+                ]
+            }
+        }
+        """)
+
+        let devices = try await accountManager.fetchDevicesForAccount(makeAccount(primaryKey: Data()))
+
+        XCTAssertEqual(mapper.registeredDevicesCallEntryIDs, ["v2-device"])
+        XCTAssertEqual(devices.map(\.id), ["v2-device"])
+        XCTAssertFalse(api.createRequestCallArgs.contains { $0.url == endpoints.logoutDevice })
+    }
+
+    func testWhenFetchingDevicesWithScopedAccessEnabledAndEntriesV2IsEmptyThenFallsBackToLegacyEntries() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let mapper = RegisteredDeviceMappingMock()
+        let accountManager = AccountManager(endpoints: endpoints,
+                                            api: api,
+                                            crypter: CryptingMock(),
+                                            registeredDeviceMapper: mapper,
+                                            isScopedAccessCredentialsEnabled: { true })
+        api.fakeRequests[devicesURL(for: endpoints)] = makeJSONRequest("""
+        {
+            "devices": {
+                "entries": [
+                    {
+                        "id": "legacy-device",
+                        "name": "encrypted_Legacy",
+                        "type": "encrypted_desktop"
+                    }
+                ],
+                "entries_v2": []
+            }
+        }
+        """)
+
+        let devices = try await accountManager.fetchDevicesForAccount(makeAccount(primaryKey: Data()))
+
+        XCTAssertEqual(mapper.registeredDevicesCallEntryIDs, ["legacy-device"])
+        XCTAssertEqual(devices.map(\.id), ["legacy-device"])
+        XCTAssertFalse(api.createRequestCallArgs.contains { $0.url == endpoints.logoutDevice })
+    }
+
+    func testWhenFetchingDevicesWithScopedAccessEnabledThenFallsBackUndecryptableEntriesWithoutLogout() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        var crypter = CryptingMock()
+        crypter._base64DecodeAndDecrypt = { _ in
+            throw SyncError.failedToDecryptValue("test")
+        }
+        let accountManager = AccountManager(endpoints: endpoints,
+                                            api: api,
+                                            crypter: crypter,
+                                            isScopedAccessCredentialsEnabled: { true })
+        api.fakeRequests[devicesURL(for: endpoints)] = makeJSONRequest("""
+        {
+            "devices": {
+                "entries_v2": [
+                    {
+                        "id": "third-party-device",
+                        "name": "undecryptable-name",
+                        "type": "undecryptable-type",
+                        "credential_id": "3party"
+                    },
+                    {
+                        "id": "native-device",
+                        "name": "undecryptable-name",
+                        "type": "undecryptable-type",
+                        "credential_id": "ddg"
+                    }
+                ]
+            }
+        }
+        """)
+
+        let devices = try await accountManager.fetchDevicesForAccount(makeAccount(primaryKey: Data()))
+
+        XCTAssertEqual(devices.map(\.id), ["third-party-device", "native-device"])
+        XCTAssertEqual(devices.map(\.name), ["Browser", "Unknown"])
+        XCTAssertEqual(devices.map(\.type), ["unknown", "unknown"])
+        XCTAssertEqual(devices.map(\.credentialId), [SyncCredentialID.thirdParty, SyncCredentialID.defaultCredential])
+        XCTAssertFalse(api.createRequestCallArgs.contains { $0.url == endpoints.logoutDevice })
+    }
+
+    func testWhenFetchingDevicesWithScopedAccessDisabledThenLegacyUndecryptableDeviceIsLoggedOut() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        var crypter = CryptingMock()
+        crypter._base64DecodeAndDecrypt = { _ in
+            throw SyncError.failedToDecryptValue("test")
+        }
+        let accountManager = AccountManager(endpoints: endpoints,
+                                            api: api,
+                                            crypter: crypter,
+                                            isScopedAccessCredentialsEnabled: { false })
+        api.fakeRequests[devicesURL(for: endpoints)] = makeJSONRequest("""
+        {
+            "devices": {
+                "entries": [
+                    {
+                        "id": "invalid-native-device",
+                        "name": "undecryptable-name",
+                        "type": "undecryptable-type"
+                    }
+                ]
+            }
+        }
+        """)
+        api.fakeRequests[endpoints.logoutDevice] = makeJSONRequest("""
+        {
+            "device_id": "invalid-native-device"
+        }
+        """)
+
+        let devices = try await accountManager.fetchDevicesForAccount(makeAccount(primaryKey: Data()))
+
+        XCTAssertTrue(devices.isEmpty)
+        XCTAssertTrue(api.createRequestCallArgs.contains { $0.url == endpoints.logoutDevice })
+    }
+
     private func makeAccount(primaryKey: Data) -> SyncAccount {
         SyncAccount(deviceId: "device-1",
                     deviceName: "iPhone",
@@ -398,6 +544,10 @@ final class AccountManagerTests: XCTestCase {
         HTTPRequestingMock(result: .init(data: Data(json.utf8), response: .init()))
     }
 
+    private func devicesURL(for endpoints: Endpoints) -> URL {
+        endpoints.syncGet.appendingPathComponent("devices")
+    }
+
     private func makeSignupBody(from api: RemoteAPIRequestCreatingMock) throws -> [String: Any] {
         let requestBody = try XCTUnwrap(api.createRequestCallArgs.last?.body)
         let json = try JSONSerialization.jsonObject(with: requestBody)
@@ -410,4 +560,43 @@ final class AccountManagerTests: XCTestCase {
         return try XCTUnwrap(json as? [String: Any])
     }
 
+}
+
+private final class RegisteredDeviceMappingMock: RegisteredDeviceMapping {
+
+    private(set) var registeredDevicesCallEntryIDs: [String] = []
+
+    func registeredDevices(from entries: [RegisteredDeviceEntry], account: SyncAccount) async -> [RegisteredDevice] {
+        registeredDevicesCallEntryIDs = entries.map(\.id)
+        return entries.map { entry in
+            RegisteredDevice(id: entry.id,
+                             name: entry.name ?? "",
+                             type: entry.type ?? "",
+                             credentialId: entry.credentialId)
+        }
+    }
+
+    func registeredDevice(fromLegacyEntry entry: RegisteredDeviceEntry, account: SyncAccount) -> RegisteredDevice? {
+        RegisteredDevice(id: entry.id,
+                         name: entry.name ?? "",
+                         type: entry.type ?? "",
+                         credentialId: entry.credentialId)
+    }
+
+    func registeredDevice(fromDefaultCredentialLoginEntryWithID id: String,
+                          encryptedName: String,
+                          encryptedType: String?,
+                          primaryKey: Data) -> RegisteredDevice? {
+        RegisteredDevice(id: id,
+                         name: encryptedName,
+                         type: encryptedType ?? "",
+                         credentialId: SyncCredentialID.defaultCredential)
+    }
+
+    func registeredDevice(fromThirdPartyLoginEntryWithID id: String, encodedName: String, encodedType: String?) -> RegisteredDevice {
+        RegisteredDevice(id: id,
+                         name: encodedName,
+                         type: encodedType ?? "",
+                         credentialId: SyncCredentialID.thirdParty)
+    }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/RegisteredDeviceMapperTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/RegisteredDeviceMapperTests.swift
@@ -151,21 +151,6 @@ final class RegisteredDeviceMapperTests: XCTestCase {
         XCTAssertEqual(devices.map { $0.credentialId }, ["future"])
     }
 
-    func testWhenMappingThirdPartyLoginEntryThenDecodesBase64PlaintextFields() {
-        let mapper = RegisteredDeviceMapper(crypter: CryptingMock(), isScopedAccessCredentialsEnabled: { true })
-        let encodedName = Data("Python Client".utf8).base64EncodedString()
-        let encodedType = Data("browser".utf8).base64EncodedString()
-
-        let device = mapper.registeredDevice(fromThirdPartyLoginEntryWithID: "third-party-device",
-                                             encodedName: encodedName,
-                                             encodedType: encodedType)
-
-        XCTAssertEqual(device.id, "third-party-device")
-        XCTAssertEqual(device.name, "Python Client")
-        XCTAssertEqual(device.type, "browser")
-        XCTAssertEqual(device.credentialId, SyncCredentialID.thirdParty)
-    }
-
     private func makeAccount() -> SyncAccount {
         SyncAccount(deviceId: "device-1",
                     deviceName: "Mac",

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/RegisteredDeviceMapperTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/RegisteredDeviceMapperTests.swift
@@ -1,0 +1,179 @@
+//
+//  RegisteredDeviceMapperTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import XCTest
+
+@testable import DDGSync
+
+final class RegisteredDeviceMapperTests: XCTestCase {
+
+    func testWhenMappingDefaultCredentialEntryThenDecryptsWithPrimaryKeyAndSetsDefaultCredentialID() {
+        let mapper = RegisteredDeviceMapper(crypter: CryptingMock(), isScopedAccessCredentialsEnabled: { true })
+        let entry = RegisteredDeviceEntry(id: "native-device",
+                                          name: "encrypted_Mac",
+                                          type: "encrypted_desktop",
+                                          credentialId: SyncCredentialID.defaultCredential)
+
+        let device = mapper.registeredDevice(fromLegacyEntry: entry, account: makeAccount())
+
+        XCTAssertEqual(device?.id, "native-device")
+        XCTAssertEqual(device?.name, "Mac")
+        XCTAssertEqual(device?.type, "desktop")
+        XCTAssertEqual(device?.credentialId, SyncCredentialID.defaultCredential)
+    }
+
+    func testWhenMappingThirdPartyEntryWithCachedScopedPasswordThenDecryptsJWEFields() async throws {
+        let account = makeAccount()
+        let scopedPassword = Data(repeating: 7, count: 32)
+        let thirdPartyMainKey = ScopedAccessKeyDerivation.mainKey(from: scopedPassword, userID: account.userId)
+        let codec = JWECompactCodec()
+        let entry = RegisteredDeviceEntry(
+            id: "third-party-device",
+            name: try codec.encryptDirect(payload: Data("Python Client".utf8),
+                                          contentEncryptionKey: thirdPartyMainKey,
+                                          kid: SyncCredentialID.thirdParty),
+            type: try codec.encryptDirect(payload: Data("browser".utf8),
+                                          contentEncryptionKey: thirdPartyMainKey,
+                                          kid: SyncCredentialID.thirdParty),
+            credentialId: SyncCredentialID.thirdParty)
+        let mapper = RegisteredDeviceMapper(crypter: CryptingMock(),
+                                            cachedScopedPassword: { scopedPassword },
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            jweCompactCodec: codec)
+
+        let devices = await mapper.registeredDevices(from: [entry], account: account)
+
+        XCTAssertEqual(devices.map { $0.id }, ["third-party-device"])
+        XCTAssertEqual(devices.map { $0.name }, ["Python Client"])
+        XCTAssertEqual(devices.map { $0.type }, ["browser"])
+        XCTAssertEqual(devices.map { $0.credentialId }, [SyncCredentialID.thirdParty])
+    }
+
+    func testWhenMappingThirdPartyEntryWithoutCachedPasswordThenRecoversScopedPasswordAndDecryptsJWEFields() async throws {
+        let account = makeAccount()
+        let scopedPassword = Data(repeating: 7, count: 32)
+        let thirdPartyMainKey = ScopedAccessKeyDerivation.mainKey(from: scopedPassword, userID: account.userId)
+        let codec = JWECompactCodec()
+        let entry = RegisteredDeviceEntry(
+            id: "third-party-device",
+            name: try codec.encryptDirect(payload: Data("Python Client".utf8),
+                                          contentEncryptionKey: thirdPartyMainKey,
+                                          kid: SyncCredentialID.thirdParty),
+            type: try codec.encryptDirect(payload: Data("browser".utf8),
+                                          contentEncryptionKey: thirdPartyMainKey,
+                                          kid: SyncCredentialID.thirdParty),
+            credentialId: SyncCredentialID.thirdParty)
+        let accessCredentials = [AccessCredential(id: SyncCredentialID.thirdParty, scope: "sync", encrypted3PartyCredential: "encrypted")]
+        let scopedAccess = ScopedAccessCredentialManagingMock()
+        scopedAccess.fetchAccessCredentialsStub = accessCredentials
+        scopedAccess.recoverScopedPasswordStub = scopedPassword
+        let mapper = RegisteredDeviceMapper(crypter: CryptingMock(),
+                                            scopedAccess: scopedAccess,
+                                            cachedScopedPassword: { nil },
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            jweCompactCodec: codec)
+
+        let devices = await mapper.registeredDevices(from: [entry], account: account)
+
+        XCTAssertEqual(scopedAccess.fetchAccessCredentialsCalls.map { $0.deviceId }, [account.deviceId])
+        XCTAssertEqual(scopedAccess.recoverScopedPasswordCalls.count, 1)
+        XCTAssertEqual(scopedAccess.recoverScopedPasswordCalls.first?.accessCredentials?.map { $0.id }, [SyncCredentialID.thirdParty])
+        XCTAssertEqual(devices.map { $0.id }, ["third-party-device"])
+        XCTAssertEqual(devices.map { $0.name }, ["Python Client"])
+        XCTAssertEqual(devices.map { $0.type }, ["browser"])
+        XCTAssertEqual(devices.map { $0.credentialId }, [SyncCredentialID.thirdParty])
+    }
+
+    func testWhenCachedScopedPasswordCannotDecryptEveryThirdPartyEntryThenFallsBackWithoutPartiallyTrustingCache() async throws {
+        let account = makeAccount()
+        let scopedPassword = Data(repeating: 7, count: 32)
+        let thirdPartyMainKey = ScopedAccessKeyDerivation.mainKey(from: scopedPassword, userID: account.userId)
+        let codec = JWECompactCodec()
+        let decryptableEntry = RegisteredDeviceEntry(
+            id: "decryptable-third-party-device",
+            name: try codec.encryptDirect(payload: Data("Python Client".utf8),
+                                          contentEncryptionKey: thirdPartyMainKey,
+                                          kid: SyncCredentialID.thirdParty),
+            type: try codec.encryptDirect(payload: Data("browser".utf8),
+                                          contentEncryptionKey: thirdPartyMainKey,
+                                          kid: SyncCredentialID.thirdParty),
+            credentialId: SyncCredentialID.thirdParty)
+        let undecryptableEntry = RegisteredDeviceEntry(id: "undecryptable-third-party-device",
+                                                       name: "not-jwe",
+                                                       type: "not-jwe",
+                                                       credentialId: SyncCredentialID.thirdParty)
+        let mapper = RegisteredDeviceMapper(crypter: CryptingMock(),
+                                            cachedScopedPassword: { scopedPassword },
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            jweCompactCodec: codec)
+
+        let devices = await mapper.registeredDevices(from: [decryptableEntry, undecryptableEntry], account: account)
+
+        XCTAssertEqual(devices.map { $0.id }, ["decryptable-third-party-device", "undecryptable-third-party-device"])
+        XCTAssertEqual(devices.map { $0.name }, ["Browser", "Browser"])
+        XCTAssertEqual(devices.map { $0.type }, ["unknown", "unknown"])
+        XCTAssertEqual(devices.map { $0.credentialId }, [SyncCredentialID.thirdParty, SyncCredentialID.thirdParty])
+    }
+
+    func testWhenMappingUnknownCredentialEntryThenFallsBackWithoutAttemptingDecryption() async {
+        var crypter = CryptingMock()
+        crypter._base64DecodeAndDecrypt = { _ in
+            XCTFail("Unknown credential entries should not be decrypted")
+            return ""
+        }
+        let mapper = RegisteredDeviceMapper(crypter: crypter, isScopedAccessCredentialsEnabled: { true })
+        let entry = RegisteredDeviceEntry(id: "future-device",
+                                          name: "encrypted_Future",
+                                          type: "encrypted_browser",
+                                          credentialId: "future")
+
+        let devices = await mapper.registeredDevices(from: [entry], account: makeAccount())
+
+        XCTAssertEqual(devices.map { $0.id }, ["future-device"])
+        XCTAssertEqual(devices.map { $0.name }, ["Unknown"])
+        XCTAssertEqual(devices.map { $0.type }, ["unknown"])
+        XCTAssertEqual(devices.map { $0.credentialId }, ["future"])
+    }
+
+    func testWhenMappingThirdPartyLoginEntryThenDecodesBase64PlaintextFields() {
+        let mapper = RegisteredDeviceMapper(crypter: CryptingMock(), isScopedAccessCredentialsEnabled: { true })
+        let encodedName = Data("Python Client".utf8).base64EncodedString()
+        let encodedType = Data("browser".utf8).base64EncodedString()
+
+        let device = mapper.registeredDevice(fromThirdPartyLoginEntryWithID: "third-party-device",
+                                             encodedName: encodedName,
+                                             encodedType: encodedType)
+
+        XCTAssertEqual(device.id, "third-party-device")
+        XCTAssertEqual(device.name, "Python Client")
+        XCTAssertEqual(device.type, "browser")
+        XCTAssertEqual(device.credentialId, SyncCredentialID.thirdParty)
+    }
+
+    private func makeAccount() -> SyncAccount {
+        SyncAccount(deviceId: "device-1",
+                    deviceName: "Mac",
+                    deviceType: "desktop",
+                    userId: "user-1",
+                    primaryKey: Data((0..<32).map(UInt8.init)),
+                    secretKey: Data(repeating: 2, count: 32),
+                    token: "token-1",
+                    state: .active)
+    }
+}

--- a/macOS/DuckDuckGo/Preferences/Model/SyncPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/SyncPreferences.swift
@@ -37,7 +37,12 @@ extension SyncDevice {
     }
 
     init(_ device: RegisteredDevice) {
-        let kind: Kind = device.type == "desktop" ? .desktop : .mobile
+        let kind: Kind
+        if device.credentialId == SyncCredentialID.thirdParty {
+            kind = .thirdParty
+        } else {
+            kind = device.type == "desktop" ? .desktop : .mobile
+        }
         self.init(kind: kind, name: device.name, id: device.id)
     }
 }

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Models/SyncDevice.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Models/SyncDevice.swift
@@ -21,7 +21,7 @@ import Foundation
 public struct SyncDevice: Identifiable, Equatable {
 
     public enum Kind: Equatable {
-        case current, desktop, mobile
+        case current, desktop, mobile, thirdParty
     }
 
     public let kind: Kind

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/ManagementView/SyncedDevicesView.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/ManagementView/SyncedDevicesView.swift
@@ -63,6 +63,8 @@ struct SyncedDeviceIcon: View {
             return NSImage(imageLiteralResourceName: "SyncedDeviceDesktop")
         case .mobile:
             return NSImage(imageLiteralResourceName: "SyncedDeviceMobile")
+        case .thirdParty:
+            return NSImage(imageLiteralResourceName: "SyncAllDevices")
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215794614540160?focus=true
Tech Design URL:
CC:

### Description
Adds support for displaying 3rd party browsers in the Sync screen list of devices

### Testing Steps

1. Ensure all Sync V2 feature flags are enabled
2. Sync macOS to a 3party client 
3. Confirm the 3party client appears in the Sync device list & uses the generic all-devices/browser icon, not desktop/mobile.
4. Connect a native DuckDuckGo device as normal
5. Confirm the native device appears in the Sync device list & still uses the expected desktop/mobile icon.
6. Disable the syncScopedAccessCredentials feature flag and confirm only the native devices are displayed.
7. Re-enable the flag & remove the 3party device from the device list.
8. Confirm the 3party device no longer appears after refreshing/reopening Sync settings, and that Sync is disabled in the 3rd party browser
9. Remove the native device from the device list.
10. Confirm the native device no longer appears after refreshing/reopening Sync settings, and that Sync is disabled on the other device

### Impact and Risks
What's the impact on users if something goes wrong?

Medium: Could disrupt specific features or user flows


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync account device-fetch semantics, scoped-credential recovery, and remote auto-logout behavior behind a feature flag; mistakes could hide devices, show wrong labels, or incorrectly log out remote devices.
> 
> **Overview**
> Adds **Sync V2 device list** support so third-party browsers can appear alongside native DuckDuckGo devices when scoped access credentials are enabled.
> 
> Device fetch now prefers **`entries_v2`** (with optional **`credential_id`**) and routes mapping through a new **`RegisteredDeviceMapper`**. Native entries still decrypt with the account primary key; **`3party`** entries decrypt name/type via JWE using a derived scoped main key (cached scoped password or recovery from access credentials). Undecryptable rows stay visible with placeholder labels (**Browser** / **Unknown**) instead of triggering remote logout. With the flag off, legacy **`entries`** behavior is unchanged: bad native devices are still auto-logged out.
> 
> **`RegisteredDevice`** exposes optional **`credentialId`**; macOS sync preferences map **`3party`** to a new **`SyncDevice.Kind.thirdParty`** and generic all-devices icon in the synced devices UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccff756699a11690d93040ba13f055922c02bd3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->