### PR TITLE
iOS: Add pixels for native AI controls

### DIFF
--- a/SharedPackages/SERPSettings/Sources/SERPSettings/SERPSettingsError.swift
+++ b/SharedPackages/SERPSettings/Sources/SERPSettings/SERPSettingsError.swift
@@ -46,5 +46,5 @@ public enum SERPSettingsError: Error {
     ///
     /// Signals a SERP/native contract mismatch: the SERP persisted a value outside the
     /// range the native side recognizes. The native getter falls back to its default.
-    case unrecognizedValue(key: String, value: String)
+    case unrecognizedValue
 }

--- a/SharedPackages/SERPSettings/Sources/SERPSettings/SERPSettingsError.swift
+++ b/SharedPackages/SERPSettings/Sources/SERPSettings/SERPSettingsError.swift
@@ -41,4 +41,10 @@ public enum SERPSettingsError: Error {
     /// This error occurs when the underlying storage mechanism fails during a write operation,
     /// such as insufficient permissions, disk full, or keychain access failures.
     case keyValueStoreWriteError
+
+    /// A stored SERP value could not be decoded into its native enum.
+    ///
+    /// Signals a SERP/native contract mismatch: the SERP persisted a value outside the
+    /// range the native side recognizes. The native getter falls back to its default.
+    case unrecognizedValue(key: String, value: String)
 }

