### PR TITLE
macOS: Add suggestions to sidebar

### DIFF
--- a/SharedPackages/AIChat/Package.resolved
+++ b/SharedPackages/AIChat/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "48971cf565b5895cc78a46f2d302829071d2dd6dbe6f92a852ebd47728e2e686",
+  "originHash" : "92cf14f5ae4b969e996b4bd4ac6f837afe73197d05c766cfac0cbb731962bc32",
   "pins" : [
     {
       "identity" : "content-scope-scripts",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "9154d509a51501cecf541b66e2c932023996fbe5",
-        "version" : "14.13.0"
+        "revision" : "5735b061ee14708ca17bc5b72b8eb9d21eb7f830",
+        "version" : "15.3.0"
       }
     },
     {

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatConsumableDataHandling.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatConsumableDataHandling.swift
@@ -135,6 +135,23 @@ public final class AIChatPageContextHandler: AIChatConsumableDataHandling {
     }
 }
 
+/// Lightweight page-type signals read from page markup, used by the duck.ai web app to pick
+/// page-tailored suggested prompts ("shortcuts"). All fields are best-effort and may be empty.
+public struct AIChatPageTypeSignals: Codable, Equatable {
+    /// `@type` values from every <script type="application/ld+json"> block (incl. `@graph`), deduped. [] if none.
+    public let jsonLdType: [String]
+    /// Content of the first <meta property="og:type">, or nil if absent.
+    public let ogType: String?
+    /// The page's declared language (e.g. <html lang>); "" if none.
+    public let lang: String
+
+    public init(jsonLdType: [String], ogType: String?, lang: String) {
+        self.jsonLdType = jsonLdType
+        self.ogType = ogType
+        self.lang = lang
+    }
+}
+
 public struct AIChatPageContextData: Codable, Equatable {
     public let title: String
     public let favicon: [PageContextFavicon]
@@ -143,13 +160,20 @@ public struct AIChatPageContextData: Codable, Equatable {
     public let truncated: Bool
     public let fullContentLength: Int
     public let attachable: Bool?
+    /// Page-type signals for the duck.ai web app's page shortcuts. Sent in both the full-content
+    /// (auto-attach on) and signals-only (auto-attach off) payloads. Omitted (nil) when unavailable.
+    public let pageTypeSignals: AIChatPageTypeSignals?
+    /// Whether the page CONTENT is attached in this payload. Distinct from `attachable` (whether
+    /// content *can ever* be attached). Absent → treated as `true` (backward compatible). `false`
+    /// marks a signals-only payload: metadata + `pageTypeSignals`, no content.
+    public let attached: Bool?
     /// Discriminator for the duck.ai web app: presence marks a tab-picker context (e.g.
     /// picked via the sidebar `@` picker or the omnibar's "Add Page Content" menu); absence
     /// marks the current sidebar page. The omnibar strips this for the entry that matches
     /// the active tab so the discriminator's semantics hold end-to-end.
     public let tabId: String?
 
-    public init(title: String, favicon: [PageContextFavicon], url: String, content: String, truncated: Bool, fullContentLength: Int, attachable: Bool? = nil, tabId: String? = nil) {
+    public init(title: String, favicon: [PageContextFavicon], url: String, content: String, truncated: Bool, fullContentLength: Int, attachable: Bool? = nil, tabId: String? = nil, pageTypeSignals: AIChatPageTypeSignals? = nil, attached: Bool? = nil) {
         self.title = title
         self.favicon = favicon
         self.url = url
@@ -158,6 +182,8 @@ public struct AIChatPageContextData: Codable, Equatable {
         self.fullContentLength = fullContentLength
         self.attachable = attachable
         self.tabId = tabId
+        self.pageTypeSignals = pageTypeSignals
+        self.attached = attached
     }
 
     /// Returns a copy of this page context with the `tabId` field set to the given value.
@@ -172,7 +198,9 @@ public struct AIChatPageContextData: Codable, Equatable {
             truncated: truncated,
             fullContentLength: fullContentLength,
             attachable: attachable,
-            tabId: tabId
+            tabId: tabId,
+            pageTypeSignals: pageTypeSignals,
+            attached: attached
         )
     }
 

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatMetricName.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatMetricName.swift
@@ -26,6 +26,7 @@ public enum AIChatMetricName: String, Codable {
     case userDidCreateNewChat
     case userDidTapKeyboardReturnKey
     case userDidAcceptTermsAndConditions
+    case userDidSelectSuggestion
 }
 
 // Model tier for AI Chat metrics
@@ -39,10 +40,17 @@ public enum AIChatModelTier: String, Codable {
 public struct AIChatMetric: Codable {
     public let metricName: AIChatMetricName
     public let modelTier: AIChatModelTier?
+    /// Fixed catalog key identifying the tapped suggestion (e.g. `summarize-page`). Carried by `userDidSelectSuggestion`.
+    public let suggestionId: String?
+    /// Coarse page classification the FE derived from JSON-LD/OpenGraph. Decoded as a plain string so a new FE
+    /// page type never breaks decoding. Carried by `userDidSelectSuggestion`.
+    public let pageType: String?
 
-     public init(metricName: AIChatMetricName, modelTier: AIChatModelTier? = nil) {
+     public init(metricName: AIChatMetricName, modelTier: AIChatModelTier? = nil, suggestionId: String? = nil, pageType: String? = nil) {
          self.metricName = metricName
          self.modelTier = modelTier
+         self.suggestionId = suggestionId
+         self.pageType = pageType
      }
 }
 

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatScriptUserValues.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatScriptUserValues.swift
@@ -99,6 +99,9 @@ public struct AIChatNativeConfigValues: Codable {
     public let supportsMultipleContexts: Bool
     public let supportsTabPicker: Bool
     public let supportsNativeStorage: Bool
+    /// `true` when the native side supplies page-type signals so the duck.ai web app can render
+    /// page-tailored suggested prompts ("suggestions").
+    public let supportsSuggestions: Bool
     /// `true` when the native app handles the "voice chat start failed" remediation UI
     /// (e.g. surfaces the OS microphone-disabled prompt). When this is `true` the FE
     /// must suppress its own in-page tooltip and post `voiceChatStartFailed` to native
@@ -173,6 +176,7 @@ public struct AIChatNativeConfigValues: Codable {
                 supportsMultipleContexts: Bool = false,
                 supportsTabPicker: Bool = false,
                 supportsNativeStorage: Bool = false,
+                supportsSuggestions: Bool = false,
                 supportsNativeVoicePermissionHandler: Bool = false,
                 installType: AIChatInstallType = .new,
                 installAge: Int = 0) {
@@ -195,6 +199,7 @@ public struct AIChatNativeConfigValues: Codable {
         self.supportsMultipleContexts = supportsMultipleContexts
         self.supportsTabPicker = supportsTabPicker
         self.supportsNativeStorage = supportsNativeStorage
+        self.supportsSuggestions = supportsSuggestions
         self.supportsNativeVoicePermissionHandler = supportsNativeVoicePermissionHandler
         self.installType = installType
         self.installAge = installAge

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatNativeConfigValuesTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatNativeConfigValuesTests.swift
@@ -77,6 +77,41 @@ final class AIChatNativeConfigValuesTests: XCTestCase {
         XCTAssertNotNil(json["installAge"])
     }
 
+    func testConfigValuesEncodeSupportsSuggestions() throws {
+        let json = try jsonObject(makeConfig(supportsSuggestions: true))
+        XCTAssertEqual(json["supportsSuggestions"] as? Bool, true)
+    }
+
+    func testSupportsSuggestionsDefaultsToFalse() throws {
+        // defaultValues does not pass supportsSuggestions, so it must encode as false.
+        let json = try jsonObject(AIChatNativeConfigValues.defaultValues)
+        XCTAssertEqual(json["supportsSuggestions"] as? Bool, false)
+    }
+
+    private func jsonObject(_ config: AIChatNativeConfigValues) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(config)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func makeConfig(supportsSuggestions: Bool) -> AIChatNativeConfigValues {
+        AIChatNativeConfigValues(
+            isAIChatHandoffEnabled: false,
+            supportsClosingAIChat: true,
+            supportsOpeningSettings: true,
+            supportsNativePrompt: true,
+            supportsStandaloneMigration: false,
+            supportsNativeChatInput: false,
+            supportsURLChatIDRestoration: false,
+            supportsFullChatRestoration: false,
+            supportsPageContext: true,
+            supportsAIChatFullMode: false,
+            supportsAIChatContextualMode: false,
+            appVersion: "1.0.0",
+            supportsAIChatSync: false,
+            supportsSuggestions: supportsSuggestions
+        )
+    }
+
     private func encodedRawValue(_ type: AIChatInstallType) throws -> String {
         let data = try JSONEncoder().encode(type)
         return try XCTUnwrap(String(data: data, encoding: .utf8)).trimmingCharacters(in: CharacterSet(charactersIn: "\""))

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatPageContextDataTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatPageContextDataTests.swift
@@ -113,6 +113,125 @@ final class AIChatPageContextDataTests: XCTestCase {
 
         XCTAssertFalse(fullContext.isEmpty(), "Context should not be empty when all fields are populated")
     }
+
+    // MARK: - pageTypeSignals & attached (Duck.ai page suggestions)
+
+    private let recipeSignals = AIChatPageTypeSignals(jsonLdType: ["Recipe", "NewsArticle"], ogType: "article", lang: "en-US")
+
+    private func jsonObject(_ context: AIChatPageContextData) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(context)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    /// C-S-S adds `pageTypeSignals` to the collected payload (when `includePageTypeSignals` is on);
+    /// it must decode into the typed field. This is the contract that drives the FE suggestions.
+    func testDecodesPageTypeSignalsFromCollectedPayload() throws {
+        let json = """
+        {
+            "title": "5-Ingredient Creamy Chicken Enchilada Casserole",
+            "favicon": [],
+            "url": "https://example.com/recipe",
+            "content": "…markdown…",
+            "truncated": false,
+            "fullContentLength": 1234,
+            "attachable": true,
+            "pageTypeSignals": { "jsonLdType": ["Recipe", "NewsArticle"], "ogType": "article", "lang": "en-US" }
+        }
+        """
+        let decoded = try JSONDecoder().decode(AIChatPageContextData.self, from: XCTUnwrap(json.data(using: .utf8)))
+
+        XCTAssertEqual(decoded.pageTypeSignals?.jsonLdType, ["Recipe", "NewsArticle"])
+        XCTAssertEqual(decoded.pageTypeSignals?.ogType, "article")
+        XCTAssertEqual(decoded.pageTypeSignals?.lang, "en-US")
+        XCTAssertNil(decoded.attached, "attached is absent in a normal collected payload (FE treats nil as attached)")
+    }
+
+    /// A payload without the new fields (setting off, or older C-S-S) must still decode, with the new
+    /// fields nil — backward compatible.
+    func testDecodesPayloadWithoutNewFields() throws {
+        let json = """
+        { "title": "T", "favicon": [], "url": "https://example.com", "content": "c", "truncated": false, "fullContentLength": 1 }
+        """
+        let decoded = try JSONDecoder().decode(AIChatPageContextData.self, from: XCTUnwrap(json.data(using: .utf8)))
+
+        XCTAssertNil(decoded.pageTypeSignals)
+        XCTAssertNil(decoded.attached)
+    }
+
+    /// The signals-only payload (auto-attach off): metadata + signals, no content, attached:false,
+    /// attachable:true. Validates the exact wire shape the FE expects.
+    func testSignalsOnlyPayloadEncodesExpectedShape() throws {
+        let signalsOnly = AIChatPageContextData(
+            title: "Recipe",
+            favicon: [],
+            url: "https://example.com/recipe",
+            content: "",
+            truncated: false,
+            fullContentLength: 0,
+            attachable: true,
+            pageTypeSignals: recipeSignals,
+            attached: false
+        )
+        let json = try jsonObject(signalsOnly)
+
+        XCTAssertEqual(json["attached"] as? Bool, false, "signals-only marks content not attached")
+        XCTAssertEqual(json["attachable"] as? Bool, true, "must NOT be false — page can still be attached on tap")
+        let signals = try XCTUnwrap(json["pageTypeSignals"] as? [String: Any])
+        XCTAssertEqual(signals["ogType"] as? String, "article")
+        XCTAssertEqual(signals["jsonLdType"] as? [String], ["Recipe", "NewsArticle"])
+    }
+
+    /// Full content payload: `attached` is omitted (nil → FE defaults to true), signals included.
+    func testFullContentPayloadOmitsAttachedAndKeepsSignals() throws {
+        let full = AIChatPageContextData(
+            title: "Recipe",
+            favicon: [],
+            url: "https://example.com/recipe",
+            content: "the page content",
+            truncated: false,
+            fullContentLength: 16,
+            attachable: true,
+            pageTypeSignals: recipeSignals
+        )
+        let json = try jsonObject(full)
+
+        XCTAssertNil(json["attached"], "attached omitted when nil so the FE applies its default (true)")
+        XCTAssertNotNil(json["pageTypeSignals"])
+    }
+
+    /// Optional fields are omitted from the wire when nil (synthesized Codable), so legacy payloads
+    /// are unchanged.
+    func testOmitsPageTypeSignalsWhenNil() throws {
+        let noSignals = AIChatPageContextData(
+            title: "T", favicon: [], url: "https://example.com", content: "c", truncated: false, fullContentLength: 1
+        )
+        let json = try jsonObject(noSignals)
+
+        XCTAssertNil(json["pageTypeSignals"])
+        XCTAssertNil(json["attached"])
+    }
+
+    /// `withTabId` must preserve the new fields (it's used at extraction/submit time).
+    func testWithTabIdPreservesPageTypeSignalsAndAttached() {
+        let context = AIChatPageContextData(
+            title: "Recipe", favicon: [], url: "https://example.com/recipe", content: "", truncated: false,
+            fullContentLength: 0, attachable: true, pageTypeSignals: recipeSignals, attached: false
+        )
+        let stamped = context.withTabId("tab-1")
+
+        XCTAssertEqual(stamped.tabId, "tab-1")
+        XCTAssertEqual(stamped.pageTypeSignals, recipeSignals)
+        XCTAssertEqual(stamped.attached, false)
+    }
+
+    /// AIChatPageTypeSignals round-trips, including a nil ogType.
+    func testPageTypeSignalsCodableRoundTrip() throws {
+        for signals in [recipeSignals, AIChatPageTypeSignals(jsonLdType: [], ogType: nil, lang: "")] {
+            let data = try JSONEncoder().encode(signals)
+            let decoded = try JSONDecoder().decode(AIChatPageTypeSignals.self, from: data)
+            XCTAssertEqual(decoded, signals)
+        }
+    }
 }
 
 final class AIChatSelectionContextDataTests: XCTestCase {

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -416,7 +416,6 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// Enables the "Attach to Duck.ai" context-menu item that attaches selected text as the sidebar's page context
     case selectionContext
 
-    /// Context-aware page suggestions shown in the Duck.ai sidebar based on page type
     case sidebarSuggestedPrompts
 
     /// Enables updated AI features settings screen

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -416,6 +416,9 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// Enables the "Attach to Duck.ai" context-menu item that attaches selected text as the sidebar's page context
     case selectionContext
 
+    /// Context-aware page suggestions shown in the Duck.ai sidebar based on page type
+    case sidebarSuggestedPrompts
+
     /// Enables updated AI features settings screen
     case aiFeaturesSettingsUpdate
 

--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -344,9 +344,9 @@ enum AIChatPixel: PixelKitEvent {
     /// Event Trigger: User submits a prompt in an ongoing Duck.ai conversation
     case aiChatMetricSentPromptOngoingChat
 
-    /// Event Trigger: User taps a page suggestion in Duck.ai (a tailored prompt or "Ask about this page").
-    /// `suggestion` is the FE's fixed catalog key; `pageType` is the FE's coarse page classification.
-    case aiChatSuggestionInvoked(suggestion: String, pageType: String)
+    /// Event Trigger: User taps a sidebar page-suggestion chip (a tailored prompt or "Ask about this page").
+    /// `suggestionId` is the FE's fixed catalog key; `pageType` is the FE's coarse page classification.
+    case aiChatSuggestionSelected(suggestionId: String, pageType: String)
 
     // MARK: - Onboarding
 
@@ -646,8 +646,8 @@ enum AIChatPixel: PixelKitEvent {
             return "aichat_start_new_conversation"
         case .aiChatMetricSentPromptOngoingChat:
             return "aichat_sent_prompt_ongoing_chat"
-        case .aiChatSuggestionInvoked:
-            return "aichat_suggestion_invoked"
+        case .aiChatSuggestionSelected:
+            return "aichat_suggestion_selected"
         case .aiChatOpenDuckAiMainMenu:
             return "aichat_open_duck_ai_main_menu"
         case .aiChatNewChatMainMenu:
@@ -860,8 +860,8 @@ enum AIChatPixel: PixelKitEvent {
             return ["failureReason": failureReason.rawValue]
         case .aiChatVoiceChatStartFailed(let reason):
             return ["reason": reason.rawValue]
-        case .aiChatSuggestionInvoked(let suggestion, let pageType):
-            return ["suggestion": suggestion, "page_type": pageType]
+        case .aiChatSuggestionSelected(let suggestionId, let pageType):
+            return ["suggestionId": suggestionId, "pageType": pageType]
         }
     }
 
@@ -956,7 +956,7 @@ enum AIChatPixel: PixelKitEvent {
                 .aiChatModelsFetchFailed,
                 .aiChatMetricStartNewConversation,
                 .aiChatMetricSentPromptOngoingChat,
-                .aiChatSuggestionInvoked,
+                .aiChatSuggestionSelected,
                 .aiChatTermsAcceptedDuplicateSyncOff,
                 .aiChatTermsAcceptedDuplicateSyncOn,
                 .aiChatReportMetricDecodeError,

--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -344,6 +344,10 @@ enum AIChatPixel: PixelKitEvent {
     /// Event Trigger: User submits a prompt in an ongoing Duck.ai conversation
     case aiChatMetricSentPromptOngoingChat
 
+    /// Event Trigger: User taps a page suggestion in Duck.ai (a tailored prompt or "Ask about this page").
+    /// `suggestion` is the FE's fixed catalog key; `pageType` is the FE's coarse page classification.
+    case aiChatSuggestionInvoked(suggestion: String, pageType: String)
+
     // MARK: - Onboarding
 
     /// Event Trigger: User enables the Duck.ai toggle during onboarding
@@ -642,6 +646,8 @@ enum AIChatPixel: PixelKitEvent {
             return "aichat_start_new_conversation"
         case .aiChatMetricSentPromptOngoingChat:
             return "aichat_sent_prompt_ongoing_chat"
+        case .aiChatSuggestionInvoked:
+            return "aichat_suggestion_invoked"
         case .aiChatOpenDuckAiMainMenu:
             return "aichat_open_duck_ai_main_menu"
         case .aiChatNewChatMainMenu:
@@ -854,6 +860,8 @@ enum AIChatPixel: PixelKitEvent {
             return ["failureReason": failureReason.rawValue]
         case .aiChatVoiceChatStartFailed(let reason):
             return ["reason": reason.rawValue]
+        case .aiChatSuggestionInvoked(let suggestion, let pageType):
+            return ["suggestion": suggestion, "page_type": pageType]
         }
     }
 
@@ -948,6 +956,7 @@ enum AIChatPixel: PixelKitEvent {
                 .aiChatModelsFetchFailed,
                 .aiChatMetricStartNewConversation,
                 .aiChatMetricSentPromptOngoingChat,
+                .aiChatSuggestionInvoked,
                 .aiChatTermsAcceptedDuplicateSyncOff,
                 .aiChatTermsAcceptedDuplicateSyncOn,
                 .aiChatReportMetricDecodeError,

--- a/macOS/DuckDuckGo/AIChat/Sidebar/AIChatSession.swift
+++ b/macOS/DuckDuckGo/AIChat/Sidebar/AIChatSession.swift
@@ -65,6 +65,11 @@ final class AIChatSession {
             .eraseToAnyPublisher()
     }
 
+    /// Emits the chat view controller as it's recreated on show / torn down on hide, so observers can re-deliver page context.
+    var chatViewControllerPublisher: AnyPublisher<AIChatViewController?, Never> {
+        chatViewControllerSubject.eraseToAnyPublisher()
+    }
+
     /// The live AI Chat URL (reads from the VC if alive, falls back to persisted state).
     var currentAIChatURL: URL {
         chatViewController?.currentAIChatURL ?? state.currentAIChatURL

--- a/macOS/DuckDuckGo/AIChat/Sidebar/AIChatSession.swift
+++ b/macOS/DuckDuckGo/AIChat/Sidebar/AIChatSession.swift
@@ -65,7 +65,6 @@ final class AIChatSession {
             .eraseToAnyPublisher()
     }
 
-    /// Emits the chat view controller as it's recreated on show / torn down on hide, so observers can re-deliver page context.
     var chatViewControllerPublisher: AnyPublisher<AIChatViewController?, Never> {
         chatViewControllerSubject.eraseToAnyPublisher()
     }

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatMessageHandler.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatMessageHandler.swift
@@ -143,6 +143,7 @@ extension AIChatMessageHandler {
             supportsMultipleContexts: featureFlagger.isFeatureOn(.aiChatPageContext) && featureFlagger.isFeatureOn(.aiChatMultiplePageContexts),
             supportsTabPicker: featureFlagger.isFeatureOn(.aiChatPageContext) && featureFlagger.isFeatureOn(.aiChatSidebarAttachMoreTabs),
             supportsNativeStorage: featureFlagger.isFeatureOn(.aiChatNativeStorage) && isNativeStorageBridgeAvailable,
+            supportsSuggestions: featureFlagger.isFeatureOn(.aiChatPageContext) && featureFlagger.isFeatureOn(.sidebarSuggestedPrompts),
             supportsNativeVoicePermissionHandler: featureFlagger.isFeatureOn(.aiChatNativeVoicePermissionFlow),
             installType: installTypeProvider(),
             installAge: AIChatNativeConfigValues.installAgeBucket(installDate: installDateProvider())

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -104,7 +104,7 @@ protocol AIChatUserScriptHandling: AnyObject {
     @MainActor func openAIChatLink(params: Any, message: UserScriptMessage) async -> Encodable?
     var aiChatNativePromptPublisher: AnyPublisher<AIChatNativePrompt, Never> { get }
 
-    func getAIChatPageContext(params: Any, message: UserScriptMessage) -> Encodable?
+    @MainActor func getAIChatPageContext(params: Any, message: UserScriptMessage) async -> Encodable?
     func getAIChatSelectionContext(params: Any, message: UserScriptMessage) -> Encodable?
     var pageContextPublisher: AnyPublisher<AIChatPageContextData?, Never> { get }
     var selectionContextPublisher: AnyPublisher<AIChatSelectionContextData, Never> { get }
@@ -277,7 +277,8 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
         messageHandling.getDataForMessageType(.nativePrompt)
     }
 
-    func getAIChatPageContext(params: Any, message: any UserScriptMessage) -> Encodable? {
+    @MainActor
+    func getAIChatPageContext(params: Any, message: any UserScriptMessage) async -> Encodable? {
         guard let payload: GetPageContext = DecodableHelper.decode(from: params) else {
             return nil
         }
@@ -286,18 +287,55 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
 
         // On an explicit user action (Ask-About-Page chip or tapping a suggestion), the user wants
         // the page CONTENT attached. If we only have a signals-only payload (auto-attach off) or no
-        // context, trigger a fresh collection; the full content arrives via the submit push.
+        // context, trigger a fresh collection and await it so the content is returned directly in
+        // this response instead of arriving later via the submit push.
         if payload.reason == "userAction" {
             let hasAttachedContent = pageContext != nil
                 && pageContext?.attached != false
                 && !(pageContext?.content.isEmpty ?? true)
             if !hasAttachedContent {
-                pageContextRequestedSubject.send()
-                return PageContextResponse(pageContext: nil)
+                let collected = await requestPageContextAndWait()
+                return PageContextResponse(pageContext: collected)
             }
         }
 
         return PageContextResponse(pageContext: pageContext)
+    }
+
+    /// Triggers a fresh page-context collection and awaits the collected result, so
+    /// `getAIChatPageContext` can return the content directly via request/response instead of
+    /// returning `nil` and relying on the later `submitAIChatPageContext` push. The pushed context
+    /// arrives back through `pageContextSubject`; we subscribe before firing the request so a fast
+    /// collection can't slip through, and race the result against `timeout`. The submit push still
+    /// fires (it serves auto-collect/navigation flows), so the FE may also receive it that way.
+    /// Mirrors `PageContextUserScript.collectAndWait`.
+    @MainActor
+    private func requestPageContextAndWait(timeout: TimeInterval = 5) async -> AIChatPageContextData? {
+        let collectedContext = AsyncStream<AIChatPageContextData?> { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = pageContextSubject
+                .first()
+                .sink { result in
+                    continuation.yield(result)
+                    continuation.finish()
+                }
+            continuation.onTermination = { _ in cancellable?.cancel() }
+            pageContextRequestedSubject.send()
+        }
+
+        return await withTaskGroup(of: AIChatPageContextData?.self) { group in
+            group.addTask {
+                for await result in collectedContext { return result }
+                return nil
+            }
+            group.addTask {
+                try? await Task.sleep(interval: timeout)
+                return nil
+            }
+            let result = await group.next() ?? nil
+            group.cancelAll()
+            return result
+        }
     }
 
     func getAIChatSelectionContext(params: Any, message: any UserScriptMessage) -> Encodable? {

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -924,6 +924,15 @@ extension AIChatUserScriptHandler: AIChatMetricReportingHandling {
         case .userDidAcceptTermsAndConditions:
             handleTermsAccepted()
             completion?()
+        case .userDidSelectSuggestion:
+            pixelFiring?.fire(
+                AIChatPixel.aiChatSuggestionInvoked(
+                    suggestion: metric.suggestionId ?? "",
+                    pageType: metric.pageType ?? "none"
+                ),
+                frequency: .standard
+            )
+            completion?()
         default:
             completion?()
             return

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -926,11 +926,11 @@ extension AIChatUserScriptHandler: AIChatMetricReportingHandling {
             completion?()
         case .userDidSelectSuggestion:
             pixelFiring?.fire(
-                AIChatPixel.aiChatSuggestionInvoked(
-                    suggestion: metric.suggestionId ?? "",
+                AIChatPixel.aiChatSuggestionSelected(
+                    suggestionId: metric.suggestionId ?? "",
                     pageType: metric.pageType ?? "none"
                 ),
-                frequency: .standard
+                frequency: .dailyAndStandard
             )
             completion?()
         default:

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -284,8 +284,17 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
 
         let pageContext = messageHandling.getDataForMessageType(.pageContext) as? AIChatPageContextData
 
-        if pageContext == nil, payload.reason == "userAction" {
-            pageContextRequestedSubject.send()
+        // On an explicit user action (Ask-About-Page chip or tapping a suggestion), the user wants
+        // the page CONTENT attached. If we only have a signals-only payload (auto-attach off) or no
+        // context, trigger a fresh collection; the full content arrives via the submit push.
+        if payload.reason == "userAction" {
+            let hasAttachedContent = pageContext != nil
+                && pageContext?.attached != false
+                && !(pageContext?.content.isEmpty ?? true)
+            if !hasAttachedContent {
+                pageContextRequestedSubject.send()
+                return PageContextResponse(pageContext: nil)
+            }
         }
 
         return PageContextResponse(pageContext: pageContext)

--- a/macOS/DuckDuckGo/Tab/Model/Tab+Navigation.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab+Navigation.swift
@@ -34,6 +34,9 @@ extension Tab: NavigationResponder {
             // AI Chat navigations handling
             .weak(nullable: self.aiChat),
 
+            // Re-collect page context/signals once a page finishes loading (sidebar suggestions)
+            .weak(nullable: self.pageContext),
+
             // Pop-ups and Navigation Key Modifiers handling
             .weak(nullable: self.popupHandling),
             .strong(NavigationPixelNavigationResponder(featureFlagger: featureFlagger)),

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -157,7 +157,6 @@ final class PageContextTabExtension {
                 // chat VC exists after `showSidebar` finishes. Independent of page context below.
                 Task { @MainActor [weak self] in self?.flushPendingSelectionContexts() }
 
-                // Pass page context to the sidebar that just appeared for this tab.
                 self.deliverContextToCurrentSidebar()
             }
             .store(in: &cancellables)
@@ -220,7 +219,6 @@ final class PageContextTabExtension {
             return
         }
 
-        // Re-deliver on VC recreation: hide/show rebuilds the webview while aiChatKeepSession keeps the session, so the session-existence sink won't re-fire; dropFirst skips the first VC, already handled above.
         session.chatViewControllerPublisher
             .dropFirst()
             .receive(on: DispatchQueue.main)
@@ -284,7 +282,6 @@ final class PageContextTabExtension {
         }
     }
 
-    /// Delivers page context to the current sidebar VC: cached snapshot when auto-collect is on, else the non-attachable + signals-only payload.
     private func deliverContextToCurrentSidebar() {
         if let cachedPageContext, isContextCollectionEnabled {
             Task { await self.handle(cachedPageContext) }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -157,17 +157,8 @@ final class PageContextTabExtension {
                 // chat VC exists after `showSidebar` finishes. Independent of page context below.
                 Task { @MainActor [weak self] in self?.flushPendingSelectionContexts() }
 
-                /// This closure is responsible for passing cached page context to the newly displayed sidebar.
-                /// It's only called when sidebar for tabID is non-nil.
-                /// Additionally, we're only calling `handle` if there's a cached page context.
-                if let cachedPageContext, isContextCollectionEnabled {
-                    Task {
-                        await self.handle(cachedPageContext)
-                    }
-                } else {
-                    sendNonAttachableContextIfNeeded()
-                    requestSignalsOnlyCollectionIfNeeded()
-                }
+                // Pass page context to the sidebar that just appeared for this tab.
+                self.deliverContextToCurrentSidebar()
             }
             .store(in: &cancellables)
 
@@ -229,6 +220,16 @@ final class PageContextTabExtension {
             return
         }
 
+        // Re-deliver on VC recreation: hide/show rebuilds the webview while aiChatKeepSession keeps the session, so the session-existence sink won't re-fire; dropFirst skips the first VC, already handled above.
+        session.chatViewControllerPublisher
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] chatViewController in
+                guard let self, chatViewController != nil else { return }
+                self.deliverContextToCurrentSidebar()
+            }
+            .store(in: &sidebarCancellables)
+
         session.pageContextRequestedPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
@@ -280,6 +281,16 @@ final class PageContextTabExtension {
                 // won't clear it until the next prompt is submitted.
                 hasContextBeenConsumedByChat = false
             }
+        }
+    }
+
+    /// Delivers page context to the current sidebar VC: cached snapshot when auto-collect is on, else the non-attachable + signals-only payload.
+    private func deliverContextToCurrentSidebar() {
+        if let cachedPageContext, isContextCollectionEnabled {
+            Task { await self.handle(cachedPageContext) }
+        } else {
+            sendNonAttachableContextIfNeeded()
+            requestSignalsOnlyCollectionIfNeeded()
         }
     }
 

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -65,6 +65,11 @@ final class PageContextTabExtension {
     /// The flag is automatically cleared after receiving a `collectionResult` message.
     private var shouldForceContextCollection: Bool = false
 
+    /// Set when we trigger a collection purely to harvest Content-Scope-Scripts page-type signals
+    /// while auto-attach is OFF. The collectionResult is then delivered as a signals-only payload
+    /// (content stripped, attached:false). Cleared when that result arrives.
+    private var pendingSignalsOnlyCollection: Bool = false
+
     /// Set when the user explicitly removes page context from the chat.
     /// Suppresses auto-collection on the current page until the next navigation.
     private var userRemovedContext: Bool = false
@@ -133,6 +138,7 @@ final class PageContextTabExtension {
                 }
                 self.handleNavigationForMultipleContexts(from: previousContent, to: tabContent)
                 self.sendNonAttachableContextIfNeeded()
+                self.requestSignalsOnlyCollectionIfNeeded()
             }
             .store(in: &cancellables)
 
@@ -160,6 +166,7 @@ final class PageContextTabExtension {
                     }
                 } else {
                     sendNonAttachableContextIfNeeded()
+                    requestSignalsOnlyCollectionIfNeeded()
                 }
             }
             .store(in: &cancellables)
@@ -196,14 +203,20 @@ final class PageContextTabExtension {
                 guard let self else {
                     return
                 }
-                /// Only process the collection result when auto-collect is enabled or the user
-                /// explicitly requested context. Unsolicited results from the page script
-                /// should not overwrite previously attached context with nil.
-                guard self.isContextCollectionEnabled else {
-                    return
-                }
-                Task {
-                    await self.handle(pageContext)
+                /// Process full collection when auto-collect is enabled (or the user explicitly
+                /// requested context). When auto-collect is OFF but we requested a signals-only
+                /// collection, deliver just the page-type signals (content stripped). Otherwise
+                /// ignore unsolicited results so they can't overwrite attached context with nil.
+                if self.isContextCollectionEnabled {
+                    self.pendingSignalsOnlyCollection = false
+                    Task {
+                        await self.handle(pageContext)
+                    }
+                } else if self.pendingSignalsOnlyCollection {
+                    self.pendingSignalsOnlyCollection = false
+                    Task {
+                        await self.handleSignalsOnly(pageContext)
+                    }
                 }
             }
             .store(in: &userScriptCancellables)
@@ -257,6 +270,8 @@ final class PageContextTabExtension {
             return
         }
         shouldForceContextCollection = false
+        // Page-type signals (for duck.ai page shortcuts) ride the collected payload from
+        // Content-Scope-Scripts (includePageTypeSignals) and are preserved through favicon encoding.
         cachedPageContext = replaceFaviconURLWithEncodedData(pageContext)
         if let chatViewController = aiChatSessionStore.sessions[tabID]?.chatViewController {
             chatViewController.setPageContext(cachedPageContext)
@@ -427,8 +442,56 @@ final class PageContextTabExtension {
             content: pageContext.content,
             truncated: pageContext.truncated,
             fullContentLength: pageContext.fullContentLength,
-            attachable: pageContext.attachable
+            attachable: pageContext.attachable,
+            tabId: pageContext.tabId,
+            pageTypeSignals: pageContext.pageTypeSignals,
+            attached: pageContext.attached
         )
+    }
+
+    // MARK: - Page Type Signals (duck.ai page shortcuts)
+
+    /// When auto-attach is OFF, trigger a page-context collection solely to harvest
+    /// Content-Scope-Scripts page-type signals; the result is delivered as a signals-only payload
+    /// (content stripped) via `handleSignalsOnly`. No-op when auto-attach is ON (the full-content
+    /// path already carries the signals) or when off a real web page.
+    private func requestSignalsOnlyCollectionIfNeeded() {
+        guard featureFlagger.isFeatureOn(.aiChatPageContext),
+              featureFlagger.isFeatureOn(.sidebarSuggestedPrompts),
+              case .url = content,
+              !isContextCollectionEnabled,
+              aiChatSessionStore.sessions[tabID]?.chatViewController != nil,
+              let pageContextUserScript else {
+            return
+        }
+        pendingSignalsOnlyCollection = true
+        pageContextUserScript.collect()
+    }
+
+    /// Delivers a signals-only payload from a collected context: keeps the Content-Scope-Scripts
+    /// page-type signals + metadata, strips the page content, and marks `attached:false` /
+    /// `attachable:true` so the duck.ai web app shows page shortcuts plus the Ask-About-Page chip
+    /// without attaching content.
+    @MainActor
+    private func handleSignalsOnly(_ pageContext: AIChatPageContextData?) async {
+        guard featureFlagger.isFeatureOn(.aiChatPageContext),
+              let pageContext,
+              let session = aiChatSessionStore.sessions[tabID],
+              session.chatViewController != nil else {
+            return
+        }
+        let signalsOnly = AIChatPageContextData(
+            title: pageContext.title,
+            favicon: [],
+            url: pageContext.url,
+            content: "",
+            truncated: false,
+            fullContentLength: 0,
+            attachable: true,
+            pageTypeSignals: pageContext.pageTypeSignals,
+            attached: false
+        )
+        session.chatViewController?.setPageContext(signalsOnly)
     }
 }
 

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -138,7 +138,9 @@ final class PageContextTabExtension {
                 }
                 self.handleNavigationForMultipleContexts(from: previousContent, to: tabContent)
                 self.sendNonAttachableContextIfNeeded()
-                self.requestSignalsOnlyCollectionIfNeeded()
+                // Signals-only collection is driven from `navigationDidFinish` (post-load, parsed
+                // markup). Collecting here at didCommit too would race the post-load re-collect for
+                // the single-shot `pendingSignalsOnlyCollection` flag and let stale signals win.
             }
             .store(in: &cancellables)
 

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -503,7 +503,7 @@ final class PageContextTabExtension {
     }
 }
 
-protocol PageContextProtocol: AnyObject {
+protocol PageContextProtocol: AnyObject, NavigationResponder {
     /// Appends a user text selection to the sidebar's selection-context list. See the
     /// implementation in `PageContextTabExtension` for buffering/lifecycle semantics.
     @MainActor func appendSelectionContext(_ selection: AIChatSelectionContextData)
@@ -511,6 +511,18 @@ protocol PageContextProtocol: AnyObject {
 
 extension PageContextTabExtension: PageContextProtocol, TabExtension {
     func getPublicProtocol() -> PageContextProtocol { self }
+}
+
+extension PageContextTabExtension: NavigationResponder {
+    /// Re-collect page context once the new page has finished loading. The `Tab.$content` trigger
+    /// fires at `didCommit` — before the page's markup (JSON-LD / og:type) is parsed — so page-type
+    /// signals would otherwise reflect the previous page and the sidebar's suggestions wouldn't
+    /// update on same-tab navigation. Mirrors Windows' `NavigationCompleted` re-collect.
+    func navigationDidFinish(_ navigation: Navigation) {
+        guard !isLoadedInSidebar else { return }
+        collectPageContextIfNeeded()
+        requestSignalsOnlyCollectionIfNeeded()
+    }
 }
 
 extension TabExtensions {

--- a/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
@@ -137,14 +137,7 @@ final class UserScripts: UserScriptsProvider, ReleaseNotesUserScriptProvider {
                                            currentCohorts: currentCohorts,
                                            themeVariant: themeVariant)
         do {
-            let baseConfigGenerator = ContentScopePrivacyConfigurationJSONGenerator(featureFlagger: sourceProvider.featureFlagger, privacyConfigurationManager: sourceProvider.privacyConfigurationManager, excludedFeatures: [PrivacyFeature.autoconsent.rawValue])
-            // DRAFT: force-enable the C-S-S `pageContext.includePageTypeSignals` setting when the
-            // sidebar suggested-prompts flag is on, so page-type signals flow in test builds without a
-            // privacy-config change. Remove once remote privacy config ships `includePageTypeSignals`.
-            let configGenerator = PageTypeSignalsConfigInjector(
-                base: baseConfigGenerator,
-                isEnabled: sourceProvider.featureFlagger.isFeatureOn(.sidebarSuggestedPrompts)
-            )
+            let configGenerator = ContentScopePrivacyConfigurationJSONGenerator(featureFlagger: sourceProvider.featureFlagger, privacyConfigurationManager: sourceProvider.privacyConfigurationManager, excludedFeatures: [PrivacyFeature.autoconsent.rawValue])
             let isolatedConfigGenerator = ContentScopePrivacyConfigurationJSONGenerator(featureFlagger: sourceProvider.featureFlagger, privacyConfigurationManager: sourceProvider.privacyConfigurationManager)
             contentScopeUserScript = try ContentScopeUserScript(sourceProvider.privacyConfigurationManager, properties: prefs, scriptContext: .contentScope(surrogateTrackerData: sourceProvider.trackerProtectionDataSource?.surrogateFilteredTrackerData), allowedNonisolatedFeatures: [PageContextUserScript.featureName, "webCompat", TrackerProtectionSubfeature.featureNameValue], privacyConfigurationJSONGenerator: configGenerator)
             contentScopeUserScriptIsolated = try ContentScopeUserScript(sourceProvider.privacyConfigurationManager, properties: prefs, scriptContext: .contentScopeIsolated, privacyConfigurationJSONGenerator: isolatedConfigGenerator)
@@ -409,30 +402,5 @@ struct HomepageSearchModeSeedUserDefaultsPersistor: HomepageSearchModeSeedPersis
                 try? keyValueStore.removeObject(forKey: Key.pendingShowSearchModeToggle.rawValue)
             }
         }
-    }
-}
-
-/// DRAFT: wraps a privacy-config JSON generator to force-enable the Content-Scope-Scripts
-/// `pageContext.includePageTypeSignals` setting, so page-type signals are collected in test builds
-/// while the suggested-prompts feature is gated locally. Remove once remote privacy config ships the
-/// setting. No-op when `isEnabled` is false or the JSON can't be parsed (falls back to the base).
-private struct PageTypeSignalsConfigInjector: CustomisedPrivacyConfigurationJSONGenerating {
-    let base: CustomisedPrivacyConfigurationJSONGenerating
-    let isEnabled: Bool
-
-    var privacyConfiguration: Data? {
-        let baseData = base.privacyConfiguration
-        guard isEnabled, let data = baseData,
-              var root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
-            return baseData
-        }
-        var features = (root["features"] as? [String: Any]) ?? [:]
-        var pageContext = (features["pageContext"] as? [String: Any]) ?? ["state": "enabled", "exceptions": [Any]()]
-        var settings = (pageContext["settings"] as? [String: Any]) ?? [:]
-        settings["includePageTypeSignals"] = "enabled"
-        pageContext["settings"] = settings
-        features["pageContext"] = pageContext
-        root["features"] = features
-        return (try? JSONSerialization.data(withJSONObject: root)) ?? baseData
     }
 }

--- a/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
@@ -137,7 +137,14 @@ final class UserScripts: UserScriptsProvider, ReleaseNotesUserScriptProvider {
                                            currentCohorts: currentCohorts,
                                            themeVariant: themeVariant)
         do {
-            let configGenerator = ContentScopePrivacyConfigurationJSONGenerator(featureFlagger: sourceProvider.featureFlagger, privacyConfigurationManager: sourceProvider.privacyConfigurationManager, excludedFeatures: [PrivacyFeature.autoconsent.rawValue])
+            let baseConfigGenerator = ContentScopePrivacyConfigurationJSONGenerator(featureFlagger: sourceProvider.featureFlagger, privacyConfigurationManager: sourceProvider.privacyConfigurationManager, excludedFeatures: [PrivacyFeature.autoconsent.rawValue])
+            // DRAFT: force-enable the C-S-S `pageContext.includePageTypeSignals` setting when the
+            // sidebar suggested-prompts flag is on, so page-type signals flow in test builds without a
+            // privacy-config change. Remove once remote privacy config ships `includePageTypeSignals`.
+            let configGenerator = PageTypeSignalsConfigInjector(
+                base: baseConfigGenerator,
+                isEnabled: sourceProvider.featureFlagger.isFeatureOn(.sidebarSuggestedPrompts)
+            )
             let isolatedConfigGenerator = ContentScopePrivacyConfigurationJSONGenerator(featureFlagger: sourceProvider.featureFlagger, privacyConfigurationManager: sourceProvider.privacyConfigurationManager)
             contentScopeUserScript = try ContentScopeUserScript(sourceProvider.privacyConfigurationManager, properties: prefs, scriptContext: .contentScope(surrogateTrackerData: sourceProvider.trackerProtectionDataSource?.surrogateFilteredTrackerData), allowedNonisolatedFeatures: [PageContextUserScript.featureName, "webCompat", TrackerProtectionSubfeature.featureNameValue], privacyConfigurationJSONGenerator: configGenerator)
             contentScopeUserScriptIsolated = try ContentScopeUserScript(sourceProvider.privacyConfigurationManager, properties: prefs, scriptContext: .contentScopeIsolated, privacyConfigurationJSONGenerator: isolatedConfigGenerator)
@@ -402,5 +409,30 @@ struct HomepageSearchModeSeedUserDefaultsPersistor: HomepageSearchModeSeedPersis
                 try? keyValueStore.removeObject(forKey: Key.pendingShowSearchModeToggle.rawValue)
             }
         }
+    }
+}
+
+/// DRAFT: wraps a privacy-config JSON generator to force-enable the Content-Scope-Scripts
+/// `pageContext.includePageTypeSignals` setting, so page-type signals are collected in test builds
+/// while the suggested-prompts feature is gated locally. Remove once remote privacy config ships the
+/// setting. No-op when `isEnabled` is false or the JSON can't be parsed (falls back to the base).
+private struct PageTypeSignalsConfigInjector: CustomisedPrivacyConfigurationJSONGenerating {
+    let base: CustomisedPrivacyConfigurationJSONGenerating
+    let isEnabled: Bool
+
+    var privacyConfiguration: Data? {
+        let baseData = base.privacyConfiguration
+        guard isEnabled, let data = baseData,
+              var root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+            return baseData
+        }
+        var features = (root["features"] as? [String: Any]) ?? [:]
+        var pageContext = (features["pageContext"] as? [String: Any]) ?? ["state": "enabled", "exceptions": [Any]()]
+        var settings = (pageContext["settings"] as? [String: Any]) ?? [:]
+        settings["includePageTypeSignals"] = "enabled"
+        pageContext["settings"] = settings
+        features["pageContext"] = pageContext
+        root["features"] = features
+        return (try? JSONSerialization.data(withJSONObject: root)) ?? baseData
     }
 }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -345,6 +345,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213279513677422
     case aiChatSidebarFloating
 
+    /// Context-aware page suggestions in the Duck.ai sidebar (macOS MVP).
+    case sidebarSuggestedPrompts
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213610208091978?focus=true
     case aiChatChromeSidebar
 
@@ -670,6 +673,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(AIChatSubfeature.ntpAttachMoreTabs), category: .duckAI)
         case .aiChatSidebarFloating:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.sidebarFloating), category: .duckAI)
+        case .sidebarSuggestedPrompts:
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.sidebarSuggestedPrompts), category: .duckAI)
         case .aiChatChromeSidebar:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.sidebar), category: .duckAI)
         case .webViewLookUpAction:

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -345,7 +345,7 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213279513677422
     case aiChatSidebarFloating
 
-    /// Context-aware page suggestions in the Duck.ai sidebar (macOS MVP).
+    /// https://app.asana.com/1/137249556945/project/1204006570077678/task/1213651763438251
     case sidebarSuggestedPrompts
 
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213610208091978?focus=true

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_pixels.json5
@@ -96,21 +96,22 @@
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
-    "m_mac_aichat_suggestion_invoked": {
-        "description": "Fired when the user taps a page suggestion in Duck.ai (a tailored prompt or \"Ask about this page\")",
+    "m_mac_aichat_suggestion_selected": {
+        "description": "Fired when the user taps a sidebar page-suggestion chip (including ask-about-page, which only attaches the page and does not submit a prompt)",
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
+        "suffixes": ["first_daily_count"],
         "parameters": [
             "appVersion",
             "pixelSource",
             {
-                "key": "suggestion",
-                "description": "Fixed catalog key identifying which suggestion was tapped (e.g. summarize-page, translate-page, ask-about-page)",
+                "key": "suggestionId",
+                "description": "Catalog key of the selected suggestion (e.g. summarize-page, translate-page, ask-about-page). Bounded and PII-free.",
                 "type": "string"
             },
             {
-                "key": "page_type",
-                "description": "Coarse page classification derived by the FE from JSON-LD/OpenGraph (never the URL, domain, or content)",
+                "key": "pageType",
+                "description": "Coarse page-type bucket the frontend computes from page-type signals. Never a URL, domain or page content.",
                 "type": "string",
                 "enum": [
                     "recipe",

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_pixels.json5
@@ -96,6 +96,44 @@
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
+    "m_mac_aichat_suggestion_invoked": {
+        "description": "Fired when the user taps a page suggestion in Duck.ai (a tailored prompt or \"Ask about this page\")",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "suggestion",
+                "description": "Fixed catalog key identifying which suggestion was tapped (e.g. summarize-page, translate-page, ask-about-page)",
+                "type": "string"
+            },
+            {
+                "key": "page_type",
+                "description": "Coarse page classification derived by the FE from JSON-LD/OpenGraph (never the URL, domain, or content)",
+                "type": "string",
+                "enum": [
+                    "recipe",
+                    "product",
+                    "article",
+                    "video",
+                    "job",
+                    "book",
+                    "event",
+                    "place",
+                    "forum",
+                    "code",
+                    "course",
+                    "review",
+                    "person",
+                    "howto",
+                    "faq",
+                    "none"
+                ]
+            },
+            "channel"
+        ]
+    },
     "m_mac_aichat_sidebar_resized": {
         "description": "Fired when user finishes dragging the sidebar resize grip (after 500 ms debounce)",
         "owners": ["jaceklyp"],

--- a/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
@@ -335,7 +335,7 @@ final class MockAIChatUserScriptHandler: AIChatUserScriptHandling {
         return nil
     }
 
-    func getAIChatPageContext(params: Any, message: any UserScriptMessage) -> (any Encodable)? {
+    func getAIChatPageContext(params: Any, message: any UserScriptMessage) async -> (any Encodable)? {
         didGetAIChatPageContext = true
         return nil
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1215970469826760?focus=true
Tech Design URL:
CC:

### Description
Wires the native side to show suggestions in the sidebar.

### Testing Steps
1. Run the app
2. Open the Debug menu and go to AI Chat and tap on Web Communication and Set Custom URL
3. Add this URL as the new one → https://euw-serp-dev-testing20.duck.ai/
4. Open the Debug menu and set the Remote Configuration URL to be: https://webhook.site/token/c69ecef0-5f06-4974-b89c-c4f4733ae9eb/request/f443e04a-e594-48e5-b1b4-113322dc8f74/raw
5. Open https://www.imdb.com/title/tt32093575 and then the sidebar
6. You should see suggestions similar to the image

<img width="1624" height="1061" alt="movie" src="https://github.com/user-attachments/assets/77dab5b3-5786-4fc5-b475-26047ac097ef” />


### Impact and Risks
Low: Minor visual changes, most of fixes are done in the FE.

#### What could go wrong?
Nothing specific, the code is behind a FF.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
FE work is still ongoing.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Medium Risk**
> Changes page-context collection and delivery timing (navigation finish, auto-attach off, user-action pulls), which could affect existing sidebar attach behavior; mitigated by feature flags and backward-compatible optional JSON fields.
> 
> **Overview**
> Adds native support for **page-tailored suggestion chips** in the Duck.ai sidebar, gated by **`sidebarSuggestedPrompts`** (with **`aiChatPageContext`**) and advertised to the web app via **`supportsSuggestions`**.
> 
> **Page context wire format** gains **`AIChatPageTypeSignals`** (JSON-LD types, `og:type`, `lang`) plus optional **`attached`** so the FE can distinguish full content vs **signals-only** payloads when auto-attach is off. **`getAIChatPageContext`** now triggers a fresh collection on **`userAction`** when only signals (or no content) are cached, so tapping a suggestion or Ask-About-Page can attach real page content.
> 
> **`PageContextTabExtension`** collects signals-only when auto-attach is disabled, re-delivers context when the sidebar chat VC appears, and re-collects on **`navigationDidFinish`** so suggestions update after markup loads. **Content-scope-scripts** is bumped to **15.3.0**.
> 
> **Metrics:** new **`userDidSelectSuggestion`** / **`m_mac_aichat_suggestion_selected`** with `suggestionId` and `pageType`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aae3f2bd5a9a764f11567d9b0b4fb7761e5f1d7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how page context is collected and delivered (navigation finish, signals-only vs full attach, async user-action fetch), which could affect existing sidebar attach behavior; mitigated by feature flags and backward-compatible optional JSON fields.
> 
> **Overview**
> Adds **macOS native plumbing** so the Duck.ai sidebar can show **page-tailored suggestion chips**, behind **`sidebarSuggestedPrompts`** (with page context) and exposed to the web app as **`supportsSuggestions`**.
> 
> **Shared contract:** New **`AIChatPageTypeSignals`** and optional **`pageTypeSignals` / `attached`** on **`AIChatPageContextData`** let the FE tell full page content from **signals-only** payloads (metadata + JSON-LD/OG hints, no body) when auto-attach is off. **`getAIChatPageContext`** is now **async** and, on **`userAction`**, waits for a fresh collection when only signals are cached so tapping a suggestion or Ask-about-page can return attached content in the same response.
> 
> **Tab / sidebar behavior:** **`PageContextTabExtension`** drives signals-only collection when auto-attach is disabled, re-delivers context when the chat VC appears, and re-collects on **`navigationDidFinish`** so suggestions match the loaded page. Content-scope-scripts is bumped to **15.3.0**.
> 
> **Telemetry:** **`userDidSelectSuggestion`** metric and **`m_mac_aichat_suggestion_selected`** pixel with **`suggestionId`** and **`pageType`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a0be97a73817df56cfb9bb65a02658a5336a2c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->