### PR TITLE
iOS: Add forward-only new-user cutoff for Unified Toggle Input

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -457,6 +457,12 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
 
     case unifiedToggleInput
 
+    /// Forward-only lever for the unified toggle input rollout. When disabled, *new* (un-granted)
+    /// users stop receiving the unified toggle input; users who have already been granted it keep
+    /// it. Independent of the master `unifiedToggleInput` flag (which revokes from everyone when
+    /// turned off). See `UnifiedToggleInputFeature`.
+    case unifiedToggleInputIncludeNewUsers
+
     /// Hides the Search↔Duck.ai toggle in the unified input when the user is on a Duck.ai tab,
     /// regardless of the user's `Settings → Address Bar → Show Duck.ai Toggle` preference. Lets us
     /// roll out the new Duck.ai-tab nav UI (no toggle on chat) independently of the master flag.

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -318,6 +318,13 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1206488453854252/task/1212289671815991
     case unifiedToggleInput
 
+    /// Forward-only new-user cutoff for the unified toggle input rollout. On by default; ship a
+    /// privacy-config entry disabling it to stop *new* (un-granted) users from receiving UTI
+    /// without revoking it from anyone already granted. Distinct from `unifiedToggleInput`, which
+    /// is the full kill switch. See `UnifiedToggleInputFeature`.
+    /// https://app.asana.com/1/137249556945/project/1206488453854252/task/1212289671815991
+    case unifiedToggleInputIncludeNewUsers
+
     /// Production kill switch (on by default) for web-scroll-freeze observability: the passive scroll-failure
     /// observer (bystander recognizer) + the symptom/mechanism pixels. Ship a privacy-config entry to roll back.
     case webScrollFreezeObservability
@@ -736,6 +743,10 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.showWhatsNewPromptOnDemand))
         case .unifiedToggleInput:
             Config(source: .remoteReleasable(AIChatSubfeature.unifiedToggleInput))
