### PR TITLE
Increase Maestro concurrency, and allow running individual suites.

### DIFF
--- a/.github/workflows/ios_end_to_end.yml
+++ b/.github/workflows/ios_end_to_end.yml
@@ -17,6 +17,11 @@ on:
         - production
         - internal
         - both
+      test_tags:
+        description: "Comma-separated suite tags to run in isolation (e.g. 'release' or 'release,privacy'). Empty = all suites. Valid: release, privacy, securityTest, adClick, duckplayer_native, device_info, duckplayer_classic, duckai_chrome_shortcut."
+        type: string
+        default: ""
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -158,6 +163,7 @@ jobs:
       run: |
         event="${{ github.event_name }}"
         input_modes="${{ inputs.user_modes }}"
+        input_tags="${{ inputs.test_tags }}"
         case "$event" in
           schedule)
             modes='["production", "internal"]'
@@ -185,15 +191,34 @@ jobs:
           {"test-tag":"duckplayer_classic","exclude-tags":"iphone","device-model":"iPad-10th-generation","device":"ipad"},
           {"test-tag":"duckai_chrome_shortcut","exclude-tags":"iphone","device-model":"iPad-10th-generation","device":"ipad"}
         ]'
-        include=$(echo "$base" | jq -c --argjson modes "$modes" '[.[] as $b | $modes[] | $b + {"user-mode": .}]')
+        # Comma-separated suite tags from dispatch -> trimmed JSON array; empty = all suites.
+        tags=$(jq -nc --arg s "$input_tags" '$s | split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length > 0))')
+        # Fail fast on a typo'd tag rather than silently running fewer (or zero) suites.
+        if [ "$tags" != "[]" ]; then
+          valid=$(echo "$base" | jq -c '[.[]."test-tag"] | unique')
+          unknown=$(jq -nc --argjson req "$tags" --argjson ok "$valid" '$req - $ok')
+          if [ "$unknown" != "[]" ]; then
+            echo "::error::Unknown test_tags $unknown. Valid: $(echo "$valid" | jq -r 'join(", ")')"
+            exit 1
+          fi
+        fi
+        include=$(echo "$base" | jq -c \
+          --argjson modes "$modes" \
+          --argjson tags "$tags" \
+          '[ .[]
+             | select(($tags | length) == 0 or (.["test-tag"] as $t | $tags | index($t) != null))
+             | . as $b
+             | $modes[]
+             | $b + {"user-mode": .} ]')
         echo "include=$include" >> $GITHUB_OUTPUT
+        echo "Requested tags: $tags"
         echo "Resolved include: $include"
 
   end-to-end-tests:
     name: "E2E: ${{ matrix.test-tag }}${{ matrix.user-mode == 'internal' && ' - internal' || '' }}"
     needs: [build-end-to-end-tests, setup-matrix]
     runs-on: macos-26
-    timeout-minutes: 300
+    timeout-minutes: 160
 
     env:
       RUNS_ON: macos-26 # keep this in sync with runs-on above
@@ -201,7 +226,9 @@ jobs:
     strategy:
       matrix:
         include: ${{ fromJSON(needs.setup-matrix.outputs.include) }}
-      max-parallel: 1 # Uncomment this line to run tests sequentially.
+      # We have 2 Maestro Cloud runners; legs beyond that just queue cloud-side,
+      # so 2 is the effective ceiling until we provision more runners.
+      max-parallel: 2
       fail-fast: false
 
     steps:
@@ -228,7 +255,7 @@ jobs:
         api-key: ${{ secrets.ROBIN_API_KEY }}
         project-id: ${{ vars.ROBIN_PROJECT_KEY }}
         name: ${{ matrix.test-tag }}${{ matrix.user-mode == 'internal' && '_internal' || '' }}_${{ matrix.device-name }}_${{ github.sha }}
-        timeout: 300
+        timeout: 150
         app-file: iOS/DerivedData/Build/Products/Debug-iphonesimulator/DuckDuckGo.app
         workspace: .maestro
         include-tags: ${{ matrix.test-tag }}


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1215818560543270?focus=true
Tech Design URL:
CC:

### Description

This PR improves the Maestro workflow in a few ways:
1. It can now run two suites in parallel
2. You can pass a custom list of suites to run, rather than having to run all of them
3. The maximum timeout has been reduced, it was previously set to 5 hours but really anything after 2.5 hours can be considered stuck - our slowest suite at the moment runs in under 1.5 hours

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that [this workflow run](https://github.com/duckduckgo/apple-browsers/actions/runs/27714769319) only ran release tests - they did not succeed, but that is true on main as well

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
5. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the iOS E2E GitHub workflow; no app code or user-facing behavior is affected.
> 
> **Overview**
> **Manual iOS E2E runs** can now pass a comma-separated `test_tags` input so only chosen Maestro suites enter the matrix; empty still runs everything. The setup step validates tags against the known suite list and **fails the workflow** on typos instead of quietly skipping suites.
> 
> **Throughput and stuck-run limits** are tightened: the E2E job matrix runs with **`max-parallel: 2`** (aligned with two Maestro Cloud runners), job timeout drops from 300 to **160** minutes, and the Maestro Cloud action timeout from 300 to **150** minutes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9d492bdd9a885bf1d9bc007e5c2d3578f6b6780. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->