### PR TITLE
[macOS] Add Favicons debug inspector

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -460,8 +460,6 @@
 		31F3BB10909E47A4B05D8524 /* AutoconsentPopupManagedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4635C8FD7CF47F0A3D22F8A /* AutoconsentPopupManagedEvent.swift */; };
 		31FBF22E2CDD068000626C17 /* AIChatUserScriptHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FBF22D2CDD068000626C17 /* AIChatUserScriptHandling.swift */; };
 		31FBF22F2CDD068000626C17 /* AIChatUserScriptHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FBF22D2CDD068000626C17 /* AIChatUserScriptHandling.swift */; };
-		D1A7B0010000000000000012 /* AIChatTabPickerSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000011 /* AIChatTabPickerSource.swift */; };
-		D1A7B0010000000000000013 /* AIChatTabPickerSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000011 /* AIChatTabPickerSource.swift */; };
 		31FBF2312CDD130900626C17 /* AIChatUserScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FBF2302CDD12FE00626C17 /* AIChatUserScriptTests.swift */; };
 		31FBF2322CDD130900626C17 /* AIChatUserScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FBF2302CDD12FE00626C17 /* AIChatUserScriptTests.swift */; };
 		31FC23512DB7A86F00900574 /* AddressBarMenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FC23502DB7A86A00900574 /* AddressBarMenuButton.swift */; };
@@ -1073,6 +1071,8 @@
 		371BFF5F2D3936140075DB87 /* HistoryViewActionsManagerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371BFF5E2D39360E0075DB87 /* HistoryViewActionsManagerExtension.swift */; };
 		371BFF602D3936140075DB87 /* HistoryViewActionsManagerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371BFF5E2D39360E0075DB87 /* HistoryViewActionsManagerExtension.swift */; };
 		371C0A2927E33EDC0070591F /* FeedbackPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371C0A2827E33EDC0070591F /* FeedbackPresenter.swift */; };
+		371C3DE42FE40ADF003D31C1 /* FaviconsDebugInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371C3DE32FE40ADF003D31C1 /* FaviconsDebugInspector.swift */; };
+		371C3DE52FE40ADF003D31C1 /* FaviconsDebugInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371C3DE32FE40ADF003D31C1 /* FaviconsDebugInspector.swift */; };
 		371E1D672D0B2E9F00F9205B /* NewTabPageCustomizationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371E1D662D0B2E9F00F9205B /* NewTabPageCustomizationProvider.swift */; };
 		371E1D682D0B2E9F00F9205B /* NewTabPageCustomizationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371E1D662D0B2E9F00F9205B /* NewTabPageCustomizationProvider.swift */; };
 		372042D42DF9B0AD00CE099A /* InternalFeedbackFormTabExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372042D32DF9B0A400CE099A /* InternalFeedbackFormTabExtension.swift */; };
@@ -1287,8 +1287,6 @@
 		37AA017D2E2100DA00844427 /* CrashPixelAppIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AA017B2E2100D500844427 /* CrashPixelAppIdentifierTests.swift */; };
 		37AA017F2E2164A700844427 /* AIChatUserScriptHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AA017E2E2164A500844427 /* AIChatUserScriptHandlerTests.swift */; };
 		37AA01802E2164A700844427 /* AIChatUserScriptHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AA017E2E2164A500844427 /* AIChatUserScriptHandlerTests.swift */; };
-		D1A7B0010000000000000022 /* AIChatTabPickerSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000021 /* AIChatTabPickerSourceTests.swift */; };
-		D1A7B0010000000000000023 /* AIChatTabPickerSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000021 /* AIChatTabPickerSourceTests.swift */; };
 		37ABFE7C2DED901200DE39F2 /* SettingsPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37ABFE7B2DED901000DE39F2 /* SettingsPixel.swift */; };
 		37ABFE7D2DED901200DE39F2 /* SettingsPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37ABFE7B2DED901000DE39F2 /* SettingsPixel.swift */; };
 		37ADC3EE2DF031890001CA03 /* MoreOptionsMenuPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37ADC3ED2DF031830001CA03 /* MoreOptionsMenuPixel.swift */; };
@@ -2100,9 +2098,7 @@
 		7B1522B92DE9D19600887371 /* MockLoginItemsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1522B82DE9D19200887371 /* MockLoginItemsManager.swift */; };
 		7B1522BA2DE9D19600887371 /* MockLoginItemsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1522B82DE9D19200887371 /* MockLoginItemsManager.swift */; };
 		7B15FB6B2FACF8BF00019A26 /* FaviconMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B15FB6A2FACF8BF00019A26 /* FaviconMetadata.swift */; };
-		FADEC0DE0000000000000B01 /* FaviconsDebugInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADEC0DE0000000000000A01 /* FaviconsDebugInspector.swift */; };
 		7B15FB6C2FACF8BF00019A26 /* FaviconMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B15FB6A2FACF8BF00019A26 /* FaviconMetadata.swift */; };
-		FADEC0DE0000000000000B02 /* FaviconsDebugInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADEC0DE0000000000000A01 /* FaviconsDebugInspector.swift */; };
 		7B17AA872F757C350087A9ED /* UnloadedTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B17AA862F757C350087A9ED /* UnloadedTab.swift */; };
 		7B17AA882F757C350087A9ED /* UnloadedTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B17AA862F757C350087A9ED /* UnloadedTab.swift */; };
 		7B17AA8A2F757C3B0087A9ED /* AnyTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B17AA892F757C3B0087A9ED /* AnyTab.swift */; };
@@ -4183,6 +4179,12 @@
 		CD89DD622C89E08D0080F9AF /* MaliciousSiteProtectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD89DD5D2C89E08D0080F9AF /* MaliciousSiteProtectionTests.swift */; };
 		CFCB0D03ADA84A06A1B05235 /* ContextualDaxDialogsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B63E5D7F5349E0ADA3EDEA /* ContextualDaxDialogsProvider.swift */; };
 		D16140583C0346C5BE2D9B96 /* QuickFeedbackWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6323C46A8F7693E56A2AD5F8 /* QuickFeedbackWindowController.swift */; };
+		D1A7B0010000000000000002 /* NewTabPageOmnibarTabsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000001 /* NewTabPageOmnibarTabsProvider.swift */; };
+		D1A7B0010000000000000003 /* NewTabPageOmnibarTabsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000001 /* NewTabPageOmnibarTabsProvider.swift */; };
+		D1A7B0010000000000000012 /* AIChatTabPickerSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000011 /* AIChatTabPickerSource.swift */; };
+		D1A7B0010000000000000013 /* AIChatTabPickerSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000011 /* AIChatTabPickerSource.swift */; };
+		D1A7B0010000000000000022 /* AIChatTabPickerSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000021 /* AIChatTabPickerSourceTests.swift */; };
+		D1A7B0010000000000000023 /* AIChatTabPickerSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000021 /* AIChatTabPickerSourceTests.swift */; };
 		D1E601A12D510FE0003BB417 /* OSUpgradeCapabilityOverride.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E601A02D510FE0003BB417 /* OSUpgradeCapabilityOverride.swift */; };
 		D1E601A22D510FE0003BB417 /* OSUpgradeCapabilityOverride.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E601A02D510FE0003BB417 /* OSUpgradeCapabilityOverride.swift */; };
 		D1EC9FDAACABFE5B574FD557 /* WebViewUserAgentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAAA013D5BF54C0C260E784E /* WebViewUserAgentProvider.swift */; };
@@ -4223,8 +4225,6 @@
 		E2BC1B232E210AF200F58D61 /* NewTabPageOmnibarConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BC1B222E210AE600F58D61 /* NewTabPageOmnibarConfigProvider.swift */; };
 		E2BC1B242E210AF300F58D61 /* NewTabPageOmnibarConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BC1B222E210AE600F58D61 /* NewTabPageOmnibarConfigProvider.swift */; };
 		E41E58E59C4B4B578F57BE4B /* AIChatTabOpenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DF815DCDE34CFBA7F38DFA /* AIChatTabOpenerTests.swift */; };
-		D1A7B0010000000000000002 /* NewTabPageOmnibarTabsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000001 /* NewTabPageOmnibarTabsProvider.swift */; };
-		D1A7B0010000000000000003 /* NewTabPageOmnibarTabsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000001 /* NewTabPageOmnibarTabsProvider.swift */; };
 		E5A6E743849E63F8101AC616 /* QuickFeedbackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A043BAE1603803A839C0CB52 /* QuickFeedbackService.swift */; };
 		E8775A4655DE1D195717B932 /* UpdateNotificationPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FD43DAF77B35315FBE6255D /* UpdateNotificationPresenterTests.swift */; };
 		E8D0D97DCB179322B9986E5A /* DarkReaderFeatureSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 361EABC017D9923C4758C171 /* DarkReaderFeatureSettings.swift */; };
@@ -5011,7 +5011,6 @@
 		31F28C4E28C8EEC500119F70 /* YoutubeOverlayUserScript.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YoutubeOverlayUserScript.swift; sourceTree = "<group>"; };
 		31F28C5228C8EECA00119F70 /* DuckURLSchemeHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DuckURLSchemeHandler.swift; sourceTree = "<group>"; };
 		31FBF22D2CDD068000626C17 /* AIChatUserScriptHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatUserScriptHandling.swift; sourceTree = "<group>"; };
-		D1A7B0010000000000000011 /* AIChatTabPickerSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTabPickerSource.swift; sourceTree = "<group>"; };
 		31FBF2302CDD12FE00626C17 /* AIChatUserScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatUserScriptTests.swift; sourceTree = "<group>"; };
 		31FC23502DB7A86A00900574 /* AddressBarMenuButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBarMenuButton.swift; sourceTree = "<group>"; };
 		336B39E22726B4B700C417D3 /* LocalUnprotectedDomains.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalUnprotectedDomains.swift; sourceTree = "<group>"; };
@@ -5056,6 +5055,7 @@
 		371BBC5D2D00CA3E008FA0C7 /* NewTabPageWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageWebViewModel.swift; sourceTree = "<group>"; };
 		371BFF5E2D39360E0075DB87 /* HistoryViewActionsManagerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewActionsManagerExtension.swift; sourceTree = "<group>"; };
 		371C0A2827E33EDC0070591F /* FeedbackPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackPresenter.swift; sourceTree = "<group>"; };
+		371C3DE32FE40ADF003D31C1 /* FaviconsDebugInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaviconsDebugInspector.swift; sourceTree = "<group>"; };
 		371E1D662D0B2E9F00F9205B /* NewTabPageCustomizationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageCustomizationProvider.swift; sourceTree = "<group>"; };
 		372042D32DF9B0A400CE099A /* InternalFeedbackFormTabExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalFeedbackFormTabExtension.swift; sourceTree = "<group>"; };
 		372042DF2DF9C04400CE099A /* internal-feedback-autofiller.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "internal-feedback-autofiller.js"; sourceTree = "<group>"; };
@@ -5190,7 +5190,6 @@
 		37AA01722E1FE88900844427 /* CrashPixelAppIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashPixelAppIdentifier.swift; sourceTree = "<group>"; };
 		37AA017B2E2100D500844427 /* CrashPixelAppIdentifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashPixelAppIdentifierTests.swift; sourceTree = "<group>"; };
 		37AA017E2E2164A500844427 /* AIChatUserScriptHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatUserScriptHandlerTests.swift; sourceTree = "<group>"; };
-		D1A7B0010000000000000021 /* AIChatTabPickerSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTabPickerSourceTests.swift; sourceTree = "<group>"; };
 		37ABFE7B2DED901000DE39F2 /* SettingsPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPixel.swift; sourceTree = "<group>"; };
 		37ADC3ED2DF031830001CA03 /* MoreOptionsMenuPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreOptionsMenuPixel.swift; sourceTree = "<group>"; };
 		37ADC4002DF040000001CA03 /* WebViewZoomPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewZoomPixel.swift; sourceTree = "<group>"; };
@@ -5653,7 +5652,6 @@
 		7B1522B02DE9CCA500887371 /* MockFeatureGatekeeper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFeatureGatekeeper.swift; sourceTree = "<group>"; };
 		7B1522B82DE9D19200887371 /* MockLoginItemsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLoginItemsManager.swift; sourceTree = "<group>"; };
 		7B15FB6A2FACF8BF00019A26 /* FaviconMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaviconMetadata.swift; sourceTree = "<group>"; };
-		FADEC0DE0000000000000A01 /* FaviconsDebugInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaviconsDebugInspector.swift; sourceTree = "<group>"; };
 		7B17AA862F757C350087A9ED /* UnloadedTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnloadedTab.swift; sourceTree = "<group>"; };
 		7B17AA892F757C3B0087A9ED /* AnyTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyTab.swift; sourceTree = "<group>"; };
 		7B17AA8C2F757C480087A9ED /* UnloadedTabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnloadedTabViewModel.swift; sourceTree = "<group>"; };
@@ -6832,6 +6830,9 @@
 		CDE248A62C821FFE00F9399D /* phishingFilterSet.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = phishingFilterSet.json; sourceTree = "<group>"; };
 		CDE248A72C821FFE00F9399D /* MaliciousSiteProtectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionState.swift; sourceTree = "<group>"; };
 		D09265BA0D784C47B9644675 /* RebrandedContextualOnboardingDialogs+Fire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RebrandedContextualOnboardingDialogs+Fire.swift"; sourceTree = "<group>"; };
+		D1A7B0010000000000000001 /* NewTabPageOmnibarTabsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageOmnibarTabsProvider.swift; sourceTree = "<group>"; };
+		D1A7B0010000000000000011 /* AIChatTabPickerSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTabPickerSource.swift; sourceTree = "<group>"; };
+		D1A7B0010000000000000021 /* AIChatTabPickerSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTabPickerSourceTests.swift; sourceTree = "<group>"; };
 		D1E601A02D510FE0003BB417 /* OSUpgradeCapabilityOverride.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSUpgradeCapabilityOverride.swift; sourceTree = "<group>"; };
 		D1F501A02D510FE0003BB417 /* OSSupportDebugMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSSupportDebugMenu.swift; sourceTree = "<group>"; };
 		D4912774B0E942D597229E05 /* AutoplayPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoplayPreferences.swift; sourceTree = "<group>"; };
@@ -6848,7 +6849,6 @@
 		E274EFF52E1D55CF00373C41 /* NewTabPageOmnibarSuggestionsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageOmnibarSuggestionsProvider.swift; sourceTree = "<group>"; };
 		E274EFF82E1E8DED00373C41 /* NewTabPageOmnibarActionsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageOmnibarActionsHandler.swift; sourceTree = "<group>"; };
 		E2BC1B222E210AE600F58D61 /* NewTabPageOmnibarConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageOmnibarConfigProvider.swift; sourceTree = "<group>"; };
-		D1A7B0010000000000000001 /* NewTabPageOmnibarTabsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageOmnibarTabsProvider.swift; sourceTree = "<group>"; };
 		E30AB59CE2084D638FEC58AD /* RebrandedContextualOnboardingDialogs+TrySite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RebrandedContextualOnboardingDialogs+TrySite.swift"; sourceTree = "<group>"; };
 		E5E98EDA7AE9931D95CEA01E /* AdBlockingDebugMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdBlockingDebugMenu.swift; sourceTree = "<group>"; };
 		EA0BA3A8272217E6002A0B6C /* ClickToLoadUserScript.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClickToLoadUserScript.swift; sourceTree = "<group>"; };
@@ -10914,10 +10914,10 @@
 				AA512D1324D99D9800230283 /* FaviconManager.swift */,
 				37F09AD22DDE433000643A1B /* FaviconManagerMock.swift */,
 				7B15FB6A2FACF8BF00019A26 /* FaviconMetadata.swift */,
