### PR TITLE
Remove iPadAIToggle feature flag

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -241,9 +241,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213227027157584
     case iPadDuckaiOnTab
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213313932650457
-    case iPadAIToggle
-
     /// macOS: https://app.asana.com/1/137249556945/project/1211834678943996/task/1212015252281641
     /// iOS: https://app.asana.com/1/137249556945/project/1211834678943996/task/1212015250423471
     case attributedMetrics
@@ -695,8 +692,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(AIChatSubfeature.fullDuckAIMode))
         case .iPadDuckaiOnTab:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.iPadDuckaiOnTab))
-        case .iPadAIToggle:
-            Config(source: .remoteReleasable(AIChatSubfeature.iPadAIChatToggle))
         case .attributedMetrics:
             Config(defaultValue: .enabled, source: .remoteReleasable(AttributedMetricsSubfeature.featureEnabled))
         case .onboardingDuckAIFlow:

--- a/iOS/DuckDuckGo/AIChat/AIChatAddressBarExperience.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatAddressBarExperience.swift
@@ -64,7 +64,6 @@ struct AIChatAddressBarExperience: AIChatAddressBarExperienceProviding {
 
     var isIPadAIToggleExperienceEnabled: Bool {
         userInterfaceIdiomProvider.userInterfaceIdiom == .pad
-            && featureFlagger.isFeatureOn(.iPadAIToggle)
     }
 
     private var isIPadChromeShortcutInPlay: Bool {

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -445,7 +445,7 @@ final class DefaultOmniBarViewController: OmniBarViewController {
 
 // MARK: - iPad Duck.ai Mode Toggle
 //
-// On iPad, the address bar has a search/duck.ai toggle (gated by the iPadAIToggle feature flag).
+// On iPad, the address bar has a search/duck.ai toggle.
 // When the user switches between modes, the text must transfer seamlessly between the UITextField
 // (search mode) and the UITextView (duck.ai expanded mode) while keeping the keyboard visible.
 

--- a/iOS/DuckDuckGo/MainView.swift
+++ b/iOS/DuckDuckGo/MainView.swift
@@ -186,7 +186,6 @@ extension MainViewFactory {
     final class NavigationBarContainer: UIView {
 
         /// Enables overflow hit testing for iPad expanded search area.
-        /// Set to `true` when `FeatureFlag.iPadAIToggle` is on.
         var allowsOverflowHitTesting = false {
             didSet {
                 guard allowsOverflowHitTesting != oldValue else { return }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -658,10 +658,8 @@ class MainViewController: UIViewController {
                                                               mobileCustomization: mobileCustomization,
                                                               duckAiNativeStorageHandler: duckAiNativeStorageHandler)
 
-        if featureFlagger.isFeatureOn(.iPadAIToggle) {
-            viewCoordinator.navigationBarContainer.allowsOverflowHitTesting = true
-            viewCoordinator.navigationBarCollectionView.allowsOverflowHitTesting = true
-        }
+        viewCoordinator.navigationBarContainer.allowsOverflowHitTesting = true
+        viewCoordinator.navigationBarCollectionView.allowsOverflowHitTesting = true
 
         viewCoordinator.moveAddressBarToPosition(appSettings.currentAddressBarPosition)
 

--- a/iOS/DuckDuckGo/OmniBarState.swift
+++ b/iOS/DuckDuckGo/OmniBarState.swift
@@ -108,7 +108,6 @@ extension OmniBarState {
 
     var showRefreshOutsideAddressBar: Bool {
         hasLargeWidth
-            && dependencies.featureFlagger.isFeatureOn(.iPadAIToggle)
     }
 }
 

--- a/iOS/DuckDuckGo/SettingsAIExperimentalPickerView.swift
+++ b/iOS/DuckDuckGo/SettingsAIExperimentalPickerView.swift
@@ -70,11 +70,7 @@ struct SettingsAIExperimentalPickerView: View {
     }
 
     private var shouldUseIPadAssets: Bool {
-        isIPadAIToggleOn && UIDevice.current.userInterfaceIdiom == .pad
-    }
-
-    private var isIPadAIToggleOn: Bool {
-        AppDependencyProvider.shared.featureFlagger.isFeatureOn(.iPadAIToggle)
+        UIDevice.current.userInterfaceIdiom == .pad
     }
 
     private func rebrandableImage(_ rebranded: ImageResource, legacy: ImageResource) -> ImageResource {

--- a/iOS/DuckDuckGoTests/AIChat/AIChatAddressBarExperienceTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatAddressBarExperienceTests.swift
@@ -37,7 +37,7 @@ final class AIChatAddressBarExperienceTests: XCTestCase {
 
     func testWhenIPhoneAndSearchInputEnabledThenUsesExperimentalEditingState() {
         MockUIDevice.mockUserInterfaceIdiom = .phone
-        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.iPadAIToggle])
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [])
         let aiChatSettings = MockAIChatSettingsProvider(isAIChatAddressBarUserSettingsEnabled: true,
                                                         isAIChatSearchInputUserSettingsEnabled: true)
         let testee = AIChatAddressBarExperience(featureFlagger: featureFlagger,
@@ -46,9 +46,9 @@ final class AIChatAddressBarExperienceTests: XCTestCase {
         XCTAssertTrue(testee.shouldUseExperimentalEditingState)
     }
 
-    func testWhenIPadAndIPadAIToggleEnabledThenDoesNotUseExperimentalEditingState() {
+    func testWhenIPadThenDoesNotUseExperimentalEditingState() {
         MockUIDevice.mockUserInterfaceIdiom = .pad
-        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.iPadAIToggle])
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [])
         let aiChatSettings = MockAIChatSettingsProvider(isAIChatAddressBarUserSettingsEnabled: true,
                                                         isAIChatSearchInputUserSettingsEnabled: true)
         let testee = AIChatAddressBarExperience(featureFlagger: featureFlagger,
@@ -57,20 +57,9 @@ final class AIChatAddressBarExperienceTests: XCTestCase {
         XCTAssertFalse(testee.shouldUseExperimentalEditingState)
     }
 
-    func testWhenIPadAndIPadAIToggleDisabledThenUsesExperimentalEditingState() {
-        MockUIDevice.mockUserInterfaceIdiom = .pad
-        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [])
-        let aiChatSettings = MockAIChatSettingsProvider(isAIChatAddressBarUserSettingsEnabled: true,
-                                                        isAIChatSearchInputUserSettingsEnabled: true)
-        let testee = AIChatAddressBarExperience(featureFlagger: featureFlagger,
-                                                aiChatSettings: aiChatSettings)
-
-        XCTAssertTrue(testee.shouldUseExperimentalEditingState)
-    }
-
-    func testWhenIPhoneAndIPadAIToggleEnabledThenDuckAIAddressBarButtonIsShown() {
+    func testWhenIPhoneThenDuckAIAddressBarButtonIsShown() {
         MockUIDevice.mockUserInterfaceIdiom = .phone
-        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.iPadAIToggle])
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [])
         let aiChatSettings = MockAIChatSettingsProvider(isAIChatAddressBarUserSettingsEnabled: true)
         let testee = AIChatAddressBarExperience(featureFlagger: featureFlagger,
                                                 aiChatSettings: aiChatSettings)
@@ -78,17 +67,7 @@ final class AIChatAddressBarExperienceTests: XCTestCase {
         XCTAssertTrue(testee.shouldShowDuckAIAddressBarButton)
     }
 
-    func testWhenIPadAndIPadAIToggleEnabledThenDuckAIAddressBarButtonIsShown() {
-        MockUIDevice.mockUserInterfaceIdiom = .pad
-        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.iPadAIToggle])
-        let aiChatSettings = MockAIChatSettingsProvider(isAIChatAddressBarUserSettingsEnabled: true)
-        let testee = AIChatAddressBarExperience(featureFlagger: featureFlagger,
-                                                aiChatSettings: aiChatSettings)
-
-        XCTAssertTrue(testee.shouldShowDuckAIAddressBarButton)
-    }
-
-    func testWhenIPadAndIPadAIToggleDisabledThenDuckAIAddressBarButtonIsShown() {
+    func testWhenIPadThenDuckAIAddressBarButtonIsShown() {
         MockUIDevice.mockUserInterfaceIdiom = .pad
         let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [])
         let aiChatSettings = MockAIChatSettingsProvider(isAIChatAddressBarUserSettingsEnabled: true)
@@ -98,9 +77,9 @@ final class AIChatAddressBarExperienceTests: XCTestCase {
         XCTAssertTrue(testee.shouldShowDuckAIAddressBarButton)
     }
 
-    func testWhenIPhoneAndIPadAIToggleEnabledAndSearchInputEnabledThenModeToggleIsHidden() {
+    func testWhenIPhoneAndSearchInputEnabledThenModeToggleIsHidden() {
         MockUIDevice.mockUserInterfaceIdiom = .phone
-        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.iPadAIToggle])
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [])
         let aiChatSettings = MockAIChatSettingsProvider(isAIChatAddressBarUserSettingsEnabled: true,
                                                         isAIChatSearchInputUserSettingsEnabled: true)
         let testee = AIChatAddressBarExperience(featureFlagger: featureFlagger,
@@ -109,9 +88,9 @@ final class AIChatAddressBarExperienceTests: XCTestCase {
         XCTAssertFalse(testee.shouldShowModeToggle)
     }
 
-    func testWhenIPadAndIPadAIToggleEnabledAndSearchInputEnabledThenModeToggleIsShown() {
+    func testWhenIPadAndSearchInputEnabledThenModeToggleIsShown() {
         MockUIDevice.mockUserInterfaceIdiom = .pad
-        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.iPadAIToggle])
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [])
         let aiChatSettings = MockAIChatSettingsProvider(isAIChatAddressBarUserSettingsEnabled: true,
                                                         isAIChatSearchInputUserSettingsEnabled: true)
         let testee = AIChatAddressBarExperience(featureFlagger: featureFlagger,
@@ -120,9 +99,9 @@ final class AIChatAddressBarExperienceTests: XCTestCase {
         XCTAssertTrue(testee.shouldShowModeToggle)
     }
 
-    func testWhenIPadAndIPadAIToggleEnabledAndAddressBarDisabledAndSearchInputEnabledThenModeToggleIsShown() {
+    func testWhenIPadAndAddressBarDisabledAndSearchInputEnabledThenModeToggleIsShown() {
         MockUIDevice.mockUserInterfaceIdiom = .pad
-        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.iPadAIToggle])
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [])
         let aiChatSettings = MockAIChatSettingsProvider(isAIChatAddressBarUserSettingsEnabled: false,
                                                         isAIChatSearchInputUserSettingsEnabled: true)
         let testee = AIChatAddressBarExperience(featureFlagger: featureFlagger,
@@ -131,20 +110,9 @@ final class AIChatAddressBarExperienceTests: XCTestCase {
         XCTAssertTrue(testee.shouldShowModeToggle)
     }
 
-    func testWhenIPadAndIPadAIToggleDisabledAndSearchInputEnabledThenModeToggleIsHidden() {
+    func testWhenIPadAndSearchInputDisabledThenModeToggleIsHidden() {
         MockUIDevice.mockUserInterfaceIdiom = .pad
         let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [])
-        let aiChatSettings = MockAIChatSettingsProvider(isAIChatAddressBarUserSettingsEnabled: true,
-                                                        isAIChatSearchInputUserSettingsEnabled: true)
-        let testee = AIChatAddressBarExperience(featureFlagger: featureFlagger,
-                                                aiChatSettings: aiChatSettings)
-
-        XCTAssertFalse(testee.shouldShowModeToggle)
-    }
-
-    func testWhenIPadAndIPadAIToggleEnabledAndSearchInputDisabledThenModeToggleIsHidden() {
-        MockUIDevice.mockUserInterfaceIdiom = .pad
-        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.iPadAIToggle])
         let aiChatSettings = MockAIChatSettingsProvider(isAIChatAddressBarUserSettingsEnabled: true,
                                                         isAIChatSearchInputUserSettingsEnabled: false)
         let testee = AIChatAddressBarExperience(featureFlagger: featureFlagger,

--- a/iOS/DuckDuckGoTests/LargeOmniBarStateTests.swift
+++ b/iOS/DuckDuckGoTests/LargeOmniBarStateTests.swift
@@ -567,12 +567,11 @@ class LargeOmniBarStateTests: XCTestCase {
         XCTAssertEqual(testee.onBrowsingStoppedState.name, LargeOmniBarState.HomeNonEditingState(dependencies: MockOmnibarDependency(voiceSearchHelper: enabledVoiceSearchHelper, featureFlagger: mockFeatureFlagger), isLoading: false).name)
     }
 
-    func testWhenIPadAIToggleEnabledThenAIChatButtonAndModeToggleAreShown() {
+    func testWhenIPadThenAIChatButtonAndModeToggleAreShown() {
         UIDevice.swizzleCurrent()
         defer { UIDevice.unswizzleCurrent() }
         MockUIDevice.mockUserInterfaceIdiom = .pad
 
-        mockFeatureFlagger.enabledFeatureFlags = [.iPadAIToggle]
         let dependencies = MockOmnibarDependency(voiceSearchHelper: disabledVoiceSearchHelper,
                                                  featureFlagger: mockFeatureFlagger,
                                                  aiChatSettings: mockAIChatSettingsEnabled)
@@ -581,7 +580,11 @@ class LargeOmniBarStateTests: XCTestCase {
         XCTAssertTrue(testee.showAIChatModeToggle)
     }
 
-    func testWhenIPadAIToggleDisabledThenShowAIChatModeToggleIsFalse() {
+    func testWhenIPhoneThenShowAIChatModeToggleIsFalse() {
+        UIDevice.swizzleCurrent()
+        defer { UIDevice.unswizzleCurrent() }
+        MockUIDevice.mockUserInterfaceIdiom = .phone
+
         let dependencies = MockOmnibarDependency(voiceSearchHelper: disabledVoiceSearchHelper,
                                                  featureFlagger: mockFeatureFlagger,
                                                  aiChatSettings: mockAIChatSettingsEnabled)
@@ -590,12 +593,11 @@ class LargeOmniBarStateTests: XCTestCase {
         XCTAssertFalse(testee.showAIChatModeToggle)
     }
 
-    func testWhenAIChatButtonHiddenThenShowAIChatModeToggleIsFalseEvenIfFlagEnabled() {
+    func testWhenAIChatButtonHiddenThenShowAIChatModeToggleIsFalse() {
         UIDevice.swizzleCurrent()
         defer { UIDevice.unswizzleCurrent() }
         MockUIDevice.mockUserInterfaceIdiom = .pad
 
-        mockFeatureFlagger.enabledFeatureFlags = [.iPadAIToggle]
         let dependencies = MockOmnibarDependency(voiceSearchHelper: disabledVoiceSearchHelper,
                                                  featureFlagger: mockFeatureFlagger)
         let testee = LargeOmniBarState.BrowsingNonEditingState(dependencies: dependencies, isLoading: false)
@@ -603,12 +605,11 @@ class LargeOmniBarStateTests: XCTestCase {
         XCTAssertFalse(testee.showAIChatModeToggle)
     }
 
-    func testWhenAIChatSearchInputSettingDisabledThenAIChatButtonIsShownAndModeToggleIsHiddenIfFlagEnabled() {
+    func testWhenAIChatSearchInputSettingDisabledThenAIChatButtonIsShownAndModeToggleIsHidden() {
         UIDevice.swizzleCurrent()
         defer { UIDevice.unswizzleCurrent() }
         MockUIDevice.mockUserInterfaceIdiom = .pad
 
-        mockFeatureFlagger.enabledFeatureFlags = [.iPadAIToggle]
         let aiChatSettings = MockAIChatSettingsProvider(isAIChatEnabled: true,
                                                         isAIChatAddressBarUserSettingsEnabled: true,
                                                         isAIChatSearchInputUserSettingsEnabled: false)
@@ -620,12 +621,7 @@ class LargeOmniBarStateTests: XCTestCase {
         XCTAssertFalse(testee.showAIChatModeToggle)
     }
 
-    func testWhenIPadAIToggleEnabledAndRefreshEnabledThenShowRefreshOutsideAddressBarIsTrue() {
-        UIDevice.swizzleCurrent()
-        defer { UIDevice.unswizzleCurrent() }
-        MockUIDevice.mockUserInterfaceIdiom = .pad
-
-        mockFeatureFlagger.enabledFeatureFlags = [.iPadAIToggle]
+    func testWhenLargeWidthAndRefreshEnabledThenShowRefreshOutsideAddressBarIsTrue() {
         let appSettings = AppSettingsMock()
         appSettings.currentRefreshButtonPosition = .addressBar
         let dependencies = MockOmnibarDependency(voiceSearchHelper: disabledVoiceSearchHelper,
@@ -633,16 +629,6 @@ class LargeOmniBarStateTests: XCTestCase {
                                                  appSettings: appSettings)
         let testee = LargeOmniBarState.BrowsingNonEditingState(dependencies: dependencies, isLoading: false)
         XCTAssertTrue(testee.showRefreshOutsideAddressBar)
-    }
-
-    func testWhenIPadAIToggleDisabledThenShowRefreshOutsideAddressBarIsFalse() {
-        let appSettings = AppSettingsMock()
-        appSettings.currentRefreshButtonPosition = .addressBar
-        let dependencies = MockOmnibarDependency(voiceSearchHelper: disabledVoiceSearchHelper,
-                                                 featureFlagger: mockFeatureFlagger,
-                                                 appSettings: appSettings)
-        let testee = LargeOmniBarState.BrowsingNonEditingState(dependencies: dependencies, isLoading: false)
-        XCTAssertFalse(testee.showRefreshOutsideAddressBar)
     }
 
     // MARK: - AI Chat Mode State Tests

--- a/iOS/DuckDuckGoTests/SmallOmniBarStateTests.swift
+++ b/iOS/DuckDuckGoTests/SmallOmniBarStateTests.swift
@@ -543,7 +543,6 @@ class SmallOmniBarStateTests: XCTestCase {
     }
 
     func testWhenStateIsNotLargeWidthThenShowRefreshOutsideAddressBarIsFalse() {
-        mockFeatureFlagger.enabledFeatureFlags = [.iPadAIToggle]
         let appSettings = AppSettingsMock()
         appSettings.currentRefreshButtonPosition = .addressBar
         let dependencies = MockOmnibarDependency(voiceSearchHelper: disabledVoiceSearchHelper,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1209671977594486/task/1213313932650457?focus=true
Tech Design URL:
CC:

### Description
Removes the `iPadAIToggle` feature flag and hardcodes the enabled path at every decision point, so the iPad address-bar search/duck.ai toggle is always on. The `isIPadAIToggleExperienceEnabled` property now resolves to "is iPad". Tests were updated to the now-default iPad behavior and the unreachable flag-disabled cases removed.

### Testing Steps
1. On an iPad, open the browser and confirm the address bar shows the search/duck.ai mode toggle (with the Duck.ai search-input setting enabled).
2. On an iPhone, confirm the address bar behaves as before (no iPad mode toggle, experimental editing state still used).

### Impact and Risks
Low — the flag was being graduated to fully on; behavior on iPad matches the previously flag-enabled path.

#### What could go wrong?
If the flag was not actually at 100% rollout, some iPad users would see the toggle experience earlier than expected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Graduation of an existing rollout path with no new logic beyond removing the flag gate; main risk is iPad users seeing the toggle if remote rollout was not actually at 100%.
> 
> **Overview**
> Removes the **`iPadAIToggle`** feature flag and treats the iPad search/Duck.ai address-bar experience as always on for iPad.
> 
> **`isIPadAIToggleExperienceEnabled`** now means “device is iPad” only (no remote flag). That drives the in-bar mode toggle, non-experimental editing on iPad, and related omnibar behavior. **Overflow hit testing** on the navigation bar is always enabled at startup instead of being flag-gated. **`showRefreshOutsideAddressBar`** on large-width layouts no longer checks the removed flag. The AI experimental settings picker uses iPad assets whenever the idiom is iPad.
> 
> Unit tests were renamed and simplified to match idiom-based behavior; cases that only existed for flag-off were dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de6cec5901dc8a6b1b82d927a13668e9135d6c58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->