### PR TITLE
Show "Add Page Content" when navigating from NTP with sidebar open

### DIFF
--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -337,10 +337,10 @@ final class PageContextTabExtension {
         case keepExistingContext
     }
 
-    private func navigationAction(autoCollectEnabled: Bool, contextConsumed: Bool) -> NavigationContextAction {
+    private func navigationAction(autoCollectEnabled: Bool, contextConsumed: Bool, fromAttachablePage: Bool = true) -> NavigationContextAction {
         if autoCollectEnabled {
             return .collectNewContext
-        } else if contextConsumed {
+        } else if contextConsumed || !fromAttachablePage {
             return .sendNavigationSignal
         } else {
             return .keepExistingContext
@@ -352,15 +352,26 @@ final class PageContextTabExtension {
     private func handleNavigationForMultipleContexts(from previousContent: Tab.TabContent?, to newContent: Tab.TabContent) {
         guard featureFlagger.isFeatureOn(.aiChatMultiplePageContexts),
               case .url(let newURL, _, _) = newContent,
-              case .url(let oldURL, _, _) = previousContent,
-              newURL != oldURL,
               let session = aiChatSessionStore.sessions[tabID],
               session.state.presentationMode != .hidden,
               session.chatViewController != nil else {
             return
         }
 
-        switch navigationAction(autoCollectEnabled: isContextCollectionEnabled, contextConsumed: hasContextBeenConsumedByChat) {
+        // When the previous page was also a URL, skip if the URL hasn't changed.
+        // When coming from a non-URL page (NTP, settings, etc.) always proceed —
+        // the attachability just changed from false to true, so the sidebar needs a signal.
+        let previousWasURL: Bool
+        if case .url(let oldURL, _, _) = previousContent {
+            guard oldURL != newURL else { return }
+            previousWasURL = true
+        } else {
+            previousWasURL = false
+        }
+
+        switch navigationAction(autoCollectEnabled: isContextCollectionEnabled,
+                                contextConsumed: hasContextBeenConsumedByChat,
+                                fromAttachablePage: previousWasURL) {
         case .collectNewContext:
             collectPageContextIfNeeded()
         case .sendNavigationSignal:

--- a/macOS/UnitTests/AIChat/PageContextMultipleContextsTests.swift
+++ b/macOS/UnitTests/AIChat/PageContextMultipleContextsTests.swift
@@ -27,10 +27,10 @@ import Testing
 struct NavigationContextActionTests {
 
     /// Helper that mirrors the logic in PageContextTabExtension.navigationAction
-    private func navigationAction(autoCollectEnabled: Bool, contextConsumed: Bool) -> String {
+    private func navigationAction(autoCollectEnabled: Bool, contextConsumed: Bool, fromAttachablePage: Bool = true) -> String {
         if autoCollectEnabled {
             return "collectNewContext"
-        } else if contextConsumed {
+        } else if contextConsumed || !fromAttachablePage {
             return "sendNavigationSignal"
         } else {
             return "keepExistingContext"
@@ -51,6 +51,23 @@ struct NavigationContextActionTests {
     @Test("Auto-collect OFF without consumed context returns keepExistingContext")
     func autoCollectOffNotConsumedKeeps() {
         #expect(navigationAction(autoCollectEnabled: false, contextConsumed: false) == "keepExistingContext")
+    }
+
+    // fromAttachablePage = false (navigating FROM NTP/settings/etc. to a URL)
+
+    @Test("NTP to URL with auto-collect OFF and no prior chat sends navigation signal")
+    func ntpToURLAutoCollectOffNoChat() {
+        #expect(navigationAction(autoCollectEnabled: false, contextConsumed: false, fromAttachablePage: false) == "sendNavigationSignal")
+    }
+
+    @Test("NTP to URL with auto-collect ON collects new context")
+    func ntpToURLAutoCollectOn() {
+        #expect(navigationAction(autoCollectEnabled: true, contextConsumed: false, fromAttachablePage: false) == "collectNewContext")
+    }
+
+    @Test("NTP to URL with consumed context sends navigation signal")
+    func ntpToURLContextConsumed() {
+        #expect(navigationAction(autoCollectEnabled: false, contextConsumed: true, fromAttachablePage: false) == "sendNavigationSignal")
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1213881875984009/task/1215563906944488?focus=true

### Description

Fixes a macOS-only bug where the AI Chat sidebar's "Add Page Content" button never appeared after navigating to a real page from the New Tab Page with the sidebar already open.

Root cause: `handleNavigationForMultipleContexts` in `PageContextTabExtension` only ran when **both** the previous and new content were `.url`. Navigating NTP→URL therefore fired no page-context signal, leaving the sidebar stuck in the non-attachable NTP state. Opening the sidebar *after* navigating worked because sidebar init pulls current context rather than waiting for a navigation signal.

Windows already handles this via a dedicated attachability-transition handler; this brings macOS to parity.

### Testing Steps
1. Open a new tab (NTP), then open the AI Chat sidebar.
2. Navigate to wikipedia.org in the address bar.
3. The "Add Page Content" button should appear in the sidebar. (Before this fix it did not.)
4. Regression — reverse order: navigate to wikipedia.org first, then open the sidebar → button still appears.
5. Regression — URL→URL: on bbc.com attach page context and send a prompt, then navigate to wikipedia.org → button re-appears.

### Impact and Risks
Low. Scoped to AI Chat sidebar page-context signalling behind the `aiChatMultiplePageContexts` feature flag.

#### What could go wrong?
The guard change widens when `handleNavigationForMultipleContexts` runs. Risk is mitigated by `fromAttachablePage` defaulting to `true` (so URL→URL paths are unchanged) and by the early-return when the URL is unchanged. Unit tests cover the NTP→URL cases and the existing URL→URL cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to AI Chat page-context signaling behind `aiChatMultiplePageContexts`; URL→URL paths are unchanged via defaults and unchanged-URL early return.
> 
> **Overview**
> Fixes macOS AI Chat sidebar staying in a non-attachable state after **NTP → URL** navigation when the sidebar was already open, so **Add Page Content** never appeared.
> 
> **`handleNavigationForMultipleContexts`** no longer requires the previous tab content to be a URL—only the new content must be a URL. URL→URL still bails out when the URL is unchanged; transitions from NTP, settings, bookmarks, etc. to a URL always run so the sidebar gets an update when attachability flips.
> 
> **`navigationAction`** gains **`fromAttachablePage`** (default `true`). When auto-collect is off and the user came from a non-attachable page, it sends the same nil page-context signal as after a consumed prompt, which drives the frontend **Add Page Content** UI.
> 
> Unit tests cover NTP→URL decision paths; behavior remains behind **`aiChatMultiplePageContexts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f10d3029e19abc7f33077a14d5a481f943138933. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->