### PR TITLE
Reduce per-frame work during chrome bar hide/show on scroll

### DIFF
--- a/iOS/DuckDuckGo/Customization/MobileCustomization.swift
+++ b/iOS/DuckDuckGo/Customization/MobileCustomization.swift
@@ -175,10 +175,15 @@ class MobileCustomization {
         return buttons
     }
 
+    private var cachedState: State?
+
     var state: State {
-        State(isEnabled: isEnabled,
-              currentToolbarButton: current(forKey: .toolbarButton, containedIn: toolbarButtonOptions, Self.toolbarDefault),
-              currentAddressBarButton: current(forKey: .addressBarButton, containedIn: addressBarButtonOptions, Self.addressBarDefault))
+        if let cachedState { return cachedState }
+        let state = State(isEnabled: isEnabled,
+                          currentToolbarButton: current(forKey: .toolbarButton, containedIn: toolbarButtonOptions, Self.toolbarDefault),
+                          currentAddressBarButton: current(forKey: .addressBarButton, containedIn: addressBarButtonOptions, Self.addressBarDefault))
+        cachedState = state
+        return state
     }
 
     var hasFireButton: Bool {
@@ -233,6 +238,7 @@ class MobileCustomization {
     func persist(_ state: State) {
         setCurrentToolbarButton(state.currentToolbarButton)
         setCurrentAddressBarButton(state.currentAddressBarButton)
+        cachedState = nil
         postChangeNotification(state)
     }
 

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3681,7 +3681,10 @@ extension MainViewController: BrowserChromeDelegate {
     
     func setBarsVisibility(_ percent: CGFloat, animated: Bool, animationDuration: CGFloat?) {
         if percent < 1 {
-            hideKeyboard()
+            if omniBar.isTextFieldEditing || unifiedToggleInputCoordinator?.isOmnibarSession == true {
+                dismissOmniBar()
+            }
+            _ = findInPageView?.resignFirstResponder()
             hideMenuHighlighter()
         } else {
             showMenuHighlighterIfNeeded()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1216091927087468?focus=true
Tech Design URL:
CC:

### Description
During scroll, hiding/showing the address bar and toolbar ran a full omnibar/UTI refresh every frame (via `hideKeyboard` → `dismissOmniBar` → `refreshOmniBar`) and re-read the file-backed customization store on every layout. This change only dismisses the omnibar when it is actually being edited, and caches `MobileCustomization.state` (invalidated on `persist`). The result is noticeably less main-thread work per scroll frame, most visible on older devices like the iPhone 6S.

### Testing Steps
1. On a content-heavy page, scroll up and down repeatedly and confirm the address bar / toolbar hide-show stays smooth (ideally on an older device).
2. Tap the address bar to start editing, then scroll — confirm the keyboard/omnibar still dismisses.
3. Open address-bar / toolbar customization, change a button, and confirm the customizable button updates correctly.

### Impact and Risks
Low — behavior-preserving optimizations on the scroll/chrome path.

#### What could go wrong?
If the omnibar editing-state check is wrong, scrolling could fail to dismiss the keyboard in an edge case (the find-in-page resign is left unconditional to mitigate).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scroll-path optimizations only; the main edge case would be failing to dismiss the keyboard while editing if the editing-session checks are wrong.
> 
> **Overview**
> **Reduces main-thread work while the address bar and toolbar animate during scroll** by avoiding omnibar/UTI teardown on every visibility frame and by not re-reading customization from the key-value store on every `state` access.
> 
> In **`MainViewController.setBarsVisibility`**, the unconditional `hideKeyboard()` (which always called `dismissOmniBar`) is replaced with **`dismissOmniBar` only when** the omnibar text field is editing or a unified-input omnibar session is active; **find-in-page still always resigns first responder**.
> 
> In **`MobileCustomization`**, **`state` is memoized** in `cachedState` and **cleared in `persist`** so toolbar/address-bar button reads stay correct after the user changes customization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92d4026161ce31b2f9f6a2897cc55ec481432fb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->