### PR TITLE
macOS: Remove aiChatOmnibarCluster feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -449,9 +449,6 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// Enables the omnibar onboarding for AI Chat
     case omnibarOnboarding
 
-    /// Enables the omnibar cluster for AI Chat
-    case omnibarCluster
-
     /// Enables the omnibar tools (customize, search toggle, image upload) for AI Chat
     case omnibarTools
 

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -313,7 +313,7 @@ final class AddressBarTextField: NSTextField {
             let barStyleProvider = themeManager.theme.addressBarStyleProvider
             let newTabFontSize = barStyleProvider.newTabOrHomePageAddressBarFontSize
             let defaultFontSize = barStyleProvider.defaultAddressBarFontSize
-            let hideSuffix = !isFirstResponder || (Application.appDelegate.featureFlagger.isFeatureOn(.aiChatOmnibarToggle) && Application.appDelegate.featureFlagger.isFeatureOn(.aiChatOmnibarCluster))
+            let hideSuffix = !isFirstResponder
 
             if let attributedString = value.toAttributedString(size: isHomePage ? newTabFontSize : defaultFontSize, isBurner: isBurner, hideSuffix: hideSuffix) {
                 self.attributedStringValue = attributedString

--- a/macOS/DuckDuckGo/Suggestions/View/SuggestionViewController.swift
+++ b/macOS/DuckDuckGo/Suggestions/View/SuggestionViewController.swift
@@ -200,7 +200,7 @@ final class SuggestionViewController: NSViewController {
         }
 
         // Remove the second reload that causes visual glitch in the beginning of typing
-        if suggestionContainerViewModel.suggestionContainer.result != nil || suggestionContainerViewModel.shouldShowSearchCell {
+        if suggestionContainerViewModel.suggestionContainer.result != nil {
             updateHeight()
             tableView.reloadData()
 
@@ -231,13 +231,7 @@ final class SuggestionViewController: NSViewController {
         guard let rowIndex,
               rowIndex >= 0,
               rowIndex < suggestionContainerViewModel.numberOfRows else {
-            if let defaultRow = suggestionContainerViewModel.defaultSelectedRow {
-                tableView.selectRowIndexes(IndexSet(integer: defaultRow), byExtendingSelection: false)
-                // Sync view model with the default selection so keyboard navigation works correctly
-                suggestionContainerViewModel.selectRow(at: defaultRow)
-            } else {
-                self.clearSelection()
-            }
+            self.clearSelection()
             return
         }
 
@@ -377,21 +371,10 @@ extension SuggestionViewController: NSTableViewDelegate {
         cell.isAIChatToggleBeingDisplayed = isAIChatToggleBeingDisplayed
 
         switch rowContent {
-        case .searchCell:
-            let userText = suggestionContainerViewModel.userStringValue ?? ""
-            let searchIcon = themeManager.theme.iconsProvider.suggestionsIconsProvider.phraseEntryIcon
-            cell.display(userText: userText, style: .search, icon: searchIcon, isBurner: self.isBurner)
-
         case .aiChatCell:
             let userText = suggestionContainerViewModel.userStringValue ?? ""
             let aiChatIcon: NSImage = .aiChat
             cell.display(userText: userText, style: .aiChat, icon: aiChatIcon, isBurner: self.isBurner)
-
-        case .visitCell:
-            let userText = suggestionContainerViewModel.userStringValue ?? ""
-            let host = suggestionContainerViewModel.visitCellHost ?? ""
-            let websiteIcon = themeManager.theme.iconsProvider.suggestionsIconsProvider.websiteEntryIcon
-            cell.display(userText: userText, style: .visit(host: host), icon: websiteIcon, isBurner: self.isBurner)
 
         case .sectionDivider:
             break // Already handled above

--- a/macOS/DuckDuckGo/Suggestions/ViewModel/SuggestionContainerViewModel.swift
+++ b/macOS/DuckDuckGo/Suggestions/ViewModel/SuggestionContainerViewModel.swift
@@ -34,12 +34,8 @@ enum SuggestionListSection: Int, CaseIterable {
 
 /// Represents the type of content to display in a suggestion row
 enum SuggestionRowContent: Equatable {
-    /// The search cell row (shown when AI chat toggle is enabled)
-    case searchCell
-    /// The AI chat cell row (shown when AI chat toggle and AI features are enabled)
+    /// The AI chat cell row (shown when the AI chat toggle and AI features are enabled)
     case aiChatCell
-    /// The visit cell row (shown when user types a URL-like string)
-    case visitCell
     /// A divider row between sections
     case sectionDivider
     /// A suggestion item at the given index
@@ -77,74 +73,18 @@ final class SuggestionContainerViewModel {
 
     // MARK: - Section-based API (for TableView)
 
-    /// Indicates whether the top suggestion has been auto-selected (e.g., user typed "apple" and there's a matching bookmark).
-    /// When true, the header section is hidden and the AI chat cell moves to the footer.
-    @Published private(set) var hasAutoSelectedSuggestion = false
-
-    /// Whether the user input looks like a URL (e.g., "apple.com").
-    /// When true, the visit cell is shown first and the search cell is hidden.
-    private var userInputIsURL: Bool {
-        guard let userStringValue, !userStringValue.isEmpty else { return false }
-        guard let url = URL(trimmedAddressBarString: userStringValue) else { return false }
-        return url.isValid
-    }
-
-    /// The URL parsed from user input, used for the visit cell display.
-    var parsedURLFromUserInput: URL? {
-        guard let userStringValue, !userStringValue.isEmpty else { return nil }
-        guard let url = URL(trimmedAddressBarString: userStringValue), url.isValid else { return nil }
-        return url
-    }
-
-    /// The host to display in the visit cell suffix (e.g., "apple.com").
-    var visitCellHost: String? {
-        parsedURLFromUserInput?.root?.toString(decodePunycode: true, dropScheme: true, dropTrailingSlash: true)
-    }
-
-    /// Whether to show header cells (search and AI chat at the top).
-    /// Header is hidden when a suggestion is auto-selected OR when user input is a URL.
-    private var shouldShowHeaderSection: Bool {
-        !hasAutoSelectedSuggestion && !userInputIsURL
-    }
-
     /// Whether to show the AI chat cell in the footer section.
-    /// Footer AI chat is shown when:
-    /// - aiChatOmnibarCluster is OFF: always show at bottom (never at top)
-    /// - aiChatOmnibarCluster is ON: show when a suggestion is auto-selected OR when user input is a URL
+    /// Shown when the AI chat toggle is enabled, AI features are enabled, and the user has typed input.
     private var shouldShowAIChatCellInFooter: Bool {
-        guard shouldShowAIChatCellBase else { return false }
-        if !featureFlagger.isFeatureOn(.aiChatOmnibarCluster) {
-            return true
-        }
-        return hasAutoSelectedSuggestion || userInputIsURL
-    }
-
-    /// Whether to show the visit cell in the header (when user types a URL-like string).
-    private var shouldShowVisitCell: Bool {
-        guard featureFlagger.isFeatureOn(.aiChatOmnibarToggle) && featureFlagger.isFeatureOn(.aiChatOmnibarCluster) else { return false }
-        return userInputIsURL
+        shouldShowAIChatCellBase
     }
 
     private func invalidateRowContentsCache() {
         cachedRowContents = nil
     }
 
-    var numberOfHeaderRows: Int {
-        var count = 0
-        if shouldShowVisitCell { count += 1 }
-        guard shouldShowHeaderSection else { return count }
-        if shouldShowSearchCell { count += 1 }
-        if shouldShowAIChatCell { count += 1 }
-        return count
-    }
-
     var numberOfFooterRows: Int {
         shouldShowAIChatCellInFooter ? 1 : 0
-    }
-
-    private var shouldShowHeaderDivider: Bool {
-        guard !shouldShowVisitCell else { return false }
-        return numberOfHeaderRows > 0 && numberOfSuggestions > 0
     }
 
     private var shouldShowFooterDivider: Bool {
@@ -152,16 +92,9 @@ final class SuggestionContainerViewModel {
     }
 
     var numberOfRows: Int {
-        numberOfHeaderRows
-        + (shouldShowHeaderDivider ? 1 : 0)
-        + numberOfSuggestions
+        numberOfSuggestions
         + (shouldShowFooterDivider ? 1 : 0)
         + numberOfFooterRows
-    }
-
-    /// Returns the row index where the suggestions section starts
-    private var suggestionsSectionStartRow: Int {
-        numberOfHeaderRows + (shouldShowHeaderDivider ? 1 : 0)
     }
 
     /// Returns the type of content to display for the given row index.
@@ -178,12 +111,6 @@ final class SuggestionContainerViewModel {
     private func buildRowContents() -> [SuggestionRowContent] {
         var contents: [SuggestionRowContent] = []
 
-        if shouldShowVisitCell { contents.append(.visitCell) }
-        if shouldShowSearchCell { contents.append(.searchCell) }
-        if shouldShowAIChatCell { contents.append(.aiChatCell) }
-
-        if shouldShowHeaderDivider { contents.append(.sectionDivider) }
-
         for index in 0..<numberOfSuggestions {
             contents.append(.suggestion(index: index))
         }
@@ -195,15 +122,13 @@ final class SuggestionContainerViewModel {
     }
 
     func selectionIndex(forRow row: Int) -> Int? {
-        guard row >= suggestionsSectionStartRow else { return nil }
-        let index = row - suggestionsSectionStartRow
-        guard index >= 0, index < numberOfSuggestions else { return nil }
-        return index
+        guard row >= 0, row < numberOfSuggestions else { return nil }
+        return row
     }
 
     func tableRow(forSelectionIndex index: Int?) -> Int? {
         guard let index, index >= 0, index < numberOfSuggestions else { return nil }
-        return index + suggestionsSectionStartRow
+        return index
     }
 
     func isDividerRow(_ row: Int) -> Bool {
@@ -216,30 +141,10 @@ final class SuggestionContainerViewModel {
         return content != .sectionDivider
     }
 
-    /// Returns the default row to select when no suggestion is selected.
-    /// - When visit cell is shown: returns 0 (visit cell is first and should be selected)
-    /// - When auto-selection is active: returns nil (the auto-selected suggestion handles selection)
-    /// - When no auto-selection: returns the search cell row (0) if shown, otherwise nil
-    var defaultSelectedRow: Int? {
-        if shouldShowVisitCell {
-            return 0
-        }
-        if hasAutoSelectedSuggestion {
-            return nil
-        }
-        return shouldShowSearchCell ? 0 : nil
-    }
-
     // MARK: - Suggestion Data
 
     var numberOfSuggestions: Int {
         suggestionContainer.result?.count ?? 0
-    }
-
-    private var shouldShowSearchCellBase: Bool {
-        guard featureFlagger.isFeatureOn(.aiChatOmnibarToggle) && featureFlagger.isFeatureOn(.aiChatOmnibarCluster) else { return false }
-        guard let userStringValue, !userStringValue.isEmpty else { return false }
-        return true
     }
 
     private var shouldShowAIChatCellBase: Bool {
@@ -249,16 +154,7 @@ final class SuggestionContainerViewModel {
         return true
     }
 
-    var shouldShowSearchCell: Bool {
-        shouldShowHeaderSection && shouldShowSearchCellBase
-    }
-
-    var shouldShowAIChatCell: Bool {
-        guard featureFlagger.isFeatureOn(.aiChatOmnibarCluster) else { return false }
-        return shouldShowHeaderSection && shouldShowAIChatCellBase
-    }
-
-    // MARK: - Row Selection (includes prefix rows)
+    // MARK: - Row Selection
 
     @Published private(set) var selectedRowIndex: Int?
 
@@ -331,10 +227,8 @@ final class SuggestionContainerViewModel {
                 do {
                     try validateShouldSelectTopSuggestion(from: result)
                 } catch {
-                    self.hasAutoSelectedSuggestion = false
                     return
                 }
-                self.hasAutoSelectedSuggestion = true
                 self.select(at: 0)
             }
     }
@@ -348,17 +242,12 @@ final class SuggestionContainerViewModel {
         invalidateRowContentsCache()
 
         guard !userStringValue.isEmpty else {
-            hasAutoSelectedSuggestion = false
             suggestionContainer.stopGettingSuggestions()
             return
         }
         guard userStringValue.lowercased() != oldValue?.lowercased() else { return }
 
         self.isTopSuggestionSelectionExpected = userAppendedStringToTheEnd && !userStringValue.contains(" ")
-
-        if !isTopSuggestionSelectionExpected {
-            hasAutoSelectedSuggestion = false
-        }
 
         suggestionContainer.getSuggestions(for: userStringValue)
     }
@@ -371,7 +260,6 @@ final class SuggestionContainerViewModel {
 
     func clearUserStringValue() {
         self.userStringValue = nil
-        hasAutoSelectedSuggestion = false
         invalidateRowContentsCache()
         suggestionContainer.stopGettingSuggestions()
     }

--- a/macOS/DuckDuckGo/Suggestions/ViewModel/SuggestionViewModel.swift
+++ b/macOS/DuckDuckGo/Suggestions/ViewModel/SuggestionViewModel.swift
@@ -148,19 +148,13 @@ struct SuggestionViewModel {
     }
 
     var suffix: String? {
-        let isAIChatToggleEnabled = featureFlagger.isFeatureOn(.aiChatOmnibarToggle) && featureFlagger.isFeatureOn(.aiChatOmnibarCluster)
-
         switch suggestion {
         // for punycoded urls display real url as a suffix
         case .website(url: let url) where url.toString(forUserInput: userStringValue, decodePunycode: false) != self.string:
             return url.toString(decodePunycode: false, dropScheme: true, dropTrailingSlash: true)
 
-        case .website(url: let url):
-            guard isAIChatToggleEnabled,
-                  let host = url.root?.toString(decodePunycode: true, dropScheme: true, dropTrailingSlash: true) else {
-                return nil
-            }
-            return "\(UserText.addressBarVisitSuffix) \(host)"
+        case .website:
+            return nil
 
         case .phrase, .unknown, .askAIChat:
             return nil

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -140,9 +140,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212016242789291
     case aiChatOmnibarToggle
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212227266479719
-    case aiChatOmnibarCluster
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212745919983886?focus=true
     case aiChatSuggestions
 
@@ -544,8 +541,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(AIChatSubfeature.keepSession), category: .duckAI)
         case .aiChatOmnibarToggle:
             Config(source: .remoteReleasable(AIChatSubfeature.omnibarToggle), category: .duckAI)
-        case .aiChatOmnibarCluster:
-            Config(source: .remoteReleasable(AIChatSubfeature.omnibarCluster), category: .duckAI)
         case .aiChatSuggestions:
             Config(defaultValue: .enabled, source: .remoteReleasable(DuckAiChatHistorySubfeature.featureEnabled), category: .duckAI)
         case .aiChatOmnibarTools:

--- a/macOS/UnitTests/Suggestions/ViewModel/SuggestionContainerViewModelTests.swift
+++ b/macOS/UnitTests/Suggestions/ViewModel/SuggestionContainerViewModelTests.swift
@@ -379,12 +379,12 @@ final class SuggestionContainerViewModelTests: XCTestCase {
         XCTAssertEqual(openTabsResult, openTabs)
     }
 
-    // MARK: - AI Chat and Search Cell Position Tests
+    // MARK: - AI Chat Footer Cell Tests
 
     @MainActor
-    func testWhenAIChatToggleEnabledAndNoAutoSelection_ThenSearchAndAIChatCellsAppearAtTop() {
-        // Setup with AI chat toggle enabled and AI features enabled
-        featureFlagger.enabledFeatureFlags = [.aiChatOmnibarToggle, .aiChatOmnibarCluster]
+    func testWhenAIChatToggleAndFeaturesEnabled_ThenAIChatCellAppearsInFooter() {
+        // Cluster removed: the AI chat cell only ever appears in the footer, never at the top
+        featureFlagger.enabledFeatureFlags = [.aiChatOmnibarToggle]
         let aiChatStorage = MockAIChatPreferencesStorage()
         aiChatStorage.isAIFeaturesEnabled = true
 
@@ -401,93 +401,17 @@ final class SuggestionContainerViewModelTests: XCTestCase {
             aiChatPreferencesStorage: aiChatStorage
         )
 
-        // User types without triggering auto-selection (inserting in middle)
         suggestionContainerViewModel.setUserStringValue("test query", userAppendedStringToTheEnd: false)
         suggestionLoadingMock.completion?(SuggestionResult.noTopHitsResult, nil)
 
-        // Both search and AI chat cells should be in the header (top)
-        XCTAssertTrue(suggestionContainerViewModel.shouldShowSearchCell, "Search cell should appear at top")
-        XCTAssertTrue(suggestionContainerViewModel.shouldShowAIChatCell, "AI chat cell should appear at top")
-
-        // Verify row structure: [searchCell, aiChatCell, divider, suggestions...]
-        XCTAssertEqual(suggestionContainerViewModel.rowContent(at: 0), .searchCell)
-        XCTAssertEqual(suggestionContainerViewModel.rowContent(at: 1), .aiChatCell)
-    }
-
-    @MainActor
-    func testWhenAIChatToggleEnabledAndHasAutoSelectedSuggestion_ThenAIChatCellAppearsAtBottom() {
-        // Setup with AI chat toggle enabled and AI features enabled
-        featureFlagger.enabledFeatureFlags = [.aiChatOmnibarToggle, .aiChatOmnibarCluster]
-        let aiChatStorage = MockAIChatPreferencesStorage()
-        aiChatStorage.isAIFeaturesEnabled = true
-
-        suggestionContainerViewModel = SuggestionContainerViewModel(
-            isHomePage: false,
-            isBurner: false,
-            suggestionContainer: suggestionContainer,
-            searchPreferences: SearchPreferences(
-                persistor: searchPreferencesPersistorMock,
-                windowControllersManager: WindowControllersManagerMock()
-            ),
-            themeManager: MockThemeManager(),
-            featureFlagger: featureFlagger,
-            aiChatPreferencesStorage: aiChatStorage
-        )
-
-        // User appends text triggering auto-selection
-        suggestionContainerViewModel.setUserStringValue("duck", userAppendedStringToTheEnd: true)
-        suggestionLoadingMock.completion?(SuggestionResult.aSuggestionResult, nil)
-
-        // Wait for auto-selection to happen
-        XCTAssertTrue(suggestionContainerViewModel.hasAutoSelectedSuggestion, "Should have auto-selected suggestion")
-
-        // Search and AI chat cells should NOT be in the header
-        XCTAssertFalse(suggestionContainerViewModel.shouldShowSearchCell, "Search cell should not appear at top")
-        XCTAssertFalse(suggestionContainerViewModel.shouldShowAIChatCell, "AI chat cell should not appear at top")
-
-        // AI chat cell should appear at the bottom (footer)
+        // AI chat cell should appear at the bottom (footer), not at the top
+        XCTAssertNotEqual(suggestionContainerViewModel.rowContent(at: 0), .aiChatCell, "AI chat cell should not appear at top")
         let lastRowIndex = suggestionContainerViewModel.numberOfRows - 1
-        XCTAssertEqual(suggestionContainerViewModel.rowContent(at: lastRowIndex), .aiChatCell, "AI chat cell should appear at bottom")
+        XCTAssertEqual(suggestionContainerViewModel.rowContent(at: lastRowIndex), .aiChatCell, "AI chat cell should appear in footer")
     }
 
     @MainActor
-    func testWhenAIChatToggleEnabledAndUserInputIsURL_ThenVisitCellAtTopAndAIChatCellAtBottom() {
-        // Setup with AI chat toggle enabled and AI features enabled
-        featureFlagger.enabledFeatureFlags = [.aiChatOmnibarToggle, .aiChatOmnibarCluster]
-        let aiChatStorage = MockAIChatPreferencesStorage()
-        aiChatStorage.isAIFeaturesEnabled = true
-
-        suggestionContainerViewModel = SuggestionContainerViewModel(
-            isHomePage: false,
-            isBurner: false,
-            suggestionContainer: suggestionContainer,
-            searchPreferences: SearchPreferences(
-                persistor: searchPreferencesPersistorMock,
-                windowControllersManager: WindowControllersManagerMock()
-            ),
-            themeManager: MockThemeManager(),
-            featureFlagger: featureFlagger,
-            aiChatPreferencesStorage: aiChatStorage
-        )
-
-        // User types a URL
-        suggestionContainerViewModel.setUserStringValue("apple.com", userAppendedStringToTheEnd: false)
-        suggestionLoadingMock.completion?(SuggestionResult.noTopHitsResult, nil)
-
-        // Visit cell should appear at top
-        XCTAssertEqual(suggestionContainerViewModel.rowContent(at: 0), .visitCell, "Visit cell should appear at top")
-
-        // Search and AI chat cells should NOT be in the header
-        XCTAssertFalse(suggestionContainerViewModel.shouldShowSearchCell, "Search cell should not appear at top when URL")
-        XCTAssertFalse(suggestionContainerViewModel.shouldShowAIChatCell, "AI chat cell should not appear at top when URL")
-
-        // AI chat cell should appear at the bottom (footer)
-        let lastRowIndex = suggestionContainerViewModel.numberOfRows - 1
-        XCTAssertEqual(suggestionContainerViewModel.rowContent(at: lastRowIndex), .aiChatCell, "AI chat cell should appear at bottom when URL")
-    }
-
-    @MainActor
-    func testWhenAIChatToggleDisabled_ThenNoSearchOrAIChatCells() {
+    func testWhenAIChatToggleDisabled_ThenListShowsOnlySuggestions() {
         // Setup without AI chat toggle
 
         suggestionContainerViewModel = SuggestionContainerViewModel(
@@ -506,84 +430,16 @@ final class SuggestionContainerViewModelTests: XCTestCase {
         suggestionContainerViewModel.setUserStringValue("test query", userAppendedStringToTheEnd: false)
         suggestionLoadingMock.completion?(SuggestionResult.noTopHitsResult, nil)
 
-        // No search or AI chat cells should appear
-        XCTAssertFalse(suggestionContainerViewModel.shouldShowSearchCell, "Search cell should not appear when toggle disabled")
-        XCTAssertFalse(suggestionContainerViewModel.shouldShowAIChatCell, "AI chat cell should not appear when toggle disabled")
+        // No AI chat cell should appear when the toggle is disabled
+        XCTAssertEqual(suggestionContainerViewModel.numberOfFooterRows, 0, "Footer should have no rows when toggle disabled")
 
-        // First row should be a suggestion, not a search or AI chat cell
+        // First row should be a suggestion
         XCTAssertEqual(suggestionContainerViewModel.rowContent(at: 0), .suggestion(index: 0))
     }
 
     @MainActor
-    func testWhenAIChatToggleEnabledButAIFeaturesDisabled_ThenOnlySearchCellAppears() {
-        // Setup with AI chat toggle enabled but AI features disabled
-        featureFlagger.enabledFeatureFlags = [.aiChatOmnibarToggle, .aiChatOmnibarCluster]
-        let aiChatStorage = MockAIChatPreferencesStorage()
-        aiChatStorage.isAIFeaturesEnabled = false
-
-        suggestionContainerViewModel = SuggestionContainerViewModel(
-            isHomePage: false,
-            isBurner: false,
-            suggestionContainer: suggestionContainer,
-            searchPreferences: SearchPreferences(
-                persistor: searchPreferencesPersistorMock,
-                windowControllersManager: WindowControllersManagerMock()
-            ),
-            themeManager: MockThemeManager(),
-            featureFlagger: featureFlagger,
-            aiChatPreferencesStorage: aiChatStorage
-        )
-
-        suggestionContainerViewModel.setUserStringValue("test query", userAppendedStringToTheEnd: false)
-        suggestionLoadingMock.completion?(SuggestionResult.noTopHitsResult, nil)
-
-        // Only search cell should appear, not AI chat cell
-        XCTAssertTrue(suggestionContainerViewModel.shouldShowSearchCell, "Search cell should appear when toggle enabled")
-        XCTAssertFalse(suggestionContainerViewModel.shouldShowAIChatCell, "AI chat cell should not appear when AI features disabled")
-
-        // First row should be search cell
-        XCTAssertEqual(suggestionContainerViewModel.rowContent(at: 0), .searchCell)
-    }
-
-    @MainActor
-    func testWhenAIFeaturesDisabledAfterInit_ThenAIChatCellIsHidden() {
-        // Setup with AI chat toggle enabled and AI features initially enabled
-        featureFlagger.enabledFeatureFlags = [.aiChatOmnibarToggle, .aiChatOmnibarCluster]
-        let aiChatStorage = MockAIChatPreferencesStorage()
-        aiChatStorage.isAIFeaturesEnabled = true
-
-        suggestionContainerViewModel = SuggestionContainerViewModel(
-            isHomePage: false,
-            isBurner: false,
-            suggestionContainer: suggestionContainer,
-            searchPreferences: SearchPreferences(
-                persistor: searchPreferencesPersistorMock,
-                windowControllersManager: WindowControllersManagerMock()
-            ),
-            themeManager: MockThemeManager(),
-            featureFlagger: featureFlagger,
-            aiChatPreferencesStorage: aiChatStorage
-        )
-
-        suggestionContainerViewModel.setUserStringValue("test query", userAppendedStringToTheEnd: false)
-        suggestionLoadingMock.completion?(SuggestionResult.noTopHitsResult, nil)
-
-        // AI chat cell should initially be visible
-        XCTAssertTrue(suggestionContainerViewModel.shouldShowAIChatCell, "AI chat cell should appear when AI features enabled")
-
-        // Disable AI features after init (simulates user toggling the setting)
-        aiChatStorage.isAIFeaturesEnabled = false
-
-        // AI chat cell should now be hidden
-        XCTAssertFalse(suggestionContainerViewModel.shouldShowAIChatCell, "AI chat cell should be hidden after AI features disabled")
-
-        // Only search cell should remain in the header
-        XCTAssertTrue(suggestionContainerViewModel.shouldShowSearchCell, "Search cell should still appear")
-    }
-
-    @MainActor
     func testWhenAIFeaturesDisabledAfterInit_ThenAIChatCellFooterIsHidden() {
-        // Setup with AI chat toggle enabled but cluster OFF (AI chat always in footer)
+        // AI chat toggle enabled: AI chat always appears in the footer
         featureFlagger.enabledFeatureFlags = [.aiChatOmnibarToggle]
         let aiChatStorage = MockAIChatPreferencesStorage()
         aiChatStorage.isAIFeaturesEnabled = true

--- a/macOS/UnitTests/Suggestions/ViewModel/SuggestionViewModelTests.swift
+++ b/macOS/UnitTests/Suggestions/ViewModel/SuggestionViewModelTests.swift
@@ -215,32 +215,13 @@ final class SuggestionViewModelTests: XCTestCase {
         XCTAssertEqual(suggestionViewModel.suffix, UserText.duckDuckGo)
     }
 
-    // MARK: - AI Chat Omnibar Toggle Tests
+    // MARK: - Website Suggestion Suffix Tests
 
-    func testWhenAIChatToggleEnabledAndSuggestionIsWebsite_ThenSuffixShowsVisitHost() {
+    func testWhenSuggestionIsWebsite_ThenSuffixIsNil() {
         let urlString = "https://spreadprivacy.com"
         let url = URL(string: urlString)!
         let suggestion = Suggestion.website(url: url)
         let featureFlagger = MockFeatureFlagger()
-        featureFlagger.enabledFeatureFlags = [.aiChatOmnibarToggle, .aiChatOmnibarCluster]
-
-        let suggestionViewModel = SuggestionViewModel(
-            isHomePage: false,
-            suggestion: suggestion,
-            userStringValue: "",
-            themeManager: MockThemeManager(),
-            featureFlagger: featureFlagger
-        )
-
-        XCTAssertEqual(suggestionViewModel.suffix, "\(UserText.addressBarVisitSuffix) spreadprivacy.com")
-    }
-
-    func testWhenAIChatToggleDisabledAndSuggestionIsWebsite_ThenSuffixIsNil() {
-        let urlString = "https://spreadprivacy.com"
-        let url = URL(string: urlString)!
-        let suggestion = Suggestion.website(url: url)
-        let featureFlagger = MockFeatureFlagger()
-        // Feature flag is disabled by default
 
         let suggestionViewModel = SuggestionViewModel(
             isHomePage: false,
@@ -251,24 +232,6 @@ final class SuggestionViewModelTests: XCTestCase {
         )
 
         XCTAssertNil(suggestionViewModel.suffix)
-    }
-
-    func testWhenAIChatToggleEnabledAndSuggestionIsWebsiteWithPath_ThenSuffixShowsVisitRootHost() {
-        let urlString = "https://spreadprivacy.com/blog/article"
-        let url = URL(string: urlString)!
-        let suggestion = Suggestion.website(url: url)
-        let featureFlagger = MockFeatureFlagger()
-        featureFlagger.enabledFeatureFlags = [.aiChatOmnibarToggle, .aiChatOmnibarCluster]
-
-        let suggestionViewModel = SuggestionViewModel(
-            isHomePage: false,
-            suggestion: suggestion,
-            userStringValue: "",
-            themeManager: MockThemeManager(),
-            featureFlagger: featureFlagger
-        )
-
-        XCTAssertEqual(suggestionViewModel.suffix, "\(UserText.addressBarVisitSuffix) spreadprivacy.com")
     }
 
     // MARK: - Ask AI Chat Suggestion Tests


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1212227266479719?focus=true
Tech Design URL:
CC:

### Description
Removes the rejected `aiChatOmnibarCluster` feature flag (and its `omnibarCluster` privacy subfeature) on macOS

### Testing Steps
1. With Duck.ai enabled, type a query in the address bar and confirm the suggestions list shows no top search/visit/AI-chat header cells — only suggestions plus the "Ask Duck.ai" cell at the bottom.
2. I suggest opening this PR build side by side with our current prod one, use both the address bar suggestions and duck.ai and make sure there are no regressions (it's what I did to validate this)

### Impact and Risks
Low — flag-gated UI removal; the default (flag-off) behavior is unchanged, only the rejected cluster path is deleted.

#### What could go wrong?
Suggestion-row indexing or the footer AI-chat cell could regress if the simplified row math is off.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only cleanup that removes a rejected code path; default omnibar/suggestions behavior should match the old flag-off state, with minor risk around suggestion row indexing and keyboard selection after the simplified row model.
> 
> **Overview**
> Removes the rejected **`aiChatOmnibarCluster`** flag and **`omnibarCluster`** privacy subfeature on macOS, locking in the prior flag-off behavior.
> 
> The autocomplete dropdown no longer has a **header** with top search, visit, or AI-chat rows—only normal suggestions, an optional footer divider, and the **Ask Duck.ai** row when **`aiChatOmnibarToggle`** and AI features are on. Related view-model logic (URL visit row, auto-selected header hiding, default row selection) and UI for **`searchCell`** / **`visitCell`** are deleted. **`SuggestionViewModel`** no longer adds a "Visit {host}" suffix on website suggestions tied to that flag.
> 
> The address bar hides suffix text only when the field is **not** focused (cluster no longer keeps suffix visible while focused). Unit tests are trimmed to match the footer-only AI chat layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c656662dffbbf68c80de9aa0444d214f51acaf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->