### PR TITLE
iOS: Stop deferring Duck.ai native-storage migration once it's done

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -573,6 +573,12 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// legacy App Group path.
     case nativeStoragePathMigration
 
+    /// Once the native-storage path migration is complete (or not needed), opens
+    /// the store on locked / background launches instead of deferring on the
+    /// protected-data gate. Off keeps the legacy behavior where any locked launch
+    /// nils the handler — which makes the Duck.ai front-end re-prompt T&C.
+    case nativeStorageMigrationLockedLaunchFix
+
     /// Enables the rich Duck.ai tab grid card in the iOS tab switcher (rendered from
     /// native-storage chat data). When off, Duck.ai tabs fall back to the standard
     /// screenshot preview.

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -439,6 +439,11 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215106459483563?focus=true
     case duckAINativeStoragePathMigration
 
+    /// Once the native-storage path migration is done (or not needed), opens the
+    /// store on locked/background launches instead of deferring — fixes the
+    /// Duck.ai T&C re-prompt (`m.aichat.terms.accepted.duplicate`) spike.
+    case duckAINativeStorageMigrationLockedLaunchFix
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214025222413375
     case aiChatNativeDataAccess
 
@@ -805,6 +810,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(AIChatSubfeature.nativeStorage))
         case .duckAINativeStoragePathMigration:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.nativeStoragePathMigration))
+        case .duckAINativeStorageMigrationLockedLaunchFix:
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.nativeStorageMigrationLockedLaunchFix))
         case .aiChatNativeDataAccess:
             Config(source: .remoteReleasable(AIChatSubfeature.nativeDataAccess))
         case .aiFeaturesNativeControls:

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -439,9 +439,7 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215106459483563?focus=true
     case duckAINativeStoragePathMigration
 
-    /// Once the native-storage path migration is done (or not needed), opens the
-    /// store on locked/background launches instead of deferring — fixes the
-    /// Duck.ai T&C re-prompt (`m.aichat.terms.accepted.duplicate`) spike.
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215920422347500?focus=true
     case duckAINativeStorageMigrationLockedLaunchFix
 
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214025222413375

--- a/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
+++ b/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
@@ -87,9 +87,6 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
 
     @discardableResult
     func run() -> DuckAiNativeStorageContainerMigrationOutcome {
-        // Legacy gate (kill switch): when the fix is disabled, defer up front so
-        // behavior matches the pre-fix code exactly — even an already-completed
-        // migration is skipped on a locked / background launch.
         if !lockedLaunchFixEnabled, let deferred = deferIfProtectedDataUnavailable() {
             return deferred
         }
@@ -107,9 +104,6 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
         }
     }
 
-    /// Returns `.skip` (after logging and firing the defer pixel) when protected
-    /// data is unavailable, else `nil`. Shared by the legacy up-front gate in
-    /// `run()` and the relocation-only gate in `performMigration()`.
     private func deferIfProtectedDataUnavailable() -> DuckAiNativeStorageContainerMigrationOutcome? {
         guard !isProtectedDataAvailable() else { return nil }
         Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] protected data unavailable; deferring")
@@ -134,12 +128,6 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
             return .proceed
         }
 
-        // The relocation reads the protected App-Group source. With the fix on,
-        // defer only here so completed / not-needed migrations (handled above)
-        // still open on locked launches instead of nilling the handler — the cause
-        // of the Duck.ai T&C re-prompt (`aichat.terms.accepted.duplicate`) spike.
-        // The migrated destination is completeUntilFirstUserAuthentication,
-        // readable while locked. When the fix is off, `run()` already gated above.
         if lockedLaunchFixEnabled, let deferred = deferIfProtectedDataUnavailable() {
             return deferred
         }

--- a/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
+++ b/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
@@ -80,12 +80,6 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
 
     @discardableResult
     func run() -> DuckAiNativeStorageContainerMigrationOutcome {
-        guard isProtectedDataAvailable() else {
-            Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] protected data unavailable; deferring")
-            pixelFiring.fire(.protectedDataUnavailable(label: label))
-            return .skip
-        }
-
         do {
             return try performMigration()
         } catch let kvError as MigrationStateStore.ReadError {
@@ -108,8 +102,6 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
             return .proceed
         }
 
