### PR TITLE
Add Maestro E2E flows for .vcf contact-links feature

### DIFF
--- a/.maestro/browser_features/vcf_contact_links_happy_path.yaml
+++ b/.maestro/browser_features/vcf_contact_links_happy_path.yaml
@@ -18,11 +18,15 @@ tags:
 - inputText: "https://privacy-test-pages.site/features/download/contact-full.vcf"
 - pressKey: Enter
 
-# CNContactViewController(forUnknownContact:) has no stable nav title, so assert
-# on the family name from the fixture (FN: Johnny Q. Appleseed). It only renders
-# on the contact card — the .vcf URL triggers a download, not a page render.
+# The native "Add to Contacts" card has appeared. We anchor on the card's Cancel
+# button accessibility id rather than the contact's name/fields: the iOS 26 system
+# Contacts UI renders its content in a remote view whose accessibility is only
+# intermittently captured by Maestro, whereas this app-owned nav-bar button is
+# reliably exposed. The id (vs the bare "Cancel" text) also disambiguates it from
+# the browser omnibar's own Cancel button.
 - extendedWaitUntil:
-    visible: "Appleseed"
+    visible:
+        id: "contactPreviewCancelButton"
     timeout: 10000
 
 # No parse-failure toast for a happy-path single contact.

--- a/.maestro/browser_features/vcf_contact_links_happy_path.yaml
+++ b/.maestro/browser_features/vcf_contact_links_happy_path.yaml
@@ -1,0 +1,29 @@
+# vcf_contact_links_happy_path.yaml
+# Single-VCARD .vcf file should present the native CNContactViewController
+# ("Add to Contacts" card) without a fallback toast.
+appId: com.duckduckgo.mobile.ios
+tags:
+    - iphone
+    - release
+
+---
+
+- runFlow:
+    file: ../shared/setup.yaml
+
+- assertVisible:
+    id: "searchEntry"
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://privacy-test-pages.site/features/download/contact-full.vcf"
+- pressKey: Enter
+
+# CNContactViewController(forUnknownContact:) has no stable nav title, so assert
+# on the family name from the fixture (FN: Johnny Q. Appleseed). It only renders
+# on the contact card — the .vcf URL triggers a download, not a page render.
+- extendedWaitUntil:
+    visible: "Appleseed"
+    timeout: 10000
+
+# No parse-failure toast for a happy-path single contact.
+- assertNotVisible: "Unable to add contact. Try opening the contact file from Downloads instead."

--- a/.maestro/browser_features/vcf_contact_links_multiple_contacts.yaml
+++ b/.maestro/browser_features/vcf_contact_links_multiple_contacts.yaml
@@ -1,0 +1,33 @@
+# vcf_contact_links_multiple_contacts.yaml
+# Multi-VCARD .vcf presents the FIRST contact's native card (the rest are
+# silently truncated). Unlike .ics multi-event, it does NOT fall back to QuickLook.
+appId: com.duckduckgo.mobile.ios
+tags:
+    - iphone
+    - release
+
+---
+
+- runFlow:
+    file: ../shared/setup.yaml
+
+- assertVisible:
+    id: "searchEntry"
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://privacy-test-pages.site/features/download/contact-multiple.vcf"
+- pressKey: Enter
+
+# contact-multiple.vcf holds Alice Smith, Bob Jones, Carol Garcia.
+# Only the first contact's card is presented.
+- extendedWaitUntil:
+    visible: "Alice Smith"
+    timeout: 10000
+
+# Truncation: the remaining contacts must not appear.
+- assertNotVisible: "Bob Jones"
+- assertNotVisible: "Carol Garcia"
+
+# Multi-contact .vcf shows the native card, not QuickLook (differs from .ics multi-event).
+- assertNotVisible:
+    id: "QLOverlayDoneButtonAccessibilityIdentifier"

--- a/.maestro/browser_features/vcf_contact_links_multiple_contacts.yaml
+++ b/.maestro/browser_features/vcf_contact_links_multiple_contacts.yaml
@@ -18,16 +18,18 @@ tags:
 - inputText: "https://privacy-test-pages.site/features/download/contact-multiple.vcf"
 - pressKey: Enter
 
-# contact-multiple.vcf holds Alice Smith, Bob Jones, Carol Garcia.
-# Only the first contact's card is presented.
+# contact-multiple.vcf holds Alice Smith, Bob Jones, Carol Garcia. A multi-contact
+# .vcf still presents a native "Add to Contacts" card (the first contact; the rest
+# are silently truncated during parsing). We anchor on the card's Cancel button id:
+# the system Contacts UI content isn't reliably captured by Maestro, and the card is
+# CNContactViewController(forUnknownContact:) for a single contact, so the other
+# names never render on it regardless.
 - extendedWaitUntil:
-    visible: "Alice Smith"
+    visible:
+        id: "contactPreviewCancelButton"
     timeout: 10000
 
-# Truncation: the remaining contacts must not appear.
-- assertNotVisible: "Bob Jones"
-- assertNotVisible: "Carol Garcia"
-
-# Multi-contact .vcf shows the native card, not QuickLook (differs from .ics multi-event).
+# The key behavioural difference from .ics multi-event: a multi-contact .vcf shows
+# the native card, NOT a QuickLook fallback.
 - assertNotVisible:
     id: "QLOverlayDoneButtonAccessibilityIdentifier"

