### PR TITLE
Only trigger idle-return NTP from browsing surfaces

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2955,6 +2955,22 @@ class MainViewController: UIViewController {
     }
 
     // MARK: - Idle return NTP (dismiss overlays so NTP is visible)
+
+    /// True when the browser's current tab is frontmost (nothing non-browsing is
+    /// covering it). The idle-return escape hatch can only return to a tab, so we
+    /// gate idle-return NTP on this — leaving the user in place on Settings, the
+    /// tab switcher, Duck Player, or any other modal. The omnibar editing state is
+    /// part of browsing the current tab and does not count as covering it.
+    var isCurrentTabFrontmostSurface: Bool {
+        if tabSwitcherController != nil {
+            return false
+        }
+        if let presented = presentedViewController, !presented.isBeingDismissed {
+            return presented is OmniBarEditingStateViewController
+        }
+        return true
+    }
+
     /// Dismisses tab switcher and any presented view controller (e.g. Settings) so the caller can then show the NTP.
     func prepareForIdleReturnNTP(completion: @escaping () -> Void) {
         guard let presented = presentedViewController, !presented.isBeingDismissed else {

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -887,6 +887,13 @@ extension MainCoordinator: IdleReturnLaunchDelegate {
             return
         }
 
+        // Only replace the browser's own tab (a web page or Duck.ai) — the surface
+        // the after-idle escape hatch can return to. If a non-browsing surface is
+        // frontmost (Settings, the tab switcher, Duck Player, etc.), leave it be.
+        guard controller.isCurrentTabFrontmostSurface else {
+            return
+        }
+
         // Already on the NTP — no rebuild needed. This preserves any existing
         // escape hatch state, avoids bouncing the omnibar/keyboard on idle return,
         // and avoids surfacing a stale hatch when the user has already consumed


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1214737710404431

### Description

Idle-return NTP (showing the New Tab Page after the app has been backgrounded past the idle threshold) previously tore down whatever surface was frontmost — Settings, the tab switcher, any modal — to force the NTP. That produced the reported bug (background from Settings → reopen → Settings is dismissed and the NTP appears) and an escape-hatch card pointing at a stale/irrelevant tab.

The after-idle escape hatch can only return the user to a **tab**, so the NTP should only replace a surface that has a real tab to return to. This change gates idle-return NTP on the current tab being the frontmost surface:

- New `MainViewController.isCurrentTabFrontmostSurface` — `false` when the tab switcher is open or any presented modal (other than the omnibar editing state) is on top; `true` only when the browser's own tab is frontmost.
- `MainCoordinator.showNewTabPageAfterIdleReturn()` now bails early unless that holds.

Result: idle-return NTP fires on a web page or Duck.ai tab (both have a return-to card) and leaves the user in place on Settings, the tab switcher, Duck Player, the legacy Duck.ai sheet, and any other modal.

### Testing Steps

1. Enable the idle-return NTP feature and set the After-Inactivity option to **New Tab**; set a short idle threshold (debug override) so it triggers quickly.
2. Open **Settings**, background the app (Home, don't close), wait past the threshold, reopen → app stays on Settings (NTP is **not** shown). *(This is the reported bug.)*
3. Open the **tab switcher**, background + reopen past the threshold → stays on the tab switcher.
4. On a **web page**, background + reopen past the threshold → NTP is shown with the "Return to …" escape-hatch card (unchanged behaviour).
5. On **Duck.ai** (in-tab / full mode), background + reopen past the threshold → NTP is shown with the escape-hatch card.
6. If **Duck Player** is available, start it, background + reopen past the threshold → stays in Duck Player.

### Impact and Risks

Low. Behaviour change is scoped to the idle-return NTP flow; it only adds an early-return that suppresses the NTP on non-browsing surfaces. No change to the web/Duck.ai paths.

#### What could go wrong?

If a browsing surface were misclassified as non-browsing, idle-return NTP would stop firing where it should. The gate treats only the tab switcher and presented modals (excluding the omnibar editing state) as non-browsing, so web and Duck.ai tabs — the surfaces with a return-to card — are unaffected. The legacy Duck.ai modal sheet now stays put instead of jumping to the NTP; this is intentional and only affects the pre–full-mode presentation.

### Notes to Reviewer

- The gate lives alongside the existing (UIKit-coupled, untested) `prepareForIdleReturnNTP`; there's no clean unit seam without a refactor. Upstream `LaunchActionHandlerTests` still cover whether the NTP delegate is invoked.
- Builds with zero Swift compile errors (local command-line build stops only at the GRDB-copy / iOS 18.4+ simulator WebKit-workaround script phases, unrelated to this change).
