### PR TITLE
[macOS] Disables Tab Animations on Keyboard Event

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -551,11 +551,13 @@ final class TabBarItemCellView: NSView {
         faviconView.startSpinnerIfNeeded(isLoading: isLoading, url: url, error: error)
     }
 
-    func refreshStateIfNeeded(isSelected: Bool, isDragged: Bool, isMouseOver: Bool, animated: Bool = true) {
+    func refreshStateIfNeeded(isSelected: Bool, isDragged: Bool, isMouseOver: Bool) {
         guard displaysTabsAnimations else {
             return
         }
 
+        // Don't animate when switching Tabs via Keyboard Shortcuts
+        let animated = NSApp.currentEvent?.isMouse ?? true
         backgroundView.refreshStateIfNeeded(isSelected: isSelected, isDragged: isDragged, isMouseOver: isMouseOver, animated: animated)
     }
 }

--- a/macOS/LocalPackages/AppKitExtensions/Sources/AppKitExtensions/NSEventExtension.swift
+++ b/macOS/LocalPackages/AppKitExtensions/Sources/AppKitExtensions/NSEventExtension.swift
@@ -64,6 +64,19 @@ public extension NSEvent {
         KeyEquivalent(event: self)
     }
 
+    /// Whether the event originates from the mouse (button, drag, movement or scroll).
+    var isMouse: Bool {
+        switch type {
+        case .leftMouseDown, .leftMouseUp,
+             .rightMouseDown, .rightMouseUp,
+             .otherMouseDown, .otherMouseUp,
+             .leftMouseDragged, .rightMouseDragged, .otherMouseDragged,
+             .mouseMoved, .mouseEntered, .mouseExited,
+             .scrollWheel: true
+        default: false
+        }
+    }
+
     /// is NSEvent representing right mouse down event or cntrl+mouse down event
     var isContextClick: Bool {
         let isControlClick = type == .leftMouseDown && (modifierFlags.rawValue & NSEvent.ModifierFlags.control.rawValue != 0)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/inbox/1211150618028591/item/1215062191928954/story/1215138752417755?focus=true
Tech Design URL:
CC:

### Description
As discussed in the linked Task, in this PR we're disabling Tab Animations when the current event is a Keyboard event.

### Testing Steps
1. Launch the macOS browser
2. Add several tabs

- [ ] Verify that if you click on any Tab, it's activated with an animation
- [ ] Verify that if you navigate across Tabs with the keyboard, the animation is no longer performed

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Worst case scenario, we incorrectly prevent presenting the Tab Activation Animation

### Quality Considerations
None

### Notes to Reviewer
Thank you!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only behavior gated on `displaysTabsAnimations`; worst case is wrong animate vs instant when `currentEvent` is missing (defaults to animated).
> 
> **Overview**
> **macOS tab bar** no longer runs selection/hover background animations when the active tab change comes from the keyboard; mouse-driven tab clicks still animate as before.
> 
> `TabBarItemCellView.refreshStateIfNeeded` drops its `animated` parameter and sets animation from `NSApp.currentEvent?.isMouse ?? true` before calling `TabBackgroundView.refreshStateIfNeeded`. A new **`NSEvent.isMouse`** helper in AppKitExtensions treats button, drag, move, enter/exit, and scroll events as mouse-origin; everything else (e.g. key down) is non-mouse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 504a19e3e956da1bb7124140fdb6c932da483516. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->