### PR TITLE
[iOS] Sync V2 pixels

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
@@ -26,6 +26,7 @@ public protocol SyncConnectionControllerDelegate: AnyObject {
     func controllerDidReceiveRecoveryKey()
 
     func controllerDidRecognizeCode(setupSource: SyncSetupSource, codeSource: SyncCodeSource) async
+    func controllerDidRecognizeCode(setupSource: SyncSetupSource, codeSource: SyncCodeSource, codeVersion: SyncSetupCodeVersion) async
 
     func controllerWillPerformServerSyncOperation(setupRole: SyncSetupRole) async -> Bool
     func controllerShouldAllowPairingV2PeerToJoin(peerName: String?, peerKind: PairingV2DeviceKind) async -> Bool
@@ -61,6 +62,9 @@ public enum SyncConnectionError: Error {
 
     case failedToCreateAccount
     case failedToTransmitConnectRecoveryKey
+
+    case accountUpgradeFailed
+    case protocolError
 
     case pollingForRecoveryKeyTimedOut
 }
@@ -263,7 +267,7 @@ public class SyncConnectionController: SyncConnectionControlling {
 
         if let exchangeKey = syncCode.exchangeKey {
             let setupRole: SyncSetupRole = .receiver(.exchange, codeSource)
-            await delegate?.controllerDidRecognizeCode(setupSource: .exchange, codeSource: codeSource)
+            await delegate?.controllerDidRecognizeCode(setupSource: .exchange, codeSource: codeSource, codeVersion: .v1)
             guard await shouldContinueServerSyncOperation(setupRole: setupRole) else {
                 return false
             }
@@ -271,14 +275,14 @@ public class SyncConnectionController: SyncConnectionControlling {
             return await handleExchangeKey(exchangeKey, codeSource: codeSource)
         } else if let connectKey = syncCode.connect {
             let setupRole: SyncSetupRole = .receiver(.connect, codeSource)
-            await delegate?.controllerDidRecognizeCode(setupSource: .connect, codeSource: codeSource)
+            await delegate?.controllerDidRecognizeCode(setupSource: .connect, codeSource: codeSource, codeVersion: .v1)
             guard await shouldContinueServerSyncOperation(setupRole: setupRole) else {
                 return false
             }
             await state.prepareForNewFlow()
             return await handleConnectKey(connectKey, codeSource: codeSource)
         } else {
-            await delegate?.controllerDidRecognizeCode(setupSource: .recovery, codeSource: codeSource)
+            await delegate?.controllerDidRecognizeCode(setupSource: .recovery, codeSource: codeSource, codeVersion: .v1)
             await delegate?.controllerDidError(.unableToRecognizeCode, underlyingError: nil, setupRole: .receiver(.unknown, codeSource))
             return false
         }
@@ -345,7 +349,7 @@ public class SyncConnectionController: SyncConnectionControlling {
     private func handleDecodedSyncCode(_ syncCode: SyncCode, codeSource: SyncCodeSource) async -> Bool {
         if let exchangeKey = syncCode.exchangeKey {
             let setupRole: SyncSetupRole = .receiver(.exchange, codeSource)
-            await delegate?.controllerDidRecognizeCode(setupSource: .exchange, codeSource: codeSource)
+            await delegate?.controllerDidRecognizeCode(setupSource: .exchange, codeSource: codeSource, codeVersion: .v1)
             guard await shouldContinueServerSyncOperation(setupRole: setupRole) else {
                 return false
             }
@@ -355,7 +359,7 @@ public class SyncConnectionController: SyncConnectionControlling {
             return await handleRecoveryCode(recovery, codeSource: codeSource)
         } else if let connectKey = syncCode.connect {
             let setupRole: SyncSetupRole = .receiver(.connect, codeSource)
-            await delegate?.controllerDidRecognizeCode(setupSource: .connect, codeSource: codeSource)
+            await delegate?.controllerDidRecognizeCode(setupSource: .connect, codeSource: codeSource, codeVersion: .v1)
             guard await shouldContinueServerSyncOperation(setupRole: setupRole) else {
                 return false
             }
@@ -393,7 +397,7 @@ public class SyncConnectionController: SyncConnectionControlling {
             await delegate?.controllerDidError(.unableToRecognizeCode, underlyingError: nil, setupRole: setupRole)
             return false
         }
-        await delegate?.controllerDidRecognizeCode(setupSource: .exchange, codeSource: codeSource)
+        await delegate?.controllerDidRecognizeCode(setupSource: .exchange, codeSource: codeSource, codeVersion: .v2)
         guard await shouldContinueServerSyncOperation(setupRole: setupRole) else {
             return false
         }
@@ -656,7 +660,7 @@ public class SyncConnectionController: SyncConnectionControlling {
             return false
         }
 
-        await delegate?.controllerDidRecognizeCode(setupSource: .recovery, codeSource: codeSource)
+        await delegate?.controllerDidRecognizeCode(setupSource: .recovery, codeSource: codeSource, codeVersion: recovery.syncSetupCodeVersion)
         guard await shouldContinueServerSyncOperation(setupRole: setupRole) else {
             return false
         }
@@ -733,6 +737,8 @@ public class SyncConnectionController: SyncConnectionControlling {
             return .failedToTransmitExchangeRecoveryKey
         case .loginFailed:
             return .failedToLogIn
+        case .upgradeFailed:
+            return .accountUpgradeFailed
         case .nativeCredentialAlreadyPresent:
             return .thirdPartyAccountAlreadyUpgraded
         case .recoveryCodeDenied:
@@ -743,7 +749,9 @@ public class SyncConnectionController: SyncConnectionControlling {
             return unsupportedVersionConnectionError(for: version, supportedMajor: PairingV2ProtocolVersion.supportedMajor)
         case .v2ScanningDisabled, .unknownCode, .unsupportedFlow:
             return .unableToRecognizeCode
-        case .secondHello, .unexpectedEvent, .pairingSessionNotReady, .relayChannelUnavailable, .relayChannelExpired:
+        case .secondHello, .unexpectedEvent, .pairingSessionNotReady:
+            return .protocolError
+        case .relayChannelUnavailable, .relayChannelExpired:
             return .failedToFetchExchangeRecoveryKey
         case .cancelled:
             return .syncCancelledFromOtherDevice
@@ -770,8 +778,27 @@ public class SyncConnectionController: SyncConnectionControlling {
     }
 }
 
+private extension SyncCode.Recovery {
+
+    var syncSetupCodeVersion: SyncSetupCodeVersion {
+        switch self {
+        case .v1:
+            return .v1
+        case .v2:
+            return .v2
+        }
+    }
+}
+
 @MainActor
 public extension SyncConnectionControllerDelegate {
+    func controllerDidRecognizeCode(setupSource _: SyncSetupSource, codeSource _: SyncCodeSource) async {
+    }
+
+    func controllerDidRecognizeCode(setupSource: SyncSetupSource, codeSource: SyncCodeSource, codeVersion _: SyncSetupCodeVersion) async {
+        await controllerDidRecognizeCode(setupSource: setupSource, codeSource: codeSource)
+    }
+
     func controllerWillPerformServerSyncOperation(setupRole _: SyncSetupRole) async -> Bool {
         true
     }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConstants.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConstants.swift
@@ -21,6 +21,11 @@ public enum SyncSetupRole {
     case sharer
 }
 
+public enum SyncSetupCodeVersion: String {
+    case v1
+    case v2
+}
+
 public enum SyncSetupSource: String {
     case recovery
     case exchange

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncModels.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncModels.swift
@@ -170,6 +170,7 @@ public struct PairingInfo {
 
     enum Keys {
         static let code = "code"
+        static let pairingV2Code = "code2"
         static let deviceName = "deviceName"
     }
 
@@ -184,15 +185,7 @@ public struct PairingInfo {
         guard let fragment = URLComponents(url: url, resolvingAgainstBaseURL: false)?.fragment else {
             return nil
         }
-        let params = fragment
-            .split(separator: "&")
-            .compactMap { part -> (String, String)? in
-                let keyValue = part.split(separator: "=", maxSplits: 1).map(String.init)
-                guard keyValue.count == 2 else { return nil }
-                return (keyValue[0], keyValue[1].removingPercentEncoding ?? keyValue[1])
-            }
-
-        let dict = Dictionary(uniqueKeysWithValues: params)
+        let dict = Self.fragmentParameters(from: fragment)
         guard let code = dict[Keys.code], let deviceName = dict[Keys.deviceName] else {
             return nil
         }
@@ -222,8 +215,29 @@ public struct PairingInfo {
         return urlComponents?.url ?? url
     }
 
+    public static func isPairingV2URL(_ url: URL) -> Bool {
+        guard Self.isPairing(url: url),
+              let fragment = URLComponents(url: url, resolvingAgainstBaseURL: false)?.fragment else {
+            return false
+        }
+
+        return Self.fragmentParameters(from: fragment)[Keys.pairingV2Code] != nil
+    }
+
     private static func isPairing(url: URL) -> Bool {
         url.pathComponents.contains("sync") && url.pathComponents.last == "pairing" && url.isPart(ofDomain: "duckduckgo.com")
+    }
+
+    private static func fragmentParameters(from fragment: String) -> [String: String] {
+        let params = fragment
+            .split(separator: "&")
+            .compactMap { part -> (String, String)? in
+                let keyValue = part.split(separator: "=", maxSplits: 1).map(String.init)
+                guard keyValue.count == 2 else { return nil }
+                return (keyValue[0], keyValue[1].removingPercentEncoding ?? keyValue[1])
+            }
+
+        return Dictionary(uniqueKeysWithValues: params)
     }
 
     private static func restoreBase64(from base64URLCode: String) -> String {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/PairingV2/PairingV2Coordinator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/PairingV2/PairingV2Coordinator.swift
@@ -342,7 +342,7 @@ final class PairingV2Coordinator {
                 case .nativeCredentialAlreadyPresent:
                     pairingError = .nativeCredentialAlreadyPresent
                 default:
-                    pairingError = .loginFailed
+                    pairingError = .upgradeFailed
                 }
                 try await execute(stateMachine.handle(.failed(pairingError)))
                 throw pairingError
@@ -350,8 +350,8 @@ final class PairingV2Coordinator {
                 try await execute(stateMachine.handle(.failed(error)))
                 throw error
             } catch {
-                try await execute(stateMachine.handle(.failed(.loginFailed)))
-                throw PairingV2Error.loginFailed
+                try await execute(stateMachine.handle(.failed(.upgradeFailed)))
+                throw PairingV2Error.upgradeFailed
             }
             try await execute(stateMachine.handle(.loginSucceeded))
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/PairingV2/PairingV2StateMachine.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/PairingV2/PairingV2StateMachine.swift
@@ -174,6 +174,7 @@ enum PairingV2Error: Error, Equatable {
     case recoveryCodePreparationFailed
     case recoveryCodeSendFailed
     case loginFailed
+    case upgradeFailed
     case recoveryCodeDenied
     case recoveryCodeUnavailable
     case unsupportedVersion(String)

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/PairingV2/PairingV2CoordinatorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/PairingV2/PairingV2CoordinatorTests.swift
@@ -762,19 +762,19 @@ final class PairingV2CoordinatorTests: XCTestCase {
         XCTAssertEqual(setup.coordinator.state, .failed(.nativeCredentialAlreadyPresent))
     }
 
-    func testWhenThirdPartyUpgradeReportsGenericUpgradeErrorThenPairingFailsWithLoginFailed() async throws {
+    func testWhenThirdPartyUpgradeReportsGenericUpgradeErrorThenPairingFailsWithUpgradeFailed() async throws {
         let setup = try await makeNativeJoinerReadyForThirdPartyUpgrade(upgradeError: ThirdPartyAccountUpgradeError.noUsableThirdPartyProtectedKeys)
 
         do {
             try await setup.coordinator.pollOnce()
             XCTFail("Expected upgrade failure to abort pairing")
-        } catch PairingV2Error.loginFailed {
+        } catch PairingV2Error.upgradeFailed {
         } catch {
             XCTFail("Unexpected error: \(error)")
         }
 
         XCTAssertEqual(setup.upgradeCoordinator.upgradeThirdPartyAccountCalls.map(\.recoveryCode), ["third-party-recovery-code"])
-        XCTAssertEqual(setup.coordinator.state, .failed(.loginFailed))
+        XCTAssertEqual(setup.coordinator.state, .failed(.upgradeFailed))
     }
 
     func testWhenNativeJoinerConfirmationIsDeniedThenDoesNotLoginIfRecoveryCodeArrives() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SyncConnectionControllerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SyncConnectionControllerTests.swift
@@ -79,7 +79,7 @@ final class MockSyncConnectionControllerDelegate: SyncConnectionControllerDelega
         didReceiveRecoveryKeyCalled()
     }
 
-    func controllerDidRecognizeCode(setupSource: SyncSetupSource, codeSource: SyncCodeSource) async {
+    func controllerDidRecognizeCode(setupSource: SyncSetupSource, codeSource: SyncCodeSource, codeVersion: SyncSetupCodeVersion) async {
         didRecognizeScannedCodeCalled()
     }
 

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1115,6 +1115,7 @@ extension Pixel {
         case syncSetupManualCodeEnteredSuccess
         case syncSetupManualCodeEnteredFailed
         case syncSetupEndedAbandoned
+        case syncSetupEndedFailed
         case syncSetupEndedSuccessful
         case syncSetupDeepLinkFlowStarted
         case syncSetupDeepLinkFlowSuccess
@@ -3084,6 +3085,7 @@ extension Pixel.Event {
         case .syncSetupManualCodeEnteredSuccess: return "sync_setup_manual_code_entered_success"
         case .syncSetupManualCodeEnteredFailed: return "sync_setup_manual_code_entered_failed"
         case .syncSetupEndedAbandoned: return "sync_setup_ended_abandoned"
+        case .syncSetupEndedFailed: return "sync_setup_ended_failed"
         case .syncSetupEndedSuccessful: return "sync_setup_ended_successful"
         case .syncSetupDeepLinkFlowStarted: return "sync_setup_deep_link_flow_started"
         case .syncSetupDeepLinkFlowSuccess: return "sync_setup_deep_link_flow_success"

--- a/iOS/DuckDuckGo/SyncSettingsViewController+PDFRendering.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController+PDFRendering.swift
@@ -80,7 +80,7 @@ extension SyncSettingsViewController {
         }
     }
 
-    func shareCode(_ code: String) {
+    func shareCode(_ code: String, source: CodeCollectionSource) {
 
         navigationController?.visibleViewController?.presentShareSheet(withItems: [code],
                                                                        fromView: view,
@@ -89,7 +89,7 @@ extension SyncSettingsViewController {
             guard case .copyToPasteboard = activity, didComplete else {
                 return
             }
-            self.fireBarcodeCodeCopiedPixel(for: code)
+            self.fireBarcodeCodeCopiedPixel(for: code, sourceHint: source)
         }
     }
 

--- a/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -590,6 +590,7 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
     }
 
     private func collectCode(showQRCode: Bool) {
+        pairingV2PeerKind = nil
         guard featureFlagger.isFeatureOn(.exchangeKeysToSyncWithAnotherDevice) else {
             legacyCollectCode(showQRCode: showQRCode)
             return
@@ -623,11 +624,12 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                 stringForQRCode: stringForQRCode,
                 showQRCode: showQRCode,
                 source: source,
-                onPresentPixelInfo: .init(pixel: .syncSetupBarcodeScreenShown, source: source))
+                onPresentPixelInfo: .init(pixel: .syncSetupBarcodeScreenShown, source: source, flowVersion: syncSetupPixelFlowVersion))
         }
     }
 
     private func legacyCollectCode(showQRCode: Bool) {
+        pairingV2PeerKind = nil
         Task {
             let stringForQRCode: String
             let codeForDisplayOrPasting: String
@@ -644,7 +646,7 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                     stringForQRCode = featureFlagger.isFeatureOn(.syncSetupBarcodeIsUrlBased) ? pairingInfo.url.absoluteString : pairingInfo.base64Code
                     codeForDisplayOrPasting = pairingInfo.base64Code
                     source = showQRCode ? .connect : .recovery
-                    onPresentPixelInfo = .init(pixel: .syncSetupBarcodeScreenShown, source: source)
+                    onPresentPixelInfo = .init(pixel: .syncSetupBarcodeScreenShown, source: source, flowVersion: syncSetupPixelFlowVersion)
                 } catch {
                     await handleError(SyncErrorMessage.unableToSyncToServer, error: error, event: .syncLoginError)
                     return
@@ -701,7 +703,12 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
             self.checkCameraPermission(model: model)
             if let onPresentPixelInfo {
                 let pixelSource = self.source ?? onPresentPixelInfo.source.rawValue
-                Pixel.fire(onPresentPixelInfo.pixel, withAdditionalParameters: [PixelParameters.source: pixelSource])
+                var parameters = [
+                    PixelParameters.source: pixelSource,
+                    SyncSetupPixelInfo.Parameter.myKind: SyncSetupPixelInfo.Value.ddg
+                ]
+                parameters[SyncSetupPixelInfo.Parameter.flowVersion] = onPresentPixelInfo.flowVersion
+                Pixel.fire(onPresentPixelInfo.pixel, withAdditionalParameters: parameters, includedParameters: [.appVersion])
                 self.syncSetupExperimentPixels.fireBarcodeScreenShown()
             }
         }
@@ -725,19 +732,23 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
     }
 
     func controllerShouldAllowPairingV2PeerToJoin(peerName: String?, peerKind: PairingV2DeviceKind) async -> Bool {
-        await confirmPairingV2Peer(peerName: peerName, peerKind: peerKind)
+        await confirmPairingV2Peer(peerName: peerName, peerKind: peerKind, setupRole: .sharer)
     }
 
     func controllerShouldJoinPairingV2Peer(peerName: String?, peerKind: PairingV2DeviceKind) async -> Bool {
-        await confirmPairingV2Peer(peerName: peerName, peerKind: peerKind)
+        // codeSource is unused for the abandonment pixel; only the source/role matter.
+        await confirmPairingV2Peer(peerName: peerName, peerKind: peerKind, setupRole: .receiver(.exchange, .qrCode))
     }
 
-    private func confirmPairingV2Peer(peerName: String?, peerKind: PairingV2DeviceKind) async -> Bool {
+    private func confirmPairingV2Peer(peerName: String?, peerKind: PairingV2DeviceKind, setupRole: SyncSetupRole) async -> Bool {
         let peerName = pairingV2DisplayName(for: peerName)
         let message = UserText.syncPairingV2ConfirmationMessage(peerName, isThirdPartyPeer: peerKind == .thirdParty)
         let isConfirmed = await presentPairingV2ConfirmationAlert(message: message)
         if !isConfirmed {
+            sendSyncConfirmationDeniedSetupEndedAbandonedPixel(setupRole: setupRole)
             dismissPairingV2UIAfterDeniedConfirmation()
+        } else {
+            pairingV2PeerKind = peerKind
         }
         return isConfirmed
     }
@@ -892,12 +903,17 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
     }
 
     func codeEntryScreenShown() {
-        Pixel.fire(pixel: .syncSetupManualCodeEntryScreenShown, includedParameters: [.appVersion])
+        Pixel.fire(pixel: .syncSetupManualCodeEntryScreenShown,
+                   withAdditionalParameters: [
+                    SyncSetupPixelInfo.Parameter.myKind: SyncSetupPixelInfo.Value.ddg,
+                    SyncSetupPixelInfo.Parameter.flowVersion: syncSetupPixelFlowVersion
+                   ],
+                   includedParameters: [.appVersion])
         syncSetupExperimentPixels.fireManualCodeEntryScreenShown()
     }
 
-    func codeCopied(_ code: String) {
-        fireBarcodeCodeCopiedPixel(for: code)
+    func codeCopied(_ code: String, source: CodeCollectionSource) {
+        fireBarcodeCodeCopiedPixel(for: code, sourceHint: source)
     }
 
     @MainActor
@@ -1015,6 +1031,25 @@ private extension CodeCollectionSource {
 }
 
 private struct SyncSetupPixelInfo {
+    enum Parameter {
+        static let flowVersion = "flow_version"
+        static let myKind = "my_kind"
+    }
+
+    enum Value {
+        static let ddg = "ddg"
+        static let v1 = "v1"
+        static let v2 = "v2"
+    }
+
     let pixel: Pixel.Event
     let source: SyncSetupSource
+    let flowVersion: String?
+}
+
+extension SyncSettingsViewController {
+
+    var syncSetupPixelFlowVersion: String {
+        featureFlagger.isFeatureOn(.syncCanUseV2ConnectFlow) ? SyncSetupPixelInfo.Value.v2 : SyncSetupPixelInfo.Value.v1
+    }
 }

--- a/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -708,7 +708,7 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                     SyncSetupPixelInfo.Parameter.myKind: SyncSetupPixelInfo.Value.ddg
                 ]
                 parameters[SyncSetupPixelInfo.Parameter.flowVersion] = onPresentPixelInfo.flowVersion
-                Pixel.fire(onPresentPixelInfo.pixel, withAdditionalParameters: parameters, includedParameters: [.appVersion])
+                Pixel.fire(pixel: onPresentPixelInfo.pixel, withAdditionalParameters: parameters, includedParameters: [.appVersion])
                 self.syncSetupExperimentPixels.fireBarcodeScreenShown()
             }
         }

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -813,7 +813,7 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         pairingV2PeerKind = nil
     }
 
-    func sendSetupEndedAbandonedPixel(setupRole: SyncSetupRole, reason: String?) {
+    private func sendSetupEndedAbandonedPixel(setupRole: SyncSetupRole, reason: String?) {
         let parameters: [String: String]
         switch setupRole {
         case .receiver(let setupSource, _):

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -94,6 +94,7 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsRootView> {
 
     var source: String?
     var pairingInfo: PairingInfo?
+    var pairingV2PeerKind: PairingV2DeviceKind?
     var needsPreservedAccountCleanupBeforeServerOperation = false
     var autoRestorePromptSource: AutoRestorePromptSource?
 
@@ -557,7 +558,8 @@ extension SyncSettingsViewController: ScanOrPasteCodeViewModelDelegate {
         dismissPresentedViewController()
         endConnectMode()
         Pixel.fire(pixel: .syncSetupEndedAbandoned,
-                   withAdditionalParameters: [PixelParameters.source: source.rawValue],
+                   withAdditionalParameters: syncSetupPixelParameters(setupSource: SyncSetupSource(codeCollectionSource: source),
+                                                                      reason: SyncSetupPixelValue.scanningCancelled),
                    includedParameters: [.appVersion])
         syncSetupExperimentPixels.fireSetupEndedAbandoned()
     }
@@ -634,9 +636,14 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
     }
 
     func controllerDidFinishTransmittingRecoveryKey(shouldWaitForDevicesToChange: Bool) {
+        let parameters = syncSetupPixelParameters(setupSource: .exchange,
+                                                  path: SyncSetupPixelValue.pairing,
+                                                  peerKind: pairingV2PeerKind?.syncSetupPeerKind,
+                                                  myRole: SyncSetupPixelValue.host)
         Pixel.fire(pixel: .syncSetupEndedSuccessful,
-                   withAdditionalParameters: [PixelParameters.source: SyncSetupSource.exchange.rawValue],
+                   withAdditionalParameters: parameters,
                    includedParameters: [.appVersion])
+        pairingV2PeerKind = nil
         if shouldWaitForDevicesToChange {
             waitForDevicesToChangeThenPresentSyncing()
         } else {
@@ -650,8 +657,8 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         }
     }
     
-    func controllerDidRecognizeCode(setupSource: SyncSetupSource, codeSource: SyncCodeSource) async {
-        sendCodeRecognisedPixel(setupSource: setupSource, codeSource: codeSource)
+    func controllerDidRecognizeCode(setupSource: SyncSetupSource, codeSource: SyncCodeSource, codeVersion: SyncSetupCodeVersion) async {
+        sendCodeRecognisedPixel(setupSource: setupSource, codeSource: codeSource, codeVersion: codeVersion)
         await dismissPresentedViewController()
         await showPreparingSync(context: setupSource == .recovery ? .recoveringData : .syncingDevices)
     }
@@ -683,16 +690,22 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         presentSyncCompletionAfterDelay()
         guard case .receiver(let syncSetupSource, let syncCodeSource) = setupRole else {
             // .sharer reaches here only via the connect flow (exchange-sharer terminates in controllerDidFinishTransmittingRecoveryKey).
+            let parameters = syncSetupPixelParameters(setupSource: .connect,
+                                                      path: SyncSetupPixelValue.pairing,
+                                                      peerKind: pairingV2PeerKind?.syncSetupPeerKind,
+                                                      myRole: SyncSetupPixelValue.joiner)
             Pixel.fire(pixel: .syncSetupEndedSuccessful,
-                       withAdditionalParameters: [PixelParameters.source: SyncSetupSource.connect.rawValue],
+                       withAdditionalParameters: parameters,
                        includedParameters: [.appVersion])
+            pairingV2PeerKind = nil
             return
         }
 
         sendSetupEndedSuccessfullyPixel(setupSource: syncSetupSource, codeSource: syncCodeSource)
     }
 
-    func controllerDidCompletePairingWithAlreadyConnectedAccount(setupRole _: SyncSetupRole) {
+    func controllerDidCompletePairingWithAlreadyConnectedAccount(setupRole: SyncSetupRole) {
+        sendSetupEndedFailedPixel(setupRole: setupRole, reason: SyncSetupPixelValue.alreadyPaired)
         Task { @MainActor in
             await handleError(.alreadyPairedWithAccount, error: nil, event: nil)
         }
@@ -701,24 +714,29 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
     func controllerDidError(_ error: SyncConnectionError, underlyingError: (any Error)?, setupRole: SyncSetupRole) async {
         switch error {
         case .unableToRecognizeCode:
-            sendCodeParsingFailedPixel(setupRole: setupRole)
+            sendCodeParsingFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             await handleError(.unableToRecognizeCode, error: underlyingError, event: nil)
         case .updateRequired:
-            sendCodeParsingFailedPixel(setupRole: setupRole)
+            sendCodeParsingFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             await handleError(.updateRequired, error: nil, event: nil)
         case .unsupportedThirdPartyRecoveryCode:
-            sendCodeParsingFailedPixel(setupRole: setupRole)
+            sendCodeParsingFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             await handleError(.unsupportedThirdPartyRecoveryCode, error: nil, event: nil)
         case .thirdPartyAccountAlreadyUpgraded:
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             await handleError(.thirdPartyAccountAlreadyUpgraded, error: nil, event: nil)
         case .syncCancelledFromOtherDevice:
+            sendSetupEndedAbandonedPixel(setupRole: setupRole, reason: SyncSetupPixelValue.syncConfirmationDenied)
             await handleError(.syncCancelledFromOtherDevice, error: nil, event: nil)
-        case .failedToFetchPublicKey, .failedToTransmitExchangeRecoveryKey, .failedToFetchConnectRecoveryKey, .failedToLogIn, .failedToTransmitExchangeKey, .failedToFetchExchangeRecoveryKey, .failedToTransmitConnectRecoveryKey:
+        case .failedToFetchPublicKey, .failedToTransmitExchangeRecoveryKey, .failedToFetchConnectRecoveryKey, .failedToLogIn, .failedToTransmitExchangeKey, .failedToFetchExchangeRecoveryKey, .failedToTransmitConnectRecoveryKey, .accountUpgradeFailed, .protocolError:
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             fireCodeHandlingFailedExperimentPixel(setupRole: setupRole)
             await handleError(.unableToSyncWithDevice, error: underlyingError, event: .syncLoginError)
         case .failedToCreateAccount:
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             await handleError(.unableToSyncWithDevice, error: underlyingError, event: .syncSignupError)
         case .pollingForRecoveryKeyTimedOut:
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             await dismissPresentedViewController()
             handleRecoveryKeyPollingTimeout(setupRole: setupRole)
             await handleError(.unableToSyncWithDevice, error: underlyingError, event: nil)
@@ -739,9 +757,9 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         }
     }
 
-    private func sendCodeRecognisedPixel(setupSource: SyncSetupSource, codeSource: SyncCodeSource) {
+    private func sendCodeRecognisedPixel(setupSource: SyncSetupSource, codeSource: SyncCodeSource, codeVersion: SyncSetupCodeVersion) {
         guard setupSource != .unknown else { return }
-        let parameters = source.map { [PixelParameters.source: $0] } ?? [PixelParameters.source: setupSource.rawValue]
+        let parameters = syncSetupPixelParameters(setupSource: setupSource, codeType: setupSource.syncSetupCodeType, codeVersion: codeVersion.rawValue)
         switch codeSource {
         case .qrCode:
             Pixel.fire(pixel: .syncSetupBarcodeScannerSuccess, withAdditionalParameters: parameters, includedParameters: [.appVersion])
@@ -754,17 +772,18 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         }
     }
 
-    private func sendCodeParsingFailedPixel(setupRole: SyncSetupRole) {
-        guard case .receiver(_, let codeSource) = setupRole else {
+    private func sendCodeParsingFailedPixel(setupRole: SyncSetupRole, reason: String?) {
+        guard case .receiver(let setupSource, let codeSource) = setupRole else {
             return
         }
+        let parameters = syncSetupPixelParameters(setupSource: setupSource, reason: reason)
 
         switch codeSource {
         case .qrCode:
-            Pixel.fire(pixel: .syncSetupBarcodeScannerFailed, includedParameters: [.appVersion])
+            Pixel.fire(pixel: .syncSetupBarcodeScannerFailed, withAdditionalParameters: parameters, includedParameters: [.appVersion])
             syncSetupExperimentPixels.fireBarcodeScannerFailed()
         case .pastedCode:
-            Pixel.fire(pixel: .syncSetupManualCodeEnteredFailed, includedParameters: [.appVersion])
+            Pixel.fire(pixel: .syncSetupManualCodeEnteredFailed, withAdditionalParameters: parameters, includedParameters: [.appVersion])
             syncSetupExperimentPixels.fireManualCodeEnteredFailed()
         case .deepLink:
             break
@@ -773,14 +792,80 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
 
     private func sendSetupEndedSuccessfullyPixel(setupSource: SyncSetupSource, codeSource: SyncCodeSource) {
         guard setupSource != .unknown else { return }
-        let parameters = source.map { [PixelParameters.source: $0] } ?? [PixelParameters.source: setupSource.rawValue]
+        let parameters = syncSetupPixelParameters(setupSource: setupSource,
+                                                  path: setupSource.syncSetupPath,
+                                                  peerKind: pairingV2PeerKind?.syncSetupPeerKind,
+                                                  myRole: setupSource.syncSetupMyRole)
         switch codeSource {
         case .pastedCode, .qrCode:
             Pixel.fire(pixel: .syncSetupEndedSuccessful, withAdditionalParameters: parameters, includedParameters: [.appVersion])
+            pairingV2PeerKind = nil
         case .deepLink:
             Pixel.fire(pixel: .syncSetupDeepLinkFlowSuccess, includedParameters: [.appVersion])
             syncSetupExperimentPixels.fireDeepLinkFlowSuccess()
         }
+    }
+
+    private func sendSetupEndedFailedPixel(setupRole: SyncSetupRole, reason: String?) {
+        Pixel.fire(pixel: .syncSetupEndedFailed,
+                   withAdditionalParameters: syncSetupPixelParameters(setupRole: setupRole, reason: reason),
+                   includedParameters: [.appVersion])
+        pairingV2PeerKind = nil
+    }
+
+    func sendSetupEndedAbandonedPixel(setupRole: SyncSetupRole, reason: String?) {
+        let parameters: [String: String]
+        switch setupRole {
+        case .receiver(let setupSource, _):
+            parameters = syncSetupPixelParameters(setupSource: setupSource, reason: reason)
+        case .sharer:
+            parameters = syncSetupPixelParameters(setupSource: .exchange, reason: reason)
+        }
+        Pixel.fire(pixel: .syncSetupEndedAbandoned,
+                   withAdditionalParameters: parameters,
+                   includedParameters: [.appVersion])
+        pairingV2PeerKind = nil
+    }
+
+    func sendSyncConfirmationDeniedSetupEndedAbandonedPixel(setupRole: SyncSetupRole) {
+        sendSetupEndedAbandonedPixel(setupRole: setupRole, reason: SyncSetupPixelValue.syncConfirmationDenied)
+    }
+
+    private func syncSetupPixelParameters(setupRole: SyncSetupRole, reason: String?) -> [String: String] {
+        switch setupRole {
+        case .receiver(let setupSource, _):
+            return syncSetupPixelParameters(setupSource: setupSource,
+                                            path: setupSource.syncSetupPath,
+                                            reason: reason,
+                                            peerKind: pairingV2PeerKind?.syncSetupPeerKind,
+                                            myRole: setupSource.syncSetupMyRole)
+        case .sharer:
+            return syncSetupPixelParameters(setupSource: .exchange,
+                                            path: SyncSetupPixelValue.pairing,
+                                            reason: reason,
+                                            peerKind: pairingV2PeerKind?.syncSetupPeerKind,
+                                            myRole: SyncSetupPixelValue.host)
+        }
+    }
+
+    private func syncSetupPixelParameters(setupSource: SyncSetupSource,
+                                          codeType: String? = nil,
+                                          codeVersion: String? = nil,
+                                          path: String? = nil,
+                                          flowVersion: String? = nil,
+                                          reason: String? = nil,
+                                          peerKind: String? = nil,
+                                          myRole: String? = nil) -> [String: String] {
+        var parameters = source.map { [PixelParameters.source: $0] } ?? [PixelParameters.source: setupSource.rawValue]
+        parameters[SyncSetupPixelParameter.myKind] = SyncSetupPixelValue.ddg
+        parameters[SyncSetupPixelParameter.codeType] = codeType
+        parameters[SyncSetupPixelParameter.codeVersion] = codeVersion
+        parameters[SyncSetupPixelParameter.path] = path
+        parameters[SyncSetupPixelParameter.flowVersion] = flowVersion ?? syncSetupPixelFlowVersion
+        parameters[SyncSetupPixelParameter.reason] = reason
+        parameters[SyncSetupPixelParameter.peerKind] = peerKind
+        parameters[SyncSetupPixelParameter.myRole] = myRole
+        return parameters
     }
 
     func handleSuccessfulSetupOutcome(_ outcome: SyncSetupSuccessOutcome) {
@@ -800,7 +885,16 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         }
     }
 
-    func fireBarcodeCodeCopiedPixel(for code: String) {
+    func fireBarcodeCodeCopiedPixel(for code: String, sourceHint: CodeCollectionSource?) {
+        if let url = URL(string: code), PairingInfo.isPairingV2URL(url) {
+            let source = sourceHint.map(SyncSetupSource.init(codeCollectionSource:)) ?? .exchange
+            Pixel.fire(pixel: .syncSetupBarcodeCodeCopied,
+                       withAdditionalParameters: syncSetupPixelParameters(setupSource: source,
+                                                                          codeType: SyncSetupPixelValue.linking))
+            syncSetupExperimentPixels.fireBarcodeCodeCopied()
+            return
+        }
+
         guard let decoded = try? SyncCode.decodeBase64String(code) else { return }
         let source: SyncSetupSource
         if decoded.connect != nil {
@@ -811,7 +905,8 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
             return
         }
         Pixel.fire(pixel: .syncSetupBarcodeCodeCopied,
-                   withAdditionalParameters: [PixelParameters.source: source.rawValue])
+                   withAdditionalParameters: syncSetupPixelParameters(setupSource: source,
+                                                                      codeType: source.syncSetupCodeType))
         syncSetupExperimentPixels.fireBarcodeCodeCopied()
     }
 
@@ -837,4 +932,126 @@ extension SyncSettingsViewController {
 
     }
 
+}
+
+private enum SyncSetupPixelParameter {
+    static let flowVersion = "flow_version"
+    static let myKind = "my_kind"
+    static let codeType = "code_type"
+    static let codeVersion = "code_version"
+    static let path = "path"
+    static let reason = "reason"
+    static let peerKind = "peer_kind"
+    static let myRole = "my_role"
+}
+
+private enum SyncSetupPixelValue {
+    static let ddg = "ddg"
+    static let recovery = "recovery"
+    static let pairing = "pairing"
+    static let linking = "linking"
+    static let sessionTimeout = "session_timeout"
+    static let transportFailure = "transport_failure"
+    static let needsUpgrade = "needs_upgrade"
+    static let incompatibleCode = "incompatible_code"
+    static let unrecognizedCode = "unrecognized_code"
+    static let scanningCancelled = "scanning_cancelled"
+    static let syncConfirmationDenied = "sync_confirmation_denied"
+    static let invalidCredentials = "invalid_credentials"
+    static let alreadyUpgraded = "already_upgraded"
+    static let alreadyPaired = "already_paired"
+    static let accountCreationFailed = "account_creation_failed"
+    static let accountUpgradeFailed = "account_upgrade_failed"
+    static let protocolError = "protocol_error"
+    static let host = "host"
+    static let joiner = "joiner"
+}
+
+private extension SyncSetupSource {
+
+    init(codeCollectionSource: CodeCollectionSource) {
+        switch codeCollectionSource {
+        case .connect:
+            self = .connect
+        case .exchange:
+            self = .exchange
+        case .recovery:
+            self = .recovery
+        }
+    }
+
+    var syncSetupCodeType: String? {
+        switch self {
+        case .recovery:
+            return SyncSetupPixelValue.recovery
+        case .exchange, .connect:
+            return SyncSetupPixelValue.linking
+        case .unknown:
+            return nil
+        }
+    }
+
+    var syncSetupPath: String? {
+        switch self {
+        case .recovery:
+            return SyncSetupPixelValue.recovery
+        case .exchange, .connect:
+            return SyncSetupPixelValue.pairing
+        case .unknown:
+            return nil
+        }
+    }
+
+    var syncSetupMyRole: String? {
+        switch self {
+        case .connect:
+            return SyncSetupPixelValue.host
+        case .exchange:
+            return SyncSetupPixelValue.joiner
+        case .recovery, .unknown:
+            return nil
+        }
+    }
+}
+
+private extension PairingV2DeviceKind {
+
+    var syncSetupPeerKind: String {
+        rawValue
+    }
+}
+
+private extension SyncConnectionError {
+
+    var syncSetupFailureReason: String? {
+        switch self {
+        case .failedToLogIn:
+            return SyncSetupPixelValue.invalidCredentials
+        case .failedToFetchPublicKey,
+                .failedToTransmitExchangeRecoveryKey,
+                .failedToFetchConnectRecoveryKey,
+                .failedToTransmitExchangeKey,
+                .failedToFetchExchangeRecoveryKey,
+                .failedToTransmitConnectRecoveryKey:
+            return SyncSetupPixelValue.transportFailure
+        case .pollingForRecoveryKeyTimedOut:
+            return SyncSetupPixelValue.sessionTimeout
+        case .updateRequired:
+            return SyncSetupPixelValue.needsUpgrade
+        case .unsupportedThirdPartyRecoveryCode:
+            return SyncSetupPixelValue.incompatibleCode
+        case .thirdPartyAccountAlreadyUpgraded:
+            return SyncSetupPixelValue.alreadyUpgraded
+        case .unableToRecognizeCode:
+            return SyncSetupPixelValue.unrecognizedCode
+        case .failedToCreateAccount:
+            return SyncSetupPixelValue.accountCreationFailed
+        case .accountUpgradeFailed:
+            return SyncSetupPixelValue.accountUpgradeFailed
+        case .protocolError:
+            return SyncSetupPixelValue.protocolError
+        case .syncCancelledFromOtherDevice:
+            return nil
+        }
+    }
 }

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/ScanOrPasteCodeViewModel.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/ScanOrPasteCodeViewModel.swift
@@ -42,10 +42,10 @@ public protocol ScanOrPasteCodeViewModelDelegate: AnyObject {
 
     func codeCollectionCancelled(source: CodeCollectionSource)
     func gotoSettings()
-    func shareCode(_ code: String)
+    func shareCode(_ code: String, source: CodeCollectionSource)
 
     func codeEntryScreenShown()
-    func codeCopied(_ code: String)
+    func codeCopied(_ code: String, source: CodeCollectionSource)
 }
 
 public class ScanOrPasteCodeViewModel: ObservableObject {
@@ -102,7 +102,7 @@ public class ScanOrPasteCodeViewModel: ObservableObject {
         guard showQRCodeModel.codeForDisplayOrPasting.isEmpty == false else { return }
         showQRCodeModel.copy()
         UINotificationFeedbackGenerator().notificationOccurred(.success)
-        delegate?.codeCopied(showQRCodeModel.codeForDisplayOrPasting)
+        delegate?.codeCopied(showQRCodeModel.codeForDisplayOrPasting, source: source)
     }
 
     @MainActor
@@ -131,7 +131,7 @@ public class ScanOrPasteCodeViewModel: ObservableObject {
     }
 
     func showShareCodeSheet() {
-        delegate?.shareCode(showQRCodeModel.codeForDisplayOrPasting)
+        delegate?.shareCode(showQRCodeModel.codeForDisplayOrPasting, source: source)
     }
 
     func endConnectMode() {

--- a/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -1,0 +1,356 @@
+{
+    "sync_setup_barcode_screen_shown": {
+        "description": "Fired when the Sync setup QR/code screen is shown.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source or entry surface."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            }
+        ]
+    },
+    "sync_setup_barcode_scanner_success": {
+        "description": "Fired when Sync setup recognizes a scanned code.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source or recognized code source."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            },
+            {
+                "key": "code_type",
+                "type": "string",
+                "description": "The type of Sync setup code recognized.",
+                "enum": ["recovery", "linking"]
+            },
+            {
+                "key": "code_version",
+                "type": "string",
+                "description": "The version of Sync setup code recognized.",
+                "enum": ["v1", "v2"]
+            }
+        ]
+    },
+    "sync_setup_barcode_scanner_failed": {
+        "description": "Fired when Sync setup rejects a scanned code.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source or rejected code source."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            },
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "The reason the scanned code was rejected, when it can be mapped safely.",
+                "enum": ["unrecognized_code", "needs_upgrade", "incompatible_code"]
+            }
+        ]
+    },
+    "sync_setup_barcode_code_copied": {
+        "description": "Fired when the user copies the Sync setup code.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            },
+            {
+                "key": "code_type",
+                "type": "string",
+                "description": "The type of Sync setup code copied.",
+                "enum": ["recovery", "linking"]
+            }
+        ]
+    },
+    "sync_setup_manual_code_entry_screen_shown": {
+        "description": "Fired when the Sync setup manual code-entry screen is shown.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            }
+        ]
+    },
+    "sync_setup_manual_code_entered_success": {
+        "description": "Fired when Sync setup recognizes a manually entered or pasted code.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source or recognized code source."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            },
+            {
+                "key": "code_type",
+                "type": "string",
+                "description": "The type of Sync setup code recognized.",
+                "enum": ["recovery", "linking"]
+            },
+            {
+                "key": "code_version",
+                "type": "string",
+                "description": "The version of Sync setup code recognized.",
+                "enum": ["v1", "v2"]
+            }
+        ]
+    },
+    "sync_setup_manual_code_entered_failed": {
+        "description": "Fired when Sync setup rejects a manually entered or pasted code.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source or rejected code source."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            },
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "The reason the entered code was rejected, when it can be mapped safely.",
+                "enum": ["unrecognized_code", "needs_upgrade", "incompatible_code"]
+            }
+        ]
+    },
+    "sync_setup_ended_abandoned": {
+        "description": "Fired when the user abandons Sync setup before completion.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source or entry surface."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            },
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "The reason Sync setup was abandoned, when it can be mapped safely.",
+                "enum": ["scanning_cancelled", "sync_confirmation_denied"]
+            }
+        ]
+    },
+    "sync_setup_ended_failed": {
+        "description": "Fired when Sync setup started from a recognized code but failed before completion.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source or entry surface."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            },
+            {
+                "key": "path",
+                "type": "string",
+                "description": "Whether the setup flow was recovery or pairing.",
+                "enum": ["recovery", "pairing"]
+            },
+            {
+                "key": "peer_kind",
+                "type": "string",
+                "description": "The kind of the peer client, when known.",
+                "enum": ["ddg", "3party"]
+            },
+            {
+                "key": "my_role",
+                "type": "string",
+                "description": "This client's role in the pairing flow, when applicable.",
+                "enum": ["host", "joiner"]
+            },
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "The reason Sync setup failed, when it can be mapped safely.",
+                "enum": [
+                    "session_timeout",
+                    "transport_failure",
+                    "invalid_credentials",
+                    "already_upgraded",
+                    "already_paired",
+                    "account_creation_failed",
+                    "account_upgrade_failed",
+                    "protocol_error"
+                ]
+            }
+        ]
+    },
+    "sync_setup_ended_successful": {
+        "description": "Fired when Sync setup completes successfully.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source or entry surface."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            },
+            {
+                "key": "path",
+                "type": "string",
+                "description": "Whether the setup flow was recovery or pairing.",
+                "enum": ["recovery", "pairing"]
+            },
+            {
+                "key": "peer_kind",
+                "type": "string",
+                "description": "The kind of the peer client, when known.",
+                "enum": ["ddg", "3party"]
+            },
+            {
+                "key": "my_role",
+                "type": "string",
+                "description": "This client's role in the pairing flow, when applicable.",
+                "enum": ["host", "joiner"]
+            }
+        ]
+    }
+}

