### PR TITLE
[macOS] Add support for detecting and installing the Chrome extension (feature flagged)

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -200,6 +200,9 @@ public enum MacOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/1211264967278501/task/1211806114021633?focus=true
     case onboardingRebranding
 
+    /// Option to install Chrome extension during onboarding (DMG only)
+    case onboardingChromeExtension
+
     /// Routes reload-after-error through `_evaluateJavaScriptWithoutUserGesture` instead of the
     /// legacy `javascript:` URL trampoline. Kill switch — disable remotely to revert to the
     /// trampoline if the SPI ever misbehaves.

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -3939,6 +3939,16 @@
 		C5965506B4FA4A4E92FD11C9 /* ContextMenuSubfeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91BBCD4E443448C19C16F91E /* ContextMenuSubfeatureTests.swift */; };
 		C8C8050EED40EF171CC2784D /* QuickFeedbackDiagnosticsCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F511D9CB8F68D9D9B0341314 /* QuickFeedbackDiagnosticsCollector.swift */; };
 		C8E4E6A94A9FA76E5ABF3A2A /* QuickFeedbackTipController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76403F87E9F53E2C9FFA007 /* QuickFeedbackTipController.swift */; };
+		C8F1A3D52B6E4C7091D4E8F0 /* DDGChromeExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E7C4B12D8F4A6C93E5F1B0 /* DDGChromeExtension.swift */; };
+		C8F1A3D52B6E4C7091D4E8F1 /* DDGChromeExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E7C4B12D8F4A6C93E5F1B0 /* DDGChromeExtension.swift */; };
+		C8F1A3D52B6E4C7091D4E8F2 /* ThirdPartyBrowserExtensionInstalling.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E7C4B12D8F4A6C93E5F1B1 /* ThirdPartyBrowserExtensionInstalling.swift */; };
+		C8F1A3D52B6E4C7091D4E8F3 /* ThirdPartyBrowserExtensionInstalling.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E7C4B12D8F4A6C93E5F1B1 /* ThirdPartyBrowserExtensionInstalling.swift */; };
+		C8F1A3D52B6E4C7091D4E8F4 /* ChromeExtensionInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E7C4B12D8F4A6C93E5F1B2 /* ChromeExtensionInstaller.swift */; };
+		C8F1A3D52B6E4C7091D4E8F5 /* ChromeExtensionInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E7C4B12D8F4A6C93E5F1B2 /* ChromeExtensionInstaller.swift */; };
+		C8F1A3D52B6E4C7091D4E8F6 /* ChromeExtensionInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E7C4B12D8F4A6C93E5F1B3 /* ChromeExtensionInstallerTests.swift */; };
+		C8F1A3D52B6E4C7091D4E8F7 /* ChromeExtensionInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E7C4B12D8F4A6C93E5F1B3 /* ChromeExtensionInstallerTests.swift */; };
+		C8F1A3D52B6E4C7091D4E8F8 /* ChromeExtensionDebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E7C4B12D8F4A6C93E5F1B4 /* ChromeExtensionDebugMenu.swift */; };
+		C8F1A3D52B6E4C7091D4E8F9 /* ChromeExtensionDebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E7C4B12D8F4A6C93E5F1B4 /* ChromeExtensionDebugMenu.swift */; };
 		CB24F70C29A3D9CB006DCC58 /* AppConfigurationURLProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB24F70B29A3D9CB006DCC58 /* AppConfigurationURLProvider.swift */; };
 		CB24F70D29A3D9CB006DCC58 /* AppConfigurationURLProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB24F70B29A3D9CB006DCC58 /* AppConfigurationURLProvider.swift */; };
 		CB63DECB2CDC0BBE0097986A /* PageRefreshMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB63DECA2CDC0BB80097986A /* PageRefreshMonitor.swift */; };
@@ -6075,6 +6085,11 @@
 		A3E61483DDA440CEAD33A5C5 /* AIChatDeleteChatsDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatDeleteChatsDialog.swift; sourceTree = "<group>"; };
 		A5A7430C39C716A6A3A1F654 /* WebNotificationPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebNotificationPixel.swift; sourceTree = "<group>"; };
 		A86EE9A7B2E24D47BACF8241 /* AdBlockingAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdBlockingAvailability.swift; sourceTree = "<group>"; };
+		A9E7C4B12D8F4A6C93E5F1B0 /* DDGChromeExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDGChromeExtension.swift; sourceTree = "<group>"; };
+		A9E7C4B12D8F4A6C93E5F1B1 /* ThirdPartyBrowserExtensionInstalling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThirdPartyBrowserExtensionInstalling.swift; sourceTree = "<group>"; };
+		A9E7C4B12D8F4A6C93E5F1B2 /* ChromeExtensionInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeExtensionInstaller.swift; sourceTree = "<group>"; };
+		A9E7C4B12D8F4A6C93E5F1B3 /* ChromeExtensionInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeExtensionInstallerTests.swift; sourceTree = "<group>"; };
+		A9E7C4B12D8F4A6C93E5F1B4 /* ChromeExtensionDebugMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeExtensionDebugMenu.swift; sourceTree = "<group>"; };
 		AA0000012F00000100000001 /* TabRestorationData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabRestorationData.swift; sourceTree = "<group>"; };
 		AA0877B726D5160D00B05660 /* SafariVersionReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariVersionReaderTests.swift; sourceTree = "<group>"; };
 		AA0877B926D5161D00B05660 /* WebKitVersionProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebKitVersionProviderTests.swift; sourceTree = "<group>"; };
@@ -10192,6 +10207,7 @@
 			isa = PBXGroup;
 			children = (
 				560EB9302C78943E0080DBC8 /* ContextualOnboarding */,
