### PR TITLE
iOS: web-scroll-freeze diagnostics — window-wide capture, transition log, gate-state pixels, gated scoped recovery

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -269,6 +269,9 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// from `webScrollFreezeObservability` so the production observer ships without the capture.
     case webScrollFreezeCapture
 
+    /// Speculative, scoped auto-recovery triggered on a confirmed freeze; default internal/off.
+    case webScrollFreezeAutoRecovery
+
     case screenTimeCleaning
 
     case minimalChromeInLandscape

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -327,8 +327,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/414235014887631/task/1215895676655232
     case webScrollFreezeCapture
 
-    /// SPECULATIVE, scoped auto-recovery that fires when a confirmed freeze is detected. Skips during live touch.
-    /// Default internal/off — not shipped to production without explicit sign-off. Mirrors `webScrollFreezeCapture`.
     /// https://app.asana.com/1/137249556945/project/1206488453854252/task/1214241865640178
     case webScrollFreezeAutoRecovery
 

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -329,6 +329,7 @@ public enum FeatureFlag: String {
 
     /// SPECULATIVE, scoped auto-recovery that fires when a confirmed freeze is detected. Skips during live touch.
     /// Default internal/off — not shipped to production without explicit sign-off. Mirrors `webScrollFreezeCapture`.
+    /// https://app.asana.com/1/137249556945/project/1206488453854252/task/1214241865640178
     case webScrollFreezeAutoRecovery
 
     /// Failsafe kill switch for hiding the Search↔Duck.ai toggle on Duck.ai tabs. On by

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -327,6 +327,10 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/414235014887631/task/1215895676655232
     case webScrollFreezeCapture
 
+    /// SPECULATIVE, scoped auto-recovery that fires when a confirmed freeze is detected. Skips during live touch.
+    /// Default internal/off — not shipped to production without explicit sign-off. Mirrors `webScrollFreezeCapture`.
+    case webScrollFreezeAutoRecovery
+
     /// Failsafe kill switch for hiding the Search↔Duck.ai toggle on Duck.ai tabs. On by
     /// default; ship a privacy-config entry to roll back. See
     /// `UnifiedToggleInputFeatureProviding.isToggleHiddenOnDuckAITab`.
@@ -737,6 +741,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.webScrollFreezeObservability))
         case .webScrollFreezeCapture:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(iOSBrowserConfigSubfeature.webScrollFreezeCapture))
+        case .webScrollFreezeAutoRecovery:
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(iOSBrowserConfigSubfeature.webScrollFreezeAutoRecovery))
         case .aiChatTabHideToggle:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.aiChatTabHideToggle))
         case .freeTrialConversionWideEvent:

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -980,6 +980,9 @@ extension Pixel {
         case debugInteractionRepeatedFailedScroll
         case debugInteractionWedgedRecognizer
 
+        case debugInteractionRecoveryAttempted
+        case debugInteractionRecoveryOutcome
+
         case debugPromptCoordinationFailedToSaveLastPresentationDate
         case debugPromptCoordinationFailedToRetrieveLastPresentationDate
 
@@ -2975,6 +2978,8 @@ extension Pixel.Event {
 
         case .debugInteractionRepeatedFailedScroll: return "m_debug_interaction_repeated_failed_scroll"
         case .debugInteractionWedgedRecognizer: return "m_debug_interaction_wedged_recognizer"
+        case .debugInteractionRecoveryAttempted: return "m_debug_interaction_recovery_attempted"
+        case .debugInteractionRecoveryOutcome: return "m_debug_interaction_recovery_outcome"
 
             // MARK: - Debug Prompt Coordination
 

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1770,7 +1770,7 @@
 		AC7100D1A6105DEBEEF00002 /* InteractionDiagnosticsDebugScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC7100D1A6105DEBEEF00001 /* InteractionDiagnosticsDebugScreen.swift */; };
 		AC7100D1A6105DEBEEF00004 /* InteractionIntegrityMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC7100D1A6105DEBEEF00003 /* InteractionIntegrityMonitor.swift */; };
 		AC7100D1A6105DEBEEF00006 /* WebScrollObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC7100D1A6105DEBEEF00005 /* WebScrollObserver.swift */; };
-		AC7100D1A6105DEBEEF00008 /* WebScrollFreezeProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC7100D1A6105DEBEEF00007 /* WebScrollFreezeProbe.swift */; };
+		AC7100D1A6105DEBEEF00008 /* WebScrollFreezeDebugProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC7100D1A6105DEBEEF00007 /* WebScrollFreezeDebugProbe.swift */; };
 		B2258FABEA7BDFCEF297DCFE /* RebrandedOnboardingView+SearchExperienceContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF81E0C6EDC46254CF28AFCB /* RebrandedOnboardingView+SearchExperienceContent.swift */; };
 		B39FB0F42E25368100DF2C4E /* AutoconsentPixels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39FB0F32E25368100DF2C4E /* AutoconsentPixels.swift */; };
 		B50DAF4F2FBE4FD3007BFA26 /* EscapeHatchModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50DAF4E2FBE4FD3007BFA26 /* EscapeHatchModelTests.swift */; };
@@ -4486,7 +4486,7 @@
 		AC7100D1A6105DEBEEF00001 /* InteractionDiagnosticsDebugScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractionDiagnosticsDebugScreen.swift; sourceTree = "<group>"; };
 		AC7100D1A6105DEBEEF00003 /* InteractionIntegrityMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractionIntegrityMonitor.swift; sourceTree = "<group>"; };
 		AC7100D1A6105DEBEEF00005 /* WebScrollObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebScrollObserver.swift; sourceTree = "<group>"; };
-		AC7100D1A6105DEBEEF00007 /* WebScrollFreezeProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebScrollFreezeProbe.swift; sourceTree = "<group>"; };
+		AC7100D1A6105DEBEEF00007 /* WebScrollFreezeDebugProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebScrollFreezeDebugProbe.swift; sourceTree = "<group>"; };
 		AC7D7E5EB7B04D2385E0E48E /* AfterInactivityOptionAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterInactivityOptionAdapterTests.swift; sourceTree = "<group>"; };
 		AD8CF8E4B152CDB3A4ACB14C /* StartupOnboardingCover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupOnboardingCover.swift; sourceTree = "<group>"; };
 		AF81E0C6EDC46254CF28AFCB /* RebrandedOnboardingView+SearchExperienceContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "RebrandedOnboardingView+SearchExperienceContent.swift"; sourceTree = "<group>"; };
@@ -7873,7 +7873,7 @@
 			children = (
 				852BCC4C2EC4AEA60093C753 /* DataAuditDebugScreen.swift */,
 				AC7100D1A6105DEBEEF00005 /* WebScrollObserver.swift */,
-				AC7100D1A6105DEBEEF00007 /* WebScrollFreezeProbe.swift */,
+				AC7100D1A6105DEBEEF00007 /* WebScrollFreezeDebugProbe.swift */,
 				AC7100D1A6105DEBEEF00003 /* InteractionIntegrityMonitor.swift */,
 				AC7100D1A6105DEBEEF00001 /* InteractionDiagnosticsDebugScreen.swift */,
 				36A96A092E6606C0003D4529 /* LocalNotificationsPlaygroundView.swift */,
@@ -13180,7 +13180,7 @@
 				9F387DE22EA891E8006861F8 /* NewAddressBarPickerModalPromptProvider.swift in Sources */,
 				852BCC4D2EC4AEAC0093C753 /* DataAuditDebugScreen.swift in Sources */,
 				AC7100D1A6105DEBEEF00006 /* WebScrollObserver.swift in Sources */,
-				AC7100D1A6105DEBEEF00008 /* WebScrollFreezeProbe.swift in Sources */,
+				AC7100D1A6105DEBEEF00008 /* WebScrollFreezeDebugProbe.swift in Sources */,
 				AC7100D1A6105DEBEEF00004 /* InteractionIntegrityMonitor.swift in Sources */,
 				AC7100D1A6105DEBEEF00002 /* InteractionDiagnosticsDebugScreen.swift in Sources */,
 				31A968192E4F692200F4305E /* SettingsAIExperimentalPickerView.swift in Sources */,

--- a/iOS/DuckDuckGo/InteractionDiagnosticsDebugScreen.swift
+++ b/iOS/DuckDuckGo/InteractionDiagnosticsDebugScreen.swift
@@ -73,16 +73,18 @@ private struct InteractionCaptureView: View {
             Section {
                 Button { model.probeProgrammaticScroll() } label: { Text(verbatim: "Scrollability probe (programmatic scroll ±400pt)") }
                 Button { model.runRecovery(.resetDeferringGates) } label: { Text(verbatim: "Reset WebKit deferring gates (scoped, self-skips on live touch)") }
+                Button { model.runRecovery(.resetScrollPan) } label: { Text(verbatim: "Reset web scroll pan only (scoped, self-skips on live touch)") }
                 if !model.actionResult.isEmpty {
                     Text(verbatim: model.actionResult).font(.footnote)
                 }
             } header: {
                 Text(verbatim: "Diagnostics (safe)")
             } footer: {
-                Text(verbatim: "Both are safe — no broad recogniser/window toggling. Scrollability probe: setContentOffset "
-                     + "(MOVES → block is in gesture delivery; doesn't → scroll view itself is stuck). Reset deferring gates: "
-                     + "WebKit's own scoped pattern — resets only the webView's deferring gates, self-skips if a touch is "
-                     + "live; if scrolling recovers after, the deferring gate WAS the cause.")
+                Text(verbatim: "All three are safe — no broad recogniser or window toggling. "
+                     + "Scrollability probe: setContentOffset (MOVES → block is in gesture delivery; doesn't → scroll view itself is stuck). "
+                     + "Both resets are scoped and self-skip if a touch is in flight. "
+                     + "Each reset AUTO-SAVES a pre- and post-reset capture to the ring buffer — compare those captures to see what changed. "
+                     + "If scrolling recovers after a reset, that supports (but does not prove) the corresponding hypothesis.")
             }
             Section {
                 Text(verbatim: "Saved captures: \(model.savedCount)")

--- a/iOS/DuckDuckGo/InteractionDiagnosticsDebugScreen.swift
+++ b/iOS/DuckDuckGo/InteractionDiagnosticsDebugScreen.swift
@@ -25,7 +25,7 @@ import Core
 ///
 /// The freeze is PERSISTENT (it stays until the app is force-closed), so a capture taken minutes later
 /// is still valid. Dumps the web scroll view's drag state, the WKWebView's internal gesture recognizers,
-/// presentation/transition state, and a full window census. Captures auto-persist to a ring buffer so
+/// presentation/transition state, and a full window scan. Captures auto-persist to a ring buffer so
 /// they can be diffed against a healthy baseline after the fact.
 struct InteractionDiagnosticsDebugScreen: View {
 
@@ -113,13 +113,13 @@ final class InteractionDiagnosticsModel: ObservableObject {
 
     @Published var report = ""
     @Published var actionResult = ""
-    @Published var savedCount = FreezeCaptureStore.count()
+    @Published var savedCount = WebScrollFreezeDebugCaptureStore.count()
 
     @MainActor
     func capture() {
-        report = WebScrollFreezeProbe.captureNow()
-        FreezeCaptureStore.save(report)
-        savedCount = FreezeCaptureStore.count()
+        report = WebScrollFreezeDebugProbe.captureNow()
+        WebScrollFreezeDebugCaptureStore.save(report)
+        savedCount = WebScrollFreezeDebugCaptureStore.count()
     }
 
     func copy() {
@@ -127,18 +127,18 @@ final class InteractionDiagnosticsModel: ObservableObject {
     }
 
     func copySaved() {
-        UIPasteboard.general.string = FreezeCaptureStore.exportAll()
+        UIPasteboard.general.string = WebScrollFreezeDebugCaptureStore.exportAll()
     }
 
     func clearSaved() {
-        FreezeCaptureStore.clear()
-        savedCount = FreezeCaptureStore.count()
+        WebScrollFreezeDebugCaptureStore.clear()
+        savedCount = WebScrollFreezeDebugCaptureStore.count()
     }
 
     @MainActor
     func runRecovery(_ rung: WebScrollFreezeRecovery.Rung) {
         actionResult = WebScrollFreezeRecovery.runRung(rung)
-        savedCount = FreezeCaptureStore.count()
+        savedCount = WebScrollFreezeDebugCaptureStore.count()
     }
 
     /// Safe diagnostic: drive the scroll view directly via `setContentOffset` (no recogniser or
@@ -147,7 +147,7 @@ final class InteractionDiagnosticsModel: ObservableObject {
     /// does NOT move, the scroll view / content itself is stuck.
     @MainActor
     func probeProgrammaticScroll() {
-        guard let scrollView = WebScrollFreezeProbe.findMainViewController()?.currentTab?.webView?.scrollView else {
+        guard let scrollView = WebScrollFreezeDebugProbe.findMainViewController()?.currentTab?.webView?.scrollView else {
             actionResult = "Scroll probe: no web scroll view found"
             return
         }

--- a/iOS/DuckDuckGo/InteractionDiagnosticsDebugScreen.swift
+++ b/iOS/DuckDuckGo/InteractionDiagnosticsDebugScreen.swift
@@ -138,6 +138,7 @@ final class InteractionDiagnosticsModel: ObservableObject {
     @MainActor
     func runRecovery(_ rung: WebScrollFreezeRecovery.Rung) {
         actionResult = WebScrollFreezeRecovery.runRung(rung)
+        savedCount = FreezeCaptureStore.count()
     }
 
     /// Safe diagnostic: drive the scroll view directly via `setContentOffset` (no recogniser or

--- a/iOS/DuckDuckGo/InteractionDiagnosticsDebugScreen.swift
+++ b/iOS/DuckDuckGo/InteractionDiagnosticsDebugScreen.swift
@@ -53,6 +53,17 @@ struct InteractionDiagnosticsDebugScreen: View {
                      + "shipping path (no reliable safe action found); the one safe scoped experiment lives under "
                      + "Capture → Diagnostics. Each submenu is short so it fits even if the screen can't scroll.")
             }
+            Section {
+                Button { model.injectStuckGesture() } label: { Text(verbatim: "Inject stuck gesture (freezes scroll)") }
+                Button(role: .destructive) { model.clearStuckGesture() } label: { Text(verbatim: "Clear stuck gesture") }
+            } header: {
+                Text(verbatim: "Pixel test (provocation, debug-only)")
+            } footer: {
+                Text(verbatim: "Verifies the production freeze pixel end-to-end. Arm this, leave the screen, then drag a long "
+                     + "web page a few times across the screen: scroll stays dead (taps stay alive) and "
+                     + "m_debug_interaction_repeated_failed_scroll fires (mechanism wedged:*) — confirm it in the pixel log. "
+                     + "It only CREATES the freeze and runs no recovery, so it can't brick taps. Clear (or force-quit) to recover.")
+            }
         }
         .navigationTitle("Interaction Diagnostics")
     }
@@ -141,6 +152,16 @@ final class InteractionDiagnosticsModel: ObservableObject {
         savedCount = WebScrollFreezeDebugCaptureStore.count()
     }
 
+    @MainActor
+    func injectStuckGesture() {
+        actionResult = WebScrollFreezeDebugStuckGesture.inject()
+    }
+
+    @MainActor
+    func clearStuckGesture() {
+        actionResult = WebScrollFreezeDebugStuckGesture.clear()
+    }
+
     /// Safe diagnostic: drive the scroll view directly via `setContentOffset` (no recogniser or
     /// window-interaction changes, so it cannot make a freeze worse). Splits the field mystery in two:
     /// if the page MOVES, the scroll view is healthy and the block is in gesture/touch delivery; if it
@@ -166,4 +187,73 @@ final class InteractionDiagnosticsModel: ObservableObject {
             ? "Scroll probe: offset \(Int(before)) → \(Int(after)) — MOVED ✅ scroll view is fine; block is in gesture/touch delivery."
             : "Scroll probe: offset \(Int(before)) → \(Int(after)) (target \(Int(targetY))) — DID NOT MOVE ❌ scroll view / content itself is stuck."
     }
+}
+
+// MARK: - Stuck-gesture provocation (debug-only — used to confirm the freeze pixel fires)
+
+/// Debug-only tool to verify the production freeze pixel end-to-end. Installs a window-level recognizer
+/// that wedges once a drag starts and then prevents pans (scroll) while leaving taps alive — the
+/// "scroll dead, taps alive" signature. With it armed, dragging a long page repeatedly drives the real
+/// detection path in `WebScrollObserver`, so `m_debug_interaction_repeated_failed_scroll` fires
+/// (mechanism `wedged:*`) and can be confirmed in the pixel log.
+///
+/// NOT a shipping path: it only CREATES the freeze (recoverable by `clear()` or force-quit). It runs no
+/// recovery, so it can't brick taps. Reachable only from the internal/debug-gated diagnostics screen.
+@MainActor
+enum WebScrollFreezeDebugStuckGesture {
+
+    private static var injected: WebScrollFreezeDebugStuckGestureRecognizer?
+
+    static func inject() -> String {
+        guard injected == nil else { return "Already armed — clear it first." }
+        guard let window = WebScrollFreezeDebugProbe.keyWindow() else { return "No key window." }
+        let recognizer = WebScrollFreezeDebugStuckGestureRecognizer()
+        recognizer.cancelsTouchesInView = false
+        window.addGestureRecognizer(recognizer)
+        injected = recognizer
+        return "Armed. Leave this screen, then DRAG a long web page a few times across the screen — scroll "
+            + "stays dead (taps stay alive) and the freeze pixel fires after 3 drags across 2+ regions. Then tap Clear."
+    }
+
+    static func clear() -> String {
+        guard let recognizer = injected else { return "Nothing armed." }
+        recognizer.isEnabled = false
+        recognizer.view?.removeGestureRecognizer(recognizer)
+        injected = nil
+        return "Cleared."
+    }
+}
+
+/// Deliberately wedged recognizer for the stuck-gesture provocation. Never cancels touches (taps stay
+/// alive) and prevents only pans (scroll). Wedges once a DRAG starts (a tap never arms it), then stays in
+/// `.changed` with no touches.
+final class WebScrollFreezeDebugStuckGestureRecognizer: UIGestureRecognizer {
+
+    private var disarmed = false
+
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
+        guard !disarmed else { return }
+        state = (state == .possible) ? .began : .changed
+    }
+
+    /// Intentionally does not advance to a terminal state — that is the wedge under test.
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {}
+
+    /// Intentionally ignored — keeps the recognizer wedged.
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent) {}
+
+    /// Once an `isEnabled` toggle resets us, stay inert so a follow-up drag is unaffected — re-arm via the
+    /// debug screen to test again.
+    override func reset() {
+        super.reset()
+        disarmed = true
+    }
+
+    /// Prevent only pans (the scroll view's pan is a `UIPanGestureRecognizer`) so scrolling freezes while
+    /// taps keep recognising.
+    override func canPrevent(_ preventedGestureRecognizer: UIGestureRecognizer) -> Bool {
+        preventedGestureRecognizer is UIPanGestureRecognizer
+    }
+
+    override func canBePrevented(by preventingGestureRecognizer: UIGestureRecognizer) -> Bool { false }
 }

--- a/iOS/DuckDuckGo/InteractionDiagnosticsDebugScreen.swift
+++ b/iOS/DuckDuckGo/InteractionDiagnosticsDebugScreen.swift
@@ -166,5 +166,3 @@ final class InteractionDiagnosticsModel: ObservableObject {
             : "Scroll probe: offset \(Int(before)) → \(Int(after)) (target \(Int(targetY))) — DID NOT MOVE ❌ scroll view / content itself is stuck."
     }
 }
-
-// MARK: - Diagnostics model uses WebScrollFreezeProbe (capture) and WebScrollFreezeRecovery (scoped reset).

--- a/iOS/DuckDuckGo/InteractionDiagnosticsDebugScreen.swift
+++ b/iOS/DuckDuckGo/InteractionDiagnosticsDebugScreen.swift
@@ -19,16 +19,14 @@
 
 import SwiftUI
 import UIKit
-import OSLog
-import QuartzCore
 import Core
 
 /// Debug screen for the hard-to-reproduce "web view can't be scrolled but taps still work" freeze.
 ///
 /// The freeze is PERSISTENT (it stays until the app is force-closed), so a capture taken minutes later
-/// is still valid. Dumps every scroll view's drag state, presentation/transition state, and a full
-/// window census. Captures auto-persist to a ring buffer so they can be exported after the fact, and
-/// the Provocation section forces the suspected triggers so a reproduction *indicates the cause*.
+/// is still valid. Dumps the web scroll view's drag state, the WKWebView's internal gesture recognizers,
+/// presentation/transition state, and a full window census. Captures auto-persist to a ring buffer so
+/// they can be diffed against a healthy baseline after the fact.
 struct InteractionDiagnosticsDebugScreen: View {
 
     @StateObject private var model: InteractionDiagnosticsModel
@@ -47,48 +45,16 @@ struct InteractionDiagnosticsDebugScreen: View {
                 }
             }
             Section {
-                NavigationLink { InteractionRecoveryView(model: model) } label: { Text(verbatim: "Recovery") }
                 NavigationLink { InteractionCaptureView(model: model) } label: { Text(verbatim: "Capture & snapshot") }
-                NavigationLink { InteractionProvocationsView(model: model) } label: { Text(verbatim: "Provocations (debug)") }
             } header: {
                 Text(verbatim: "Interaction Diagnostics")
             } footer: {
-                Text(verbatim: "During a freeze this list itself may not scroll — so each action lives in a short "
-                     + "submenu that fits without scrolling, and the Recover button (top right) is always reachable.")
+                Text(verbatim: "Capture is the focus — diff a freeze capture against a healthy baseline. Recovery is not a "
+                     + "shipping path (no reliable safe action found); the one safe scoped experiment lives under "
+                     + "Capture → Diagnostics. Each submenu is short so it fits even if the screen can't scroll.")
             }
         }
         .navigationTitle("Interaction Diagnostics")
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button { model.recover() } label: { Text(verbatim: "🛟 Recover") }
-            }
-        }
-    }
-}
-
-private struct InteractionRecoveryView: View {
-    @ObservedObject var model: InteractionDiagnosticsModel
-    var body: some View {
-        List {
-            Section {
-                Button { model.recover() } label: { Text(verbatim: "Recover (surgical — reset pan/wedged recognizers)") }
-                Button { model.resetScrollPan() } label: { Text(verbatim: "R1 · Reset web scroll pan only") }
-                Button { model.runRecovery(.flushAppRecognizers) } label: { Text(verbatim: "R2 · Reset app recognizers") }
-                Button { model.runRecovery(.bounceWindowInteraction) } label: { Text(verbatim: "R3 · Bounce window interaction") }
-                Button(role: .destructive) { model.runRecovery(.flushAll) } label: { Text(verbatim: "Flush ALL recognizers (incl. system)") }
-                if !model.actionResult.isEmpty {
-                    Text(verbatim: model.actionResult).font(.footnote)
-                }
-            } header: {
-                Text(verbatim: "Recovery ladder")
-            } footer: {
-                Text(verbatim: "Run least→most invasive against a live freeze to find the minimal action that recovers. "
-                     + "R1 should fail (victim-side), R2 should clear a wedged recognizer, R3 targets a phantom touch. "
-                     + "'Recover' resets only pan/wedged recognizers (no window bounce). Recovery is debug-only here — "
-                     + "productionised in Part 3.")
-            }
-        }
-        .navigationTitle("Recovery")
     }
 }
 
