### PR TITLE
[macOS] Fix tab & bookmarks bar favicon flicker on cache updates

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -1365,6 +1365,8 @@
 		37D315C32D4A42280019C1F8 /* RecentActivityFavoritesHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D315C12D4A42200019C1F8 /* RecentActivityFavoritesHandlerTests.swift */; };
 		37D40D3A2EBBFA9B004895A6 /* RecentlyClosedCoordinatorMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D40D392EBBFA8E004895A6 /* RecentlyClosedCoordinatorMock.swift */; };
 		37D40D3B2EBBFA9B004895A6 /* RecentlyClosedCoordinatorMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D40D392EBBFA8E004895A6 /* RecentlyClosedCoordinatorMock.swift */; };
+		37D95B8C2FEC134D00051A72 /* FaviconsTabExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D95B8B2FEC134D00051A72 /* FaviconsTabExtensionTests.swift */; };
+		37D95B8D2FEC134D00051A72 /* FaviconsTabExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D95B8B2FEC134D00051A72 /* FaviconsTabExtensionTests.swift */; };
 		37DB56F22C3B36B80093D4DC /* RemoteMessagingClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DB56F12C3B36B80093D4DC /* RemoteMessagingClientTests.swift */; };
 		37DB56F32C3B36B80093D4DC /* RemoteMessagingClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DB56F12C3B36B80093D4DC /* RemoteMessagingClientTests.swift */; };
 		37DF37052CF38B96005ED34B /* PrivacyStats in Frameworks */ = {isa = PBXBuildFile; productRef = 37DF37042CF38B96005ED34B /* PrivacyStats */; };
@@ -2921,6 +2923,7 @@
 		A1A1A1A12F50000200A0A0A0 /* AppStoreCrashCollection in Frameworks */ = {isa = PBXBuildFile; productRef = A1A1A1A12F50000700A0A0A0 /* AppStoreCrashCollection */; };
 		A1A1A1A12F50000300A0A0A0 /* CrashReportingShared in Frameworks */ = {isa = PBXBuildFile; productRef = A1A1A1A12F50000A00A0A0A0 /* CrashReportingShared */; };
 		A1A1A1A12F50000400A0A0A0 /* CrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = A1A1A1A12F50000900A0A0A0 /* CrashReporting */; };
+		A1A1A1A12F50000B00A0A0A0 /* CrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = A1A1A1A12F50000900A0A0A0 /* CrashReporting */; };
 		A1B2C3D42E5F601100000001 /* PromoType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42E5F600100000001 /* PromoType.swift */; };
 		A1B2C3D42E5F601200000002 /* PromoHistoryRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42E5F600200000002 /* PromoHistoryRecord.swift */; };
 		A1B2C3D42E5F601300000003 /* Promo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42E5F600300000003 /* Promo.swift */; };
@@ -3956,11 +3959,6 @@
 		CC0943012E16B6F000E67336 /* FavoritesImportProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0942FF2E16B6F000E67336 /* FavoritesImportProcessorTests.swift */; };
 		CC0DD90F2E5DD74600277E46 /* AppStateRestorationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD90E2E5DD74600277E46 /* AppStateRestorationManagerTests.swift */; };
 		CC0DD9102E5DD74600277E46 /* AppStateRestorationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD90E2E5DD74600277E46 /* AppStateRestorationManagerTests.swift */; };
-		CC0DD9212E5DD74600277E46 /* UncleanExitRestartSourceResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9202E5DD74600277E46 /* UncleanExitRestartSourceResolverTests.swift */; };
-		CC0DD9222E5DD74600277E46 /* UncleanExitRestartSourceResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9202E5DD74600277E46 /* UncleanExitRestartSourceResolverTests.swift */; };
-		CC0DD9242E5DD74700277E46 /* UncleanExitRestartSourceResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9232E5DD74700277E46 /* UncleanExitRestartSourceResolver.swift */; };
-		CC0DD9252E5DD74700277E46 /* UncleanExitRestartSourceResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9232E5DD74700277E46 /* UncleanExitRestartSourceResolver.swift */; };
-		A1A1A1A12F50000B00A0A0A0 /* CrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = A1A1A1A12F50000900A0A0A0 /* CrashReporting */; };
 		CC0DD9132E5DF47E00277E46 /* SessionRestorePromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9122E5DF47E00277E46 /* SessionRestorePromptView.swift */; };
 		CC0DD9142E5DF47E00277E46 /* SessionRestorePromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9122E5DF47E00277E46 /* SessionRestorePromptView.swift */; };
 		CC0DD9162E5DF4B600277E46 /* SessionRestorePromptViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9152E5DF4B000277E46 /* SessionRestorePromptViewModel.swift */; };
