### PR TITLE
[iOS] Duck.ai tab grid: crossfade transition into rich cards

### DIFF
--- a/iOS/DuckDuckGo/RichDuckAICells/DuckAIGridCardView.swift
+++ b/iOS/DuckDuckGo/RichDuckAICells/DuckAIGridCardView.swift
@@ -74,6 +74,7 @@ final class DuckAIGridCardView: UIView {
         thumbnailImageView.image = image
     }
 
+
     /// Resets to the default light appearance. Called on cell reuse so a recycled `.voice` (dark)
     /// card never lingers in dark state if shown before the next `configure(with:)`.
     func resetAppearance() {

--- a/iOS/DuckDuckGo/RichDuckAICells/DuckAIGridCardView.swift
+++ b/iOS/DuckDuckGo/RichDuckAICells/DuckAIGridCardView.swift
@@ -74,6 +74,8 @@ final class DuckAIGridCardView: UIView {
         thumbnailImageView.image = image
     }
 
+    /// Whether the `.image` thumbnail is already populated — lets the snapshot path skip a redundant load.
+    var hasThumbnail: Bool { thumbnailImageView.image != nil }
 
     /// Resets to the default light appearance. Called on cell reuse so a recycled `.voice` (dark)
     /// card never lingers in dark state if shown before the next `configure(with:)`.

--- a/iOS/DuckDuckGo/RichDuckAICells/DuckAIGridContentResolver.swift
+++ b/iOS/DuckDuckGo/RichDuckAICells/DuckAIGridContentResolver.swift
@@ -101,27 +101,28 @@ final class DuckAIGridContentResolver: DuckAIGridContentProviding {
     }
 
     func loadImage(fileRef: String) async -> UIImage? {
-        guard let storageHandler, aiChatFeatureFlagProvider.isNativeDataAccessEnabled() else {
+        guard let storageHandler,
+              aiChatFeatureFlagProvider.isNativeDataAccessEnabled() else {
             return nil
         }
+        // Decode off the main thread — this path runs during normal grid scrolling.
         return await Task.detached {
-            do {
-                guard let file = try storageHandler.getFile(uuid: fileRef) else { return nil }
-                return Self.decodeImage(from: file.data)
-            } catch {
-                Logger.aiChat.error("DuckAIGridContentResolver: failed to read file: \(error.localizedDescription)")
-                return nil
-            }
+            Self.readAndDecodeImage(fileRef: fileRef, storageHandler: storageHandler)
         }.value
     }
 
     func loadImageSynchronously(fileRef: String) -> UIImage? {
-        guard let storageHandler, aiChatFeatureFlagProvider.isNativeDataAccessEnabled() else {
+        guard let storageHandler,
+              aiChatFeatureFlagProvider.isNativeDataAccessEnabled() else {
             return nil
         }
+        return Self.readAndDecodeImage(fileRef: fileRef, storageHandler: storageHandler)
+    }
+
+    nonisolated private static func readAndDecodeImage(fileRef: String, storageHandler: DuckAiNativeStorageHandling) -> UIImage? {
         do {
             guard let file = try storageHandler.getFile(uuid: fileRef) else { return nil }
-            return Self.decodeImage(from: file.data)
+            return decodeImage(from: file.data)
         } catch {
             Logger.aiChat.error("DuckAIGridContentResolver: failed to read file: \(error.localizedDescription)")
             return nil

--- a/iOS/DuckDuckGo/RichDuckAICells/DuckAIGridContentResolver.swift
+++ b/iOS/DuckDuckGo/RichDuckAICells/DuckAIGridContentResolver.swift
@@ -18,6 +18,7 @@
 //
 
 import UIKit
+import ImageIO
 import AIChat
 import PrivacyConfig
 import os.log
@@ -48,6 +49,11 @@ protocol DuckAIGridContentProviding: DuckAIGridItemProviding, DuckAIThumbnailLoa
 /// reading from native chat storage.
 @MainActor
 final class DuckAIGridContentResolver: DuckAIGridContentProviding {
+    
+    private enum Constants {
+        // Card thumbnail is 80×145pt; 512px covers it at 3× + aspectFill crop with margin.
+        static let thumbnailMaxPixelSize = 512
+    }
 
     private let featureFlagger: FeatureFlagger
     private let storageHandler: DuckAiNativeStorageHandling?
@@ -130,13 +136,29 @@ final class DuckAIGridContentResolver: DuckAIGridContentProviding {
     }
 
     /// Native files may be raw image bytes OR a `{data: <base64>, mimeType: ...}` JSON
-    /// wrapper (debug-server dashboard is the reference). Try wrapper first, then raw.
+    /// wrapper (debug-server dashboard is the reference). Try wrapper first, then raw,
+    /// then downsample to the card's display size so the full-res bitmap is never decoded.
     nonisolated private static func decodeImage(from data: Data) -> UIImage? {
+        let bytes: Data
         if let wrapper = try? JSONDecoder().decode(FileWrapper.self, from: data),
-           let bytes = Data(base64Encoded: wrapper.data) {
-            return UIImage(data: bytes)
+           let decoded = Data(base64Encoded: wrapper.data) {
+            bytes = decoded
+        } else {
+            bytes = data
         }
-        return UIImage(data: data)
+        return downsample(bytes, maxPixelSize: Constants.thumbnailMaxPixelSize)
+    }
+
+    /// Decodes straight from the encoded bytes to a thumbnail-sized `CGImage` via ImageIO
+    nonisolated private static func downsample(_ data: Data, maxPixelSize: Int) -> UIImage? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize
+        ]
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else { return nil }
+        return UIImage(cgImage: cgImage)
     }
 
     private struct FileWrapper: Decodable {

--- a/iOS/DuckDuckGo/RichDuckAICells/DuckAIGridContentResolver.swift
+++ b/iOS/DuckDuckGo/RichDuckAICells/DuckAIGridContentResolver.swift
@@ -36,7 +36,6 @@ protocol DuckAIGridItemProviding: AnyObject {
 @MainActor
 protocol DuckAIThumbnailLoading: AnyObject {
     func loadImage(fileRef: String) async -> UIImage?
-    /// Synchronous load for the tab-switcher transition, which must populate the destination
     /// Decodes on the calling thread; only used for the single cell being snapshotted.
     func loadImageSynchronously(fileRef: String) -> UIImage?
 }

--- a/iOS/DuckDuckGo/RichDuckAICells/DuckAIGridContentResolver.swift
+++ b/iOS/DuckDuckGo/RichDuckAICells/DuckAIGridContentResolver.swift
@@ -36,6 +36,9 @@ protocol DuckAIGridItemProviding: AnyObject {
 @MainActor
 protocol DuckAIThumbnailLoading: AnyObject {
     func loadImage(fileRef: String) async -> UIImage?
+    /// Synchronous load for the tab-switcher transition, which must populate the destination
+    /// Decodes on the calling thread; only used for the single cell being snapshotted.
+    func loadImageSynchronously(fileRef: String) -> UIImage?
 }
 
 /// Composition of both grid-content capabilities.
@@ -111,6 +114,19 @@ final class DuckAIGridContentResolver: DuckAIGridContentProviding {
                 return nil
             }
         }.value
+    }
+
+    func loadImageSynchronously(fileRef: String) -> UIImage? {
+        guard let storageHandler, aiChatFeatureFlagProvider.isNativeDataAccessEnabled() else {
+            return nil
+        }
+        do {
+            guard let file = try storageHandler.getFile(uuid: fileRef) else { return nil }
+            return Self.decodeImage(from: file.data)
+        } catch {
+            Logger.aiChat.error("DuckAIGridContentResolver: failed to read file: \(error.localizedDescription)")
+            return nil
+        }
     }
 
     /// Native files may be raw image bytes OR a `{data: <base64>, mimeType: ...}` JSON

--- a/iOS/DuckDuckGo/TabViewCell.swift
+++ b/iOS/DuckDuckGo/TabViewCell.swift
@@ -125,6 +125,7 @@ class TabViewCell: UICollectionViewCell {
     /// File-ref token guarding the in-flight thumbnail load.
     private var currentThumbnailFileRef: String?
     private var thumbnailLoadTask: Task<Void, Never>?
+    private weak var thumbnailLoader: DuckAIThumbnailLoading?
 
     weak var previewAspectRatio: NSLayoutConstraint?
     var previewTopConstraint: NSLayoutConstraint?
@@ -611,12 +612,23 @@ class TabViewCell: UICollectionViewCell {
         thumbnailLoadTask?.cancel()
         thumbnailLoadTask = nil
         currentThumbnailFileRef = nil
+        thumbnailLoader = nil
+    }
+
+    /// Synchronously loads the `.image` thumbnail into the card so a snapshot taken during the
+    /// tab-switcher transition includes it. No-op for non-image cards or once it's already set.
+    func prepareForSnapshot() {
+        guard let fileRef = currentThumbnailFileRef,
+              let loader = thumbnailLoader,
+              let image = loader.loadImageSynchronously(fileRef: fileRef) else { return }
+        richCardContainer?.setThumbnail(image)
     }
 
     private func startThumbnailLoadIfNeeded(for item: DuckAIGridItem,
                                             loader: DuckAIThumbnailLoading?) {
         guard case .image(_, let fileRef) = item, let loader else { return }
         currentThumbnailFileRef = fileRef
+        thumbnailLoader = loader
         thumbnailLoadTask = Task { @MainActor [weak self, weak loader] in
             guard let loader else { return }
             let image = await loader.loadImage(fileRef: fileRef)

--- a/iOS/DuckDuckGo/TabViewCell.swift
+++ b/iOS/DuckDuckGo/TabViewCell.swift
@@ -620,6 +620,7 @@ class TabViewCell: UICollectionViewCell {
     func prepareForSnapshot() {
         guard let fileRef = currentThumbnailFileRef,
               let loader = thumbnailLoader,
+              richCardContainer?.hasThumbnail == false,
               let image = loader.loadImageSynchronously(fileRef: fileRef) else { return }
         richCardContainer?.setThumbnail(image)
     }

--- a/iOS/DuckDuckGo/Transitions/WebViewTransition.swift
+++ b/iOS/DuckDuckGo/Transitions/WebViewTransition.swift
@@ -115,6 +115,9 @@ class FromWebViewTransition: WebViewTransition {
         if tab.isAITab {
             tabSwitcherViewController.collectionView.layoutIfNeeded()
             if let cell = tabSwitcherViewController.collectionView.cellForItem(at: indexPath) as? TabViewGridCell {
+                // Force the .image thumbnail in synchronously — its async load won't finish
+                // before snapshotView captures the cell.
+                cell.prepareForSnapshot()
                 let currentBorderHidden = cell.border.isHidden
                 cell.border.isHidden = true
                 if let snapshot = cell.snapshotView(afterScreenUpdates: true) {

--- a/iOS/DuckDuckGo/Transitions/WebViewTransition.swift
+++ b/iOS/DuckDuckGo/Transitions/WebViewTransition.swift
@@ -109,10 +109,10 @@ class FromWebViewTransition: WebViewTransition {
 
         // Duck.ai tabs land on a rich card, not a screenshot. Crossfade a snapshot of the
         // destination cell over the webview preview so the shrink ends on matching content
-        // instead of popping from screenshot to card. Non-AI tabs keep the screenshot-only
-        // shrink below. nil snapshot (cell not laid out) falls back to that path too.
+        // instead of popping from screenshot to card. Gated on the rich-card flag: with it off
+        // the AI cell is a screenshot, so there's nothing to crossfade to
         var cellSnapshot: UIView?
-        if tab.isAITab {
+        if tab.isAITab, mainViewController.featureFlagger.isFeatureOn(.aiChatTabSwitcherRichCard) {
             tabSwitcherViewController.collectionView.layoutIfNeeded()
             if let cell = tabSwitcherViewController.collectionView.cellForItem(at: indexPath) as? TabViewGridCell {
                 // Force the .image thumbnail in synchronously — its async load won't finish

--- a/iOS/DuckDuckGo/Transitions/WebViewTransition.swift
+++ b/iOS/DuckDuckGo/Transitions/WebViewTransition.swift
@@ -107,6 +107,28 @@ class FromWebViewTransition: WebViewTransition {
         imageView.frame = imageContainer.bounds
         imageView.image = preview
 
+        // Duck.ai tabs land on a rich card, not a screenshot. Crossfade a snapshot of the
+        // destination cell over the webview preview so the shrink ends on matching content
+        // instead of popping from screenshot to card. Non-AI tabs keep the screenshot-only
+        // shrink below. nil snapshot (cell not laid out) falls back to that path too.
+        var cellSnapshot: UIView?
+        if tab.isAITab {
+            tabSwitcherViewController.collectionView.layoutIfNeeded()
+            if let cell = tabSwitcherViewController.collectionView.cellForItem(at: indexPath) as? TabViewGridCell {
+                let currentBorderHidden = cell.border.isHidden
+                cell.border.isHidden = true
+                if let snapshot = cell.snapshotView(afterScreenUpdates: true) {
+                    snapshot.frame = imageContainer.bounds
+                    snapshot.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+                    snapshot.alpha = 0
+                    imageContainer.addSubview(snapshot)
+                    cellSnapshot = snapshot
+                }
+                cell.border.isHidden = currentBorderHidden
+            }
+               
+        }
+
         UIView.animateKeyframes(withDuration: TabSwitcherTransition.Constants.duration, delay: 0, options: .calculationModeLinear, animations: {
 
             UIView.addKeyframe(withRelativeStartTime: 0, relativeDuration: 1.0) {
@@ -119,8 +141,14 @@ class FromWebViewTransition: WebViewTransition {
             UIView.addKeyframe(withRelativeStartTime: 0.3, relativeDuration: 0.7) {
                 self.tabSwitcherViewController.view.alpha = 1
             }
-            
-            if !self.tabSwitcherSettings.isGridViewEnabled {
+
+            if let cellSnapshot {
+                // Crossfade webview preview out / cell snapshot in over the first half.
+                UIView.addKeyframe(withRelativeStartTime: 0, relativeDuration: 0.5) {
+                    self.imageView.alpha = 0
+                    cellSnapshot.alpha = 1
+                }
+            } else if !self.tabSwitcherSettings.isGridViewEnabled {
                 UIView.addKeyframe(withRelativeStartTime: 0.3, relativeDuration: 0.5) {
                     self.imageView.alpha = 0
                 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211767540372501/task/1215715724804178?focus=true

### Description

When entering the tab switcher from a Duck.ai chat, the existing transition shrinks a screenshot of the web view down into its grid cell. Now that Duck.ai tabs render a rich card (title/snippet/chip, image thumbnail, voice, or empty) instead of a screenshot, the animation ended by hard-cutting from the shrunk screenshot to a completely different-looking card.

This change crossfades a snapshot of the destination rich-card cell over the shrinking web-view screenshot, so the shrink lands on matching content instead of popping. For image cards, the thumbnail normally loads asynchronously and wouldn't be ready when the cell is snapshotted, leaving a blank thumbnail in the crossfade — a synchronous load path (`loadImageSynchronously` / `prepareForSnapshot`) populates it before capture, with a guard to skip the work when it's already loaded.

The entire crossfade is gated behind the `aiChatTabSwitcherRichCard` feature flag (the same flag that controls the rich cards themselves). With the flag off, the destination cell is a screenshot and the transition behaves exactly as before.

### Testing Steps

1. Enable the `aiChatTabSwitcherRichCard` feature flag
2. Open a Duck.ai **text** chat that has messages, then tap the tab-switcher button. Confirm the web view shrinks into its grid cell and crossfades into the rich card — no hard "pop" from screenshot to card at the end.
3. Open a Duck.ai **image** chat with a generated image, tap the tab switcher, and confirm the card's thumbnail is already visible during the crossfade (no blank/empty thumbnail flicker).
4. Repeat with **voice/transcript** and **empty** Duck.ai chats — the shrink should land on the matching card.
5. Turn the flag **off** and repeat step 2: you should see the original transition
6. Switch into the tab grid from a **regular web tab** (flag on and off): confirm its transition is unchanged.

### Impact and Risks

**Low.** The change is scoped to the WebView→TabSwitcher present transition and is gated behind the `aiChatTabSwitcherRichCard` flag (default off), which acts as a kill switch — flag off is byte-for-byte the previous behavior. If the destination cell can't be snapshotted (e.g. not laid out), the code falls back to the existing screenshot-only shrink. Non-Duck.ai tabs and list mode are unaffected.

One thing to note: for image cards the thumbnail is decoded synchronously on the main thread for the single snapshotted cell at the start of the transition. It's guarded to skip when already loaded.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the present transition behind `aiChatTabSwitcherRichCard` (default off); the only notable risk is brief main-thread decode for one image cell when snapshotting.
> 
> **Overview**
> When leaving a Duck.ai chat for the tab switcher with **`aiChatTabSwitcherRichCard`** on, the web-view shrink animation now **crossfades** from the shrinking screenshot into a **snapshot of the destination rich-card cell**, instead of popping to different-looking content at the end. Non–Duck.ai tabs and flag-off behavior stay on the previous path.
> 
> **Image cards** get a **`prepareForSnapshot`** path on the grid cell that **synchronously** loads the thumbnail (via new **`loadImageSynchronously`**) only when it is not already shown, so the snapshot is not blank. Thumbnail loading is refactored to shared read/decode logic; **async** loads still run off the main thread, and decoding now **downsamples via ImageIO** (512px max) rather than full-resolution **`UIImage(data:)`**, including for normal grid scrolling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b07934740a47c42172f4c05346399fc90691fccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->