### PR TITLE
[macOS] Block data: URL popups in new tabs/windows

### DIFF
--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -1517,7 +1517,12 @@ extension Tab/*: NavigationResponder*/ { // to be moved to Tab+Navigation.swift
         invalidateInteractionStateData()
 
         guard !error.isNavigationCancelled, /* user stopped loading */
-              !error.isFrameLoadInterrupted /* navigation cancelled by a Navigation Responder */ else { return }
+              !error.isFrameLoadInterrupted /* navigation cancelled by a Navigation Responder or Content Blocker */ else {
+            // Update tab content to the current URL to avoid race conditions with
+            // WebView.url publisher that may cause `reloadIfNeeded` to reload the same URL again.
+            handleUrlDidChange()
+            return
+        }
 
         // don‘t show an error page if the error was already handled
         // (by SearchNonexistentDomainNavigationResponder) or another navigation was triggered by `setContent`.

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PopupHandlingTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PopupHandlingTabExtension.swift
@@ -270,7 +270,7 @@ final class PopupHandlingTabExtension {
                                     of kind: NewWindowPolicy,
                                     isUserInitiated: Bool) -> WKWebView? {
         // disable opening 'javascript:' links in new tab
-        guard navigationAction.request.url?.navigationalScheme != .javascript else { return nil }
+        guard ![.javascript, .data].contains(navigationAction.request.url?.navigationalScheme) else { return nil }
         // disable opening internal pages in pop-up windows
         guard TabContent.contentFromURL(navigationAction.request.url, source: .link).isExternalUrl || !kind.isPopup else { return nil }
 

--- a/macOS/UITests/TabNavigationPopupTests.swift
+++ b/macOS/UITests/TabNavigationPopupTests.swift
@@ -603,6 +603,205 @@ final class TabNavigationPopupTests: UITestCase, TabNavigationTestHelpers {
         XCTAssertEqual(app.windows.firstMatch.title, foregroundWindow.title, "New window should be frontmost when opened in foreground")
     }
 
+    // MARK: - Scheme Blocking Tests
+    // window.open() path — popup window (with full WKWindowFeatures options)
+
+    func testWhenJavascriptSchemePopupIsRequestedThenNoWindowIsCreated() {
+        app.setSwitchToNewTab(enabled: false)
+
+        openTestPage("Scheme Block Source #1") {
+            """
+            <a href='javascript:window.open("javascript:void(0)", "popup", "directories=0,toolbar=0,scrollbars=1,location=0,statusbar=0,menubar=0,resizable=1,width=1000,height=800")'>Open popup</a>
+            """
+        }
+        let mainWindow = app.windows.containing(.keyPath(\.title, equalTo: "Scheme Block Source #1")).firstMatch
+        let link = mainWindow.webViews["Scheme Block Source #1"].links["Open popup"]
+        XCTAssertTrue(link.waitForExistence(timeout: UITests.Timeouts.elementExistence))
+        link.click()
+
+        XCTAssertFalse(app.windows.element(boundBy: 1).waitForExistence(timeout: UITests.Timeouts.elementExistence),
+                      "No popup window should be created for javascript: URLs")
+        XCTAssertEqual(mainWindow.tabs.count, 1)
+    }
+
+    func testWhenDataSchemePopupIsRequestedThenNoWindowIsCreated() {
+        app.setSwitchToNewTab(enabled: false)
+
+        openTestPage("Scheme Block Source #2") {
+            """
+            <a href='javascript:window.open("data:text/html,hello", "popup", "directories=0,toolbar=0,scrollbars=1,location=0,statusbar=0,menubar=0,resizable=1,width=1000,height=800")'>Open popup</a>
+            """
+        }
+        let mainWindow = app.windows.containing(.keyPath(\.title, equalTo: "Scheme Block Source #2")).firstMatch
+        let link = mainWindow.webViews["Scheme Block Source #2"].links["Open popup"]
+        XCTAssertTrue(link.waitForExistence(timeout: UITests.Timeouts.elementExistence))
+        link.click()
+
+        XCTAssertFalse(app.windows.element(boundBy: 1).waitForExistence(timeout: UITests.Timeouts.elementExistence),
+                      "No popup window should be created for data: URLs")
+        XCTAssertEqual(mainWindow.tabs.count, 1)
+    }
+
+    // window.open() path — new tab (_blank)
+
+    func testWhenJavascriptSchemeNewTabIsRequestedThenNoTabIsCreated() {
+        app.setSwitchToNewTab(enabled: false)
+
+        openTestPage("Scheme Block Source #3") {
+            """
+            <a href='javascript:window.open("javascript:void(0)", "_blank")'>Open new tab</a>
+            """
+        }
+        let mainWindow = app.windows.containing(.keyPath(\.title, equalTo: "Scheme Block Source #3")).firstMatch
+        let link = mainWindow.webViews["Scheme Block Source #3"].links["Open new tab"]
+        XCTAssertTrue(link.waitForExistence(timeout: UITests.Timeouts.elementExistence))
+        link.click()
+
+        XCTAssertFalse(mainWindow.tabs.element(boundBy: 1).waitForExistence(timeout: UITests.Timeouts.elementExistence),
+                      "No new tab should be created for javascript: URLs")
+        XCTAssertEqual(app.windows.count, 1)
+    }
+
+    func testWhenDataSchemeNewTabIsRequestedThenNoTabIsCreatedAndAddressBarIsUnchanged() {
+        app.setSwitchToNewTab(enabled: false)
+
+        openTestPage("Scheme Block Source #4") {
+            """
+            <a href='javascript:window.open("data:text/html,hello", "_blank")'>Open new tab</a>
+            """
+        }
+        let mainWindow = app.windows.containing(.keyPath(\.title, equalTo: "Scheme Block Source #4")).firstMatch
+        let link = mainWindow.webViews["Scheme Block Source #4"].links["Open new tab"]
+        XCTAssertTrue(link.waitForExistence(timeout: UITests.Timeouts.elementExistence))
+        link.click()
+
+        XCTAssertFalse(mainWindow.tabs.element(boundBy: 1).waitForExistence(timeout: UITests.Timeouts.elementExistence),
+                      "No new tab should be created for data: URLs")
+        XCTAssertEqual(app.windows.count, 1)
+        // Source page must remain active — the data: URL must not appear in the address bar.
+        XCTAssertTrue(mainWindow.webViews["Scheme Block Source #4"].exists,
+                      "Source page should remain active after blocked data: URL open attempt")
+    }
+
+    // Modifier-click path — cmd+click / cmd+opt+click / middle-click on direct scheme links.
+    // These go through decidePolicy → loadInNewWindow → createChildWebView, a separate code path from window.open().
+
+    func testWhenJavascriptSchemeLinkIsCommandClickedThenNoTabIsCreated() {
+        app.setSwitchToNewTab(enabled: false)
+
+        openTestPage("Scheme Block Source #5") {
+            """
+            <a href='javascript:void(0)'>JS link</a>
+            """
+        }
+        let mainWindow = app.windows.containing(.keyPath(\.title, equalTo: "Scheme Block Source #5")).firstMatch
+        let link = mainWindow.webViews["Scheme Block Source #5"].links["JS link"]
+        XCTAssertTrue(link.waitForExistence(timeout: UITests.Timeouts.elementExistence))
+        XCUIElement.perform(withKeyModifiers: [.command]) {
+            link.click()
+        }
+
+        XCTAssertFalse(mainWindow.tabs.element(boundBy: 1).waitForExistence(timeout: UITests.Timeouts.elementExistence),
+                      "Cmd+click on javascript: link must not open a new tab")
+        XCTAssertEqual(app.windows.count, 1)
+    }
+
+    func testWhenJavascriptSchemeLinkIsCommandOptionClickedThenNoWindowIsCreated() {
+        app.setSwitchToNewTab(enabled: false)
+
+        openTestPage("Scheme Block Source #6") {
+            """
+            <a href='javascript:void(0)'>JS link</a>
+            """
+        }
+        let mainWindow = app.windows.containing(.keyPath(\.title, equalTo: "Scheme Block Source #6")).firstMatch
+        let link = mainWindow.webViews["Scheme Block Source #6"].links["JS link"]
+        XCTAssertTrue(link.waitForExistence(timeout: UITests.Timeouts.elementExistence))
+        XCUIElement.perform(withKeyModifiers: [.command, .option]) {
+            link.click()
+        }
+
+        XCTAssertFalse(app.windows.element(boundBy: 1).waitForExistence(timeout: UITests.Timeouts.elementExistence),
+                      "Cmd+Opt+click on javascript: link must not open a new window")
+        XCTAssertEqual(mainWindow.tabs.count, 1)
+    }
+
+    func testWhenJavascriptSchemeLinkIsMiddleClickedThenNoTabIsCreated() {
+        app.setSwitchToNewTab(enabled: false)
+
+        openTestPage("Scheme Block Source #7") {
+            """
+            <a href='javascript:void(0)'>JS link</a>
+            """
+        }
+        let mainWindow = app.windows.containing(.keyPath(\.title, equalTo: "Scheme Block Source #7")).firstMatch
+        let link = mainWindow.webViews["Scheme Block Source #7"].links["JS link"]
+        XCTAssertTrue(link.waitForExistence(timeout: UITests.Timeouts.elementExistence))
+        link.middleClick()
+
+        XCTAssertFalse(mainWindow.tabs.element(boundBy: 1).waitForExistence(timeout: UITests.Timeouts.elementExistence),
+                      "Middle-click on javascript: link must not open a new tab")
+        XCTAssertEqual(app.windows.count, 1)
+    }
+
+    func testWhenDataSchemeLinkIsCommandClickedThenNoTabIsCreated() {
+        app.setSwitchToNewTab(enabled: false)
+
+        openTestPage("Scheme Block Source #8") {
+            """
+            <a href='data:text/html,hello'>Data link</a>
+            """
+        }
+        let mainWindow = app.windows.containing(.keyPath(\.title, equalTo: "Scheme Block Source #8")).firstMatch
+        let link = mainWindow.webViews["Scheme Block Source #8"].links["Data link"]
+        XCTAssertTrue(link.waitForExistence(timeout: UITests.Timeouts.elementExistence))
+        XCUIElement.perform(withKeyModifiers: [.command]) {
+            link.click()
+        }
+
+        XCTAssertFalse(mainWindow.tabs.element(boundBy: 1).waitForExistence(timeout: UITests.Timeouts.elementExistence),
+                      "Cmd+click on data: link must not open a new tab")
+        XCTAssertEqual(app.windows.count, 1)
+    }
+
+    func testWhenDataSchemeLinkIsCommandOptionClickedThenNoWindowIsCreated() {
+        app.setSwitchToNewTab(enabled: false)
+
+        openTestPage("Scheme Block Source #9") {
+            """
+            <a href='data:text/html,hello'>Data link</a>
+            """
+        }
+        let mainWindow = app.windows.containing(.keyPath(\.title, equalTo: "Scheme Block Source #9")).firstMatch
+        let link = mainWindow.webViews["Scheme Block Source #9"].links["Data link"]
+        XCTAssertTrue(link.waitForExistence(timeout: UITests.Timeouts.elementExistence))
+        XCUIElement.perform(withKeyModifiers: [.command, .option]) {
+            link.click()
+        }
+
+        XCTAssertFalse(app.windows.element(boundBy: 1).waitForExistence(timeout: UITests.Timeouts.elementExistence),
+                      "Cmd+Opt+click on data: link must not open a new window")
+        XCTAssertEqual(mainWindow.tabs.count, 1)
+    }
+
+    func testWhenDataSchemeLinkIsMiddleClickedThenNoTabIsCreated() {
+        app.setSwitchToNewTab(enabled: false)
+
+        openTestPage("Scheme Block Source #10") {
+            """
+            <a href='data:text/html,hello'>Data link</a>
+            """
+        }
+        let mainWindow = app.windows.containing(.keyPath(\.title, equalTo: "Scheme Block Source #10")).firstMatch
+        let link = mainWindow.webViews["Scheme Block Source #10"].links["Data link"]
+        XCTAssertTrue(link.waitForExistence(timeout: UITests.Timeouts.elementExistence))
+        link.middleClick()
+
+        XCTAssertFalse(mainWindow.tabs.element(boundBy: 1).waitForExistence(timeout: UITests.Timeouts.elementExistence),
+                      "Middle-click on data: link must not open a new tab")
+        XCTAssertEqual(app.windows.count, 1)
+    }
+
     // MARK: - Fire Window Popup Navigation Tests
 
     func testFireWindowPopupCommandClickOpensBackgroundTab() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1216062092531208
Tech Design URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1216062092531210
CC: @diegoreymendez 

UI Tests run: https://github.com/duckduckgo/apple-browsers/actions/runs/28361470888

### Description
- Extend the `javascript:` scheme block in `PopupHandlingTabExtension` to also block `data:` URLs from being opened in new tabs or windows via `window.open()`, modifier-clicks, or middle-clicks
- Add 10 UI tests covering both `javascript:` and `data:` scheme blocking across all open-in-new-context paths (popup window, `_blank` new tab, cmd+click, cmd+opt+click, middle-click)

### Testing Steps
Using the test page [spammy-data-fragment.html](https://github.com/user-attachments/files/29379105/spammy-data-fragment.html):
1. Click **"Open data: URL in new tab"** — no new tab should open
2. Click **"Open short data: URL in popup"** — no popup window should appear
3. Click **"Load data: URL in iframe"** — iframe should still load normally (iframes are not affected by this change)
4. Click **"Open equivalent blob: in this tab"** — the page should navigate in the current tab and load normally (blob: URLs are not blocked)
5. Verify the source page remains active and the address bar is unchanged after each blocked attempt in steps 1–2

To validate the secondary defence in `Tab.handleUrlDidChange`:
6. Comment out the `guard ![.javascript, .data].contains(...)` line in `PopupHandlingTabExtension.createChildWebView`
7. Repeat steps 1–2: this time a new tab or popup window **will** open, but it **must not load the data: URL content** — the tab should remain blank
8. Retry steps 1–2 several times to confirm the behaviour is consistent

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- Legitimate use of `data:` URLs opened via user gesture — this is intentional blocking consistent with our existing `javascript:` scheme policy; no known legitimate use case is affected

### Quality Considerations
- Covers both code paths: `createChildWebView` (used by `window.open()`) already guarded `javascript:`; the one-line change extends it to `data:`
- Iframe loading of `data:` URLs is unaffected — only new-tab/new-window creation is blocked
- A secondary defence in `Tab.handleUrlDidChange` independently prevents data: URL content from loading even if the `createChildWebView` guard were bypassed
- All new tests follow the existing `TabNavigationPopupTests` naming and structure conventions

### Notes to Reviewer
The fix is a one-liner in `createChildWebView`; the bulk of the PR is UI test coverage for both schemes across every open-in-new-context path.