### PR TITLE
Pass error to configuration fetch error pixel

### DIFF
--- a/macOS/DuckDuckGo/Configuration/ConfigurationManager.swift
+++ b/macOS/DuckDuckGo/Configuration/ConfigurationManager.swift
@@ -186,7 +186,7 @@ final class ConfigurationManager: DefaultConfigurationManager {
         }
 
         Logger.config.error("Failed to complete configuration update \(error.localizedDescription, privacy: .public)")
-        PixelKit.fire(DebugEvent(GeneralPixel.configurationFetchError(error: error)))
+        PixelKit.fire(DebugEvent(GeneralPixel.configurationFetchError(error: error), error: error))
         tryAgainSoon()
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1216027084333021?focus=true

### Testing Steps
1. Trigger privacy config fetch error
2. Verify that pixel parameters contain error.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line telemetry change with no logic or retry behavior changes.
> 
> **Overview**
> When a remote configuration refresh fails (except expected **304** responses), the **`configurationFetchError`** debug pixel now includes the **`error:`** argument on **`DebugEvent`**, matching how other configuration debug events are reported in the same file.
> 
> This enriches pixel parameters with the underlying fetch failure for internal diagnostics; behavior of retries and 304 suppression is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ebb846b341ebbc348ceff82128c7ad4552f818c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->