### PR TITLE
[iOS][macOS] Improve Malicious Site Protection instrumentation

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/MaliciousSiteProtection/Model/Event.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/MaliciousSiteProtection/Model/Event.swift
@@ -39,6 +39,7 @@ public extension PixelKit {
 public enum Event: PixelKitEvent {
     case errorPageShown(category: ThreatKind, clientSideHit: Bool?)
     case visitSite(category: ThreatKind)
+    case leaveSite(category: ThreatKind)
     case iframeLoaded(category: ThreatKind)
     case settingToggled(to: Bool)
     case matchesApiTimeout
@@ -57,6 +58,8 @@ public enum Event: PixelKitEvent {
             return "malicious-site-protection_error-page-shown"
         case .visitSite:
             return "malicious-site-protection_visit-site"
+        case .leaveSite:
+            return "malicious-site-protection_leave-site"
         case .iframeLoaded:
             return "malicious-site-protection_iframe-loaded"
         case .settingToggled:
@@ -95,7 +98,8 @@ public enum Event: PixelKitEvent {
             }
             return parameters
         case .visitSite(category: let category),
-             .iframeLoaded(category: let category):
+                .leaveSite(category: let category),
+                .iframeLoaded(category: let category):
             return [
                 PixelKit.Parameters.category: category.rawValue,
             ]
@@ -151,6 +155,7 @@ public enum Event: PixelKitEvent {
         #if os(iOS)
         case .errorPageShown,
                 .visitSite,
+                .leaveSite,
                 .iframeLoaded,
                 .settingToggled,
                 .matchesApiTimeout,
@@ -164,6 +169,7 @@ public enum Event: PixelKitEvent {
         #else
         case .errorPageShown,
                 .visitSite,
+                .leaveSite,
                 .iframeLoaded,
                 .settingToggled,
                 .matchesApiTimeout,

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -4098,6 +4098,7 @@ public extension Pixel.Event {
     enum MaliciousSiteProtectionEvent: Equatable {
         case errorPageShown(category: ThreatKind, clientSideHit: Bool?)
         case visitSite(category: ThreatKind)
+        case leaveSite(category: ThreatKind)
         case iframeLoaded(category: ThreatKind)
         case settingToggled(to: Bool)
         case matchesApiTimeout
@@ -4113,6 +4114,8 @@ public extension Pixel.Event {
                 self = .errorPageShown(category: category, clientSideHit: clientSideHit)
             case .visitSite(category: let category):
                 self = .visitSite(category: category)
+            case .leaveSite(category: let category):
+                self = .leaveSite(category: category)
             case .iframeLoaded(category: let category):
                 self = .iframeLoaded(category: category)
             case .settingToggled(let enabled):
@@ -4140,6 +4143,8 @@ public extension Pixel.Event {
                 return MaliciousSiteProtection.Event.errorPageShown(category: category, clientSideHit: clientSideHit)
             case .visitSite(let category):
                 return MaliciousSiteProtection.Event.visitSite(category: category)
+            case .leaveSite(category: let category):
+                return MaliciousSiteProtection.Event.leaveSite(category: category)
             case .iframeLoaded(let category):
                 return MaliciousSiteProtection.Event.iframeLoaded(category: category)
             case .settingToggled(let enabled):

--- a/iOS/DuckDuckGo/MaliciousSiteProtection/Events/MaliciousSiteProtection+Pixel.swift
+++ b/iOS/DuckDuckGo/MaliciousSiteProtection/Events/MaliciousSiteProtection+Pixel.swift
@@ -33,4 +33,9 @@ extension Pixel {
         DailyPixel.fireDailyAndCount(pixel: .maliciousSiteProtection(event: convertedPixelEvent), withAdditionalParameters: convertedPixelEvent.parameters)
     }
 
+    static func fireDailyAndStandard(_ event: MaliciousSiteProtection.Event) {
+        guard let convertedPixelEvent = Event.MaliciousSiteProtectionEvent(event) else { return }
+        DailyPixel.fireDailyAndCount(pixel: .maliciousSiteProtection(event: convertedPixelEvent), pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes, withAdditionalParameters: convertedPixelEvent.parameters)
+    }
+
 }

--- a/iOS/DuckDuckGo/MaliciousSiteProtection/Events/MaliciousSiteProtectionEventMapper.swift
+++ b/iOS/DuckDuckGo/MaliciousSiteProtection/Events/MaliciousSiteProtectionEventMapper.swift
@@ -27,8 +27,10 @@ enum MaliciousSiteProtectionEventMapper {
 
     static let debugEvents = EventMapping<MaliciousSiteProtection.Event> { event, _, _, _ in
         switch event {
-        case .errorPageShown,
-             .visitSite,
+        case .errorPageShown:
+            Pixel.fireDailyAndStandard(event)
+        case .visitSite,
+             .leaveSite,
              .iframeLoaded,
              .settingToggled,
              .matchesApiTimeout,

--- a/iOS/DuckDuckGo/SpecialErrorPage/SpecialErrorPageInterfaces/SpecialErrorPageActionHandler.swift
+++ b/iOS/DuckDuckGo/SpecialErrorPage/SpecialErrorPageInterfaces/SpecialErrorPageActionHandler.swift
@@ -38,6 +38,12 @@ protocol SpecialErrorPageActionHandler {
     func visitSite()
 
     /// Handles the action of leaving the site associated with the error page
+    /// - Parameters:
+    ///  - errorData: The special error information.
+    @MainActor
+    func leaveSite(errorData: SpecialErrorData)
+
+    /// Handles the action of leaving the site associated with the error page
     @MainActor
     func leaveSite()
 
@@ -51,5 +57,9 @@ extension SpecialErrorPageActionHandler {
     func visitSite(url: URL, errorData: SpecialErrorData) { }
 
     func visitSite() { }
+
+    func leaveSite(errorData: SpecialErrorData) {}
+
+    func leaveSite() { }
 
 }

--- a/iOS/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler+MaliciousSite.swift
+++ b/iOS/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler+MaliciousSite.swift
@@ -154,7 +154,14 @@ extension MaliciousSiteProtectionNavigationHandler: SpecialErrorPageActionHandle
         Pixel.fire(MaliciousSiteProtection.Event.visitSite(category: threatKind))
     }
 
-    func leaveSite() { }
+    func leaveSite(errorData: SpecialErrorData) {
+        guard let threatKind = errorData.threatKind else {
+            assertionFailure("Error Data should have a threat kind")
+            return
+        }
+
+        Pixel.fire(MaliciousSiteProtection.Event.leaveSite(category: threatKind))
+    }
 
     func advancedInfoPresented() { }
 

--- a/iOS/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler.swift
+++ b/iOS/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler.swift
@@ -156,7 +156,7 @@ extension SpecialErrorPageNavigationHandler: SpecialErrorPageUserScriptDelegate 
             sslErrorPageNavigationHandler.leaveSite()
             navigateBackIfPossible()
         case .maliciousSite:
-            maliciousSiteProtectionNavigationHandler.leaveSite()
+            maliciousSiteProtectionNavigationHandler.leaveSite(errorData: errorData)
             closeTab(shouldCreateNewTab: true)
         }
     }

--- a/iOS/DuckDuckGoTests/SpecialErrorPage/SpecialErrorPageNavigationHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/SpecialErrorPage/SpecialErrorPageNavigationHandlerTests.swift
@@ -246,12 +246,14 @@ final class SpecialErrorPageNavigationHandlerTests {
         _ = await sut.handleDecidePolicy(for: navigationResponse, webView: webView)
 
         #expect(!maliciousSiteProtectionNavigationHandler.didCallLeaveSite)
+        #expect(maliciousSiteProtectionNavigationHandler.capturedLeaveSiteErrorData == nil)
 
         // WHEN
         sut.leaveSiteAction()
 
         // THEN
         #expect(maliciousSiteProtectionNavigationHandler.didCallLeaveSite)
+        #expect(maliciousSiteProtectionNavigationHandler.capturedLeaveSiteErrorData == errorData)
     }
 
     @MainActor

--- a/iOS/DuckDuckGoTests/SpecialErrorPage/TestDoubles/MockMaliciousSiteProtectionNavigationHandler.swift
+++ b/iOS/DuckDuckGoTests/SpecialErrorPage/TestDoubles/MockMaliciousSiteProtectionNavigationHandler.swift
@@ -37,6 +37,7 @@ final class MockMaliciousSiteProtectionNavigationHandler: MaliciousSiteProtectio
     private(set) var capturedErrorData: SpecialErrorData?
 
     private(set) var didCallLeaveSite = false
+    private(set) var capturedLeaveSiteErrorData: SpecialErrorData?
 
     private(set) var didCallAdvancedInfoPresented = false
 
@@ -73,8 +74,9 @@ final class MockMaliciousSiteProtectionNavigationHandler: MaliciousSiteProtectio
         capturedErrorData = errorData
     }
     
-    func leaveSite() {
+    func leaveSite(errorData: SpecialErrorData) {
         didCallLeaveSite = true
+        capturedLeaveSiteErrorData = errorData
     }
     
     func advancedInfoPresented() {

--- a/iOS/PixelDefinitions/pixels/definitions/malicious_site_protection.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/malicious_site_protection.json5
@@ -1,0 +1,40 @@
+{
+    "m_malicious-site-protection_error-page-shown": {
+        "description": "Fires when the Malicious Site Protection error page is shown to the user, blocking a navigation to a known phishing, malware, or scam site.",
+        "owners": ["alessandroboron"],
+        "triggers": ["other"],
+        "suffixes": ["daily_standard", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "category",
+                "description": "Threat category that triggered the error page.",
+                "type": "string",
+                "enum": ["phishing", "malware", "scam"]
+            },
+            {
+                "key": "clientSideHit",
+                "description": "Whether the threat was detected client-side (true) or via the matches API (false). Omitted when not applicable.",
+                "type": "boolean",
+                "enum": [true, false]
+            }
+        ]
+    },
+    "m_malicious-site-protection_leave-site": {
+        "description": "Fires when the user taps \"Leave Site\" on the Malicious Site Protection error page.",
+        "owners": ["alessandroboron"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "category",
+                "description": "Threat category of the error page the user left.",
+                "type": "string",
+                "enum": ["phishing", "malware", "scam"]
+            }
+        ]
+    }
+}

--- a/macOS/DuckDuckGo/MaliciousSiteProtection/MaliciousSiteProtectionManager.swift
+++ b/macOS/DuckDuckGo/MaliciousSiteProtection/MaliciousSiteProtectionManager.swift
@@ -158,8 +158,10 @@ public class MaliciousSiteProtectionManager: MaliciousSiteDetecting {
 
     private static let debugEvents = EventMapping<MaliciousSiteProtection.Event> { event, _, _, _ in
         switch event {
-        case .errorPageShown,
-             .visitSite,
+        case .errorPageShown:
+            PixelKit.fire(event, frequency: .dailyAndStandard)
+        case .visitSite,
+             .leaveSite,
              .iframeLoaded,
              .settingToggled,
              .matchesApiTimeout:

--- a/macOS/DuckDuckGo/Tab/TabExtensions/SpecialErrorPageTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/SpecialErrorPageTabExtension.swift
@@ -213,7 +213,8 @@ extension SpecialErrorPageTabExtension: SpecialErrorPageUserScriptDelegate {
     func leaveSiteAction() {
         guard let errorData, let webView else { return }
         switch errorData {
-        case .maliciousSite:
+        case .maliciousSite(let threatKind, _):
+            PixelKit.fire(MaliciousSiteProtection.Event.leaveSite(category: threatKind))
             closeAndOpenNewTab()
         case .ssl:
             if webView.canGoBack {

--- a/macOS/PixelDefinitions/pixels/definitions/malicious_site_protection.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/malicious_site_protection.json5
@@ -1,0 +1,41 @@
+{
+    "m_mac_malicious-site-protection_error-page-shown": {
+        "description": "Fires when the Malicious Site Protection error page is shown to the user, blocking a navigation to a known phishing, malware, or scam site.",
+        "owners": ["alessandroboron"],
+        "triggers": ["other"],
+        "suffixes": ["daily_standard"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "category",
+                "description": "Threat category that triggered the error page.",
+                "type": "string",
+                "enum": ["phishing", "malware", "scam"]
+            },
+            {
+                "key": "clientSideHit",
+                "description": "Whether the threat was detected client-side (true) or via the matches API (false). Omitted when not applicable.",
+                "type": "boolean",
+                "enum": [true, false]
+            }
+        ]
+    },
+    "m_mac_malicious-site-protection_leave-site": {
+        "description": "Fires when the user taps \"Leave Site\" on the Malicious Site Protection error page.",
+        "owners": ["alessandroboron"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "category",
+                "description": "Threat category of the error page the user left.",
+                "type": "string",
+                "enum": ["phishing", "malware", "scam"]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1215833647066431?focus=true
Tech Design URL:
CC:

### Description

This PR improve instrumentation for Malicious Site Protection:

`error-page-shown` (daily + standard): fires when the MSP error page is shown to the user. This was previously measured as a standard pixel; now it also fires a daily companion to measure the volume of impacted users.

`leave-site`: fires when the user taps "Leave Site" on the malicious site error page, carrying the threat category (phishing/malware/scam).

### Testing Steps
1. Build and run the app (iOS or macOS).
2. Navigate to a known phishing/malware/scam URL using https://privacy-test-pages.site/security/badware/phishing.html.
3. Verify `malicious-site-protection_error-page-shown` fires (daily + standard suffix).
4. Tap "Leave Site" and verify `malicious-site-protection_leave-site` fires with the correct category parameter.

### Impact and Risks
**Low:** Pixels only; no user-facing behavior changes.

### Quality Considerations
Added test to verify the error data is passed through correctly.

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to pixel wiring and definitions; no security, data, or user-facing navigation logic changes beyond firing analytics.
> 
> **Overview**
> Improves **Malicious Site Protection** analytics on iOS and macOS without changing blocking or navigation behavior.
> 
> **`error-page-shown`** now fires as **daily + standard** (via `fireDailyAndStandard` / `PixelKit.fire(..., frequency: .dailyAndStandard)`) so volume and unique impacted users can both be measured; it was previously a standard-only pixel in the event mappers.
> 
> Adds a new **`leave-site`** pixel (`malicious-site-protection_leave-site`) with **threat category** when the user taps Leave Site on the MSP error page. Shared BSK defines `Event.leaveSite(category:)`, iOS maps it through `Pixel.Event.MaliciousSiteProtectionEvent`, and handlers take **`leaveSite(errorData:)`** so category comes from `SpecialErrorData` (macOS fires from the tab extension when dismissing a malicious-site error).
> 
> New **pixel definition JSON5** documents both events for iOS and macOS. Tests assert malicious-site leave passes **`errorData`** through to the navigation handler mock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 634c29fa3038945d6029827128a565ce9cfa6811. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->