### PR TITLE
Remove minimalChromeInLandscape feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -274,8 +274,6 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
 
     case screenTimeCleaning
 
-    case minimalChromeInLandscape
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215448831345663?focus=true
     case bottomBarViewportFixedElementsWorkaround
 

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -442,9 +442,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213763338305579?focus=true
     case aiChatContextualFireButton
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213809475913723?focus=true
-    case minimalChromeInLandscape
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215448831345663?focus=true
     case bottomBarViewportFixedElementsWorkaround
 
@@ -822,8 +819,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.screenTimeCleaning))
         case .aiChatContextualFireButton:
             Config(source: .remoteReleasable(AIChatSubfeature.contextualFireButton))
-        case .minimalChromeInLandscape:
-            Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.minimalChromeInLandscape))
         case .bottomBarViewportFixedElementsWorkaround:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.bottomBarViewportFixedElementsWorkaround))
         case .aiChatNativeStorage:

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2472,7 +2472,7 @@ class MainViewController: UIViewController {
         isUTIRotating = true
 
         let isKeyboardShowing = omniBar.isTextFieldEditing
-        if isKeyboardShowing && !AppWidthObserver.shared.isPad && minimalChromeSettings.isFeatureEnabled {
+        if isKeyboardShowing && !AppWidthObserver.shared.isPad {
             omniBar.barView.textField.suppressResignFirstResponder = true
         }
 
@@ -2489,7 +2489,6 @@ class MainViewController: UIViewController {
         }()
 
         let needsWidthUpdate = AppWidthObserver.shared.willResize(toWidth: size.width)
-            && (AppWidthObserver.shared.isPad || isInMinimalChromeLayout || minimalChromeSettings.isFeatureEnabled)
         if needsWidthUpdate {
             applyWidth(for: size)
         }

--- a/iOS/DuckDuckGo/MinimalChromeSettings.swift
+++ b/iOS/DuckDuckGo/MinimalChromeSettings.swift
@@ -18,31 +18,21 @@
 //
 
 import Foundation
-import PrivacyConfig
 
 protocol MinimalChromeSettingsProviding {
 
-    var isFeatureEnabled: Bool { get }
     func shouldApplyMinimalChrome(isCurrentTabAITab: Bool) -> Bool
 }
 
 struct MinimalChromeSettings: MinimalChromeSettingsProviding {
 
-    private let featureFlagger: FeatureFlagger
     private let unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding
 
-    init(featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
-         unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature()) {
-        self.featureFlagger = featureFlagger
+    init(unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature()) {
         self.unifiedToggleInputFeature = unifiedToggleInputFeature
     }
 
-    var isFeatureEnabled: Bool {
-        featureFlagger.isFeatureOn(.minimalChromeInLandscape)
-    }
-
     func shouldApplyMinimalChrome(isCurrentTabAITab: Bool) -> Bool {
-        guard isFeatureEnabled else { return false }
         if isCurrentTabAITab && unifiedToggleInputFeature.isAvailable { return false }
         return true
     }

--- a/iOS/DuckDuckGo/UICoordination/OverlayWindowManager.swift
+++ b/iOS/DuckDuckGo/UICoordination/OverlayWindowManager.swift
@@ -78,7 +78,6 @@ final class OverlayWindowManager: OverlayWindowManaging {
                                                                       appSettings: appSettings,
                                                                       mobileCustomization: mobileCustomization)
         let isMinimalChrome = !AppWidthObserver.shared.isPad
-            && featureFlagger.isFeatureOn(.minimalChromeInLandscape)
             && window.bounds.width > window.bounds.height
         blankSnapshotViewController.useMinimalChromeLayout = AppWidthObserver.shared.isLargeWidth || isMinimalChrome
         blankSnapshotViewController.delegate = self


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215195605176787
Tech Design URL:
CC:

### Description
Removes the `minimalChromeInLandscape` feature flag.

### Testing Steps
1. On iPhone, open a web page and rotate to landscape, verify chrome collapses to the minimal single-bar layout (tab bar and toolbar hidden, address bar present).
2. Rotate back to portrait, verify the full chrome is restored.
3. With the omnibar keyboard showing on iPhone, rotate the device, verify the text field keeps focus through the rotation.
4. On a Duck.ai tab with unified toggle input available, verify minimal chrome is NOT applied in landscape (AI-tab exception preserved).
5. On iPad, verify behaviour is unchanged (large-width layout still used).

### Impact and Risks
Low. The flag default was already enabled in production, so this only removes the now-unreachable disabled path. No behaviour change for users.

#### What could go wrong?
--

### Quality Considerations
--

### Notes to Reviewer
--

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flag removal only; production already defaulted to enabled, so user-visible behavior should be unchanged aside from losing a remote kill switch.
> 
> **Overview**
> Removes the **`minimalChromeInLandscape`** remote flag from privacy config, iOS **`FeatureFlag`**, and its wiring so iPhone landscape minimal chrome is always on (it previously defaulted to enabled).
> 
> **`MinimalChromeSettings`** no longer reads a feature flag: **`isFeatureEnabled`** and **`FeatureFlagger`** are dropped; **`shouldApplyMinimalChrome`** still skips minimal chrome on Duck.ai tabs when unified toggle input is available.
> 
> **`MainViewController`** rotation handling no longer gates keyboard focus preservation or width updates on the flag. **`OverlayWindowManager`** uses landscape-on-iPhone (non‑iPad) for blank snapshot minimal chrome without checking the flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fa5efcc34fd4f6e6e8dd0f24bc9ffad961620df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->