@@ -103,6 +69,20 @@ private struct InteractionCaptureView: View {
                 }
             } footer: {
                 Text(verbatim: "Reads the live view tree of the foreground tab. Auto-saved to the ring buffer.")
+            }
+            Section {
+                Button { model.probeProgrammaticScroll() } label: { Text(verbatim: "Scrollability probe (programmatic scroll ±400pt)") }
+                Button { model.runRecovery(.resetDeferringGates) } label: { Text(verbatim: "Reset WebKit deferring gates (scoped, self-skips on live touch)") }
+                if !model.actionResult.isEmpty {
+                    Text(verbatim: model.actionResult).font(.footnote)
+                }
+            } header: {
+                Text(verbatim: "Diagnostics (safe)")
+            } footer: {
+                Text(verbatim: "Both are safe — no broad recogniser/window toggling. Scrollability probe: setContentOffset "
+                     + "(MOVES → block is in gesture delivery; doesn't → scroll view itself is stuck). Reset deferring gates: "
+                     + "WebKit's own scoped pattern — resets only the webView's deferring gates, self-skips if a touch is "
+                     + "live; if scrolling recovers after, the deferring gate WAS the cause.")
             }
             Section {
                 Text(verbatim: "Saved captures: \(model.savedCount)")
@@ -124,30 +104,6 @@ private struct InteractionCaptureView: View {
             }
         }
         .navigationTitle("Capture")
-    }
-}
-
-private struct InteractionProvocationsView: View {
-    @ObservedObject var model: InteractionDiagnosticsModel
-    var body: some View {
-        List {
-            Section {
-                Button { model.run(.injectStuckGesture) } label: { Text(verbatim: "E1 · Inject stuck gesture") }
-                Button { model.run(.clearStuckGesture) } label: { Text(verbatim: "E1 · Clear injection") }
-                Button { model.run(.reparentWebView) } label: { Text(verbatim: "E2 · Reparent web view mid-drag") }
-                Button { model.run(.utiHide) } label: { Text(verbatim: "E2 · UTI transition mid-drag") }
-                Button { model.run(.newTab) } label: { Text(verbatim: "E2 · New tab mid-drag") }
-                if !model.actionResult.isEmpty {
-                    Text(verbatim: model.actionResult).font(.footnote)
-                }
-            } header: {
-                Text(verbatim: "Provocation")
-            } footer: {
-                Text(verbatim: "Force a suspected trigger so a reproduction indicates the cause. E1 wedges a gesture "
-                     + "(taps stay alive); E2 fires on your next drag after dismissing this screen.")
-            }
-        }
-        .navigationTitle("Provocations")
     }
 }
 
@@ -178,182 +134,35 @@ final class InteractionDiagnosticsModel: ObservableObject {
     }
 
     @MainActor
-    func run(_ action: InteractionProvocation.Action) {
-        actionResult = InteractionProvocation.run(action)
-    }
-
-    @MainActor
-    func recover() {
-        actionResult = WebScrollFreezeRecovery.recover()
-    }
-
-    @MainActor
     func runRecovery(_ rung: WebScrollFreezeRecovery.Rung) {
         actionResult = WebScrollFreezeRecovery.runRung(rung)
     }
 
+    /// Safe diagnostic: drive the scroll view directly via `setContentOffset` (no recogniser or
+    /// window-interaction changes, so it cannot make a freeze worse). Splits the field mystery in two:
+    /// if the page MOVES, the scroll view is healthy and the block is in gesture/touch delivery; if it
+    /// does NOT move, the scroll view / content itself is stuck.
     @MainActor
-    func resetScrollPan() {
+    func probeProgrammaticScroll() {
         guard let scrollView = WebScrollFreezeProbe.findMainViewController()?.currentTab?.webView?.scrollView else {
-            actionResult = "R1: no web scroll view found"
+            actionResult = "Scroll probe: no web scroll view found"
             return
         }
-        scrollView.panGestureRecognizer.isEnabled = false
-        scrollView.panGestureRecognizer.isEnabled = true
-        actionResult = "R1: reset web scroll pan"
+        let minY = -scrollView.adjustedContentInset.top
+        let maxY = max(minY, scrollView.contentSize.height - scrollView.bounds.height + scrollView.adjustedContentInset.bottom)
+        guard maxY - minY > 64 else {
+            actionResult = "Scroll probe: page is not scrollable (vertical range ≤ 64pt) — nothing to test here."
+            return
+        }
+        let before = scrollView.contentOffset.y
+        let targetY = before < maxY - 1 ? min(before + 400, maxY) : max(minY, before - 400)
+        scrollView.setContentOffset(CGPoint(x: scrollView.contentOffset.x, y: targetY), animated: false)
+        let after = scrollView.contentOffset.y
+        let moved = abs(after - before) >= 1
+        actionResult = moved
+            ? "Scroll probe: offset \(Int(before)) → \(Int(after)) — MOVED ✅ scroll view is fine; block is in gesture/touch delivery."
+            : "Scroll probe: offset \(Int(before)) → \(Int(after)) (target \(Int(targetY))) — DID NOT MOVE ❌ scroll view / content itself is stuck."
     }
 }
 
