### PR TITLE
macOS: Add pixels for native AI controls

### DIFF
--- a/SharedPackages/SERPSettings/Sources/SERPSettings/SERPSettingsError.swift
+++ b/SharedPackages/SERPSettings/Sources/SERPSettings/SERPSettingsError.swift
@@ -46,5 +46,5 @@ public enum SERPSettingsError: Error {
     ///
     /// Signals a SERP/native contract mismatch: the SERP persisted a value outside the
     /// range the native side recognizes. The native getter falls back to its default.
-    case unrecognizedValue(key: String, value: String)
+    case unrecognizedValue
 }

--- a/SharedPackages/SERPSettings/Sources/SERPSettings/SERPSettingsError.swift
+++ b/SharedPackages/SERPSettings/Sources/SERPSettings/SERPSettingsError.swift
@@ -41,4 +41,10 @@ public enum SERPSettingsError: Error {
     /// This error occurs when the underlying storage mechanism fails during a write operation,
     /// such as insufficient permissions, disk full, or keychain access failures.
     case keyValueStoreWriteError
+
+    /// A stored SERP value could not be decoded into its native enum.
+    ///
+    /// Signals a SERP/native contract mismatch: the SERP persisted a value outside the
+    /// range the native side recognizes. The native getter falls back to its default.
+    case unrecognizedValue(key: String, value: String)
 }

--- a/SharedPackages/SERPSettings/Sources/SERPSettings/SERPSettingsProviding.swift
+++ b/SharedPackages/SERPSettings/Sources/SERPSettings/SERPSettingsProviding.swift
@@ -228,7 +228,7 @@ public extension SERPSettingsProviding {
             }
             guard let frequency = SearchAssistFrequency(rawValue: rawValue) else {
                 // Key is present but holds a value the native enum doesn't recognize (contract mismatch).
-                eventMapper?.fire(.unrecognizedValue(key: SERPSettingsConstants.searchAssistKey, value: rawValue))
+                eventMapper?.fire(.unrecognizedValue)
                 return .defaultValue
             }
             return frequency
@@ -250,7 +250,7 @@ public extension SERPSettingsProviding {
             }
             guard let hidden = HideAIGeneratedImages.isHidden(fromRawValue: rawValue) else {
                 // Key is present but holds a value the native side doesn't recognize (contract mismatch).
-                eventMapper?.fire(.unrecognizedValue(key: SERPSettingsConstants.hideAIGeneratedImagesKey, value: rawValue))
+                eventMapper?.fire(.unrecognizedValue)
                 return HideAIGeneratedImages.defaultValue
             }
             return hidden

