### PR TITLE
Fix release-notes startup hang and async LoginItem PoC

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -2921,6 +2921,7 @@
 		A1A1A1A12F50000200A0A0A0 /* AppStoreCrashCollection in Frameworks */ = {isa = PBXBuildFile; productRef = A1A1A1A12F50000700A0A0A0 /* AppStoreCrashCollection */; };
 		A1A1A1A12F50000300A0A0A0 /* CrashReportingShared in Frameworks */ = {isa = PBXBuildFile; productRef = A1A1A1A12F50000A00A0A0A0 /* CrashReportingShared */; };
 		A1A1A1A12F50000400A0A0A0 /* CrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = A1A1A1A12F50000900A0A0A0 /* CrashReporting */; };
+		A1A1A1A12F50000B00A0A0A0 /* CrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = A1A1A1A12F50000900A0A0A0 /* CrashReporting */; };
 		A1B2C3D42E5F601100000001 /* PromoType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42E5F600100000001 /* PromoType.swift */; };
 		A1B2C3D42E5F601200000002 /* PromoHistoryRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42E5F600200000002 /* PromoHistoryRecord.swift */; };
 		A1B2C3D42E5F601300000003 /* Promo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42E5F600300000003 /* Promo.swift */; };
@@ -3956,11 +3957,6 @@
 		CC0943012E16B6F000E67336 /* FavoritesImportProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0942FF2E16B6F000E67336 /* FavoritesImportProcessorTests.swift */; };
 		CC0DD90F2E5DD74600277E46 /* AppStateRestorationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD90E2E5DD74600277E46 /* AppStateRestorationManagerTests.swift */; };
 		CC0DD9102E5DD74600277E46 /* AppStateRestorationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD90E2E5DD74600277E46 /* AppStateRestorationManagerTests.swift */; };
-		CC0DD9212E5DD74600277E46 /* UncleanExitRestartSourceResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9202E5DD74600277E46 /* UncleanExitRestartSourceResolverTests.swift */; };
-		CC0DD9222E5DD74600277E46 /* UncleanExitRestartSourceResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9202E5DD74600277E46 /* UncleanExitRestartSourceResolverTests.swift */; };
-		CC0DD9242E5DD74700277E46 /* UncleanExitRestartSourceResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9232E5DD74700277E46 /* UncleanExitRestartSourceResolver.swift */; };
-		CC0DD9252E5DD74700277E46 /* UncleanExitRestartSourceResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9232E5DD74700277E46 /* UncleanExitRestartSourceResolver.swift */; };
-		A1A1A1A12F50000B00A0A0A0 /* CrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = A1A1A1A12F50000900A0A0A0 /* CrashReporting */; };
 		CC0DD9132E5DF47E00277E46 /* SessionRestorePromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9122E5DF47E00277E46 /* SessionRestorePromptView.swift */; };
 		CC0DD9142E5DF47E00277E46 /* SessionRestorePromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9122E5DF47E00277E46 /* SessionRestorePromptView.swift */; };
 		CC0DD9162E5DF4B600277E46 /* SessionRestorePromptViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9152E5DF4B000277E46 /* SessionRestorePromptViewModel.swift */; };
@@ -3969,6 +3965,10 @@
 		CC0DD91A2E5DFA5800277E46 /* SessionRestorePromptPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9182E5DFA4D00277E46 /* SessionRestorePromptPopover.swift */; };
 		CC0DD91C2E5EF7CE00277E46 /* SessionRestorePromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD91B2E5EF7C100277E46 /* SessionRestorePromptCoordinator.swift */; };
 		CC0DD91D2E5EF7CE00277E46 /* SessionRestorePromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD91B2E5EF7C100277E46 /* SessionRestorePromptCoordinator.swift */; };
+		CC0DD9212E5DD74600277E46 /* UncleanExitRestartSourceResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9202E5DD74600277E46 /* UncleanExitRestartSourceResolverTests.swift */; };
+		CC0DD9222E5DD74600277E46 /* UncleanExitRestartSourceResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9202E5DD74600277E46 /* UncleanExitRestartSourceResolverTests.swift */; };
+		CC0DD9242E5DD74700277E46 /* UncleanExitRestartSourceResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9232E5DD74700277E46 /* UncleanExitRestartSourceResolver.swift */; };
+		CC0DD9252E5DD74700277E46 /* UncleanExitRestartSourceResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9232E5DD74700277E46 /* UncleanExitRestartSourceResolver.swift */; };
 		CC199E6E2F4E182C009646F9 /* PromoServiceFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC199E6D2F4E182C009646F9 /* PromoServiceFactory.swift */; };
 		CC199E6F2F4E182C009646F9 /* PromoServiceFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC199E6D2F4E182C009646F9 /* PromoServiceFactory.swift */; };
 		CC199E962F4E182C00964711 /* PromoDebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC199E952F4E182C00964710 /* PromoDebugMenu.swift */; };
