### PR TITLE
[macOS] Serialize favicon image cache store writes to fix duplicate rows

### DIFF
--- a/macOS/DuckDuckGo/Favicons/Model/FaviconImageCache.swift
+++ b/macOS/DuckDuckGo/Favicons/Model/FaviconImageCache.swift
@@ -103,6 +103,12 @@ final class FaviconImageCache: FaviconImageCaching {
     @MainActor
     private var inFlightImageLoads = Set<URL>()
 
+    // Tail of a serial chain of store-mutating work from `insert(_:)`. Each insert enqueues its
+    // remove+save after this task so concurrent inserts can't interleave their remove/save and leave
+    // duplicate rows behind in the store. See `insert(_:)`.
+    @MainActor
+    private var storeWriteTask: Task<Void, Never>?
+
     init(faviconStoring: FaviconStoring) {
         storing = faviconStoring
     }
@@ -143,7 +149,14 @@ final class FaviconImageCache: FaviconImageCaching {
             cacheImage(favicon.image, for: favicon.url)
         }
 
-        Task {
+        // Chain this store write after any in-flight one. Concurrent inserts for the same favicon URL
+        // each remove the previous row and save a new one; if those remove/save pairs interleave, a
+        // removal can run before the row it supersedes has been saved, leaving the old row behind as a
+        // duplicate. Serializing the writes guarantees each insert's save completes before the next
+        // insert's removal runs, so exactly one row survives per favicon URL.
+        let previousWrite = storeWriteTask
+        storeWriteTask = Task {
+            await previousWrite?.value
             do {
                 await self.removeFaviconsFromStore(oldMetadata)
                 try await self.storing.save(favicons)
@@ -470,6 +483,11 @@ final class EagerFaviconImageCache: FaviconImageCaching {
     @MainActor
     private var entries = [URL: Favicon]()
 
+    // Tail of a serial chain of store-mutating work from `insert(_:)`; see the lazy `FaviconImageCache`
+    // twin for why concurrent inserts must be serialized to avoid leaving duplicate rows.
+    @MainActor
+    private var storeWriteTask: Task<Void, Never>?
+
     init(faviconStoring: FaviconStoring) {
         storing = faviconStoring
     }
@@ -508,7 +526,11 @@ final class EagerFaviconImageCache: FaviconImageCaching {
             entries[favicon.url] = favicon
         }
 
-        Task {
+        // Chain this store write after any in-flight one so concurrent inserts for the same favicon URL
+        // can't interleave their remove/save and leave a superseded row behind. See the lazy twin.
+        let previousWrite = storeWriteTask
+        storeWriteTask = Task {
+            await previousWrite?.value
             do {
                 await self.removeFaviconsFromStore(oldFavicons)
                 try await self.storing.save(favicons)
@@ -625,6 +647,7 @@ final class EagerFaviconImageCache: FaviconImageCaching {
         return await removeFaviconsFromStore(faviconsToRemove)
     }
 
+    @discardableResult
     private func removeFaviconsFromStore(_ favicons: [Favicon]) async -> Result<Void, Error> {
         guard !favicons.isEmpty else { return .success(()) }
 

--- a/macOS/UnitTests/Favicons/FaviconImageCacheTests.swift
+++ b/macOS/UnitTests/Favicons/FaviconImageCacheTests.swift
@@ -123,6 +123,42 @@ final class FaviconImageCacheTests: XCTestCase {
         XCTAssertEqual(store.loadImageCallCount, 1)
     }
 
+    // MARK: insert store-write serialization (race)
+
+    @MainActor
+    func testConcurrentInsertsForSameURLLeaveExactlyOneStoredRow() async throws {
+        let store = RecordingFaviconStore()
+        let cache = FaviconImageCache(faviconStoring: store)
+        try await cache.load()
+
+        let faviconURL = try XCTUnwrap("https://example.com/favicon.ico".url)
+        let documentURL = try XCTUnwrap("https://example.com".url)
+
+        // Each insert persists a freshly-identified row that is meant to supersede the previous row for
+        // the same favicon URL (remove the old row, save the new one). Fire many back-to-back: without
+        // serialized store writes, a later insert's removal can run before an earlier insert's save lands,
+        // so the superseded row is never deleted and survives as a duplicate.
+        let insertCount = 25
+        let cacheUpdated = expectation(forNotification: .faviconCacheUpdated, object: nil)
+        cacheUpdated.expectedFulfillmentCount = insertCount
+
+        for _ in 0..<insertCount {
+            cache.insert([
+                Favicon(identifier: UUID(),
+                        url: faviconURL,
+                        image: makeBitmapImage(pixelsWide: 16, pixelsHigh: 16),
+                        relation: .favicon,
+                        documentUrl: documentURL,
+                        dateCreated: Date())
+            ])
+        }
+
+        await fulfillment(of: [cacheUpdated], timeout: 10)
+
+        XCTAssertEqual(store.savedCount(forURL: faviconURL), 1,
+                       "Exactly one row should remain for a single favicon URL after concurrent inserts")
+    }
+
     // MARK: eager fallback cache (faviconLazyImageLoading kill switch OFF)
 
     @MainActor
@@ -148,6 +184,37 @@ final class FaviconImageCacheTests: XCTestCase {
         // the on-demand loadImage path.
         XCTAssertEqual(store.loadFaviconsCallCount, 1)
         XCTAssertEqual(store.loadImageCallCount, 0)
+    }
+
+    @MainActor
+    func testEagerCacheConcurrentInsertsForSameURLLeaveExactlyOneStoredRow() async throws {
+        let store = RecordingFaviconStore()
+        let cache = EagerFaviconImageCache(faviconStoring: store)
+        try await cache.load()
+
+        let faviconURL = try XCTUnwrap("https://example.com/favicon.ico".url)
+        let documentURL = try XCTUnwrap("https://example.com".url)
+
+        // Same serialization invariant as the lazy cache: superseding inserts must not leave duplicates.
+        let insertCount = 25
+        let cacheUpdated = expectation(forNotification: .faviconCacheUpdated, object: nil)
+        cacheUpdated.expectedFulfillmentCount = insertCount
+
+        for _ in 0..<insertCount {
+            cache.insert([
+                Favicon(identifier: UUID(),
+                        url: faviconURL,
+                        image: makeBitmapImage(pixelsWide: 16, pixelsHigh: 16),
+                        relation: .favicon,
+                        documentUrl: documentURL,
+                        dateCreated: Date())
+            ])
+        }
+
+        await fulfillment(of: [cacheUpdated], timeout: 10)
+
+        XCTAssertEqual(store.savedCount(forURL: faviconURL), 1,
+                       "Exactly one row should remain for a single favicon URL after concurrent inserts")
     }
 
     // MARK: async get
@@ -362,4 +429,46 @@ final class FaviconImageCacheTests: XCTestCase {
 
 private enum TestError: Error {
     case transientFailure
+}
+
+/// A favicon store that records persisted favicons (honoring removals) so tests can assert how many rows
+/// survive for a given favicon URL. `save` yields a few times before recording to widen the window in
+/// which a concurrent insert's removal can race ahead of this save — surfacing duplicate rows when
+/// inserts aren't serialized.
+private final class RecordingFaviconStore: FaviconStoring, @unchecked Sendable {
+
+    private let lock = NSLock()
+    private var savedFavicons: [Favicon] = []
+
+    func savedCount(forURL url: URL) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return savedFavicons.filter { $0.url == url }.count
+    }
+
+    func loadFavicons() async throws -> [Favicon] { [] }
+    func loadFaviconMetadata() async throws -> [FaviconMetadata] { [] }
+    func loadImage(for identifier: UUID) async throws -> NSImage? { nil }
+
+    func save(_ favicons: [Favicon]) async throws {
+        // Suspend a few times so a concurrent insert's removal can interleave before this save records —
+        // exactly the window that produces duplicate rows when store writes aren't serialized.
+        for _ in 0..<4 { await Task.yield() }
+        lock.lock()
+        savedFavicons.append(contentsOf: favicons)
+        lock.unlock()
+    }
+
+    func removeFavicons(_ favicons: [Favicon]) async throws {
+        let identifiers = Set(favicons.map(\.identifier))
+        lock.lock()
+        savedFavicons.removeAll { identifiers.contains($0.identifier) }
+        lock.unlock()
+    }
+
+    func loadFaviconReferences() async throws -> ([FaviconHostReference], [FaviconUrlReference]) { ([], []) }
+    func save(hostReference: FaviconHostReference) async throws {}
+    func save(urlReference: FaviconUrlReference) async throws {}
+    func remove(hostReferences: [FaviconHostReference]) async throws {}
+    func remove(urlReferences: [FaviconUrlReference]) async throws {}
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215836113672223?focus=true

### Description
Concurrent inserts for the same favicon URL could interleave their store remove/save, so a removal ran before the superseded row was saved and the old row was left behind as a duplicate. Chaining each insert's store write behind the previous one keeps exactly one row per favicon URL. Applies to both the lazy and eager image caches; adds concurrency tests covering both.

### Testing Steps
1. Enable state restoration
2. Open several tabs to a website (e.g. github.com)
3. Open favicons inspector
4. Delete all github.com favicons
5. Relaunch the browser, verify that you only have one set of favicons for github.com (could be 2-3 favicons).

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized favicon persistence serialization and tab chrome layout; no auth, security, or payment paths touched.
> 
> **Overview**
> Fixes **duplicate favicon rows** in persistent storage when many inserts target the same favicon URL at once. **`FaviconImageCache`** and **`EagerFaviconImageCache`** now chain each `insert`’s remove-then-save work on a **`storeWriteTask`** tail so overlapping writes cannot interleave removals ahead of earlier saves.
> 
> Adds **unit tests** with a **`RecordingFaviconStore`** that stress concurrent inserts (25×) and assert exactly one stored row per URL for both cache implementations.
> 
> **Tab bar:** **`TabBarViewItem`** lays out the close button when it must be visible for interaction—including **⌘-held** close-on-narrow-tabs—via **`mustLayoutCloseButton`**, not only when `closeButton.isShown` is true.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f32fe0a3536f2861cf88305b09bd6c6728457c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->