--- a/SharedPackages/SERPSettings/Sources/SERPSettings/SERPSettingsProviding.swift
+++ b/SharedPackages/SERPSettings/Sources/SERPSettings/SERPSettingsProviding.swift
@@ -223,8 +223,12 @@ public extension SERPSettingsProviding {
     /// default removes the key, mirroring the SERP (which omits defaults) so the two stay consistent.
     var searchAssistFrequency: SearchAssistFrequency {
         get {
-            guard let rawValue = serpSettingValue(forKey: SERPSettingsConstants.searchAssistKey),
-                  let frequency = SearchAssistFrequency(rawValue: rawValue) else {
+            guard let rawValue = serpSettingValue(forKey: SERPSettingsConstants.searchAssistKey) else {
+                return .defaultValue
+            }
+            guard let frequency = SearchAssistFrequency(rawValue: rawValue) else {
+                // Key is present but holds a value the native enum doesn't recognize (contract mismatch).
+                eventMapper?.fire(.unrecognizedValue(key: SERPSettingsConstants.searchAssistKey, value: rawValue))
                 return .defaultValue
             }
             return frequency
@@ -241,8 +245,12 @@ public extension SERPSettingsProviding {
     /// default removes the key.
     var hideAIGeneratedImages: Bool {
         get {
-            guard let rawValue = serpSettingValue(forKey: SERPSettingsConstants.hideAIGeneratedImagesKey),
-                  let hidden = HideAIGeneratedImages.isHidden(fromRawValue: rawValue) else {
+            guard let rawValue = serpSettingValue(forKey: SERPSettingsConstants.hideAIGeneratedImagesKey) else {
+                return HideAIGeneratedImages.defaultValue
+            }
+            guard let hidden = HideAIGeneratedImages.isHidden(fromRawValue: rawValue) else {
+                // Key is present but holds a value the native side doesn't recognize (contract mismatch).
+                eventMapper?.fire(.unrecognizedValue(key: SERPSettingsConstants.hideAIGeneratedImagesKey, value: rawValue))
                 return HideAIGeneratedImages.defaultValue
             }
             return hidden

--- a/iOS/DuckDuckGo/SERP/SERPSettingsEventHandler.swift
+++ b/iOS/DuckDuckGo/SERP/SERPSettingsEventHandler.swift
@@ -78,6 +78,9 @@ final class SERPSettingsEventHandler: EventMapping<SERPSettingsError> {
             case .keyValueStoreWriteError:
                 // Fires when writing to persistent storage fails.
                 PixelKit.fire(SERPSettingsPixel.serpSettingsKeyValueStoreWriteError, frequency: .dailyAndCount)
+            case .unrecognizedValue:
+                // iOS pixel for this case is added with the iOS AI-features controls; no-op here to keep the switch exhaustive.
+                break
             }
         }
     }

--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -433,7 +433,7 @@ enum AIChatPixel: PixelKitEvent {
     case aiFeaturesSearchAssistOften
     case aiFeaturesHideImagesOn
     case aiFeaturesHideImagesOff
-    case serpSettingsUnrecognizedValue(key: String, value: String)
+    case serpSettingsUnrecognizedValue
 
     // MARK: -
 
@@ -805,7 +805,8 @@ enum AIChatPixel: PixelKitEvent {
                 .aiFeaturesSearchAssistSometimes,
                 .aiFeaturesSearchAssistOften,
                 .aiFeaturesHideImagesOn,
-                .aiFeaturesHideImagesOff:
+                .aiFeaturesHideImagesOff,
+                .serpSettingsUnrecognizedValue:
             return nil
         case .aiChatIsEnabled(let isEnabled):
             return ["is_enabled": isEnabled ? "1" : "0"]
@@ -816,8 +817,6 @@ enum AIChatPixel: PixelKitEvent {
                 "hide_ai_images": hideAIImages ? "on" : "off",
                 "no_ai": noAI ? "true" : "false"
             ]
-        case .serpSettingsUnrecognizedValue(let key, let value):
-            return ["key": key, "value": value]
         case .aiChatAddressBarSubmitWithImage(let imageCount),
              .aiChatNtpSubmitWithImage(let imageCount):
             return ["imageCount": String(imageCount)]

--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -421,6 +421,20 @@ enum AIChatPixel: PixelKitEvent {
     /// unrelated WebKit failures and for sizing the OS-deny remediation funnel.
     case aiChatVoiceChatStartFailed(reason: AIChatVoiceChatStartFailedReason)
 
+    // MARK: - AI Features telemetry
+
+    // These deliberately omit the `m_mac_` prefix (fired with `doNotEnforcePrefix: true`) so the
+    // name body + params match the other platforms exactly.
+    case aiFeaturesState(duckAI: Bool, searchAssist: String, hideAIImages: Bool, noAI: Bool)
+    case aiFeaturesDisabled
+    case aiFeaturesSearchAssistNever
+    case aiFeaturesSearchAssistOnDemand
+    case aiFeaturesSearchAssistSometimes
+    case aiFeaturesSearchAssistOften
+    case aiFeaturesHideImagesOn
+    case aiFeaturesHideImagesOff
+    case serpSettingsUnrecognizedValue(key: String, value: String)
+
     // MARK: -
 
     var name: String {
@@ -664,6 +678,24 @@ enum AIChatPixel: PixelKitEvent {
             return "aichat_is_enabled"
         case .aiChatVoiceChatStartFailed:
             return "aichat_voice_chat_start_failed"
+        case .aiFeaturesState:
+            return "ai_features_state"
+        case .aiFeaturesDisabled:
+            return "ai_features_disabled"
+        case .aiFeaturesSearchAssistNever:
+            return "ai_features_search_assist_never"
+        case .aiFeaturesSearchAssistOnDemand:
+            return "ai_features_search_assist_on_demand"
+        case .aiFeaturesSearchAssistSometimes:
+            return "ai_features_search_assist_sometimes"
+        case .aiFeaturesSearchAssistOften:
+            return "ai_features_search_assist_often"
+        case .aiFeaturesHideImagesOn:
+            return "ai_features_hide_images_on"
+        case .aiFeaturesHideImagesOff:
+            return "ai_features_hide_images_off"
+        case .serpSettingsUnrecognizedValue:
+            return "serp_settings_unrecognized_value"
         }
     }
 
@@ -766,10 +798,26 @@ enum AIChatPixel: PixelKitEvent {
                 .aiChatViewAllChatsMainMenu,
                 .aiChatViewAllChatsMoreOptionsMenu,
                 .aiChatTabDidTerminate,
-                .aiChatTabTerminationLoop:
+                .aiChatTabTerminationLoop,
+                .aiFeaturesDisabled,
+                .aiFeaturesSearchAssistNever,
+                .aiFeaturesSearchAssistOnDemand,
+                .aiFeaturesSearchAssistSometimes,
+                .aiFeaturesSearchAssistOften,
+                .aiFeaturesHideImagesOn,
+                .aiFeaturesHideImagesOff:
             return nil
         case .aiChatIsEnabled(let isEnabled):
             return ["is_enabled": isEnabled ? "1" : "0"]
+        case .aiFeaturesState(let duckAI, let searchAssist, let hideAIImages, let noAI):
+            return [
+                "duck_ai": duckAI ? "true" : "false",
+                "search_assist": searchAssist,
+                "hide_ai_images": hideAIImages ? "on" : "off",
+                "no_ai": noAI ? "true" : "false"
+            ]
+        case .serpSettingsUnrecognizedValue(let key, let value):
+            return ["key": key, "value": value]
         case .aiChatAddressBarSubmitWithImage(let imageCount),
              .aiChatNtpSubmitWithImage(let imageCount):
             return ["imageCount": String(imageCount)]
@@ -928,7 +976,16 @@ enum AIChatPixel: PixelKitEvent {
                 .aiChatIsEnabled,
                 .aiChatVoiceChatStartFailed,
                 .aiChatTabDidTerminate,
-                .aiChatTabTerminationLoop:
+                .aiChatTabTerminationLoop,
+                .aiFeaturesState,
+                .aiFeaturesDisabled,
+                .aiFeaturesSearchAssistNever,
+                .aiFeaturesSearchAssistOnDemand,
+                .aiFeaturesSearchAssistSometimes,
+                .aiFeaturesSearchAssistOften,
+                .aiFeaturesHideImagesOn,
+                .aiFeaturesHideImagesOff,
+                .serpSettingsUnrecognizedValue:
             return [.pixelSource]
         }
     }

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -1633,8 +1633,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                                   hideAIImages: hideAIImages,
                                                   noAI: noAI),
                       frequency: .daily,
-                      includeAppVersionParameter: true,
-                      doNotEnforcePrefix: true)
+                      includeAppVersionParameter: true)
     }
 
     private func fireDailyAdBlockingPixel() {

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -54,6 +54,7 @@ import os.log
 import Persistence
 import PixelExperimentKit
 import PixelKit
+import SERPSettings
 import PrivacyConfig
 import PrivacyStats
 import RemoteMessaging
@@ -1567,6 +1568,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         fireDailyActiveUserPixels()
         fireDailyFireWindowConfigurationPixels()
         fireDailyAIChatEnabledPixel()
+        fireDailyAIFeaturesStatePixel()
         fireDailyAdBlockingPixel()
 
         fireAutoconsentDailyPixel()
@@ -1616,6 +1618,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func fireDailyAIChatEnabledPixel() {
         PixelKit.fire(AIChatPixel.aiChatIsEnabled(isEnabled: aiChatPreferences.isAIFeaturesEnabled), frequency: .daily)
+    }
+
+    /// Once-daily snapshot of the three AI settings + the derived "no AI" state, across the active base.
+    private func fireDailyAIFeaturesStatePixel() {
+        let serpSettings = SERPSettingsProvider()
+        let duckAIEnabled = aiChatPreferences.isAIFeaturesEnabled
+        let searchAssist = serpSettings.searchAssistFrequency
+        let hideAIImages = serpSettings.hideAIGeneratedImages
+        let noAI = !duckAIEnabled && searchAssist == .never && hideAIImages
+
+        PixelKit.fire(AIChatPixel.aiFeaturesState(duckAI: duckAIEnabled,
+                                                  searchAssist: searchAssist.rawValue,
+                                                  hideAIImages: hideAIImages,
+                                                  noAI: noAI),
+                      frequency: .daily,
+                      includeAppVersionParameter: true,
+                      doNotEnforcePrefix: true)
     }
 
     private func fireDailyAdBlockingPixel() {

--- a/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
@@ -166,8 +166,7 @@ final class AIChatPreferences: ObservableObject {
                 self.serpSettings.searchAssistFrequency = newValue
                 PixelKit.fire(Self.searchAssistPixel(for: newValue),
                               frequency: .dailyAndCount,
-                              includeAppVersionParameter: true,
-                              doNotEnforcePrefix: true)
+                              includeAppVersionParameter: true)
             }
         )
     }
@@ -181,8 +180,7 @@ final class AIChatPreferences: ObservableObject {
                 self.serpSettings.hideAIGeneratedImages = newValue.hidden
                 PixelKit.fire(newValue.hidden ? AIChatPixel.aiFeaturesHideImagesOn : .aiFeaturesHideImagesOff,
                               frequency: .dailyAndCount,
-                              includeAppVersionParameter: true,
-                              doNotEnforcePrefix: true)
+                              includeAppVersionParameter: true)
             }
         )
     }
@@ -231,8 +229,7 @@ final class AIChatPreferences: ObservableObject {
         serpSettings.hideAIGeneratedImages = true
         PixelKit.fire(AIChatPixel.aiFeaturesDisabled,
                       frequency: .dailyAndCount,
-                      includeAppVersionParameter: true,
-                      doNotEnforcePrefix: true)
+                      includeAppVersionParameter: true)
     }
 
     // Properties for managing the current state of AI Chat preference options