@@ -6724,12 +6724,12 @@
 		CC0942FC2E16AF6000E67336 /* FavoritesImportProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesImportProcessor.swift; sourceTree = "<group>"; };
 		CC0942FF2E16B6F000E67336 /* FavoritesImportProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesImportProcessorTests.swift; sourceTree = "<group>"; };
 		CC0DD90E2E5DD74600277E46 /* AppStateRestorationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateRestorationManagerTests.swift; sourceTree = "<group>"; };
-		CC0DD9202E5DD74600277E46 /* UncleanExitRestartSourceResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UncleanExitRestartSourceResolverTests.swift; sourceTree = "<group>"; };
-		CC0DD9232E5DD74700277E46 /* UncleanExitRestartSourceResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UncleanExitRestartSourceResolver.swift; sourceTree = "<group>"; };
 		CC0DD9122E5DF47E00277E46 /* SessionRestorePromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestorePromptView.swift; sourceTree = "<group>"; };
 		CC0DD9152E5DF4B000277E46 /* SessionRestorePromptViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestorePromptViewModel.swift; sourceTree = "<group>"; };
 		CC0DD9182E5DFA4D00277E46 /* SessionRestorePromptPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestorePromptPopover.swift; sourceTree = "<group>"; };
 		CC0DD91B2E5EF7C100277E46 /* SessionRestorePromptCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestorePromptCoordinator.swift; sourceTree = "<group>"; };
+		CC0DD9202E5DD74600277E46 /* UncleanExitRestartSourceResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UncleanExitRestartSourceResolverTests.swift; sourceTree = "<group>"; };
+		CC0DD9232E5DD74700277E46 /* UncleanExitRestartSourceResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UncleanExitRestartSourceResolver.swift; sourceTree = "<group>"; };
 		CC199E6D2F4E182C009646F9 /* PromoServiceFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoServiceFactory.swift; sourceTree = "<group>"; };
 		CC199E952F4E182C00964710 /* PromoDebugMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoDebugMenu.swift; sourceTree = "<group>"; };
 		CC199E972F4E183000964712 /* DebugSimulatedDateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSimulatedDateStore.swift; sourceTree = "<group>"; };
@@ -6942,8 +6942,8 @@
 		F14890842ECCCAA800B5239E /* AttributedMetricUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedMetricUtils.swift; sourceTree = "<group>"; };
 		F14890962ECDD24400B5239E /* AttributedMetricDebugMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedMetricDebugMenu.swift; sourceTree = "<group>"; };
 		F14B813E2F323C5200C39E26 /* SubscriptionPixelHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPixelHandlerTests.swift; sourceTree = "<group>"; };
-		F15CEA792FC0717C00FBD10A /* TabContentCapabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabContentCapabilityTests.swift; sourceTree = "<group>"; };
 		F156E39A2FB5FBCC004A8424 /* Documentation.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = Documentation.docc; sourceTree = "<group>"; };
+		F15CEA792FC0717C00FBD10A /* TabContentCapabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabContentCapabilityTests.swift; sourceTree = "<group>"; };
 		F1664A672D708EC60034CCB8 /* SubscriptionPagesUseSubscriptionFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPagesUseSubscriptionFeature.swift; sourceTree = "<group>"; };
 		F17114812C7C98FB009836C1 /* Logger+Favicons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+Favicons.swift"; sourceTree = "<group>"; };
 		F17114842C7C9D28009836C1 /* Logger+Fire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+Fire.swift"; sourceTree = "<group>"; };

--- a/macOS/DuckDuckGo/Application/Application.swift
+++ b/macOS/DuckDuckGo/Application/Application.swift
@@ -104,7 +104,7 @@ final class Application: NSApplication, WarnBeforeQuitManagerDelegate {
 
     override func run() {
         let buildType = StandardApplicationBuildType()
-        if !buildType.isAppStoreBuild && !buildType.isDebugBuild {
+        /*if !buildType.isAppStoreBuild && !buildType.isDebugBuild {
             // The prompt is modal and blocks the launch for as long as it stays unanswered,
             // which would inflate startup timings by arbitrary user think-time. Flag the
             // measurement as invalid up-front so the startup pixel is discarded for this launch.
@@ -112,7 +112,7 @@ final class Application: NSApplication, WarnBeforeQuitManagerDelegate {
                 Application.appDelegate.startupProfiler.invalidate()
             }
             PFMoveToApplicationsFolderIfNecessary(/*allowAlertSilencing:*/ true)
-        }
+        }*/
 
         super.run()
     }

