### PR TITLE
Remove OS version parameter from new tab page loading time pixel

### DIFF
--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageLoadMetrics.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageLoadMetrics.swift
@@ -72,8 +72,7 @@ final class NewTabPageLoadMetrics {
         guard loadTime <= 10 else {
             return
         }
-        let osVersion = ProcessInfo.processInfo.operatingSystemVersion.majorVersion
-        firePixel(NewTabPagePixel.newTabPageLoadingTime(duration: loadTime, osMajorVersion: osVersion))
+        firePixel(NewTabPagePixel.newTabPageLoadingTime(duration: loadTime))
     }
 
 }

--- a/macOS/DuckDuckGo/Statistics/NewTabPagePixel.swift
+++ b/macOS/DuckDuckGo/Statistics/NewTabPagePixel.swift
@@ -162,7 +162,7 @@ enum NewTabPagePixel: PixelKitEvent {
     case aiChatRecentChatSelectedKeyboard
 
     // Parameter duration: Load time in **seconds** (will be converted to milliseconds in pixel).
-    case newTabPageLoadingTime(duration: TimeInterval, osMajorVersion: Int)
+    case newTabPageLoadingTime(duration: TimeInterval)
 
     // See macOS/PixelDefinitions/pixels/new_tab_page_pixels.json5
     case nextStepsCardClicked(_ card: String, cardImpressionCount: Int, ntpImpressionCount: Int, daysSinceInstall: Int?, activeUsageDays: Int)
@@ -222,11 +222,10 @@ enum NewTabPagePixel: PixelKitEvent {
             return [
                 "mode": mode.rawValue
             ]
-        case .newTabPageLoadingTime(let duration, let osMajorVersion):
+        case .newTabPageLoadingTime(let duration):
             // "loadingTime" is reported in **milliseconds**
             return [
-                "loadingTime": String(Int(duration * 1000)),
-                "osMajorVersion": "\(osMajorVersion)"
+                "loadingTime": String(Int(duration * 1000))
             ]
         case let .nextStepsCardClicked(_, cardImpressionCount, ntpImpressionCount, daysSinceInstall, activeUsageDays),
             let .nextStepsCardDismissed(_, cardImpressionCount, ntpImpressionCount, daysSinceInstall, activeUsageDays):

--- a/macOS/PixelDefinitions/pixels/definitions/new_tab_page_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/new_tab_page_pixels.json5
@@ -103,11 +103,6 @@
         "suffixes": [],
         "parameters": [
             "pixelSource",
-            {
-                "key": "osMajorVersion",
-                "type": "string",
-                "description": "Operating system major version"
-            },
             "appVersion",
             {
                 "key": "loadingTime",

--- a/macOS/UnitTests/NewTabPage/NewTabPageLoadMetricsTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageLoadMetricsTests.swift
@@ -36,7 +36,7 @@ final class NewTabPageLoadMetricsTests: XCTestCase {
 
         let metrics = NewTabPageLoadMetrics { pixel in
             if let event = pixel as? NewTabPagePixel,
-               case .newTabPageLoadingTime(let duration, _) = event {
+               case .newTabPageLoadingTime(let duration) = event {
                 XCTAssertGreaterThan(duration, 0)
                 pixelFired = true
                 expectation.fulfill()
@@ -63,7 +63,7 @@ final class NewTabPageLoadMetricsTests: XCTestCase {
 
         let metrics = NewTabPageLoadMetrics { pixel in
             if let event = pixel as? NewTabPagePixel,
-               case .newTabPageLoadingTime(let duration, _) = event {
+               case .newTabPageLoadingTime(let duration) = event {
                 XCTAssertEqual(duration, 0)
                 expectation.fulfill()
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215844303479933?focus=true

### Description

Removes the `osMajorVersion` parameter from the `m_mac_new-tab-page_loading_time` pixel. The change is applied end-to-end so the sent payload matches the validated definition:

- `NewTabPagePixel.swift`: dropped the `osMajorVersion` associated value from the `newTabPageLoadingTime` case and removed it from the parameters dictionary (only `loadingTime` remains as a custom param).
- `NewTabPageLoadMetrics.swift`: removed the `ProcessInfo` OS-version lookup at the fire site.
- `new_tab_page_pixels.json5`: removed the `osMajorVersion` parameter from the pixel definition (`pixelSource`, `appVersion`, `loadingTime`, `channel` remain).
- `NewTabPageLoadMetricsTests.swift`: updated the two pattern matches to the new single-value arity.

### Testing Steps
1. Trigger the new tab page so the loading-time pixel fires.
2. Confirm the pixel request carries `loadingTime` (plus standard `appVersion`/`channel`/`pixelSource`) and no longer includes `osMajorVersion`.

### Impact and Risks
Low — analytics-only change, no user-facing behaviour. Worst case is loss of the OS version dimension for this pixel, which is the intended outcome.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only schema change with no user-facing behavior; only effect is losing OS version breakdown for this pixel, which is intentional.
> 
> **Overview**
> Removes the **`osMajorVersion`** dimension from the **`m_mac_new-tab-page_loading_time`** pixel so the emitted payload matches the updated pixel definition.
> 
> **`NewTabPageLoadMetrics`** no longer reads macOS major version via **`ProcessInfo`** when reporting load time. **`NewTabPagePixel.newTabPageLoadingTime`** now only carries duration; the parameters map sends **`loadingTime`** (ms) alone. **`new_tab_page_pixels.json5`** drops the **`osMajorVersion`** parameter entry. Unit tests match the single-argument enum case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a393c48b2da7384bbddccdf29644660726a59df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->