### PR TITLE
Add missing channel and petal params to macOS pixel definitions

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/autoconsent.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/autoconsent.json5
@@ -394,6 +394,11 @@
                 "type": "string",
                 "enum": ["0s", "1-10s", "10-60s", "1-5min", "5-10min", "10-20min", "20-40min", "40-60min", "1-2hr", "2hr+", "unknown"]
             },
+            {
+                "key": "petal",
+                "description": "Routes the pixel through the PETAL timestamp-randomization pipeline",
+                "enum": ["true"]
+            },
             "channel"
         ]
     },
@@ -423,7 +428,7 @@
         "owners": ["miasma13"],
         "triggers": ["user_submitted"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_autoconsent_popover-autodismissed_daily": {
         "description": "Fires when the autoconsent stats popover is automatically dismissed after the timeout period.",

--- a/macOS/PixelDefinitions/pixels/definitions/web_extensions.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/web_extensions.json5
@@ -271,7 +271,8 @@
                 "key": "extension_type",
                 "type": "string",
                 "description": "The web extension type the scriptlets belong to"
-            }
+            },
+            "channel"
         ]
     },
     "m_mac_web_extension_scriptlet_validation_error": {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203936086921904/task/1215891186043374?focus=true
Tech Design URL: N/A
CC:

### Description

A pixel report flagged three macOS pixels sending parameters that were absent from their JSON5 definitions. All three reports were verified accurate against the firing code, and the definitions are updated to match (reusing the existing `channel` shared key and the inline `petal` pattern):

- `m_mac_autoconsent_usage-stats_daily` — added `petal`. `AutoconsentPixels.swift` sets `params["petal"] = "true"` per the privacy-triage requirement. Used `enum: ["true"]` (the literal value fired), distinct from the os_distribution pixels' `"randomize"`.
- `m_mac_web_extension_scriptlet_fetch_error` — added `channel`.
- `m_mac_autoconsent_popover-new-tab-opened_daily` — added `channel`.

`channel` is appended to every PixelKit pixel in non-production (canary/dev) builds (`PixelKit.swift`), so any definition omitting it gets flagged.

### Testing Steps
1. From `macOS/`, the pixel definitions are validated in CI via `npm run validate-pixel-defs`.
2. Confirm the added params match the firing code: `petal = "true"` in `AutoconsentPixels.swift`, and `channel` appended globally in `PixelKit.swift`.

### Impact and Risks

Low — definitions-only change. No runtime behavior is affected; these parameters are already being sent. The update only brings the schema in line with reality so pixel validation/monitoring stops flagging them.

#### What could go wrong?

Minimal. If the `petal` enum value were wrong it would fail validation, but it matches the literal `"true"` fired by the code.

### Quality Considerations

Two sibling pixels (`m_mac_autoconsent_popover-clicked_daily`, `m_mac_autoconsent_popover-autodismissed_daily`) also omit `channel` and will likely be flagged once they fire in canary/dev builds. Left out of this PR as they weren't in the report — easy follow-up if desired.

### Notes to Reviewer

The local `validate-pixel-defs` script couldn't run in my worktree due to a stale `@duckduckgo/pixel-schema` in node_modules expecting an older layout; verified instead via JSON5 parse + prettier + pattern-matching existing entries. CI runs the correct schema version.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only changes; no runtime or telemetry behavior changes.
> 
> **Overview**
> Updates macOS pixel JSON5 definitions so validation matches parameters the app already sends, after monitoring flagged mismatches.
> 
> For **`m_mac_autoconsent_usage-stats_daily`**, the schema now includes **`petal`** with `enum: ["true"]`, matching `AutoconsentPixels.swift` (distinct from os-distribution pixels that use `"randomize"`). **`channel`** is also listed on that pixel alongside the other autoconsent definitions.
> 
> **`channel`** is added to **`m_mac_autoconsent_popover-new-tab-opened_daily`** and **`m_mac_web_extension_scriptlet_fetch_error`**, consistent with PixelKit appending `channel` on non-production builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37385ce2dbca13ad592e708f057e8efd8060078f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->