### PR TITLE
Add aiFeaturesNativeControls feature flag (iOS + macOS)

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -565,6 +565,11 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// macOS only. When on, the onboarding Search/Duck.ai toggle choice also drives the New Tab Page
     /// search-mode toggle and seeds the duckduckgo.com homepage. Off keeps the choice address-bar only.
     case onboardingToggleAffectsNtpAndDdg
+
+    /// Replaces the web-link Search Assist and Hide AI-Generated Images rows on the AI Features
+    /// settings screen with native controls, regroups the main AI settings at the top, and adds the
+    /// "Disable All AI Options" / Reset button. Off keeps today's web-link rows.
+    case aiFeaturesNativeControls
 }
 
 public enum HtmlNewTabPageSubfeature: String, Equatable, PrivacySubfeature {

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -432,6 +432,12 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214025222413375
     case aiChatNativeDataAccess
 
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215798369772677
+    /// Replaces the web-link Search Assist and Hide AI-Generated Images rows on the AI Features
+    /// settings screen with native controls, regroups the main AI settings at the top, and adds the
+    /// "Disable All AI Options" / Reset button. Off keeps today's web-link rows.
+    case aiFeaturesNativeControls
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214777651593367?focus=true
     case omniBarLongPressMenu
 
@@ -791,6 +797,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.nativeStoragePathMigration))
         case .aiChatNativeDataAccess:
             Config(source: .remoteReleasable(AIChatSubfeature.nativeDataAccess))
+        case .aiFeaturesNativeControls:
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.aiFeaturesNativeControls))
         case .omniBarLongPressMenu:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.omniBarLongPressMenu))
         case .customProductPageDuckAiChat:

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -379,6 +379,12 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214025222413375
     case aiChatNativeDataAccess
 
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215798415697847
+    /// Replaces the web-link Search Assist and Hide AI-Generated Images rows on the AI Features
+    /// settings screen with native controls, regroups the main AI settings at the top, and adds the
+    /// "Disable All AI Options" / Reset button. Off keeps today's web-link rows.
+    case aiFeaturesNativeControls
+
     /// macOS only. Gates the native-driven Duck.ai voice-chat microphone permission flow
     /// (auto-grant at launch, locked Permission Center row, system-disabled warning UI,
     /// FE→native failure handler that surfaces the popover).
@@ -662,6 +668,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(AIChatSubfeature.nativeStorage), category: .duckAI)
         case .aiChatNativeDataAccess:
             Config(source: .remoteReleasable(AIChatSubfeature.nativeDataAccess), category: .duckAI)
+        case .aiFeaturesNativeControls:
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.aiFeaturesNativeControls), category: .duckAI)
         case .aiChatNativeVoicePermissionFlow:
             Config(defaultValue: .enabled,
                    source: .remoteReleasable(AIChatSubfeature.nativeVoicePermissionFlow),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215795303326182
Tech Design URL:
CC:

### Description
Add the `aiFeaturesNativeControls` feature flag on iOS and macOS as a part of `AIChatSubfeature`. Dedicated for AI Features settings screen (native Search Assist / Hide AI-Generated Images controls, regroup, Disable All AI Options). Flag-only change, no call sites or behavior changes yet. Default is `.internalOnly`.

### Testing Steps
1. Build the iOS and macOS targets, verify they compile.
2. In an internal build, confirm the flag is on by default and can be toggled from the feature flag debug menu.

### Impact and Risks
Low. Adds a flag definition only, the flag is currently unused.

#### What could go wrong?
N/A. No code reads the flag yet. `.internalOnly` keeps partial feature hidden for public release.

### Quality Considerations
N/A

### Notes to Reviewer
--

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flag-only wiring with no runtime consumers; `.internalOnly` limits exposure until follow-up PRs read the flag.
> 
> **Overview**
> Introduces the **`aiFeaturesNativeControls`** remote feature flag across shared privacy config and platform **`FeatureFlag`** enums on **iOS** and **macOS**. The flag is wired to **`AIChatSubfeature.aiFeaturesNativeControls`** with default **`.internalOnly`** so it is available in internal builds and via privacy config before any UI ships.
> 
> When enabled in follow-up work, it will gate native **Search Assist** and **Hide AI-Generated Images** controls on the AI Features settings screen, regroup main AI settings, and add **Disable All AI Options** / Reset; with the flag off, behavior stays on today’s web-link rows. **This PR adds definitions and config only—no call sites or user-visible changes yet.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28fada824787f4006b65f0f0c529c7c8c3d95049. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->