### PR TITLE
[macOS] Fix flaky navigation integration tests

### DIFF
--- a/macOS/IntegrationTests/Tab/AddressBarTests.swift
+++ b/macOS/IntegrationTests/Tab/AddressBarTests.swift
@@ -761,15 +761,26 @@ class AddressBarTests: XCTestCase {
         _=try await tab.webViewDidFinishNavigationPublisher.timeout(10).first().promise().value
         XCTAssertEqual(window.firstResponder, tab.webView)
 
+        let requestReceived = expectation(description: "reload request received")
+        var resumeNavigation: (() -> Void)?
+        schemeHandler.middleware = [{ request in
+            guard request.url == .duckDuckGo else { return .ok(.html(Self.testHtml)) }
+            return WKURLSchemeTaskHandler { task in
+                resumeNavigation = { WKURLSchemeTaskHandler.ok(.html(Self.testHtml))(task) }
+                requestReceived.fulfill()
+            }
+        }]
+
         // activate address bar, trigger reload by sending Return key and re-activate the address bar - it should be kept active
         let didFinishNavigation = tab.webViewDidFinishNavigationPublisher.timeout(10).first().promise()
         _=window.makeFirstResponder(addressBarTextField)
         type("\r")
-        try await Task.sleep(interval: 0.1)
+
+        await fulfillment(of: [requestReceived], timeout: 5)
         _=window.makeFirstResponder(addressBarTextField)
         type("some-text")
 
-        try await Task.sleep(interval: 1.0)
+        resumeNavigation?()
         try await didFinishNavigation.value
         XCTAssertTrue(isAddressBarFirstResponder)
         XCTAssertEqual(addressBarValue, "some-text")
@@ -877,14 +888,25 @@ class AddressBarTests: XCTestCase {
 
         _=try await tab.webViewDidFinishNavigationPublisher.timeout(10).first().promise().value
 
+        let requestReceived = expectation(description: "navigation request received")
+        var resumeNavigation: (() -> Void)?
+        schemeHandler.middleware = [{ request in
+            guard request.url == .duckDuckGo else { return .ok(.html(Self.testHtml)) }
+            return WKURLSchemeTaskHandler { task in
+                resumeNavigation = { WKURLSchemeTaskHandler.ok(.html(Self.testHtml))(task) }
+                requestReceived.fulfill()
+            }
+        }]
+
         let didFinishNavigation = tab.webViewDidFinishNavigationPublisher.timeout(10).first().promise()
         type(URL.duckDuckGo.absoluteString + "\r")
 
-        try await Task.sleep(interval: 0.1)
+        await fulfillment(of: [requestReceived], timeout: 5)
         _=window.makeFirstResponder(addressBarTextField)
         type("some-text")
 
-        try await Task.sleep(interval: 0.01)
+        // let the held navigation complete now that the user is editing the address bar
+        resumeNavigation?()
         try await didFinishNavigation.value
         XCTAssertTrue(isAddressBarFirstResponder)
         XCTAssertEqual(addressBarValue, "some-text")


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1216094540560400?focus=true
Tech Design URL:
CC:

### Description

This PR updates the address bar integration tests in the macOS test suite to be less flaky. The overall change is to move away from `sleep` calls as a way to wait for something to have occurred, and instead wait for it explicitly.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that tests are green

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to macOS integration tests; no production app behavior is modified.
> 
> **Overview**
> Two macOS address bar integration tests that assert the field **stays active and keeps in-progress text when navigation finishes** no longer rely on fixed `Task.sleep` delays.
> 
> Each test now installs **scheme handler middleware** that **holds** the DuckDuckGo load until the test re-focuses the address bar and types, then **explicitly resumes** the navigation. Synchronization uses **`XCTestExpectation` + `fulfillment(of:)`** for the in-flight request instead of arbitrary sleeps before and after that window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bfa5e09f39494d4ee8de9f353dcc6518de22331. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->