--- a/.maestro/browser_features/vcf_contact_links_parse_failure.yaml
+++ b/.maestro/browser_features/vcf_contact_links_parse_failure.yaml
@@ -1,0 +1,27 @@
+# vcf_contact_links_parse_failure.yaml
+# A malformed .vcf is NOT previewed in QuickLook; the app shows the
+# parse-failure toast instead.
+appId: com.duckduckgo.mobile.ios
+tags:
+    - iphone
+    - release
+
+---
+
+- runFlow:
+    file: ../shared/setup.yaml
+
+- assertVisible:
+    id: "searchEntry"
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://privacy-test-pages.site/features/download/contact-malformed.vcf"
+- pressKey: Enter
+
+- extendedWaitUntil:
+    visible: "Unable to add contact. Try opening the contact file from Downloads instead."
+    timeout: 15000
+
+# QuickLook must not be presented for a malformed file.
+- assertNotVisible:
+    id: "QLOverlayDoneButtonAccessibilityIdentifier"

--- a/iOS/DuckDuckGo/Contacts/ContactPreviewHelper.swift
+++ b/iOS/DuckDuckGo/Contacts/ContactPreviewHelper.swift
@@ -35,11 +35,16 @@ enum ContactCardFactory {
         contactViewController.contactStore = CNContactStore()
         contactViewController.allowsActions = true
         contactViewController.delegate = delegate
-        contactViewController.navigationItem.leftBarButtonItem = UIBarButtonItem(
+        let cancelButton = UIBarButtonItem(
             barButtonSystemItem: .cancel,
             target: cancelTarget,
             action: cancelAction
         )
+        // Stable anchor for E2E tests: the system Contacts UI renders its content (name, fields) in
+        // a remote view whose accessibility is only intermittently captured, but this nav-bar button
+        // is app-owned and reliably exposed. Distinguishes the card from the browser omnibar's Cancel.
+        cancelButton.accessibilityIdentifier = "contactPreviewCancelButton"
+        contactViewController.navigationItem.leftBarButtonItem = cancelButton
         pixelFiring.fire(.vcardContactEditorPresented, withAdditionalParameters: [:])
         return UINavigationController(rootViewController: contactViewController)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1215172677539195/task/1215934268121039?focus=true
Tech Design URL:
CC:

### Description

The `.ics` calendar-links feature has four Maestro release flows (`.maestro/browser_features/ics_calendar_links_*.yaml`). The parallel `.vcf` contact-links feature (`ContactPreviewHelper`, behind the `vcardContactLinks` flag) shipped with unit tests but no E2E coverage. This adds matching flows (tagged `iphone` + `release`).

- **Happy path** (`vcf_contact_links_happy_path.yaml`) — single contact (`contact-full.vcf`) presents the native "Add to Contacts" card; asserts the parse-failure toast is not shown.
- **Multiple contacts** (`vcf_contact_links_multiple_contacts.yaml`) — multi-contact (`contact-multiple.vcf`) presents the card (first contact; the rest are truncated during parsing); asserts QuickLook is not shown. This differs from `.ics` multi-event, which falls back to QuickLook.
- **Parse failure** (`vcf_contact_links_parse_failure.yaml`) — malformed (`contact-malformed.vcf`) shows the toast "Unable to add contact. Try opening the contact file from Downloads instead."; asserts QuickLook is not shown.

### Testing Steps
1. Build the `iOS Browser` scheme to an iPhone simulator (iOS 26.x) with the `vcardContactLinks` flag enabled.
2. Run the flows, e.g. `maestro test .maestro/browser_features/vcf_contact_links_happy_path.yaml` (pass `-e ONBOARDING_COMPLETED=true`), and likewise for `vcf_contact_links_multiple_contacts.yaml` and `vcf_contact_links_parse_failure.yaml`.

Verified locally on iPhone 17 / iOS 26.4: all three pass, and the two card flows are 3/3 stable across repeated runs.

- [GH Workflow run](https://github.com/duckduckgo/apple-browsers/actions/runs/28859360304/job/85596445689)
- [Maestro](https://app.maestro.dev/project/proj_01jbvx6s96ewmaza6kdnhqctjc/maestro-test/app/app_01jbw1evv8evxswcf2ge5bncnt/upload/mupload_01kwy2t8seew7rh5rn1raw1qn1?sort=name)

### Impact and Risks

Low. The only product change is adding an `accessibilityIdentifier` to an existing bar-button item (no behavioural change); the rest is new test-only Maestro flows.

#### What could go wrong?
Nothing user-facing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Maestro flows plus a non-behavioral accessibility identifier on an existing Cancel button; no user-facing logic changes.
> 
> **Overview**
> Adds **release Maestro coverage** for the `.vcf` contact-links feature, mirroring the existing `.ics` calendar-link flows.
> 
> Three new flows navigate to privacy-test `.vcf` URLs and assert: single-contact shows the native Add to Contacts card (via `contactPreviewCancelButton`) with no parse-failure toast; multi-contact still shows that card (first contact only) and **not** QuickLook (unlike multi-event `.ics`); malformed files show the parse-failure toast and **not** QuickLook.
> 
> The only app change is assigning **`contactPreviewCancelButton`** to the contact card’s Cancel bar button in `ContactCardFactory` so Maestro can reliably detect the system contact UI without changing user-visible behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae8b941f759ac7b581e606a1aa70e0adcadeaefa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->