### PR TITLE
Add AI Settings entry point to Duck.ai menu

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -404,6 +404,12 @@ enum AIChatPixel: PixelKitEvent {
     /// Event Trigger: User taps "View All Chats..." from the more options menu
     case aiChatViewAllChatsMoreOptionsMenu
 
+    /// Event Trigger: User opens AI Settings from the main menu
+    case aiChatOpenSettingsMainMenu
+
+    /// Event Trigger: User opens AI Settings from the more options menu
+    case aiChatOpenSettingsMoreOptionsMenu
+
     /// Event Trigger: Duck.ai tab WebKit process terminates
     case aiChatTabDidTerminate(error: Error)
 
@@ -656,6 +662,10 @@ enum AIChatPixel: PixelKitEvent {
             return "aichat_view_all_chats_main_menu"
         case .aiChatViewAllChatsMoreOptionsMenu:
             return "aichat_view_all_chats_more_options_menu"
+        case .aiChatOpenSettingsMainMenu:
+            return "aichat_open_settings_main_menu"
+        case .aiChatOpenSettingsMoreOptionsMenu:
+            return "aichat_open_settings_more_options_menu"
         case .aiChatTabDidTerminate:
             return "aichat_tab_did_terminate"
         case .aiChatTabTerminationLoop:
@@ -765,6 +775,8 @@ enum AIChatPixel: PixelKitEvent {
                 .aiChatDeleteAllChatsMoreOptionsMenu,
                 .aiChatViewAllChatsMainMenu,
                 .aiChatViewAllChatsMoreOptionsMenu,
+                .aiChatOpenSettingsMainMenu,
+                .aiChatOpenSettingsMoreOptionsMenu,
                 .aiChatTabDidTerminate,
                 .aiChatTabTerminationLoop:
             return nil
@@ -919,6 +931,8 @@ enum AIChatPixel: PixelKitEvent {
                 .aiChatDeleteAllChatsMoreOptionsMenu,
                 .aiChatViewAllChatsMainMenu,
                 .aiChatViewAllChatsMoreOptionsMenu,
+                .aiChatOpenSettingsMainMenu,
+                .aiChatOpenSettingsMoreOptionsMenu,
                 .aiChatAddressBarImageGenerationActivated,
                 .aiChatAddressBarImageGenerationDeactivated,
                 .aiChatAddressBarImageGenerationSubmitted,

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -620,6 +620,7 @@ struct UserText {
     static let aiChatMenuDeleteAllChatsDialogTitle = NSLocalizedString("duckai.menu.delete-all-chats.dialog-title", value: "Delete Chats", comment: "Title of the custom delete dialog when there are 2 or fewer chats to delete")
     static let aiChatMenuDeleteAllChatsAlertMessage = NSLocalizedString("duckai.menu.delete-all-chats.alert-message", value: "This will permanently delete all your Duck.ai chats.", comment: "Message body of the confirmation dialog before deleting all Duck.ai chats")
     static let aiChatMenuDeleteAllChatsConfirmButton = NSLocalizedString("duckai.menu.delete-all-chats.confirm-button", value: "Delete Chats", comment: "Confirm button in the Delete All Duck.ai Chats alert")
+    static let aiChatMenuSettings = NSLocalizedString("duckai.menu.settings", value: "AI Settings", comment: "Duck.ai menu item to open the AI Settings preferences pane")
 
     static let aiChatAddressBarTrustedIndicator = NSLocalizedString("aichat.address-bar.trusted-indicator", value: "Duck.ai", comment: "Label for the AI Chat displayed in the address bar")
 

--- a/macOS/DuckDuckGo/Menus/AIChatMenu.swift
+++ b/macOS/DuckDuckGo/Menus/AIChatMenu.swift
@@ -41,6 +41,7 @@ final class AIChatMenu: NSMenu {
         var openNewImageChat: @MainActor () -> Void
         var openChat: @MainActor (AIChatSuggestion) -> Void
         var deleteAllChats: () async -> Void
+        var openSettings: @MainActor () -> Void
     }
 
     // MARK: - Static items
@@ -98,6 +99,15 @@ final class AIChatMenu: NSMenu {
         return item
     }()
 
+    private lazy var settingsItem: NSMenuItem = {
+        let item = NSMenuItem(title: UserText.aiChatMenuSettings, action: #selector(settingsTapped), keyEquivalent: "")
+        item.target = self
+        item.image = origin == .moreOptionsMenu
+            ? DesignSystemImages.Glyphs.Size16.settings
+            : DesignSystemImages.Glyphs.Size12.settings
+        return item
+    }()
+
     // MARK: - Dynamic chat items
 
     private var chatItems: [NSMenuItem] = []
@@ -142,6 +152,8 @@ final class AIChatMenu: NSMenu {
         // Dynamic chat items are inserted after recentChatsLabel by insertChatItems(_:)
         addItem(.separator())
         addItem(deleteAllChatsItem)
+        addItem(.separator())
+        addItem(settingsItem)
     }
 
     // MARK: - NSMenu update
@@ -250,6 +262,12 @@ final class AIChatMenu: NSMenu {
         }
         dialog.show()
     }
+
+    @objc private func settingsTapped() {
+        actions.openSettings()
+        let pixel: AIChatPixel = origin == .moreOptionsMenu ? .aiChatOpenSettingsMoreOptionsMenu : .aiChatOpenSettingsMainMenu
+        PixelKit.fire(pixel, frequency: .dailyAndStandard)
+    }
 }
 
 // MARK: - Default actions factory
@@ -291,6 +309,9 @@ extension AIChatMenu.Actions {
                         tab.reload()
                     }
                 }
+            },
+            openSettings: {
+                Application.appDelegate.windowControllersManager.showPreferencesTab(withSelectedPane: .aiChat)
             }
         )
     }

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_main_menu_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_main_menu_pixels.json5
@@ -96,5 +96,19 @@
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
         "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_open_settings_main_menu": {
+        "description": "Fired when user opens AI Settings from the main menu",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["daily_standard"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_open_settings_more_options_menu": {
+        "description": "Fired when user opens AI Settings from the more options menu",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["daily_standard"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
     }
 }

--- a/macOS/UnitTests/AIChat/AIChatMenuTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatMenuTests.swift
@@ -33,6 +33,7 @@ final class AIChatMenuTests: XCTestCase {
     private var openNewImageChatCalled = false
     private var openedChat: AIChatSuggestion?
     private var deleteAllChatsCalled = false
+    private var openSettingsCalled = false
 
     override func setUp() {
         super.setUp()
@@ -42,7 +43,8 @@ final class AIChatMenuTests: XCTestCase {
             openNewVoiceChat: { [weak self] in self?.openNewVoiceChatCalled = true },
             openNewImageChat: { [weak self] in self?.openNewImageChatCalled = true },
             openChat: { [weak self] suggestion in self?.openedChat = suggestion },
-            deleteAllChats: { [weak self] in self?.deleteAllChatsCalled = true }
+            deleteAllChats: { [weak self] in self?.deleteAllChatsCalled = true },
+            openSettings: { [weak self] in self?.openSettingsCalled = true }
         )
     }
 
@@ -68,6 +70,7 @@ final class AIChatMenuTests: XCTestCase {
         XCTAssertTrue(titles.contains(UserText.aiChatMenuNewImageChat))
         XCTAssertTrue(titles.contains(UserText.aiChatMenuRecentChats))
         XCTAssertTrue(titles.contains(UserText.aiChatMenuDeleteAllChats))
+        XCTAssertTrue(titles.contains(UserText.aiChatMenuSettings))
     }
 
     func testOpenDuckAIItemHasOptionCommandNShortcut() {
@@ -81,6 +84,15 @@ final class AIChatMenuTests: XCTestCase {
         let menu = AIChatMenu(suggestionsReader: suggestionsReader, actions: actions, origin: .moreOptionsMenu)
         let item = menu.items.first { $0.title == UserText.aiChatMenuOpenDuckAI }
         XCTAssertEqual(item?.keyEquivalent, "")
+    }
+
+    func testSettingsItem_appearsLastAfterDeleteAll() {
+        let menu = AIChatMenu(suggestionsReader: suggestionsReader, actions: actions)
+        let deleteAllIndex = menu.items.firstIndex { $0.title == UserText.aiChatMenuDeleteAllChats }!
+        let settingsIndex = menu.items.firstIndex { $0.title == UserText.aiChatMenuSettings }!
+        XCTAssertLessThan(deleteAllIndex, settingsIndex)
+        XCTAssertTrue(menu.items[deleteAllIndex + 1].isSeparatorItem)
+        XCTAssertEqual(menu.items[settingsIndex].title, UserText.aiChatMenuSettings)
     }
 
     // MARK: - Dynamic chat items


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1213881875984009/task/1215438194342413?focus=true

### Description

Internal feedback asked for an easy way to reach the browser's AI Features settings from the Duck.ai menu, to improve discoverability of the AI on/off controls.

- Adds an **AI Settings** item to the bottom of the Duck.ai menu, in both the main menu and the More Options (⋯) submenu.
- It opens the native **Settings → AI Features** pane (`showPreferencesTab(withSelectedPane: .aiChat)`), not the Duck.ai web settings modal.
- Label is "AI Settings" rather than "Open AI Settings" — the "Open" verb made it read as "OpenAI Settings" (raised in the Asana thread).
- New pixels `aichat_open_settings_main_menu` / `aichat_open_settings_more_options_menu`, following the existing per-origin menu pixel pattern.

### Testing Steps

1. Enable the Duck.ai application menu shortcut in Settings → AI Features (so the top-level Duck.ai menu shows).
2. Menu bar → **Duck.ai** → confirm **AI Settings** sits at the bottom under "Delete All Chats", with a gear icon and a separator above it.
3. Click it → native Settings window opens directly on the AI Features pane.
4. ⋯ More Options → Duck.ai submenu → confirm **AI Settings** appears there too.

### Impact and Risks

Low — additive menu item that routes to an existing preferences pane. No data or privacy surface touched.

#### What could go wrong?

Minimal. The navigation reuses `showPreferencesTab(withSelectedPane:)` already used elsewhere (e.g. password manager, tab bar). Worst case is a misplaced menu item, covered by a new ordering unit test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive UI and navigation to an existing preferences pane; no auth, data, or privacy logic changes.
> 
> **Overview**
> Adds an **AI Settings** item at the bottom of the Duck.ai menu (main menu and More Options), separated below **Delete All Chats**, with a gear icon sized per menu origin.
> 
> Selecting it invokes a new `openSettings` action that opens native **Settings → AI Features** via `showPreferencesTab(withSelectedPane: .aiChat)`, and fires origin-specific pixels (`aichat_open_settings_main_menu` / `aichat_open_settings_more_options_menu`) wired through `AIChatPixel` and pixel definitions.
> 
> Includes the `UserText.aiChatMenuSettings` string and unit coverage that the settings item appears last after delete-all.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c5e4ffdc51d1af30cd3ad0db707a07f2847fccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->