@@ -3969,6 +3967,10 @@
 		CC0DD91A2E5DFA5800277E46 /* SessionRestorePromptPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9182E5DFA4D00277E46 /* SessionRestorePromptPopover.swift */; };
 		CC0DD91C2E5EF7CE00277E46 /* SessionRestorePromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD91B2E5EF7C100277E46 /* SessionRestorePromptCoordinator.swift */; };
 		CC0DD91D2E5EF7CE00277E46 /* SessionRestorePromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD91B2E5EF7C100277E46 /* SessionRestorePromptCoordinator.swift */; };
+		CC0DD9212E5DD74600277E46 /* UncleanExitRestartSourceResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9202E5DD74600277E46 /* UncleanExitRestartSourceResolverTests.swift */; };
+		CC0DD9222E5DD74600277E46 /* UncleanExitRestartSourceResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9202E5DD74600277E46 /* UncleanExitRestartSourceResolverTests.swift */; };
+		CC0DD9242E5DD74700277E46 /* UncleanExitRestartSourceResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9232E5DD74700277E46 /* UncleanExitRestartSourceResolver.swift */; };
+		CC0DD9252E5DD74700277E46 /* UncleanExitRestartSourceResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9232E5DD74700277E46 /* UncleanExitRestartSourceResolver.swift */; };
 		CC199E6E2F4E182C009646F9 /* PromoServiceFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC199E6D2F4E182C009646F9 /* PromoServiceFactory.swift */; };
 		CC199E6F2F4E182C009646F9 /* PromoServiceFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC199E6D2F4E182C009646F9 /* PromoServiceFactory.swift */; };
 		CC199E962F4E182C00964711 /* PromoDebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC199E952F4E182C00964710 /* PromoDebugMenu.swift */; };
@@ -5238,6 +5240,7 @@
 		37D2771427E870D4003365FD /* PreferencesAppearanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesAppearanceView.swift; sourceTree = "<group>"; };
 		37D315C12D4A42200019C1F8 /* RecentActivityFavoritesHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentActivityFavoritesHandlerTests.swift; sourceTree = "<group>"; };
 		37D40D392EBBFA8E004895A6 /* RecentlyClosedCoordinatorMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentlyClosedCoordinatorMock.swift; sourceTree = "<group>"; };
+		37D95B8B2FEC134D00051A72 /* FaviconsTabExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaviconsTabExtensionTests.swift; sourceTree = "<group>"; };
 		37D9BBA329376EE8000B99F9 /* DuckDuckGoAppStore.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DuckDuckGoAppStore.entitlements; sourceTree = "<group>"; };
 		37DB56F12C3B36B80093D4DC /* RemoteMessagingClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteMessagingClientTests.swift; sourceTree = "<group>"; };
 		37DD516C296EAEDC00837F27 /* DuckDuckGoAppStore.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DuckDuckGoAppStore.xcconfig; sourceTree = "<group>"; };
@@ -6722,12 +6725,12 @@
 		CC0942FC2E16AF6000E67336 /* FavoritesImportProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesImportProcessor.swift; sourceTree = "<group>"; };
 		CC0942FF2E16B6F000E67336 /* FavoritesImportProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesImportProcessorTests.swift; sourceTree = "<group>"; };
 		CC0DD90E2E5DD74600277E46 /* AppStateRestorationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateRestorationManagerTests.swift; sourceTree = "<group>"; };
-		CC0DD9202E5DD74600277E46 /* UncleanExitRestartSourceResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UncleanExitRestartSourceResolverTests.swift; sourceTree = "<group>"; };
-		CC0DD9232E5DD74700277E46 /* UncleanExitRestartSourceResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UncleanExitRestartSourceResolver.swift; sourceTree = "<group>"; };
 		CC0DD9122E5DF47E00277E46 /* SessionRestorePromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestorePromptView.swift; sourceTree = "<group>"; };
 		CC0DD9152E5DF4B000277E46 /* SessionRestorePromptViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestorePromptViewModel.swift; sourceTree = "<group>"; };
 		CC0DD9182E5DFA4D00277E46 /* SessionRestorePromptPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestorePromptPopover.swift; sourceTree = "<group>"; };
 		CC0DD91B2E5EF7C100277E46 /* SessionRestorePromptCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestorePromptCoordinator.swift; sourceTree = "<group>"; };
+		CC0DD9202E5DD74600277E46 /* UncleanExitRestartSourceResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UncleanExitRestartSourceResolverTests.swift; sourceTree = "<group>"; };
+		CC0DD9232E5DD74700277E46 /* UncleanExitRestartSourceResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UncleanExitRestartSourceResolver.swift; sourceTree = "<group>"; };
 		CC199E6D2F4E182C009646F9 /* PromoServiceFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoServiceFactory.swift; sourceTree = "<group>"; };
 		CC199E952F4E182C00964710 /* PromoDebugMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoDebugMenu.swift; sourceTree = "<group>"; };
 		CC199E972F4E183000964712 /* DebugSimulatedDateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSimulatedDateStore.swift; sourceTree = "<group>"; };
@@ -7643,6 +7646,7 @@
 				37EC314B2D8C02BC0026C348 /* FaviconTests.swift */,
 				379E65582FE05BE60061949A /* FaviconImageCacheTests.swift */,
 				1D77921728FDC54C00BE0210 /* FaviconReferenceCacheTests.swift */,
