### PR TITLE
[iOS] Add pixels for the Duck\.ai model recovery flow

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1789,6 +1789,9 @@ extension Pixel {
         case unifiedToggleInputSubscriptionUpsellTriggered
         case unifiedToggleInputChatHeaderUpgradeTapped
         case unifiedToggleInputPromptSubmitted
+        case unifiedToggleInputShowModelPicker
+        case unifiedToggleInputSubmitChangeModel
+        case unifiedToggleInputSubmitChangeModelPromptSent
         case unifiedToggleInputDuckAIDirectNavigation
 
         // MARK: Unified Toggle Input - Duck.ai autocomplete suggestion clicks
@@ -3637,6 +3640,9 @@ extension Pixel.Event {
         case .unifiedToggleInputSubscriptionUpsellTriggered: return "m_aichat_unified_input_subscription_upsell_triggered"
         case .unifiedToggleInputChatHeaderUpgradeTapped: return "m_aichat_unified_input_chat_header_upgrade_tapped"
         case .unifiedToggleInputPromptSubmitted: return "m_aichat_unified_input_prompt_submitted"
+        case .unifiedToggleInputShowModelPicker: return "aichat_unified_input_show_model_picker"
+        case .unifiedToggleInputSubmitChangeModel: return "aichat_unified_input_submit_change_model"
+        case .unifiedToggleInputSubmitChangeModelPromptSent: return "aichat_unified_input_submit_change_model_prompt_sent"
         case .unifiedToggleInputDuckAIDirectNavigation: return "m_aichat_unified_input_duck_ai_direct_navigation"
 
         case .autocompleteDuckAIClickWebsite: return "m_autocomplete_duckai_click_website"

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1399,6 +1399,10 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             return
         }
         userScript.submitChangeModel(modelId)
+        guard isModelPickerForcedVisible, userScript.canDispatchBridgeMessages else {
+            return
+        }
+        UnifiedToggleInputCoordinatorPixelHelper.fireSubmitChangeModelPixel(modelId: modelId)
     }
 
     /// Surfaces the native model picker on the **active** chat in response to the FE's
@@ -1418,6 +1422,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         // expand animation before we ask the button to open its menu.
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
+            UnifiedToggleInputCoordinatorPixelHelper.fireShowModelPickerPixel()
             self.viewController.presentModelPickerMenu()
         }
     }
@@ -2346,11 +2351,15 @@ private extension UnifiedToggleInputCoordinator {
     }
 
     private func markActiveChatPromptSubmitted() {
+        let wasInRecoveryPickerSession = isModelPickerForcedVisible
         hasSubmittedPrompt = true
         isModelPickerForcedVisible = false
         persistModelPickerPinClearedAfterHideIfNeeded()
         updateModelChipVisibility()
         syncHasSubmittedPromptToHandler()
+        if wasInRecoveryPickerSession {
+            UnifiedToggleInputCoordinatorPixelHelper.fireSubmitChangeModelPromptSentPixel()
+        }
     }
 
     func syncInputBehaviorToHandler() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinatorPixelHelper.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinatorPixelHelper.swift
@@ -147,6 +147,18 @@ final class UnifiedToggleInputCoordinatorPixelHelper {
         )
     }
 