-				FADEC0DE0000000000000A01 /* FaviconsDebugInspector.swift */,
 				AA222CB82760F74E00321475 /* FaviconReferenceCache.swift */,
 				AAEF6BC7276A081C0024DCF4 /* FaviconSelector.swift */,
 				AA6197C3276B314D008396F0 /* FaviconUrlReference.swift */,
+				371C3DE32FE40ADF003D31C1 /* FaviconsDebugInspector.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -15230,7 +15230,6 @@
 				BB53CF3F2E26CEED007F0B42 /* RequestNewFeatureFormView.swift in Sources */,
 				BB8E05722EE0D2B9006CD2E6 /* HomePageSubscriptionCardPersistor.swift in Sources */,
 				7B15FB6B2FACF8BF00019A26 /* FaviconMetadata.swift in Sources */,
-				FADEC0DE0000000000000B01 /* FaviconsDebugInspector.swift in Sources */,
 				3706FB2D293F65D500E42796 /* PasswordManagementPopover.swift in Sources */,
 				C1935A152C88F958001AD72D /* SyncPromoView.swift in Sources */,
 				1D955E273EB784CB1672BB43 /* AdBlockingDebugMenu.swift in Sources */,
@@ -15436,6 +15435,7 @@
 				EDC4D5102F23C414001BCE10 /* SecureVaultModels+CreditCardSummary.swift in Sources */,
 				F1664A692D708EC60034CCB8 /* SubscriptionPagesUseSubscriptionFeature.swift in Sources */,
 				3706FB85293F65D500E42796 /* AddBookmarkPopover.swift in Sources */,
+				371C3DE42FE40ADF003D31C1 /* FaviconsDebugInspector.swift in Sources */,
 				F18826922BC0105900D9AC4F /* PixelDataRecord.swift in Sources */,
 				F18826932BC0105900D9AC4F /* PixelDataStore.swift in Sources */,
 				CCAA80362F5B290400BB58F4 /* DefaultBrowserAndDockPromptUIHosting.swift in Sources */,
@@ -17512,7 +17512,6 @@
 				84F950B92F150E3D00863D32 /* PrivacyStatsAppTerminationDecider.swift in Sources */,
 				84CE00172DAE41F100852AA2 /* ResizablePreviewView.swift in Sources */,
 				7B15FB6C2FACF8BF00019A26 /* FaviconMetadata.swift in Sources */,
-				FADEC0DE0000000000000B02 /* FaviconsDebugInspector.swift in Sources */,
 				4B379C2427BDE1B0008A968E /* FlatButton.swift in Sources */,
 				B6FA8941269C425400588ECD /* PrivacyDashboardPopover.swift in Sources */,
 				1D5C232A2F150A680055046E /* AIChatSuggestionsView.swift in Sources */,
@@ -18344,6 +18343,7 @@
 				1DE906D42F3DBF4900C3B853 /* AIChatImageAttachmentThumbnailView.swift in Sources */,
 				AA7412B224D0B3AC00D22FE0 /* TabBarViewItem.swift in Sources */,
 				856C98D52570116900A22F1F /* NSWindow+Toast.swift in Sources */,
+				371C3DE52FE40ADF003D31C1 /* FaviconsDebugInspector.swift in Sources */,
 				B31055C427A1BA1D001AC618 /* AutoconsentUserScript.swift in Sources */,
 				7B3618C22ADE75C8000D6154 /* NetworkProtectionNavBarPopoverManager.swift in Sources */,
 				859E7D6B27453BF3009C2B69 /* BookmarksExporter.swift in Sources */,

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -2100,7 +2100,9 @@
 		7B1522B92DE9D19600887371 /* MockLoginItemsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1522B82DE9D19200887371 /* MockLoginItemsManager.swift */; };
 		7B1522BA2DE9D19600887371 /* MockLoginItemsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1522B82DE9D19200887371 /* MockLoginItemsManager.swift */; };
 		7B15FB6B2FACF8BF00019A26 /* FaviconMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B15FB6A2FACF8BF00019A26 /* FaviconMetadata.swift */; };
+		FADEC0DE0000000000000B01 /* FaviconsDebugInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADEC0DE0000000000000A01 /* FaviconsDebugInspector.swift */; };
 		7B15FB6C2FACF8BF00019A26 /* FaviconMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B15FB6A2FACF8BF00019A26 /* FaviconMetadata.swift */; };
+		FADEC0DE0000000000000B02 /* FaviconsDebugInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADEC0DE0000000000000A01 /* FaviconsDebugInspector.swift */; };
 		7B17AA872F757C350087A9ED /* UnloadedTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B17AA862F757C350087A9ED /* UnloadedTab.swift */; };
 		7B17AA882F757C350087A9ED /* UnloadedTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B17AA862F757C350087A9ED /* UnloadedTab.swift */; };
 		7B17AA8A2F757C3B0087A9ED /* AnyTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B17AA892F757C3B0087A9ED /* AnyTab.swift */; };
@@ -5651,6 +5653,7 @@
 		7B1522B02DE9CCA500887371 /* MockFeatureGatekeeper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFeatureGatekeeper.swift; sourceTree = "<group>"; };
 		7B1522B82DE9D19200887371 /* MockLoginItemsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLoginItemsManager.swift; sourceTree = "<group>"; };
 		7B15FB6A2FACF8BF00019A26 /* FaviconMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaviconMetadata.swift; sourceTree = "<group>"; };
+		FADEC0DE0000000000000A01 /* FaviconsDebugInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaviconsDebugInspector.swift; sourceTree = "<group>"; };
 		7B17AA862F757C350087A9ED /* UnloadedTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnloadedTab.swift; sourceTree = "<group>"; };
 		7B17AA892F757C3B0087A9ED /* AnyTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyTab.swift; sourceTree = "<group>"; };
 		7B17AA8C2F757C480087A9ED /* UnloadedTabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnloadedTabViewModel.swift; sourceTree = "<group>"; };
@@ -10911,6 +10914,7 @@
 				AA512D1324D99D9800230283 /* FaviconManager.swift */,
 				37F09AD22DDE433000643A1B /* FaviconManagerMock.swift */,
 				7B15FB6A2FACF8BF00019A26 /* FaviconMetadata.swift */,
+				FADEC0DE0000000000000A01 /* FaviconsDebugInspector.swift */,
 				AA222CB82760F74E00321475 /* FaviconReferenceCache.swift */,
 				AAEF6BC7276A081C0024DCF4 /* FaviconSelector.swift */,
 				AA6197C3276B314D008396F0 /* FaviconUrlReference.swift */,
@@ -15226,6 +15230,7 @@
 				BB53CF3F2E26CEED007F0B42 /* RequestNewFeatureFormView.swift in Sources */,
 				BB8E05722EE0D2B9006CD2E6 /* HomePageSubscriptionCardPersistor.swift in Sources */,
 				7B15FB6B2FACF8BF00019A26 /* FaviconMetadata.swift in Sources */,
+				FADEC0DE0000000000000B01 /* FaviconsDebugInspector.swift in Sources */,
 				3706FB2D293F65D500E42796 /* PasswordManagementPopover.swift in Sources */,
 				C1935A152C88F958001AD72D /* SyncPromoView.swift in Sources */,
 				1D955E273EB784CB1672BB43 /* AdBlockingDebugMenu.swift in Sources */,
@@ -17507,6 +17512,7 @@
 				84F950B92F150E3D00863D32 /* PrivacyStatsAppTerminationDecider.swift in Sources */,
 				84CE00172DAE41F100852AA2 /* ResizablePreviewView.swift in Sources */,
 				7B15FB6C2FACF8BF00019A26 /* FaviconMetadata.swift in Sources */,
+				FADEC0DE0000000000000B02 /* FaviconsDebugInspector.swift in Sources */,
 				4B379C2427BDE1B0008A968E /* FlatButton.swift in Sources */,
 				B6FA8941269C425400588ECD /* PrivacyDashboardPopover.swift in Sources */,
 				1D5C232A2F150A680055046E /* AIChatSuggestionsView.swift in Sources */,

--- a/macOS/DuckDuckGo/Common/Extensions/URLExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/URLExtension.swift
@@ -167,6 +167,8 @@ extension URL {
     static let settings = URL(string: "duck://settings")!
     static let bookmarks = URL(string: "duck://bookmarks")!
     static let history = URL(string: "duck://history")!
+    /// Debug-only favicon manager page (Debug ▸ Favicon Browser). Served by `DuckURLSchemeHandler`.
+    static let favicons = URL(string: "duck://favicons")!
     // base url for Error Page Alternate HTML loaded into Web View
     static let error = URL(string: "duck://error")!
 
@@ -195,6 +197,11 @@ extension URL {
 
     var isNTP: Bool {
         return navigationalScheme == .duck && host == URL.newtab.host
+    }
+
+    /// `duck://favicons` (and its sub-paths) — the debug-only favicon manager page.
+    var isFavicons: Bool {
+        return navigationalScheme == .duck && host == URL.favicons.host
     }
 
 #endif

--- a/macOS/DuckDuckGo/Favicons/Model/FaviconImageCache.swift
+++ b/macOS/DuckDuckGo/Favicons/Model/FaviconImageCache.swift
@@ -60,6 +60,16 @@ protocol FaviconImageCaching {
                      exceptSavedLogins logins: Set<String>,
                      exceptHistoryDomains history: Set<String>,
                      tld: TLD) async -> Result<Void, Error>
+
+    /// Debug/admin: deletes the favicon image records with the given identifiers from memory + store and
+    /// posts `.faviconCacheUpdated`. References pointing at a deleted favicon resolve to a cache miss and
+    /// re-fetch on the next visit. No-op for an empty set.
+    @MainActor
+    func removeFavicons(withIdentifiers identifiers: Set<UUID>) async
+
+    /// Debug/admin: deletes every cached favicon image record (memory + store) and posts `.faviconCacheUpdated`.
+    @MainActor
+    func removeAllFavicons() async
 }
 
 final class FaviconImageCache: FaviconImageCaching {
@@ -268,6 +278,37 @@ final class FaviconImageCache: FaviconImageCaching {
                 && !logins.contains(host)
                 && !history.contains(host)
         }
+    }
+
+    // MARK: - Debug / admin removal
+
+    @MainActor
+    func removeFavicons(withIdentifiers identifiers: Set<UUID>) async {
+        guard !identifiers.isEmpty else { return }
+        await deleteFaviconsAndNotify { identifiers.contains($0.identifier) }
+    }
+
+    @MainActor
+    func removeAllFavicons() async {
+        await deleteFaviconsAndNotify { _ in true }
+    }
+
+    /// Removes matching favicons from the in-memory metadata map and the decoded-image NSCache, deletes
+    /// them from the store, and posts `.faviconCacheUpdated` so open UI re-resolves. Unlike the private
+    /// `removeFavicons(filter:)` used by clean/burn, this always notifies.
+    @MainActor
+    private func deleteFaviconsAndNotify(filter isRemoved: (FaviconMetadata) -> Bool) async {
+        let toRemove = entries.values.filter(isRemoved)
+        guard !toRemove.isEmpty else { return }
+        for metadata in toRemove {
+            entries[metadata.url] = nil
+            imageCache.removeObject(forKey: metadata.url as NSURL)
+        }
+        await removeFaviconsFromStore(Array(toRemove))
+        NotificationCenter.default.postFaviconCacheUpdated(
+            faviconURLs: Set(toRemove.map(\.url)),
+            documentURLs: Set(toRemove.map(\.documentUrl))
+        )
     }
 
     // MARK: - Private
@@ -509,6 +550,31 @@ final class EagerFaviconImageCache: FaviconImageCaching {
                 && !logins.contains(host)
                 && !history.contains(host)
         }
+    }
+
+    // MARK: - Debug / admin removal
+
+    @MainActor
+    func removeFavicons(withIdentifiers identifiers: Set<UUID>) async {
+        guard !identifiers.isEmpty else { return }
+        await deleteFaviconsAndNotify { identifiers.contains($0.identifier) }
+    }
+
+    @MainActor
+    func removeAllFavicons() async {
+        await deleteFaviconsAndNotify { _ in true }
+    }
+
+    @MainActor
+    private func deleteFaviconsAndNotify(filter isRemoved: (Favicon) -> Bool) async {
+        let toRemove = entries.values.filter(isRemoved)
+        guard !toRemove.isEmpty else { return }
+        toRemove.forEach { entries[$0.url] = nil }
+        await removeFaviconsFromStore(toRemove)
+        NotificationCenter.default.postFaviconCacheUpdated(
+            faviconURLs: Set(toRemove.map(\.url)),
+            documentURLs: Set(toRemove.map(\.documentUrl))
+        )
     }
 
     // MARK: - Private