+				37D95B8B2FEC134D00051A72 /* FaviconsTabExtensionTests.swift */,
 				1D77921928FDC79800BE0210 /* FaviconStoringMock.swift */,
 				1D1C36E229FAE8DA001FA40C /* FaviconManagerTests.swift */,
 			);
@@ -16596,6 +16600,7 @@
 				9F982F142B822C7400231028 /* AddEditBookmarkFolderDialogViewModelTests.swift in Sources */,
 				B6CA4825298CE4B70067ECCE /* AdClickAttributionTabExtensionTests.swift in Sources */,
 				BBC277932FB2367300756A85 /* DuckAiVoiceChatFailureHandlerTests.swift in Sources */,
+				37D95B8C2FEC134D00051A72 /* FaviconsTabExtensionTests.swift in Sources */,
 				BBC2779E2FBF000200756A85 /* DuckAiVoiceChatPermissionOverrideTests.swift in Sources */,
 				BBC277A12FBF000300756A85 /* DuckAiVoiceChatLegacyConsentCleanupTests.swift in Sources */,
 				1D2EE7092E267D6B00F51C57 /* NewTabPageOmnibarConfigProviderTests.swift in Sources */,
@@ -18842,6 +18847,7 @@
 				56D145EE29E6DAD900E3488A /* DataImportProviderTests.swift in Sources */,
 				B51A90DA2F044C3E00FB9C0C /* ScriptStyleProviderTests.swift in Sources */,
 				C11198342C89AEFA00F0272C /* FreemiumDBPFirstProfileSavedNotifierTests.swift in Sources */,
+				37D95B8D2FEC134D00051A72 /* FaviconsTabExtensionTests.swift in Sources */,
 				4BB99D0F26FE1A84001E4761 /* ChromiumBookmarksReaderTests.swift in Sources */,
 				1D9FDEB72B9B5D150040B78C /* SearchPreferencesTests.swift in Sources */,
 				56BFB4D52ED60E29008A380E /* SubscriptionPageFeatureFlagAdapterTests.swift in Sources */,

--- a/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarViewController.swift
+++ b/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarViewController.swift
@@ -238,9 +238,18 @@ final class BookmarksBarViewController: NSViewController {
             }
             .store(in: &cancellables)
 
+        // Favicon images are decoded lazily and `.faviconCacheUpdated` fires for every favicon that
+        // becomes available anywhere in the app. Reloading the bar on each post rebuilds every item and
+        // makes the bar's favicons flicker during the decode cascade. Reload only when an updated host
+        // belongs to a bookmark, using the notification payload (matches `BookmarksBarMenuViewController`).
         NotificationCenter.default.publisher(for: .faviconCacheUpdated)