+				A9E7C4B12D8F4A6C93E5F1B5 /* ThirdPartyBrowserExtensions */,
 				56A053FB2C19E8F7007D8FAB /* OnboardingActionsManager.swift */,
 				56A054012C1AFA5D007D8FAB /* OnboardingConfiguration.swift */,
 				56A0543D2C215FB3007D8FAB /* OnboardingUserScript.swift */,
@@ -10288,6 +10304,7 @@
 			children = (
 				567A23D92C8894840010F66C /* ContextualOnboarding */,
 				56A054062C1B4772007D8FAB /* Mocks */,
+				A9E7C4B12D8F4A6C93E5F1B3 /* ChromeExtensionInstallerTests.swift */,
 				56A053FE2C1AEFA1007D8FAB /* OnboardingManagerTests.swift */,
 				56A054432C2252CE007D8FAB /* OnboardingUserScriptTests.swift */,
 			);
@@ -10530,6 +10547,17 @@
 				C76403F87E9F53E2C9FFA007 /* QuickFeedbackTipController.swift */,
 			);
 			path = QuickFeedback;
+			sourceTree = "<group>";
+		};
+		A9E7C4B12D8F4A6C93E5F1B5 /* ThirdPartyBrowserExtensions */ = {
+			isa = PBXGroup;
+			children = (
+				A9E7C4B12D8F4A6C93E5F1B0 /* DDGChromeExtension.swift */,
+				A9E7C4B12D8F4A6C93E5F1B1 /* ThirdPartyBrowserExtensionInstalling.swift */,
+				A9E7C4B12D8F4A6C93E5F1B2 /* ChromeExtensionInstaller.swift */,
+				A9E7C4B12D8F4A6C93E5F1B4 /* ChromeExtensionDebugMenu.swift */,
+			);
+			path = ThirdPartyBrowserExtensions;
 			sourceTree = "<group>";
 		};
 		AA0877B626D515EE00B05660 /* UserAgent */ = {
@@ -15504,6 +15532,10 @@
 				7BA64F682EE1E86B00289E30 /* ContentScopeExperimentsMenu.swift in Sources */,
 				37E13B8F2D54B03D002ECD62 /* HistoryViewDataProvider.swift in Sources */,
 				56A053FD2C1A0AC9007D8FAB /* OnboardingActionsManager.swift in Sources */,
+				C8F1A3D52B6E4C7091D4E8F1 /* DDGChromeExtension.swift in Sources */,
+				C8F1A3D52B6E4C7091D4E8F3 /* ThirdPartyBrowserExtensionInstalling.swift in Sources */,
+				C8F1A3D52B6E4C7091D4E8F5 /* ChromeExtensionInstaller.swift in Sources */,
+				C8F1A3D52B6E4C7091D4E8F9 /* ChromeExtensionDebugMenu.swift in Sources */,
 				B626A76E29928B1600053070 /* TestsClosureNavigationResponder.swift in Sources */,
 				3707C71A294B5D0F00682A9F /* TabExtensions.swift in Sources */,
 				B66260DE29AC5D4300E9E3EE /* NavigationProtectionTabExtension.swift in Sources */,
@@ -16429,6 +16461,7 @@
 				7BAB1A0100000000A00000B1 /* AIChatMentionPickerViewControllerTests.swift in Sources */,
 				1A77VST00000000000000006 /* VoiceSessionTrackerTests.swift in Sources */,
 				56A054482C22536A007D8FAB /* CapturingOnboardingActionsManager.swift in Sources */,
+				C8F1A3D52B6E4C7091D4E8F7 /* ChromeExtensionInstallerTests.swift in Sources */,
 				3706FE3D293F661700E42796 /* DataEncryptionTests.swift in Sources */,
 				1D39F7292DCA2C9200F258F0 /* InitialWindowFrameProviderTests.swift in Sources */,
 				BB72939E2EE709AB00BCC3BB /* ReinstallUserDetectionTests.swift in Sources */,
@@ -18278,6 +18311,10 @@
 				B65E6B9E26D9EC0800095F96 /* CircularProgressView.swift in Sources */,
 				BB3229052D08644400DA92E9 /* TabBarRemoteMessageView.swift in Sources */,
 				56A053FC2C19E8F7007D8FAB /* OnboardingActionsManager.swift in Sources */,
+				C8F1A3D52B6E4C7091D4E8F0 /* DDGChromeExtension.swift in Sources */,
+				C8F1A3D52B6E4C7091D4E8F2 /* ThirdPartyBrowserExtensionInstalling.swift in Sources */,
+				C8F1A3D52B6E4C7091D4E8F4 /* ChromeExtensionInstaller.swift in Sources */,
+				C8F1A3D52B6E4C7091D4E8F8 /* ChromeExtensionDebugMenu.swift in Sources */,
 				EEE50C292C38249C003DD7FF /* OptionalExtension.swift in Sources */,
 				AABEE69C24A902BB0043105B /* SuggestionContainer.swift in Sources */,
 				1D68604F2D36BD28006FC53E /* WebExtensionsDebugMenu.swift in Sources */,
@@ -18698,6 +18735,7 @@
 				B63ED0DC26AE7B1E00A9DAD1 /* WebViewMock.swift in Sources */,
 				1D39F7282DCA2C9200F258F0 /* InitialWindowFrameProviderTests.swift in Sources */,
 				56A053FF2C1AEFA1007D8FAB /* OnboardingManagerTests.swift in Sources */,
+				C8F1A3D52B6E4C7091D4E8F6 /* ChromeExtensionInstallerTests.swift in Sources */,
 				BB9BA2212D10BC72009229F3 /* TabBarRemoteMessageViewModelTests.swift in Sources */,
 				CC26B6762F0D269D00D380B6 /* NewTabPageNextStepsCardsActionHandlerTests.swift in Sources */,
 				C172E7332C93759C00521D9A /* SyncPromoManagerTests.swift in Sources */,

--- a/macOS/DuckDuckGo/Menus/MainMenu.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenu.swift
@@ -1148,6 +1148,20 @@ final class MainMenu: NSMenu {
                 NSMenuItem(title: "⚠️ App restart required.", action: nil, target: nil)
             }
 
+            NSMenuItem(title: "Chrome Extension")
+                .submenu(ChromeExtensionDebugMenu(
+                    featureFlagger: featureFlagger,
+                    installer: ChromeExtensionInstaller(
+                        featureFlagger: featureFlagger,
+                        buildType: StandardApplicationBuildType(),
+                        isChromeInstalled: { ThirdPartyBrowser.chrome.isInstalled },
+                        applicationSupportURL: .nonSandboxApplicationSupportDirectoryURL,
+                        fileManager: .default,
+                        pixelFiring: PixelKit.shared
+                    )
+                ))
+                .withAccessibilityIdentifier("MainMenu.chromeExtensionDebugMenu")
+
             NSMenuItem(title: "Logging").submenu(setupLoggingMenu())
             NSMenuItem(title: "AI Chat").submenu(AIChatDebugMenu())
             NSMenuItem(title: "Base URL Configuration").submenu(BaseURLDebugMenu())

--- a/macOS/DuckDuckGo/Onboarding/ThirdPartyBrowserExtensions/ChromeExtensionDebugMenu.swift
+++ b/macOS/DuckDuckGo/Onboarding/ThirdPartyBrowserExtensions/ChromeExtensionDebugMenu.swift
@@ -1,0 +1,80 @@
+//
+//  ChromeExtensionDebugMenu.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppKit
+import FeatureFlags
+import PrivacyConfig
+
+final class ChromeExtensionDebugMenu: NSMenu {
+
+    private let featureFlagger: FeatureFlagger
+    private let installer: ThirdPartyBrowserExtensionInstalling
+    private let featureFlagHintMenuItem = NSMenuItem(title: "Enable onboardingChromeExtension feature flag")
+    private let eligibilityMenuItem = NSMenuItem(title: "")
+    private let installSearchExtensionMenuItem = NSMenuItem(title: "Install search extension", action: #selector(installSearchExtension))
+
+    init(featureFlagger: FeatureFlagger, installer: ThirdPartyBrowserExtensionInstalling) {
+        self.featureFlagger = featureFlagger
+        self.installer = installer
+        super.init(title: "")
+
+        autoenablesItems = false
+        installSearchExtensionMenuItem.target = self
+        featureFlagHintMenuItem.isEnabled = false
+
+        buildItems {
+            featureFlagHintMenuItem
+            eligibilityMenuItem
+            installSearchExtensionMenuItem
+        }
+
+        updateMenuItemsState()
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func update() {
+        updateMenuItemsState()
+    }
+
+    @objc private func installSearchExtension() {
+        let installationSucceeded = installer.installDDGExtension()
+        let alert = NSAlert()
+        alert.messageText = installationSucceeded ? "Search extension installed" : "Search extension installation failed"
+        alert.alertStyle = installationSucceeded ? .informational : .warning
+        alert.runModal()
+
+        updateMenuItemsState()
+    }
+
+    private func updateMenuItemsState() {
+        let isFeatureEnabled = featureFlagger.isFeatureOn(.onboardingChromeExtension)
+        featureFlagHintMenuItem.isHidden = isFeatureEnabled
+        eligibilityMenuItem.isHidden = !isFeatureEnabled
+        installSearchExtensionMenuItem.isHidden = !isFeatureEnabled
+
+        if isFeatureEnabled {
+            let canInstallExtension = installer.canInstallDDGExtension
+            eligibilityMenuItem.title = canInstallExtension ? "Chrome extension: eligible" : "Chrome extension: not eligible"
+            eligibilityMenuItem.isEnabled = false
+            installSearchExtensionMenuItem.isEnabled = canInstallExtension
+        }
+    }
+}

--- a/macOS/DuckDuckGo/Onboarding/ThirdPartyBrowserExtensions/ChromeExtensionInstaller.swift
+++ b/macOS/DuckDuckGo/Onboarding/ThirdPartyBrowserExtensions/ChromeExtensionInstaller.swift
@@ -1,0 +1,176 @@
+//
+//  ChromeExtensionInstaller.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import FeatureFlags
+import Foundation
+import PixelKit
+import PrivacyConfig
+import os.log
+
+enum ChromeExtensionInstallerPixelEvent: PixelKitEvent {
+    case detectionFailed
+    case installFailed
+
+    var name: String {
+        switch self {
+        case .detectionFailed:
+            return "onboarding_chrome-extension-install_detection-failed"
+        case .installFailed:
+            return "onboarding_chrome-extension-install_install-failed"
+        }
+    }
+
+    var parameters: [String: String]? {
+        nil
+    }
+
+    var standardParameters: [PixelKitStandardParameter]? {
+        [.pixelSource]
+    }
+}
+
+final class ChromeExtensionInstaller: ThirdPartyBrowserExtensionInstalling {
+
+    private enum Constants {
+        static let externalExtensionUpdateURL = "https://clients2.google.com/service/update2/crx"
+        static let externalExtensionsPath = "External Extensions"
+        static let profileExtensionsPath = "Extensions"
+    }
+
+    private let featureFlagger: FeatureFlagger
+    private let buildType: ApplicationBuildType
+    private let isChromeInstalled: () -> Bool
+    private let applicationSupportURL: URL
+    private let fileManager: FileManager
+    private let pixelFiring: PixelFiring?
+
+    init(
+        featureFlagger: FeatureFlagger,
+        buildType: ApplicationBuildType,
+        isChromeInstalled: @escaping () -> Bool,
+        applicationSupportURL: URL,
+        fileManager: FileManager,
+        pixelFiring: PixelFiring?
+    ) {
+        self.featureFlagger = featureFlagger
+        self.buildType = buildType
+        self.isChromeInstalled = isChromeInstalled
+        self.applicationSupportURL = applicationSupportURL
+        self.fileManager = fileManager
+        self.pixelFiring = pixelFiring
+    }
+
+    private var installedChannelRoots: [URL] {
+        ThirdPartyBrowser.chrome.profilesDirectories(applicationSupportURL: applicationSupportURL)
+            .filter { fileManager.fileExists(atPath: $0.path) }
+    }
+
+    /// Whether the Chrome extension can be staged for the user.
+    ///
+    /// Returns `true` only when all of the following hold:
+    /// - The `onboardingChromeExtension` feature flag is enabled
+    /// - The app is a Sparkle (DMG) build
+    /// - Chrome is installed and has been launched before
+    /// - None of the DDG extension variants are already installed in any Chrome channel or profile
+    ///
+    /// On filesystem errors during detection, the implementation logs, fires a debug pixel, and returns `false`.
+    var canInstallDDGExtension: Bool {
+        guard featureFlagger.isFeatureOn(.onboardingChromeExtension),
+              buildType.isSparkleBuild,
+              isChromeInstalled(),
+              !installedChannelRoots.isEmpty else {
+            return false
+        }
+
+        do {
+            return try DDGChromeExtension.allCases.allSatisfy { chromeExtension in
+                try isInstalled(extensionID: chromeExtension.extensionID) == false
+            }
+        } catch {
+            Logger.general.error("Failed to detect third-party browser extension install state: \(String(describing: error), privacy: .public)")
+            pixelFiring?.fire(DebugEvent(ChromeExtensionInstallerPixelEvent.detectionFailed, error: error), frequency: .dailyAndStandard)
+            return false
+        }
+    }
+
+    /// Stages the Chrome search extension by writing External Extensions JSON for each installed Chrome channel.
+    ///
+    /// - Returns: `true` if all writes succeed or `false` if the user is ineligible, or if any write fails.
+    @discardableResult
+    func installDDGExtension() -> Bool {
+        guard canInstallDDGExtension else {
+            return false
+        }
+
+        let extensionID = DDGChromeExtension.search.extensionID
+        var writeSucceededForAllChannels = true
+        for channelRoot in installedChannelRoots {
+            let externalExtensionsDirectory = channelRoot.appendingPathComponent(Constants.externalExtensionsPath, isDirectory: true)
+            let externalExtensionFile = externalExtensionsDirectory.appendingPathComponent("\(extensionID).json", isDirectory: false)
+            let fileContents = #"{"external_update_url":"\#(Constants.externalExtensionUpdateURL)"}"#
+
+            do {
+                guard let fileData = fileContents.data(using: .utf8) else {
+                    throw CocoaError(.fileWriteUnknown)
+                }
+                try fileManager.createDirectory(at: externalExtensionsDirectory, withIntermediateDirectories: true)
+                try fileData.write(to: externalExtensionFile, options: [.atomic])
+            } catch {
+                writeSucceededForAllChannels = false
+                Logger.general.error("Failed to write third-party browser extension install file: \(String(describing: error), privacy: .public)")
+                pixelFiring?.fire(DebugEvent(ChromeExtensionInstallerPixelEvent.installFailed, error: error), frequency: .dailyAndStandard)
+            }
+        }
+
+        return writeSucceededForAllChannels
+    }
+
+    private func isInstalled(extensionID: String) throws -> Bool {
+        // Check if the extension is installed in any channel's external staging directory.
+        for channelRoot in installedChannelRoots {
+            let externalExtensionFile = channelRoot
+                .appendingPathComponent(Constants.externalExtensionsPath, isDirectory: true)
+                .appendingPathComponent("\(extensionID).json", isDirectory: false)
+
+            if fileManager.fileExists(atPath: externalExtensionFile.path) {
+                return true
+            }
+        }
+
+        // Check if the extension is installed in any profile.
+        let browserProfiles = ThirdPartyBrowser.chrome.browserProfiles(applicationSupportURL: applicationSupportURL)
+        for profile in browserProfiles.profiles {
+            let extensionsDirectory = profile.profileURL.appendingPathComponent(Constants.profileExtensionsPath, isDirectory: true)
+            guard fileManager.fileExists(atPath: extensionsDirectory.path) else {
+                continue
+            }
+
+            let extensionDirectories = try fileManager.contentsOfDirectory(
+                at: extensionsDirectory,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )
+
+            if extensionDirectories.contains(where: { $0.hasDirectoryPath && $0.lastPathComponent == extensionID }) {
+                return true
+            }
+        }
+
+        return false
+    }
+}

--- a/macOS/DuckDuckGo/Onboarding/ThirdPartyBrowserExtensions/ChromeExtensionInstaller.swift
+++ b/macOS/DuckDuckGo/Onboarding/ThirdPartyBrowserExtensions/ChromeExtensionInstaller.swift
@@ -90,16 +90,18 @@ final class ChromeExtensionInstaller: ThirdPartyBrowserExtensionInstalling {
     ///
     /// On filesystem errors during detection, the implementation logs, fires a debug pixel, and returns `false`.
     var canInstallDDGExtension: Bool {
+        let channelRoots = installedChannelRoots
+
         guard featureFlagger.isFeatureOn(.onboardingChromeExtension),
               buildType.isSparkleBuild,
               isChromeInstalled(),
-              !installedChannelRoots.isEmpty else {
+              !channelRoots.isEmpty else {
             return false
         }
 
         do {
             return try DDGChromeExtension.allCases.allSatisfy { chromeExtension in
-                try isInstalled(extensionID: chromeExtension.extensionID) == false
+                try isInstalled(extensionID: chromeExtension.extensionID, in: channelRoots) == false
             }
         } catch {
             Logger.general.error("Failed to detect third-party browser extension install state: \(String(describing: error), privacy: .public)")
@@ -120,16 +122,16 @@ final class ChromeExtensionInstaller: ThirdPartyBrowserExtensionInstalling {
         let extensionID = DDGChromeExtension.search.extensionID
         var writeSucceededForAllChannels = true
         for channelRoot in installedChannelRoots {
-            let externalExtensionsDirectory = channelRoot.appendingPathComponent(Constants.externalExtensionsPath, isDirectory: true)
-            let externalExtensionFile = externalExtensionsDirectory.appendingPathComponent("\(extensionID).json", isDirectory: false)
+            let directory = externalExtensionsDirectoryURL(channelRoot: channelRoot)
+            let file = externalExtensionFileURL(channelRoot: channelRoot, extensionID: extensionID)
             let fileContents = #"{"external_update_url":"\#(Constants.externalExtensionUpdateURL)"}"#
 
             do {
                 guard let fileData = fileContents.data(using: .utf8) else {
                     throw CocoaError(.fileWriteUnknown)
                 }
-                try fileManager.createDirectory(at: externalExtensionsDirectory, withIntermediateDirectories: true)
-                try fileData.write(to: externalExtensionFile, options: [.atomic])
+                try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+                try fileData.write(to: file, options: [.atomic])
             } catch {
                 writeSucceededForAllChannels = false
                 Logger.general.error("Failed to write third-party browser extension install file: \(String(describing: error), privacy: .public)")
@@ -140,14 +142,11 @@ final class ChromeExtensionInstaller: ThirdPartyBrowserExtensionInstalling {
         return writeSucceededForAllChannels
     }
 
-    private func isInstalled(extensionID: String) throws -> Bool {
+    private func isInstalled(extensionID: String, in channelRoots: [URL]) throws -> Bool {
         // Check if the extension is installed in any channel's external staging directory.
-        for channelRoot in installedChannelRoots {
-            let externalExtensionFile = channelRoot
-                .appendingPathComponent(Constants.externalExtensionsPath, isDirectory: true)
-                .appendingPathComponent("\(extensionID).json", isDirectory: false)
-
-            if fileManager.fileExists(atPath: externalExtensionFile.path) {
+        for channelRoot in channelRoots {
+            let file = externalExtensionFileURL(channelRoot: channelRoot, extensionID: extensionID)
+            if fileManager.fileExists(atPath: file.path) {
                 return true
             }
         }
@@ -172,5 +171,14 @@ final class ChromeExtensionInstaller: ThirdPartyBrowserExtensionInstalling {
         }
 
         return false
+    }
+
+    private func externalExtensionsDirectoryURL(channelRoot: URL) -> URL {
+        channelRoot.appendingPathComponent(Constants.externalExtensionsPath, isDirectory: true)
+    }
+
+    private func externalExtensionFileURL(channelRoot: URL, extensionID: String) -> URL {
+        externalExtensionsDirectoryURL(channelRoot: channelRoot)
+            .appendingPathComponent("\(extensionID).json", isDirectory: false)
     }
 }

--- a/macOS/DuckDuckGo/Onboarding/ThirdPartyBrowserExtensions/ChromeExtensionInstaller.swift
+++ b/macOS/DuckDuckGo/Onboarding/ThirdPartyBrowserExtensions/ChromeExtensionInstaller.swift
@@ -40,7 +40,7 @@ enum ChromeExtensionInstallerPixelEvent: PixelKitEvent {
     }
 
     var standardParameters: [PixelKitStandardParameter]? {
-        [.pixelSource]
+        nil
     }
 }
 

--- a/macOS/DuckDuckGo/Onboarding/ThirdPartyBrowserExtensions/DDGChromeExtension.swift
+++ b/macOS/DuckDuckGo/Onboarding/ThirdPartyBrowserExtensions/DDGChromeExtension.swift
@@ -1,0 +1,34 @@
+//
+//  DDGChromeExtension.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+enum DDGChromeExtension: CaseIterable {
+    case full
+    case search
+    case noAISearch
+
+    var extensionID: String {
+        switch self {
+        case .full:
+            return "bkdgflcldnnnapblkhphbgpggdiikppg"
+        case .search:
+            return "jhagicoeeifaamcacdeifbjacnbgbeip"
+        case .noAISearch:
+            return "faoilnlkccdjdkpljainiiimmijofmpd"
+        }
+    }
+}

--- a/macOS/DuckDuckGo/Onboarding/ThirdPartyBrowserExtensions/ThirdPartyBrowserExtensionInstalling.swift
+++ b/macOS/DuckDuckGo/Onboarding/ThirdPartyBrowserExtensions/ThirdPartyBrowserExtensionInstalling.swift
@@ -1,0 +1,24 @@
+//
+//  ThirdPartyBrowserExtensionInstalling.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+protocol ThirdPartyBrowserExtensionInstalling {
+    var canInstallDDGExtension: Bool { get }
+
+    @discardableResult
+    func installDDGExtension() -> Bool
+}

--- a/macOS/DuckDuckGo/Onboarding/ThirdPartyBrowserExtensions/ThirdPartyBrowserExtensionInstalling.swift
+++ b/macOS/DuckDuckGo/Onboarding/ThirdPartyBrowserExtensions/ThirdPartyBrowserExtensionInstalling.swift
@@ -17,8 +17,12 @@
 //
 
 protocol ThirdPartyBrowserExtensionInstalling {
+    /// Whether the DuckDuckGo extension can be installed in a third-party browser.
+    ///
     var canInstallDDGExtension: Bool { get }
 
+    /// Installs the DuckDuckGo extension in a third-party browser.
+    ///
     @discardableResult
     func installDDGExtension() -> Bool
 }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -35,6 +35,10 @@ public enum FeatureFlag: String, CaseIterable {
     /// Onboarding rebranding feature flag
     case onboardingRebranding
 
+    /// Option to install Chrome extension during onboarding (DMG only)
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216010708822357
+    case onboardingChromeExtension
+
     // https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866715698981
     case unknownUsernameCategorization
 
@@ -478,6 +482,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(ContextualOnboardingSubfeature.featureEnabled), supportsLocalOverriding: false)
         case .onboardingRebranding:
             Config(defaultValue: .enabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.onboardingRebranding))
+        case .onboardingChromeExtension:
+            Config(defaultValue: .disabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.onboardingChromeExtension))
         case .unknownUsernameCategorization:
             Config(source: .remoteReleasable(AutofillSubfeature.unknownUsernameCategorization), supportsLocalOverriding: false)
         case .credentialsImportPromotionForExistingUsers:

--- a/macOS/PixelDefinitions/pixels/definitions/onboarding_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/onboarding_pixels.json5
@@ -126,5 +126,19 @@
         "owners": ["SabrinaTardio", "rachelmcr"],
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_debug_onboarding_chrome-extension-install_detection-failed": {
+        "description": "Fired when onboarding Chrome extension eligibility detection fails to read Application Support.",
+        "owners": ["rachelmcr"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
+    },
+    "m_mac_debug_onboarding_chrome-extension-install_install-failed": {
+        "description": "Fired when onboarding Chrome extension install fails to write Application Support.",
+        "owners": ["rachelmcr"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/onboarding_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/onboarding_pixels.json5
@@ -131,14 +131,14 @@
         "description": "Fired when onboarding Chrome extension eligibility detection fails to read Application Support.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
-        "suffixes": ["first_daily_count"],
+        "suffixes": ["daily_standard"],
         "parameters": ["appVersion", "pixelSource", "channel", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_mac_debug_onboarding_chrome-extension-install_install-failed": {
         "description": "Fired when onboarding Chrome extension install fails to write Application Support.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
-        "suffixes": ["first_daily_count"],
+        "suffixes": ["daily_standard"],
         "parameters": ["appVersion", "pixelSource", "channel", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/onboarding_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/onboarding_pixels.json5
@@ -132,13 +132,13 @@
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource", "channel", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
+        "parameters": ["appVersion", "channel", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     },
     "m_mac_debug_onboarding_chrome-extension-install_install-failed": {
         "description": "Fired when onboarding Chrome extension install fails to write Application Support.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource", "channel", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
+        "parameters": ["appVersion", "channel", "errorDomain", "errorCode", "underlyingErrorCode", "underlyingErrorDomain"]
     }
 }

--- a/macOS/UnitTests/Onboarding/ChromeExtensionInstallerTests.swift
+++ b/macOS/UnitTests/Onboarding/ChromeExtensionInstallerTests.swift
@@ -1,0 +1,261 @@
+//
+//  ChromeExtensionInstallerTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import FeatureFlags
+import Foundation
+import PixelKit
+import PixelKitTestingUtilities
+import PrivacyConfig
+import XCTest
+
+@testable import DuckDuckGo_Privacy_Browser
+
+final class ChromeExtensionInstallerTests: XCTestCase {
+
+    private var applicationSupportURL: URL!
+
+    override func setUp() {
+        super.setUp()
+        applicationSupportURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.removeItem(at: applicationSupportURL)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: applicationSupportURL)
+        applicationSupportURL = nil
+        super.tearDown()
+    }
+
+    func testWhenFeatureFlagIsOffThenCanInstallIsFalse() {
+        let installer = makeSUT(enableOnboardingChromeExtensionFlag: false)
+
+        XCTAssertFalse(installer.canInstallDDGExtension)
+    }
+
+    func testWhenBuildIsNotSparkleThenCanInstallIsFalse() throws {
+        let buildType = ApplicationBuildTypeMock()
+        buildType.isSparkleBuild = false
+
+        let installer = makeSUT(buildType: buildType)
+
+        XCTAssertFalse(installer.canInstallDDGExtension)
+    }
+
+    func testWhenChromeIsNotInstalledThenCanInstallIsFalse() {
+        let installer = makeSUT(isChromeInstalled: { false })
+
+        XCTAssertFalse(installer.canInstallDDGExtension)
+    }
+
+    func testWhenChromeIsInstalledButNoChannelRootExistsThenCanInstallIsFalse() {
+        let installer = makeSUT()
+
+        XCTAssertFalse(installer.canInstallDDGExtension)
+    }
+
+    func testWhenExternalExtensionFileExistsForAnyEligibilityExtensionThenCanInstallIsFalse() throws {
+        try createChromeChannelDirectory(named: "Chrome")
+        try createExternalExtensionFile(channel: "Chrome", extensionID: DDGChromeExtension.full.extensionID)
+
+        let installer = makeSUT()
+
+        XCTAssertFalse(installer.canInstallDDGExtension)
+    }
+
+    func testWhenProfileExtensionDirectoryExistsForAnyEligibilityExtensionThenCanInstallIsFalse() throws {
+        try createChromeChannelDirectory(named: "Chrome")
+        try createProfileExtensionDirectory(channel: "Chrome",
+                                            profileName: "Default",
+                                            extensionID: DDGChromeExtension.noAISearch.extensionID)
+
+        let installer = makeSUT()
+
+        XCTAssertFalse(installer.canInstallDDGExtension)
+    }
+
+    func testWhenAllEligibilityChecksPassThenCanInstallIsTrue() throws {
+        try createChromeChannelDirectory(named: "Chrome")
+
+        let installer = makeSUT()
+
+        XCTAssertTrue(installer.canInstallDDGExtension)
+    }
+
+    func testWhenInstallSucceedsThenSearchExtensionFileIsWrittenForInstalledChannelsOnly() throws {
+        try createChromeChannelDirectory(named: "Chrome")
+        try createChromeChannelDirectory(named: "Chrome Beta")
+
+        let installer = makeSUT()
+        let didInstall = installer.installDDGExtension()
+
+        XCTAssertTrue(didInstall)
+        XCTAssertTrue(externalExtensionFileURL(channel: "Chrome", extensionID: DDGChromeExtension.search.extensionID).isExistingFile)
+        XCTAssertTrue(externalExtensionFileURL(channel: "Chrome Beta", extensionID: DDGChromeExtension.search.extensionID).isExistingFile)
+        XCTAssertFalse(externalExtensionFileURL(channel: "Chrome Dev", extensionID: DDGChromeExtension.search.extensionID).isExistingFile)
+        XCTAssertFalse(externalExtensionFileURL(channel: "Chrome Canary", extensionID: DDGChromeExtension.search.extensionID).isExistingFile)
+
+        XCTAssertFalse(externalExtensionFileURL(channel: "Chrome", extensionID: DDGChromeExtension.full.extensionID).isExistingFile)
+        XCTAssertFalse(externalExtensionFileURL(channel: "Chrome", extensionID: DDGChromeExtension.noAISearch.extensionID).isExistingFile)
+    }
+
+    func testWhenInstallSucceedsThenCanInstallIsFalse() throws {
+        try createChromeChannelDirectory(named: "Chrome")
+
+        let installer = makeSUT()
+
+        XCTAssertTrue(installer.canInstallDDGExtension)
+        XCTAssertTrue(installer.installDDGExtension())
+        XCTAssertFalse(installer.canInstallDDGExtension)
+    }
+
+    func testWhenDetectionHitsFileSystemErrorThenDetectionFailedPixelIsFiredAndCanInstallIsFalse() throws {
+        try createChromeChannelDirectory(named: "Chrome")
+        try createProfileExtensionDirectory(channel: "Chrome", profileName: "Default", extensionID: "unrelated-extension-id")
+
+        let fileManager = ThrowingFileManager()
+        fileManager.throwOnContentsOfDirectory = true
+
+        let pixelFiring = PixelKitMock()
+        let installer = makeSUT(fileManager: fileManager, pixelFiring: pixelFiring)
+
+        XCTAssertFalse(installer.canInstallDDGExtension)
+        XCTAssertEqual(firedInstallerPixelEvents(from: pixelFiring), [.detectionFailed])
+        XCTAssertEqual(pixelFiring.actualFireCalls.first?.frequency, .dailyAndStandard)
+    }
+
+    func testWhenInstallHitsFileSystemErrorThenInstallFailedPixelIsFiredAndInstallReturnsFalse() throws {
+        try createChromeChannelDirectory(named: "Chrome")
+
+        let fileManager = ThrowingFileManager()
+        fileManager.throwOnCreateDirectory = true
+
+        let pixelFiring = PixelKitMock()
+        let installer = makeSUT(fileManager: fileManager, pixelFiring: pixelFiring)
+
+        XCTAssertFalse(installer.installDDGExtension())
+        XCTAssertEqual(firedInstallerPixelEvents(from: pixelFiring), [.installFailed])
+        XCTAssertEqual(pixelFiring.actualFireCalls.first?.frequency, .dailyAndStandard)
+    }
+
+    // MARK: - Helpers
+
+    private func makeSUT(
+        enableOnboardingChromeExtensionFlag: Bool = true,
+        buildType: ApplicationBuildTypeMock = {
+            let buildType = ApplicationBuildTypeMock()
+            buildType.isSparkleBuild = true
+            return buildType
+        }(),
+        isChromeInstalled: @escaping () -> Bool = { true },
+        fileManager: FileManager = .default,
+        pixelFiring: PixelFiring? = nil
+    ) -> ChromeExtensionInstaller {
+        let featureFlagger = MockFeatureFlagger()
+        if enableOnboardingChromeExtensionFlag {
+            featureFlagger.enableFeatures([.onboardingChromeExtension])
+        }
+
+        return ChromeExtensionInstaller(
+            featureFlagger: featureFlagger,
+            buildType: buildType,
+            isChromeInstalled: isChromeInstalled,
+            applicationSupportURL: applicationSupportURL,
+            fileManager: fileManager,
+            pixelFiring: pixelFiring
+        )
+    }
+
+    private func createChromeChannelDirectory(named channelName: String) throws {
+        let channelDirectory = applicationSupportURL
+            .appendingPathComponent("Google", isDirectory: true)
+            .appendingPathComponent(channelName, isDirectory: true)
+        try FileManager.default.createDirectory(at: channelDirectory, withIntermediateDirectories: true)
+    }
+
+    private func createExternalExtensionFile(channel: String, extensionID: String) throws {
+        let fileURL = externalExtensionFileURL(channel: channel, extensionID: extensionID)
+        let fileContents = #"{"external_update_url":"https://clients2.google.com/service/update2/crx"}"#
+        guard let fileData = fileContents.data(using: .utf8) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        try FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try fileData.write(to: fileURL)
+    }
+
+    private func createProfileExtensionDirectory(channel: String, profileName: String, extensionID: String) throws {
+        let extensionDirectory = applicationSupportURL
+            .appendingPathComponent("Google", isDirectory: true)
+            .appendingPathComponent(channel, isDirectory: true)
+            .appendingPathComponent(profileName, isDirectory: true)
+            .appendingPathComponent("Extensions", isDirectory: true)
+            .appendingPathComponent(extensionID, isDirectory: true)
+        try FileManager.default.createDirectory(at: extensionDirectory, withIntermediateDirectories: true)
+    }
+
+    private func externalExtensionFileURL(channel: String, extensionID: String) -> URL {
+        applicationSupportURL
+            .appendingPathComponent("Google", isDirectory: true)
+            .appendingPathComponent(channel, isDirectory: true)
+            .appendingPathComponent("External Extensions", isDirectory: true)
+            .appendingPathComponent("\(extensionID).json", isDirectory: false)
+    }
+}
+
+private func firedInstallerPixelEvents(from pixelFiring: PixelKitMock) -> [ChromeExtensionInstallerPixelEvent] {
+    pixelFiring.actualFireCalls.compactMap { call in
+        guard let debugEvent = call.pixel as? DebugEvent,
+              case .custom(let event) = debugEvent.eventType,
+              let installerEvent = event as? ChromeExtensionInstallerPixelEvent else {
+            return nil
+        }
+        return installerEvent
+    }
+}
+
+private final class ThrowingFileManager: FileManager, @unchecked Sendable {
+    var throwOnContentsOfDirectory = false
+    var throwOnCreateDirectory = false
+
+    override func contentsOfDirectory(
+        at url: URL,
+        includingPropertiesForKeys keys: [URLResourceKey]?,
+        options mask: FileManager.DirectoryEnumerationOptions = []
+    ) throws -> [URL] {
+        if throwOnContentsOfDirectory {
+            throw CocoaError(.fileReadUnknown)
+        }
+        return try super.contentsOfDirectory(at: url, includingPropertiesForKeys: keys, options: mask)
+    }
+
+    override func createDirectory(
+        at url: URL,
+        withIntermediateDirectories createIntermediates: Bool,
+        attributes: [FileAttributeKey: Any]? = nil
+    ) throws {
+        if throwOnCreateDirectory {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        try super.createDirectory(at: url, withIntermediateDirectories: createIntermediates, attributes: attributes)
+    }
+}
+
+private extension URL {
+    var isExistingFile: Bool {
+        FileManager.default.fileExists(atPath: path)
+    }
+}

--- a/macOS/UnitTests/Onboarding/ChromeExtensionInstallerTests.swift
+++ b/macOS/UnitTests/Onboarding/ChromeExtensionInstallerTests.swift
@@ -29,16 +29,20 @@ final class ChromeExtensionInstallerTests: XCTestCase {
 
     private var applicationSupportURL: URL!
 
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         applicationSupportURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try? FileManager.default.removeItem(at: applicationSupportURL)
+        if FileManager.default.fileExists(atPath: applicationSupportURL.path) {
+            try FileManager.default.removeItem(at: applicationSupportURL)
+        }
     }
 
-    override func tearDown() {
-        try? FileManager.default.removeItem(at: applicationSupportURL)
+    override func tearDownWithError() throws {
+        if FileManager.default.fileExists(atPath: applicationSupportURL.path) {
+            try FileManager.default.removeItem(at: applicationSupportURL)
+        }
         applicationSupportURL = nil
-        super.tearDown()
+        try super.tearDownWithError()
     }
 
     func testWhenFeatureFlagIsOffThenCanInstallIsFalse() {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1216006558410866?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1215768372026404
CC:

### Description

Adds feature-flagged support for detecting and installing the Chrome search extension.

This will be used for a new option in onboarding to install the Chrome extension. For now, this is not connected to the app UI; it can be tested via the debug menu. (The debug menu will be removed once the full flow can be tested in the app.)

Support for Frontend <> Native communication and showing this option in onboarding will follow in a separate PR.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
Prerequisites:
* Install the Chrome app
* Remove any DDG extension from any Chrome profiles

To test:
1. Build and run the DMG version of the app.
2. Enable the `onboardingChromeExtension` feature flag (Debug → Feature Flag Overrides → Other)
3. Open Debug → Chrome Extension
4. Confirm eligibility shows "eligible" when no DDG extension is present
5. Tap "Install search extension" and confirm success alert
6. Confirm eligibility in Debug menu updates to "not eligible"
7. Launch Chrome and select a profile
8. Confirm you see a prompt to enable the DuckDuckGo Search extension

Additional scenarios:
* Remove the JSON file under `Application Support/Google/Chrome/External Extensions/`
* Build and run the App Store version of the app and confirm eligibility in Debug menu shows "not eligible"
* Add the [DuckDuckGo extension](https://chromewebstore.google.com/detail/duckduckgo-search-tracker/bkdgflcldnnnapblkhphbgpggdiikppg) to Chrome and confirm eligibility in Debug menu shows "not eligible"
* With Chrome fully uninstalled, confirm eligibility in Debug menu shows "not eligible"

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
10. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low: Not yet connected to app UI

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
- Feature flag can disable eligibility remotely
- Failures when detecting or installing the extension are measured with debug pixels
- Unit tests cover eligibility, install, multi-channel behavior, and error paths

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->
- Edge cases:
   - Multiple Chrome channels (e.g. stable, canary, dev) - we handle all of them (detecting/installing the extension in any channel)
   - Multiple Chrome profiles - we handle all of them (detecting the extension in any profile; the install method stages the extension for all profiles)
- Monitoring: Debug pixels (privacy triage required)

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Not user-facing in production UI yet; gated by flag and DMG-only eligibility, with filesystem writes limited to Chrome’s external-extension staging and debug telemetry on errors.
> 
> **Overview**
> Adds **`onboardingChromeExtension`** (remote, default off) and wires it through privacy config and macOS feature flags for a future DMG onboarding step.
> 
> Introduces **`ChromeExtensionInstaller`**, which decides eligibility (Sparkle build, Chrome present with profile data, no existing DDG Chrome extension variants) by scanning Chrome **Application Support**, then stages the **search** extension via **External Extensions** JSON per installed channel. Failures emit **debug pixels**; behavior is covered by **unit tests**.
> 
> A **Debug → Chrome Extension** menu exercises eligibility and install until onboarding UI lands in a follow-up PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf61f8ca442a865c1d1e74377a249d8a04e35a86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->