-        Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] starting (prior attempts: \(state.attempts)); old=\(oldURL.path, privacy: .public) new=\(newURL.path, privacy: .public)")
-
         guard fileManager.fileExists(atPath: oldURL.path) else {
             Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] no old directory; marking done")
             stateStore.markMigrated()
@@ -117,6 +109,14 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
             ensureProtection(priorAttempts: state.protectionAttempts)
             return .proceed
         }
+
+        guard isProtectedDataAvailable() else {
+            Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] protected data unavailable; deferring")
+            pixelFiring.fire(.protectedDataUnavailable(label: label))
+            return .skip
+        }
+
+        Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] starting (prior attempts: \(state.attempts)); old=\(oldURL.path, privacy: .public) new=\(newURL.path, privacy: .public)")
 
         if fileManager.fileExists(atPath: newURL.path) {
             // Destination exists without `migrated`. If data is present, treat

--- a/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
+++ b/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
@@ -49,6 +49,11 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
     let isProtectedDataAvailable: () -> Bool
     let maxAttempts: Int
 
+    /// When true, the protected-data gate only guards the relocation; completed /
+    /// not-needed migrations proceed on locked launches. When false, the legacy
+    /// behavior applies (any locked launch defers). Phased-rollout / kill switch.
+    let lockedLaunchFixEnabled: Bool
+
     private let stateStore: MigrationStateStore
     private let protectionDispatcher: ProtectionDispatcher
 
@@ -61,6 +66,7 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
          pixelFiring: DuckAiNativeStorageContainerMigrationPixelFiring = NullDuckAiNativeStorageContainerMigrationPixelFiring(),
          isProtectedDataAvailable: @escaping () -> Bool = { DuckAiNativeStorageContainerMigration.defaultIsProtectedDataAvailable() },
          maxAttempts: Int = DuckAiNativeStorageContainerMigration.defaultMaxAttempts,
+         lockedLaunchFixEnabled: Bool = true,
          protectionDispatcher: @escaping ProtectionDispatcher = { work in
              DispatchQueue.global(qos: .utility).async(execute: work)
          }) {
@@ -72,6 +78,7 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
         self.isProtectedDataAvailable = isProtectedDataAvailable
         // 0 / negative would give up on the first failure.
         self.maxAttempts = max(1, maxAttempts)
+        self.lockedLaunchFixEnabled = lockedLaunchFixEnabled
         self.stateStore = MigrationStateStore(keyValueStore: keyValueStore, migrationKey: migrationKey)
         self.protectionDispatcher = protectionDispatcher
     }
@@ -80,6 +87,13 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
 
     @discardableResult
     func run() -> DuckAiNativeStorageContainerMigrationOutcome {
+        // Legacy gate (kill switch): when the fix is disabled, defer up front so
+        // behavior matches the pre-fix code exactly — even an already-completed
+        // migration is skipped on a locked / background launch.
+        if !lockedLaunchFixEnabled, let deferred = deferIfProtectedDataUnavailable() {
+            return deferred
+        }
+
         do {
             return try performMigration()
         } catch let kvError as MigrationStateStore.ReadError {
@@ -91,6 +105,16 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
             Self.logger.error("[NativeStorage] [\(label.rawValue, privacy: .public)] unexpected migration error; deferring: \(error.localizedDescription, privacy: .public)")
             return .skip
         }
+    }
+
+    /// Returns `.skip` (after logging and firing the defer pixel) when protected
+    /// data is unavailable, else `nil`. Shared by the legacy up-front gate in
+    /// `run()` and the relocation-only gate in `performMigration()`.
+    private func deferIfProtectedDataUnavailable() -> DuckAiNativeStorageContainerMigrationOutcome? {
+        guard !isProtectedDataAvailable() else { return nil }
+        Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] protected data unavailable; deferring")
+        pixelFiring.fire(.protectedDataUnavailable(label: label))
+        return .skip
     }
 
     private func performMigration() throws -> DuckAiNativeStorageContainerMigrationOutcome {
@@ -110,10 +134,14 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
             return .proceed
         }
 
