### PR TITLE
macOS: Keep passwords toolbar button anchored while onboarding popover is shown

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarPopovers.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarPopovers.swift
@@ -157,6 +157,10 @@ final class NavigationBarPopovers: NSObject, PopoverPresenter {
         autofillPopoverPresenter.popoverIsShown
     }
 
+    var isAutofillOnboardingPopoverShown: Bool {
+        autofillOnboardingPopover?.isShown ?? false
+    }
+
     var isSaveCredentialsPopoverShown: Bool {
         saveCredentialsPopover?.isShown ?? false
     }

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -689,7 +689,11 @@ final class NavigationBarViewController: NSViewController {
         if pinningManager.isPinned(.autofill) && !isInPopUpWindow {
             passwordManagementButton.isHidden = false
         } else {
-            passwordManagementButton.isShown = popovers.isPasswordManagementPopoverShown || isAutoFillAutosaveMessageVisible
+            // Keep the button visible while the onboarding popover is anchored to it, otherwise hiding the button
+            // collapses the stack view and the popover detaches to a stray position.
+            passwordManagementButton.isShown = popovers.isPasswordManagementPopoverShown
+                || isAutoFillAutosaveMessageVisible
+                || popovers.isAutofillOnboardingPopoverShown
         }
 
         popovers.passwordManagementDomain = nil


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1215768200899762?focus=true
Tech Design URL:
CC:

### Description

The "Add passwords shortcut?" autofill onboarding popover could appear detached in a stray position (e.g. floating in the top-right of the window) instead of anchored beneath the passwords toolbar button.

The popover anchors to `passwordManagementButton`, which lives in the "Menu Buttons" stack view configured with `detachesHiddenViews="YES"`. `updatePasswordManagementButton()` decides that button's visibility, and the old condition only kept it shown for the password-management popover or the autosave message. When that method ran *while the onboarding popover was open* — e.g. on a `.PasswordManagerChanged` / sync-driven nav-bar refresh fired right after saving the first credential — it momentarily set the button hidden. Because the stack view detaches hidden views, the anchor collapsed out of layout and AppKit re-floated the popover to a fallback position; even once the button was restored to visible, the popover stayed detached.

The fix treats an open onboarding popover the same way save popovers are already treated (`hasAnySavePopoversVisible()`), keeping the button visible so the popover remains anchored for its whole lifetime.

### Testing Steps

1. Start with autofill **not** pinned to the toolbar and no saved passwords (so the first-credential prompt path is exercised).
2. Visit a site with a login form and sign in so the Save-Credentials prompt appears; click **Save**.
3. The "Add passwords shortcut?" popover should appear **anchored directly below the passwords toolbar button**, not detached elsewhere in the window.
4. Most reproducible on macOS 26 with Sync enabled (the post-save refresh that triggered the detachment fires more readily there).

### Impact and Risks

Low — scoped to the visibility condition of a single toolbar button; no behavior change when autofill is pinned or when the onboarding popover isn't shown.

#### What could go wrong?

The button is now also kept visible while the onboarding popover is open. When the popover closes, `updatePasswordManagementButton()` runs again with `isAutofillOnboardingPopoverShown == false`, so the button reverts to its normal hidden/pinned state (or stays pinned if the user tapped "Add Shortcut"). No lingering-visibility path was found.

### Notes to Reviewer

`isAutofillOnboardingPopoverShown` mirrors the existing `is…PopoverShown` accessors on `NavigationBarPopovers`. The change is intentionally minimal — an earlier attempt to fix this by forcing a layout pass before presenting did not work, because the popover anchors correctly and is only detached by a *later* hide of the anchor view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single toolbar visibility condition; no change when autofill is pinned or onboarding is not shown.
> 
> **Overview**
> Fixes the **"Add passwords shortcut?"** autofill onboarding popover sometimes appearing detached (e.g. top-right of the window) instead of under the passwords toolbar button.
> 
> When autofill is not pinned, `updatePasswordManagementButton()` could hide `passwordManagementButton` during a nav-bar refresh (e.g. after `.PasswordManagerChanged` / sync right after saving the first credential). The menu-buttons stack uses `detachesHiddenViews`, so hiding the anchor collapsed layout and AppKit left the popover in a fallback position.
> 
> Adds `isAutofillOnboardingPopoverShown` on `NavigationBarPopovers` (same pattern as other popover visibility accessors) and includes it in the button visibility condition alongside the password-management popover and autosave message, so the anchor stays in layout for the onboarding popover’s lifetime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa236ef7ceaee170e85a838efa084d05c100d6d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->