### PR TITLE
macOS: Parse release notes with XMLDocument instead of NSAttributedString

### DIFF
--- a/macOS/LocalPackages/AppUpdater/Sources/AppUpdaterShared/ReleaseNotesParser.swift
+++ b/macOS/LocalPackages/AppUpdater/Sources/AppUpdaterShared/ReleaseNotesParser.swift
@@ -39,14 +39,12 @@ public final class ReleaseNotesParser {
 
     /// Parses the release notes HTML fragment into an `XMLDocument`.
     ///
-    /// The fragment is wrapped in a minimal document declaring a UTF-8 charset. Without it,
-    /// libxml2's HTML parser assumes ISO-8859-1 and mangles multi-byte characters (e.g. `⌘`).
+    /// The fragment is prefixed with a `Content-Type` charset declaration. Without it, libxml2's
+    /// HTML parser assumes ISO-8859-1 and mangles multi-byte characters (e.g. `⌘`). The HTML5
+    /// `<meta charset>` shorthand is not honored by libxml2, so the `http-equiv` form is used.
     private static func htmlDocument(from description: String) -> XMLDocument? {
-        let wrapped = """
-        <html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>\
-        <body>\(description)</body></html>
-        """
-        guard let data = wrapped.data(using: .utf8) else { return nil }
+        let charsetDeclaration = #"<meta http-equiv="Content-Type" content="text/html; charset=utf-8">"#
+        guard let data = (charsetDeclaration + description).data(using: .utf8) else { return nil }
 
         do {
             return try XMLDocument(data: data, options: [.documentTidyHTML])

--- a/macOS/LocalPackages/AppUpdater/Sources/AppUpdaterShared/ReleaseNotesParser.swift
+++ b/macOS/LocalPackages/AppUpdater/Sources/AppUpdaterShared/ReleaseNotesParser.swift
@@ -20,69 +20,56 @@ import Foundation
 
 public final class ReleaseNotesParser {
 
+    /// Extracts the "What's new" and "For DuckDuckGo subscribers" bullet lists from an appcast
+    /// item description.
+    ///
+    /// Parsing is done with `XMLDocument` (libxml2) rather than `NSAttributedString`'s HTML
+    /// importer: the latter instantiates WebKit and must run on the main thread, which blocked
+    /// app launch while release notes were parsed. `XMLDocument` is a pure libxml2 parse with no
+    /// such dependency.
     public static func parseReleaseNotes(from description: String?) -> ([String], [String]) {
         guard let description else { return ([], []) }
 
-        var standardReleaseNotes = [String]()
-        var subscriptionReleaseNotes = [String]()
+        guard let document = htmlDocument(from: description) else { return ([], []) }
 
-        // Patterns for the two sections with more flexible spacing
-        let standardPattern = "<h3[^>]*>What's new</h3>\\s*<ul>(.*?)</ul>"
-        let subscriptionPattern = "<h3[^>]*>For DuckDuckGo subscribers</h3>\\s*<ul>(.*?)</ul>"
-
-        do {
-            let standardRegex = try NSRegularExpression(pattern: standardPattern, options: .dotMatchesLineSeparators)
-            let subscriptionRegex = try NSRegularExpression(pattern: subscriptionPattern, options: .dotMatchesLineSeparators)
-
-            // Extract the standard release notes section
-            if let standardMatch = standardRegex.firstMatch(in: description, options: [], range: NSRange(location: 0, length: description.utf16.count)) {
-                if let range = Range(standardMatch.range(at: 1), in: description) {
-                    let standardList = String(description[range])
-                    standardReleaseNotes = extractListItems(from: standardList)
-                }
-            }
-
-            // Extract the Subscription release notes section
-            if let subscriptionMatch = subscriptionRegex.firstMatch(in: description, options: [], range: NSRange(location: 0, length: description.utf16.count)) {
-                if let range = Range(subscriptionMatch.range(at: 1), in: description) {
-                    let subscriptionList = String(description[range])
-                    subscriptionReleaseNotes = extractListItems(from: subscriptionList)
-                }
-            }
-        } catch {
-            assertionFailure("Error creating regular expression: \(error)")
-        }
-
+        let standardReleaseNotes = releaseNotes(in: document, forSectionTitled: "What's new")
+        let subscriptionReleaseNotes = releaseNotes(in: document, forSectionTitled: "For DuckDuckGo subscribers")
         return (standardReleaseNotes, subscriptionReleaseNotes)
     }
 
-    // Helper method to extract list items
-    private static func extractListItems(from list: String) -> [String] {
-        var items = [String]()
-        let pattern = "<li>(.*?)</li>"
+    /// Parses the release notes HTML fragment into an `XMLDocument`.
+    ///
+    /// The fragment is wrapped in a minimal document declaring a UTF-8 charset. Without it,
+    /// libxml2's HTML parser assumes ISO-8859-1 and mangles multi-byte characters (e.g. `⌘`).
+    private static func htmlDocument(from description: String) -> XMLDocument? {
+        let wrapped = """
+        <html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>\
+        <body>\(description)</body></html>
+        """
+        guard let data = wrapped.data(using: .utf8) else { return nil }
 
         do {
-            let regex = try NSRegularExpression(pattern: pattern, options: .dotMatchesLineSeparators)
-            let matches = regex.matches(in: list, options: [], range: NSRange(location: 0, length: list.utf16.count))
-
-            for match in matches {
-                if let range = Range(match.range(at: 1), in: list) {
-                    let item = String(list[range])
-
-                    // Convert HTML to plain text
-                    if let data = item.data(using: .utf8),
-                       let attributedString = try? NSAttributedString(data: data,
-                                                                      options: [.documentType: NSAttributedString.DocumentType.html,
-                                                                                .characterEncoding: String.Encoding.utf8.rawValue],
-                                                                      documentAttributes: nil) {
-                        items.append(attributedString.string)
-                    }
-                }
-            }
+            return try XMLDocument(data: data, options: [.documentTidyHTML])
         } catch {
-            assertionFailure("Error creating regular expression: \(error)")
+            assertionFailure("Error parsing release notes HTML: \(error)")
+            return nil
         }
+    }
 
-        return items
+    /// Returns the plain-text list items from the `<ul>` immediately following the `<h3>` whose
+    /// text matches `title`.
+    private static func releaseNotes(in document: XMLDocument, forSectionTitled title: String) -> [String] {
+        let xpath = "//h3[normalize-space(.)=\"\(title)\"]/following-sibling::ul[1]/li"
+        guard let items = try? document.nodes(forXPath: xpath) else { return [] }
+
+        return items.compactMap { item in
+            guard let text = item.stringValue else { return nil }
+            // Collapse runs of whitespace (including the newlines/indentation between tags) into
+            // single spaces, matching how the HTML would render as plain text.
+            let normalized = text.components(separatedBy: .whitespacesAndNewlines)
+                .filter { !$0.isEmpty }
+                .joined(separator: " ")
+            return normalized.isEmpty ? nil : normalized
+        }
     }
 }

--- a/macOS/LocalPackages/AppUpdater/Tests/AppUpdaterSharedTests/ReleaseNotesParserTests.swift
+++ b/macOS/LocalPackages/AppUpdater/Tests/AppUpdaterSharedTests/ReleaseNotesParserTests.swift
@@ -77,7 +77,47 @@ final class ReleaseNotesParserTests: XCTestCase {
         XCTAssertEqual(subscription, ["Exclusive feature X", "Exclusive improvement Y"])
     }
 
-    func testParseReleaseNotes_withInvalidHTML() {
+    /// The section header carries a `style` attribute in real appcast payloads (see the real-data
+    /// fixtures below). Matching must be on the header text, not an exact tag.
+    func testParseReleaseNotes_withStyledHeader() {
+        let description = """
+        <h3 style="font-size:14px">What's new</h3>
+        <ul>
+            <li>New feature A</li>
+        </ul>
+        """
+        let (standard, _) = ReleaseNotesParser.parseReleaseNotes(from: description)
+
+        XCTAssertEqual(standard, ["New feature A"])
+    }
+
+    /// Multi-byte characters (e.g. `⌘`) and HTML entities (e.g. `&amp;`) must survive parsing.
+    /// This guards against libxml2's HTML parser defaulting to ISO-8859-1 for the byte stream.
+    func testParseReleaseNotes_preservesUnicodeAndEntities() {
+        let description = """
+        <h3>What's new</h3>
+        <ul>
+            <li>Open Duck.ai with the ⌘+E shortcut &amp; enjoy it.</li>
+        </ul>
+        """
+        let (standard, _) = ReleaseNotesParser.parseReleaseNotes(from: description)
+
+        XCTAssertEqual(standard, ["Open Duck.ai with the ⌘+E shortcut & enjoy it."])
+    }
+
+    func testParseReleaseNotes_withMissingSectionsReturnsEmpty() {
+        let description = "<p>No release notes here.</p>"
+        let (standard, subscription) = ReleaseNotesParser.parseReleaseNotes(from: description)
+
+        XCTAssertTrue(standard.isEmpty)
+        XCTAssertTrue(subscription.isEmpty)
+    }
+
+    /// Behavioral note: the legacy regex/`NSAttributedString` parser silently dropped an unterminated
+    /// `<li>` item. The `XMLDocument` parser recovers it instead (libxml2 closes the tag), which is the
+    /// safer behavior. This is the one intentional divergence from the legacy parser and is excluded
+    /// from the equivalence test below.
+    func testParseReleaseNotes_recoversUnterminatedListItem() {
         let description = """
         <h3>What's new</h3>
         <ul>
@@ -92,8 +132,149 @@ final class ReleaseNotesParserTests: XCTestCase {
         """
         let (standard, subscription) = ReleaseNotesParser.parseReleaseNotes(from: description)
 
-        XCTAssertEqual(standard, ["New feature A"])
+        XCTAssertEqual(standard, ["New feature A", "Improvement B"])
         XCTAssertEqual(subscription, ["Exclusive feature X", "Exclusive improvement Y"])
     }
 
+    // MARK: - Real appcast fixtures
+
+    func testParseReleaseNotes_realAppcastSingleItem() {
+        let (standard, subscription) = ReleaseNotesParser.parseReleaseNotes(from: Self.realStandardOnly)
+
+        XCTAssertEqual(standard, ["Bug fixes and improvements."])
+        XCTAssertTrue(subscription.isEmpty)
+    }
+
+    func testParseReleaseNotes_realAppcastMultipleItems() {
+        let (standard, subscription) = ReleaseNotesParser.parseReleaseNotes(from: Self.realMultiItem)
+
+        XCTAssertEqual(standard, [
+            "You can now open and close the Duck.ai sidebar with the ⌘+E keyboard shortcut. If you have text selected when using the shortcut to open Duck.ai, it will automatically be pasted into the sidebar.",
+            "We fixed a bug that caused the website permission dialog to appear in the middle of the page instead of up in the left side of the address bar where it should be.",
+            "Any issues you may have experienced with autocomplete when the browser update reminder was visible have also been fixed.",
+            "As usual, this update includes other bug fixes and improvements."
+        ])
+        XCTAssertTrue(subscription.isEmpty)
+    }
+
+    // MARK: - Equivalence with the legacy parser
+
+    /// Proves the new `XMLDocument` parser produces identical output to the original regex /
+    /// `NSAttributedString` implementation (reproduced verbatim as `LegacyReleaseNotesParser`)
+    /// for every well-formed input. The only known divergence — recovery of malformed/unterminated
+    /// list items — is covered separately by `testParseReleaseNotes_recoversUnterminatedListItem`.
+    func testParseReleaseNotes_matchesLegacyParserForWellFormedHTML() {
+        let fixtures = [
+            Self.realStandardOnly,
+            Self.realMultiItem,
+            Self.syntheticBothSections,
+            "<h3 style=\"font-size:14px\">What's new</h3><ul><li>Open Duck.ai with the ⌘+E shortcut &amp; enjoy it.</li></ul>",
+            "<p>No release notes here.</p>"
+        ]
+
+        for fixture in fixtures {
+            let new = ReleaseNotesParser.parseReleaseNotes(from: fixture)
+            let legacy = LegacyReleaseNotesParser.parseReleaseNotes(from: fixture)
+            XCTAssertEqual(new.0, legacy.0, "Standard notes differ for fixture:\n\(fixture)")
+            XCTAssertEqual(new.1, legacy.1, "Subscription notes differ for fixture:\n\(fixture)")
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private static let realStandardOnly = """
+    <h3 style="font-size:14px">What's new</h3>
+    <ul>
+    <li>Bug fixes and improvements.</li>
+    </ul>
+    """
+
+    private static let realMultiItem = """
+    <h3 style="font-size:14px">What's new</h3>
+    <ul>
+    <li>You can now open and close the Duck.ai sidebar with the ⌘+E keyboard shortcut. If you have text selected when using the shortcut to open Duck.ai, it will automatically be pasted into the sidebar.</li>
+    <li>We fixed a bug that caused the website permission dialog to appear in the middle of the page instead of up in the left side of the address bar where it should be.</li>
+    <li>Any issues you may have experienced with autocomplete when the browser update reminder was visible have also been fixed.</li>
+    <li>As usual, this update includes other bug fixes and improvements.</li>
+    </ul>
+    """
+
+    private static let syntheticBothSections = """
+    <h3>What's new</h3>
+    <ul>
+        <li>New feature A</li>
+        <li>Improvement B</li>
+    </ul>
+    <h3>For DuckDuckGo subscribers</h3>
+    <ul>
+        <li>Exclusive feature X</li>
+        <li>Exclusive improvement Y</li>
+    </ul>
+    """
+}
+
+/// Verbatim copy of the original `ReleaseNotesParser` implementation (regex + `NSAttributedString`),
+/// kept in the test target only, as the reference for the equivalence test above.
+private enum LegacyReleaseNotesParser {
+
+    static func parseReleaseNotes(from description: String?) -> ([String], [String]) {
+        guard let description else { return ([], []) }
+
+        var standardReleaseNotes = [String]()
+        var subscriptionReleaseNotes = [String]()
+
+        let standardPattern = "<h3[^>]*>What's new</h3>\\s*<ul>(.*?)</ul>"
+        let subscriptionPattern = "<h3[^>]*>For DuckDuckGo subscribers</h3>\\s*<ul>(.*?)</ul>"
+
+        do {
+            let standardRegex = try NSRegularExpression(pattern: standardPattern, options: .dotMatchesLineSeparators)
+            let subscriptionRegex = try NSRegularExpression(pattern: subscriptionPattern, options: .dotMatchesLineSeparators)
+
+            if let standardMatch = standardRegex.firstMatch(in: description, options: [], range: NSRange(location: 0, length: description.utf16.count)) {
+                if let range = Range(standardMatch.range(at: 1), in: description) {
+                    let standardList = String(description[range])
+                    standardReleaseNotes = extractListItems(from: standardList)
+                }
+            }
+
+            if let subscriptionMatch = subscriptionRegex.firstMatch(in: description, options: [], range: NSRange(location: 0, length: description.utf16.count)) {
+                if let range = Range(subscriptionMatch.range(at: 1), in: description) {
+                    let subscriptionList = String(description[range])
+                    subscriptionReleaseNotes = extractListItems(from: subscriptionList)
+                }
+            }
+        } catch {
+            assertionFailure("Error creating regular expression: \(error)")
+        }
+
+        return (standardReleaseNotes, subscriptionReleaseNotes)
+    }
+
+    private static func extractListItems(from list: String) -> [String] {
+        var items = [String]()
+        let pattern = "<li>(.*?)</li>"
+
+        do {
+            let regex = try NSRegularExpression(pattern: pattern, options: .dotMatchesLineSeparators)
+            let matches = regex.matches(in: list, options: [], range: NSRange(location: 0, length: list.utf16.count))
+
+            for match in matches {
+                if let range = Range(match.range(at: 1), in: list) {
+                    let item = String(list[range])
+
+                    if let data = item.data(using: .utf8),
+                       let attributedString = try? NSAttributedString(data: data,
+                                                                      options: [.documentType: NSAttributedString.DocumentType.html,
+                                                                                .characterEncoding: String.Encoding.utf8.rawValue],
+                                                                      documentAttributes: nil) {
+                        items.append(attributedString.string)
+                    }
+                }
+            }
+        } catch {
+            assertionFailure("Error creating regular expression: \(error)")
+        }
+
+        return items
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1216074376178272?focus=true

### Description

Release notes were parsed using `NSAttributedString`'s HTML importer, which instantiates WebKit and must run on the main thread — blocking app launch while the notes were parsed.

This PR switches parsing to `XMLDocument` (libxml2), which has no WebKit dependency and no main-thread requirement, removing that source of startup hangs without adding any third-party dependency.

### Testing Steps

This is covered by unit tests in the AppUpdater package, including equivalence against the previous implementation across real appcast payloads. To verify manually (requires a Sparkle build):

1. Open the options menu (the ⋯ button at the right of the address bar) and choose Release Notes (also available under the Help menu).
2. Confirm the Release Notes tab renders the "What's new" bullet list correctly, with no missing or garbled characters.

### Impact and Risks

Low. The parser's output contract is unchanged for well-formed release notes; only the parsing mechanism changes. Release notes are display-only, so a parsing regression would at worst show an empty or slightly different list, not affect browsing or data.

#### What could go wrong?

Release notes could render differently than before. Unlikely: a test asserts the new parser produces identical output to the old one across real appcast payloads, so well-formed notes are unchanged.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)







<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only parsing with unchanged public API; well-formed output is asserted against the legacy parser, with only minor behavior change on malformed HTML.
> 
> **Overview**
> **Replaces release-notes HTML parsing** so appcast descriptions no longer go through regex plus `NSAttributedString` HTML import (WebKit, main-thread). Parsing now uses **`XMLDocument`** with XPath on the "What's new" and "For DuckDuckGo subscribers" sections, a UTF-8 **`Content-Type` meta prefix** for libxml2, and whitespace-normalized list text.
> 
> **Tests** add styled headers, Unicode/entities, real appcast fixtures, legacy equivalence for well-formed HTML, and document one intentional change: malformed unterminated `<li>` items are recovered instead of dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcbc316581a8779aae7abfeb91adb9ecbba8fdb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->