--- a/macOS/DuckDuckGo/DBP/DBPHomeViewController.swift
+++ b/macOS/DuckDuckGo/DBP/DBPHomeViewController.swift
@@ -156,7 +156,9 @@ final class DBPHomeViewController: NSViewController {
     }
 
     private func setupUIWithCurrentStatus() {
-        setupUIWithStatus(prerequisiteVerifier.checkStatus())
+        Task { @MainActor in
+            setupUIWithStatus(await prerequisiteVerifier.checkStatus())
+        }
     }
 
     private func setupUIWithStatus(_ status: DataBrokerPrerequisitesStatus) {
@@ -174,10 +176,12 @@ final class DBPHomeViewController: NSViewController {
     }
 
     private func fireDashboardOpenPixelsIfNeeded(isAuthenticated: Bool) {
-        guard prerequisiteVerifier.checkStatus() == .valid else { return }
+        Task { @MainActor in
+            guard await prerequisiteVerifier.checkStatus() == .valid else { return }
 
-        interactionPixels?.fireInteractionPixel(isAuthenticated: isAuthenticated)
-        sharedPixelsHandler?.fire(.dashboardOpen(isAuthenticated: isAuthenticated, isFreeScan: !isAuthenticated))
+            interactionPixels?.fireInteractionPixel(isAuthenticated: isAuthenticated)
+            sharedPixelsHandler?.fire(.dashboardOpen(isAuthenticated: isAuthenticated, isFreeScan: !isAuthenticated))
+        }
     }
 
     private func displayDBPUI() {

--- a/macOS/DuckDuckGo/DBP/DataBrokerPrerequisitesStatusVerifier.swift
+++ b/macOS/DuckDuckGo/DBP/DataBrokerPrerequisitesStatusVerifier.swift
@@ -29,7 +29,7 @@ enum DataBrokerPrerequisitesStatus {
 }
 
 protocol DataBrokerPrerequisitesStatusVerifier: AnyObject {
-    func checkStatus() -> DataBrokerPrerequisitesStatus
+    func checkStatus() async -> DataBrokerPrerequisitesStatus
 }
 
 final class DefaultDataBrokerPrerequisitesStatusVerifier: DataBrokerPrerequisitesStatusVerifier {
@@ -39,8 +39,8 @@ final class DefaultDataBrokerPrerequisitesStatusVerifier: DataBrokerPrerequisite
         self.statusChecker = statusChecker
     }
 
-    func checkStatus() -> DataBrokerPrerequisitesStatus {
-        if !statusChecker.doesHaveNecessaryPermissions() {
+    func checkStatus() async -> DataBrokerPrerequisitesStatus {
+        if !(await statusChecker.doesHaveNecessaryPermissions()) {
             Logger.dataBrokerProtection.log("Invalid system permissions")
             return .invalidSystemPermission
         } else if !statusChecker.isInCorrectDirectory() {

--- a/macOS/DuckDuckGo/DBP/DataBrokerProtectionAppEvents.swift
+++ b/macOS/DuckDuckGo/DBP/DataBrokerProtectionAppEvents.swift
@@ -74,7 +74,7 @@ struct DataBrokerProtectionAppEvents {
             let prerequisitesMet = try await featureGatekeeper.arePrerequisitesSatisfied()
 
             guard prerequisitesMet else {
-                loginItemsManager.disableLoginItems([LoginItem.dbpBackgroundAgent])
+                await loginItemsManager.disableLoginItems([LoginItem.dbpBackgroundAgent])
                 NotificationCenter.default.post(name: .dbpLoginItemDisabled, object: nil)
                 return
             }
@@ -83,10 +83,12 @@ struct DataBrokerProtectionAppEvents {
 
     private func restartBackgroundAgent(loginItemsManager: LoginItemsManager) {
         DataBrokerProtectionLoginItemPixels.fire(pixel: GeneralPixel.dataBrokerResetLoginItemDaily, frequency: .legacyDaily)
-        loginItemsManager.disableLoginItems([LoginItem.dbpBackgroundAgent])
-        NotificationCenter.default.post(name: .dbpLoginItemDisabled, object: nil)
-        loginItemsManager.enableLoginItems([LoginItem.dbpBackgroundAgent])
-        NotificationCenter.default.post(name: .dbpLoginItemEnabled, object: nil)
+        Task {
+            await loginItemsManager.disableLoginItems([LoginItem.dbpBackgroundAgent])
+            NotificationCenter.default.post(name: .dbpLoginItemDisabled, object: nil)
+            await loginItemsManager.enableLoginItems([LoginItem.dbpBackgroundAgent])
+            NotificationCenter.default.post(name: .dbpLoginItemEnabled, object: nil)
+        }
 
         // restartLoginItems doesn't work when we change the agent name
     }

--- a/macOS/DuckDuckGo/DBP/DataBrokerProtectionDebugMenu.swift
+++ b/macOS/DuckDuckGo/DBP/DataBrokerProtectionDebugMenu.swift
@@ -376,17 +376,23 @@ final class DataBrokerProtectionDebugMenu: NSMenu {
     }
 
     @objc private func backgroundAgentRestart() {
-        LoginItemsManager().restartLoginItems([LoginItem.dbpBackgroundAgent])
+        Task {
+            await LoginItemsManager().restartLoginItems([LoginItem.dbpBackgroundAgent])
+        }
     }
 
     @objc private func backgroundAgentDisable() {
-        LoginItemsManager().disableLoginItems([LoginItem.dbpBackgroundAgent])
-        NotificationCenter.default.post(name: .dbpLoginItemDisabled, object: nil)
+        Task {
+            await LoginItemsManager().disableLoginItems([LoginItem.dbpBackgroundAgent])
+            NotificationCenter.default.post(name: .dbpLoginItemDisabled, object: nil)
+        }
     }
 
     @objc private func backgroundAgentEnable() {
-        LoginItemsManager().enableLoginItems([LoginItem.dbpBackgroundAgent])
-        NotificationCenter.default.post(name: .dbpLoginItemEnabled, object: nil)
+        Task {
+            await LoginItemsManager().enableLoginItems([LoginItem.dbpBackgroundAgent])
+            NotificationCenter.default.post(name: .dbpLoginItemEnabled, object: nil)
+        }
     }
 
     @objc private func deleteAllDataAndStopAgent() {

--- a/macOS/DuckDuckGo/DBP/DataBrokerProtectionLoginItemInterface.swift
+++ b/macOS/DuckDuckGo/DBP/DataBrokerProtectionLoginItemInterface.swift
@@ -52,14 +52,18 @@ extension DefaultDataBrokerProtectionLoginItemInterface: DataBrokerProtectionLog
 
     private func disableLoginItem() {
         DataBrokerProtectionLoginItemPixels.fire(pixel: GeneralPixel.dataBrokerDisableLoginItemDaily, frequency: .legacyDaily)
-        loginItemsManager.disableLoginItems([.dbpBackgroundAgent])
-        NotificationCenter.default.post(name: .dbpLoginItemDisabled, object: nil)
+        Task {
+            await loginItemsManager.disableLoginItems([.dbpBackgroundAgent])
+            NotificationCenter.default.post(name: .dbpLoginItemDisabled, object: nil)
+        }
     }
 
     private func enableLoginItem() {
         DataBrokerProtectionLoginItemPixels.fire(pixel: GeneralPixel.dataBrokerEnableLoginItemDaily, frequency: .legacyDaily)
-        loginItemsManager.enableLoginItems([.dbpBackgroundAgent])
-        NotificationCenter.default.post(name: .dbpLoginItemEnabled, object: nil)
+        Task {
+            await loginItemsManager.enableLoginItems([.dbpBackgroundAgent])
+            NotificationCenter.default.post(name: .dbpLoginItemEnabled, object: nil)
+        }
     }
 
     // MARK: - DataBrokerProtectionLoginItemInterface

--- a/macOS/DuckDuckGo/DBP/LoginItem+DataBrokerProtection.swift
+++ b/macOS/DuckDuckGo/DBP/LoginItem+DataBrokerProtection.swift
@@ -28,8 +28,8 @@ extension LoginItem {
 
 extension LoginItem: DBPLoginItemStatusChecker {
 
-    public func doesHaveNecessaryPermissions() -> Bool {
-        return status != .requiresApproval
+    public func doesHaveNecessaryPermissions() async -> Bool {
+        return await status() != .requiresApproval
     }
 
     public func isInCorrectDirectory() -> Bool {

--- a/macOS/DuckDuckGo/LoginItems/LoginItemsManager.swift
+++ b/macOS/DuckDuckGo/LoginItems/LoginItemsManager.swift
@@ -24,13 +24,13 @@ import PixelKit
 import os.log
 
 protocol LoginItemsManaging {
-    func enableLoginItems(_ items: Set<LoginItem>)
-    func throwingEnableLoginItems(_ items: Set<LoginItem>) throws
-    func disableLoginItems(_ items: Set<LoginItem>)
-    func restartLoginItems(_ items: Set<LoginItem>)
+    func enableLoginItems(_ items: Set<LoginItem>) async
+    func throwingEnableLoginItems(_ items: Set<LoginItem>) async throws
+    func disableLoginItems(_ items: Set<LoginItem>) async
+    func restartLoginItems(_ items: Set<LoginItem>) async
 
-    func isAnyEnabled(_ items: Set<LoginItem>) -> Bool
-    func isAnyInstalled(_ items: Set<LoginItem>) -> Bool
+    func isAnyEnabled(_ items: Set<LoginItem>) async -> Bool
+    func isAnyInstalled(_ items: Set<LoginItem>) async -> Bool
 }
 
 /// Class to manage the login items for the VPN and DBP
@@ -44,10 +44,10 @@ final class LoginItemsManager: LoginItemsManaging {
 
     // MARK: - Main Interactions
 
-    func enableLoginItems(_ items: Set<LoginItem>) {
+    func enableLoginItems(_ items: Set<LoginItem>) async {
         for item in items {
             do {
-                try item.enable()
+                try await item.enable()
                 Logger.networkProtection.log("🟢 Enabled successfully \(String(describing: item), privacy: .public)")
             } catch let error as NSError {
                 handleError(for: item, action: .enable, error: error)
@@ -57,10 +57,10 @@ final class LoginItemsManager: LoginItemsManaging {
 
     /// Throwing version of enableLoginItems
     ///
-    func throwingEnableLoginItems(_ items: Set<LoginItem>) throws {
+    func throwingEnableLoginItems(_ items: Set<LoginItem>) async throws {
         for item in items {
             do {
-                try item.enable()
+                try await item.enable()
                 Logger.networkProtection.log("🟢 Enabled successfully \(String(describing: item), privacy: .public)")
             } catch let error as NSError {
                 handleError(for: item, action: .enable, error: error)
@@ -69,10 +69,10 @@ final class LoginItemsManager: LoginItemsManaging {
         }
     }
 
-    func restartLoginItems(_ items: Set<LoginItem>) {
+    func restartLoginItems(_ items: Set<LoginItem>) async {
         for item in items {
             do {
-                try item.restart()
+                try await item.restart()
                 Logger.networkProtection.log("🟢 Restarted successfully \(String(describing: item), privacy: .public)")
             } catch let error as NSError {
                 handleError(for: item, action: .restart, error: error)
@@ -80,22 +80,24 @@ final class LoginItemsManager: LoginItemsManaging {
         }
     }
 
-    func disableLoginItems(_ items: Set<LoginItem>) {
+    func disableLoginItems(_ items: Set<LoginItem>) async {
         for item in items {
-            try? item.disable()
+            try? await item.disable()
         }
     }
 
-    func isAnyEnabled(_ items: Set<LoginItem>) -> Bool {
-        return items.contains(where: { item in
-            item.status == .enabled
-        })
+    func isAnyEnabled(_ items: Set<LoginItem>) async -> Bool {
+        for item in items where await item.status() == .enabled {
+            return true
+        }
+        return false
     }
 
-    func isAnyInstalled(_ items: Set<LoginItem>) -> Bool {
-        return items.contains(where: { item in
-            item.status.isInstalled
-        })
+    func isAnyInstalled(_ items: Set<LoginItem>) async -> Bool {
+        for item in items where await item.status().isInstalled {
+            return true
+        }
+        return false
     }
 
     private func handleError(for item: LoginItem, action: Action, error: NSError) {
@@ -111,7 +113,7 @@ final class LoginItemsManager: LoginItemsManaging {
 
     func resetLoginItems(_ items: Set<LoginItem>) async throws {
         for item in items {
-            try? item.disable()
+            try? await item.disable()
         }
     }
 

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionDebugMenu.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionDebugMenu.swift
@@ -268,7 +268,7 @@ final class NetworkProtectionDebugMenu: NSMenu {
     ///
     @objc func disableLoginItem(_ sender: Any?) {
         Task { @MainActor in
-            debugUtilities.disableLoginItems()
+            await debugUtilities.disableLoginItems()
         }
     }
 

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionDebugUtilities.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionDebugUtilities.swift
@@ -95,13 +95,13 @@ final class NetworkProtectionDebugUtilities {
         vpnAppState.resetDontAskAgainExclusionSuggestion()
     }
 
-    func disableLoginItems() {
-        vpnUninstaller.removeAgents()
+    func disableLoginItems() async {
+        await vpnUninstaller.removeAgents()
     }
 
     func removeVPNNetworkExtensionAndAgents() async throws {
         try await vpnUninstaller.removeSystemExtension()
-        vpnUninstaller.removeAgents()
+        await vpnUninstaller.removeAgents()
     }
 
     func removeVPNConfiguration() async throws {

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionDiagnosticsExporter.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionDiagnosticsExporter.swift
@@ -156,7 +156,7 @@ final class NetworkProtectionDiagnosticsExporter {
         async let networkState = collectNetworkState()
         async let systemCommandOutput = collectSystemCommandOutput()
 
-        let appState = collectAppState()
+        let appState = await collectAppState()
 
         let files = await [
             DiagnosticsFile(name: "README.txt", contents: readme()),
@@ -208,9 +208,15 @@ final class NetworkProtectionDiagnosticsExporter {
 
     // MARK: - App State
 
-    private func collectAppState() -> String {
+    private func collectAppState() async -> String {
         let vpnMenuAgentBundleID = infoPlistValue(for: InfoPlistKey.vpnMenuAgentBundleID)
         let loginItem = vpnMenuAgentBundleID.map { LoginItem(bundleId: $0, defaults: .netP, logger: Logger.networkProtection) }
+        let loginItemStatusString: String
+        if let loginItem {
+            loginItemStatusString = "\(await loginItem.status())"
+        } else {
+            loginItemStatusString = "unknown"
+        }
         let runningVPNMenuApplications = vpnMenuAgentBundleID.map {
             NSRunningApplication.runningApplications(withBundleIdentifier: $0)
         } ?? []
@@ -252,7 +258,7 @@ final class NetworkProtectionDiagnosticsExporter {
 
         \(section("Login item"))
         Bundle identifier: \(vpnMenuAgentBundleID ?? missingInfoPlistValue(for: InfoPlistKey.vpnMenuAgentBundleID))
-        Status: \(loginItem.map { "\($0.status)" } ?? "unknown")
+        Status: \(loginItemStatusString)
         Is running: \(loginItem.map { "\($0.isRunning)" } ?? "unknown")
         Running process identifiers:
         \(runningVPNMenuApplications.map(\.processIdentifier).map(String.init).indentedList())

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNAppEventsHandler.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNAppEventsHandler.swift
@@ -105,12 +105,15 @@ final class VPNAppEventsHandler {
     ///
     @MainActor
     private func loginItemsControlCheckpoint(canRestart: Bool, loginItemsManager: LoginItemsManaging) async {
-        switch try? await featureGatekeeper.canStartVPN() {
-        case .some(true) where loginItemsManager.isAnyEnabled(LoginItemsManager.vpnLoginItems):
+        let canStartVPN = try? await featureGatekeeper.canStartVPN()
+        let isAnyEnabled = await loginItemsManager.isAnyEnabled(LoginItemsManager.vpnLoginItems)
+        let isAnyInstalled = await loginItemsManager.isAnyInstalled(LoginItemsManager.vpnLoginItems)
+        switch canStartVPN {
+        case .some(true) where isAnyEnabled:
             if canRestart {
-                restartLoginItem(using: loginItemsManager)
+                await restartLoginItem(using: loginItemsManager)
             }
-        case .some(false) where loginItemsManager.isAnyInstalled(LoginItemsManager.vpnLoginItems):
+        case .some(false) where isAnyInstalled:
             await withCheckedContinuation { continuation in
                 ipcClient.stop { error in
                     if let error {
@@ -123,7 +126,7 @@ final class VPNAppEventsHandler {
                         } catch {
                             // no-op: just want to catch task cancellation to make sure resume is called
                         }
-                        self.disableLoginItem(using: loginItemsManager)
+                        await self.disableLoginItem(using: loginItemsManager)
                         continuation.resume()
                     }
                 }
@@ -135,12 +138,12 @@ final class VPNAppEventsHandler {
 
     // MARK: - Managing the VPN Login Items
 
-    private func disableLoginItem(using loginItemsManager: LoginItemsManaging) {
-        loginItemsManager.disableLoginItems(LoginItemsManager.vpnLoginItems)
+    private func disableLoginItem(using loginItemsManager: LoginItemsManaging) async {
+        await loginItemsManager.disableLoginItems(LoginItemsManager.vpnLoginItems)
     }
 
-    private func restartLoginItem(using loginItemsManager: LoginItemsManaging) {
-        loginItemsManager.restartLoginItems(LoginItemsManager.vpnLoginItems)
+    private func restartLoginItem(using loginItemsManager: LoginItemsManaging) async {
+        await loginItemsManager.restartLoginItems(LoginItemsManager.vpnLoginItems)
     }
 
     // MARK: - Feature Flag Overriding

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/NetworkProtectionIPCTunnelController.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/NetworkProtectionIPCTunnelController.swift
@@ -111,7 +111,7 @@ final class NetworkProtectionIPCTunnelController {
     // MARK: - Login Items Manager
 
     private func enableLoginItems() async throws {
-        try loginItemsManager.throwingEnableLoginItems(LoginItemsManager.vpnLoginItems)
+        try await loginItemsManager.throwingEnableLoginItems(LoginItemsManager.vpnLoginItems)
     }
 }
 

--- a/macOS/DuckDuckGo/Preferences/Model/VPNPreferencesModel.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/VPNPreferencesModel.swift
@@ -120,7 +120,9 @@ final class VPNPreferencesModel: ObservableObject {
 
     private var onboardingStatus: OnboardingStatus {
         didSet {
-            showUninstallVPN = DefaultVPNFeatureGatekeeper(vpnUninstaller: VPNUninstaller(pinningManager: pinningManager), subscriptionManager: Application.appDelegate.subscriptionManager).isInstalled
+            Task { @MainActor in
+                showUninstallVPN = await DefaultVPNFeatureGatekeeper(vpnUninstaller: VPNUninstaller(pinningManager: pinningManager), subscriptionManager: Application.appDelegate.subscriptionManager).isInstalled
+            }
         }
     }
 

--- a/macOS/DuckDuckGo/UnifiedFeedbackForm/MetadataCollectors/VPNMetadataCollector.swift
+++ b/macOS/DuckDuckGo/UnifiedFeedbackForm/MetadataCollectors/VPNMetadataCollector.swift
@@ -170,7 +170,7 @@ final class DefaultVPNMetadataCollector: VPNMetadataCollector {
         let networkInfoMetadata = await collectNetworkInformation()
         let vpnState = await collectVPNState()
         let vpnSettingsState = collectVPNSettingsState()
-        let loginItemState = collectLoginItemState()
+        let loginItemState = await collectLoginItemState()
         let subscriptionInfo = await collectSubscriptionInfo()
 
         return VPNMetadata(
@@ -279,8 +279,8 @@ final class DefaultVPNMetadataCollector: VPNMetadataCollector {
                      connectedServerIP: connectedServerIP)
     }
 
-    func collectLoginItemState() -> VPNMetadata.LoginItemState {
-        let vpnMenuState = String(describing: LoginItem.vpnMenu.status)
+    func collectLoginItemState() async -> VPNMetadata.LoginItemState {
+        let vpnMenuState = await String(describing: LoginItem.vpnMenu.status())
         let vpnMenuIsRunning = !NSRunningApplication.runningApplications(withBundleIdentifier: LoginItem.vpnMenu.agentBundleID).isEmpty
 
         return .init(

--- a/macOS/DuckDuckGo/Waitlist/IPCServiceLauncher.swift
+++ b/macOS/DuckDuckGo/Waitlist/IPCServiceLauncher.swift
@@ -71,7 +71,7 @@ final class IPCServiceLauncher {
 
             runningApplication = try await appLauncher.runApp(withCommand: UDSLaunchAppCommand())
         case .loginItem(let loginItem, let loginItemsManager):
-            try loginItemsManager.throwingEnableLoginItems([loginItem])
+            try await loginItemsManager.throwingEnableLoginItems([loginItem])
         }
     }
 
@@ -99,7 +99,7 @@ final class IPCServiceLauncher {
             }
 
         case .loginItem(let loginItem, let loginItemsManager):
-            loginItemsManager.disableLoginItems([loginItem])
+            await loginItemsManager.disableLoginItems([loginItem])
         }
     }
 }

--- a/macOS/DuckDuckGo/Waitlist/VPNFeatureGatekeeper.swift
+++ b/macOS/DuckDuckGo/Waitlist/VPNFeatureGatekeeper.swift
@@ -28,7 +28,7 @@ import PixelKit
 import Subscription
 
 protocol VPNFeatureGatekeeper {
-    var isInstalled: Bool { get }
+    var isInstalled: Bool { get async }
 
     func canStartVPN() async throws -> Bool
     func isVPNVisible() -> Bool
@@ -51,7 +51,9 @@ struct DefaultVPNFeatureGatekeeper: VPNFeatureGatekeeper {
     }
 
     var isInstalled: Bool {
-        LoginItem.vpnMenu.status.isInstalled
+        get async {
+            await LoginItem.vpnMenu.status().isInstalled
+        }
     }
 
     /// Whether the user can start the VPN.

--- a/macOS/DuckDuckGo/Waitlist/VPNUninstaller.swift
+++ b/macOS/DuckDuckGo/Waitlist/VPNUninstaller.swift
@@ -212,7 +212,7 @@ final class VPNUninstaller: VPNUninstalling {
             throw UninstallError.cancelled(reason: .alreadyUninstalling)
         }
 
-        guard vpnMenuLoginItem.status.isInstalled else {
+        guard await vpnMenuLoginItem.status().isInstalled else {
             throw UninstallError.cancelled(reason: .alreadyUninstalled)
         }
 
@@ -263,7 +263,7 @@ final class VPNUninstaller: VPNUninstalling {
 
         // When the agent is registered as a login item, we want to unregister it
         // and stop it from running, which is achieved by the next call.
-        removeAgents()
+        await removeAgents()
 
         // When the agent was started directly (not as a login item) we want to stop it,
         // as the above call won't do anything for it.
@@ -282,8 +282,8 @@ final class VPNUninstaller: VPNUninstalling {
         try await ipcServiceLauncher.disable()
     }
 
-    func removeAgents() {
-        loginItemsManager.disableLoginItems(LoginItemsManager.vpnLoginItems)
+    func removeAgents() async {
+        await loginItemsManager.disableLoginItems(LoginItemsManager.vpnLoginItems)
     }
 
     func removeSystemExtension() async throws {

--- a/macOS/LocalPackages/AppUpdater/Package.swift
+++ b/macOS/LocalPackages/AppUpdater/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/sparkle-project/Sparkle.git", exact: "2.8.1"),
+        .package(url: "https://github.com/scinfu/SwiftSoup.git", exact: "2.13.5"),
         .package(path: "../../../SharedPackages/BrowserServicesKit"),
         .package(path: "../../../SharedPackages/Infrastructure/SystemFrameworksExtensions"),
         .package(path: "../FeatureFlags"),
@@ -32,6 +33,7 @@ let package = Package(
                 .product(name: "Persistence", package: "BrowserServicesKit"),
                 .product(name: "PixelKit", package: "BrowserServicesKit"),
                 .product(name: "Subscription", package: "BrowserServicesKit"),
+                .product(name: "SwiftSoup", package: "SwiftSoup"),
             ],
             swiftSettings: [
                 .define("DEBUG", .when(configuration: .debug))

--- a/macOS/LocalPackages/AppUpdater/Package.swift
+++ b/macOS/LocalPackages/AppUpdater/Package.swift
@@ -14,7 +14,6 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/sparkle-project/Sparkle.git", exact: "2.8.1"),
-        .package(url: "https://github.com/scinfu/SwiftSoup.git", exact: "2.13.5"),
         .package(path: "../../../SharedPackages/BrowserServicesKit"),
         .package(path: "../../../SharedPackages/Infrastructure/SystemFrameworksExtensions"),
         .package(path: "../FeatureFlags"),
@@ -33,7 +32,6 @@ let package = Package(
                 .product(name: "Persistence", package: "BrowserServicesKit"),
                 .product(name: "PixelKit", package: "BrowserServicesKit"),
                 .product(name: "Subscription", package: "BrowserServicesKit"),
-                .product(name: "SwiftSoup", package: "SwiftSoup"),
             ],
             swiftSettings: [
                 .define("DEBUG", .when(configuration: .debug))

--- a/macOS/LocalPackages/AppUpdater/Sources/AppUpdaterShared/ReleaseNotesParser.swift
+++ b/macOS/LocalPackages/AppUpdater/Sources/AppUpdaterShared/ReleaseNotesParser.swift
@@ -58,31 +58,9 @@ public final class ReleaseNotesParser {
 
     // Helper method to extract list items
     private static func extractListItems(from list: String) -> [String] {
-        var items = [String]()
-        let pattern = "<li>(.*?)</li>"
-
-        do {
-            let regex = try NSRegularExpression(pattern: pattern, options: .dotMatchesLineSeparators)
-            let matches = regex.matches(in: list, options: [], range: NSRange(location: 0, length: list.utf16.count))
-
-            for match in matches {
-                if let range = Range(match.range(at: 1), in: list) {
-                    let item = String(list[range])
-
-                    // Convert HTML to plain text
-                    if let data = item.data(using: .utf8),
-                       let attributedString = try? NSAttributedString(data: data,
-                                                                      options: [.documentType: NSAttributedString.DocumentType.html,
-                                                                                .characterEncoding: String.Encoding.utf8.rawValue],
-                                                                      documentAttributes: nil) {
-                        items.append(attributedString.string)
-                    }
-                }
-            }
-        } catch {
-            assertionFailure("Error creating regular expression: \(error)")
-        }
-
-        return items
+        // TEMP(profiling): bypass the per-item NSAttributedString HTML→text conversion
+        // (synchronous, main-thread-only, spins a WebKit/nested run loop) to test whether
+        // it is responsible for the launch hang. REVERT before commit.
+        return ["Release note one", "Release note two", "Release note three"]
     }
 }

--- a/macOS/LocalPackages/AppUpdater/Sources/AppUpdaterShared/ReleaseNotesParser.swift
+++ b/macOS/LocalPackages/AppUpdater/Sources/AppUpdaterShared/ReleaseNotesParser.swift
@@ -17,31 +17,72 @@
 //
 
 import Foundation
-import SwiftSoup
 
 public final class ReleaseNotesParser {
 
     public static func parseReleaseNotes(from description: String?) -> ([String], [String]) {
         guard let description else { return ([], []) }
 
+        var standardReleaseNotes = [String]()
+        var subscriptionReleaseNotes = [String]()
+
+        // Patterns for the two sections with more flexible spacing
+        let standardPattern = "<h3[^>]*>What's new</h3>\\s*<ul>(.*?)</ul>"
+        let subscriptionPattern = "<h3[^>]*>For DuckDuckGo subscribers</h3>\\s*<ul>(.*?)</ul>"
+
         do {
-            let document = try SwiftSoup.parse(description)
-            let standardReleaseNotes = try releaseNotes(in: document, forSectionTitled: "What's new")
-            let subscriptionReleaseNotes = try releaseNotes(in: document, forSectionTitled: "For DuckDuckGo subscribers")
-            return (standardReleaseNotes, subscriptionReleaseNotes)
+            let standardRegex = try NSRegularExpression(pattern: standardPattern, options: .dotMatchesLineSeparators)
+            let subscriptionRegex = try NSRegularExpression(pattern: subscriptionPattern, options: .dotMatchesLineSeparators)
+
+            // Extract the standard release notes section
+            if let standardMatch = standardRegex.firstMatch(in: description, options: [], range: NSRange(location: 0, length: description.utf16.count)) {
+                if let range = Range(standardMatch.range(at: 1), in: description) {
+                    let standardList = String(description[range])
+                    standardReleaseNotes = extractListItems(from: standardList)
+                }
+            }
+
+            // Extract the Subscription release notes section
+            if let subscriptionMatch = subscriptionRegex.firstMatch(in: description, options: [], range: NSRange(location: 0, length: description.utf16.count)) {
+                if let range = Range(subscriptionMatch.range(at: 1), in: description) {
+                    let subscriptionList = String(description[range])
+                    subscriptionReleaseNotes = extractListItems(from: subscriptionList)
+                }
+            }
         } catch {
-            assertionFailure("Error parsing release notes HTML: \(error)")
-            return ([], [])
+            assertionFailure("Error creating regular expression: \(error)")
         }
+
+        return (standardReleaseNotes, subscriptionReleaseNotes)
     }
 
-    /// Returns the plain-text list items from the `<ul>` immediately following the `<h3>` with the given title.
-    private static func releaseNotes(in document: Document, forSectionTitled title: String) throws -> [String] {
-        guard let header = try document.select("h3").first(where: { try $0.text() == title }),
-              let list = try header.nextElementSibling(), list.tagName() == "ul" else {
-            return []
+    // Helper method to extract list items
+    private static func extractListItems(from list: String) -> [String] {
+        var items = [String]()
+        let pattern = "<li>(.*?)</li>"
+
+        do {
+            let regex = try NSRegularExpression(pattern: pattern, options: .dotMatchesLineSeparators)
+            let matches = regex.matches(in: list, options: [], range: NSRange(location: 0, length: list.utf16.count))
+
+            for match in matches {
+                if let range = Range(match.range(at: 1), in: list) {
+                    let item = String(list[range])
+
+                    // Convert HTML to plain text
+                    if let data = item.data(using: .utf8),
+                       let attributedString = try? NSAttributedString(data: data,
+                                                                      options: [.documentType: NSAttributedString.DocumentType.html,
+                                                                                .characterEncoding: String.Encoding.utf8.rawValue],
+                                                                      documentAttributes: nil) {
+                        items.append(attributedString.string)
+                    }
+                }
+            }
+        } catch {
+            assertionFailure("Error creating regular expression: \(error)")
         }
 
-        return try list.select("li").map { try $0.text() }
+        return items
     }
 }

--- a/macOS/LocalPackages/AppUpdater/Sources/AppUpdaterShared/ReleaseNotesParser.swift
+++ b/macOS/LocalPackages/AppUpdater/Sources/AppUpdaterShared/ReleaseNotesParser.swift
@@ -17,50 +17,31 @@
 //
 
 import Foundation
+import SwiftSoup
 
 public final class ReleaseNotesParser {
 
     public static func parseReleaseNotes(from description: String?) -> ([String], [String]) {
         guard let description else { return ([], []) }
 
-        var standardReleaseNotes = [String]()
-        var subscriptionReleaseNotes = [String]()
-
-        // Patterns for the two sections with more flexible spacing
-        let standardPattern = "<h3[^>]*>What's new</h3>\\s*<ul>(.*?)</ul>"
-        let subscriptionPattern = "<h3[^>]*>For DuckDuckGo subscribers</h3>\\s*<ul>(.*?)</ul>"
-
         do {
-            let standardRegex = try NSRegularExpression(pattern: standardPattern, options: .dotMatchesLineSeparators)
-            let subscriptionRegex = try NSRegularExpression(pattern: subscriptionPattern, options: .dotMatchesLineSeparators)
-
-            // Extract the standard release notes section
-            if let standardMatch = standardRegex.firstMatch(in: description, options: [], range: NSRange(location: 0, length: description.utf16.count)) {
-                if let range = Range(standardMatch.range(at: 1), in: description) {
-                    let standardList = String(description[range])
-                    standardReleaseNotes = extractListItems(from: standardList)
-                }
-            }
-
-            // Extract the Subscription release notes section
-            if let subscriptionMatch = subscriptionRegex.firstMatch(in: description, options: [], range: NSRange(location: 0, length: description.utf16.count)) {
-                if let range = Range(subscriptionMatch.range(at: 1), in: description) {
-                    let subscriptionList = String(description[range])
-                    subscriptionReleaseNotes = extractListItems(from: subscriptionList)
-                }
-            }
+            let document = try SwiftSoup.parse(description)
+            let standardReleaseNotes = try releaseNotes(in: document, forSectionTitled: "What's new")
+            let subscriptionReleaseNotes = try releaseNotes(in: document, forSectionTitled: "For DuckDuckGo subscribers")
+            return (standardReleaseNotes, subscriptionReleaseNotes)
         } catch {
-            assertionFailure("Error creating regular expression: \(error)")
+            assertionFailure("Error parsing release notes HTML: \(error)")
+            return ([], [])
         }
-
-        return (standardReleaseNotes, subscriptionReleaseNotes)
     }
 
-    // Helper method to extract list items
-    private static func extractListItems(from list: String) -> [String] {
-        // TEMP(profiling): bypass the per-item NSAttributedString HTML→text conversion
-        // (synchronous, main-thread-only, spins a WebKit/nested run loop) to test whether
-        // it is responsible for the launch hang. REVERT before commit.
-        return ["Release note one", "Release note two", "Release note three"]
+    /// Returns the plain-text list items from the `<ul>` immediately following the `<h3>` with the given title.
+    private static func releaseNotes(in document: Document, forSectionTitled title: String) throws -> [String] {
+        guard let header = try document.select("h3").first(where: { try $0.text() == title }),
+              let list = try header.nextElementSibling(), list.tagName() == "ul" else {
+            return []
+        }
+
+        return try list.select("li").map { try $0.text() }
     }
 }

--- a/macOS/LocalPackages/AppUpdater/Sources/SparkleAppUpdater/SparkleUpdateController.swift
+++ b/macOS/LocalPackages/AppUpdater/Sources/SparkleAppUpdater/SparkleUpdateController.swift
@@ -83,24 +83,28 @@ public final class SparkleUpdateController: NSObject, SparkleUpdateControlling {
 
     private var cachedUpdateResult: UpdateCheckResult? {
         didSet {
-            if let cachedUpdateResult {
-                refreshUpdateFromCache(cachedUpdateResult)
-            } else {
+            guard let cachedUpdateResult else {
                 latestUpdate = nil
                 hasPendingUpdate = false
                 needsNotificationDot = false
+                return
             }
+            // Rebuild the Update view-model only when the appcast result changes. This is the
+            // only place that parses release notes, so it must not run on every progress tick.
+            latestUpdate = Update(appcastItem: cachedUpdateResult.item, isInstalled: cachedUpdateResult.isInstalled)
+            refreshPendingUpdateState()
         }
     }
 
-    private func refreshUpdateFromCache(_ cachedUpdateResult: UpdateCheckResult, progress: UpdateCycleProgress? = nil) {
-        latestUpdate = Update(appcastItem: cachedUpdateResult.item, isInstalled: cachedUpdateResult.isInstalled)
-        let isInstalled = latestUpdate?.isInstalled == false
+    /// Recomputes `hasPendingUpdate` from the current `latestUpdate` and progress state.
+    ///
+    /// Cheap and safe to call on every progress change — unlike rebuilding `latestUpdate`, it
+    /// does not re-parse release notes.
+    private func refreshPendingUpdateState(progress: UpdateCycleProgress? = nil) {
+        let hasInstallableUpdate = latestUpdate?.isInstalled == false
         // Use passed progress if available (avoids @Published willSet timing issue)
         let currentProgress = progress ?? progressState.updateProgress
-        let isDone = currentProgress.isDone
-        let isResumable = progressState.isResumable
-        hasPendingUpdate = isInstalled && isDone && isResumable
+        hasPendingUpdate = hasInstallableUpdate && currentProgress.isDone && progressState.isResumable
     }
 
     // MARK: - Update Progress State Machine
@@ -114,9 +118,7 @@ public final class SparkleUpdateController: NSObject, SparkleUpdateControlling {
     public var updateProgressPublisher: Published<UpdateCycleProgress>.Publisher { progressState.updateProgressPublisher }
 
     private func handleProgressChange(_ progress: UpdateCycleProgress) {
-        if let cachedUpdateResult {
-            refreshUpdateFromCache(cachedUpdateResult, progress: progress)
-        }
+        refreshPendingUpdateState(progress: progress)
         handleUpdateNotification()
     }
 

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/IPC/DataBrokerProtectionIPCClient.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/IPC/DataBrokerProtectionIPCClient.swift
@@ -30,7 +30,7 @@ public protocol IPCClientInterface: AnyObject {
 }
 
 public protocol DBPLoginItemStatusChecker {
-    func doesHaveNecessaryPermissions() -> Bool
+    func doesHaveNecessaryPermissions() async -> Bool
     func isInCorrectDirectory() -> Bool
 }
 

--- a/macOS/LocalPackages/LoginItems/Sources/LoginItems/LoginItem.swift
+++ b/macOS/LocalPackages/LoginItems/Sources/LoginItems/LoginItem.swift
@@ -71,16 +71,27 @@ public struct LoginItem: Equatable, Hashable {
         }
     }
 
-    public var status: Status {
+    /// Reads the login item status.
+    ///
+    /// The underlying `SMAppService` read performs synchronous XPC to the Service Management
+    /// daemon, so it is dispatched onto a detached `Task` to keep it off the caller's thread
+    /// (notably the main thread during launch).
+    public func status() async -> Status {
+        let agentBundleID = agentBundleID
+        let logger = logger
         guard #available(macOS 13.0, *) else {
-            guard let job = ServiceManagement.copyAllJobDictionaries(kSMDomainUserLaunchd).first(where: {
-                $0["Label"] as? String == agentBundleID
-            }) else { return .notRegistered }
+            return await Task.detached {
+                guard let job = ServiceManagement.copyAllJobDictionaries(kSMDomainUserLaunchd).first(where: {
+                    $0["Label"] as? String == agentBundleID
+                }) else { return .notRegistered }
 
-            logger.debug("🟢 found login item job: \(job.debugDescription, privacy: .public)")
-            return job["OnDemand"] as? Bool == true ? .enabled : .requiresApproval
+                logger.debug("🟢 found login item job: \(job.debugDescription, privacy: .public)")
+                return job["OnDemand"] as? Bool == true ? .enabled : .requiresApproval
+            }.value
         }
-        return Status(SMAppService.loginItem(identifier: agentBundleID).status)
+        return await Task.detached {
+            Status(SMAppService.loginItem(identifier: agentBundleID).status)
+        }.value
     }
 
     public init(bundleId: String, defaults: UserDefaults, logger: Logger) {
@@ -90,31 +101,39 @@ public struct LoginItem: Equatable, Hashable {
         self.logger = logger
     }
 
-    public func enable() throws {
+    public func enable() async throws {
         logger.debug("🟢 registering login item \(self.debugDescription, privacy: .public)")
 
+        let agentBundleID = agentBundleID
         if #available(macOS 13.0, *) {
-            try SMAppService.loginItem(identifier: agentBundleID).register()
+            try await Task.detached {
+                try SMAppService.loginItem(identifier: agentBundleID).register()
+            }.value
         } else {
-            let success = SMLoginItemSetEnabled(agentBundleID as CFString, true)
-            if !success {
-                throw SMLoginItemSetEnabledError.failed
-            }
+            try await Task.detached {
+                if !SMLoginItemSetEnabled(agentBundleID as CFString, true) {
+                    throw SMLoginItemSetEnabledError.failed
+                }
+            }.value
         }
 
         launchInformation.updateLastEnabledTimestamp()
     }
 
-    public func disable() throws {
+    public func disable() async throws {
         logger.debug("🟢 unregistering login item \(self.debugDescription, privacy: .public)")
 
+        let agentBundleID = agentBundleID
         if #available(macOS 13.0, *) {
-            try SMAppService.loginItem(identifier: agentBundleID).unregister()
+            try await Task.detached {
+                try SMAppService.loginItem(identifier: agentBundleID).unregister()
+            }.value
         } else {
-            let success = SMLoginItemSetEnabled(agentBundleID as CFString, false)
-            if !success {
-                throw SMLoginItemSetEnabledError.failed
-            }
+            try await Task.detached {
+                if !SMLoginItemSetEnabled(agentBundleID as CFString, false) {
+                    throw SMLoginItemSetEnabledError.failed
+                }
+            }.value
         }
     }
 
@@ -122,13 +141,13 @@ public struct LoginItem: Equatable, Hashable {
     ///
     /// This call will only enable the login item if it was enabled to begin with.
     ///
-    public func restart() throws {
-        guard [.enabled].contains(status) else {
+    public func restart() async throws {
+        guard await status() == .enabled else {
             logger.debug("🟢 restart not needed for login item \(self.debugDescription, privacy: .public)")
             return
         }
-        try? disable()
-        try enable()
+        try? await disable()
+        try await enable()
     }
 
     public func forceStop() {
@@ -150,7 +169,7 @@ public struct LoginItem: Equatable, Hashable {
 extension LoginItem: CustomDebugStringConvertible {
 
     public var debugDescription: String {
-        "<LoginItem \(agentBundleID) isEnabled: \(status) isRunning: \(isRunning)>"
+        "<LoginItem \(agentBundleID) isRunning: \(isRunning)>"
     }
 
 }

--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Views/StatusView/NetworkProtectionStatusViewModel.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Views/StatusView/NetworkProtectionStatusViewModel.swift
@@ -208,7 +208,9 @@ extension NetworkProtectionStatusView {
         }
 
         func refreshLoginItemStatus() {
-            self.loginItemNeedsApproval = agentLoginItem?.status == .requiresApproval
+            Task { @MainActor in
+                self.loginItemNeedsApproval = await self.agentLoginItem?.status() == .requiresApproval
+            }
         }
 
         func openLoginItemSettings() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1215959562779970?focus=true

### Description

Two main-thread hangs were observed a few seconds into a Release-build macOS launch. Both trace to the Sparkle release-notes parser, which rendered each appcast list item with `NSAttributedString(.html)` — a synchronous XPC call to an out-of-process HTML renderer that is only safe on the main thread. This replaces that rendering with SwiftSoup DOM parsing, and stops `SparkleUpdateController` from rebuilding (and re-parsing) the `Update` view-model on every update-progress emission.

It also includes a proof-of-concept that makes the `LoginItem` `SMAppService` API async, so register/unregister/status run off the main thread via detached tasks, with the async call chain propagated through the VPN and DBP login-item paths.

This is a PoC branch: it bundles two independent changesets and also carries a profiling-only stub (`Application.swift` disables the move-to-Applications prompt) that must not merge as-is.

### Testing Steps

1. Build and run the macOS app.
2. Trigger an update check from the Debug menu.
3. Open the release notes view.
   Release notes render as plain text, with HTML tags removed and entities decoded.
4. Enable the VPN from Settings.
   The VPN login item enables and the tunnel starts.
5. Disable the VPN.
   The login item is removed with no errors.

### Impact and Risks

Medium. The release-notes change is user-visible in the update UI, and the async login-item change alters the VPN and DBP login-item enable/disable lifecycle.

#### What could go wrong?

SwiftSoup may normalise whitespace and entities slightly differently from `NSAttributedString`, so release-notes text could shift in edge cases; parser unit tests should pin the expected output. The async login-item conversion changes timing/ordering of register/unregister calls, which could affect VPN/DBP startup checkpoints.

### Quality Considerations

Performance is the point: the change removes two main-thread hangs and the per-progress re-parse. Note that TTI (measured to first window via `viewDidAppear`) is unaffected — these hangs occur after that milestone; the win is post-launch responsiveness. Test target may not build until login-item mocks are updated to the async signatures.

### Notes to Reviewer

Two independent efforts live here. The `Application.swift` profiling stub is not for merge. If this should become a shippable PR, the startup-hang fix is worth splitting onto its own branch.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
