### PR TITLE
Fix: Tab Title Unexpected Animations

### DIFF
--- a/macOS/DuckDuckGo/TabBar/Tools/TitleDisplayPolicy.swift
+++ b/macOS/DuckDuckGo/TabBar/Tools/TitleDisplayPolicy.swift
@@ -20,7 +20,7 @@ import Foundation
 
 protocol TitleDisplayPolicy {
     func mustSkipDisplayingTitle(title: String, url: URL?, previousTitle: String?, previousURL: URL?, isLoading: Bool) -> Bool
-    func mustAnimateTitleTransition(title: String, previousTitle: String) -> Bool
+    func mustAnimateTitleTransition(title: String, url: URL?, previousTitle: String, previousURL: URL?) -> Bool
 }
 
 struct DefaultTitleDisplayPolicy: TitleDisplayPolicy {
@@ -48,7 +48,15 @@ struct DefaultTitleDisplayPolicy: TitleDisplayPolicy {
 
     /// We avoid animating title transitions when the actual text didn't change
     ///
-    func mustAnimateTitleTransition(title: String, previousTitle: String) -> Bool {
-        title != previousTitle && previousTitle.isEmpty == false
+    func mustAnimateTitleTransition(title: String, url: URL?, previousTitle: String, previousURL: URL?) -> Bool {
+        let isDifferentURL = url != nil && url != previousURL
+        let isDifferentTitle = title != previousTitle && previousTitle.isEmpty == false
+
+        let suggestedTitlePlaceholder = url?.suggestedTitlePlaceholder
+        let isPreviousTitlePlaceholder = suggestedTitlePlaceholder == previousTitle
+        let isCurrentTitlePlaceholder = suggestedTitlePlaceholder == title
+
+        let output = (isDifferentURL && isDifferentTitle) || (isPreviousTitlePlaceholder && !isCurrentTitlePlaceholder)
+        return output
     }
 }

--- a/macOS/DuckDuckGo/TabBar/View/TabTitleView.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabTitleView.swift
@@ -60,7 +60,8 @@ extension TabTitleView {
     ///
     func displayTitleIfNeeded(title: String, url: URL?, isLoading: Bool, animated: Bool = true) {
         let previousTitle = titleTextField.stringValue
-        if displayPolicy.mustSkipDisplayingTitle(title: title, url: url, previousTitle: previousTitle, previousURL: sourceURL, isLoading: isLoading) {
+        let previousURL = sourceURL
+        if displayPolicy.mustSkipDisplayingTitle(title: title, url: url, previousTitle: previousTitle, previousURL: previousURL, isLoading: isLoading) {
             return
         }
 
@@ -68,7 +69,7 @@ extension TabTitleView {
         previousTextField.stringValue = previousTitle
         sourceURL = url
 
-        guard animated, displayPolicy.mustAnimateTitleTransition(title: title, previousTitle: previousTitle) else {
+        guard animated, displayPolicy.mustAnimateTitleTransition(title: title, url: url, previousTitle: previousTitle, previousURL: previousURL) else {
             return
         }
 
@@ -114,6 +115,7 @@ private extension TabTitleView {
     func setupTextFields() {
         titleTextField.textColor = .labelColor
         previousTextField.textColor = .labelColor
+        previousTextField.alphaValue = 0
     }
 
     func buildTitleTextField() -> NSTextField {

--- a/macOS/UnitTests/TabBar/Tools/TitleDisplayPolicyTests.swift
+++ b/macOS/UnitTests/TabBar/Tools/TitleDisplayPolicyTests.swift
@@ -78,14 +78,44 @@ final class TitleDisplayPolicyTests: XCTestCase {
     // MARK: - Title Transitions
 
     func testTitleTransitionAnimatesWhenTitleChanges() {
-        XCTAssertTrue(policy.mustAnimateTitleTransition(title: "New Title", previousTitle: "Old Title") == true)
+        let url = URL(string: "https://www.example.com/")
+        let previousURL = URL(string: "https://www.different.com/")
+        XCTAssertTrue(policy.mustAnimateTitleTransition(title: "New Title", url: url, previousTitle: "Old Title", previousURL: previousURL))
     }
 
     func testTitleTransitionDoesNotAnimateWhenIsTheSame() {
-        XCTAssertTrue(policy.mustAnimateTitleTransition(title: "Same Title", previousTitle: "Same Title") == false)
+        let url = URL(string: "https://www.example.com/")
+        XCTAssertFalse(policy.mustAnimateTitleTransition(title: "Same Title", url: url, previousTitle: "Same Title", previousURL: url))
     }
 
     func testTitleTransitionDoesNotAnimateWhenPreviousTitleWasEmpty() {
-        XCTAssertTrue(policy.mustAnimateTitleTransition(title: "New Title", previousTitle: "") == false)
+        let url = URL(string: "https://www.example.com/")
+        let previousURL = URL(string: "https://www.different.com/")
+        XCTAssertFalse(policy.mustAnimateTitleTransition(title: "New Title", url: url, previousTitle: "", previousURL: previousURL))
+    }
+
+    func testTitleTransitionDoesNotAnimateWhenURLIsUnchanged() {
+        let url = URL(string: "https://www.example.com/")
+        XCTAssertFalse(policy.mustAnimateTitleTransition(title: "New Title", url: url, previousTitle: "Old Title", previousURL: url))
+    }
+
+    func testTitleTransitionDoesNotAnimateWhenURLIsNil() {
+        XCTAssertFalse(policy.mustAnimateTitleTransition(title: "New Title", url: nil, previousTitle: "Old Title", previousURL: nil))
+    }
+
+    func testTitleTransitionDoesNotAnimateWhenURLChangesButTitleIsTheSame() {
+        let url = URL(string: "https://www.example.com/")
+        let previousURL = URL(string: "https://www.different.com/")
+        XCTAssertFalse(policy.mustAnimateTitleTransition(title: "Same Title", url: url, previousTitle: "Same Title", previousURL: previousURL))
+    }
+
+    func testTitleTransitionAnimatesWhenPlaceholderIsReplacedByRealTitle() {
+        let url = URL(string: "https://www.example.com/")
+        XCTAssertTrue(policy.mustAnimateTitleTransition(title: "Example Page", url: url, previousTitle: "example.com", previousURL: url))
+    }
+
+    func testTitleTransitionDoesNotAnimateWhenRealTitleIsReplacedByPlaceholder() {
+        let url = URL(string: "https://www.example.com/")
+        XCTAssertFalse(policy.mustAnimateTitleTransition(title: "example.com", url: url, previousTitle: "Example Page", previousURL: url))
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1213905392439005?focus=true
Tech Design URL:
CC:

### Description
This PR updates the Tab Title Animation logic, so that we avoid animating Title transitions when the URL didn't change.

### Testing Steps
1. Launch the macOS browser
2. Open this URL: https://store.devilhunter.net/p/stylish-scrolling-title.html

- [ ] Verify the Tab Title no longer animates Title Updates (for the same URL)

### Testing: Regressions
1. Launch the macOS browser
2. Open `arstechnica.com`

- [ ] Verify the Title Placeholder is presented with an animation (just the URL)
- [ ] Verify that, once loaded, the website's Title is presented with an animation as well

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Worst case scenario, we incorrectly avoid animating Tab Title transitions.

### Quality Considerations
Nothing in particular

### Notes to Reviewer
Thank you!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only tab bar title animation policy with expanded unit tests; worst case is missing or extra title transitions, not data or security impact.
> 
> **Overview**
> Fixes **unexpected tab title animations** when a page keeps changing `document.title` at the same URL (e.g. scrolling-title demos).
> 
> **`DefaultTitleDisplayPolicy.mustAnimateTitleTransition`** now takes current and previous URLs. Animation runs only when **both** URL and title change (navigation), or when a **domain placeholder** is replaced by the real page title on the same URL. Same-URL title-only updates no longer trigger the transition.
> 
> **`TabTitleView`** passes `previousURL` into the policy and initializes the hidden **previous** title field with **`alphaValue = 0`** so non-animated updates don’t flash the overlay.
> 
> Unit tests in **`TitleDisplayPolicyTests`** cover unchanged URL, nil URL, unchanged title across URLs, and placeholder vs real title in both directions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb0708a282016391cceff3d3858470d69f6d83c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->