### PR TITLE
[iOS] Maestro: temporarily disable flaky internal-mode e2e flows

### DIFF
--- a/.maestro/release_tests/firebutton.yaml
+++ b/.maestro/release_tests/firebutton.yaml
@@ -1,8 +1,11 @@
 # firebutton.yaml
 appId: com.duckduckgo.mobile.ios
+# TEMPORARILY DISABLED from gating CI: the `release` tag (which the e2e job includes) is removed
+# on purpose. Fails in internal/unified-input mode — after the fire button the address bar still
+# shows the just-visited URL (stale unified-input suggestions flash post-burn), so the
+# "assertNotVisible <URL>" check fails. Re-enable by restoring the `- release` tag once fixed.
 tags:
     - iphone
-    - release
 
 ---
 

--- a/.maestro/release_tests/local-storage.yaml
+++ b/.maestro/release_tests/local-storage.yaml
@@ -1,8 +1,11 @@
 # local-storage.yaml
 appId: com.duckduckgo.mobile.ios
+# TEMPORARILY DISABLED from gating CI: the `release` tag (which the e2e job includes) is removed
+# on purpose. Fails in internal/unified-input mode — after the fire button the address bar still
+# shows the just-visited URL (stale unified-input suggestions flash post-burn), so the
+# "assertNotVisible <URL>" check fails. Re-enable by restoring the `- release` tag once fixed.
 tags:
     - iphone
-    - release
 
 ---
 

--- a/.maestro/unified_toggle_input/test_chat_tab_stop_generating.yaml
+++ b/.maestro/unified_toggle_input/test_chat_tab_stop_generating.yaml
@@ -1,7 +1,11 @@
 appId: com.duckduckgo.mobile.ios
+# TEMPORARILY DISABLED from gating CI: the `release` tag (which the e2e job includes) is removed
+# on purpose. This flow is non-deterministic — it races a live backend for the "Stop generating"
+# button and depends on the Duck.ai web consent which only appears intermittently. Re-enable by
+# restoring the `- release` tag once it no longer depends on live generation / web consent
+# (follow-up task to be created).
 tags:
     - iphone
-    - release
     - unified_toggle_input
 name: test_chat_tab_stop_generating
 

--- a/.maestro/unified_toggle_input/test_unified_input_send_prompt.yaml
+++ b/.maestro/unified_toggle_input/test_unified_input_send_prompt.yaml
@@ -1,7 +1,11 @@
 appId: com.duckduckgo.mobile.ios
+# TEMPORARILY DISABLED from gating CI: the `release` tag (which the e2e job includes) is removed
+# on purpose. This flow is flaky — submitting from the NTP omnibar in Duck.ai mode intermittently
+# opens an empty chat (prompt not committed), and it depends on the Duck.ai web consent which only
+# appears intermittently. Re-enable by restoring the `- release` tag once the submit/consent
+# flakiness is fixed (follow-up task to be created).
 tags:
     - iphone
-    - release
     - unified_toggle_input
 name: test_unified_input_send_prompt
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1215659889529108
Tech Design URL:
CC:

### Description

Temporarily disables 4 Maestro e2e flows that fail on the `E2E: release - internal` leg (internal / unified-input mode) by removing their `release` tag — the only tag the gating e2e job selects on (`include-tags: release`). The flow files are kept in place, each with an inline comment explaining why and how to re-enable (restore `- release`). **No app code changes.**

| Flow | Why it fails (internal / unified-input mode) |
|------|----------------------------------------------|
| `test_unified_input_send_prompt` | Submitting from the NTP omnibar in Duck.ai mode intermittently opens an empty chat (prompt not committed); also depends on the Duck.ai web consent, which appears only intermittently. |
| `test_chat_tab_stop_generating` | Races a live backend for the "Stop generating" button (self-documented as non-deterministic) + the same intermittent web consent. |
| `local-storage` | After the fire button, stale unified-input suggestions flash the just-visited URL, so `assertNotVisible "<url>"` fails. |
| `firebutton` | Same post-fire stale-suggestion behaviour as `local-storage`. |

### Testing Steps

CI-config only; no app behaviour changes. To verify the flows are excluded from every Maestro job:
1. The only workflows running Maestro are `ios_end_to_end.yml` (include-tags: `release`/`privacy`/`securityTest`/`adClick`/`duckplayer_native`/`device_info`/`duckplayer_classic`/`duckai_chrome_shortcut`) and `ios_sync_end_to_end.yml` (include-tags: `sync`).
2. The 4 flows now carry only `iphone` / `unified_toggle_input`, which are never used as include-tags (`iphone`/`ipad` are exclude-only) — so they match no job, in either production or internal mode.
3. Dispatch **iOS - End-to-End tests** (internal mode) on this branch and confirm `E2E: release - internal` is green with the 4 flows skipped.

### Impact and Risks

**Low → None.** CI test-config only; no production code changed. The only impact is reduced e2e coverage until the flows are re-enabled.

#### What could go wrong?

A regression in the affected areas (unified-input submit, fire-button data clearing) could land without these flows catching it. Mitigated by: the follow-up task to re-enable, #5414 fixing the fire-button pair, and existing unit/other coverage of the underlying features.

### Notes to Reviewer

Each disabled flow has an inline comment with the reason and the re-enable instruction. No flow bodies were modified — only the `release` tag was removed.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
