### PR TITLE
[iOS][UTI] Restore multi-line expansion for long URLs so the end is editable

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -545,12 +545,11 @@ class SwitchBarTextEntryView: UIView {
     }
 
     /// https://app.asana.com/1/137249556945/project/392891325557410/task/1210835160047733?focus=true
-    /// A URL stays single-line unless it's an interactive AI-chat composer: search mode, or
-    /// search-only (no toggle, so AI chat is unavailable), or before the user interacts — all
-    /// single-line. Only an interacted AI-chat field (toggle present) lets a long URL expand.
+    /// A URL is single-line only before the user interacts; once tapped it expands to multiple lines
+    /// so the caret can reach the end to edit (the original behaviour, restored after #5373/#5429
+    /// made long URLs single-line and therefore not editable to the end).
     private func isUnexpandedURL() -> Bool {
-        guard isURL else { return false }
-        return currentMode == .search || !handler.isToggleEnabled || !hasBeenInteractedWith
+        return !hasBeenInteractedWith && isURL
     }
 
     private func updateTextViewHeight() {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -546,7 +546,9 @@ final class UnifiedToggleInputViewTests: XCTestCase {
 
     private let longURL = "https://www.cinemark.com/theatres/ca-playa-vista/cinemark-playa-vista-and-xd?showDate=2026-06-12"
 
-    func test_urlDoesNotExpandHeightInSearchModeAfterUserTap() {
+    // A long URL expands to multiple lines once the user taps in, so the caret can reach its end to
+    // edit — in search mode too (the single-line gating from #5373/#5429 was reverted; see isUnexpandedURL).
+    func test_urlExpandsHeightInSearchModeAfterUserTap() {
         let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
         handler.setToggleState(.search)
         let sut = SwitchBarTextEntryView(handler: handler)
@@ -559,7 +561,7 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         sut.updatePoseForCurrentState()
         let heightAfterTap = applyFittingHeight(to: sut)
 
-        XCTAssertEqual(heightAfterTap, singleLineHeight, accuracy: 1)
+        XCTAssertGreaterThan(heightAfterTap, singleLineHeight)
     }
 
     func test_urlCanExpandInAIChatModeAfterUserTap() {
@@ -578,27 +580,11 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         XCTAssertGreaterThan(heightAfterTap, singleLineHeight)
     }
 
-    func test_urlCollapsesToSingleLineWhenModeSwitchesFromAIChatToSearch() {
-        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
-        handler.setToggleState(.aiChat)
-        let sut = SwitchBarTextEntryView(handler: handler)
-        sut.isExpandable = true
-        prepareForFitting(sut)
-        sut.setQueryText(longURL)
-        sut.hasBeenInteractedWith = true
-        sut.updatePoseForCurrentState()
-        let expandedHeight = applyFittingHeight(to: sut)
-
-        handler.setToggleState(.search)
-        sut.updatePoseForCurrentState()
-        let heightAfterSwitch = applyFittingHeight(to: sut)
-
-        XCTAssertGreaterThan(expandedHeight, heightAfterSwitch)
-    }
-
-    // Search-only: UTI shown without a toggle (AI chat unavailable). Even though the handler's
-    // toggle state may still be its `.aiChat` default, a tapped URL must stay single-line.
-    func test_urlDoesNotExpandHeightInSearchOnlyModeWithoutToggle() {
+    // Search-only: UTI shown without a toggle (AI chat unavailable), but the handler keeps its
+    // `.aiChat` default toggle state. A tapped URL expands to multiple lines so the user can edit
+    // its end — matching AI chat mode. (The single-line gating for this case was reverted; see
+    // isUnexpandedURL.)
+    func test_urlExpandsHeightInSearchOnlyModeAfterUserTap() {
         let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false, isToggleEnabled: false)
         let sut = SwitchBarTextEntryView(handler: handler)
         sut.isExpandable = true
@@ -610,7 +596,7 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         sut.updatePoseForCurrentState()
         let heightAfterTap = applyFittingHeight(to: sut)
 
-        XCTAssertEqual(heightAfterTap, singleLineHeight, accuracy: 1)
+        XCTAssertGreaterThan(heightAfterTap, singleLineHeight)
     }
 
     private func flushMainQueue() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1215798111901228?focus=true

### Description

In the Unified Toggle Input (UTI), focusing the address bar on a page with a long URL showed the URL clipped to a single, truncated line. Because that line is not horizontally scrollable, the caret could not reach the end of the URL, so the user couldn't edit the tail of a long URL — unlike the plain omnibar (a single-line `UITextField`, which scrolls horizontally for free).

The single-line behaviour was introduced by #5373 (`currentMode == .search` clause) and extended by #5429 (`!handler.isToggleEnabled` clause). This restores the original `isUnexpandedURL()`:

```swift
private func isUnexpandedURL() -> Bool {
    return !hasBeenInteractedWith && isURL
}
```

So a URL is single-line only **before** the user interacts; once the field is interacted with, the URL falls into the existing expandable path and grows to multiple lines (capped at the max height, then scrolls), making the whole URL — including its end — visible and editable.

Unit tests that asserted the single-line behaviour are updated to expect expansion (search and search-only modes), and the now-obsolete "collapses to single line on mode switch to search" test is removed.

### Testing Steps
1. Use the UTI omnibar (search-only / toggle-disabled config) on a tab loaded on a page with a long URL.
2. Tap the address bar → the URL expands to multiple lines, with its end visible.
3. Place the caret at the end of the URL and edit it → the end is reachable and editable.
4. A short URL / search query still shows on a single line; Duck.ai multi-line prompt input is unaffected.

### Impact and Risks
Low. Scoped to a single function (`isUnexpandedURL`) that gates URL height in the UTI; reuses the existing expandable layout path. No change to non-URL text, the focus animation, or multi-line prompt input.

#### What could go wrong?
A very long URL grows the card up to its max height before scrolling (the original behaviour #5373 had intentionally capped to one line). This is the accepted, intended trade-off for editability.

### Notes to Reviewer
- Targets the **release branch** `release/ios/7.225.0` for the imminent release. The same gating exists on `main` (via #5429) and will need the equivalent revert there.
- Behaviour validated manually on the simulator: a long URL now expands and its end is editable.
- Unit tests couldn't be executed locally (the `iOS Browser` scheme doesn't include the `DuckDuckGoTests` target); CI will run them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single helper change in UTI text entry height logic; intentional trade-off is taller cards for very long URLs up to max height before scrolling.
> 
> **Overview**
> Reverts the **#5373 / #5429** single-line URL rules in the Unified Toggle Input so long URLs are only forced to one line **before** the user taps the field. After interaction, `isUnexpandedURL()` no longer keeps URLs collapsed in search mode or when the AI toggle is disabled—they use the existing expandable height path so the caret can reach the end of the URL.
> 
> Unit tests now expect height growth after tap in search and search-only configurations, and the obsolete test that asserted collapse when switching from AI chat to search is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b0bc6b3589667f0d09ca6d01b4ca224c3845956. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->