### PR TITLE
macOS: Move login item Service Management calls off the main thread

### DIFF
--- a/macOS/DBPE2ETests/DBPEndToEndTests.swift
+++ b/macOS/DBPE2ETests/DBPEndToEndTests.swift
@@ -40,7 +40,7 @@ final class DBPEndToEndTests: XCTestCase {
     var viewModel: DBPUIViewModel!
     var testUserDefault: UserDefaults! = UserDefaults(suiteName: #function)
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         continueAfterFailure = false
 
         // Store the integration test run type so that the agent can reliably access it:
@@ -49,7 +49,7 @@ final class DBPEndToEndTests: XCTestCase {
 
         pirProtectionManager = DataBrokerProtectionManager.shared
         loginItemsManager = LoginItemsManager()
-        loginItemsManager.disableLoginItems([LoginItem.dbpBackgroundAgent])
+        await loginItemsManager.disableLoginItems([LoginItem.dbpBackgroundAgent])
 
         communicationLayer = DBPUICommunicationLayer(webURLSettings: DataBrokerProtectionWebUIURLSettings(UserDefaults.standard),
                                                      privacyConfig: PrivacyConfigurationManagingMock())
@@ -67,7 +67,7 @@ final class DBPEndToEndTests: XCTestCase {
 
     override func tearDown() async throws {
         try pirProtectionManager.dataManager!.database.deleteProfileData()
-        loginItemsManager.disableLoginItems([LoginItem.dbpBackgroundAgent])
+        await loginItemsManager.disableLoginItems([LoginItem.dbpBackgroundAgent])
 
         loginItemsManager = nil
         pirProtectionManager = nil
@@ -191,8 +191,9 @@ final class DBPEndToEndTests: XCTestCase {
         print("Successfully detected 1 non-removed broker and 1 removed broker with proper filtering")
 
         // At this stage the login item should be running
+        let isLoginItemEnabled = await loginItemsManager.isAnyEnabled([.dbpBackgroundAgent])
         assertCondition(withExpectationDescription: "Login item enabled after profile save",
-                        condition: { loginItemsManager.isAnyEnabled([.dbpBackgroundAgent]) })
+                        condition: { isLoginItemEnabled })
 
         // This needs to be await since it takes time to start the login item
         let loginItemRunningExpectation = expectation(description: "Login item running after profile save")

--- a/macOS/DuckDuckGo/DBP/DBPHomeViewController.swift
+++ b/macOS/DuckDuckGo/DBP/DBPHomeViewController.swift
@@ -156,7 +156,9 @@ final class DBPHomeViewController: NSViewController {
     }
 
     private func setupUIWithCurrentStatus() {
-        setupUIWithStatus(prerequisiteVerifier.checkStatus())
+        Task { @MainActor in
+            setupUIWithStatus(await prerequisiteVerifier.checkStatus())
+        }
     }
 
     private func setupUIWithStatus(_ status: DataBrokerPrerequisitesStatus) {
@@ -174,10 +176,12 @@ final class DBPHomeViewController: NSViewController {
     }
 
     private func fireDashboardOpenPixelsIfNeeded(isAuthenticated: Bool) {
-        guard prerequisiteVerifier.checkStatus() == .valid else { return }
+        Task { @MainActor in
+            guard await prerequisiteVerifier.checkStatus() == .valid else { return }
 
-        interactionPixels?.fireInteractionPixel(isAuthenticated: isAuthenticated)
-        sharedPixelsHandler?.fire(.dashboardOpen(isAuthenticated: isAuthenticated, isFreeScan: !isAuthenticated))
+            interactionPixels?.fireInteractionPixel(isAuthenticated: isAuthenticated)
+            sharedPixelsHandler?.fire(.dashboardOpen(isAuthenticated: isAuthenticated, isFreeScan: !isAuthenticated))
+        }
     }
 
     private func displayDBPUI() {

--- a/macOS/DuckDuckGo/DBP/DBPHomeViewController.swift
+++ b/macOS/DuckDuckGo/DBP/DBPHomeViewController.swift
@@ -134,7 +134,7 @@ final class DBPHomeViewController: NSViewController {
                 return
             }
 
-            fireDashboardOpenPixelsIfNeeded(isAuthenticated: isAuthenticated)
+            await fireDashboardOpenPixelsIfNeeded(isAuthenticated: isAuthenticated)
         }
     }
 
@@ -175,13 +175,11 @@ final class DBPHomeViewController: NSViewController {
         }
     }
 
-    private func fireDashboardOpenPixelsIfNeeded(isAuthenticated: Bool) {
-        Task { @MainActor in
-            guard await prerequisiteVerifier.checkStatus() == .valid else { return }
+    private func fireDashboardOpenPixelsIfNeeded(isAuthenticated: Bool) async {
+        guard await prerequisiteVerifier.checkStatus() == .valid else { return }
 
-            interactionPixels?.fireInteractionPixel(isAuthenticated: isAuthenticated)
-            sharedPixelsHandler?.fire(.dashboardOpen(isAuthenticated: isAuthenticated, isFreeScan: !isAuthenticated))
-        }
+        interactionPixels?.fireInteractionPixel(isAuthenticated: isAuthenticated)
+        sharedPixelsHandler?.fire(.dashboardOpen(isAuthenticated: isAuthenticated, isFreeScan: !isAuthenticated))
     }
 
     private func displayDBPUI() {

--- a/macOS/DuckDuckGo/DBP/DataBrokerPrerequisitesStatusVerifier.swift
+++ b/macOS/DuckDuckGo/DBP/DataBrokerPrerequisitesStatusVerifier.swift
@@ -29,7 +29,7 @@ enum DataBrokerPrerequisitesStatus {
 }
 
 protocol DataBrokerPrerequisitesStatusVerifier: AnyObject {
-    func checkStatus() -> DataBrokerPrerequisitesStatus
+    func checkStatus() async -> DataBrokerPrerequisitesStatus
 }
 
 final class DefaultDataBrokerPrerequisitesStatusVerifier: DataBrokerPrerequisitesStatusVerifier {
@@ -39,8 +39,8 @@ final class DefaultDataBrokerPrerequisitesStatusVerifier: DataBrokerPrerequisite
         self.statusChecker = statusChecker
     }
 
-    func checkStatus() -> DataBrokerPrerequisitesStatus {
-        if !statusChecker.doesHaveNecessaryPermissions() {
+    func checkStatus() async -> DataBrokerPrerequisitesStatus {
+        if !(await statusChecker.doesHaveNecessaryPermissions()) {
             Logger.dataBrokerProtection.log("Invalid system permissions")
             return .invalidSystemPermission
         } else if !statusChecker.isInCorrectDirectory() {

--- a/macOS/DuckDuckGo/DBP/DataBrokerProtectionAppEvents.swift
+++ b/macOS/DuckDuckGo/DBP/DataBrokerProtectionAppEvents.swift
@@ -74,7 +74,7 @@ struct DataBrokerProtectionAppEvents {
             let prerequisitesMet = try await featureGatekeeper.arePrerequisitesSatisfied()
 
             guard prerequisitesMet else {
-                loginItemsManager.disableLoginItems([LoginItem.dbpBackgroundAgent])
+                await loginItemsManager.disableLoginItems([LoginItem.dbpBackgroundAgent])
                 NotificationCenter.default.post(name: .dbpLoginItemDisabled, object: nil)
                 return
             }
@@ -83,10 +83,12 @@ struct DataBrokerProtectionAppEvents {
 
     private func restartBackgroundAgent(loginItemsManager: LoginItemsManager) {
         DataBrokerProtectionLoginItemPixels.fire(pixel: GeneralPixel.dataBrokerResetLoginItemDaily, frequency: .legacyDaily)
-        loginItemsManager.disableLoginItems([LoginItem.dbpBackgroundAgent])
-        NotificationCenter.default.post(name: .dbpLoginItemDisabled, object: nil)
-        loginItemsManager.enableLoginItems([LoginItem.dbpBackgroundAgent])
-        NotificationCenter.default.post(name: .dbpLoginItemEnabled, object: nil)
+        Task {
+            await loginItemsManager.disableLoginItems([LoginItem.dbpBackgroundAgent])
+            NotificationCenter.default.post(name: .dbpLoginItemDisabled, object: nil)
+            await loginItemsManager.enableLoginItems([LoginItem.dbpBackgroundAgent])
+            NotificationCenter.default.post(name: .dbpLoginItemEnabled, object: nil)
+        }
 
         // restartLoginItems doesn't work when we change the agent name
     }

--- a/macOS/DuckDuckGo/DBP/DataBrokerProtectionAppEvents.swift
+++ b/macOS/DuckDuckGo/DBP/DataBrokerProtectionAppEvents.swift
@@ -56,7 +56,7 @@ struct DataBrokerProtectionAppEvents {
                let profileQueriesCount = try? dataManager.profileQueriesCount(),
                profileQueriesCount > 0 {
                 Logger.dataBrokerProtection.log("Found \(profileQueriesCount) profile queries in DB. Restarting agent.")
-                restartBackgroundAgent(loginItemsManager: loginItemsManager)
+                await restartBackgroundAgent(loginItemsManager: loginItemsManager)
 
                 // Wait to make sure the agent has had time to restart before attempting to call a method on it
                 try await Task.sleep(nanoseconds: 1_000_000_000)
@@ -81,15 +81,12 @@ struct DataBrokerProtectionAppEvents {
         }
     }
 
-    private func restartBackgroundAgent(loginItemsManager: LoginItemsManager) {
+    private func restartBackgroundAgent(loginItemsManager: LoginItemsManager) async {
         DataBrokerProtectionLoginItemPixels.fire(pixel: GeneralPixel.dataBrokerResetLoginItemDaily, frequency: .legacyDaily)
-        Task {
-            await loginItemsManager.disableLoginItems([LoginItem.dbpBackgroundAgent])
-            NotificationCenter.default.post(name: .dbpLoginItemDisabled, object: nil)
-            await loginItemsManager.enableLoginItems([LoginItem.dbpBackgroundAgent])
-            NotificationCenter.default.post(name: .dbpLoginItemEnabled, object: nil)
-        }
-
+        await loginItemsManager.disableLoginItems([LoginItem.dbpBackgroundAgent])
+        NotificationCenter.default.post(name: .dbpLoginItemDisabled, object: nil)
+        await loginItemsManager.enableLoginItems([LoginItem.dbpBackgroundAgent])
+        NotificationCenter.default.post(name: .dbpLoginItemEnabled, object: nil)
         // restartLoginItems doesn't work when we change the agent name
     }
 }

--- a/macOS/DuckDuckGo/DBP/DataBrokerProtectionDebugMenu.swift
+++ b/macOS/DuckDuckGo/DBP/DataBrokerProtectionDebugMenu.swift
@@ -376,17 +376,23 @@ final class DataBrokerProtectionDebugMenu: NSMenu {
     }
 
     @objc private func backgroundAgentRestart() {
-        LoginItemsManager().restartLoginItems([LoginItem.dbpBackgroundAgent])
+        Task {
+            await LoginItemsManager().restartLoginItems([LoginItem.dbpBackgroundAgent])
+        }
     }
 
     @objc private func backgroundAgentDisable() {
-        LoginItemsManager().disableLoginItems([LoginItem.dbpBackgroundAgent])
-        NotificationCenter.default.post(name: .dbpLoginItemDisabled, object: nil)
+        Task {
+            await LoginItemsManager().disableLoginItems([LoginItem.dbpBackgroundAgent])
+            NotificationCenter.default.post(name: .dbpLoginItemDisabled, object: nil)
+        }
     }
 
     @objc private func backgroundAgentEnable() {
-        LoginItemsManager().enableLoginItems([LoginItem.dbpBackgroundAgent])
-        NotificationCenter.default.post(name: .dbpLoginItemEnabled, object: nil)
+        Task {
+            await LoginItemsManager().enableLoginItems([LoginItem.dbpBackgroundAgent])
+            NotificationCenter.default.post(name: .dbpLoginItemEnabled, object: nil)
+        }
     }
 
     @objc private func deleteAllDataAndStopAgent() {

--- a/macOS/DuckDuckGo/DBP/DataBrokerProtectionLoginItemInterface.swift
+++ b/macOS/DuckDuckGo/DBP/DataBrokerProtectionLoginItemInterface.swift
@@ -52,14 +52,18 @@ extension DefaultDataBrokerProtectionLoginItemInterface: DataBrokerProtectionLog
 
     private func disableLoginItem() {
         DataBrokerProtectionLoginItemPixels.fire(pixel: GeneralPixel.dataBrokerDisableLoginItemDaily, frequency: .legacyDaily)
-        loginItemsManager.disableLoginItems([.dbpBackgroundAgent])
-        NotificationCenter.default.post(name: .dbpLoginItemDisabled, object: nil)
+        Task {
+            await loginItemsManager.disableLoginItems([.dbpBackgroundAgent])
+            NotificationCenter.default.post(name: .dbpLoginItemDisabled, object: nil)
+        }
     }
 
     private func enableLoginItem() {
         DataBrokerProtectionLoginItemPixels.fire(pixel: GeneralPixel.dataBrokerEnableLoginItemDaily, frequency: .legacyDaily)
-        loginItemsManager.enableLoginItems([.dbpBackgroundAgent])
-        NotificationCenter.default.post(name: .dbpLoginItemEnabled, object: nil)
+        Task {
+            await loginItemsManager.enableLoginItems([.dbpBackgroundAgent])
+            NotificationCenter.default.post(name: .dbpLoginItemEnabled, object: nil)
+        }
     }
 
     // MARK: - DataBrokerProtectionLoginItemInterface

--- a/macOS/DuckDuckGo/DBP/DataBrokerProtectionLoginItemInterface.swift
+++ b/macOS/DuckDuckGo/DBP/DataBrokerProtectionLoginItemInterface.swift
@@ -50,33 +50,31 @@ extension DefaultDataBrokerProtectionLoginItemInterface: DataBrokerProtectionLog
 
     // MARK: - Login Item Management
 
-    private func disableLoginItem() {
+    private func disableLoginItem() async {
         DataBrokerProtectionLoginItemPixels.fire(pixel: GeneralPixel.dataBrokerDisableLoginItemDaily, frequency: .legacyDaily)
-        Task {
-            await loginItemsManager.disableLoginItems([.dbpBackgroundAgent])
-            NotificationCenter.default.post(name: .dbpLoginItemDisabled, object: nil)
-        }
+        await loginItemsManager.disableLoginItems([.dbpBackgroundAgent])
+        NotificationCenter.default.post(name: .dbpLoginItemDisabled, object: nil)
     }
 
-    private func enableLoginItem() {
+    private func enableLoginItem() async {
         DataBrokerProtectionLoginItemPixels.fire(pixel: GeneralPixel.dataBrokerEnableLoginItemDaily, frequency: .legacyDaily)
-        Task {
-            await loginItemsManager.enableLoginItems([.dbpBackgroundAgent])
-            NotificationCenter.default.post(name: .dbpLoginItemEnabled, object: nil)
-        }
+        await loginItemsManager.enableLoginItems([.dbpBackgroundAgent])
+        NotificationCenter.default.post(name: .dbpLoginItemEnabled, object: nil)
     }
 
     // MARK: - DataBrokerProtectionLoginItemInterface
 
     func dataDeleted() {
-        disableLoginItem()
+        Task {
+            await disableLoginItem()
+        }
     }
 
     // MARK: - DataBrokerProtectionAppToAgentInterface
     // MARK: - DataBrokerProtectionAgentAppEvents
 
-    func profileSaved() {
-        enableLoginItem()
+    func profileSaved() async {
+        await enableLoginItem()
 
         Task {
             // Wait to make sure the agent has had time to launch

--- a/macOS/DuckDuckGo/DBP/LoginItem+DataBrokerProtection.swift
+++ b/macOS/DuckDuckGo/DBP/LoginItem+DataBrokerProtection.swift
@@ -28,8 +28,8 @@ extension LoginItem {
 
 extension LoginItem: DBPLoginItemStatusChecker {
 
-    public func doesHaveNecessaryPermissions() -> Bool {
-        return status != .requiresApproval
+    public func doesHaveNecessaryPermissions() async -> Bool {
+        return await status() != .requiresApproval
     }
 
     public func isInCorrectDirectory() -> Bool {

--- a/macOS/DuckDuckGo/LoginItems/LoginItemsManager.swift
+++ b/macOS/DuckDuckGo/LoginItems/LoginItemsManager.swift
@@ -24,13 +24,13 @@ import PixelKit
 import os.log
 
 protocol LoginItemsManaging {
-    func enableLoginItems(_ items: Set<LoginItem>)
-    func throwingEnableLoginItems(_ items: Set<LoginItem>) throws
-    func disableLoginItems(_ items: Set<LoginItem>)
-    func restartLoginItems(_ items: Set<LoginItem>)
+    func enableLoginItems(_ items: Set<LoginItem>) async
+    func throwingEnableLoginItems(_ items: Set<LoginItem>) async throws
+    func disableLoginItems(_ items: Set<LoginItem>) async
+    func restartLoginItems(_ items: Set<LoginItem>) async
 
-    func isAnyEnabled(_ items: Set<LoginItem>) -> Bool
-    func isAnyInstalled(_ items: Set<LoginItem>) -> Bool
+    func isAnyEnabled(_ items: Set<LoginItem>) async -> Bool
+    func isAnyInstalled(_ items: Set<LoginItem>) async -> Bool
 }
 
 /// Class to manage the login items for the VPN and DBP
@@ -44,10 +44,10 @@ final class LoginItemsManager: LoginItemsManaging {
 
     // MARK: - Main Interactions
 
-    func enableLoginItems(_ items: Set<LoginItem>) {
+    func enableLoginItems(_ items: Set<LoginItem>) async {
         for item in items {
             do {
-                try item.enable()
+                try await item.enable()
                 Logger.networkProtection.log("🟢 Enabled successfully \(String(describing: item), privacy: .public)")
             } catch let error as NSError {
                 handleError(for: item, action: .enable, error: error)
@@ -57,10 +57,10 @@ final class LoginItemsManager: LoginItemsManaging {
 
     /// Throwing version of enableLoginItems
     ///
-    func throwingEnableLoginItems(_ items: Set<LoginItem>) throws {
+    func throwingEnableLoginItems(_ items: Set<LoginItem>) async throws {
         for item in items {
             do {
-                try item.enable()
+                try await item.enable()
                 Logger.networkProtection.log("🟢 Enabled successfully \(String(describing: item), privacy: .public)")
             } catch let error as NSError {
                 handleError(for: item, action: .enable, error: error)
@@ -69,10 +69,10 @@ final class LoginItemsManager: LoginItemsManaging {
         }
     }
 
-    func restartLoginItems(_ items: Set<LoginItem>) {
+    func restartLoginItems(_ items: Set<LoginItem>) async {
         for item in items {
             do {
-                try item.restart()
+                try await item.restart()
                 Logger.networkProtection.log("🟢 Restarted successfully \(String(describing: item), privacy: .public)")
             } catch let error as NSError {
                 handleError(for: item, action: .restart, error: error)
@@ -80,22 +80,24 @@ final class LoginItemsManager: LoginItemsManaging {
         }
     }
 
-    func disableLoginItems(_ items: Set<LoginItem>) {
+    func disableLoginItems(_ items: Set<LoginItem>) async {
         for item in items {
-            try? item.disable()
+            try? await item.disable()
         }
     }
 
-    func isAnyEnabled(_ items: Set<LoginItem>) -> Bool {
-        return items.contains(where: { item in
-            item.status == .enabled
-        })
+    func isAnyEnabled(_ items: Set<LoginItem>) async -> Bool {
+        for item in items where await item.status() == .enabled {
+            return true
+        }
+        return false
     }
 
-    func isAnyInstalled(_ items: Set<LoginItem>) -> Bool {
-        return items.contains(where: { item in
-            item.status.isInstalled
-        })
+    func isAnyInstalled(_ items: Set<LoginItem>) async -> Bool {
+        for item in items where await item.status().isInstalled {
+            return true
+        }
+        return false
     }
 
     private func handleError(for item: LoginItem, action: Action, error: NSError) {
@@ -111,7 +113,7 @@ final class LoginItemsManager: LoginItemsManaging {
 
     func resetLoginItems(_ items: Set<LoginItem>) async throws {
         for item in items {
-            try? item.disable()
+            try? await item.disable()
         }
     }
 

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionDebugMenu.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionDebugMenu.swift
@@ -268,7 +268,7 @@ final class NetworkProtectionDebugMenu: NSMenu {
     ///
     @objc func disableLoginItem(_ sender: Any?) {
         Task { @MainActor in
-            debugUtilities.disableLoginItems()
+            await debugUtilities.disableLoginItems()
         }
     }
 

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionDebugUtilities.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionDebugUtilities.swift
@@ -95,13 +95,13 @@ final class NetworkProtectionDebugUtilities {
         vpnAppState.resetDontAskAgainExclusionSuggestion()
     }
 
-    func disableLoginItems() {
-        vpnUninstaller.removeAgents()
+    func disableLoginItems() async {
+        await vpnUninstaller.removeAgents()
     }
 
     func removeVPNNetworkExtensionAndAgents() async throws {
         try await vpnUninstaller.removeSystemExtension()
-        vpnUninstaller.removeAgents()
+        await vpnUninstaller.removeAgents()
     }
 
     func removeVPNConfiguration() async throws {

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionDiagnosticsExporter.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionDiagnosticsExporter.swift
@@ -156,7 +156,7 @@ final class NetworkProtectionDiagnosticsExporter {
         async let networkState = collectNetworkState()
         async let systemCommandOutput = collectSystemCommandOutput()
 
-        let appState = collectAppState()
+        let appState = await collectAppState()
 
         let files = await [
             DiagnosticsFile(name: "README.txt", contents: readme()),
@@ -208,9 +208,15 @@ final class NetworkProtectionDiagnosticsExporter {
 
     // MARK: - App State
 
-    private func collectAppState() -> String {
+    private func collectAppState() async -> String {
         let vpnMenuAgentBundleID = infoPlistValue(for: InfoPlistKey.vpnMenuAgentBundleID)
         let loginItem = vpnMenuAgentBundleID.map { LoginItem(bundleId: $0, defaults: .netP, logger: Logger.networkProtection) }
+        let loginItemStatusString: String
+        if let loginItem {
+            loginItemStatusString = "\(await loginItem.status())"
+        } else {
+            loginItemStatusString = "unknown"
+        }
         let runningVPNMenuApplications = vpnMenuAgentBundleID.map {
             NSRunningApplication.runningApplications(withBundleIdentifier: $0)
         } ?? []
@@ -252,7 +258,7 @@ final class NetworkProtectionDiagnosticsExporter {
 
         \(section("Login item"))
         Bundle identifier: \(vpnMenuAgentBundleID ?? missingInfoPlistValue(for: InfoPlistKey.vpnMenuAgentBundleID))
-        Status: \(loginItem.map { "\($0.status)" } ?? "unknown")
+        Status: \(loginItemStatusString)
         Is running: \(loginItem.map { "\($0.isRunning)" } ?? "unknown")
         Running process identifiers:
         \(runningVPNMenuApplications.map(\.processIdentifier).map(String.init).indentedList())

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNAppEventsHandler.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNAppEventsHandler.swift
@@ -105,12 +105,15 @@ final class VPNAppEventsHandler {
     ///
     @MainActor
     private func loginItemsControlCheckpoint(canRestart: Bool, loginItemsManager: LoginItemsManaging) async {
-        switch try? await featureGatekeeper.canStartVPN() {
-        case .some(true) where loginItemsManager.isAnyEnabled(LoginItemsManager.vpnLoginItems):
+        let canStartVPN = try? await featureGatekeeper.canStartVPN()
+        let isAnyEnabled = await loginItemsManager.isAnyEnabled(LoginItemsManager.vpnLoginItems)
+        let isAnyInstalled = await loginItemsManager.isAnyInstalled(LoginItemsManager.vpnLoginItems)
+        switch canStartVPN {
+        case .some(true) where isAnyEnabled:
             if canRestart {
-                restartLoginItem(using: loginItemsManager)
+                await restartLoginItem(using: loginItemsManager)
             }
-        case .some(false) where loginItemsManager.isAnyInstalled(LoginItemsManager.vpnLoginItems):
+        case .some(false) where isAnyInstalled:
             await withCheckedContinuation { continuation in
                 ipcClient.stop { error in
                     if let error {
@@ -123,7 +126,7 @@ final class VPNAppEventsHandler {
                         } catch {
                             // no-op: just want to catch task cancellation to make sure resume is called
                         }
-                        self.disableLoginItem(using: loginItemsManager)
+                        await self.disableLoginItem(using: loginItemsManager)
                         continuation.resume()
                     }
                 }
@@ -135,12 +138,12 @@ final class VPNAppEventsHandler {
 
     // MARK: - Managing the VPN Login Items
 
-    private func disableLoginItem(using loginItemsManager: LoginItemsManaging) {
-        loginItemsManager.disableLoginItems(LoginItemsManager.vpnLoginItems)
+    private func disableLoginItem(using loginItemsManager: LoginItemsManaging) async {
+        await loginItemsManager.disableLoginItems(LoginItemsManager.vpnLoginItems)
     }
 
-    private func restartLoginItem(using loginItemsManager: LoginItemsManaging) {
-        loginItemsManager.restartLoginItems(LoginItemsManager.vpnLoginItems)
+    private func restartLoginItem(using loginItemsManager: LoginItemsManaging) async {
+        await loginItemsManager.restartLoginItems(LoginItemsManager.vpnLoginItems)
     }
 
     // MARK: - Feature Flag Overriding

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/NetworkProtectionIPCTunnelController.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/NetworkProtectionIPCTunnelController.swift
@@ -111,7 +111,7 @@ final class NetworkProtectionIPCTunnelController {
     // MARK: - Login Items Manager
 
     private func enableLoginItems() async throws {
-        try loginItemsManager.throwingEnableLoginItems(LoginItemsManager.vpnLoginItems)
+        try await loginItemsManager.throwingEnableLoginItems(LoginItemsManager.vpnLoginItems)
     }
 }
 

--- a/macOS/DuckDuckGo/Preferences/Model/VPNPreferencesModel.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/VPNPreferencesModel.swift
@@ -133,7 +133,9 @@ final class VPNPreferencesModel: ObservableObject {
 
     private var onboardingStatus: OnboardingStatus {
         didSet {
-            showUninstallVPN = DefaultVPNFeatureGatekeeper(vpnUninstaller: VPNUninstaller(pinningManager: pinningManager), subscriptionManager: Application.appDelegate.subscriptionManager).isInstalled
+            Task { @MainActor in
+                showUninstallVPN = await DefaultVPNFeatureGatekeeper(vpnUninstaller: VPNUninstaller(pinningManager: pinningManager), subscriptionManager: Application.appDelegate.subscriptionManager).isInstalled
+            }
         }
     }
 

--- a/macOS/DuckDuckGo/UnifiedFeedbackForm/MetadataCollectors/VPNMetadataCollector.swift
+++ b/macOS/DuckDuckGo/UnifiedFeedbackForm/MetadataCollectors/VPNMetadataCollector.swift
@@ -187,7 +187,7 @@ final class DefaultVPNMetadataCollector: VPNMetadataCollector {
         let networkInfoMetadata = await collectNetworkInformation()
         let vpnState = await collectVPNState()
         let vpnSettingsState = collectVPNSettingsState()
-        let loginItemState = collectLoginItemState()
+        let loginItemState = await collectLoginItemState()
         let subscriptionInfo = await collectSubscriptionInfo()
 
         return VPNMetadata(
@@ -322,8 +322,8 @@ final class DefaultVPNMetadataCollector: VPNMetadataCollector {
         return "KnownFailure code=\(knownFailure.error)"
     }
 
-    func collectLoginItemState() -> VPNMetadata.LoginItemState {
-        let vpnMenuState = String(describing: LoginItem.vpnMenu.status)
+    func collectLoginItemState() async -> VPNMetadata.LoginItemState {
+        let vpnMenuState = await String(describing: LoginItem.vpnMenu.status())
         let vpnMenuIsRunning = !NSRunningApplication.runningApplications(withBundleIdentifier: LoginItem.vpnMenu.agentBundleID).isEmpty
 
         return .init(

--- a/macOS/DuckDuckGo/Waitlist/IPCServiceLauncher.swift
+++ b/macOS/DuckDuckGo/Waitlist/IPCServiceLauncher.swift
@@ -71,7 +71,7 @@ final class IPCServiceLauncher {
 
             runningApplication = try await appLauncher.runApp(withCommand: UDSLaunchAppCommand())
         case .loginItem(let loginItem, let loginItemsManager):
-            try loginItemsManager.throwingEnableLoginItems([loginItem])
+            try await loginItemsManager.throwingEnableLoginItems([loginItem])
         }
     }
 
@@ -99,7 +99,7 @@ final class IPCServiceLauncher {
             }
 
         case .loginItem(let loginItem, let loginItemsManager):
-            loginItemsManager.disableLoginItems([loginItem])
+            await loginItemsManager.disableLoginItems([loginItem])
         }
     }
 }

--- a/macOS/DuckDuckGo/Waitlist/VPNFeatureGatekeeper.swift
+++ b/macOS/DuckDuckGo/Waitlist/VPNFeatureGatekeeper.swift
@@ -28,7 +28,7 @@ import PixelKit
 import Subscription
 
 protocol VPNFeatureGatekeeper {
-    var isInstalled: Bool { get }
+    var isInstalled: Bool { get async }
 
     func canStartVPN() async throws -> Bool
     func isVPNVisible() -> Bool
@@ -51,7 +51,9 @@ struct DefaultVPNFeatureGatekeeper: VPNFeatureGatekeeper {
     }
 
     var isInstalled: Bool {
-        LoginItem.vpnMenu.status.isInstalled
+        get async {
+            await LoginItem.vpnMenu.status().isInstalled
+        }
     }
 
     /// Whether the user can start the VPN.

--- a/macOS/DuckDuckGo/Waitlist/VPNUninstaller.swift
+++ b/macOS/DuckDuckGo/Waitlist/VPNUninstaller.swift
@@ -212,7 +212,7 @@ final class VPNUninstaller: VPNUninstalling {
             throw UninstallError.cancelled(reason: .alreadyUninstalling)
         }
 
-        guard vpnMenuLoginItem.status.isInstalled else {
+        guard await vpnMenuLoginItem.status().isInstalled else {
             throw UninstallError.cancelled(reason: .alreadyUninstalled)
         }
 
@@ -263,7 +263,7 @@ final class VPNUninstaller: VPNUninstalling {
 
         // When the agent is registered as a login item, we want to unregister it
         // and stop it from running, which is achieved by the next call.
-        removeAgents()
+        await removeAgents()
 
         // When the agent was started directly (not as a login item) we want to stop it,
         // as the above call won't do anything for it.
@@ -282,8 +282,8 @@ final class VPNUninstaller: VPNUninstalling {
         try await ipcServiceLauncher.disable()
     }
 
-    func removeAgents() {
-        loginItemsManager.disableLoginItems(LoginItemsManager.vpnLoginItems)
+    func removeAgents() async {
+        await loginItemsManager.disableLoginItems(LoginItemsManager.vpnLoginItems)
     }
 
     func removeSystemExtension() async throws {

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/IPC/DataBrokerProtectionIPCClient.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/IPC/DataBrokerProtectionIPCClient.swift
@@ -30,7 +30,7 @@ public protocol IPCClientInterface: AnyObject {
 }
 
 public protocol DBPLoginItemStatusChecker {
-    func doesHaveNecessaryPermissions() -> Bool
+    func doesHaveNecessaryPermissions() async -> Bool
     func isInCorrectDirectory() -> Bool
 }
 

--- a/macOS/LocalPackages/LoginItems/Sources/LoginItems/LoginItem.swift
+++ b/macOS/LocalPackages/LoginItems/Sources/LoginItems/LoginItem.swift
@@ -71,16 +71,27 @@ public struct LoginItem: Equatable, Hashable {
         }
     }
 
-    public var status: Status {
+    /// Reads the login item status.
+    ///
+    /// The underlying `SMAppService` read performs synchronous XPC to the Service Management
+    /// daemon, so it is dispatched onto a detached `Task` to keep it off the caller's thread
+    /// (notably the main thread during launch).
+    public func status() async -> Status {
+        let agentBundleID = agentBundleID
+        let logger = logger
         guard #available(macOS 13.0, *) else {
-            guard let job = ServiceManagement.copyAllJobDictionaries(kSMDomainUserLaunchd).first(where: {
-                $0["Label"] as? String == agentBundleID
-            }) else { return .notRegistered }
+            return await Task.detached {
+                guard let job = ServiceManagement.copyAllJobDictionaries(kSMDomainUserLaunchd).first(where: {
+                    $0["Label"] as? String == agentBundleID
+                }) else { return .notRegistered }
 
-            logger.debug("🟢 found login item job: \(job.debugDescription, privacy: .public)")
-            return job["OnDemand"] as? Bool == true ? .enabled : .requiresApproval
+                logger.debug("🟢 found login item job: \(job.debugDescription, privacy: .public)")
+                return job["OnDemand"] as? Bool == true ? .enabled : .requiresApproval
+            }.value
         }
-        return Status(SMAppService.loginItem(identifier: agentBundleID).status)
+        return await Task.detached {
+            Status(SMAppService.loginItem(identifier: agentBundleID).status)
+        }.value
     }
 
     public init(bundleId: String, defaults: UserDefaults, logger: Logger) {
@@ -90,31 +101,39 @@ public struct LoginItem: Equatable, Hashable {
         self.logger = logger
     }
 
-    public func enable() throws {
+    public func enable() async throws {
         logger.debug("🟢 registering login item \(self.debugDescription, privacy: .public)")
 
+        let agentBundleID = agentBundleID
         if #available(macOS 13.0, *) {
-            try SMAppService.loginItem(identifier: agentBundleID).register()
+            try await Task.detached {
+                try SMAppService.loginItem(identifier: agentBundleID).register()
+            }.value
         } else {
-            let success = SMLoginItemSetEnabled(agentBundleID as CFString, true)
-            if !success {
-                throw SMLoginItemSetEnabledError.failed
-            }
+            try await Task.detached {
+                if !SMLoginItemSetEnabled(agentBundleID as CFString, true) {
+                    throw SMLoginItemSetEnabledError.failed
+                }
+            }.value
         }
 
         launchInformation.updateLastEnabledTimestamp()
     }
 
-    public func disable() throws {
+    public func disable() async throws {
         logger.debug("🟢 unregistering login item \(self.debugDescription, privacy: .public)")
 
+        let agentBundleID = agentBundleID
         if #available(macOS 13.0, *) {
-            try SMAppService.loginItem(identifier: agentBundleID).unregister()
+            try await Task.detached {
+                try SMAppService.loginItem(identifier: agentBundleID).unregister()
+            }.value
         } else {
-            let success = SMLoginItemSetEnabled(agentBundleID as CFString, false)
-            if !success {
-                throw SMLoginItemSetEnabledError.failed
-            }
+            try await Task.detached {
+                if !SMLoginItemSetEnabled(agentBundleID as CFString, false) {
+                    throw SMLoginItemSetEnabledError.failed
+                }
+            }.value
         }
     }
 
@@ -122,13 +141,13 @@ public struct LoginItem: Equatable, Hashable {
     ///
     /// This call will only enable the login item if it was enabled to begin with.
     ///
-    public func restart() throws {
-        guard [.enabled].contains(status) else {
+    public func restart() async throws {
+        guard await status() == .enabled else {
             logger.debug("🟢 restart not needed for login item \(self.debugDescription, privacy: .public)")
             return
         }
-        try? disable()
-        try enable()
+        try? await disable()
+        try await enable()
     }
 
     public func forceStop() {
@@ -150,7 +169,7 @@ public struct LoginItem: Equatable, Hashable {
 extension LoginItem: CustomDebugStringConvertible {
 
     public var debugDescription: String {
-        "<LoginItem \(agentBundleID) isEnabled: \(status) isRunning: \(isRunning)>"
+        "<LoginItem \(agentBundleID) isRunning: \(isRunning)>"
     }
 
 }

--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Views/StatusView/NetworkProtectionStatusViewModel.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Views/StatusView/NetworkProtectionStatusViewModel.swift
@@ -208,7 +208,9 @@ extension NetworkProtectionStatusView {
         }
 
         func refreshLoginItemStatus() {
-            self.loginItemNeedsApproval = agentLoginItem?.status == .requiresApproval
+            Task { @MainActor in
+                self.loginItemNeedsApproval = await self.agentLoginItem?.status() == .requiresApproval
+            }
         }
 
         func openLoginItemSettings() {

--- a/macOS/UnitTests/DBP/Tests/DataBrokerPrerequisitesStatusVerifierTests.swift
+++ b/macOS/UnitTests/DBP/Tests/DataBrokerPrerequisitesStatusVerifierTests.swift
@@ -28,27 +28,27 @@ final class DataBrokerPrerequisitesStatusVerifierTests: XCTestCase {
         statusChecker = nil
     }
 
-    func testIncorrectDirectory_thenReturnIncorrectDirectoryStatus() {
+    func testIncorrectDirectory_thenReturnIncorrectDirectoryStatus() async {
         statusChecker.isInCorrectDirectoryValue = false
-        let result = DefaultDataBrokerPrerequisitesStatusVerifier(statusChecker: statusChecker).checkStatus()
+        let result = await DefaultDataBrokerPrerequisitesStatusVerifier(statusChecker: statusChecker).checkStatus()
         XCTAssertEqual(result, DataBrokerPrerequisitesStatus.invalidDirectory)
     }
 
-    func testIncorrectPermission_thenReturnIncorrectPermissionStatus() {
+    func testIncorrectPermission_thenReturnIncorrectPermissionStatus() async {
         statusChecker.doesHavePermissionValue = false
-        let result = DefaultDataBrokerPrerequisitesStatusVerifier(statusChecker: statusChecker).checkStatus()
+        let result = await DefaultDataBrokerPrerequisitesStatusVerifier(statusChecker: statusChecker).checkStatus()
         XCTAssertEqual(result, DataBrokerPrerequisitesStatus.invalidSystemPermission)
     }
 
-    func testIncorrectDirectoryAndIncorrectPermission_thenReturnIncorrectPermissionStatus() {
+    func testIncorrectDirectoryAndIncorrectPermission_thenReturnIncorrectPermissionStatus() async {
         statusChecker.isInCorrectDirectoryValue = false
         statusChecker.doesHavePermissionValue = false
-        let result = DefaultDataBrokerPrerequisitesStatusVerifier(statusChecker: statusChecker).checkStatus()
+        let result = await DefaultDataBrokerPrerequisitesStatusVerifier(statusChecker: statusChecker).checkStatus()
         XCTAssertEqual(result, DataBrokerPrerequisitesStatus.invalidSystemPermission)
     }
 
-    func testCorrectStatus_thenReturnValidStatus() {
-        let result = DefaultDataBrokerPrerequisitesStatusVerifier(statusChecker: statusChecker).checkStatus()
+    func testCorrectStatus_thenReturnValidStatus() async {
+        let result = await DefaultDataBrokerPrerequisitesStatusVerifier(statusChecker: statusChecker).checkStatus()
         XCTAssertEqual(result, DataBrokerPrerequisitesStatus.valid)
     }
 }

--- a/macOS/UnitTests/NetworkProtection/Mocks/MockLoginItemsManager.swift
+++ b/macOS/UnitTests/NetworkProtection/Mocks/MockLoginItemsManager.swift
@@ -46,27 +46,27 @@ struct MockLoginItemsManager: LoginItemsManaging {
         self.isAnyInstalledCallback = isAnyInstalledCallback
     }
 
-    func enableLoginItems(_ items: Set<LoginItems.LoginItem>) {
+    func enableLoginItems(_ items: Set<LoginItems.LoginItem>) async {
         enableLoginItemsCallback(items)
     }
 
-    func throwingEnableLoginItems(_ items: Set<LoginItems.LoginItem>) throws {
+    func throwingEnableLoginItems(_ items: Set<LoginItems.LoginItem>) async throws {
         try throwingEnableLoginItemsCallback(items)
     }
 
-    func disableLoginItems(_ items: Set<LoginItems.LoginItem>) {
+    func disableLoginItems(_ items: Set<LoginItems.LoginItem>) async {
         disableLoginItemsCallback(items)
     }
 
-    func restartLoginItems(_ items: Set<LoginItems.LoginItem>) {
+    func restartLoginItems(_ items: Set<LoginItems.LoginItem>) async {
         restartLoginItemsCallback(items)
     }
 
-    func isAnyEnabled(_ items: Set<LoginItems.LoginItem>) -> Bool {
+    func isAnyEnabled(_ items: Set<LoginItems.LoginItem>) async -> Bool {
         isAnyEnabledCallback(items)
     }
 
-    func isAnyInstalled(_ items: Set<LoginItems.LoginItem>) -> Bool {
+    func isAnyInstalled(_ items: Set<LoginItems.LoginItem>) async -> Bool {
         isAnyInstalledCallback(items)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216076259555493

### Description

Login items were registered, unregistered, and status-checked through synchronous `SMAppService` calls that perform XPC to the Service Management daemon on the calling thread. During app launch this ran on the main thread and could hang startup. This makes the `LoginItem` API async so the blocking work runs off the main thread, and propagates the async call chain through the VPN and DBP login-item paths.

### Testing Steps

1. Launch the app under Instruments using the Hangs (or Time Profiler) instrument on a Sparkle (non-App Store) build.
2. Confirm no main-thread hangs are attributed to `SMAppService` calls (`register()`, `unregister()`, `loginItem(identifier:).status`) during startup.

### Impact and Risks

Low. The change is confined to how login-item Service Management calls are dispatched; behavior is unchanged aside from running off the calling thread.

#### What could go wrong?

A login item could register/unregister with different timing now that the calls are async. Unlikely to matter because callers already treated these as fire-and-forget side effects and the await points preserve ordering within each flow.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is the same with different threading; main risk is slightly different timing for async enable/disable, which existing flows already treat as ordered side effects.
> 
> **Overview**
> **Login item APIs are now async** so `SMAppService` register/unregister/status work runs on detached tasks instead of blocking the caller (especially the main thread at launch). The sync `status` property becomes `status() async`; `enable`, `disable`, and `restart` are `async throws`.
> 
> **Call sites across VPN and DBP** were updated to `await` through `LoginItemsManager`, uninstall/debug flows, IPC launchers, diagnostics/metadata collectors, and DBP prerequisite checks (including DBP home UI setup and dashboard pixels). `VPNFeatureGatekeeper.isInstalled` and related gates now read login-item state asynchronously. Unit tests and mocks match the new signatures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f40bfa1f73f10e48c2b75600db5273ddbdb19e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->