### PR TITLE
iOS: Default Duck.ai native chat-history flag to enabled

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -736,7 +736,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .aiChatSuggestions:
             Config(defaultValue: .enabled, source: .remoteReleasable(DuckAiChatHistorySubfeature.featureEnabled))
         case .aiChatNativeChatHistory:
-            Config(defaultValue: .disabled, source: .remoteReleasable(DuckAiChatHistorySubfeature.nativeChatHistory))
+            Config(defaultValue: .enabled, source: .remoteReleasable(DuckAiChatHistorySubfeature.nativeChatHistory))
         case .aiChatContextualSheetImprovements:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.contextualSheetImprovements))
         case .showWhatsNewPromptOnDemand:


### PR DESCRIPTION
Task/Issue URL:
Tech Design URL:
CC:

### Description

Flips the `aiChatNativeChatHistory` feature flag's local `defaultValue` from `.disabled` to `.enabled`.

The flag is `.remoteReleasable`, so the `defaultValue` is the fallback used when the remote privacy config doesn't specify the `DuckAiChatHistory.nativeChatHistory` subfeature. With this change, the native chat-history sheet is on by default in that case; the remote config still takes precedence when it's present.

### Testing Steps
1. Build with no override for `aiChatNativeChatHistory` and a privacy config that doesn't include the subfeature.
2. On iPhone, open Duck.ai → app menu → **Chats**: the native history sheet should appear.

### Impact and Risks

Medium — enables the native chat-history experience by default (iPhone) where remote config is silent. Remote config can still disable it.

#### What could go wrong?
- Surfaces the feature to users on builds without the remote subfeature entry. Mitigated by remote config remaining authoritative when present.

### Notes to Reviewer
- One-line default flip; no other behaviour changes.
