### PR TITLE
iOS: Fix favorites reorder double-applying move (favoritesListIndexNotMatchingBookmark spike)

### DIFF
--- a/iOS/DuckDuckGo/FavoritesViewModel.swift
+++ b/iOS/DuckDuckGo/FavoritesViewModel.swift
@@ -150,7 +150,8 @@ class FavoritesViewModel: ObservableObject {
         let favorite = allFavorites[fromIndex]
 
         favoriteDataSource.moveFavorite(favorite, fromIndex: fromIndex, toIndex: index)
-        allFavorites.move(fromOffsets: IndexSet(integer: fromIndex), toOffset: index)
+        // Reload from the data source; it already republishes the reordered list, so don't re-apply the move.
+        updateData()
     }
 
     // MARK: -

--- a/iOS/DuckDuckGoTests/NewTabPageFavoritesModelTests.swift
+++ b/iOS/DuckDuckGoTests/NewTabPageFavoritesModelTests.swift
@@ -20,6 +20,9 @@
 import XCTest
 import Combine
 import Bookmarks
+import CoreData
+import Common
+import Persistence
 @testable import Core
 @testable import DuckDuckGo
 
@@ -85,6 +88,74 @@ final class NewTabPageFavoritesModelTests: XCTestCase {
                            pixelFiring: PixelFiringMock.self,
                            dailyPixelFiring: PixelFiringMock.self)
     }
