### PR TITLE
[macOS] Fix bookmarks bar submenu closing on favicon cache update

### DIFF
--- a/macOS/DuckDuckGo/Bookmarks/View/BookmarkOutlineCellView.swift
+++ b/macOS/DuckDuckGo/Bookmarks/View/BookmarkOutlineCellView.swift
@@ -368,6 +368,16 @@ final class BookmarkOutlineCellView: NSTableCellView {
         updateConstraints(isSearch: isSearch)
     }
 
+    /// Upgrades the displayed favicon in place to the latest cached image, if one is available.
+    ///
+    /// Used by the bookmarks bar menu to reflect lazily-decoded favicons without a full
+    /// `reloadData()` — a reload while a submenu is open dismisses the submenu and flickers the
+    /// menu. Never downgrades an already-shown favicon back to the placeholder on a transient miss.
+    func refreshFavicon(for bookmark: Bookmark) {
+        guard let favicon = bookmark.favicon(.small) else { return }
+        faviconImageView.image = favicon
+    }
+
     func update(from folder: BookmarkFolder, isSearch: Bool = false) {
         faviconImageView.image = theme.iconsProvider.bookmarksIconsProvider.bookmarkFolderColorIcon
         faviconImageView.isHidden = false

--- a/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarMenuViewController.swift
+++ b/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarMenuViewController.swift
@@ -263,8 +263,8 @@ final class BookmarksBarMenuViewController: NSViewController {
             }
             .store(in: &cancellables)
 
-        // Favicon images are decoded lazily; reload when an image becomes available for a bookmark
-        // currently shown in this menu so it isn't stuck on the letter placeholder.
+        // Favicon images are decoded lazily; when new favicons are available, refresh cells in place.
+        // We aren't calling `reloadData()` as a full reload would dismiss the submenu.
         NotificationCenter.default.publisher(for: .faviconCacheUpdated)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] notification in
@@ -273,7 +273,7 @@ final class BookmarksBarMenuViewController: NSViewController {
                    update.hosts.isDisjoint(with: self.bookmarkManager.allHosts()) {
                     return
                 }
-                self.reloadData()
+                self.refreshVisibleFavicons()
             }
             .store(in: &cancellables)
 
@@ -517,6 +517,20 @@ final class BookmarksBarMenuViewController: NSViewController {
 
         if outlineView.numberOfRows > 0 {
             updateHighlightedRowAfterReload(isChangingRootFolder: isChangingRootFolder)
+        }
+    }
+
+    /// Refresh favicons in place for the currently visible bookmark rows, without a full `reloadData()`.
+    private func refreshVisibleFavicons() {
+        let visibleRows = outlineView.rows(in: outlineView.visibleRect)
+        guard visibleRows.length > 0 else { return }
+        for row in visibleRows.location..<(visibleRows.location + visibleRows.length) {
+            guard let node = outlineView.item(atRow: row) as? BookmarkNode,
+                  let bookmark = node.representedObject as? Bookmark,
+                  let cell = outlineView.view(atColumn: 0, row: row, makeIfNecessary: false) as? BookmarkOutlineCellView else {
+                continue
+            }
+            cell.refreshFavicon(for: bookmark)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1199230911884351/task/1215999008194803?focus=true

### Description
Fix bookmarks bar sub-folder menus occasionally closing when a favicon finishes loading.
We're switching from calling reloadData() to reloading individual favicon views in visible cells
to avoid side effects like removing selection from the view or closing the entire menu.

### Testing Steps
1. Have bookmarks tree with sub-folders.
2. Hover over a sub-folder in the bookmarks bar to open its menu.
3. Verify that after sub-folder favicons get loaded, the sub-folder menu doesn't get closed.

### Impact and Risks
Low. Bookmarks-bar menu rendering only — changes how the menu reacts to favicon-cache updates (in-place upgrade vs. full reload). No change to favicon fetching, storage, bookmark data, or privacy.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bookmarks bar menu UI only; favicon fetch/storage and bookmark data are unchanged. In-place refresh may leave a stale icon until the next reload if a favicon is explicitly removed from cache.
> 
> **Overview**
> Fixes bookmarks bar **folder submenus closing** when lazy favicon decoding posts `.faviconCacheUpdated`. That observer used to call **`reloadData()`**, which reset highlight/submenu state and dismissed open submenus.
> 
> On favicon cache updates (still gated by the existing host filter), the menu now calls **`refreshVisibleFavicons()`** instead: it walks **visible outline rows** and updates bookmark cells via new **`BookmarkOutlineCellView.refreshFavicon(for:)`**, which only **upgrades** the icon when a cached image exists—no placeholder downgrade on a miss.
> 
> Bookmark list changes still reload through **`listPublisher`**; only the favicon-notification path changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d8b6cc16555df7f8f0f60bc4657c302062714fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->