### PR TITLE
[iOS] Sync V2 device list support updated to include 3rd parties

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncModels.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncModels.swift
@@ -117,11 +117,17 @@ public struct SyncAccount: Codable, Sendable {
 }
 
 public struct RegisteredDevice: Codable, Sendable {
-
     public let id: String
     public let name: String
     public let type: String
+    public let credentialId: String?
 
+    public init(id: String, name: String, type: String, credentialId: String? = nil) {
+        self.id = id
+        self.name = name
+        self.type = type
+        self.credentialId = credentialId
+    }
 }
 
 public struct AccountCreationKeys {
@@ -233,9 +239,9 @@ public struct PairingInfo {
 
 // MARK: - Scoped Access Credentials
 
-enum SyncCredentialID {
-    static let defaultCredential = "ddg"
-    static let thirdParty = "3party"
+public enum SyncCredentialID {
+    public static let defaultCredential = "ddg"
+    public static let thirdParty = "3party"
 }
 
 // AccessCredential is decoded from API responses using JSONDecoder.snakeCaseKeys. The server key

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
@@ -19,7 +19,6 @@
 import Foundation
 import DDGSyncCrypto
 import Networking
-import os.log
 
 struct AccountManager: AccountManaging {
 
@@ -28,7 +27,21 @@ struct AccountManager: AccountManaging {
     let endpoints: Endpoints
     let api: RemoteAPIRequestCreating
     let crypter: CryptingInternal
+    let registeredDeviceMapper: any RegisteredDeviceMapping
     let isScopedAccessCredentialsEnabled: () -> Bool
+
+    init(endpoints: Endpoints,
+         api: RemoteAPIRequestCreating,
+         crypter: CryptingInternal,
+         registeredDeviceMapper: (any RegisteredDeviceMapping)? = nil,
+         isScopedAccessCredentialsEnabled: @escaping () -> Bool) {
+        self.endpoints = endpoints
+        self.api = api
+        self.crypter = crypter
+        self.registeredDeviceMapper = registeredDeviceMapper ?? RegisteredDeviceMapper(crypter: crypter,
+                                                                                       isScopedAccessCredentialsEnabled: isScopedAccessCredentialsEnabled)
+        self.isScopedAccessCredentialsEnabled = isScopedAccessCredentialsEnabled
+    }
 
     func createAccount(deviceName: String, deviceType: String) async throws -> SyncAccount {
         let deviceId = UUID().uuidString
@@ -128,15 +141,25 @@ struct AccountManager: AccountManaging {
             throw SyncError.unableToDecodeResponse("Failed to decode devices")
         }
 
-        var devices = [RegisteredDevice]()
+        // Scoped access enabled: never auto-logout. Prefer entries_v2; otherwise map legacy entries with
+        // decrypt-or-generic-fallback (undecryptable native -> "Unknown", undecryptable 3party -> "Browser").
+        if isScopedAccessCredentialsEnabled() {
+            let entries: [RegisteredDeviceEntry]
+            if let entriesV2 = result.devices?.entriesV2, !entriesV2.isEmpty {
+                entries = entriesV2
+            } else {
+                entries = result.devices?.entries ?? []
+            }
+            return await registeredDeviceMapper.registeredDevices(from: entries, account: account)
+        }
+
+        // Legacy behaviour (scoped access disabled): invalid native devices are automatically logged out.
+        var devices: [RegisteredDevice] = []
         if let entries = result.devices?.entries {
             for device in entries {
-                do {
-                    let name = try crypter.base64DecodeAndDecrypt(device.name, using: account.primaryKey)
-                    let type = try crypter.base64DecodeAndDecrypt(device.type, using: account.primaryKey)
-                    devices.append(RegisteredDevice(id: device.id, name: name, type: type))
-                } catch {
-                    // Invalid devices should be automatically logged out
+                if let registeredDevice = registeredDeviceMapper.registeredDevice(fromLegacyEntry: device, account: account) {
+                    devices.append(registeredDevice)
+                } else {
                     try await logout(deviceId: device.id, token: token)
                 }
             }
@@ -219,14 +242,10 @@ struct AccountManager: AccountManaging {
                 state: .addingNewDevice
             ),
             devices: result.devices.compactMap { device in
-                // Prevent devices with `null` type from blocking login while the V2 device payload is in flux.
-                guard let encryptedType = device.type,
-                      let name = try? crypter.base64DecodeAndDecrypt(device.name, using: info.primaryKey),
-                      let type = try? crypter.base64DecodeAndDecrypt(encryptedType, using: info.primaryKey) else {
-                    return nil
-                }
-
-                return RegisteredDevice(id: device.id, name: name, type: type)
+                registeredDeviceMapper.registeredDevice(fromDefaultCredentialLoginEntryWithID: device.id,
+                                                        encryptedName: device.name,
+                                                        encryptedType: device.type,
+                                                        primaryKey: info.primaryKey)
             },
             keys: result.keys,
             accessCredentials: result.accessCredentials
@@ -293,7 +312,8 @@ struct AccountManager: AccountManaging {
     struct FetchDevicesResult: Decodable {
         struct DeviceWrapper: Decodable {
             var lastModified: String?
-            var entries: [RegisteredDevice]
+            var entries: [RegisteredDeviceEntry]?
+            var entriesV2: [RegisteredDeviceEntry]?
         }
 
         var devices: DeviceWrapper?

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
@@ -84,8 +84,17 @@ struct ProductionDependencies: SyncDependencies {
         payloadCompressor = SyncGzipPayloadCompressor()
 
         crypter = Crypter(secureStore: secureStore)
-        account = AccountManager(endpoints: endpoints, api: api, crypter: crypter, isScopedAccessCredentialsEnabled: { syncFeatureFlags.isScopedAccessCredentialsEnabled() })
-        scopedAccess = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: crypter)
+        let scopedAccess = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: crypter)
+        let registeredDeviceMapper = RegisteredDeviceMapper(crypter: crypter,
+                                                            scopedAccess: scopedAccess,
+                                                            cachedScopedPassword: secureStore.scopedPassword,
+                                                            isScopedAccessCredentialsEnabled: { syncFeatureFlags.isScopedAccessCredentialsEnabled() })
+        account = AccountManager(endpoints: endpoints,
+                                 api: api,
+                                 crypter: crypter,
+                                 registeredDeviceMapper: registeredDeviceMapper,
+                                 isScopedAccessCredentialsEnabled: { syncFeatureFlags.isScopedAccessCredentialsEnabled() })
+        self.scopedAccess = scopedAccess
         scheduler = SyncScheduler()
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
@@ -1,0 +1,230 @@
+//
+//  RegisteredDeviceMapper.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import os.log
+
+protocol RegisteredDeviceMapping {
+    func registeredDevices(from entries: [RegisteredDeviceEntry], account: SyncAccount) async -> [RegisteredDevice]
+    func registeredDevice(fromLegacyEntry entry: RegisteredDeviceEntry, account: SyncAccount) -> RegisteredDevice?
+    func registeredDevice(fromDefaultCredentialLoginEntryWithID id: String,
+                          encryptedName: String,
+                          encryptedType: String?,
+                          primaryKey: Data) -> RegisteredDevice?
+    func registeredDevice(fromThirdPartyLoginEntryWithID id: String, encodedName: String, encodedType: String?) -> RegisteredDevice
+}
+
+/// Maps raw Sync device payloads into app-facing devices without hiding entries that cannot be decrypted locally.
+struct RegisteredDeviceMapper: RegisteredDeviceMapping {
+
+    private static let undecryptableThirdPartyDeviceName = "Browser"
+    private static let undecryptableDeviceName = "Unknown"
+    private static let undecryptableDeviceType = "unknown"
+
+    let crypter: CryptingInternal
+    let scopedAccess: ScopedAccessCredentialManaging?
+    let cachedScopedPassword: () throws -> Data?
+    let isScopedAccessCredentialsEnabled: () -> Bool
+    private let jweCompactCodec: JWECompactCodec
+
+    init(crypter: CryptingInternal,
+         scopedAccess: ScopedAccessCredentialManaging? = nil,
+         cachedScopedPassword: @escaping () throws -> Data? = { nil },
+         isScopedAccessCredentialsEnabled: @escaping () -> Bool,
+         jweCompactCodec: JWECompactCodec = JWECompactCodec()) {
+        self.crypter = crypter
+        self.scopedAccess = scopedAccess
+        self.cachedScopedPassword = cachedScopedPassword
+        self.isScopedAccessCredentialsEnabled = isScopedAccessCredentialsEnabled
+        self.jweCompactCodec = jweCompactCodec
+    }
+
+    func registeredDevices(from entries: [RegisteredDeviceEntry], account: SyncAccount) async -> [RegisteredDevice] {
+        let thirdPartyMainKey = await thirdPartyMainKeyIfNeeded(for: entries, account: account)
+        return entries.map { registeredDevice(from: $0, account: account, thirdPartyMainKey: thirdPartyMainKey) }
+    }
+
+    func registeredDevice(fromLegacyEntry entry: RegisteredDeviceEntry, account: SyncAccount) -> RegisteredDevice? {
+        decryptedDefaultCredentialRegisteredDevice(id: entry.id,
+                                                   encryptedName: entry.name,
+                                                   encryptedType: entry.type,
+                                                   primaryKey: account.primaryKey,
+                                                   credentialId: SyncCredentialID.defaultCredential)
+    }
+
+    func registeredDevice(fromDefaultCredentialLoginEntryWithID id: String,
+                          encryptedName: String,
+                          encryptedType: String?,
+                          primaryKey: Data) -> RegisteredDevice? {
+        guard let encryptedType else {
+            return nil
+        }
+
+        return decryptedDefaultCredentialRegisteredDevice(id: id,
+                                                         encryptedName: encryptedName,
+                                                         encryptedType: encryptedType,
+                                                         primaryKey: primaryKey,
+                                                         credentialId: SyncCredentialID.defaultCredential)
+    }
+
+    func registeredDevice(fromThirdPartyLoginEntryWithID id: String, encodedName: String, encodedType: String?) -> RegisteredDevice {
+        // Login-response 3party fields are base64-encoded plaintext (not a JWE like device-list entries); fall back to the raw value if it isn't base64.
+        RegisteredDevice(id: id,
+                         name: Self.utf8String(fromBase64EncodedString: encodedName) ?? encodedName,
+                         type: encodedType.flatMap { Self.utf8String(fromBase64EncodedString: $0) } ?? encodedType ?? "",
+                         credentialId: SyncCredentialID.thirdParty)
+    }
+
+    private func registeredDevice(from entry: RegisteredDeviceEntry, account: SyncAccount, thirdPartyMainKey: Data?) -> RegisteredDevice {
+        // Keep every server entry visible even if one encrypted field is malformed or uses a key we cannot recover.
+        decryptedRegisteredDevice(from: entry, account: account, thirdPartyMainKey: thirdPartyMainKey) ?? fallbackRegisteredDevice(from: entry)
+    }
+
+    private func decryptedRegisteredDevice(from entry: RegisteredDeviceEntry, account: SyncAccount, thirdPartyMainKey: Data?) -> RegisteredDevice? {
+        switch entry.credentialId {
+        case SyncCredentialID.thirdParty:
+            return decryptedThirdPartyRegisteredDevice(from: entry, thirdPartyMainKey: thirdPartyMainKey)
+        case SyncCredentialID.defaultCredential, nil:
+            // A nil credentialId is a legacy native entry; treat it as the default (ddg) credential.
+            return decryptedDefaultCredentialRegisteredDevice(id: entry.id,
+                                                             encryptedName: entry.name,
+                                                             encryptedType: entry.type,
+                                                             primaryKey: account.primaryKey,
+                                                             credentialId: SyncCredentialID.defaultCredential)
+        default:
+            // Unknown credential kind (e.g. a future type): fall back rather than guess at decryption.
+            return nil
+        }
+    }
+
+    private func decryptedDefaultCredentialRegisteredDevice(id: String,
+                                                            encryptedName: String?,
+                                                            encryptedType: String?,
+                                                            primaryKey: Data,
+                                                            credentialId: String?) -> RegisteredDevice? {
+        guard let encryptedName,
+              let encryptedType,
+              let name = try? crypter.base64DecodeAndDecrypt(encryptedName, using: primaryKey),
+              let type = try? crypter.base64DecodeAndDecrypt(encryptedType, using: primaryKey) else {
+            return nil
+        }
+
+        return RegisteredDevice(id: id, name: name, type: type, credentialId: credentialId)
+    }
+
+    private func decryptedThirdPartyRegisteredDevice(from entry: RegisteredDeviceEntry, thirdPartyMainKey: Data?) -> RegisteredDevice? {
+        guard let thirdPartyMainKey,
+              let name = decryptThirdPartyDeviceField(entry.name, using: thirdPartyMainKey),
+              let type = decryptThirdPartyDeviceField(entry.type, using: thirdPartyMainKey) else {
+            return nil
+        }
+
+        return RegisteredDevice(id: entry.id, name: name, type: type, credentialId: entry.credentialId)
+    }
+
+    private func decryptThirdPartyDeviceField(_ value: String?, using thirdPartyMainKey: Data) -> String? {
+        guard let value,
+              let plaintext = try? jweCompactCodec.decryptDirect(token: value, contentEncryptionKey: thirdPartyMainKey) else {
+            return nil
+        }
+
+        // 3party device fields are direct JWE plaintext strings, not base64-wrapped values.
+        return String(data: plaintext, encoding: .utf8)
+    }
+
+    private func thirdPartyMainKeyIfNeeded(for entries: [RegisteredDeviceEntry], account: SyncAccount) async -> Data? {
+        guard entries.contains(where: { $0.credentialId == SyncCredentialID.thirdParty }) else {
+            return nil
+        }
+        guard isScopedAccessCredentialsEnabled() else {
+            return nil
+        }
+
+        if let cachedMainKey = cachedThirdPartyMainKey(for: entries, account: account) {
+            return cachedMainKey
+        }
+
+        return await recoveredScopedPassword(for: account)
+            .map { ScopedAccessKeyDerivation.mainKey(from: $0, userID: account.userId) }
+    }
+
+    private func cachedThirdPartyMainKey(for entries: [RegisteredDeviceEntry], account: SyncAccount) -> Data? {
+        guard let scopedPassword = try? cachedScopedPassword(), !scopedPassword.isEmpty else {
+            return nil
+        }
+
+        let mainKey = ScopedAccessKeyDerivation.mainKey(from: scopedPassword, userID: account.userId)
+        let thirdPartyEntries = entries.filter { $0.credentialId == SyncCredentialID.thirdParty }
+        // A cached scoped password is only trusted if it can decrypt the 3party fields in this response.
+        guard thirdPartyEntries.allSatisfy({ canDecryptThirdPartyDeviceEntry($0, using: mainKey) }) else {
+            return nil
+        }
+
+        return mainKey
+    }
+
+    private func canDecryptThirdPartyDeviceEntry(_ entry: RegisteredDeviceEntry, using thirdPartyMainKey: Data) -> Bool {
+        // Probe with `type` only: a decryptable type is the signal that this 3party key matches the entry.
+        decryptThirdPartyDeviceField(entry.type, using: thirdPartyMainKey) != nil
+    }
+
+    private func recoveredScopedPassword(for account: SyncAccount) async -> Data? {
+        guard let scopedAccess else {
+            return nil
+        }
+
+        do {
+            let accessCredentials = try await scopedAccess.fetchAccessCredentials(account)
+            guard let scopedPassword = try scopedAccess.recoverScopedPassword(from: accessCredentials,
+                                                                              primaryKey: account.primaryKey,
+                                                                              userID: account.userId) else {
+                return nil
+            }
+            return scopedPassword
+        } catch {
+            Logger.sync.debug("Unable to recover 3party scoped password for device list: \(String(reflecting: error))")
+            return nil
+        }
+    }
+
+    private func fallbackRegisteredDevice(from entry: RegisteredDeviceEntry) -> RegisteredDevice {
+        let credentialId = entry.credentialId ?? SyncCredentialID.defaultCredential
+        // Preserve undecryptable entries so a bad encrypted field cannot hide a device from the list.
+        let name = credentialId == SyncCredentialID.thirdParty
+            ? Self.undecryptableThirdPartyDeviceName
+            : Self.undecryptableDeviceName
+        return RegisteredDevice(id: entry.id,
+                                name: name,
+                                type: Self.undecryptableDeviceType,
+                                credentialId: credentialId)
+    }
+
+    private static func utf8String(fromBase64EncodedString value: String) -> String? {
+        guard let data = Data(base64Encoded: value) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+}
+
+struct RegisteredDeviceEntry: Decodable {
+    let id: String
+    let name: String?
+    let type: String?
+    let credentialId: String?
+}

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
@@ -26,7 +26,6 @@ protocol RegisteredDeviceMapping {
                           encryptedName: String,
                           encryptedType: String?,
                           primaryKey: Data) -> RegisteredDevice?
-    func registeredDevice(fromThirdPartyLoginEntryWithID id: String, encodedName: String, encodedType: String?) -> RegisteredDevice
 }
 
 /// Maps raw Sync device payloads into app-facing devices without hiding entries that cannot be decrypted locally.
@@ -80,14 +79,6 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
                                                          encryptedType: encryptedType,
                                                          primaryKey: primaryKey,
                                                          credentialId: SyncCredentialID.defaultCredential)
-    }
-
-    func registeredDevice(fromThirdPartyLoginEntryWithID id: String, encodedName: String, encodedType: String?) -> RegisteredDevice {
-        // Login-response 3party fields are base64-encoded plaintext (not a JWE like device-list entries); fall back to the raw value if it isn't base64.
-        RegisteredDevice(id: id,
-                         name: Self.utf8String(fromBase64EncodedString: encodedName) ?? encodedName,
-                         type: encodedType.flatMap { Self.utf8String(fromBase64EncodedString: $0) } ?? encodedType ?? "",
-                         credentialId: SyncCredentialID.thirdParty)
     }
 
     private func registeredDevice(from entry: RegisteredDeviceEntry, account: SyncAccount, thirdPartyMainKey: Data?) -> RegisteredDevice {
@@ -214,12 +205,6 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
                                 credentialId: credentialId)
     }
 
-    private static func utf8String(fromBase64EncodedString value: String) -> String? {
-        guard let data = Data(base64Encoded: value) else {
-            return nil
-        }
-        return String(data: data, encoding: .utf8)
-    }
 }
 
 struct RegisteredDeviceEntry: Decodable {

--- a/SharedPackages/Infrastructure/DesignResourcesKitIcons/Sources/DesignResourcesKitIcons/DesignSystemImages+Glyphs.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKitIcons/Sources/DesignResourcesKitIcons/DesignSystemImages+Glyphs.swift
@@ -483,6 +483,7 @@ public extension DesignSystemImages {
             public static var crossRecolorable: DesignSystemImage { .init(resource: .crossRecolorable24) }
             public static var crossSolidSmall: DesignSystemImage { .init(resource: .crossSolidSmall24) }
             public static var cut: DesignSystemImage { .init(resource: .cut24) }
+            public static var deviceAll: DesignSystemImage { .init(resource: .deviceAll24) }
             public static var deviceDesktop: DesignSystemImage { .init(resource: .deviceDesktop24) }
             public static var deviceMobile: DesignSystemImage { .init(resource: .deviceMobile24) }
             public static var deviceMobileDouble: DesignSystemImage { .init(resource: .deviceMobileDouble24) }

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -387,7 +387,11 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsRootView> {
 
     func mapDevices(_ devices: [RegisteredDevice]) {
         viewModel.devices = devices.map {
-            .init(id: $0.id, name: $0.name, type: $0.type, isThisDevice: $0.id == syncService.account?.deviceId)
+            .init(id: $0.id,
+                  name: $0.name,
+                  type: $0.type,
+                  credentialId: $0.credentialId,
+                  isThisDevice: $0.id == syncService.account?.deviceId)
         }.sorted(by: { lhs, _ in
             lhs.isThisDevice
         })

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/Internal/EditDeviceViewModel.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/Internal/EditDeviceViewModel.swift
@@ -34,7 +34,11 @@ class EditDeviceViewModel: ObservableObject {
     }
 
     func save() {
-        onSave(.init(id: device.id, name: name, type: device.type, isThisDevice: device.isThisDevice))
+        onSave(.init(id: device.id,
+                     name: name,
+                     type: device.type,
+                     credentialId: device.credentialId,
+                     isThisDevice: device.isThisDevice))
     }
     
 }

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/SyncSettingsViewModel.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/SyncSettingsViewModel.swift
@@ -85,12 +85,22 @@ public class SyncSettingsViewModel: ObservableObject {
         public let id: String
         public let name: String
         public let type: String
+        public let credentialId: String?
         public let isThisDevice: Bool
 
-        public init(id: String, name: String, type: String, isThisDevice: Bool) {
+        // Keep these values aligned with DDGSync.SyncCredentialID without coupling SyncUI_iOS to DDGSync.
+        public static let defaultCredentialId = "ddg"
+        public static let thirdPartyCredentialId = "3party"
+
+        public var isThirdParty: Bool {
+            credentialId == Self.thirdPartyCredentialId
+        }
+
+        public init(id: String, name: String, type: String, credentialId: String? = nil, isThisDevice: Bool) {
             self.id = id
             self.name = name
             self.type = type
+            self.credentialId = credentialId
             self.isThisDevice = isThisDevice
         }
 

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SimplifiedSyncSettingsView.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SimplifiedSyncSettingsView.swift
@@ -451,13 +451,17 @@ extension SimplifiedSyncSettingsView {
 
     @ViewBuilder
     func deviceTypeImage(_ device: SyncSettingsViewModel.Device) -> some View {
-        switch device.type {
-        case "desktop":
-            Image(uiImage: DesignSystemImages.Glyphs.Size24.deviceDesktop)
-        case "tablet":
-            Image(uiImage: DesignSystemImages.Glyphs.Size24.deviceTablet)
-        default:
-            Image(uiImage: DesignSystemImages.Glyphs.Size24.deviceMobile)
+        if device.isThirdParty {
+            Image(uiImage: DesignSystemImages.Glyphs.Size24.deviceAll)
+        } else {
+            switch device.type {
+            case "desktop":
+                Image(uiImage: DesignSystemImages.Glyphs.Size24.deviceDesktop)
+            case "tablet":
+                Image(uiImage: DesignSystemImages.Glyphs.Size24.deviceTablet)
+            default:
+                Image(uiImage: DesignSystemImages.Glyphs.Size24.deviceMobile)
+            }
         }
     }
 

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncSettingsView.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncSettingsView.swift
@@ -174,15 +174,19 @@ public struct SyncSettingsView: View {
     // At some point work out how to change at least the fallback image to a resource.
     @ViewBuilder
     func deviceTypeImage(_ device: SyncSettingsViewModel.Device) -> some View {
-        switch device.type {
-        case "desktop":
-            Image(uiImage: DesignSystemImages.Glyphs.Size24.deviceDesktop)
+        if device.isThirdParty {
+            Image(uiImage: DesignSystemImages.Glyphs.Size24.deviceAll)
+        } else {
+            switch device.type {
+            case "desktop":
+                Image(uiImage: DesignSystemImages.Glyphs.Size24.deviceDesktop)
 
-        case "tablet":
-            Image(uiImage: DesignSystemImages.Glyphs.Size24.deviceTablet)
+            case "tablet":
+                Image(uiImage: DesignSystemImages.Glyphs.Size24.deviceTablet)
 
-        default: // including phone
-            Image(uiImage: DesignSystemImages.Glyphs.Size24.deviceMobile)
+            default: // including phone
+                Image(uiImage: DesignSystemImages.Glyphs.Size24.deviceMobile)
+            }
         }
 
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215794614540159?focus=true
Tech Design URL:
CC:

### Description
Adds support for displaying 3rd party browsers in the Sync screen list of devices on iOS

### Testing Steps

1. Ensure all Sync V2 feature flags are enabled
2. Sync macOS to a 3party client
3. Confirm the 3party client appears in the Sync device list & uses the generic all-devices/browser icon, not desktop/mobile.
4. Connect a native DuckDuckGo device as normal
5. Confirm the native device appears in the Sync device list & still uses the expected desktop/mobile icon.
6. Disable the syncScopedAccessCredentials feature flag and confirm only the native devices are displayed.
7. Re-enable the flag & remove the 3party device from the device list.
8. Confirm the 3party device no longer appears after refreshing/reopening Sync settings, and that Sync is disabled in the 3rd party browser
9. Remove the native device from the device list.
10. Confirm the native device no longer appears after refreshing/reopening Sync settings, and that Sync is disabled on the other device

### Impact and Risks
What's the impact on users if something goes wrong?

Medium: Could disrupt specific features or user flows


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync account device-fetch semantics (V2 entries, 3party decryption, and when auto-logout runs), which can alter which devices appear or get disconnected if mapping or credential recovery fails.
> 
> **Overview**
> **Sync device list** now understands V2 payloads (`entries_v2`, per-device `credentialId`) and can show **third-party (“3party”) browsers** when scoped access credentials are enabled, instead of only native DuckDuckGo devices decrypted with the account primary key.
> 
> Device fetch/mapping moves into a new **`RegisteredDeviceMapper`**: native entries still use primary-key decryption; 3party name/type use JWE with a derived main key from cached or recovered scoped passwords. With scoped access on, **undecryptable rows stay visible** with generic labels (“Browser” / “Unknown”) and **no auto-logout** on bad entries; with the flag off, legacy behavior remains (invalid native entries still trigger remote logout). Login-time device mapping reuses the same mapper.
> 
> **iOS Sync settings** pass `credentialId` through the view model and use a new **generic device icon** for third-party devices; native devices keep desktop/tablet/mobile icons. `RegisteredDevice` and **`SyncCredentialID`** are extended/public for this.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd364125454df118138cdac6f3e35f4b7c588e1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->