--- a/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
@@ -164,6 +164,10 @@ final class AIChatPreferences: ObservableObject {
                 guard newValue != self.serpSettings.searchAssistFrequency else { return }
                 self.objectWillChange.send()
                 self.serpSettings.searchAssistFrequency = newValue
+                PixelKit.fire(Self.searchAssistPixel(for: newValue),
+                              frequency: .dailyAndCount,
+                              includeAppVersionParameter: true,
+                              doNotEnforcePrefix: true)
             }
         )
     }
@@ -175,6 +179,10 @@ final class AIChatPreferences: ObservableObject {
                 guard newValue.hidden != self.serpSettings.hideAIGeneratedImages else { return }
                 self.objectWillChange.send()
                 self.serpSettings.hideAIGeneratedImages = newValue.hidden
+                PixelKit.fire(newValue.hidden ? AIChatPixel.aiFeaturesHideImagesOn : .aiFeaturesHideImagesOff,
+                              frequency: .dailyAndCount,
+                              includeAppVersionParameter: true,
+                              doNotEnforcePrefix: true)
             }
         )
     }
@@ -194,6 +202,16 @@ final class AIChatPreferences: ObservableObject {
         )
     }
 
+    /// Maps a Search Assist frequency to its value-in-name AI Features pixel.
+    private static func searchAssistPixel(for frequency: SearchAssistFrequency) -> AIChatPixel {
+        switch frequency {
+        case .never: return .aiFeaturesSearchAssistNever
+        case .onDemand: return .aiFeaturesSearchAssistOnDemand
+        case .sometimes: return .aiFeaturesSearchAssistSometimes
+        case .often: return .aiFeaturesSearchAssistOften
+        }
+    }
+
     // Duck.ai-only; `isAIFeaturesEnabled` is the legacy name (kept to avoid an app-wide rename).
     private var isDuckAIEnabled: Bool {
         get { isAIFeaturesEnabled }
@@ -211,6 +229,10 @@ final class AIChatPreferences: ObservableObject {
         isDuckAIEnabled = false
         serpSettings.searchAssistFrequency = .never
         serpSettings.hideAIGeneratedImages = true
+        PixelKit.fire(AIChatPixel.aiFeaturesDisabled,
+                      frequency: .dailyAndCount,
+                      includeAppVersionParameter: true,
+                      doNotEnforcePrefix: true)
     }
 
     // Properties for managing the current state of AI Chat preference options

--- a/macOS/DuckDuckGo/Tab/UserScripts/SERPSettingsEventHandler.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/SERPSettingsEventHandler.swift
@@ -61,9 +61,8 @@ final class SERPSettingsEventHandler: EventMapping<SERPSettingsError> {
             case .keyValueStoreWriteError:
                 // Fires when writing to persistent storage fails.
                 PixelKit.fire(GeneralPixel.serpSettingsKeyValueStoreWriteError, frequency: .dailyAndCount)
-            case .unrecognizedValue(let key, let value):
-                // Daily-only: the SERP getters run on every read, so a count variant would spam.
-                PixelKit.fire(AIChatPixel.serpSettingsUnrecognizedValue(key: key, value: value),
+            case .unrecognizedValue:
+                PixelKit.fire(AIChatPixel.serpSettingsUnrecognizedValue,
                               frequency: .daily,
                               includeAppVersionParameter: true)
             }

--- a/macOS/DuckDuckGo/Tab/UserScripts/SERPSettingsEventHandler.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/SERPSettingsEventHandler.swift
@@ -62,8 +62,9 @@ final class SERPSettingsEventHandler: EventMapping<SERPSettingsError> {
                 // Fires when writing to persistent storage fails.
                 PixelKit.fire(GeneralPixel.serpSettingsKeyValueStoreWriteError, frequency: .dailyAndCount)
             case .unrecognizedValue(let key, let value):
+                // Daily-only: the SERP getters run on every read, so a count variant would spam.
                 PixelKit.fire(AIChatPixel.serpSettingsUnrecognizedValue(key: key, value: value),
-                              frequency: .dailyAndCount,
+                              frequency: .daily,
                               includeAppVersionParameter: true)
             }
         }

--- a/macOS/DuckDuckGo/Tab/UserScripts/SERPSettingsEventHandler.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/SERPSettingsEventHandler.swift
@@ -62,11 +62,9 @@ final class SERPSettingsEventHandler: EventMapping<SERPSettingsError> {
                 // Fires when writing to persistent storage fails.
                 PixelKit.fire(GeneralPixel.serpSettingsKeyValueStoreWriteError, frequency: .dailyAndCount)
             case .unrecognizedValue(let key, let value):
-                // No `m_mac_` prefix so the wire name matches the other platforms exactly.
                 PixelKit.fire(AIChatPixel.serpSettingsUnrecognizedValue(key: key, value: value),
                               frequency: .dailyAndCount,
-                              includeAppVersionParameter: true,
-                              doNotEnforcePrefix: true)
+                              includeAppVersionParameter: true)
             }
         }
     }

