### PR TITLE
[iOS/macOS][NA Experiment Framework] Add Duck Ai chat metrics for automatic measurements

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PixelExperimentKit/PixelExperimentKit.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelExperimentKit/PixelExperimentKit.swift
@@ -42,6 +42,8 @@ extension PixelKit {
         static let enrollmentDateKey = "enrollmentDate"
         static let searchMetricValue = "search"
         static let appUseMetricValue = "app_use"
+        static let aiChatMetricValue = "duck_ai_prompt_sent"
+        static let aiChatNewChatMetricValue = "duck_ai_new_chat"
     }
 
     // Static property to hold shared dependencies
@@ -183,6 +185,54 @@ extension PixelKit {
                 for: experiment.key,
                 experimentData: experiment.value,
                 metric: Constants.appUseMetricValue,
+                valueConversionDictionary: valueConversionDictionary
+            )
+        }
+    }
+
+    /// Fires AI chat prompt experiment pixels for all active experiments.
+    ///
+    /// This function iterates through all active experiments and triggers
+    /// pixel firing based on predefined AI chat value and conversion window mappings.
+    /// - The value and conversion windows define when and how many AI prompt sent actions
+    ///   must occur before the pixel is fired.
+    public static func fireNewAIPromptExperimentPixels() {
+        let valueConversionDictionary: [NumberOfActions: [ConversionWindow]] = [
+            1: [0...0, 1...1, 5...7, 8...14]
+        ]
+        guard let featureFlagger = ExperimentConfig.featureFlagger else {
+            assertionFailure("PixelKit is not configured for experiments")
+            return
+        }
+        featureFlagger.allActiveExperiments.forEach { experiment in
+            fireExperimentPixels(
+                for: experiment.key,
+                experimentData: experiment.value,
+                metric: Constants.aiChatMetricValue,
+                valueConversionDictionary: valueConversionDictionary
+            )
+        }
+    }
+
+    /// Fires new AI chat experiment pixels for all active experiments.
+    ///
+    /// This function iterates through all active experiments and triggers
+    /// pixel firing based on predefined AI chat value and conversion window mappings.
+    /// - The value and conversion windows define when and how many new AI chat sent actions
+    ///   must occur before the pixel is fired.
+    public static func fireNewAIChatExperimentPixels() {
+        let valueConversionDictionary: [NumberOfActions: [ConversionWindow]] = [
+            1: [0...0, 1...1, 5...7, 8...14]
+        ]
+        guard let featureFlagger = ExperimentConfig.featureFlagger else {
+            assertionFailure("PixelKit is not configured for experiments")
+            return
+        }
+        featureFlagger.allActiveExperiments.forEach { experiment in
+            fireExperimentPixels(
+                for: experiment.key,
+                experimentData: experiment.value,
+                metric: Constants.aiChatNewChatMetricValue,
                 valueConversionDictionary: valueConversionDictionary
             )
         }

--- a/SharedPackages/BrowserServicesKit/Tests/PixelExperimentKitTests/PixelExperimentKitTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelExperimentKitTests/PixelExperimentKitTests.swift
@@ -590,6 +590,241 @@ final class PixelExperimentKitTests: XCTestCase {
         )
     }
 
