### PR TITLE
[iOS] Duck.ai: show the open-source icon for Tinfoil models (Gemma)

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatModelsService.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatModelsService.swift
@@ -176,12 +176,15 @@ public final class AIChatModelsService: AIChatModelsProviding {
         }
     }
 
+    /// The production AI Chat API origin, built from the canonical `URL.duckAIHost`.
+    public static let defaultBaseURL = URL(string: "https://\(URL.duckAIHost)")!
+
     private let baseURL: URL
     private let session: URLSession
     private let cookieProvider: AIChatCookieProviding
 
     public init(
-        baseURL: URL = URL(string: "https://duck.ai")!,
+        baseURL: URL = AIChatModelsService.defaultBaseURL,
         session: URLSession = .shared,
         cookieProvider: AIChatCookieProviding = WKHTTPCookieStoreProvider()
     ) {
@@ -264,7 +267,7 @@ extension AIChatModel.ModelProvider {
             return .meta
         } else if isMistralProvider {
             return .mistral
-        } else if id.contains("gpt-oss") {
+        } else if id.contains("gpt-oss") || normalizedProviderString == "tinfoil" {
             return .oss
         } else if normalizedProviderString == "anthropic" {
             return .anthropic

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatModelsServiceTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatModelsServiceTests.swift
@@ -762,6 +762,11 @@ final class AIChatModelsServiceTests: XCTestCase {
         XCTAssertEqual(provider, .oss)
     }
 
+    func testWhenProviderIsTinfoilForNonGptOssModel_ThenMapsToOSS() {
+        let provider = AIChatModel.ModelProvider.from(id: "tinfoil/gemma4-31b", providerString: "tinfoil")
+        XCTAssertEqual(provider, .oss)
+    }
+
     func testWhenProviderIsOpenAIString_ThenMapsToOpenAI() {
         let provider = AIChatModel.ModelProvider.from(id: "gpt-5", providerString: "openai")
         XCTAssertEqual(provider, .openAI)

--- a/iOS/DuckDuckGo/IPadOmnibarModelPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarModelPickerController.swift
@@ -36,12 +36,15 @@ final class IPadOmnibarModelPickerController {
     var onModelsUpdated: (() -> Void)?
 
     init(
-        modelsService: AIChatModelsProviding = AIChatModelsService(),
+        modelsService: AIChatModelsProviding? = nil,
         preferences: AIChatPreferencesPersisting = AIChatPreferencesPersistor(),
-        subscriptionManager: any SubscriptionManager = AppDependencyProvider.shared.subscriptionManager
+        subscriptionManager: any SubscriptionManager = AppDependencyProvider.shared.subscriptionManager,
+        aiChatSettings: AIChatSettingsProvider = AIChatSettings()
     ) {
         store = UTIModelStore(
-            modelsService: modelsService,
+            modelsService: modelsService ?? AIChatModelsService(
+                baseURL: aiChatModelsBaseURL(forChatURL: aiChatSettings.aiChatURL)
+            ),
             preferences: preferences,
             subscriptionManager: subscriptionManager
         )

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -380,7 +380,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         duckAiNativeStoragePixelFiring: DuckAiNativeStoragePixelFiring = DuckAiNativeStoragePixelAdapter(),
         lastUsedModelProvider: DuckAiLastUsedModelProviding? = nil,
         lastUsedReasoningModeProvider: DuckAiLastUsedReasoningModeProviding? = nil,
-        modelsService: AIChatModelsProviding = AIChatModelsService(),
+        modelsService: AIChatModelsProviding? = nil,
         preferences: AIChatPreferencesPersisting = AIChatPreferencesPersistor(),
         subscriptionManager: any SubscriptionManager = AppDependencyProvider.shared.subscriptionManager,
         toggleModeStorage: ToggleModeStoring = ToggleModeStorage(),
@@ -404,7 +404,9 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             toggleModeStorage: toggleModeStorage
         )
         self.modelStore = UTIModelStore(
-            modelsService: modelsService,
+            modelsService: modelsService ?? AIChatModelsService(
+                baseURL: aiChatModelsBaseURL(forChatURL: aiChatSettings.aiChatURL)
+            ),
             preferences: preferences,
             subscriptionManager: subscriptionManager
         )
@@ -2706,4 +2708,17 @@ extension UnifiedToggleInputCoordinator {
             }
             .store(in: &cancellables)
     }
+}
+
+/// Derives the AI Chat models API base (scheme + host) from the resolved chat URL, so `/models` is fetched
+/// from the same origin the chat loads from — production `duck.ai`, or a debug/dev host when the chat URL is
+/// overridden via Debug → "Set Custom AI Chat URL". Falls back to `AIChatModelsService.defaultBaseURL` if the
+/// chat URL lacks a host.
+func aiChatModelsBaseURL(forChatURL chatURL: URL) -> URL {
+    guard let scheme = chatURL.scheme, let host = chatURL.host else { return AIChatModelsService.defaultBaseURL }
+    var components = URLComponents()
+    components.scheme = scheme
+    components.host = host
+    components.port = chatURL.port
+    return components.url ?? AIChatModelsService.defaultBaseURL
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1216088573929232

### Description

When **Gemma 4** (`tinfoil/gemma4-31b`) is returned by the Duck.ai `/models` API, the native iOS model picker rendered it with **no icon** — the `tinfoil` provider fell through to `.unknown`, whose `menuIcon` is `nil`. This maps the `tinfoil` provider to the existing open-source (`.oss`) icon — the same glyph the web frontend uses for Gemma and `gpt-oss-120b` — so Gemma (and any other Tinfoil-hosted open-source model) renders with the correct icon.

Changes:
- Map the `tinfoil` provider to the `.oss` icon (`AIChatModel.ModelProvider.from`).
- Derive the `/models` base URL from the resolved chat URL (`aiChatModelsBaseURL`).
- Unit test for the provider mapping.

### Testing Steps

**Full end-to-end on the Gemma model (internal/staff — requires dev-server SSO)**
1. Settings → Debug → AI Chat → **Set Custom AI Chat URL** = `https://use-serp-dev-testing1.duck.ai/chat?duckai=4`
2. Open a Duck.ai chat and complete the SSO login (this establishes the session cookie).
3. Open the unified input → confirm **Gemma 4 31B** appears in the model picker with the open-source icon (same glyph as gpt-oss-120b).
4. Reset when done: Debug → AI Chat → Reset Custom URL.

### Impact and Risks

**Low.** The icon mapping is cosmetic. The `/models`-follows-chat-URL change is a no-op in production (chat host = `duck.ai` = models host); it only diverges when an internal debug URL override is set. No cookie or networking code is added — cookies are carried by the existing default provider.

#### What could go wrong?
- A future *non*-open-source Tinfoil-hosted model would also get the OSS icon. Acceptable today (gpt-oss-120b and Gemma are both open-source Tinfoil models); revisit if that changes.
- If the resolved chat URL lacks a host, the `/models` base falls back to `https://duck.ai`.

### Notes to Reviewer
- The model picker fetches on unified-input open, so the session cookie must already be present then (open the Duck.ai chat first in the dev-server test). For the shipped feature this is moot — Gemma goes public, no cookie needed.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic icon mapping and origin alignment for model fetch; production behavior stays on duck.ai unless a debug chat URL override is set.
> 
> **Overview**
> Fixes **missing model picker icons** for Tinfoil-hosted models (e.g. Gemma) by mapping provider **`tinfoil`** to **`.oss`**, matching **`gpt-oss`** and the web UI, instead of falling through to **`.unknown`** (no `menuIcon`).
> 
> **Models API base URL** is aligned with the chat the app loads: **`AIChatModelsService.defaultBaseURL`** uses **`URL.duckAIHost`**, and unified input / iPad omnibar construct the service with **`aiChatModelsBaseURL(forChatURL:)`** so **`duckchat/v1/models`** hits the same host as a **Debug → custom AI Chat URL** override (production unchanged).
> 
> Adds a unit test for **`tinfoil/gemma4-31b → .oss`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d1ce47f9c594a7f60aedd9424b17d27a1fbf49e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->