### PR TITLE
Fix VPN excluded-domain hostname matching

### DIFF
--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Provider/TransparentProxyProvider.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Provider/TransparentProxyProvider.swift
@@ -574,8 +574,17 @@ open class TransparentProxyProvider: NETransparentProxyProvider {
     }
 
     private func isExcludedDomain(_ hostname: String) -> Bool {
-        settings.excludedDomains.contains { excludedDomain in
-            hostname.hasSuffix(excludedDomain)
+        Self.isExcludedDomain(hostname, excludedDomains: settings.excludedDomains)
+    }
+
+    /// Whether `hostname` should be excluded from the VPN given the list of excluded domains.
+    ///
+    /// A hostname matches an excluded domain only when it's exactly equal to it or is a subdomain of it
+    /// (i.e. ends with `.<excludedDomain>`). This prevents an excluded `bank.com` from also matching an
+    /// unrelated `evilbank.com`, which would steer that traffic around the tunnel.
+    static func isExcludedDomain(_ hostname: String, excludedDomains: [String]) -> Bool {
+        excludedDomains.contains { excludedDomain in
+            hostname == excludedDomain || hostname.hasSuffix(".\(excludedDomain)")
         }
     }
 

--- a/macOS/LocalPackages/NetworkProtectionMac/Tests/NetworkProtectionProxyTests/TransparentProxyProviderExclusionTests.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Tests/NetworkProtectionProxyTests/TransparentProxyProviderExclusionTests.swift
@@ -1,0 +1,57 @@
+//
+//  TransparentProxyProviderExclusionTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+@testable import NetworkProtectionProxy
+import XCTest
+
+final class TransparentProxyProviderExclusionTests: XCTestCase {
+
+    func testExactDomainMatches() {
+        XCTAssertTrue(TransparentProxyProvider.isExcludedDomain("bank.com", excludedDomains: ["bank.com"]))
+    }
+
+    func testSubdomainMatches() {
+        XCTAssertTrue(TransparentProxyProvider.isExcludedDomain("app.bank.com", excludedDomains: ["bank.com"]))
+        XCTAssertTrue(TransparentProxyProvider.isExcludedDomain("login.app.bank.com", excludedDomains: ["bank.com"]))
+    }
+
+    func testLookalikeSuffixDoesNotMatch() {
+        // Regression: a bare hasSuffix match would steer evilbank.com around the tunnel.
+        XCTAssertFalse(TransparentProxyProvider.isExcludedDomain("evilbank.com", excludedDomains: ["bank.com"]))
+        XCTAssertFalse(TransparentProxyProvider.isExcludedDomain("notbank.com", excludedDomains: ["bank.com"]))
+    }
+
+    func testPartialLabelDoesNotMatch() {
+        XCTAssertFalse(TransparentProxyProvider.isExcludedDomain("bank.com.evil.com", excludedDomains: ["bank.com"]))
+    }
+
+    func testUnrelatedDomainDoesNotMatch() {
+        XCTAssertFalse(TransparentProxyProvider.isExcludedDomain("example.com", excludedDomains: ["bank.com"]))
+    }
+
+    func testEmptyExclusionsMatchNothing() {
+        XCTAssertFalse(TransparentProxyProvider.isExcludedDomain("bank.com", excludedDomains: []))
+    }
+
+    func testMatchesAnyEntryInList() {
+        let exclusions = ["example.com", "bank.com"]
+        XCTAssertTrue(TransparentProxyProvider.isExcludedDomain("app.bank.com", excludedDomains: exclusions))
+        XCTAssertFalse(TransparentProxyProvider.isExcludedDomain("evilbank.com", excludedDomains: exclusions))
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215958595063372

### Description

Tightens how the VPN matches a connection's hostname against the excluded-domains list so that only the configured domain and its subdomains are matched. Previously the check could match unintended hostnames that happened to share a trailing string with an excluded domain.

### Testing Steps
1. Add `myip.com` to the VPN excluded domains.
2. Visit myip.com and confirm it is excluded from the VPN.
3. Visit whatismyip.com and confirm it still routes through the VPN.

Note: the proxy only evaluates exclusions for new connections, so it cannot re-route a connection that is already open. To avoid waiting for an existing connection to refresh, do each check in a freshly opened browser (or a different browser) rather than reusing the same window. Restarting the VPN connection also forces re-evaluation, but that is heavier than necessary for this.

### Impact and Risks

Medium. Adjusts which connections match an excluded domain.

#### What could go wrong?

N/A

### Quality Considerations

The matching logic was extracted into a pure helper and covered with unit tests for exact match, subdomains, and near-miss hostnames.

### Notes to Reviewer

I've noticed there's an issue where the proxy takes a while to refresh properly on open connections.  I've [opened an issue for it](https://app.asana.com/1/137249556945/project/1207603085593419/task/1215959562779962?focus=true), so the testing here shouldn't focus too much on whether the exclusions are being immediate.  I recommend checking before and after in different browsers so you get a fresh connection on each attempt.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which connections bypass the VPN for excluded domains; behavior shifts for hostnames that previously matched via loose suffix rules.
> 
> **Overview**
> **VPN excluded-domain matching** no longer treats any hostname that merely ends with the configured string as excluded. Matching now requires an **exact domain** or a **proper subdomain** (`.<excludedDomain>`), so lookalikes like `evilbank.com` when excluding `bank.com` stay on the tunnel.
> 
> The check is refactored into a **static `isExcludedDomain(_:excludedDomains:)`** helper used by the instance method, with **unit tests** covering exact/subdomain hits, suffix false positives, and unrelated hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b79af85f03fba201dd36303f05d5b2cd3510155d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->