--- a/macOS/DuckDuckGo/Preferences/Model/LegacySyncPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/LegacySyncPreferences.swift
@@ -1074,7 +1074,7 @@ extension LegacySyncPreferences: SyncConnectionControllerDelegate {
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .thirdPartyAccountAlreadyUpgraded)
         case .syncCancelledFromOtherDevice:
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .syncCancelledFromOtherDevice)
-        case .failedToFetchPublicKey, .failedToTransmitExchangeRecoveryKey, .failedToFetchConnectRecoveryKey, .failedToLogIn, .failedToTransmitExchangeKey, .failedToFetchExchangeRecoveryKey, .failedToTransmitConnectRecoveryKey:
+        case .failedToFetchPublicKey, .failedToTransmitExchangeRecoveryKey, .failedToFetchConnectRecoveryKey, .failedToLogIn, .failedToTransmitExchangeKey, .failedToFetchExchangeRecoveryKey, .failedToTransmitConnectRecoveryKey, .accountUpgradeFailed, .protocolError:
             handleError(.unableToSyncToOtherDevice, error: underlyingError, pixelEvent: GeneralPixel.syncLoginError(error: underlyingError ?? error))
         case .failedToCreateAccount:
             handleError(.unableToSyncToOtherDevice, error: underlyingError, pixelEvent: GeneralPixel.syncSignupError(error: underlyingError ?? error))

