### PR TITLE
Fix Duck.ai sidebar covering web content after navigation

### DIFF
--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -565,6 +565,8 @@ protocol TabDelegate: ContentOverlayUserScriptDelegate {
     let webViewDidReceiveRedirectPublisher = PassthroughSubject<Void, Never>()
     let webViewDidFailNavigationPublisher = PassthroughSubject<Void, Never>()
     let webViewRenderingProgressDidChangePublisher = PassthroughSubject<Void, Never>()
+    /// Fires on same-document (SPA) navigations, which `webViewDidFinishNavigationPublisher` filters out.
+    let webViewDidPerformSameDocumentNavigationPublisher = PassthroughSubject<Void, Never>()
 
     // MARK: - Properties
 
@@ -1505,6 +1507,7 @@ extension Tab/*: NavigationResponder*/ { // to be moved to Tab+Navigation.swift
         guard navigation.isCurrent else { return }
 
         invalidateInteractionStateData()
+        webViewDidPerformSameDocumentNavigationPublisher.send()
     }
 
     @MainActor

--- a/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -294,6 +294,19 @@ final class BrowserTabViewController: NSViewController {
         }
     }
 
+    /// Re-sync the WKWebView to its container after navigation. The webview is sized by frame +
+    /// autoresizing, so a direct frame set during navigation can leave it full-width (rendered
+    /// behind the sidebar) inside an already-narrowed container, with nothing re-running the
+    /// container's `layout()`. `needsLayout = true` forces that layout (a bare `layoutSubtreeIfNeeded`
+    /// is a no-op when nothing marked it dirty). No-op when the sidebar is hidden (leading < 0 means
+    /// it is pulled into view, matching the idiom in `viewDidLayout`).
+    private func reconcileWebContentLayoutForSidebarIfNeeded() {
+        guard let leading = sidebarContainerLeadingConstraint?.constant, leading < 0,
+              let webViewContainer else { return }
+        webViewContainer.needsLayout = true
+        webViewContainer.layoutSubtreeIfNeeded()
+    }
+
     override func viewWillAppear() {
         super.viewWillAppear()
 
@@ -847,8 +860,12 @@ final class BrowserTabViewController: NSViewController {
                     return Just(()).eraseToAnyPublisher()
                 }
 
-                // Pre-set the webview frame so WebKit renders at the correct size while offscreen
-                if let bounds = self?.view.bounds {
+                // Pre-set the webview frame so WebKit renders at the correct size while offscreen,
+                // accounting for an open AI Chat sidebar so it doesn't render full-width and reflow
+                // (or end up rendered behind the sidebar).
+                if let self {
+                    var bounds = self.view.bounds
+                    bounds.size.width -= max(0, -(self.sidebarContainerLeadingConstraint?.constant ?? 0))
                     tabViewModel.tab.webView.frame = bounds
                 }
 
@@ -893,6 +910,8 @@ final class BrowserTabViewController: NSViewController {
 
         tabViewModel?.tab.webViewDidFinishNavigationPublisher.sink { [weak self] in
             guard let self else { return }
+            // keep the web content sized to the sidebar-adjusted bounds after navigation
+            self.reconcileWebContentLayoutForSidebarIfNeeded()
             // remove dialog on reload
             if tabViewModel?.tab == lastTab && self.lastURL == tabViewModel?.tab.url && self.lastURL != nil {
                 self.removeExistingDialog()
@@ -902,6 +921,12 @@ final class BrowserTabViewController: NSViewController {
             self.presentContextualOnboarding()
             self.lastURL = self.tabViewModel?.tab.url
             self.lastTab = self.tabViewModel?.tab
+        }.store(in: &tabViewModelCancellables)
+
+        // Same-document (SPA) navigations don't emit on webViewDidFinishNavigationPublisher,
+        // so reconcile the web content layout for them here too.
+        tabViewModel?.tab.webViewDidPerformSameDocumentNavigationPublisher.sink { [weak self] in
+            self?.reconcileWebContentLayoutForSidebarIfNeeded()
         }.store(in: &tabViewModelCancellables)
     }
 

--- a/macOS/UnitTests/Tab/Model/TabTests.swift
+++ b/macOS/UnitTests/Tab/Model/TabTests.swift
@@ -248,6 +248,34 @@ final class TabTests: XCTestCase {
     }
 
     @MainActor
+    func testWhenSameDocumentNavigationOccursThenSameDocumentNavigationPublisherEmits() {
+        schemeHandler.middleware = [{ _ in
+            .ok(.html("<html><body>test</body></html>"))
+        }]
+        tab = Tab(content: .none, webViewConfiguration: schemeHandler.webViewConfiguration(), privacyFeatures: privacyFeaturesMock)
+
+        // Wait for the initial full-page navigation to finish before triggering pushState.
+        let eDidFinish = expectation(description: "initial navigation finished")
+        let finishCancellable = tab.webViewDidFinishNavigationPublisher.sink {
+            eDidFinish.fulfill()
+        }
+        tab.setContent(.url(urls.url, source: .link))
+        wait(for: [eDidFinish], timeout: 5)
+        finishCancellable.cancel()
+
+        // A same-document navigation (history.pushState) must emit on the dedicated publisher,
+        // since webViewDidFinishNavigationPublisher filters these out.
+        let eSameDocument = expectation(description: "same-document navigation published")
+        tab.webViewDidPerformSameDocumentNavigationPublisher.sink {
+            eSameDocument.fulfill()
+        }.store(in: &cancellables)
+
+        tab.webView.evaluateJavaScript("history.pushState({}, '', '/pushed')")
+
+        wait(for: [eSameDocument], timeout: 5)
+    }
+
+    @MainActor
     func testWhenGoingBackInvalidatingBackItem_BackForwardButtonsDoNotBlink() throws {
         var didFinishExpectations = [String: XCTestExpectation]()
         var eDidRedirect: XCTestExpectation!


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1213881875984009/task/1215392627603791

### Description

Fixes the Duck.ai sidebar sometimes covering the right edge of the web content after a navigation while the sidebar is open (the reporter found that resizing the sidebar made it correct itself).

### Testing Steps

1. Open a tab and open the Duck.ai sidebar (docked on the right).
2. Full-page: navigate to a site, then to another (address bar or links). The page content should always fill the area left of the sidebar — nothing hidden behind the sidebar
3. run `history.pushState({}, '', '/foo')` in the Web Inspector console to trigger an in-app route change with the sidebar open. Verify the viewport stays correctly sized and nothing is hidden behind the sidebar.
4. Reopen sidebar a couple of times, switch tabs with and without the sidebar open, do multiple navigations on sites while sidebar is open and verify everything works as expected

### Impact and Risks

Low — macOS only, scoped to the web-content / sidebar layout path. The relayout runs only when the sidebar is open; popup and burner windows without a sidebar are no-ops.

#### What could go wrong?

- The forced relayout runs on every navigation while the sidebar is open, but it's a single `layoutSubtreeIfNeeded()` on the web-container subtree (not the sidebar), so the cost is negligible and it can't interfere with the sidebar open/close animation.
- If some navigation type emits neither a finish nor a same-document event, the relayout won't fire for it. The two reported cases (full-page and SPA) are covered.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> macOS-only view layout changes gated on an open sidebar; no auth, data, or networking impact. Residual risk is an uncovered navigation type that emits neither finish nor same-document events.
> 
> **Overview**
> Fixes web pages rendering **full-width behind the open Duck.ai sidebar** after navigation, when the WKWebView was sized to the window bounds instead of the narrowed content area.
> 
> **Tab** adds `webViewDidPerformSameDocumentNavigationPublisher`, emitted on same-document (SPA) navigations that `webViewDidFinishNavigationPublisher` intentionally excludes.
> 
> **BrowserTabViewController** pre-sizes the offscreen web view using sidebar-adjusted width (from the sidebar leading constraint), and after full-page and SPA navigations calls `reconcileWebContentLayoutForSidebarIfNeeded()` to mark the web container dirty and run layout so `WebViewContainerView` resyncs the web view frame. Relayout is skipped when the sidebar is hidden.
> 
> A unit test verifies the new SPA publisher fires on `history.pushState`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0ad6d323349083764409b0792042f0a0aebe881. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->