-            .sink { [weak self] _ in
-                self?.refreshFavicons()
+            .sink { [weak self] notification in
+                guard let self else { return }
+                if let update = notification.faviconsCacheUpdate,
+                   update.hosts.isDisjoint(with: self.bookmarkManager.allHosts()) {
+                    return
+                }
+                self.refreshFavicons()
             }
             .store(in: &cancellables)
 

--- a/macOS/DuckDuckGo/Tab/TabExtensions/FaviconsTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/FaviconsTabExtension.swift
@@ -78,7 +78,9 @@ final class FaviconsTabExtension {
             .sink { [weak self] _ in
                 Task { @MainActor in
                     guard let self, self.content != nil else { return }
-                    self.loadCachedFavicon(isBurner: false)
+                    // This is a cache refresh, not a navigation – only upgrade to a decoded image, never clear.
+                    // pass nil as `oldValue` since there's no navigation - no previous content to compare to.
+                    self.loadCachedFavicon(oldValue: nil, isBurner: false, error: nil, clearStaleFaviconOnHostChange: false)
                 }
             }
             .store(in: &cancellables)
@@ -89,10 +91,17 @@ final class FaviconsTabExtension {
         // the first display of a not-yet-decoded favicon would keep the
         // placeholder until the next navigation re-triggered resolution.
         NotificationCenter.default.publisher(for: .faviconCacheUpdated)
-            .sink { [weak self] _ in
+            .sink { [weak self] notification in
+                let updatedHosts = notification.faviconsCacheUpdate?.hosts
                 Task { @MainActor in
-                    guard let self, self.content != nil else { return }
-                    self.loadCachedFavicon(isBurner: false)
+                    guard let self, let content = self.content else { return }
+                    // only action cache updates for the current tab's host
+                    if let updatedHosts, let host = content.urlForWebView?.host,
+                       !updatedHosts.contains(where: { host == $0 || host.hasSuffix("." + $0) || $0.hasSuffix("." + host) }) {
+                        return
+                    }
+                    // Refresh, not navigation: only upgrade to a decoded image, never clear.
+                    self.loadCachedFavicon(oldValue: nil, isBurner: false, error: nil, clearStaleFaviconOnHostChange: false)
                 }
             }
             .store(in: &cancellables)
@@ -100,6 +109,18 @@ final class FaviconsTabExtension {
 
     @MainActor
     func loadCachedFavicon(oldValue: TabContent? = nil, isBurner: Bool, error: Error? = nil) {
+        loadCachedFavicon(oldValue: oldValue, isBurner: isBurner, error: error, clearStaleFaviconOnHostChange: true)
+    }
+
+    /// - Parameter clearStaleFaviconOnHostChange: When `true` (navigation), the favicon is cleared if
+    ///   the cache has no image for the new host, so a previous site's icon isn't left behind. When
+    ///   `false` (a cache-update / cache-loaded *refresh*, where `oldValue` is always `nil`), the
+    ///   favicon is only upgraded once a decoded image is available and is never cleared. Clearing on a
+    ///   refresh blanked the favicon to the LetterView placeholder during the lazy off-main decode
+    ///   window (`getCachedFavicon(…)?.image` is `nil` while decoding), which made favicons blink
+    ///   between placeholder and image as `.faviconCacheUpdated` fired repeatedly.
+    @MainActor
+    private func loadCachedFavicon(oldValue: TabContent?, isBurner: Bool, error: Error?, clearStaleFaviconOnHostChange: Bool) {
         guard let content, content.isExternalUrl, let url = content.urlForWebView, error == nil else {
             // Load default Favicon for SpecialURL(s) such as newtab
             favicon = content?.displayedFavicon(error: error, isBurner: isBurner)
@@ -112,7 +133,7 @@ final class FaviconsTabExtension {
             if cachedFavicon != favicon {
                 favicon = cachedFavicon
             }
-        } else if oldValue?.urlForWebView?.host != url.host {
+        } else if clearStaleFaviconOnHostChange, oldValue?.urlForWebView?.host != url.host {
             // If the domain matches the previous value, just keep the same favicon
             favicon = nil
         }

--- a/macOS/UnitTests/Favicons/FaviconsTabExtensionTests.swift
+++ b/macOS/UnitTests/Favicons/FaviconsTabExtensionTests.swift
@@ -308,8 +308,15 @@ final class FaviconsTabExtensionTests: XCTestCase {
     func testCacheUpdateReResolvesOnlyForThisTabsSite() async {
         // Regression: re-resolving every tab on every `.faviconCacheUpdated` post ran an O(N) `URL.host`
         // scan per tab and pegged the main thread. The observer must use the notification payload and
-        // skip tabs whose site isn't among the favicons that just became available.
+        // re-resolve only for tabs whose site is among the favicons that just became available.
+        //
+        // Observed through the published `favicon`: a decoded image is available in the cache, so the
+        // tab picks it up only when it actually re-resolves — which must happen for its own site's
+        // update but not for an unrelated site's.
         let documentUrl = URL(string: "https://example.com")!
+        let faviconUrl = URL(string: "https://example.com/favicon.ico")!
+        let image = NSImage(size: NSSize(width: 16, height: 16))
+
         let faviconScript = FaviconUserScript()
         let provider = MockFaviconUserScriptProvider(faviconScript: faviconScript)
         let extension_ = FaviconsTabExtension(
@@ -321,22 +328,22 @@ final class FaviconsTabExtensionTests: XCTestCase {
         contentSubject.send(.url(documentUrl, credential: nil, source: .userEntered("")))
         scriptsSubject.send(provider)
         try? await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertNil(extension_.favicon)
 
-        // An unrelated site's favicon became available → this tab must NOT re-resolve.
-        mockFaviconManagement.getCachedFaviconForDocumentCallCount = 0
+        // A decoded favicon for this tab's site is now available in the cache.
+        mockFaviconManagement.getCachedFaviconResult = Favicon(identifier: UUID(), url: faviconUrl, image: image, relation: .icon, documentUrl: documentUrl, dateCreated: Date())
+
+        // An unrelated site's favicon became available → this tab must NOT re-resolve, so it keeps
+        // showing nothing despite the cached image being available.
         NotificationCenter.default.postFaviconCacheUpdated(faviconURLs: [URL(string: "https://other.com/favicon.ico")!],
                                                            documentURLs: [URL(string: "https://other.com")!])
         try? await Task.sleep(nanoseconds: 200_000_000)
-        XCTAssertEqual(mockFaviconManagement.getCachedFaviconForDocumentCallCount, 0,
-                       "Re-resolved favicon for an unrelated cache update")
+        XCTAssertNil(extension_.favicon, "Re-resolved and showed a favicon for an unrelated cache update")
 
-        // This tab's own site updated → it should re-resolve.
-        mockFaviconManagement.getCachedFaviconForDocumentCallCount = 0
-        NotificationCenter.default.postFaviconCacheUpdated(faviconURLs: [URL(string: "https://example.com/favicon.ico")!],
-                                                           documentURLs: [documentUrl])
+        // This tab's own site updated → it should re-resolve and pick up the now-available image.
+        NotificationCenter.default.postFaviconCacheUpdated(faviconURLs: [faviconUrl], documentURLs: [documentUrl])
         try? await Task.sleep(nanoseconds: 200_000_000)
-        XCTAssertGreaterThan(mockFaviconManagement.getCachedFaviconForDocumentCallCount, 0,
-                             "Did not re-resolve favicon for this tab's own cache update")
+        XCTAssertEqual(extension_.favicon, image, "Did not re-resolve favicon for this tab's own cache update")
     }
 }
 
@@ -353,11 +360,10 @@ private final class MockFaviconManagement: FaviconManagement {
     var handleFaviconLinksCalls: [(links: [FaviconUserScript.FaviconLink], documentUrl: URL)] = []
     var faviconToReturn: Favicon?
 
-    /// Favicon returned by the cached lookups (a `nil` image simulates the lazy off-main decode window).
+    /// Favicon returned by the cached lookups; a `nil` value (or one with a `nil` image) simulates the
+    /// lazy off-main decode window before an image is available. `getCachedFavicon(forUrlOrAnySubdomain:)`
+    /// is a protocol-extension method (not a requirement), so it routes through `getCachedFavicon(for:)`.
     var getCachedFaviconResult: Favicon?
-    /// Number of times the document-URL cached lookup ran — used to assert a tab re-resolves only when
-    /// the cache update actually concerns its site.
-    var getCachedFaviconForDocumentCallCount = 0
 
     func handleFaviconLinks(_ faviconLinks: [FaviconUserScript.FaviconLink], documentUrl: URL, webView: WebKit.WKWebView?) async -> Favicon? {
         handleFaviconLinksCalls.append((links: faviconLinks, documentUrl: documentUrl))
@@ -371,10 +377,8 @@ private final class MockFaviconManagement: FaviconManagement {
     func populateFaviconCache(bookmarkManager: BookmarkManager, waitFor timeout: TimeInterval) async {}
 
     func getCachedFavicon(for documentURL: URL, sizeCategory: Favicon.SizeCategory, fallBackToSmaller: Bool) -> Favicon? {
-        getCachedFaviconForDocumentCallCount += 1
-        return getCachedFaviconResult
+        getCachedFaviconResult
     }
-    func getCachedFavicon(forUrlOrAnySubdomain url: URL, sizeCategory: Favicon.SizeCategory, fallBackToSmaller: Bool) -> Favicon? { nil }
     func getCachedFavicon(forDomainOrAnySubdomain baseDomain: String, sizeCategory: Favicon.SizeCategory, fallBackToSmaller: Bool) -> Favicon? { nil }
     func getCachedFaviconURL(for documentURL: URL, sizeCategory: Favicon.SizeCategory, fallBackToSmaller: Bool) -> URL? { nil }
     func getFaviconURLForDomainMatch(documentUrl: URL, sizeCategory: Favicon.SizeCategory, fallBackToSmaller: Bool) -> URL? { nil }

--- a/macOS/UnitTests/Favicons/FaviconsTabExtensionTests.swift
+++ b/macOS/UnitTests/Favicons/FaviconsTabExtensionTests.swift
@@ -17,15 +17,18 @@
 //
 
 import Combine
+import Common
+import History
 import UserScript
+import WebKit
 import XCTest
 
 @testable import DuckDuckGo_Privacy_Browser
 
 final class FaviconsTabExtensionTests: XCTestCase {
 
-    var mockFaviconManagement: MockFaviconManagement!
-    var scriptsSubject: PassthroughSubject<MockFaviconUserScriptProvider, Never>!
+    private var mockFaviconManagement: MockFaviconManagement!
+    private var scriptsSubject: PassthroughSubject<MockFaviconUserScriptProvider, Never>!
     var contentSubject: PassthroughSubject<Tab.TabContent, Never>!
     var cancellables: Set<AnyCancellable>!
 
@@ -188,7 +191,7 @@ final class FaviconsTabExtensionTests: XCTestCase {
 
         // Set up mock to return a favicon
         let testImage = NSImage(size: NSSize(width: 16, height: 16))
-        mockFaviconManagement.faviconToReturn = Favicon(image: testImage, url: documentUrl, dateCreated: Date())
+        mockFaviconManagement.faviconToReturn = Favicon(identifier: UUID(), url: documentUrl, image: testImage, relation: .icon, documentUrl: documentUrl, dateCreated: Date())
 
         let extension_ = FaviconsTabExtension(
             scriptsPublisher: scriptsSubject.eraseToAnyPublisher(),
@@ -258,6 +261,83 @@ final class FaviconsTabExtensionTests: XCTestCase {
         XCTAssertEqual(mockFaviconManagement.handleFaviconLinksCalls.count, 1)
         XCTAssertEqual(mockFaviconManagement.handleFaviconLinksCalls.first?.links.count, 3)
     }
+
+    // MARK: - Cache-update refresh (favicon blink / CPU regressions)
+
+    @MainActor
+    func testCacheUpdateRefreshDoesNotClearShownFaviconWhileImageIsStillDecoding() async {
+        // Regression: a `.faviconCacheUpdated` refresh must not blank an already-shown favicon to the
+        // LetterView placeholder just because the cache hasn't decoded the image yet. Doing so made
+        // favicons blink between placeholder and image as the notification fired repeatedly.
+        let documentUrl = URL(string: "https://example.com")!
+        let faviconUrl = URL(string: "https://example.com/favicon.ico")!
+        let testImage = NSImage(size: NSSize(width: 16, height: 16))
+        mockFaviconManagement.faviconToReturn = Favicon(identifier: UUID(), url: faviconUrl, image: testImage, relation: .icon, documentUrl: documentUrl, dateCreated: Date())
+        // Cache resolution finds no decoded image yet (the lazy off-main decode window).
+        mockFaviconManagement.getCachedFaviconResult = nil
+
+        let faviconScript = FaviconUserScript()
+        let provider = MockFaviconUserScriptProvider(faviconScript: faviconScript)
+        let extension_ = FaviconsTabExtension(
+            scriptsPublisher: scriptsSubject.eraseToAnyPublisher(),
+            contentPublisher: contentSubject.eraseToAnyPublisher(),
+            faviconManagement: mockFaviconManagement
+        )
+
+        var receivedFavicons: [NSImage?] = []
+        extension_.faviconPublisher.sink { receivedFavicons.append($0) }.store(in: &cancellables)
+
+        contentSubject.send(.url(documentUrl, credential: nil, source: .userEntered("")))
+        scriptsSubject.send(provider)
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // The user script resolves and shows a favicon.
+        extension_.faviconUserScript(faviconScript, didFindFaviconLinks: [FaviconUserScript.FaviconLink(href: faviconUrl, rel: "icon")], for: documentUrl, in: nil)
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        XCTAssertNotNil(extension_.favicon)
+
+        // A cache update for this site arrives while its image is still decoding.
+        NotificationCenter.default.postFaviconCacheUpdated(faviconURLs: [faviconUrl], documentURLs: [documentUrl])
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        XCTAssertNotNil(extension_.favicon, "Favicon was blanked during a cache-update refresh (blink)")
+        XCTAssertFalse(receivedFavicons.contains(where: { $0 == nil }), "Favicon publisher emitted nil during a cache-update refresh (blink)")
+    }
+
+    @MainActor
+    func testCacheUpdateReResolvesOnlyForThisTabsSite() async {
+        // Regression: re-resolving every tab on every `.faviconCacheUpdated` post ran an O(N) `URL.host`
+        // scan per tab and pegged the main thread. The observer must use the notification payload and
+        // skip tabs whose site isn't among the favicons that just became available.
+        let documentUrl = URL(string: "https://example.com")!
+        let faviconScript = FaviconUserScript()
+        let provider = MockFaviconUserScriptProvider(faviconScript: faviconScript)
+        let extension_ = FaviconsTabExtension(
+            scriptsPublisher: scriptsSubject.eraseToAnyPublisher(),
+            contentPublisher: contentSubject.eraseToAnyPublisher(),
+            faviconManagement: mockFaviconManagement
+        )
+
+        contentSubject.send(.url(documentUrl, credential: nil, source: .userEntered("")))
+        scriptsSubject.send(provider)
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // An unrelated site's favicon became available → this tab must NOT re-resolve.
+        mockFaviconManagement.getCachedFaviconForDocumentCallCount = 0
+        NotificationCenter.default.postFaviconCacheUpdated(faviconURLs: [URL(string: "https://other.com/favicon.ico")!],
+                                                           documentURLs: [URL(string: "https://other.com")!])
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        XCTAssertEqual(mockFaviconManagement.getCachedFaviconForDocumentCallCount, 0,
+                       "Re-resolved favicon for an unrelated cache update")
+
+        // This tab's own site updated → it should re-resolve.
+        mockFaviconManagement.getCachedFaviconForDocumentCallCount = 0
+        NotificationCenter.default.postFaviconCacheUpdated(faviconURLs: [URL(string: "https://example.com/favicon.ico")!],
+                                                           documentURLs: [documentUrl])
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        XCTAssertGreaterThan(mockFaviconManagement.getCachedFaviconForDocumentCallCount, 0,
+                             "Did not re-resolve favicon for this tab's own cache update")
+    }
 }
 
 // MARK: - Mocks
@@ -268,8 +348,16 @@ private struct MockFaviconUserScriptProvider: FaviconUserScriptProvider {
 
 private final class MockFaviconManagement: FaviconManagement {
     var isCacheLoaded: Bool = true
+    @Published var faviconsLoaded = true
+    var faviconsLoadedPublisher: Published<Bool>.Publisher { $faviconsLoaded }
     var handleFaviconLinksCalls: [(links: [FaviconUserScript.FaviconLink], documentUrl: URL)] = []
     var faviconToReturn: Favicon?
+
+    /// Favicon returned by the cached lookups (a `nil` image simulates the lazy off-main decode window).
+    var getCachedFaviconResult: Favicon?
+    /// Number of times the document-URL cached lookup ran — used to assert a tab re-resolves only when
+    /// the cache update actually concerns its site.
+    var getCachedFaviconForDocumentCallCount = 0
 
     func handleFaviconLinks(_ faviconLinks: [FaviconUserScript.FaviconLink], documentUrl: URL, webView: WebKit.WKWebView?) async -> Favicon? {
         handleFaviconLinksCalls.append((links: faviconLinks, documentUrl: documentUrl))
@@ -282,7 +370,10 @@ private final class MockFaviconManagement: FaviconManagement {
 
     func populateFaviconCache(bookmarkManager: BookmarkManager, waitFor timeout: TimeInterval) async {}
 
-    func getCachedFavicon(for documentURL: URL, sizeCategory: Favicon.SizeCategory, fallBackToSmaller: Bool) -> Favicon? { nil }
+    func getCachedFavicon(for documentURL: URL, sizeCategory: Favicon.SizeCategory, fallBackToSmaller: Bool) -> Favicon? {
+        getCachedFaviconForDocumentCallCount += 1
+        return getCachedFaviconResult
+    }
     func getCachedFavicon(forUrlOrAnySubdomain url: URL, sizeCategory: Favicon.SizeCategory, fallBackToSmaller: Bool) -> Favicon? { nil }
     func getCachedFavicon(forDomainOrAnySubdomain baseDomain: String, sizeCategory: Favicon.SizeCategory, fallBackToSmaller: Bool) -> Favicon? { nil }
     func getCachedFaviconURL(for documentURL: URL, sizeCategory: Favicon.SizeCategory, fallBackToSmaller: Bool) -> URL? { nil }
@@ -293,8 +384,13 @@ private final class MockFaviconManagement: FaviconManagement {
     func loadFavicons(forHost host: String, sizeCategory: Favicon.SizeCategory, fallBackToSmaller: Bool) async -> [Favicon] { [] }
     func loadFaviconImages(forHost host: String, sizeCategory: Favicon.SizeCategory, fallBackToSmaller: Bool) async -> [NSImage] { [] }
 
-    func burnExcept(fireproofDomains: FireproofDomains, bookmarkManager: BookmarkManager) async {}
-    func burnDomains(_ domains: Set<String>, exceptBookmarks bookmarkManager: BookmarkManager) {}
-    func burnAllExceptBookmarked(_ bookmarkManager: BookmarkManager) {}
-    func handleFaviconsByDocumentUrl(_ faviconsByDocumentUrl: [URL: [Favicon]]) {}
+    func getCachedFavicon(for host: String, sizeCategory: Favicon.SizeCategory, fallBackToSmaller: Bool) -> Favicon? { nil }
+
+    func resolvedCachedFavicon(for documentUrl: URL, sizeCategory: Favicon.SizeCategory, fallBackToSmaller: Bool) async -> Favicon? { nil }
+    func resolvedCachedFavicon(for host: String, sizeCategory: Favicon.SizeCategory) async -> Favicon? { nil }
+
+    func handleFaviconsByDocumentUrl(_ faviconsByDocumentUrl: [URL: [Favicon]]) async {}
+
+    func burn(except fireproofDomains: FireproofDomains, bookmarkManager: BookmarkManager, savedLogins: Set<String>) async -> Result<Void, Error> { .success(()) }
+    func burnDomains(_ domains: Set<String>, exceptBookmarks bookmarkManager: BookmarkManager, exceptSavedLogins: Set<String>, exceptExistingHistory history: BrowsingHistory, tld: TLD) async -> Result<Void, Error> { .success(()) }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1215999008194803?focus=true

### Description

Tab bar and bookmarks bar favicons flickered between the LetterView placeholder and the real icon
(with the main thread spiking) after lazy favicon image loading was introduced (#5403).
`.faviconCacheUpdated` fires for every favicon that finishes decoding anywhere in the app,
and two observers - TabBarViewItem and bookmarks bar - reacted to *every* post, instead of
filtering the update notification for events matching its host.

Also adds regression tests for the tab-bar behaviour and wires `FaviconsTabExtensionTests` into the Xcode project (it was previously not a project member, so it had never compiled).

### Testing Steps
1. Add several sites with distinct favicons to the bookmarks bar, and open several tabs to sites with favicons (e.g. github.com, asana.com, plus a few more).
2. Quit and relaunch the browser — a cold start forces favicons to decode lazily off-main (optionally clear the favicon cache from the Debug menu first to amplify it).
3. Watch the tab bar and the bookmarks bar favicons during the first few seconds after launch / as pages load.
   - Before: favicons rapidly flicker between the letter placeholder and the real icon; the main thread spikes.
   - After: each favicon renders once and stays stable — no flicker.
4. Navigate a tab from site A to a different site B that has no cached favicon, and confirm the icon still clears to the placeholder (navigation clearing is preserved).
5. Run the `FaviconsTabExtensionTests` unit tests — all pass.

### Impact and Risks
Low. UI-only — this changes *when/whether* cached favicons are re-resolved and displayed. No change to favicon fetching, storage, privacy, or navigation. Worst case is a favicon showing its placeholder slightly longer in an edge case; never a wrong favicon (resolution remains exact-first).

#### What could go wrong?
- A favicon shared across the domain hierarchy (e.g. `www.example.com` borrowing `example.com`'s icon) must still refresh when it decodes — handled by the subdomain-aware host match in the tab observer; literal-only matching would leave it on the placeholder until the next navigation.
- Explicitly deleting a favicon from the cache via the Favicon Inspector (debug) no longer clears the icon from an open tab until its next navigation (the refresh path intentionally never clears). Normal site-driven favicon changes (navigation/reload) and burn-on-quit are unaffected.
- If `.faviconCacheUpdated` is ever posted without a payload (e.g. the one-shot "references loaded" post), observers reload defensively — no regression vs. previous behaviour.

### Quality Considerations
- The notification payload (`FaviconsCacheUpdate`) was purpose-built to let observers reload selectively; this PR makes the tab bar and bookmarks bar actually use it, matching the other favicon-update observers.
- Removes the per-post O(N) `URL.host` scan across all open tabs that the `sample` profile showed saturating the main thread.
- Favicon resolution stays exact-first, so the broadened (subdomain-aware) match only affects *whether* a tab re-resolves, never *which* favicon it shows.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only timing for cached favicons; navigation still clears stale icons on host change. Edge case: explicit cache deletion may leave a tab icon until next navigation.
> 
> **Overview**
> Fixes tab and bookmarks bar favicon flicker and main-thread churn after lazy favicon decoding, by reacting to `.faviconCacheUpdated` selectively instead of on every post.
> 
> **Tab bar (`FaviconsTabExtension`)** — Cache-loaded and cache-update paths now call `loadCachedFavicon` with `clearStaleFaviconOnHostChange: false`, so refreshes only upgrade to a decoded image and no longer clear the icon during the lazy-decode window (which caused placeholder ↔ icon blinking). The `.faviconCacheUpdated` observer filters on the `FaviconsCacheUpdate` hosts and subdomain-aware tab host matching so only relevant tabs re-resolve, instead of every open tab on each notification.
> 
> **Bookmarks bar (`BookmarksBarViewController`)** — `refreshFavicons()` runs only when updated hosts overlap bookmark hosts (same payload guard as other bookmark UI).
> 
> **Tests / project** — Adds `FaviconsTabExtensionTests` to the Xcode target with regression tests for non-clearing refresh and host-scoped re-resolve; fixes mock `FaviconManagement` / `Favicon` usage so the suite compiles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2458306493c4b333d58a5ea95873d5f865002ad7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->