### PR TITLE
Add Duck.ai reasoning dropdown on iPad

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -20,8 +20,11 @@
 		02BA15B126A89ECA00472DD7 /* ios-config.json in Resources */ = {isa = PBXBuildFile; fileRef = 02BA15B026A89ECA00472DD7 /* ios-config.json */; };
 		02F880642AB206740020C2DF /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 02ECEC602A965074009F0654 /* PrivacyInfo.xcprivacy */; };
 		067CACE8BC2AA354D969019F /* NewAddressBarPickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFAB87418082C5BDE38CE4D /* NewAddressBarPickerViewModelTests.swift */; };
+		06D744C1F541FF4F91F7A664 /* DuckAISubscriptionUpsellPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A43FA34A9C65835FF48566 /* DuckAISubscriptionUpsellPresenter.swift */; };
 		0928A567CE4F37AC8E19B215 /* NavigationPixelNavigationResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2870028D8D7FA19512B7FD0 /* NavigationPixelNavigationResponder.swift */; };
 		0A6CC0EF23904D5400E4F627 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 0A6CC0EE23904D5400E4F627 /* Settings.bundle */; };
+		10357EC5C05F09BDB3388E23 /* ReasoningModeAccessResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD00141E45DB79DEAE23EFC /* ReasoningModeAccessResolver.swift */; };
+		18EB298166184F06B6A87190 /* OnboardingSearchAIToggleGrey.lottie in Resources */ = {isa = PBXBuildFile; fileRef = 17BA504D98D84DB79BDE168D /* OnboardingSearchAIToggleGrey.lottie */; };
 		1AD965E390AC1B7FDE09D956 /* RebrandedOnboardingView+BrowsersComparisonContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8693FFCAC02CE4A85D0BD62C /* RebrandedOnboardingView+BrowsersComparisonContent.swift */; };
 		1CB7B82123CEA1F800AA24EA /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB7B82023CEA1F800AA24EA /* DateExtension.swift */; };
 		1CB7B82323CEA28300AA24EA /* DateExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB7B82223CEA28300AA24EA /* DateExtensionTests.swift */; };
@@ -401,8 +404,10 @@
 		4BEE4ACD2DB60FCE0061470B /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8551912624746EDC0010FDD0 /* SnapshotHelper.swift */; };
 		4BEEEA992E24670800B0BE00 /* DBPDebugWebViewWindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEEEA982E24670700B0BE00 /* DBPDebugWebViewWindowManager.swift */; };
 		4BF557F02DF79393008E16A8 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4BF557EF2DF79393008E16A8 /* WebKit.framework */; };
+		4E03B2B377CD424EB2A38BEA /* OnboardingSearchAIToggle.lottie in Resources */ = {isa = PBXBuildFile; fileRef = 681283C1263F43E4BA42ED6B /* OnboardingSearchAIToggle.lottie */; };
 		4EEE6B9BEB9F0F385341C0F1 /* DarkReaderFeatureSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C36CDBF1DD7FBC036F9067 /* DarkReaderFeatureSettingsTests.swift */; };
 		55061A111C096D2FEDBC4869 /* RebrandedAddToDockPromoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05C3CB91F3D61FF6CC5527F5 /* RebrandedAddToDockPromoView.swift */; };
+		553E0CD471E54E97B85C6F55 /* AIChatHistoryInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE3A9DD8385464FA82977B9 /* AIChatHistoryInstrumentation.swift */; };
 		56038D5F2E0E97B20001419D /* SubscriptionURLNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56038D5E2E0E97B20001419D /* SubscriptionURLNavigationHandler.swift */; };
 		5608B5132F2125CC00ABC3F4 /* UITestOverridesDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5608B5122F2125CC00ABC3F4 /* UITestOverridesDebugView.swift */; };
 		560E84852EE0FA53008F6B74 /* TierBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560E84842EE0FA53008F6B74 /* TierBadgeView.swift */; };
@@ -455,7 +460,6 @@
 		5AB12C3D4E5F60718293A4B5 /* AIChatHistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB12C3D4E5F60718293A4B6 /* AIChatHistoryViewController.swift */; };
 		5AB12C3D4E5F60718293A4B7 /* AIChatHistoryEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB12C3D4E5F60718293A4B8 /* AIChatHistoryEmptyStateView.swift */; };
 		5AB12C3D4E5F60718293A4B9 /* AIChatHistoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB12C3D4E5F60718293A4BA /* AIChatHistoryViewModel.swift */; };
-		553E0CD471E54E97B85C6F55 /* AIChatHistoryInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE3A9DD8385464FA82977B9 /* AIChatHistoryInstrumentation.swift */; };
 		5AB12C3D4E5F60718293A4BB /* AIChatHistoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB12C3D4E5F60718293A4BC /* AIChatHistoryCell.swift */; };
 		5AB12C3D4E5F60718293A4BF /* MockChatHistoryReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB12C3D4E5F60718293A4C0 /* MockChatHistoryReader.swift */; };
 		5AB12C3D4E5F60718293A4D1 /* AIChatHistoryNoResultsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB12C3D4E5F60718293A4D2 /* AIChatHistoryNoResultsCell.swift */; };
@@ -476,11 +480,6 @@
 		5B6D65182FB3B48500BDCF4D /* CalendarEventEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6D65172FB3B47F00BDCF4D /* CalendarEventEditView.swift */; };
 		5B6D651A2FB4BB8000BDCF4D /* ICSFileReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6D65192FB4BB7E00BDCF4D /* ICSFileReader.swift */; };
 		5B6D651D2FB4D2EB00BDCF4D /* ICSFileReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6D651C2FB4D2E900BDCF4D /* ICSFileReaderTests.swift */; };
-		95C3B5788F2B2DA78E266C2A /* CalendarEventPreviewHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFDD2F8A58E59142D8FDD931 /* CalendarEventPreviewHelperTests.swift */; };
-		BCC0F7A12FB3000000BDCF01 /* VCardFileReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC0F7A02FB3000000BDCF01 /* VCardFileReader.swift */; };
-		BCC0F7A32FB3000000BDCF02 /* ContactPreviewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC0F7A22FB3000000BDCF02 /* ContactPreviewHelper.swift */; };
-		BCC0F7A52FB3000000BDCF03 /* ContactCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC0F7A42FB3000000BDCF03 /* ContactCardView.swift */; };
-		BCC0F7A82FB3000000BDCF05 /* VCardFileReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC0F7A72FB3000000BDCF05 /* VCardFileReaderTests.swift */; };
 		5B6D651F2FB4D30A00BDCF4D /* CompleteDownloadRowViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6D651E2FB4D30700BDCF4D /* CompleteDownloadRowViewModelTests.swift */; };
 		5B6D65212FBA000000BDCF4D /* FilePreviewHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6D65202FBA000000BDCF4D /* FilePreviewHelperTests.swift */; };
 		5B7CA46B2FAE693000D69C83 /* ICSParser in Frameworks */ = {isa = PBXBuildFile; productRef = 5B7CA46A2FAE693000D69C83 /* ICSParser */; };
@@ -580,8 +579,6 @@
 		6F8496412BC3D8EE00ADA54E /* OnboardingButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F8496402BC3D8EE00ADA54E /* OnboardingButtonsView.swift */; };
 		6F87A7942D96AEA3006BFD71 /* OmniBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F87A7932D96AEA3006BFD71 /* OmniBarViewController.swift */; };
 		6F922EDB2D8C36510062DFC1 /* DefaultOmniBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F922EDA2D8C364C0062DFC1 /* DefaultOmniBarViewController.swift */; };
-		FBA1C0DE0000000000000001 /* IPadOmnibarModelPickerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE0000000000000002 /* IPadOmnibarModelPickerController.swift */; };
-		FBA1C0DE0000000000000005 /* IPadDuckAIControlsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE0000000000000006 /* IPadDuckAIControlsFeature.swift */; };
 		6F922EDD2D8C372F0062DFC1 /* DefaultOmniBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F922EDC2D8C372F0062DFC1 /* DefaultOmniBarView.swift */; };
 		6F922EDF2D8C5AFA0062DFC1 /* DefaultOmniBarSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F922EDE2D8C5AEC0062DFC1 /* DefaultOmniBarSearchView.swift */; };
 		6F922EE12D8C5C6B0062DFC1 /* URLSeparatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F922EE02D8C5C6B0062DFC1 /* URLSeparatorView.swift */; };
@@ -624,6 +621,7 @@
 		6FF9AD412CE6610F00C5A406 /* TabSwitcherOpenDailyPixelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9AD402CE6610600C5A406 /* TabSwitcherOpenDailyPixelTests.swift */; };
 		71DFABCA706A402AB4B27F50 /* UnifiedToggleInputFloatingReturnKeyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5BA3FF1041A3BB9396AE65 /* UnifiedToggleInputFloatingReturnKeyViewController.swift */; };
 		770F04AEA51E0EF84C52CD53 /* MainViewController+UnifiedToggleInputSwipeTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18A7DE942EC889067320A83 /* MainViewController+UnifiedToggleInputSwipeTabs.swift */; };
+		7A1B2C3D2E0000000000F001 /* TabsBarViewControllerSizingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1B2C3D2E0000000000F002 /* TabsBarViewControllerSizingTests.swift */; };
 		7B020B9A2D11F99D00876178 /* FavoritesDisplayMode+UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373608912ABB430D00629E7F /* FavoritesDisplayMode+UserDefaults.swift */; };
 		7B059F0F2D0387E900371ED0 /* NumberedParagraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B059F0A2D0387E900371ED0 /* NumberedParagraphView.swift */; };
 		7B059F112D0387E900371ED0 /* WidgetEducationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B059F0D2D0387E900371ED0 /* WidgetEducationViewController.swift */; };
@@ -777,7 +775,6 @@
 		850365F323DE087800D0F787 /* UIImageViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850365F223DE087800D0F787 /* UIImageViewExtension.swift */; };
 		85047C772A0D5D3D00D2FF3F /* SyncSettingsViewController+SyncDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85047C762A0D5D3D00D2FF3F /* SyncSettingsViewController+SyncDelegate.swift */; };
 		8504E9EA2D8883BA00FF1352 /* TabSwitcherBarsStateHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8504E9E92D8883AE00FF1352 /* TabSwitcherBarsStateHandlerTests.swift */; };
-		7A1B2C3D2E0000000000F001 /* TabsBarViewControllerSizingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1B2C3D2E0000000000F002 /* TabsBarViewControllerSizingTests.swift */; };
 		850559C923C61B5D0055C0D5 /* login-form-detection.js in Resources */ = {isa = PBXBuildFile; fileRef = 850559C823C61B5D0055C0D5 /* login-form-detection.js */; };
 		850559D023CF647C0055C0D5 /* Fireproofing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850559CF23CF647C0055C0D5 /* Fireproofing.swift */; };
 		85058366219AE9EA00ED4EDB /* HomePageConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85058365219AE9EA00ED4EDB /* HomePageConfiguration.swift */; };
@@ -855,6 +852,7 @@
 		854D678D2F6D4BA8008707A3 /* TabSwitcherMenuBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 854D678C2F6D4BA8008707A3 /* TabSwitcherMenuBuilder.swift */; };
 		854D678F2F6D4C71008707A3 /* TabSwitcherMenuBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 854D678E2F6D4C71008707A3 /* TabSwitcherMenuBuilderTests.swift */; };
 		85514FFD2372DA0100DBC528 /* ios13-home-row.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 85514FFC2372DA0000DBC528 /* ios13-home-row.mp4 */; };
+		85563CDA09A69E6ADAFB7C39 /* ReasoningModeAccessResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E0B95A939268F4937B4ED4 /* ReasoningModeAccessResolverTests.swift */; };
 		85582E0029D7409700E9AE35 /* SyncSettingsViewController+PDFRendering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85582DFF29D7409700E9AE35 /* SyncSettingsViewController+PDFRendering.swift */; };
 		855D914D2063EF6A00C4B448 /* TabSwitcherTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 855D914C2063EF6A00C4B448 /* TabSwitcherTransition.swift */; };
 		855ED5082E841EFE00047A88 /* QuickActionsWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 855ED5072E841EFE00047A88 /* QuickActionsWidgetView.swift */; };
@@ -985,10 +983,15 @@
 		85F98F98296F4CB100742F4A /* SyncAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 85F98F97296F4CB100742F4A /* SyncAssets.xcassets */; };
 		85F996CE2E54ADC0006B4641 /* OpenAIChatFromAddressBarHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F996CD2E54ADB9006B4641 /* OpenAIChatFromAddressBarHandling.swift */; };
 		85F996D02E54C268006B4641 /* OpenAIChatFromAddressBarHandlingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F996CF2E54C260006B4641 /* OpenAIChatFromAddressBarHandlingTests.swift */; };
+		88CED5F7656BFDD8D99B3CA0 /* UnifiedToggleInputReasoningMenuFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D09A21E8CF1A9B32BC45E19 /* UnifiedToggleInputReasoningMenuFactoryTests.swift */; };
+		8AA7DA9074610EBDBF3FAA34 /* UnifiedToggleInputReasoningMenuFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B631B1C80B6A67A6FD9FCE /* UnifiedToggleInputReasoningMenuFactory.swift */; };
 		8C4724502217A14B004C9B2D /* TabViewControllerSaveBookmarkExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C47244F2217A14B004C9B2D /* TabViewControllerSaveBookmarkExtension.swift */; };
 		8C4838B5221C8F7F008A6739 /* GestureToolbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C4838B4221C8F7F008A6739 /* GestureToolbarButton.swift */; };
+		912A3FDC1F6C41E88FE334D9 /* SearchExperienceToggleAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114B20D6843A4D239C58435F /* SearchExperienceToggleAnimationView.swift */; };
 		91B67D60DCF5B9213184F1B9 /* NewAddressBarPickerRefreshContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0466F5E63C5ECC76F75718F8 /* NewAddressBarPickerRefreshContentView.swift */; };
 		925EB62CBE6C4A27B4E4A25A /* AIBoundaryNavigationDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD56A4878844306BD83E026 /* AIBoundaryNavigationDecision.swift */; };
+		9354C33177CC2A51CA978356 /* IPadOmnibarReasoningPickerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 883AAA241504625A0E8455C1 /* IPadOmnibarReasoningPickerController.swift */; };
+		95C3B5788F2B2DA78E266C2A /* CalendarEventPreviewHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFDD2F8A58E59142D8FDD931 /* CalendarEventPreviewHelperTests.swift */; };
 		9710D4A12ED5B323006C14FF /* FadeOutContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9710D4A02ED5B323006C14FF /* FadeOutContainerViewController.swift */; };
 		9770D4A92F6AFD3F0029361F /* DuckAIVoiceShortcutFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9770D4A82F6AFD3F0029361F /* DuckAIVoiceShortcutFeature.swift */; };
 		9770D4AB2F6AFD600029361F /* NavigationActionBarViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9770D4AA2F6AFD600029361F /* NavigationActionBarViewModelTests.swift */; };
@@ -1750,6 +1753,7 @@
 		A1F4C5322F8D100000D1A111 /* DataImportHubPixelContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F4C5302F8D100000D1A111 /* DataImportHubPixelContext.swift */; };
 		A1F4C5332F8D100000D1A111 /* DataImportHubSimulatedCompletionPersistor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F4C5312F8D100000D1A111 /* DataImportHubSimulatedCompletionPersistor.swift */; };
 		A5B373DCAC231125EC470ADF /* RebrandedOnboardingView+AddressBarPositionContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81E935251F047CE4825824A5 /* RebrandedOnboardingView+AddressBarPositionContent.swift */; };
+		A5B8480FBFA9435CA9A67425 /* OnboardingSearchAIToggle_dark.lottie in Resources */ = {isa = PBXBuildFile; fileRef = AEC7FF2261884003814DB9D0 /* OnboardingSearchAIToggle_dark.lottie */; };
 		A627D8C9C6C477E0A51B89E5 /* NavigationPixelNavigationResponderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A30EF03B7EC51B89770CA36 /* NavigationPixelNavigationResponderTests.swift */; };
 		AA2000010000000000000002 /* TabSwitcherTrackerInfoHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1000010000000000000002 /* TabSwitcherTrackerInfoHeaderView.swift */; };
 		AA2000040000000000000004 /* TabSwitcherTrackerCountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1000040000000000000004 /* TabSwitcherTrackerCountViewModel.swift */; };
@@ -1766,7 +1770,6 @@
 		AABB00010001000100010009 /* UTIAttachmentPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0001000100010001000A /* UTIAttachmentPolicyTests.swift */; };
 		AABB0001000100010001000B /* UTIModelStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0001000100010001000C /* UTIModelStore.swift */; };
 		AABB0001000100010001000D /* UTIModelStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0001000100010001000E /* UTIModelStoreTests.swift */; };
-		FBA1C0DE0000000000000003 /* IPadOmnibarModelPickerControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE0000000000000004 /* IPadOmnibarModelPickerControllerTests.swift */; };
 		AABB0001000100010001000F /* UTIToolsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB00010001000100010010 /* UTIToolsController.swift */; };
 		AABB00010001000100010101 /* UnifiedToggleInputViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB00010001000100010100 /* UnifiedToggleInputViewTests.swift */; };
 		AABB00010001000100010201 /* UnifiedToggleInputToggleViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB00010001000100010200 /* UnifiedToggleInputToggleViewTests.swift */; };
@@ -1790,6 +1793,7 @@
 		B57702B52FAA6D89007CE868 /* NewAddressBarPickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57702B42FAA6D89007CE868 /* NewAddressBarPickerViewModel.swift */; };
 		B59B16982FAB879900C1040A /* OmniBarFocuser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59B16972FAB879900C1040A /* OmniBarFocuser.swift */; };
 		B5E5F7432FB6362D00A318E7 /* EscapeHatchModel+Previews.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E5F7422FB6362D00A318E7 /* EscapeHatchModel+Previews.swift */; };
+		B5F92C17DEEE4D1993394E8C /* OnboardingSearchAIToggleGrey_dark.lottie in Resources */ = {isa = PBXBuildFile; fileRef = 52CC2F8B19BA4ED5AAB32605 /* OnboardingSearchAIToggleGrey_dark.lottie */; };
 		B603974929C19F6F00902A34 /* Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B603974829C19F6F00902A34 /* Assertions.swift */; };
 		B609D5522862EAFF0088CAC2 /* InlineWKDownloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B609D5512862EAFF0088CAC2 /* InlineWKDownloadDelegate.swift */; };
 		B60DFF072872B64B0061E7C2 /* JSAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60DFF062872B64B0061E7C2 /* JSAlertView.swift */; };
@@ -1856,6 +1860,10 @@
 		BBFF18B12C76448100C48D7D /* QuerySubmittedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFF18B02C76448100C48D7D /* QuerySubmittedTests.swift */; };
 		BBFF22EF2F3469160055A710 /* MockFreeTrialConversionInstrumentationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFF22EE2F3469160055A710 /* MockFreeTrialConversionInstrumentationService.swift */; };
 		BBFF22F02F3469160055A710 /* MockFreeTrialConversionInstrumentationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFF22EE2F3469160055A710 /* MockFreeTrialConversionInstrumentationService.swift */; };
+		BCC0F7A12FB3000000BDCF01 /* VCardFileReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC0F7A02FB3000000BDCF01 /* VCardFileReader.swift */; };
+		BCC0F7A32FB3000000BDCF02 /* ContactPreviewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC0F7A22FB3000000BDCF02 /* ContactPreviewHelper.swift */; };
+		BCC0F7A52FB3000000BDCF03 /* ContactCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC0F7A42FB3000000BDCF03 /* ContactCardView.swift */; };
+		BCC0F7A82FB3000000BDCF05 /* VCardFileReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC0F7A72FB3000000BDCF05 /* VCardFileReaderTests.swift */; };
 		BD10B8AA2C7629740033115D /* Logger+Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD10B8A92C7629740033115D /* Logger+Subscription.swift */; };
 		BD2F39EB2C19F955005B19E7 /* NetworkProtectionDNSSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2F39EA2C19F955005B19E7 /* NetworkProtectionDNSSettingsView.swift */; };
 		BD408CED2DCDB17900265476 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = BD408CEC2DCDB17900265476 /* ZIPFoundation */; };
@@ -1876,6 +1884,7 @@
 		BDFF031D2BA3D2BD00F324C9 /* DefaultNetworkProtectionVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFF031C2BA3D2BD00F324C9 /* DefaultNetworkProtectionVisibility.swift */; };
 		BDFF03222BA3D8E200F324C9 /* NetworkProtectionFeatureVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFF03192BA39C5A00F324C9 /* NetworkProtectionFeatureVisibility.swift */; };
 		BDFF03232BA3D8E300F324C9 /* NetworkProtectionFeatureVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFF03192BA39C5A00F324C9 /* NetworkProtectionFeatureVisibility.swift */; };