+    func testFireNewAIPromptExperimentPixels_WithValue1() {
+        let subfeatureID = "credentialsSaving"
+        let cohort = "control"
+        let enrollmentDate0 = Date()
+        let enrollmentDate1 = Date().addingTimeInterval(.days(-1)) // 1 day ago
+        let enrollmentDate2 = Date().addingTimeInterval(.days(-2)) // 2 days ago
+        let enrollmentDate4 = Date().addingTimeInterval(.days(-4)) // 4 days ago
+        let enrollmentDate5 = Date().addingTimeInterval(.days(-5)) // 5 days ago
+        let enrollmentDate7 = Date().addingTimeInterval(.days(-7)) // 7 days ago
+        let enrollmentDate8 = Date().addingTimeInterval(.days(-8)) // 8 days ago
+        let enrollmentDate14 = Date().addingTimeInterval(.days(-14)) // 14 days ago
+        let enrollmentDate15 = Date().addingTimeInterval(.days(-15)) // 15 days ago
+        let experimentData0 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate0)
+        let experimentData1 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate1)
+        let experimentData2 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate2)
+        let experimentData4 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate4)
+        let experimentData5 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate5)
+        let experimentData7 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate7)
+        let experimentData8 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate8)
+        let experimentData14 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate14)
+        let experimentData15 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate15)
+
+        mockFeatureFlagger.experiments = [subfeatureID: experimentData0]
+        PixelKit.fireNewAIPromptExperimentPixels()
+        XCTAssertEqual(firedEvent.count, 1) // Fires 1 0-0
+        clearEvents()
+
+        mockFeatureFlagger.experiments = [subfeatureID: experimentData1]
+        PixelKit.fireNewAIPromptExperimentPixels()
+        XCTAssertEqual(firedEvent.count, 1) // Fires 1 1-1
+        clearEvents()
+
+        mockFeatureFlagger.experiments = [subfeatureID: experimentData2]
+        PixelKit.fireNewAIPromptExperimentPixels()
+        XCTAssertEqual(firedEvent.count, 0) // Nothing (days 2-4 not in any window)
+        clearEvents()
+
+        mockFeatureFlagger.experiments = [subfeatureID: experimentData4]
+        PixelKit.fireNewAIPromptExperimentPixels()
+        XCTAssertEqual(firedEvent.count, 0) // Nothing (days 2-4 not in any window)
+        clearEvents()
+
+        mockFeatureFlagger.experiments = [subfeatureID: experimentData5]
+        PixelKit.fireNewAIPromptExperimentPixels()
+        XCTAssertEqual(firedEvent.count, 1) // Fires 1 5-7
+        clearEvents()
+
+        mockFeatureFlagger.experiments = [subfeatureID: experimentData7]
+        PixelKit.fireNewAIPromptExperimentPixels()
+        XCTAssertEqual(firedEvent.count, 1) // Fires 1 5-7
+        clearEvents()
+
+        mockFeatureFlagger.experiments = [subfeatureID: experimentData8]
+        PixelKit.fireNewAIPromptExperimentPixels()
+        XCTAssertEqual(firedEvent.count, 1) // Fires 1 8-14
+        clearEvents()
+
+        mockFeatureFlagger.experiments = [subfeatureID: experimentData14]
+        PixelKit.fireNewAIPromptExperimentPixels()
+        XCTAssertEqual(firedEvent.count, 1) // Fires 1 8-14
+        clearEvents()
+
+        mockFeatureFlagger.experiments = [subfeatureID: experimentData15]
+        PixelKit.fireNewAIPromptExperimentPixels()
+        XCTAssertEqual(firedEvent.count, 0) // Nothing (after day 14)
+    }
+
+    func testFireNewAIPromptExperimentPixels_WithMultipleExperiments() {
+        // GIVEN
+        let subfeatureID1 = "credentialsSaving"
+        let cohort1 = "control"
+        let enrollmentDate1 = Date().addingTimeInterval(.days(-6)) // 6 days ago
+        let experimentData1 = ExperimentData(parentID: "autofill", cohortID: cohort1, enrollmentDate: enrollmentDate1)
+
+        let subfeatureID2 = "inlineIconCredentials"
+        let cohort2 = "test"
+        let enrollmentDate2 = Date().addingTimeInterval(.days(-10)) // 10 days ago
+        let experimentData2 = ExperimentData(parentID: "autofill", cohortID: cohort2, enrollmentDate: enrollmentDate2)
+
+        mockFeatureFlagger.experiments = [
+            subfeatureID1: experimentData1,
+            subfeatureID2: experimentData2
+        ]
+
+        // WHEN
+        PixelKit.fireNewAIPromptExperimentPixels()
+
+        // THEN
+        // Verify pixel for the first experiment
+        XCTAssertTrue(
+            firedEvent.contains {
+                $0.name == "experiment_metrics_\(subfeatureID1)_\(cohort1)"
+            }
+        )
+        XCTAssertTrue(
+            firedEvent.contains {
+                $0.parameters?[PixelKit.Constants.metricKey] == PixelKit.Constants.aiChatMetricValue
+            }
+        )
+        XCTAssertTrue(
+            firedEvent.contains {
+                $0.parameters?[PixelKit.Constants.conversionWindowDaysKey] == "5-7"
+            }
+        )
+
+        // Verify pixel also fired for the second experiment (day 10 is within 8-14 window)
+        XCTAssertTrue(
+            firedEvent.contains {
+                $0.name == "experiment_metrics_\(subfeatureID2)_\(cohort2)"
+            }
+        )
+        XCTAssertTrue(
+            firedEvent.contains {
+                $0.parameters?[PixelKit.Constants.conversionWindowDaysKey] == "8-14"
+            }
+        )
+    }
+
+    func testFireNewAIChatExperimentPixels_WithValue1() {
+        let subfeatureID = "credentialsSaving"
+        let cohort = "control"
+        let enrollmentDate0 = Date()
+        let enrollmentDate1 = Date().addingTimeInterval(.days(-1))
+        let enrollmentDate2 = Date().addingTimeInterval(.days(-2))
+        let enrollmentDate4 = Date().addingTimeInterval(.days(-4))
+        let enrollmentDate5 = Date().addingTimeInterval(.days(-5))
+        let enrollmentDate7 = Date().addingTimeInterval(.days(-7))
+        let enrollmentDate8 = Date().addingTimeInterval(.days(-8))
+        let enrollmentDate14 = Date().addingTimeInterval(.days(-14))
+        let enrollmentDate15 = Date().addingTimeInterval(.days(-15))
+        let experimentData0 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate0)
+        let experimentData1 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate1)
+        let experimentData2 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate2)
+        let experimentData4 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate4)
+        let experimentData5 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate5)
+        let experimentData7 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate7)
+        let experimentData8 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate8)
+        let experimentData14 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate14)
+        let experimentData15 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate15)
+
+        mockFeatureFlagger.experiments = [subfeatureID: experimentData0]
+        PixelKit.fireNewAIChatExperimentPixels()
+        XCTAssertEqual(firedEvent.count, 1) // Fires 1 0-0
+        clearEvents()
+
+        mockFeatureFlagger.experiments = [subfeatureID: experimentData1]
+        PixelKit.fireNewAIChatExperimentPixels()
+        XCTAssertEqual(firedEvent.count, 1) // Fires 1 1-1
+        clearEvents()
+
+        mockFeatureFlagger.experiments = [subfeatureID: experimentData2]
+        PixelKit.fireNewAIChatExperimentPixels()
+        XCTAssertEqual(firedEvent.count, 0) // Nothing (days 2-4 not in any window)
+        clearEvents()
+
+        mockFeatureFlagger.experiments = [subfeatureID: experimentData4]
+        PixelKit.fireNewAIChatExperimentPixels()
+        XCTAssertEqual(firedEvent.count, 0) // Nothing (days 2-4 not in any window)
+        clearEvents()
+
+        mockFeatureFlagger.experiments = [subfeatureID: experimentData5]
+        PixelKit.fireNewAIChatExperimentPixels()
+        XCTAssertEqual(firedEvent.count, 1) // Fires 1 5-7
+        clearEvents()
+
+        mockFeatureFlagger.experiments = [subfeatureID: experimentData7]
+        PixelKit.fireNewAIChatExperimentPixels()
+        XCTAssertEqual(firedEvent.count, 1) // Fires 1 5-7
+        clearEvents()
+
+        mockFeatureFlagger.experiments = [subfeatureID: experimentData8]
+        PixelKit.fireNewAIChatExperimentPixels()
+        XCTAssertEqual(firedEvent.count, 1) // Fires 1 8-14
+        clearEvents()
+
+        mockFeatureFlagger.experiments = [subfeatureID: experimentData14]
+        PixelKit.fireNewAIChatExperimentPixels()
+        XCTAssertEqual(firedEvent.count, 1) // Fires 1 8-14
+        clearEvents()
+
+        mockFeatureFlagger.experiments = [subfeatureID: experimentData15]
+        PixelKit.fireNewAIChatExperimentPixels()
+        XCTAssertEqual(firedEvent.count, 0) // Nothing (after day 14)
+    }
+
+    func testFireNewAIChatExperimentPixels_WithMultipleExperiments() {
+        // GIVEN
+        let subfeatureID1 = "credentialsSaving"
+        let cohort1 = "control"
+        let enrollmentDate1 = Date().addingTimeInterval(.days(-6)) // 6 days ago
+        let experimentData1 = ExperimentData(parentID: "autofill", cohortID: cohort1, enrollmentDate: enrollmentDate1)
+
+        let subfeatureID2 = "inlineIconCredentials"
+        let cohort2 = "test"
+        let enrollmentDate2 = Date().addingTimeInterval(.days(-10)) // 10 days ago
+        let experimentData2 = ExperimentData(parentID: "autofill", cohortID: cohort2, enrollmentDate: enrollmentDate2)
+
+        mockFeatureFlagger.experiments = [
+            subfeatureID1: experimentData1,
+            subfeatureID2: experimentData2
+        ]
+
+        // WHEN
+        PixelKit.fireNewAIChatExperimentPixels()
+
+        // THEN
+        XCTAssertTrue(
+            firedEvent.contains {
+                $0.name == "experiment_metrics_\(subfeatureID1)_\(cohort1)"
+            }
+        )
+        XCTAssertTrue(
+            firedEvent.contains {
+                $0.parameters?[PixelKit.Constants.metricKey] == PixelKit.Constants.aiChatNewChatMetricValue
+            }
+        )
+        XCTAssertTrue(
+            firedEvent.contains {
+                $0.parameters?[PixelKit.Constants.conversionWindowDaysKey] == "5-7"
+            }
+        )
+
+        // Verify pixel also fired for the second experiment (day 10 is within 8-14 window)
+        XCTAssertTrue(
+            firedEvent.contains {
+                $0.name == "experiment_metrics_\(subfeatureID2)_\(cohort2)"
+            }
+        )
+        XCTAssertTrue(
+            firedEvent.contains {
+                $0.parameters?[PixelKit.Constants.conversionWindowDaysKey] == "8-14"
+            }
+        )
+    }
+
     private func clearEvents() {
         firedEvent = []
         firedEventSet = []

--- a/iOS/Core/StatisticsLoader.swift
+++ b/iOS/Core/StatisticsLoader.swift
@@ -40,6 +40,7 @@ public class StatisticsLoader {
     private let parser = AtbParser()
     private let fireSearchExperimentPixels: () -> Void
     private let fireAppRetentionExperimentPixels: () -> Void
+    private let fireNewAIPromptExperimentPixels: () -> Void
     private let fireOSDistributionPixel: (OSDistributionPixel.Metric) -> Void
     private let pixelFiring: PixelFiring.Type
     private var isDuckAIRetentionRequestInProgress = false
@@ -57,6 +58,7 @@ public class StatisticsLoader {
             StatisticsLoader.fireLegacySearchRetentionExperimentPixels()
             StatisticsLoader.fireSearchTokenExperimentPixels(metric: "search")
          },
+         fireNewAIPromptExperimentPixels: @escaping () -> Void = PixelKit.fireNewAIPromptExperimentPixels,
          fireOSDistributionPixel: @escaping (OSDistributionPixel.Metric) -> Void = PixelKit.fireOSDistributionPixel(metric:),
          pixelFiring: PixelFiring.Type = Pixel.self,
          isPad: Bool = UIDevice.current.userInterfaceIdiom == .pad) {
@@ -65,6 +67,7 @@ public class StatisticsLoader {
         self.usageSegmentation = usageSegmentation
         self.fireSearchExperimentPixels = fireSearchExperimentPixels
         self.fireAppRetentionExperimentPixels = fireAppRetentionExperimentPixels
+        self.fireNewAIPromptExperimentPixels = fireNewAIPromptExperimentPixels
         self.fireOSDistributionPixel = fireOSDistributionPixel
         self.pixelFiring = pixelFiring
         self.isPad = isPad
@@ -257,6 +260,7 @@ public class StatisticsLoader {
 
     private func refreshDuckAIRetentionAtb(completion: @escaping Completion = {}) {
         dispatchPrecondition(condition: .onQueue(.main))
+        fireNewAIPromptExperimentPixels()
 
         guard !isDuckAIRetentionRequestInProgress else {
             completion()

--- a/iOS/DuckDuckGoTests/StatisticsLoaderTests.swift
+++ b/iOS/DuckDuckGoTests/StatisticsLoaderTests.swift
@@ -32,6 +32,7 @@ class StatisticsLoaderTests: XCTestCase {
     var testee: StatisticsLoader!
     private var fireAppRetentionExperimentPixelsCalled = false
     private var fireSearchExperimentPixelsCalled = false
+    private var fireNewAIPromptExperimentPixelsCalled = false
     private var firedOSDistributionMetrics: [OSDistributionPixel.Metric] = []
 
     override func setUpWithError() throws {
@@ -46,6 +47,7 @@ class StatisticsLoaderTests: XCTestCase {
                                   usageSegmentation: mockUsageSegmentation,
                                   fireAppRetentionExperimentPixels: { self.fireAppRetentionExperimentPixelsCalled = true },
                                   fireSearchExperimentPixels: { self.fireSearchExperimentPixelsCalled = true },
+                                  fireNewAIPromptExperimentPixels: { self.fireNewAIPromptExperimentPixelsCalled = true },
                                   fireOSDistributionPixel: { self.firedOSDistributionMetrics.append($0) },
                                   pixelFiring: mockPixelFiring)
     }
@@ -508,6 +510,23 @@ class StatisticsLoaderTests: XCTestCase {
         }
         wait(for: [testExpectation], timeout: 1)
         XCTAssertTrue(mockUsageSegmentation.atbs[0].installAtb.isReturningUser)
+    }
+
+    func testWhenDuckAIRefreshHappens_ThenAIChatExperimentPixelsFired() {
+        // Given
+        mockStatisticsStore.atb = "atb"
+        mockStatisticsStore.duckAIRetentionAtb = "retentionatb"
+
+        // When
+        loadSuccessfulAtbStub()
+
+        let testExpectation = expectation(description: "refresh complete")
+        testee.refreshRetentionAtbOnDuckAIPromptSubmission {
+            // Then
+            testExpectation.fulfill()
+        }
+        wait(for: [testExpectation], timeout: 1)
+        XCTAssertTrue(fireNewAIPromptExperimentPixelsCalled)
     }
 
 }

--- a/macOS/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
+++ b/macOS/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
@@ -136,6 +136,7 @@ final class StatisticsLoader {
             self.refreshSearchRetentionAtb {
                 group.leave()
             }
+            self.fireSearchExperimentPixels()
 
             self.refreshDuckAIRetentionAtb {
                 group.leave()

--- a/macOS/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
+++ b/macOS/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
@@ -43,6 +43,7 @@ final class StatisticsLoader {
     var isDuckAIRetentionRequestInProgress = false
     private let fireSearchExperimentPixels: () -> Void
     private let fireAppRetentionExperimentPixels: () -> Void
+    private let fireNewAIPromptExperimentPixels: () -> Void
 
     init(
         statisticsStore: StatisticsStore = LocalStatisticsStore(),
@@ -54,7 +55,8 @@ final class StatisticsLoader {
         fireSearchExperimentPixels: @escaping () -> Void = {
             PixelKit.fireSearchExperimentPixels()
             StatisticsLoader.fireLegacySearchRetentionExperimentPixels()
-        }
+        },
+        fireNewAIPromptExperimentPixels: @escaping () -> Void = PixelKit.fireNewAIPromptExperimentPixels
     ) {
         self.statisticsStore = statisticsStore
         self.emailManager = emailManager
@@ -63,6 +65,7 @@ final class StatisticsLoader {
         self.dockCustomization = dockCustomization
         self.fireSearchExperimentPixels = fireSearchExperimentPixels
         self.fireAppRetentionExperimentPixels = fireAppRetentionExperimentPixels
+        self.fireNewAIPromptExperimentPixels = fireNewAIPromptExperimentPixels
     }
 
     /// Transitional: preserves the previous 8-15 search window for experiments already running when
@@ -306,6 +309,7 @@ final class StatisticsLoader {
 
     func refreshDuckAIRetentionAtb(completion: @escaping Completion = {}) {
         dispatchPrecondition(condition: .onQueue(.main))
+        fireNewAIPromptExperimentPixels()
 
         guard !isDuckAIRetentionRequestInProgress else {
             completion()

--- a/macOS/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
+++ b/macOS/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
@@ -42,8 +42,21 @@ final class StatisticsLoader {
     var isSearchRetentionRequestInProgress = false
     var isDuckAIRetentionRequestInProgress = false
     private let fireSearchExperimentPixels: () -> Void
+    private let fireDuckAISearchExperimentPixels: () -> Void
     private let fireAppRetentionExperimentPixels: () -> Void
     private let fireNewAIPromptExperimentPixels: () -> Void
+
+    /// Experiments that were already running when Duck.ai prompts began counting toward the search metric.
+    /// They keep the previous definition (search navigation only, no Duck.ai) so their in-flight pre/post
+    /// analysis stays comparable. Experiments enrolled *after* this change are intentionally absent, so they
+    /// do count Duck.ai prompts as search. Remove each entry as its experiment is cleaned up; delete this
+    /// once none remain.
+    static let experimentsExcludedFromDuckAISearchMetric: Set<SubfeatureID> = [
+        MacOSBrowserConfigSubfeature.onboardingChromeExtension.rawValue,
+        AutoconsentSubfeature.heuristicAction.rawValue,
+        AutoconsentSubfeature.cookiePopupOptInDialogExperiment.rawValue,
+        PrivacyProSubfeature.onboardingSubscriptionUpsellExperiment.rawValue
+    ]
 
     init(
         statisticsStore: StatisticsStore = LocalStatisticsStore(),
@@ -56,6 +69,9 @@ final class StatisticsLoader {
             PixelKit.fireSearchExperimentPixels()
             StatisticsLoader.fireLegacySearchRetentionExperimentPixels()
         },
+        fireDuckAISearchExperimentPixels: @escaping () -> Void = {
+            StatisticsLoader.fireSearchExperimentPixelsForDuckAIEligibleExperiments()
+        },
         fireNewAIPromptExperimentPixels: @escaping () -> Void = PixelKit.fireNewAIPromptExperimentPixels
     ) {
         self.statisticsStore = statisticsStore
@@ -64,6 +80,7 @@ final class StatisticsLoader {
         self.usageSegmentation = usageSegmentation
         self.dockCustomization = dockCustomization
         self.fireSearchExperimentPixels = fireSearchExperimentPixels
+        self.fireDuckAISearchExperimentPixels = fireDuckAISearchExperimentPixels
         self.fireAppRetentionExperimentPixels = fireAppRetentionExperimentPixels
         self.fireNewAIPromptExperimentPixels = fireNewAIPromptExperimentPixels
     }
@@ -87,6 +104,41 @@ final class StatisticsLoader {
                 )
             }
         }
+    }
+
+    /// Fires the search experiment metric for a Duck.ai prompt, but only for experiments that should count
+    /// Duck.ai prompts as search — i.e. every active experiment except those enrolled before this change
+    /// (see `experimentsExcludedFromDuckAISearchMetric`). Filtering happens here rather than in
+    /// PixelExperimentKit so the grandfathered list stays a macOS concern; experiments enrolled later are
+    /// included automatically.
+    ///
+    /// The value/window mapping mirrors `PixelKit.fireSearchExperimentPixels` so a Duck.ai prompt produces
+    /// the same search pixels a real search navigation would. Keep the two in sync.
+    static func fireSearchExperimentPixelsForDuckAIEligibleExperiments(
+        featureFlagger: FeatureFlagger = Application.appDelegate.featureFlagger
+    ) {
+        let valueConversionDictionary: [NumberOfCalls: [ConversionWindow]] = [
+            1: [0...0, 1...1, 2...2, 3...3, 4...4, 5...5, 6...6, 7...7, 5...7, 8...14],
+            4: [5...7, 8...14],
+            6: [5...7, 8...14],
+            11: [5...7, 8...14],
+            21: [5...7, 8...14],
+            30: [5...7, 8...14]
+        ]
+        featureFlagger.allActiveExperiments.keys
+            .filter { !experimentsExcludedFromDuckAISearchMetric.contains($0) }
+            .forEach { subfeatureID in
+                valueConversionDictionary.forEach { value, windows in
+                    windows.forEach { window in
+                        PixelKit.fireExperimentPixelIfThresholdReached(
+                            for: subfeatureID,
+                            metric: "search",
+                            conversionWindowDays: window,
+                            threshold: value
+                        )
+                    }
+                }
+            }
     }
 
     func refreshRetentionAtbOnNavigation(isSearch: Bool,
@@ -136,7 +188,10 @@ final class StatisticsLoader {
             self.refreshSearchRetentionAtb {
                 group.leave()
             }
-            self.fireSearchExperimentPixels()
+            // Count Duck.ai prompts toward the search experiment metric, but only for experiments enrolled
+            // after this change. Experiments already running are excluded (see
+            // experimentsExcludedFromDuckAISearchMetric) so their search definition doesn't shift mid-flight.
+            self.fireDuckAISearchExperimentPixels()
 
             self.refreshDuckAIRetentionAtb {
                 group.leave()

--- a/macOS/UnitTests/Statistics/ATB/StatisticsLoaderTests.swift
+++ b/macOS/UnitTests/Statistics/ATB/StatisticsLoaderTests.swift
@@ -30,6 +30,7 @@ class StatisticsLoaderTests: XCTestCase {
     private var testee: StatisticsLoader!
     private var fireAppRetentionExperimentPixelsCalled = false
     private var fireSearchExperimentPixelsCalled = false
+    private var fireNewAIPromptExperimentPixelsCalled = false
     var pixelKit: PixelKit! = PixelKit(dryRun: true,
                                        appVersion: "1.0.0",
                                        defaultHeaders: [:],
@@ -45,7 +46,8 @@ class StatisticsLoaderTests: XCTestCase {
                                   attributionPixelHandler: mockAttributionsPixelHandler,
                                   dockCustomization: DockCustomizerMock(),
                                   fireAppRetentionExperimentPixels: { self.fireAppRetentionExperimentPixelsCalled = true },
-                                  fireSearchExperimentPixels: { self.fireSearchExperimentPixelsCalled = true })
+                                  fireSearchExperimentPixels: { self.fireSearchExperimentPixelsCalled = true },
+                                  fireNewAIPromptExperimentPixels: { self.fireNewAIPromptExperimentPixelsCalled = true })
     }
 
     override func tearDown() {
@@ -56,6 +58,7 @@ class StatisticsLoaderTests: XCTestCase {
         testee = nil
         fireAppRetentionExperimentPixelsCalled = false
         fireSearchExperimentPixelsCalled = false
+        fireNewAIPromptExperimentPixelsCalled = false
         pixelKit = nil
     }
 
@@ -595,6 +598,20 @@ class StatisticsLoaderTests: XCTestCase {
         let expect = expectation(description: "DuckAI refresh triggers install statistics")
         testee.refreshDuckAIRetentionAtb {
             XCTAssertTrue(self.mockStatisticsStore.hasInstallStatistics)
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testWhenDuckAIRefreshHappens_ThenAIChatExperimentPixelsFired() {
+        mockStatisticsStore.atb = "atb"
+        mockStatisticsStore.duckAIRetentionAtb = "retentionAtb"
+        loadSuccessfulAtbStub()
+
+        let expect = expectation(description: "DuckAI refresh fires AI chat experiment pixels")
+        testee.refreshDuckAIRetentionAtb {
+            XCTAssertTrue(self.fireNewAIPromptExperimentPixelsCalled)
             expect.fulfill()
         }
 

--- a/macOS/UnitTests/Statistics/ATB/StatisticsLoaderTests.swift
+++ b/macOS/UnitTests/Statistics/ATB/StatisticsLoaderTests.swift
@@ -618,6 +618,21 @@ class StatisticsLoaderTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 
+    func testWhenDuckAIPromptSubmitted_ThenSearchExperimentPixelsFired() {
+        mockStatisticsStore.atb = "atb"
+        mockStatisticsStore.searchRetentionAtb = "searchRetentionAtb"
+        mockStatisticsStore.duckAIRetentionAtb = "duckAIRetentionAtb"
+        loadSuccessfulUpdateAtbStub()
+
+        let expect = expectation(description: "DuckAI prompt submission fires search experiment pixels")
+        testee.refreshRetentionAtbOnDuckAiPromptSubmition {
+            XCTAssertTrue(self.fireSearchExperimentPixelsCalled)
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
     func testWhenDuckAIRefreshCalledWhileAnotherIsInProgressThenSecondCallIsIgnored() {
         mockStatisticsStore.atb = "atb"
         mockStatisticsStore.duckAIRetentionAtb = "retentionAtb"

--- a/macOS/UnitTests/Statistics/ATB/StatisticsLoaderTests.swift
+++ b/macOS/UnitTests/Statistics/ATB/StatisticsLoaderTests.swift
@@ -20,6 +20,7 @@ import XCTest
 import OHHTTPStubs
 import OHHTTPStubsSwift
 import PixelExperimentKit
+import PrivacyConfig
 @testable import PixelKit
 @testable import DuckDuckGo_Privacy_Browser
 
@@ -30,6 +31,7 @@ class StatisticsLoaderTests: XCTestCase {
     private var testee: StatisticsLoader!
     private var fireAppRetentionExperimentPixelsCalled = false
     private var fireSearchExperimentPixelsCalled = false
+    private var fireDuckAISearchExperimentPixelsCalled = false
     private var fireNewAIPromptExperimentPixelsCalled = false
     var pixelKit: PixelKit! = PixelKit(dryRun: true,
                                        appVersion: "1.0.0",
@@ -47,6 +49,7 @@ class StatisticsLoaderTests: XCTestCase {
                                   dockCustomization: DockCustomizerMock(),
                                   fireAppRetentionExperimentPixels: { self.fireAppRetentionExperimentPixelsCalled = true },
                                   fireSearchExperimentPixels: { self.fireSearchExperimentPixelsCalled = true },
+                                  fireDuckAISearchExperimentPixels: { self.fireDuckAISearchExperimentPixelsCalled = true },
                                   fireNewAIPromptExperimentPixels: { self.fireNewAIPromptExperimentPixelsCalled = true })
     }
 
@@ -58,6 +61,7 @@ class StatisticsLoaderTests: XCTestCase {
         testee = nil
         fireAppRetentionExperimentPixelsCalled = false
         fireSearchExperimentPixelsCalled = false
+        fireDuckAISearchExperimentPixelsCalled = false
         fireNewAIPromptExperimentPixelsCalled = false
         pixelKit = nil
     }
@@ -618,19 +622,47 @@ class StatisticsLoaderTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 
-    func testWhenDuckAIPromptSubmitted_ThenSearchExperimentPixelsFired() {
+    func testWhenDuckAIPromptSubmitted_ThenDuckAIScopedSearchExperimentPixelsFired() {
         mockStatisticsStore.atb = "atb"
         mockStatisticsStore.searchRetentionAtb = "searchRetentionAtb"
         mockStatisticsStore.duckAIRetentionAtb = "duckAIRetentionAtb"
         loadSuccessfulUpdateAtbStub()
 
-        let expect = expectation(description: "DuckAI prompt submission fires search experiment pixels")
+        // A Duck.ai prompt fires the search experiment metric via the Duck.ai-scoped path, which excludes
+        // experiments already running so their search definition doesn't shift mid-flight. It must NOT go
+        // through the generic fireSearchExperimentPixels, which would count Duck.ai for every active experiment.
+        let expect = expectation(description: "DuckAI prompt submission fires the Duck.ai-scoped search experiment pixels")
         testee.refreshRetentionAtbOnDuckAiPromptSubmition {
-            XCTAssertTrue(self.fireSearchExperimentPixelsCalled)
+            XCTAssertTrue(self.fireDuckAISearchExperimentPixelsCalled)
+            XCTAssertFalse(self.fireSearchExperimentPixelsCalled)
             expect.fulfill()
         }
 
         waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testFireSearchExperimentPixelsForDuckAIEligibleExperiments_ExcludesGrandfatheredExperiments() {
+        // GIVEN a grandfathered experiment and a newer one, both freshly enrolled (day 0 fires the 0...0 window)
+        var firedEventNames = [String]()
+        let grandfatheredID = StatisticsLoader.experimentsExcludedFromDuckAISearchMetric.first!
+        let newExperimentID = "someNewDuckAIEligibleExperiment"
+        let flagger = MockFeatureFlagger()
+        flagger.allActiveExperiments = [
+            grandfatheredID: ExperimentData(parentID: "parent", cohortID: "control", enrollmentDate: Date()),
+            newExperimentID: ExperimentData(parentID: "parent", cohortID: "control", enrollmentDate: Date())
+        ]
+        PixelKit.configureExperimentKit(
+            featureFlagger: flagger,
+            eventTracker: ExperimentEventTracker(store: MockExperimentActionPixelStore()),
+            fire: { event, _, _ in firedEventNames.append(event.name) }
+        )
+
+        // WHEN
+        StatisticsLoader.fireSearchExperimentPixelsForDuckAIEligibleExperiments(featureFlagger: flagger)
+
+        // THEN the newer experiment counts the Duck.ai prompt as search; the grandfathered one does not
+        XCTAssertTrue(firedEventNames.contains { $0.contains(newExperimentID) })
+        XCTAssertFalse(firedEventNames.contains { $0.contains(grandfatheredID) })
     }
 
     func testWhenDuckAIRefreshCalledWhileAnotherIsInProgressThenSecondCallIsIgnored() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1215989417161867?focus=true
Tech Design URL:
CC:

### Description

Adds AI prompts experiment pixels mirroring the existing`fireSearchExperimentPixels()` and` fireAppRetentionExperimentPixels()` functions.

This allows Duck.ai prompt/search activity to be automatically measured as a metric across all active experiments.

The new metric uses the name:
- `duck_ai_prompt_sent` is triggered from `refreshDuckAIRetentionAtb` on both iOS and macOS, so it fires whenever a user submits a Duck.ai prompt.

### Testing Steps
1. Enroll in an active experiment (e.g. `autofillOnboardingDismissExperiment`)
2. Submit a Duck.ai prompt
3. Verify experiment_metrics_ autofillOnboardingDismissExperiment_<cohortID> pixel fires with metric=duck_ai_prompt_sent
4. Do a regular DDG search and verify metric=search pixel still fires correctly

### Impact and Risks
**Low:**: Additive change to the experiment framework. No changes to existing ATB behaviour or public APIs.

#### What could go wrong?
- The `performRefreshSearchRetentionAtb` refactor accidentally breaking search ATB, mitigated by existing `StatisticsLoaderTests` which cover the search ATB refresh path and are unchanged.

### Quality Considerations
- Conversion windows and metric name aligned with Android's `DuckAiPromptSentMetricPixelsPlugin` for cross-platform consistency.
- Unit tests added to `PixelExperimentKitTests` and `StatisticsLoaderTests` on both platforms.

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how experiment conversion metrics are recorded for Duck.ai (including macOS search-metric grandfathering), which can affect in-flight experiment analysis if misconfigured; core ATB paths are mostly additive with test coverage.
> 
> **Overview**
> Adds **automatic experiment measurement** for Duck.ai usage via two new metrics: `duck_ai_prompt_sent` and `duck_ai_new_chat`, wired through `PixelKit.fireNewAIPromptExperimentPixels()` and `fireNewAIChatExperimentPixels()` (same conversion windows as other AI prompt plugins: 0–0, 1–1, 5–7, 8–14).
> 
> **Prompt sent:** iOS and macOS call `fireNewAIPromptExperimentPixels()` from `refreshDuckAIRetentionAtb` when Duck.ai retention ATB is refreshed after a prompt.
> 
> **New chat:** iOS (`AIChatContentHandler`, `AIChatViewControllerManager`) and macOS (`AIChatUserScriptHandler`) fire `fireNewAIChatExperimentPixels()` when the frontend reports `userDidCreateNewChat`.
> 
> **macOS-only:** On Duck.ai prompt submission, search experiment pixels are also fired via a new `fireSearchExperimentPixelsForDuckAIEligibleExperiments()` path that mirrors search thresholds but **skips grandfathered experiments** listed in `experimentsExcludedFromDuckAISearchMetric`, so in-flight experiments keep “search = navigation only.” iOS does not add this scoped search path in this PR.
> 
> Unit tests cover `PixelExperimentKit`, `StatisticsLoader`, and AI chat metric routing on both platforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a131f27c57648854ee5d46b2dc2e932bb63950b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->