### PR TITLE
Remove "currently available on Mac & Windows" subtitle from PIR upsell row

### DIFF
--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -2269,7 +2269,6 @@ struct UserText {
     static let aiChatFeatureTitle = NSLocalizedString("subscription.upsell.popover.features.ai.chat.title", value: "Chat privately with advanced AI models", comment: "Title for the AI chat feature listed in the VPN Upsell popover")
     static let identityTheftProtectionFeatureTitle = NSLocalizedString("subscription.upsell.popover.features.identity.theft.protection.title", value: "Restore your identity if it's stolen", comment: "Title for the identity theft protection feature listed in the VPN Upsell popover")
     static let pirFeatureTitle = NSLocalizedString("subscription.upsell.popover.plus.features.pir.title", value: "Remove info from sites that sell it", comment: "Title for the Private Information Removal feature listed in the VPN Upsell popover")
-    static let pirFeatureSubtitle = NSLocalizedString("subscription.upsell.popover.plus.features.pir.subtitle", value: "currently available on Mac & Windows", comment: "Subtitle for the Private Information Removal feature listed in the VPN Upsell popover")
 
     // Mark: Sync Promo
     static let syncPromoBookmarksTitle = NSLocalizedString("sync.promo.bookmarks.title", value: "Sync & Back Up Your Bookmarks", comment: "Title for the Sync Promotion banner")

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -103706,66 +103706,6 @@
         }
       }
     },
-    "subscription.upsell.popover.plus.features.pir.subtitle" : {
-      "comment" : "Subtitle for the Private Information Removal feature listed in the VPN Upsell popover",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "derzeit verfügbar auf Mac & Windows"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "currently available on Mac & Windows"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "actualmente disponible en Mac y Windows"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "actuellement disponible sur Mac et Windows"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "attualmente disponibile su Mac e Windows"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "nu beschikbaar op Mac en Windows"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "obecnie dostępna na komputerach Mac i Windows"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "atualmente disponível no Mac e no Windows"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "сейчас доступно на Mac и Windows"
-          }
-        }
-      }
-    },
     "subscription.upsell.popover.plus.features.pir.title" : {
       "comment" : "Title for the Private Information Removal feature listed in the VPN Upsell popover",
       "extractionState" : "extracted_with_value",

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellNew/VPNUpsellPopover.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellNew/VPNUpsellPopover.swift
@@ -117,7 +117,7 @@ struct VPNUpsellPopoverView: View {
     private var features: some View {
         VStack(spacing: Constants.featuresVerticalSpacing) {
             ForEach(viewModel.featureSet.core, id: \.title) { feature in
-                FeatureRow(text: feature.title, subtitle: feature.subtitle)
+                FeatureRow(text: feature.title)
             }
             HStack(spacing: Constants.plusRowHorizontalSpacing) {
                 horizontalLine
@@ -129,7 +129,7 @@ struct VPNUpsellPopoverView: View {
             .padding(.vertical, Constants.plusRowVerticalSpacing)
 
             ForEach(viewModel.featureSet.plus, id: \.title) { feature in
-                FeatureRow(text: feature.title, subtitle: feature.subtitle)
+                FeatureRow(text: feature.title)
             }
         }
     }
@@ -169,11 +169,9 @@ struct VPNUpsellPopoverView: View {
 
 private struct FeatureRow: View {
     let text: String
-    let subtitle: String?
 
-    init(text: String, subtitle: String? = nil) {
+    init(text: String) {
         self.text = text
-        self.subtitle = subtitle
     }
 
     var body: some View {
@@ -184,19 +182,10 @@ private struct FeatureRow: View {
                 .frame(width: Constants.featureRowImageSize.width, height: Constants.featureRowImageSize.height)
                 .padding(.top, Constants.featureRowImageTopPadding)
 
-            VStack(alignment: .leading, spacing: Constants.featureRowSubtitleVerticalSpacing) {
-                Text(text)
-                    .font(.body)
-                    .foregroundColor(Color(designSystemColor: .textPrimary))
-                    .fixedSize(horizontal: false, vertical: true)
-
-                if let subtitle = subtitle {
-                    Text(subtitle)
-                        .font(.caption)
-                        .foregroundColor(Color(designSystemColor: .textSecondary))
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            }
+            Text(text)
+                .font(.body)
+                .foregroundColor(Color(designSystemColor: .textPrimary))
+                .fixedSize(horizontal: false, vertical: true)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellNew/VPNUpsellPopoverViewModel.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellNew/VPNUpsellPopoverViewModel.swift
@@ -61,15 +61,6 @@ extension VPNUpsellPopoverViewModel {
                 return UserText.pirFeatureTitle
             }
         }
-
-        var subtitle: String? {
-            switch self {
-            case .pir:
-                return "(\(UserText.pirFeatureSubtitle))"
-            default:
-                return nil
-            }
-        }
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207260194172075/task/1215830032574928
Tech Design URL:
CC:

### Description

Removes the "currently available on Mac & Windows" subtitle from the PIR row in the VPN upsell popover. The subtitle and its now-unused localized string have been deleted across all locales.

| Before | After |
|--------|-------|
|  <img width="424" height="599" alt="Screenshot 2026-06-18 at 13 23 05" src="https://github.com/user-attachments/assets/b44d2060-cbc8-48bb-a3ff-2baa5fd45be6" /> |  <img width="424" height="586" alt="Screenshot 2026-06-18 at 13 19 39" src="https://github.com/user-attachments/assets/0e2877bb-ffeb-4fa9-9925-95e517978b7c" /> |

### Testing Steps
* Make sure you have PIR included in your subscription. Alternatively you can modify line 127 of `VPNUpsellPopoverViewModel`:

```swift
// Comment out the `if` here, so PIR is always shown
if isPIRFeatureEnabled {
    plusFeatures.append(.pir)
}
```

* Launch the app.
* Show the VPN Upsell button via `Debug > VPN > Upsell > Show Upsell Button`
* Verify that the copy is correct, and nothing in the UI is misaligned.

### Impact and Risks

None: this PR just removes copy

#### What could go wrong?

N/A

### Quality Considerations

N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and presentation-only changes in the VPN upsell popover with no logic, subscription, or security impact.
> 
> **Overview**
> Removes the **“currently available on Mac & Windows”** subtitle from the Private Information Removal row in the VPN upsell popover, so PIR is shown with only its feature title like the other Plus items.
> 
> This drops `UserText.pirFeatureSubtitle` and the matching `subscription.upsell.popover.plus.features.pir.subtitle` entry from `Localizable.xcstrings` (all locales), removes `subtitle` from the upsell feature model, and simplifies `FeatureRow` to a single title line instead of optional secondary text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb639aa83da0ef28c8ed5129f412c789243300c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->