-        guard isProtectedDataAvailable() else {
-            Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] protected data unavailable; deferring")
-            pixelFiring.fire(.protectedDataUnavailable(label: label))
-            return .skip
+        // The relocation reads the protected App-Group source. With the fix on,
+        // defer only here so completed / not-needed migrations (handled above)
+        // still open on locked launches instead of nilling the handler — the cause
+        // of the Duck.ai T&C re-prompt (`aichat.terms.accepted.duplicate`) spike.
+        // The migrated destination is completeUntilFirstUserAuthentication,
+        // readable while locked. When the fix is off, `run()` already gated above.
+        if lockedLaunchFixEnabled, let deferred = deferIfProtectedDataUnavailable() {
+            return deferred
         }
 
         Self.logger.info("[NativeStorage] [\(label.rawValue, privacy: .public)] starting (prior attempts: \(state.attempts)); old=\(oldURL.path, privacy: .public) new=\(newURL.path, privacy: .public)")

--- a/iOS/DuckDuckGo/AIChat/FireModeNativeStorageController.swift
+++ b/iOS/DuckDuckGo/AIChat/FireModeNativeStorageController.swift
@@ -89,7 +89,8 @@ final class FireModeNativeStorageController: DuckAiNativeStorageHandling {
                     migrationKey: "com.duckduckgo.duckai.nativeStorage.fireModeMigratedFromAppGroup",
                     label: .fireMode,
                     keyValueStore: keyValueStore,
-                    pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter()
+                    pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter(),
+                    lockedLaunchFixEnabled: featureFlagger.isFeatureOn(.duckAINativeStorageMigrationLockedLaunchFix)
                 ).run()
                 if outcome == .skip {
                     return nil

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -414,7 +414,8 @@ struct Launching: LaunchingHandling {
                     migrationKey: "com.duckduckgo.duckai.nativeStorage.defaultMigratedFromAppGroup",
                     label: .default,
                     keyValueStore: keyValueStore,
-                    pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter()
+                    pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter(),
+                    lockedLaunchFixEnabled: featureFlagger.isFeatureOn(.duckAINativeStorageMigrationLockedLaunchFix)
                 ).run()
                 if outcome == .skip {
                     return nil

--- a/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
@@ -329,6 +329,50 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         XCTAssertEqual(pixelSpy.firedEventNames, ["notNeeded"])
     }
 
+    // MARK: - Locked-launch fix kill switch (lockedLaunchFixEnabled == false)
+
+    /// Rollback contract: with the fix disabled, a completed migration must
+    /// reproduce the legacy behavior — defer up front on a locked launch.
+    func testWhenFixDisabledAndMigratedAndProtectedDataIsUnavailableThenStillDefers() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try? keyValueStore.set(true, forKey: migratedKey)
+
+        let outcome = migrate(from: oldURL, to: newURL, isProtectedDataAvailable: { false }, lockedLaunchFixEnabled: false)
+
+        XCTAssertEqual(outcome, .skip)
+        XCTAssertEqual(pixelSpy.firedEventNames, ["protectedDataUnavailable"])
+    }
+
+    /// With the fix disabled, the not-needed case also defers up front rather than
+    /// marking done — the legacy behavior the rollout flips away from.
+    func testWhenFixDisabledAndNotNeededAndProtectedDataIsUnavailableThenStillDefers() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+
+        let outcome = migrate(from: oldURL, to: newURL, isProtectedDataAvailable: { false }, lockedLaunchFixEnabled: false)
+
+        XCTAssertEqual(outcome, .skip)
+        XCTAssertFalse(keyValueStore.bool(forKey: migratedKey))
+        XCTAssertEqual(pixelSpy.firedEventNames, ["protectedDataUnavailable"])
+    }
+
+    /// With the fix disabled, an unlocked launch must still complete the move —
+    /// the gate moving location must not change the available-data path.
+    func testWhenFixDisabledAndProtectedDataIsAvailableThenMigrationCompletes() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
+        try Data("chats".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
+
+        let outcome = migrate(from: oldURL, to: newURL, isProtectedDataAvailable: { true }, lockedLaunchFixEnabled: false)
+
+        XCTAssertEqual(outcome, .proceed)
+        XCTAssertTrue(keyValueStore.bool(forKey: migratedKey))
+        XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("chats".utf8))
+        XCTAssertEqual(pixelSpy.firedEventNames, ["success"])
+    }
+
     // MARK: - Exhausted retry budget reset
 
     func testWhenAttemptsAreAtCapWithoutMigratedFlagThenBudgetResetsAndMigrationRuns() throws {
@@ -768,6 +812,7 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
                          fileManager: FileManager = .default,
                          isProtectedDataAvailable: @escaping () -> Bool = { true },
                          maxAttempts: Int = DuckAiNativeStorageContainerMigration.defaultMaxAttempts,
+                         lockedLaunchFixEnabled: Bool = true,
                          protectionDispatcher: @escaping DuckAiNativeStorageContainerMigration.ProtectionDispatcher = { $0() }) -> DuckAiNativeStorageContainerMigrationOutcome {
         DuckAiNativeStorageContainerMigration(
             oldURL: oldURL,
@@ -779,6 +824,7 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
             pixelFiring: pixelSpy,
             isProtectedDataAvailable: isProtectedDataAvailable,
             maxAttempts: maxAttempts,
+            lockedLaunchFixEnabled: lockedLaunchFixEnabled,
             protectionDispatcher: protectionDispatcher
         ).run()
     }

