### PR TITLE
Set WireGuard persistent keepalive to 25s

### DIFF
--- a/SharedPackages/VPN/Sources/VPN/NetworkProtectionDeviceManager.swift
+++ b/SharedPackages/VPN/Sources/VPN/NetworkProtectionDeviceManager.swift
@@ -360,6 +360,7 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
 
         peerConfiguration.allowedIPs = [IPAddressRange(from: "0.0.0.0/0")!, IPAddressRange(from: "::/0")!]
         peerConfiguration.endpoint = serverEndpoint
+        peerConfiguration.persistentKeepAlive = 25
 
         return peerConfiguration
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206580121312550/task/1215443703087742?focus=true

### Description

Enables WireGuard persistent keepalive at 25 seconds for the VPN tunnel on iOS and macOS, where it was previously disabled (interval 0).

Without a keepalive, a stateful firewall or NAT in front of the client can drop the idle UDP mapping after a period of inactivity. When that happens the server can no longer reach the client and the tunnel can get stuck failing to re-handshake until the client sends traffic again. A 25s keepalive holds the mapping open from the inside, which is the standard interval and matches what other WireGuard clients use on Apple platforms.

### Testing Steps

1. Build and install on a physical iOS device (the packet tunnel extension does not run in the simulator).
2. Connect the VPN.
   - Connection succeeds and traffic flows.
3. Leave the device idle with the screen off for several minutes.
4. Resume use and load a page over the VPN.
   - The tunnel is still connected and serves traffic without a manual reconnect.
5. Repeat on macOS.
   - Same result.

### Impact and Risks

Low. Affects every VPN user, since the keepalive applies to all tunnel connections. The change is a single configuration value with no change to connection logic.

#### What could go wrong?

The client sends a small keepalive packet every 25 seconds while otherwise idle, which is a minor, expected increase in background radio activity and data use on mobile. No functional regression is expected; if the keepalive caused problems the value can be reverted in one line.

We've explored competitors and some of them have 25 sec keepalive by default, which is a good proxy to imagine it's not problematic.

### Quality Considerations

The interval is shared across iOS and macOS through the common VPN package, so behavior stays consistent across platforms.

### Notes to Reviewer

The value is set once in the shared peer configuration, so it applies to both platforms from a single line.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single tunnel config constant with broad but standard behavior; minor extra idle UDP traffic, no auth or routing changes.
> 
> **Overview**
> Sets **WireGuard persistent keepalive** to **25 seconds** on the VPN peer built in `NetworkProtectionDeviceManager.peerConfiguration`, so idle tunnels keep NAT/firewall UDP mappings alive instead of relying on the previous unset value (effectively **0** / disabled in tunnel settings).
> 
> This applies to **all tunnel connections** on **iOS and macOS** through the shared VPN package, with no other connection or routing logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac39a1cfb35dfa0180aa49124c8bddb86967661e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->