### PR TITLE
iOS: Ship web-scroll-freeze observability to production

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -260,9 +260,14 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
 
     case crashReportOptInStatusResetting
 
-    /// Internal-only observability for the hard-to-reproduce "web view scroll frozen, taps still work" bug:
-    /// a passive scroll-failure observer plus a gesture watchdog. Off for the general population by default.
+    /// Production observability for the hard-to-reproduce "web view scroll frozen, taps still work" bug:
+    /// a passive scroll-failure observer plus the symptom/mechanism pixels. On by default for everyone;
+    /// ship a privacy-config entry to roll back.
     case webScrollFreezeObservability
+
+    /// Internal-only gate for the heavier on-device freeze capture (snapshot + ring buffer), kept separate
+    /// from `webScrollFreezeObservability` so the production observer ships without the capture.
+    case webScrollFreezeCapture
 
     case screenTimeCleaning
 

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -327,6 +327,7 @@ public enum FeatureFlag: String {
 
     /// Internal-only gate for the heavier on-device freeze capture (snapshot + ring buffer). Kept separate from
     /// `webScrollFreezeObservability` so the production observer ships without the capture.
+    /// https://app.asana.com/1/137249556945/project/414235014887631/task/1215895676655232
     case webScrollFreezeCapture
 
     /// Failsafe kill switch for hiding the Search↔Duck.ai toggle on Duck.ai tabs. On by

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -321,8 +321,13 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1206488453854252/task/1212289671815991
     case unifiedToggleInput
 
-    /// Internal-only gate for web-scroll-freeze observability (scroll-failure observer + gesture watchdog).
+    /// Production kill switch (on by default) for web-scroll-freeze observability: the passive scroll-failure
+    /// observer (bystander recognizer) + the symptom/mechanism pixels. Ship a privacy-config entry to roll back.
     case webScrollFreezeObservability
+
+    /// Internal-only gate for the heavier on-device freeze capture (snapshot + ring buffer). Kept separate from
+    /// `webScrollFreezeObservability` so the production observer ships without the capture.
+    case webScrollFreezeCapture
 
     /// Failsafe kill switch for hiding the Search↔Duck.ai toggle on Duck.ai tabs. On by
     /// default; ship a privacy-config entry to roll back. See
@@ -744,7 +749,9 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .unifiedToggleInput:
             Config(source: .remoteReleasable(AIChatSubfeature.unifiedToggleInput))
         case .webScrollFreezeObservability:
-            Config(defaultValue: .internalOnly, source: .remoteReleasable(iOSBrowserConfigSubfeature.webScrollFreezeObservability))
+            Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.webScrollFreezeObservability))
+        case .webScrollFreezeCapture:
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(iOSBrowserConfigSubfeature.webScrollFreezeCapture))
         case .aiChatTabHideToggle:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.aiChatTabHideToggle))
         case .freeTrialConversionWideEvent:

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1771,6 +1771,7 @@
 		AC7100D1A6105DEBEEF00002 /* InteractionDiagnosticsDebugScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC7100D1A6105DEBEEF00001 /* InteractionDiagnosticsDebugScreen.swift */; };
 		AC7100D1A6105DEBEEF00004 /* InteractionIntegrityMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC7100D1A6105DEBEEF00003 /* InteractionIntegrityMonitor.swift */; };
 		AC7100D1A6105DEBEEF00006 /* WebScrollObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC7100D1A6105DEBEEF00005 /* WebScrollObserver.swift */; };
+		AC7100D1A6105DEBEEF00008 /* WebScrollFreezeProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC7100D1A6105DEBEEF00007 /* WebScrollFreezeProbe.swift */; };
 		B2258FABEA7BDFCEF297DCFE /* RebrandedOnboardingView+SearchExperienceContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF81E0C6EDC46254CF28AFCB /* RebrandedOnboardingView+SearchExperienceContent.swift */; };
 		B39FB0F42E25368100DF2C4E /* AutoconsentPixels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39FB0F32E25368100DF2C4E /* AutoconsentPixels.swift */; };
 		B50DAF4F2FBE4FD3007BFA26 /* EscapeHatchModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50DAF4E2FBE4FD3007BFA26 /* EscapeHatchModelTests.swift */; };
@@ -4483,6 +4484,7 @@
 		AC7100D1A6105DEBEEF00001 /* InteractionDiagnosticsDebugScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractionDiagnosticsDebugScreen.swift; sourceTree = "<group>"; };
 		AC7100D1A6105DEBEEF00003 /* InteractionIntegrityMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractionIntegrityMonitor.swift; sourceTree = "<group>"; };
 		AC7100D1A6105DEBEEF00005 /* WebScrollObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebScrollObserver.swift; sourceTree = "<group>"; };
+		AC7100D1A6105DEBEEF00007 /* WebScrollFreezeProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebScrollFreezeProbe.swift; sourceTree = "<group>"; };
 		AC7D7E5EB7B04D2385E0E48E /* AfterInactivityOptionAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterInactivityOptionAdapterTests.swift; sourceTree = "<group>"; };
 		AD8CF8E4B152CDB3A4ACB14C /* StartupOnboardingCover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupOnboardingCover.swift; sourceTree = "<group>"; };
 		AF81E0C6EDC46254CF28AFCB /* RebrandedOnboardingView+SearchExperienceContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "RebrandedOnboardingView+SearchExperienceContent.swift"; sourceTree = "<group>"; };
@@ -7863,6 +7865,7 @@
 			children = (
 				852BCC4C2EC4AEA60093C753 /* DataAuditDebugScreen.swift */,
 				AC7100D1A6105DEBEEF00005 /* WebScrollObserver.swift */,
+				AC7100D1A6105DEBEEF00007 /* WebScrollFreezeProbe.swift */,
 				AC7100D1A6105DEBEEF00003 /* InteractionIntegrityMonitor.swift */,
 				AC7100D1A6105DEBEEF00001 /* InteractionDiagnosticsDebugScreen.swift */,
 				36A96A092E6606C0003D4529 /* LocalNotificationsPlaygroundView.swift */,
@@ -13167,6 +13170,7 @@
 				9F387DE22EA891E8006861F8 /* NewAddressBarPickerModalPromptProvider.swift in Sources */,
 				852BCC4D2EC4AEAC0093C753 /* DataAuditDebugScreen.swift in Sources */,
 				AC7100D1A6105DEBEEF00006 /* WebScrollObserver.swift in Sources */,
+				AC7100D1A6105DEBEEF00008 /* WebScrollFreezeProbe.swift in Sources */,
 				AC7100D1A6105DEBEEF00004 /* InteractionIntegrityMonitor.swift in Sources */,
 				AC7100D1A6105DEBEEF00002 /* InteractionDiagnosticsDebugScreen.swift in Sources */,
 				31A968192E4F692200F4305E /* SettingsAIExperimentalPickerView.swift in Sources */,

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -2262,6 +2262,7 @@
 		CBD79F4D2D130F6500DBB45A /* Simulated.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBD79F4C2D130F6300DBB45A /* Simulated.swift */; };
 		CBDD5AC62F238F7300441F0A /* PrivacyStats in Frameworks */ = {isa = PBXBuildFile; productRef = AA3000060000000000000006 /* PrivacyStats */; };
 		CBDD5DDF29A6736A00832877 /* APIHeadersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBDD5DDE29A6736A00832877 /* APIHeadersTests.swift */; };
+		AC7100D1A6105DEBEEF0000A /* WebScrollObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC7100D1A6105DEBEEF00009 /* WebScrollObserverTests.swift */; };
 		CBDEDA162D8079E500123E00 /* RoundedCornersMaskView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBDEDA152D8079E500123E00 /* RoundedCornersMaskView.swift */; };
 		CBE77C752FD2F3A300CB7C6D /* SuggestionRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE77C742FD2F3A300CB7C6D /* SuggestionRow.swift */; };
 		CBE77C772FD2F3B300CB7C6D /* SuggestionRowMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE77C762FD2F3B300CB7C6D /* SuggestionRowMapperTests.swift */; };
@@ -5008,6 +5009,7 @@
 		CBD79F4C2D130F6300DBB45A /* Simulated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Simulated.swift; sourceTree = "<group>"; };
 		CBD7AE812AF6D5B6009052FD /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		CBDD5DDE29A6736A00832877 /* APIHeadersTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIHeadersTests.swift; sourceTree = "<group>"; };
+		AC7100D1A6105DEBEEF00009 /* WebScrollObserverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebScrollObserverTests.swift; sourceTree = "<group>"; };
 		CBDEDA152D8079E500123E00 /* RoundedCornersMaskView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedCornersMaskView.swift; sourceTree = "<group>"; };
 		CBE099292AF6D54D000EFC47 /* lv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lv; path = lv.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		CBE77C742FD2F3A300CB7C6D /* SuggestionRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionRow.swift; sourceTree = "<group>"; };
@@ -11188,6 +11190,7 @@
 				22CB1ED7203DDD2C00D2C724 /* AppDeepLinksTests.swift */,
 				F17D72381E8B35C6003E8B0E /* AppURLsTests.swift */,
 				CBDD5DDE29A6736A00832877 /* APIHeadersTests.swift */,
+				AC7100D1A6105DEBEEF00009 /* WebScrollObserverTests.swift */,
 				F189AEE31F18FDAF001EBAE1 /* LinkTests.swift */,
 			);
 			name = Domain;
@@ -14046,6 +14049,7 @@
 				98D094832E6AFA6B00D94984 /* InternalUserCommandsTests.swift in Sources */,
 				850259682EC353EC004607A9 /* MobileCustomizationTests.swift in Sources */,
 				CBDD5DDF29A6736A00832877 /* APIHeadersTests.swift in Sources */,
+				AC7100D1A6105DEBEEF0000A /* WebScrollObserverTests.swift in Sources */,
 				9FD1BDEC2D8C183C002F4EFE /* OnboardingManagerTests.swift in Sources */,
 				986B45D0299E30A50089D2D7 /* BookmarkEntityTests.swift in Sources */,
 				BBFA34402F19286D0003CB58 /* SubscriptionPagesUseSubscriptionFeatureTests.swift in Sources */,

