### PR TITLE
[iOS/macOS][Dependencies] Downgrade Swift clocks from 1.1.0 to 1.0.6

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ad5792b5c381cf4a1182e2256f303f1828856d1b4c3a90897161b6a52517abaf",
+  "originHash" : "0cf56cc4298e43c9a46dee65743760a6d1321a51d1ea1478efc87d297b5f45ee",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks.git",
       "state" : {
-        "revision" : "72d749bf341b78851203066ab421869b783ec42a",
-        "version" : "1.1.0"
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -63,7 +63,7 @@ let package = Package(
         .package(url: "https://github.com/httpswift/swifter.git", exact: "1.5.0"),
         .package(url: "https://github.com/1024jp/GzipSwift.git", exact: "6.0.1"),
         .package(url: "https://github.com/vapor/jwt-kit.git", exact: "4.13.5"),
-        .package(url: "https://github.com/pointfreeco/swift-clocks.git", exact: "1.1.0"),
+        .package(url: "https://github.com/pointfreeco/swift-clocks.git", exact: "1.0.6"),
         .package(url: "https://github.com/duckduckgo/content-scope-scripts.git", exact: "15.2.0"),
         .package(path: "../URLPredictor"),
         .package(path: "../Infrastructure/SystemFrameworksExtensions"),

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fcd762c731d8d93ced0b51a332e570496d1450ab54bee31f0580e917bec69eba",
+  "originHash" : "01626ca990ad62d63ab373a591e0d6d1d1ea34570c6ad31c03a40df527e5c4cc",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks.git",
       "state" : {
-        "revision" : "72d749bf341b78851203066ab421869b783ec42a",
-        "version" : "1.1.0"
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
       }
     },
     {

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -20234,7 +20234,7 @@
 			repositoryURL = "https://github.com/pointfreeco/swift-clocks.git";
 			requirement = {
 				kind = exactVersion;
-				version = 1.1.0;
+				version = 1.0.6;
 			};
 		};
 		9FF521422BAA8FF300B9819B /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0d52a776d387e95dbbc7303c3068c680dfacb3d81c985f339bb6bca06e1f9274",
+  "originHash" : "9605e76bede420efc95761d79fa966db1d91002f08f6951fba254f09f23d124a",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks.git",
       "state" : {
-        "revision" : "72d749bf341b78851203066ab421869b783ec42a",
-        "version" : "1.1.0"
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1215795636220053?focus=true
Tech Design URL:
CC:

### Description

Downgrade Swift Clocks to 1.0.6.
Dependabot flagged Swift Clocks was outdated. 
We updated to version 1.0.0 but this included tools version (6.0.0)
We run sync E2E on macOS14 using Xcode 15.4 which doesn't support Swift 6.

### Testing Steps
1. Ensure CI pass

###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version pin and lockfile updates only; minor behavioral differences in the Clocks test helper library are possible but scope is limited to dependency resolution and test timing utilities.
> 
> **Overview**
> Pins **pointfreeco/swift-clocks** from **1.1.0** to **1.0.6** across iOS/macOS workspaces and **BrowserServicesKit**’s `Package.swift`, with matching **Package.resolved** updates and the macOS Xcode project’s exact-version requirement.
> 
> This is a dependency-only change (no app or library source edits). It keeps builds compatible with **Xcode 15.4** / pre–Swift 6 tooling after newer **swift-clocks** raised the Swift tools version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05c8f05ce48d059b0f8e947379959673d03aa39f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->