### PR TITLE
Handle focusChatInput message to focus Unified Toggle Input

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatUserScriptMessages.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatUserScriptMessages.swift
@@ -76,6 +76,10 @@ public enum AIChatUserScriptMessages: String, CaseIterable {
     /// Posted by the FE when the subscription recovery card is dismissed for the active chat.
     case enableChatInput
 
+    /// Posted by the FE to request focus on the native address bar (omnibar).
+    /// Native honors this only when the Unified Toggle Input feature is enabled.
+    case focusChatInput
+
     // Sync
     case getSyncStatus
     case getScopedSyncAuthToken

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatUserScriptMessages.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatUserScriptMessages.swift
@@ -76,7 +76,7 @@ public enum AIChatUserScriptMessages: String, CaseIterable {
     /// Posted by the FE when the subscription recovery card is dismissed for the active chat.
     case enableChatInput
 
-    /// Posted by the FE to request focus on the native address bar (omnibar).
+    /// Posted by the FE to request focus on the native address bar (UTI).
     /// Native honors this only when the Unified Toggle Input feature is enabled.
     case focusChatInput
 

--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
@@ -180,6 +180,7 @@ final class AIChatUserScript: NSObject, Subfeature {
             Logger.aiChat.debug("AIChatUserScript: unhandled message: \(methodName)")
             return nil
         }
+        Logger.aiChat.debug("AIChatUserScript: handled message: \(methodName)")
 
         delegate?.aiChatUserScript(self, didReceiveMessage: message)
 
@@ -250,6 +251,8 @@ final class AIChatUserScript: NSObject, Subfeature {
             return handler.disableChatInput
         case .enableChatInput:
             return handler.enableChatInput
+        case .focusChatInput:
+            return handler.focusChatInput
         default:
             return nil
         }
@@ -277,6 +280,10 @@ final class AIChatUserScript: NSObject, Subfeature {
 
     func setFireModeProvider(_ provider: (() -> Bool)?) {
         handler.isFireModeProvider = provider
+    }
+
+    func setFocusChatInputHandler(_ handler: (@MainActor () -> Void)?) {
+        self.handler.focusChatInputHandler = handler
     }
 
     // MARK: - Input Box Event Subscription

--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -147,6 +147,7 @@ final class AIChatUserScriptErrorEventMapper: EventMapping<AIChatUserScriptError
 protocol AIChatUserScriptHandling: AnyObject {
     var displayMode: AIChatDisplayMode? { get set }
     var isFireModeProvider: (() -> Bool)? { get set }
+    var focusChatInputHandler: (@MainActor () -> Void)? { get set }
     func setPageContextProvider(_ provider: ((PageContextRequestReason) -> AIChatPageContextData?)?)
     func setContextualModePixelHandler(_ pixelHandler: AIChatContextualModePixelFiring)
     func getAIChatNativeConfigValues(params: Any, message: UserScriptMessage) -> Encodable?
@@ -179,6 +180,7 @@ protocol AIChatUserScriptHandling: AnyObject {
     func showModelPicker(params: Any, message: UserScriptMessage) async -> Encodable?
     func disableChatInput(params: Any, message: UserScriptMessage) async -> Encodable?
     func enableChatInput(params: Any, message: UserScriptMessage) async -> Encodable?
+    func focusChatInput(params: Any, message: UserScriptMessage) async -> Encodable?
 
     // Sync
     func getSyncStatus(params: Any, message: UserScriptMessage) -> Encodable?
@@ -219,6 +221,9 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
     /// Provider that returns whether the current context is fire mode.
     /// Each owner (tab, contextual sheet, modal) is responsible for setting this.
     var isFireModeProvider: (() -> Bool)?
+
+    /// Called when the FE requests focus on the native address bar via `focusChatInput`.
+    var focusChatInputHandler: (@MainActor () -> Void)?
 
     /// Closure that provides page context on getAIChatPageContext requests.
     /// Parameter is the request reason (e.g., `.userAction` for manual attach).
@@ -598,6 +603,13 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
     @MainActor
     func enableChatInput(params: Any, message: UserScriptMessage) async -> Encodable? {
         inputBoxHandler?.isSubmitBlockedByRecoveryCard = false
+        return nil
+    }
+
+    @MainActor
+    func focusChatInput(params: Any, message: UserScriptMessage) async -> Encodable? {
+        guard unifiedToggleInputFeature.isAvailable else { return nil }
+        focusChatInputHandler?()
         return nil
     }
 

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -3602,7 +3602,8 @@ extension TabViewController: UserContentControllerDelegate {
         
         userScripts.aiChatUserScript.setFireModeProvider { [weak self] in self?.tabModel.fireTab ?? false }
         userScripts.aiChatUserScript.setFocusChatInputHandler { [weak self] in
-            (self?.parent as? MainViewController)?.focusUnifiedToggleInputForActiveChat()
+            guard let self else { return }
+            (self.parent as? MainViewController)?.focusUnifiedToggleInputForActiveChat(from: self.webView)
         }
         userScripts.duckAiNativeStorageUserScript?.fireModeStorageProvider = { [weak self] in
             guard let self else { return .notFireMode }

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -3602,7 +3602,7 @@ extension TabViewController: UserContentControllerDelegate {
         
         userScripts.aiChatUserScript.setFireModeProvider { [weak self] in self?.tabModel.fireTab ?? false }
         userScripts.aiChatUserScript.setFocusChatInputHandler { [weak self] in
-            (self?.parent as? MainViewController)?.beginSearch()
+            (self?.parent as? MainViewController)?.focusUnifiedToggleInputForActiveChat()
         }
         userScripts.duckAiNativeStorageUserScript?.fireModeStorageProvider = { [weak self] in
             guard let self else { return .notFireMode }

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -3601,6 +3601,9 @@ extension TabViewController: UserContentControllerDelegate {
         userScripts.serpSettingsUserScript.webView = webView
         
         userScripts.aiChatUserScript.setFireModeProvider { [weak self] in self?.tabModel.fireTab ?? false }
+        userScripts.aiChatUserScript.setFocusChatInputHandler { [weak self] in
+            (self?.parent as? MainViewController)?.beginSearch()
+        }
         userScripts.duckAiNativeStorageUserScript?.fireModeStorageProvider = { [weak self] in
             guard let self else { return .notFireMode }
             return .resolve(isFireMode: self.tabModel.fireTab,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1158,12 +1158,6 @@ extension MainViewController {
         completion?()
     }
 
-    /// Focuses the Duck.ai Unified Toggle Input on the active AI tab in response to the FE's
-    /// `focusChatInput` message. Expands the bottom input bar and makes its text field first
-    /// responder — the Duck.ai-specific input — instead of activating the omnibar (the legacy
-    /// `beginSearch()` behavior). No-ops unless the message came from the foreground Duck.ai
-    /// tab's web view, mirroring `handleShowModelPicker` so a backgrounded chat can't steal
-    /// focus on the current tab.
     func focusUnifiedToggleInputForActiveChat(from webView: WKWebView) {
         guard let controller = tabManager.controller(forWebView: webView),
               controller === currentTab,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1158,6 +1158,15 @@ extension MainViewController {
         completion?()
     }
 
+    /// Focuses the Duck.ai Unified Toggle Input on the active AI tab in response to the FE's
+    /// `focusChatInput` message. Expands the bottom input bar and makes its text field first
+    /// responder — the Duck.ai-specific input — instead of activating the omnibar (the legacy
+    /// `beginSearch()` behavior). No-ops when the active tab isn't a Duck.ai tab.
+    func focusUnifiedToggleInputForActiveChat() {
+        guard let coordinator = unifiedToggleInputCoordinator, coordinator.isAITabState else { return }
+        coordinator.showExpanded(inputMode: .aiChat)
+    }
+
     func handleUnifiedToggleInputSearchSubmission(_ query: String) {
         fireDirectDuckAINavigationPixelIfNeeded(for: query)
         if let tab = tabManager.currentTabsModel.currentTab, tab.link == nil {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1161,9 +1161,14 @@ extension MainViewController {
     /// Focuses the Duck.ai Unified Toggle Input on the active AI tab in response to the FE's
     /// `focusChatInput` message. Expands the bottom input bar and makes its text field first
     /// responder — the Duck.ai-specific input — instead of activating the omnibar (the legacy
-    /// `beginSearch()` behavior). No-ops when the active tab isn't a Duck.ai tab.
-    func focusUnifiedToggleInputForActiveChat() {
-        guard let coordinator = unifiedToggleInputCoordinator, coordinator.isAITabState else { return }
+    /// `beginSearch()` behavior). No-ops unless the message came from the foreground Duck.ai
+    /// tab's web view, mirroring `handleShowModelPicker` so a backgrounded chat can't steal
+    /// focus on the current tab.
+    func focusUnifiedToggleInputForActiveChat(from webView: WKWebView) {
+        guard let controller = tabManager.controller(forWebView: webView),
+              controller === currentTab,
+              let coordinator = unifiedToggleInputCoordinator,
+              coordinator.isAITabState else { return }
         coordinator.showExpanded(inputMode: .aiChat)
     }
 

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContentHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContentHandlerTests.swift
@@ -769,6 +769,7 @@ final class MockAIChatUserScript: AIChatUserScriptProviding {
 final class MockAIChatUserScriptHandling: AIChatUserScriptHandling {
     var displayMode: AIChatDisplayMode?
     var isFireModeProvider: (() -> Bool)?
+    var focusChatInputHandler: (@MainActor () -> Void)?
 
     func setPageContextProvider(_ provider: ((PageContextRequestReason) -> AIChatPageContextData?)?) {}
     func setContextualModePixelHandler(_ pixelHandler: AIChatContextualModePixelFiring) {}
@@ -809,6 +810,7 @@ final class MockAIChatUserScriptHandling: AIChatUserScriptHandling {
     func showModelPicker(params: Any, message: UserScriptMessage) async -> Encodable? { nil }
     func disableChatInput(params: Any, message: UserScriptMessage) async -> Encodable? { nil }
     func enableChatInput(params: Any, message: UserScriptMessage) async -> Encodable? { nil }
+    func focusChatInput(params: Any, message: UserScriptMessage) async -> Encodable? { nil }
 }
 // swiftlint:enable inclusive_language
 

--- a/iOS/DuckDuckGoTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -37,6 +37,7 @@ class AIChatUserScriptHandlerTests: XCTestCase {
     var mockAIChatSyncHandler: MockAIChatSyncHandling!
     var mockAIChatFullModeFeature: MockAIChatFullModeFeatureProviding!
     var mockAIChatContextualModeFeature: MockAIChatContextualModeFeatureProviding!
+    var mockUnifiedToggleInputFeature: MockUnifiedToggleInputFeatureProvider!
     private var mockUserScriptErrorEventMapper: CapturingAIChatUserScriptErrorEventMapper!
     private var mockUserDefaults: UserDefaults!
 
@@ -51,6 +52,7 @@ class AIChatUserScriptHandlerTests: XCTestCase {
         mockAIChatSyncHandler = MockAIChatSyncHandling()
         mockAIChatFullModeFeature = MockAIChatFullModeFeatureProviding()
         mockAIChatContextualModeFeature = MockAIChatContextualModeFeatureProviding()
+        mockUnifiedToggleInputFeature = MockUnifiedToggleInputFeatureProvider()
         mockUserScriptErrorEventMapper = CapturingAIChatUserScriptErrorEventMapper()
 
         mockUserDefaults = UserDefaults(suiteName: mockSuiteName)
@@ -67,6 +69,7 @@ class AIChatUserScriptHandlerTests: XCTestCase {
         mockAIChatSyncHandler = nil
         mockAIChatFullModeFeature = nil
         mockAIChatContextualModeFeature = nil
+        mockUnifiedToggleInputFeature = nil
         mockUserScriptErrorEventMapper = nil
         PixelFiringMock.tearDown()
         super.tearDown()
@@ -84,6 +87,7 @@ class AIChatUserScriptHandlerTests: XCTestCase {
             keyValueStore: mockUserDefaults,
             aichatFullModeFeature: mockAIChatFullModeFeature,
             aichatContextualModeFeature: mockAIChatContextualModeFeature,
+            unifiedToggleInputFeature: mockUnifiedToggleInputFeature,
             aiChatUserScriptErrorEventMapper: aiChatUserScriptErrorEventMapper ?? AIChatUserScriptErrorEventMapper(),
             isNativeStorageBridgeAvailable: isNativeStorageBridgeAvailable,
             installDateProvider: installDateProvider,
@@ -946,5 +950,62 @@ extension AIChatUserScriptHandlerTests {
 
         // Then
         XCTAssertEqual(mockUserDefaults.object(forKey: termsAcceptedKey) as? Bool, true)
+    }
+}
+
+// MARK: - focusChatInput Tests
+
+extension AIChatUserScriptHandlerTests {
+
+    @MainActor
+    func testWhenUnifiedToggleInputFeatureIsAvailableThenFocusChatInputCallsHandler() async {
+        // Given
+        mockUnifiedToggleInputFeature.isAvailable = true
+        var handlerCallCount = 0
+        aiChatUserScriptHandler.focusChatInputHandler = { handlerCallCount += 1 }
+
+        // When
+        let result = await aiChatUserScriptHandler.focusChatInput(
+            params: [],
+            message: MockUserScriptMessage(name: "test", body: [:])
+        )
+
+        // Then
+        XCTAssertNil(result)
+        XCTAssertEqual(handlerCallCount, 1)
+    }
+
+    @MainActor
+    func testWhenUnifiedToggleInputFeatureIsUnavailableThenFocusChatInputDoesNotCallHandler() async {
+        // Given
+        mockUnifiedToggleInputFeature.isAvailable = false
+        var handlerCallCount = 0
+        aiChatUserScriptHandler.focusChatInputHandler = { handlerCallCount += 1 }
+
+        // When
+        let result = await aiChatUserScriptHandler.focusChatInput(
+            params: [],
+            message: MockUserScriptMessage(name: "test", body: [:])
+        )
+
+        // Then
+        XCTAssertNil(result)
+        XCTAssertEqual(handlerCallCount, 0)
+    }
+
+    @MainActor
+    func testWhenFocusChatInputHandlerIsNotSetThenFocusChatInputReturnsNilWithoutCrashing() async {
+        // Given
+        mockUnifiedToggleInputFeature.isAvailable = true
+        aiChatUserScriptHandler.focusChatInputHandler = nil
+
+        // When
+        let result = await aiChatUserScriptHandler.focusChatInput(
+            params: [],
+            message: MockUserScriptMessage(name: "test", body: [:])
+        )
+
+        // Then
+        XCTAssertNil(result)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215752428757172?focus=true
Tech Design URL:
CC:

### Description
Adds handling for a new `focusChatInput` user script message sent by the Duck.ai frontend to request focus on the native input bar. When the Unified Toggle Input feature is active and the current tab is an AI tab, this expands the bottom input bar and focuses the Duck.ai text field instead of the omnibar. The handler is no-op when the feature flag is disabled or the active tab isn't a Duck.ai tab.

### Testing Steps
1. Enable the Unified Toggle Input feature flag and open a Duck.ai tab.
2. Trigger the `focusChatInput` message from the Duck.ai frontend by selecting "Customize responses" 
3. Verify the bottom bar disappears while the modal is visible and closes auto-selecting the input field when the modal closes

### Impact and Risks
Low — new message handler is gated behind the existing `unifiedToggleInputFeature.isAvailable` check and no-ops outside AI tabs.

#### What could go wrong?
If the coordinator state is unexpectedly nil or not in AI tab state, the method silently no-ops with no visible effect.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is gated on `unifiedToggleInputFeature.isAvailable` and current-tab/AI-tab checks; wrong context silently no-ops with no data or auth impact.
> 
> **Overview**
> Adds a **`focusChatInput`** bridge message so Duck.ai can ask native iOS to focus the Unified Toggle Input (UTI) instead of the in-page field.
> 
> When **Unified Toggle Input** is on and the message comes from the **foreground Duck.ai tab**, native expands the bottom bar in **`.aiChat`** mode via `focusUnifiedToggleInputForActiveChat`. The handler is wired from `TabViewController` through `setFocusChatInputHandler`; `AIChatUserScriptHandler.focusChatInput` no-ops if the feature flag is off or no handler is set.
> 
> Mocks and unit tests cover the feature-gate and handler invocation. A debug log was added for handled user-script messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8839778a481f8218ec74c098848e8a0caa88be87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->