### PR TITLE
Add Duck.ai tool picker to the iPad address bar

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -991,6 +991,7 @@
 		91B67D60DCF5B9213184F1B9 /* NewAddressBarPickerRefreshContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0466F5E63C5ECC76F75718F8 /* NewAddressBarPickerRefreshContentView.swift */; };
 		925EB62CBE6C4A27B4E4A25A /* AIBoundaryNavigationDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD56A4878844306BD83E026 /* AIBoundaryNavigationDecision.swift */; };
 		9354C33177CC2A51CA978356 /* IPadOmnibarReasoningPickerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 883AAA241504625A0E8455C1 /* IPadOmnibarReasoningPickerController.swift */; };
+		7A11B0C0D0E0F00102030405 /* IPadOmnibarToolPickerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11B0C0D0E0F00102030406 /* IPadOmnibarToolPickerController.swift */; };
 		95C3B5788F2B2DA78E266C2A /* CalendarEventPreviewHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFDD2F8A58E59142D8FDD931 /* CalendarEventPreviewHelperTests.swift */; };
 		9710D4A12ED5B323006C14FF /* FadeOutContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9710D4A02ED5B323006C14FF /* FadeOutContainerViewController.swift */; };
 		9770D4A92F6AFD3F0029361F /* DuckAIVoiceShortcutFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9770D4A82F6AFD3F0029361F /* DuckAIVoiceShortcutFeature.swift */; };
@@ -2398,6 +2399,7 @@
 		E44F90F056A0488A976B6AFE /* FileCorruptErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E44F90E856A0488A976B6AFE /* FileCorruptErrorView.swift */; };
 		E53A32E13739A86D87B5FB44 /* SafariRedirectHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7594859CB2334A38D629EF5 /* SafariRedirectHandlerTests.swift */; };
 		E6B11AC3844012B6E947B7AA /* IPadOmnibarReasoningPickerControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E7EE5FF3B14EBB6C0AAB71A /* IPadOmnibarReasoningPickerControllerTests.swift */; };
+		7A11B0C0D0E0F00102030407 /* IPadOmnibarToolPickerControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11B0C0D0E0F00102030408 /* IPadOmnibarToolPickerControllerTests.swift */; };
 		E9D5A3B42C3D4E5F6A708192 /* AIChatRecentChatsPopupViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E6B4C53D4E5F6A70819203 /* AIChatRecentChatsPopupViewModelTests.swift */; };
 		EA39B7E2268A1A35000C62CD /* privacy-reference-tests in Resources */ = {isa = PBXBuildFile; fileRef = EA39B7E1268A1A35000C62CD /* privacy-reference-tests */; };
 		EA90A5267F61028E3525A81E /* RebrandedAppIconPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D67C082BD4927358D771DB /* RebrandedAppIconPicker.swift */; };
@@ -3646,9 +3648,11 @@
 		8693FFCAC02CE4A85D0BD62C /* RebrandedOnboardingView+BrowsersComparisonContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "RebrandedOnboardingView+BrowsersComparisonContent.swift"; sourceTree = "<group>"; };
 		87D22C154C1851EFAB573AAE /* TabSwipeOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSwipeOverlayView.swift; sourceTree = "<group>"; };
 		883AAA241504625A0E8455C1 /* IPadOmnibarReasoningPickerController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IPadOmnibarReasoningPickerController.swift; sourceTree = "<group>"; };
+		7A11B0C0D0E0F00102030406 /* IPadOmnibarToolPickerController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IPadOmnibarToolPickerController.swift; sourceTree = "<group>"; };
 		8C47244F2217A14B004C9B2D /* TabViewControllerSaveBookmarkExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabViewControllerSaveBookmarkExtension.swift; sourceTree = "<group>"; };
 		8C4838B4221C8F7F008A6739 /* GestureToolbarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GestureToolbarButton.swift; sourceTree = "<group>"; };
 		8E7EE5FF3B14EBB6C0AAB71A /* IPadOmnibarReasoningPickerControllerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IPadOmnibarReasoningPickerControllerTests.swift; sourceTree = "<group>"; };
+		7A11B0C0D0E0F00102030408 /* IPadOmnibarToolPickerControllerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IPadOmnibarToolPickerControllerTests.swift; sourceTree = "<group>"; };
 		970C8DE9831CD77A979A1354 /* RebrandedOnboardingView+SkipOnboardingContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "RebrandedOnboardingView+SkipOnboardingContent.swift"; sourceTree = "<group>"; };
 		9710D4A02ED5B323006C14FF /* FadeOutContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FadeOutContainerViewController.swift; sourceTree = "<group>"; };
 		9770D4A82F6AFD3F0029361F /* DuckAIVoiceShortcutFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAIVoiceShortcutFeature.swift; sourceTree = "<group>"; };
@@ -9724,6 +9728,7 @@
 				2D09A21E8CF1A9B32BC45E19 /* UnifiedToggleInputReasoningMenuFactoryTests.swift */,
 				E71D2723FF8B5622E2904F40 /* DuckAISubscriptionUpsellPresenterTests.swift */,
 				8E7EE5FF3B14EBB6C0AAB71A /* IPadOmnibarReasoningPickerControllerTests.swift */,
+				7A11B0C0D0E0F00102030408 /* IPadOmnibarToolPickerControllerTests.swift */,
 			);
 			path = UnifiedToggleInput;
 			sourceTree = "<group>";
@@ -11410,6 +11415,7 @@
 				6F922EE02D8C5C6B0062DFC1 /* URLSeparatorView.swift */,
 				6F9F62D22F86A4C20029CCEA /* MinimalChromeSettings.swift */,
 				883AAA241504625A0E8455C1 /* IPadOmnibarReasoningPickerController.swift */,
