### PR TITLE
Prevent border on privacy icon hover on iPad

### DIFF
--- a/iOS/DuckDuckGo/PrivacyIconView.swift
+++ b/iOS/DuckDuckGo/PrivacyIconView.swift
@@ -404,7 +404,7 @@ extension PrivacyIconView: UIPointerInteractionDelegate {
         if icon == .daxLogo {
             return nil
         }
-        return UIPointerStyle(effect: .automatic(.init(view: self)), shape: .roundedRect(frame, radius: 12))
+        return UIPointerStyle(effect: .lift(.init(view: self)))
     }
     
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1213902532584609?focus=true
Tech Design URL:
CC:

### Description
Privacy shield icon iPad pointer hover used `.automatic` + rounded-rect shape, which rendered a bordered highlight platter. Switched to `.lift` effect so hover lifts the icon without drawing a border.

### Testing Steps
1. Run on iPad (or iPad simulator with trackpad/mouse pointer enabled).
2. Hover the pointer over the privacy shield icon in the address bar.
3. Verify the icon lifts with no rounded border platter around it.
4. Verify the Dax logo (new tab / empty address bar) still shows no hover effect.

### Impact and Risks
Low. Single-line cosmetic change to one view's pointer style, no logic change.

#### What could go wrong?
Hover may look inconsistent with neighbor buttons (which use `.highlight`). Intentional per request.

### Quality Considerations
N/A

### Notes to Reviewer
Affects `.shield` / `.shieldWithDot` / `.alert` icons only

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line UI pointer styling change with no behavior or logic impact; hover may differ slightly from neighboring toolbar controls that use highlight.
> 
> **Overview**
> On iPad with a trackpad or mouse, **privacy shield/alert** pointer hover no longer uses `.automatic` with a **rounded-rect shape**, which drew a bordered highlight platter around the icon.
> 
> Hover now uses **`.lift`** on the view so the icon lifts without a border. The **Dax logo** path is unchanged—it still returns no pointer style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45bfa29590a14bc65478e37bf5f099c57dc9ab98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->