--- a/macOS/DuckDuckGo/Tab/UserScripts/SERPSettingsEventHandler.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/SERPSettingsEventHandler.swift
@@ -61,6 +61,12 @@ final class SERPSettingsEventHandler: EventMapping<SERPSettingsError> {
             case .keyValueStoreWriteError:
                 // Fires when writing to persistent storage fails.
                 PixelKit.fire(GeneralPixel.serpSettingsKeyValueStoreWriteError, frequency: .dailyAndCount)
+            case .unrecognizedValue(let key, let value):
+                // No `m_mac_` prefix so the wire name matches the other platforms exactly.
+                PixelKit.fire(AIChatPixel.serpSettingsUnrecognizedValue(key: key, value: value),
+                              frequency: .dailyAndCount,
+                              includeAppVersionParameter: true,
+                              doNotEnforcePrefix: true)
             }
         }
     }

--- a/macOS/PixelDefinitions/pixels/definitions/ai_features_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/ai_features_pixels.json5
@@ -1,8 +1,6 @@
 // AI Features telemetry for the "Make Disabling AI Clearer" settings.
-// These pixels deliberately omit the `m_mac_` prefix (fired with `doNotEnforcePrefix: true`)
-// so the name body + params match the other platforms exactly.
 {
-    "ai_features_state": {
+    "m_mac_ai_features_state": {
         "description": "Daily snapshot of the three AI settings and whether the user is fully in the No-AI state, fired on app foreground across the active base",
         "owners": ["dus7"],
         "triggers": ["startup"],
@@ -36,56 +34,56 @@
             }
         ]
     },
