### PR TITLE
[iPad] Improve tabs bar scroll to the selected tab

### DIFF
--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -303,7 +303,7 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
         if scrollToSelected {
             DispatchQueue.main.async {
                 if let currentIndex = self.currentIndex {
-                    self.collectionView.scrollToItem(at: IndexPath(row: currentIndex, section: 0), at: .right, animated: true)
+                    self.collectionView.scrollToItem(at: IndexPath(row: currentIndex, section: 0), at: [], animated: true)
                 }
             }
         }
@@ -473,7 +473,7 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
         }
         DispatchQueue.main.async {
             if let currentIndex = self.currentIndex {
-                self.collectionView.scrollToItem(at: IndexPath(row: currentIndex, section: 0), at: .right, animated: true)
+                self.collectionView.scrollToItem(at: IndexPath(row: currentIndex, section: 0), at: [], animated: true)
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1213689230070668?focus=true
Tech Design URL:
CC:

### Description
On iPad the tabs bar scrolled to the selected tab using `scrollToItem(at: .right)`, which pins the selected tab to the right edge every time. With enough tabs to make the strip scroll, this meant switching back and forth between two visible tabs re-scrolled the bar on each switch, and a newly opened tab could land off-screen.

Both scroll-to-selected sites (the `refresh(scrollToSelected:)` branch and `requestNewTab`) now use the empty scroll position, `scrollToItem(at: [], animated: true)`, which scrolls the minimum needed to reveal the tab: a no-op when it is already fully visible, and a minimal reveal when it is off-screen.

### Testing Steps
1. On iPad, open enough tabs that the tabs bar scrolls.
2. With two tabs that are both visible, switch between them repeatedly, verify the bar no longer scrolls/jumps on each switch.
3. Select a tab that is currently off-screen, verify the bar scrolls it just into view rather than pinning it to the right edge.
4. Open a link in a new tab (for example via open-in-new-tab or an external link), verify the new selected tab is visible in the strip.

### Impact and Risks
Low. iPad tabs bar only, and only the scroll alignment used when scrolling to the selected tab changes.

#### What could go wrong?
— 

### Quality Considerations
N/A

### Notes to Reviewer
--

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> iPad-only tabs bar scrolling behavior; no auth, data, or API changes.
> 
> **Overview**
> On iPad, when the tabs strip scrolls to the selected tab, **`scrollToItem` no longer uses `.right` alignment** in `refresh(scrollToSelected:)` and after **`requestNewTab`**. Both call sites now pass an **empty scroll position** (`at: []`), consistent with `scrollCurrentTabIntoView()`.
> 
> That change stops pinning the active tab to the right edge on every selection or new tab, so switching between already-visible tabs should not re-scroll the bar, and off-screen tabs should scroll in with the **minimum offset** needed to become visible instead of jumping to the trailing edge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7ceb21f54f89d704a87fdf02192657b8e385906. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->