+    static func fireShowModelPickerPixel() {
+        DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputShowModelPicker)
+    }
+
+    static func fireSubmitChangeModelPixel(modelId: String) {
+        DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputSubmitChangeModel, withAdditionalParameters: ["model_id": modelId])
+    }
+
+    static func fireSubmitChangeModelPromptSentPixel() {
+        DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputSubmitChangeModelPromptSent)
+    }
+
     static func fireToolSubmittedPixelIfNeeded(selectedTool: AIChatRAGTool?, attachments: [UnifiedToggleInputAttachment]) {
         guard let selectedTool else { return }
         switch selectedTool {

--- a/iOS/DuckDuckGoTests/PixelTests.swift
+++ b/iOS/DuckDuckGoTests/PixelTests.swift
@@ -63,7 +63,10 @@ class PixelTests: XCTestCase {
             (.unifiedToggleInputStopGenerationTapped, "m_aichat_unified_input_stop_generation_tapped"),
             (.unifiedToggleInputSubscriptionUpsellTriggered, "m_aichat_unified_input_subscription_upsell_triggered"),
             (.unifiedToggleInputChatHeaderUpgradeTapped, "m_aichat_unified_input_chat_header_upgrade_tapped"),
-            (.unifiedToggleInputPromptSubmitted, "m_aichat_unified_input_prompt_submitted")
+            (.unifiedToggleInputPromptSubmitted, "m_aichat_unified_input_prompt_submitted"),
+            (.unifiedToggleInputShowModelPicker, "aichat_unified_input_show_model_picker"),
+            (.unifiedToggleInputSubmitChangeModel, "aichat_unified_input_submit_change_model"),
+            (.unifiedToggleInputSubmitChangeModelPromptSent, "aichat_unified_input_submit_change_model_prompt_sent")
         ]
 
         for (event, expectedName) in expectedNames {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -19,7 +19,10 @@
 
 import AIChat
 import Combine
+import Core
 import UIKit
+import UserScript
+import WebKit
 import XCTest
 @testable import DuckDuckGo
 
@@ -232,6 +235,52 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
 
         XCTAssertTrue(sut.isSubmitBlockedByRecoveryCard,
                       "Empty model list ⇒ no access-checked selectedModel ⇒ block must remain")
+    }
+
+    // MARK: - Recovery Picker Session Pixels
+
+    func test_recoveryPickerSession_fullFunnel_smokeTest() {
+        let previousDryRun = Pixel.isDryRun
+        Pixel.isDryRun = true
+        defer { Pixel.isDryRun = previousDryRun }
+
+        _ = sut.prepareExternalPromptSubmission()
+        let userScript = makeBridgeReadyUserScript()
+        sut.bindToTab(userScript, hasExistingChat: true)
+        sut.modelStore.models = [makeModel(id: "gpt-5", access: true)]
+
+        sut.presentModelPickerForActiveChat()
+        sut.handleModelSelection("gpt-5")
+        sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "follow-up", mode: .aiChat)
+
+        XCTAssertTrue(sut.viewController.isModelChipHidden)
+    }
+
+    func test_recoveryPickerSession_submitChangeModelPixel_smokeTest_withoutRecoveryPin() {
+        let previousDryRun = Pixel.isDryRun
+        Pixel.isDryRun = true
+        defer { Pixel.isDryRun = previousDryRun }
+
+        _ = sut.prepareExternalPromptSubmission()
+        let userScript = makeBridgeReadyUserScript()
+        sut.bindToTab(userScript, hasExistingChat: true)
+        sut.modelStore.models = [
+            makeModel(id: "haiku", access: true),
+            makeModel(id: "gpt-5", access: true)
+        ]
+        sut.updateSelectedModel("haiku")
+
+        sut.handleModelSelection("gpt-5")
+    }
+
+    func test_recoveryPickerSession_promptSentPixel_notFiredWithoutRecoveryPin() {
+        let previousDryRun = Pixel.isDryRun
+        Pixel.isDryRun = true
+        defer { Pixel.isDryRun = previousDryRun }
+
+        sut.modelStore.models = [makeModel(id: "gpt-5", access: true)]
+        sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "first prompt", mode: .aiChat)
+        sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "follow-up", mode: .aiChat)
     }
 
     func test_hide_clearsRecoveryBlock() {
@@ -2277,6 +2326,15 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         mockPreferences.selectedModelId = "image-model"
         sut.modelStore.models = [makeModel(id: "image-model", access: true, supportsImageUpload: true)]
         sut.modelStore.attachmentLimits = makeLimits()
+    }
+
+    private func makeBridgeReadyUserScript() -> AIChatUserScript {
+        let userScript = makeTestUserScript()
+        let webView = WKWebView()
+        let broker = UserScriptMessageBroker(context: "test", requiresRunInPageContentWorld: true)
+        userScript.with(broker: broker)
+        userScript.webView = webView
+        return userScript
     }
 
     private func makeModel(id: String,

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
@@ -292,14 +292,14 @@
         "description": "Fires when native surfaces the model picker in response to the FE showModelPicker bridge message (recovery picker session entry).",
         "owners": ["pikorddg"],
         "triggers": ["other"],
-        "suffixes": ["platform", "form_factor"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "aichat_unified_input_submit_change_model": {
         "description": "Fires when native emits submitChangeModelAction to the FE during an active recovery picker session.",
         "owners": ["pikorddg"],
         "triggers": ["other"],
-        "suffixes": ["platform", "form_factor"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": [
             "appVersion",
             {
@@ -313,7 +313,7 @@
         "description": "Fires when the user successfully submits a prompt that ends a recovery picker session.",
         "owners": ["pikorddg"],
         "triggers": ["other"],
-        "suffixes": ["platform", "form_factor"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "m_aichat_unified_input_duck_ai_direct_navigation": {

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
@@ -288,6 +288,34 @@
             }
         ]
     },
+    "aichat_unified_input_show_model_picker": {
+        "description": "Fires when native surfaces the model picker in response to the FE showModelPicker bridge message (recovery picker session entry).",
+        "owners": ["pikorddg"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "aichat_unified_input_submit_change_model": {
+        "description": "Fires when native emits submitChangeModelAction to the FE during an active recovery picker session.",
+        "owners": ["pikorddg"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "model_id",
+                "description": "The model id reported to the FE via submitChangeModelAction.",
+                "type": "string"
+            }
+        ]
+    },
+    "aichat_unified_input_submit_change_model_prompt_sent": {
+        "description": "Fires when the user successfully submits a prompt that ends a recovery picker session.",
+        "owners": ["pikorddg"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
     "m_aichat_unified_input_duck_ai_direct_navigation": {
         "description": "Fires when Duck.ai is disabled under AI Features settings yet the user navigates directly to Duck.ai by typing its address into the Unified Toggle Input and submitting. Does not fire for the in-input Duck.ai shortcut button or other Duck.ai entry points.",
         "owners": ["aataraxiaa"],


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210947754188321/task/1215723000513647?focus=true
Tech Design URL:
CC: 

### Description
Adds pixels for the subscription recovery flow. This allows to measure how often users enter recovery via the FE's `showModelPicker` bridge message, change models mid-session, and successfully submit a follow-up prompt.

### Testing Steps
Setup:
* unifiedToggleInput enabled
* active subscription
* filter Xcode console logs by `pixel`
* Note: all pixels are fired in `daily & count` mode

1. Create a chat with either Plus or Pro model. Send at least one prompt on that chat. Remove subscription.
2. Open that paid chat from step 1
3. Tap on “Switch model” button from web card. Verify `aichat.unified.input.show.model.picker` is fired
4. Select one of the free models. Verify `aichat.unified.input.submit.change.model` is fired
   * Note: because first available model is automatically preselected, you’ll see one of this pixel right after tap on “Switch model”. But, select a different model from the one preselected, and verify if this pixel was fired.
5. Open model picker once more and select one of the gated models. Upsell screen is presented, verify `aichat.unified.input.submit.change.model` is **not** fired
6. Having availble model (from step 4) selected, sent a prompt. Verify `aichat.unified.input.submit.change.model.prompt.sent` is fired.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
**Low** — analytics-only change scoped to the UTI recovery picker session. No user-facing behavior changes; bridge contracts and recovery UI logic are unchanged.

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
- **False positives:** `submit_change_model` could fire outside recovery if `isModelPickerForcedVisible` is set incorrectly — gated on both recovery pin and `canDispatchBridgeMessages`.
- **Double-counting:** Multiple model changes in one session each fire `submit_change_model` (intentional — measures re-selection before submit).
### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->
- **Edge cases:** Auto-reconcile when a supported model is already selected on `showModelPicker`; post-purchase application of a previously gated model; tab switch with persisted recovery pin (completion pixel fires only on submit, not tab switch).
- **Privacy:** `model_id` is a product model identifier (same pattern as existing `unifiedToggleInputModelSelected`); no prompt text, URLs, or PII. Completion pixel carries no `model_id` by design (model change is reported separately).

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only instrumentation gated on existing recovery state and bridge readiness; no user-facing or bridge behavior changes.
> 
> **Overview**
> Adds **three daily/count pixels** to measure the Duck.ai **subscription recovery** path when the web UI asks native to show the model picker (`showModelPicker`).
> 
> Instrumentation is wired in `UnifiedToggleInputCoordinator`: **`aichat_unified_input_show_model_picker`** when the recovery picker is presented; **`aichat_unified_input_submit_change_model`** (with `model_id`) only when native sends `submitChangeModelAction` during an active recovery pin and the bridge can dispatch; **`aichat_unified_input_submit_change_model_prompt_sent`** when a prompt submit ends that recovery session. Helpers live in `UnifiedToggleInputCoordinatorPixelHelper`; events and names are registered in `PixelEvent.swift`, `ai_chat_unified_input.json5`, and `PixelTests`. Coordinator smoke tests exercise the funnel with `Pixel.isDryRun`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b037c8a27ef8dcba6ca6b83169ebb2114cb9ec8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->