### PR TITLE
Bump ddg_apple_automation to 4.1.4 + one-off Asana update for 7.226.0

### DIFF
--- a/.github/workflows/ios_oneoff_update_asana_7226.yml
+++ b/.github/workflows/ios_oneoff_update_asana_7226.yml
@@ -1,0 +1,117 @@
+name: iOS - ONE-OFF Update Asana for 7.226.0
+
+# TEMPORARY one-off workflow. The "iOS - Tag Release and Update Asana" run for
+# 7.226.0+ios crashed in tag_release's report_status because github handle
+# "pballart" was missing from the user-id mapping (fixed in
+# fastlane-plugin-ddg_apple_automation 4.1.4). The tag, GitHub release and
+# branch deletion all succeeded, but every Asana update was skipped. This
+# workflow reproduces ONLY the skipped Asana steps. DELETE after running once.
+
+defaults:
+  run:
+    working-directory: iOS
+
+on:
+  workflow_dispatch:
+    inputs:
+      asana-task-url:
+        description: "7.226.0 release task URL"
+        required: true
+        default: "https://app.asana.com/1/137249556945/project/1214200115953388/task/1215899328995417?focus=true"
+        type: string
+      tag:
+        description: "Release tag"
+        required: true
+        default: "7.226.0+ios"
+        type: string
+      branch:
+        description: "Deleted release branch (for the 'tagged' comment)"
+        required: true
+        default: "release/ios/7.226.0"
+        type: string
+
+jobs:
+  update-asana:
+
+    name: Update Asana for 7.226.0
+
+    runs-on: macos-26-xlarge
+    timeout-minutes: 15
+
+    env:
+      TAG: ${{ github.event.inputs.tag }}
+      BRANCH: ${{ github.event.inputs.branch }}
+      asana-task-url: ${{ github.event.inputs.asana-task-url }}
+      RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.event.inputs.tag }}
+      WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+    steps:
+
+      - name: Check out main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Setup Ruby and dependencies
+        uses: ./.github/actions/setup-ruby
+        with:
+          working-directory: iOS
+          cache-key-prefix: ios-ruby
+
+      - name: Extract Asana Task ID
+        id: task-id
+        run: bundle exec fastlane run asana_extract_task_id task_url:"${{ env.asana-task-url }}"
+
+      # (0) Reproduce tag_release report_status: add actor as follower on the
+      #     Automation subtask and post the "release tagged" comment.
+      - name: Post 'release tagged' comment
+        env:
+          ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+        run: |
+          bundle exec fastlane run asana_log_message \
+            task_url:"${{ env.asana-task-url }}" \
+            template_name:"public-release-tagged" \
+            github_handle:"${{ github.actor }}"
+
+      # (1) Move release-tagged tasks to Done, complete them, create the
+      #     "Announce the release to the company" subtask.
+      - name: Update Asana for the release
+        env:
+          ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          bundle exec fastlane run update_asana_for_release \
+            platform:ios \
+            release_type:public \
+            github_handle:"${{ github.actor }}" \
+            release_task_id:"${{ steps.task-id.outputs.asana_task_id }}" \
+            target_section_id:"${{ vars.IOS_APP_BOARD_DONE_SECTION_ID }}" \
+            tag:"${{ env.TAG }}"
+
+      # (2) Post the public-release-complete comment on the release task.
+      - name: Add a comment to the release task
+        env:
+          ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+        run: |
+          bundle exec fastlane run asana_add_comment \
+            task_url:"${{ env.asana-task-url }}" \
+            template_name:"public-release-complete-ios"
+
+      # (3) Release annotation pixel.
+      - name: Send release annotation pixel
+        continue-on-error: true
+        uses: ./.github/actions/send-release-annotation-pixel
+        with:
+          version: ${{ env.TAG }}
+          platform: "ios"
+
+      # (4) Asana notification task in the Apple Deployments project.
+      - name: Create Asana notification task
+        continue-on-error: true
+        uses: ./.github/actions/send-release-notification-task
+        with:
+          platform: ios
+          tag: ${{ env.TAG }}
+          asana-project: ${{ vars.APPLE_DEPLOYMENTS_ASANA_PROJECT_ID }}
+          asana-section: ${{ vars.APPLE_DEPLOYMENTS_SECTION_ID }}
+          asana-access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/ios_oneoff_update_asana_7226.yml
+++ b/.github/workflows/ios_oneoff_update_asana_7226.yml
@@ -94,12 +94,14 @@ jobs:
             task_url:"${{ env.asana-task-url }}" \
             template_name:"public-release-complete-ios"
 
-      # (3) Release annotation pixel.
+      # (3) Release annotation pixel. Use the promoted tag to match the value
+      #     the real Tag Release workflow feeds this step (env.TAG there is the
+      #     promoted, build-numbered tag), keeping pixel names consistent.
       - name: Send release annotation pixel
         continue-on-error: true
         uses: ./.github/actions/send-release-annotation-pixel
         with:
-          version: ${{ env.TAG }}
+          version: ${{ env.PROMOTED_TAG }}
           platform: "ios"
 
       # (4) Asana notification task in the Apple Deployments project.

