### PR TITLE
[macOS] Fix: Misplaced Close Button

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -290,7 +290,7 @@ final class TabBarItemCellView: NSView {
     }()
 
     private var mustLayoutCloseButton: Bool {
-        closeButtons.isShown || !widthStage.isCloseButtonHidden || NSApp.isCommandPressed
+        closeButton.isShown || !widthStage.isCloseButtonHidden || NSApp.isCommandPressed
     }
 
     convenience init() {

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -290,7 +290,7 @@ final class TabBarItemCellView: NSView {
     }()
 
     private var mustLayoutCloseButton: Bool {
-        !widthStage.isCloseButtonHidden || NSApp.isCommandPressed
+        closeButtons.isShown || !widthStage.isCloseButtonHidden || NSApp.isCommandPressed
     }
 
     convenience init() {

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -289,6 +289,10 @@ final class TabBarItemCellView: NSView {
         return layer
     }()
 
+    private var mustLayoutCloseButton: Bool {
+        !widthStage.isCloseButtonHidden || NSApp.isCommandPressed
+    }
+
     convenience init() {
         self.init(frame: .zero)
     }
@@ -435,7 +439,7 @@ final class TabBarItemCellView: NSView {
             minX = audioButton.frame.maxX
         }
         var maxX = bounds.maxX - 9
-        if closeButton.isShown {
+        if mustLayoutCloseButton {
             closeButton.frame = NSRect(x: maxX - Metrics.closeButtonDimension, y: bounds.midY - Metrics.closeButtonDimension * 0.5, width: Metrics.closeButtonDimension, height: Metrics.closeButtonDimension)
             maxX = closeButton.frame.minX - 4
         } else {
@@ -492,7 +496,7 @@ final class TabBarItemCellView: NSView {
             audioButton.frame = NSRect(x: x.rounded(), y: bounds.midY - 8, width: Metrics.audioAndCrashButtonSide, height: Metrics.audioAndCrashButtonSide)
             x = audioButton.frame.maxX + spacing
         }
-        if closeButton.isShown {
+        if mustLayoutCloseButton {
             // close button appears in place of favicon in compact mode
             closeButton.frame = NSRect(x: x.rounded(), y: bounds.midY - Metrics.closeButtonDimension * 0.5, width: Metrics.closeButtonDimension, height: Metrics.closeButtonDimension)
             x = closeButton.frame.maxX + spacing


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1215815941808038
Tech Design URL:
CC:

### Description
This PR ensures that the Close Button gets its position adjusted when appropriate.

### Testing Steps
1. Launch the macOS browser
2. Open several Tabs
3. Resize the Window
4. Use `CMD + [ ]` to switch across tabs

- [ ] Verify the `x` button looks great

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Worst case scenario, we adjust the Close Button position, even when it will never be visible.

### Quality Considerations
None

### Notes to Reviewer
Thank you!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change in tab bar layout; worst case is extra reserved space when the close button is not visible.
> 
> **Overview**
> Fixes **misplaced tab close (×) buttons** on macOS when tabs are narrow, the window is resized, or tabs are switched with **⌘ + [ / ]**.
> 
> `TabBarItemCellView` now uses a **`mustLayoutCloseButton`** helper instead of only checking `closeButton.isShown` when laying out in **normal** and **compact** modes. Layout reserves the trailing slot when the button is shown, when the tab’s **`widthStage`** still allows a close control, or when **⌘** is held—matching how **`updateSubviews()`** decides to show the close button on hover, selection, and Command-key tab switching.
> 
> Worst case, layout may reserve close-button space even if the control stays hidden; no behavior change beyond positioning and title spacing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72317fd35109735d70bcbd1f94193e18f0da2324. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->