+        case .unifiedToggleInputIncludeNewUsers:
+            Config(defaultValue: .enabled,
+                   source: .remoteReleasable(AIChatSubfeature.unifiedToggleInputIncludeNewUsers),
+                   supportsLocalOverriding: false)
         case .webScrollFreezeObservability:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.webScrollFreezeObservability))
         case .webScrollFreezeCapture:

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputFeature.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputFeature.swift
@@ -35,13 +35,33 @@ protocol UnifiedToggleInputFeatureProviding {
 
 struct UnifiedToggleInputFeature: UnifiedToggleInputFeatureProviding {
 
-    private static let isFeatureFlagEnabledKey = "com.duckduckgo.unifiedToggleInput.session.enabled"
+    private static let isEligibleKey = "com.duckduckgo.unifiedToggleInput.eligible"
     private static let isToggleHiddenOnDuckAITabKey = "com.duckduckgo.unifiedToggleInput.aiChatTabHideToggle.session.enabled"
 
+    /// Forward-only "this device has had UTI" bit. Persists across launches and flag flips and is
+    /// cleared only by uninstall. Lets the new-user cutoff (`unifiedToggleInputIncludeNewUsers`)
+    /// stop *new* users without revoking UTI from anyone already granted.
+    private static let hasGrantedKey = "com.duckduckgo.unifiedToggleInput.hasGranted"
+
     /// Snapshot the feature flags once per session. Call early at launch, before any consumer reads `isAvailable` / `isToggleHiddenOnDuckAITab`.
-    static func resolve(using featureFlagger: FeatureFlagger) {
-        UserDefaults.app.set(featureFlagger.isFeatureOn(.unifiedToggleInput), forKey: isFeatureFlagEnabledKey)
+    static func resolve(using featureFlagger: FeatureFlagger,
+                        devicePlatform: DevicePlatformProviding.Type = DevicePlatform.self) {
+        let featureOn = featureFlagger.isFeatureOn(.unifiedToggleInput)
+        let includeNewUsers = featureFlagger.isFeatureOn(.unifiedToggleInputIncludeNewUsers)
+        let hasGranted = UserDefaults.app.bool(forKey: hasGrantedKey)
+
+        // Eligible when the `unifiedToggleInput` flag is on AND the user either already had UTI
+        // (sticky grant) or new users are still being included. That flag off revokes UTI from everyone.
+        let isEligible = featureOn && (hasGranted || includeNewUsers)
+        UserDefaults.app.set(isEligible, forKey: isEligibleKey)
         UserDefaults.app.set(featureFlagger.isFeatureOn(.aiChatTabHideToggle), forKey: isToggleHiddenOnDuckAITabKey)
+
+        // Lock in the grant the first launch UTI is actually available on this device, so a later
+        // new-user cutoff never revokes it. Device-gated so a device that never showed UTI is not
+        // wrongly treated as granted if UTI later expands beyond iPhone.
+        if isEligible && devicePlatform.isIphone && !hasGranted {
+            UserDefaults.app.set(true, forKey: hasGrantedKey)
+        }
     }
 
     private let devicePlatform: DevicePlatformProviding.Type
@@ -50,15 +70,24 @@ struct UnifiedToggleInputFeature: UnifiedToggleInputFeatureProviding {
         self.devicePlatform = devicePlatform
     }
 
-    private var isFeatureFlagEnabled: Bool {
-        UserDefaults.app.bool(forKey: Self.isFeatureFlagEnabledKey)
+    private var isEligible: Bool {
+        UserDefaults.app.bool(forKey: Self.isEligibleKey)
     }
 
     var isAvailable: Bool {
-        isFeatureFlagEnabled && devicePlatform.isIphone
+        isEligible && devicePlatform.isIphone
     }
 
     var isToggleHiddenOnDuckAITab: Bool {
         UserDefaults.app.bool(forKey: Self.isToggleHiddenOnDuckAITabKey)
     }
+
+#if DEBUG
+    /// Test-only: clears the persisted UTI state (sticky grant + eligibility snapshot) so each test
+    /// starts from a clean, un-granted device without depending on a follow-up `resolve(...)`.
+    static func resetPersistedStateForTesting() {
+        UserDefaults.app.removeObject(forKey: hasGrantedKey)
+        UserDefaults.app.removeObject(forKey: isEligibleKey)
+    }
+#endif
 }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputFeatureTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputFeatureTests.swift
@@ -34,42 +34,107 @@ final class UnifiedToggleInputFeatureTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        UnifiedToggleInputFeature.resolve(using: MockFeatureFlagger(enabledFeatureFlags: []))
-        MockDevicePlatform.isIphone = false
+        resetState()
     }
 
     override func tearDown() {
-        UnifiedToggleInputFeature.resolve(using: MockFeatureFlagger(enabledFeatureFlags: []))
-        MockDevicePlatform.isIphone = false
+        resetState()
         super.tearDown()
+    }
+
+    private func resetState() {
+        UnifiedToggleInputFeature.resetPersistedStateForTesting()
+        UnifiedToggleInputFeature.resolve(using: MockFeatureFlagger(enabledFeatureFlags: []),
+                                          devicePlatform: MockDevicePlatform.self)
+        MockDevicePlatform.isIphone = false
     }
 
     // MARK: - Helpers
 
-    private func makeFeature(flagEnabled: Bool, isIphone: Bool) -> UnifiedToggleInputFeature {
+    /// Mirrors a launch: snapshots the given flag state for the given device.
+    private func resolve(featureOn: Bool, includeNewUsers: Bool, isIphone: Bool) {
         MockDevicePlatform.isIphone = isIphone
-        let flags: [FeatureFlag] = flagEnabled ? [.unifiedToggleInput] : []
-        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: flags)
-        UnifiedToggleInputFeature.resolve(using: featureFlagger)
+        var flags: [FeatureFlag] = []
+        if featureOn { flags.append(.unifiedToggleInput) }
+        if includeNewUsers { flags.append(.unifiedToggleInputIncludeNewUsers) }
+        UnifiedToggleInputFeature.resolve(using: MockFeatureFlagger(enabledFeatureFlags: flags),
+                                          devicePlatform: MockDevicePlatform.self)
+    }
+
+    private func makeFeature(isIphone: Bool) -> UnifiedToggleInputFeature {
+        MockDevicePlatform.isIphone = isIphone
         return UnifiedToggleInputFeature(devicePlatform: MockDevicePlatform.self)
     }
 
-    // MARK: - Tests
+    // MARK: - Feature flag × device
 
     func test_isAvailable_whenFlagOnAndIphone() {
-        XCTAssertTrue(makeFeature(flagEnabled: true, isIphone: true).isAvailable)
+        resolve(featureOn: true, includeNewUsers: true, isIphone: true)
+        XCTAssertTrue(makeFeature(isIphone: true).isAvailable)
     }
 
     func test_isNotAvailable_whenFlagOnButNotIphone() {
-        XCTAssertFalse(makeFeature(flagEnabled: true, isIphone: false).isAvailable)
+        resolve(featureOn: true, includeNewUsers: true, isIphone: false)
+        XCTAssertFalse(makeFeature(isIphone: false).isAvailable)
     }
 
     func test_isNotAvailable_whenFlagOffButIphone() {
-        XCTAssertFalse(makeFeature(flagEnabled: false, isIphone: true).isAvailable)
+        resolve(featureOn: false, includeNewUsers: true, isIphone: true)
+        XCTAssertFalse(makeFeature(isIphone: true).isAvailable)
     }
 
     func test_isNotAvailable_whenFlagOffAndNotIphone() {
-        XCTAssertFalse(makeFeature(flagEnabled: false, isIphone: false).isAvailable)
+        resolve(featureOn: false, includeNewUsers: true, isIphone: false)
+        XCTAssertFalse(makeFeature(isIphone: false).isAvailable)
+    }
+
+    // MARK: - New-user cutoff
+
+    /// A new iPhone user with both flags on gets UTI, and the grant is sticky: flipping the
+    /// new-user cutoff off afterwards must NOT take UTI away from them.
+    func test_grantedUser_keepsUTI_afterNewUserCutoff() {
+        resolve(featureOn: true, includeNewUsers: true, isIphone: true)
+        XCTAssertTrue(makeFeature(isIphone: true).isAvailable, "Precondition: new user is granted UTI")
+
+        resolve(featureOn: true, includeNewUsers: false, isIphone: true)
+        XCTAssertTrue(makeFeature(isIphone: true).isAvailable,
+                      "A granted user must keep UTI after the new-user cutoff")
+    }
+
+    /// A user who has never been granted UTI must not receive it once the cutoff is active, and
+    /// re-launching must keep them out (no grant was ever recorded).
+    func test_newUser_afterCutoff_neverGetsUTI() {
+        resolve(featureOn: true, includeNewUsers: false, isIphone: true)
+        XCTAssertFalse(makeFeature(isIphone: true).isAvailable)
+
+        resolve(featureOn: true, includeNewUsers: false, isIphone: true)
+        XCTAssertFalse(makeFeature(isIphone: true).isAvailable,
+                       "An un-granted user stays out across launches while the cutoff is active")
+    }
+
+    /// The `unifiedToggleInput` flag remains a full kill switch: turning it off revokes UTI even
+    /// from a user who was previously granted.
+    func test_featureFlagOff_revokesEvenGrantedUser() {
+        resolve(featureOn: true, includeNewUsers: true, isIphone: true)
+        XCTAssertTrue(makeFeature(isIphone: true).isAvailable, "Precondition: user is granted UTI")
+
+        resolve(featureOn: false, includeNewUsers: true, isIphone: true)
+        XCTAssertFalse(makeFeature(isIphone: true).isAvailable,
+                       "Turning the feature flag off removes UTI from everyone, including granted users")
+    }
+
+    /// Exercises the device guard on grant-recording. The first launch is eligible by flags
+    /// (`includeNewUsers` on) but runs on a non-iPhone, so the grant must be blocked solely by the
+    /// `&& devicePlatform.isIphone` guard. The second launch — now an iPhone with the cutoff active —
+    /// would return `isAvailable == true` if a grant had leaked through on the non-iPhone launch, so
+    /// asserting `false` here proves the device guard held. (Drop the guard and this test fails.)
+    func test_nonIphone_doesNotRecordGrant() {
+        resolve(featureOn: true, includeNewUsers: true, isIphone: false)
+        XCTAssertFalse(makeFeature(isIphone: false).isAvailable, "Precondition: non-iPhone never shows UTI")
+
+        resolve(featureOn: true, includeNewUsers: false, isIphone: true)
+        XCTAssertFalse(makeFeature(isIphone: true).isAvailable,
+                       "No grant was recorded on the non-iPhone launch, so the new-user cutoff now excludes it")
     }
 
     // MARK: - Snapshot semantics
@@ -78,8 +143,8 @@ final class UnifiedToggleInputFeatureTests: XCTestCase {
     /// value into UserDefaults, while readers still apply the device availability gate.
     func test_isAvailable_usesLaunchResolvedFlagSnapshot() {
         MockDevicePlatform.isIphone = true
-        let flagger = MockFeatureFlagger(enabledFeatureFlags: [.unifiedToggleInput])
-        UnifiedToggleInputFeature.resolve(using: flagger)
+        let flagger = MockFeatureFlagger(enabledFeatureFlags: [.unifiedToggleInput, .unifiedToggleInputIncludeNewUsers])
+        UnifiedToggleInputFeature.resolve(using: flagger, devicePlatform: MockDevicePlatform.self)
         let feature = UnifiedToggleInputFeature(devicePlatform: MockDevicePlatform.self)
         XCTAssertTrue(feature.isAvailable, "Precondition: availability is ON after resolve")
 
@@ -91,7 +156,7 @@ final class UnifiedToggleInputFeatureTests: XCTestCase {
         XCTAssertTrue(UnifiedToggleInputFeature(devicePlatform: MockDevicePlatform.self).isAvailable,
                       "A fresh instance must read the same snapshot, not the mutated live flagger")
 
-        UnifiedToggleInputFeature.resolve(using: flagger)
+        UnifiedToggleInputFeature.resolve(using: flagger, devicePlatform: MockDevicePlatform.self)
         XCTAssertFalse(feature.isAvailable,
                        "After re-resolving the snapshot must flip — otherwise resolve isn't doing its job")
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1214241865640183?focus=true

### Description

Adds a second, gentler de-risk lever for the Unified Toggle Input (UTI) rollout: a forward-only **new-user cutoff** that stops *new* (un-granted) users from receiving UTI **without** revoking it from users who already have it.

- New flag `unifiedToggleInputIncludeNewUsers` (default **enabled**, `supportsLocalOverriding: false`) — flip it off remotely to stop new users.
- Sticky per-device `hasGranted` bit. Eligibility `= unifiedToggleInput && (hasGranted || includeNewUsers)`, computed once at launch in `UnifiedToggleInputFeature.resolve(...)`; `isAvailable` stays a pure read (no consumer-site changes).
- The existing `unifiedToggleInput` flag remains the full kill switch (off → revoked for everyone).

### Testing Steps
Test on a device as an internal user. Only internal users currently get UTI and the new `hasGranted` bit won't exist yet, so **force the flags in code** for deterministic results — and **fresh install** between the steps that need it. In `UnifiedToggleInputFeature.resolve(...)`, replace these two lines:

```swift
let featureOn = featureFlagger.isFeatureOn(.unifiedToggleInput)
let includeNewUsers = featureFlagger.isFeatureOn(.unifiedToggleInputIncludeNewUsers)
```

with hardcoded values per step:

1. **New user gets it:** `let featureOn = true` / `let includeNewUsers = true`. **Fresh install**, launch → UTI appears (grant recorded).
2. **Existing user keeps it after cutoff:** change to `let includeNewUsers = false` (keep `let featureOn = true`), rebuild **without uninstalling**, relaunch → UTI **still present** (already granted; the cutoff does not revoke).
3. **New user blocked:** keep `let featureOn = true` / `let includeNewUsers = false`, **uninstall and reinstall**, launch → UTI **absent** (un-granted new user is cut off; no grant recorded).
4. **Kill switch:** set `let featureOn = false`, relaunch → UTI **gone** for everyone, even a previously granted user.

Unit tests cover every branch above with no code edits: `UnifiedToggleInputFeatureTests` (9 cases), passing locally.

### Impact and Risks
**Low.** Gated behind feature flags; UTI is internal-only in production today.

#### What could go wrong?
An existing UTI user could in theory lose UTI if the cutoff were flipped off *before* they first launch the build carrying this change (they'd have no `hasGranted` bit yet). The at-risk population is empty in production (UTI is internal-only), and this PR ships the grant mechanism *before* UTI reaches production users, so the case cannot materialise.

### Notes to Reviewer
All gate + grant logic lives in `resolve(...)` (the single launch-time mutation point); `isAvailable` is unchanged in shape. The flags are snapshotted once at launch and `unifiedToggleInputIncludeNewUsers` has `supportsLocalOverriding: false`, so the debug menu can't drive these states — hence the in-code overrides above.
