### PR TITLE
[Release PR] Update Duck.ai prompt wide event with additional delivery parameters

### DIFF
--- a/iOS/DuckDuckGo/AIChat/WideEvent/DuckAIPromptWideEventData.swift
+++ b/iOS/DuckDuckGo/AIChat/WideEvent/DuckAIPromptWideEventData.swift
@@ -29,7 +29,7 @@ final class DuckAIPromptWideEventData: WideEventData {
         featureName: "duckai-prompt",
         mobileMetaType: "ios-duckai-prompt",
         desktopMetaType: "macos-duckai-prompt",
-        version: "1.0.0"
+        version: "1.1.0"
     )
 
     var globalData: WideEventGlobalData
@@ -49,6 +49,7 @@ final class DuckAIPromptWideEventData: WideEventData {
     var frontendDeliveryPath: FrontendDeliveryPath
     var frontendDeliveryQueued: Bool
     var didSendBridgeMessage: Bool?
+    var didAttemptDelivery: Bool = false
 
     var hasPageContext: Bool
     var toolsSelected: Bool
@@ -160,6 +161,10 @@ final class DuckAIPromptWideEventData: WideEventData {
         /// Another prompt submission started in the same tab or contextual
         /// sheet before this flow reached a terminal outcome.
         case supersededByNewSubmission = "superseded_by_new_submission"
+        /// The submitted text was interpreted as a URL and loaded as a web page
+        /// instead of being sent to Duck.ai, so the started flow never became a
+        /// real prompt submission.
+        case interpretedAsURL = "interpreted_as_url"
     }
 
     enum InputMode: String, Codable {
@@ -221,6 +226,7 @@ extension DuckAIPromptWideEventData {
         parameters[WideEventParameter.DuckAIPromptFeature.isFirstPrompt] = isFirstPrompt
         parameters[WideEventParameter.DuckAIPromptFeature.frontendDeliveryQueued] = frontendDeliveryQueued
         parameters[WideEventParameter.DuckAIPromptFeature.didReceiveBridgeMessage] = frontendSubmissionAckInterval.end != nil
+        parameters[WideEventParameter.DuckAIPromptFeature.didAttemptDelivery] = didAttemptDelivery
         parameters[WideEventParameter.DuckAIPromptFeature.hasPageContext] = hasPageContext
         parameters[WideEventParameter.DuckAIPromptFeature.toolsSelected] = toolsSelected
         parameters[WideEventParameter.DuckAIPromptFeature.attachmentsSelected] = attachmentsSelected
@@ -245,6 +251,7 @@ extension WideEventParameter {
         static let frontendDeliveryQueued = "feature.data.ext.delivery.queued"
         static let didSendBridgeMessage = "feature.data.ext.delivery.did_send_bridge_message"
         static let didReceiveBridgeMessage = "feature.data.ext.delivery.did_receive_bridge_message"
+        static let didAttemptDelivery = "feature.data.ext.delivery.did_attempt_delivery"
         static let hasPageContext = "feature.data.ext.prompt.has_page_context"
         static let toolsSelected = "feature.data.ext.prompt.tools_selected"
         static let attachmentsSelected = "feature.data.ext.prompt.attachments_selected"

--- a/iOS/DuckDuckGo/AIChat/WideEvent/DuckAIWideEventInstrumentation.swift
+++ b/iOS/DuckDuckGo/AIChat/WideEvent/DuckAIWideEventInstrumentation.swift
@@ -88,6 +88,11 @@ protocol DuckAIWideEventInstrumentation: AnyObject {
     /// `NSError` domain/code to the event's error data. No-op if no flow is in
     /// flight.
     func pageLoadFailed(scope: DuckAIWideEventFlowScope, error: Error)
+
+    /// The submitted text was interpreted as a URL and navigated to instead of
+    /// being sent to Duck.ai. Completes the active flow as CANCELLED with
+    /// `cancellation_reason = interpreted_as_url`. No-op if no flow is active.
+    func promptInterpretedAsURL(scope: DuckAIWideEventFlowScope)
 }
 
 @MainActor
@@ -156,6 +161,10 @@ final class DefaultDuckAIWideEventInstrumentation: DuckAIWideEventInstrumentatio
 
         if let didSendBridgeMessage {
             data.didSendBridgeMessage = didSendBridgeMessage
+        }
+
+        if wasQueued != true {
+            data.didAttemptDelivery = true
         }
 
         wideEvent.updateFlow(data)
@@ -252,6 +261,10 @@ final class DefaultDuckAIWideEventInstrumentation: DuckAIWideEventInstrumentatio
         activeFlow.data.endedInterval.end = dateProvider()
         wideEvent.completeFlow(activeFlow.data, status: .failure, onComplete: { _, _ in })
         activeFlows[scope] = nil
+    }
+
+    func promptInterpretedAsURL(scope: DuckAIWideEventFlowScope) {
+        cancelFlow(scope: scope, reason: .interpretedAsURL)
     }
 
     // MARK: - Helpers

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1197,6 +1197,7 @@ extension MainViewController: UnifiedToggleInputDelegate {
            images?.isEmpty ?? true, files?.isEmpty ?? true,
            let url = URL(trimmedAddressBarString: prompt, useUnifiedLogic: isUnifiedURLPredictionEnabled),
            url.isValid(usingUnifiedLogic: isUnifiedURLPredictionEnabled) {
+            unifiedToggleInputCoordinator?.recordDuckAIPromptInterpretedAsURL()
             loadUrlRespectingAIBoundary(url)
             return
         }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1956,6 +1956,7 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
                 recordDuckAIPromptDelivered(wasQueued: false, didSendBridgeMessage: didSendBridgeMessage)
             } else {
                 delegate?.unifiedToggleInputDidSubmitPrompt(text, modelId: configuration.modelId, tools: tools, reasoningEffort: configuration.reasoningEffort, images: images, files: files)
+                recordDuckAIPromptDelivered(wasQueued: false, didSendBridgeMessage: nil)
             }
         }
     }
@@ -2658,6 +2659,11 @@ extension UnifiedToggleInputCoordinator {
     func recordDuckAIPromptDelivered(wasQueued: Bool?, didSendBridgeMessage: Bool?) {
         guard let scope = currentDuckAIWideEventFlowScope else { return }
         duckAIWideEventInstrumentation?.promptDeliveryUpdated(scope: scope, wasQueued: wasQueued, didSendBridgeMessage: didSendBridgeMessage)
+    }
+
+    func recordDuckAIPromptInterpretedAsURL() {
+        guard let scope = currentDuckAIWideEventFlowScope else { return }
+        duckAIWideEventInstrumentation?.promptInterpretedAsURL(scope: scope)
     }
 
     /// Called by the contextual sheet's native-input path, which submits its initial prompt

--- a/iOS/DuckDuckGoTests/AIChat/DuckAIWideEventInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAIWideEventInstrumentationTests.swift
@@ -234,6 +234,55 @@ struct DuckAIWideEventInstrumentationTests {
         #expect(wideEvent.completions.isEmpty)
     }
 
+    @available(iOS 16, *)
+    @Test("promptDeliveryUpdated wasQueued=false marks did_attempt_delivery", .timeLimit(.minutes(1)))
+    func deliveryNotQueuedMarksAttempted() {
+        let (sut, wideEvent, _) = makeSUT()
+        startPromptSubmission(on: Self.activeTab, sut: sut)
+
+        sut.promptDeliveryUpdated(scope: .tab(Self.activeTab), wasQueued: false, didSendBridgeMessage: nil)
+
+        let update = lastUpdatedData(wideEvent)
+        #expect(update?.didAttemptDelivery == true)
+    }
+
+    @available(iOS 16, *)
+    @Test("promptDeliveryUpdated wasQueued=nil marks did_attempt_delivery", .timeLimit(.minutes(1)))
+    func deliveryNilQueuedMarksAttempted() {
+        let (sut, wideEvent, _) = makeSUT()
+        startPromptSubmission(on: Self.activeTab, sut: sut)
+
+        sut.promptDeliveryUpdated(scope: .tab(Self.activeTab), wasQueued: nil, didSendBridgeMessage: true)
+
+        let update = lastUpdatedData(wideEvent)
+        #expect(update?.didAttemptDelivery == true)
+    }
+
+    @available(iOS 16, *)
+    @Test("promptDeliveryUpdated wasQueued=true does not mark did_attempt_delivery", .timeLimit(.minutes(1)))
+    func queuedDeliveryDoesNotMarkAttempted() {
+        let (sut, wideEvent, _) = makeSUT()
+        startPromptSubmission(on: Self.activeTab, sut: sut)
+
+        sut.promptDeliveryUpdated(scope: .tab(Self.activeTab), wasQueued: true, didSendBridgeMessage: nil)
+
+        let update = lastUpdatedData(wideEvent)
+        #expect(update?.didAttemptDelivery == false)
+    }
+
+    @available(iOS 16, *)
+    @Test("A queued delivery that later flushes marks did_attempt_delivery", .timeLimit(.minutes(1)))
+    func queuedThenFlushedMarksAttempted() {
+        let (sut, wideEvent, _) = makeSUT()
+        startPromptSubmission(on: Self.activeTab, sut: sut)
+
+        sut.promptDeliveryUpdated(scope: .tab(Self.activeTab), wasQueued: true, didSendBridgeMessage: nil)
+        #expect(lastUpdatedData(wideEvent)?.didAttemptDelivery == false)
+
+        sut.promptDeliveryUpdated(scope: .tab(Self.activeTab), wasQueued: nil, didSendBridgeMessage: true)
+        #expect(lastUpdatedData(wideEvent)?.didAttemptDelivery == true)
+    }
+
     // MARK: - Frontend acknowledgement
 
     @available(iOS 16, *)
@@ -633,6 +682,35 @@ struct DuckAIWideEventInstrumentationTests {
         #expect(wideEvent.completions.isEmpty)
     }
 
+    @available(iOS 16, *)
+    @Test("promptInterpretedAsURL cancels the active flow with interpreted_as_url", .timeLimit(.minutes(1)))
+    func promptInterpretedAsURLCancels() {
+        let (sut, wideEvent, clock) = makeSUT()
+        startPromptSubmission(on: Self.activeTab, sut: sut)
+
+        clock.advance(by: 1.0)
+        sut.promptInterpretedAsURL(scope: .tab(Self.activeTab))
+
+        guard let completion = lastCompletion(wideEvent) else {
+            Issue.record("Expected a cancellation completion")
+            return
+        }
+        #expect(completion.1 == .cancelled)
+        #expect(completion.0.cancellationReason == .interpretedAsURL)
+        #expect(completion.0.didAttemptDelivery == false)
+        #expect(completion.0.endedInterval.end == Self.baseNow.addingTimeInterval(1.0))
+    }
+
+    @available(iOS 16, *)
+    @Test("promptInterpretedAsURL on an unknown scope is a no-op", .timeLimit(.minutes(1)))
+    func promptInterpretedAsURLOnUnknownScopeIsNoop() {
+        let (sut, wideEvent, _) = makeSUT()
+
+        sut.promptInterpretedAsURL(scope: .tab(Self.activeTab))
+
+        #expect(wideEvent.completions.isEmpty)
+    }
+
     // MARK: - Page load failures
 
     @available(iOS 16, *)
@@ -754,7 +832,7 @@ struct DuckAIWideEventInstrumentationTests {
         #expect(DuckAIPromptWideEventData.metadata.pixelName == "duckai_prompt")
         #expect(DuckAIPromptWideEventData.metadata.featureName == "duckai-prompt")
         #expect(DuckAIPromptWideEventData.metadata.type == "ios-duckai-prompt")
-        #expect(DuckAIPromptWideEventData.metadata.version == "1.0.0")
+        #expect(DuckAIPromptWideEventData.metadata.version == "1.1.0")
     }
 
     @available(iOS 16, *)
@@ -777,9 +855,21 @@ struct DuckAIWideEventInstrumentationTests {
         #expect(params["feature.data.ext.prompt.is_first_prompt"] as? Bool == false)
         #expect(params["feature.data.ext.delivery.queued"] as? Bool == false)
         #expect(params["feature.data.ext.delivery.did_receive_bridge_message"] as? Bool == false)
+        #expect(params["feature.data.ext.delivery.did_attempt_delivery"] as? Bool == false)
         #expect(params["feature.data.ext.prompt.has_page_context"] as? Bool == true)
         #expect(params["feature.data.ext.prompt.tools_selected"] as? Bool == true)
         #expect(params["feature.data.ext.prompt.attachments_selected"] as? Bool == true)
+    }
+
+    @available(iOS 16, *)
+    @Test("did_attempt_delivery is emitted true once set", .timeLimit(.minutes(1)))
+    func didAttemptDeliveryEmittedWhenSet() {
+        let data = makeData()
+        data.didAttemptDelivery = true
+
+        let params = data.jsonParameters()
+
+        #expect(params["feature.data.ext.delivery.did_attempt_delivery"] as? Bool == true)
     }
 
     @available(iOS 16, *)
@@ -824,6 +914,7 @@ struct DuckAIWideEventInstrumentationTests {
         data.cancellationReason = .switchedTabs
         data.frontendDeliveryQueued = true
         data.didSendBridgeMessage = false
+        data.didAttemptDelivery = true
         data.startThinkingInterval.end = Self.baseNow.addingTimeInterval(1.0)
         data.startGeneratingInterval.end = Self.baseNow.addingTimeInterval(2.0)
         data.generatingCompletedInterval.end = Self.baseNow.addingTimeInterval(3.0)
@@ -845,6 +936,7 @@ struct DuckAIWideEventInstrumentationTests {
         #expect(decoded.frontendDeliveryPath == .urlAutoSubmit)
         #expect(decoded.frontendDeliveryQueued == true)
         #expect(decoded.didSendBridgeMessage == false)
+        #expect(decoded.didAttemptDelivery == true)
         #expect(decoded.hasPageContext == true)
         #expect(decoded.toolsSelected == true)
         #expect(decoded.attachmentsSelected == true)

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -3625,6 +3625,7 @@ final class MockSwitchBarSubmissionMetrics: SwitchBarSubmissionMetricsProviding 
 private final class MockDuckAIWideEventInstrumentation: DuckAIWideEventInstrumentation {
     private(set) var submissionStartedScopes: [DuckAIWideEventFlowScope] = []
     private(set) var tabSwitchedAwayCalls: [TabUID] = []
+    private(set) var promptInterpretedAsURLScopes: [DuckAIWideEventFlowScope] = []
 
     func submissionStarted(scope: DuckAIWideEventFlowScope,
                            modelId: String?,
@@ -3649,4 +3650,5 @@ private final class MockDuckAIWideEventInstrumentation: DuckAIWideEventInstrumen
     func fireButtonClearedTabDuringGeneration(tabID: TabUID) {}
     func sheetDismissedDuringGeneration(scope: DuckAIWideEventFlowScope) {}
     func pageLoadFailed(scope: DuckAIWideEventFlowScope, error: Error) {}
+    func promptInterpretedAsURL(scope: DuckAIWideEventFlowScope) { promptInterpretedAsURLScopes.append(scope) }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/duckai_prompt_wide_event.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/duckai_prompt_wide_event.json5
@@ -56,8 +56,16 @@
             {
                 "key": "feature.data.ext.outcome.cancellation_reason",
                 "type": "string",
-                "description": "Why the flow was cancelled. Present only on CANCELLED outcomes. `stop_button` = user tapped the stop-generating button; `tab_closed` = user closed the Duck.ai tab while the response was still in flight; `sheet_dismissed` = the contextual chat sheet's session was explicitly ended (delete-chat tap or fire-button clear) while the response was still in flight; `fire_button` = user used the Fire button to clear the Duck.ai tab while the response was still in flight; `switched_tabs` = user switched away from the Duck.ai tab while the response was still in flight, breaking the current native UI status connection; `superseded_by_new_submission` = another prompt was submitted in the same tab or contextual sheet before this flow reached a terminal outcome.",
-                "enum": ["stop_button", "tab_closed", "sheet_dismissed", "fire_button", "switched_tabs", "superseded_by_new_submission"]
+                "description": "Why the flow was cancelled. Present only on CANCELLED outcomes. `stop_button` = user tapped the stop-generating button; `tab_closed` = user closed the Duck.ai tab while the response was still in flight; `sheet_dismissed` = the contextual chat sheet's session was explicitly ended (delete-chat tap or fire-button clear) while the response was still in flight; `fire_button` = user used the Fire button to clear the Duck.ai tab while the response was still in flight; `switched_tabs` = user switched away from the Duck.ai tab while the response was still in flight, breaking the current native UI status connection; `superseded_by_new_submission` = another prompt was submitted in the same tab or contextual sheet before this flow reached a terminal outcome; `interpreted_as_url` = the submitted text was interpreted as a URL and loaded as a web page instead of being sent to Duck.ai.",
+                "enum": [
+                    "stop_button",
+                    "tab_closed",
+                    "sheet_dismissed",
+                    "fire_button",
+                    "switched_tabs",
+                    "superseded_by_new_submission",
+                    "interpreted_as_url"
+                ]
             },
             {
                 "key": "feature.data.ext.outcome.last_step",
@@ -117,27 +125,32 @@
                 "description": "Whether this submission was the first prompt in the chat session. True for prompts that initiate a new chat (no prior submissions and no pre-existing chat bound to the tab); false for follow-up prompts within an already-active chat. Disambiguates failure modes that differ between cold-start (page load + initial chat creation) and warm-start (existing chat) paths."
             },
 
-            // Native-to-frontend delivery signals
+            // How the native app handed the prompt to the Duck.ai web frontend
             {
                 "key": "feature.data.ext.delivery.path",
                 "type": "string",
-                "description": "How native attempted to deliver the prompt to Duck.ai frontend. `user_script` = native UTI pushed directly through a bound user script; `url_autosubmit` = native delegated to host URL/prompt handoff; `contextual_native_input` = contextual sheet native input handed the prompt to the contextual web view.",
+                "description": "How the native app tried to hand the prompt to the Duck.ai frontend (the Duck.ai web UI running in an in-app web view). Always present. `user_script` = the app injected the prompt straight into the web view by calling JavaScript over the user-script bridge; `url_autosubmit` = the app handed off to the host, which opened a Duck.ai URL carrying the prompt so the page submits it on load; `contextual_native_input` = the contextual chat sheet's native input passed the prompt to its web view.",
                 "enum": ["user_script", "url_autosubmit", "contextual_native_input"]
             },
             {
                 "key": "feature.data.ext.delivery.queued",
                 "type": "boolean",
-                "description": "Whether contextual delivery had to wait for the page/content handler to become ready before native could push the prompt to frontend."
+                "description": "Whether delivery had to wait for the page/content handler to become ready before the app could push the prompt to the frontend. Always present; defaults to false. Only set true on the `contextual_native_input` path, when the contextual chat sheet's handler was not yet ready; false for every other path and whenever no wait occurred."
             },
             {
                 "key": "feature.data.ext.delivery.did_send_bridge_message",
                 "type": "boolean",
-                "description": "Whether native successfully sent the prompt over the user-script bridge - measured at the precondition level (web view and message broker were both available when push was attempted). True does not guarantee WebKit evaluated the JS, only that native reached the point of calling into the broker. False means native entered the bridge-push branch but the push failed (e.g. broker was missing). Absent for paths that don't involve the bridge (URL-autosubmit, or contextual deliveries that terminated while still queued). Pair with `did_receive_bridge_message` to isolate where delivery broke."
+                "description": "Whether the app reached the point of pushing the prompt over the user-script bridge - measured at the precondition level (the web view and the bridge's message router were both available when the push was attempted). True does not guarantee the web engine evaluated the injected JavaScript, only that the app called into the router. False means the app entered the bridge-push branch but the push failed (e.g. the router was missing). Present only on bridge paths; absent for `url_autosubmit` and for contextual deliveries that ended while still queued. This field is path-specific - to ask whether the app tried to deliver at all, on any path, use the always-present `did_attempt_delivery` instead. Pair with `did_receive_bridge_message` to isolate where delivery broke."
             },
             {
                 "key": "feature.data.ext.delivery.did_receive_bridge_message",
                 "type": "boolean",
-                "description": "Whether the Duck.ai frontend reported its `userDidSubmitPrompt` (or `userDidSubmitFirstPrompt`) metric back across the bridge for this submission before the flow ended. True confirms the frontend received and accepted the prompt; false means the prompt never landed on the frontend submission state machine - either WebKit dropped the JS call, the frontend rejected the message, or the flow terminated before the metric arrived."
+                "description": "Whether the Duck.ai frontend reported back, over the user-script bridge, that it had submitted this prompt (it fired its `userDidSubmitPrompt` or `userDidSubmitFirstPrompt` metric) before the flow ended. Present on every event; defaults to false until the frontend acknowledges. True confirms the frontend received and accepted the prompt. False means the frontend never registered it as submitted - either the web engine never ran the injected JavaScript, the frontend rejected the message, or the flow ended before the acknowledgement arrived; these cannot be told apart from this field alone. To separate 'the app never attempted delivery' from 'the app attempted but got no acknowledgement', pair with `did_attempt_delivery`."
+            },
+            {
+                "key": "feature.data.ext.delivery.did_attempt_delivery",
+                "type": "boolean",
+                "description": "Whether the app reached the point of handing the prompt to the Duck.ai frontend by any delivery path (user-script bridge push, URL/prompt handoff, or contextual submit). Present on every event. Pair with `did_receive_bridge_message`: `did_attempt_delivery && did_receive_bridge_message` = end-to-end success; `did_attempt_delivery && !did_receive_bridge_message` = the app dispatched but the frontend never acknowledged; `!did_attempt_delivery` = the app never got to dispatch (e.g. the flow ended while a contextual delivery was still queued). Unlike `did_send_bridge_message`, this is path-agnostic and always present."
             },
 
             {

--- a/iOS/PixelDefinitions/wide_events/definitions/duckai-prompt.json5
+++ b/iOS/PixelDefinitions/wide_events/definitions/duckai-prompt.json5
@@ -4,7 +4,7 @@
         "owners": ["samsymons"],
         "meta": {
             "type": "ios-duckai-prompt",
-            "version": "0.0"
+            "version": "1.0"
         },
         "feature": {
             "name": "duckai-prompt",
@@ -22,14 +22,15 @@
                         "properties": {
                             "cancellation_reason": {
                                 "type": "string",
-                                "description": "Why the flow was cancelled. Present only on CANCELLED outcomes. `stop_button` = user tapped the stop-generating button; `tab_closed` = user closed the Duck.ai tab while the response was still in flight; `sheet_dismissed` = the contextual chat sheet's session was explicitly ended (delete-chat tap or fire-button clear) while the response was still in flight; `fire_button` = user used the Fire button to clear the Duck.ai tab while the response was still in flight; `switched_tabs` = user switched away from the Duck.ai tab while the response was still in flight, breaking the current native UI status connection; `superseded_by_new_submission` = another prompt was submitted in the same tab or contextual sheet before this flow reached a terminal outcome.",
+                                "description": "Why the flow was cancelled. Present only on CANCELLED outcomes. `stop_button` = user tapped the stop-generating button; `tab_closed` = user closed the Duck.ai tab while the response was still in flight; `sheet_dismissed` = the contextual chat sheet's session was explicitly ended (delete-chat tap or fire-button clear) while the response was still in flight; `fire_button` = user used the Fire button to clear the Duck.ai tab while the response was still in flight; `switched_tabs` = user switched away from the Duck.ai tab while the response was still in flight, breaking the current native UI status connection; `superseded_by_new_submission` = another prompt was submitted in the same tab or contextual sheet before this flow reached a terminal outcome; `interpreted_as_url` = the submitted text was interpreted as a URL and loaded as a web page instead of being sent to Duck.ai.",
                                 "enum": [
                                     "stop_button",
                                     "tab_closed",
                                     "sheet_dismissed",
                                     "fire_button",
                                     "switched_tabs",
-                                    "superseded_by_new_submission"
+                                    "superseded_by_new_submission",
+                                    "interpreted_as_url"
                                 ]
                             },
                             "last_step": {
@@ -115,24 +116,28 @@
                     },
                     "delivery": {
                         "type": "object",
-                        "description": "Native-to-frontend delivery signals for the submitted prompt.",
+                        "description": "Signals describing how the native app handed the submitted prompt to the Duck.ai frontend (the Duck.ai web UI running in an in-app web view).",
                         "properties": {
                             "path": {
                                 "type": "string",
-                                "description": "How native attempted to deliver the prompt to Duck.ai frontend. `user_script` = native UTI pushed directly through a bound user script; `url_autosubmit` = native delegated to host URL/prompt handoff; `contextual_native_input` = contextual sheet native input handed the prompt to the contextual web view.",
+                                "description": "How the native app tried to hand the prompt to the Duck.ai frontend (the Duck.ai web UI running in an in-app web view). Always present. `user_script` = the app injected the prompt straight into the web view by calling JavaScript over the user-script bridge; `url_autosubmit` = the app handed off to the host, which opened a Duck.ai URL carrying the prompt so the page submits it on load; `contextual_native_input` = the contextual chat sheet's native input passed the prompt to its web view.",
                                 "enum": ["user_script", "url_autosubmit", "contextual_native_input"]
                             },
                             "queued": {
                                 "type": "boolean",
-                                "description": "Whether contextual delivery had to wait for the page/content handler to become ready before native could push the prompt to frontend."
+                                "description": "Whether delivery had to wait for the page/content handler to become ready before the app could push the prompt to the frontend. Always present; defaults to false. Only set true on the `contextual_native_input` path, when the contextual chat sheet's handler was not yet ready; false for every other path and whenever no wait occurred."
                             },
                             "did_send_bridge_message": {
                                 "type": "boolean",
-                                "description": "Whether native successfully sent the prompt over the user-script bridge - measured at the precondition level (web view and message broker were both available when push was attempted). True does not guarantee WebKit evaluated the JS, only that native reached the point of calling into the broker. False means native entered the bridge-push branch but the push failed (e.g. broker was missing). Absent for paths that don't involve the bridge (URL-autosubmit, or contextual deliveries that terminated while still queued). Pair with `did_receive_bridge_message` to isolate where delivery broke."
+                                "description": "Whether the app reached the point of pushing the prompt over the user-script bridge - measured at the precondition level (the web view and the bridge's message router were both available when the push was attempted). True does not guarantee the web engine evaluated the injected JavaScript, only that the app called into the router. False means the app entered the bridge-push branch but the push failed (e.g. the router was missing). Present only on bridge paths; absent for `url_autosubmit` and for contextual deliveries that ended while still queued. This field is path-specific - to ask whether the app tried to deliver at all, on any path, use the always-present `did_attempt_delivery` instead. Pair with `did_receive_bridge_message` to isolate where delivery broke."
                             },
                             "did_receive_bridge_message": {
                                 "type": "boolean",
-                                "description": "Whether the Duck.ai frontend reported its `userDidSubmitPrompt` (or `userDidSubmitFirstPrompt`) metric back across the bridge for this submission before the flow ended. True confirms the frontend received and accepted the prompt; false means the prompt never landed on the frontend submission state machine - either WebKit dropped the JS call, the frontend rejected the message, or the flow terminated before the metric arrived."
+                                "description": "Whether the Duck.ai frontend reported back, over the user-script bridge, that it had submitted this prompt (it fired its `userDidSubmitPrompt` or `userDidSubmitFirstPrompt` metric) before the flow ended. Present on every event; defaults to false until the frontend acknowledges. True confirms the frontend received and accepted the prompt. False means the frontend never registered it as submitted - either the web engine never ran the injected JavaScript, the frontend rejected the message, or the flow ended before the acknowledgement arrived; these cannot be told apart from this field alone. To separate 'the app never attempted delivery' from 'the app attempted but got no acknowledgement', pair with `did_attempt_delivery`."
+                            },
+                            "did_attempt_delivery": {
+                                "type": "boolean",
+                                "description": "Whether the app reached the point of handing the prompt to the Duck.ai frontend by any delivery path (user-script bridge push, URL/prompt handoff, or contextual submit). Present on every event. Pair with `did_receive_bridge_message`: `did_attempt_delivery && did_receive_bridge_message` = end-to-end success; `did_attempt_delivery && !did_receive_bridge_message` = the app dispatched but the frontend never acknowledged; `!did_attempt_delivery` = the app never got to dispatch (e.g. the flow ended while a contextual delivery was still queued). Unlike `did_send_bridge_message`, this is path-agnostic and always present."
                             }
                         }
                     },

--- a/iOS/PixelDefinitions/wide_events/generated_schemas/ios-duckai-prompt-1.1.0.json
+++ b/iOS/PixelDefinitions/wide_events/generated_schemas/ios-duckai-prompt-1.1.0.json
@@ -1,0 +1,232 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Sent at the end of a Duck.ai prompt submission journey on iOS, from the moment the user submits a prompt through the Unified Toggle Input until the page either delivers a response (status returns to `.ready`) or the journey is orphaned by app termination.",
+    "$comment": "{\"owners\":[\"samsymons\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "ios-duckai-prompt" }, "version": { "const": "1.1.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application",
+                    "enum": ["DuckDuckGo", "DuckDuckGo-Alpha", "DuckDuckGo-Experimental", "PacketTunnelProvider"]
+                },
+                "version": { "type": "string", "description": "The version of the application", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
+                "form_factor": { "type": "string", "description": "The form factor of the device", "enum": ["phone", "tablet"] }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["iOS"] },
+                "type": { "type": "string", "description": "The type of application", "enum": ["app"] },
+                "sample_rate": { "type": "number", "description": "Sample rate for this event", "minimum": 0, "maximum": 1 },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first occurrence of this event today. Only included when true."
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["duckai-prompt"] },
+                "status": {
+                    "type": "string",
+                    "description": "The overall status of the operation",
+                    "enum": ["SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"]
+                },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "status_reason": {
+                                    "type": "string",
+                                    "description": "Terminal reason accompanying UNKNOWN outcomes. Present when an orphaned flow from a previous app session is completed after app launch.",
+                                    "enum": ["app_terminated"]
+                                },
+                                "outcome": {
+                                    "type": "object",
+                                    "description": "Outcome-specific fields describing where and why the flow ended.",
+                                    "properties": {
+                                        "cancellation_reason": {
+                                            "type": "string",
+                                            "description": "Why the flow was cancelled. Present only on CANCELLED outcomes. `stop_button` = user tapped the stop-generating button; `tab_closed` = user closed the Duck.ai tab while the response was still in flight; `sheet_dismissed` = the contextual chat sheet's session was explicitly ended (delete-chat tap or fire-button clear) while the response was still in flight; `fire_button` = user used the Fire button to clear the Duck.ai tab while the response was still in flight; `switched_tabs` = user switched away from the Duck.ai tab while the response was still in flight, breaking the current native UI status connection; `superseded_by_new_submission` = another prompt was submitted in the same tab or contextual sheet before this flow reached a terminal outcome; `interpreted_as_url` = the submitted text was interpreted as a URL and loaded as a web page instead of being sent to Duck.ai.",
+                                            "enum": [
+                                                "stop_button",
+                                                "tab_closed",
+                                                "sheet_dismissed",
+                                                "fire_button",
+                                                "switched_tabs",
+                                                "superseded_by_new_submission",
+                                                "interpreted_as_url"
+                                            ]
+                                        },
+                                        "last_step": {
+                                            "type": "string",
+                                            "description": "Where in the journey the flow was when it ended. Emitted on FAILURE, CANCELLED, and UNKNOWN outcomes (absent on SUCCESS). For CANCELLED outcomes, this is the latest observed page status before the user/system cancelled the flow. For UNKNOWN orphans recovered from a previous app session, this is the last step persisted before the app was killed. Terminal failure types (`navigation_failed`, `response_state_error`, `response_state_blocked`) are themselves last steps - they appear here instead of the progression step that preceded them.",
+                                            "enum": [
+                                                "submitted",
+                                                "loading",
+                                                "start_stream_new_prompt",
+                                                "start_stream_restart_stream",
+                                                "streaming",
+                                                "unknown_status",
+                                                "navigation_failed",
+                                                "response_state_error",
+                                                "response_state_blocked"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "error": {
+                                    "type": "object",
+                                    "description": "Underlying `NSError` captured on FAILURE when navigation_failed.",
+                                    "properties": {
+                                        "domain": { "type": "string", "description": "NSError domain." },
+                                        "code": { "type": "integer", "description": "NSError code." },
+                                        "underlying_domain": {
+                                            "type": "string",
+                                            "description": "Domain of the wrapped NSError, when present."
+                                        },
+                                        "underlying_code": {
+                                            "type": "integer",
+                                            "description": "Code of the wrapped NSError, when present."
+                                        },
+                                        "error_description": {
+                                            "type": "string",
+                                            "description": "Optional human-readable description attached at capture time."
+                                        }
+                                    }
+                                },
+                                "prompt": {
+                                    "type": "object",
+                                    "description": "Prompt, composer, and submission context captured at submit time.",
+                                    "properties": {
+                                        "model_id": {
+                                            "type": "string",
+                                            "description": "Identifier of the Duck.ai model selected at submit time (e.g. 'gpt-4o', 'claude-sonnet-4-5'). Absent if the user has not selected a specific model."
+                                        },
+                                        "user_tier": {
+                                            "type": "string",
+                                            "description": "The submitting user's Duck.ai subscription tier at the moment of submission.",
+                                            "enum": ["free", "plus", "pro", "internal"]
+                                        },
+                                        "reasoning_effort": {
+                                            "type": "string",
+                                            "description": "The reasoning effort selected for this submission, derived from the user's reasoning-mode preference resolved against the model's supported efforts. Absent when the selected model does not support a reasoning picker.",
+                                            "enum": ["none", "minimal", "low", "medium", "high"]
+                                        },
+                                        "entry_point": {
+                                            "type": "string",
+                                            "description": "Where the user composed and submitted the prompt. `omnibar` = browser address bar composer; `ai_tab` = dedicated Duck.ai tab composer; `contextual_chat` = contextual chat sheet opened from a regular web tab.",
+                                            "enum": ["omnibar", "ai_tab", "contextual_chat"]
+                                        },
+                                        "input_mode": {
+                                            "type": "string",
+                                            "description": "How the user produced the prompt text. `keyboard` = typed/pasted in the composer; `voice` = voice-search transcription submitted directly. Additional values (suggestion tap, address-bar Duck.ai shortcut, URL scheme/Intent) will be added as those paths are instrumented.",
+                                            "enum": ["keyboard", "voice"]
+                                        },
+                                        "fire_mode": {
+                                            "type": "boolean",
+                                            "description": "Whether the submitting tab was a fire tab at submit time."
+                                        },
+                                        "is_first_prompt": {
+                                            "type": "boolean",
+                                            "description": "Whether this submission was the first prompt in the chat session. True for prompts that initiate a new chat (no prior submissions and no pre-existing chat bound to the tab); false for follow-up prompts within an already-active chat. Disambiguates failure modes that differ between cold-start (page load + initial chat creation) and warm-start (existing chat) paths."
+                                        },
+                                        "has_page_context": {
+                                            "type": "boolean",
+                                            "description": "Whether a page-context attachment was present at submit time (i.e. the user attached the current page's content to the prompt)."
+                                        },
+                                        "tools_selected": {
+                                            "type": "boolean",
+                                            "description": "Whether the user had any tool selected at submit time. The iOS UI currently only exposes WebSearch and GenerateImage tools."
+                                        },
+                                        "attachments_selected": {
+                                            "type": "boolean",
+                                            "description": "Whether the user had any attachment (image, file, or attachment that failed validation) in the composer at submit time."
+                                        }
+                                    }
+                                },
+                                "delivery": {
+                                    "type": "object",
+                                    "description": "Signals describing how the native app handed the submitted prompt to the Duck.ai frontend (the Duck.ai web UI running in an in-app web view).",
+                                    "properties": {
+                                        "path": {
+                                            "type": "string",
+                                            "description": "How the native app tried to hand the prompt to the Duck.ai frontend (the Duck.ai web UI running in an in-app web view). Always present. `user_script` = the app injected the prompt straight into the web view by calling JavaScript over the user-script bridge; `url_autosubmit` = the app handed off to the host, which opened a Duck.ai URL carrying the prompt so the page submits it on load; `contextual_native_input` = the contextual chat sheet's native input passed the prompt to its web view.",
+                                            "enum": ["user_script", "url_autosubmit", "contextual_native_input"]
+                                        },
+                                        "queued": {
+                                            "type": "boolean",
+                                            "description": "Whether delivery had to wait for the page/content handler to become ready before the app could push the prompt to the frontend. Always present; defaults to false. Only set true on the `contextual_native_input` path, when the contextual chat sheet's handler was not yet ready; false for every other path and whenever no wait occurred."
+                                        },
+                                        "did_send_bridge_message": {
+                                            "type": "boolean",
+                                            "description": "Whether the app reached the point of pushing the prompt over the user-script bridge - measured at the precondition level (the web view and the bridge's message router were both available when the push was attempted). True does not guarantee the web engine evaluated the injected JavaScript, only that the app called into the router. False means the app entered the bridge-push branch but the push failed (e.g. the router was missing). Present only on bridge paths; absent for `url_autosubmit` and for contextual deliveries that ended while still queued. This field is path-specific - to ask whether the app tried to deliver at all, on any path, use the always-present `did_attempt_delivery` instead. Pair with `did_receive_bridge_message` to isolate where delivery broke."
+                                        },
+                                        "did_receive_bridge_message": {
+                                            "type": "boolean",
+                                            "description": "Whether the Duck.ai frontend reported back, over the user-script bridge, that it had submitted this prompt (it fired its `userDidSubmitPrompt` or `userDidSubmitFirstPrompt` metric) before the flow ended. Present on every event; defaults to false until the frontend acknowledges. True confirms the frontend received and accepted the prompt. False means the frontend never registered it as submitted - either the web engine never ran the injected JavaScript, the frontend rejected the message, or the flow ended before the acknowledgement arrived; these cannot be told apart from this field alone. To separate 'the app never attempted delivery' from 'the app attempted but got no acknowledgement', pair with `did_attempt_delivery`."
+                                        },
+                                        "did_attempt_delivery": {
+                                            "type": "boolean",
+                                            "description": "Whether the app reached the point of handing the prompt to the Duck.ai frontend by any delivery path (user-script bridge push, URL/prompt handoff, or contextual submit). Present on every event. Pair with `did_receive_bridge_message`: `did_attempt_delivery && did_receive_bridge_message` = end-to-end success; `did_attempt_delivery && !did_receive_bridge_message` = the app dispatched but the frontend never acknowledged; `!did_attempt_delivery` = the app never got to dispatch (e.g. the flow ended while a contextual delivery was still queued). Unlike `did_send_bridge_message`, this is path-agnostic and always present."
+                                        }
+                                    }
+                                },
+                                "latency": {
+                                    "type": "object",
+                                    "description": "Latency milestones measured in milliseconds from prompt submission. All values are bucketed (round-up) into one of: 100, 500, 1000, 2000, 3000, 5000, 10000, 30000. Any duration over 10s collapses into the 30000 bucket.",
+                                    "properties": {
+                                        "start_thinking_ms": {
+                                            "type": "integer",
+                                            "description": "Milliseconds from prompt submission to the first non-`ready` chat status observed (page began processing the prompt). Absent if no non-ready status was observed before the flow ended."
+                                        },
+                                        "start_generating_ms": {
+                                            "type": "integer",
+                                            "description": "Milliseconds from prompt submission to the first `streaming` chat status (time to first token). Absent if the journey never reached a streaming state."
+                                        },
+                                        "generating_completed_ms": {
+                                            "type": "integer",
+                                            "description": "Milliseconds from prompt submission to the `ready` chat status that completed the flow (time to last token). Present only on SUCCESS outcomes."
+                                        },
+                                        "ended_ms": {
+                                            "type": "integer",
+                                            "description": "Milliseconds from prompt submission to the outcome, regardless of status. Present on SUCCESS, FAILURE, and CANCELLED outcomes; absent on UNKNOWN outcomes where the end time is not observed."
+                                        },
+                                        "frontend_submission_ack_ms": {
+                                            "type": "integer",
+                                            "description": "Milliseconds from native prompt submission to the frontend `userDidSubmitPrompt` metric. Absent if the frontend never acknowledged the submission before the flow ended."
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1215985355565340?focus=true
Tech Design URL:
CC:

### Description

This PR adds a few extra flags to the Duck.ai prompt wide event `delivery` section, which tells us how far the prompt made it before failing, or whether one of the delivery steps is not happening.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Run the app from this branch and send a Duck.ai prompt from the unified input (you will need to be an internal user and relaunch the app if it's not enabled for you)
2. Check that the wide event has sent in the console, and includes the new delivery parameters

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to analytics schema and instrumentation hooks; user navigation behavior is unchanged aside from correctly classifying URL redirects in telemetry.
> 
> **Overview**
> Bumps the **Duck.ai prompt** wide event to **1.1.0** and adds path-agnostic delivery analytics so funnels can tell “never tried to hand off” from “tried but no frontend ack.”
> 
> **`did_attempt_delivery`** is emitted on every event and is set when `promptDeliveryUpdated` runs with delivery **not** still queued (`wasQueued != true`). **`UnifiedToggleInputCoordinator`** now calls **`recordDuckAIPromptDelivered`** on the delegate handoff path (no bound user script), so URL autosubmit and similar paths are counted as attempts. Pixel/wide-event definitions and the generated **1.1.0** JSON schema document the new field and clarify existing delivery parameters.
> 
> When Duck.ai-mode input is treated as a **URL** on a non–Duck.ai tab, the active wide-event flow completes as **CANCELLED** with **`interpreted_as_url`** via **`promptInterpretedAsURL`**, wired from **`MainViewController+UnifiedToggleInput`**. Unit tests cover delivery flags, URL cancellation, and schema version expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3018eb28184f86bbf69afaedc16096320aaecfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->