+
+    // MARK: - Reordering (regression for m_d_favorites_list_index_not_matching_bookmark)
+
+    // These exercise the real model -> adapter -> view model stack, because the bug only appears
+    // when the adapter forwards the model's in-process `localUpdates` back into the originating
+    // view model (added in 7.225), making `updateData()` re-enter during `moveFavorites`.
+
+    func testReorderingFavoriteKeepsInMemoryListInSyncWithModel() throws {
+        let env = try makeReorderEnvironment()
+        defer { try? env.db.tearDown(deleteStores: true) }
+
+        XCTAssertEqual(env.sut.allFavorites.map(\.title), BasicBookmarksStructure.favoriteTitles)
+
+        env.sut.moveFavorites(from: IndexSet(integer: 0), to: 2)
+
+        // The in-memory list must match the persisted order. Before the fix the move was applied
+        // twice — once by the re-entrant model update and again by the manual `allFavorites.move(...)`
+        // — leaving the in-memory list permanently out of step with Core Data.
+        XCTAssertEqual(env.sut.allFavorites.map(\.id), env.adapter.favorites.map(\.id))
+        XCTAssertFalse(env.recorder.events.contains(.favoritesListIndexNotMatchingBookmark))
+    }
+
+    func testRepeatedReorderingDoesNotFireIndexMismatch() throws {
+        let env = try makeReorderEnvironment()
+        defer { try? env.db.tearDown(deleteStores: true) }
+
+        env.sut.moveFavorites(from: IndexSet(integer: 0), to: 2)
+        env.sut.moveFavorites(from: IndexSet(integer: 0), to: 2)
+
+        XCTAssertFalse(env.recorder.events.contains(.favoritesListIndexNotMatchingBookmark),
+                       "Reordering favorites desynced the in-memory list from the model, firing favoritesListIndexNotMatchingBookmark")
+    }
+
+    private typealias ReorderEnvironment = (
+        sut: FavoritesViewModel,
+        adapter: FavoritesListInteractingAdapter,
+        db: CoreDataDatabase,
+        recorder: BookmarksModelErrorRecorder
+    )
+
+    private func makeReorderEnvironment() throws -> ReorderEnvironment {
+        let managedObjectModel = try XCTUnwrap(CoreDataDatabase.loadModel(from: Bookmarks.bundle, named: "BookmarksModel"))
+        let db = CoreDataDatabase(name: "Test", containerLocation: tempDBDir(), model: managedObjectModel)
+        db.loadStore()
+        let context = db.makeContext(concurrencyType: .mainQueueConcurrencyType, name: "TestContext")
+        BasicBookmarksStructure.populateDB(context: context)
+
+        let recorder = BookmarksModelErrorRecorder()
+        let model = FavoritesListViewModel(
+            bookmarksDatabase: db,
+            errorEvents: .init(mapping: { event, _, _, _ in
+                recorder.events.append(event)
+            }),
+            favoritesDisplayMode: .displayNative(.mobile))
+        let adapter = FavoritesListInteractingAdapter(favoritesListInteracting: model, appSettings: AppSettingsMock())
+        let sut = FavoritesViewModel(isFocussedState: false,
+                                     favoriteDataSource: adapter,
+                                     faviconLoader: MockFavoritesFaviconLoading(),
+                                     faviconsCache: MockFavoritesFaviconCaching(),
+                                     pixelFiring: PixelFiringMock.self,
+                                     dailyPixelFiring: PixelFiringMock.self)
+        // `adapter` retains `model`, keeping the Core Data stack alive for the test's lifetime.
+        return (sut, adapter, db, recorder)
+    }
+}
+
+private final class BookmarksModelErrorRecorder {
+    var events: [BookmarksModelError] = []
 }
 
 private final class MockNewTabPageFavoriteDataSource: NewTabPageFavoriteDataSource {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1215957790970786
Tech Design URL:
CC:

### Description

`m_d_favorites_list_index_not_matching_bookmark` (`d_favorites_list_index_not_matching_bookmark_ios_phone`) spiked +1000% in 7.225.

Cause: PR #5337 made `FavoritesListInteractingAdapter` forward the model's `localUpdates` into `externalUpdates`, and `FavoritesListViewModel.save()` refresh its published list before emitting. So `FavoritesViewModel.updateData()` now re-enters synchronously during a New Tab Page reorder, and `moveFavorites` applied the move twice — once via that re-entrant refresh, once via `allFavorites.move(...)` — desyncing the in-memory list from Core Data. The drop delegate calls `moveFavorites` repeatedly within a single drag, so once desynced the index guard `visibleChildren[fromIndex] == favorite` fails and fires the pixel during that drag. The reorder itself still works and persists (Core Data stays the source of truth; failed-guard moves are skipped, not corrupted) — the pixel is spurious. Not gated by `unifiedToggleInput`, so it affects all iOS phone NTP favorites reordering.

Fix: in `FavoritesViewModel.moveFavorites`, reload from the data source via `updateData()` instead of re-applying the move locally (matches `deleteFavorite`).

### Testing Steps

**Reproduce the bug** (on a build without this fix, e.g. current `release/ios/7.226.0`):
1. New Tab Page with 3+ favorites.
2. Open Console and filter `favorites.list.index.not.matching`.
3. Drag-reorder a favorite and release. **The move fails on the first attempt** — the favorite does not move (it returns to its original position) and `m_d_favorites_list_index_not_matching_bookmark` fires at that moment. (The index guard `visibleChildren[fromIndex] == favorite` is a single branch: it both skips the move *and* fires the pixel — the user-visible failure and the pixel are the same event.)
4. Drag-reorder the same favorite again — **the move succeeds on the second attempt** (the in-memory list has re-synced). So the symptom is "reordering only works on the second try," and each failed first attempt fires the pixel (the +1000% spike).

**Verify the fix** (this branch):
1. Repeat the steps above — the reorder **succeeds on the first attempt** and no pixel fires.
2. Run `NewTabPageFavoritesModelTests` (scheme **iOS Unit Tests**: `-only-testing:UnitTests/NewTabPageFavoritesModelTests`) → 7/7 pass.

**Smoke Test** (this branch):
1. Smoke test: adding, removing favorite, and reorder 

### Impact and Risks

Bug impact: Low for users / high telemetry noise — NTP favorites reordering still works and persists (no data loss, no crash; Core Data stays the source of truth), but the spurious index-mismatch pixel fires on essentially every reorder (the +1000% spike on a diagnostic pixel) because the in-memory list double-applies the move and desyncs mid-drag. Fix risk: Low — one line, mirrors `deleteFavorite`, covered by new + existing tests.

#### What could go wrong?
SwiftUI now sees a wholesale `allFavorites` refresh instead of a relative `.move`; that refresh already happened in 7.225, so the rendering input is simpler than today. The reorder animation is the only thing the tests don't cover (hence the manual step).

### Notes to Reviewer

Regression came from #5337 (the changed files sit below the `unifiedToggleInput` flag, which is why a UTI PR affected everyone).

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