-// MARK: - Provocation (forces a suspected trigger so a reproduction indicates the cause)
-
-@MainActor
-enum InteractionProvocation {
-
-    enum Action {
-        case injectStuckGesture, clearStuckGesture, reparentWebView, utiHide, newTab, forceFlush
-    }
-
-    private static var injected: StuckGestureRecognizer?
-    private static var armer: ProvocationArmingRecognizer?
-
-    static func run(_ action: Action) -> String {
-        switch action {
-        case .injectStuckGesture: return injectStuckGesture()
-        case .clearStuckGesture: return clearStuckGesture()
-        case .reparentWebView: return armOnNextDrag(.reparentWebView, label: "reparent the web view")
-        case .utiHide: return armOnNextDrag(.utiHide, label: "UTI hide()")
-        case .newTab: return armOnNextDrag(.newTab, label: "open a new tab")
-        case .forceFlush: return forceFlush()
-        }
-    }
-
-    /// E1 — wedge a window-level continuous gesture to test whether that signature reproduces the freeze.
-    /// Models the bug faithfully: `cancelsTouchesInView = false` (taps stay alive), it only prevents pans
-    /// (scroll), and it wedges once a DRAG starts (a tap never arms it), then stays in `.changed` forever.
-    private static func injectStuckGesture() -> String {
-        guard injected == nil else { return "Already armed. Clear it first." }
-        guard let window = WebScrollFreezeProbe.keyWindow() else { return "No key window." }
-        let recognizer = StuckGestureRecognizer()
-        recognizer.cancelsTouchesInView = false
-        window.addGestureRecognizer(recognizer)
-        injected = recognizer
-        return "Armed. Dismiss this screen, then DRAG the web view once — the gesture wedges in .changed (taps stay alive). Test scrolling everywhere (web + menu), then 'Clear injection'."
-    }
-
-    private static func clearStuckGesture() -> String {
-        guard let recognizer = injected else { return "Nothing injected." }
-        recognizer.isEnabled = false
-        recognizer.view?.removeGestureRecognizer(recognizer)
-        injected = nil
-        return "Cleared."
-    }
-
-    /// E2 — arm a passive recognizer that fires `effect` on the NEXT drag (truly mid-gesture), then disarms.
-    /// Robust to navigation timing: dismiss this screen, then drag the web view whenever you're ready. The
-    /// reparent yanks the touch's view mid-gesture — the prime way a touch never gets its `end`.
-    private static func armOnNextDrag(_ effect: Action, label: String) -> String {
-        if let armer { return "Already armed (\(armer.label)) — fires on your next drag." }
-        guard let window = WebScrollFreezeProbe.keyWindow() else { return "No key window." }
-        let recognizer = ProvocationArmingRecognizer()
-        recognizer.cancelsTouchesInView = false
-        recognizer.label = label
-        recognizer.onDragDetected = {
-            perform(effect)
-            Logger.interaction.error("PROVOKE \(label, privacy: .public) fired mid-drag")
-            disarm()
-        }
-        window.addGestureRecognizer(recognizer)
-        armer = recognizer
-        return "Armed. Dismiss this screen and DRAG the web view — '\(label)' fires mid-drag, then disarms."
-    }
-
-    private static func disarm() {
-        guard let recognizer = armer else { return }
-        recognizer.isEnabled = false
-        recognizer.view?.removeGestureRecognizer(recognizer)
-        armer = nil
-    }
-
-    private static func perform(_ effect: Action) {
-        guard let mainVC = WebScrollFreezeProbe.findMainViewController() else { return }
-        switch effect {
-        case .reparentWebView:
-            guard let webView = mainVC.currentTab?.webView, let superview = webView.superview else { return }
-            let frame = webView.frame
-            webView.removeFromSuperview()
-            superview.addSubview(webView)
-            webView.frame = frame
-        case .utiHide:
-            mainVC.unifiedToggleInputCoordinator?.hide()
-        case .newTab:
-            mainVC.newTab()
-        default:
-            break
-        }
-    }
-
-    /// E3 — force-cancel every gesture recognizer (toggle isEnabled) to flush a wedged recognizer / stuck
-    /// touch. If scrolling recovers, a stuck touch/recognizer is confirmed AND this is a viable mitigation.
-    private static func forceFlush() -> String {
-        var count = 0
-        for window in WebScrollFreezeProbe.allWindows() {
-            flush(window, &count)
-        }
-        return "Toggled \(count) gesture recognizers (force-cancel). Try scrolling now — if it works, a stuck touch/recognizer was the cause."
-    }
-
-    private static func flush(_ view: UIView, _ count: inout Int) {
-        view.gestureRecognizers?.forEach { recognizer in
-            recognizer.isEnabled = false
-            recognizer.isEnabled = true
-            count += 1
-        }
-        view.subviews.forEach { flush($0, &count) }
-    }
-}
-
-/// A deliberately wedged recognizer used only by E1. Models the bug: never cancels touches (taps stay
-/// alive) and prevents only pans (scroll). Wedges once a DRAG starts (a tap never arms it), then stays in
-/// `.changed` with no touches — the "scroll dead, taps alive" signature.
-final class StuckGestureRecognizer: UIGestureRecognizer {
-    private var disarmed = false
-    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
-        guard !disarmed else { return }
-        state = (state == .possible) ? .began : .changed
-    }
-    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
-        // Intentionally do NOT advance to a terminal state — this is the wedge under test.
-    }
-    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent) {
-        // Intentionally ignored.
-    }
-    /// Once recovery resets us (via an isEnabled toggle, which forces this reset), stay inert so the
-    /// recovery is verifiable on the next drag — the real bug fires once and does not re-arm. Tap
-    /// "E1 · Inject stuck gesture" again to re-test.
-    override func reset() {
-        super.reset()
-        disarmed = true
-    }
-    /// Prevent only pans (the scroll view's pan is a UIPanGestureRecognizer) so scrolling freezes while
-    /// taps keep recognising.
-    override func canPrevent(_ preventedGestureRecognizer: UIGestureRecognizer) -> Bool {
-        preventedGestureRecognizer is UIPanGestureRecognizer
-    }
-    override func canBePrevented(by preventingGestureRecognizer: UIGestureRecognizer) -> Bool { false }
-}
-
-/// Passive arming recognizer for E2: detects the next drag (first `touchesMoved`) without interfering,
-/// fires its callback once, then fails. Never cancels, delays, prevents, or is prevented.
-final class ProvocationArmingRecognizer: UIGestureRecognizer {
-    var label = ""
-    var onDragDetected: (() -> Void)?
-    private var fired = false
-    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
-        guard !fired else { return }
-        fired = true
-        onDragDetected?()
-        state = .failed
-    }
-    override func canPrevent(_ preventedGestureRecognizer: UIGestureRecognizer) -> Bool { false }
-    override func canBePrevented(by preventingGestureRecognizer: UIGestureRecognizer) -> Bool { false }
-}
+// MARK: - Diagnostics model uses WebScrollFreezeProbe (capture) and WebScrollFreezeRecovery (scoped reset).

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2244,7 +2244,7 @@ class MainViewController: UIViewController {
     private func addToContentContainer(controller: UIViewController) {
         viewCoordinator.contentContainer.isHidden = false
         addChild(controller)
-        WebScrollFreezeBreadcrumb.drop("mainVC.contentContainer.remove")
+        WebScrollFreezeBreadcrumb.drop("mainVC.contentContainer.swap")
         viewCoordinator.contentContainer.subviews.forEach { $0.removeFromSuperview() }
         viewCoordinator.contentContainer.addSubview(controller.view)
 

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2175,6 +2175,7 @@ class MainViewController: UIViewController {
 
     private func transitionTo(tab: TabViewController?, from previousTab: TabViewController?) {
         guard let tab else { return }
+        WebScrollFreezeBreadcrumb.drop("mainVC.tabTransition")
         previousTab?.aiChatContextualSheetCoordinator.dismissSheet()
         previousTab?.tabModel.openedAfterIdle = false
         previousTab?.dismiss()
@@ -2243,6 +2244,7 @@ class MainViewController: UIViewController {
     private func addToContentContainer(controller: UIViewController) {
         viewCoordinator.contentContainer.isHidden = false
         addChild(controller)
+        WebScrollFreezeBreadcrumb.drop("mainVC.contentContainer.remove")
         viewCoordinator.contentContainer.subviews.forEach { $0.removeFromSuperview() }
         viewCoordinator.contentContainer.addSubview(controller.view)
 

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2175,7 +2175,7 @@ class MainViewController: UIViewController {
 
     private func transitionTo(tab: TabViewController?, from previousTab: TabViewController?) {
         guard let tab else { return }
-        WebScrollFreezeBreadcrumb.drop("mainVC.tabTransition")
+        WebScrollFreezeDebugTransitionLog.note("mainVC.tabTransition")
         previousTab?.aiChatContextualSheetCoordinator.dismissSheet()
         previousTab?.tabModel.openedAfterIdle = false
         previousTab?.dismiss()
@@ -2244,7 +2244,7 @@ class MainViewController: UIViewController {
     private func addToContentContainer(controller: UIViewController) {
         viewCoordinator.contentContainer.isHidden = false
         addChild(controller)
-        WebScrollFreezeBreadcrumb.drop("mainVC.contentContainer.swap")
+        WebScrollFreezeDebugTransitionLog.note("mainVC.contentContainer.swap")
         viewCoordinator.contentContainer.subviews.forEach { $0.removeFromSuperview() }
         viewCoordinator.contentContainer.addSubview(controller.view)
 

--- a/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
+++ b/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
@@ -631,9 +631,11 @@ extension SwipeTabsCoordinator: UICollectionViewDelegate {
         }
         feedbackGenerator.selectionChanged()
         if index >= tabsModel.count {
+            WebScrollFreezeBreadcrumb.drop("swipeTabs.newTab")
             newTab()
         } else {
             if let tab = tabsModel.get(tabAt: index) {
+                WebScrollFreezeBreadcrumb.drop("swipeTabs.selectTab")
                 selectTab(tab)
             }
         }
@@ -733,6 +735,7 @@ extension SwipeTabsCoordinator {
 
         switch gesture.state {
         case .began:
+            WebScrollFreezeBreadcrumb.drop("uti.swipe.begin")
             // A prior external pan's settling animation can still be in flight, or another
             // attached recognizer (UTI bar / AI header) may have left non-idle state behind.
             // Reset before starting so `scrollViewWillBeginDragging` (which only transitions
@@ -755,6 +758,7 @@ extension SwipeTabsCoordinator {
             collectionView.contentOffset = CGPoint(x: max(0, min(proposedX, maxX)), y: 0)
 
         case .ended, .cancelled, .failed:
+            WebScrollFreezeBreadcrumb.drop(gesture.state == .cancelled || gesture.state == .failed ? "uti.swipe.cancel" : "uti.swipe.end")
             let pageWidth = collectionView.frame.width
             guard pageWidth > 0 else {
                 scrollViewDidEndDecelerating(collectionView)

--- a/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
+++ b/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
@@ -631,11 +631,11 @@ extension SwipeTabsCoordinator: UICollectionViewDelegate {
         }
         feedbackGenerator.selectionChanged()
         if index >= tabsModel.count {
-            WebScrollFreezeBreadcrumb.drop("swipeTabs.newTab")
+            WebScrollFreezeDebugTransitionLog.note("swipeTabs.newTab")
             newTab()
         } else {
             if let tab = tabsModel.get(tabAt: index) {
-                WebScrollFreezeBreadcrumb.drop("swipeTabs.selectTab")
+                WebScrollFreezeDebugTransitionLog.note("swipeTabs.selectTab")
                 selectTab(tab)
             }
         }
@@ -735,7 +735,7 @@ extension SwipeTabsCoordinator {
 
         switch gesture.state {
         case .began:
-            WebScrollFreezeBreadcrumb.drop("uti.swipe.begin")
+            WebScrollFreezeDebugTransitionLog.note("uti.swipe.begin")
             // A prior external pan's settling animation can still be in flight, or another
             // attached recognizer (UTI bar / AI header) may have left non-idle state behind.
             // Reset before starting so `scrollViewWillBeginDragging` (which only transitions
@@ -758,7 +758,7 @@ extension SwipeTabsCoordinator {
             collectionView.contentOffset = CGPoint(x: max(0, min(proposedX, maxX)), y: 0)
 
         case .ended, .cancelled, .failed:
-            WebScrollFreezeBreadcrumb.drop(gesture.state == .cancelled || gesture.state == .failed ? "uti.swipe.cancel" : "uti.swipe.end")
+            WebScrollFreezeDebugTransitionLog.note(gesture.state == .cancelled || gesture.state == .failed ? "uti.swipe.cancel" : "uti.swipe.end")
             let pageWidth = collectionView.frame.width
             guard pageWidth > 0 else {
                 scrollViewDidEndDecelerating(collectionView)

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -1018,7 +1018,10 @@ class TabViewController: UIViewController {
                                                   currentURL: { [weak self] in self?.webView?.url },
                                                   captureFreeze: captureEnabled
                                                     ? { FreezeCaptureStore.save(WebScrollFreezeProbe.captureNow()) }
-                                                    : {})
+                                                    : {},
+                                                  autoRecover: featureFlagger.isFeatureOn(.webScrollFreezeAutoRecovery)
+                                                    ? { DailyPixel.fireDailyAndCount(pixel: .debugInteractionRecoveryAttempted, withAdditionalParameters: [:]); _ = WebScrollFreezeRecovery.autoRecover(); return true }
+                                                    : { false })
             webScrollObserver?.install()
             if captureEnabled, let window = WebScrollFreezeProbe.keyWindow() {
                 TouchCensus.installIfNeeded(on: window)

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -1020,10 +1020,8 @@ class TabViewController: UIViewController {
                                                     ? { FreezeCaptureStore.save(WebScrollFreezeProbe.captureNow()) }
                                                     : {},
                                                   autoRecover: featureFlagger.isFeatureOn(.webScrollFreezeAutoRecovery)
-                                                    ? {
-                                                        // Fire the attempt pixel + arm the outcome ONLY if recovery actually ran
-                                                        // (autoRecover returns false when it skips on a live touch / missing web view).
-                                                        let ran = WebScrollFreezeRecovery.autoRecover()
+                                                    ? { [weak self] in
+                                                        let ran = WebScrollFreezeRecovery.autoRecover(scrollView: self?.webView?.scrollView)
                                                         if ran { DailyPixel.fireDailyAndCount(pixel: .debugInteractionRecoveryAttempted, withAdditionalParameters: [:]) }
                                                         return ran
                                                     }

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -1079,7 +1079,7 @@ class TabViewController: UIViewController {
                                               scrollView: { [weak self] in self?.webView?.scrollView },
                                               currentURL: { [weak self] in self?.webView?.url },
                                               captureFreeze: captureEnabled
-                                                ? { FreezeCaptureStore.save(WebScrollFreezeProbe.captureNow()) }
+                                                ? { WebScrollFreezeDebugCaptureStore.save(WebScrollFreezeDebugProbe.captureNow()) }
                                                 : {},
                                               autoRecover: featureFlagger.isFeatureOn(.webScrollFreezeAutoRecovery)
                                                 ? { [weak self] in
@@ -1089,8 +1089,8 @@ class TabViewController: UIViewController {
                                                 }
                                                 : { false })
         webScrollObserver?.install()
-        if captureEnabled, let window = WebScrollFreezeProbe.keyWindow() {
-            TouchCensus.installIfNeeded(on: window)
+        if captureEnabled, let window = WebScrollFreezeDebugProbe.keyWindow() {
+            WebScrollFreezeDebugActiveTouchProbe.installIfNeeded(on: window)
         }
     }
 

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -1020,7 +1020,13 @@ class TabViewController: UIViewController {
                                                     ? { FreezeCaptureStore.save(WebScrollFreezeProbe.captureNow()) }
                                                     : {},
                                                   autoRecover: featureFlagger.isFeatureOn(.webScrollFreezeAutoRecovery)
-                                                    ? { DailyPixel.fireDailyAndCount(pixel: .debugInteractionRecoveryAttempted, withAdditionalParameters: [:]); _ = WebScrollFreezeRecovery.autoRecover(); return true }
+                                                    ? {
+                                                        // Fire the attempt pixel + arm the outcome ONLY if recovery actually ran
+                                                        // (autoRecover returns false when it skips on a live touch / missing web view).
+                                                        let ran = WebScrollFreezeRecovery.autoRecover()
+                                                        if ran { DailyPixel.fireDailyAndCount(pixel: .debugInteractionRecoveryAttempted, withAdditionalParameters: [:]) }
+                                                        return ran
+                                                    }
                                                     : { false })
             webScrollObserver?.install()
             if captureEnabled, let window = WebScrollFreezeProbe.keyWindow() {

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -1020,6 +1020,9 @@ class TabViewController: UIViewController {
                                                     ? { FreezeCaptureStore.save(WebScrollFreezeProbe.captureNow()) }
                                                     : {})
             webScrollObserver?.install()
+            if captureEnabled, let window = WebScrollFreezeProbe.keyWindow() {
+                TouchCensus.installIfNeeded(on: window)
+            }
         }
 
         if isAITab {

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -1008,29 +1008,7 @@ class TabViewController: UIViewController {
             self?.handlePullToRefresh()
         })
 
-        // Symptom detection + pixels ship to production behind the `webScrollFreezeObservability` kill switch
-        // (on by default). The heavy on-device freeze capture is injected only when `webScrollFreezeCapture`
-        // (internal-only) is on — in production `captureFreeze` is a no-op.
-        if webScrollObserver == nil, featureFlagger.isFeatureOn(.webScrollFreezeObservability) {
-            let captureEnabled = featureFlagger.isFeatureOn(.webScrollFreezeCapture)
-            webScrollObserver = WebScrollObserver(container: webViewContainer,
-                                                  scrollView: { [weak self] in self?.webView?.scrollView },
-                                                  currentURL: { [weak self] in self?.webView?.url },
-                                                  captureFreeze: captureEnabled
-                                                    ? { FreezeCaptureStore.save(WebScrollFreezeProbe.captureNow()) }
-                                                    : {},
-                                                  autoRecover: featureFlagger.isFeatureOn(.webScrollFreezeAutoRecovery)
-                                                    ? { [weak self] in
-                                                        let ran = WebScrollFreezeRecovery.autoRecover(scrollView: self?.webView?.scrollView)
-                                                        if ran { DailyPixel.fireDailyAndCount(pixel: .debugInteractionRecoveryAttempted, withAdditionalParameters: [:]) }
-                                                        return ran
-                                                    }
-                                                    : { false })
-            webScrollObserver?.install()
-            if captureEnabled, let window = WebScrollFreezeProbe.keyWindow() {
-                TouchCensus.installIfNeeded(on: window)
-            }
-        }
+        attachScrollFreezeDiagnosticsIfNeeded()
 
         if isAITab {
             pullToRefreshViewAdapter?.setRefreshControlEnabled(false)
@@ -1089,6 +1067,31 @@ class TabViewController: UIViewController {
 
         borderView.insertSelf(into: webView)
         borderView.updateForAddressBarPosition(appSettings.currentAddressBarPosition)
+    }
+
+    // Symptom detection + pixels ship to production behind the `webScrollFreezeObservability` kill switch
+    // (on by default). The heavy on-device freeze capture is injected only when `webScrollFreezeCapture`
+    // (internal-only) is on — in production `captureFreeze` is a no-op.
+    private func attachScrollFreezeDiagnosticsIfNeeded() {
+        guard webScrollObserver == nil, featureFlagger.isFeatureOn(.webScrollFreezeObservability) else { return }
+        let captureEnabled = featureFlagger.isFeatureOn(.webScrollFreezeCapture)
+        webScrollObserver = WebScrollObserver(container: webViewContainer,
+                                              scrollView: { [weak self] in self?.webView?.scrollView },
+                                              currentURL: { [weak self] in self?.webView?.url },
+                                              captureFreeze: captureEnabled
+                                                ? { FreezeCaptureStore.save(WebScrollFreezeProbe.captureNow()) }
+                                                : {},
+                                              autoRecover: featureFlagger.isFeatureOn(.webScrollFreezeAutoRecovery)
+                                                ? { [weak self] in
+                                                    let ran = WebScrollFreezeRecovery.autoRecover(scrollView: self?.webView?.scrollView)
+                                                    if ran { DailyPixel.fireDailyAndCount(pixel: .debugInteractionRecoveryAttempted, withAdditionalParameters: [:]) }
+                                                    return ran
+                                                }
+                                                : { false })
+        webScrollObserver?.install()
+        if captureEnabled, let window = WebScrollFreezeProbe.keyWindow() {
+            TouchCensus.installIfNeeded(on: window)
+        }
     }
 
     private func addObservers() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -828,9 +828,9 @@ private extension MainViewController {
         chromeManager.reset(animated: false)
         if coordinator.isActive {
             coordinator.deactivateToOmnibar()
-            WebScrollFreezeBreadcrumb.drop("uti.hide")
+            WebScrollFreezeDebugTransitionLog.note("uti.hide")
             coordinator.hide()
-            WebScrollFreezeBreadcrumb.drop("uti.unbind")
+            WebScrollFreezeDebugTransitionLog.note("uti.unbind")
             coordinator.unbind()
         }
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -828,7 +828,9 @@ private extension MainViewController {
         chromeManager.reset(animated: false)
         if coordinator.isActive {
             coordinator.deactivateToOmnibar()
+            WebScrollFreezeBreadcrumb.drop("uti.hide")
             coordinator.hide()
+            WebScrollFreezeBreadcrumb.drop("uti.unbind")
             coordinator.unbind()
         }
     }

--- a/iOS/DuckDuckGo/WebScrollFreezeDebugProbe.swift
+++ b/iOS/DuckDuckGo/WebScrollFreezeDebugProbe.swift
@@ -530,9 +530,7 @@ enum WebScrollFreezeDebugCaptureStore {
     }
 
     /// Monotonic counter so back-to-back saves (e.g. a recovery's pre + post captures, written within the
-    /// same wall-clock second) get distinct filenames instead of the second-granularity name colliding and
-    /// the post-capture overwriting the pre-capture. Zero-padded so the string sort in `files()` stays
-    /// chronological within a second.
+    /// same wall-clock second) get distinct filenames.
     private static var sequence = 0
 
     static func save(_ text: String) {

--- a/iOS/DuckDuckGo/WebScrollFreezeDebugProbe.swift
+++ b/iOS/DuckDuckGo/WebScrollFreezeDebugProbe.swift
@@ -1,5 +1,5 @@
 //
-//  WebScrollFreezeProbe.swift
+//  WebScrollFreezeDebugProbe.swift
 //  DuckDuckGo
 //
 //  Copyright © 2026 DuckDuckGo. All rights reserved.
@@ -28,15 +28,15 @@ import Core
 /// tree), so it is callable from the Interaction Diagnostics debug screen, from the auto-capture in
 /// `WebScrollObserver` (gated by `webScrollFreezeCapture`, internal-only), and from lldb:
 ///
-///     expr -l Swift -O -- print(WebScrollFreezeProbe.captureNow())
-enum WebScrollFreezeProbe {
+///     expr -l Swift -O -- print(WebScrollFreezeDebugProbe.captureNow())
+enum WebScrollFreezeDebugProbe {
 
     @MainActor
     static func captureNow() -> String {
         var out = "# Interaction Diagnostics — \(Date())\n"
         out += "App: \(appVersion)\n\n"
         out += touchSection() + "\n"
-        out += breadcrumbSection() + "\n"
+        out += transitionLogSection() + "\n"
         out += featureFlagsSection() + "\n"
         out += currentTabSection() + "\n"
         out += scrollViewsSection() + "\n"
@@ -48,16 +48,16 @@ enum WebScrollFreezeProbe {
         return out
     }
 
-    // MARK: Touch ledger
+    // MARK: Active touches
 
     @MainActor
     private static func touchSection() -> String {
-        "## Touch ledger\n" + TouchCensus.report() + "\n"
+        "## Active touches\n" + WebScrollFreezeDebugActiveTouchProbe.report() + "\n"
     }
 
     @MainActor
-    private static func breadcrumbSection() -> String {
-        "## Recent transition breadcrumbs\n" + WebScrollFreezeBreadcrumb.recent() + "\n"
+    private static func transitionLogSection() -> String {
+        "## Recent transitions\n" + WebScrollFreezeDebugTransitionLog.recent() + "\n"
     }
 
     private static func featureFlagsSection() -> String {
@@ -149,7 +149,7 @@ enum WebScrollFreezeProbe {
     }
 
     /// Window-wide scan of all gesture recognizers, grouped into four buckets:
-    ///   (a) `.began` / `.changed` — actively tracking a gesture right now,
+    ///   (a) `.began` / `.changed` — actively recognizing a gesture right now,
     ///   (b) `.began` / `.changed` AND `numberOfTouches == 0` — active with no live touches, a suspect
     ///       pattern worth comparing against a healthy baseline (a recognizer in (b) also appears in (a)),
     ///   (c) `numberOfTouches > 0` — holding touch references without being active,
@@ -518,7 +518,7 @@ enum WebScrollFreezeProbe {
 
 /// Last N freeze captures, written to Caches so they survive leaving the debug screen and can be exported
 /// after the fact (the freeze persists, so the user has time). No pixel — purely on-device, no triage.
-enum FreezeCaptureStore {
+enum WebScrollFreezeDebugCaptureStore {
 
     private static let maxCaptures = 10
 

--- a/iOS/DuckDuckGo/WebScrollFreezeProbe.swift
+++ b/iOS/DuckDuckGo/WebScrollFreezeProbe.swift
@@ -187,53 +187,30 @@ enum WebScrollFreezeProbe {
         var out = "## Window-wide recognizer suspects\n"
 
         out += "\n### (a) Active recognizers (.began / .changed)\n"
-        if active.isEmpty {
-            out += "- (none)\n"
-        } else {
-            for (recognizer, view, window) in active {
-                out += "- ⚠️ \(typeName(recognizer)) state=\(recognizer.state.diagnosticName)"
-                    + " touches=\(recognizer.numberOfTouches)\n"
-                out += "    \(viewContextDescription(view, window: window))\n"
-            }
-        }
-
+        out += formatRecognizerBucket(active)
         out += "\n### (b) Active with zero touches (.began / .changed, numberOfTouches == 0 — wedge suspects)\n"
         out += "- NOTE: active-but-zero-touches is a suspect pattern; compare against a healthy-baseline capture to assess.\n"
-        if activeZeroTouches.isEmpty {
-            out += "- (none)\n"
-        } else {
-            for (recognizer, view, window) in activeZeroTouches {
-                out += "- ⚠️ \(typeName(recognizer)) state=\(recognizer.state.diagnosticName)"
-                    + " touches=\(recognizer.numberOfTouches)\n"
-                out += "    \(viewContextDescription(view, window: window))\n"
-            }
-        }
-
+        out += formatRecognizerBucket(activeZeroTouches)
         out += "\n### (c) Recognizers holding touches (numberOfTouches > 0, not active)\n"
-        if holdingTouches.isEmpty {
-            out += "- (none)\n"
-        } else {
-            for (recognizer, view, window) in holdingTouches {
-                out += "- ⚠️ \(typeName(recognizer)) state=\(recognizer.state.diagnosticName)"
-                    + " touches=\(recognizer.numberOfTouches)\n"
-                out += "    \(viewContextDescription(view, window: window))\n"
-            }
-        }
-
+        out += formatRecognizerBucket(holdingTouches)
         out += "\n### (d) WebKit/private recognizers (.possible / .began / .changed)\n"
         out += "- NOTE: .possible/0-touches is the NORMAL idle state for WebKit gates."
             + " Useful only when diffed against a healthy-baseline capture.\n"
-        if webKitNonEnded.isEmpty {
-            out += "- (none)\n"
-        } else {
-            for (recognizer, view, window) in webKitNonEnded {
-                out += "- \(typeName(recognizer)) state=\(recognizer.state.diagnosticName)"
-                    + " touches=\(recognizer.numberOfTouches)\n"
-                out += "    \(viewContextDescription(view, window: window))\n"
-            }
-        }
+        out += formatRecognizerBucket(webKitNonEnded, warning: false)
 
         return out
+    }
+
+    private static func formatRecognizerBucket(
+        _ entries: [(UIGestureRecognizer, UIView, UIWindow)],
+        warning: Bool = true
+    ) -> String {
+        guard !entries.isEmpty else { return "- (none)\n" }
+        return entries.map { recognizer, view, window in
+            "- \(warning ? "⚠️ " : "")\(typeName(recognizer)) state=\(recognizer.state.diagnosticName)"
+                + " touches=\(recognizer.numberOfTouches)\n"
+                + "    \(viewContextDescription(view, window: window))\n"
+        }.joined()
     }
 
     /// Short description of a view's position in the window hierarchy: superview type chain, frame,

--- a/iOS/DuckDuckGo/WebScrollFreezeProbe.swift
+++ b/iOS/DuckDuckGo/WebScrollFreezeProbe.swift
@@ -39,17 +39,19 @@ enum WebScrollFreezeProbe {
         out += featureFlagsSection() + "\n"
         out += currentTabSection() + "\n"
         out += scrollViewsSection() + "\n"
+        out += allScrollViewsSection() + "\n"
+        out += windowWideRecognizerSuspectsSection() + "\n"
         out += presentationSection() + "\n"
         out += windowSection() + "\n"
         out += "## Recent interaction logs (last 5 min)\n" + recentInteractionLogs()
         return out
     }
 
-    // MARK: Touch ledger (reserved for Part 2 — not instrumented in Part 1)
+    // MARK: Touch ledger
 
     @MainActor
     private static func touchSection() -> String {
-        "## Touch ledger\n- (not instrumented in this build — Part 2 work)\n"
+        "## Touch ledger\n" + TouchCensus.report() + "\n"
     }
 
     private static func featureFlagsSection() -> String {
@@ -113,6 +115,112 @@ enum WebScrollFreezeProbe {
         }
         if !found { out += "- (none active — all idle)\n" }
         return out
+    }
+
+    /// Every UIScrollView in every window — regardless of gesture state — so a frozen scroll view that is
+    /// NOT mid-gesture (e.g. stuck after a failed reset) still shows up. Listed per window with host view
+    /// type, interaction flags, gesture state, content geometry, and whether it could be the culprit.
+    private static func allScrollViewsSection() -> String {
+        var out = "## All scroll views (window-wide)\n"
+        var count = 0
+        for window in allWindows() {
+            let windowName = typeName(window)
+            walkSubviews(window) { view in
+                guard let sv = view as? UIScrollView else { return }
+                count += 1
+                let pan = sv.panGestureRecognizer
+                let contentRange = sv.contentSize.height - sv.bounds.height
+                out += "- \(typeName(sv)) in \(windowName)\n"
+                out += "    scrollEnabled=\(sv.isScrollEnabled) userInteractionEnabled=\(sv.isUserInteractionEnabled)\n"
+                out += "    tracking=\(sv.isTracking) dragging=\(sv.isDragging) decelerating=\(sv.isDecelerating)\n"
+                out += "    pan: state=\(pan.state.diagnosticName) touches=\(pan.numberOfTouches)\n"
+                out += "    contentOffset=\(sv.contentOffset) contentSize.h=\(sv.contentSize.height)"
+                    + " bounds.h=\(sv.bounds.height) range=\(contentRange)\n"
+            }
+        }
+        if count == 0 { out += "- (no UIScrollViews found)\n" }
+        return out
+    }
+
+    /// Window-wide scan of all gesture recognizers, grouped into three buckets:
+    ///   (a) `.began` / `.changed` — actively tracking a gesture right now,
+    ///   (b) `numberOfTouches > 0` — holding touch references without being active,
+    ///   (c) WebKit/private recognizers that are `.possible` with `numberOfTouches == 0` — the idle
+    ///       suspects that should be compared against a healthy-baseline capture.
+    /// Each entry includes a short superview-chain path, frame, window, visibility, and alpha.
+    private static func windowWideRecognizerSuspectsSection() -> String {
+        var active: [(UIGestureRecognizer, UIView, UIWindow)] = []
+        var holdingTouches: [(UIGestureRecognizer, UIView, UIWindow)] = []
+        var webKitIdle: [(UIGestureRecognizer, UIView, UIWindow)] = []
+
+        for window in allWindows() {
+            walkSubviews(window) { view in
+                guard let recognizers = view.gestureRecognizers else { return }
+                for recognizer in recognizers {
+                    let state = recognizer.state
+                    let touches = recognizer.numberOfTouches
+                    if state == .began || state == .changed {
+                        active.append((recognizer, view, window))
+                    } else if touches > 0 {
+                        holdingTouches.append((recognizer, view, window))
+                    } else if isWebKitPrivate(recognizer) && state == .possible && touches == 0 {
+                        webKitIdle.append((recognizer, view, window))
+                    }
+                }
+            }
+        }
+
+        var out = "## Window-wide recognizer suspects\n"
+
+        out += "\n### (a) Active recognizers (.began / .changed)\n"
+        if active.isEmpty {
+            out += "- (none)\n"
+        } else {
+            for (recognizer, view, window) in active {
+                out += "- ⚠️ \(typeName(recognizer)) state=\(recognizer.state.diagnosticName)"
+                    + " touches=\(recognizer.numberOfTouches)\n"
+                out += "    \(viewContextDescription(view, window: window))\n"
+            }
+        }
+
+        out += "\n### (b) Recognizers holding touches (numberOfTouches > 0, not active)\n"
+        if holdingTouches.isEmpty {
+            out += "- (none)\n"
+        } else {
+            for (recognizer, view, window) in holdingTouches {
+                out += "- ⚠️ \(typeName(recognizer)) state=\(recognizer.state.diagnosticName)"
+                    + " touches=\(recognizer.numberOfTouches)\n"
+                out += "    \(viewContextDescription(view, window: window))\n"
+            }
+        }
+
+        out += "\n### (c) WebKit/private recognizers (.possible, 0 touches — idle suspects)\n"
+        out += "- NOTE: .possible/0-touches is the NORMAL idle state for WebKit gates."
+            + " Useful only when diffed against a healthy-baseline capture.\n"
+        if webKitIdle.isEmpty {
+            out += "- (none)\n"
+        } else {
+            for (recognizer, view, window) in webKitIdle {
+                out += "- \(typeName(recognizer))\n"
+                out += "    \(viewContextDescription(view, window: window))\n"
+            }
+        }
+
+        return out
+    }
+
+    /// Short description of a view's position in the window hierarchy: superview type chain, frame,
+    /// which window it lives in, and visibility.
+    private static func viewContextDescription(_ view: UIView, window: UIWindow) -> String {
+        var chain: [String] = []
+        var cursor: UIView? = view.superview
+        while let current = cursor, !(current is UIWindow) {
+            chain.append(typeName(current))
+            cursor = current.superview
+        }
+        let path = chain.isEmpty ? "(root)" : chain.joined(separator: " > ")
+        return "host=\(typeName(view)) superviews=[\(path)] frame=\(view.frame)"
+            + " window=\(typeName(window)) hidden=\(view.isHidden) alpha=\(view.alpha)"
     }
 
     /// A presentation/transition left mid-flight can wedge UIKit's pan routing while taps still work.

--- a/iOS/DuckDuckGo/WebScrollFreezeProbe.swift
+++ b/iOS/DuckDuckGo/WebScrollFreezeProbe.swift
@@ -91,6 +91,7 @@ enum WebScrollFreezeProbe {
         out += "- delegate: \(scrollView.delegate.map { typeName($0) } ?? "nil")\n"
 
         out += "\n" + panGesture(of: scrollView)
+        out += "\n" + webViewSubtreeSection(of: webView)
         out += "\n" + gestureChainSection(from: webView)
         out += "\n" + competingRecognizersSection()
         out += "\n" + overlaySection(over: webView, boundary: findMainViewController()?.view)
@@ -163,6 +164,97 @@ enum WebScrollFreezeProbe {
 
     private static func panGesture(of scrollView: UIScrollView) -> String {
         "## webView.scrollView.panGestureRecognizer\n- \(describe(scrollView.panGestureRecognizer))\n"
+    }
+
+    /// Dumps EVERY gesture recogniser in the webView's SUBTREE (descending into WKScrollView / WKContentView)
+    /// — the recognisers the `webView → window` ancestor chain never reaches, and where the leading-hypothesis
+    /// wedge lives (a WebKit deferring/gating recogniser). We list all of them (robust to not knowing the exact
+    /// WebKit class names) with full public state, classify each, and flag `.possible`-with-0-touches WebKit
+    /// recognisers as SUSPECTS — deliberately NOT "wedged", because those states are also the normal idle state.
+    @MainActor
+    private static func webViewSubtreeSection(of webView: UIView) -> String {
+        var entries: [(recognizer: UIGestureRecognizer, host: UIView)] = []
+        collectSubtreeRecognizers(in: webView, into: &entries)
+
+        var out = "## WKWebView subtree recognizers (descending into WKContentView — NOT the ancestor chain)\n"
+        if entries.isEmpty {
+            out += "- (no recognizers found under the web view subtree)\n"
+            return out
+        }
+        for entry in entries {
+            out += "    \(describeSubtreeRecognizer(entry.recognizer, host: entry.host))\n"
+        }
+
+        out += "\n### Possible gate suspects (WebKit/private recognizers .possible, 0 touches — SUSPECTS ONLY)\n"
+        let suspects = entries.filter {
+            isWebKitPrivate($0.recognizer) && $0.recognizer.state == .possible && $0.recognizer.numberOfTouches == 0
+        }
+        if suspects.isEmpty {
+            out += "- (none)\n"
+        } else {
+            for suspect in suspects {
+                out += "    - \(typeName(suspect.recognizer)) on \(typeName(suspect.host))\n"
+            }
+        }
+        out += "- NOTE: WebKit gates sit .possible/0-touches in the NORMAL idle state too. This list confirms"
+            + " nothing on its own — it is diagnostic only when a FREEZE capture is diffed against a healthy"
+            + " baseline (which gate failed to reset / differs in state).\n"
+        return out
+    }
+
+    private static func collectSubtreeRecognizers(
+        in view: UIView,
+        into entries: inout [(recognizer: UIGestureRecognizer, host: UIView)]
+    ) {
+        view.gestureRecognizers?.forEach { entries.append(($0, view)) }
+        view.subviews.forEach { collectSubtreeRecognizers(in: $0, into: &entries) }
+    }
+
+    @MainActor
+    private static func describeSubtreeRecognizer(_ recognizer: UIGestureRecognizer, host: UIView) -> String {
+        let active = (recognizer.state == .began || recognizer.state == .changed)
+        return "[\(suspectClass(recognizer))] \(typeName(recognizer)) on \(typeName(host))"
+            + " — state=\(recognizer.state.diagnosticName)\(active ? " ⚠️ ACTIVE" : "")"
+            + " enabled=\(recognizer.isEnabled) touches=\(recognizer.numberOfTouches)"
+            + " cancels=\(recognizer.cancelsTouchesInView)"
+            + " delaysBegan=\(recognizer.delaysTouchesBegan) delaysEnded=\(recognizer.delaysTouchesEnded)"
+            + (isWebKitPrivate(recognizer) ? " (private)" : "")
+    }
+
+    /// Classify by runtime type name only (no private API). WebKit/private recognisers first, then fall back
+    /// to the existing app-recogniser buckets so app recognisers keep their established labels.
+    @MainActor
+    private static func suspectClass(_ recognizer: UIGestureRecognizer) -> String {
+        let name = String(describing: type(of: recognizer))
+        if name.contains("WKDeferring") { return "wk_deferring" }
+        if name.contains("WKTouchAction") { return "wk_touch_action" }
+        if name.contains("WebTouchEvents") || name.contains("UIWebTouch") { return "wk_touch_events" }
+        if name.contains("WKContent") { return "wk_content" }
+        if name.hasPrefix("WK") || name.hasPrefix("_") { return "wk_other" }
+        return WebScrollObserver.bucket(for: recognizer)
+    }
+
+    private static func isWebKitPrivate(_ recognizer: UIGestureRecognizer) -> Bool {
+        let name = String(describing: type(of: recognizer))
+        return name.hasPrefix("WK") || name.hasPrefix("_") || name.contains("WebTouch") || name.contains("UIWebTouch")
+    }
+
+    /// Recursively collect recognisers whose class is a WebKit deferring gate (WKDeferringGestureRecognizer)
+    /// from the webView's subtree. Shared with `WebScrollFreezeRecovery` so recovery resets exactly what the
+    /// capture reports.
+    static func deferringGates(in view: UIView) -> [UIGestureRecognizer] {
+        var gates: [UIGestureRecognizer] = []
+        collectDeferringGates(in: view, into: &gates)
+        return gates
+    }
+
+    private static func collectDeferringGates(in view: UIView, into gates: inout [UIGestureRecognizer]) {
+        view.gestureRecognizers?.forEach { recognizer in
+            if String(describing: type(of: recognizer)).contains("Deferring") {
+                gates.append(recognizer)
+            }
+        }
+        view.subviews.forEach { collectDeferringGates(in: $0, into: &gates) }
     }
 
     private static func gestureChainSection(from start: UIView) -> String {

--- a/iOS/DuckDuckGo/WebScrollFreezeProbe.swift
+++ b/iOS/DuckDuckGo/WebScrollFreezeProbe.swift
@@ -552,9 +552,16 @@ enum FreezeCaptureStore {
         return url
     }
 
+    /// Monotonic counter so back-to-back saves (e.g. a recovery's pre + post captures, written within the
+    /// same wall-clock second) get distinct filenames instead of the second-granularity name colliding and
+    /// the post-capture overwriting the pre-capture. Zero-padded so the string sort in `files()` stays
+    /// chronological within a second.
+    private static var sequence = 0
+
     static func save(_ text: String) {
         guard let directory else { return }
-        let name = "capture-\(Int(Date().timeIntervalSince1970)).txt"
+        sequence += 1
+        let name = "capture-\(Int(Date().timeIntervalSince1970))-\(String(format: "%03d", sequence)).txt"
         try? text.write(to: directory.appendingPathComponent(name), atomically: true, encoding: .utf8)
         prune()
     }

--- a/iOS/DuckDuckGo/WebScrollFreezeProbe.swift
+++ b/iOS/DuckDuckGo/WebScrollFreezeProbe.swift
@@ -36,6 +36,7 @@ enum WebScrollFreezeProbe {
         var out = "# Interaction Diagnostics — \(Date())\n"
         out += "App: \(appVersion)\n\n"
         out += touchSection() + "\n"
+        out += breadcrumbSection() + "\n"
         out += featureFlagsSection() + "\n"
         out += currentTabSection() + "\n"
         out += scrollViewsSection() + "\n"
@@ -52,6 +53,11 @@ enum WebScrollFreezeProbe {
     @MainActor
     private static func touchSection() -> String {
         "## Touch ledger\n" + TouchCensus.report() + "\n"
+    }
+
+    @MainActor
+    private static func breadcrumbSection() -> String {
+        "## Recent transition breadcrumbs\n" + WebScrollFreezeBreadcrumb.recent() + "\n"
     }
 
     private static func featureFlagsSection() -> String {
@@ -142,16 +148,19 @@ enum WebScrollFreezeProbe {
         return out
     }
 
-    /// Window-wide scan of all gesture recognizers, grouped into three buckets:
+    /// Window-wide scan of all gesture recognizers, grouped into four buckets:
     ///   (a) `.began` / `.changed` — actively tracking a gesture right now,
-    ///   (b) `numberOfTouches > 0` — holding touch references without being active,
-    ///   (c) WebKit/private recognizers that are `.possible` with `numberOfTouches == 0` — the idle
-    ///       suspects that should be compared against a healthy-baseline capture.
+    ///   (b) `.began` / `.changed` AND `numberOfTouches == 0` — active with no live touches, a suspect
+    ///       pattern worth comparing against a healthy baseline (a recognizer in (b) also appears in (a)),
+    ///   (c) `numberOfTouches > 0` — holding touch references without being active,
+    ///   (d) WebKit/private recognizers in `.possible`, `.began`, or `.changed` — compare against a
+    ///       healthy baseline; `.possible`/0-touches is also the normal idle state for these gates.
     /// Each entry includes a short superview-chain path, frame, window, visibility, and alpha.
     private static func windowWideRecognizerSuspectsSection() -> String {
         var active: [(UIGestureRecognizer, UIView, UIWindow)] = []
+        var activeZeroTouches: [(UIGestureRecognizer, UIView, UIWindow)] = []
         var holdingTouches: [(UIGestureRecognizer, UIView, UIWindow)] = []
-        var webKitIdle: [(UIGestureRecognizer, UIView, UIWindow)] = []
+        var webKitNonEnded: [(UIGestureRecognizer, UIView, UIWindow)] = []
 
         for window in allWindows() {
             walkSubviews(window) { view in
@@ -159,12 +168,17 @@ enum WebScrollFreezeProbe {
                 for recognizer in recognizers {
                     let state = recognizer.state
                     let touches = recognizer.numberOfTouches
-                    if state == .began || state == .changed {
+                    let isActive = state == .began || state == .changed
+                    if isActive {
                         active.append((recognizer, view, window))
+                        if touches == 0 {
+                            activeZeroTouches.append((recognizer, view, window))
+                        }
                     } else if touches > 0 {
                         holdingTouches.append((recognizer, view, window))
-                    } else if isWebKitPrivate(recognizer) && state == .possible && touches == 0 {
-                        webKitIdle.append((recognizer, view, window))
+                    }
+                    if isWebKitPrivate(recognizer) && (state == .possible || state == .began || state == .changed) {
+                        webKitNonEnded.append((recognizer, view, window))
                     }
                 }
             }
@@ -183,7 +197,19 @@ enum WebScrollFreezeProbe {
             }
         }
 
-        out += "\n### (b) Recognizers holding touches (numberOfTouches > 0, not active)\n"
+        out += "\n### (b) Active with zero touches (.began / .changed, numberOfTouches == 0 — wedge suspects)\n"
+        out += "- NOTE: active-but-zero-touches is a suspect pattern; compare against a healthy-baseline capture to assess.\n"
+        if activeZeroTouches.isEmpty {
+            out += "- (none)\n"
+        } else {
+            for (recognizer, view, window) in activeZeroTouches {
+                out += "- ⚠️ \(typeName(recognizer)) state=\(recognizer.state.diagnosticName)"
+                    + " touches=\(recognizer.numberOfTouches)\n"
+                out += "    \(viewContextDescription(view, window: window))\n"
+            }
+        }
+
+        out += "\n### (c) Recognizers holding touches (numberOfTouches > 0, not active)\n"
         if holdingTouches.isEmpty {
             out += "- (none)\n"
         } else {
@@ -194,14 +220,15 @@ enum WebScrollFreezeProbe {
             }
         }
 
-        out += "\n### (c) WebKit/private recognizers (.possible, 0 touches — idle suspects)\n"
+        out += "\n### (d) WebKit/private recognizers (.possible / .began / .changed)\n"
         out += "- NOTE: .possible/0-touches is the NORMAL idle state for WebKit gates."
             + " Useful only when diffed against a healthy-baseline capture.\n"
-        if webKitIdle.isEmpty {
+        if webKitNonEnded.isEmpty {
             out += "- (none)\n"
         } else {
-            for (recognizer, view, window) in webKitIdle {
-                out += "- \(typeName(recognizer))\n"
+            for (recognizer, view, window) in webKitNonEnded {
+                out += "- \(typeName(recognizer)) state=\(recognizer.state.diagnosticName)"
+                    + " touches=\(recognizer.numberOfTouches)\n"
                 out += "    \(viewContextDescription(view, window: window))\n"
             }
         }
@@ -275,10 +302,10 @@ enum WebScrollFreezeProbe {
     }
 
     /// Dumps EVERY gesture recogniser in the webView's SUBTREE (descending into WKScrollView / WKContentView)
-    /// — the recognisers the `webView → window` ancestor chain never reaches, and where the leading-hypothesis
-    /// wedge lives (a WebKit deferring/gating recogniser). We list all of them (robust to not knowing the exact
-    /// WebKit class names) with full public state, classify each, and flag `.possible`-with-0-touches WebKit
-    /// recognisers as SUSPECTS — deliberately NOT "wedged", because those states are also the normal idle state.
+    /// — the recognisers the `webView → window` ancestor chain never reaches, and where a suspected wedge
+    /// may reside (e.g. a WebKit deferring/gating recogniser). We list all of them (robust to not knowing the
+    /// exact WebKit class names) with full public state, classify each, and flag `.possible`-with-0-touches
+    /// WebKit recognisers as SUSPECTS — deliberately NOT "wedged", because those states are also the normal idle state.
     @MainActor
     private static func webViewSubtreeSection(of webView: UIView) -> String {
         var entries: [(recognizer: UIGestureRecognizer, host: UIView)] = []

--- a/iOS/DuckDuckGo/WebScrollObserver.swift
+++ b/iOS/DuckDuckGo/WebScrollObserver.swift
@@ -795,25 +795,21 @@ enum WebScrollFreezeRecovery {
     /// only — bracketed by exactly one pre-capture and one post-capture. The closure is intentionally
     /// narrow: no broad window resets, no flushAll. Call only when no touch is in flight.
     ///
-    /// Returns a summary string so callers can log or surface it. The leading hypothesis is that one or
-    /// both of these resets may help; compare the pre/post captures rather than treating the return value
-    /// as confirmation.
+    /// Returns `true` ONLY if it actually ran the resets — `false` if it skipped (a touch is in flight, or
+    /// no web view was found). Callers MUST gate the attempt pixel + outcome arming on this, so a skipped
+    /// attempt does not emit a misleading recovery outcome. The leading hypothesis is that one or both
+    /// resets may help; compare the pre/post captures rather than treating the return value as confirmation.
     @discardableResult
-    static func autoRecover() -> String {
-        guard !anyTouchInFlight() else {
-            return "skipped — touch in flight"
-        }
-        guard let webView = WebScrollFreezeProbe.findMainViewController()?.currentTab?.webView else {
-            return "auto-recover: no webView found"
-        }
+    static func autoRecover() -> Bool {
+        guard !anyTouchInFlight() else { return false }
+        guard let webView = WebScrollFreezeProbe.findMainViewController()?.currentTab?.webView else { return false }
         let pan = webView.scrollView.panGestureRecognizer
-        let pre = WebScrollFreezeProbe.captureNow()
-        FreezeCaptureStore.save(pre)
+        FreezeCaptureStore.save(WebScrollFreezeProbe.captureNow())
         applyScrollPanReset(pan)
         applyDeferringGateReset(in: webView)
-        let post = WebScrollFreezeProbe.captureNow()
-        FreezeCaptureStore.save(post)
-        return "auto-recover: applied scroll-pan + deferring-gate resets; pre/post captures saved — compare them"
+        FreezeCaptureStore.save(WebScrollFreezeProbe.captureNow())
+        Logger.interaction.error("Auto-recover: applied scroll-pan + deferring-gate resets; pre/post captures saved")
+        return true
     }
 
     /// Core: toggle the web scroll pan recognizer off then on. Does NOT save captures — callers are

--- a/iOS/DuckDuckGo/WebScrollObserver.swift
+++ b/iOS/DuckDuckGo/WebScrollObserver.swift
@@ -270,15 +270,31 @@ final class WebScrollObserver: NSObject {
         }
     }
 
-    private func deferringCountBucket() -> String {
-        guard let container else { return "0" }
-        let count = WebScrollFreezeDebugProbe.deferringGates(in: container).count
+    /// Maps a raw recognizer count to the 4-level param bucket (deferring-gate + possible-zero-touch params).
+    /// Pure, so it is unit-tested directly — the live window scans that feed it read `UIApplication` state
+    /// that a test host can't control deterministically.
+    static func countBucket3Plus(_ count: Int) -> String {
         switch count {
         case 0:  return "0"
         case 1:  return "1"
         case 2:  return "2"
         default: return "3_plus"
         }
+    }
+
+    /// Maps a raw recognizer count to the 2-level param bucket (window-active-no-touch param, where a single
+    /// active-but-touchless recognizer is already a strong signal). Pure — see `countBucket3Plus`.
+    static func countBucket2Plus(_ count: Int) -> String {
+        switch count {
+        case 0:  return "0"
+        case 1:  return "1"
+        default: return "2_plus"
+        }
+    }
+
+    private func deferringCountBucket() -> String {
+        guard let container else { return "0" }
+        return Self.countBucket3Plus(WebScrollFreezeDebugProbe.deferringGates(in: container).count)
     }
 
     static func possibleZeroTouchCountRaw() -> Int {
@@ -307,13 +323,7 @@ final class WebScrollObserver: NSObject {
     }
 
     func possibleZeroTouchCountBucket() -> String {
-        let count = Self.possibleZeroTouchCountRaw()
-        switch count {
-        case 0:  return "0"
-        case 1:  return "1"
-        case 2:  return "2"
-        default: return "3_plus"
-        }
+        Self.countBucket3Plus(Self.possibleZeroTouchCountRaw())
     }
 
     static func windowActiveNoTouchCountRaw() -> Int {
@@ -332,12 +342,7 @@ final class WebScrollObserver: NSObject {
     }
 
     func windowActiveNoTouchBucket() -> String {
-        let count = Self.windowActiveNoTouchCountRaw()
-        switch count {
-        case 0:  return "0"
-        case 1:  return "1"
-        default: return "2_plus"
-        }
+        Self.countBucket2Plus(Self.windowActiveNoTouchCountRaw())
     }
 
     private static func forEachRecognizer(in view: UIView, _ body: (UIGestureRecognizer) -> Void) {

--- a/iOS/DuckDuckGo/WebScrollObserver.swift
+++ b/iOS/DuckDuckGo/WebScrollObserver.swift
@@ -35,8 +35,8 @@ import Core
 /// recognizer still receives the drag touches it needs to classify.
 ///
 /// Fires two pixels: the symptom signal (`debugInteractionRepeatedFailedScroll`) and a mechanism signal
-/// (`debugInteractionWedgedRecognizer`, via `checkForWedgedRecognizer`). Logs every failed attempt as a
-/// breadcrumb so the Interaction Diagnostics snapshot has the recent history even below the pixel threshold.
+/// (`debugInteractionWedgedRecognizer`, via `checkForWedgedRecognizer`). Logs every failed attempt so the
+/// Interaction Diagnostics snapshot has the recent history even below the pixel threshold.
 /// No Swift concurrency — the post-gesture and wedge re-checks use `asyncAfter` on the main queue.
 /// `firePixel*` closures are injected so the detectors are unit-testable without the static pipeline.
 @MainActor
@@ -202,7 +202,7 @@ final class WebScrollObserver: NSObject {
         guard failureStreak >= Constant.streakThreshold else { return }
 
         // Capture LIBERALLY (once per streak, before the precision gate) so a real freeze always leaves the
-        // touch/recognizer census. Injected closure: a no-op in production, the real capture only when the
+        // touch/recognizer snapshot. Injected closure: a no-op in production, the real capture only when the
         // debug flag `webScrollFreezeCapture` is on. The pixel below ships to everyone regardless.
         if !capturedThisStreak {
             capturedThisStreak = true
@@ -272,7 +272,7 @@ final class WebScrollObserver: NSObject {
 
     private func deferringCountBucket() -> String {
         guard let container else { return "0" }
-        let count = WebScrollFreezeProbe.deferringGates(in: container).count
+        let count = WebScrollFreezeDebugProbe.deferringGates(in: container).count
         switch count {
         case 0:  return "0"
         case 1:  return "1"
@@ -493,49 +493,49 @@ final class WebScrollObserverGestureRecognizer: UIGestureRecognizer {
     override func canBePrevented(by preventingGestureRecognizer: UIGestureRecognizer) -> Bool { false }
 }
 
-// MARK: - Touch Census
+// MARK: - Active touch probe (internal-only)
 
-/// Passive window-level touch ledger that records when touches begin and end, keyed by touch identity.
+/// Passive window-level map of active touches, noting when touches begin and end, keyed by touch identity.
 /// Installed as a single bystander recognizer on a `UIWindow`; never recognizes or interferes.
 ///
-/// A non-zero `activeTouchCount` while no finger is on screen indicates an orphaned touch — the leading
+/// A non-zero active-touch count while no finger is on screen indicates an orphaned touch — the leading
 /// hypothesis for why WebKit's deferring gate stays blocked and scroll never begins.
 @MainActor
-enum TouchCensus {
+enum WebScrollFreezeDebugActiveTouchProbe {
 
-    private static var ledger: [ObjectIdentifier: Date] = [:]
+    private static var activeTouches: [ObjectIdentifier: Date] = [:]
     private static var lastBegan: Date?
     private static var lastEnded: Date?
     private static var lastCancelled: Date?
 
-    private static weak var installedRecognizer: TouchCensusRecognizer?
+    private static weak var installedRecognizer: WebScrollFreezeDebugActiveTouchRecognizer?
 
-    /// True once a `TouchCensusRecognizer` has been installed on a window.
+    /// True once a `WebScrollFreezeDebugActiveTouchRecognizer` has been installed on a window.
     static var isInstalled: Bool { installedRecognizer != nil }
 
-    /// Adds exactly one passive `TouchCensusRecognizer` to `window`. Idempotent — returns immediately if
+    /// Adds exactly one passive `WebScrollFreezeDebugActiveTouchRecognizer` to `window`. Idempotent — returns immediately if
     /// a recognizer is already installed and alive.
     static func installIfNeeded(on window: UIWindow) {
         if let existing = installedRecognizer, existing.view != nil { return }
-        let r = TouchCensusRecognizer()
+        let r = WebScrollFreezeDebugActiveTouchRecognizer()
         r.onBegan = { touches in
             let now = Date()
             for touch in touches {
-                ledger[ObjectIdentifier(touch)] = now
+                activeTouches[ObjectIdentifier(touch)] = now
             }
             lastBegan = now
         }
         r.onEnded = { touches in
             let now = Date()
             for touch in touches {
-                ledger.removeValue(forKey: ObjectIdentifier(touch))
+                activeTouches.removeValue(forKey: ObjectIdentifier(touch))
             }
             lastEnded = now
         }
         r.onCancelled = { touches in
             let now = Date()
             for touch in touches {
-                ledger.removeValue(forKey: ObjectIdentifier(touch))
+                activeTouches.removeValue(forKey: ObjectIdentifier(touch))
             }
             lastCancelled = now
         }
@@ -543,7 +543,7 @@ enum TouchCensus {
         installedRecognizer = r
     }
 
-    /// Returns the body lines for a "Touch ledger" capture section. If not installed, returns a
+    /// Returns the body lines for an "Active touches" capture section. If not installed, returns a
     /// single line noting the feature is off.
     static func report() -> String {
         guard isInstalled else {
@@ -551,9 +551,9 @@ enum TouchCensus {
         }
         let now = Date()
         var lines = ""
-        lines += "- active touch count: \(ledger.count)"
-        if !ledger.isEmpty {
-            let oldest = ledger.values.map { now.timeIntervalSince($0) }.max() ?? 0
+        lines += "- active touch count: \(activeTouches.count)"
+        if !activeTouches.isEmpty {
+            let oldest = activeTouches.values.map { now.timeIntervalSince($0) }.max() ?? 0
             lines += " (oldest \(String(format: "%.2f", oldest))s)"
             lines += " — NOTE: non-zero active touches while no finger is on screen = orphaned touch (leading hypothesis: may keep a deferring gate blocked below the recognizer layer; compare pre/post captures to assess)"
         }
@@ -571,9 +571,9 @@ enum TouchCensus {
     }
 }
 
-/// A pure bystander recognizer attached to a `UIWindow` by `TouchCensus`. Modeled on
+/// A pure bystander recognizer attached to a `UIWindow` by `WebScrollFreezeDebugActiveTouchProbe`. Modeled on
 /// `WebScrollObserverGestureRecognizer`: never recognizes; never cancels or blocks other gestures.
-final class TouchCensusRecognizer: UIGestureRecognizer {
+final class WebScrollFreezeDebugActiveTouchRecognizer: UIGestureRecognizer {
 
     var onBegan: ((Set<UITouch>) -> Void)?
     var onEnded: ((Set<UITouch>) -> Void)?
@@ -606,15 +606,15 @@ final class TouchCensusRecognizer: UIGestureRecognizer {
     override func canBePrevented(by preventingGestureRecognizer: UIGestureRecognizer) -> Bool { false }
 }
 
-// MARK: - Transition Breadcrumbs
+// MARK: - Transition log (internal-only)
 
-/// Lightweight transition-event ledger for scroll-freeze diagnostics. Callers drop a breadcrumb before
+/// Lightweight transition-event log for scroll-freeze diagnostics. Callers add a note before
 /// and after any navigation or tab-switch transition so that a freeze capture includes recent activity.
 ///
-/// Each entry is a snapshot of observable UI state at the moment of the drop — not a proof of cause,
+/// Each entry is a snapshot of observable UI state at the moment it is noted — not a proof of cause,
 /// just evidence to compare across captures.
 @MainActor
-enum WebScrollFreezeBreadcrumb {
+enum WebScrollFreezeDebugTransitionLog {
 
     private struct Entry {
         let timestamp: Date
@@ -630,16 +630,16 @@ enum WebScrollFreezeBreadcrumb {
 
     /// Captures a lightweight snapshot and appends it to the in-memory ring buffer (capped at ~20 entries);
     /// logs a concise summary via `Logger.interaction`. `nonisolated` so non-`@MainActor` call sites (e.g.
-    /// `SwipeTabsCoordinator`) can drop a breadcrumb without each needing the annotation; `assumeIsolated`
-    /// bridges to the main actor — safe because every breadcrumb site (gesture handlers, view transitions)
+    /// `SwipeTabsCoordinator`) can add a note without each needing the annotation; `assumeIsolated`
+    /// bridges to the main actor — safe because every call site (gesture handlers, view transitions)
     /// already runs on the main thread.
-    nonisolated static func drop(_ label: String) {
+    nonisolated static func note(_ label: String) {
         MainActor.assumeIsolated {
             let touchInFlight = anyTouchInFlight()
             let activeCount = activeRecognizerCount()
             let panState = webScrollPanStateName()
             let suspectCount = wkSuspectCount()
-            Logger.interaction.debug("Breadcrumb [\(label, privacy: .public)]: touchInFlight=\(touchInFlight, privacy: .public) activeRecognizers=\(activeCount, privacy: .public) webScrollPan=\(panState, privacy: .public) wkSuspects=\(suspectCount, privacy: .public)")
+            Logger.interaction.debug("Transition [\(label, privacy: .public)]: touchInFlight=\(touchInFlight, privacy: .public) activeRecognizers=\(activeCount, privacy: .public) webScrollPan=\(panState, privacy: .public) wkSuspects=\(suspectCount, privacy: .public)")
             let entry = Entry(
                 timestamp: Date(),
                 label: label,
@@ -685,7 +685,7 @@ enum WebScrollFreezeBreadcrumb {
     }
 
     private static func webScrollPanStateName() -> String {
-        guard let pan = WebScrollFreezeProbe.findMainViewController()?.currentTab?.webView?.scrollView.panGestureRecognizer else {
+        guard let pan = WebScrollFreezeDebugProbe.findMainViewController()?.currentTab?.webView?.scrollView.panGestureRecognizer else {
             return "unavailable"
         }
         switch pan.state {
@@ -700,8 +700,8 @@ enum WebScrollFreezeBreadcrumb {
     }
 
     /// Count of WK/private-class recognizers (type name starts with `_` or `WK`, or contains `WebTouch`)
-    /// that are in `.possible` with zero tracked touches, window-wide. A non-zero count is a suspect
-    /// reading — compare across breadcrumbs rather than treating any single value as conclusive.
+    /// that are in `.possible` with zero active touches, window-wide. A non-zero count is a suspect
+    /// reading — compare across transition notes rather than treating any single value as conclusive.
     private static func wkSuspectCount() -> Int {
         var count = 0
         for window in windows() {
@@ -744,7 +744,7 @@ enum WebScrollFreezeBreadcrumb {
 /// `WKDeferringGestureRecognizer` becomes wedged in `.possible`, but that remains unconfirmed; recovery
 /// is intended to produce evidence (via captures), not to silently fix the problem.
 ///
-/// Both rungs are guarded against live touches: toggling `isEnabled` while a touch is tracked orphans
+/// Both rungs are guarded against live touches: toggling `isEnabled` while a touch is in flight orphans
 /// that touch and can re-trigger the freeze. Manual rungs are debug-only; `autoRecover()` is a
 /// gated scoped sequence intended for production when enabled by a feature flag in a calling layer.
 @MainActor
@@ -761,11 +761,11 @@ enum WebScrollFreezeRecovery {
     }
 
     private static func savePrePostCaptures(label: String, reset: () -> Void) -> String {
-        let pre = WebScrollFreezeProbe.captureNow()
-        FreezeCaptureStore.save(pre)
+        let pre = WebScrollFreezeDebugProbe.captureNow()
+        WebScrollFreezeDebugCaptureStore.save(pre)
         reset()
-        let post = WebScrollFreezeProbe.captureNow()
-        FreezeCaptureStore.save(post)
+        let post = WebScrollFreezeDebugProbe.captureNow()
+        WebScrollFreezeDebugCaptureStore.save(post)
         return "\(label); pre/post captures saved — compare them"
     }
 
@@ -776,7 +776,7 @@ enum WebScrollFreezeRecovery {
         guard !anyTouchInFlight() else {
             return "skipped — touch in flight (would orphan it)"
         }
-        guard let webView = WebScrollFreezeProbe.findMainViewController()?.currentTab?.webView else {
+        guard let webView = WebScrollFreezeDebugProbe.findMainViewController()?.currentTab?.webView else {
             return "deferring-gate reset: no webView found"
         }
         return savePrePostCaptures(label: "reset deferring gate(s)") {
@@ -792,7 +792,7 @@ enum WebScrollFreezeRecovery {
         guard !anyTouchInFlight() else {
             return "skipped — touch in flight (would orphan it)"
         }
-        guard let pan = WebScrollFreezeProbe.findMainViewController()?.currentTab?.webView?.scrollView.panGestureRecognizer else {
+        guard let pan = WebScrollFreezeDebugProbe.findMainViewController()?.currentTab?.webView?.scrollView.panGestureRecognizer else {
             return "scroll-pan reset: no webView found"
         }
         return savePrePostCaptures(label: "reset web scroll pan") {
@@ -812,10 +812,10 @@ enum WebScrollFreezeRecovery {
     static func autoRecover(scrollView: UIScrollView?) -> Bool {
         guard !anyTouchInFlight() else { return false }
         guard let scrollView else { return false }
-        FreezeCaptureStore.save(WebScrollFreezeProbe.captureNow())
+        WebScrollFreezeDebugCaptureStore.save(WebScrollFreezeDebugProbe.captureNow())
         applyScrollPanReset(scrollView.panGestureRecognizer)
         applyDeferringGateReset(in: scrollView)
-        FreezeCaptureStore.save(WebScrollFreezeProbe.captureNow())
+        WebScrollFreezeDebugCaptureStore.save(WebScrollFreezeDebugProbe.captureNow())
         Logger.interaction.error("Auto-recover: applied scroll-pan + deferring-gate resets; pre/post captures saved")
         return true
     }
@@ -831,7 +831,7 @@ enum WebScrollFreezeRecovery {
     /// Core: toggle all deferring-gate recognizers off then on. Does NOT save captures — callers are
     /// responsible for bracketing with pre/post saves.
     private static func applyDeferringGateReset(in webView: UIView) {
-        let gates = WebScrollFreezeProbe.deferringGates(in: webView)
+        let gates = WebScrollFreezeDebugProbe.deferringGates(in: webView)
         for gate in gates {
             gate.isEnabled = false
             gate.isEnabled = true
@@ -839,7 +839,7 @@ enum WebScrollFreezeRecovery {
         Logger.interaction.error("Deferring-gate reset: toggled \(gates.count, privacy: .public) deferring recognizer(s)")
     }
 
-    /// True if any recogniser in any window is currently tracking touches — i.e. a gesture is live and it is
+    /// True if any recogniser in any window currently has touches in flight — i.e. a gesture is live and it is
     /// NOT safe to toggle `isEnabled` (that would strand the touch).
     private static func anyTouchInFlight() -> Bool {
         var found = false

--- a/iOS/DuckDuckGo/WebScrollObserver.swift
+++ b/iOS/DuckDuckGo/WebScrollObserver.swift
@@ -199,11 +199,117 @@ final class WebScrollObserver: NSObject {
         } else {
             mechanism = "none_wedged"
         }
+
+        let scrollView = scrollViewProvider()
         firePixelDailyAndCount(.debugInteractionRepeatedFailedScroll, [
             "attempt_count_bucket": bucket,
             "direction": streakDirections.count > 1 ? "mixed" : (streakDirections.first ?? "mixed"),
-            "mechanism": mechanism
+            "mechanism": mechanism,
+            "web_scroll_pan_state": webScrollPanState(scrollView),
+            "web_scroll_pan_touches": webScrollPanTouches(scrollView),
+            "wk_deferring_count_bucket": deferringCountBucket(),
+            "wk_possible_zero_touch_count_bucket": possibleZeroTouchCountBucket(),
+            "window_active_no_touch_bucket": windowActiveNoTouchBucket()
         ])
+    }
+
+    // MARK: - Production pixel param helpers
+
+    private func webScrollPanState(_ scrollView: UIScrollView?) -> String {
+        guard let pan = scrollView?.panGestureRecognizer else { return "none" }
+        switch pan.state {
+        case .possible:   return "possible"
+        case .began:      return "began"
+        case .changed:    return "changed"
+        case .ended:      return "ended"
+        case .cancelled:  return "cancelled"
+        case .failed:     return "failed"
+        @unknown default: return "possible"
+        }
+    }
+
+    private func webScrollPanTouches(_ scrollView: UIScrollView?) -> String {
+        guard let pan = scrollView?.panGestureRecognizer else { return "0" }
+        switch pan.numberOfTouches {
+        case 0:  return "0"
+        case 1:  return "1"
+        default: return "2_plus"
+        }
+    }
+
+    private func deferringCountBucket() -> String {
+        guard let container else { return "0" }
+        let count = WebScrollFreezeProbe.deferringGates(in: container).count
+        switch count {
+        case 0:  return "0"
+        case 1:  return "1"
+        case 2:  return "2"
+        default: return "3_plus"
+        }
+    }
+
+    private static func possibleZeroTouchCountRaw() -> Int {
+        let windows = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+        var count = 0
+        for window in windows {
+            forEachPossibleZeroTouchWebKitRecognizer(in: window) { count += 1 }
+        }
+        return count
+    }
+
+    private static func forEachPossibleZeroTouchWebKitRecognizer(in view: UIView, _ body: (UIGestureRecognizer) -> Void) {
+        if let recognizers = view.gestureRecognizers {
+            for r in recognizers where r.state == .possible && r.numberOfTouches == 0 {
+                let typeName = String(describing: type(of: r))
+                if typeName.hasPrefix("_") || typeName.hasPrefix("WK") || typeName.contains("WebTouch") {
+                    body(r)
+                }
+            }
+        }
+        for subview in view.subviews {
+            forEachPossibleZeroTouchWebKitRecognizer(in: subview, body)
+        }
+    }
+
+    private func possibleZeroTouchCountBucket() -> String {
+        let count = Self.possibleZeroTouchCountRaw()
+        switch count {
+        case 0:  return "0"
+        case 1:  return "1"
+        case 2:  return "2"
+        default: return "3_plus"
+        }
+    }
+
+    private static func windowActiveNoTouchCountRaw() -> Int {
+        let windows = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+        var count = 0
+        for window in windows {
+            forEachRecognizer(in: window) { r in
+                if (r.state == .began || r.state == .changed) && r.numberOfTouches == 0 {
+                    count += 1
+                }
+            }
+        }
+        return count
+    }
+
+    private func windowActiveNoTouchBucket() -> String {
+        let count = Self.windowActiveNoTouchCountRaw()
+        switch count {
+        case 0:  return "0"
+        case 1:  return "1"
+        default: return "2_plus"
+        }
+    }
+
+    private static func forEachRecognizer(in view: UIView, _ body: (UIGestureRecognizer) -> Void) {
+        view.gestureRecognizers?.forEach(body)
+        view.subviews.forEach { forEachRecognizer(in: $0, body) }
     }
 
     /// Bucket the drag's start position into vertical thirds of the container, for the spatial-spread gate.
@@ -354,44 +460,191 @@ final class WebScrollObserverGestureRecognizer: UIGestureRecognizer {
     override func canBePrevented(by preventingGestureRecognizer: UIGestureRecognizer) -> Bool { false }
 }
 
+// MARK: - Touch Census
+
+/// Passive window-level touch ledger that records when touches begin and end, keyed by touch identity.
+/// Installed as a single bystander recognizer on a `UIWindow`; never recognizes or interferes.
+///
+/// A non-zero `activeTouchCount` while no finger is on screen indicates an orphaned touch — the leading
+/// hypothesis for why WebKit's deferring gate stays blocked and scroll never begins.
+@MainActor
+enum TouchCensus {
+
+    private struct TouchEntry {
+        let began: Date
+    }
+
+    private static var ledger: [ObjectIdentifier: TouchEntry] = [:]
+    private static var lastBegan: Date?
+    private static var lastEnded: Date?
+    private static var lastCancelled: Date?
+
+    private static weak var installedRecognizer: TouchCensusRecognizer?
+
+    /// True once a `TouchCensusRecognizer` has been installed on a window.
+    static var isInstalled: Bool { installedRecognizer != nil }
+
+    /// Adds exactly one passive `TouchCensusRecognizer` to `window`. Idempotent — returns immediately if
+    /// a recognizer is already installed and alive.
+    static func installIfNeeded(on window: UIWindow) {
+        if let existing = installedRecognizer, existing.view != nil { return }
+        let r = TouchCensusRecognizer()
+        r.onBegan = { touches in
+            let now = Date()
+            for touch in touches {
+                ledger[ObjectIdentifier(touch)] = TouchEntry(began: now)
+            }
+            lastBegan = now
+        }
+        r.onEnded = { touches in
+            let now = Date()
+            for touch in touches {
+                ledger.removeValue(forKey: ObjectIdentifier(touch))
+            }
+            lastEnded = now
+        }
+        r.onCancelled = { touches in
+            let now = Date()
+            for touch in touches {
+                ledger.removeValue(forKey: ObjectIdentifier(touch))
+            }
+            lastCancelled = now
+        }
+        window.addGestureRecognizer(r)
+        installedRecognizer = r
+    }
+
+    /// Returns the body lines for a "Touch ledger" capture section. If not installed, returns a
+    /// single line noting the feature is off.
+    static func report() -> String {
+        guard isInstalled else {
+            return "- (not installed — enable webScrollFreezeCapture)\n"
+        }
+        let now = Date()
+        var lines = ""
+        lines += "- active touch count: \(ledger.count)"
+        if !ledger.isEmpty {
+            let oldest = ledger.values.map { now.timeIntervalSince($0.began) }.max() ?? 0
+            lines += " (oldest \(String(format: "%.2f", oldest))s)"
+            lines += " — NOTE: non-zero active touches while no finger is on screen = orphaned touch (suspected freeze trigger, below the recognizer layer)"
+        }
+        lines += "\n"
+        if let date = lastBegan {
+            lines += "- last began: \(String(format: "%.2f", now.timeIntervalSince(date)))s ago\n"
+        }
+        if let date = lastEnded {
+            lines += "- last ended: \(String(format: "%.2f", now.timeIntervalSince(date)))s ago\n"
+        }
+        if let date = lastCancelled {
+            lines += "- last cancelled: \(String(format: "%.2f", now.timeIntervalSince(date)))s ago\n"
+        }
+        return lines
+    }
+}
+
+/// A pure bystander recognizer attached to a `UIWindow` by `TouchCensus`. Modeled on
+/// `WebScrollObserverGestureRecognizer`: never recognizes; never cancels or blocks other gestures.
+final class TouchCensusRecognizer: UIGestureRecognizer {
+
+    var onBegan: ((Set<UITouch>) -> Void)?
+    var onEnded: ((Set<UITouch>) -> Void)?
+    var onCancelled: ((Set<UITouch>) -> Void)?
+
+    override init(target: Any?, action: Selector?) {
+        super.init(target: target, action: action)
+        cancelsTouchesInView = false
+        delaysTouchesBegan = false
+        delaysTouchesEnded = false
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
+        onBegan?(touches)
+    }
+
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {}
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
+        onEnded?(touches)
+        state = .failed
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent) {
+        onCancelled?(touches)
+        state = .failed
+    }
+
+    override func canPrevent(_ preventedGestureRecognizer: UIGestureRecognizer) -> Bool { false }
+    override func canBePrevented(by preventingGestureRecognizer: UIGestureRecognizer) -> Bool { false }
+}
+
 // MARK: - Recovery (single manual debug rung — internal only)
 
-/// Single safe recovery rung for the web-scroll-freeze: `resetDeferringGates`, scoped to the WKWebView's
-/// WKDeferringGestureRecognizers (WebKit's own pattern) and guarded against live touches via
-/// `anyTouchInFlight`. Debug-only and manual — there is no production auto-recovery. Meant to run BETWEEN
-/// gestures (no active touch).
+/// Diagnostic recovery rungs for the web-scroll-freeze. Two rungs are available: `resetDeferringGates`
+/// and `resetScrollPan`. Neither is a proven fix — both are diagnostic tools that save pre/post captures
+/// so you can compare recognizer state before and after. The leading hypothesis is that a
+/// `WKDeferringGestureRecognizer` becomes wedged in `.possible`, but that remains unconfirmed; recovery
+/// is intended to produce evidence (via captures), not to silently fix the problem.
+///
+/// Both rungs are guarded against live touches: toggling `isEnabled` while a touch is tracked orphans
+/// that touch and can re-trigger the freeze. Debug-only and manual — there is no production auto-recovery.
 @MainActor
 enum WebScrollFreezeRecovery {
 
-    enum Rung { case resetDeferringGates }
+    enum Rung { case resetDeferringGates, resetScrollPan }
 
     @discardableResult
     static func runRung(_ rung: Rung) -> String {
         switch rung {
         case .resetDeferringGates: return resetDeferringGates()
+        case .resetScrollPan:      return resetScrollPan()
         }
     }
 
-    /// PRIMARY safe recovery candidate (WebKit's own pattern, scoped). The leading-hypothesis freeze is a
-    /// WKDeferringGestureRecognizer wedged in `.possible`: it gates the scroll pan (which `require(toFail:)`s
-    /// it), so the pan never begins — and it's invisible to the `.began`/`.changed` wedge scan. This resets
-    /// ONLY those deferring gates, and ONLY when no touch is in flight (toggling a recogniser's `isEnabled`
-    /// while a touch is live is what orphans touches and bricked the broad rungs). Surgical + guarded = safe.
+    private static func savePrePostCaptures(label: String, reset: () -> Void) -> String {
+        let pre = WebScrollFreezeProbe.captureNow()
+        FreezeCaptureStore.save(pre)
+        reset()
+        let post = WebScrollFreezeProbe.captureNow()
+        FreezeCaptureStore.save(post)
+        return "\(label); pre/post captures saved — compare them"
+    }
+
+    /// Resets ONLY the WKWebView's `WKDeferringGestureRecognizer` instances. The deferring gate is the
+    /// leading hypothesis for why the scroll pan never begins, but this is unconfirmed. Surgical + guarded.
     @discardableResult
     private static func resetDeferringGates() -> String {
         guard !anyTouchInFlight() else {
-            return "deferring-gate reset SKIPPED — a touch is in flight (would orphan it). Auto-recovery only fires between gestures."
+            return "skipped — touch in flight (would orphan it)"
         }
         guard let webView = WebScrollFreezeProbe.findMainViewController()?.currentTab?.webView else {
             return "deferring-gate reset: no webView found"
         }
         let gates = WebScrollFreezeProbe.deferringGates(in: webView)
-        for gate in gates {
-            gate.isEnabled = false
-            gate.isEnabled = true
+        return savePrePostCaptures(label: "reset \(gates.count) deferring gate(s)") {
+            for gate in gates {
+                gate.isEnabled = false
+                gate.isEnabled = true
+            }
+            Logger.interaction.error("Deferring-gate reset: reset \(gates.count, privacy: .public) deferring recognizers")
         }
-        Logger.interaction.error("Deferring-gate reset: reset \(gates.count, privacy: .public) deferring recognizers")
-        return "deferring-gate reset: reset \(gates.count) WKDeferringGestureRecognizer(s)"
+    }
+
+    /// Resets ONLY the web scroll view's `panGestureRecognizer` by toggling `isEnabled` off then on.
+    /// This is a complementary hypothesis to the deferring-gate path — compare pre/post captures to
+    /// assess whether the pan state changed meaningfully.
+    @discardableResult
+    private static func resetScrollPan() -> String {
+        guard !anyTouchInFlight() else {
+            return "skipped — touch in flight (would orphan it)"
+        }
+        guard let pan = WebScrollFreezeProbe.findMainViewController()?.currentTab?.webView?.scrollView.panGestureRecognizer else {
+            return "scroll-pan reset: no webView found"
+        }
+        return savePrePostCaptures(label: "reset web scroll pan") {
+            pan.isEnabled = false
+            pan.isEnabled = true
+            Logger.interaction.error("Scroll-pan reset: toggled panGestureRecognizer isEnabled")
+        }
     }
 
     /// True if any recogniser in any window is currently tracking touches — i.e. a gesture is live and it is

--- a/iOS/DuckDuckGo/WebScrollObserver.swift
+++ b/iOS/DuckDuckGo/WebScrollObserver.swift
@@ -73,11 +73,18 @@ final class WebScrollObserver: NSObject {
     private var streakRegions: Set<Int> = []
     private var highestBucketFired: String?
     private var capturedThisStreak = false
+    private var autoRecoveredThisStreak = false
+    private var pendingOutcomeCheck = false
 
     private weak var wedgeCandidate: UIGestureRecognizer?
 
     /// Human-readable last outcome, surfaced in the Interaction Diagnostics snapshot.
     private(set) var recentStatus = "no scroll attempt observed yet"
+
+    /// Called exactly once per confirmed freeze episode, after the region-spread gate passes. Returns `true`
+    /// only if it actually ran the recovery (so the outcome pixel is armed ONLY then). The default returns
+    /// `false`, keeping the production path unchanged; inject a real action only when auto-recovery is enabled.
+    private let autoRecover: () -> Bool
 
     init(container: UIView,
          scrollView: @escaping () -> UIScrollView?,
@@ -86,13 +93,15 @@ final class WebScrollObserver: NSObject {
             DailyPixel.fireDailyAndCount(pixel: $0, withAdditionalParameters: $1)
          },
          now: @escaping () -> Date = { Date() },
-         captureFreeze: @escaping () -> Void = {}) {
+         captureFreeze: @escaping () -> Void = {},
+         autoRecover: @escaping () -> Bool = { false }) {
         self.container = container
         self.scrollViewProvider = scrollView
         self.currentURL = currentURL
         self.firePixelDailyAndCount = firePixelDailyAndCount
         self.now = now
         self.captureFreeze = captureFreeze
+        self.autoRecover = autoRecover
         super.init()
     }
 
@@ -114,6 +123,8 @@ final class WebScrollObserver: NSObject {
         streakRegions = []
         highestBucketFired = nil
         capturedThisStreak = false
+        autoRecoveredThisStreak = false
+        pendingOutcomeCheck = false
     }
 
     // MARK: - Symptom detection (C1)
@@ -151,6 +162,11 @@ final class WebScrollObserver: NSObject {
         guard hasHeadroom else { return }
 
         let moved = abs(scrollView.contentOffset.y - startOffsetY) >= Constant.movedThreshold
+        if pendingOutcomeCheck {
+            pendingOutcomeCheck = false
+            let outcome = moved ? "recovered" : "still_frozen"
+            firePixelDailyAndCount(.debugInteractionRecoveryOutcome, ["outcome": outcome])
+        }
         if moved {
             reset()
             recentStatus = "last drag scrolled OK (\(formatted(now())))"
@@ -166,6 +182,8 @@ final class WebScrollObserver: NSObject {
             streakRegions = []
             highestBucketFired = nil
             capturedThisStreak = false
+            autoRecoveredThisStreak = false
+            pendingOutcomeCheck = false
         }
         failureStreak += 1
         lastFailureAt = now()
@@ -211,11 +229,18 @@ final class WebScrollObserver: NSObject {
             "wk_possible_zero_touch_count_bucket": possibleZeroTouchCountBucket(),
             "window_active_no_touch_bucket": windowActiveNoTouchBucket()
         ])
+
+        if !autoRecoveredThisStreak {
+            autoRecoveredThisStreak = true
+            // Arm the outcome pixel ONLY if recovery actually ran (flag on + no live touch); otherwise the
+            // default `{ false }` closure leaves the production path untouched and fires no outcome pixel.
+            pendingOutcomeCheck = autoRecover()
+        }
     }
 
     // MARK: - Production pixel param helpers
 
-    private func webScrollPanState(_ scrollView: UIScrollView?) -> String {
+    func webScrollPanState(_ scrollView: UIScrollView?) -> String {
         guard let pan = scrollView?.panGestureRecognizer else { return "none" }
         switch pan.state {
         case .possible:   return "possible"
@@ -228,7 +253,7 @@ final class WebScrollObserver: NSObject {
         }
     }
 
-    private func webScrollPanTouches(_ scrollView: UIScrollView?) -> String {
+    func webScrollPanTouches(_ scrollView: UIScrollView?) -> String {
         guard let pan = scrollView?.panGestureRecognizer else { return "0" }
         switch pan.numberOfTouches {
         case 0:  return "0"
@@ -248,7 +273,7 @@ final class WebScrollObserver: NSObject {
         }
     }
 
-    private static func possibleZeroTouchCountRaw() -> Int {
+    static func possibleZeroTouchCountRaw() -> Int {
         let windows = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
             .flatMap { $0.windows }
@@ -259,7 +284,7 @@ final class WebScrollObserver: NSObject {
         return count
     }
 
-    private static func forEachPossibleZeroTouchWebKitRecognizer(in view: UIView, _ body: (UIGestureRecognizer) -> Void) {
+    static func forEachPossibleZeroTouchWebKitRecognizer(in view: UIView, _ body: (UIGestureRecognizer) -> Void) {
         if let recognizers = view.gestureRecognizers {
             for r in recognizers where r.state == .possible && r.numberOfTouches == 0 {
                 let typeName = String(describing: type(of: r))
@@ -273,7 +298,7 @@ final class WebScrollObserver: NSObject {
         }
     }
 
-    private func possibleZeroTouchCountBucket() -> String {
+    func possibleZeroTouchCountBucket() -> String {
         let count = Self.possibleZeroTouchCountRaw()
         switch count {
         case 0:  return "0"
@@ -283,7 +308,7 @@ final class WebScrollObserver: NSObject {
         }
     }
 
-    private static func windowActiveNoTouchCountRaw() -> Int {
+    static func windowActiveNoTouchCountRaw() -> Int {
         let windows = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
             .flatMap { $0.windows }
@@ -298,7 +323,7 @@ final class WebScrollObserver: NSObject {
         return count
     }
 
-    private func windowActiveNoTouchBucket() -> String {
+    func windowActiveNoTouchBucket() -> String {
         let count = Self.windowActiveNoTouchCountRaw()
         switch count {
         case 0:  return "0"
@@ -313,7 +338,7 @@ final class WebScrollObserver: NSObject {
     }
 
     /// Bucket the drag's start position into vertical thirds of the container, for the spatial-spread gate.
-    private func screenRegion(forY y: CGFloat) -> Int {
+    func screenRegion(forY y: CGFloat) -> Int {
         let height = container?.bounds.height ?? UIScreen.main.bounds.height
         guard height > 0 else { return 0 }
         return max(0, min(2, Int(y / (height / 3))))
@@ -352,7 +377,7 @@ final class WebScrollObserver: NSObject {
         return (minY, max(minY, maxY))
     }
 
-    private func attemptBucket(_ count: Int) -> String {
+    func attemptBucket(_ count: Int) -> String {
         switch count {
         case ..<4: return "3"
         case 4...5: return "4_5"
@@ -526,7 +551,7 @@ enum TouchCensus {
         if !ledger.isEmpty {
             let oldest = ledger.values.map { now.timeIntervalSince($0.began) }.max() ?? 0
             lines += " (oldest \(String(format: "%.2f", oldest))s)"
-            lines += " — NOTE: non-zero active touches while no finger is on screen = orphaned touch (suspected freeze trigger, below the recognizer layer)"
+            lines += " — NOTE: non-zero active touches while no finger is on screen = orphaned touch (leading hypothesis: may keep a deferring gate blocked below the recognizer layer; compare pre/post captures to assess)"
         }
         lines += "\n"
         if let date = lastBegan {
@@ -577,6 +602,131 @@ final class TouchCensusRecognizer: UIGestureRecognizer {
     override func canBePrevented(by preventingGestureRecognizer: UIGestureRecognizer) -> Bool { false }
 }
 
+// MARK: - Transition Breadcrumbs
+
+/// Lightweight transition-event ledger for scroll-freeze diagnostics. Callers drop a breadcrumb before
+/// and after any navigation or tab-switch transition so that a freeze capture includes recent activity.
+///
+/// Each entry is a snapshot of observable UI state at the moment of the drop — not a proof of cause,
+/// just evidence to compare across captures.
+@MainActor
+enum WebScrollFreezeBreadcrumb {
+
+    private struct Entry {
+        let timestamp: Date
+        let label: String
+        let touchInFlight: Bool
+        let activeRecognizerCount: Int
+        let webScrollPanState: String
+        let wkSuspectCount: Int
+    }
+
+    private static var ring: [Entry] = []
+    private static let ringCapacity = 20
+
+    /// Captures a lightweight snapshot and appends it to the in-memory ring buffer (capped at ~20 entries).
+    /// Logs a concise summary line via `Logger.interaction`.
+    static func drop(_ label: String) {
+        let touchInFlight = anyTouchInFlight()
+        let activeCount = activeRecognizerCount()
+        let panState = webScrollPanStateName()
+        let suspectCount = wkSuspectCount()
+        Logger.interaction.debug("Breadcrumb [\(label, privacy: .public)]: touchInFlight=\(touchInFlight, privacy: .public) activeRecognizers=\(activeCount, privacy: .public) webScrollPan=\(panState, privacy: .public) wkSuspects=\(suspectCount, privacy: .public)")
+        let entry = Entry(
+            timestamp: Date(),
+            label: label,
+            touchInFlight: touchInFlight,
+            activeRecognizerCount: activeCount,
+            webScrollPanState: panState,
+            wkSuspectCount: suspectCount
+        )
+        if ring.count >= ringCapacity { ring.removeFirst() }
+        ring.append(entry)
+    }
+
+    /// Formats the ring buffer as a multi-line string for inclusion in a freeze capture. Returns a
+    /// `(none)` line when the buffer is empty.
+    static func recent() -> String {
+        guard !ring.isEmpty else { return "- (none)\n" }
+        let now = Date()
+        var lines = ""
+        for entry in ring {
+            let age = String(format: "%.1f", now.timeIntervalSince(entry.timestamp))
+            lines += "- \(age)s ago [\(entry.label)] touchInFlight=\(entry.touchInFlight) activeRecognizers=\(entry.activeRecognizerCount) webScrollPan=\(entry.webScrollPanState) wkSuspects=\(entry.wkSuspectCount)\n"
+        }
+        return lines
+    }
+
+    private static func anyTouchInFlight() -> Bool {
+        var found = false
+        for window in windows() {
+            forEachRecognizer(in: window) { if $0.numberOfTouches > 0 { found = true } }
+        }
+        return found
+    }
+
+    private static func activeRecognizerCount() -> Int {
+        var count = 0
+        for window in windows() {
+            forEachRecognizer(in: window) { r in
+                if r.state == .began || r.state == .changed { count += 1 }
+            }
+        }
+        return count
+    }
+
+    private static func webScrollPanStateName() -> String {
+        guard let pan = WebScrollFreezeProbe.findMainViewController()?.currentTab?.webView?.scrollView.panGestureRecognizer else {
+            return "unavailable"
+        }
+        switch pan.state {
+        case .possible:   return "possible"
+        case .began:      return "began"
+        case .changed:    return "changed"
+        case .ended:      return "ended"
+        case .cancelled:  return "cancelled"
+        case .failed:     return "failed"
+        @unknown default: return "possible"
+        }
+    }
+
+    /// Count of WK/private-class recognizers (type name starts with `_` or `WK`, or contains `WebTouch`)
+    /// that are in `.possible` with zero tracked touches, window-wide. A non-zero count is a suspect
+    /// reading — compare across breadcrumbs rather than treating any single value as conclusive.
+    private static func wkSuspectCount() -> Int {
+        var count = 0
+        for window in windows() {
+            forEachPossibleZeroTouchWebKitRecognizer(in: window) { count += 1 }
+        }
+        return count
+    }
+
+    private static func windows() -> [UIWindow] {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+    }
+
+    private static func forEachRecognizer(in view: UIView, _ body: (UIGestureRecognizer) -> Void) {
+        view.gestureRecognizers?.forEach(body)
+        view.subviews.forEach { forEachRecognizer(in: $0, body) }
+    }
+
+    private static func forEachPossibleZeroTouchWebKitRecognizer(in view: UIView, _ body: (UIGestureRecognizer) -> Void) {
+        if let recognizers = view.gestureRecognizers {
+            for r in recognizers where r.state == .possible && r.numberOfTouches == 0 {
+                let typeName = String(describing: type(of: r))
+                if typeName.hasPrefix("_") || typeName.hasPrefix("WK") || typeName.contains("WebTouch") {
+                    body(r)
+                }
+            }
+        }
+        for subview in view.subviews {
+            forEachPossibleZeroTouchWebKitRecognizer(in: subview, body)
+        }
+    }
+}
+
 // MARK: - Recovery (single manual debug rung — internal only)
 
 /// Diagnostic recovery rungs for the web-scroll-freeze. Two rungs are available: `resetDeferringGates`
@@ -586,7 +736,8 @@ final class TouchCensusRecognizer: UIGestureRecognizer {
 /// is intended to produce evidence (via captures), not to silently fix the problem.
 ///
 /// Both rungs are guarded against live touches: toggling `isEnabled` while a touch is tracked orphans
-/// that touch and can re-trigger the freeze. Debug-only and manual — there is no production auto-recovery.
+/// that touch and can re-trigger the freeze. Manual rungs are debug-only; `autoRecover()` is a
+/// gated scoped sequence intended for production when enabled by a feature flag in a calling layer.
 @MainActor
 enum WebScrollFreezeRecovery {
 
@@ -619,18 +770,13 @@ enum WebScrollFreezeRecovery {
         guard let webView = WebScrollFreezeProbe.findMainViewController()?.currentTab?.webView else {
             return "deferring-gate reset: no webView found"
         }
-        let gates = WebScrollFreezeProbe.deferringGates(in: webView)
-        return savePrePostCaptures(label: "reset \(gates.count) deferring gate(s)") {
-            for gate in gates {
-                gate.isEnabled = false
-                gate.isEnabled = true
-            }
-            Logger.interaction.error("Deferring-gate reset: reset \(gates.count, privacy: .public) deferring recognizers")
+        return savePrePostCaptures(label: "reset deferring gate(s)") {
+            applyDeferringGateReset(in: webView)
         }
     }
 
     /// Resets ONLY the web scroll view's `panGestureRecognizer` by toggling `isEnabled` off then on.
-    /// This is a complementary hypothesis to the deferring-gate path — compare pre/post captures to
+    /// A complementary suspect path to the deferring-gate hypothesis — compare pre/post captures to
     /// assess whether the pan state changed meaningfully.
     @discardableResult
     private static func resetScrollPan() -> String {
@@ -641,10 +787,52 @@ enum WebScrollFreezeRecovery {
             return "scroll-pan reset: no webView found"
         }
         return savePrePostCaptures(label: "reset web scroll pan") {
-            pan.isEnabled = false
-            pan.isEnabled = true
-            Logger.interaction.error("Scroll-pan reset: toggled panGestureRecognizer isEnabled")
+            applyScrollPanReset(pan)
         }
+    }
+
+    /// Gated auto-recovery sequence. Applies the safe scoped resets once — pan only, then deferring gates
+    /// only — bracketed by exactly one pre-capture and one post-capture. The closure is intentionally
+    /// narrow: no broad window resets, no flushAll. Call only when no touch is in flight.
+    ///
+    /// Returns a summary string so callers can log or surface it. The leading hypothesis is that one or
+    /// both of these resets may help; compare the pre/post captures rather than treating the return value
+    /// as confirmation.
+    @discardableResult
+    static func autoRecover() -> String {
+        guard !anyTouchInFlight() else {
+            return "skipped — touch in flight"
+        }
+        guard let webView = WebScrollFreezeProbe.findMainViewController()?.currentTab?.webView else {
+            return "auto-recover: no webView found"
+        }
+        let pan = webView.scrollView.panGestureRecognizer
+        let pre = WebScrollFreezeProbe.captureNow()
+        FreezeCaptureStore.save(pre)
+        applyScrollPanReset(pan)
+        applyDeferringGateReset(in: webView)
+        let post = WebScrollFreezeProbe.captureNow()
+        FreezeCaptureStore.save(post)
+        return "auto-recover: applied scroll-pan + deferring-gate resets; pre/post captures saved — compare them"
+    }
+
+    /// Core: toggle the web scroll pan recognizer off then on. Does NOT save captures — callers are
+    /// responsible for bracketing with pre/post saves.
+    private static func applyScrollPanReset(_ pan: UIPanGestureRecognizer) {
+        pan.isEnabled = false
+        pan.isEnabled = true
+        Logger.interaction.error("Scroll-pan reset: toggled panGestureRecognizer isEnabled")
+    }
+
+    /// Core: toggle all deferring-gate recognizers off then on. Does NOT save captures — callers are
+    /// responsible for bracketing with pre/post saves.
+    private static func applyDeferringGateReset(in webView: UIView) {
+        let gates = WebScrollFreezeProbe.deferringGates(in: webView)
+        for gate in gates {
+            gate.isEnabled = false
+            gate.isEnabled = true
+        }
+        Logger.interaction.error("Deferring-gate reset: toggled \(gates.count, privacy: .public) deferring recognizer(s)")
     }
 
     /// True if any recogniser in any window is currently tracking touches — i.e. a gesture is live and it is

--- a/iOS/DuckDuckGo/WebScrollObserver.swift
+++ b/iOS/DuckDuckGo/WebScrollObserver.swift
@@ -624,24 +624,29 @@ enum WebScrollFreezeBreadcrumb {
     private static var ring: [Entry] = []
     private static let ringCapacity = 20
 
-    /// Captures a lightweight snapshot and appends it to the in-memory ring buffer (capped at ~20 entries).
-    /// Logs a concise summary line via `Logger.interaction`.
-    static func drop(_ label: String) {
-        let touchInFlight = anyTouchInFlight()
-        let activeCount = activeRecognizerCount()
-        let panState = webScrollPanStateName()
-        let suspectCount = wkSuspectCount()
-        Logger.interaction.debug("Breadcrumb [\(label, privacy: .public)]: touchInFlight=\(touchInFlight, privacy: .public) activeRecognizers=\(activeCount, privacy: .public) webScrollPan=\(panState, privacy: .public) wkSuspects=\(suspectCount, privacy: .public)")
-        let entry = Entry(
-            timestamp: Date(),
-            label: label,
-            touchInFlight: touchInFlight,
-            activeRecognizerCount: activeCount,
-            webScrollPanState: panState,
-            wkSuspectCount: suspectCount
-        )
-        if ring.count >= ringCapacity { ring.removeFirst() }
-        ring.append(entry)
+    /// Captures a lightweight snapshot and appends it to the in-memory ring buffer (capped at ~20 entries);
+    /// logs a concise summary via `Logger.interaction`. `nonisolated` so non-`@MainActor` call sites (e.g.
+    /// `SwipeTabsCoordinator`) can drop a breadcrumb without each needing the annotation; `assumeIsolated`
+    /// bridges to the main actor — safe because every breadcrumb site (gesture handlers, view transitions)
+    /// already runs on the main thread.
+    nonisolated static func drop(_ label: String) {
+        MainActor.assumeIsolated {
+            let touchInFlight = anyTouchInFlight()
+            let activeCount = activeRecognizerCount()
+            let panState = webScrollPanStateName()
+            let suspectCount = wkSuspectCount()
+            Logger.interaction.debug("Breadcrumb [\(label, privacy: .public)]: touchInFlight=\(touchInFlight, privacy: .public) activeRecognizers=\(activeCount, privacy: .public) webScrollPan=\(panState, privacy: .public) wkSuspects=\(suspectCount, privacy: .public)")
+            let entry = Entry(
+                timestamp: Date(),
+                label: label,
+                touchInFlight: touchInFlight,
+                activeRecognizerCount: activeCount,
+                webScrollPanState: panState,
+                wkSuspectCount: suspectCount
+            )
+            if ring.count >= ringCapacity { ring.removeFirst() }
+            ring.append(entry)
+        }
     }
 
     /// Formats the ring buffer as a multi-line string for inclusion in a freeze capture. Returns a

--- a/iOS/DuckDuckGo/WebScrollObserver.swift
+++ b/iOS/DuckDuckGo/WebScrollObserver.swift
@@ -279,7 +279,7 @@ final class WebScrollObserver: NSObject {
             .flatMap { $0.windows }
         var count = 0
         for window in windows {
-            forEachPossibleZeroTouchWebKitRecognizer(in: window) { count += 1 }
+            forEachPossibleZeroTouchWebKitRecognizer(in: window) { _ in count += 1 }
         }
         return count
     }
@@ -696,7 +696,7 @@ enum WebScrollFreezeBreadcrumb {
     private static func wkSuspectCount() -> Int {
         var count = 0
         for window in windows() {
-            forEachPossibleZeroTouchWebKitRecognizer(in: window) { count += 1 }
+            forEachPossibleZeroTouchWebKitRecognizer(in: window) { _ in count += 1 }
         }
         return count
     }

--- a/iOS/DuckDuckGo/WebScrollObserver.swift
+++ b/iOS/DuckDuckGo/WebScrollObserver.swift
@@ -354,92 +354,54 @@ final class WebScrollObserverGestureRecognizer: UIGestureRecognizer {
     override func canBePrevented(by preventingGestureRecognizer: UIGestureRecognizer) -> Bool { false }
 }
 
-// MARK: - Recovery (manual debug rungs — internal only)
+// MARK: - Recovery (single manual debug rung — internal only)
 
-/// Self-heal actions for the web-scroll-freeze. `recover()` is the surgical reset (pan + wedged recognizers);
-/// the individual rungs are exposed for the debug Recovery screen to find the minimal sufficient action.
-/// Debug-only and manual for now — there is no production auto-recovery; that is productionised in Part 3.
-/// All are idempotent and meant to run BETWEEN gestures (no active touch).
+/// Single safe recovery rung for the web-scroll-freeze: `resetDeferringGates`, scoped to the WKWebView's
+/// WKDeferringGestureRecognizers (WebKit's own pattern) and guarded against live touches via
+/// `anyTouchInFlight`. Debug-only and manual — there is no production auto-recovery. Meant to run BETWEEN
+/// gestures (no active touch).
 @MainActor
 enum WebScrollFreezeRecovery {
 
-    enum Rung { case flushAppRecognizers, bounceWindowInteraction, flushAll }
-
-    /// Surgical self-heal: reset only the recognisers that can actually block scrolling — pan recognisers
-    /// (incl. the web scroll view's own pan) and anything stuck mid-gesture. Does NOT touch window
-    /// interaction (toggling `isUserInteractionEnabled` orphans touches into a stuck Stationary/nil-window
-    /// state — the very freeze we're fixing) and leaves taps untouched.
-    @discardableResult
-    static func recover() -> String {
-        let count = resetBlockingRecognizers()
-        Logger.interaction.error("Manual recovery ran: reset \(count, privacy: .public) pan/wedged recognizers")
-        return "recover: reset \(count) pan/wedged recognizers"
-    }
-
-    /// Reset pan recognisers + any recogniser stuck in `began`/`changed`. Skips UIKit-internal (`_UI…`)
-    /// system gates and all taps. Typically a handful, not the whole app.
-    @discardableResult
-    private static func resetBlockingRecognizers() -> Int {
-        var count = 0
-        for window in windows() {
-            forEachRecognizer(in: window) { recognizer in
-                guard !String(describing: type(of: recognizer)).hasPrefix("_") else { return }
-                let isPan = recognizer is UIPanGestureRecognizer
-                let isWedged = recognizer.state == .began || recognizer.state == .changed
-                guard isPan || isWedged else { return }
-                recognizer.isEnabled = false
-                recognizer.isEnabled = true
-                count += 1
-            }
-        }
-        return count
-    }
+    enum Rung { case resetDeferringGates }
 
     @discardableResult
     static func runRung(_ rung: Rung) -> String {
         switch rung {
-        case .flushAppRecognizers: return "reset \(flushAppRecognizers()) app recognizers"
-        case .bounceWindowInteraction: bounceWindowInteraction(); return "bounced window interaction"
-        case .flushAll: return "reset \(flushAll()) recognizers (all, incl. system)"
+        case .resetDeferringGates: return resetDeferringGates()
         }
     }
 
-    /// Reset every non-UIKit-internal recogniser (skip `_UI…` classes so we don't disturb system gates).
-    /// This also re-arms the web scroll view's own pan.
+    /// PRIMARY safe recovery candidate (WebKit's own pattern, scoped). The leading-hypothesis freeze is a
+    /// WKDeferringGestureRecognizer wedged in `.possible`: it gates the scroll pan (which `require(toFail:)`s
+    /// it), so the pan never begins — and it's invisible to the `.began`/`.changed` wedge scan. This resets
+    /// ONLY those deferring gates, and ONLY when no touch is in flight (toggling a recogniser's `isEnabled`
+    /// while a touch is live is what orphans touches and bricked the broad rungs). Surgical + guarded = safe.
     @discardableResult
-    private static func flushAppRecognizers() -> Int {
-        var count = 0
-        for window in windows() {
-            forEachRecognizer(in: window) { recognizer in
-                guard !String(describing: type(of: recognizer)).hasPrefix("_") else { return }
-                recognizer.isEnabled = false
-                recognizer.isEnabled = true
-                count += 1
-            }
+    private static func resetDeferringGates() -> String {
+        guard !anyTouchInFlight() else {
+            return "deferring-gate reset SKIPPED — a touch is in flight (would orphan it). Auto-recovery only fires between gestures."
         }
-        return count
+        guard let webView = WebScrollFreezeProbe.findMainViewController()?.currentTab?.webView else {
+            return "deferring-gate reset: no webView found"
+        }
+        let gates = WebScrollFreezeProbe.deferringGates(in: webView)
+        for gate in gates {
+            gate.isEnabled = false
+            gate.isEnabled = true
+        }
+        Logger.interaction.error("Deferring-gate reset: reset \(gates.count, privacy: .public) deferring recognizers")
+        return "deferring-gate reset: reset \(gates.count) WKDeferringGestureRecognizer(s)"
     }
 
-    /// Cancel any touches the gesture environment is still tracking (the phantom-touch flush). The async
-    /// re-enable lets UIKit process the cancellation; the gap is one run-loop tick, imperceptible.
-    private static func bounceWindowInteraction() {
-        for window in windows() where window.isKeyWindow {
-            window.isUserInteractionEnabled = false
-            DispatchQueue.main.async { window.isUserInteractionEnabled = true }
-        }
-    }
-
-    @discardableResult
-    private static func flushAll() -> Int {
-        var count = 0
+    /// True if any recogniser in any window is currently tracking touches — i.e. a gesture is live and it is
+    /// NOT safe to toggle `isEnabled` (that would strand the touch).
+    private static func anyTouchInFlight() -> Bool {
+        var found = false
         for window in windows() {
-            forEachRecognizer(in: window) { recognizer in
-                recognizer.isEnabled = false
-                recognizer.isEnabled = true
-                count += 1
-            }
+            forEachRecognizer(in: window) { if $0.numberOfTouches > 0 { found = true } }
         }
-        return count
+        return found
     }
 
     private static func windows() -> [UIWindow] {

--- a/iOS/DuckDuckGo/WebScrollObserver.swift
+++ b/iOS/DuckDuckGo/WebScrollObserver.swift
@@ -75,6 +75,7 @@ final class WebScrollObserver: NSObject {
     private var capturedThisStreak = false
     private var autoRecoveredThisStreak = false
     private var pendingOutcomeCheck = false
+    private var outcomeArmedAt: Date?
 
     private weak var wedgeCandidate: UIGestureRecognizer?
 
@@ -125,6 +126,7 @@ final class WebScrollObserver: NSObject {
         capturedThisStreak = false
         autoRecoveredThisStreak = false
         pendingOutcomeCheck = false
+        outcomeArmedAt = nil
     }
 
     // MARK: - Symptom detection (C1)
@@ -145,7 +147,18 @@ final class WebScrollObserver: NSObject {
 
     /// Internal (not private) so unit tests can drive classification directly, bypassing the post-gesture
     /// `asyncAfter` recheck. In production this is only ever called from `dragEnded`.
+    ///
+    /// Also resolves a pending auto-recovery outcome: a stale one (older than the streak window, with no
+    /// real scroll attempt to resolve it) is dropped so it can't be mis-attributed to a later/unrelated
+    /// drag; otherwise `recovery_outcome` fires on the next eligible vertical drag. reset() clears it on
+    /// navigation / tab change / streak expiry.
     func classifyDrag(dx: CGFloat, dy: CGFloat, startOffsetY: CGFloat, startScreenY: CGFloat) {
+        if pendingOutcomeCheck, let armedAt = outcomeArmedAt,
+           now().timeIntervalSince(armedAt) > Constant.streakWindow {
+            pendingOutcomeCheck = false
+            outcomeArmedAt = nil
+        }
+
         guard isEligible(), let scrollView = scrollViewProvider() else { return }
 
         // Only count vertical-dominant drags long enough to be a real scroll attempt.
@@ -164,8 +177,8 @@ final class WebScrollObserver: NSObject {
         let moved = abs(scrollView.contentOffset.y - startOffsetY) >= Constant.movedThreshold
         if pendingOutcomeCheck {
             pendingOutcomeCheck = false
-            let outcome = moved ? "recovered" : "still_frozen"
-            firePixelDailyAndCount(.debugInteractionRecoveryOutcome, ["outcome": outcome])
+            outcomeArmedAt = nil
+            firePixelDailyAndCount(.debugInteractionRecoveryOutcome, ["outcome": moved ? "recovered" : "still_frozen"])
         }
         if moved {
             reset()
@@ -184,6 +197,7 @@ final class WebScrollObserver: NSObject {
             capturedThisStreak = false
             autoRecoveredThisStreak = false
             pendingOutcomeCheck = false
+            outcomeArmedAt = nil
         }
         failureStreak += 1
         lastFailureAt = now()
@@ -231,10 +245,11 @@ final class WebScrollObserver: NSObject {
         ])
 
         if !autoRecoveredThisStreak {
-            autoRecoveredThisStreak = true
-            // Arm the outcome pixel ONLY if recovery actually ran (flag on + no live touch); otherwise the
-            // default `{ false }` closure leaves the production path untouched and fires no outcome pixel.
-            pendingOutcomeCheck = autoRecover()
+            if autoRecover() {
+                autoRecoveredThisStreak = true
+                pendingOutcomeCheck = true
+                outcomeArmedAt = now()
+            }
         }
     }
 
@@ -805,13 +820,12 @@ enum WebScrollFreezeRecovery {
     /// attempt does not emit a misleading recovery outcome. The leading hypothesis is that one or both
     /// resets may help; compare the pre/post captures rather than treating the return value as confirmation.
     @discardableResult
-    static func autoRecover() -> Bool {
+    static func autoRecover(scrollView: UIScrollView?) -> Bool {
         guard !anyTouchInFlight() else { return false }
-        guard let webView = WebScrollFreezeProbe.findMainViewController()?.currentTab?.webView else { return false }
-        let pan = webView.scrollView.panGestureRecognizer
+        guard let scrollView else { return false }
         FreezeCaptureStore.save(WebScrollFreezeProbe.captureNow())
-        applyScrollPanReset(pan)
-        applyDeferringGateReset(in: webView)
+        applyScrollPanReset(scrollView.panGestureRecognizer)
+        applyDeferringGateReset(in: scrollView)
         FreezeCaptureStore.save(WebScrollFreezeProbe.captureNow())
         Logger.interaction.error("Auto-recover: applied scroll-pan + deferring-gate resets; pre/post captures saved")
         return true

--- a/iOS/DuckDuckGo/WebScrollObserver.swift
+++ b/iOS/DuckDuckGo/WebScrollObserver.swift
@@ -190,14 +190,7 @@ final class WebScrollObserver: NSObject {
 
     private func registerFailedAttempt(direction: String, startScreenY: CGFloat) {
         if let last = lastFailureAt, now().timeIntervalSince(last) > Constant.streakWindow {
-            failureStreak = 0
-            streakDirections = []
-            streakRegions = []
-            highestBucketFired = nil
-            capturedThisStreak = false
-            autoRecoveredThisStreak = false
-            pendingOutcomeCheck = false
-            outcomeArmedAt = nil
+            reset()
         }
         failureStreak += 1
         lastFailureAt = now()
@@ -510,11 +503,7 @@ final class WebScrollObserverGestureRecognizer: UIGestureRecognizer {
 @MainActor
 enum TouchCensus {
 
-    private struct TouchEntry {
-        let began: Date
-    }
-
-    private static var ledger: [ObjectIdentifier: TouchEntry] = [:]
+    private static var ledger: [ObjectIdentifier: Date] = [:]
     private static var lastBegan: Date?
     private static var lastEnded: Date?
     private static var lastCancelled: Date?
@@ -532,7 +521,7 @@ enum TouchCensus {
         r.onBegan = { touches in
             let now = Date()
             for touch in touches {
-                ledger[ObjectIdentifier(touch)] = TouchEntry(began: now)
+                ledger[ObjectIdentifier(touch)] = now
             }
             lastBegan = now
         }
@@ -564,7 +553,7 @@ enum TouchCensus {
         var lines = ""
         lines += "- active touch count: \(ledger.count)"
         if !ledger.isEmpty {
-            let oldest = ledger.values.map { now.timeIntervalSince($0.began) }.max() ?? 0
+            let oldest = ledger.values.map { now.timeIntervalSince($0) }.max() ?? 0
             lines += " (oldest \(String(format: "%.2f", oldest))s)"
             lines += " — NOTE: non-zero active touches while no finger is on screen = orphaned touch (leading hypothesis: may keep a deferring gate blocked below the recognizer layer; compare pre/post captures to assess)"
         }

--- a/iOS/DuckDuckGoTests/WebScrollObserverTests.swift
+++ b/iOS/DuckDuckGoTests/WebScrollObserverTests.swift
@@ -354,7 +354,7 @@ final class WebScrollObserverBucketTests: XCTestCase {
 
 // MARK: - Deferring-gate collection tests
 
-/// Tests for `WebScrollFreezeProbe.deferringGates(in:)`.
+/// Tests for `WebScrollFreezeDebugProbe.deferringGates(in:)`.
 /// The filter is purely by runtime class name — any recognizer whose type name contains "Deferring"
 /// is collected; all others are skipped. We use a custom subclass name that satisfies that check
 /// without requiring any private WebKit types.
@@ -372,7 +372,7 @@ final class DeferringGateCollectionTests: XCTestCase {
         view.addGestureRecognizer(deferring)
         view.addGestureRecognizer(plain)
 
-        let gates = WebScrollFreezeProbe.deferringGates(in: view)
+        let gates = WebScrollFreezeDebugProbe.deferringGates(in: view)
 
         XCTAssertEqual(gates.count, 1)
         XCTAssertTrue(gates.first === deferring)
@@ -384,7 +384,7 @@ final class DeferringGateCollectionTests: XCTestCase {
         view.addGestureRecognizer(UIPanGestureRecognizer())
         view.addGestureRecognizer(UILongPressGestureRecognizer())
 
-        let gates = WebScrollFreezeProbe.deferringGates(in: view)
+        let gates = WebScrollFreezeDebugProbe.deferringGates(in: view)
 
         XCTAssertTrue(gates.isEmpty)
     }
@@ -400,7 +400,7 @@ final class DeferringGateCollectionTests: XCTestCase {
         let deferring = SimulatedDeferringGestureRecognizer()
         grandchild.addGestureRecognizer(deferring)
 
-        let gates = WebScrollFreezeProbe.deferringGates(in: root)
+        let gates = WebScrollFreezeDebugProbe.deferringGates(in: root)
 
         XCTAssertEqual(gates.count, 1)
         XCTAssertTrue(gates.first === deferring)
@@ -408,7 +408,7 @@ final class DeferringGateCollectionTests: XCTestCase {
 
     func testDeferringGates_emptyViewTreeReturnsEmptyArray() {
         let view = UIView()
-        XCTAssertTrue(WebScrollFreezeProbe.deferringGates(in: view).isEmpty)
+        XCTAssertTrue(WebScrollFreezeDebugProbe.deferringGates(in: view).isEmpty)
     }
 
     func testDeferringGates_collectsMultipleDeferringRecognizersAcrossTree() {
@@ -421,7 +421,7 @@ final class DeferringGateCollectionTests: XCTestCase {
         root.addGestureRecognizer(d1)
         child.addGestureRecognizer(d2)
 
-        let gates = WebScrollFreezeProbe.deferringGates(in: root)
+        let gates = WebScrollFreezeDebugProbe.deferringGates(in: root)
 
         XCTAssertEqual(gates.count, 2)
         XCTAssertTrue(gates.contains { $0 === d1 })
@@ -434,7 +434,7 @@ final class DeferringGateCollectionTests: XCTestCase {
 
 /// Tests for the "not scrollable" guard in `InteractionDiagnosticsModel.probeProgrammaticScroll`.
 ///
-/// `probeProgrammaticScroll` calls `WebScrollFreezeProbe.findMainViewController()` to locate the
+/// `probeProgrammaticScroll` calls `WebScrollFreezeDebugProbe.findMainViewController()` to locate the
 /// web scroll view. That method walks `UIApplication.shared.connectedScenes` looking for a
 /// `MainViewController`, which does not exist in the XCTest host process. The method therefore
 /// returns `nil` and sets `actionResult = "Scroll probe: no web scroll view found"` — the scroll

--- a/iOS/DuckDuckGoTests/WebScrollObserverTests.swift
+++ b/iOS/DuckDuckGoTests/WebScrollObserverTests.swift
@@ -298,24 +298,24 @@ final class WebScrollObserverBucketTests: XCTestCase {
         XCTAssertEqual(observer.webScrollPanTouches(sv), "0")
     }
 
-    // MARK: possibleZeroTouchCountBucket / windowActiveNoTouchBucket
-    // These walk UIApplication.shared.connectedScenes, which returns nothing useful in the test host
-    // (no UIWindowScene is set up by XCTest). The raw count will always be 0 in this context, so we
-    // can still assert the "0" branch returns the right bucket string.
+    // MARK: count → bucket mapping (possibleZeroTouchCountBucket / windowActiveNoTouchBucket)
+    // The live scans behind these params walk UIApplication.shared.connectedScenes, whose recognizer
+    // state isn't controllable in a test host (the app host has real WebKit recognizers), so we test the
+    // pure count→bucket mapping directly rather than asserting a host-dependent live count.
 
-    func testPossibleZeroTouchCountBucket_returnsZeroInTestHost() {
-        let observer = WebScrollObserver(container: UIView(),
-                                         scrollView: { nil },
-                                         currentURL: { nil })
-        // In the test host there are no WK/private recognizers visible to the scanner; "0" must come back.
-        XCTAssertEqual(observer.possibleZeroTouchCountBucket(), "0")
+    func testCountBucket3PlusThresholds() {
+        XCTAssertEqual(WebScrollObserver.countBucket3Plus(0), "0")
+        XCTAssertEqual(WebScrollObserver.countBucket3Plus(1), "1")
+        XCTAssertEqual(WebScrollObserver.countBucket3Plus(2), "2")
+        XCTAssertEqual(WebScrollObserver.countBucket3Plus(3), "3_plus")
+        XCTAssertEqual(WebScrollObserver.countBucket3Plus(99), "3_plus")
     }
 
-    func testWindowActiveNoTouchBucket_returnsZeroInTestHost() {
-        let observer = WebScrollObserver(container: UIView(),
-                                         scrollView: { nil },
-                                         currentURL: { nil })
-        XCTAssertEqual(observer.windowActiveNoTouchBucket(), "0")
+    func testCountBucket2PlusThresholds() {
+        XCTAssertEqual(WebScrollObserver.countBucket2Plus(0), "0")
+        XCTAssertEqual(WebScrollObserver.countBucket2Plus(1), "1")
+        XCTAssertEqual(WebScrollObserver.countBucket2Plus(2), "2_plus")
+        XCTAssertEqual(WebScrollObserver.countBucket2Plus(5), "2_plus")
     }
 
     // MARK: static bucket(for:)

--- a/iOS/DuckDuckGoTests/WebScrollObserverTests.swift
+++ b/iOS/DuckDuckGoTests/WebScrollObserverTests.swift
@@ -493,15 +493,11 @@ final class RecoveryWordingTests: XCTestCase {
     }
 
     @MainActor
-    func testAutoRecoverResult_inTestHostReportsNoWebView() {
-        // In the test host there is no MainViewController, so autoRecover() returns the "no webView
-        // found" path — not a false success or a crash.
-        let result = WebScrollFreezeRecovery.autoRecover()
-        XCTAssertFalse(result.isEmpty)
-        XCTAssertFalse(result.contains("WAS the cause"),
-                       "autoRecover result must not make causal claim: \"\(result)\"")
-        XCTAssertFalse(result.contains("proven"),
-                       "autoRecover result must not use 'proven': \"\(result)\"")
+    func testAutoRecoverInTestHostReturnsFalse() {
+        // autoRecover() returns Bool — true only if it actually ran the scoped resets. In the test host
+        // there is no MainViewController, so it finds no web view and returns false (never a false success).
+        XCTAssertFalse(WebScrollFreezeRecovery.autoRecover(),
+                       "autoRecover must return false when there is no web view to recover.")
     }
 
     // Scoped recovery skips when a recognizer has touches:

--- a/iOS/DuckDuckGoTests/WebScrollObserverTests.swift
+++ b/iOS/DuckDuckGoTests/WebScrollObserverTests.swift
@@ -153,3 +153,363 @@ final class WebScrollObserverTests: XCTestCase {
         XCTAssertTrue(firedPixels.isEmpty, "Short or horizontal drags are not scroll attempts")
     }
 }
+
+// MARK: - Bucket helper tests
+
+/// Tests for the classification/bucket helpers that are `internal` (visible via `@testable import`).
+@MainActor
+final class WebScrollObserverBucketTests: XCTestCase {
+
+    // MARK: attemptBucket
+
+    func testAttemptBucket_threeReturnsThree() {
+        let container = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 600))
+        let scrollView = UIScrollView()
+        let observer = WebScrollObserver(container: container,
+                                         scrollView: { scrollView },
+                                         currentURL: { nil })
+        XCTAssertEqual(observer.attemptBucket(3), "3")
+    }
+
+    func testAttemptBucket_belowThresholdAlsoReturnsThree() {
+        let container = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 600))
+        let observer = WebScrollObserver(container: container,
+                                         scrollView: { nil },
+                                         currentURL: { nil })
+        // The method uses `..<4` — values 1, 2, 3 all map to "3".
+        XCTAssertEqual(observer.attemptBucket(1), "3")
+        XCTAssertEqual(observer.attemptBucket(2), "3")
+    }
+
+    func testAttemptBucket_fourAndFiveReturnFourFive() {
+        let observer = WebScrollObserver(container: UIView(),
+                                         scrollView: { nil },
+                                         currentURL: { nil })
+        XCTAssertEqual(observer.attemptBucket(4), "4_5")
+        XCTAssertEqual(observer.attemptBucket(5), "4_5")
+    }
+
+    func testAttemptBucket_sixAndAboveReturnSixPlus() {
+        let observer = WebScrollObserver(container: UIView(),
+                                         scrollView: { nil },
+                                         currentURL: { nil })
+        XCTAssertEqual(observer.attemptBucket(6), "6_plus")
+        XCTAssertEqual(observer.attemptBucket(100), "6_plus")
+    }
+
+    // MARK: screenRegion(forY:)
+
+    func testScreenRegion_topThirdIsRegionZero() {
+        // Container height 600 → thirds at [0,200), [200,400), [400,600].
+        let container = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 600))
+        let observer = WebScrollObserver(container: container,
+                                         scrollView: { nil },
+                                         currentURL: { nil })
+        XCTAssertEqual(observer.screenRegion(forY: 0), 0)
+        XCTAssertEqual(observer.screenRegion(forY: 100), 0)
+        XCTAssertEqual(observer.screenRegion(forY: 199), 0)
+    }
+
+    func testScreenRegion_middleThirdIsRegionOne() {
+        let container = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 600))
+        let observer = WebScrollObserver(container: container,
+                                         scrollView: { nil },
+                                         currentURL: { nil })
+        XCTAssertEqual(observer.screenRegion(forY: 200), 1)
+        XCTAssertEqual(observer.screenRegion(forY: 300), 1)
+        XCTAssertEqual(observer.screenRegion(forY: 399), 1)
+    }
+
+    func testScreenRegion_bottomThirdIsRegionTwo() {
+        let container = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 600))
+        let observer = WebScrollObserver(container: container,
+                                         scrollView: { nil },
+                                         currentURL: { nil })
+        XCTAssertEqual(observer.screenRegion(forY: 400), 2)
+        XCTAssertEqual(observer.screenRegion(forY: 500), 2)
+        XCTAssertEqual(observer.screenRegion(forY: 600), 2)
+    }
+
+    func testScreenRegion_clampsBelowZero() {
+        let container = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 600))
+        let observer = WebScrollObserver(container: container,
+                                         scrollView: { nil },
+                                         currentURL: { nil })
+        // Negative Y is possible on a rubber-band bounce — must not produce a region below 0.
+        XCTAssertEqual(observer.screenRegion(forY: -50), 0)
+    }
+
+    func testScreenRegion_clampsAboveTwo() {
+        let container = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 600))
+        let observer = WebScrollObserver(container: container,
+                                         scrollView: { nil },
+                                         currentURL: { nil })
+        XCTAssertEqual(observer.screenRegion(forY: 1000), 2)
+    }
+
+    // MARK: webScrollPanState
+
+    func testWebScrollPanState_nilScrollViewReturnsNone() {
+        let observer = WebScrollObserver(container: UIView(),
+                                         scrollView: { nil },
+                                         currentURL: { nil })
+        XCTAssertEqual(observer.webScrollPanState(nil), "none")
+    }
+
+    func testWebScrollPanState_freshScrollViewReturnsPossible() {
+        let sv = UIScrollView()
+        let observer = WebScrollObserver(container: UIView(),
+                                         scrollView: { sv },
+                                         currentURL: { nil })
+        // A freshly-created UIScrollView's pan recognizer starts in .possible.
+        XCTAssertEqual(observer.webScrollPanState(sv), "possible")
+    }
+
+    // MARK: webScrollPanTouches
+
+    func testWebScrollPanTouches_nilScrollViewReturnsZero() {
+        let observer = WebScrollObserver(container: UIView(),
+                                         scrollView: { nil },
+                                         currentURL: { nil })
+        XCTAssertEqual(observer.webScrollPanTouches(nil), "0")
+    }
+
+    func testWebScrollPanTouches_idleScrollViewReturnsZero() {
+        let sv = UIScrollView()
+        let observer = WebScrollObserver(container: UIView(),
+                                         scrollView: { sv },
+                                         currentURL: { nil })
+        // A pan recognizer with no active touches reports numberOfTouches == 0.
+        XCTAssertEqual(observer.webScrollPanTouches(sv), "0")
+    }
+
+    // MARK: possibleZeroTouchCountBucket / windowActiveNoTouchBucket
+    // These walk UIApplication.shared.connectedScenes, which returns nothing useful in the test host
+    // (no UIWindowScene is set up by XCTest). The raw count will always be 0 in this context, so we
+    // can still assert the "0" branch returns the right bucket string.
+
+    func testPossibleZeroTouchCountBucket_returnsZeroInTestHost() {
+        let observer = WebScrollObserver(container: UIView(),
+                                         scrollView: { nil },
+                                         currentURL: { nil })
+        // In the test host there are no WK/private recognizers visible to the scanner; "0" must come back.
+        XCTAssertEqual(observer.possibleZeroTouchCountBucket(), "0")
+    }
+
+    func testWindowActiveNoTouchBucket_returnsZeroInTestHost() {
+        let observer = WebScrollObserver(container: UIView(),
+                                         scrollView: { nil },
+                                         currentURL: { nil })
+        XCTAssertEqual(observer.windowActiveNoTouchBucket(), "0")
+    }
+
+    // MARK: static bucket(for:)
+
+    func testBucket_tapRecognizerReturnsTap() {
+        let tap = UITapGestureRecognizer()
+        XCTAssertEqual(WebScrollObserver.bucket(for: tap), "tap")
+    }
+
+    func testBucket_longPressReturnsLongPress() {
+        let lp = UILongPressGestureRecognizer()
+        XCTAssertEqual(WebScrollObserver.bucket(for: lp), "long_press")
+    }
+
+    func testBucket_screenEdgePanReturnsEdgePan() {
+        let edge = UIScreenEdgePanGestureRecognizer()
+        XCTAssertEqual(WebScrollObserver.bucket(for: edge), "edge_pan")
+    }
+
+    func testBucket_scrollViewOwnPanReturnsWebScrollPan() {
+        let sv = UIScrollView()
+        XCTAssertEqual(WebScrollObserver.bucket(for: sv.panGestureRecognizer), "web_scroll_pan")
+    }
+
+    func testBucket_plainPanReturnsOtherPan() {
+        let pan = UIPanGestureRecognizer()
+        XCTAssertEqual(WebScrollObserver.bucket(for: pan), "other_pan")
+    }
+
+    func testBucket_unknownRecognizerReturnsOther() {
+        // A bare UIGestureRecognizer is not a pan, tap, long-press, or edge-pan — falls through to "other".
+        let r = UIGestureRecognizer()
+        XCTAssertEqual(WebScrollObserver.bucket(for: r), "other")
+    }
+}
+
+// MARK: - Deferring-gate collection tests
+
+/// Tests for `WebScrollFreezeProbe.deferringGates(in:)`.
+/// The filter is purely by runtime class name — any recognizer whose type name contains "Deferring"
+/// is collected; all others are skipped. We use a custom subclass name that satisfies that check
+/// without requiring any private WebKit types.
+@MainActor
+final class DeferringGateCollectionTests: XCTestCase {
+
+    /// A `UIGestureRecognizer` whose type name contains "Deferring", simulating a
+    /// `WKDeferringGestureRecognizer` without using private API.
+    private final class SimulatedDeferringGestureRecognizer: UIGestureRecognizer {}
+
+    func testDeferringGates_findsSubclassWhoseNameContainsDeferring() {
+        let view = UIView()
+        let deferring = SimulatedDeferringGestureRecognizer()
+        let plain = UITapGestureRecognizer()
+        view.addGestureRecognizer(deferring)
+        view.addGestureRecognizer(plain)
+
+        let gates = WebScrollFreezeProbe.deferringGates(in: view)
+
+        XCTAssertEqual(gates.count, 1)
+        XCTAssertTrue(gates.first === deferring)
+    }
+
+    func testDeferringGates_ignoresRecognizersThatDoNotContainDeferring() {
+        let view = UIView()
+        view.addGestureRecognizer(UITapGestureRecognizer())
+        view.addGestureRecognizer(UIPanGestureRecognizer())
+        view.addGestureRecognizer(UILongPressGestureRecognizer())
+
+        let gates = WebScrollFreezeProbe.deferringGates(in: view)
+
+        XCTAssertTrue(gates.isEmpty)
+    }
+
+    func testDeferringGates_descendsIntoSubviews() {
+        let root = UIView()
+        let child = UIView()
+        root.addSubview(child)
+        let grandchild = UIView()
+        child.addSubview(grandchild)
+
+        // Only the grandchild has the deferring recognizer.
+        let deferring = SimulatedDeferringGestureRecognizer()
+        grandchild.addGestureRecognizer(deferring)
+
+        let gates = WebScrollFreezeProbe.deferringGates(in: root)
+
+        XCTAssertEqual(gates.count, 1)
+        XCTAssertTrue(gates.first === deferring)
+    }
+
+    func testDeferringGates_emptyViewTreeReturnsEmptyArray() {
+        let view = UIView()
+        XCTAssertTrue(WebScrollFreezeProbe.deferringGates(in: view).isEmpty)
+    }
+
+    func testDeferringGates_collectsMultipleDeferringRecognizersAcrossTree() {
+        let root = UIView()
+        let child = UIView()
+        root.addSubview(child)
+
+        let d1 = SimulatedDeferringGestureRecognizer()
+        let d2 = SimulatedDeferringGestureRecognizer()
+        root.addGestureRecognizer(d1)
+        child.addGestureRecognizer(d2)
+
+        let gates = WebScrollFreezeProbe.deferringGates(in: root)
+
+        XCTAssertEqual(gates.count, 2)
+        XCTAssertTrue(gates.contains { $0 === d1 })
+        XCTAssertTrue(gates.contains { $0 === d2 })
+    }
+}
+
+// MARK: - Non-scrollable probe tests
+
+/// Tests for the "not scrollable" guard in `InteractionDiagnosticsModel.probeProgrammaticScroll`.
+///
+/// `probeProgrammaticScroll` calls `WebScrollFreezeProbe.findMainViewController()` to locate the
+/// web scroll view. That method walks `UIApplication.shared.connectedScenes` looking for a
+/// `MainViewController`, which does not exist in the XCTest host process. The method therefore
+/// returns `nil` and sets `actionResult = "Scroll probe: no web scroll view found"` — the scroll
+/// view is never reached, so the ≤64pt guard cannot be exercised through the public API without a
+/// full app fixture.
+///
+/// The logic under test (the guard: `maxY - minY > 64`) is a two-liner inside
+/// `probeProgrammaticScroll` that is not extracted into a separately-testable helper; exercising it
+/// requires a live `MainViewController` → `TabViewController` → `WKWebView` chain. That chain is not
+/// set up by the test host, so the guard is not unit-testable without an integration fixture.
+final class ProbeProgrammaticScrollTests: XCTestCase {
+
+    @MainActor
+    func testProbeProgrammaticScroll_noWebViewFoundMessage() {
+        // In the test host there is no MainViewController, so the probe reports "no web scroll view found"
+        // rather than running the scrollability check. This test confirms the "no view" path returns a
+        // sensible message that does NOT contain "DID NOT MOVE" (which would be a false failure signal).
+        let model = InteractionDiagnosticsModel()
+        model.probeProgrammaticScroll()
+        XCTAssertFalse(model.actionResult.isEmpty)
+        XCTAssertFalse(model.actionResult.contains("DID NOT MOVE"),
+                       "The 'no scroll view' path must not emit the failure message")
+    }
+}
+
+// MARK: - Recovery wording / hypothesis-language tests
+
+/// Asserts that the static result strings emitted by `WebScrollFreezeRecovery` use suspect/hypothesis
+/// wording and do NOT make definitive causal claims.
+final class RecoveryWordingTests: XCTestCase {
+
+    /// Known result strings — collected from the source rather than running them, because running
+    /// `runRung` needs a live `MainViewController` (it calls `WebScrollFreezeProbe.findMainViewController()`).
+    /// Each string is verified here in its source form rather than at runtime.
+    func testRecoveryStrings_doNotContainWasTheCause() {
+        // These are the strings the code actually returns; grep them for banned wording.
+        let recoveryStrings = [
+            // From resetDeferringGates / resetScrollPan when no touch is in flight:
+            "reset deferring gate(s); pre/post captures saved — compare them",
+            "reset web scroll pan; pre/post captures saved — compare them",
+            // From autoRecover:
+            "auto-recover: applied scroll-pan + deferring-gate resets; pre/post captures saved — compare them",
+            // From resetDeferringGates / resetScrollPan when a touch is in flight:
+            "skipped — touch in flight (would orphan it)",
+            "skipped — touch in flight",
+            // From no-webView paths:
+            "deferring-gate reset: no webView found",
+            "scroll-pan reset: no webView found",
+            "auto-recover: no webView found",
+        ]
+
+        for s in recoveryStrings {
+            XCTAssertFalse(s.contains("WAS the cause"),
+                           "Recovery message must not make definitive causal claim: \"\(s)\"")
+            XCTAssertFalse(s.contains("proven"),
+                           "Recovery message must not use 'proven': \"\(s)\"")
+        }
+    }
+
+    func testRecoveryStrings_compareThemPhraseSignalsHypothesisWording() {
+        // The canonical hypothesis-language pattern is "compare them" — that phrase means
+        // "look at the evidence, draw your own conclusion", which is the intended signal.
+        let comparingStrings = [
+            "reset deferring gate(s); pre/post captures saved — compare them",
+            "reset web scroll pan; pre/post captures saved — compare them",
+            "auto-recover: applied scroll-pan + deferring-gate resets; pre/post captures saved — compare them",
+        ]
+        for s in comparingStrings {
+            XCTAssertTrue(s.contains("compare them"),
+                          "Recovery message that runs a reset should direct user to compare captures: \"\(s)\"")
+        }
+    }
+
+    @MainActor
+    func testAutoRecoverResult_inTestHostReportsNoWebView() {
+        // In the test host there is no MainViewController, so autoRecover() returns the "no webView
+        // found" path — not a false success or a crash.
+        let result = WebScrollFreezeRecovery.autoRecover()
+        XCTAssertFalse(result.isEmpty)
+        XCTAssertFalse(result.contains("WAS the cause"),
+                       "autoRecover result must not make causal claim: \"\(result)\"")
+        XCTAssertFalse(result.contains("proven"),
+                       "autoRecover result must not use 'proven': \"\(result)\"")
+    }
+
+    // Scoped recovery skips when a recognizer has touches:
+    //
+    // `WebScrollFreezeRecovery.anyTouchInFlight()` iterates `UIApplication.shared.connectedScenes`
+    // exactly like the deferring-gate scanner. There is no public API to inject an artificial touch
+    // count into a recognizer (numberOfTouches is read-only and backed by UIKit internal state), and
+    // the scene/window hierarchy that `anyTouchInFlight` walks is not set up in the test host.
+    // Verifying the "touch in flight → skip" guard therefore requires a live app window with a real
+    // UITouch in-flight — it is not unit-testable without an integration fixture.
+}

--- a/iOS/DuckDuckGoTests/WebScrollObserverTests.swift
+++ b/iOS/DuckDuckGoTests/WebScrollObserverTests.swift
@@ -450,54 +450,28 @@ final class ProbeProgrammaticScrollTests: XCTestCase {
 /// wording and do NOT make definitive causal claims.
 final class RecoveryWordingTests: XCTestCase {
 
-    /// Known result strings — collected from the source rather than running them, because running
-    /// `runRung` needs a live `MainViewController` (it calls `WebScrollFreezeProbe.findMainViewController()`).
-    /// Each string is verified here in its source form rather than at runtime.
-    func testRecoveryStrings_doNotContainWasTheCause() {
-        // These are the strings the code actually returns; grep them for banned wording.
-        let recoveryStrings = [
-            // From resetDeferringGates / resetScrollPan when no touch is in flight:
-            "reset deferring gate(s); pre/post captures saved — compare them",
-            "reset web scroll pan; pre/post captures saved — compare them",
-            // From autoRecover:
-            "auto-recover: applied scroll-pan + deferring-gate resets; pre/post captures saved — compare them",
-            // From resetDeferringGates / resetScrollPan when a touch is in flight:
-            "skipped — touch in flight (would orphan it)",
-            "skipped — touch in flight",
-            // From no-webView paths:
-            "deferring-gate reset: no webView found",
-            "scroll-pan reset: no webView found",
-            "auto-recover: no webView found",
-        ]
-
-        for s in recoveryStrings {
-            XCTAssertFalse(s.contains("WAS the cause"),
-                           "Recovery message must not make definitive causal claim: \"\(s)\"")
-            XCTAssertFalse(s.contains("proven"),
-                           "Recovery message must not use 'proven': \"\(s)\"")
-        }
-    }
-
-    func testRecoveryStrings_compareThemPhraseSignalsHypothesisWording() {
-        // The canonical hypothesis-language pattern is "compare them" — that phrase means
-        // "look at the evidence, draw your own conclusion", which is the intended signal.
-        let comparingStrings = [
-            "reset deferring gate(s); pre/post captures saved — compare them",
-            "reset web scroll pan; pre/post captures saved — compare them",
-            "auto-recover: applied scroll-pan + deferring-gate resets; pre/post captures saved — compare them",
-        ]
-        for s in comparingStrings {
-            XCTAssertTrue(s.contains("compare them"),
-                          "Recovery message that runs a reset should direct user to compare captures: \"\(s)\"")
-        }
-    }
-
+    /// Recovery result strings must never claim a proven cause. Exercises the LIVE return values — in the
+    /// test host there is no MainViewController, so each rung returns its non-causal "no web view" status.
     @MainActor
-    func testAutoRecoverInTestHostReturnsFalse() {
-        // autoRecover() returns Bool — true only if it actually ran the scoped resets. In the test host
-        // there is no MainViewController, so it finds no web view and returns false (never a false success).
-        XCTAssertFalse(WebScrollFreezeRecovery.autoRecover(),
-                       "autoRecover must return false when there is no web view to recover.")
+    func testRecoveryResultStringsMakeNoCausalClaim() {
+        let results = [
+            WebScrollFreezeRecovery.runRung(.resetScrollPan),
+            WebScrollFreezeRecovery.runRung(.resetDeferringGates)
+        ]
+        for result in results {
+            XCTAssertFalse(result.contains("WAS the cause"),
+                           "Recovery result must not claim a proven cause: \"\(result)\"")
+            XCTAssertFalse(result.contains("proven"),
+                           "Recovery result must not use 'proven': \"\(result)\"")
+        }
+    }
+
+    /// autoRecover returns Bool — true only if it actually ran the scoped resets. With no scroll view it
+    /// returns false (never a false success), which is also what happens in the test host.
+    @MainActor
+    func testAutoRecoverWithNoScrollViewReturnsFalse() {
+        XCTAssertFalse(WebScrollFreezeRecovery.autoRecover(scrollView: nil),
+                       "autoRecover must return false when there is no scroll view to recover.")
     }
 
     // Scoped recovery skips when a recognizer has touches:

--- a/iOS/DuckDuckGoTests/WebScrollObserverTests.swift
+++ b/iOS/DuckDuckGoTests/WebScrollObserverTests.swift
@@ -152,6 +152,21 @@ final class WebScrollObserverTests: XCTestCase {
 
         XCTAssertTrue(firedPixels.isEmpty, "Short or horizontal drags are not scroll attempts")
     }
+
+    func testNormalScrollsNeverFirePixel() {
+        let observer = makeObserver()
+
+        // 20 successful scrolls across all three screen regions — content moves each time.
+        for i in 0..<20 {
+            let startY: CGFloat = 100
+            scrollView.contentOffset = CGPoint(x: 0, y: startY + 100)
+            let screenY = CGFloat([100, 300, 500][i % 3])
+            observer.classifyDrag(dx: 0, dy: -100, startOffsetY: startY, startScreenY: screenY)
+        }
+
+        XCTAssertTrue(firedPixels.isEmpty,
+                      "m_debug_interaction_repeated_failed_scroll must not fire for successful scrolls")
+    }
 }
 
 // MARK: - Bucket helper tests
@@ -412,6 +427,7 @@ final class DeferringGateCollectionTests: XCTestCase {
         XCTAssertTrue(gates.contains { $0 === d1 })
         XCTAssertTrue(gates.contains { $0 === d2 })
     }
+
 }
 
 // MARK: - Non-scrollable probe tests

--- a/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
@@ -152,9 +152,7 @@
         "owners": ["aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
-        "parameters": [
-            "appVersion"
-        ],
+        "parameters": ["appVersion"],
         "expires": "2026-09-21"
     },
     "m_debug_interaction_recovery_outcome": {

--- a/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
@@ -97,6 +97,36 @@
                 "key": "mechanism",
                 "description": "Gesture-environment state at the moment the freeze is confirmed. 'wedged:<type>' means a recognizer is stuck active with no touches (e.g. wedged:swipe_tabs); 'none_wedged' means no stuck recognizer was found, consistent with the phantom-touch hypothesis.",
                 "type": "string"
+            },
+            {
+                "key": "web_scroll_pan_state",
+                "description": "State of the web scroll view's pan recognizer at the freeze instant.",
+                "type": "string",
+                "enum": ["possible", "began", "changed", "ended", "cancelled", "failed", "none"]
+            },
+            {
+                "key": "web_scroll_pan_touches",
+                "description": "Touches on the web scroll pan at the freeze instant.",
+                "type": "string",
+                "enum": ["0", "1", "2_plus"]
+            },
+            {
+                "key": "wk_deferring_count_bucket",
+                "description": "Count of WKWebView deferring gates found.",
+                "type": "string",
+                "enum": ["0", "1", "2", "3_plus"]
+            },
+            {
+                "key": "wk_possible_zero_touch_count_bucket",
+                "description": "WebKit/private recognizers in .possible with 0 touches (gate suspects).",
+                "type": "string",
+                "enum": ["0", "1", "2", "3_plus"]
+            },
+            {
+                "key": "window_active_no_touch_bucket",
+                "description": "Recognizers active (began/changed) with 0 touches, window-wide.",
+                "type": "string",
+                "enum": ["0", "1", "2_plus"]
             }
         ],
         "expires": "2026-09-21"

--- a/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/debug_pixels.json5
@@ -146,5 +146,31 @@
             }
         ],
         "expires": "2026-09-21"
+    },
+    "m_debug_interaction_recovery_attempted": {
+        "description": "Scoped auto-recovery attempted after a confirmed scroll freeze (gated by webScrollFreezeAutoRecovery, internal/off by default). Fires immediately before the recovery sequence runs.",
+        "owners": ["aataraxiaa"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion"
+        ],
+        "expires": "2026-09-21"
+    },
+    "m_debug_interaction_recovery_outcome": {
+        "description": "Outcome on the next scroll event after an auto-recovery attempt. Emitted only when a prior recovery was attempted.",
+        "owners": ["aataraxiaa"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "outcome",
+                "description": "Whether the scroll recovered after the auto-recovery attempt.",
+                "type": "string",
+                "enum": ["recovered", "still_frozen"]
+            }
+        ],
+        "expires": "2026-09-21"
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215895676655234

### Description

Diagnostics for the hard-to-reproduce iOS scroll freeze (*page visible, taps work, vertical scroll dead until force-quit*). Follows #5491. This is not a proven fix — observability first.

**What ships to production (all users):**
- Five bucketed, no-class-name params added to the existing `m_debug_interaction_repeated_failed_scroll` pixel: `web_scroll_pan_state`, `web_scroll_pan_touches`, `wk_deferring_count_bucket`, `wk_possible_zero_touch_count_bucket`, `window_active_no_touch_bucket`. Fires only on a confirmed freeze (3+ non-moving scrolls across 2+ screen regions). No change to normal scrolling behaviour. ⚠️ **Privacy triage required** before relying on these params.

**What ships internal only (both flags `.internalOnly`/off):**
- `webScrollFreezeCapture` (existing): WKWebView subtree dump, window-wide scroll view + recognizer scan, active-touch probe (orphaned-touch signal), transition log (last ~20 tab switches / UTI events), ring-buffer file export.
- `webScrollFreezeAutoRecovery` (new, [Asana](https://app.asana.com/1/137249556945/project/1206488453854252/task/1214241865640178)): on a confirmed freeze with no touch in flight, runs once — reset web scroll pan + reset WK deferring gates — with pre/post captures. Fires `m_debug_interaction_recovery_attempted` and `m_debug_interaction_recovery_outcome` (`recovered`/`still_frozen`). No broad recovery; no window-interaction toggles (those bricked taps).

**Debug menu** (internal/debug-gated): capture + scrollability probe + two scoped manual recovery controls + a single **stuck-gesture provocation** used to confirm the freeze pixel fires end-to-end (see testing step 3). The broad recovery rungs and the destructive (reparent / force-flush) provocations stay removed.

### Testing Steps

1. **Normal scrolling unaffected.** Scroll a long page up and down repeatedly. Confirm scrolling works and the app behaves normally. (The freeze pixel requires 3+ consecutive non-moving vertical scrolls across 2+ screen regions — it must not fire during normal use.)

2. **Production pixels do NOT fire during normal use.** Run the app from Xcode on a simulator/device (or attach **Console.app** to the device). In the log, filter for `Pixel fired` (subsystem `pixels`) — every pixel fire logs `Pixel fired <name> <params>`. Now use the app normally for a minute: scroll long pages up/down many times, switch and swipe tabs, open Settings and scroll it, navigate between pages. **PASS = none of these appear in the log:**
   - `interaction_repeated_failed_scroll`
   - `interaction_recovery_attempted`
   - `interaction_recovery_outcome`

   This is the do-no-harm guarantee for the production change: nothing fires unless a real freeze is detected. (Automated coverage: `WebScrollObserverTests` — `testThreeFailedDragsAcrossTwoRegionsFiresSymptomPixel`, `testNormalScrollsNeverFirePixel`, `testFailedDragsInOneRegionDoNotFire`, `testSuccessfulDragResetsTheStreak`, `testNonWebPagesAreIgnored`, plus the `countBucket*` threshold tests.)

3. **Production pixel DOES fire on a freeze (debug/internal build) — via the stuck-gesture provocation.** Settings → Debug → Interaction Diagnostics → **Inject stuck gesture (freezes scroll)**. Leave the screen, then drag a long web page a few times across different parts of the screen — scroll stays dead, taps stay alive. After 3 failed drags across 2+ screen regions, confirm `interaction_repeated_failed_scroll` fires in the `Pixel fired` log (mechanism `wedged:*`). Tap **Clear stuck gesture** (or force-quit) to recover.
   - The provocation only *creates* the freeze and runs no recovery, so it can't brick taps.
   - It produces `wedged:*`; the real field bug is `none_wedged` — so this confirms the pixel + bucketed params are well-formed, not the root cause.
   - With `webScrollFreezeAutoRecovery` flipped on, the same provocation also exercises `interaction_recovery_attempted` and `interaction_recovery_outcome` (`still_frozen`, since the injected recognizer isn't a scroll pan / deferring gate).

4. **Capture works (internal build, `webScrollFreezeCapture` on).** Settings → Debug → Interaction Diagnostics → Capture Snapshot. Confirm the output includes the sections: **Active touches**, **Recent transitions**, **WKWebView subtree recognizers**, **All scroll views (window-wide)**, **Window-wide recognizer suspects**.

5. **Recent transitions reflect navigation (internal build).** Switch tabs or swipe between tabs, then capture. Confirm the **Recent transitions** section lists recent tab-switch and UTI events.

### Notes
- Root cause unproven: orphaned touch vs stuck WKDeferringGestureRecognizer vs other. Capture built to discriminate, not assert.
- Auto-recovery cannot be validated without a reproducible freeze. The `recovery_outcome` pixel is the field test.
- **New external pixel params → privacy triage needed.**

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches main-thread gesture/recognizer state on the web tab path and adds production pixel params (privacy triage noted); auto-recovery is internal-only and touch-guarded but could still affect scroll if mis-enabled remotely.
> 
> **Overview**
> Extends iOS **web scroll freeze** work with more field signal and internal tooling—not a claimed fix.
> 
> **Production (when a freeze is already confirmed):** `m_debug_interaction_repeated_failed_scroll` gains five bucketed params (`web_scroll_pan_state`, `web_scroll_pan_touches`, `wk_deferring_count_bucket`, `wk_possible_zero_touch_count_bucket`, `window_active_no_touch_bucket`). Normal scrolling behavior is unchanged.
> 
> **Internal-only (`webScrollFreezeCapture`):** Renames probe/capture types to `WebScrollFreezeDebug*`, expands snapshots (WKWebView subtree recognizers, window-wide scroll views and recognizer suspects, active-touch probe, ~20-entry transition log on tab/UTI/swipe paths), and improves ring-buffer filenames for pre/post recovery diffs.
> 
> **Internal-only (`webScrollFreezeAutoRecovery`, new):** After a confirmed freeze with no touch in flight, `WebScrollObserver` may run once—reset web scroll pan + WK deferring gates with pre/post captures—and fire `m_debug_interaction_recovery_attempted` / `m_debug_interaction_recovery_outcome`. Broad recovery (window interaction toggles, flush-all) is removed in favor of touch-guarded scoped resets.
> 
> **Debug UI:** Interaction Diagnostics drops the old recovery ladder and destructive provocations; keeps capture, programmatic scroll probe, two manual scoped resets, and a stuck-gesture provocation for pixel validation.
> 
> **Tests:** Substantial `WebScrollObserver` bucket/region tests, deferring-gate collection tests, and recovery wording guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e99985a02b1f267e978c4860cd03694c4f8eaf35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->