### PR TITLE
Remove retry tracking params from PixelKit retry queue

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/RetryQueue/PixelRetryQueue.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/RetryQueue/PixelRetryQueue.swift
@@ -190,8 +190,13 @@ final class PixelRetryQueue {
                 continue
             }
 
+            // Strip the legacy retry timestamp that older builds baked into the persisted parameters, so
+            // items queued before this key was dropped don't keep sending it on replay.
+            // For more info see https://app.asana.com/1/137249556945/task/1215909080171360?focus=true
+            let parameters = item.parameters.filter { $0.key != "originalPixelTimestamp" }
+
             dispatchGroup.enter()
-            underlyingFireRequest(item.pixelName, item.headers, item.parameters, item.allowedQueryReservedCharacters, false) { success, _ in
+            underlyingFireRequest(item.pixelName, item.headers, parameters, item.allowedQueryReservedCharacters, false) { success, _ in
                 if success {
                     idsAccessQueue.sync { _ = idsToRemove.insert(item.id) }
                 }

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/RetryQueue/PixelRetryQueue.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/RetryQueue/PixelRetryQueue.swift
@@ -44,12 +44,6 @@ final class PixelRetryQueue {
 #endif
     }
 
-    /// Wire parameter keys, matching iOS so the backend sees identical data.
-    enum Parameters {
-        static let originalPixelTimestamp = "originalPixelTimestamp"
-        static let retriedPixel = "retriedPixel"
-    }
-
     private let underlyingFireRequest: PixelKit.FireRequest
     private let store: PixelRetryQueueStoring
     private let lastProcessingDateStorage: ThrowingKeyValueStoring
@@ -65,12 +59,6 @@ final class PixelRetryQueue {
 
     private let workQueue = DispatchQueue(label: "PixelKit Retry Queue")
     private let logger = Logger(subsystem: "PixelKit", category: "PixelRetryQueue")
-
-    private let dateFormatter: ISO8601DateFormatter = {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime]
-        return formatter
-    }()
 
     init(fireRequest: @escaping PixelKit.FireRequest,
          store: PixelRetryQueueStoring = PixelRetryQueueFileStore(),
@@ -113,8 +101,6 @@ final class PixelRetryQueue {
                                     parameters: [String: String],
                                     allowedQueryReservedCharacters: CharacterSet?) {
         let now = dateGenerator()
-        var parameters = parameters
-        parameters[Parameters.originalPixelTimestamp] = dateFormatter.string(from: now)
 
         let item = PixelRetryQueueItem(pixelName: pixelName,
                                        headers: headers,
@@ -204,11 +190,8 @@ final class PixelRetryQueue {
                 continue
             }
 
-            var parameters = item.parameters
-            parameters[Parameters.retriedPixel] = "1"
-
             dispatchGroup.enter()
-            underlyingFireRequest(item.pixelName, item.headers, parameters, item.allowedQueryReservedCharacters, false) { success, _ in
+            underlyingFireRequest(item.pixelName, item.headers, item.parameters, item.allowedQueryReservedCharacters, false) { success, _ in
                 if success {
                     idsAccessQueue.sync { _ = idsToRemove.insert(item.id) }
                 }

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/RetryQueue/PixelRetryQueueTestDoubles.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/RetryQueue/PixelRetryQueueTestDoubles.swift
@@ -57,34 +57,28 @@ final class MockPixelRetryQueueStore: PixelRetryQueueStoring {
     }
 }
 
-/// Controllable `PixelKit.FireRequest`. Distinguishes organic fires from retries by whether the fired
-/// pixel is a replay of an item still in the queue store (replays fire while their item is queued; it's
-/// removed only once the send completes). Retries can be held (deferred) to drive concurrency tests,
-/// mirroring iOS `DelayedPixelFiringMock`.
+/// Controllable `PixelKit.FireRequest`, modelling the network sender that `PixelRetryQueue` decorates.
+/// Like the real sender it is retry-agnostic: it records every fire and returns `defaultResult`, with no
+/// notion of organic-vs-replay. Tests drive scenarios through the pixel identities they control — naming
+/// the pixels they enqueue and asserting on calls by name. Named fires can be held (deferred) via
+/// `deferredPixelNames` to drive concurrency tests, mirroring iOS `DelayedPixelFiringMock`.
 final class FireRequestMock {
-
-    /// The store the decorated `PixelRetryQueue` drains from. A fire whose pixel name matches a queued
-    /// item is treated as a retry. Set this to the same store passed to the queue under test.
-    weak var retryQueueStore: MockPixelRetryQueueStore?
 
     struct Call {
         let pixelName: String
         let headers: [String: String]
         let parameters: [String: String]
         let allowedQueryReservedCharacters: CharacterSet?
-        let isRetry: Bool
     }
 
     private let lock = NSLock()
     private var _calls: [Call] = []
-    private var pendingRetryCompletions: [PixelKit.CompletionBlock] = []
+    private var pendingCompletions: [PixelKit.CompletionBlock] = []
 
-    /// Result returned for organic (non-retry) fires.
-    var organicResult: (success: Bool, error: Error?) = (true, nil)
-    /// Result returned for retry fires when `deferRetries` is false.
-    var retryResult: (success: Bool, error: Error?) = (true, nil)
-    /// When true, retry fires' completions are held until `completePendingRetries` is called.
-    var deferRetries = false
+    /// Result returned for every fire that isn't held by `deferredPixelNames`.
+    var defaultResult: (success: Bool, error: Error?) = (true, nil)
+    /// Fires for these pixel names have their completions held until `completePendingFires` is called.
+    var deferredPixelNames: Set<String> = []
 
     /// Invoked (synchronously, on the firing thread) after each call is recorded.
     var onFireReceived: ((Call) -> Void)?
@@ -94,42 +88,30 @@ final class FireRequestMock {
         return _calls
     }
 
-    var pendingRetryCount: Int {
-        lock.lock(); defer { lock.unlock() }
-        return pendingRetryCompletions.count
-    }
-
     var fireRequest: PixelKit.FireRequest {
         { [self] pixelName, headers, parameters, allowedChars, _, onComplete in
-            let isRetry = retryQueueStore?.items.contains { $0.pixelName == pixelName } ?? false
             let call = Call(pixelName: pixelName,
                             headers: headers,
                             parameters: parameters,
-                            allowedQueryReservedCharacters: allowedChars,
-                            isRetry: isRetry)
+                            allowedQueryReservedCharacters: allowedChars)
             lock.lock()
             _calls.append(call)
-            let shouldDefer = isRetry && deferRetries
-            if shouldDefer { pendingRetryCompletions.append(onComplete) }
-            let organic = organicResult
-            let retry = retryResult
+            let shouldDefer = deferredPixelNames.contains(pixelName)
+            if shouldDefer { pendingCompletions.append(onComplete) }
+            let result = defaultResult
             lock.unlock()
 
             onFireReceived?(call)
 
             if shouldDefer { return }
-            if isRetry {
-                onComplete(retry.success, retry.error)
-            } else {
-                onComplete(organic.success, organic.error)
-            }
+            onComplete(result.success, result.error)
         }
     }
 
-    func completePendingRetries(success: Bool, error: Error? = nil) {
+    func completePendingFires(success: Bool, error: Error? = nil) {
         lock.lock()
-        let completions = pendingRetryCompletions
-        pendingRetryCompletions.removeAll()
+        let completions = pendingCompletions
+        pendingCompletions.removeAll()
         lock.unlock()
         completions.forEach { $0(success, error) }
     }

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/RetryQueue/PixelRetryQueueTestDoubles.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/RetryQueue/PixelRetryQueueTestDoubles.swift
@@ -57,10 +57,15 @@ final class MockPixelRetryQueueStore: PixelRetryQueueStoring {
     }
 }
 
-/// Controllable `PixelKit.FireRequest`. Distinguishes organic fires from retries by the `retriedPixel`
-/// parameter that `PixelRetryQueue` adds on replay. Retries can be held (deferred) to drive concurrency
-/// tests, mirroring iOS `DelayedPixelFiringMock`.
+/// Controllable `PixelKit.FireRequest`. Distinguishes organic fires from retries by whether the fired
+/// pixel is a replay of an item still in the queue store (replays fire while their item is queued; it's
+/// removed only once the send completes). Retries can be held (deferred) to drive concurrency tests,
+/// mirroring iOS `DelayedPixelFiringMock`.
 final class FireRequestMock {
+
+    /// The store the decorated `PixelRetryQueue` drains from. A fire whose pixel name matches a queued
+    /// item is treated as a retry. Set this to the same store passed to the queue under test.
+    weak var retryQueueStore: MockPixelRetryQueueStore?
 
     struct Call {
         let pixelName: String
@@ -96,7 +101,7 @@ final class FireRequestMock {
 
     var fireRequest: PixelKit.FireRequest {
         { [self] pixelName, headers, parameters, allowedChars, _, onComplete in
-            let isRetry = parameters["retriedPixel"] == "1"
+            let isRetry = retryQueueStore?.items.contains { $0.pixelName == pixelName } ?? false
             let call = Call(pixelName: pixelName,
                             headers: headers,
                             parameters: parameters,

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/RetryQueue/PixelRetryQueueTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/RetryQueue/PixelRetryQueueTests.swift
@@ -31,6 +31,7 @@ final class PixelRetryQueueTests: XCTestCase {
         super.setUp()
         store = MockPixelRetryQueueStore()
         fireMock = FireRequestMock()
+        fireMock.retryQueueStore = store
         lastProcessingStorage = MockKeyValueStore()
         now = Date(timeIntervalSince1970: 1_700_000_000)
     }
@@ -88,7 +89,6 @@ final class PixelRetryQueueTests: XCTestCase {
         XCTAssertEqual(stored.pixelName, "m_organic")
         XCTAssertEqual(stored.headers, ["H": "V"])
         XCTAssertEqual(stored.parameters["k"], "v")
-        XCTAssertNotNil(stored.parameters["originalPixelTimestamp"])
         XCTAssertEqual(stored.timestamp, now)
     }
 
@@ -112,7 +112,7 @@ final class PixelRetryQueueTests: XCTestCase {
         XCTAssertEqual(fireMock.calls.first?.pixelName, "m_queued")
     }
 
-    func testWhenReplayingItem_ThenRetriedPixelParameterIsAdded() {
+    func testWhenReplayingItem_ThenItemIsFiredAsRetryWithUnmodifiedParameters() {
         let item = makeItem(name: "m_queued")
         try? store.append([item])
         let queue = makeQueue()
@@ -122,8 +122,8 @@ final class PixelRetryQueueTests: XCTestCase {
         wait(for: [drained], timeout: 2.0)
 
         let call = fireMock.calls.first
-        XCTAssertEqual(call?.parameters["retriedPixel"], "1")
-        XCTAssertEqual(call?.parameters["key"], "value")
+        XCTAssertTrue(call?.isRetry == true)
+        XCTAssertEqual(call?.parameters, ["key": "value"])
     }
 
     func testWhenItemIsOlderThan28Days_ThenItIsNotSentButIsRemoved() {

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/RetryQueue/PixelRetryQueueTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/RetryQueue/PixelRetryQueueTests.swift
@@ -109,6 +109,23 @@ final class PixelRetryQueueTests: XCTestCase {
         XCTAssertEqual(fireMock.calls.count, 1)
         XCTAssertEqual(fireMock.calls.first?.pixelName, "m_queued")
         // The replay carries the item's stored parameters unchanged — nothing is injected on send.
+        XCTAssertEqual(fireMock.calls.first?.parameters, item.parameters)
+    }
+
+    func testWhenReplayingItemWithLegacyTimestampParameter_ThenItIsStrippedBeforeSending() {
+        // Items persisted by builds that still baked in `originalPixelTimestamp` must not replay with it.
+        let legacy = PixelRetryQueueItem(pixelName: "m_queued",
+                                         headers: [:],
+                                         parameters: ["key": "value", "originalPixelTimestamp": "2026-06-11T00:00:00Z"],
+                                         allowedQueryReservedCharacters: nil,
+                                         timestamp: now)
+        try? store.append([legacy])
+        let queue = makeQueue()
+        let drained = expectation(description: "drained")
+
+        queue.sendQueuedPixels { _ in drained.fulfill() }
+        wait(for: [drained], timeout: 2.0)
+
         XCTAssertEqual(fireMock.calls.first?.parameters, ["key": "value"])
     }
 

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/RetryQueue/PixelRetryQueueTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/RetryQueue/PixelRetryQueueTests.swift
@@ -31,7 +31,6 @@ final class PixelRetryQueueTests: XCTestCase {
         super.setUp()
         store = MockPixelRetryQueueStore()
         fireMock = FireRequestMock()
-        fireMock.retryQueueStore = store
         lastProcessingStorage = MockKeyValueStore()
         now = Date(timeIntervalSince1970: 1_700_000_000)
     }
@@ -56,7 +55,6 @@ final class PixelRetryQueueTests: XCTestCase {
     // MARK: - Persist on failure
 
     func testWhenOrganicFireSucceeds_ThenNothingIsStored_AndCompletionIsForwarded() {
-        fireMock.organicResult = (true, nil)
         let queue = makeQueue()
         let completed = expectation(description: "onComplete")
 
@@ -72,7 +70,7 @@ final class PixelRetryQueueTests: XCTestCase {
 
     func testWhenOrganicFireFails_ThenItemIsStoredWithTimestamp_AndCompletionIsForwarded() {
         let error = NSError(domain: "test", code: 7)
-        fireMock.organicResult = (false, error)
+        fireMock.defaultResult = (false, error)
         let queue = makeQueue()
         let completed = expectation(description: "onComplete")
 
@@ -110,20 +108,8 @@ final class PixelRetryQueueTests: XCTestCase {
         XCTAssertTrue(store.items.isEmpty)
         XCTAssertEqual(fireMock.calls.count, 1)
         XCTAssertEqual(fireMock.calls.first?.pixelName, "m_queued")
-    }
-
-    func testWhenReplayingItem_ThenItemIsFiredAsRetryWithUnmodifiedParameters() {
-        let item = makeItem(name: "m_queued")
-        try? store.append([item])
-        let queue = makeQueue()
-        let drained = expectation(description: "drained")
-
-        queue.sendQueuedPixels { _ in drained.fulfill() }
-        wait(for: [drained], timeout: 2.0)
-
-        let call = fireMock.calls.first
-        XCTAssertTrue(call?.isRetry == true)
-        XCTAssertEqual(call?.parameters, ["key": "value"])
+        // The replay carries the item's stored parameters unchanged — nothing is injected on send.
+        XCTAssertEqual(fireMock.calls.first?.parameters, ["key": "value"])
     }
 
     func testWhenItemIsOlderThan28Days_ThenItIsNotSentButIsRemoved() {
@@ -196,33 +182,34 @@ final class PixelRetryQueueTests: XCTestCase {
         try? store.append([item])
         let queue = makeQueue()
 
-        let retryReceived = expectation(description: "retry received")
+        // The queued pixel is only ever fired via replay, so receiving it confirms the drain ran.
+        let queuedReplayed = expectation(description: "queued item replayed")
         fireMock.onFireReceived = { call in
-            if call.isRetry { retryReceived.fulfill() }
+            if call.pixelName == "m_queued" { queuedReplayed.fulfill() }
         }
 
         // An organic success should trigger a drain that replays the queued item.
         queue.fireRequest("m_organic", [:], [:], nil, true) { _, _ in }
 
-        wait(for: [retryReceived], timeout: 2.0)
-        XCTAssertTrue(fireMock.calls.contains { $0.isRetry && $0.pixelName == "m_queued" })
+        wait(for: [queuedReplayed], timeout: 2.0)
+        XCTAssertTrue(fireMock.calls.contains { $0.pixelName == "m_queued" })
     }
 
     func testWhenNewFireFailsWhileDraining_ThenNewItemIsAlsoStored() {
         let initialItem = makeItem(name: "m_initial")
         try? store.append([initialItem])
 
-        fireMock.deferRetries = true            // hold the in-flight retry open
-        fireMock.organicResult = (false, NSError(domain: "test", code: 1))  // the new organic fire fails
+        fireMock.deferredPixelNames = ["m_initial"]   // hold the in-flight replay open
+        fireMock.defaultResult = (false, NSError(domain: "test", code: 1))  // the new organic fire fails
         let queue = makeQueue()
 
-        // Start the drain; wait until the retry call is received (and held).
-        let retryReceived = expectation(description: "retry received")
+        // Start the drain; wait until the replay of the queued item is received (and held).
+        let replayReceived = expectation(description: "replay received")
         fireMock.onFireReceived = { call in
-            if call.isRetry { retryReceived.fulfill() }
+            if call.pixelName == "m_initial" { replayReceived.fulfill() }
         }
         queue.sendQueuedPixels()
-        wait(for: [retryReceived], timeout: 2.0)
+        wait(for: [replayReceived], timeout: 2.0)
 
         // Fire a failing organic pixel while the drain is in flight.
         let organicCompleted = expectation(description: "organic completed")
@@ -233,14 +220,14 @@ final class PixelRetryQueueTests: XCTestCase {
         XCTAssertEqual(store.items.count, 2)
         XCTAssertTrue(store.items.contains(initialItem))
 
-        // Release the held retry so the drain completes.
-        fireMock.completePendingRetries(success: true)
+        // Release the held replay so the drain completes.
+        fireMock.completePendingFires(success: true)
     }
 
     func testWhenRetryFails_ThenItemRemainsQueued() {
         let item = makeItem(name: "m_queued")
         try? store.append([item])
-        fireMock.retryResult = (false, NSError(domain: "test", code: 2))
+        fireMock.defaultResult = (false, NSError(domain: "test", code: 2))
         let queue = makeQueue()
         let drained = expectation(description: "drained")
 
@@ -253,7 +240,7 @@ final class PixelRetryQueueTests: XCTestCase {
     func testWhenAFailedPixelIsEnqueued_ThenExpiredItemsArePruned() {
         let expired = makeItem(name: "m_stale", ageInDays: 30)
         try? store.append([expired])
-        fireMock.organicResult = (false, NSError(domain: "test", code: 1))
+        fireMock.defaultResult = (false, NSError(domain: "test", code: 1))
         let queue = makeQueue()
         let completed = expectation(description: "onComplete")
 
@@ -268,7 +255,7 @@ final class PixelRetryQueueTests: XCTestCase {
 
     func testWhenExpiredPruningFails_ThenTheFailedPixelIsStillQueued() {
         store.storedItemsError = NSError(domain: "test", code: 9)   // the prune's read throws
-        fireMock.organicResult = (false, NSError(domain: "test", code: 1))
+        fireMock.defaultResult = (false, NSError(domain: "test", code: 1))
         let queue = makeQueue()
         let completed = expectation(description: "onComplete")
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215909080171360

### Description

[PixelKit's retry queue](https://app.asana.com/1/137249556945/task/1215909080171360?focus=true) attached two tracking parameters (`originalPixelTimestamp` and `retriedPixel`) globally that did not go through proper privacy triage.  I'm removing them here.

### Testing Steps

This is internal pixel-firing infrastructure with no user-facing surface, and reliably forcing a pixel send to fail (then succeed on replay) isn't feasible to drive manually. Coverage is via the PixelKit retry-queue unit tests.

1. Verify the CI is green.

### Impact and Risks

Low. Pixel firing, queuing, and retry behavior are unchanged; only the two extra parameters are no longer sent.

#### What could go wrong?

Any backend reporting that keys off `originalPixelTimestamp` or `retriedPixel` for PixelKit-originated pixels will no longer see those values. Retry behavior itself is unaffected and is covered by the existing retry-queue tests.

### Quality Considerations

The retry-vs-organic distinction these parameters provided was only relied on by the test double; it now derives that distinction from queue-store membership instead, so test fidelity is preserved without a wire parameter.

### Notes to Reviewer

The iOS `PersistentPixel` system uses the same two parameter names independently — this change is scoped to the macOS PixelKit retry queue only and leaves iOS untouched.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only parameter changes; retry queuing and drain logic are unchanged aside from stripping a legacy key on replay.
> 
> **Overview**
> Stops the PixelKit retry queue from adding **`originalPixelTimestamp`** on failed fires and **`retriedPixel`** on replays. Queued items keep the caller’s parameters as-is; replay no longer injects retry markers.
> 
> On drain, **`originalPixelTimestamp`** is stripped from parameters when replaying items that older builds persisted with that key, so legacy queue data does not keep sending it.
> 
> Unit tests and **`FireRequestMock`** were updated to assert behavior by pixel name and stored parameters instead of inferring organic vs retry from wire params.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01c1480afb585a7f3bdf8ff4a81e62bfbd54ed34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->