+				7A11B0C0D0E0F00102030406 /* IPadOmnibarToolPickerController.swift */,
 			);
 			name = OmniBar;
 			sourceTree = "<group>";
@@ -14008,6 +14014,7 @@
 				8AA7DA9074610EBDBF3FAA34 /* UnifiedToggleInputReasoningMenuFactory.swift in Sources */,
 				06D744C1F541FF4F91F7A664 /* DuckAISubscriptionUpsellPresenter.swift in Sources */,
 				9354C33177CC2A51CA978356 /* IPadOmnibarReasoningPickerController.swift in Sources */,
+				7A11B0C0D0E0F00102030405 /* IPadOmnibarToolPickerController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14531,6 +14538,7 @@
 				88CED5F7656BFDD8D99B3CA0 /* UnifiedToggleInputReasoningMenuFactoryTests.swift in Sources */,
 				BE83A575896316C700B212FA /* DuckAISubscriptionUpsellPresenterTests.swift in Sources */,
 				E6B11AC3844012B6E947B7AA /* IPadOmnibarReasoningPickerControllerTests.swift in Sources */,
+				7A11B0C0D0E0F00102030407 /* IPadOmnibarToolPickerControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -470,6 +470,49 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         isReasoningPickerEnabled && aiChatReasoningIcon != nil
     }
 
+    let toolPickerButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.accessibilityIdentifier = "AIChat.Omnibar.iPad.ToolPicker"
+        button.accessibilityLabel = UserText.aiChatToolbarToolsButtonAccessibilityLabel
+        button.setImage(DesignSystemImages.Glyphs.Size24.options, for: .normal)
+        button.tintColor = UIColor(designSystemColor: .iconsSecondary)
+        button.isHidden = true
+        button.setContentHuggingPriority(.required, for: .horizontal)
+        button.setContentCompressionResistancePriority(.required, for: .horizontal)
+        if #available(iOS 16.0, *) {
+            button.preferredMenuElementOrder = .fixed
+        }
+        return button
+    }()
+
+    /// Enables the tool picker chip (driven by the `iPadDuckAIBarControls` flag).
+    var isToolPickerEnabled: Bool = false {
+        didSet { refreshToolPickerVisibility() }
+    }
+
+    /// The pull-down menu listing selectable tools. Setting it enables the chip's primary action;
+    /// setting it nil hides the chip — i.e. when the selected model offers no tools.
+    var aiChatToolPickerMenu: UIMenu? {
+        get { toolPickerButton.menu }
+        set {
+            toolPickerButton.menu = newValue
+            toolPickerButton.showsMenuAsPrimaryAction = (newValue != nil)
+            refreshToolPickerVisibility()
+        }
+    }
+
+    /// Whether a tool is currently selected — tints the chip to signal the active state.
+    var isToolSelected: Bool = false {
+        didSet {
+            toolPickerButton.tintColor = UIColor(designSystemColor: isToolSelected ? .accentPrimary : .iconsSecondary)
+        }
+    }
+
+    private var canShowToolPicker: Bool {
+        isToolPickerEnabled && toolPickerButton.menu != nil
+    }
+
     let aiChatTextView: UITextView = {
         let textView = UITextView()
         textView.translatesAutoresizingMaskIntoConstraints = false
@@ -578,6 +621,7 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         searchAreaContainerView.addSubview(aiChatSendButton)
         searchAreaContainerView.addSubview(modelPickerButton)
         searchAreaContainerView.addSubview(reasoningPickerButton)
+        searchAreaContainerView.addSubview(toolPickerButton)
         searchAreaContainerView.addSubview(aiChatLeftButton)
 
         addSubview(activeOutlineView)
@@ -968,7 +1012,7 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
 
     private func overflowTarget(at point: CGPoint, with event: UIEvent?) -> UIView? {
         guard isSearchAreaExpanded else { return nil }
-        let candidates: [UIView] = [aiChatSendButton, modelPickerButton, reasoningPickerButton, aiChatTextView]
+        let candidates: [UIView] = [aiChatSendButton, modelPickerButton, reasoningPickerButton, toolPickerButton, aiChatTextView]
         return candidates.first { candidate in
             guard !candidate.isHidden else { return false }
             let localPoint = candidate.convert(point, from: self)
@@ -1130,6 +1174,9 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         // Duck.ai reasoning picker chip (iPad), icon-only, sits to the left of the model chip.
         static let reasoningPickerChipSize: CGFloat = 40.0
         static let reasoningToModelPickerSpacing: CGFloat = 4.0
+
+        // Duck.ai tool picker chip (iPad), icon-only, pinned to the far left of the controls row.
+        static let toolPickerChipSize: CGFloat = 40.0
 
         static let expandedPadSizeSpacing: CGFloat = 24.0
         static let expandedPadSizeMargins = NSDirectionalEdgeInsets(
@@ -1393,6 +1440,12 @@ extension DefaultOmniBarView {
             reasoningPickerButton.widthAnchor.constraint(equalToConstant: Metrics.reasoningPickerChipSize),
             reasoningPickerButton.heightAnchor.constraint(equalToConstant: Metrics.reasoningPickerChipSize),
             reasoningPickerButton.leadingAnchor.constraint(greaterThanOrEqualTo: aiChatTextView.leadingAnchor),
+
+            // Pinned to the far left of the controls row — the mirror image of the send button.
+            toolPickerButton.leadingAnchor.constraint(equalTo: searchAreaContainerView.leadingAnchor, constant: Metrics.duckAITextViewBottomPadding),
+            toolPickerButton.centerYAnchor.constraint(equalTo: aiChatSendButton.centerYAnchor),
+            toolPickerButton.widthAnchor.constraint(equalToConstant: Metrics.toolPickerChipSize),
+            toolPickerButton.heightAnchor.constraint(equalToConstant: Metrics.toolPickerChipSize),
         ])
 
         let bottomEqual = searchAreaStackView.bottomAnchor.constraint(equalTo: searchAreaAlignmentView.bottomAnchor)
@@ -1435,10 +1488,12 @@ extension DefaultOmniBarView {
             aiChatSendButton.alpha = isSearchAreaExpanded ? 1 : 0
             modelPickerButton.alpha = (isSearchAreaExpanded && canShowModelPicker) ? 1 : 0
             reasoningPickerButton.alpha = (isSearchAreaExpanded && canShowReasoningPicker) ? 1 : 0
+            toolPickerButton.alpha = (isSearchAreaExpanded && canShowToolPicker) ? 1 : 0
             if !isSearchAreaExpanded {
                 aiChatSendButton.isHidden = true
                 modelPickerButton.isHidden = true
                 reasoningPickerButton.isHidden = true
+                toolPickerButton.isHidden = true
             }
             applyExpansionConstraints()
             applyExpansionClipping()
@@ -1473,11 +1528,13 @@ extension DefaultOmniBarView {
                 self.aiChatSendButton.alpha = 1
                 self.modelPickerButton.alpha = self.canShowModelPicker ? 1 : 0
                 self.reasoningPickerButton.alpha = self.canShowReasoningPicker ? 1 : 0
+                self.toolPickerButton.alpha = self.canShowToolPicker ? 1 : 0
             } else {
                 self.searchAreaContainerView.applyShadowOpacityMultiplier(0)
                 self.aiChatSendButton.alpha = 0
                 self.modelPickerButton.alpha = 0
                 self.reasoningPickerButton.alpha = 0
+                self.toolPickerButton.alpha = 0
             }
             self.layoutIfNeeded()
         } completion: { _ in
@@ -1487,6 +1544,7 @@ extension DefaultOmniBarView {
                 self.aiChatSendButton.isHidden = true
                 self.modelPickerButton.isHidden = true
                 self.reasoningPickerButton.isHidden = true
+                self.toolPickerButton.isHidden = true
                 self.onCollapseAnimationCompleted?()
                 self.onCollapseAnimationCompleted = nil
             } else {
@@ -1522,6 +1580,12 @@ extension DefaultOmniBarView {
                 reasoningPickerButton.isHidden = false
                 reasoningPickerButton.alpha = 0
                 searchAreaContainerView.bringSubviewToFront(reasoningPickerButton)
+            }
+
+            if canShowToolPicker {
+                toolPickerButton.isHidden = false
+                toolPickerButton.alpha = 0
+                searchAreaContainerView.bringSubviewToFront(toolPickerButton)
             }
         } else {
             let currentText = aiChatTextView.text ?? ""
@@ -1562,6 +1626,20 @@ extension DefaultOmniBarView {
         searchAreaContainerView.bringSubviewToFront(reasoningPickerButton)
         UIView.animate(withDuration: Metrics.expansionAnimationDuration) {
             self.reasoningPickerButton.alpha = 1
+        }
+    }
+
+    private func refreshToolPickerVisibility() {
+        guard isSearchAreaExpanded, canShowToolPicker else {
+            toolPickerButton.isHidden = true
+            return
+        }
+        guard toolPickerButton.isHidden else { return }
+        toolPickerButton.isHidden = false
+        toolPickerButton.alpha = 0
+        searchAreaContainerView.bringSubviewToFront(toolPickerButton)
+        UIView.animate(withDuration: Metrics.expansionAnimationDuration) {
+            self.toolPickerButton.alpha = 1
         }
     }
 

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -1174,8 +1174,6 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         // Duck.ai reasoning picker chip (iPad), icon-only, sits to the left of the model chip.
         static let reasoningPickerChipSize: CGFloat = 40.0
         static let reasoningToModelPickerSpacing: CGFloat = 4.0
-
-        // Duck.ai tool picker chip (iPad), icon-only, pinned to the far left of the controls row.
         static let toolPickerChipSize: CGFloat = 40.0
 
         static let expandedPadSizeSpacing: CGFloat = 24.0
@@ -1441,7 +1439,6 @@ extension DefaultOmniBarView {
             reasoningPickerButton.heightAnchor.constraint(equalToConstant: Metrics.reasoningPickerChipSize),
             reasoningPickerButton.leadingAnchor.constraint(greaterThanOrEqualTo: aiChatTextView.leadingAnchor),
 
-            // Pinned to the far left of the controls row — the mirror image of the send button.
             toolPickerButton.leadingAnchor.constraint(equalTo: searchAreaContainerView.leadingAnchor, constant: Metrics.duckAITextViewBottomPadding),
             toolPickerButton.centerYAnchor.constraint(equalTo: aiChatSendButton.centerYAnchor),
             toolPickerButton.widthAnchor.constraint(equalToConstant: Metrics.toolPickerChipSize),

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -484,6 +484,7 @@ extension DefaultOmniBarViewController {
                 omniBarView.setSearchAreaExpanded(false, animated: false)
                 omniBarView.aiChatTextView.resignFirstResponder()
                 omniDelegate?.onPromptSubmitted(query, tools: nil)
+                toolPickerController?.resetSelection()
             }
         } else {
             omniDelegate?.onOmniQuerySubmitted(query)

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -48,11 +48,13 @@ final class DefaultOmniBarViewController: OmniBarViewController {
     private let modeToggleTextModel: IPadModeToggleTextModeling = IPadModeToggleTextModel()
     private var modelPickerController: IPadOmnibarModelPickerController?
     private var reasoningPickerController: IPadOmnibarReasoningPickerController?
+    private var toolPickerController: IPadOmnibarToolPickerController?
 
     override var iPadDuckAIControlValues: IPadDuckAIControlValues {
         IPadDuckAIControlValuesSnapshot(
             selectedModelId: modelPickerController?.currentModelId,
-            selectedReasoningEffort: reasoningPickerController?.selectedReasoningEffort
+            selectedReasoningEffort: reasoningPickerController?.selectedReasoningEffort,
+            selectedTools: toolPickerController?.selectedToolsForSubmission
         )
     }
 
@@ -580,28 +582,41 @@ extension DefaultOmniBarViewController {
         let controller = IPadOmnibarModelPickerController()
         modelPickerController = controller
 
-        // The reasoning picker shares the model picker's store so both chips reflect the same
-        // selected model and a single `/models` fetch.
+        // The reasoning and tool pickers share the model picker's store so all chips reflect the
+        // same selected model and a single `/models` fetch.
         let reasoningController = IPadOmnibarReasoningPickerController(store: controller.modelStore)
         reasoningPickerController = reasoningController
         reasoningController.onReasoningUpdated = { [weak self] in
             self?.refreshReasoningPicker()
         }
 
+        let toolController = IPadOmnibarToolPickerController(store: controller.modelStore)
+        toolPickerController = toolController
+        toolController.onToolsUpdated = { [weak self] in
+            // Tool selection can toggle the reasoning picker's visibility (image generation hides
+            // it), so refresh both chips together.
+            self?.refreshToolPicker()
+            self?.refreshReasoningPicker()
+        }
+
         controller.onModelsUpdated = { [weak self] in
             guard let self else { return }
             // Re-apply any model/reasoning selection unblocked by a subscription refresh, then
-            // refresh both chips (selecting a new model changes which reasoning modes apply).
+            // refresh every chip (a new model changes which reasoning modes and tools apply).
             self.modelPickerController?.handleModelsUpdated()
             self.reasoningPickerController?.handleModelsUpdated()
+            self.toolPickerController?.handleModelChanged()
             self.refreshModelPicker()
             self.refreshReasoningPicker()
+            self.refreshToolPicker()
         }
 
         omniBarView.isModelPickerEnabled = true
         omniBarView.aiChatModelName = controller.currentModelLabel
         omniBarView.isReasoningPickerEnabled = true
+        omniBarView.isToolPickerEnabled = true
         refreshReasoningPicker()
+        refreshToolPicker()
     }
 
     private func handleModelPickerExpansionChanged(isExpanded: Bool) {
@@ -609,6 +624,7 @@ extension DefaultOmniBarViewController {
         controller.activate()
         refreshModelPicker()
         refreshReasoningPicker()
+        refreshToolPicker()
     }
 
     private func refreshModelPicker() {
@@ -618,21 +634,40 @@ extension DefaultOmniBarViewController {
             omniBarView.aiChatModelName = shortName
         }
         omniBarView.aiChatModelPickerMenu = controller.makeMenu { [weak self] modelId in
-            self?.modelPickerController?.handleModelSelection(modelId)
-            self?.refreshModelPicker()
-            self?.refreshReasoningPicker()
+            guard let self else { return }
+            self.modelPickerController?.handleModelSelection(modelId)
+            // A new model may support a different set of tools, so clear any now-unsupported tool.
+            self.toolPickerController?.handleModelChanged()
+            self.refreshModelPicker()
+            self.refreshReasoningPicker()
+            self.refreshToolPicker()
         }
     }
 
     private func refreshReasoningPicker() {
         guard let controller = reasoningPickerController else { return }
 
-        if controller.isReasoningPickerAvailable {
+        // Match the iPhone behavior: the reasoning picker is hidden while a tool that suppresses it
+        // (image generation) is selected.
+        let hiddenByTool = toolPickerController?.selectedToolHidesReasoningPicker ?? false
+        if controller.isReasoningPickerAvailable, !hiddenByTool {
             omniBarView.aiChatReasoningIcon = controller.currentReasoningMode?.unifiedToggleInputButtonImage
             omniBarView.aiChatReasoningPickerMenu = controller.makeMenu()
         } else {
             omniBarView.aiChatReasoningIcon = nil
             omniBarView.aiChatReasoningPickerMenu = nil
+        }
+    }
+
+    private func refreshToolPicker() {
+        guard let controller = toolPickerController else { return }
+
+        if controller.isToolPickerAvailable {
+            omniBarView.aiChatToolPickerMenu = controller.makeMenu()
+            omniBarView.isToolSelected = controller.isToolSelected
+        } else {
+            omniBarView.aiChatToolPickerMenu = nil
+            omniBarView.isToolSelected = false
         }
     }
 }

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -594,8 +594,6 @@ extension DefaultOmniBarViewController {
         let toolController = IPadOmnibarToolPickerController(store: controller.modelStore)
         toolPickerController = toolController
         toolController.onToolsUpdated = { [weak self] in
-            // Tool selection can toggle the reasoning picker's visibility (image generation hides
-            // it), so refresh both chips together.
             self?.refreshToolPicker()
             self?.refreshReasoningPicker()
         }
@@ -637,7 +635,6 @@ extension DefaultOmniBarViewController {
         omniBarView.aiChatModelPickerMenu = controller.makeMenu { [weak self] modelId in
             guard let self else { return }
             self.modelPickerController?.handleModelSelection(modelId)
-            // A new model may support a different set of tools, so clear any now-unsupported tool.
             self.toolPickerController?.handleModelChanged()
             self.refreshModelPicker()
             self.refreshReasoningPicker()
@@ -648,8 +645,6 @@ extension DefaultOmniBarViewController {
     private func refreshReasoningPicker() {
         guard let controller = reasoningPickerController else { return }
 
-        // Match the iPhone behavior: the reasoning picker is hidden while a tool that suppresses it
-        // (image generation) is selected.
         let hiddenByTool = toolPickerController?.selectedToolHidesReasoningPicker ?? false
         if controller.isReasoningPickerAvailable, !hiddenByTool {
             omniBarView.aiChatReasoningIcon = controller.currentReasoningMode?.unifiedToggleInputButtonImage

--- a/iOS/DuckDuckGo/IPadDuckAIControlValues.swift
+++ b/iOS/DuckDuckGo/IPadDuckAIControlValues.swift
@@ -28,6 +28,10 @@ protocol IPadDuckAIControlValues {
 
     /// The Duck.ai reasoning effort selected in the iPad address-bar reasoning picker, or `nil`.
     var selectedReasoningEffort: AIChatReasoningEffort? { get }
+
+    /// The Duck.ai tools selected in the iPad address-bar tool picker, or `nil` when no tool is
+    /// selected or the picker is inactive.
+    var selectedTools: [AIChatRAGTool]? { get }
 }
 
 /// A concrete snapshot of `IPadDuckAIControlValues`. Every value defaults to `nil`, so callers
@@ -35,4 +39,5 @@ protocol IPadDuckAIControlValues {
 struct IPadDuckAIControlValuesSnapshot: IPadDuckAIControlValues {
     var selectedModelId: String?
     var selectedReasoningEffort: AIChatReasoningEffort?
+    var selectedTools: [AIChatRAGTool]?
 }

--- a/iOS/DuckDuckGo/IPadOmnibarToolPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarToolPickerController.swift
@@ -104,6 +104,12 @@ final class IPadOmnibarToolPickerController {
         onToolsUpdated?()
     }
 
+    func resetSelection() {
+        guard toolsController.selectedTool != nil else { return }
+        toolsController.clearSelection()
+        onToolsUpdated?()
+    }
+
     // MARK: - Private
 
     private var presentation: UTIToolsController.Presentation {

--- a/iOS/DuckDuckGo/IPadOmnibarToolPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarToolPickerController.swift
@@ -1,0 +1,124 @@
+//
+//  IPadOmnibarToolPickerController.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import UIKit
+
+/// Drives the Duck.ai tool picker shown on the far left of the iPad address bar's expanded
+/// AI-chat input area.
+///
+/// Like the sibling `IPadOmnibarModelPickerController` and `IPadOmnibarReasoningPickerController`,
+/// this is a thin wrapper around the shared UnifiedToggleInput tool components
+/// (`UTIToolsController` + `UTIToolsMenuFactory`) so tools behave identically to the iPhone
+/// Duck.ai bar. Tools are gated purely by the selected model's capabilities (no subscription
+/// upsell), so this controller is simpler than the model / reasoning pickers. It shares the model
+/// picker's `UTIModelStore` so a single `/models` fetch drives tool-support gating for every chip.
+@MainActor
+final class IPadOmnibarToolPickerController {
+
+    private let store: UTIModelStore
+    private let toolsController = UTIToolsController()
+    private let menuFactory = UTIToolsMenuFactory()
+
+    /// The iPad address bar is an omnibar surface (never an AI tab), so the tools menu never
+    /// offers the AI-tab-only "Customize Responses" action.
+    private let displayState: UnifiedToggleInputDisplayState = .omnibar(.active)
+
+    /// Invoked whenever the tool selection changes so the host can refresh the chip (tint and
+    /// menu) and re-evaluate the reasoning picker's visibility.
+    var onToolsUpdated: (() -> Void)?
+
+    init(store: UTIModelStore) {
+        self.store = store
+    }
+
+    /// Whether the tools button should be shown — i.e. the selected model offers at least one
+    /// actionable tool (mirrors the iPhone presentation rule for the omnibar surface).
+    var isToolPickerAvailable: Bool {
+        !presentation.isToolsButtonHidden
+    }
+
+    /// Whether a tool is currently selected — drives the chip's active tint.
+    var isToolSelected: Bool {
+        toolsController.selectedTool != nil
+    }
+
+    /// Whether the currently selected tool hides the reasoning picker (image generation), so the
+    /// host can match the iPhone behavior of hiding reasoning while image generation is active.
+    var selectedToolHidesReasoningPicker: Bool {
+        guard let tool = toolsController.selectedTool,
+              let identifier = UTIToolsMenu.Item.Identifier(tool: tool) else { return false }
+        return identifier.hidesReasoningPicker
+    }
+
+    /// The tools to forward at submission (the single selected tool wrapped in an array, or `nil`).
+    var selectedToolsForSubmission: [AIChatRAGTool]? {
+        toolsController.selectedToolsForSubmission()
+    }
+
+    func makeMenu() -> UIMenu? {
+        guard let toolsMenu = presentation.toolsMenu else { return nil }
+        return menuFactory.makeMenu(toolsMenu) { [weak self] identifier in
+            self?.handleToolSelection(identifier)
+        }
+    }
+
+    func handleToolSelection(_ identifier: UTIToolsMenu.Item.Identifier) {
+        let tool: AIChatRAGTool
+        switch identifier {
+        case .webSearch:
+            tool = .webSearch
+        case .imageGeneration:
+            tool = .imageGeneration
+        case .customizeResponses:
+            // Never offered on the omnibar surface — nothing to toggle.
+            return
+        }
+
+        let previousTool = toolsController.selectedTool
+        toolsController.toggleSelection(for: tool, modelStore: store)
+        fireToggleTransitionPixel(previous: previousTool, current: toolsController.selectedTool)
+        onToolsUpdated?()
+    }
+
+    /// Call when the selected model changes so a tool the new model doesn't support is cleared
+    /// (mirrors the iPhone `UTIToolsController.clearSelectionIfUnsupported`).
+    func handleModelChanged() {
+        toolsController.clearSelectionIfUnsupported(for: store)
+        onToolsUpdated?()
+    }
+
+    // MARK: - Private
+
+    private var presentation: UTIToolsController.Presentation {
+        toolsController.presentation(displayState: displayState, modelStore: store)
+    }
+
+    /// Mirrors the iPhone coordinator's `fireToolToggleTransitionPixel`: a deselect pixel for the
+    /// outgoing tool and a select pixel for the incoming one.
+    private func fireToggleTransitionPixel(previous: AIChatRAGTool?, current: AIChatRAGTool?) {
+        guard previous != current else { return }
+        if let previous, current == nil || current != previous {
+            UnifiedToggleInputCoordinatorPixelHelper.fireToolDeselectedPixel(for: previous)
+        }
+        if let current {
+            UnifiedToggleInputCoordinatorPixelHelper.fireToolSelectedPixel(for: current)
+        }
+    }
+}

--- a/iOS/DuckDuckGo/IPadOmnibarToolPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarToolPickerController.swift
@@ -22,52 +22,34 @@ import UIKit
 
 /// Drives the Duck.ai tool picker shown on the far left of the iPad address bar's expanded
 /// AI-chat input area.
-///
-/// Like the sibling `IPadOmnibarModelPickerController` and `IPadOmnibarReasoningPickerController`,
-/// this is a thin wrapper around the shared UnifiedToggleInput tool components
-/// (`UTIToolsController` + `UTIToolsMenuFactory`) so tools behave identically to the iPhone
-/// Duck.ai bar. Tools are gated purely by the selected model's capabilities (no subscription
-/// upsell), so this controller is simpler than the model / reasoning pickers. It shares the model
-/// picker's `UTIModelStore` so a single `/models` fetch drives tool-support gating for every chip.
+
 @MainActor
 final class IPadOmnibarToolPickerController {
 
     private let store: UTIModelStore
     private let toolsController = UTIToolsController()
     private let menuFactory = UTIToolsMenuFactory()
-
-    /// The iPad address bar is an omnibar surface (never an AI tab), so the tools menu never
-    /// offers the AI-tab-only "Customize Responses" action.
     private let displayState: UnifiedToggleInputDisplayState = .omnibar(.active)
-
-    /// Invoked whenever the tool selection changes so the host can refresh the chip (tint and
-    /// menu) and re-evaluate the reasoning picker's visibility.
     var onToolsUpdated: (() -> Void)?
 
     init(store: UTIModelStore) {
         self.store = store
     }
 
-    /// Whether the tools button should be shown — i.e. the selected model offers at least one
-    /// actionable tool (mirrors the iPhone presentation rule for the omnibar surface).
     var isToolPickerAvailable: Bool {
         !presentation.isToolsButtonHidden
     }
 
-    /// Whether a tool is currently selected — drives the chip's active tint.
     var isToolSelected: Bool {
         toolsController.selectedTool != nil
     }
 
-    /// Whether the currently selected tool hides the reasoning picker (image generation), so the
-    /// host can match the iPhone behavior of hiding reasoning while image generation is active.
     var selectedToolHidesReasoningPicker: Bool {
         guard let tool = toolsController.selectedTool,
               let identifier = UTIToolsMenu.Item.Identifier(tool: tool) else { return false }
         return identifier.hidesReasoningPicker
     }
 
-    /// The tools to forward at submission (the single selected tool wrapped in an array, or `nil`).
     var selectedToolsForSubmission: [AIChatRAGTool]? {
         toolsController.selectedToolsForSubmission()
     }
@@ -87,7 +69,6 @@ final class IPadOmnibarToolPickerController {
         case .imageGeneration:
             tool = .imageGeneration
         case .customizeResponses:
-            // Never offered on the omnibar surface — nothing to toggle.
             return
         }
 
@@ -97,8 +78,6 @@ final class IPadOmnibarToolPickerController {
         onToolsUpdated?()
     }
 
-    /// Call when the selected model changes so a tool the new model doesn't support is cleared
-    /// (mirrors the iPhone `UTIToolsController.clearSelectionIfUnsupported`).
     func handleModelChanged() {
         toolsController.clearSelectionIfUnsupported(for: store)
         onToolsUpdated?()
@@ -116,8 +95,6 @@ final class IPadOmnibarToolPickerController {
         toolsController.presentation(displayState: displayState, modelStore: store)
     }
 
-    /// Mirrors the iPhone coordinator's `fireToolToggleTransitionPixel`: a deselect pixel for the
-    /// outgoing tool and a select pixel for the incoming one.
     private func fireToggleTransitionPixel(previous: AIChatRAGTool?, current: AIChatRAGTool?) {
         guard previous != current else { return }
         if let previous, current == nil || current != previous {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3935,8 +3935,6 @@ extension MainViewController: OmniBarDelegate {
         commitToggleMode(.aiChat)
         
         let controlValues = viewCoordinator.omniBar.iPadDuckAIControlValues
-        // `tools` is supplied by the iPhone editing-state path; the iPad tool picker supplies its
-        // selection via the control-values snapshot. The two surfaces never both provide tools.
         openAIChat(query, autoSend: true, tools: tools ?? controlValues.selectedTools,
                    modelId: controlValues.selectedModelId,
                    reasoningEffort: controlValues.selectedReasoningEffort)

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3935,7 +3935,9 @@ extension MainViewController: OmniBarDelegate {
         commitToggleMode(.aiChat)
         
         let controlValues = viewCoordinator.omniBar.iPadDuckAIControlValues
-        openAIChat(query, autoSend: true, tools: tools,
+        // `tools` is supplied by the iPhone editing-state path; the iPad tool picker supplies its
+        // selection via the control-values snapshot. The two surfaces never both provide tools.
+        openAIChat(query, autoSend: true, tools: tools ?? controlValues.selectedTools,
                    modelId: controlValues.selectedModelId,
                    reasoningEffort: controlValues.selectedReasoningEffort)
     }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarToolPickerControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarToolPickerControllerTests.swift
@@ -1,0 +1,208 @@
+//
+//  IPadOmnibarToolPickerControllerTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import Combine
+import SubscriptionTestingUtilities
+import UIKit
+import XCTest
+@testable import DuckDuckGo
+
+@MainActor
+final class IPadOmnibarToolPickerControllerTests: XCTestCase {
+
+    private var sut: IPadOmnibarToolPickerController!
+    private var store: UTIModelStore!
+    private var preferences: StubToolPreferences!
+
+    override func setUp() {
+        super.setUp()
+        preferences = StubToolPreferences()
+        store = UTIModelStore(
+            modelsService: StubModelsService(),
+            preferences: preferences,
+            subscriptionManager: SubscriptionManagerMock()
+        )
+        sut = IPadOmnibarToolPickerController(store: store)
+    }
+
+    override func tearDown() {
+        sut = nil
+        store = nil
+        preferences = nil
+        super.tearDown()
+    }
+
+    // MARK: - Availability
+
+    func testWhenModelSupportsAToolThenAvailableWithMenu() {
+        store.models = [makeModel(id: "gpt-5.2", supportedTools: [.webSearch])]
+
+        XCTAssertTrue(sut.isToolPickerAvailable)
+        XCTAssertNotNil(sut.makeMenu())
+    }
+
+    func testWhenModelSupportsNoToolsThenNotAvailable() {
+        store.models = [makeModel(id: "gpt-oss", supportedTools: [])]
+
+        XCTAssertFalse(sut.isToolPickerAvailable)
+        XCTAssertNil(sut.makeMenu())
+    }
+
+    func testWhenNoModelsThenNotAvailableAndMenuNil() {
+        XCTAssertFalse(sut.isToolPickerAvailable)
+        XCTAssertNil(sut.makeMenu())
+    }
+
+    // MARK: - Selection
+
+    func testWhenSupportedToolSelectedThenForwardedForSubmission() {
+        store.models = [makeModel(id: "gpt-5.2", supportedTools: [.webSearch])]
+
+        sut.handleToolSelection(.webSearch)
+
+        XCTAssertEqual(sut.selectedToolsForSubmission, [.webSearch])
+        XCTAssertTrue(sut.isToolSelected)
+    }
+
+    func testWhenSelectedToolToggledOffThenCleared() {
+        store.models = [makeModel(id: "gpt-5.2", supportedTools: [.webSearch])]
+
+        sut.handleToolSelection(.webSearch)
+        sut.handleToolSelection(.webSearch)
+
+        XCTAssertNil(sut.selectedToolsForSubmission)
+        XCTAssertFalse(sut.isToolSelected)
+    }
+
+    func testWhenSwitchingToolsThenOnlyLatestSelected() {
+        store.models = [makeModel(id: "gpt-5.2", supportedTools: [.webSearch, .imageGeneration])]
+
+        sut.handleToolSelection(.webSearch)
+        sut.handleToolSelection(.imageGeneration)
+
+        XCTAssertEqual(sut.selectedToolsForSubmission, [.imageGeneration])
+    }
+
+    func testWhenUnsupportedToolSelectedThenIgnored() {
+        store.models = [makeModel(id: "gpt-5.2", supportedTools: [.webSearch])]
+
+        sut.handleToolSelection(.imageGeneration)
+
+        XCTAssertNil(sut.selectedToolsForSubmission)
+        XCTAssertFalse(sut.isToolSelected)
+    }
+
+    func testSelectedToolsForSubmissionIsNilWhenNothingSelected() {
+        store.models = [makeModel(id: "gpt-5.2", supportedTools: [.webSearch])]
+
+        XCTAssertNil(sut.selectedToolsForSubmission)
+    }
+
+    // MARK: - Reasoning picker interaction
+
+    func testWhenImageGenerationSelectedThenHidesReasoningPicker() {
+        store.models = [makeModel(id: "gpt-5.2", supportedTools: [.imageGeneration])]
+
+        sut.handleToolSelection(.imageGeneration)
+
+        XCTAssertTrue(sut.selectedToolHidesReasoningPicker)
+    }
+
+    func testWhenWebSearchSelectedThenDoesNotHideReasoningPicker() {
+        store.models = [makeModel(id: "gpt-5.2", supportedTools: [.webSearch])]
+
+        sut.handleToolSelection(.webSearch)
+
+        XCTAssertFalse(sut.selectedToolHidesReasoningPicker)
+    }
+
+    func testWhenNoToolSelectedThenDoesNotHideReasoningPicker() {
+        store.models = [makeModel(id: "gpt-5.2", supportedTools: [.webSearch])]
+
+        XCTAssertFalse(sut.selectedToolHidesReasoningPicker)
+    }
+
+    // MARK: - Model change clears unsupported tool
+
+    func testWhenModelChangesToOneWithoutToolThenSelectionCleared() {
+        store.models = [makeModel(id: "gpt-5.2", supportedTools: [.imageGeneration])]
+        sut.handleToolSelection(.imageGeneration)
+        XCTAssertEqual(sut.selectedToolsForSubmission, [.imageGeneration])
+
+        // The newly selected model doesn't support image generation.
+        store.models = [makeModel(id: "gpt-basic", supportedTools: [.webSearch])]
+        sut.handleModelChanged()
+
+        XCTAssertNil(sut.selectedToolsForSubmission)
+        XCTAssertFalse(sut.isToolSelected)
+    }
+
+    func testWhenModelChangesButStillSupportsToolThenSelectionKept() {
+        store.models = [makeModel(id: "gpt-5.2", supportedTools: [.webSearch])]
+        sut.handleToolSelection(.webSearch)
+
+        store.models = [makeModel(id: "gpt-5.3", supportedTools: [.webSearch, .imageGeneration])]
+        sut.handleModelChanged()
+
+        XCTAssertEqual(sut.selectedToolsForSubmission, [.webSearch])
+    }
+
+    // MARK: - Update callback
+
+    func testWhenToolSelectedThenOnToolsUpdatedFires() {
+        store.models = [makeModel(id: "gpt-5.2", supportedTools: [.webSearch])]
+        var updateCount = 0
+        sut.onToolsUpdated = { updateCount += 1 }
+
+        sut.handleToolSelection(.webSearch)
+
+        XCTAssertEqual(updateCount, 1)
+    }
+
+    // MARK: - Helpers
+
+    private func makeModel(id: String, supportedTools: [AIChatRAGTool]) -> AIChatModel {
+        AIChatModel(
+            id: id,
+            name: id,
+            shortName: id,
+            provider: .openAI,
+            supportsImageUpload: false,
+            supportedTools: supportedTools,
+            entityHasAccess: true
+        )
+    }
+}
+
+private final class StubToolPreferences: AIChatPreferencesPersisting {
+    var selectedReasoningEffort: String?
+    var selectedModelId: String?
+    var selectedModelShortName: String?
+    var selectedReasoningMode: AIChatReasoningMode?
+    var selectedTool: AIChatRAGTool?
+    var selectedModelIdPublisher: AnyPublisher<String?, Never> { Empty().eraseToAnyPublisher() }
+    var selectedReasoningEffortPublisher: AnyPublisher<String?, Never> { Empty().eraseToAnyPublisher() }
+}
+
+private final class StubModelsService: AIChatModelsProviding {
+    var result: Result<AIChatModelsResponse, Error> = .success(AIChatModelsResponse(models: []))
+
+    func fetchModels() async throws -> AIChatModelsResponse { try result.get() }
+}

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarToolPickerControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarToolPickerControllerTests.swift
@@ -164,6 +164,41 @@ final class IPadOmnibarToolPickerControllerTests: XCTestCase {
         XCTAssertEqual(sut.selectedToolsForSubmission, [.webSearch])
     }
 
+    // MARK: - Reset on submit
+
+    func testWhenResetSelectionThenToolClearedAndReasoningRestored() {
+        store.models = [makeModel(id: "gpt-5.2", supportedTools: [.imageGeneration])]
+        sut.handleToolSelection(.imageGeneration)
+        XCTAssertTrue(sut.selectedToolHidesReasoningPicker)
+
+        sut.resetSelection()
+
+        XCTAssertNil(sut.selectedToolsForSubmission)
+        XCTAssertFalse(sut.isToolSelected)
+        XCTAssertFalse(sut.selectedToolHidesReasoningPicker)
+    }
+
+    func testWhenResetSelectionWithSelectedToolThenOnToolsUpdatedFires() {
+        store.models = [makeModel(id: "gpt-5.2", supportedTools: [.webSearch])]
+        sut.handleToolSelection(.webSearch)
+        var updateCount = 0
+        sut.onToolsUpdated = { updateCount += 1 }
+
+        sut.resetSelection()
+
+        XCTAssertEqual(updateCount, 1)
+    }
+
+    func testWhenResetSelectionWithNoSelectedToolThenNoUpdate() {
+        store.models = [makeModel(id: "gpt-5.2", supportedTools: [.webSearch])]
+        var updateCount = 0
+        sut.onToolsUpdated = { updateCount += 1 }
+
+        sut.resetSelection()
+
+        XCTAssertEqual(updateCount, 0)
+    }
+
     // MARK: - Update callback
 
     func testWhenToolSelectedThenOnToolsUpdatedFires() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215931148718741?focus=true
Tech Design URL:
CC:

### Description
Adds an icon-only tool picker to the far left of the iPad expanded Duck.ai address bar, mirroring the iPhone tools menu 

### Testing Steps
1. On an iPad with `iPadDuckAIBarControls` enabled, switch the address bar to Duck.ai and expand the input — a tools chip appears on the far left.
2. Tap it and toggle Web Search / Image Generation; confirm the chip tints when active and tools unsupported by the selected model are disabled.
3. Select Image Generation and confirm the reasoning chip hides, then submit a prompt and confirm the chosen tool is applied in the chat.

### Impact and Risks
Low — additive, behind an existing feature flag, with no change to iPhone behavior.

#### What could go wrong?
The chip overlaps the expanded text view, so a hit-test regression could route taps to the text field instead of the button.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive iPad UI behind an existing flag; main regression risk is layout/hit-testing where path overlaps with the expanded text field.
> 
> **Overview**
> Adds an **iPad-only tools chip** on the far left of the expanded Duck.ai address bar (behind `iPadDuckAIBarControls`), wired like the existing model and reasoning pickers.
> 
> **`IPadOmnibarToolPickerController`** reuses the shared `UTIModelStore` and UTI tools menu logic for Web Search / Image Generation, toggles selection with analytics pixels, clears unsupported tools when the model changes, and **hides the reasoning chip** when Image Generation is active.
> 
> **`DefaultOmniBarView`** gains the tool button (menu, accent tint when selected, expansion/hit-test behavior). **`DefaultOmniBarViewController`** refreshes tool and reasoning UI together, resets tools after submit, and exposes **`selectedTools`** via `IPadDuckAIControlValues`. **`MainViewController`** opens chat with `tools ?? controlValues.selectedTools` so omnibar selections apply even when submit passes `tools: nil`.
> 
> Unit tests cover availability, selection, model-change clearing, reasoning interaction, and reset-on-submit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0ca9f494aadfe5df8a9362197ed0f68e8439064. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->