+		BE83A575896316C700B212FA /* DuckAISubscriptionUpsellPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71D2723FF8B5622E2904F40 /* DuckAISubscriptionUpsellPresenterTests.swift */; };
 		BEC5B10A1F9E4CF5A889BBDC /* EscapeHatchModelBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98109F19E7F142578C327237 /* EscapeHatchModelBuilder.swift */; };
 		BFA000022F90000000FEEE01 /* FreemiumPIREligibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA000012F90000000FEEE01 /* FreemiumPIREligibility.swift */; };
 		C10454E22F8D0F2C002BB02C /* CredentialExchangeImportHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10454E12F8D0F2C002BB02C /* CredentialExchangeImportHandler.swift */; };
@@ -2265,7 +2274,6 @@
 		CBD79F4D2D130F6500DBB45A /* Simulated.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBD79F4C2D130F6300DBB45A /* Simulated.swift */; };
 		CBDD5AC62F238F7300441F0A /* PrivacyStats in Frameworks */ = {isa = PBXBuildFile; productRef = AA3000060000000000000006 /* PrivacyStats */; };
 		CBDD5DDF29A6736A00832877 /* APIHeadersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBDD5DDE29A6736A00832877 /* APIHeadersTests.swift */; };
-		AC7100D1A6105DEBEEF0000A /* WebScrollObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC7100D1A6105DEBEEF00009 /* WebScrollObserverTests.swift */; };
 		CBDEDA162D8079E500123E00 /* RoundedCornersMaskView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBDEDA152D8079E500123E00 /* RoundedCornersMaskView.swift */; };
 		CBE77C752FD2F3A300CB7C6D /* SuggestionRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE77C742FD2F3A300CB7C6D /* SuggestionRow.swift */; };
 		CBE77C772FD2F3B300CB7C6D /* SuggestionRowMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE77C762FD2F3B300CB7C6D /* SuggestionRowMapperTests.swift */; };
@@ -2386,14 +2394,10 @@
 		DA0001022F3D000100000002 /* DarkReaderFeatureSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0001042F3D000100000002 /* DarkReaderFeatureSettings.swift */; };
 		DA46CDBDABEE6B9945F597C3 /* AIChatDebugServer in Frameworks */ = {isa = PBXBuildFile; productRef = 3C12C8760D7AF6C888DAD36A /* AIChatDebugServer */; };
 		DA9073A7F6F11BD081C2FA27 /* RebrandedOnboardingSearchExperiencePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EDFAE3163584454362A466 /* RebrandedOnboardingSearchExperiencePicker.swift */; };
-		912A3FDC1F6C41E88FE334D9 /* SearchExperienceToggleAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114B20D6843A4D239C58435F /* SearchExperienceToggleAnimationView.swift */; };
-		4E03B2B377CD424EB2A38BEA /* OnboardingSearchAIToggle.lottie in Resources */ = {isa = PBXBuildFile; fileRef = 681283C1263F43E4BA42ED6B /* OnboardingSearchAIToggle.lottie */; };
-		A5B8480FBFA9435CA9A67425 /* OnboardingSearchAIToggle_dark.lottie in Resources */ = {isa = PBXBuildFile; fileRef = AEC7FF2261884003814DB9D0 /* OnboardingSearchAIToggle_dark.lottie */; };
-		18EB298166184F06B6A87190 /* OnboardingSearchAIToggleGrey.lottie in Resources */ = {isa = PBXBuildFile; fileRef = 17BA504D98D84DB79BDE168D /* OnboardingSearchAIToggleGrey.lottie */; };
-		B5F92C17DEEE4D1993394E8C /* OnboardingSearchAIToggleGrey_dark.lottie in Resources */ = {isa = PBXBuildFile; fileRef = 52CC2F8B19BA4ED5AAB32605 /* OnboardingSearchAIToggleGrey_dark.lottie */; };
 		E1A4A4D52F2A111100AA11BB /* TabViewController+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A4A4D42F2A111100AA11BB /* TabViewController+UI.swift */; };
 		E44F90F056A0488A976B6AFE /* FileCorruptErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E44F90E856A0488A976B6AFE /* FileCorruptErrorView.swift */; };
 		E53A32E13739A86D87B5FB44 /* SafariRedirectHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7594859CB2334A38D629EF5 /* SafariRedirectHandlerTests.swift */; };
+		E6B11AC3844012B6E947B7AA /* IPadOmnibarReasoningPickerControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E7EE5FF3B14EBB6C0AAB71A /* IPadOmnibarReasoningPickerControllerTests.swift */; };
 		E9D5A3B42C3D4E5F6A708192 /* AIChatRecentChatsPopupViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E6B4C53D4E5F6A70819203 /* AIChatRecentChatsPopupViewModelTests.swift */; };
 		EA39B7E2268A1A35000C62CD /* privacy-reference-tests in Resources */ = {isa = PBXBuildFile; fileRef = EA39B7E1268A1A35000C62CD /* privacy-reference-tests */; };
 		EA90A5267F61028E3525A81E /* RebrandedAppIconPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D67C082BD4927358D771DB /* RebrandedAppIconPicker.swift */; };
@@ -2587,6 +2591,10 @@
 		F4F7F10C25813FE200045D62 /* 03_Airstream_divided_by_four.json in Resources */ = {isa = PBXBuildFile; fileRef = F4F7F10925813FE200045D62 /* 03_Airstream_divided_by_four.json */; };
 		F5CAE9782DE14DD28D909F48 /* FireModePromotionCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597F658232184635B5E6D2A7 /* FireModePromotionCardView.swift */; };
 		FA58D524242AADCE97992F46 /* RebrandedOnboardingView+SkipOnboardingContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970C8DE9831CD77A979A1354 /* RebrandedOnboardingView+SkipOnboardingContent.swift */; };
+		FBA1C0DE0000000000000001 /* IPadOmnibarModelPickerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE0000000000000002 /* IPadOmnibarModelPickerController.swift */; };
+		FBA1C0DE0000000000000003 /* IPadOmnibarModelPickerControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE0000000000000004 /* IPadOmnibarModelPickerControllerTests.swift */; };
+		FBA1C0DE0000000000000005 /* IPadDuckAIControlsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE0000000000000006 /* IPadDuckAIControlsFeature.swift */; };
+		FBA1C0DE0000000000000007 /* IPadDuckAIControlsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE0000000000000008 /* IPadDuckAIControlsFeatureTests.swift */; };
 		FD555C0BE82E630360DC2E5A /* ToggleModeStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6090D90640A2B1A529EDBAAB /* ToggleModeStorage.swift */; };
 /* End PBXBuildFile section */
 
@@ -2755,9 +2763,12 @@
 		0466F5E63C5ECC76F75718F8 /* NewAddressBarPickerRefreshContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewAddressBarPickerRefreshContentView.swift; sourceTree = "<group>"; };
 		05C3CB91F3D61FF6CC5527F5 /* RebrandedAddToDockPromoView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RebrandedAddToDockPromoView.swift; sourceTree = "<group>"; };
 		0A6CC0EE23904D5400E4F627 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
+		0AD00141E45DB79DEAE23EFC /* ReasoningModeAccessResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReasoningModeAccessResolver.swift; sourceTree = "<group>"; };
 		0D5BA3FF1041A3BB9396AE65 /* UnifiedToggleInputFloatingReturnKeyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputFloatingReturnKeyViewController.swift; sourceTree = "<group>"; };
 		0DB842C9EB504CCBA5A14D4C /* RebrandedOnboardingView+DaxAnimationOverlay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "RebrandedOnboardingView+DaxAnimationOverlay.swift"; sourceTree = "<group>"; };
+		114B20D6843A4D239C58435F /* SearchExperienceToggleAnimationView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SearchExperienceToggleAnimationView.swift; sourceTree = "<group>"; };
 		136D952152194AD431654F8D /* RemoteMessagingUIPreviewsDebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteMessagingUIPreviewsDebugView.swift; sourceTree = "<group>"; };
+		17BA504D98D84DB79BDE168D /* OnboardingSearchAIToggleGrey.lottie */ = {isa = PBXFileReference; lastKnownFileType = file; path = OnboardingSearchAIToggleGrey.lottie; sourceTree = "<group>"; };
 		1CB7B82023CEA1F800AA24EA /* DateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
 		1CB7B82223CEA28300AA24EA /* DateExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtensionTests.swift; sourceTree = "<group>"; };
 		1D200C962BA3157A00108701 /* SettingsNextStepsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsNextStepsView.swift; sourceTree = "<group>"; };
@@ -2847,6 +2858,7 @@
 		1EF24234273BB9D200DE3D02 /* IntervalSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntervalSlider.swift; sourceTree = "<group>"; };
 		1EFDCBC027D2393C00916BC5 /* DownloadsDeleteHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsDeleteHelper.swift; sourceTree = "<group>"; };
 		22CB1ED7203DDD2C00D2C724 /* AppDeepLinksTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDeepLinksTests.swift; sourceTree = "<group>"; };
+		2D09A21E8CF1A9B32BC45E19 /* UnifiedToggleInputReasoningMenuFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputReasoningMenuFactoryTests.swift; sourceTree = "<group>"; };
 		2DC3FBD62FBAF21E87610FA8 /* AutofillNoAuthAvailableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutofillNoAuthAvailableView.swift; sourceTree = "<group>"; };
 		2E8EA7278F9B57FA589BC54A /* UnifiedToggleInputModelMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputModelMenu.swift; sourceTree = "<group>"; };
 		3105BCF02DF214A000EB755E /* AIChatPixelMetricHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatPixelMetricHandler.swift; sourceTree = "<group>"; };
@@ -3020,6 +3032,7 @@
 		392856D96DBE03E4E18EFCF8 /* RebrandedOnboardingAddressBarPositionPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RebrandedOnboardingAddressBarPositionPicker.swift; sourceTree = "<group>"; };
 		40D67C082BD4927358D771DB /* RebrandedAppIconPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RebrandedAppIconPicker.swift; sourceTree = "<group>"; };
 		46DD3D592D0A29F400F33D49 /* CrashReportSenderExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportSenderExtensions.swift; sourceTree = "<group>"; };
+		48B631B1C80B6A67A6FD9FCE /* UnifiedToggleInputReasoningMenuFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputReasoningMenuFactory.swift; sourceTree = "<group>"; };
 		4AD56A4878844306BD83E026 /* AIBoundaryNavigationDecision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIBoundaryNavigationDecision.swift; sourceTree = "<group>"; };
 		4B0295182537BC6700E00CEF /* ConfigurationDebugViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationDebugViewController.swift; sourceTree = "<group>"; };
 		4B0F3F4F2B9BFF2100392892 /* NetworkProtectionFAQView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionFAQView.swift; sourceTree = "<group>"; };
@@ -3076,6 +3089,7 @@
 		4C0B70EF2418A35A5D863506 /* AIChatRecentChatsPopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatRecentChatsPopupViewController.swift; sourceTree = "<group>"; };
 		4C8AD06BCB81EA991F22DD66 /* DefaultTogglePositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTogglePositionTests.swift; sourceTree = "<group>"; };
 		4D434F523CEFF1B86C75ECC6 /* RebrandedOnboardingView+AddToDockContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "RebrandedOnboardingView+AddToDockContent.swift"; sourceTree = "<group>"; };
+		52CC2F8B19BA4ED5AAB32605 /* OnboardingSearchAIToggleGrey_dark.lottie */ = {isa = PBXFileReference; lastKnownFileType = file; path = OnboardingSearchAIToggleGrey_dark.lottie; sourceTree = "<group>"; };
 		56038D5E2E0E97B20001419D /* SubscriptionURLNavigationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionURLNavigationHandler.swift; sourceTree = "<group>"; };
 		5608B5122F2125CC00ABC3F4 /* UITestOverridesDebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestOverridesDebugView.swift; sourceTree = "<group>"; };
 		560E84842EE0FA53008F6B74 /* TierBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TierBadgeView.swift; sourceTree = "<group>"; };
@@ -3126,7 +3140,6 @@
 		5AB12C3D4E5F60718293A4B6 /* AIChatHistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatHistoryViewController.swift; sourceTree = "<group>"; };
 		5AB12C3D4E5F60718293A4B8 /* AIChatHistoryEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatHistoryEmptyStateView.swift; sourceTree = "<group>"; };
 		5AB12C3D4E5F60718293A4BA /* AIChatHistoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatHistoryViewModel.swift; sourceTree = "<group>"; };
-		7BE3A9DD8385464FA82977B9 /* AIChatHistoryInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatHistoryInstrumentation.swift; sourceTree = "<group>"; };
 		5AB12C3D4E5F60718293A4BC /* AIChatHistoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatHistoryCell.swift; sourceTree = "<group>"; };
 		5AB12C3D4E5F60718293A4C0 /* MockChatHistoryReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockChatHistoryReader.swift; sourceTree = "<group>"; };
 		5AB12C3D4E5F60718293A4D2 /* AIChatHistoryNoResultsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatHistoryNoResultsCell.swift; sourceTree = "<group>"; };
@@ -3145,11 +3158,6 @@
 		5B6D65172FB3B47F00BDCF4D /* CalendarEventEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarEventEditView.swift; sourceTree = "<group>"; };
 		5B6D65192FB4BB7E00BDCF4D /* ICSFileReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICSFileReader.swift; sourceTree = "<group>"; };
 		5B6D651C2FB4D2E900BDCF4D /* ICSFileReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICSFileReaderTests.swift; sourceTree = "<group>"; };
-		EFDD2F8A58E59142D8FDD931 /* CalendarEventPreviewHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarEventPreviewHelperTests.swift; sourceTree = "<group>"; };
-		BCC0F7A02FB3000000BDCF01 /* VCardFileReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VCardFileReader.swift; sourceTree = "<group>"; };
-		BCC0F7A22FB3000000BDCF02 /* ContactPreviewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactPreviewHelper.swift; sourceTree = "<group>"; };
-		BCC0F7A42FB3000000BDCF03 /* ContactCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactCardView.swift; sourceTree = "<group>"; };
-		BCC0F7A72FB3000000BDCF05 /* VCardFileReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VCardFileReaderTests.swift; sourceTree = "<group>"; };
 		5B6D651E2FB4D30700BDCF4D /* CompleteDownloadRowViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteDownloadRowViewModelTests.swift; sourceTree = "<group>"; };
 		5B6D65202FBA000000BDCF4D /* FilePreviewHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewHelperTests.swift; sourceTree = "<group>"; };
 		5B941E712FA29A2900AF2CE7 /* QuickActionsMediumWidgetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionsMediumWidgetTests.swift; sourceTree = "<group>"; };
@@ -3165,11 +3173,6 @@
 		5BF65FE12F5F224000BCC9F4 /* ListBasedPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListBasedPicker.swift; sourceTree = "<group>"; };
 		6090D90640A2B1A529EDBAAB /* ToggleModeStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleModeStorage.swift; sourceTree = "<group>"; };
 		61EDFAE3163584454362A466 /* RebrandedOnboardingSearchExperiencePicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RebrandedOnboardingSearchExperiencePicker.swift; sourceTree = "<group>"; };
-		114B20D6843A4D239C58435F /* SearchExperienceToggleAnimationView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SearchExperienceToggleAnimationView.swift; sourceTree = "<group>"; };
-		681283C1263F43E4BA42ED6B /* OnboardingSearchAIToggle.lottie */ = {isa = PBXFileReference; lastKnownFileType = file; path = "OnboardingSearchAIToggle.lottie"; sourceTree = "<group>"; };
-		AEC7FF2261884003814DB9D0 /* OnboardingSearchAIToggle_dark.lottie */ = {isa = PBXFileReference; lastKnownFileType = file; path = "OnboardingSearchAIToggle_dark.lottie"; sourceTree = "<group>"; };
-		17BA504D98D84DB79BDE168D /* OnboardingSearchAIToggleGrey.lottie */ = {isa = PBXFileReference; lastKnownFileType = file; path = "OnboardingSearchAIToggleGrey.lottie"; sourceTree = "<group>"; };
-		52CC2F8B19BA4ED5AAB32605 /* OnboardingSearchAIToggleGrey_dark.lottie */ = {isa = PBXFileReference; lastKnownFileType = file; path = "OnboardingSearchAIToggleGrey_dark.lottie"; sourceTree = "<group>"; };
 		650552962D673E440067D4F2 /* muteAudio.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = muteAudio.js; sourceTree = "<group>"; };
 		650552A12D67768E0067D4F2 /* DuckPlayerEntryPillViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckPlayerEntryPillViewModel.swift; sourceTree = "<group>"; };
 		6526CA6A2D70CAAD0048819E /* DuckPlayerMiniPillViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DuckPlayerMiniPillViewModel.swift; sourceTree = "<group>"; };
@@ -3202,6 +3205,7 @@
 		65F436132D9AD4610034CC36 /* NativeDuckPlayerNavigationHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeDuckPlayerNavigationHandlerTests.swift; sourceTree = "<group>"; };
 		65F436142D9AD4610034CC36 /* YoutublePlayerNavigationHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YoutublePlayerNavigationHandlerTests.swift; sourceTree = "<group>"; };
 		65F4CB452D7A0EFF00E89416 /* DuckPlayerWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckPlayerWebView.swift; sourceTree = "<group>"; };
+		681283C1263F43E4BA42ED6B /* OnboardingSearchAIToggle.lottie */ = {isa = PBXFileReference; lastKnownFileType = file; path = OnboardingSearchAIToggle.lottie; sourceTree = "<group>"; };
 		6A30EF03B7EC51B89770CA36 /* NavigationPixelNavigationResponderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationPixelNavigationResponderTests.swift; sourceTree = "<group>"; };
 		6AC6DAB228804F97002723C0 /* BarsAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarsAnimator.swift; sourceTree = "<group>"; };
 		6AC98418288055C1005FA9CA /* BarsAnimatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarsAnimatorTests.swift; sourceTree = "<group>"; };
@@ -3255,8 +3259,6 @@
 		6F8496402BC3D8EE00ADA54E /* OnboardingButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingButtonsView.swift; sourceTree = "<group>"; };
 		6F87A7932D96AEA3006BFD71 /* OmniBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmniBarViewController.swift; sourceTree = "<group>"; };
 		6F922EDA2D8C364C0062DFC1 /* DefaultOmniBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultOmniBarViewController.swift; sourceTree = "<group>"; };
-		FBA1C0DE0000000000000002 /* IPadOmnibarModelPickerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadOmnibarModelPickerController.swift; sourceTree = "<group>"; };
-		FBA1C0DE0000000000000006 /* IPadDuckAIControlsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadDuckAIControlsFeature.swift; sourceTree = "<group>"; };
 		6F922EDC2D8C372F0062DFC1 /* DefaultOmniBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultOmniBarView.swift; sourceTree = "<group>"; };
 		6F922EDE2D8C5AEC0062DFC1 /* DefaultOmniBarSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultOmniBarSearchView.swift; sourceTree = "<group>"; };
 		6F922EE02D8C5C6B0062DFC1 /* URLSeparatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSeparatorView.swift; sourceTree = "<group>"; };
@@ -3298,6 +3300,7 @@
 		6FF4943E2DDDDC4000BCF5F0 /* NSLayoutConstraintExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLayoutConstraintExtension.swift; sourceTree = "<group>"; };
 		6FF9AD3E2CE63DC200C5A406 /* TabSwitcherOpenDailyPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSwitcherOpenDailyPixel.swift; sourceTree = "<group>"; };
 		6FF9AD402CE6610600C5A406 /* TabSwitcherOpenDailyPixelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSwitcherOpenDailyPixelTests.swift; sourceTree = "<group>"; };
+		7A1B2C3D2E0000000000F002 /* TabsBarViewControllerSizingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsBarViewControllerSizingTests.swift; sourceTree = "<group>"; };
 		7B059F0A2D0387E900371ED0 /* NumberedParagraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberedParagraphView.swift; sourceTree = "<group>"; };
 		7B059F0C2D0387E900371ED0 /* WidgetEducationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetEducationView.swift; sourceTree = "<group>"; };
 		7B059F0D2D0387E900371ED0 /* WidgetEducationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetEducationViewController.swift; sourceTree = "<group>"; };
@@ -3326,6 +3329,7 @@
 		7BC16BAB2E72550A0016EE8E /* LoggingDebugViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingDebugViewController.swift; sourceTree = "<group>"; };
 		7BC5711F2BDBB877003B0CCE /* VPNActivationDateStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VPNActivationDateStore.swift; sourceTree = "<group>"; };
 		7BDBAD0D2CBFB3F1000379B7 /* VPN.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = VPN.xcassets; sourceTree = "<group>"; };
+		7BE3A9DD8385464FA82977B9 /* AIChatHistoryInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatHistoryInstrumentation.swift; sourceTree = "<group>"; };
 		7BF78E012CA2CC3E0026A1FC /* TipKitAppEventHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipKitAppEventHandling.swift; sourceTree = "<group>"; };
 		7BFC32AF2CB291BB007A8E17 /* VPNControlWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNControlWidget.swift; sourceTree = "<group>"; };
 		7BFD5FD42C9DA310000FF959 /* VPNAddWidgetTip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNAddWidgetTip.swift; sourceTree = "<group>"; };
@@ -3439,7 +3443,6 @@
 		850365F223DE087800D0F787 /* UIImageViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageViewExtension.swift; sourceTree = "<group>"; };
 		85047C762A0D5D3D00D2FF3F /* SyncSettingsViewController+SyncDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SyncSettingsViewController+SyncDelegate.swift"; sourceTree = "<group>"; };
 		8504E9E92D8883AE00FF1352 /* TabSwitcherBarsStateHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSwitcherBarsStateHandlerTests.swift; sourceTree = "<group>"; };
-		7A1B2C3D2E0000000000F002 /* TabsBarViewControllerSizingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsBarViewControllerSizingTests.swift; sourceTree = "<group>"; };
 		850559C823C61B5D0055C0D5 /* login-form-detection.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "login-form-detection.js"; sourceTree = "<group>"; };
 		850559CF23CF647C0055C0D5 /* Fireproofing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fireproofing.swift; sourceTree = "<group>"; };
 		850559D123CF710C0055C0D5 /* WebCacheManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCacheManagerTests.swift; sourceTree = "<group>"; };
@@ -3642,8 +3645,10 @@
 		85F996CF2E54C260006B4641 /* OpenAIChatFromAddressBarHandlingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIChatFromAddressBarHandlingTests.swift; sourceTree = "<group>"; };
 		8693FFCAC02CE4A85D0BD62C /* RebrandedOnboardingView+BrowsersComparisonContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "RebrandedOnboardingView+BrowsersComparisonContent.swift"; sourceTree = "<group>"; };
 		87D22C154C1851EFAB573AAE /* TabSwipeOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSwipeOverlayView.swift; sourceTree = "<group>"; };
+		883AAA241504625A0E8455C1 /* IPadOmnibarReasoningPickerController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IPadOmnibarReasoningPickerController.swift; sourceTree = "<group>"; };
 		8C47244F2217A14B004C9B2D /* TabViewControllerSaveBookmarkExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabViewControllerSaveBookmarkExtension.swift; sourceTree = "<group>"; };
 		8C4838B4221C8F7F008A6739 /* GestureToolbarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GestureToolbarButton.swift; sourceTree = "<group>"; };
+		8E7EE5FF3B14EBB6C0AAB71A /* IPadOmnibarReasoningPickerControllerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IPadOmnibarReasoningPickerControllerTests.swift; sourceTree = "<group>"; };
 		970C8DE9831CD77A979A1354 /* RebrandedOnboardingView+SkipOnboardingContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "RebrandedOnboardingView+SkipOnboardingContent.swift"; sourceTree = "<group>"; };
 		9710D4A02ED5B323006C14FF /* FadeOutContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FadeOutContainerViewController.swift; sourceTree = "<group>"; };
 		9770D4A82F6AFD3F0029361F /* DuckAIVoiceShortcutFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAIVoiceShortcutFeature.swift; sourceTree = "<group>"; };
@@ -4493,7 +4498,6 @@
 		AABB0001000100010001000A /* UTIAttachmentPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIAttachmentPolicyTests.swift; sourceTree = "<group>"; };
 		AABB0001000100010001000C /* UTIModelStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIModelStore.swift; sourceTree = "<group>"; };
 		AABB0001000100010001000E /* UTIModelStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIModelStoreTests.swift; sourceTree = "<group>"; };
-		FBA1C0DE0000000000000004 /* IPadOmnibarModelPickerControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadOmnibarModelPickerControllerTests.swift; sourceTree = "<group>"; };
 		AABB00010001000100010010 /* UTIToolsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIToolsController.swift; sourceTree = "<group>"; };
 		AABB00010001000100010100 /* UnifiedToggleInputViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputViewTests.swift; sourceTree = "<group>"; };
 		AABB00010001000100010200 /* UnifiedToggleInputToggleViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputToggleViewTests.swift; sourceTree = "<group>"; };
@@ -4504,6 +4508,7 @@
 		AC7100D1A6105DEBEEF00007 /* WebScrollFreezeDebugProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebScrollFreezeDebugProbe.swift; sourceTree = "<group>"; };
 		AC7D7E5EB7B04D2385E0E48E /* AfterInactivityOptionAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterInactivityOptionAdapterTests.swift; sourceTree = "<group>"; };
 		AD8CF8E4B152CDB3A4ACB14C /* StartupOnboardingCover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupOnboardingCover.swift; sourceTree = "<group>"; };
+		AEC7FF2261884003814DB9D0 /* OnboardingSearchAIToggle_dark.lottie */ = {isa = PBXFileReference; lastKnownFileType = file; path = OnboardingSearchAIToggle_dark.lottie; sourceTree = "<group>"; };
 		AF81E0C6EDC46254CF28AFCB /* RebrandedOnboardingView+SearchExperienceContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "RebrandedOnboardingView+SearchExperienceContent.swift"; sourceTree = "<group>"; };
 		B39FB0F32E25368100DF2C4E /* AutoconsentPixels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoconsentPixels.swift; sourceTree = "<group>"; };
 		B4E5D6C7A8F9012345678901 /* AIChatTabChatHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTabChatHeaderViewTests.swift; sourceTree = "<group>"; };
@@ -4568,6 +4573,10 @@
 		BBFE75F62EA64DBD0055480B /* WinBackOfferDebugMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WinBackOfferDebugMenu.swift; sourceTree = "<group>"; };
 		BBFF18B02C76448100C48D7D /* QuerySubmittedTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuerySubmittedTests.swift; sourceTree = "<group>"; };
 		BBFF22EE2F3469160055A710 /* MockFreeTrialConversionInstrumentationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFreeTrialConversionInstrumentationService.swift; sourceTree = "<group>"; };
+		BCC0F7A02FB3000000BDCF01 /* VCardFileReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VCardFileReader.swift; sourceTree = "<group>"; };
+		BCC0F7A22FB3000000BDCF02 /* ContactPreviewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactPreviewHelper.swift; sourceTree = "<group>"; };
+		BCC0F7A42FB3000000BDCF03 /* ContactCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactCardView.swift; sourceTree = "<group>"; };
+		BCC0F7A72FB3000000BDCF05 /* VCardFileReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VCardFileReaderTests.swift; sourceTree = "<group>"; };
 		BD10B8A92C7629740033115D /* Logger+Subscription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Logger+Subscription.swift"; sourceTree = "<group>"; };
 		BD2F39EA2C19F955005B19E7 /* NetworkProtectionDNSSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionDNSSettingsView.swift; sourceTree = "<group>"; };
 		BD7008D32E1F1EED00CF9C3E /* DataBrokerProtection-iOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = "DataBrokerProtection-iOS.xctestplan"; path = "LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOS.xctestplan"; sourceTree = "<group>"; };
@@ -4588,6 +4597,7 @@
 		BDFF031C2BA3D2BD00F324C9 /* DefaultNetworkProtectionVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultNetworkProtectionVisibility.swift; sourceTree = "<group>"; };
 		BEA13CC2BC37C33434640638 /* WebViewInputAccessoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewInputAccessoryTests.swift; sourceTree = "<group>"; };
 		BFA000012F90000000FEEE01 /* FreemiumPIREligibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreemiumPIREligibility.swift; sourceTree = "<group>"; };
+		C0A43FA34A9C65835FF48566 /* DuckAISubscriptionUpsellPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuckAISubscriptionUpsellPresenter.swift; sourceTree = "<group>"; };
 		C10454E12F8D0F2C002BB02C /* CredentialExchangeImportHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialExchangeImportHandler.swift; sourceTree = "<group>"; };
 		C1056A552E253D98003220BA /* AutofillCredentialsImportPresentationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillCredentialsImportPresentationManagerTests.swift; sourceTree = "<group>"; };
 		C106BAC22E4627E000DDF54A /* DaxEasterEggFullScreenViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaxEasterEggFullScreenViewController.swift; sourceTree = "<group>"; };
@@ -5023,7 +5033,6 @@
 		CBD79F4C2D130F6300DBB45A /* Simulated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Simulated.swift; sourceTree = "<group>"; };
 		CBD7AE812AF6D5B6009052FD /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		CBDD5DDE29A6736A00832877 /* APIHeadersTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIHeadersTests.swift; sourceTree = "<group>"; };
-		AC7100D1A6105DEBEEF00009 /* WebScrollObserverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebScrollObserverTests.swift; sourceTree = "<group>"; };
 		CBDEDA152D8079E500123E00 /* RoundedCornersMaskView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedCornersMaskView.swift; sourceTree = "<group>"; };
 		CBE099292AF6D54D000EFC47 /* lv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lv; path = lv.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		CBE77C742FD2F3A300CB7C6D /* SuggestionRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionRow.swift; sourceTree = "<group>"; };
@@ -5167,7 +5176,9 @@
 		E0742FD8DD5F46AB8243A001 /* IdleReturnTabCountInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleReturnTabCountInstrumentation.swift; sourceTree = "<group>"; };
 		E1A4A4D42F2A111100AA11BB /* TabViewController+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabViewController+UI.swift"; sourceTree = "<group>"; };
 		E3663DD21563403B96D50EF0 /* AfterInactivityOptionAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterInactivityOptionAdapter.swift; sourceTree = "<group>"; };
+		E3E0B95A939268F4937B4ED4 /* ReasoningModeAccessResolverTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReasoningModeAccessResolverTests.swift; sourceTree = "<group>"; };
 		E44F90E856A0488A976B6AFE /* FileCorruptErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCorruptErrorView.swift; sourceTree = "<group>"; };
+		E71D2723FF8B5622E2904F40 /* DuckAISubscriptionUpsellPresenterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuckAISubscriptionUpsellPresenterTests.swift; sourceTree = "<group>"; };
 		E7971E90992B46FABF42A908 /* AIChatContextualWebViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualWebViewControllerTests.swift; sourceTree = "<group>"; };
 		EA39B7E1268A1A35000C62CD /* privacy-reference-tests */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = folder; name = "privacy-reference-tests"; path = "../SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Resources/privacy-reference-tests"; sourceTree = SOURCE_ROOT; };
 		EA8E5DCD620608EB3A162D3D /* AIChatTabChatHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTabChatHeaderView.swift; sourceTree = "<group>"; };
@@ -5242,6 +5253,7 @@
 		EEF7091E2DDE77B000BA3C36 /* SyncExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncExtensions.swift; sourceTree = "<group>"; };
 		EEFC6A5F2AC0F2F80065027D /* UserText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserText.swift; sourceTree = "<group>"; };
 		EEFE9C722A603CE9005B0A26 /* NetworkProtectionStatusViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionStatusViewModelTests.swift; sourceTree = "<group>"; };
+		EFDD2F8A58E59142D8FDD931 /* CalendarEventPreviewHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarEventPreviewHelperTests.swift; sourceTree = "<group>"; };
 		F0A100002F30200100BAD001 /* NewBadgeVisibilityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBadgeVisibilityManager.swift; sourceTree = "<group>"; };
 		F0A1B2C3D4E5F60718293A01 /* FloatingUIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingUIManager.swift; sourceTree = "<group>"; };
 		F0A1B2C3D4E5F60718293A02 /* FloatingUIChromeStyler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingUIChromeStyler.swift; sourceTree = "<group>"; };
@@ -5383,6 +5395,10 @@
 		F4F7F10925813FE200045D62 /* 03_Airstream_divided_by_four.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = 03_Airstream_divided_by_four.json; sourceTree = "<group>"; };
 		F7594859CB2334A38D629EF5 /* SafariRedirectHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariRedirectHandlerTests.swift; sourceTree = "<group>"; };
 		F99D6557A506491EFDAD68A2 /* DBPIOSContentBlockingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DBPIOSContentBlockingTests.swift; sourceTree = "<group>"; };
+		FBA1C0DE0000000000000002 /* IPadOmnibarModelPickerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadOmnibarModelPickerController.swift; sourceTree = "<group>"; };
+		FBA1C0DE0000000000000004 /* IPadOmnibarModelPickerControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadOmnibarModelPickerControllerTests.swift; sourceTree = "<group>"; };
+		FBA1C0DE0000000000000006 /* IPadDuckAIControlsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadDuckAIControlsFeature.swift; sourceTree = "<group>"; };
+		FBA1C0DE0000000000000008 /* IPadDuckAIControlsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadDuckAIControlsFeatureTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -6918,16 +6934,6 @@
 			path = Calendar;
 			sourceTree = "<group>";
 		};
-		BCC0F7A62FB3000000BDCF04 /* Contacts */ = {
-			isa = PBXGroup;
-			children = (
-				BCC0F7A02FB3000000BDCF01 /* VCardFileReader.swift */,
-				BCC0F7A22FB3000000BDCF02 /* ContactPreviewHelper.swift */,
-				BCC0F7A42FB3000000BDCF03 /* ContactCardView.swift */,
-			);
-			path = Contacts;
-			sourceTree = "<group>";
-		};
 		5B6D651B2FB4D2DC00BDCF4D /* Calendar */ = {
 			isa = PBXGroup;
 			children = (
@@ -6935,14 +6941,6 @@
 				EFDD2F8A58E59142D8FDD931 /* CalendarEventPreviewHelperTests.swift */,
 			);
 			path = Calendar;
-			sourceTree = "<group>";
-		};
-		BCC0F7AB2FB3000000BDCF07 /* Contacts */ = {
-			isa = PBXGroup;
-			children = (
-				BCC0F7A72FB3000000BDCF05 /* VCardFileReaderTests.swift */,
-			);
-			path = Contacts;
 			sourceTree = "<group>";
 		};
 		5B941E702FA29A1600AF2CE7 /* Widgets */ = {
@@ -9338,6 +9336,24 @@
 			path = WinBackOffer;
 			sourceTree = "<group>";
 		};