--- a/macOS/DuckDuckGo/Preferences/Model/SyncDialogController.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/SyncDialogController.swift
@@ -704,7 +704,7 @@ extension SyncDialogController: SyncConnectionControllerDelegate {
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .thirdPartyAccountAlreadyUpgraded)
         case .syncCancelledFromOtherDevice:
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .syncCancelledFromOtherDevice)
-        case .failedToFetchPublicKey, .failedToTransmitExchangeRecoveryKey, .failedToFetchConnectRecoveryKey, .failedToLogIn, .failedToTransmitExchangeKey, .failedToFetchExchangeRecoveryKey, .failedToTransmitConnectRecoveryKey:
+        case .failedToFetchPublicKey, .failedToTransmitExchangeRecoveryKey, .failedToFetchConnectRecoveryKey, .failedToLogIn, .failedToTransmitExchangeKey, .failedToFetchExchangeRecoveryKey, .failedToTransmitConnectRecoveryKey, .accountUpgradeFailed, .protocolError:
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unableToSyncToOtherDevice, description: underlyingError?.localizedDescription)
             PixelKit.fire(DebugEvent(GeneralPixel.syncLoginError(error: underlyingError ?? error)))
         case .failedToCreateAccount:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215816968103856?focus=true
Tech Design URL:
CC: @miasma13 