--- a/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
@@ -306,6 +306,29 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         XCTAssertEqual(pixelSpy.firedEventNames, ["protectedDataUnavailable", "success"])
     }
 
+    func testWhenMigratedAndProtectedDataIsUnavailableThenProceedsAsNoOpWithoutDeferring() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+        try? keyValueStore.set(true, forKey: migratedKey)
+
+        let outcome = migrate(from: oldURL, to: newURL, isProtectedDataAvailable: { false })
+
+        XCTAssertEqual(outcome, .proceed)
+        XCTAssertTrue(pixelSpy.firedEventNames.isEmpty,
+                      "a completed migration must not fire protectedDataUnavailable on a locked launch")
+    }
+
+    func testWhenMigrationNotNeededAndProtectedDataIsUnavailableThenMarksDoneWithoutDeferring() throws {
+        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
+        let newURL = sandbox.appendingPathComponent("new/DuckAi")
+
+        let outcome = migrate(from: oldURL, to: newURL, isProtectedDataAvailable: { false })
+
+        XCTAssertEqual(outcome, .proceed)
+        XCTAssertTrue(keyValueStore.bool(forKey: migratedKey))
+        XCTAssertEqual(pixelSpy.firedEventNames, ["notNeeded"])
+    }
+
     // MARK: - Exhausted retry budget reset
 
     func testWhenAttemptsAreAtCapWithoutMigratedFlagThenBudgetResetsAndMigrationRuns() throws {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1215909616166810?focus=true
Tech Design URL:
CC:

### Description
Do not run deferred path on duck.ai native storage migration path after migration is done when the app runs in background mode.

### Testing Steps
1. Run the app without this PR changes, on duck.ai (normal and fire mode) create some chats and images.
2. Make sure you're running on internal (so the feature flag is on by default)
3. Run this PR on top of the same build as before, check if the data is all there

### Impact and Risks
Medium — touches the native-storage availability path that gates the Duck.ai bridge and T&C re-prompts, but it is behind a remote-releasable flag defaulting to internal-only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when Duck.ai native storage is available on locked/background launch—a path that gates the bridge and consent UX—but behavior is behind an internal-only remote flag with explicit rollback tests.
> 
> **Overview**
> Fixes Duck.ai **re-prompting T&C** when the app launches in the background or while the device is locked after App Group → Application Support migration has already finished.
> 
> **`DuckAiNativeStorageContainerMigration`** no longer bails at the top on unavailable protected data when the new fix is on. It only defers the **actual relocation**; **already migrated** and **not-needed** paths return **`.proceed`** on locked launches so launch and fire-mode can still open the native store. With the fix off, the old upfront defer behavior is preserved.
> 
> Wired behind remote-releasable **`duckAINativeStorageMigrationLockedLaunchFix`** (internal-only default) in **`Launching.makeNativeStorageHandler`** and **`FireModeNativeStorageController`**. Unit tests cover the new paths and the kill-switch rollback contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c6e8c17619fb06e5be889f17c2b768fb3d4ff8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->