+		BCC0F7A62FB3000000BDCF04 /* Contacts */ = {
+			isa = PBXGroup;
+			children = (
+				BCC0F7A02FB3000000BDCF01 /* VCardFileReader.swift */,
+				BCC0F7A22FB3000000BDCF02 /* ContactPreviewHelper.swift */,
+				BCC0F7A42FB3000000BDCF03 /* ContactCardView.swift */,
+			);
+			path = Contacts;
+			sourceTree = "<group>";
+		};
+		BCC0F7AB2FB3000000BDCF07 /* Contacts */ = {
+			isa = PBXGroup;
+			children = (
+				BCC0F7A72FB3000000BDCF05 /* VCardFileReaderTests.swift */,
+			);
+			path = Contacts;
+			sourceTree = "<group>";
+		};
 		BDE91CD42C6292BF0005CB74 /* Feedback */ = {
 			isa = PBXGroup;
 			children = (
@@ -9672,6 +9688,9 @@
 				CB6D17BF2FB488BE00ECD5AE /* UTIDismissSnapshot.swift */,
 				CBE77C722FD2F36A00CB7C6D /* Suggestions */,
 				CBB4A8722FD83C4100A65956 /* ModeSwitchSwipeGestureController.swift */,
+				0AD00141E45DB79DEAE23EFC /* ReasoningModeAccessResolver.swift */,
+				48B631B1C80B6A67A6FD9FCE /* UnifiedToggleInputReasoningMenuFactory.swift */,
+				C0A43FA34A9C65835FF48566 /* DuckAISubscriptionUpsellPresenter.swift */,
 			);
 			path = UnifiedToggleInput;
 			sourceTree = "<group>";
@@ -9701,6 +9720,10 @@
 				CB6D17A12FA397FC00ECD5AE /* UnifiedToggleInputPageContextChipViewModelTests.swift */,
 				CB22D7A12FC603EB00128979 /* MainViewControllerRefreshActionTests.swift */,
 				CBE77C732FD2F39800CB7C6D /* Suggestions */,
+				E3E0B95A939268F4937B4ED4 /* ReasoningModeAccessResolverTests.swift */,
+				2D09A21E8CF1A9B32BC45E19 /* UnifiedToggleInputReasoningMenuFactoryTests.swift */,
+				E71D2723FF8B5622E2904F40 /* DuckAISubscriptionUpsellPresenterTests.swift */,
+				8E7EE5FF3B14EBB6C0AAB71A /* IPadOmnibarReasoningPickerControllerTests.swift */,
 			);
 			path = UnifiedToggleInput;
 			sourceTree = "<group>";
@@ -11385,6 +11408,7 @@
 				FBA1C0DE0000000000000006 /* IPadDuckAIControlsFeature.swift */,
 				6F922EE02D8C5C6B0062DFC1 /* URLSeparatorView.swift */,
 				6F9F62D22F86A4C20029CCEA /* MinimalChromeSettings.swift */,
+				883AAA241504625A0E8455C1 /* IPadOmnibarReasoningPickerController.swift */,
 			);
 			name = OmniBar;
 			sourceTree = "<group>";
@@ -12242,10 +12266,10 @@
 				4BC8948A2C7902E6009AA141 /* XCRemoteSwiftPackageReference "wireguard-apple" */,
 				84EFBCCA2D817CB500706739 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */,
 				9FDD72032D895D8C0016246B /* XCRemoteSwiftPackageReference "combine-schedulers" */,
-				BD0C4D872DC54508001F034F /* XCLocalSwiftPackageReference "LocalPackages/DuckUI" */,
-				7B0752DA2F21BFDB00ACA559 /* XCLocalSwiftPackageReference "../SharedPackages/AutomationServer" */,
+				BD0C4D872DC54508001F034F /* XCLocalSwiftPackageReference "DuckUI" */,
+				7B0752DA2F21BFDB00ACA559 /* XCLocalSwiftPackageReference "AutomationServer" */,
 				9FADFC482F5FC56400CA16F7 /* XCRemoteSwiftPackageReference "native-apps-ducksans" */,
-				315E39632F86ABE100D2289D /* XCLocalSwiftPackageReference "../SharedPackages/DebugServer" */,
+				315E39632F86ABE100D2289D /* XCLocalSwiftPackageReference "DebugServer" */,
 			);
 			productRefGroup = 84E341931E2F7EFB00BDBA6F /* Products */;
 			projectDirPath = "";
@@ -13978,6 +14002,10 @@
 				AAE51CD3558F68CEF6919A73 /* DBPIOSContentBlocking.swift in Sources */,
 				A14E0FE9F5A5E908BBD19F4E /* FireConfirmationPresenter+Suggestions.swift in Sources */,
 				0928A567CE4F37AC8E19B215 /* NavigationPixelNavigationResponder.swift in Sources */,
+				10357EC5C05F09BDB3388E23 /* ReasoningModeAccessResolver.swift in Sources */,
+				8AA7DA9074610EBDBF3FAA34 /* UnifiedToggleInputReasoningMenuFactory.swift in Sources */,
+				06D744C1F541FF4F91F7A664 /* DuckAISubscriptionUpsellPresenter.swift in Sources */,
+				9354C33177CC2A51CA978356 /* IPadOmnibarReasoningPickerController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14497,6 +14525,10 @@
 				39BD5432CF6280442CDE88F0 /* DBPIOSContentBlockingTests.swift in Sources */,
 				B7A97190FB026429E034DB99 /* TabViewControllerSiteLoadingPixelTests.swift in Sources */,
 				A627D8C9C6C477E0A51B89E5 /* NavigationPixelNavigationResponderTests.swift in Sources */,
+				85563CDA09A69E6ADAFB7C39 /* ReasoningModeAccessResolverTests.swift in Sources */,
+				88CED5F7656BFDD8D99B3CA0 /* UnifiedToggleInputReasoningMenuFactoryTests.swift in Sources */,
+				BE83A575896316C700B212FA /* DuckAISubscriptionUpsellPresenterTests.swift in Sources */,
+				E6B11AC3844012B6E947B7AA /* IPadOmnibarReasoningPickerControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -18244,15 +18276,15 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		315E39632F86ABE100D2289D /* XCLocalSwiftPackageReference "../SharedPackages/DebugServer" */ = {
+		315E39632F86ABE100D2289D /* XCLocalSwiftPackageReference "DebugServer" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ../SharedPackages/DebugServer;
 		};
-		7B0752DA2F21BFDB00ACA559 /* XCLocalSwiftPackageReference "../SharedPackages/AutomationServer" */ = {
+		7B0752DA2F21BFDB00ACA559 /* XCLocalSwiftPackageReference "AutomationServer" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ../SharedPackages/AutomationServer;
 		};
-		BD0C4D872DC54508001F034F /* XCLocalSwiftPackageReference "LocalPackages/DuckUI" */ = {
+		BD0C4D872DC54508001F034F /* XCLocalSwiftPackageReference "DuckUI" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = LocalPackages/DuckUI;
 		};
@@ -18330,8 +18362,6 @@
 				kind = exactVersion;
 				version = 1.2.0;
 			};
-			traits = (
-			);
 		};
 		B6F997C22B8F374300476735 /* XCRemoteSwiftPackageReference "apple-toolbox" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -18638,7 +18668,7 @@
 		};
 		7B0752D82F21BFDB00ACA559 /* AutomationServer */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 7B0752DA2F21BFDB00ACA559 /* XCLocalSwiftPackageReference "../SharedPackages/AutomationServer" */;
+			package = 7B0752DA2F21BFDB00ACA559 /* XCLocalSwiftPackageReference "AutomationServer" */;
 			productName = AutomationServer;
 		};
 		7B2CCBA22D11ABB100FE5852 /* VPNWidgetSupport */ = {

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -2595,7 +2595,6 @@
 		FBA1C0DE0000000000000003 /* IPadOmnibarModelPickerControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE0000000000000004 /* IPadOmnibarModelPickerControllerTests.swift */; };
 		FBA1C0DE0000000000000005 /* IPadDuckAIControlsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE0000000000000006 /* IPadDuckAIControlsFeature.swift */; };
 		FBA1C0DE0000000000000009 /* IPadDuckAIControlValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE000000000000000A /* IPadDuckAIControlValues.swift */; };
