### PR TITLE
Fix invalid state of bottom address bar after rotation

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -274,8 +274,6 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
 
     case screenTimeCleaning
 
-    case minimalChromeInLandscape
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215448831345663?focus=true
     case bottomBarViewportFixedElementsWorkaround
 

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -442,9 +442,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213763338305579?focus=true
     case aiChatContextualFireButton
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213809475913723?focus=true
-    case minimalChromeInLandscape
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215448831345663?focus=true
     case bottomBarViewportFixedElementsWorkaround
 
@@ -822,8 +819,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.screenTimeCleaning))
         case .aiChatContextualFireButton:
             Config(source: .remoteReleasable(AIChatSubfeature.contextualFireButton))
-        case .minimalChromeInLandscape:
-            Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.minimalChromeInLandscape))
         case .bottomBarViewportFixedElementsWorkaround:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.bottomBarViewportFixedElementsWorkaround))
         case .aiChatNativeStorage:

--- a/iOS/DuckDuckGo/BrowserChromeManager.swift
+++ b/iOS/DuckDuckGo/BrowserChromeManager.swift
@@ -33,6 +33,7 @@ protocol BrowserChromeDelegate: AnyObject {
     var isToolbarHidden: Bool { get }
     var toolbarHeight: CGFloat { get }
     var barsMaxHeight: CGFloat { get }
+    var isInMinimalChromeLayout: Bool { get }
 
     var omniBar: any OmniBar { get }
     var tabBarContainer: UIView { get }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2516,6 +2516,12 @@ class MainViewController: UIViewController {
         } completion: { _ in
             toolbarSnapshot?.removeFromSuperview()
 
+            // Rotation changes the bar geometry, so the scroll-hide state can't carry across it.
+            // Reset to revealed (editing and AI chrome manage their own layout).
+            if !self.isCurrentTabUsingUnifiedInputAIChrome, !isKeyboardShowing {
+                self.resetBars(animated: false)
+            }
+
             self.omniBar.barView.textField.suppressResignFirstResponder = false
             if isKeyboardShowing {
                 self.omniBar.beginEditing(animated: false)
@@ -2562,7 +2568,14 @@ class MainViewController: UIViewController {
             && (size.width > size.height)
     }
 
+    private var isApplyingWidth = false
+
     private func applyWidth(for size: CGSize? = nil) {
+        // Re-entrancy guard: a refreshOmniBar side-effect calls applyWidth() with no size
+        // mid-rotation, which reads stale view.bounds and re-applies the wrong chrome mode.
+        guard !isApplyingWidth else { return }
+        isApplyingWidth = true
+        defer { isApplyingWidth = false }
 
         if AppWidthObserver.shared.isLargeWidth {
             applyLargeWidth()

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2472,7 +2472,7 @@ class MainViewController: UIViewController {
         isUTIRotating = true
 
         let isKeyboardShowing = omniBar.isTextFieldEditing
-        if isKeyboardShowing && !AppWidthObserver.shared.isPad && minimalChromeSettings.isFeatureEnabled {
+        if isKeyboardShowing && !AppWidthObserver.shared.isPad {
             omniBar.barView.textField.suppressResignFirstResponder = true
         }
 
@@ -2489,7 +2489,6 @@ class MainViewController: UIViewController {
         }()
 
         let needsWidthUpdate = AppWidthObserver.shared.willResize(toWidth: size.width)
-            && (AppWidthObserver.shared.isPad || isInMinimalChromeLayout || minimalChromeSettings.isFeatureEnabled)
         if needsWidthUpdate {
             applyWidth(for: size)
         }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2516,11 +2516,7 @@ class MainViewController: UIViewController {
         } completion: { _ in
             toolbarSnapshot?.removeFromSuperview()
 
-            // Rotation changes the bar geometry, so the scroll-hide state can't carry across it.
-            // Reset to revealed (editing and AI chrome manage their own layout).
-            if !self.isCurrentTabUsingUnifiedInputAIChrome, !isKeyboardShowing {
-                self.resetBars(animated: false)
-            }
+            self.resetBarsAfterTransitionAnimationIfNeeded(wasKeyboardShowing: isKeyboardShowing)
 
             self.omniBar.barView.textField.suppressResignFirstResponder = false
             if isKeyboardShowing {
@@ -2546,6 +2542,14 @@ class MainViewController: UIViewController {
         }
 
         hideNotificationBarIfBrokenSitePromptShown()
+    }
+
+    private func resetBarsAfterTransitionAnimationIfNeeded(wasKeyboardShowing: Bool) {
+        // Rotation changes the bar geometry, so the scroll-hide state can't carry across it.
+        // Reset to revealed (editing and AI chrome manage their own layout).
+        if !self.isCurrentTabUsingUnifiedInputAIChrome, !wasKeyboardShowing {
+            self.resetBars(animated: false)
+        }
     }
 
     private func deferredFireOrientationPixel() {

--- a/iOS/DuckDuckGo/MinimalChromeSettings.swift
+++ b/iOS/DuckDuckGo/MinimalChromeSettings.swift
@@ -18,31 +18,21 @@
 //
 
 import Foundation
-import PrivacyConfig
 
 protocol MinimalChromeSettingsProviding {
 
-    var isFeatureEnabled: Bool { get }
     func shouldApplyMinimalChrome(isCurrentTabAITab: Bool) -> Bool
 }
 
 struct MinimalChromeSettings: MinimalChromeSettingsProviding {
 
-    private let featureFlagger: FeatureFlagger
     private let unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding
 
-    init(featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
-         unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature()) {
-        self.featureFlagger = featureFlagger
+    init(unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature()) {
         self.unifiedToggleInputFeature = unifiedToggleInputFeature
     }
 
-    var isFeatureEnabled: Bool {
-        featureFlagger.isFeatureOn(.minimalChromeInLandscape)
-    }
-
     func shouldApplyMinimalChrome(isCurrentTabAITab: Bool) -> Bool {
-        guard isFeatureEnabled else { return false }
         if isCurrentTabAITab && unifiedToggleInputFeature.isAvailable { return false }
         return true
     }

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -865,21 +865,29 @@ class TabViewController: UIViewController {
 
     func updateWebViewBottomAnchor(for barsVisibilityPercent: CGFloat) {
         if appSettings.currentAddressBarPosition == .bottom && !(isAITab && unifiedToggleInputFeature.isAvailable) {
-            /// When address bar is at bottom on iPhone, offset webview to make room for the bars.
-            /// AI tabs skip this inset only when unifiedToggleInput is active — that feature
-            /// manages its own native bottom layout via the UnifiedToggleInput container.
-            let targetHeight = chromeDelegate?.barsMaxHeight ?? 0.0
-            let effectiveBarsVisibilityPercent: CGFloat
-            if #available(iOS 26, *),
-               featureFlagger.isFeatureOn(.bottomBarViewportFixedElementsWorkaround) {
-                /// iOS 26 regressed fixed-bottom webpage elements when the browser continuously
-                /// resizes the webview's bottom inset while chrome hides/shows. Keep the inset
-                /// stable in bottom-address-bar mode to avoid pushing page-fixed footers offscreen.
-                effectiveBarsVisibilityPercent = 1.0
+            if chromeDelegate?.isInMinimalChromeLayout == true {
+                // Minimal chrome: inset follows the bars so the slot is reclaimed when hidden. The
+                // iOS 26 fixed inset is skipped; in landscape it leaves a visible gap once the bar
+                // scrolls away (contentContainer is exactly the screen height).
+                let targetHeight = chromeDelegate?.barsMaxHeight ?? 0.0
+                webViewBottomAnchorConstraint?.constant = -targetHeight * barsVisibilityPercent
             } else {
-                effectiveBarsVisibilityPercent = barsVisibilityPercent
+                /// When address bar is at bottom on iPhone, offset webview to make room for the bars.
+                /// AI tabs skip this inset only when unifiedToggleInput is active — that feature
+                /// manages its own native bottom layout via the UnifiedToggleInput container.
+                let targetHeight = chromeDelegate?.barsMaxHeight ?? 0.0
+                let effectiveBarsVisibilityPercent: CGFloat
+                if #available(iOS 26, *),
+                   featureFlagger.isFeatureOn(.bottomBarViewportFixedElementsWorkaround) {
+                    /// iOS 26 regressed fixed-bottom webpage elements when the browser continuously
+                    /// resizes the webview's bottom inset while chrome hides/shows. Keep the inset
+                    /// stable in bottom-address-bar mode to avoid pushing page-fixed footers offscreen.
+                    effectiveBarsVisibilityPercent = 1.0
+                } else {
+                    effectiveBarsVisibilityPercent = barsVisibilityPercent
+                }
+                webViewBottomAnchorConstraint?.constant = -targetHeight * effectiveBarsVisibilityPercent
             }
-            webViewBottomAnchorConstraint?.constant = -targetHeight * effectiveBarsVisibilityPercent
         } else {
             webViewBottomAnchorConstraint?.constant = 0
         }

--- a/iOS/DuckDuckGo/UICoordination/OverlayWindowManager.swift
+++ b/iOS/DuckDuckGo/UICoordination/OverlayWindowManager.swift
@@ -78,7 +78,6 @@ final class OverlayWindowManager: OverlayWindowManaging {
                                                                       appSettings: appSettings,
                                                                       mobileCustomization: mobileCustomization)
         let isMinimalChrome = !AppWidthObserver.shared.isPad
-            && featureFlagger.isFeatureOn(.minimalChromeInLandscape)
             && window.bounds.width > window.bounds.height
         blankSnapshotViewController.useMinimalChromeLayout = AppWidthObserver.shared.isLargeWidth || isMinimalChrome
         blankSnapshotViewController.delegate = self

--- a/iOS/DuckDuckGoTests/BarsAnimatorTests.swift
+++ b/iOS/DuckDuckGoTests/BarsAnimatorTests.swift
@@ -269,6 +269,8 @@ private class BrowserChromeDelegateMock: BrowserChromeDelegate {
 
     var barsMaxHeight: CGFloat = 0
 
+    var isInMinimalChromeLayout: Bool = false
+
     var omniBar: OmniBar = {
         let omniBar = MockOmniBar()
         omniBar.mockBarView.expectedHeight = 52

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/DuckPlayerMocks.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/DuckPlayerMocks.swift
@@ -622,6 +622,8 @@ final class DuckPlayerBrowserChromeDelegateMock: BrowserChromeDelegate {
 
     var barsMaxHeight: CGFloat = 30
 
+    var isInMinimalChromeLayout: Bool = false
+
     var omniBar: OmniBar = DefaultOmniBarViewController(
         dependencies: MockOmnibarDependency(
             voiceSearchHelper: MockVoiceSearchHelper(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1215804934790777
Tech Design URL:
CC:

### Description
Rotating the device while the browser bars were hidden left the omnibar in a broken layout. Two visible symptoms with the bottom address bar: a too-narrow omnibar when rotating back to portrait, and a leftover background strip at the bottom in landscape minimal chrome.

### Testing Steps
1. iPhone, bottom address bar position, in landscape (minimal chrome).
2. Open a page, scroll down to hide the bars.
3. Rotate to portrait, verify the omnibar is full-size and correctly laid out (not narrow).
4. Rotate back to landscape, verify no empty or half bar is left on screen.
7. In landscape, scroll to hide the bars, verify content reclaims the bar's area with no leftover background strip, and that when shown the bar sits flush at the bottom with no content visible under it.
8. Lay flat on the table, pick up device into landscape mode
6. Rotate to portrait, verify the omni bar looks good.
9. Repeat with the top address bar position, confirm no regression.

### Impact and Risks
Medium. See what could go wrong.

#### What could go wrong?
Anything with bars really. I manually tested all the permutations I could think of.

### Quality Considerations
—

### Notes to Reviewer
Root cause is a re-entrant `applyWidth`: while applying the chrome layout, an omnibar refresh side-effect (`reconcileToolbarVisibilityForCurrentTab` to `refreshOmniBar`) calls `applyWidth()` with no size. Mid-rotation that nested call reads the still-stale `view.bounds` and re-applies the wrong chrome mode. `applyWidth` now has a guard against re-entrancy, resets the bars to revealed once the rotation completes, and in minimal chrome lets the webview bottom inset follow the bars.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bar visibility, rotation, and webview inset logic across MainViewController and TabViewController; regressions could affect any bottom/top bar or orientation combination.
> 
> **Overview**
> Fixes broken omnibar and leftover bottom chrome when rotating on iPhone with a **bottom address bar**, especially after scroll-hiding bars in landscape minimal chrome.
> 
> **Rotation / layout:** Adds a re-entrancy guard on `applyWidth()` so omnibar refresh cannot re-enter with stale `view.bounds` mid-rotation. After the transition animation, bars are reset to fully revealed (unless the keyboard or unified-input AI chrome owns layout). Rotation handling no longer gates on the removed feature flag.
> 
> **Minimal chrome:** Removes the `minimalChromeInLandscape` privacy/feature flag and makes landscape minimal chrome the default path via `MinimalChromeSettings` (still excluding AI tabs when unified toggle input is on). Blank snapshot overlays use landscape geometry instead of the flag.
> 
> **Web content inset:** Exposes `isInMinimalChromeLayout` on the chrome delegate so tabs can treat minimal chrome differently: the webview bottom inset follows scroll bar visibility instead of the iOS 26 fixed-inset workaround, so hidden bars reclaim space without a background strip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de953974203c58ee96034872e3b8a20d609c7950. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->