### PR TITLE
[iOS] lazy instantiate js controller (alert, confirm, prompt)

### DIFF
--- a/iOS/DuckDuckGo/TabViewController+UI.swift
+++ b/iOS/DuckDuckGo/TabViewController+UI.swift
@@ -208,7 +208,16 @@ extension TabViewController {
         ])
     }
 
-    func setupJSAlertController() {
+    /// Lazily instantiates the JSAlertController storyboard on first use.
+    ///
+    /// This is deliberately not called from `viewDidLoad`: the storyboard contains a
+    /// `UIVisualEffectView`/`UIBlurEffect` whose first decode triggers a synchronous
+    /// CoreMaterial recipe-bundle scan. Doing that for every tab on the cold-launch path
+    /// could exhaust the scene-create CPU budget and trip the watchdog (SIGKILL 0x8BADF00D).
+    /// Deferring it to the first presented JS alert keeps that work off the launch path.
+    func setupJSAlertControllerIfNeeded() {
+        guard jsAlertController == nil else { return }
+
         let storyboard = UIStoryboard(name: "JSAlertController", bundle: nil)
         guard let controller = storyboard.instantiateInitialViewController() as? JSAlertController else {
             fatalError("Failed to instantiate JSAlertController")

--- a/iOS/DuckDuckGo/TabViewController+UI.swift
+++ b/iOS/DuckDuckGo/TabViewController+UI.swift
@@ -120,6 +120,10 @@ extension TabViewController {
 
         jsAlertContainerView = UIView()
         jsAlertContainerView.translatesAutoresizingMaskIntoConstraints = false
+        // Hidden until a JS alert is presented. This fills rootView and sits above the web view,
+        // so leaving it visible would swallow all touches/scrolls. Previously JSAlertController's
+        // viewDidAppear hid it during eager setup; now that setup is deferred, hide it explicitly.
+        jsAlertContainerView.isHidden = true
         rootView.addSubview(jsAlertContainerView)
         NSLayoutConstraint.activate([
             jsAlertContainerView.topAnchor.constraint(equalTo: rootView.topAnchor),

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -436,16 +436,17 @@ class TabViewController: UIViewController {
     private var canDisplayJavaScriptAlert: Bool {
         return presentedViewController == nil
             && delegate?.tabCheckIfItsBeingCurrentlyPresented(self) ?? false
-            && !self.jsAlertController.isShown
+            && !(jsAlertController?.isShown ?? false)
     }
 
     func present(_ alert: WebJSAlert) {
-        self.jsAlertController.present(alert)
+        setupJSAlertControllerIfNeeded()
+        jsAlertController.present(alert)
     }
 
     private func dismissJSAlertIfNeeded() {
-        if jsAlertController.isShown {
-            jsAlertController.dismiss(animated: false)
+        if jsAlertController?.isShown == true {
+            jsAlertController?.dismiss(animated: false)
         }
     }
 
@@ -750,7 +751,10 @@ class TabViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupJSAlertController()
+        // Note: JSAlertController is intentionally NOT set up here. Instantiating its
+        // storyboard eagerly triggers a first-time UIVisualEffectView/CoreMaterial bundle
+        // scan on the cold-launch critical path, which can trip the scene-create watchdog
+        // (0x8BADF00D). It is now lazily created on first use via setupJSAlertControllerIfNeeded().
 
         fireproofingWorker = FireproofingWorking(controller: self, fireproofing: fireproofing, favicons: favicons)
         initAttributionLogic()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1215854976092959?focus=true
Tech Design URL:
CC:

### Description
Defers loading of the `jsAlertContainerView` until it's needed in order to prevent cold launch crash.

### Testing Steps
1. Validate JS alerts on https://privacy-test-pages.site/features/js-alerts.html
2. Smoke test browsing (follow links, swipe to switch tab, etc)

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
Could break JS alerts and generally browsing

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tab UI setup and JS dialog presentation; regressions could break alerts or block scrolling if the overlay visibility is wrong.
> 
> **Overview**
> Defers **`JSAlertController`** storyboard setup so cold launch no longer instantiates blur/material UI for every tab, avoiding scene-create watchdog kills (**0x8BADF00D**).
> 
> **`setupJSAlertController()`** is removed from **`viewDidLoad`** and replaced with **`setupJSAlertControllerIfNeeded()`**, which runs only when a page triggers **`alert` / `confirm` / `prompt`**. Alert gating and dismiss paths use optional **`jsAlertController`** access.
> 
> Because the full-screen **`jsAlertContainerView`** is no longer hidden via the controller’s **`viewDidAppear`** during eager setup, it is **`isHidden = true`** at creation so it does not block touches until an alert is shown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48dae5f698b5477f72cc05357a74c7f3adbc30d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->