-		FBA1C0DE0000000000000007 /* IPadDuckAIControlsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE0000000000000008 /* IPadDuckAIControlsFeatureTests.swift */; };
 		FD555C0BE82E630360DC2E5A /* ToggleModeStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6090D90640A2B1A529EDBAAB /* ToggleModeStorage.swift */; };
 /* End PBXBuildFile section */
 
@@ -5400,7 +5399,6 @@
 		FBA1C0DE0000000000000004 /* IPadOmnibarModelPickerControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadOmnibarModelPickerControllerTests.swift; sourceTree = "<group>"; };
 		FBA1C0DE0000000000000006 /* IPadDuckAIControlsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadDuckAIControlsFeature.swift; sourceTree = "<group>"; };
 		FBA1C0DE000000000000000A /* IPadDuckAIControlValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadDuckAIControlValues.swift; sourceTree = "<group>"; };
-		FBA1C0DE0000000000000008 /* IPadDuckAIControlsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadDuckAIControlsFeatureTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -2594,6 +2594,7 @@
 		FBA1C0DE0000000000000001 /* IPadOmnibarModelPickerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE0000000000000002 /* IPadOmnibarModelPickerController.swift */; };
 		FBA1C0DE0000000000000003 /* IPadOmnibarModelPickerControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE0000000000000004 /* IPadOmnibarModelPickerControllerTests.swift */; };
 		FBA1C0DE0000000000000005 /* IPadDuckAIControlsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE0000000000000006 /* IPadDuckAIControlsFeature.swift */; };
+		FBA1C0DE0000000000000009 /* IPadDuckAIControlValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE000000000000000A /* IPadDuckAIControlValues.swift */; };
 		FBA1C0DE0000000000000007 /* IPadDuckAIControlsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE0000000000000008 /* IPadDuckAIControlsFeatureTests.swift */; };
 		FD555C0BE82E630360DC2E5A /* ToggleModeStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6090D90640A2B1A529EDBAAB /* ToggleModeStorage.swift */; };
 /* End PBXBuildFile section */
@@ -5398,6 +5399,7 @@
 		FBA1C0DE0000000000000002 /* IPadOmnibarModelPickerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadOmnibarModelPickerController.swift; sourceTree = "<group>"; };
 		FBA1C0DE0000000000000004 /* IPadOmnibarModelPickerControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadOmnibarModelPickerControllerTests.swift; sourceTree = "<group>"; };
 		FBA1C0DE0000000000000006 /* IPadDuckAIControlsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadDuckAIControlsFeature.swift; sourceTree = "<group>"; };
+		FBA1C0DE000000000000000A /* IPadDuckAIControlValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadDuckAIControlValues.swift; sourceTree = "<group>"; };
 		FBA1C0DE0000000000000008 /* IPadDuckAIControlsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadDuckAIControlsFeatureTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -11406,6 +11408,7 @@
 				6F922EDA2D8C364C0062DFC1 /* DefaultOmniBarViewController.swift */,
 				FBA1C0DE0000000000000002 /* IPadOmnibarModelPickerController.swift */,
 				FBA1C0DE0000000000000006 /* IPadDuckAIControlsFeature.swift */,
+				FBA1C0DE000000000000000A /* IPadDuckAIControlValues.swift */,
 				6F922EE02D8C5C6B0062DFC1 /* URLSeparatorView.swift */,
 				6F9F62D22F86A4C20029CCEA /* MinimalChromeSettings.swift */,
 				883AAA241504625A0E8455C1 /* IPadOmnibarReasoningPickerController.swift */,
@@ -13509,6 +13512,7 @@
 				6F922EDB2D8C36510062DFC1 /* DefaultOmniBarViewController.swift in Sources */,
 				FBA1C0DE0000000000000001 /* IPadOmnibarModelPickerController.swift in Sources */,
 				FBA1C0DE0000000000000005 /* IPadDuckAIControlsFeature.swift in Sources */,
+				FBA1C0DE0000000000000009 /* IPadDuckAIControlValues.swift in Sources */,
 				4B0163D92F704AB60002E7FF /* MarketplaceAdPostbackStorage.swift in Sources */,
 				4B0163DA2F704AB60002E7FF /* MarketplaceAdPostbackManager.swift in Sources */,
 				4B0163DB2F704AB60002E7FF /* MarketplaceAdPostback.swift in Sources */,

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -429,6 +429,50 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         isModelPickerEnabled && !(aiChatModelName?.isEmpty ?? true)
     }
 
