### PR TITLE
[iOS][MacOS][Subscription] Link subscription funnel origins to their Asana entry-point subtasks

### DIFF
--- a/iOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
+++ b/iOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
@@ -38,15 +38,19 @@ enum SubscriptionFunnelOrigin: String {
     case newTabMenu = "funnel_appmenu_ios"
 
     /// User entered the funnel by tapping a gated model in the Unified Toggle Input model picker from the address bar.
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1213994750860310
     case addressBarModelPicker = "funnel_addressbar_ios__modelpicker"
 
     /// User entered the funnel by tapping a gated reasoning level in the Unified Toggle Input reasoning picker from the address bar.
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1213994750860310
     case addressBarReasoningPicker = "funnel_addressbar_ios__reasoningpicker"
 
     /// User entered the funnel by tapping a gated model in the Unified Toggle Input model picker from the Duck.ai tab.
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1213994750860310
     case duckAIModelPicker = "funnel_duckai_ios__modelpicker"
 
     /// User entered the funnel by tapping a gated reasoning level in the Unified Toggle Input reasoning picker from the Duck.ai tab.
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1213994750860310
     case duckAIReasoningPicker = "funnel_duckai_ios__reasoningpicker"
 
     // MARK: - Win-Back Offer Origins
@@ -58,9 +62,6 @@ enum SubscriptionFunnelOrigin: String {
     /// User entered via win-back offer in App Settings
     /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1213998044482808
     case winBackSettings = "funnel_appsettings_ios_winback"
-
-    /// User triggered a plan change by cancelling a pending downgrade
-    case cancelDowngrade = "funnel_canceldowngrade_ios"
 
     /// User entered the funnel via the VPN access-revoked alert when their subscription was revoked.
     /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1214811710571517
@@ -99,4 +100,10 @@ enum SubscriptionRestoreFunnelOrigin: String {
 
     /// User entered the restore funnel during the pre-purchase check.
     case prePurchaseCheck = "funnel_prepurchasecheck_ios"
+}
+
+/// Represents the origin of a subscription plan change (not a subscription entry point) in the iOS app.
+enum SubscriptionPlanChangeOrigin: String {
+    /// User triggered a plan change by cancelling a pending downgrade.
+    case cancelDowngrade = "funnel_canceldowngrade_ios"
 }

--- a/iOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
+++ b/iOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
@@ -22,15 +22,19 @@ import Foundation
 /// Represents the origin point from which the user enters the subscription funnel in the iOS app.
 enum SubscriptionFunnelOrigin: String {
     /// User entered the funnel via the onboarding dialog screen.
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1210468753388385
     case onboarding = "funnel_onboarding_ios"
 
     /// User entered the funnel via the skipped-onboarding promo modal.
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1213994750860308
     case skippedOnboarding = "funnel_modal_ios__skippedonboardingupsell"
 
     /// User entered the funnel via the App Settings screen.
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1210468753388392
     case appSettings = "funnel_appsettings_ios"
 
     /// User entered the funnel via the VPN menu item in the New Tab Page app menu.
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1212891971534036
     case newTabMenu = "funnel_appmenu_ios"
 
     /// User entered the funnel by tapping a gated model in the Unified Toggle Input model picker from the address bar.
@@ -48,32 +52,40 @@ enum SubscriptionFunnelOrigin: String {
     // MARK: - Win-Back Offer Origins
     
     /// User entered via win-back offer launch prompt
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1213998044482808
     case winBackLaunch = "funnel_applaunch_ios_winback"
     
     /// User entered via win-back offer in App Settings
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1213998044482808
     case winBackSettings = "funnel_appsettings_ios_winback"
 
     /// User triggered a plan change by cancelling a pending downgrade
     case cancelDowngrade = "funnel_canceldowngrade_ios"
 
     /// User entered the funnel via the VPN access-revoked alert when their subscription was revoked.
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1214811710571517
     case vpnAccessRevokedAlert = "funnel_alert_ios__subscriptionvpnrevoked"
 
     // MARK: - VPN Entry Points (non-subscriber fallback)
 
     /// User entered the funnel by tapping the customizable toolbar VPN button without an active VPN entitlement.
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1215296884609840
     case toolbarVPN = "funnel_toolbar_ios__subscriptionvpn"
 
     /// User entered the funnel by tapping the customizable address-bar VPN button without an active VPN entitlement.
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1215296884609842
     case addressBarVPN = "funnel_addressbar_ios__subscriptionvpn"
 
     /// User entered the funnel via the VPN Control Center widget / App Intent deep link without an active VPN entitlement.
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1215398999855855
     case widgetVPN = "funnel_widget_ios__subscriptionvpn"
 
     /// User entered the funnel via the home-screen app-icon VPN quick action without an active VPN entitlement.
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1215398999855857
     case shortcutVPN = "funnel_integration_ios_shortcut_subscriptionvpn"
 
     /// User entered the funnel by tapping the VPN push notification without an active VPN entitlement.
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1215398999855859
     case notificationVPN = "funnel_notification_ios__subscriptionvpn"
 }
 

--- a/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModel.swift
+++ b/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModel.swift
@@ -335,7 +335,7 @@ final class SubscriptionSettingsViewModel: ObservableObject {
         let setStatus: (SubscriptionTransactionStatus) -> Void = { [weak self] in self?.setCancelDowngradeStatus($0) }
         await subscriptionFlowsExecuter.performTierChange(to: productId,
                                                           changeType: "upgrade",
-                                                          contextName: SubscriptionFunnelOrigin.cancelDowngrade.rawValue,
+                                                          contextName: SubscriptionPlanChangeOrigin.cancelDowngrade.rawValue,
                                                           setTransactionStatus: setStatus,
                                                           setTransactionError: setError,
                                                           pushPurchaseUpdate: nil)

--- a/macOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
@@ -21,41 +21,53 @@ import Foundation
 /// Represents the origin point from which the user enters the subscription funnel in the macOS app.
 enum SubscriptionFunnelOrigin: String {
     /// User entered the funnel via the App Settings screen.
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1210468753388392
     case appSettings = "funnel_appsettings_macos"
 
     /// User entered the funnel via the App More Menu.
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1210468753388401
     case appMenu = "funnel_appmenu_macos"
 
     /// User entered the funnel via the Free Scan feature.
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1210468753388402
     case freeScan = "funnel_freescan_macos"
 
     // MARK: - Win-Back Offer Origins
 
     /// User entered via win-back offer launch prompt
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1213998044482808
     case winBackLaunch = "funnel_applaunch_macos_winback"
 
     /// User entered via win-back offer in App More Menu
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1213998044482808
     case winBackMenu = "funnel_appmenu_macos_winback"
 
     /// User entered via win-back offer in App Settings
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1213998044482808
     case winBackSettings = "funnel_appsettings_macos_winback"
 
     /// User entered via win-back offer in New Tab Page
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1213998044482808
     case winBackNewTabPage = "funnel_newtab_macos_winback"
 
     /// User entered the funnel via the New Tab Page next steps card.
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1213994750860324
     case newTabPageNextStepsCard = "funnel_onboarding_macOS__nextstepscard"
 
     /// User entered the funnel via the subscription promo on the Fire Window home page.
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1214355390442152
     case fireWindowPromo = "funnel_newtab_macos__firewindowvpn"
 
     /// User entered the funnel via the VPN toolbar button upsell popover.
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1213994750860320
     case vpnToolbarUpsell = "funnel_toolbar_macos__subscriptionvpnupsell"
 
     /// User entered the funnel via the VPN toolbar button popover when their subscription was revoked.
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1214811710571517
     case vpnToolbarRevoked = "funnel_toolbar_macos__subscriptionvpnrevoked"
 
     /// User entered the funnel via the VPN menu-bar status item popover when their subscription was revoked.
+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1214811710571517
     case vpnMenuBarRevoked = "funnel_menubar_macos__subscriptionvpnrevoked"
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215777090564807?focus=true
### Description

Adds an Asana doc-comment link above each `SubscriptionFunnelOrigin` case on iOS and macOS, pointing to the matching entry-point subtask under the [Subscription Entry Points task](https://app.asana.com/1/137249556945/project/1207260194172075/task/1209784982258586). This ties each funnel origin in code to its tracking subtask, so the funnel-origin dashboards stay complete and instrumentation drift is easier to catch.

It also moves `cancelDowngrade` out of `SubscriptionFunnelOrigin` into a new `SubscriptionPlanChangeOrigin` enum — it is a plan-management action, not a subscription entry point. Its `funnel_canceldowngrade_ios` rawValue is unchanged, so analytics are unaffected.

**All `SubscriptionFunnelOrigin` cases are now linked** (iOS + macOS), each verified against the origin rawValue listed in the target subtask's Asana notes. The separate `SubscriptionRestoreFunnelOrigin` enum is out of scope (restore funnel).

**Related PR:** the Danger check that enforces this convention going forward — warning when a new `SubscriptionFunnelOrigin` case is added without a link — lives in [duckduckgo/danger-settings#23](https://github.com/duckduckgo/danger-settings/pull/23). It is a separate repo/PR and is not part of this change.

### Testing Steps

1. Comments plus a small enum move — no behavioral change to existing entry points. Build to confirm it compiles.
2. Spot-check that each added `/// https://...` link resolves to the entry-point subtask matching that case's origin rawValue.

### Impact and Risks

Low — documentation/comments, plus moving one enum case (`cancelDowngrade`) to a new enum with a single call site updated. The `funnel_canceldowngrade_ios` rawValue is preserved, so there is no analytics impact.

#### What could go wrong?

- A link could point to the wrong subtask. Mitigation: every mapping was verified against the origin rawValue listed in the target subtask's Asana notes; ambiguous cases were not guessed.
- The `cancelDowngrade` move could miss a call site. Mitigation: there is a single call site (`SubscriptionSettingsViewModel`), updated and grep-verified; the rawValue is unchanged.

### Quality Considerations

- Establishes a per-subtask Asana-link convention for subscription funnel origins, enforced going forward by the Danger check in [duckduckgo/danger-settings#23](https://github.com/duckduckgo/danger-settings/pull/23).
- Separates `cancelDowngrade` from entry-point origins for clearer semantics, without changing its analytics rawValue.

### Notes to Reviewer

- Mostly a comments diff plus a small enum move. Easiest to review by confirming each `/// https://...` line matches its case's origin rawValue, and that the `cancelDowngrade` move preserves the `funnel_canceldowngrade_ios` rawValue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only mapping on macOS/iOS funnel cases plus a single call-site enum swap with an unchanged analytics rawValue; no subscription purchase flow logic changes in the diff.
> 
> **Overview**
> Adds **Asana subtask doc-comment links** above every `SubscriptionFunnelOrigin` case on **iOS and macOS**, so each funnel raw value maps to its entry-point tracking task and instrumentation drift is easier to spot.
> 
> On **iOS**, **`cancelDowngrade`** is removed from `SubscriptionFunnelOrigin` and moved into a new **`SubscriptionPlanChangeOrigin`** enum (plan management, not a funnel entry). **`SubscriptionSettingsViewModel`** now passes `SubscriptionPlanChangeOrigin.cancelDowngrade` into tier-change context; the **`funnel_canceldowngrade_ios`** raw value is unchanged, so analytics behavior should stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f686c487129b44d9b177d66d527cfc55bbd94d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->