### PR TITLE
Fix ai-chat-settings maestro test for native AI Features layout

### DIFF
--- a/.maestro/release_tests/ai-chat-settings.yaml
+++ b/.maestro/release_tests/ai-chat-settings.yaml
@@ -1,8 +1,9 @@
 # ai-chat-settings.yaml
 # Validates the "Duck.ai Settings" row in Settings > AI Features:
-#  - it is shown below the Duck.ai toggle when Duck.ai is enabled
-#  - it is hidden when the Duck.ai toggle is disabled
+#  - it is shown in the "Duck.ai" section when Duck.ai is enabled
+#  - it is hidden when the Duck.ai toggle is disabled (the whole section collapses)
 #  - tapping it dismisses Settings and opens duck.ai in a new tab
+
 appId: com.duckduckgo.mobile.ios
 tags:
     - iphone
@@ -22,21 +23,37 @@ tags:
     direction: DOWN
 - tapOn: "AI Features"
 
-# Duck.ai is enabled by default - the new row should be visible below the toggle
+# Duck.ai is enabled by default - the row should be visible in the Duck.ai section
+- scrollUntilVisible:
+    element:
+        id: "Settings.AIFeatures.DuckAISettings"
+    direction: DOWN
+    centerElement: true
 - assertVisible:
     id: "Settings.AIFeatures.DuckAISettings"
 - assertVisible: "Duck.ai Settings"
 
-# Disable the main Duck.ai toggle - the row should be hidden
+# Disable the main Duck.ai toggle (back at the top) - the section should collapse
+- scrollUntilVisible:
+    element:
+        id: "Settings.AIFeatures.EnableToggle"
+    direction: UP
 - tapOn:
     id: "Settings.AIFeatures.EnableToggle"
+- waitForAnimationToEnd
 - assertNotVisible:
     id: "Settings.AIFeatures.DuckAISettings"
 - assertNotVisible: "Duck.ai Settings"
 
-# Re-enable the main Duck.ai toggle - the row should reappear
+# Re-enable the main Duck.ai toggle - the Duck.ai section should reappear
 - tapOn:
     id: "Settings.AIFeatures.EnableToggle"
+- waitForAnimationToEnd
+- scrollUntilVisible:
+    element:
+        id: "Settings.AIFeatures.DuckAISettings"
+    direction: DOWN
+    centerElement: true
 - assertVisible:
     id: "Settings.AIFeatures.DuckAISettings"
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1216088857985246?focus=true
Tech Design URL:
CC:

### Description
PR #5502 enabled `aiFeaturesNativeControls` by default, which moved the Duck.ai Settings row out of the top section into a lower "Duck.ai" section below the new pickers, so the `ai-chat-settings` maestro test failed asserting it was visible. This scrolls the row into view before asserting/tapping it, and scrolls back up to the toggle before disabling. No app code changes — test-only.

### Testing Steps
1. Run the `ai-chat-settings` flow: `maestro test .maestro/release_tests/ai-chat-settings.yaml`.
2. Confirm it passes through enabling, disabling (section collapses), re-enabling, and tapping Duck.ai Settings to open duck.ai.

### Impact and Risks
Low — test-only change, no production code touched.

#### What could go wrong?
The row could fail to scroll into view on very small screens, but `scrollUntilVisible` retries until the timeout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Maestro YAML changes; no production app code is modified.
> 
> **Overview**
> Updates the **`ai-chat-settings`** Maestro release flow so it matches the native AI Features screen, where **Duck.ai Settings** lives in a lower **Duck.ai** section instead of directly under the main toggle.
> 
> The flow now **scrolls** to `Settings.AIFeatures.DuckAISettings` before visibility checks and taps, **scrolls up** to `Settings.AIFeatures.EnableToggle` before turning Duck.ai off, and adds **`waitForAnimationToEnd`** after toggle changes so collapsed/re-expanded sections are stable. Comments were refreshed to describe section collapse rather than a single hidden row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 835fe98eb40dee139cc6872e9b93a1342da7e172. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->