### PR TITLE
[CI] Additional Maestro improvements

### DIFF
--- a/.github/workflows/ios_end_to_end.yml
+++ b/.github/workflows/ios_end_to_end.yml
@@ -294,7 +294,6 @@ jobs:
         ATTEMPT_BUDGET_MIN=120
         MAX_ATTEMPTS=2
         RETRY_DELAY=30
-        NETWORK_SIGNATURE='getaddrinfo ENOTFOUND|EAI_AGAIN|FetchError|Could not get Upload status|ETIMEDOUT|ECONNRESET|socket hang up'
         TIMEOUT_BIN="$(command -v timeout || command -v gtimeout)"
 
         flags=(
@@ -322,30 +321,37 @@ jobs:
             exit 0
           fi
 
-          # Maestro hit its own --timeout (rc=1, distinct from a flow failure). Not retried: a
-          # retry re-runs the full leg under the same budget, so a genuine overrun fails twice.
-          # Checked BEFORE the network signature below because a 90m poll legitimately logs
-          # transient "Could not get Upload status"/ETIMEDOUT lines mid-run; matching those first
-          # would spuriously retry a definitive polling timeout. The rc!=124 guard keeps the outer
-          # hard-kill (below) as a retryable hang. Surface it clearly instead of masquerading as a
-          # test failure.
+          # Retry by default; only a positively-identified outcome stops us. The inverse - an
+          # allowlist of known transient error strings - is unsafe: it can never enumerate every way
+          # a cloud poll drops, so any unlisted transient red-fails a run that passed cloud-side.
+          # (CLI 2.6.1 alone emits both "Could not get Upload status" and "Failed to fetch the
+          # status of an upload ... Status code = null"; the second slipped the old allowlist.) So we
+          # retry unless the run provably reached a verdict - the two definitive cases below.
+
+          # Maestro's own --timeout polling budget elapsed. Not a flow failure, but re-running the
+          # full leg under the same budget overruns identically, so don't retry. The rc!=124 guard
+          # leaves the outer hard-kill (a true hang) on the retry path below.
           if [ "$rc" -ne 124 ] && grep -qE "Waiting for flows to complete has timed out" maestro.log; then
             echo "::error::Maestro Cloud's ${MAESTRO_TIMEOUT_MIN}m polling budget elapsed before all flows finished (not a test failure). Most of the budget is cloud-side queuing - only 2 runners serve every leg. Raise MAESTRO_TIMEOUT_MIN (and ATTEMPT_BUDGET_MIN / job timeout-minutes to keep them nested) if this recurs on an otherwise-green run."
             exit "$rc"
           fi
 
-          if [ "$rc" -eq 124 ] || grep -qE "$NETWORK_SIGNATURE" maestro.log; then
-            echo "::warning::Transient Maestro Cloud/network failure on attempt $attempt (rc=$rc)."
-            if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
-              echo "Retrying in ${RETRY_DELAY}s..."
-              sleep "$RETRY_DELAY"
-              continue
-            fi
-            echo "::error::Transient Maestro Cloud failures persisted across $MAX_ATTEMPTS attempts."
+          # The run reached a verdict and a flow genuinely failed, identified positively by Maestro's
+          # per-flow "[Failed]" marker / "N/M Flow(s) Failed" summary - not by absence of a transient.
+          if grep -qE "\[Failed\]|[0-9]+/[0-9]+ Flows? Failed" maestro.log; then
+            echo "Genuine Maestro flow failure (rc=$rc) - not retrying."
             exit "$rc"
           fi
 
-          echo "Genuine Maestro flow failure (rc=$rc) - not retrying."
+          # No verdict produced (dropped poll, DNS hang, null status code, socket reset, rc=124 hang,
+          # or any phrasing we've never seen) - treat as transient infrastructure and retry.
+          echo "::warning::No Maestro verdict produced on attempt $attempt (rc=$rc) - treating as transient infrastructure failure."
+          if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+            echo "Retrying in ${RETRY_DELAY}s..."
+            sleep "$RETRY_DELAY"
+            continue
+          fi
+          echo "::error::Transient Maestro Cloud failures persisted across $MAX_ATTEMPTS attempts (no verdict)."
           exit "$rc"
         done
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1216061543035893?focus=true
Tech Design URL:
CC:

### Description

This PR improves the Maestro workflow by making it less dependent on exact error copy.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that [this CI run](https://github.com/duckduckgo/apple-browsers/actions/runs/28206944589) passed

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only internal CI retry heuristics for Maestro Cloud; no app runtime, auth, or user-facing behavior.
> 
> **Overview**
> **Flips Maestro Cloud retry logic** in the iOS E2E workflow from a transient-error **allowlist** to **retry-by-default**, stopping only when the log shows a clear outcome.
> 
> After a failed attempt, the job still **does not retry** when Maestro’s polling budget times out (`Waiting for flows to complete has timed out`) or when logs show a **real test failure** (`[Failed]` or `N/M Flow(s) Failed`). Any other non-zero exit—including new CLI messages like null upload status, network blips, or `rc=124` hangs—is treated as **infrastructure** and retried up to `MAX_ATTEMPTS`, with updated warning/error text when no verdict is produced.
> 
> The **`NETWORK_SIGNATURE`** grep pattern is removed so passing cloud-side runs are less likely to be marked failed because an error string wasn’t on the list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dfc55a4778d73a44f3dfc8d13b778ab96b72f95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->