### Description
Adds iOS pixels for Sync V2 flows (one new pixel, existing pixels augmented with additional parameters related to Sync flow (e.g. flow_version: v1/v2, my_role: host/joiner, peer_kind: ddg/3party) and additional failure reasons. BSK code is identical to https://github.com/duckduckgo/apple-browsers/pull/5448

### Testing Steps
1. See https://github.com/duckduckgo/apple-browsers/pull/5448 for test steps

### Impact and Risks
What's the impact on users if something goes wrong?

Low: Minor visual changes, small bug fixes, improvement to existing features



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly analytics and error classification; sync pairing behavior is unchanged aside from clearer upgrade vs login failure mapping in Pairing V2.
> 
> **Overview**
> Adds **Sync V2–aware setup telemetry** on iOS: a new `sync_setup_ended_failed` pixel, a `sync_setup.json5` schema for enriched parameters, and centralized helpers so existing setup events carry **flow_version**, **code_type/code_version**, **path**, **my_role**, **peer_kind**, and **reason** where applicable. Success, abandon, copy/share, scan/manual entry, and pairing-confirmation denial paths are wired to these parameters; **pairingV2PeerKind** is tracked after the user confirms a V2 peer.
> 
> **BrowserServicesKit** gains `SyncSetupCodeVersion` and extends `controllerDidRecognizeCode` with an optional **codeVersion** (default extension preserves old delegates). Connection errors **`accountUpgradeFailed`** and **`protocolError`** are added; Pairing V2 third-party upgrade failures map to **`upgradeFailed`** instead of **`loginFailed`**. **`PairingInfo.isPairingV2URL`** detects V2 pairing URLs via a `code2` fragment key.
> 
> macOS sync preferences only **handle the new connection error cases** in existing error switches; macOS delegates still use the default **codeVersion** shim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1166335c548d3fc73bae9e8fce7e1e0379392a02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->