### PR TITLE
[macOS] Harden bookmarks bar favicon refresh against flicker

### DIFF
--- a/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarCollectionViewItem.swift
+++ b/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarCollectionViewItem.swift
@@ -133,6 +133,19 @@ final class BookmarksBarCollectionViewItem: NSCollectionViewItem {
         titleLabel.alphaValue = isInteractionPrevented ? 0.3 : 1
     }
 
+    /// Re-resolves this bookmark's favicon and shows it in place if a decoded image is now available.
+    ///
+    /// Never downgrades an already-shown favicon back to the placeholder.
+    func refreshDisplayedFavicon() {
+        guard let bookmark = representedObject as? Bookmark else { return }
+        let host = URL(string: bookmark.url)?.host ?? ""
+        guard let favicon = (bookmark.favicon(.small) ?? NSApp.delegateTyped.faviconManager.getCachedFavicon(for: host, sizeCategory: .small)?.image)?.copy() as? NSImage else {
+            return
+        }
+        favicon.size = NSSize.faviconSize
+        faviconView.image = favicon
+    }
+
     @IBAction func mouseClickAction(_ sender: Any) {
         delegate?.bookmarksBarCollectionViewItemClicked(self)
     }

--- a/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarViewController.swift
+++ b/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarViewController.swift
@@ -345,7 +345,12 @@ final class BookmarksBarViewController: NSViewController {
 
     private func refreshFavicons() {
         dispatchPrecondition(condition: .onQueue(.main))
-        bookmarksBarCollectionView.reloadData()
+        // Update favicons in place on the existing cells rather than `reloadData()`. Rebuilding every
+        // cell on each favicon-cache update would cause favicons flickering. In-place refresh only
+        // upgrades placeholder → image and never "downgrades" to a placeholder image.
+        for case let item as BookmarksBarCollectionViewItem in bookmarksBarCollectionView.visibleItems() {
+            item.refreshDisplayedFavicon()
+        }
     }
 
     @IBAction func importBookmarksClicked(_ sender: Any) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1215999008194803?focus=true

### Description

Follow-up to #5534 to further limit flickering of the bookmarks bar favicons.

Instead of reloading data of the entire bookmarks bar on favicons cache update, only refresh
displayed favicons using a dedicated function that never clears the favicon (only updates existing one if needed).

### Testing Steps
1. Put several bookmarks with favicons on the bookmarks bar (e.g. a few github.com pages, plus other sites).
2. Quit and relaunch the browser (a cold start forces favicons to decode lazily off-main); for a stronger repro, open many tabs/bookmarks with favicons so the image cache churns.
3. Watch the bookmarks bar favicons during the first seconds after launch / as pages load.
   - Before: favicons flicker between the real icon and the generic placeholder.
   - After: each favicon appears once and stays — placeholder upgrades to the real icon and never reverts.
4. Confirm favicons still appear for newly-bookmarked sites and after the favicon finishes downloading (placeholder → real upgrade still works).

### Impact and Risks
Low. Bookmarks-bar rendering only — changes how the bar reacts to favicon-cache updates (in-place upgrade vs. full reload). No change to favicon fetching, storage, bookmark data, or privacy.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bookmarks bar UI only; favicon fetch/storage and bookmark data are unchanged.
> 
> **Overview**
> Follow-up to harden bookmarks bar favicon updates when `.faviconCacheUpdated` fires during lazy decode.
> 
> **`refreshFavicons()`** no longer calls **`reloadData()`** on the collection view. It walks **visible** `BookmarksBarCollectionViewItem` instances and calls a new **`refreshDisplayedFavicon()`** on each.
> 
> **`refreshDisplayedFavicon()`** re-resolves the bookmark favicon (stored favicon or `faviconManager` cache), sets the image view only when a decoded image exists, and **never** replaces an already-shown icon with the generic placeholder.
> 
> Placeholder → real favicon upgrades still work; full cell rebuilds on every cache notification are avoided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35e732fbbdc90368044538288c3bb773b43a9656. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->