+    /// Icon-only reasoning-level chip shown to the left of the model picker, styled to match
+    /// the iPhone reasoning button. Like the iPhone button it carries a pull-down menu and
+    /// swaps its glyph for the selected reasoning mode.
+    let reasoningPickerButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.accessibilityIdentifier = "AIChat.Omnibar.iPad.ReasoningPicker"
+        button.tintColor = UIColor(designSystemColor: .iconsSecondary)
+        button.isHidden = true
+        button.setContentHuggingPriority(.required, for: .horizontal)
+        button.setContentCompressionResistancePriority(.required, for: .horizontal)
+        if #available(iOS 16.0, *) {
+            button.preferredMenuElementOrder = .fixed
+        }
+        return button
+    }()
+
+    /// Enables the reasoning picker chip (driven by the `iPadDuckAIBarControls` flag).
+    var isReasoningPickerEnabled: Bool = false {
+        didSet { refreshReasoningPickerVisibility() }
+    }
+
+    /// The glyph for the selected reasoning mode. The chip stays hidden while this is nil —
+    /// i.e. when the selected model doesn't support a reasoning picker.
+    var aiChatReasoningIcon: UIImage? {
+        didSet {
+            reasoningPickerButton.setImage(aiChatReasoningIcon, for: .normal)
+            refreshReasoningPickerVisibility()
+        }
+    }
+
+    /// The pull-down menu listing reasoning modes. Setting it enables the chip's primary action.
+    var aiChatReasoningPickerMenu: UIMenu? {
+        get { reasoningPickerButton.menu }
+        set {
+            reasoningPickerButton.menu = newValue
+            reasoningPickerButton.showsMenuAsPrimaryAction = (newValue != nil)
+        }
+    }
+
+    private var canShowReasoningPicker: Bool {
+        isReasoningPickerEnabled && aiChatReasoningIcon != nil
+    }
+
     let aiChatTextView: UITextView = {
         let textView = UITextView()
         textView.translatesAutoresizingMaskIntoConstraints = false
@@ -536,6 +580,7 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         searchAreaContainerView.addSubview(aiChatTextView)
         searchAreaContainerView.addSubview(aiChatSendButton)
         searchAreaContainerView.addSubview(modelPickerButton)
+        searchAreaContainerView.addSubview(reasoningPickerButton)
         searchAreaContainerView.addSubview(aiChatLeftButton)
 
         addSubview(activeOutlineView)
@@ -926,7 +971,7 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
 
     private func overflowTarget(at point: CGPoint, with event: UIEvent?) -> UIView? {
         guard isSearchAreaExpanded else { return nil }
-        let candidates: [UIView] = [aiChatSendButton, modelPickerButton, aiChatTextView]
+        let candidates: [UIView] = [aiChatSendButton, modelPickerButton, reasoningPickerButton, aiChatTextView]
         return candidates.first { candidate in
             guard !candidate.isHidden else { return false }
             let localPoint = candidate.convert(point, from: self)
@@ -1084,6 +1129,10 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         static let modelPickerChipHorizontalPadding: CGFloat = 16.0
         static let modelPickerChipSpacing: CGFloat = 4.0
         static let modelPickerToSendButtonSpacing: CGFloat = 8.0
+
+        // Duck.ai reasoning picker chip (iPad), icon-only, sits to the left of the model chip.
+        static let reasoningPickerChipSize: CGFloat = 40.0
+        static let reasoningToModelPickerSpacing: CGFloat = 4.0
 
         static let expandedPadSizeSpacing: CGFloat = 24.0
         static let expandedPadSizeMargins = NSDirectionalEdgeInsets(
@@ -1341,6 +1390,14 @@ extension DefaultOmniBarView {
             modelPickerButton.centerYAnchor.constraint(equalTo: aiChatSendButton.centerYAnchor),
             modelPickerButton.heightAnchor.constraint(equalToConstant: Metrics.modelPickerChipHeight),
             modelPickerButton.leadingAnchor.constraint(greaterThanOrEqualTo: aiChatTextView.leadingAnchor),
+
+            // Reasoning chip hugs the left edge of the model chip; its fixed width takes
+            // priority so the model name truncates rather than the icon clipping.
+            reasoningPickerButton.trailingAnchor.constraint(equalTo: modelPickerButton.leadingAnchor, constant: -Metrics.reasoningToModelPickerSpacing),
+            reasoningPickerButton.centerYAnchor.constraint(equalTo: aiChatSendButton.centerYAnchor),
+            reasoningPickerButton.widthAnchor.constraint(equalToConstant: Metrics.reasoningPickerChipSize),
+            reasoningPickerButton.heightAnchor.constraint(equalToConstant: Metrics.reasoningPickerChipSize),
+            reasoningPickerButton.leadingAnchor.constraint(greaterThanOrEqualTo: aiChatTextView.leadingAnchor),
         ])
 
         let bottomEqual = searchAreaStackView.bottomAnchor.constraint(equalTo: searchAreaAlignmentView.bottomAnchor)
@@ -1382,9 +1439,11 @@ extension DefaultOmniBarView {
             searchAreaContainerView.applyShadowOpacityMultiplier(1)
             aiChatSendButton.alpha = isSearchAreaExpanded ? 1 : 0
             modelPickerButton.alpha = (isSearchAreaExpanded && canShowModelPicker) ? 1 : 0
+            reasoningPickerButton.alpha = (isSearchAreaExpanded && canShowReasoningPicker) ? 1 : 0
             if !isSearchAreaExpanded {
                 aiChatSendButton.isHidden = true
                 modelPickerButton.isHidden = true
+                reasoningPickerButton.isHidden = true
             }
             applyExpansionConstraints()
             applyExpansionClipping()
@@ -1418,10 +1477,12 @@ extension DefaultOmniBarView {
                 self.searchAreaContainerView.applyShadowOpacityMultiplier(1)
                 self.aiChatSendButton.alpha = 1
                 self.modelPickerButton.alpha = self.canShowModelPicker ? 1 : 0
+                self.reasoningPickerButton.alpha = self.canShowReasoningPicker ? 1 : 0
             } else {
                 self.searchAreaContainerView.applyShadowOpacityMultiplier(0)
                 self.aiChatSendButton.alpha = 0
                 self.modelPickerButton.alpha = 0
+                self.reasoningPickerButton.alpha = 0
             }
             self.layoutIfNeeded()
         } completion: { _ in
@@ -1430,6 +1491,7 @@ extension DefaultOmniBarView {
                 self.searchAreaContainerView.applyShadowOpacityMultiplier(1)
                 self.aiChatSendButton.isHidden = true
                 self.modelPickerButton.isHidden = true
+                self.reasoningPickerButton.isHidden = true
                 self.onCollapseAnimationCompleted?()
                 self.onCollapseAnimationCompleted = nil
             } else {
@@ -1460,6 +1522,12 @@ extension DefaultOmniBarView {
             if canShowModelPicker {
                 prepareModelPickerButtonForDisplay()
             }
+
+            if canShowReasoningPicker {
+                reasoningPickerButton.isHidden = false
+                reasoningPickerButton.alpha = 0
+                searchAreaContainerView.bringSubviewToFront(reasoningPickerButton)
+            }
         } else {
             let currentText = aiChatTextView.text ?? ""
             aiChatTextView.isHidden = true
@@ -1486,6 +1554,20 @@ extension DefaultOmniBarView {
         modelPickerButton.isHidden = false
         modelPickerButton.alpha = 0
         searchAreaContainerView.bringSubviewToFront(modelPickerButton)
+    }
+
+    private func refreshReasoningPickerVisibility() {
+        guard isSearchAreaExpanded, canShowReasoningPicker else {
+            reasoningPickerButton.isHidden = true
+            return
+        }
+        guard reasoningPickerButton.isHidden else { return }
+        reasoningPickerButton.isHidden = false
+        reasoningPickerButton.alpha = 0
+        searchAreaContainerView.bringSubviewToFront(reasoningPickerButton)
+        UIView.animate(withDuration: Metrics.expansionAnimationDuration) {
+            self.reasoningPickerButton.alpha = 1
+        }
     }
 
     /// Toggles the textField's visibility so its placeholder shows through

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -429,9 +429,6 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         isModelPickerEnabled && !(aiChatModelName?.isEmpty ?? true)
     }
 
-    /// Icon-only reasoning-level chip shown to the left of the model picker, styled to match
-    /// the iPhone reasoning button. Like the iPhone button it carries a pull-down menu and
-    /// swaps its glyph for the selected reasoning mode.
     let reasoningPickerButton: UIButton = {
         let button = UIButton(type: .system)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -1391,8 +1388,6 @@ extension DefaultOmniBarView {
             modelPickerButton.heightAnchor.constraint(equalToConstant: Metrics.modelPickerChipHeight),
             modelPickerButton.leadingAnchor.constraint(greaterThanOrEqualTo: aiChatTextView.leadingAnchor),
 
-            // Reasoning chip hugs the left edge of the model chip; its fixed width takes
-            // priority so the model name truncates rather than the icon clipping.
             reasoningPickerButton.trailingAnchor.constraint(equalTo: modelPickerButton.leadingAnchor, constant: -Metrics.reasoningToModelPickerSpacing),
             reasoningPickerButton.centerYAnchor.constraint(equalTo: aiChatSendButton.centerYAnchor),
             reasoningPickerButton.widthAnchor.constraint(equalToConstant: Metrics.reasoningPickerChipSize),

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -590,8 +590,9 @@ extension DefaultOmniBarViewController {
 
         controller.onModelsUpdated = { [weak self] in
             guard let self else { return }
-            // Re-apply any reasoning selection unblocked by a subscription refresh, then
+            // Re-apply any model/reasoning selection unblocked by a subscription refresh, then
             // refresh both chips (selecting a new model changes which reasoning modes apply).
+            self.modelPickerController?.handleModelsUpdated()
             self.reasoningPickerController?.handleModelsUpdated()
             self.refreshModelPicker()
             self.refreshReasoningPicker()
@@ -617,7 +618,7 @@ extension DefaultOmniBarViewController {
             omniBarView.aiChatModelName = shortName
         }
         omniBarView.aiChatModelPickerMenu = controller.makeMenu { [weak self] modelId in
-            self?.modelPickerController?.selectModel(modelId)
+            self?.modelPickerController?.handleModelSelection(modelId)
             self?.refreshModelPicker()
             self?.refreshReasoningPicker()
         }

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -49,12 +49,10 @@ final class DefaultOmniBarViewController: OmniBarViewController {
     private var modelPickerController: IPadOmnibarModelPickerController?
     private var reasoningPickerController: IPadOmnibarReasoningPickerController?
 
-    /// The Duck.ai model id selected in the iPad picker, forwarded into `openAIChat` on submission.
     override var iPadDuckAISelectedModelId: String? {
         modelPickerController?.currentModelId
     }
 
-    /// The Duck.ai reasoning effort selected in the iPad picker, forwarded into `openAIChat` on submission.
     override var iPadDuckAISelectedReasoningEffort: AIChatReasoningEffort? {
         reasoningPickerController?.selectedReasoningEffort
     }
@@ -76,8 +74,6 @@ final class DefaultOmniBarViewController: OmniBarViewController {
         shiftEnter.wantsPriorityOverSystemBehavior = true
         commands.append(shiftEnter)
 
-        // The text view is multi-line, so only claim the arrows when navigating the list or when the caret has no
-        // line to move into; otherwise they fall through to normal caret movement.
         if omniBarView.aiChatTextView.isFirstResponder {
             let hasHighlight = omniDelegate?.hasAIChatSuggestionsHighlight() ?? false
             let canEnterList = omniDelegate?.isAIChatSuggestionsNavigationAvailable() ?? false

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -47,10 +47,16 @@ final class DefaultOmniBarViewController: OmniBarViewController {
     /// Manages shared text state for the iPad duck.ai ↔ search mode toggle.
     private let modeToggleTextModel: IPadModeToggleTextModeling = IPadModeToggleTextModel()
     private var modelPickerController: IPadOmnibarModelPickerController?
+    private var reasoningPickerController: IPadOmnibarReasoningPickerController?
 
     /// The Duck.ai model id selected in the iPad picker, forwarded into `openAIChat` on submission.
     override var iPadDuckAISelectedModelId: String? {
         modelPickerController?.currentModelId
+    }
+
+    /// The Duck.ai reasoning effort selected in the iPad picker, forwarded into `openAIChat` on submission.
+    override var iPadDuckAISelectedReasoningEffort: AIChatReasoningEffort? {
+        reasoningPickerController?.selectedReasoningEffort
     }
 
     override func loadView() {
@@ -577,18 +583,36 @@ extension DefaultOmniBarViewController {
               dependencies.featureFlagger.isFeatureOn(.iPadDuckAIBarControls) else { return }
 
         let controller = IPadOmnibarModelPickerController()
-        controller.onModelsUpdated = { [weak self] in
-            self?.refreshModelPicker()
-        }
         modelPickerController = controller
+
+        // The reasoning picker shares the model picker's store so both chips reflect the same
+        // selected model and a single `/models` fetch.
+        let reasoningController = IPadOmnibarReasoningPickerController(store: controller.modelStore)
+        reasoningPickerController = reasoningController
+        reasoningController.onReasoningUpdated = { [weak self] in
+            self?.refreshReasoningPicker()
+        }
+
+        controller.onModelsUpdated = { [weak self] in
+            guard let self else { return }
+            // Re-apply any reasoning selection unblocked by a subscription refresh, then
+            // refresh both chips (selecting a new model changes which reasoning modes apply).
+            self.reasoningPickerController?.handleModelsUpdated()
+            self.refreshModelPicker()
+            self.refreshReasoningPicker()
+        }
+
         omniBarView.isModelPickerEnabled = true
         omniBarView.aiChatModelName = controller.currentModelLabel
+        omniBarView.isReasoningPickerEnabled = true
+        refreshReasoningPicker()
     }
 
     private func handleModelPickerExpansionChanged(isExpanded: Bool) {
         guard isExpanded, let controller = modelPickerController else { return }
         controller.activate()
         refreshModelPicker()
+        refreshReasoningPicker()
     }
 
     private func refreshModelPicker() {
@@ -600,6 +624,19 @@ extension DefaultOmniBarViewController {
         omniBarView.aiChatModelPickerMenu = controller.makeMenu { [weak self] modelId in
             self?.modelPickerController?.selectModel(modelId)
             self?.refreshModelPicker()
+            self?.refreshReasoningPicker()
+        }
+    }
+
+    private func refreshReasoningPicker() {
+        guard let controller = reasoningPickerController else { return }
+
+        if controller.isReasoningPickerAvailable {
+            omniBarView.aiChatReasoningIcon = controller.currentReasoningMode?.unifiedToggleInputButtonImage
+            omniBarView.aiChatReasoningPickerMenu = controller.makeMenu()
+        } else {
+            omniBarView.aiChatReasoningIcon = nil
+            omniBarView.aiChatReasoningPickerMenu = nil
         }
     }
 }

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -49,12 +49,11 @@ final class DefaultOmniBarViewController: OmniBarViewController {
     private var modelPickerController: IPadOmnibarModelPickerController?
     private var reasoningPickerController: IPadOmnibarReasoningPickerController?
 
-    override var iPadDuckAISelectedModelId: String? {
-        modelPickerController?.currentModelId
-    }
-
-    override var iPadDuckAISelectedReasoningEffort: AIChatReasoningEffort? {
-        reasoningPickerController?.selectedReasoningEffort
+    override var iPadDuckAIControlValues: IPadDuckAIControlValues {
+        IPadDuckAIControlValuesSnapshot(
+            selectedModelId: modelPickerController?.currentModelId,
+            selectedReasoningEffort: reasoningPickerController?.selectedReasoningEffort
+        )
     }
 
     override func loadView() {

--- a/iOS/DuckDuckGo/IPadDuckAIControlValues.swift
+++ b/iOS/DuckDuckGo/IPadDuckAIControlValues.swift
@@ -1,0 +1,38 @@
+//
+//  IPadDuckAIControlValues.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import AIChat
+
+/// The values currently selected across the iPad address-bar Duck.ai controls
+protocol IPadDuckAIControlValues {
+
+    /// The Duck.ai model id selected in the iPad address-bar model picker, or `nil`.
+    var selectedModelId: String? { get }
+
+    /// The Duck.ai reasoning effort selected in the iPad address-bar reasoning picker, or `nil`.
+    var selectedReasoningEffort: AIChatReasoningEffort? { get }
+}
+
+/// A concrete snapshot of `IPadDuckAIControlValues`. Every value defaults to `nil`, so callers
+/// without active controls (iPhone, the base omnibar, tests) can use `IPadDuckAIControlValuesSnapshot()`.
+struct IPadDuckAIControlValuesSnapshot: IPadDuckAIControlValues {
+    var selectedModelId: String?
+    var selectedReasoningEffort: AIChatReasoningEffort?
+}

--- a/iOS/DuckDuckGo/IPadOmnibarModelPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarModelPickerController.swift
@@ -33,7 +33,12 @@ final class IPadOmnibarModelPickerController {
 
     private let store: UTIModelStore
     private let menuFactory = UnifiedToggleInputModelMenuFactory()
+    private let upsellPresenter: DuckAISubscriptionUpselling
     var onModelsUpdated: (() -> Void)?
+
+    /// A model whose selection was blocked behind an upsell; re-applied once a
+    /// subscription refresh grants the user access.
+    private var pendingGatedModelId: String?
 
     /// The shared model store. Exposed so the sibling reasoning picker can read the same
     /// selected model / subscription state and avoid a second `/models` fetch.
@@ -43,8 +48,10 @@ final class IPadOmnibarModelPickerController {
         modelsService: AIChatModelsProviding? = nil,
         preferences: AIChatPreferencesPersisting = AIChatPreferencesPersistor(),
         subscriptionManager: any SubscriptionManager = AppDependencyProvider.shared.subscriptionManager,
-        aiChatSettings: AIChatSettingsProvider = AIChatSettings()
+        aiChatSettings: AIChatSettingsProvider = AIChatSettings(),
+        upsellPresenter: DuckAISubscriptionUpselling = DuckAISubscriptionUpsellPresenter()
     ) {
+        self.upsellPresenter = upsellPresenter
         store = UTIModelStore(
             modelsService: modelsService ?? AIChatModelsService(
                 baseURL: aiChatModelsBaseURL(forChatURL: aiChatSettings.aiChatURL)
@@ -85,7 +92,65 @@ final class IPadOmnibarModelPickerController {
         )
     }
 
-    func selectModel(_ modelId: String) {
+    /// Selects the model if the user has access; otherwise routes to the matching subscription
+    /// upsell (mirrors the iPhone `UnifiedToggleInputCoordinator.handleModelSelection`).
+    func handleModelSelection(_ modelId: String) {
+        guard let model = store.models.first(where: { $0.id == modelId }) else { return }
+
+        if model.entityHasAccess {
+            pendingGatedModelId = nil
+            store.updateSelectedModel(modelId, isNewChatContext: true)
+        } else if routeGatedModelSelection(model) {
+            // Remember the gated model so a post-purchase `/models` refresh can apply it.
+            pendingGatedModelId = modelId
+        }
+    }
+
+    /// Re-applies a model selection that was blocked behind an upsell once a subscription
+    /// refresh has granted the user access. Invoked after `/models` re-fetches.
+    func handleModelsUpdated() {
+        applyPendingGatedModelSelectionIfPossible()
+    }
+
+    // MARK: - Private
+
+    @discardableResult
+    private func routeGatedModelSelection(_ model: AIChatModel) -> Bool {
+        guard let requiredTier = model.lowestPublicAccessTier else { return false }
+
+        let userTier = store.subscriptionState.userTier
+
+        if userTier == .free, requiredTier == .plus || requiredTier == .pro {
+            UnifiedToggleInputCoordinatorPixelHelper.fireSubscriptionUpsellTriggeredPixel(
+                source: .modelPicker,
+                currentTier: userTier,
+                requiredTier: requiredTier,
+                flowType: .purchase
+            )
+            upsellPresenter.presentPurchaseFlow(source: .modelPicker, isAITabState: false)
+            return true
+        }
+
+        if userTier == .plus, requiredTier == .pro {
+            UnifiedToggleInputCoordinatorPixelHelper.fireSubscriptionUpsellTriggeredPixel(
+                source: .modelPicker,
+                currentTier: userTier,
+                requiredTier: requiredTier,
+                flowType: .upgrade
+            )
+            upsellPresenter.presentUpgradeFlow(source: .modelPicker, isAITabState: false)
+            return true
+        }
+
+        return false
+    }
+
+    private func applyPendingGatedModelSelectionIfPossible() {
+        guard let modelId = pendingGatedModelId,
+              store.models.first(where: { $0.id == modelId })?.entityHasAccess == true else {
+            return
+        }
+        pendingGatedModelId = nil
         store.updateSelectedModel(modelId, isNewChatContext: true)
     }
 }

--- a/iOS/DuckDuckGo/IPadOmnibarModelPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarModelPickerController.swift
@@ -35,6 +35,10 @@ final class IPadOmnibarModelPickerController {
     private let menuFactory = UnifiedToggleInputModelMenuFactory()
     var onModelsUpdated: (() -> Void)?
 
+    /// The shared model store. Exposed so the sibling reasoning picker can read the same
+    /// selected model / subscription state and avoid a second `/models` fetch.
+    var modelStore: UTIModelStore { store }
+
     init(
         modelsService: AIChatModelsProviding? = nil,
         preferences: AIChatPreferencesPersisting = AIChatPreferencesPersistor(),

--- a/iOS/DuckDuckGo/IPadOmnibarModelPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarModelPickerController.swift
@@ -117,32 +117,12 @@ final class IPadOmnibarModelPickerController {
     @discardableResult
     private func routeGatedModelSelection(_ model: AIChatModel) -> Bool {
         guard let requiredTier = model.lowestPublicAccessTier else { return false }
-
-        let userTier = store.subscriptionState.userTier
-
-        if userTier == .free, requiredTier == .plus || requiredTier == .pro {
-            UnifiedToggleInputCoordinatorPixelHelper.fireSubscriptionUpsellTriggeredPixel(
-                source: .modelPicker,
-                currentTier: userTier,
-                requiredTier: requiredTier,
-                flowType: .purchase
-            )
-            upsellPresenter.presentPurchaseFlow(source: .modelPicker, isAITabState: false)
-            return true
-        }
-
-        if userTier == .plus, requiredTier == .pro {
-            UnifiedToggleInputCoordinatorPixelHelper.fireSubscriptionUpsellTriggeredPixel(
-                source: .modelPicker,
-                currentTier: userTier,
-                requiredTier: requiredTier,
-                flowType: .upgrade
-            )
-            upsellPresenter.presentUpgradeFlow(source: .modelPicker, isAITabState: false)
-            return true
-        }
-
-        return false
+        return upsellPresenter.routeGatedSelection(
+            requiredTier: requiredTier,
+            userTier: store.subscriptionState.userTier,
+            source: .modelPicker,
+            isAITabState: false
+        )
     }
 
     private func applyPendingGatedModelSelectionIfPossible() {

--- a/iOS/DuckDuckGo/IPadOmnibarReasoningPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarReasoningPickerController.swift
@@ -1,0 +1,167 @@
+//
+//  IPadOmnibarReasoningPickerController.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import Core
+import UIKit
+
+/// Drives the Duck.ai reasoning-level picker shown to the left of the model picker in the
+/// iPad address bar's expanded AI-chat input area.
+///
+/// Like `IPadOmnibarModelPickerController`, this is a thin wrapper around the shared
+/// `UTIModelStore` — it reuses the same selection / persistence logic as the iPhone
+/// `UnifiedToggleInputCoordinator` (the reasoning menu factory, the tier-access resolver
+/// and the subscription upsell presenter) so reasoning behaves identically across
+/// Duck.ai surfaces. The store is shared with the model picker so both chips reflect the
+/// same selected model and a single `/models` fetch.
+@MainActor
+final class IPadOmnibarReasoningPickerController {
+
+    private let store: UTIModelStore
+    private let menuFactory: UnifiedToggleInputReasoningMenuFactory
+    private let accessResolver: ReasoningModeAccessResolving
+    private let upsellPresenter: DuckAISubscriptionUpselling
+
+    /// A reasoning mode whose selection was blocked behind an upsell; re-applied once a
+    /// subscription refresh grants the user access (mirrors the iPhone coordinator).
+    private var pendingGatedSelection: (modelId: String, mode: AIChatReasoningMode)?
+
+    /// Invoked whenever the reasoning state changes so the host can refresh the chip
+    /// (icon, menu and visibility).
+    var onReasoningUpdated: (() -> Void)?
+
+    init(
+        store: UTIModelStore,
+        menuFactory: UnifiedToggleInputReasoningMenuFactory = UnifiedToggleInputReasoningMenuFactory(),
+        accessResolver: ReasoningModeAccessResolving = ReasoningModeAccessResolver(),
+        upsellPresenter: DuckAISubscriptionUpselling = DuckAISubscriptionUpsellPresenter()
+    ) {
+        self.store = store
+        self.menuFactory = menuFactory
+        self.accessResolver = accessResolver
+        self.upsellPresenter = upsellPresenter
+    }
+
+    /// Whether the reasoning picker should be shown for the selected model. Matches the
+    /// iPhone rule: the model must expose more than one accessible reasoning mode. (The iPad
+    /// omnibar input has no image-generation tool, so that iPhone hide-case doesn't apply.)
+    var isReasoningPickerAvailable: Bool {
+        store.selectedModel?.supportsReasoningPicker ?? false
+    }
+
+    /// The reasoning mode currently in effect, resolved against the model's accessible modes.
+    /// Drives the chip icon and the menu checkmark.
+    var currentReasoningMode: AIChatReasoningMode? {
+        guard let model = store.selectedModel else { return nil }
+        return model.resolvedReasoningMode(from: store.selectedReasoningMode)
+    }
+
+    /// The reasoning effort to forward at submission. Delegates to the shared store so the iPad
+    /// picker forwards exactly what the iPhone coordinator does (see `submissionReasoningEffort`).
+    var selectedReasoningEffort: AIChatReasoningEffort? {
+        store.submissionReasoningEffort
+    }
+
+    func makeMenu() -> UIMenu? {
+        guard let model = store.selectedModel else { return nil }
+        return menuFactory.makeMenu(model: model, selectedMode: currentReasoningMode) { [weak self] mode in
+            self?.handleReasoningModeSelection(mode)
+        }
+    }
+
+    func handleReasoningModeSelection(_ mode: AIChatReasoningMode) {
+        guard let model = store.selectedModel else { return }
+
+        guard let requiredTier = accessResolver.requiredPublicTier(for: mode, model: model) else {
+            pendingGatedSelection = nil
+            select(mode)
+            return
+        }
+
+        if accessResolver.canSelect(modeRequiring: requiredTier, userTier: store.subscriptionState.userTier) {
+            pendingGatedSelection = nil
+            select(mode)
+        } else {
+            if routeGatedSelection(requiredTier: requiredTier) {
+                pendingGatedSelection = (model.id, mode)
+            }
+            // The selection was rejected — refresh so the chip restores the previous mode.
+            onReasoningUpdated?()
+        }
+    }
+
+    /// Call from the shared store's `onModelsUpdated` so a pending gated selection is applied
+    /// once a subscription refresh grants access.
+    func handleModelsUpdated() {
+        applyPendingGatedSelectionIfPossible()
+    }
+
+    // MARK: - Private
+
+    private func select(_ mode: AIChatReasoningMode) {
+        store.updateSelectedReasoningMode(mode)
+        Pixel.fire(pixel: .unifiedToggleInputReasoningEffortSelected, withAdditionalParameters: ["effort_level": mode.rawValue])
+        onReasoningUpdated?()
+    }
+
+    @discardableResult
+    private func routeGatedSelection(requiredTier: AIChatModelPublicAccessTier) -> Bool {
+        let userTier = store.subscriptionState.userTier
+
+        if userTier == .free, requiredTier == .plus || requiredTier == .pro {
+            UnifiedToggleInputCoordinatorPixelHelper.fireSubscriptionUpsellTriggeredPixel(
+                source: .reasoningPicker,
+                currentTier: userTier,
+                requiredTier: requiredTier,
+                flowType: .purchase
+            )
+            upsellPresenter.presentPurchaseFlow(source: .reasoningPicker, isAITabState: false)
+            return true
+        }
+
+        if userTier == .plus, requiredTier == .pro {
+            UnifiedToggleInputCoordinatorPixelHelper.fireSubscriptionUpsellTriggeredPixel(
+                source: .reasoningPicker,
+                currentTier: userTier,
+                requiredTier: requiredTier,
+                flowType: .upgrade
+            )
+            upsellPresenter.presentUpgradeFlow(source: .reasoningPicker, isAITabState: false)
+            return true
+        }
+
+        return false
+    }
+
+    private func applyPendingGatedSelectionIfPossible() {
+        guard let pending = pendingGatedSelection else { return }
+        guard let model = store.selectedModel, model.id == pending.modelId else {
+            pendingGatedSelection = nil
+            return
+        }
+
+        if let requiredTier = accessResolver.requiredPublicTier(for: pending.mode, model: model),
+           !accessResolver.canSelect(modeRequiring: requiredTier, userTier: store.subscriptionState.userTier) {
+            return
+        }
+
+        pendingGatedSelection = nil
+        select(pending.mode)
+    }
+}

--- a/iOS/DuckDuckGo/IPadOmnibarReasoningPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarReasoningPickerController.swift
@@ -21,15 +21,7 @@ import AIChat
 import Core
 import UIKit
 
-/// Drives the Duck.ai reasoning-level picker shown to the left of the model picker in the
-/// iPad address bar's expanded AI-chat input area.
-///
-/// Like `IPadOmnibarModelPickerController`, this is a thin wrapper around the shared
-/// `UTIModelStore` — it reuses the same selection / persistence logic as the iPhone
-/// `UnifiedToggleInputCoordinator` (the reasoning menu factory, the tier-access resolver
-/// and the subscription upsell presenter) so reasoning behaves identically across
-/// Duck.ai surfaces. The store is shared with the model picker so both chips reflect the
-/// same selected model and a single `/models` fetch.
+/// Drives the Duck.ai reasoning-level picker
 @MainActor
 final class IPadOmnibarReasoningPickerController {
 
@@ -39,7 +31,7 @@ final class IPadOmnibarReasoningPickerController {
     private let upsellPresenter: DuckAISubscriptionUpselling
 
     /// A reasoning mode whose selection was blocked behind an upsell; re-applied once a
-    /// subscription refresh grants the user access (mirrors the iPhone coordinator).
+    /// subscription refresh grants the user access
     private var pendingGatedSelection: (modelId: String, mode: AIChatReasoningMode)?
 
     /// Invoked whenever the reasoning state changes so the host can refresh the chip
@@ -58,22 +50,15 @@ final class IPadOmnibarReasoningPickerController {
         self.upsellPresenter = upsellPresenter
     }
 
-    /// Whether the reasoning picker should be shown for the selected model. Matches the
-    /// iPhone rule: the model must expose more than one accessible reasoning mode. (The iPad
-    /// omnibar input has no image-generation tool, so that iPhone hide-case doesn't apply.)
     var isReasoningPickerAvailable: Bool {
         store.selectedModel?.supportsReasoningPicker ?? false
     }
 
-    /// The reasoning mode currently in effect, resolved against the model's accessible modes.
-    /// Drives the chip icon and the menu checkmark.
     var currentReasoningMode: AIChatReasoningMode? {
         guard let model = store.selectedModel else { return nil }
         return model.resolvedReasoningMode(from: store.selectedReasoningMode)
     }
 
-    /// The reasoning effort to forward at submission. Delegates to the shared store so the iPad
-    /// picker forwards exactly what the iPhone coordinator does (see `submissionReasoningEffort`).
     var selectedReasoningEffort: AIChatReasoningEffort? {
         store.submissionReasoningEffort
     }
@@ -106,8 +91,6 @@ final class IPadOmnibarReasoningPickerController {
         }
     }
 
-    /// Call from the shared store's `onModelsUpdated` so a pending gated selection is applied
-    /// once a subscription refresh grants access.
     func handleModelsUpdated() {
         applyPendingGatedSelectionIfPossible()
     }

--- a/iOS/DuckDuckGo/IPadOmnibarReasoningPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarReasoningPickerController.swift
@@ -83,7 +83,7 @@ final class IPadOmnibarReasoningPickerController {
             pendingGatedSelection = nil
             select(mode)
         } else {
-            if routeGatedSelection(requiredTier: requiredTier) {
+            if routeGatedReasoningSelection(requiredTier: requiredTier) {
                 pendingGatedSelection = (model.id, mode)
             }
             // The selection was rejected — refresh so the chip restores the previous mode.
@@ -104,32 +104,13 @@ final class IPadOmnibarReasoningPickerController {
     }
 
     @discardableResult
-    private func routeGatedSelection(requiredTier: AIChatModelPublicAccessTier) -> Bool {
-        let userTier = store.subscriptionState.userTier
-
-        if userTier == .free, requiredTier == .plus || requiredTier == .pro {
-            UnifiedToggleInputCoordinatorPixelHelper.fireSubscriptionUpsellTriggeredPixel(
-                source: .reasoningPicker,
-                currentTier: userTier,
-                requiredTier: requiredTier,
-                flowType: .purchase
-            )
-            upsellPresenter.presentPurchaseFlow(source: .reasoningPicker, isAITabState: false)
-            return true
-        }
-
-        if userTier == .plus, requiredTier == .pro {
-            UnifiedToggleInputCoordinatorPixelHelper.fireSubscriptionUpsellTriggeredPixel(
-                source: .reasoningPicker,
-                currentTier: userTier,
-                requiredTier: requiredTier,
-                flowType: .upgrade
-            )
-            upsellPresenter.presentUpgradeFlow(source: .reasoningPicker, isAITabState: false)
-            return true
-        }
-
-        return false
+    private func routeGatedReasoningSelection(requiredTier: AIChatModelPublicAccessTier) -> Bool {
+        upsellPresenter.routeGatedSelection(
+            requiredTier: requiredTier,
+            userTier: store.subscriptionState.userTier,
+            source: .reasoningPicker,
+            isAITabState: false
+        )
     }
 
     private func applyPendingGatedSelectionIfPossible() {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3935,7 +3935,8 @@ extension MainViewController: OmniBarDelegate {
         commitToggleMode(.aiChat)
         
         let modelId = viewCoordinator.omniBar.iPadDuckAISelectedModelId
-        openAIChat(query, autoSend: true, tools: tools, modelId: modelId)
+        let reasoningEffort = viewCoordinator.omniBar.iPadDuckAISelectedReasoningEffort
+        openAIChat(query, autoSend: true, tools: tools, modelId: modelId, reasoningEffort: reasoningEffort)
     }
 
     func onChatHistorySelected(url: URL) {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3934,9 +3934,10 @@ extension MainViewController: OmniBarDelegate {
         // toggle, which a refresh-on-submit can reset to the stored last-used before we read it.
         commitToggleMode(.aiChat)
         
-        let modelId = viewCoordinator.omniBar.iPadDuckAISelectedModelId
-        let reasoningEffort = viewCoordinator.omniBar.iPadDuckAISelectedReasoningEffort
-        openAIChat(query, autoSend: true, tools: tools, modelId: modelId, reasoningEffort: reasoningEffort)
+        let controlValues = viewCoordinator.omniBar.iPadDuckAIControlValues
+        openAIChat(query, autoSend: true, tools: tools,
+                   modelId: controlValues.selectedModelId,
+                   reasoningEffort: controlValues.selectedReasoningEffort)
     }
 
     func onChatHistorySelected(url: URL) {

--- a/iOS/DuckDuckGo/OmniBar.swift
+++ b/iOS/DuckDuckGo/OmniBar.swift
@@ -17,6 +17,7 @@
 //  limitations under the License.
 //
 
+import AIChat
 import Foundation
 import PrivacyDashboard
 
@@ -96,6 +97,11 @@ protocol OmniBar: AnyObject {
     /// picker is not active (non-iPad, flag off). Forwarded into `openAIChat` on submission so
     /// Duck.ai honors the selection. Defaults to `nil` for omnibars without the iPad picker.
     var iPadDuckAISelectedModelId: String? { get }
+
+    /// The Duck.ai reasoning effort selected in the iPad address-bar reasoning picker, or `nil`
+    /// when the picker is not active or hidden. Forwarded into `openAIChat` on submission so
+    /// Duck.ai honors the selection. Defaults to `nil` for omnibars without the iPad picker.
+    var iPadDuckAISelectedReasoningEffort: AIChatReasoningEffort? { get }
 
     func prepareForMoveTransition()
     func moveTransitionCompleted()

--- a/iOS/DuckDuckGo/OmniBar.swift
+++ b/iOS/DuckDuckGo/OmniBar.swift
@@ -17,7 +17,6 @@
 //  limitations under the License.
 //
 
-import AIChat
 import Foundation
 import PrivacyDashboard
 
@@ -93,11 +92,8 @@ protocol OmniBar: AnyObject {
     /// Sets the selected text entry mode for the toggle (search or aiChat).
     func setSelectedTextEntryMode(_ mode: TextEntryMode)
 
-    /// The Duck.ai model id selected in the iPad address-bar model picker, or `nil`
-    var iPadDuckAISelectedModelId: String? { get }
-
-    /// The Duck.ai reasoning effort selected in the iPad address-bar reasoning picker, or `nil`
-    var iPadDuckAISelectedReasoningEffort: AIChatReasoningEffort? { get }
+    /// The values currently selected across the iPad address-bar Duck.ai controls
+    var iPadDuckAIControlValues: IPadDuckAIControlValues { get }
 
     func prepareForMoveTransition()
     func moveTransitionCompleted()

--- a/iOS/DuckDuckGo/OmniBar.swift
+++ b/iOS/DuckDuckGo/OmniBar.swift
@@ -93,14 +93,10 @@ protocol OmniBar: AnyObject {
     /// Sets the selected text entry mode for the toggle (search or aiChat).
     func setSelectedTextEntryMode(_ mode: TextEntryMode)
 
-    /// The Duck.ai model id selected in the iPad address-bar model picker, or `nil` when the
-    /// picker is not active (non-iPad, flag off). Forwarded into `openAIChat` on submission so
-    /// Duck.ai honors the selection. Defaults to `nil` for omnibars without the iPad picker.
+    /// The Duck.ai model id selected in the iPad address-bar model picker, or `nil`
     var iPadDuckAISelectedModelId: String? { get }
 
     /// The Duck.ai reasoning effort selected in the iPad address-bar reasoning picker, or `nil`
-    /// when the picker is not active or hidden. Forwarded into `openAIChat` on submission so
-    /// Duck.ai honors the selection. Defaults to `nil` for omnibars without the iPad picker.
     var iPadDuckAISelectedReasoningEffort: AIChatReasoningEffort? { get }
 
     func prepareForMoveTransition()

--- a/iOS/DuckDuckGo/OmniBarViewController.swift
+++ b/iOS/DuckDuckGo/OmniBarViewController.swift
@@ -38,6 +38,9 @@ class OmniBarViewController: UIViewController, OmniBar {
     /// Overridden by `DefaultOmniBarViewController` when the iPad model picker is active. `nil` here.
     var iPadDuckAISelectedModelId: String? { nil }
 
+    /// Overridden by `DefaultOmniBarViewController` when the iPad reasoning picker is active. `nil` here.
+    var iPadDuckAISelectedReasoningEffort: AIChatReasoningEffort? { nil }
+
     var isBackButtonEnabled: Bool {
         get { barView.backButton.isEnabled }
         set { barView.backButton.isEnabled = newValue }

--- a/iOS/DuckDuckGo/OmniBarViewController.swift
+++ b/iOS/DuckDuckGo/OmniBarViewController.swift
@@ -35,11 +35,9 @@ class OmniBarViewController: UIViewController, OmniBar {
     /// Access to iPad-specific expandable search area features.
     var expandableBarView: ExpandableOmniBarView? { barView as? ExpandableOmniBarView }
 
-    /// Overridden by `DefaultOmniBarViewController` when the iPad model picker is active. `nil` here.
-    var iPadDuckAISelectedModelId: String? { nil }
-
-    /// Overridden by `DefaultOmniBarViewController` when the iPad reasoning picker is active. `nil` here.
-    var iPadDuckAISelectedReasoningEffort: AIChatReasoningEffort? { nil }
+    /// Overridden by `DefaultOmniBarViewController` when the iPad Duck.ai controls are active.
+    /// Empty here (all values `nil`).
+    var iPadDuckAIControlValues: IPadDuckAIControlValues { IPadDuckAIControlValuesSnapshot() }
 
     var isBackButtonEnabled: Bool {
         get { barView.backButton.isEnabled }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/DuckAISubscriptionUpsellPresenter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/DuckAISubscriptionUpsellPresenter.swift
@@ -21,9 +21,7 @@ import Foundation
 import Subscription
 
 /// Routes the Duck.ai subscription purchase / upgrade flows triggered by tapping a gated
-/// model or reasoning level. The flows are decoupled via NotificationCenter
-/// (`.settingsDeepLinkNotification`) so this needs no presenting view controller — which lets
-/// the iPhone `UnifiedToggleInputCoordinator` and the iPad omnibar controllers share it.
+/// model or reasoning level. 
 protocol DuckAISubscriptionUpselling {
     func presentPurchaseFlow(source: SubscriptionFlowSource, isAITabState: Bool)
     func presentUpgradeFlow(source: SubscriptionFlowSource, isAITabState: Bool)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/DuckAISubscriptionUpsellPresenter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/DuckAISubscriptionUpsellPresenter.swift
@@ -17,14 +17,53 @@
 //  limitations under the License.
 //
 
+import AIChat
 import Foundation
 import Subscription
 
 /// Routes the Duck.ai subscription purchase / upgrade flows triggered by tapping a gated
-/// model or reasoning level. 
+/// model or reasoning level.
 protocol DuckAISubscriptionUpselling {
     func presentPurchaseFlow(source: SubscriptionFlowSource, isAITabState: Bool)
     func presentUpgradeFlow(source: SubscriptionFlowSource, isAITabState: Bool)
+}
+
+extension DuckAISubscriptionUpselling {
+
+    /// Routes a gated Duck.ai control selection (a model or a reasoning level) to the matching
+    /// subscription upsell and fires the upsell-triggered pixel. Returns `true` when a flow was
+    /// presented
+    @discardableResult
+    func routeGatedSelection(
+        requiredTier: AIChatModelPublicAccessTier,
+        userTier: AIChatUserTier,
+        source: SubscriptionFlowSource,
+        isAITabState: Bool
+    ) -> Bool {
+        if userTier == .free, requiredTier == .plus || requiredTier == .pro {
+            UnifiedToggleInputCoordinatorPixelHelper.fireSubscriptionUpsellTriggeredPixel(
+                source: source,
+                currentTier: userTier,
+                requiredTier: requiredTier,
+                flowType: .purchase
+            )
+            presentPurchaseFlow(source: source, isAITabState: isAITabState)
+            return true
+        }
+
+        if userTier == .plus, requiredTier == .pro {
+            UnifiedToggleInputCoordinatorPixelHelper.fireSubscriptionUpsellTriggeredPixel(
+                source: source,
+                currentTier: userTier,
+                requiredTier: requiredTier,
+                flowType: .upgrade
+            )
+            presentUpgradeFlow(source: source, isAITabState: isAITabState)
+            return true
+        }
+
+        return false
+    }
 }
 
 struct DuckAISubscriptionUpsellPresenter: DuckAISubscriptionUpselling {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/DuckAISubscriptionUpsellPresenter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/DuckAISubscriptionUpsellPresenter.swift
@@ -19,7 +19,28 @@
 
 import AIChat
 import Foundation
+import os.log
 import Subscription
+
+/// The subscription upsell flow that a gated Duck.ai selection should route to.
+enum DuckAISubscriptionUpsellingFlow {
+    case purchase
+    case upgrade
+    case none
+}
+
+extension AIChatUserTier {
+    func upgradeFlow(for requiredTier: AIChatModelPublicAccessTier) -> DuckAISubscriptionUpsellingFlow {
+        switch (self, requiredTier) {
+        case (.plus, .pro):
+            return .upgrade
+        case (.free, .plus), (.free, .pro):
+            return .purchase
+        default:
+            return .none
+        }
+    }
+}
 
 /// Routes the Duck.ai subscription purchase / upgrade flows triggered by tapping a gated
 /// model or reasoning level.
@@ -40,7 +61,8 @@ extension DuckAISubscriptionUpselling {
         source: SubscriptionFlowSource,
         isAITabState: Bool
     ) -> Bool {
-        if userTier == .free, requiredTier == .plus || requiredTier == .pro {
+        switch userTier.upgradeFlow(for: requiredTier) {
+        case .purchase:
             UnifiedToggleInputCoordinatorPixelHelper.fireSubscriptionUpsellTriggeredPixel(
                 source: source,
                 currentTier: userTier,
@@ -49,9 +71,7 @@ extension DuckAISubscriptionUpselling {
             )
             presentPurchaseFlow(source: source, isAITabState: isAITabState)
             return true
-        }
-
-        if userTier == .plus, requiredTier == .pro {
+        case .upgrade:
             UnifiedToggleInputCoordinatorPixelHelper.fireSubscriptionUpsellTriggeredPixel(
                 source: source,
                 currentTier: userTier,
@@ -60,9 +80,15 @@ extension DuckAISubscriptionUpselling {
             )
             presentUpgradeFlow(source: source, isAITabState: isAITabState)
             return true
+        case .none:
+            switch source {
+            case .modelPicker:
+                Logger.unifiedInputState.debug("No native subscription flow for gated model")
+            case .reasoningPicker:
+                Logger.unifiedInputState.debug("No native subscription flow for gated reasoning mode")
+            }
+            return false
         }
-
-        return false
     }
 }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/DuckAISubscriptionUpsellPresenter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/DuckAISubscriptionUpsellPresenter.swift
@@ -1,0 +1,81 @@
+//
+//  DuckAISubscriptionUpsellPresenter.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Subscription
+
+/// Routes the Duck.ai subscription purchase / upgrade flows triggered by tapping a gated
+/// model or reasoning level. The flows are decoupled via NotificationCenter
+/// (`.settingsDeepLinkNotification`) so this needs no presenting view controller — which lets
+/// the iPhone `UnifiedToggleInputCoordinator` and the iPad omnibar controllers share it.
+protocol DuckAISubscriptionUpselling {
+    func presentPurchaseFlow(source: SubscriptionFlowSource, isAITabState: Bool)
+    func presentUpgradeFlow(source: SubscriptionFlowSource, isAITabState: Bool)
+}
+
+struct DuckAISubscriptionUpsellPresenter: DuckAISubscriptionUpselling {
+
+    private static let subscriptionFeaturePage = "duckai"
+
+    private let notificationCenter: NotificationCenter
+
+    init(notificationCenter: NotificationCenter = .default) {
+        self.notificationCenter = notificationCenter
+    }
+
+    func presentPurchaseFlow(source: SubscriptionFlowSource, isAITabState: Bool) {
+        notificationCenter.post(
+            name: .settingsDeepLinkNotification,
+            object: SettingsViewModel.SettingsDeepLinkSection.subscriptionFlow(
+                redirectURLComponents: makeRedirectURLComponents(source: source, isAITabState: isAITabState)
+            )
+        )
+    }
+
+    func presentUpgradeFlow(source: SubscriptionFlowSource, isAITabState: Bool) {
+        notificationCenter.post(
+            name: .settingsDeepLinkNotification,
+            object: SettingsViewModel.SettingsDeepLinkSection.subscriptionPlanChangeFlow(
+                redirectURLComponents: makeRedirectURLComponents(source: source, isAITabState: isAITabState)
+            )
+        )
+    }
+
+    private func makeRedirectURLComponents(source: SubscriptionFlowSource, isAITabState: Bool) -> URLComponents {
+        var components = URLComponents()
+        components.queryItems = [
+            URLQueryItem(name: "featurePage", value: Self.subscriptionFeaturePage),
+            URLQueryItem(name: AttributionParameter.origin, value: origin(for: source, isAITabState: isAITabState).rawValue)
+        ]
+        return components
+    }
+
+    private func origin(for source: SubscriptionFlowSource, isAITabState: Bool) -> SubscriptionFunnelOrigin {
+        switch (isAITabState, source) {
+        case (true, .modelPicker):
+            return .duckAIModelPicker
+        case (true, .reasoningPicker):
+            return .duckAIReasoningPicker
+        case (false, .modelPicker):
+            return .addressBarModelPicker
+        case (false, .reasoningPicker):
+            return .addressBarReasoningPicker
+        }
+    }
+}

--- a/iOS/DuckDuckGo/UnifiedToggleInput/ReasoningModeAccessResolver.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/ReasoningModeAccessResolver.swift
@@ -1,0 +1,52 @@
+//
+//  ReasoningModeAccessResolver.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+
+/// Pure tier-access decisions for the reasoning picker, shared between the iPhone
+/// `UnifiedToggleInputCoordinator` and the iPad `IPadOmnibarReasoningPickerController`
+/// so both platforms gate reasoning modes identically.
+protocol ReasoningModeAccessResolving {
+    /// The public access tier required to use `mode` on `model`, or `nil` when the mode
+    /// is already accessible to the current user (or the model doesn't support it).
+    func requiredPublicTier(for mode: AIChatReasoningMode, model: AIChatModel) -> AIChatModelPublicAccessTier?
+
+    /// Whether a user at `userTier` is allowed to select a mode that requires `requiredTier`.
+    func canSelect(modeRequiring requiredTier: AIChatModelPublicAccessTier, userTier: AIChatUserTier) -> Bool
+}
+
+struct ReasoningModeAccessResolver: ReasoningModeAccessResolving {
+
+    func requiredPublicTier(for mode: AIChatReasoningMode, model: AIChatModel) -> AIChatModelPublicAccessTier? {
+        guard !model.accessibleReasoningModes.contains(mode) else { return nil }
+        guard let effort = model.reasoningEffort(for: mode) else { return nil }
+        return model.lowestPublicAccessTier(for: effort)
+    }
+
+    func canSelect(modeRequiring requiredTier: AIChatModelPublicAccessTier, userTier: AIChatUserTier) -> Bool {
+        switch requiredTier {
+        case .free:
+            return true
+        case .plus:
+            return userTier != .free
+        case .pro:
+            return userTier == .pro || userTier == .internal
+        }
+    }
+}

--- a/iOS/DuckDuckGo/UnifiedToggleInput/ReasoningModeAccessResolver.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/ReasoningModeAccessResolver.swift
@@ -19,9 +19,6 @@
 
 import AIChat
 
-/// Pure tier-access decisions for the reasoning picker, shared between the iPhone
-/// `UnifiedToggleInputCoordinator` and the iPad `IPadOmnibarReasoningPickerController`
-/// so both platforms gate reasoning modes identically.
 protocol ReasoningModeAccessResolving {
     /// The public access tier required to use `mode` on `model`, or `nil` when the mode
     /// is already accessible to the current user (or the model doesn't support it).

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIModelStore.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIModelStore.swift
@@ -61,6 +61,16 @@ final class UTIModelStore {
         preferences.selectedReasoningMode
     }
 
+    /// The reasoning effort to forward to the back end at submission, shared by the iPhone
+    /// coordinator and the iPad reasoning picker. Returns `nil` (no `reasoning_effort` sent)
+    /// unless a mode was explicitly persisted or the model exposes a reasoning picker — so a
+    /// single-mode model with no user choice doesn't pin an effort the user never selected.
+    var submissionReasoningEffort: AIChatReasoningEffort? {
+        guard let selectedModel else { return nil }
+        guard selectedReasoningMode != nil || selectedModel.supportsReasoningPicker else { return nil }
+        return selectedModel.resolvedReasoningEffort(from: selectedReasoningMode)
+    }
+
     var selectedModel: AIChatModel? {
         guard let persistedModelId else { return nil }
         return models.first(where: { $0.id == persistedModelId })

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIModelStore.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIModelStore.swift
@@ -61,10 +61,6 @@ final class UTIModelStore {
         preferences.selectedReasoningMode
     }
 
-    /// The reasoning effort to forward to the back end at submission, shared by the iPhone
-    /// coordinator and the iPad reasoning picker. Returns `nil` (no `reasoning_effort` sent)
-    /// unless a mode was explicitly persisted or the model exposes a reasoning picker — so a
-    /// single-mode model with no user choice doesn't pin an effort the user never selected.
     var submissionReasoningEffort: AIChatReasoningEffort? {
         guard let selectedModel else { return nil }
         guard selectedReasoningMode != nil || selectedModel.supportsReasoningPicker else { return nil }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -168,7 +168,6 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
 
     private enum Constants {
         static let topOmnibarKeyboardPresentationTimeout: TimeInterval = 0.35
-        static let subscriptionFeaturePage = "duckai"
     }
 
     private var attachmentPolicy: UTIAttachmentPolicy {
@@ -194,10 +193,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     var isVoiceSessionActivePublisher: Published<Bool>.Publisher { $isVoiceSessionActive }
     var attachmentUsagePublisher: Published<AIChatAttachmentUsage?>.Publisher { $attachmentUsage }
     var persistedReasoningEffort: AIChatReasoningEffort? {
-        guard let selectedModel else { return nil }
-        guard persistedReasoningMode != nil || selectedModel.supportsReasoningPicker else { return nil }
-
-        return selectedModel.resolvedReasoningEffort(from: persistedReasoningMode)
+        modelStore.submissionReasoningEffort
     }
     private var promptSubmissionModelId: String? {
         hasSubmittedPrompt ? nil : persistedModelId
@@ -344,6 +340,9 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     private let toolsController = UTIToolsController()
     private let toolsMenuFactory = UTIToolsMenuFactory()
     private let modelMenuFactory = UnifiedToggleInputModelMenuFactory()
+    private let reasoningMenuFactory = UnifiedToggleInputReasoningMenuFactory()
+    private let reasoningAccessResolver: ReasoningModeAccessResolving = ReasoningModeAccessResolver()
+    private let subscriptionUpsellPresenter: DuckAISubscriptionUpselling = DuckAISubscriptionUpsellPresenter()
     private let attachmentPresenter = UnifiedToggleInputAttachmentPresenter()
 
     private let intentSubject = PassthroughSubject<UnifiedToggleInputIntent, Never>()
@@ -1496,43 +1495,11 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     }
 
     private func presentPurchaseFlow(source: SubscriptionFlowSource) {
-        NotificationCenter.default.post(
-            name: .settingsDeepLinkNotification,
-            object: SettingsViewModel.SettingsDeepLinkSection.subscriptionFlow(
-                redirectURLComponents: makeSubscriptionRedirectURLComponents(source: source)
-            )
-        )
+        subscriptionUpsellPresenter.presentPurchaseFlow(source: source, isAITabState: isAITabState)
     }
 
     private func presentUpgradeFlow(source: SubscriptionFlowSource) {
-        NotificationCenter.default.post(
-            name: .settingsDeepLinkNotification,
-            object: SettingsViewModel.SettingsDeepLinkSection.subscriptionPlanChangeFlow(
-                redirectURLComponents: makeSubscriptionRedirectURLComponents(source: source)
-            )
-        )
-    }
-
-    private func makeSubscriptionRedirectURLComponents(source: SubscriptionFlowSource) -> URLComponents {
-        var components = URLComponents()
-        components.queryItems = [
-            URLQueryItem(name: "featurePage", value: Constants.subscriptionFeaturePage),
-            URLQueryItem(name: AttributionParameter.origin, value: subscriptionOrigin(for: source).rawValue)
-        ]
-        return components
-    }
-
-    private func subscriptionOrigin(for source: SubscriptionFlowSource) -> SubscriptionFunnelOrigin {
-        switch (isAITabState, source) {
-        case (true, .modelPicker):
-            return .duckAIModelPicker
-        case (true, .reasoningPicker):
-            return .duckAIReasoningPicker
-        case (false, .modelPicker):
-            return .addressBarModelPicker
-        case (false, .reasoningPicker):
-            return .addressBarReasoningPicker
-        }
+        subscriptionUpsellPresenter.presentUpgradeFlow(source: source, isAITabState: isAITabState)
     }
 
     private func refreshModelPickerMenuAfterRejectedSelection() {
@@ -1616,20 +1583,11 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     }
     
     private func requiredPublicTier(for mode: AIChatReasoningMode, model: AIChatModel) -> AIChatModelPublicAccessTier? {
-        guard !model.accessibleReasoningModes.contains(mode) else { return nil }
-        guard let effort = model.reasoningEffort(for: mode) else { return nil }
-        return model.lowestPublicAccessTier(for: effort)
+        reasoningAccessResolver.requiredPublicTier(for: mode, model: model)
     }
 
     private func canSelectReasoningModeRequiringTier(_ requiredTier: AIChatModelPublicAccessTier) -> Bool {
-        switch requiredTier {
-        case .free:
-            return true
-        case .plus:
-            return subscriptionState.userTier != .free
-        case .pro:
-            return subscriptionState.userTier == .pro || subscriptionState.userTier == .internal
-        }
+        reasoningAccessResolver.canSelect(modeRequiring: requiredTier, userTier: subscriptionState.userTier)
     }
 
     @discardableResult
@@ -1690,21 +1648,14 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     }
 
     private func buildReasoningPickerMenu() -> UIMenu? {
-        guard let selectedModel, selectedModel.supportsReasoningPicker else { return nil }
+        guard let selectedModel else { return nil }
 
-        let selectedMode = resolvedSelectedReasoningMode
-        let actions = selectedModel.availableReasoningModes.map { mode in
-            UIAction(
-                title: mode.unifiedToggleInputTitle,
-                subtitle: mode.unifiedToggleInputSubtitle,
-                image: mode.unifiedToggleInputMenuImage,
-                state: mode == selectedMode ? .on : .off
-            ) { [weak self] _ in
-                self?.handleReasoningModeSelection(mode)
-            }
+        return reasoningMenuFactory.makeMenu(
+            model: selectedModel,
+            selectedMode: resolvedSelectedReasoningMode
+        ) { [weak self] mode in
+            self?.handleReasoningModeSelection(mode)
         }
-
-        return UIMenu(options: .singleSelection, children: actions)
     }
 
     private func updateReasoningPicker() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1466,40 +1466,16 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             return false
         }
 
-        let userTier = subscriptionState.userTier
-
-        if userTier == .free, requiredPublicTier == .plus || requiredPublicTier == .pro {
-            UnifiedToggleInputCoordinatorPixelHelper.fireSubscriptionUpsellTriggeredPixel(
-                source: .modelPicker,
-                currentTier: userTier,
-                requiredTier: requiredPublicTier,
-                flowType: .purchase
-            )
-            presentPurchaseFlow(source: .modelPicker)
-            return true
+        let routed = subscriptionUpsellPresenter.routeGatedSelection(
+            requiredTier: requiredPublicTier,
+            userTier: subscriptionState.userTier,
+            source: .modelPicker,
+            isAITabState: isAITabState
+        )
+        if !routed {
+            Logger.unifiedInputState.debug("No native subscription flow for gated model")
         }
-
-        if userTier == .plus, requiredPublicTier == .pro {
-            UnifiedToggleInputCoordinatorPixelHelper.fireSubscriptionUpsellTriggeredPixel(
-                source: .modelPicker,
-                currentTier: userTier,
-                requiredTier: requiredPublicTier,
-                flowType: .upgrade
-            )
-            presentUpgradeFlow(source: .modelPicker)
-            return true
-        }
-
-        Logger.unifiedInputState.debug("No native subscription flow for gated model")
-        return false
-    }
-
-    private func presentPurchaseFlow(source: SubscriptionFlowSource) {
-        subscriptionUpsellPresenter.presentPurchaseFlow(source: source, isAITabState: isAITabState)
-    }
-
-    private func presentUpgradeFlow(source: SubscriptionFlowSource) {
-        subscriptionUpsellPresenter.presentUpgradeFlow(source: source, isAITabState: isAITabState)
+        return routed
     }
 
     private func refreshModelPickerMenuAfterRejectedSelection() {
@@ -1592,32 +1568,16 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
 
     @discardableResult
     private func routeGatedReasoningModeSelection(requiredPublicTier: AIChatModelPublicAccessTier) -> Bool {
-        let userTier = subscriptionState.userTier
-
-        if userTier == .free, requiredPublicTier == .plus || requiredPublicTier == .pro {
-            UnifiedToggleInputCoordinatorPixelHelper.fireSubscriptionUpsellTriggeredPixel(
-                source: .reasoningPicker,
-                currentTier: userTier,
-                requiredTier: requiredPublicTier,
-                flowType: .purchase
-            )
-            presentPurchaseFlow(source: .reasoningPicker)
-            return true
+        let routed = subscriptionUpsellPresenter.routeGatedSelection(
+            requiredTier: requiredPublicTier,
+            userTier: subscriptionState.userTier,
+            source: .reasoningPicker,
+            isAITabState: isAITabState
+        )
+        if !routed {
+            Logger.unifiedInputState.debug("No native subscription flow for gated reasoning mode")
         }
-
-        if userTier == .plus, requiredPublicTier == .pro {
-            UnifiedToggleInputCoordinatorPixelHelper.fireSubscriptionUpsellTriggeredPixel(
-                source: .reasoningPicker,
-                currentTier: userTier,
-                requiredTier: requiredPublicTier,
-                flowType: .upgrade
-            )
-            presentUpgradeFlow(source: .reasoningPicker)
-            return true
-        }
-
-        Logger.unifiedInputState.debug("No native subscription flow for gated reasoning mode")
-        return false
+        return routed
     }
 
     func selectTool(_ tool: AIChatRAGTool) {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1466,16 +1466,12 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             return false
         }
 
-        let routed = subscriptionUpsellPresenter.routeGatedSelection(
+        return subscriptionUpsellPresenter.routeGatedSelection(
             requiredTier: requiredPublicTier,
             userTier: subscriptionState.userTier,
             source: .modelPicker,
             isAITabState: isAITabState
         )
-        if !routed {
-            Logger.unifiedInputState.debug("No native subscription flow for gated model")
-        }
-        return routed
     }
 
     private func refreshModelPickerMenuAfterRejectedSelection() {
@@ -1568,16 +1564,12 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
 
     @discardableResult
     private func routeGatedReasoningModeSelection(requiredPublicTier: AIChatModelPublicAccessTier) -> Bool {
-        let routed = subscriptionUpsellPresenter.routeGatedSelection(
+        return subscriptionUpsellPresenter.routeGatedSelection(
             requiredTier: requiredPublicTier,
             userTier: subscriptionState.userTier,
             source: .reasoningPicker,
             isAITabState: isAITabState
         )
-        if !routed {
-            Logger.unifiedInputState.debug("No native subscription flow for gated reasoning mode")
-        }
-        return routed
     }
 
     func selectTool(_ tool: AIChatRAGTool) {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputReasoningMenuFactory.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputReasoningMenuFactory.swift
@@ -20,13 +20,9 @@
 import AIChat
 import UIKit
 
-/// Builds the reasoning-mode pull-down menu shared by the iPhone
-/// `UnifiedToggleInputCoordinator` and the iPad `IPadOmnibarReasoningPickerController`.
-/// Mirrors `UnifiedToggleInputModelMenuFactory` so both pickers stay consistent.
+/// Builds the reasoning-mode pull-down menu
 struct UnifiedToggleInputReasoningMenuFactory {
 
-    /// Builds a single-selection menu of the model's available reasoning modes, or `nil`
-    /// when the model doesn't support a reasoning picker (so callers can hide the button).
     func makeMenu(
         model: AIChatModel,
         selectedMode: AIChatReasoningMode?,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputReasoningMenuFactory.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputReasoningMenuFactory.swift
@@ -1,0 +1,50 @@
+//
+//  UnifiedToggleInputReasoningMenuFactory.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import UIKit
+
+/// Builds the reasoning-mode pull-down menu shared by the iPhone
+/// `UnifiedToggleInputCoordinator` and the iPad `IPadOmnibarReasoningPickerController`.
+/// Mirrors `UnifiedToggleInputModelMenuFactory` so both pickers stay consistent.
+struct UnifiedToggleInputReasoningMenuFactory {
+
+    /// Builds a single-selection menu of the model's available reasoning modes, or `nil`
+    /// when the model doesn't support a reasoning picker (so callers can hide the button).
+    func makeMenu(
+        model: AIChatModel,
+        selectedMode: AIChatReasoningMode?,
+        onSelect: @escaping (AIChatReasoningMode) -> Void
+    ) -> UIMenu? {
+        guard model.supportsReasoningPicker else { return nil }
+
+        let actions = model.availableReasoningModes.map { mode in
+            UIAction(
+                title: mode.unifiedToggleInputTitle,
+                subtitle: mode.unifiedToggleInputSubtitle,
+                image: mode.unifiedToggleInputMenuImage,
+                state: mode == selectedMode ? .on : .off
+            ) { _ in
+                onSelect(mode)
+            }
+        }
+
+        return UIMenu(options: .singleSelection, children: actions)
+    }
+}

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/DuckAISubscriptionUpsellPresenterTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/DuckAISubscriptionUpsellPresenterTests.swift
@@ -1,0 +1,102 @@
+//
+//  DuckAISubscriptionUpsellPresenterTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo
+
+final class DuckAISubscriptionUpsellPresenterTests: XCTestCase {
+
+    private var notificationCenter: NotificationCenter!
+    private var sut: DuckAISubscriptionUpsellPresenter!
+
+    override func setUp() {
+        super.setUp()
+        notificationCenter = NotificationCenter()
+        sut = DuckAISubscriptionUpsellPresenter(notificationCenter: notificationCenter)
+    }
+
+    override func tearDown() {
+        sut = nil
+        notificationCenter = nil
+        super.tearDown()
+    }
+
+    func testPresentPurchaseFlowFromReasoningPickerInAddressBarPostsSubscriptionFlowWithAddressBarOrigin() {
+        let expectation = expectation(forNotification: .settingsDeepLinkNotification, object: nil, notificationCenter: notificationCenter) { notification in
+            guard let deepLink = notification.object as? SettingsViewModel.SettingsDeepLinkSection,
+                  case .subscriptionFlow(let components) = deepLink else {
+                return false
+            }
+            return self.hasQueryItem(in: components, name: "featurePage", value: "duckai")
+                && self.hasQueryItem(in: components, name: "origin", value: "funnel_addressbar_ios__reasoningpicker")
+        }
+
+        sut.presentPurchaseFlow(source: .reasoningPicker, isAITabState: false)
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testPresentUpgradeFlowFromReasoningPickerInAddressBarPostsPlanChangeFlowWithAddressBarOrigin() {
+        let expectation = expectation(forNotification: .settingsDeepLinkNotification, object: nil, notificationCenter: notificationCenter) { notification in
+            guard let deepLink = notification.object as? SettingsViewModel.SettingsDeepLinkSection,
+                  case .subscriptionPlanChangeFlow(let components) = deepLink else {
+                return false
+            }
+            return self.hasQueryItem(in: components, name: "origin", value: "funnel_addressbar_ios__reasoningpicker")
+        }
+
+        sut.presentUpgradeFlow(source: .reasoningPicker, isAITabState: false)
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testPresentPurchaseFlowFromReasoningPickerInAITabUsesDuckAIOrigin() {
+        let expectation = expectation(forNotification: .settingsDeepLinkNotification, object: nil, notificationCenter: notificationCenter) { notification in
+            guard let deepLink = notification.object as? SettingsViewModel.SettingsDeepLinkSection,
+                  case .subscriptionFlow(let components) = deepLink else {
+                return false
+            }
+            return self.hasQueryItem(in: components, name: "origin", value: "funnel_duckai_ios__reasoningpicker")
+        }
+
+        sut.presentPurchaseFlow(source: .reasoningPicker, isAITabState: true)
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testPresentPurchaseFlowFromModelPickerInAddressBarUsesModelPickerOrigin() {
+        let expectation = expectation(forNotification: .settingsDeepLinkNotification, object: nil, notificationCenter: notificationCenter) { notification in
+            guard let deepLink = notification.object as? SettingsViewModel.SettingsDeepLinkSection,
+                  case .subscriptionFlow(let components) = deepLink else {
+                return false
+            }
+            return self.hasQueryItem(in: components, name: "origin", value: "funnel_addressbar_ios__modelpicker")
+        }
+
+        sut.presentPurchaseFlow(source: .modelPicker, isAITabState: false)
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    // MARK: - Helpers
+
+    private func hasQueryItem(in components: URLComponents?, name: String, value: String) -> Bool {
+        components?.queryItems?.contains { $0.name == name && $0.value == value } == true
+    }
+}

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarModelPickerControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarModelPickerControllerTests.swift
@@ -30,16 +30,19 @@ final class IPadOmnibarModelPickerControllerTests: XCTestCase {
     private var preferences: StubPreferences!
     private var modelsService: StubModelsService!
     private var subscriptionManager: SubscriptionManagerMock!
+    private var upsellPresenter: MockUpsellPresenter!
 
     override func setUp() {
         super.setUp()
         preferences = StubPreferences()
         modelsService = StubModelsService()
         subscriptionManager = SubscriptionManagerMock()
+        upsellPresenter = MockUpsellPresenter()
         sut = IPadOmnibarModelPickerController(
             modelsService: modelsService,
             preferences: preferences,
-            subscriptionManager: subscriptionManager
+            subscriptionManager: subscriptionManager,
+            upsellPresenter: upsellPresenter
         )
     }
 
@@ -48,6 +51,7 @@ final class IPadOmnibarModelPickerControllerTests: XCTestCase {
         preferences = nil
         modelsService = nil
         subscriptionManager = nil
+        upsellPresenter = nil
         super.tearDown()
     }
 
@@ -56,10 +60,14 @@ final class IPadOmnibarModelPickerControllerTests: XCTestCase {
         XCTAssertFalse(sut.hasModels)
     }
 
-    func testWhenSelectModelThenSelectionPersistedToPreferences() {
-        sut.selectModel("gpt-5")
+    func testWhenSelectAccessibleModelThenSelectionPersistedToPreferences() {
+        sut.modelStore.models = [makeModel(id: "gpt-5", shortName: "GPT-5")]
+
+        sut.handleModelSelection("gpt-5")
 
         XCTAssertEqual(preferences.selectedModelId, "gpt-5")
+        XCTAssertTrue(upsellPresenter.presentedPurchaseFlows.isEmpty)
+        XCTAssertTrue(upsellPresenter.presentedUpgradeFlows.isEmpty)
     }
 
     func testWhenNoModelsLoadedThenCurrentModelLabelFallsBackToCachedPreference() {
@@ -98,7 +106,7 @@ final class IPadOmnibarModelPickerControllerTests: XCTestCase {
         sut.activate()
         await fulfillment(of: [updated], timeout: 1)
 
-        sut.selectModel("gpt-5")
+        sut.handleModelSelection("gpt-5")
 
         XCTAssertEqual(preferences.selectedModelId, "gpt-5")
         XCTAssertEqual(preferences.selectedModelShortName, "GPT-5")
@@ -115,7 +123,7 @@ final class IPadOmnibarModelPickerControllerTests: XCTestCase {
         sut.activate()
         await fulfillment(of: [updated], timeout: 1)
 
-        sut.selectModel("mistral")
+        sut.handleModelSelection("mistral")
 
         XCTAssertEqual(sut.currentModelId, "mistral")
     }
@@ -130,7 +138,108 @@ final class IPadOmnibarModelPickerControllerTests: XCTestCase {
         XCTAssertEqual(sut.currentModelId, "gpt-5")
     }
 
+    // MARK: - Selection (gated → upsell)
+
+    func testWhenFreeUserSelectsGatedPlusModelThenRoutesPurchaseWithoutChangingSelection() {
+        sut.modelStore.subscriptionState = SubscriptionState(userTier: .free, hasActiveSubscription: false)
+        sut.modelStore.models = [
+            makeModel(id: "gpt-5", shortName: "GPT-5"),
+            makeModel(id: "claude", shortName: "Claude", entityHasAccess: false, accessTier: ["plus", "pro", "internal"])
+        ]
+        sut.handleModelSelection("gpt-5")
+
+        sut.handleModelSelection("claude")
+
+        XCTAssertEqual(upsellPresenter.presentedPurchaseFlows.count, 1)
+        XCTAssertEqual(upsellPresenter.presentedPurchaseFlows.first?.source, .modelPicker)
+        XCTAssertTrue(upsellPresenter.presentedUpgradeFlows.isEmpty)
+        XCTAssertEqual(preferences.selectedModelId, "gpt-5", "A gated selection must not change the persisted model")
+    }
+
+    func testWhenPlusUserSelectsGatedProModelThenRoutesUpgradeWithoutChangingSelection() {
+        sut.modelStore.subscriptionState = SubscriptionState(userTier: .plus, hasActiveSubscription: true)
+        sut.modelStore.models = [
+            makeModel(id: "gpt-5", shortName: "GPT-5"),
+            makeModel(id: "claude", shortName: "Claude", entityHasAccess: false, accessTier: ["pro", "internal"])
+        ]
+        sut.handleModelSelection("gpt-5")
+
+        sut.handleModelSelection("claude")
+
+        XCTAssertEqual(upsellPresenter.presentedUpgradeFlows.count, 1)
+        XCTAssertEqual(upsellPresenter.presentedUpgradeFlows.first?.source, .modelPicker)
+        XCTAssertTrue(upsellPresenter.presentedPurchaseFlows.isEmpty)
+        XCTAssertEqual(preferences.selectedModelId, "gpt-5")
+    }
+
+    func testWhenUserHasAccessToGatedTierModelThenSelectsWithoutUpsell() {
+        sut.modelStore.subscriptionState = SubscriptionState(userTier: .pro, hasActiveSubscription: true)
+        // entityHasAccess reflects the user's tier — a pro user has access to a pro-tier model.
+        sut.modelStore.models = [makeModel(id: "claude", shortName: "Claude", entityHasAccess: true, accessTier: ["pro", "internal"])]
+
+        sut.handleModelSelection("claude")
+
+        XCTAssertEqual(preferences.selectedModelId, "claude")
+        XCTAssertTrue(upsellPresenter.presentedPurchaseFlows.isEmpty)
+        XCTAssertTrue(upsellPresenter.presentedUpgradeFlows.isEmpty)
+    }
+
+    // MARK: - Pending gated selection re-apply
+
+    func testWhenGatedModelBecomesAccessibleAfterRefreshThenPendingModelIsApplied() {
+        sut.modelStore.subscriptionState = SubscriptionState(userTier: .free, hasActiveSubscription: false)
+        sut.modelStore.models = [
+            makeModel(id: "gpt-5", shortName: "GPT-5"),
+            makeModel(id: "claude", shortName: "Claude", entityHasAccess: false, accessTier: ["plus", "pro", "internal"])
+        ]
+        sut.handleModelSelection("gpt-5")
+        sut.handleModelSelection("claude")
+        XCTAssertEqual(preferences.selectedModelId, "gpt-5")
+
+        // Subscription purchased: /models re-fetched with the gated model now accessible.
+        sut.modelStore.subscriptionState = SubscriptionState(userTier: .plus, hasActiveSubscription: true)
+        sut.modelStore.models = [
+            makeModel(id: "gpt-5", shortName: "GPT-5"),
+            makeModel(id: "claude", shortName: "Claude", entityHasAccess: true, accessTier: ["plus", "pro", "internal"])
+        ]
+        sut.handleModelsUpdated()
+
+        XCTAssertEqual(preferences.selectedModelId, "claude")
+    }
+
+    func testWhenGatedModelStaysInaccessibleAfterRefreshThenPendingModelNotApplied() {
+        sut.modelStore.subscriptionState = SubscriptionState(userTier: .free, hasActiveSubscription: false)
+        sut.modelStore.models = [
+            makeModel(id: "gpt-5", shortName: "GPT-5"),
+            makeModel(id: "claude", shortName: "Claude", entityHasAccess: false, accessTier: ["plus", "pro", "internal"])
+        ]
+        sut.handleModelSelection("gpt-5")
+        sut.handleModelSelection("claude")
+
+        // A refresh that does not grant access (e.g. user dismissed the purchase flow).
+        sut.handleModelsUpdated()
+
+        XCTAssertEqual(preferences.selectedModelId, "gpt-5")
+    }
+
     // MARK: - Helpers
+
+    private func makeModel(
+        id: String,
+        shortName: String,
+        entityHasAccess: Bool = true,
+        accessTier: [String] = []
+    ) -> AIChatModel {
+        AIChatModel(
+            id: id,
+            name: id,
+            shortName: shortName,
+            provider: .openAI,
+            supportsImageUpload: false,
+            entityHasAccess: entityHasAccess,
+            accessTier: accessTier
+        )
+    }
 
     private func makeRemoteModel(id: String, shortName: String) -> AIChatRemoteModel {
         AIChatRemoteModel(
@@ -143,6 +252,19 @@ final class IPadOmnibarModelPickerControllerTests: XCTestCase {
             supportedTools: [],
             accessTier: []
         )
+    }
+}
+
+private final class MockUpsellPresenter: DuckAISubscriptionUpselling {
+    var presentedPurchaseFlows: [(source: SubscriptionFlowSource, isAITabState: Bool)] = []
+    var presentedUpgradeFlows: [(source: SubscriptionFlowSource, isAITabState: Bool)] = []
+
+    func presentPurchaseFlow(source: SubscriptionFlowSource, isAITabState: Bool) {
+        presentedPurchaseFlows.append((source, isAITabState))
+    }
+
+    func presentUpgradeFlow(source: SubscriptionFlowSource, isAITabState: Bool) {
+        presentedUpgradeFlows.append((source, isAITabState))
     }
 }
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarReasoningPickerControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarReasoningPickerControllerTests.swift
@@ -1,0 +1,265 @@
+//
+//  IPadOmnibarReasoningPickerControllerTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import Combine
+import SubscriptionTestingUtilities
+import UIKit
+import XCTest
+@testable import DuckDuckGo
+
+@MainActor
+final class IPadOmnibarReasoningPickerControllerTests: XCTestCase {
+
+    private var sut: IPadOmnibarReasoningPickerController!
+    private var store: UTIModelStore!
+    private var preferences: StubReasoningPreferences!
+    private var upsellPresenter: MockUpsellPresenter!
+
+    override func setUp() {
+        super.setUp()
+        preferences = StubReasoningPreferences()
+        store = UTIModelStore(
+            modelsService: StubModelsService(),
+            preferences: preferences,
+            subscriptionManager: SubscriptionManagerMock()
+        )
+        upsellPresenter = MockUpsellPresenter()
+        sut = IPadOmnibarReasoningPickerController(
+            store: store,
+            upsellPresenter: upsellPresenter
+        )
+    }
+
+    override func tearDown() {
+        sut = nil
+        store = nil
+        preferences = nil
+        upsellPresenter = nil
+        super.tearDown()
+    }
+
+    // MARK: - Availability
+
+    func testWhenModelSupportsReasoningPickerThenIsAvailable() {
+        store.models = [makeReasoningModel(id: "gpt-5.2", supportedReasoningEffort: [.none, .low, .medium])]
+
+        XCTAssertTrue(sut.isReasoningPickerAvailable)
+    }
+
+    func testWhenModelHasSingleReasoningModeThenNotAvailable() {
+        store.models = [makeReasoningModel(id: "gpt-oss", supportedReasoningEffort: [.low])]
+
+        XCTAssertFalse(sut.isReasoningPickerAvailable)
+    }
+
+    func testWhenNoModelsThenMenuIsNil() {
+        XCTAssertNil(sut.makeMenu())
+        XCTAssertFalse(sut.isReasoningPickerAvailable)
+    }
+
+    func testWhenModelSupportsReasoningPickerThenMenuIsNotNil() {
+        store.models = [makeReasoningModel(id: "gpt-5.2", supportedReasoningEffort: [.none, .low, .medium])]
+
+        XCTAssertNotNil(sut.makeMenu())
+    }
+
+    // MARK: - Selection (accessible)
+
+    func testWhenAccessibleModeSelectedThenPersistedWithoutUpsell() {
+        store.models = [makeReasoningModel(id: "gpt-5.2", supportedReasoningEffort: [.none, .low, .medium])]
+
+        sut.handleReasoningModeSelection(.reasoning)
+
+        XCTAssertEqual(preferences.selectedReasoningMode, .reasoning)
+        XCTAssertTrue(upsellPresenter.presentedPurchaseFlows.isEmpty)
+        XCTAssertTrue(upsellPresenter.presentedUpgradeFlows.isEmpty)
+    }
+
+    func testCurrentReasoningModeReflectsSelection() {
+        store.models = [makeReasoningModel(id: "gpt-5.2", supportedReasoningEffort: [.none, .low, .medium])]
+
+        sut.handleReasoningModeSelection(.extendedReasoning)
+
+        XCTAssertEqual(sut.currentReasoningMode, .extendedReasoning)
+    }
+
+    // MARK: - Selection (gated → upsell)
+
+    func testWhenFreeUserSelectsGatedExtendedThenRoutesPurchaseWithoutChangingSelection() {
+        store.models = [
+            makeReasoningModel(
+                id: "gpt-5.2",
+                supportedReasoningEffort: [.none, .low, .medium],
+                reasoningEffortAccess: gpt52MediumGatedForPlus()
+            )
+        ]
+        sut.handleReasoningModeSelection(.reasoning)
+
+        sut.handleReasoningModeSelection(.extendedReasoning)
+
+        XCTAssertEqual(upsellPresenter.presentedPurchaseFlows.count, 1)
+        XCTAssertEqual(upsellPresenter.presentedPurchaseFlows.first?.source, .reasoningPicker)
+        XCTAssertEqual(preferences.selectedReasoningMode, .reasoning, "Gated selection must not change the persisted mode")
+    }
+
+    func testWhenPlusUserSelectsGatedExtendedThenRoutesUpgradeWithoutChangingSelection() {
+        store.subscriptionState = SubscriptionState(userTier: .plus, hasActiveSubscription: true)
+        store.models = [
+            makeReasoningModel(
+                id: "gpt-5.2",
+                supportedReasoningEffort: [.none, .low, .medium],
+                reasoningEffortAccess: gpt52MediumGatedForPlus()
+            )
+        ]
+        sut.handleReasoningModeSelection(.reasoning)
+
+        sut.handleReasoningModeSelection(.extendedReasoning)
+
+        XCTAssertEqual(upsellPresenter.presentedUpgradeFlows.count, 1)
+        XCTAssertEqual(upsellPresenter.presentedUpgradeFlows.first?.source, .reasoningPicker)
+        XCTAssertEqual(preferences.selectedReasoningMode, .reasoning)
+    }
+
+    func testWhenProUserSelectsGatedExtendedThenSelects() {
+        store.subscriptionState = SubscriptionState(userTier: .pro, hasActiveSubscription: true)
+        store.models = [
+            makeReasoningModel(
+                id: "gpt-5.2",
+                supportedReasoningEffort: [.none, .low, .medium],
+                reasoningEffortAccess: gpt52MediumGatedForPlus()
+            )
+        ]
+
+        sut.handleReasoningModeSelection(.extendedReasoning)
+
+        XCTAssertEqual(preferences.selectedReasoningMode, .extendedReasoning)
+        XCTAssertTrue(upsellPresenter.presentedPurchaseFlows.isEmpty)
+        XCTAssertTrue(upsellPresenter.presentedUpgradeFlows.isEmpty)
+    }
+
+    // MARK: - Pending gated selection re-apply
+
+    func testWhenGatedSelectionBecomesAccessibleAfterRefreshThenPendingModeIsApplied() {
+        store.subscriptionState = SubscriptionState(userTier: .plus, hasActiveSubscription: true)
+        store.models = [
+            makeReasoningModel(
+                id: "gpt-5.2",
+                supportedReasoningEffort: [.none, .low, .medium],
+                reasoningEffortAccess: gpt52MediumGatedForPlus()
+            )
+        ]
+        sut.handleReasoningModeSelection(.reasoning)
+        sut.handleReasoningModeSelection(.extendedReasoning)
+        XCTAssertEqual(preferences.selectedReasoningMode, .reasoning)
+
+        // Subscription upgraded: /models re-fetched with the effort now accessible.
+        store.subscriptionState = SubscriptionState(userTier: .pro, hasActiveSubscription: true)
+        store.models = [
+            makeReasoningModel(
+                id: "gpt-5.2",
+                supportedReasoningEffort: [.none, .low, .medium],
+                reasoningEffortAccess: gpt52MediumAccessibleForPro()
+            )
+        ]
+        sut.handleModelsUpdated()
+
+        XCTAssertEqual(preferences.selectedReasoningMode, .extendedReasoning)
+    }
+
+    // MARK: - Resolved effort for submit
+
+    func testSelectedReasoningEffortResolvesFromSelectedMode() {
+        store.subscriptionState = SubscriptionState(userTier: .pro, hasActiveSubscription: true)
+        store.models = [makeReasoningModel(id: "gpt-5.2", supportedReasoningEffort: [.none, .low, .medium])]
+        sut.handleReasoningModeSelection(.extendedReasoning)
+
+        XCTAssertEqual(sut.selectedReasoningEffort, .medium)
+    }
+
+    func testSelectedReasoningEffortIsNilWhenPickerUnavailable() {
+        store.models = [makeReasoningModel(id: "gpt-oss", supportedReasoningEffort: [.low])]
+
+        XCTAssertNil(sut.selectedReasoningEffort)
+    }
+
+    // MARK: - Helpers
+
+    private func makeReasoningModel(
+        id: String,
+        supportedReasoningEffort: [AIChatReasoningEffort],
+        reasoningEffortAccess: [AIChatReasoningEffortAccess]? = nil
+    ) -> AIChatModel {
+        AIChatModel(
+            id: id,
+            name: id,
+            shortName: id,
+            provider: .openAI,
+            supportsImageUpload: false,
+            entityHasAccess: true,
+            supportedReasoningEffort: supportedReasoningEffort,
+            reasoningEffortAccess: reasoningEffortAccess
+        )
+    }
+
+    private func gpt52MediumGatedForPlus() -> [AIChatReasoningEffortAccess] {
+        [
+            AIChatReasoningEffortAccess(effort: .none, accessTier: ["plus", "pro", "internal"], entityHasAccess: true),
+            AIChatReasoningEffortAccess(effort: .low, accessTier: ["plus", "pro", "internal"], entityHasAccess: true),
+            AIChatReasoningEffortAccess(effort: .medium, accessTier: ["pro", "internal"], entityHasAccess: false)
+        ]
+    }
+
+    private func gpt52MediumAccessibleForPro() -> [AIChatReasoningEffortAccess] {
+        [
+            AIChatReasoningEffortAccess(effort: .none, accessTier: ["plus", "pro", "internal"], entityHasAccess: true),
+            AIChatReasoningEffortAccess(effort: .low, accessTier: ["plus", "pro", "internal"], entityHasAccess: true),
+            AIChatReasoningEffortAccess(effort: .medium, accessTier: ["pro", "internal"], entityHasAccess: true)
+        ]
+    }
+}
+
+private final class MockUpsellPresenter: DuckAISubscriptionUpselling {
+    var presentedPurchaseFlows: [(source: SubscriptionFlowSource, isAITabState: Bool)] = []
+    var presentedUpgradeFlows: [(source: SubscriptionFlowSource, isAITabState: Bool)] = []
+
+    func presentPurchaseFlow(source: SubscriptionFlowSource, isAITabState: Bool) {
+        presentedPurchaseFlows.append((source, isAITabState))
+    }
+
+    func presentUpgradeFlow(source: SubscriptionFlowSource, isAITabState: Bool) {
+        presentedUpgradeFlows.append((source, isAITabState))
+    }
+}
+
+private final class StubReasoningPreferences: AIChatPreferencesPersisting {
+    var selectedReasoningEffort: String?
+    var selectedModelId: String?
+    var selectedModelShortName: String?
+    var selectedReasoningMode: AIChatReasoningMode?
+    var selectedTool: AIChatRAGTool?
+    var selectedModelIdPublisher: AnyPublisher<String?, Never> { Empty().eraseToAnyPublisher() }
+    var selectedReasoningEffortPublisher: AnyPublisher<String?, Never> { Empty().eraseToAnyPublisher() }
+}
+
+private final class StubModelsService: AIChatModelsProviding {
+    var result: Result<AIChatModelsResponse, Error> = .success(AIChatModelsResponse(models: []))
+
+    func fetchModels() async throws -> AIChatModelsResponse { try result.get() }
+}

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/ReasoningModeAccessResolverTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/ReasoningModeAccessResolverTests.swift
@@ -1,0 +1,112 @@
+//
+//  ReasoningModeAccessResolverTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import XCTest
+@testable import DuckDuckGo
+
+final class ReasoningModeAccessResolverTests: XCTestCase {
+
+    private var sut: ReasoningModeAccessResolver!
+
+    override func setUp() {
+        super.setUp()
+        sut = ReasoningModeAccessResolver()
+    }
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
+    // MARK: - requiredPublicTier
+
+    func testWhenModeIsAccessibleThenRequiredPublicTierIsNil() {
+        let model = makeReasoningModel(id: "gpt-5.2", supportedReasoningEffort: [.none, .low, .medium])
+
+        XCTAssertNil(sut.requiredPublicTier(for: .reasoning, model: model))
+    }
+
+    func testWhenModelDoesNotSupportModeThenRequiredPublicTierIsNil() {
+        // Single accessible mode (.fast) — .extendedReasoning has no backing effort.
+        let model = makeReasoningModel(id: "gpt-oss", supportedReasoningEffort: [.none])
+
+        XCTAssertNil(sut.requiredPublicTier(for: .extendedReasoning, model: model))
+    }
+
+    func testWhenExtendedReasoningEffortGatedForPlusThenRequiredPublicTierIsPro() {
+        let model = makeReasoningModel(
+            id: "gpt-5.2",
+            supportedReasoningEffort: [.none, .low, .medium],
+            reasoningEffortAccess: gpt52MediumGatedForPlus()
+        )
+
+        XCTAssertEqual(sut.requiredPublicTier(for: .extendedReasoning, model: model), .pro)
+    }
+
+    // MARK: - canSelect(modeRequiring:userTier:)
+
+    func testCanSelectFreeTierAlwaysTrue() {
+        XCTAssertTrue(sut.canSelect(modeRequiring: .free, userTier: .free))
+        XCTAssertTrue(sut.canSelect(modeRequiring: .free, userTier: .plus))
+        XCTAssertTrue(sut.canSelect(modeRequiring: .free, userTier: .pro))
+        XCTAssertTrue(sut.canSelect(modeRequiring: .free, userTier: .internal))
+    }
+
+    func testCanSelectPlusRequiresNonFreeUser() {
+        XCTAssertFalse(sut.canSelect(modeRequiring: .plus, userTier: .free))
+        XCTAssertTrue(sut.canSelect(modeRequiring: .plus, userTier: .plus))
+        XCTAssertTrue(sut.canSelect(modeRequiring: .plus, userTier: .pro))
+        XCTAssertTrue(sut.canSelect(modeRequiring: .plus, userTier: .internal))
+    }
+
+    func testCanSelectProRequiresProOrInternal() {
+        XCTAssertFalse(sut.canSelect(modeRequiring: .pro, userTier: .free))
+        XCTAssertFalse(sut.canSelect(modeRequiring: .pro, userTier: .plus))
+        XCTAssertTrue(sut.canSelect(modeRequiring: .pro, userTier: .pro))
+        XCTAssertTrue(sut.canSelect(modeRequiring: .pro, userTier: .internal))
+    }
+
+    // MARK: - Helpers
+
+    private func makeReasoningModel(
+        id: String,
+        supportedReasoningEffort: [AIChatReasoningEffort],
+        reasoningEffortAccess: [AIChatReasoningEffortAccess]? = nil
+    ) -> AIChatModel {
+        AIChatModel(
+            id: id,
+            name: id,
+            shortName: id,
+            provider: .openAI,
+            supportsImageUpload: false,
+            entityHasAccess: true,
+            supportedReasoningEffort: supportedReasoningEffort,
+            reasoningEffortAccess: reasoningEffortAccess
+        )
+    }
+
+    private func gpt52MediumGatedForPlus() -> [AIChatReasoningEffortAccess] {
+        [
+            AIChatReasoningEffortAccess(effort: .none, accessTier: ["plus", "pro", "internal"], entityHasAccess: true),
+            AIChatReasoningEffortAccess(effort: .low, accessTier: ["plus", "pro", "internal"], entityHasAccess: true),
+            AIChatReasoningEffortAccess(effort: .medium, accessTier: ["pro", "internal"], entityHasAccess: false)
+        ]
+    }
+}

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputReasoningMenuFactoryTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputReasoningMenuFactoryTests.swift
@@ -1,0 +1,93 @@
+//
+//  UnifiedToggleInputReasoningMenuFactoryTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import UIKit
+import XCTest
+@testable import DuckDuckGo
+
+@MainActor
+final class UnifiedToggleInputReasoningMenuFactoryTests: XCTestCase {
+
+    private var sut: UnifiedToggleInputReasoningMenuFactory!
+
+    override func setUp() {
+        super.setUp()
+        sut = UnifiedToggleInputReasoningMenuFactory()
+    }
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
+    func testWhenModelDoesNotSupportReasoningPickerThenMenuIsNil() {
+        let model = makeReasoningModel(id: "gpt-oss", supportedReasoningEffort: [.low])
+
+        let menu = sut.makeMenu(model: model, selectedMode: nil) { _ in }
+
+        XCTAssertNil(menu)
+    }
+
+    func testMenuListsAvailableModesInFixedOrder() {
+        let model = makeReasoningModel(id: "gpt-5.2", supportedReasoningEffort: [.medium, .low, .none])
+
+        let menu = sut.makeMenu(model: model, selectedMode: nil) { _ in }
+
+        let titles = menu?.children.compactMap { ($0 as? UIAction)?.title }
+        XCTAssertEqual(titles, ["Fast", "Reasoning", "Extended Reasoning"])
+    }
+
+    func testMenuUsesSingleSelectionOption() {
+        let model = makeReasoningModel(id: "gpt-5.2", supportedReasoningEffort: [.none, .low, .medium])
+
+        let menu = sut.makeMenu(model: model, selectedMode: nil) { _ in }
+
+        XCTAssertTrue(menu?.options.contains(.singleSelection) ?? false)
+    }
+
+    func testSelectedModeActionIsMarkedOn() {
+        let model = makeReasoningModel(id: "gpt-5.2", supportedReasoningEffort: [.none, .low, .medium])
+
+        let menu = sut.makeMenu(model: model, selectedMode: .reasoning) { _ in }
+
+        let actions = menu?.children.compactMap { $0 as? UIAction }
+        let onAction = actions?.first { $0.state == .on }
+        XCTAssertEqual(onAction?.title, "Reasoning")
+        XCTAssertEqual(actions?.filter { $0.state == .on }.count, 1)
+    }
+
+    // MARK: - Helpers
+
+    private func makeReasoningModel(
+        id: String,
+        supportedReasoningEffort: [AIChatReasoningEffort]
+    ) -> AIChatModel {
+        AIChatModel(
+            id: id,
+            name: id,
+            shortName: id,
+            provider: .openAI,
+            supportsImageUpload: false,
+            entityHasAccess: true,
+            supportedReasoningEffort: supportedReasoningEffort,
+            reasoningEffortAccess: nil
+        )
+    }
+}

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/OmniBar/MockOmniBar.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/OmniBar/MockOmniBar.swift
@@ -36,8 +36,7 @@ final class MockOmniBar: OmniBar {
     func configureForSwipeTemplate(isExpandedPhone: Bool, tabCount: Int) { }
     var isTextFieldEditing: Bool = false
     var text: String?
-    var iPadDuckAISelectedModelId: String?
-    var iPadDuckAISelectedReasoningEffort: AIChatReasoningEffort?
+    var iPadDuckAIControlValues: IPadDuckAIControlValues = IPadDuckAIControlValuesSnapshot()
 
     func updateQuery(_ query: String?) { }
     func refreshText(forUrl url: URL?, forceFullURL: Bool) { }

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/OmniBar/MockOmniBar.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/OmniBar/MockOmniBar.swift
@@ -17,6 +17,7 @@
 //  limitations under the License.
 //
 
+import AIChat
 import UIKit
 import PrivacyDashboard
 
@@ -36,6 +37,7 @@ final class MockOmniBar: OmniBar {
     var isTextFieldEditing: Bool = false
     var text: String?
     var iPadDuckAISelectedModelId: String?
+    var iPadDuckAISelectedReasoningEffort: AIChatReasoningEffort?
 
     func updateQuery(_ query: String?) { }
     func refreshText(forUrl url: URL?, forceFullURL: Bool) { }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215759983177255?focus=true
Tech Design URL:
CC:

### Description
Adds an icon-only reasoning-level picker to the left of the iPad Duck.ai model chip, behind the existing `iPadDuckAIBarControls` flag, matching the iPhone appearance and visibility rules. The reasoning menu, tier-gating, subscription upsell and submit-time effort logic are extracted into shared, protocol-backed components reused by both the iPhone coordinator and the new `IPadOmnibarReasoningPickerController`, which shares the model picker's `UTIModelStore`. Stacked on #5523 (iPad model picker).

### Testing Steps
1. Enable the `iPadDuckAIBarControls` internal flag, open Duck.ai mode in the iPad address bar, and select a reasoning-capable model (e.g. GPT-5.2) — a reasoning chip appears left of the model chip; select a single-mode model and confirm it hides.
2. Tap the chip, switch the reasoning level, submit a prompt, and confirm the chosen effort is forwarded to Duck.ai.
3. As a Free/Plus user, tap a gated reasoning level and confirm the subscription purchase/upgrade flow launches without changing the current selection.

### Impact and Risks
Low — entirely gated behind the internal `iPadDuckAIBarControls` flag.

#### What could go wrong?
The shared-component refactor of the iPhone reasoning coordinator could regress iPhone behaviour; mitigated by the existing reasoning unit tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subscription upsell routing and refactors the iPhone unified input coordinator’s model/reasoning gating; impact is limited by the internal iPad flag but regressions on iPhone Duck.ai controls are possible.
> 
> **Overview**
> Adds an **icon-only reasoning chip** to the expanded iPad Duck.ai omnibar (left of the model chip), shown only when the selected model supports reasoning and **`iPadDuckAIBarControls`** is on. **`IPadOmnibarReasoningPickerController`** shares the model picker’s **`UTIModelStore`**, builds menus via **`UnifiedToggleInputReasoningMenuFactory`**, and applies tier checks through **`ReasoningModeAccessResolver`**.
> 
> Omnibar submission now reads **`IPadDuckAIControlValues`** (model id + reasoning effort) instead of model id alone; **`openAIChat`** receives **`reasoningEffort`** from the address bar. **`UTIModelStore.submissionReasoningEffort`** centralizes submit-time effort for iPhone and iPad.
> 
> **`DuckAISubscriptionUpsellPresenter`** consolidates purchase/upgrade deep links and pixels for gated model and reasoning picks; the iPad model picker and **`UnifiedToggleInputCoordinator`** use it, with **pending gated selections** re-applied after `/models` refresh post-subscription. Unit tests cover the new resolver, menu factory, upsell presenter, and iPad reasoning controller.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99f997311958ce3464ca126ca082bfd377ace21f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->