--- a/SharedPackages/SERPSettings/Sources/SERPSettings/SERPSettingsProviding.swift
+++ b/SharedPackages/SERPSettings/Sources/SERPSettings/SERPSettingsProviding.swift
@@ -221,8 +221,12 @@ public extension SERPSettingsProviding {
     /// default removes the key, mirroring the SERP (which omits defaults) so the two stay consistent.
     var searchAssistFrequency: SearchAssistFrequency {
         get {
-            guard let rawValue = serpSettingValue(forKey: SERPSettingsConstants.searchAssistKey),
-                  let frequency = SearchAssistFrequency(rawValue: rawValue) else {
+            guard let rawValue = serpSettingValue(forKey: SERPSettingsConstants.searchAssistKey) else {
+                return .defaultValue
+            }
+            guard let frequency = SearchAssistFrequency(rawValue: rawValue) else {
+                // Key is present but holds a value the native enum doesn't recognize (contract mismatch).
+                eventMapper?.fire(.unrecognizedValue(key: SERPSettingsConstants.searchAssistKey, value: rawValue))
                 return .defaultValue
             }
             return frequency
@@ -239,8 +243,12 @@ public extension SERPSettingsProviding {
     /// default removes the key.
     var hideAIGeneratedImages: Bool {
         get {
-            guard let rawValue = serpSettingValue(forKey: SERPSettingsConstants.hideAIGeneratedImagesKey),
-                  let hidden = HideAIGeneratedImages.isHidden(fromRawValue: rawValue) else {
+            guard let rawValue = serpSettingValue(forKey: SERPSettingsConstants.hideAIGeneratedImagesKey) else {
+                return HideAIGeneratedImages.defaultValue
+            }
+            guard let hidden = HideAIGeneratedImages.isHidden(fromRawValue: rawValue) else {
+                // Key is present but holds a value the native side doesn't recognize (contract mismatch).
+                eventMapper?.fire(.unrecognizedValue(key: SERPSettingsConstants.hideAIGeneratedImagesKey, value: rawValue))
                 return HideAIGeneratedImages.defaultValue
             }
             return hidden

--- a/SharedPackages/SERPSettings/Sources/SERPSettings/SERPSettingsProviding.swift
+++ b/SharedPackages/SERPSettings/Sources/SERPSettings/SERPSettingsProviding.swift
@@ -226,7 +226,7 @@ public extension SERPSettingsProviding {
             }
             guard let frequency = SearchAssistFrequency(rawValue: rawValue) else {
                 // Key is present but holds a value the native enum doesn't recognize (contract mismatch).
-                eventMapper?.fire(.unrecognizedValue(key: SERPSettingsConstants.searchAssistKey, value: rawValue))
+                eventMapper?.fire(.unrecognizedValue)
                 return .defaultValue
             }
             return frequency
@@ -248,7 +248,7 @@ public extension SERPSettingsProviding {
             }
             guard let hidden = HideAIGeneratedImages.isHidden(fromRawValue: rawValue) else {
                 // Key is present but holds a value the native side doesn't recognize (contract mismatch).
-                eventMapper?.fire(.unrecognizedValue(key: SERPSettingsConstants.hideAIGeneratedImagesKey, value: rawValue))
+                eventMapper?.fire(.unrecognizedValue)
                 return HideAIGeneratedImages.defaultValue
             }
             return hidden

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1633,6 +1633,18 @@ extension Pixel {
         case aiChatSettingsAutoContextDisabled
         case aiChatSettingsDefaultTogglePositionChanged
 
+        // AI Features telemetry (cross-platform, deliberately no `m_` platform prefix so the
+        // name + params match macOS exactly). See `name` for the wire strings.
+        case aiFeaturesStateDaily
+        case aiFeaturesDisabled
+        case aiFeaturesSearchAssistNever
+        case aiFeaturesSearchAssistOnDemand
+        case aiFeaturesSearchAssistSometimes
+        case aiFeaturesSearchAssistOften
+        case aiFeaturesHideImagesOn
+        case aiFeaturesHideImagesOff
+        case serpSettingsUnrecognizedValue
+
         case aiChatOpen
         case aiChatMetricStartNewConversation
         case aiChatMetricStartNewConversationButtonClicked
@@ -3539,6 +3551,17 @@ extension Pixel.Event {
         case .aiChatExperimentalAddressBarIsEnabledDaily: return "m_aichat_experimental_address_bar_is_enabled_daily"
         case .aiChatContextualAutoAttachDAU: return "m_aichat_contextual_auto_attach_dau"
         case .aiChatIsEnabledDaily: return "m_aichat_is_enabled_daily"
+
+        // AI Features telemetry: no `m_` prefix so the wire names are identical to macOS.
+        case .aiFeaturesStateDaily: return "ai_features_state_daily"
+        case .aiFeaturesDisabled: return "ai_features_disabled"
+        case .aiFeaturesSearchAssistNever: return "ai_features_search_assist_never"
+        case .aiFeaturesSearchAssistOnDemand: return "ai_features_search_assist_on_demand"
+        case .aiFeaturesSearchAssistSometimes: return "ai_features_search_assist_sometimes"
+        case .aiFeaturesSearchAssistOften: return "ai_features_search_assist_often"
+        case .aiFeaturesHideImagesOn: return "ai_features_hide_images_on"
+        case .aiFeaturesHideImagesOff: return "ai_features_hide_images_off"
+        case .serpSettingsUnrecognizedValue: return "serp_settings_unrecognized_value"
 
         case .duckAiNativeStorageMigrationDoneUnique(let key): return "m_duck-ai_native-storage_migration_done_\(key)_unique"
         case .duckAiNativeStorageMigrationDoneCount(let key): return "m_duck-ai_native-storage_migration_done_\(key)_count"

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
@@ -20,6 +20,7 @@
 import UIKit
 import Core
 import Persistence
+import SERPSettings
 
 private extension BoolFileMarker.Name {
     static let hasSuccessfullyLaunchedBefore = BoolFileMarker.Name(rawValue: "app-launched-successfully")
@@ -167,6 +168,27 @@ struct Foreground: ForegroundHandling {
 
         let switchBarRetentionMetrics = SwitchBarRetentionMetrics(aiChatSettings: appDependencies.aiChatSettings)
         switchBarRetentionMetrics.checkDailyAndSendPixelIfApplicable()
+
+        fireAIFeaturesStateDailyPixel()
+    }
+
+    /// Once-daily snapshot of the three AI settings + the derived "no AI" state, across the active base.
+    private func fireAIFeaturesStateDailyPixel() {
+        let aiChatSettings = appDependencies.aiChatSettings
+        let serpSettings = SERPSettingsProvider(aiChatProvider: aiChatSettings)
+        serpSettings.keyValueStore = appDependencies.services.keyValueFileStoreService.keyValueFilesStore
+
+        let duckAIEnabled = aiChatSettings.isAIChatEnabled
+        let searchAssist = serpSettings.searchAssistFrequency
+        let hideAIImages = serpSettings.hideAIGeneratedImages
+        let noAI = !duckAIEnabled && searchAssist == .never && hideAIImages
+
+        DailyPixel.fire(pixel: .aiFeaturesStateDaily, withAdditionalParameters: [
+            "duck_ai": duckAIEnabled ? "true" : "false",
+            "search_assist": searchAssist.rawValue,
+            "hide_ai_images": hideAIImages ? "on" : "off",
+            "no_ai": noAI ? "true" : "false"
+        ])
     }
 
     private func configureAppearance() {

--- a/iOS/DuckDuckGo/SERP/SERPSettingsEventHandler.swift
+++ b/iOS/DuckDuckGo/SERP/SERPSettingsEventHandler.swift
@@ -79,10 +79,9 @@ final class SERPSettingsEventHandler: EventMapping<SERPSettingsError> {
             case .keyValueStoreWriteError:
                 // Fires when writing to persistent storage fails.
                 PixelKit.fire(SERPSettingsPixel.serpSettingsKeyValueStoreWriteError, frequency: .dailyAndCount)
-            case .unrecognizedValue(let key, let value):
-                // Daily-only: the SERP getters run on every read, so a count variant would spam.
-                DailyPixel.fire(pixel: .serpSettingsUnrecognizedValue,
-                                withAdditionalParameters: ["key": key, "value": value])
+            case .unrecognizedValue:
+                // Daily-only, no params: the SERP getters run on every read, so a count variant would spam.
+                DailyPixel.fire(pixel: .serpSettingsUnrecognizedValue)
             }
         }
     }

--- a/iOS/DuckDuckGo/SERP/SERPSettingsEventHandler.swift
+++ b/iOS/DuckDuckGo/SERP/SERPSettingsEventHandler.swift
@@ -18,6 +18,7 @@
 //
 
 import Foundation
+import Core
 import Common
 import FoundationExtensions
 import PixelKit
@@ -78,6 +79,10 @@ final class SERPSettingsEventHandler: EventMapping<SERPSettingsError> {
             case .keyValueStoreWriteError:
                 // Fires when writing to persistent storage fails.
                 PixelKit.fire(SERPSettingsPixel.serpSettingsKeyValueStoreWriteError, frequency: .dailyAndCount)
+            case .unrecognizedValue(let key, let value):
+                // Standard iOS pixel (not PixelKit) so the wire name matches macOS exactly.
+                DailyPixel.fireDailyAndCount(pixel: .serpSettingsUnrecognizedValue,
+                                             withAdditionalParameters: ["key": key, "value": value])
             }
         }
     }

--- a/iOS/DuckDuckGo/SERP/SERPSettingsEventHandler.swift
+++ b/iOS/DuckDuckGo/SERP/SERPSettingsEventHandler.swift
@@ -80,9 +80,9 @@ final class SERPSettingsEventHandler: EventMapping<SERPSettingsError> {
                 // Fires when writing to persistent storage fails.
                 PixelKit.fire(SERPSettingsPixel.serpSettingsKeyValueStoreWriteError, frequency: .dailyAndCount)
             case .unrecognizedValue(let key, let value):
-                // Standard iOS pixel (not PixelKit) so the wire name matches macOS exactly.
-                DailyPixel.fireDailyAndCount(pixel: .serpSettingsUnrecognizedValue,
-                                             withAdditionalParameters: ["key": key, "value": value])
+                // Daily-only: the SERP getters run on every read, so a count variant would spam.
+                DailyPixel.fire(pixel: .serpSettingsUnrecognizedValue,
+                                withAdditionalParameters: ["key": key, "value": value])
             }
         }
     }

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -1947,6 +1947,7 @@ extension SettingsViewModel {
                 guard newValue != self.serpSettings.searchAssistFrequency else { return }
                 self.objectWillChange.send()
                 self.serpSettings.searchAssistFrequency = newValue
+                DailyPixel.fireDailyAndCount(pixel: Self.searchAssistPixel(for: newValue))
             }
         )
     }
@@ -1958,8 +1959,19 @@ extension SettingsViewModel {
                 guard newValue.hidden != self.serpSettings.hideAIGeneratedImages else { return }
                 self.objectWillChange.send()
                 self.serpSettings.hideAIGeneratedImages = newValue.hidden
+                DailyPixel.fireDailyAndCount(pixel: newValue.hidden ? .aiFeaturesHideImagesOn : .aiFeaturesHideImagesOff)
             }
         )
+    }
+
+    /// Maps a Search Assist frequency to its value-in-name AI Features pixel.
+    private static func searchAssistPixel(for frequency: SearchAssistFrequency) -> Pixel.Event {
+        switch frequency {
+        case .never: return .aiFeaturesSearchAssistNever
+        case .onDemand: return .aiFeaturesSearchAssistOnDemand
+        case .sometimes: return .aiFeaturesSearchAssistSometimes
+        case .often: return .aiFeaturesSearchAssistOften
+        }
     }
 
     /// True when Duck.ai is off and both SERP AI settings are at their most-restrictive values.
@@ -1975,6 +1987,7 @@ extension SettingsViewModel {
         aiChatSettings.enableAIChat(enable: false)
         serpSettings.searchAssistFrequency = .never
         serpSettings.hideAIGeneratedImages = true
+        DailyPixel.fireDailyAndCount(pixel: .aiFeaturesDisabled)
     }
 
     var isChatSuggestionsEnabled: Binding<Bool> {

--- a/iOS/PixelDefinitions/pixels/definitions/ai_features_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_features_pixels.json5
@@ -87,18 +87,6 @@
         "owners": ["dus7"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
-        "parameters": [
-            "appVersion",
-            {
-                "key": "key",
-                "description": "The SERP setting key whose stored value was unrecognized.",
-                "type": "string"
-            },
-            {
-                "key": "value",
-                "description": "The unrecognized stored value.",
-                "type": "string"
-            }
-        ]
+        "parameters": ["appVersion"]
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/ai_features_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_features_pixels.json5
@@ -12,8 +12,7 @@
             {
                 "key": "duck_ai",
                 "description": "Whether Duck.ai is enabled.",
-                "type": "string",
-                "enum": ["true", "false"]
+                "type": "boolean"
             },
             {
                 "key": "search_assist",
@@ -30,8 +29,7 @@
             {
                 "key": "no_ai",
                 "description": "Derived: Duck.ai off AND Search Assist never AND Hide AI Images on.",
-                "type": "string",
-                "enum": ["true", "false"]
+                "type": "boolean"
             }
         ]
     },
@@ -88,7 +86,7 @@
         "description": "Fired when a stored SERP setting value cannot be decoded into the native enum (SERP/native contract mismatch)",
         "owners": ["dus7"],
         "triggers": ["other"],
-        "suffixes": ["daily_count", "platform", "form_factor"],
+        "suffixes": ["platform", "form_factor"],
         "parameters": [
             "appVersion",
             {

--- a/iOS/PixelDefinitions/pixels/definitions/ai_features_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_features_pixels.json5
@@ -1,0 +1,106 @@
+// AI Features telemetry for the "Make Disabling AI Clearer" settings.
+// These pixels deliberately omit the `m_` prefix so the name body + params match the
+// other platforms exactly (iOS still appends its standard `_ios_<form factor>` suffix).
+{
+    "ai_features_state_daily": {
+        "description": "Daily snapshot of the three AI settings and whether the user is fully in the No-AI state, fired on app foreground across the active base",
+        "owners": ["dus7"],
+        "triggers": ["startup"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "duck_ai",
+                "description": "Whether Duck.ai is enabled.",
+                "type": "string",
+                "enum": ["true", "false"]
+            },
+            {
+                "key": "search_assist",
+                "description": "Search Assist frequency (kbe raw value): 0 never, 1 on demand, 2 sometimes, 3 often.",
+                "type": "string",
+                "enum": ["0", "1", "2", "3"]
+            },
+            {
+                "key": "hide_ai_images",
+                "description": "Whether AI-generated images are hidden.",
+                "type": "string",
+                "enum": ["on", "off"]
+            },
+            {
+                "key": "no_ai",
+                "description": "Derived: Duck.ai off AND Search Assist never AND Hide AI Images on.",
+                "type": "string",
+                "enum": ["true", "false"]
+            }
+        ]
+    },
+    "ai_features_disabled": {
+        "description": "Fired when the user taps the Disable AI Features button (disables all AI at once)",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "ai_features_search_assist_never": {
+        "description": "Fired when the user sets Search Assist to never",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "ai_features_search_assist_on_demand": {
+        "description": "Fired when the user sets Search Assist to on demand",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "ai_features_search_assist_sometimes": {
+        "description": "Fired when the user sets Search Assist to sometimes",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "ai_features_search_assist_often": {
+        "description": "Fired when the user sets Search Assist to often",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "ai_features_hide_images_on": {
+        "description": "Fired when the user turns Hide AI-Generated Images on",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "ai_features_hide_images_off": {
+        "description": "Fired when the user turns Hide AI-Generated Images off",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "serp_settings_unrecognized_value": {
+        "description": "Fired when a stored SERP setting value cannot be decoded into the native enum (SERP/native contract mismatch)",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "key",
+                "description": "The SERP setting key whose stored value was unrecognized.",
+                "type": "string"
+            },
+            {
+                "key": "value",
+                "description": "The unrecognized stored value.",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/macOS/DuckDuckGo/Tab/UserScripts/SERPSettingsEventHandler.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/SERPSettingsEventHandler.swift
@@ -61,6 +61,9 @@ final class SERPSettingsEventHandler: EventMapping<SERPSettingsError> {
             case .keyValueStoreWriteError:
                 // Fires when writing to persistent storage fails.
                 PixelKit.fire(GeneralPixel.serpSettingsKeyValueStoreWriteError, frequency: .dailyAndCount)
+            case .unrecognizedValue:
+                // No op - will be added later
+                break
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1215795303326183?focus=true
Tech Design URL:
CC:

### Description
- Adds the `ai_features_*` pixels: `ai_features_state_daily` (daily snapshot of the three AI settings + derived no-AI state), `ai_features_disabled`, the Search Assist value pixels (`ai_features_search_assist_*`), and the Hide AI-generated images value pixels (`ai_features_hide_images_on/off`).
- Adds the `serp_settings_unrecognized_value` error pixel, fired from the shared `SERPSettings` store when a stored SERP value cannot decode into the native enum.

### Testing Steps
1. Enable internal user, open Settings -> AI Features.
2. Change Search Assist and Hide AI-generated images, tap "Use DuckDuckGo Without AI", confirm the corresponding count/daily pixels fire.
3. Foreground the app, confirm `ai_features_state_daily` fires once per day with the correct `duck_ai`, `search_assist`, `hide_ai_images`, `no_ai` params.

### Impact and Risks
Low. Telemetry only, no user-facing behavior change.

#### What could go wrong?
N/A

### Quality Considerations
--

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only with unchanged user-facing defaults on SERP reads; macOS unrecognized-value pixel is intentionally not wired yet.
> 
> **Overview**
> Adds **cross-platform AI Features pixels** on iOS (wire names omit the usual `m_` prefix) and wires them from native AI settings: a once-per-day **`ai_features_state_daily`** snapshot on foreground (`duck_ai`, `search_assist`, `hide_ai_images`, `no_ai`), **daily+count** events when users change Search Assist, toggle hide-AI-images, or tap disable-all-AI, plus formal **`ai_features_pixels.json5`** definitions.
> 
> In shared **SERPSettings**, introduces **`unrecognizedValue`** when a stored key exists but cannot decode to the native enum (still falls back to defaults). iOS maps that to **`serp_settings_unrecognized_value`** (daily-only to avoid read-path spam); macOS handler stubs the case for now.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50f226ae801510345ad6c341209095086b45cb5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->