-    "ai_features_disabled": {
+    "m_mac_ai_features_disabled": {
         "description": "Fired when the user taps the Disable AI Features button (disables all AI at once)",
         "owners": ["dus7"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource"]
     },
-    "ai_features_search_assist_never": {
+    "m_mac_ai_features_search_assist_never": {
         "description": "Fired when the user sets Search Assist to never",
         "owners": ["dus7"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource"]
     },
-    "ai_features_search_assist_on_demand": {
+    "m_mac_ai_features_search_assist_on_demand": {
         "description": "Fired when the user sets Search Assist to on demand",
         "owners": ["dus7"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource"]
     },
-    "ai_features_search_assist_sometimes": {
+    "m_mac_ai_features_search_assist_sometimes": {
         "description": "Fired when the user sets Search Assist to sometimes",
         "owners": ["dus7"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource"]
     },
-    "ai_features_search_assist_often": {
+    "m_mac_ai_features_search_assist_often": {
         "description": "Fired when the user sets Search Assist to often",
         "owners": ["dus7"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource"]
     },
-    "ai_features_hide_images_on": {
+    "m_mac_ai_features_hide_images_on": {
         "description": "Fired when the user turns Hide AI-Generated Images on",
         "owners": ["dus7"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource"]
     },
-    "ai_features_hide_images_off": {
+    "m_mac_ai_features_hide_images_off": {
         "description": "Fired when the user turns Hide AI-Generated Images off",
         "owners": ["dus7"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource"]
     },
-    "serp_settings_unrecognized_value": {
+    "m_mac_serp_settings_unrecognized_value": {
         "description": "Fired when a stored SERP setting value cannot be decoded into the native enum (SERP/native contract mismatch)",
         "owners": ["dus7"],
         "triggers": ["other"],

--- a/macOS/PixelDefinitions/pixels/definitions/ai_features_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/ai_features_pixels.json5
@@ -1,0 +1,108 @@
+// AI Features telemetry for the "Make Disabling AI Clearer" settings.
+// These pixels deliberately omit the `m_mac_` prefix (fired with `doNotEnforcePrefix: true`)
+// so the name body + params match the other platforms exactly.
+{
+    "ai_features_state": {
+        "description": "Daily snapshot of the three AI settings and whether the user is fully in the No-AI state, fired on app foreground across the active base",
+        "owners": ["dus7"],
+        "triggers": ["startup"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "duck_ai",
+                "description": "Whether Duck.ai is enabled.",
+                "type": "string",
+                "enum": ["true", "false"]
+            },
+            {
+                "key": "search_assist",
+                "description": "Search Assist frequency (kbe raw value): 0 never, 1 on demand, 2 sometimes, 3 often.",
+                "type": "string",
+                "enum": ["0", "1", "2", "3"]
+            },
+            {
+                "key": "hide_ai_images",
+                "description": "Whether AI-generated images are hidden.",
+                "type": "string",
+                "enum": ["on", "off"]
+            },
+            {
+                "key": "no_ai",
+                "description": "Derived: Duck.ai off AND Search Assist never AND Hide AI Images on.",
+                "type": "string",
+                "enum": ["true", "false"]
+            }
+        ]
+    },
+    "ai_features_disabled": {
+        "description": "Fired when the user taps the Disable AI Features button (disables all AI at once)",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "ai_features_search_assist_never": {
+        "description": "Fired when the user sets Search Assist to never",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "ai_features_search_assist_on_demand": {
+        "description": "Fired when the user sets Search Assist to on demand",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "ai_features_search_assist_sometimes": {
+        "description": "Fired when the user sets Search Assist to sometimes",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "ai_features_search_assist_often": {
+        "description": "Fired when the user sets Search Assist to often",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "ai_features_hide_images_on": {
+        "description": "Fired when the user turns Hide AI-Generated Images on",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "ai_features_hide_images_off": {
+        "description": "Fired when the user turns Hide AI-Generated Images off",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "serp_settings_unrecognized_value": {
+        "description": "Fired when a stored SERP setting value cannot be decoded into the native enum (SERP/native contract mismatch)",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "key",
+                "description": "The SERP setting key whose stored value was unrecognized.",
+                "type": "string"
+            },
+            {
+                "key": "value",
+                "description": "The unrecognized stored value.",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/macOS/PixelDefinitions/pixels/definitions/ai_features_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/ai_features_pixels.json5
@@ -86,19 +86,6 @@
         "owners": ["dus7"],
         "triggers": ["other"],
         "suffixes": ["daily"],
-        "parameters": [
-            "appVersion",
-            "pixelSource",
-            {
-                "key": "key",
-                "description": "The SERP setting key whose stored value was unrecognized.",
-                "type": "string"
-            },
-            {
-                "key": "value",
-                "description": "The unrecognized stored value.",
-                "type": "string"
-            }
-        ]
+        "parameters": ["appVersion", "pixelSource"]
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/ai_features_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/ai_features_pixels.json5
@@ -11,8 +11,7 @@
             {
                 "key": "duck_ai",
                 "description": "Whether Duck.ai is enabled.",
-                "type": "string",
-                "enum": ["true", "false"]
+                "type": "boolean"
             },
             {
                 "key": "search_assist",
@@ -29,8 +28,7 @@
             {
                 "key": "no_ai",
                 "description": "Derived: Duck.ai off AND Search Assist never AND Hide AI Images on.",
-                "type": "string",
-                "enum": ["true", "false"]
+                "type": "boolean"
             }
         ]
     },
@@ -87,7 +85,7 @@
         "description": "Fired when a stored SERP setting value cannot be decoded into the native enum (SERP/native contract mismatch)",
         "owners": ["dus7"],
         "triggers": ["other"],
-        "suffixes": ["daily_count"],
+        "suffixes": ["daily"],
         "parameters": [
             "appVersion",
             "pixelSource",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1215795303326183?focus=true
Tech Design URL:
CC:

### Description
- Adds the `ai_features_*` pixels: `ai_features_state` (daily snapshot of the three AI settings + derived no-AI state), `ai_features_disabled`, the Search Assist value pixels (`ai_features_search_assist_*`), and the Hide AI-generated images value pixels (`ai_features_hide_images_on/off`).
- Adds the `serp_settings_unrecognized_value` error pixel, fired from the shared `SERPSettings` store when a stored SERP value cannot decode into the native enum.

### Testing Steps
1. Open Settings -> AI Features.
2. Change Search Assist and Hide AI-generated images, click "Use DuckDuckGo Without AI", confirm the corresponding daily/count pixels fire.
3. Foreground the app, confirm `ai_features_state` fires daily with the correct `duck_ai`, `search_assist`, `hide_ai_images`, `no_ai` params.

### Impact and Risks
Low. Telemetry only, no user-facing behavior change.

#### What could go wrong?
N/A

### Quality Considerations
--

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only on macOS with unchanged user-facing behavior; shared SERP read path only adds observability on decode mismatch.
> 
> **Overview**
> Adds **macOS telemetry** for native AI Features settings: a daily **`ai_features_state`** snapshot on app foreground (Duck.ai, Search Assist, hide AI images, derived “no AI”), **daily/count** pixels when users change Search Assist, toggle hide-AI images, or use **Disable all AI**, plus pixel definitions in `ai_features_pixels.json5`.
> 
> Extends shared **`SERPSettings`** with **`unrecognizedValue`**: when a stored SERP key exists but does not decode to the native enum, getters still fall back to defaults and **`eventMapper`** fires the new error. **macOS** maps that to **`serp_settings_unrecognized_value`**; **iOS** keeps an exhaustive **no-op** until its matching pixel lands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de24d6d62abda49b7078da778c7feffba820a4a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->