--- a/macOS/DuckDuckGo/Favicons/Model/FaviconImageCache.swift
+++ b/macOS/DuckDuckGo/Favicons/Model/FaviconImageCache.swift
@@ -293,18 +293,21 @@ final class FaviconImageCache: FaviconImageCaching {
         await deleteFaviconsAndNotify { _ in true }
     }
 
-    /// Removes matching favicons from the in-memory metadata map and the decoded-image NSCache, deletes
-    /// them from the store, and posts `.faviconCacheUpdated` so open UI re-resolves. Unlike the private
+    /// Removes matching favicons. The set to delete is resolved from the store — the inspector's source
+    /// of truth — rather than the in-memory `entries`, which may not yet hold every stored row (e.g.
+    /// before `load()` finishes); filtering memory would let deletes silently no-op while the store keeps
+    /// the rows. Deletes from the store, evicts any in-memory copies (metadata map + decoded-image
+    /// NSCache), and posts `.faviconCacheUpdated` so open UI re-resolves. Unlike the private
     /// `removeFavicons(filter:)` used by clean/burn, this always notifies.
     @MainActor
     private func deleteFaviconsAndNotify(filter isRemoved: (FaviconMetadata) -> Bool) async {
-        let toRemove = entries.values.filter(isRemoved)
+        let toRemove = ((try? await storing.loadFaviconMetadata()) ?? []).filter(isRemoved)
         guard !toRemove.isEmpty else { return }
         for metadata in toRemove {
             entries[metadata.url] = nil
             imageCache.removeObject(forKey: metadata.url as NSURL)
         }
-        await removeFaviconsFromStore(Array(toRemove))
+        await removeFaviconsFromStore(toRemove)
         NotificationCenter.default.postFaviconCacheUpdated(
             faviconURLs: Set(toRemove.map(\.url)),
             documentURLs: Set(toRemove.map(\.documentUrl))
@@ -565,12 +568,14 @@ final class EagerFaviconImageCache: FaviconImageCaching {
         await deleteFaviconsAndNotify { _ in true }
     }
 
+    /// See the lazy `FaviconImageCache` twin: resolves the set to delete from the store (the inspector's
+    /// source of truth) rather than the in-memory `entries`, so deletes don't no-op before `load()` finishes.
     @MainActor
-    private func deleteFaviconsAndNotify(filter isRemoved: (Favicon) -> Bool) async {
-        let toRemove = entries.values.filter(isRemoved)
+    private func deleteFaviconsAndNotify(filter isRemoved: (FaviconMetadata) -> Bool) async {
+        let toRemove = ((try? await storing.loadFaviconMetadata()) ?? []).filter(isRemoved)
         guard !toRemove.isEmpty else { return }
         toRemove.forEach { entries[$0.url] = nil }
-        await removeFaviconsFromStore(toRemove)
+        await removeFaviconsFromStore(toRemove.map { $0.asFaviconWithoutImage() })
         NotificationCenter.default.postFaviconCacheUpdated(
             faviconURLs: Set(toRemove.map(\.url)),
             documentURLs: Set(toRemove.map(\.documentUrl))

--- a/macOS/DuckDuckGo/Favicons/Model/FaviconManager.swift
+++ b/macOS/DuckDuckGo/Favicons/Model/FaviconManager.swift
@@ -696,3 +696,53 @@ extension NSImage {
         return "data:image/png;base64,\(pngData.base64EncodedString())"
     }
 }
+
+// MARK: - Favicon Browser (debug) support
+
+/**
+ * Read/delete access to the favicon store used by the debug-only Favicon Browser page (`duck://favicons`).
+ *
+ * Only `FaviconManager` conforms; `DuckURLSchemeHandler` downcasts its `FaviconManagement` to this
+ * protocol when serving the page, so the debug surface stays off the main `FaviconManagement` protocol
+ * (and its mocks). All access goes through the in-app favicon stack, which holds the decryption key, so
+ * the encrypted URL/image columns are handled transparently.
+ */
+@MainActor
+protocol FaviconManagementDebugging: AnyObject {
+
+    /// Metadata for every stored favicon image record (no image decode), ordered oldest-first.
+    func allFaviconsMetadata() async -> [FaviconMetadata]
+
+    /// The decoded image for a single favicon record, by its identifier, or nil if missing/undecodable.
+    func faviconImage(withIdentifier identifier: UUID) async -> NSImage?
+
+    /// Deletes the favicon image records with the given identifiers (memory + store).
+    func deleteFavicons(withIdentifiers identifiers: Set<UUID>) async
+
+    /// Deletes every favicon image record and every favicon reference (full reset).
+    func deleteAllFavicons() async
+}
+
+extension FaviconManager: FaviconManagementDebugging {
+
+    @MainActor
+    func allFaviconsMetadata() async -> [FaviconMetadata] {
+        (try? await store.loadFaviconMetadata()) ?? []
+    }
+
+    @MainActor
+    func faviconImage(withIdentifier identifier: UUID) async -> NSImage? {
+        try? await store.loadImage(for: identifier)
+    }
+
+    @MainActor
+    func deleteFavicons(withIdentifiers identifiers: Set<UUID>) async {
+        await imageCache.removeFavicons(withIdentifiers: identifiers)
+    }
+
+    @MainActor
+    func deleteAllFavicons() async {
+        await imageCache.removeAllFavicons()
+        await referenceCache.removeAllReferences()
+    }
+}

--- a/macOS/DuckDuckGo/Favicons/Model/FaviconManagerMock.swift
+++ b/macOS/DuckDuckGo/Favicons/Model/FaviconManagerMock.swift
@@ -40,6 +40,12 @@ final class FaviconManagerMock: FaviconManagement {
         imagesByHost[host] = image
     }
 
+    // MARK: - FaviconManagementDebugging test storage
+    var debugMetadata: [FaviconMetadata] = []
+    var debugImagesByIdentifier: [UUID: NSImage] = [:]
+    private(set) var deletedIdentifiers: [Set<UUID>] = []
+    private(set) var deleteAllFaviconsCallCount = 0
+
     // MARK: - FaviconManagement
 
     func handleFaviconLinks(_ faviconLinks: [FaviconUserScript.FaviconLink], documentUrl: URL, webView: WKWebView?) async -> Favicon? {
@@ -95,6 +101,27 @@ final class FaviconManagerMock: FaviconManagement {
 
     func burnDomains(_ domains: Set<String>, exceptBookmarks bookmarkManager: any BookmarkManager, exceptSavedLogins: Set<String>, exceptExistingHistory history: BrowsingHistory, tld: TLD) async -> Result<Void, Error> {
         return .success(())
+    }
+}
+
+extension FaviconManagerMock: FaviconManagementDebugging {
+
+    func allFaviconsMetadata() async -> [FaviconMetadata] {
+        debugMetadata
+    }
+
+    func faviconImage(withIdentifier identifier: UUID) async -> NSImage? {
+        debugImagesByIdentifier[identifier]
+    }
+
+    func deleteFavicons(withIdentifiers identifiers: Set<UUID>) async {
+        deletedIdentifiers.append(identifiers)
+        debugMetadata.removeAll { identifiers.contains($0.identifier) }
+    }
+
+    func deleteAllFavicons() async {
+        deleteAllFaviconsCallCount += 1
+        debugMetadata.removeAll()
     }
 }
 #endif

--- a/macOS/DuckDuckGo/Favicons/Model/FaviconReferenceCache.swift
+++ b/macOS/DuckDuckGo/Favicons/Model/FaviconReferenceCache.swift
@@ -55,6 +55,10 @@ protocol FaviconReferenceCaching {
     func burn(except fireproofDomains: FireproofDomains, bookmarkManager: BookmarkManager, savedLogins: Set<String>) async
     @MainActor
     func burnDomains(_ baseDomains: Set<String>, exceptBookmarks bookmarkManager: BookmarkManager, exceptSavedLogins logins: Set<String>, exceptHistoryDomains history: Set<String>, tld: TLD) async
+
+    /// Debug/admin: removes every host and URL favicon reference from memory + store.
+    @MainActor
+    func removeAllReferences() async
 }
 
 final class FaviconReferenceCache: FaviconReferenceCaching {
@@ -236,6 +240,14 @@ final class FaviconReferenceCache: FaviconReferenceCaching {
             }
             return baseDomains.contains(host) && !bookmarkedHosts.contains(host) && !logins.contains(host) && !history.contains(host)
         }).value
+    }
+
+    // MARK: - Debug / admin removal
+
+    @MainActor
+    func removeAllReferences() async {
+        await removeHostReferences(filter: { _ in true }).value
+        await removeUrlReferences(filter: { _ in true }).value
     }
 
     // MARK: - Private

--- a/macOS/DuckDuckGo/Favicons/Model/FaviconReferenceCache.swift
+++ b/macOS/DuckDuckGo/Favicons/Model/FaviconReferenceCache.swift
@@ -246,8 +246,13 @@ final class FaviconReferenceCache: FaviconReferenceCaching {
 
     @MainActor
     func removeAllReferences() async {
-        await removeHostReferences(filter: { _ in true }).value
-        await removeUrlReferences(filter: { _ in true }).value
+        // Resolve from the store (the source of truth) so a full reset also clears references this
+        // in-memory cache may not have loaded yet, rather than only the in-memory ones.
+        let (storedHostReferences, storedUrlReferences) = (try? await storing.loadFaviconReferences()) ?? ([], [])
+        hostReferences.removeAll()
+        urlReferences.removeAll()
+        await removeHostReferencesFromStore(storedHostReferences)
+        await removeUrlReferencesFromStore(storedUrlReferences)
     }
 
     // MARK: - Private

--- a/macOS/DuckDuckGo/Favicons/Model/FaviconsDebugInspector.swift
+++ b/macOS/DuckDuckGo/Favicons/Model/FaviconsDebugInspector.swift
@@ -1,0 +1,564 @@
+//
+//  FaviconsDebugInspector.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppKit
+import AppKitExtensions
+import Foundation
+import WebKit
+
+/// Serves the debug-only Favicons inspector page at `duck://favicons` (Debug ▸ Inspect Favicons).
+///
+/// The page is a self-contained in-app HTML/JS app plus a JSON/PNG API, so it ships without the
+/// content-scope-scripts bundle pipeline. `DuckURLSchemeHandler` routes `duck://favicons` requests here.
+/// All access goes through `FaviconManagementDebugging` — the in-app favicon stack, which holds the
+/// decryption key — so the encrypted URL/image columns are handled transparently.
+///
+/// Static assets (the page HTML and its script) are returned synchronously; the `/api/` endpoints
+/// complete asynchronously, and in-flight tasks are tracked so a task WebKit stops mid-await isn't messaged.
+/// Mutations use GET with query params on purpose: `WKURLSchemeHandler` doesn't reliably receive the
+/// HTTP body of a POST, so request data is carried in the URL.
+final class FaviconsDebugInspector {
+
+    private let faviconManager: FaviconManagement
+
+    /// In-flight API tasks that complete after an await; used to skip messaging a task WebKit has stopped.
+    private var runningTasks = Set<ObjectIdentifier>()
+
+    init(faviconManager: FaviconManagement) {
+        self.faviconManager = faviconManager
+    }
+
+    func handle(requestURL: URL, urlSchemeTask: WKURLSchemeTask) {
+        switch requestURL.path {
+        case "", "/", "/index.html":
+            send(Page.html.utf8data, mimeType: "text/html", for: requestURL, to: urlSchemeTask)
+            return
+        case "/app.js":
+            send(Page.js.utf8data, mimeType: "text/javascript", for: requestURL, to: urlSchemeTask)
+            return
+        default:
+            break
+        }
+
+        guard requestURL.path.hasPrefix("/api/"), let debug = faviconManager as? FaviconManagementDebugging else {
+            fail(urlSchemeTask, statusCode: 404, for: requestURL)
+            return
+        }
+
+        let taskID = ObjectIdentifier(urlSchemeTask)
+        runningTasks.insert(taskID)
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let result = await Self.apiResponse(for: requestURL, debug: debug)
+            // The task may have been stopped while awaiting; `remove` returns nil if so.
+            guard self.runningTasks.remove(taskID) != nil else { return }
+            switch result {
+            case .data(let data, let mimeType):
+                self.send(data, mimeType: mimeType, for: requestURL, to: urlSchemeTask)
+            case .notFound:
+                self.fail(urlSchemeTask, statusCode: 404, for: requestURL)
+            }
+        }
+    }
+
+    /// Called when WebKit stops a scheme task, so a pending async completion is skipped instead of
+    /// messaging a stopped task (which would crash).
+    func webViewDidStop(_ urlSchemeTask: WKURLSchemeTask) {
+        runningTasks.remove(ObjectIdentifier(urlSchemeTask))
+    }
+
+    // MARK: - Responses
+
+    private func send(_ data: Data, mimeType: String, for url: URL, to task: WKURLSchemeTask) {
+        // Respond with HTTP 200 (not a bare URLResponse) so the page's `fetch()` sees `response.ok`.
+        // The lazy image loader relies on `ok` to tell a served favicon apart from a 404.
+        let headers = ["Content-Type": mimeType, "Content-Length": String(data.count)]
+        guard let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: headers) else {
+            task.didFailWithError(URLError(.badServerResponse))
+            return
+        }
+        task.didReceive(response)
+        task.didReceive(data)
+        task.didFinish()
+    }
+
+    private func fail(_ task: WKURLSchemeTask, statusCode: Int, for url: URL) {
+        guard let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: "HTTP/1.1", headerFields: nil) else {
+            task.didFailWithError(URLError(.badServerResponse))
+            return
+        }
+        task.didReceive(response)
+        task.didReceive(Data())
+        task.didFinish()
+    }
+
+    @MainActor
+    private static func apiResponse(for requestURL: URL, debug: FaviconManagementDebugging) async -> Response {
+        let queryItems = URLComponents(url: requestURL, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        func queryValue(_ name: String) -> String? { queryItems.first { $0.name == name }?.value }
+
+        switch requestURL.path {
+        case "/api/list":
+            let items = await debug.allFaviconsMetadata().map(Item.init(metadata:))
+            guard let data = try? JSONEncoder().encode(items) else { return .notFound }
+            return .data(data, "application/json")
+
+        case "/api/image":
+            guard let idString = queryValue("id"), let id = UUID(uuidString: idString),
+                  let image = await debug.faviconImage(withIdentifier: id), let png = image.pngData() else {
+                return .notFound
+            }
+            return .data(png, "image/png")
+
+        case "/api/delete":
+            let ids = (queryValue("ids") ?? "").split(separator: ",").compactMap { UUID(uuidString: String($0)) }
+            await debug.deleteFavicons(withIdentifiers: Set(ids))
+            return jsonCount(ids.count)
+
+        case "/api/deleteAll":
+            let count = await debug.allFaviconsMetadata().count
+            await debug.deleteAllFavicons()
+            return jsonCount(count)
+
+        default:
+            return .notFound
+        }
+    }
+
+    private static func jsonCount(_ count: Int) -> Response {
+        guard let data = try? JSONEncoder().encode(["deleted": count]) else { return .notFound }
+        return .data(data, "application/json")
+    }
+}
+
+private enum Response {
+    case data(Data, String)
+    case notFound
+}
+
+/// JSON row shape consumed by the inspector page's script.
+private struct Item: Encodable {
+    let id: String
+    let faviconURL: String
+    let documentURL: String
+    let host: String
+    let relation: Int
+    let dateCreated: Double
+
+    init(metadata: FaviconMetadata) {
+        id = metadata.identifier.uuidString
+        faviconURL = metadata.url.absoluteString
+        documentURL = metadata.documentUrl.absoluteString
+        host = metadata.documentUrl.host ?? metadata.url.host ?? ""
+        relation = metadata.relation.rawValue
+        dateCreated = metadata.dateCreated.timeIntervalSince1970
+    }
+}
+
+/// Self-contained HTML + JS for the debug Favicons inspector. The script is served separately as `/app.js`.
+private enum Page {
+
+    static let html = """
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Favicons</title>
+    <style>
+    :root { color-scheme: light dark; }
+    body { font: 13px -apple-system, system-ui, sans-serif; margin: 0; padding: 0 16px 24px; }
+    h1 { font-size: 18px; margin: 0 0 8px; }
+    header { position: sticky; top: 0; background: Canvas; padding-top: 12px; z-index: 2; }
+    .toolbar { display: flex; gap: 8px; align-items: center; margin-bottom: 8px; flex-wrap: wrap; }
+    #search { flex: 1; min-width: 200px; padding: 4px 8px; }
+    #count { color: GrayText; white-space: nowrap; }
+    button { padding: 4px 10px; }
+    button.danger { color: #fff; background: #c0392b; border: 0; border-radius: 4px; }
+    button:disabled { opacity: 0.5; }
+    button.copy { padding: 1px 6px; font-size: 11px; }
+    /* Single table so the header row shares column widths with the body. */
+    table { width: 100%; border-collapse: collapse; table-layout: auto; }
+    th, td { text-align: left; padding: 4px 6px; border-bottom: 1px solid rgba(128,128,128,0.25); vertical-align: top; }
+    thead th { position: sticky; top: var(--header-h, 0px); background: Canvas; z-index: 1; }
+    .sortable { cursor: pointer; user-select: none; }
+    .sortable:hover { text-decoration: underline; }
+    td.host { max-width: 130px; overflow-wrap: anywhere; }
+    td.url { max-width: 360px; }
+    .urlwrap { display: flex; gap: 6px; align-items: flex-start; min-width: 0; }
+    .urltext { flex: 1 1 auto; min-width: 0; overflow-wrap: anywhere; font-family: ui-monospace, monospace; font-size: 11px; }
+    .copy { flex: 0 0 auto; }
+    td.size { white-space: nowrap; color: GrayText; font-variant-numeric: tabular-nums; }
+    img.fav { width: 16px; height: 16px; object-fit: contain; background: rgba(128,128,128,0.15); }
+    </style>
+    </head>
+    <body>
+    <header>
+    <h1>Favicons</h1>
+    <div class="toolbar">
+    <input id="search" type="search" placeholder="Filter by host or URL" autocomplete="off">
+    <span id="count"></span>
+    <button id="reload">Reload</button>
+    <button id="deleteSelected" disabled>Delete selected</button>
+    <button id="deleteAll" class="danger">Delete all</button>
+    </div>
+    </header>
+    <table>
+    <thead><tr>
+    <th><input type="checkbox" id="selectAll"></th>
+    <th>Icon</th>
+    <th class="sortable" data-sort="host">Host</th>
+    <th>Favicon URL</th>
+    <th>Document URL</th>
+    <th>Size (<span class="sortable" data-sort="px">px</span> / <span class="sortable" data-sort="bytes">B</span>)</th>
+    <th class="sortable" data-sort="rel">Rel</th>
+    <th>Created</th>
+    </tr></thead>
+    <tbody id="rows"></tbody>
+    </table>
+    <script src="/app.js"></script>
+    </body>
+    </html>
+    """
+
+    static let js = """
+    "use strict";
+    var state = { items: [], filter: "", sizes: {}, sort: { key: "created", dir: -1 } };
+    var relName = { "0": "other", "1": "icon", "2": "favicon" };
+    var loadingAllSizes = false;
+
+    function el(tag, text) {
+      var e = document.createElement(tag);
+      if (text !== undefined) { e.textContent = text; }
+      return e;
+    }
+
+    function humanBytes(n) {
+      if (n < 1024) { return n + " B"; }
+      if (n < 1048576) { return (n / 1024).toFixed(1) + " kB"; }
+      return (n / 1048576).toFixed(1) + " MB";
+    }
+
+    // Copy with a fallback for environments where navigator.clipboard is unavailable on the duck:// page.
+    function fallbackCopy(text) {
+      var ta = document.createElement("textarea");
+      ta.value = text;
+      ta.style.position = "fixed";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.focus();
+      ta.select();
+      try { document.execCommand("copy"); } catch (e) {}
+      document.body.removeChild(ta);
+    }
+
+    function copyToClipboard(text, btn) {
+      var restore = function() {
+        btn.textContent = "Copied";
+        setTimeout(function() { btn.textContent = "Copy"; }, 1000);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(restore, function() { fallbackCopy(text); restore(); });
+      } else {
+        fallbackCopy(text);
+        restore();
+      }
+    }
+
+    // Favicon images and their sizes load lazily as rows scroll into view. The row's own <img> both
+    // displays the favicon and yields its pixel dimensions on load; blob.size gives the byte size.
+    // Measured sizes are cached in state.sizes[id] so sorting by size can use them.
+    var imageObserver = new IntersectionObserver(function(entries) {
+      entries.forEach(function(entry) {
+        if (!entry.isIntersecting) { return; }
+        imageObserver.unobserve(entry.target);
+        if (entry.target.__loadFavicon) { entry.target.__loadFavicon(); }
+      });
+    }, { rootMargin: "300px" });
+
+    function lazyLoadFavicon(img, sizeCell, id) {
+      img.__loadFavicon = function() {
+        fetch("/api/image?id=" + encodeURIComponent(id)).then(function(r) {
+          if (!r.ok) { throw new Error("missing"); }
+          return r.blob();
+        }).then(function(blob) {
+          var bytes = blob.size;
+          img.onload = function() {
+            state.sizes[id] = { w: img.naturalWidth, h: img.naturalHeight, px: img.naturalWidth * img.naturalHeight, bytes: bytes };
+            sizeCell.textContent = img.naturalWidth + "×" + img.naturalHeight + " · " + humanBytes(bytes);
+          };
+          img.src = URL.createObjectURL(blob);
+        }).catch(function() {
+          state.sizes[id] = { w: 0, h: 0, px: -1, bytes: -1 };
+          sizeCell.textContent = "—";
+        });
+      };
+      imageObserver.observe(img);
+    }
+
+    // Measures one favicon (without displaying it) by decoding a detached image; records state.sizes[id].
+    function measureFavicon(id) {
+      return fetch("/api/image?id=" + encodeURIComponent(id)).then(function(r) {
+        if (!r.ok) { throw new Error("missing"); }
+        return r.blob();
+      }).then(function(blob) {
+        var bytes = blob.size;
+        return new Promise(function(resolve, reject) {
+          var url = URL.createObjectURL(blob);
+          var im = new Image();
+          im.onload = function() {
+            state.sizes[id] = { w: im.naturalWidth, h: im.naturalHeight, px: im.naturalWidth * im.naturalHeight, bytes: bytes };
+            URL.revokeObjectURL(url);
+            resolve();
+          };
+          im.onerror = function() { URL.revokeObjectURL(url); reject(new Error("decode")); };
+          im.src = url;
+        });
+      }).catch(function(err) {
+        state.sizes[id] = { w: 0, h: 0, px: -1, bytes: -1 };
+        throw err;
+      });
+    }
+
+    // Sorting by size needs every favicon measured. Fetch the not-yet-seen ones (bounded concurrency),
+    // updating a progress count, then re-render. Misses are recorded with -1 so they sort last.
+    function ensureAllSizesLoaded() {
+      if (loadingAllSizes) { return; }
+      var missing = state.items.filter(function(i) { return !state.sizes[i.id]; });
+      if (!missing.length) { return; }
+      loadingAllSizes = true;
+      var idx = 0, active = 0, completed = 0, total = missing.length;
+      function step() {
+        if (idx >= total && active === 0) {
+          loadingAllSizes = false;
+          render();
+          return;
+        }
+        while (active < 12 && idx < total) {
+          var id = missing[idx++].id;
+          active++;
+          measureFavicon(id).then(function() {}, function() {}).then(function() {
+            active--; completed++;
+            setCount(" · measuring " + completed + "/" + total);
+            step();
+          });
+        }
+      }
+      step();
+    }
+
+    function urlCell(text, withCopy) {
+      var td = el("td");
+      td.className = "url";
+      var wrap = el("div");
+      wrap.className = "urlwrap";
+      var span = el("span", text);
+      span.className = "urltext";
+      span.title = text;
+      wrap.appendChild(span);
+      if (withCopy) {
+        var btn = el("button", "Copy");
+        btn.className = "copy";
+        btn.addEventListener("click", function() { copyToClipboard(text, btn); });
+        wrap.appendChild(btn);
+      }
+      td.appendChild(wrap);
+      return td;
+    }
+
+    function syncHeaderOffset() {
+      var header = document.querySelector("header");
+      if (header) { document.documentElement.style.setProperty("--header-h", header.offsetHeight + "px"); }
+    }
+
+    function metric(id, field) {
+      var s = state.sizes[id];
+      return s ? s[field] : -1;
+    }
+
+    function cmp(a, b) { return a < b ? -1 : a > b ? 1 : 0; }
+
+    function sortItems(items) {
+      var k = state.sort.key, d = state.sort.dir;
+      var arr = items.slice();
+      arr.sort(function(a, b) {
+        var r;
+        if (k === "host") { r = a.host.localeCompare(b.host); }
+        else if (k === "rel") { r = cmp(a.relation, b.relation); }
+        else if (k === "px") { r = cmp(metric(a.id, "px"), metric(b.id, "px")); }
+        else if (k === "bytes") { r = cmp(metric(a.id, "bytes"), metric(b.id, "bytes")); }
+        else { r = cmp(a.dateCreated, b.dateCreated); }
+        if (r === 0) { r = cmp(a.dateCreated, b.dateCreated); }
+        return d * r;
+      });
+      return arr;
+    }
+
+    function filtered() {
+      var f = state.filter.trim().toLowerCase();
+      var items = !f ? state.items : state.items.filter(function(i) {
+        return (i.host + " " + i.faviconURL + " " + i.documentURL).toLowerCase().indexOf(f) !== -1;
+      });
+      return sortItems(items);
+    }
+
+    function setSort(key) {
+      if (state.sort.key === key) {
+        state.sort.dir = -state.sort.dir;
+      } else {
+        var descFirst = (key === "px" || key === "bytes" || key === "created");
+        state.sort = { key: key, dir: descFirst ? -1 : 1 };
+      }
+      if (key === "px" || key === "bytes") { ensureAllSizesLoaded(); }
+      render();
+    }
+
+    function updateSortHeaders() {
+      var els = document.querySelectorAll("[data-sort]");
+      Array.prototype.forEach.call(els, function(e) {
+        var base = e.getAttribute("data-label");
+        if (base === null) { base = e.textContent; e.setAttribute("data-label", base); }
+        var active = state.sort.key === e.getAttribute("data-sort");
+        e.textContent = base + (active ? (state.sort.dir > 0 ? " ▲" : " ▼") : "");
+      });
+    }
+
+    function setCount(suffix) {
+      var n = (state.filter.trim() ? filtered().length : state.items.length);
+      document.getElementById("count").textContent = n + " / " + state.items.length + " favicons" + (suffix || "");
+    }
+
+    function selectedIds() {
+      var boxes = document.querySelectorAll("tbody input[type=checkbox]:checked");
+      return Array.prototype.map.call(boxes, function(b) { return b.getAttribute("data-id"); });
+    }
+
+    function updateButtons() {
+      var n = selectedIds().length;
+      var btn = document.getElementById("deleteSelected");
+      btn.disabled = n === 0;
+      btn.textContent = n > 0 ? ("Delete selected (" + n + ")") : "Delete selected";
+    }
+
+    function render() {
+      var items = filtered();
+      setCount("");
+      updateSortHeaders();
+      var rows = document.getElementById("rows");
+      imageObserver.disconnect();
+      rows.textContent = "";
+      items.forEach(function(i) {
+        var tr = document.createElement("tr");
+
+        var cbCell = el("td");
+        var box = document.createElement("input");
+        box.type = "checkbox";
+        box.setAttribute("data-id", i.id);
+        box.addEventListener("change", updateButtons);
+        cbCell.appendChild(box);
+        tr.appendChild(cbCell);
+
+        var iconCell = el("td");
+        var img = document.createElement("img");
+        img.className = "fav";
+        iconCell.appendChild(img);
+        tr.appendChild(iconCell);
+
+        var hostCell = el("td", i.host);
+        hostCell.className = "host";
+        tr.appendChild(hostCell);
+
+        tr.appendChild(urlCell(i.faviconURL, true));
+        tr.appendChild(urlCell(i.documentURL, true));
+
+        var sizeCell = el("td");
+        sizeCell.className = "size";
+        var known = state.sizes[i.id];
+        if (known && known.px >= 0) {
+          sizeCell.textContent = known.w + "×" + known.h + " · " + humanBytes(known.bytes);
+        } else {
+          sizeCell.textContent = known ? "—" : "…";
+        }
+        tr.appendChild(sizeCell);
+
+        tr.appendChild(el("td", relName[String(i.relation)] || String(i.relation)));
+
+        var created = "";
+        try { created = new Date(i.dateCreated * 1000).toISOString().slice(0, 10); } catch (e) { created = ""; }
+        tr.appendChild(el("td", created));
+
+        rows.appendChild(tr);
+        lazyLoadFavicon(img, sizeCell, i.id);
+      });
+      var selectAll = document.getElementById("selectAll");
+      if (selectAll) { selectAll.checked = false; }
+      updateButtons();
+    }
+
+    function load() {
+      fetch("/api/list").then(function(r) { return r.json(); }).then(function(items) {
+        state.items = Array.isArray(items) ? items : [];
+        render();
+      }).catch(function() { state.items = []; render(); });
+    }
+
+    function deleteIds(ids) {
+      if (!ids.length) { return Promise.resolve(); }
+      return fetch("/api/delete?ids=" + encodeURIComponent(ids.join(","))).then(function(r) { return r.json(); });
+    }
+
+    document.addEventListener("DOMContentLoaded", function() {
+      syncHeaderOffset();
+      window.addEventListener("resize", syncHeaderOffset);
+      document.getElementById("search").addEventListener("input", function(e) {
+        state.filter = e.target.value;
+        render();
+      });
+      document.getElementById("reload").addEventListener("click", load);
+      document.querySelector("thead").addEventListener("click", function(e) {
+        var t = e.target.closest("[data-sort]");
+        if (t) { setSort(t.getAttribute("data-sort")); }
+      });
+      document.getElementById("selectAll").addEventListener("change", function(e) {
+        var boxes = document.querySelectorAll("tbody input[type=checkbox]");
+        Array.prototype.forEach.call(boxes, function(b) { b.checked = e.target.checked; });
+        updateButtons();
+      });
+      document.getElementById("deleteSelected").addEventListener("click", function() {
+        var ids = selectedIds();
+        if (!ids.length) { return; }
+        deleteIds(ids).then(load);
+      });
+      // Two-click confirm (avoids relying on window.confirm in the special page).
+      var armed = false;
+      var allBtn = document.getElementById("deleteAll");
+      allBtn.addEventListener("click", function() {
+        if (!armed) {
+          armed = true;
+          allBtn.textContent = "Click again to delete ALL";
+          setTimeout(function() { armed = false; allBtn.textContent = "Delete all"; }, 3000);
+          return;
+        }
+        armed = false;
+        allBtn.textContent = "Delete all";
+        fetch("/api/deleteAll").then(function(r) { return r.json(); }).then(load);
+      });
+      load();
+    });
+    """
+}

--- a/macOS/DuckDuckGo/Favicons/Model/FaviconsDebugInspector.swift
+++ b/macOS/DuckDuckGo/Favicons/Model/FaviconsDebugInspector.swift
@@ -298,11 +298,18 @@ private enum Page {
           return r.blob();
         }).then(function(blob) {
           var bytes = blob.size;
+          var url = URL.createObjectURL(blob);
           img.onload = function() {
+            URL.revokeObjectURL(url);
             state.sizes[id] = { w: img.naturalWidth, h: img.naturalHeight, px: img.naturalWidth * img.naturalHeight, bytes: bytes };
             sizeCell.textContent = img.naturalWidth + "×" + img.naturalHeight + " · " + humanBytes(bytes);
           };
-          img.src = URL.createObjectURL(blob);
+          img.onerror = function() {
+            URL.revokeObjectURL(url);
+            state.sizes[id] = { w: 0, h: 0, px: -1, bytes: -1 };
+            sizeCell.textContent = "—";
+          };
+          img.src = url;
         }).catch(function() {
           state.sizes[id] = { w: 0, h: 0, px: -1, bytes: -1 };
           sizeCell.textContent = "—";

--- a/macOS/DuckDuckGo/Menus/MainMenu.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenu.swift
@@ -926,6 +926,7 @@ final class MainMenu: NSMenu {
 
             // All items below will be automatically sorted alphabetically
             NSMenuItem(title: "Clear WebKit Cache", action: #selector(AppDelegate.debugClearWebViewCache)).withAccessibilityIdentifier("MainMenu.clearWebKitCache")
+            NSMenuItem(title: "Inspect Favicons", action: #selector(MainViewController.inspectFavicons(_:))).withAccessibilityIdentifier("MainMenu.inspectFavicons")
             NSMenuItem(title: "Open Vanilla Browser", action: #selector(MainViewController.openVanillaBrowser)).withAccessibilityIdentifier("MainMenu.openVanillaBrowser")
             NSMenuItem(title: "Skip Onboarding", action: #selector(AppDelegate.skipOnboarding)).withAccessibilityIdentifier("MainMenu.skipOnboarding")
             NSMenuItem(title: "Performance Debugging") {

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -1481,6 +1481,11 @@ extension MainViewController {
         browserTabViewController.openNewTab(with: .bookmarks)
     }
 
+    @objc func inspectFavicons(_ sender: Any?) {
+        makeKeyIfNeeded()
+        browserTabViewController.openNewTab(with: .url(.favicons, source: .ui))
+    }
+
     @objc func showHistory(_ sender: Any?) {
         makeKeyIfNeeded()
         browserTabViewController.openNewTab(with: .anyHistoryPane)

--- a/macOS/DuckDuckGo/Tab/Navigation/DuckURLSchemeHandler.swift
+++ b/macOS/DuckDuckGo/Tab/Navigation/DuckURLSchemeHandler.swift
@@ -34,6 +34,9 @@ final class DuckURLSchemeHandler: NSObject, WKURLSchemeHandler {
     /// image decode). Used to skip messaging a task that WebKit has already stopped.
     private var runningFaviconTasks = Set<ObjectIdentifier>()
 
+    /// Debug-only Favicons inspector served at `duck://favicons` (Debug ▸ Inspect Favicons).
+    private lazy var faviconsDebugInspector = FaviconsDebugInspector(faviconManager: faviconManager)
+
     init(
         featureFlagger: FeatureFlagger,
         faviconManager: FaviconManagement = NSApp.delegateTyped.faviconManager,
@@ -78,6 +81,11 @@ final class DuckURLSchemeHandler: NSObject, WKURLSchemeHandler {
             default:
                 handleSpecialPages(urlSchemeTask: urlSchemeTask)
             }
+        case .favicons:
+            guard featureFlagger.internalUserDecider.isInternalUser else {
+                fallthrough
+            }
+            faviconsDebugInspector.handle(requestURL: requestURL, urlSchemeTask: urlSchemeTask)
         default:
             handleNativeUIPages(requestURL: requestURL, urlSchemeTask: urlSchemeTask)
         }
@@ -87,6 +95,7 @@ final class DuckURLSchemeHandler: NSObject, WKURLSchemeHandler {
         // A favicon task may still be awaiting its image decode; drop it so the pending completion is
         // skipped instead of messaging a stopped task (which would crash).
         runningFaviconTasks.remove(ObjectIdentifier(urlSchemeTask))
+        faviconsDebugInspector.webViewDidStop(urlSchemeTask)
     }
 
     private lazy var faviconsFetcherOnboarding: FaviconsFetcherOnboarding? = {
@@ -379,6 +388,7 @@ private extension URL {
         case newTab
         case history
         case favicon
+        case favicons
         case customBackgroundImage
         case customBackgroundImageThumbnail
         case onboarding
@@ -406,6 +416,8 @@ private extension URL {
             return .newTab
         } else if self.isFavicon {
             return .favicon
+        } else if self.isFavicons {
+            return .favicons
         } else if self.isHistory {
             return .history
         } else {

--- a/macOS/UnitTests/DuckSchemeHandler/DuckSchemeHandlerTests.swift
+++ b/macOS/UnitTests/DuckSchemeHandler/DuckSchemeHandlerTests.swift
@@ -89,6 +89,115 @@ final class DuckSchemeHandlerTests: XCTestCase {
         XCTAssertNil(task.error)
     }
 
+    // MARK: - Favicons inspector (duck://favicons)
+
+    @MainActor
+    func testFaviconsInspectorServesPageHTML() throws {
+        let inspector = FaviconsDebugInspector(faviconManager: FaviconManagerMock())
+        let task = MockSchemeTask(request: URLRequest(url: URL.favicons))
+
+        inspector.handle(requestURL: URL.favicons, urlSchemeTask: task)
+
+        XCTAssertEqual(task.response?.mimeType, "text/html")
+        let html = String(data: try XCTUnwrap(task.data), encoding: .utf8) ?? ""
+        XCTAssertTrue(html.contains("Favicons"))
+        XCTAssertTrue(html.contains("/app.js"))
+        XCTAssertTrue(task.didFinishCalled)
+    }
+
+    @MainActor
+    func testFaviconsInspectorServesAppScript() throws {
+        let inspector = FaviconsDebugInspector(faviconManager: FaviconManagerMock())
+        let url = try XCTUnwrap(URL(string: "duck://favicons/app.js"))
+        let task = MockSchemeTask(request: URLRequest(url: url))
+
+        inspector.handle(requestURL: url, urlSchemeTask: task)
+
+        XCTAssertEqual(task.response?.mimeType, "text/javascript")
+        let js = String(data: try XCTUnwrap(task.data), encoding: .utf8) ?? ""
+        XCTAssertTrue(js.contains("/api/list"))
+        XCTAssertTrue(task.didFinishCalled)
+    }
+
+    @MainActor
+    func testFaviconsInspectorListReturnsJSON() async throws {
+        let faviconManager = FaviconManagerMock()
+        let identifier = UUID()
+        faviconManager.debugMetadata = [
+            FaviconMetadata(identifier: identifier,
+                            url: try XCTUnwrap("https://example.com/favicon.ico".url),
+                            documentUrl: try XCTUnwrap("https://example.com".url),
+                            dateCreated: Date(),
+                            relation: .favicon)
+        ]
+        let inspector = FaviconsDebugInspector(faviconManager: faviconManager)
+        let url = try XCTUnwrap(URL(string: "duck://favicons/api/list"))
+        let task = MockSchemeTask(request: URLRequest(url: url))
+        let finished = expectation(description: "list finished")
+        task.onCompletion = { finished.fulfill() }
+
+        inspector.handle(requestURL: url, urlSchemeTask: task)
+        await fulfillment(of: [finished], timeout: 5)
+
+        XCTAssertEqual(task.response?.mimeType, "application/json")
+        let json = String(data: try XCTUnwrap(task.data), encoding: .utf8) ?? ""
+        XCTAssertTrue(json.contains("example.com"))
+        XCTAssertTrue(json.contains(identifier.uuidString))
+    }
+
+    @MainActor
+    func testFaviconsInspectorDeleteRemovesFaviconsAndReportsCount() async throws {
+        let faviconManager = FaviconManagerMock()
+        let identifier = UUID()
+        faviconManager.debugMetadata = [
+            FaviconMetadata(identifier: identifier,
+                            url: try XCTUnwrap("https://example.com/favicon.ico".url),
+                            documentUrl: try XCTUnwrap("https://example.com".url),
+                            dateCreated: Date(),
+                            relation: .favicon)
+        ]
+        let inspector = FaviconsDebugInspector(faviconManager: faviconManager)
+        let url = try XCTUnwrap(URL(string: "duck://favicons/api/delete?ids=\(identifier.uuidString)"))
+        let task = MockSchemeTask(request: URLRequest(url: url))
+        let finished = expectation(description: "delete finished")
+        task.onCompletion = { finished.fulfill() }
+
+        inspector.handle(requestURL: url, urlSchemeTask: task)
+        await fulfillment(of: [finished], timeout: 5)
+
+        XCTAssertEqual(faviconManager.deletedIdentifiers, [[identifier]])
+        let json = String(data: try XCTUnwrap(task.data), encoding: .utf8) ?? ""
+        XCTAssertTrue(json.contains("\"deleted\":1"))
+    }
+
+    @MainActor
+    func testFaviconsInspectorIsNotServedToNonInternalUsers() throws {
+        let featureFlagger = MockFeatureFlagger(internalUserDecider: MockInternalUserDecider(isInternalUser: false))
+        let handler = DuckURLSchemeHandler(featureFlagger: featureFlagger, faviconManager: FaviconManagerMock())
+        let task = MockSchemeTask(request: URLRequest(url: URL.favicons))
+
+        // Route through the scheme handler (where the internal-user gate lives), not the inspector directly.
+        handler.webView(WKWebView(), start: task)
+
+        // For non-internal users duck://favicons falls through to the empty native UI page — not the inspector.
+        let html = String(data: try XCTUnwrap(task.data), encoding: .utf8) ?? ""
+        XCTAssertFalse(html.contains("Favicons"))
+        XCTAssertFalse(html.contains("/app.js"))
+    }
+
+    @MainActor
+    func testFaviconsInspectorIsServedToInternalUsers() throws {
+        let featureFlagger = MockFeatureFlagger(internalUserDecider: MockInternalUserDecider(isInternalUser: true))
+        let handler = DuckURLSchemeHandler(featureFlagger: featureFlagger, faviconManager: FaviconManagerMock())
+        let task = MockSchemeTask(request: URLRequest(url: URL.favicons))
+
+        handler.webView(WKWebView(), start: task)
+
+        let html = String(data: try XCTUnwrap(task.data), encoding: .utf8) ?? ""
+        XCTAssertTrue(html.contains("Favicons"))
+        XCTAssertTrue(html.contains("/app.js"))
+    }
+
     private func makeTestImage() -> NSImage {
         let rep = NSBitmapImageRep(
             bitmapDataPlanes: nil,

--- a/macOS/UnitTests/Favicons/FaviconImageCacheTests.swift
+++ b/macOS/UnitTests/Favicons/FaviconImageCacheTests.swift
@@ -176,4 +176,68 @@ final class FaviconImageCacheTests: XCTestCase {
         XCTAssertNotNil(cached?.image)
         XCTAssertEqual(store.loadImageCallCount, 1)
     }
+
+    // MARK: debug / admin removal (Favicon Browser)
+
+    @MainActor
+    func testRemoveFaviconsWithIdentifiersDeletesFromCacheAndStoreAndNotifies() async throws {
+        let store = FaviconStoringMock()
+        let faviconURL = try XCTUnwrap("https://example.com/favicon.ico".url)
+        let documentURL = try XCTUnwrap("https://example.com".url)
+        let identifier = UUID()
+        store.metadataToLoad = [
+            FaviconMetadata(identifier: identifier, url: faviconURL, documentUrl: documentURL, dateCreated: Date(), relation: .favicon)
+        ]
+
+        let cache = FaviconImageCache(faviconStoring: store)
+        try await cache.load()
+
+        let cacheUpdated = expectation(forNotification: .faviconCacheUpdated, object: nil)
+        await cache.removeFavicons(withIdentifiers: [identifier])
+        await fulfillment(of: [cacheUpdated], timeout: 5)
+
+        // Removed from the in-memory metadata map and from the store.
+        XCTAssertNil(cache.get(faviconUrl: faviconURL))
+        XCTAssertEqual(store.removedFaviconIdentifiers, [identifier])
+    }
+
+    @MainActor
+    func testRemoveFaviconsWithUnknownIdentifierDoesNothing() async throws {
+        let store = FaviconStoringMock()
+        let faviconURL = try XCTUnwrap("https://example.com/favicon.ico".url)
+        let documentURL = try XCTUnwrap("https://example.com".url)
+        store.metadataToLoad = [
+            FaviconMetadata(identifier: UUID(), url: faviconURL, documentUrl: documentURL, dateCreated: Date(), relation: .favicon)
+        ]
+
+        let cache = FaviconImageCache(faviconStoring: store)
+        try await cache.load()
+
+        await cache.removeFavicons(withIdentifiers: [UUID()])
+
+        XCTAssertNotNil(cache.get(faviconUrl: faviconURL))
+        XCTAssertTrue(store.removedFaviconIdentifiers.isEmpty)
+    }
+
+    @MainActor
+    func testRemoveAllFaviconsDeletesEveryRecord() async throws {
+        let store = FaviconStoringMock()
+        let url1 = try XCTUnwrap("https://a.example/favicon.ico".url)
+        let url2 = try XCTUnwrap("https://b.example/favicon.ico".url)
+        let id1 = UUID()
+        let id2 = UUID()
+        store.metadataToLoad = [
+            FaviconMetadata(identifier: id1, url: url1, documentUrl: try XCTUnwrap("https://a.example".url), dateCreated: Date(), relation: .favicon),
+            FaviconMetadata(identifier: id2, url: url2, documentUrl: try XCTUnwrap("https://b.example".url), dateCreated: Date(), relation: .icon)
+        ]
+
+        let cache = FaviconImageCache(faviconStoring: store)
+        try await cache.load()
+
+        await cache.removeAllFavicons()
+
+        XCTAssertNil(cache.get(faviconUrl: url1))
+        XCTAssertNil(cache.get(faviconUrl: url2))
+        XCTAssertEqual(Set(store.removedFaviconIdentifiers), [id1, id2])
+    }
 }

--- a/macOS/UnitTests/Favicons/FaviconImageCacheTests.swift
+++ b/macOS/UnitTests/Favicons/FaviconImageCacheTests.swift
@@ -240,4 +240,38 @@ final class FaviconImageCacheTests: XCTestCase {
         XCTAssertNil(cache.get(faviconUrl: url2))
         XCTAssertEqual(Set(store.removedFaviconIdentifiers), [id1, id2])
     }
+
+    @MainActor
+    func testRemoveFaviconsWithIdentifiersDeletesFromStoreEvenBeforeCacheLoaded() async throws {
+        let store = FaviconStoringMock()
+        let faviconURL = try XCTUnwrap("https://example.com/favicon.ico".url)
+        let documentURL = try XCTUnwrap("https://example.com".url)
+        let identifier = UUID()
+        store.metadataToLoad = [
+            FaviconMetadata(identifier: identifier, url: faviconURL, documentUrl: documentURL, dateCreated: Date(), relation: .favicon)
+        ]
+
+        let cache = FaviconImageCache(faviconStoring: store)
+        // Intentionally not loaded: the in-memory metadata map is empty, but the store has the row.
+        await cache.removeFavicons(withIdentifiers: [identifier])
+
+        XCTAssertEqual(store.removedFaviconIdentifiers, [identifier])
+    }
+
+    @MainActor
+    func testRemoveAllFaviconsDeletesFromStoreEvenBeforeCacheLoaded() async throws {
+        let store = FaviconStoringMock()
+        let id1 = UUID()
+        let id2 = UUID()
+        store.metadataToLoad = [
+            FaviconMetadata(identifier: id1, url: try XCTUnwrap("https://a.example/favicon.ico".url), documentUrl: try XCTUnwrap("https://a.example".url), dateCreated: Date(), relation: .favicon),
+            FaviconMetadata(identifier: id2, url: try XCTUnwrap("https://b.example/favicon.ico".url), documentUrl: try XCTUnwrap("https://b.example".url), dateCreated: Date(), relation: .icon)
+        ]
+
+        let cache = FaviconImageCache(faviconStoring: store)
+        // Intentionally not loaded.
+        await cache.removeAllFavicons()
+
+        XCTAssertEqual(Set(store.removedFaviconIdentifiers), [id1, id2])
+    }
 }

--- a/macOS/UnitTests/Favicons/FaviconReferenceCacheTests.swift
+++ b/macOS/UnitTests/Favicons/FaviconReferenceCacheTests.swift
@@ -75,6 +75,22 @@ class FaviconReferenceCacheTests: XCTestCase {
         XCTAssertEqual(URL.aFaviconUrl1, referenceCache.getFaviconUrl(for: URL.aDocumentUrl1.host!, sizeCategory: .small))
         XCTAssertEqual(URL.aFaviconUrl1, referenceCache.getFaviconUrl(for: URL.aDocumentUrl2, sizeCategory: .small))
     }
+
+    @MainActor
+    func testRemoveAllReferencesDeletesFromStoreEvenBeforeCacheLoaded() async throws {
+        let store = FaviconStoringMock()
+        let hostReference = FaviconHostReference(identifier: UUID(), smallFaviconUrl: URL.aFaviconUrl1, mediumFaviconUrl: nil, host: "fav.com", documentUrl: URL.aDocumentUrl1, dateCreated: Date())
+        let urlReference = FaviconUrlReference(identifier: UUID(), smallFaviconUrl: URL.aFaviconUrl2, mediumFaviconUrl: nil, documentUrl: URL.aDocumentUrl2, dateCreated: Date())
+        store.hostReferencesToLoad = [hostReference]
+        store.urlReferencesToLoad = [urlReference]
+
+        let referenceCache = FaviconReferenceCache(faviconStoring: store)
+        // Intentionally not loaded: the in-memory reference maps are empty, but the store has the rows.
+        await referenceCache.removeAllReferences()
+
+        XCTAssertEqual(store.removedHostReferenceIdentifiers, [hostReference.identifier])
+        XCTAssertEqual(store.removedUrlReferenceIdentifiers, [urlReference.identifier])
+    }
 }
 
 private extension URL {

--- a/macOS/UnitTests/Favicons/FaviconStoringMock.swift
+++ b/macOS/UnitTests/Favicons/FaviconStoringMock.swift
@@ -34,6 +34,7 @@ final class FaviconStoringMock: FaviconStoring {
     private(set) var loadFaviconMetadataCallCount = 0
     private(set) var loadImageCallCount = 0
     private(set) var loadImageIdentifiers: [UUID] = []
+    private(set) var removedFaviconIdentifiers: [UUID] = []
 
     func loadFavicons() async throws -> [Favicon] {
         loadFaviconsCallCount += 1
@@ -56,7 +57,7 @@ final class FaviconStoringMock: FaviconStoring {
     }
 
     func removeFavicons(_ favicons: [Favicon]) async throws {
-        ()
+        removedFaviconIdentifiers.append(contentsOf: favicons.map(\.identifier))
     }
 
     func loadFaviconReferences() async throws -> ([FaviconHostReference], [FaviconUrlReference]) {

--- a/macOS/UnitTests/Favicons/FaviconStoringMock.swift
+++ b/macOS/UnitTests/Favicons/FaviconStoringMock.swift
@@ -28,6 +28,8 @@ final class FaviconStoringMock: FaviconStoring {
     var faviconsToLoad: [Favicon] = []
     var metadataToLoad: [FaviconMetadata] = []
     var imagesByIdentifier: [UUID: NSImage] = [:]
+    var hostReferencesToLoad: [FaviconHostReference] = []
+    var urlReferencesToLoad: [FaviconUrlReference] = []
 
     // Call recording.
     private(set) var loadFaviconsCallCount = 0
@@ -35,6 +37,8 @@ final class FaviconStoringMock: FaviconStoring {
     private(set) var loadImageCallCount = 0
     private(set) var loadImageIdentifiers: [UUID] = []
     private(set) var removedFaviconIdentifiers: [UUID] = []
+    private(set) var removedHostReferenceIdentifiers: [UUID] = []
+    private(set) var removedUrlReferenceIdentifiers: [UUID] = []
 
     func loadFavicons() async throws -> [Favicon] {
         loadFaviconsCallCount += 1
@@ -61,7 +65,7 @@ final class FaviconStoringMock: FaviconStoring {
     }
 
     func loadFaviconReferences() async throws -> ([FaviconHostReference], [FaviconUrlReference]) {
-        ([], [])
+        (hostReferencesToLoad, urlReferencesToLoad)
     }
 
     func save(hostReference: FaviconHostReference) async throws {
@@ -73,11 +77,11 @@ final class FaviconStoringMock: FaviconStoring {
     }
 
     func remove(hostReferences: [FaviconHostReference]) async throws {
-        ()
+        removedHostReferenceIdentifiers.append(contentsOf: hostReferences.map(\.identifier))
     }
 
     func remove(urlReferences: [FaviconUrlReference]) async throws {
-        ()
+        removedUrlReferenceIdentifiers.append(contentsOf: urlReferences.map(\.identifier))
     }
 
 }

--- a/macOS/UnitTests/Favicons/Mocks/CapturingFaviconImageCache.swift
+++ b/macOS/UnitTests/Favicons/Mocks/CapturingFaviconImageCache.swift
@@ -70,6 +70,14 @@ final class CapturingFaviconImageCache: FaviconImageCaching {
         return .success(())
     }
 
+    func removeFavicons(withIdentifiers identifiers: Set<UUID>) async {
+        removeFaviconsWithIdentifiersCalls.append(identifiers)
+    }
+
+    func removeAllFavicons() async {
+        removeAllFaviconsCallsCount += 1
+    }
+
     var loadCallsCount: Int = 0
     var insertCalls: [[Favicon]] = []
     var getFaviconWithURLCalls: [URL] = []
@@ -78,6 +86,8 @@ final class CapturingFaviconImageCache: FaviconImageCaching {
     var cleanCallsCount: Int = 0
     var burnCallsCount: Int = 0
     var burnDomainsCallsCount: Int = 0
+    var removeFaviconsWithIdentifiersCalls: [Set<UUID>] = []
+    var removeAllFaviconsCallsCount: Int = 0
 
     var getFaviconWithURL: (URL) -> Favicon? = { _ in nil }
     var getFaviconsWithURLs: (any Sequence<URL>) -> [Favicon]? = { _ in nil }

--- a/macOS/UnitTests/Favicons/Mocks/CapturingFaviconReferenceCache.swift
+++ b/macOS/UnitTests/Favicons/Mocks/CapturingFaviconReferenceCache.swift
@@ -65,6 +65,10 @@ final class CapturingFaviconReferenceCache: FaviconReferenceCaching {
         burnDomainsCallsCount += 1
     }
 
+    func removeAllReferences() async {
+        removeAllReferencesCallsCount += 1
+    }
+
     struct Insert: Equatable {
         let smallURL: URL?
         let mediumURL: URL?
@@ -105,6 +109,7 @@ final class CapturingFaviconReferenceCache: FaviconReferenceCaching {
     var cleanCallsCount: Int = 0
     var burnCallsCount: Int = 0
     var burnDomainsCallsCount: Int = 0
+    var removeAllReferencesCallsCount: Int = 0
 
     var getFaviconURLForDocumentURL: (URL, Favicon.SizeCategory) -> URL? = { _, _ in nil }
     var getFaviconURLForHost: (String, Favicon.SizeCategory) -> URL? = { _, _ in nil }

--- a/macOS/scripts/db-decrypt.swift
+++ b/macOS/scripts/db-decrypt.swift
@@ -1,0 +1,322 @@
+#!/usr/bin/env swift
+//
+// ddg-db-decrypt.swift
+//
+// Read DECRYPTED contents of a DuckDuckGo macOS Core Data store (Database.sqlite).
+//
+// Sensitive columns (named *ENCRYPTED) are stored as:
+//     ChaChaPoly.seal( NSKeyedArchiver(value) ).combined
+// i.e. CryptoKit ChaCha20-Poly1305, combined = 12B nonce ‖ ciphertext ‖ 16B tag,
+// wrapping an NSKeyedArchiver(requiringSecureCoding) archive of an NSURL / NSString /
+// NSImage. This tool reverses exactly that (CryptoKit + NSKeyedUnarchiver), so it
+// matches the app byte-for-byte, including favicon images.
+//
+// The 32-byte symmetric key lives in the login keychain and is shared by all
+// non-App-Store builds (prod + debug): service "DuckDuckGo Privacy Browser Encryption
+// Key v2", account "com.duckduckgo.macos.browser". The key is NEVER hard-coded here.
+//
+// KEY SOURCES (first match wins):
+//   1. --key <base64>
+//   2. $DDG_DB_KEY
+//   3. keychain via `/usr/bin/security` (may show a one-time auth prompt — click
+//      "Always Allow" to make future runs non-interactive)
+//
+// USAGE:
+//   ddg-db-decrypt.swift [global opts] <command> [args]
+//
+// COMMANDS:
+//   tables                       List Z* entity tables (excluding Z_*) with row counts
+//   dump <ZTABLE>                Print rows as TSV; *ENCRYPTED columns are decrypted
+//                                (URL/String shown inline; image columns show byte size,
+//                                 plus WxH pixels when --pixels is given)
+//   export-favicons <OUTDIR>     Decrypt favicon images to PNGs in OUTDIR + manifest.tsv
+//   key-check                    Confirm the key decrypts a sample value
+//
+// GLOBAL OPTIONS:
+//   --db PATH        SQLite store (default: the .debug container's Database.sqlite)
+//   --key BASE64     encryption key (base64); overrides env/keychain
+//   --service NAME   keychain service (default: DuckDuckGo Privacy Browser Encryption Key v2)
+//   --account NAME   keychain account (default: com.duckduckgo.macos.browser)
+//   --limit N        max rows for dump/export-favicons (default: all)
+//   --pixels         dump: also decode image columns to report pixel WxH (slower)
+//
+// EXAMPLES:
+//   ddg-db-decrypt.swift tables
+//   ddg-db-decrypt.swift dump ZFAVICONMANAGEDOBJECT --limit 20 --pixels
+//   ddg-db-decrypt.swift dump ZHISTORYENTRYMANAGEDOBJECT --limit 50
+//   ddg-db-decrypt.swift export-favicons ~/Desktop/favicons
+//   DDG_DB_KEY=$(security find-generic-password -w -s "DuckDuckGo Privacy Browser Encryption Key v2" -a com.duckduckgo.macos.browser) ddg-db-decrypt.swift key-check
+//
+import Foundation
+import CryptoKit
+import AppKit
+import SQLite3
+
+let SERVICE_DEFAULT = "DuckDuckGo Privacy Browser Encryption Key v2"
+let ACCOUNT_DEFAULT = "com.duckduckgo.macos.browser"
+let DB_DEFAULT = ("~/Library/Containers/com.duckduckgo.macos.browser.debug/Data/Library/Application Support/Database.sqlite" as NSString).expandingTildeInPath
+
+func die(_ msg: String) -> Never {
+    FileHandle.standardError.write(Data(("error: " + msg + "\n").utf8))
+    exit(1)
+}
+
+// ---------------- argument parsing ----------------
+var args = Array(CommandLine.arguments.dropFirst())
+func popValue(_ names: [String]) -> String? {
+    for name in names {
+        if let i = args.firstIndex(of: name), i + 1 < args.count {
+            let v = args[i + 1]; args.removeSubrange(i...(i + 1)); return v
+        }
+    }
+    return nil
+}
+func popBool(_ names: [String]) -> Bool {
+    for name in names { if let i = args.firstIndex(of: name) { args.remove(at: i); return true } }
+    return false
+}
+
+let wantHelp = popBool(["-h", "--help"])
+let dbPath = popValue(["--db"]) ?? DB_DEFAULT
+let keyArg = popValue(["--key"])
+let service = popValue(["--service"]) ?? SERVICE_DEFAULT
+let account = popValue(["--account"]) ?? ACCOUNT_DEFAULT
+let limit = Int(popValue(["--limit"]) ?? "") ?? 0   // 0 == all
+let withPixels = popBool(["--pixels"])
+
+let HELP = """
+ddg-db-decrypt.swift — read decrypted DuckDuckGo Core Data contents (ChaChaPoly + NSKeyedArchiver)
+
+USAGE:  ddg-db-decrypt.swift [global opts] <command> [args]
+
+COMMANDS:
+  tables                     List Z* entity tables (excl. Z_*) with row counts
+  dump <ZTABLE>              Decrypt & print rows as TSV (*ENCRYPTED cols decrypted)
+  export-favicons <OUTDIR>   Decrypt favicon images to PNGs + manifest.tsv
+  key-check                  Verify the key can decrypt a sample value
+
+GLOBAL OPTIONS:
+  --db PATH       SQLite store (default: debug container Database.sqlite)
+  --key BASE64    encryption key (base64); else $DDG_DB_KEY; else keychain via `security`
+  --service NAME  keychain service (default: \(SERVICE_DEFAULT))
+  --account NAME  keychain account (default: \(ACCOUNT_DEFAULT))
+  --limit N       max rows for dump/export (default: all)
+  --pixels        dump: also decode image columns to report pixel WxH (slower)
+
+KEY SOURCES (in order):  --key  >  $DDG_DB_KEY  >  keychain (may prompt; click Always Allow)
+"""
+
+if wantHelp { print(HELP); exit(0) }
+guard let command = args.first else { print(HELP); exit(2) }
+args.removeFirst()
+
+// ---------------- key ----------------
+func keychainKeyBase64() -> String? {
+    let p = Process()
+    p.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+    p.arguments = ["find-generic-password", "-w", "-s", service, "-a", account]
+    let out = Pipe(); p.standardOutput = out; p.standardError = Pipe()
+    do { try p.run() } catch { return nil }
+    p.waitUntilExit()
+    guard p.terminationStatus == 0 else { return nil }
+    let d = out.fileHandleForReading.readDataToEndOfFile()
+    return String(data: d, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+func loadKey() -> SymmetricKey {
+    let b64 = keyArg ?? ProcessInfo.processInfo.environment["DDG_DB_KEY"] ?? keychainKeyBase64()
+    guard let b64 = b64, !b64.isEmpty else {
+        die("no key available — pass --key, set $DDG_DB_KEY, or allow the keychain read " +
+            "(service \"\(service)\", account \"\(account)\").")
+    }
+    guard let raw = Data(base64Encoded: b64) else { die("key is not valid base64") }
+    guard raw.count == 32 else { die("expected a 32-byte key, got \(raw.count) bytes") }
+    return SymmetricKey(data: raw)
+}
+
+// ---------------- crypto / unarchive ----------------
+func decrypt(_ blob: Data, _ key: SymmetricKey) -> Data? {
+    guard let box = try? ChaChaPoly.SealedBox(combined: blob) else { return nil }
+    return try? ChaChaPoly.open(box, using: key)
+}
+func asURL(_ d: Data) -> String? {
+    (try? NSKeyedUnarchiver.unarchivedObject(ofClass: NSURL.self, from: d)).flatMap { ($0 as URL).absoluteString }
+}
+func asString(_ d: Data) -> String? {
+    (try? NSKeyedUnarchiver.unarchivedObject(ofClass: NSString.self, from: d)) as String?
+}
+func asImage(_ d: Data) -> NSImage? {
+    try? NSKeyedUnarchiver.unarchivedObject(ofClass: NSImage.self, from: d)
+}
+func pixelSize(_ img: NSImage) -> (Int, Int) {
+    var w = 0, h = 0
+    for r in img.representations { w = max(w, r.pixelsWide); h = max(h, r.pixelsHigh) }
+    if w == 0 { w = Int(img.size.width); h = Int(img.size.height) }
+    return (w, h)
+}
+func pngData(_ img: NSImage) -> Data? {
+    let bitmaps = img.representations.compactMap { $0 as? NSBitmapImageRep }
+    if let best = bitmaps.max(by: { $0.pixelsWide * $0.pixelsHigh < $1.pixelsWide * $1.pixelsHigh }) {
+        return best.representation(using: .png, properties: [:])
+    }
+    guard let tiff = img.tiffRepresentation, let rep = NSBitmapImageRep(data: tiff) else { return nil }
+    return rep.representation(using: .png, properties: [:])
+}
+
+let isoFmt = ISO8601DateFormatter()
+func coreDataDate(_ secondsSince2001: Double) -> String {
+    isoFmt.string(from: Date(timeIntervalSinceReferenceDate: secondsSince2001))
+}
+func uuidFromBlob(_ d: Data) -> String? {
+    guard d.count == 16 else { return nil }
+    let b = [UInt8](d)
+    let u: uuid_t = (b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
+                     b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15])
+    return UUID(uuid: u).uuidString
+}
+
+// ---------------- sqlite (read-only) ----------------
+enum Cell { case null, int(Int64), real(Double), text(String), blob(Data) }
+
+func openDB() -> OpaquePointer {
+    guard FileManager.default.fileExists(atPath: dbPath) else { die("DB not found: \(dbPath)") }
+    var db: OpaquePointer?
+    guard sqlite3_open_v2(dbPath, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK, let db = db else {
+        die("cannot open DB read-only: \(dbPath)")
+    }
+    return db
+}
+func query(_ db: OpaquePointer, _ sql: String) -> (cols: [String], rows: [[Cell]]) {
+    var stmt: OpaquePointer?
+    guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+        die("SQL error: \(String(cString: sqlite3_errmsg(db)))")
+    }
+    defer { sqlite3_finalize(stmt) }
+    let n = sqlite3_column_count(stmt)
+    var cols = [String]()
+    for i in 0..<n { cols.append(String(cString: sqlite3_column_name(stmt, i))) }
+    var rows = [[Cell]]()
+    while sqlite3_step(stmt) == SQLITE_ROW {
+        var row = [Cell]()
+        for i in 0..<n {
+            switch sqlite3_column_type(stmt, i) {
+            case SQLITE_NULL: row.append(.null)
+            case SQLITE_INTEGER: row.append(.int(sqlite3_column_int64(stmt, i)))
+            case SQLITE_FLOAT: row.append(.real(sqlite3_column_double(stmt, i)))
+            case SQLITE_TEXT: row.append(.text(String(cString: sqlite3_column_text(stmt, i))))
+            case SQLITE_BLOB:
+                if let p = sqlite3_column_blob(stmt, i) {
+                    row.append(.blob(Data(bytes: p, count: Int(sqlite3_column_bytes(stmt, i)))))
+                } else { row.append(.blob(Data())) }
+            default: row.append(.null)
+            }
+        }
+        rows.append(row)
+    }
+    return (cols, rows)
+}
+func limitClause() -> String { limit > 0 ? " LIMIT \(limit)" : "" }
+
+// ---------------- formatting ----------------
+func format(col: String, cell: Cell, key: SymmetricKey) -> String {
+    let up = col.uppercased()
+    switch cell {
+    case .null: return ""
+    case .int(let v): return String(v)
+    case .real(let v): return up.contains("DATE") ? coreDataDate(v) : String(v)
+    case .text(let s): return s
+    case .blob(let d):
+        if up.hasSuffix("ENCRYPTED") {
+            if up.contains("IMAGE") {
+                var s = "<image \(d.count)B"
+                if withPixels, let plain = decrypt(d, key), let img = asImage(plain) {
+                    let (w, h) = pixelSize(img); s += " \(w)x\(h)px"
+                }
+                return s + ">"
+            }
+            guard let plain = decrypt(d, key) else { return "<decrypt-failed \(d.count)B>" }
+            return asURL(plain) ?? asString(plain) ?? "<\(plain.count)B decrypted>"
+        }
+        if up == "ZIDENTIFIER", let u = uuidFromBlob(d) { return u }
+        return "<\(d.count)B blob>"
+    }
+}
+
+// ---------------- commands ----------------
+func cmdTables() {
+    let db = openDB()
+    let t = query(db, "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'Z%' AND name NOT LIKE 'Z\\_%' ESCAPE '\\' ORDER BY name;")
+    for r in t.rows {
+        guard case let .text(name) = r[0] else { continue }
+        let c = query(db, "SELECT count(*) FROM \"\(name)\";")
+        var count: Int64 = 0
+        if case let .int(v) = c.rows.first?.first ?? .int(0) { count = v }
+        print("\(name)\t\(count)")
+    }
+}
+
+func cmdDump() {
+    guard let table = args.first else { die("dump needs a table name, e.g. ZFAVICONMANAGEDOBJECT") }
+    let key = loadKey()
+    let db = openDB()
+    let res = query(db, "SELECT * FROM \"\(table)\"\(limitClause());")
+    print(res.cols.joined(separator: "\t"))
+    for row in res.rows {
+        var out = [String]()
+        for (i, cell) in row.enumerated() {
+            out.append(format(col: res.cols[i], cell: cell, key: key).replacingOccurrences(of: "\t", with: " "))
+        }
+        print(out.joined(separator: "\t"))
+    }
+}
+
+func cmdExportFavicons() {
+    guard let dir = args.first else { die("export-favicons needs an output directory") }
+    let key = loadKey()
+    let outDir = (dir as NSString).expandingTildeInPath
+    try? FileManager.default.createDirectory(atPath: outDir, withIntermediateDirectories: true)
+    let db = openDB()
+    let res = query(db, "SELECT ZIDENTIFIER, ZURLENCRYPTED, ZIMAGEENCRYPTED FROM ZFAVICONMANAGEDOBJECT\(limitClause());")
+    var manifest = "file\tfaviconURL\tencryptedBytes\tpixels\n"
+    var ok = 0, fail = 0, idx = 0
+    for row in res.rows {
+        idx += 1
+        var id = "row\(idx)"
+        if case let .blob(d) = row[0], let u = uuidFromBlob(d) { id = u }
+        else if case let .text(s) = row[0] { id = s }
+        var faviconURL = ""
+        if case let .blob(d) = row[1], let plain = decrypt(d, key), let u = asURL(plain) { faviconURL = u }
+        guard case let .blob(imgBlob) = row[2], !imgBlob.isEmpty,
+              let plain = decrypt(imgBlob, key), let img = asImage(plain), let png = pngData(img) else {
+            fail += 1; continue
+        }
+        let (w, h) = pixelSize(img)
+        let file = "\(id).png"
+        do {
+            try png.write(to: URL(fileURLWithPath: outDir).appendingPathComponent(file))
+            manifest += "\(file)\t\(faviconURL)\t\(imgBlob.count)\t\(w)x\(h)\n"
+            ok += 1
+        } catch { fail += 1 }
+    }
+    try? manifest.write(to: URL(fileURLWithPath: outDir).appendingPathComponent("manifest.tsv"), atomically: true, encoding: .utf8)
+    print("exported \(ok) favicon image(s) to \(outDir) (\(fail) skipped). manifest.tsv written.")
+}
+
+func cmdKeyCheck() {
+    let key = loadKey()
+    let db = openDB()
+    let res = query(db, "SELECT ZURLENCRYPTED FROM ZFAVICONMANAGEDOBJECT WHERE ZURLENCRYPTED IS NOT NULL LIMIT 1;")
+    guard case let .blob(d)? = res.rows.first?.first else { die("no sample row found in ZFAVICONMANAGEDOBJECT") }
+    guard let plain = decrypt(d, key), let url = asURL(plain) else {
+        die("key did NOT decrypt the sample value — wrong key or wrong DB.")
+    }
+    print("OK — key decrypts. Sample favicon URL: \(url)")
+}
+
+switch command.lowercased() {
+case "tables":           cmdTables()
+case "dump":             cmdDump()
+case "export-favicons":  cmdExportFavicons()
+case "key-check":        cmdKeyCheck()
+default:                 die("unknown command '\(command)'. Run with --help.")
+}

--- a/macOS/scripts/import-prod-db-to-debug.sh
+++ b/macOS/scripts/import-prod-db-to-debug.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# ddg-import-prod-db-to-debug.sh
+#
+# Copy the DuckDuckGo macOS *production* Core Data store (Database.sqlite — holds
+# History + Favicons, including the encrypted favicon image BLOBs) into the *debug*
+# build's sandbox container, replacing whatever is there.
+#
+# What it does:
+#   1. Takes a CONSISTENT online snapshot of the live production DB (sqlite .backup,
+#      so it's safe to run while the production app is open; committed WAL included).
+#   2. Verifies the snapshot (integrity_check + favicon row count).
+#   3. Backs up the existing debug DB to a timestamped folder.
+#   4. Installs the snapshot and removes stale -wal/-shm sidecars.
+#
+# Encryption note: prod and debug builds share the same data-encryption key — it's a
+# login-keychain item (service "DuckDuckGo Privacy Browser Encryption Key v2",
+# account "com.duckduckgo.macos.browser") that is NOT isolated by keychain access
+# group — so the debug build can decrypt the imported favicons. On first launch the
+# debug app may show a one-time keychain "Allow" prompt; click Allow (Always Allow).
+#
+# Usage:
+#   ddg-import-prod-db-to-debug.sh [--prod-bundle ID] [--debug-bundle ID] [--db NAME] [-y]
+#
+# Defaults:
+#   --prod-bundle   com.duckduckgo.macos.browser
+#   --debug-bundle  com.duckduckgo.macos.browser.debug
+#   --db            Database.sqlite
+#   -y, --yes       skip the confirmation prompt
+#
+set -euo pipefail
+
+PROD_BUNDLE="com.duckduckgo.macos.browser"
+DEBUG_BUNDLE="com.duckduckgo.macos.browser.debug"
+DB_NAME="Database.sqlite"
+ASSUME_YES=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --prod-bundle)  PROD_BUNDLE="$2";  shift 2 ;;
+    --debug-bundle) DEBUG_BUNDLE="$2"; shift 2 ;;
+    --db)           DB_NAME="$2";      shift 2 ;;
+    -y|--yes)       ASSUME_YES=1;      shift ;;
+    -h|--help)      awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+appsup() { echo "$HOME/Library/Containers/$1/Data/Library/Application Support"; }
+PROD_DIR="$(appsup "$PROD_BUNDLE")"
+DEBUG_DIR="$(appsup "$DEBUG_BUNDLE")"
+PROD_DB="$PROD_DIR/$DB_NAME"
+DEBUG_DB="$DEBUG_DIR/$DB_NAME"
+
+# Row counts for every Core Data ENTITY table (named Z<Entity>), excluding Core
+# Data's bookkeeping/join tables (Z_PRIMARYKEY, Z_METADATA, Z_MODELCACHE, Z_Nx...).
+# The underscore in 'Z_%' is escaped so it matches a literal '_' rather than any
+# single character (which would also exclude real entity tables like ZHISTORY).
+# Output: one "TABLE<TAB>COUNT" line per table, sorted by name.
+z_entity_counts() {
+  local db="$1" t c
+  sqlite3 "$db" "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'Z%' AND name NOT LIKE 'Z\\_%' ESCAPE '\\' ORDER BY name;" |
+  while IFS= read -r t; do
+    c="$(sqlite3 "$db" "SELECT count(*) FROM \"$t\";")"
+    printf '%s\t%s\n' "$t" "$c"
+  done
+}
+
+echo "Source (prod):  $PROD_DB"
+echo "Target (debug): $DEBUG_DB"
+
+command -v sqlite3 >/dev/null 2>&1 || { echo "ERROR: sqlite3 not found" >&2; exit 1; }
+[ -f "$PROD_DB" ]  || { echo "ERROR: production DB not found: $PROD_DB" >&2; exit 1; }
+[ -d "$DEBUG_DIR" ] || { echo "ERROR: debug container not found: $DEBUG_DIR" >&2
+                         echo "       Run the debug build once so the sandbox container is created." >&2; exit 1; }
+
+# Replacing a DB under a running app corrupts its open Core Data stack. Refuse if the
+# debug app is running (its binary always lives under .../Build/Products/Debug/DuckDuckGo.app).
+if pgrep -lf "Build/Products/Debug/DuckDuckGo.app/Contents/MacOS/DuckDuckGo" >/dev/null 2>&1; then
+  echo "ERROR: the debug DuckDuckGo app appears to be running — quit it first." >&2
+  exit 1
+fi
+
+if [ "$ASSUME_YES" -ne 1 ]; then
+  printf "Replace the debug DB with a snapshot of prod? (a timestamped backup is kept) [y/N] "
+  read -r ans
+  case "$ans" in y|Y|yes|YES) ;; *) echo "Aborted."; exit 0 ;; esac
+fi
+
+TS="$(date +%Y%m%d-%H%M%S)"
+SNAP="$(mktemp -t ddg-db-snapshot.XXXXXX)"
+trap 'rm -f "$SNAP"' EXIT
+
+echo "==> Snapshotting live production DB (online backup; safe while prod is open)..."
+# mode=ro (NOT immutable) so the backup includes committed WAL data.
+sqlite3 "file:${PROD_DB}?mode=ro" ".backup '$SNAP'"
+
+echo "==> Verifying snapshot..."
+ic="$(sqlite3 "$SNAP" 'PRAGMA integrity_check;' | head -1)"
+[ "$ic" = "ok" ] || { echo "ERROR: snapshot integrity_check failed: $ic" >&2; exit 1; }
+SNAP_COUNTS="$(z_entity_counts "$SNAP")"
+echo "    integrity: ok | size: $(du -h "$SNAP" | cut -f1) | entity tables: $(printf '%s\n' "$SNAP_COUNTS" | grep -c .)"
+printf '%s\n' "$SNAP_COUNTS" | column -t | sed 's/^/      /'
+
+echo "==> Backing up existing debug DB..."
+BAK="$DEBUG_DIR/_db-backup-$TS"
+made_bak=0
+for f in "$DB_NAME" "$DB_NAME-shm" "$DB_NAME-wal"; do
+  if [ -e "$DEBUG_DIR/$f" ]; then
+    [ "$made_bak" -eq 0 ] && mkdir -p "$BAK" && made_bak=1
+    mv "$DEBUG_DIR/$f" "$BAK/"
+  fi
+done
+[ "$made_bak" -eq 1 ] && echo "    backup: $BAK" || echo "    (nothing to back up)"
+
+echo "==> Installing snapshot (single consistent file; no -wal/-shm)..."
+cp "$SNAP" "$DEBUG_DB"
+chmod 644 "$DEBUG_DB"
+
+echo "==> Verifying installed debug DB..."
+ic2="$(sqlite3 "$DEBUG_DB" 'PRAGMA integrity_check;' | head -1)"
+[ "$ic2" = "ok" ] || { echo "ERROR: installed DB integrity_check failed: $ic2" >&2; exit 1; }
+DEBUG_COUNTS="$(z_entity_counts "$DEBUG_DB")"
+if [ "$DEBUG_COUNTS" = "$SNAP_COUNTS" ]; then
+  echo "    integrity: ok | all $(printf '%s\n' "$SNAP_COUNTS" | grep -c .) entity tables match the snapshot row-for-row:"
+  printf '%s\n' "$DEBUG_COUNTS" | column -t | sed 's/^/      /'
+else
+  echo "ERROR: installed DB entity-table counts differ from the snapshot:" >&2
+  diff <(printf '%s\n' "$SNAP_COUNTS") <(printf '%s\n' "$DEBUG_COUNTS") >&2 || true
+  exit 1
+fi
+
+echo
+echo "Done — imported prod DB into the debug container."
+echo "  • Launch the debug build; click Allow on the one-time keychain prompt if it appears."
+[ "$made_bak" -eq 1 ] && echo "  • Roll back: quit debug app, then restore files from $BAK"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1215770663291731?focus=true

### Description
For internal users, Debug ▸ Inspect Favicons would open a tab at duck://favicons that lists every stored favicon,
with sortable columns (host, size in px/bytes, rel), per-row Copy for the favicon and document URLs, Size shown
as pixel dimensions + bytes, multi-select and delete-all, and host/URL filtering.
Served entirely in-app by FaviconsDebugInspector (page HTML + /app.js + JSON/PNG API), and goes through
the in-app favicon stack, which holds the decryption key the encrypted store needs.

For external users duck://favicons falls through to the empty native page. 

### Testing Steps
Launch the app and navigate to duck://favicons to view your favicons.
Disable internal user state and verify that duck://favicons serves a blank page.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes favicon persistence and cache notification paths used by normal UI after debug deletes, though the inspector is internal-gated; full delete resets references and images, so misuse could clear user favicon data in debug builds.
> 
> **Overview**
> Adds **internal-only** tooling so engineers can browse and manage the encrypted favicon store from the browser.
> 
> **Debug ▸ Inspect Favicons** opens `duck://favicons`, served by new `FaviconsDebugInspector` (embedded HTML/JS plus list/image/delete APIs). The page lists stored favicons with filter, sort, lazy-loaded previews, copy URLs, and selective or full delete. Access goes through a new `FaviconManagementDebugging` surface on `FaviconManager`, keeping debug APIs off the main protocol.
> 
> **Routing and gating:** `DuckURLSchemeHandler` handles the `duck://favicons` scheme only when `internalUserDecider.isInternalUser` is true; others get the usual empty native page. Scheme-task cancellation is tracked to avoid messaging stopped WebKit tasks.
> 
> **Cache/store behavior for deletes:** `FaviconImageCache` / `EagerFaviconImageCache` gain `removeFavicons(withIdentifiers:)` and `removeAllFavicons()` that resolve rows from the **store** (not just in-memory caches), persist removal, and post `.faviconCacheUpdated`. `FaviconReferenceCache.removeAllReferences()` clears host/URL references from the store for a full reset. `deleteAllFavicons()` also wipes references.
> 
> **Supporting scripts:** `macOS/scripts/db-decrypt.swift` and `import-prod-db-to-debug.sh` help inspect or copy prod favicon DB into the debug container for local testing.
> 
> Unit tests cover the inspector HTTP surface, internal-user gate, and delete paths (including pre-`load()` store deletes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 136c706a26135c2bc04da6345a4c17771852d4df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->