--- a/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
+++ b/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
@@ -104,8 +104,8 @@ extension DebugScreensViewModel {
             .view(title: "Data Audit", { _ in
                 DataAuditDebugScreen()
             }),
-            .view(title: "Interaction Diagnostics", { d in
-                InteractionDiagnosticsDebugScreen(tabManager: d.tabManager)
+            .view(title: "Interaction Diagnostics", { _ in
+                InteractionDiagnosticsDebugScreen()
             }),
             .view(title: "Feature Flags", { _ in
                 FeatureFlagsMenuView()

--- a/iOS/DuckDuckGo/InteractionDiagnosticsDebugScreen.swift
+++ b/iOS/DuckDuckGo/InteractionDiagnosticsDebugScreen.swift
@@ -33,8 +33,8 @@ struct InteractionDiagnosticsDebugScreen: View {
 
     @StateObject private var model: InteractionDiagnosticsModel
 
-    init(tabManager: TabManager) {
-        _model = StateObject(wrappedValue: InteractionDiagnosticsModel(tabManager: tabManager))
+    init() {
+        _model = StateObject(wrappedValue: InteractionDiagnosticsModel())
     }
 
     var body: some View {
@@ -71,7 +71,7 @@ private struct InteractionRecoveryView: View {
     var body: some View {
         List {
             Section {
-                Button { model.recover() } label: { Text(verbatim: "Recover (combined — what the watchdog runs)") }
+                Button { model.recover() } label: { Text(verbatim: "Recover (surgical — reset pan/wedged recognizers)") }
                 Button { model.resetScrollPan() } label: { Text(verbatim: "R1 · Reset web scroll pan only") }
                 Button { model.runRecovery(.flushAppRecognizers) } label: { Text(verbatim: "R2 · Reset app recognizers") }
                 Button { model.runRecovery(.bounceWindowInteraction) } label: { Text(verbatim: "R3 · Bounce window interaction") }
@@ -84,7 +84,8 @@ private struct InteractionRecoveryView: View {
             } footer: {
                 Text(verbatim: "Run least→most invasive against a live freeze to find the minimal action that recovers. "
                      + "R1 should fail (victim-side), R2 should clear a wedged recognizer, R3 targets a phantom touch. "
-                     + "'Recover' combines R2+R3 — the action the auto-watchdog uses.")
+                     + "'Recover' resets only pan/wedged recognizers (no window bounce). Recovery is debug-only here — "
+                     + "productionised in Part 3.")
             }
         }
         .navigationTitle("Recovery")
@@ -155,12 +156,6 @@ final class InteractionDiagnosticsModel: ObservableObject {
     @Published var report = ""
     @Published var actionResult = ""
     @Published var savedCount = FreezeCaptureStore.count()
-
-    private let tabManager: TabManager
-
-    init(tabManager: TabManager) {
-        self.tabManager = tabManager
-    }
 
     @MainActor
     func capture() {

--- a/iOS/DuckDuckGo/InteractionDiagnosticsDebugScreen.swift
+++ b/iOS/DuckDuckGo/InteractionDiagnosticsDebugScreen.swift
@@ -20,15 +20,15 @@
 import SwiftUI
 import UIKit
 import OSLog
+import QuartzCore
 import Core
 
-/// Debug screen that captures a root-cause-agnostic snapshot of the current scroll / gesture /
-/// overlay state of the foreground web tab, plus recent `Logger.interaction` entries.
+/// Debug screen for the hard-to-reproduce "web view can't be scrolled but taps still work" freeze.
 ///
-/// Built to diagnose the hard-to-reproduce "web view can't be scrolled but taps still work" freeze
-/// seen on internal builds: when it happens, open this screen, tap Capture, then Copy and paste the
-/// report into the bug. The report is structural (it walks the live view tree) so it stays valid even
-/// though this screen is presented on top of the frozen tab.
+/// The freeze is PERSISTENT (it stays until the app is force-closed), so a capture taken minutes later
+/// is still valid. Dumps every scroll view's drag state, presentation/transition state, and a full
+/// window census. Captures auto-persist to a ring buffer so they can be exported after the fact, and
+/// the Provocation section forces the suspected triggers so a reproduction *indicates the cause*.
 struct InteractionDiagnosticsDebugScreen: View {
 
     @StateObject private var model: InteractionDiagnosticsModel
@@ -39,29 +39,79 @@ struct InteractionDiagnosticsDebugScreen: View {
 
     var body: some View {
         List {
-            Section {
-                Button {
-                    model.capture()
-                } label: {
-                    Text(verbatim: "Capture Snapshot")
+            if !model.actionResult.isEmpty {
+                Section {
+                    Text(verbatim: model.actionResult).font(.footnote)
+                } header: {
+                    Text(verbatim: "Last action")
                 }
+            }
+            Section {
+                NavigationLink { InteractionRecoveryView(model: model) } label: { Text(verbatim: "Recovery") }
+                NavigationLink { InteractionCaptureView(model: model) } label: { Text(verbatim: "Capture & snapshot") }
+                NavigationLink { InteractionProvocationsView(model: model) } label: { Text(verbatim: "Provocations (debug)") }
+            } header: {
+                Text(verbatim: "Interaction Diagnostics")
+            } footer: {
+                Text(verbatim: "During a freeze this list itself may not scroll — so each action lives in a short "
+                     + "submenu that fits without scrolling, and the Recover button (top right) is always reachable.")
+            }
+        }
+        .navigationTitle("Interaction Diagnostics")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button { model.recover() } label: { Text(verbatim: "🛟 Recover") }
+            }
+        }
+    }
+}
 
-                if !model.report.isEmpty {
-                    Button {
-                        model.copy()
-                    } label: {
-                        Text(verbatim: "Copy to Clipboard")
-                    }
+private struct InteractionRecoveryView: View {
+    @ObservedObject var model: InteractionDiagnosticsModel
+    var body: some View {
+        List {
+            Section {
+                Button { model.recover() } label: { Text(verbatim: "Recover (combined — what the watchdog runs)") }
+                Button { model.resetScrollPan() } label: { Text(verbatim: "R1 · Reset web scroll pan only") }
+                Button { model.runRecovery(.flushAppRecognizers) } label: { Text(verbatim: "R2 · Reset app recognizers") }
+                Button { model.runRecovery(.bounceWindowInteraction) } label: { Text(verbatim: "R3 · Bounce window interaction") }
+                Button(role: .destructive) { model.runRecovery(.flushAll) } label: { Text(verbatim: "Flush ALL recognizers (incl. system)") }
+                if !model.actionResult.isEmpty {
+                    Text(verbatim: model.actionResult).font(.footnote)
                 }
             } header: {
-                Text(verbatim: "Actions")
+                Text(verbatim: "Recovery ladder")
             } footer: {
-                Text(verbatim: "Capture reads the live view tree of the foreground tab. Persistent state "
-                     + "(isScrollEnabled, overlays, which recognizers are enabled) is reliable here. A gesture "
-                     + "recognizer's transient .state may reset when this screen is presented — for that, rely "
-                     + "on the live logs below / the Log Viewer (subsystem: Interaction).")
+                Text(verbatim: "Run least→most invasive against a live freeze to find the minimal action that recovers. "
+                     + "R1 should fail (victim-side), R2 should clear a wedged recognizer, R3 targets a phantom touch. "
+                     + "'Recover' combines R2+R3 — the action the auto-watchdog uses.")
             }
+        }
+        .navigationTitle("Recovery")
+    }
+}
 
+private struct InteractionCaptureView: View {
+    @ObservedObject var model: InteractionDiagnosticsModel
+    var body: some View {
+        List {
+            Section {
+                Button { model.capture() } label: { Text(verbatim: "Capture Snapshot") }
+                if !model.report.isEmpty {
+                    Button { model.copy() } label: { Text(verbatim: "Copy to Clipboard") }
+                }
+            } footer: {
+                Text(verbatim: "Reads the live view tree of the foreground tab. Auto-saved to the ring buffer.")
+            }
+            Section {
+                Text(verbatim: "Saved captures: \(model.savedCount)")
+                if model.savedCount > 0 {
+                    Button { model.copySaved() } label: { Text(verbatim: "Copy All Saved Captures") }
+                    Button(role: .destructive) { model.clearSaved() } label: { Text(verbatim: "Clear Saved Captures") }
+                }
+            } header: {
+                Text(verbatim: "Ring buffer")
+            }
             if !model.report.isEmpty {
                 Section {
                     TextEditor(text: .constant(model.report))
@@ -72,13 +122,39 @@ struct InteractionDiagnosticsDebugScreen: View {
                 }
             }
         }
-        .navigationTitle("Interaction Diagnostics")
+        .navigationTitle("Capture")
+    }
+}
+
+private struct InteractionProvocationsView: View {
+    @ObservedObject var model: InteractionDiagnosticsModel
+    var body: some View {
+        List {
+            Section {
+                Button { model.run(.injectStuckGesture) } label: { Text(verbatim: "E1 · Inject stuck gesture") }
+                Button { model.run(.clearStuckGesture) } label: { Text(verbatim: "E1 · Clear injection") }
+                Button { model.run(.reparentWebView) } label: { Text(verbatim: "E2 · Reparent web view mid-drag") }
+                Button { model.run(.utiHide) } label: { Text(verbatim: "E2 · UTI transition mid-drag") }
+                Button { model.run(.newTab) } label: { Text(verbatim: "E2 · New tab mid-drag") }
+                if !model.actionResult.isEmpty {
+                    Text(verbatim: model.actionResult).font(.footnote)
+                }
+            } header: {
+                Text(verbatim: "Provocation")
+            } footer: {
+                Text(verbatim: "Force a suspected trigger so a reproduction indicates the cause. E1 wedges a gesture "
+                     + "(taps stay alive); E2 fires on your next drag after dismissing this screen.")
+            }
+        }
+        .navigationTitle("Provocations")
     }
 }
 
 final class InteractionDiagnosticsModel: ObservableObject {
 
     @Published var report = ""
+    @Published var actionResult = ""
+    @Published var savedCount = FreezeCaptureStore.count()
 
     private let tabManager: TabManager
 
@@ -86,242 +162,203 @@ final class InteractionDiagnosticsModel: ObservableObject {
         self.tabManager = tabManager
     }
 
+    @MainActor
+    func capture() {
+        report = WebScrollFreezeProbe.captureNow()
+        FreezeCaptureStore.save(report)
+        savedCount = FreezeCaptureStore.count()
+    }
+
     func copy() {
         UIPasteboard.general.string = report
     }
 
-    @MainActor
-    func capture() {
-        report = buildSnapshot() + "\n\n## Recent interaction logs (last 5 min)\n" + Self.recentInteractionLogs()
+    func copySaved() {
+        UIPasteboard.general.string = FreezeCaptureStore.exportAll()
     }
 
-    // MARK: - Snapshot
-
-    @MainActor
-    private func buildSnapshot() -> String {
-        var out = "# Interaction Diagnostics — \(Date())\n"
-        out += "App: \(Self.appVersion)\n\n"
-        out += featureFlagsSection()
-        out += "\n" + currentTabSection()
-        return out
-    }
-
-    private func featureFlagsSection() -> String {
-        let flagger = AppDependencyProvider.shared.featureFlagger
-        var out = "## Feature flags\n"
-        out += "- unifiedToggleInput: \(flagger.isFeatureOn(.unifiedToggleInput))\n"
-        out += "- experimentalAddressBar: \(flagger.isFeatureOn(.experimentalAddressBar))\n"
-        out += "- showAIChatAddressBarChoiceScreen: \(flagger.isFeatureOn(.showAIChatAddressBarChoiceScreen))\n"
-        return out
+    func clearSaved() {
+        FreezeCaptureStore.clear()
+        savedCount = FreezeCaptureStore.count()
     }
 
     @MainActor
-    private func currentTabSection() -> String {
-        guard let tab = tabManager.current(createIfNeeded: false) else {
-            return "## Current tab\n- No current TabViewController\n"
-        }
-        guard let webView = tab.webView else {
-            return "## Current tab\n- TabViewController has no webView\n"
-        }
-
-        let scrollView = webView.scrollView
-        var out = "## Current tab\n"
-        out += "- URL host: \(webView.url?.host ?? "nil")\n"
-        out += "- TabViewController: \(Self.typeName(tab))\n"
-        out += "- scroll observer: \(tab.webScrollObserver?.recentStatus ?? "not installed")\n\n"
-
-        out += "## webView.scrollView\n"
-        out += "- isScrollEnabled: \(scrollView.isScrollEnabled)\(scrollView.isScrollEnabled ? "" : "  ⚠️ SCROLL DISABLED")\n"
-        out += "- isUserInteractionEnabled: \(scrollView.isUserInteractionEnabled)\n"
-        out += "- delaysContentTouches: \(scrollView.delaysContentTouches)  canCancelContentTouches: \(scrollView.canCancelContentTouches)\n"
-        out += "- bounces: \(scrollView.bounces)  alwaysBounceVertical: \(scrollView.alwaysBounceVertical)\n"
-        out += "- isDragging: \(scrollView.isDragging)  isDecelerating: \(scrollView.isDecelerating)"
-            + "  isTracking: \(scrollView.isTracking)  isZooming: \(scrollView.isZooming)\n"
-        out += "- contentOffset: \(scrollView.contentOffset)\n"
-        out += "- contentSize: \(scrollView.contentSize)\n"
-        out += "- bounds: \(scrollView.bounds)\n"
-        out += "- adjustedContentInset: \(scrollView.adjustedContentInset)\n"
-        out += "- zoomScale: \(scrollView.zoomScale) (min \(scrollView.minimumZoomScale) / max \(scrollView.maximumZoomScale))\n"
-        out += "- delegate: \(scrollView.delegate.map { Self.typeName($0) } ?? "nil")\n"
-
-        out += "\n" + Self.panGesture(of: scrollView)
-        out += "\n" + Self.gestureChainSection(from: webView)
-        out += "\n" + Self.competingRecognizersSection()
-        out += "\n" + Self.overlaySection(over: webView, boundary: Self.findMainViewController()?.view)
-        out += "\n" + coordinatorSection()
-        return out
+    func run(_ action: InteractionProvocation.Action) {
+        actionResult = InteractionProvocation.run(action)
     }
 
-    /// Window-wide scan for the swipe-tabs recognizers. They live on chrome containers (toolbar, UTI
-    /// container, chat header) that are siblings of the web view, so they never appear in the
-    /// webView→window chain above — but a wedge in one is the prime scroll-freeze suspect.
-    private static func competingRecognizersSection() -> String {
-        var out = "## Swipe-tabs recognizers (window-wide)\n"
-        var found = false
-        forEachWindowGestureRecognizer { recognizer in
-            guard recognizer is UnifiedInputSwipeTabsPanGestureRecognizer else { return }
-            found = true
-            let host = recognizer.view.map { typeName($0) } ?? "nil"
-            out += "• on \(host): \(describe(recognizer))\n"
-        }
-        if !found {
-            out += "- (none found)\n"
-        }
-        return out
-    }
-
-    /// The scroll view's own pan recognizer — the one that actually drives web scrolling.
-    private static func panGesture(of scrollView: UIScrollView) -> String {
-        var out = "## webView.scrollView.panGestureRecognizer\n"
-        out += "- \(describe(scrollView.panGestureRecognizer))\n"
-        return out
-    }
-
-    /// Walk webView → window collecting every gesture recognizer on the chain. A recognizer stuck in
-    /// `began`/`changed` on an ancestor, or a stray pan with `cancelsTouchesInView`, is the prime
-    /// scroll-blocking suspect and is flagged inline.
-    private static func gestureChainSection(from start: UIView) -> String {
-        var out = "## Gesture recognizers (webView → window)\n"
-        var view: UIView? = start
-        var found = false
-        while let current = view {
-            if let recognizers = current.gestureRecognizers, !recognizers.isEmpty {
-                found = true
-                out += "• \(typeName(current)) [\(current.frame)]\n"
-                for recognizer in recognizers {
-                    out += "    - \(describe(recognizer))\n"
-                }
-            }
-            view = current.superview
-        }
-        if !found {
-            out += "- (none)\n"
-        }
-        return out
-    }
-
-    /// Structural overlay check (modal-safe — does not use hitTest). Walks webView up to MainViewController's
-    /// view (so the presented debug screen isn't itself reported as a blocker) and flags any sibling drawn
-    /// above our branch that can receive touches and covers any of three sample points down the web view —
-    /// a leftover transition snapshot / scrim / cover left interactive would block pans here.
-    private static func overlaySection(over webView: UIView, boundary: UIView?) -> String {
-        var out = "## Potential blocking overlays over the web view\n"
-        let bounds = webView.bounds
-        let samples = [CGPoint(x: bounds.midX, y: bounds.minY + 20),
-                       CGPoint(x: bounds.midX, y: bounds.midY),
-                       CGPoint(x: bounds.midX, y: bounds.maxY - 20)].map { webView.convert($0, to: nil) }
-        var branch = webView
-        var found = false
-        while branch !== boundary, let container = branch.superview {
-            if let branchIndex = container.subviews.firstIndex(of: branch) {
-                for sibling in container.subviews[(branchIndex + 1)...] where sibling.isUserInteractionEnabled
-                    && !sibling.isHidden && sibling.alpha > 0.01 {
-                    let frameInWindow = sibling.convert(sibling.bounds, to: nil)
-                    if samples.contains(where: { frameInWindow.contains($0) }) {
-                        found = true
-                        out += "- ⚠️ \(typeName(sibling)) above \(typeName(container))"
-                            + " [\(sibling.frame)] alpha \(sibling.alpha)\n"
-                    }
-                }
-            }
-            branch = container
-        }
-        if !found {
-            out += "- (none over the web view)\n"
-        }
-        return out
-    }
-
-    /// Best-effort UTI / swipe-tabs coordinator state, reached by locating MainViewController in the tree.
     @MainActor
-    private func coordinatorSection() -> String {
-        guard let mainVC = Self.findMainViewController() else {
-            return "## Coordinator state\n- MainViewController not found\n"
-        }
-        var out = "## Coordinator state\n"
-        if let swipe = mainVC.swipeTabsCoordinator {
-            out += "- swipeTabsCoordinator.isEnabled: \(swipe.isEnabled)\n"
-            out += "- swipeTabsCoordinator.state: \(String(describing: swipe.state))\n"
-        } else {
-            out += "- swipeTabsCoordinator: nil\n"
-        }
-        if let uti = mainVC.unifiedToggleInputCoordinator {
-            out += "- unifiedToggleInputCoordinator.displayState: \(String(describing: uti.displayState))\n"
-        } else {
-            out += "- unifiedToggleInputCoordinator: nil\n"
-        }
-        return out
+    func recover() {
+        actionResult = WebScrollFreezeRecovery.recover()
     }
 
-    // MARK: - Logs
+    @MainActor
+    func runRecovery(_ rung: WebScrollFreezeRecovery.Rung) {
+        actionResult = WebScrollFreezeRecovery.runRung(rung)
+    }
 
-    private static func recentInteractionLogs() -> String {
-        guard let store = try? OSLogStore(scope: .currentProcessIdentifier) else {
-            return "(OSLogStore unavailable)"
+    @MainActor
+    func resetScrollPan() {
+        guard let scrollView = WebScrollFreezeProbe.findMainViewController()?.currentTab?.webView?.scrollView else {
+            actionResult = "R1: no web scroll view found"
+            return
         }
-        let since = store.position(date: Date().addingTimeInterval(-300))
-        let predicate = NSPredicate(format: "subsystem == %@", "Interaction")
-        guard let entries = try? store.getEntries(at: since, matching: predicate) else {
-            return "(failed to read log store)"
-        }
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm:ss.SSS"
-        let lines = entries.compactMap { $0 as? OSLogEntryLog }.suffix(300).map {
-            "\(formatter.string(from: $0.date)) \($0.composedMessage)"
-        }
-        return lines.isEmpty ? "(no interaction logs in window)" : lines.joined(separator: "\n")
+        scrollView.panGestureRecognizer.isEnabled = false
+        scrollView.panGestureRecognizer.isEnabled = true
+        actionResult = "R1: reset web scroll pan"
+    }
+}
+
+// MARK: - Provocation (forces a suspected trigger so a reproduction indicates the cause)
+
+@MainActor
+enum InteractionProvocation {
+
+    enum Action {
+        case injectStuckGesture, clearStuckGesture, reparentWebView, utiHide, newTab, forceFlush
     }
 
-    // MARK: - Helpers
+    private static var injected: StuckGestureRecognizer?
+    private static var armer: ProvocationArmingRecognizer?
 
-    private static var appVersion: String {
-        let short = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
-        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
-        return "\(short) (\(build))"
-    }
-
-    private static func typeName(_ object: Any) -> String {
-        String(describing: type(of: object))
-    }
-
-    private static func describe(_ recognizer: UIGestureRecognizer) -> String {
-        let active = (recognizer.state == .began || recognizer.state == .changed)
-        return "\(typeName(recognizer)) state=\(recognizer.state.diagnosticName)\(active ? " ⚠️ ACTIVE" : "")"
-            + " enabled=\(recognizer.isEnabled) cancelsTouchesInView=\(recognizer.cancelsTouchesInView)"
-            + " delaysTouchesBegan=\(recognizer.delaysTouchesBegan) touches=\(recognizer.numberOfTouches)"
-    }
-
-    private static func findMainViewController() -> MainViewController? {
-        let windows = UIApplication.shared.connectedScenes
-            .compactMap { $0 as? UIWindowScene }
-            .flatMap { $0.windows }
-        for window in windows {
-            if let root = window.rootViewController, let match = firstDescendant(MainViewController.self, in: root) {
-                return match
-            }
-        }
-        return nil
-    }
-
-    private static func firstDescendant<T: UIViewController>(_ type: T.Type, in viewController: UIViewController) -> T? {
-        if let match = viewController as? T { return match }
-        for child in viewController.children {
-            if let match = firstDescendant(type, in: child) { return match }
-        }
-        return nil
-    }
-
-    private static func forEachWindowGestureRecognizer(_ body: (UIGestureRecognizer) -> Void) {
-        let windows = UIApplication.shared.connectedScenes
-            .compactMap { $0 as? UIWindowScene }
-            .flatMap { $0.windows }
-        for window in windows {
-            walk(window, body)
+    static func run(_ action: Action) -> String {
+        switch action {
+        case .injectStuckGesture: return injectStuckGesture()
+        case .clearStuckGesture: return clearStuckGesture()
+        case .reparentWebView: return armOnNextDrag(.reparentWebView, label: "reparent the web view")
+        case .utiHide: return armOnNextDrag(.utiHide, label: "UTI hide()")
+        case .newTab: return armOnNextDrag(.newTab, label: "open a new tab")
+        case .forceFlush: return forceFlush()
         }
     }
 
-    private static func walk(_ view: UIView, _ body: (UIGestureRecognizer) -> Void) {
-        view.gestureRecognizers?.forEach(body)
-        view.subviews.forEach { walk($0, body) }
+    /// E1 — wedge a window-level continuous gesture to test whether that signature reproduces the freeze.
+    /// Models the bug faithfully: `cancelsTouchesInView = false` (taps stay alive), it only prevents pans
+    /// (scroll), and it wedges once a DRAG starts (a tap never arms it), then stays in `.changed` forever.
+    private static func injectStuckGesture() -> String {
+        guard injected == nil else { return "Already armed. Clear it first." }
+        guard let window = WebScrollFreezeProbe.keyWindow() else { return "No key window." }
+        let recognizer = StuckGestureRecognizer()
+        recognizer.cancelsTouchesInView = false
+        window.addGestureRecognizer(recognizer)
+        injected = recognizer
+        return "Armed. Dismiss this screen, then DRAG the web view once — the gesture wedges in .changed (taps stay alive). Test scrolling everywhere (web + menu), then 'Clear injection'."
     }
+
+    private static func clearStuckGesture() -> String {
+        guard let recognizer = injected else { return "Nothing injected." }
+        recognizer.isEnabled = false
+        recognizer.view?.removeGestureRecognizer(recognizer)
+        injected = nil
+        return "Cleared."
+    }
+
+    /// E2 — arm a passive recognizer that fires `effect` on the NEXT drag (truly mid-gesture), then disarms.
+    /// Robust to navigation timing: dismiss this screen, then drag the web view whenever you're ready. The
+    /// reparent yanks the touch's view mid-gesture — the prime way a touch never gets its `end`.
+    private static func armOnNextDrag(_ effect: Action, label: String) -> String {
+        if let armer { return "Already armed (\(armer.label)) — fires on your next drag." }
+        guard let window = WebScrollFreezeProbe.keyWindow() else { return "No key window." }
+        let recognizer = ProvocationArmingRecognizer()
+        recognizer.cancelsTouchesInView = false
+        recognizer.label = label
+        recognizer.onDragDetected = {
+            perform(effect)
+            Logger.interaction.error("PROVOKE \(label, privacy: .public) fired mid-drag")
+            disarm()
+        }
+        window.addGestureRecognizer(recognizer)
+        armer = recognizer
+        return "Armed. Dismiss this screen and DRAG the web view — '\(label)' fires mid-drag, then disarms."
+    }
+
+    private static func disarm() {
+        guard let recognizer = armer else { return }
+        recognizer.isEnabled = false
+        recognizer.view?.removeGestureRecognizer(recognizer)
+        armer = nil
+    }
+
+    private static func perform(_ effect: Action) {
+        guard let mainVC = WebScrollFreezeProbe.findMainViewController() else { return }
+        switch effect {
+        case .reparentWebView:
+            guard let webView = mainVC.currentTab?.webView, let superview = webView.superview else { return }
+            let frame = webView.frame
+            webView.removeFromSuperview()
+            superview.addSubview(webView)
+            webView.frame = frame
+        case .utiHide:
+            mainVC.unifiedToggleInputCoordinator?.hide()
+        case .newTab:
+            mainVC.newTab()
+        default:
+            break
+        }
+    }
+
+    /// E3 — force-cancel every gesture recognizer (toggle isEnabled) to flush a wedged recognizer / stuck
+    /// touch. If scrolling recovers, a stuck touch/recognizer is confirmed AND this is a viable mitigation.
+    private static func forceFlush() -> String {
+        var count = 0
+        for window in WebScrollFreezeProbe.allWindows() {
+            flush(window, &count)
+        }
+        return "Toggled \(count) gesture recognizers (force-cancel). Try scrolling now — if it works, a stuck touch/recognizer was the cause."
+    }
+
+    private static func flush(_ view: UIView, _ count: inout Int) {
+        view.gestureRecognizers?.forEach { recognizer in
+            recognizer.isEnabled = false
+            recognizer.isEnabled = true
+            count += 1
+        }
+        view.subviews.forEach { flush($0, &count) }
+    }
+}
+
+/// A deliberately wedged recognizer used only by E1. Models the bug: never cancels touches (taps stay
+/// alive) and prevents only pans (scroll). Wedges once a DRAG starts (a tap never arms it), then stays in
+/// `.changed` with no touches — the "scroll dead, taps alive" signature.
+final class StuckGestureRecognizer: UIGestureRecognizer {
+    private var disarmed = false
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
+        guard !disarmed else { return }
+        state = (state == .possible) ? .began : .changed
+    }
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
+        // Intentionally do NOT advance to a terminal state — this is the wedge under test.
+    }
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent) {
+        // Intentionally ignored.
+    }
+    /// Once recovery resets us (via an isEnabled toggle, which forces this reset), stay inert so the
+    /// recovery is verifiable on the next drag — the real bug fires once and does not re-arm. Tap
+    /// "E1 · Inject stuck gesture" again to re-test.
+    override func reset() {
+        super.reset()
+        disarmed = true
+    }
+    /// Prevent only pans (the scroll view's pan is a UIPanGestureRecognizer) so scrolling freezes while
+    /// taps keep recognising.
+    override func canPrevent(_ preventedGestureRecognizer: UIGestureRecognizer) -> Bool {
+        preventedGestureRecognizer is UIPanGestureRecognizer
+    }
+    override func canBePrevented(by preventingGestureRecognizer: UIGestureRecognizer) -> Bool { false }
+}
+
+/// Passive arming recognizer for E2: detects the next drag (first `touchesMoved`) without interfering,
+/// fires its callback once, then fails. Never cancels, delays, prevents, or is prevented.
+final class ProvocationArmingRecognizer: UIGestureRecognizer {
+    var label = ""
+    var onDragDetected: (() -> Void)?
+    private var fired = false
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
+        guard !fired else { return }
+        fired = true
+        onDragDetected?()
+        state = .failed
+    }
+    override func canPrevent(_ preventedGestureRecognizer: UIGestureRecognizer) -> Bool { false }
+    override func canBePrevented(by preventingGestureRecognizer: UIGestureRecognizer) -> Bool { false }
 }

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -999,10 +999,17 @@ class TabViewController: UIViewController {
             self?.handlePullToRefresh()
         })
 
+        // Symptom detection + pixels ship to production behind the `webScrollFreezeObservability` kill switch
+        // (on by default). The heavy on-device freeze capture is injected only when `webScrollFreezeCapture`
+        // (internal-only) is on — in production `captureFreeze` is a no-op.
         if webScrollObserver == nil, featureFlagger.isFeatureOn(.webScrollFreezeObservability) {
+            let captureEnabled = featureFlagger.isFeatureOn(.webScrollFreezeCapture)
             webScrollObserver = WebScrollObserver(container: webViewContainer,
                                                   scrollView: { [weak self] in self?.webView?.scrollView },
-                                                  currentURL: { [weak self] in self?.webView?.url })
+                                                  currentURL: { [weak self] in self?.webView?.url },
+                                                  captureFreeze: captureEnabled
+                                                    ? { FreezeCaptureStore.save(WebScrollFreezeProbe.captureNow()) }
+                                                    : {})
             webScrollObserver?.install()
         }
 

--- a/iOS/DuckDuckGo/WebScrollFreezeProbe.swift
+++ b/iOS/DuckDuckGo/WebScrollFreezeProbe.swift
@@ -1,0 +1,359 @@
+//
+//  WebScrollFreezeProbe.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+import OSLog
+import QuartzCore
+import Core
+
+// MARK: - Capture authority
+
+/// Single source of truth for a freeze capture. Self-contained (locates the foreground tab via the view
+/// tree), so it is callable from the Interaction Diagnostics debug screen, from the auto-capture in
+/// `WebScrollObserver` (gated by `webScrollFreezeCapture`, internal-only), and from lldb:
+///
+///     expr -l Swift -O -- print(WebScrollFreezeProbe.captureNow())
+enum WebScrollFreezeProbe {
+
+    @MainActor
+    static func captureNow() -> String {
+        var out = "# Interaction Diagnostics — \(Date())\n"
+        out += "App: \(appVersion)\n\n"
+        out += touchSection() + "\n"
+        out += featureFlagsSection() + "\n"
+        out += currentTabSection() + "\n"
+        out += scrollViewsSection() + "\n"
+        out += presentationSection() + "\n"
+        out += windowSection() + "\n"
+        out += "## Recent interaction logs (last 5 min)\n" + recentInteractionLogs()
+        return out
+    }
+
+    // MARK: Touch ledger (reserved for Part 2 — not instrumented in Part 1)
+
+    @MainActor
+    private static func touchSection() -> String {
+        "## Touch ledger\n- (not instrumented in this build — Part 2 work)\n"
+    }
+
+    private static func featureFlagsSection() -> String {
+        let flagger = AppDependencyProvider.shared.featureFlagger
+        var out = "## Feature flags\n"
+        out += "- unifiedToggleInput: \(flagger.isFeatureOn(.unifiedToggleInput))\n"
+        out += "- experimentalAddressBar: \(flagger.isFeatureOn(.experimentalAddressBar))\n"
+        out += "- showAIChatAddressBarChoiceScreen: \(flagger.isFeatureOn(.showAIChatAddressBarChoiceScreen))\n"
+        return out
+    }
+
+    @MainActor
+    private static func currentTabSection() -> String {
+        guard let tab = findMainViewController()?.currentTab else {
+            return "## Current tab\n- No current TabViewController\n"
+        }
+        guard let webView = tab.webView else {
+            return "## Current tab\n- TabViewController has no webView\n"
+        }
+
+        let scrollView = webView.scrollView
+        var out = "## Current tab\n"
+        out += "- URL host: \(webView.url?.host ?? "nil")\n"
+        out += "- TabViewController: \(typeName(tab))\n"
+        out += "- scroll observer: \(tab.webScrollObserver?.recentStatus ?? "not installed")\n\n"
+
+        out += "## webView.scrollView\n"
+        out += "- isScrollEnabled: \(scrollView.isScrollEnabled)\(scrollView.isScrollEnabled ? "" : "  ⚠️ SCROLL DISABLED")\n"
+        out += "- isUserInteractionEnabled: \(scrollView.isUserInteractionEnabled)\n"
+        out += "- delaysContentTouches: \(scrollView.delaysContentTouches)  canCancelContentTouches: \(scrollView.canCancelContentTouches)\n"
+        out += "- bounces: \(scrollView.bounces)  alwaysBounceVertical: \(scrollView.alwaysBounceVertical)\n"
+        out += "- isDragging: \(scrollView.isDragging)  isDecelerating: \(scrollView.isDecelerating)"
+            + "  isTracking: \(scrollView.isTracking)  isZooming: \(scrollView.isZooming)\n"
+        out += "- contentOffset: \(scrollView.contentOffset)\n"
+        out += "- contentSize: \(scrollView.contentSize)\n"
+        out += "- bounds: \(scrollView.bounds)\n"
+        out += "- adjustedContentInset: \(scrollView.adjustedContentInset)\n"
+        out += "- zoomScale: \(scrollView.zoomScale) (min \(scrollView.minimumZoomScale) / max \(scrollView.maximumZoomScale))\n"
+        out += "- delegate: \(scrollView.delegate.map { typeName($0) } ?? "nil")\n"
+
+        out += "\n" + panGesture(of: scrollView)
+        out += "\n" + gestureChainSection(from: webView)
+        out += "\n" + competingRecognizersSection()
+        out += "\n" + overlaySection(over: webView, boundary: findMainViewController()?.view)
+        out += "\n" + coordinatorSection()
+        return out
+    }
+
+    /// Every scroll view that is mid-gesture — a different scroll view stuck `isDragging`/`isTracking`
+    /// could be holding the gesture environment, which would freeze pans app-wide.
+    private static func scrollViewsSection() -> String {
+        var out = "## Scroll views mid-gesture (window-wide)\n"
+        var found = false
+        forEachWindowSubview { view in
+            guard let scrollView = view as? UIScrollView,
+                  scrollView.isDragging || scrollView.isTracking || scrollView.isDecelerating else { return }
+            found = true
+            out += "- ⚠️ \(typeName(scrollView)) dragging=\(scrollView.isDragging) tracking=\(scrollView.isTracking)"
+                + " decel=\(scrollView.isDecelerating) scrollEnabled=\(scrollView.isScrollEnabled) offset=\(scrollView.contentOffset)\n"
+        }
+        if !found { out += "- (none active — all idle)\n" }
+        return out
+    }
+
+    /// A presentation/transition left mid-flight can wedge UIKit's pan routing while taps still work.
+    @MainActor
+    private static func presentationSection() -> String {
+        var out = "## Presentation / transition state\n"
+        guard let root = keyWindow()?.rootViewController else {
+            out += "- no key window root\n"
+            return out
+        }
+        var viewController: UIViewController? = root
+        var found = false
+        while let current = viewController {
+            let hasCoordinator = current.transitionCoordinator != nil
+            if current.isBeingPresented || current.isBeingDismissed || hasCoordinator {
+                found = true
+                out += "- ⚠️ \(typeName(current)) beingPresented=\(current.isBeingPresented)"
+                    + " beingDismissed=\(current.isBeingDismissed) transitionCoordinator=\(hasCoordinator)"
+                    + " style=\(current.modalPresentationStyle.rawValue)\n"
+            }
+            viewController = current.presentedViewController
+        }
+        if !found { out += "- (no view controller mid-transition)\n" }
+        return out
+    }
+
+    private static func windowSection() -> String {
+        var out = "## Windows\n"
+        for window in allWindows() {
+            out += "- \(typeName(window)) level=\(window.windowLevel.rawValue) hidden=\(window.isHidden)"
+                + " key=\(window.isKeyWindow) root=\(window.rootViewController.map { typeName($0) } ?? "nil")\n"
+        }
+        return out
+    }
+
+    /// Window-wide scan for the swipe-tabs recognizers (siblings of the web view, never in its chain).
+    private static func competingRecognizersSection() -> String {
+        var out = "## Swipe-tabs recognizers (window-wide)\n"
+        var found = false
+        forEachWindowGestureRecognizer { recognizer in
+            guard recognizer is UnifiedInputSwipeTabsPanGestureRecognizer else { return }
+            found = true
+            let host = recognizer.view.map { typeName($0) } ?? "nil"
+            out += "• on \(host): \(describe(recognizer))\n"
+        }
+        if !found { out += "- (none found)\n" }
+        return out
+    }
+
+    private static func panGesture(of scrollView: UIScrollView) -> String {
+        "## webView.scrollView.panGestureRecognizer\n- \(describe(scrollView.panGestureRecognizer))\n"
+    }
+
+    private static func gestureChainSection(from start: UIView) -> String {
+        var out = "## Gesture recognizers (webView → window)\n"
+        var view: UIView? = start
+        var found = false
+        while let current = view {
+            if let recognizers = current.gestureRecognizers, !recognizers.isEmpty {
+                found = true
+                out += "• \(typeName(current)) [\(current.frame)]\n"
+                for recognizer in recognizers {
+                    out += "    - \(describe(recognizer))\n"
+                }
+            }
+            view = current.superview
+        }
+        if !found { out += "- (none)\n" }
+        return out
+    }
+
+    private static func overlaySection(over webView: UIView, boundary: UIView?) -> String {
+        var out = "## Potential blocking overlays over the web view\n"
+        let bounds = webView.bounds
+        let samples = [CGPoint(x: bounds.midX, y: bounds.minY + 20),
+                       CGPoint(x: bounds.midX, y: bounds.midY),
+                       CGPoint(x: bounds.midX, y: bounds.maxY - 20)].map { webView.convert($0, to: nil) }
+        var branch = webView
+        var found = false
+        while branch !== boundary, let container = branch.superview {
+            if let branchIndex = container.subviews.firstIndex(of: branch) {
+                for sibling in container.subviews[(branchIndex + 1)...] where sibling.isUserInteractionEnabled
+                    && !sibling.isHidden && sibling.alpha > 0.01 {
+                    let frameInWindow = sibling.convert(sibling.bounds, to: nil)
+                    if samples.contains(where: { frameInWindow.contains($0) }) {
+                        found = true
+                        out += "- ⚠️ \(typeName(sibling)) above \(typeName(container))"
+                            + " [\(sibling.frame)] alpha \(sibling.alpha)\n"
+                    }
+                }
+            }
+            branch = container
+        }
+        if !found { out += "- (none over the web view)\n" }
+        return out
+    }
+
+    @MainActor
+    private static func coordinatorSection() -> String {
+        guard let mainVC = findMainViewController() else {
+            return "## Coordinator state\n- MainViewController not found\n"
+        }
+        var out = "## Coordinator state\n"
+        if let swipe = mainVC.swipeTabsCoordinator {
+            out += "- swipeTabsCoordinator.isEnabled: \(swipe.isEnabled)\n"
+            out += "- swipeTabsCoordinator.state: \(String(describing: swipe.state))\n"
+        } else {
+            out += "- swipeTabsCoordinator: nil\n"
+        }
+        if let uti = mainVC.unifiedToggleInputCoordinator {
+            out += "- unifiedToggleInputCoordinator.displayState: \(String(describing: uti.displayState))\n"
+        } else {
+            out += "- unifiedToggleInputCoordinator: nil\n"
+        }
+        return out
+    }
+
+    private static func recentInteractionLogs() -> String {
+        guard let store = try? OSLogStore(scope: .currentProcessIdentifier) else {
+            return "(OSLogStore unavailable)"
+        }
+        let since = store.position(date: Date().addingTimeInterval(-300))
+        let predicate = NSPredicate(format: "subsystem == %@", "Interaction")
+        guard let entries = try? store.getEntries(at: since, matching: predicate) else {
+            return "(failed to read log store)"
+        }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss.SSS"
+        let lines = entries.compactMap { $0 as? OSLogEntryLog }.suffix(300).map {
+            "\(formatter.string(from: $0.date)) \($0.composedMessage)"
+        }
+        return lines.isEmpty ? "(no interaction logs in window)" : lines.joined(separator: "\n")
+    }
+
+    // MARK: Shared helpers
+
+    static var appVersion: String {
+        let short = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
+        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
+        return "\(short) (\(build))"
+    }
+
+    static func typeName(_ object: Any) -> String { String(describing: type(of: object)) }
+
+    static func describe(_ recognizer: UIGestureRecognizer) -> String {
+        let active = (recognizer.state == .began || recognizer.state == .changed)
+        return "\(typeName(recognizer)) state=\(recognizer.state.diagnosticName)\(active ? " ⚠️ ACTIVE" : "")"
+            + " enabled=\(recognizer.isEnabled) cancelsTouchesInView=\(recognizer.cancelsTouchesInView)"
+            + " delaysTouchesBegan=\(recognizer.delaysTouchesBegan) touches=\(recognizer.numberOfTouches)"
+    }
+
+    static func allWindows() -> [UIWindow] {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+    }
+
+    @MainActor
+    static func keyWindow() -> UIWindow? {
+        allWindows().first { $0.isKeyWindow } ?? allWindows().first
+    }
+
+    static func findMainViewController() -> MainViewController? {
+        for window in allWindows() {
+            if let root = window.rootViewController, let match = firstDescendant(MainViewController.self, in: root) {
+                return match
+            }
+        }
+        return nil
+    }
+
+    private static func firstDescendant<T: UIViewController>(_ type: T.Type, in viewController: UIViewController) -> T? {
+        if let match = viewController as? T { return match }
+        for child in viewController.children {
+            if let match = firstDescendant(type, in: child) { return match }
+        }
+        return nil
+    }
+
+    private static func forEachWindowGestureRecognizer(_ body: (UIGestureRecognizer) -> Void) {
+        for window in allWindows() { walkRecognizers(window, body) }
+    }
+
+    private static func walkRecognizers(_ view: UIView, _ body: (UIGestureRecognizer) -> Void) {
+        view.gestureRecognizers?.forEach(body)
+        view.subviews.forEach { walkRecognizers($0, body) }
+    }
+
+    private static func forEachWindowSubview(_ body: (UIView) -> Void) {
+        for window in allWindows() { walkSubviews(window, body) }
+    }
+
+    private static func walkSubviews(_ view: UIView, _ body: (UIView) -> Void) {
+        body(view)
+        view.subviews.forEach { walkSubviews($0, body) }
+    }
+}
+
+// MARK: - Persistent ring buffer
+
+/// Last N freeze captures, written to Caches so they survive leaving the debug screen and can be exported
+/// after the fact (the freeze persists, so the user has time). No pixel — purely on-device, no triage.
+enum FreezeCaptureStore {
+
+    private static let maxCaptures = 10
+
+    private static var directory: URL? {
+        guard let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else { return nil }
+        let url = caches.appendingPathComponent("freeze-captures", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    static func save(_ text: String) {
+        guard let directory else { return }
+        let name = "capture-\(Int(Date().timeIntervalSince1970)).txt"
+        try? text.write(to: directory.appendingPathComponent(name), atomically: true, encoding: .utf8)
+        prune()
+    }
+
+    static func count() -> Int { files().count }
+
+    static func exportAll() -> String {
+        files().reversed().compactMap { try? String(contentsOf: $0, encoding: .utf8) }
+            .joined(separator: "\n\n========================================\n\n")
+    }
+
+    static func clear() {
+        files().forEach { try? FileManager.default.removeItem(at: $0) }
+    }
+
+    private static func files() -> [URL] {
+        guard let directory,
+              let urls = try? FileManager.default.contentsOfDirectory(at: directory,
+                                                                      includingPropertiesForKeys: nil,
+                                                                      options: [.skipsHiddenFiles]) else { return [] }
+        return urls.sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
+    private static func prune() {
+        let all = files()
+        guard all.count > maxCaptures else { return }
+        all.prefix(all.count - maxCaptures).forEach { try? FileManager.default.removeItem(at: $0) }
+    }
+}

--- a/iOS/DuckDuckGo/WebScrollObserver.swift
+++ b/iOS/DuckDuckGo/WebScrollObserver.swift
@@ -356,9 +356,10 @@ final class WebScrollObserverGestureRecognizer: UIGestureRecognizer {
 
 // MARK: - Recovery (manual debug rungs — internal only)
 
-/// Self-heal actions for the web-scroll-freeze. `recover()` is the combined production action the
-/// auto-watchdog runs; the individual rungs are exposed for the debug Recovery screen to find the minimal
-/// sufficient action. All are idempotent and meant to run BETWEEN gestures (no active touch).
+/// Self-heal actions for the web-scroll-freeze. `recover()` is the surgical reset (pan + wedged recognizers);
+/// the individual rungs are exposed for the debug Recovery screen to find the minimal sufficient action.
+/// Debug-only and manual for now — there is no production auto-recovery; that is productionised in Part 3.
+/// All are idempotent and meant to run BETWEEN gestures (no active touch).
 @MainActor
 enum WebScrollFreezeRecovery {
 
@@ -371,7 +372,7 @@ enum WebScrollFreezeRecovery {
     @discardableResult
     static func recover() -> String {
         let count = resetBlockingRecognizers()
-        Logger.interaction.error("Auto-recovery ran: reset \(count, privacy: .public) pan/wedged recognizers")
+        Logger.interaction.error("Manual recovery ran: reset \(count, privacy: .public) pan/wedged recognizers")
         return "recover: reset \(count) pan/wedged recognizers"
     }
 

--- a/iOS/DuckDuckGo/WebScrollObserver.swift
+++ b/iOS/DuckDuckGo/WebScrollObserver.swift
@@ -59,7 +59,7 @@ final class WebScrollObserver: NSObject {
     private let scrollViewProvider: () -> UIScrollView?
     private let currentURL: () -> URL?
     private let firePixelDailyAndCount: (Pixel.Event, [String: String]) -> Void
-    /// Debug-only freeze capture, injected by `TabViewController` only when `webScrollFreezeObservability`
+    /// Debug-only freeze capture, injected by `TabViewController` only when `webScrollFreezeCapture`
     /// is on. The production observer (symptom detection + pixels) is unaffected — default is a no-op.
     private let captureFreeze: () -> Void
     private let now: () -> Date
@@ -178,7 +178,7 @@ final class WebScrollObserver: NSObject {
 
         // Capture LIBERALLY (once per streak, before the precision gate) so a real freeze always leaves the
         // touch/recognizer census. Injected closure: a no-op in production, the real capture only when the
-        // debug flag `webScrollFreezeObservability` is on. The pixel below ships to everyone regardless.
+        // debug flag `webScrollFreezeCapture` is on. The pixel below ships to everyone regardless.
         if !capturedThisStreak {
             capturedThisStreak = true
             captureFreeze()

--- a/iOS/DuckDuckGo/WebScrollObserver.swift
+++ b/iOS/DuckDuckGo/WebScrollObserver.swift
@@ -132,7 +132,9 @@ final class WebScrollObserver: NSObject {
         }
     }
 
-    private func classifyDrag(dx: CGFloat, dy: CGFloat, startOffsetY: CGFloat, startScreenY: CGFloat) {
+    /// Internal (not private) so unit tests can drive classification directly, bypassing the post-gesture
+    /// `asyncAfter` recheck. In production this is only ever called from `dragEnded`.
+    func classifyDrag(dx: CGFloat, dy: CGFloat, startOffsetY: CGFloat, startScreenY: CGFloat) {
         guard isEligible(), let scrollView = scrollViewProvider() else { return }
 
         // Only count vertical-dominant drags long enough to be a real scroll attempt.
@@ -350,4 +352,103 @@ final class WebScrollObserverGestureRecognizer: UIGestureRecognizer {
 
     override func canPrevent(_ preventedGestureRecognizer: UIGestureRecognizer) -> Bool { false }
     override func canBePrevented(by preventingGestureRecognizer: UIGestureRecognizer) -> Bool { false }
+}
+
+// MARK: - Recovery (manual debug rungs — internal only)
+
+/// Self-heal actions for the web-scroll-freeze. `recover()` is the combined production action the
+/// auto-watchdog runs; the individual rungs are exposed for the debug Recovery screen to find the minimal
+/// sufficient action. All are idempotent and meant to run BETWEEN gestures (no active touch).
+@MainActor
+enum WebScrollFreezeRecovery {
+
+    enum Rung { case flushAppRecognizers, bounceWindowInteraction, flushAll }
+
+    /// Surgical self-heal: reset only the recognisers that can actually block scrolling — pan recognisers
+    /// (incl. the web scroll view's own pan) and anything stuck mid-gesture. Does NOT touch window
+    /// interaction (toggling `isUserInteractionEnabled` orphans touches into a stuck Stationary/nil-window
+    /// state — the very freeze we're fixing) and leaves taps untouched.
+    @discardableResult
+    static func recover() -> String {
+        let count = resetBlockingRecognizers()
+        Logger.interaction.error("Auto-recovery ran: reset \(count, privacy: .public) pan/wedged recognizers")
+        return "recover: reset \(count) pan/wedged recognizers"
+    }
+
+    /// Reset pan recognisers + any recogniser stuck in `began`/`changed`. Skips UIKit-internal (`_UI…`)
+    /// system gates and all taps. Typically a handful, not the whole app.
+    @discardableResult
+    private static func resetBlockingRecognizers() -> Int {
+        var count = 0
+        for window in windows() {
+            forEachRecognizer(in: window) { recognizer in
+                guard !String(describing: type(of: recognizer)).hasPrefix("_") else { return }
+                let isPan = recognizer is UIPanGestureRecognizer
+                let isWedged = recognizer.state == .began || recognizer.state == .changed
+                guard isPan || isWedged else { return }
+                recognizer.isEnabled = false
+                recognizer.isEnabled = true
+                count += 1
+            }
+        }
+        return count
+    }
+
+    @discardableResult
+    static func runRung(_ rung: Rung) -> String {
+        switch rung {
+        case .flushAppRecognizers: return "reset \(flushAppRecognizers()) app recognizers"
+        case .bounceWindowInteraction: bounceWindowInteraction(); return "bounced window interaction"
+        case .flushAll: return "reset \(flushAll()) recognizers (all, incl. system)"
+        }
+    }
+
+    /// Reset every non-UIKit-internal recogniser (skip `_UI…` classes so we don't disturb system gates).
+    /// This also re-arms the web scroll view's own pan.
+    @discardableResult
+    private static func flushAppRecognizers() -> Int {
+        var count = 0
+        for window in windows() {
+            forEachRecognizer(in: window) { recognizer in
+                guard !String(describing: type(of: recognizer)).hasPrefix("_") else { return }
+                recognizer.isEnabled = false
+                recognizer.isEnabled = true
+                count += 1
+            }
+        }
+        return count
+    }
+
+    /// Cancel any touches the gesture environment is still tracking (the phantom-touch flush). The async
+    /// re-enable lets UIKit process the cancellation; the gap is one run-loop tick, imperceptible.
+    private static func bounceWindowInteraction() {
+        for window in windows() where window.isKeyWindow {
+            window.isUserInteractionEnabled = false
+            DispatchQueue.main.async { window.isUserInteractionEnabled = true }
+        }
+    }
+
+    @discardableResult
+    private static func flushAll() -> Int {
+        var count = 0
+        for window in windows() {
+            forEachRecognizer(in: window) { recognizer in
+                recognizer.isEnabled = false
+                recognizer.isEnabled = true
+                count += 1
+            }
+        }
+        return count
+    }
+
+    private static func windows() -> [UIWindow] {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+    }
+
+    private static func forEachRecognizer(in view: UIView, _ body: (UIGestureRecognizer) -> Void) {
+        view.gestureRecognizers?.forEach(body)
+        view.subviews.forEach { forEachRecognizer(in: $0, body) }
+    }
 }

--- a/iOS/DuckDuckGo/WebScrollObserver.swift
+++ b/iOS/DuckDuckGo/WebScrollObserver.swift
@@ -19,17 +19,26 @@
 
 import UIKit
 import OSLog
+import QuartzCore
 import Core
 
 /// Detects the symptom of the hard-to-reproduce "web page visible, taps work, scroll dead" freeze:
 /// the user drags to scroll a scrollable web page and the content doesn't move, repeatedly.
 ///
 /// Owned per `TabViewController`, attached to `webViewContainer` via a passive bystander recognizer that
-/// never interferes with scrolling or taps. Fires three telemetry signals (symptom + two daily liveness
-/// heartbeats) and a separate mechanism signal (`checkForWedgedRecognizer`). Logs every failed attempt as
-/// a breadcrumb so the Interaction Diagnostics snapshot has the recent history even below the pixel
-/// threshold. No Swift concurrency — the post-gesture and wedge re-checks use `asyncAfter` on the main
-/// queue. `firePixel*` closures are injected so the detectors are unit-testable without the static pipeline.
+/// never interferes with scrolling or taps. Detection is intentionally web-only: the recognizer is on the
+/// web container (not the window) and "did it move" is measured against the web view's own `contentOffset`,
+/// so it counts failed drags on the page itself — the canonical first symptom. The freeze is actually
+/// window-wide (a modal like Settings presented over the page is frozen too, even though it's a brand-new
+/// view), but we only count where we own the scroll view; the window-wide nature is captured instead by the
+/// app-wide wedge scan (`firstWedgedRecognizer`). Discrete taps keep flowing during a freeze, so the
+/// recognizer still receives the drag touches it needs to classify.
+///
+/// Fires two pixels: the symptom signal (`debugInteractionRepeatedFailedScroll`) and a mechanism signal
+/// (`debugInteractionWedgedRecognizer`, via `checkForWedgedRecognizer`). Logs every failed attempt as a
+/// breadcrumb so the Interaction Diagnostics snapshot has the recent history even below the pixel threshold.
+/// No Swift concurrency — the post-gesture and wedge re-checks use `asyncAfter` on the main queue.
+/// `firePixel*` closures are injected so the detectors are unit-testable without the static pipeline.
 @MainActor
 final class WebScrollObserver: NSObject {
 
@@ -41,6 +50,7 @@ final class WebScrollObserver: NSObject {
         static let movedThreshold: CGFloat = 3
         static let postEndRecheck: TimeInterval = 0.2
         static let streakThreshold = 3
+        static let minRegionSpread = 2
         static let streakWindow: TimeInterval = 30
         static let wedgeRecheck: TimeInterval = 1.0
     }
@@ -49,6 +59,9 @@ final class WebScrollObserver: NSObject {
     private let scrollViewProvider: () -> UIScrollView?
     private let currentURL: () -> URL?
     private let firePixelDailyAndCount: (Pixel.Event, [String: String]) -> Void
+    /// Debug-only freeze capture, injected by `TabViewController` only when `webScrollFreezeObservability`
+    /// is on. The production observer (symptom detection + pixels) is unaffected — default is a no-op.
+    private let captureFreeze: () -> Void
     private let now: () -> Date
 
     private var recognizer: WebScrollObserverGestureRecognizer?
@@ -57,7 +70,9 @@ final class WebScrollObserver: NSObject {
     private var failureStreak = 0
     private var lastFailureAt: Date?
     private var streakDirections: Set<String> = []
+    private var streakRegions: Set<Int> = []
     private var highestBucketFired: String?
+    private var capturedThisStreak = false
 
     private weak var wedgeCandidate: UIGestureRecognizer?
 
@@ -70,12 +85,14 @@ final class WebScrollObserver: NSObject {
          firePixelDailyAndCount: @escaping (Pixel.Event, [String: String]) -> Void = {
             DailyPixel.fireDailyAndCount(pixel: $0, withAdditionalParameters: $1)
          },
-         now: @escaping () -> Date = { Date() }) {
+         now: @escaping () -> Date = { Date() },
+         captureFreeze: @escaping () -> Void = {}) {
         self.container = container
         self.scrollViewProvider = scrollView
         self.currentURL = currentURL
         self.firePixelDailyAndCount = firePixelDailyAndCount
         self.now = now
+        self.captureFreeze = captureFreeze
         super.init()
     }
 
@@ -84,7 +101,7 @@ final class WebScrollObserver: NSObject {
         let recognizer = WebScrollObserverGestureRecognizer(target: nil, action: nil)
         recognizer.delegate = self
         recognizer.onBegan = { [weak self] in self?.dragBegan() }
-        recognizer.onEnded = { [weak self] dx, dy in self?.dragEnded(dx: dx, dy: dy) }
+        recognizer.onEnded = { [weak self] dx, dy, start in self?.dragEnded(dx: dx, dy: dy, start: start) }
         container.addGestureRecognizer(recognizer)
         self.recognizer = recognizer
     }
@@ -94,7 +111,9 @@ final class WebScrollObserver: NSObject {
         failureStreak = 0
         lastFailureAt = nil
         streakDirections = []
+        streakRegions = []
         highestBucketFired = nil
+        capturedThisStreak = false
     }
 
     // MARK: - Symptom detection (C1)
@@ -103,17 +122,17 @@ final class WebScrollObserver: NSObject {
         dragStartOffsetY = scrollViewProvider()?.contentOffset.y ?? 0
     }
 
-    private func dragEnded(dx: CGFloat, dy: CGFloat) {
+    private func dragEnded(dx: CGFloat, dy: CGFloat, start: CGPoint) {
         // Capture the start offset by value now — a second drag within the recheck window would
         // otherwise overwrite `dragStartOffsetY` before this closure runs.
         let startOffsetY = dragStartOffsetY
         // Re-sample after a beat so late settling counts as movement.
         DispatchQueue.main.asyncAfter(deadline: .now() + Constant.postEndRecheck) { [weak self] in
-            self?.classifyDrag(dx: dx, dy: dy, startOffsetY: startOffsetY)
+            self?.classifyDrag(dx: dx, dy: dy, startOffsetY: startOffsetY, startScreenY: start.y)
         }
     }
 
-    private func classifyDrag(dx: CGFloat, dy: CGFloat, startOffsetY: CGFloat) {
+    private func classifyDrag(dx: CGFloat, dy: CGFloat, startOffsetY: CGFloat, startScreenY: CGFloat) {
         guard isEligible(), let scrollView = scrollViewProvider() else { return }
 
         // Only count vertical-dominant drags long enough to be a real scroll attempt.
@@ -134,30 +153,62 @@ final class WebScrollObserver: NSObject {
             reset()
             recentStatus = "last drag scrolled OK (\(formatted(now())))"
         } else {
-            registerFailedAttempt(direction: fingerUp ? "up" : "down")
+            registerFailedAttempt(direction: fingerUp ? "up" : "down", startScreenY: startScreenY)
         }
     }
 
-    private func registerFailedAttempt(direction: String) {
+    private func registerFailedAttempt(direction: String, startScreenY: CGFloat) {
         if let last = lastFailureAt, now().timeIntervalSince(last) > Constant.streakWindow {
             failureStreak = 0
             streakDirections = []
+            streakRegions = []
             highestBucketFired = nil
+            capturedThisStreak = false
         }
         failureStreak += 1
         lastFailureAt = now()
         streakDirections.insert(direction)
+        streakRegions.insert(screenRegion(forY: startScreenY))
         recentStatus = "\(failureStreak) failed scroll attempt(s) (\(formatted(now())))"
-        Logger.interaction.error("Web scroll did not move: failed attempt #\(self.failureStreak, privacy: .public), direction \(direction, privacy: .public)")
+        Logger.interaction.error("Web scroll did not move: failed attempt #\(self.failureStreak, privacy: .public), direction \(direction, privacy: .public), regions \(self.streakRegions.count, privacy: .public)")
 
         guard failureStreak >= Constant.streakThreshold else { return }
+
+        // Capture LIBERALLY (once per streak, before the precision gate) so a real freeze always leaves the
+        // touch/recognizer census. Injected closure: a no-op in production, the real capture only when the
+        // debug flag `webScrollFreezeObservability` is on. The pixel below ships to everyone regardless.
+        if !capturedThisStreak {
+            capturedThisStreak = true
+            captureFreeze()
+        }
+
+        // Fire the population pixel ONLY for our case. A benign content-consumed drag (carousel, map,
+        // overflow scroller, sticky element) is localised; the genuine freeze fails EVERYWHERE — so
+        // require the failed drags to span ≥2 distinct screen regions before counting it as our freeze.
+        guard streakRegions.count >= Constant.minRegionSpread else { return }
         let bucket = attemptBucket(failureStreak)
         guard bucket != highestBucketFired else { return }
         highestBucketFired = bucket
+        // Scan for a wedged recognizer at the moment we confirm the freeze (not just at viewDidAppear),
+        // so `none_wedged` is meaningful evidence for the phantom-touch hypothesis.
+        let mechanism: String
+        if let wedged = Self.firstWedgedRecognizer() {
+            mechanism = "wedged:\(Self.bucket(for: wedged))"
+        } else {
+            mechanism = "none_wedged"
+        }
         firePixelDailyAndCount(.debugInteractionRepeatedFailedScroll, [
             "attempt_count_bucket": bucket,
-            "direction": streakDirections.count > 1 ? "mixed" : (streakDirections.first ?? "mixed")
+            "direction": streakDirections.count > 1 ? "mixed" : (streakDirections.first ?? "mixed"),
+            "mechanism": mechanism
         ])
+    }
+
+    /// Bucket the drag's start position into vertical thirds of the container, for the spatial-spread gate.
+    private func screenRegion(forY y: CGFloat) -> Int {
+        let height = container?.bounds.height ?? UIScreen.main.bounds.height
+        guard height > 0 else { return 0 }
+        return max(0, min(2, Int(y / (height / 3))))
     }
 
     // MARK: - Wedged-recognizer detection (C2)
@@ -260,7 +311,7 @@ extension WebScrollObserver: UIGestureRecognizerDelegate {
 final class WebScrollObserverGestureRecognizer: UIGestureRecognizer {
 
     var onBegan: (() -> Void)?
-    var onEnded: ((CGFloat, CGFloat) -> Void)?
+    var onEnded: ((CGFloat, CGFloat, CGPoint) -> Void)?
 
     private var startPoint: CGPoint = .zero
     private var lastPoint: CGPoint = .zero
@@ -293,7 +344,7 @@ final class WebScrollObserverGestureRecognizer: UIGestureRecognizer {
     }
 
     private func finish() {
-        onEnded?(lastPoint.x - startPoint.x, lastPoint.y - startPoint.y)
+        onEnded?(lastPoint.x - startPoint.x, lastPoint.y - startPoint.y, startPoint)
         state = .failed
     }
 

--- a/iOS/DuckDuckGoTests/WebScrollObserverTests.swift
+++ b/iOS/DuckDuckGoTests/WebScrollObserverTests.swift
@@ -1,0 +1,155 @@
+//
+//  WebScrollObserverTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import UIKit
+import Core
+@testable import DuckDuckGo
+
+/// Drives `WebScrollObserver.classifyDrag` directly (the synchronous classification entry) to validate the
+/// symptom-pixel logic — failure streak, the ≥2-region spatial-spread gate, the 30s streak window, and
+/// eligibility — without simulating real touches or the post-gesture async recheck.
+@MainActor
+final class WebScrollObserverTests: XCTestCase {
+
+    private var container: UIView!
+    private var scrollView: UIScrollView!
+    private var url: URL?
+    private var currentDate: Date!
+    private var firedPixels: [(event: Pixel.Event, params: [String: String])] = []
+
+    override func setUp() {
+        super.setUp()
+        // Container height 600 → screen regions are thirds at y<200 / 200..<400 / ≥400.
+        container = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 600))
+        // A genuinely scrollable page: 2000pt content in a 600pt viewport → ~1400pt of range.
+        scrollView = UIScrollView(frame: CGRect(x: 0, y: 0, width: 390, height: 600))
+        scrollView.contentSize = CGSize(width: 390, height: 2000)
+        scrollView.contentOffset = CGPoint(x: 0, y: 100)
+        url = URL(string: "https://example.com")
+        currentDate = Date(timeIntervalSince1970: 1_000_000)
+        firedPixels = []
+    }
+
+    override func tearDown() {
+        container = nil
+        scrollView = nil
+        url = nil
+        currentDate = nil
+        firedPixels = []
+        super.tearDown()
+    }
+
+    private func makeObserver() -> WebScrollObserver {
+        WebScrollObserver(container: container,
+                          scrollView: { [weak self] in self?.scrollView },
+                          currentURL: { [weak self] in self?.url },
+                          firePixelDailyAndCount: { [weak self] event, params in
+                              self?.firedPixels.append((event, params))
+                          },
+                          now: { [weak self] in self?.currentDate ?? Date() })
+    }
+
+    /// A failed (non-moving) upward drag starting at the given screen-Y. `contentOffset` is left at the
+    /// start offset so the observer sees zero movement.
+    private func failedDrag(at startScreenY: CGFloat, on observer: WebScrollObserver) {
+        scrollView.contentOffset = CGPoint(x: 0, y: 100)
+        observer.classifyDrag(dx: 0, dy: -100, startOffsetY: 100, startScreenY: startScreenY)
+    }
+
+    func testThreeFailedDragsAcrossTwoRegionsFiresSymptomPixel() {
+        let observer = makeObserver()
+
+        failedDrag(at: 100, on: observer) // region 0
+        failedDrag(at: 300, on: observer) // region 1
+        XCTAssertTrue(firedPixels.isEmpty, "Should not fire before the streak threshold")
+
+        failedDrag(at: 500, on: observer) // region 2 → streak 3, spans 3 regions
+
+        XCTAssertEqual(firedPixels.count, 1)
+        XCTAssertEqual(firedPixels.first?.event, .debugInteractionRepeatedFailedScroll)
+        XCTAssertEqual(firedPixels.first?.params["attempt_count_bucket"], "3")
+        XCTAssertEqual(firedPixels.first?.params["direction"], "up")
+        XCTAssertEqual(firedPixels.first?.params["mechanism"], "none_wedged")
+    }
+
+    func testFailedDragsInOneRegionDoNotFire() {
+        let observer = makeObserver()
+
+        failedDrag(at: 100, on: observer)
+        failedDrag(at: 100, on: observer)
+        failedDrag(at: 100, on: observer)
+        failedDrag(at: 100, on: observer)
+
+        XCTAssertTrue(firedPixels.isEmpty, "A single-region streak is benign and must not fire")
+    }
+
+    func testSuccessfulDragResetsTheStreak() {
+        let observer = makeObserver()
+
+        failedDrag(at: 100, on: observer) // region 0, streak 1
+        failedDrag(at: 300, on: observer) // region 1, streak 2
+
+        // A drag that actually scrolls (content moved well beyond the 3pt threshold) resets the streak.
+        scrollView.contentOffset = CGPoint(x: 0, y: 100)
+        observer.classifyDrag(dx: 0, dy: -100, startOffsetY: 0, startScreenY: 100)
+
+        // Two more failures across two regions → only streak 2 again, so still below threshold.
+        failedDrag(at: 100, on: observer)
+        failedDrag(at: 300, on: observer)
+
+        XCTAssertTrue(firedPixels.isEmpty, "A successful scroll must reset the failure streak")
+    }
+
+    func testStreakWindowExpiryResetsBeforeFiring() {
+        let observer = makeObserver()
+
+        failedDrag(at: 100, on: observer) // region 0
+        failedDrag(at: 300, on: observer) // region 1
+
+        // More than the 30s streak window later, the next failure restarts the streak from 1.
+        currentDate = currentDate.addingTimeInterval(31)
+        failedDrag(at: 500, on: observer) // region 2, but streak reset to 1
+
+        XCTAssertTrue(firedPixels.isEmpty, "A gap beyond the streak window must reset before firing")
+    }
+
+    func testNonHTTPPageIsIneligible() {
+        url = URL(string: "duck://player")
+        let observer = makeObserver()
+
+        failedDrag(at: 100, on: observer)
+        failedDrag(at: 300, on: observer)
+        failedDrag(at: 500, on: observer)
+
+        XCTAssertTrue(firedPixels.isEmpty, "Non-http(s) pages are not eligible for symptom detection")
+    }
+
+    func testShortOrHorizontalDragIsIgnored() {
+        let observer = makeObserver()
+
+        // Below the 48pt vertical threshold.
+        observer.classifyDrag(dx: 0, dy: -20, startOffsetY: 100, startScreenY: 100)
+        // Horizontally dominant.
+        observer.classifyDrag(dx: -200, dy: -60, startOffsetY: 100, startScreenY: 300)
+        observer.classifyDrag(dx: -200, dy: -60, startOffsetY: 100, startScreenY: 500)
+
+        XCTAssertTrue(firedPixels.isEmpty, "Short or horizontal drags are not scroll attempts")
+    }
+}

--- a/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
@@ -99,7 +99,7 @@
                 "type": "string"
             }
         ],
-        "expires": "2026-07-11"
+        "expires": "2026-09-21"
     },
     "m_debug_interaction_wedged_recognizer": {
         "description": "Fires when a non-scroll gesture recognizer is found in an active (began/changed) state with no touches down, and is still wedged on a re-check ~1s later, while a web page is shown. Reliable mechanism signal for a recognizer that may be starving the web scroll pan.",
@@ -115,6 +115,6 @@
                 "enum": ["web_scroll_pan", "pull_to_refresh_pan", "swipe_tabs", "edge_pan", "tap", "long_press", "other_pan", "other"]
             }
         ],
-        "expires": "2026-07-11"
+        "expires": "2026-09-21"
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
@@ -92,6 +92,11 @@
                 "description": "Dominant drag direction across the failed attempts.",
                 "type": "string",
                 "enum": ["up", "down", "mixed"]
+            },
+            {
+                "key": "mechanism",
+                "description": "Gesture-environment state at the moment the freeze is confirmed. 'wedged:<type>' means a recognizer is stuck active with no touches (e.g. wedged:swipe_tabs); 'none_wedged' means no stuck recognizer was found, consistent with the phantom-touch hypothesis.",
+                "type": "string"
             }
         ],
         "expires": "2026-07-11"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1215895676655232

### Description

**Part 1 of 3 — observability + debugging** for the hard-to-reproduce "web page visible, taps work, vertical scroll dead" freeze. (Plan: 1) observability + debugging, 2) root cause, 3) recovery.)

Ships the freeze **observability** to the external population **and** the internal **debugging** tooling needed to reproduce and inspect it — in one PR (no separate debug PR).

**Flags (two):**
- `webScrollFreezeObservability` — `.enabled`, the production kill switch. Gates the passive bystander gesture recognizer + the two pixels (`m_debug_interaction_repeated_failed_scroll`, `m_debug_interaction_wedged_recognizer`).
- `webScrollFreezeCapture` — `.internalOnly`. Gates only the heavier auto-capture-on-freeze hook.

**What's here:**
- Production: bystander recognizer + symptom/mechanism pixels (incl. the `mechanism` param — at the freeze instant we scan all windows for a recognizer stuck active with no touches: `wedged:<type>` or `none_wedged`).
- Internal debug menu (**Interaction Diagnostics**): a capture & snapshot viewer over a ring buffer, **E1/E2/E3 provocations** that reproduce the freeze on-device, and manual recovery rungs (recovery is productionised in Part 3).
- Capture mechanism lives in `WebScrollFreezeProbe.swift`.
- `WebScrollObserverTests` covering the detector logic.

### Testing Steps

**On-device repro + pixel validation (internal build):**
1. Open the debug menu → **Interaction Diagnostics → Provocations**.
2. Tap **E1 · Inject stuck gesture**, dismiss the screen (might need to tap back a few times, and scroll to get it to dismiss), then **drag the web page a few times** in different parts of the screen. Scrolling is dead while taps still work — the freeze, reproduced.
3. After 3 dead drags spanning ≥2 vertical regions, `m_debug_interaction_repeated_failed_scroll` fires — confirm via the pixel debug log, with `attempt_count_bucket`, `direction`, and `mechanism`.
4. **Interaction Diagnostics → Capture & snapshot** shows the auto-saved capture (ring buffer); **Copy All** to export.
5. Tap **Interaction Diagnostics → Provocations → **E1 · Clear injection** to restore normal scrolling.

### Impact and Risks

**Low.** No user-facing behaviour change. The only production-path code is a bystander `UIGestureRecognizer` on the web container, deliberately fully passive (`cancelsTouchesInView=false`, `delaysTouchesBegan/Ended=false`, `canPrevent/canBePrevented=false`, always `.failed`). Pixels are fire-and-forget DailyPixels. The debug menu, provocations, and capture are internal-only (debug menu surface / `webScrollFreezeCapture`).

#### What could go wrong?
- If the bystander recognizer interfered with the web touch path it would affect all browsing — mitigated by the `webScrollFreezeObservability` kill switch (remotely disableable).
- Benign "content consumed the drag" false positives — filtered by the ≥2-region spatial gate + http(s)/scrollable eligibility.
- Captured data never leaves the device (read only via the internal debug screen); the capture flag is internal-only.

### Quality Considerations
- **Monitoring:** symptom + mechanism pixels, plus per-attempt `Logger.interaction` breadcrumbs.
- **Privacy:** privacy triage owed (DRI: Pete) before external enablement, given external-population collection + the `mechanism` param. Gates rollout, not merge.
- **Detection scope:** intentionally web-view-only; the window-wide nature of the freeze is carried by the app-wide wedged-recognizer scan (rationale in `WebScrollObserver.swift`).

### Notes to Reviewer
- Pixels carry `expires: 2026-09-21` (temporary observability, per pixels.mdc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> A passive bystander recognizer runs on every web tab for external users with new telemetry (including mechanism); mitigated by remote disable and spatial gating, but touch-path regressions would be high impact if the recognizer misbehaved.
> 
> **Overview**
> **Part 1 observability** for the “scroll dead, taps work” web freeze: production detection ships **on by default** behind `webScrollFreezeObservability` (was internal-only), with remote kill-switch via privacy config.
> 
> A new **`webScrollFreezeCapture`** flag (internal-only) gates heavier on-device snapshot + ring-buffer capture; `TabViewController` wires an optional `captureFreeze` closure into `WebScrollObserver` while symptom pixels run for everyone when capture is off.
> 
> **`WebScrollObserver`** now tracks failed drags across vertical screen regions (≥2 regions before firing), attaches **`mechanism`** (`wedged:<type>` vs `none_wedged`) to the repeated-failed-scroll pixel, and can auto-capture once per streak when capture is enabled. **`WebScrollFreezeProbe`** centralizes freeze snapshots; **`FreezeCaptureStore`** persists up to 10 captures in Caches.
> 
> **Interaction Diagnostics** is reorganized into Recovery / Capture / Provocations submenus, uses `WebScrollFreezeProbe` + recovery rungs (`WebScrollFreezeRecovery`), and adds E1/E2 provocation helpers to reproduce wedged gestures on device.
> 
> **`WebScrollObserverTests`** cover streak, region gate, eligibility, and reset behavior. Debug pixel definitions gain the `mechanism` parameter and extended expiry (**2026-09-21**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a20fb26e11cf4f41dd1289a18a7779f7cc6205f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



