### PR TITLE
[iOS] Fix failing .ics handling Maestro tests

### DIFF
--- a/.github/workflows/ios_end_to_end.yml
+++ b/.github/workflows/ios_end_to_end.yml
@@ -218,7 +218,7 @@ jobs:
     name: "E2E: ${{ matrix.test-tag }}${{ matrix.user-mode == 'internal' && ' - internal' || '' }}"
     needs: [build-end-to-end-tests, setup-matrix]
     runs-on: macos-26
-    timeout-minutes: 210
+    timeout-minutes: 250
 
     env:
       RUNS_ON: macos-26 # keep this in sync with runs-on above
@@ -290,8 +290,8 @@ jobs:
         #   ATTEMPT_BUDGET_MIN   outer hard-kill belt; only fires if maestro ignores its own
         #                        clock (a true hang), surfacing as rc=124, which we retry.
         #   MAX_ATTEMPTS x ATTEMPT_BUDGET_MIN must fit under the job's timeout-minutes.
-        MAESTRO_TIMEOUT_MIN=90
-        ATTEMPT_BUDGET_MIN=100
+        MAESTRO_TIMEOUT_MIN=110
+        ATTEMPT_BUDGET_MIN=120
         MAX_ATTEMPTS=2
         RETRY_DELAY=30
         NETWORK_SIGNATURE='getaddrinfo ENOTFOUND|EAI_AGAIN|FetchError|Could not get Upload status|ETIMEDOUT|ECONNRESET|socket hang up'

--- a/.maestro/browser_features/ics_calendar_links_happy_path.yaml
+++ b/.maestro/browser_features/ics_calendar_links_happy_path.yaml
@@ -25,5 +25,5 @@ tags:
     timeout: 10000
 
 # No fallback toast for a happy-path single event.
-- assertNotVisible: "Multiple events aren't supported"
-- assertNotVisible: "This file can't be processed"
+- assertNotVisible: "Multiple events aren't supported. Try opening the downloaded file instead."
+- assertNotVisible: "This file can't be processed. Try opening the downloaded file instead."

--- a/.maestro/browser_features/ics_calendar_links_parse_failure_fallback.yaml
+++ b/.maestro/browser_features/ics_calendar_links_parse_failure_fallback.yaml
@@ -19,7 +19,7 @@ tags:
 - pressKey: Enter
 
 - extendedWaitUntil:
-    visible: "This file can't be processed"
+    visible: "This file can't be processed. Try opening the downloaded file instead."
     timeout: 15000
 
 # QuickLook must not be presented for a malformed file.

--- a/.maestro/browser_features/ics_calendar_links_parse_failure_fallback.yaml
+++ b/.maestro/browser_features/ics_calendar_links_parse_failure_fallback.yaml
@@ -1,5 +1,6 @@
 # ics_calendar_links_parse_failure_fallback.yaml
-# Malformed .ics should fall back to QuickLook (and show the parse-failure toast).
+# A malformed .ics is NOT previewed in QuickLook (that would only render a
+# "couldn't open" placeholder); the app shows the parse-failure toast instead.
 appId: com.duckduckgo.mobile.ios
 tags:
     - iphone
@@ -18,6 +19,9 @@ tags:
 - pressKey: Enter
 
 - extendedWaitUntil:
-    visible:
-        id: "QLOverlayDoneButtonAccessibilityIdentifier"
-    timeout: 10000
+    visible: "This file can't be processed"
+    timeout: 15000
+
+# QuickLook must not be presented for a malformed file.
+- assertNotVisible:
+    id: "QLOverlayDoneButtonAccessibilityIdentifier"


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1215899257967447?focus=true
Tech Design URL:
CC:

### Description

This PR fixes tests that had gotten out of sync with production.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that this test run succeeded: https://github.com/duckduckgo/apple-browsers/actions/runs/27907796931/job/82580080893

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Maestro flows and GitHub Actions timeouts; no production app code is modified.
> 
> **Overview**
> Updates **Maestro release flows** for `.ics` calendar links so assertions match current app copy and behavior, after tests had drifted from production.
> 
> The happy-path flow now asserts the full fallback toast strings (including *"Try opening the downloaded file instead."*). The malformed-file flow expects the parse-failure toast within a longer wait and **asserts QuickLook is not shown**, replacing the old expectation that QuickLook would open.
> 
> **iOS end-to-end CI** gets more headroom: job `timeout-minutes` 210→250, `MAESTRO_TIMEOUT_MIN` 90→110, and `ATTEMPT_BUDGET_MIN` 100→120 so nested budgets still fit under the job cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c14e8b5a8085d7db26c27a56096f4152c7648ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->