### PR TITLE
iOS: Default aiChatTabSwitcherRichCard feature flag on

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -850,7 +850,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .staleFaviconCleanup:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.staleFaviconCleanup))
         case .aiChatTabSwitcherRichCard:
-            Config(source: .remoteReleasable(AIChatSubfeature.tabSwitcherRichCard))
+            Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.tabSwitcherRichCard))
         case .syncScopedAccessCredentials:
             Config(source: .remoteReleasable(SyncSubfeature.scopedAccessCredentials))
         case .syncCanUseV2ConnectFlow:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211767540372501/task/1216068956859406

### Description

Sets the local default value of the `aiChatTabSwitcherRichCard` feature flag to `.enabled`.

The subfeature already exists in privacy config (currently enabled for internal users only), so while it remains there, remote config continues to take precedence and controls rollout. Changing the local default to on means that when the subfeature is eventually removed from privacy config, users on the current version keep the rich tab-switcher card instead of having it silently turned off.

### Testing Steps

No testing needed. Changes are straightforward.

### Impact and Risks

**Low.** Single-line default-value change. While the subfeature is present in privacy config (internal-only), behavior is unchanged for all users — remote config takes precedence. The new default only takes effect as a fallback once the subfeature is removed from privacy config.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line default-value change with remote privacy config still controlling rollout until the subfeature is removed.
> 
> **Overview**
> Sets the **local default** for `aiChatTabSwitcherRichCard` to **enabled** in `FeatureFlag.swift` (previously the `Config` default of **disabled**).
> 
> While `AIChatSubfeature.tabSwitcherRichCard` remains in privacy config, **remote config still wins**, so day-to-day behavior should be unchanged. The new default only matters as a **fallback** after that subfeature is removed from privacy config, so app versions that ship this change keep the rich AI chat card in the tab switcher instead of turning it off silently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 495cec3f405f67e7f878c4a00fcc033cb0f80222. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->