--- a/.github/workflows/ios_oneoff_update_asana_7226.yml
+++ b/.github/workflows/ios_oneoff_update_asana_7226.yml
@@ -19,11 +19,6 @@ on:
         required: true
         default: "https://app.asana.com/1/137249556945/project/1214200115953388/task/1215899328995417?focus=true"
         type: string
-      tag:
-        description: "Release tag"
-        required: true
-        default: "7.226.0+ios"
-        type: string
       branch:
         description: "Deleted release branch (for the 'tagged' comment)"
         required: true
@@ -39,10 +34,11 @@ jobs:
     timeout-minutes: 15
 
     env:
-      TAG: ${{ github.event.inputs.tag }}
+      TAG: "7.226.0+ios"
+      PROMOTED_TAG: "7.226.0-11+ios"
       BRANCH: ${{ github.event.inputs.branch }}
       asana-task-url: ${{ github.event.inputs.asana-task-url }}
-      RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.event.inputs.tag }}
+      RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/7.226.0+ios
       WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
     steps:
@@ -74,7 +70,8 @@ jobs:
             github_handle:"${{ github.actor }}"
 
       # (1) Move release-tagged tasks to Done, complete them, create the
-      #     "Announce the release to the company" subtask.
+      #     "Announce the release to the company" subtask. Use the promoted
+      #     tag here so the fastlane action derives Asana tag "ios-app-release-7.226.0".
       - name: Update Asana for the release
         env:
           ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
@@ -86,7 +83,7 @@ jobs:
             github_handle:"${{ github.actor }}" \
             release_task_id:"${{ steps.task-id.outputs.asana_task_id }}" \
             target_section_id:"${{ vars.IOS_APP_BOARD_DONE_SECTION_ID }}" \
-            tag:"${{ env.TAG }}"
+            tag:"${{ env.PROMOTED_TAG }}"
 
       # (2) Post the public-release-complete comment on the release task.
       - name: Add a comment to the release task

--- a/iOS/Gemfile.lock
+++ b/iOS/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: 296c4e8ca6e2fc6958857cdd5261ac584b9221e1
-  tag: 4.1.3
+  revision: c51aff9c682a93254ce654e36ec58404f596d6e1
+  tag: 4.1.4
   specs:
     fastlane-plugin-ddg_apple_automation (4.1.3)
       asana

--- a/iOS/fastlane/Pluginfile
+++ b/iOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '4.1.3'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '4.1.4'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214200115953388/task/1216108902675913?focus=true
Tech Design URL:
CC:

## Context

The `iOS - Tag Release and Update Asana` run for **7.226.0+ios** ([run](https://github.com/duckduckgo/apple-browsers/actions/runs/28366736095/job/84034374081)) crashed in `tag_release`'s `report_status`: github handle `pballart` was missing from the plugin's `github-asana-user-id-mapping.yml`, so `add_followers_for_task(followers: [nil])` failed with `Actor cannot be null`. The tag, GitHub release, and release-branch deletion all completed first — only the Asana automation was skipped.

## Changes

**Permanent (the real fix):**
- Bump `fastlane-plugin-ddg_apple_automation` 4.1.3 → **4.1.4** in `Pluginfile` + `Gemfile.lock`. 4.1.4 adds `pballart` to the mapping. `VERSION` is still `4.1.3` at the 4.1.4 tag, so only the git `revision`/`tag` change in the lock.

**Temporary (remove after running):**
- `ios_oneoff_update_asana_7226.yml` — a `workflow_dispatch` that reproduces **only** the Asana steps that were skipped, in order:
  1. `asana_log_message` → the "release tagged ✅" comment + adds the actor as follower (the step that originally crashed)
  2. `update_asana_for_release` → moves the release-tagged tasks to Done, completes them, creates the "Announce the release to the company" subtask
  3. `asana_add_comment` → the `public-release-complete-ios` comment on the release task
  4. release annotation pixel
  5. Asana notification task in the Apple Deployments project

`workflow_dispatch` requires the file on the default branch, hence merging it here. **Follow-up: delete `ios_oneoff_update_asana_7226.yml` once it has run successfully.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI dependency version and a documented one-off manual workflow; no app runtime or auth logic is modified.
> 
> **Overview**
> Fixes a failed **7.226.0+ios** tag-release run where Asana automation stopped after a missing GitHub→Asana user mapping for `pballart`, even though tagging and the GitHub release succeeded.
> 
> **Permanent:** `fastlane-plugin-ddg_apple_automation` is bumped **4.1.3 → 4.1.4** in `Pluginfile` and `Gemfile.lock` so future releases resolve that handle correctly.
> 
> **Temporary:** Adds `ios_oneoff_update_asana_7226.yml`, a manual `workflow_dispatch` that replays only the skipped Asana steps for 7.226.0 (tagged comment, `update_asana_for_release`, completion comment, annotation pixel, deployment notification task). The workflow file is intended to be **deleted after one successful run**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 185bf68fcf66e9409a24d771b5857730b49a2606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->