### PR TITLE
iOS: Show the unified toggle input on the presubmission contextual sheet (part 1)

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -525,9 +525,6 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// Enables voice chat shortcut in the focused address bar
     case voiceShortcut
 
-    /// Enables improved contextual sheet UX (welcome message, ask about page, etc.)
-    case contextualSheetImprovements
-
     /// Shows the unified toggle input on the presubmission contextual sheet in place of the basic native input
     case contextualUnifiedToggleInput
 

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -528,6 +528,9 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// Enables improved contextual sheet UX (welcome message, ask about page, etc.)
     case contextualSheetImprovements
 
+    /// Shows the unified toggle input on the presubmission contextual sheet in place of the basic native input
+    case contextualUnifiedToggleInput
+
     /// Enables removing individual AI chat suggestions
     case removeSuggestion
 

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -311,9 +311,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1204186595873227/task/1213651297612976?focus=true
     case aiChatNativeChatHistory
 
-    /// https://app.asana.com/1/137249556945/project/1208671677432066/task/1213651262338059
-    case aiChatContextualSheetImprovements
-
     /// Shows the unified toggle input on the presubmission contextual sheet in place of the basic native input.
     case aiChatContextualUnifiedToggleInput
 
@@ -742,8 +739,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(DuckAiChatHistorySubfeature.featureEnabled))
         case .aiChatNativeChatHistory:
             Config(defaultValue: .enabled, source: .remoteReleasable(DuckAiChatHistorySubfeature.nativeChatHistory))
-        case .aiChatContextualSheetImprovements:
-            Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.contextualSheetImprovements))
         case .aiChatContextualUnifiedToggleInput:
             Config(source: .remoteReleasable(AIChatSubfeature.contextualUnifiedToggleInput))
         case .showWhatsNewPromptOnDemand:

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -314,6 +314,9 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1208671677432066/task/1213651262338059
     case aiChatContextualSheetImprovements
 
+    /// Shows the unified toggle input on the presubmission contextual sheet in place of the basic native input.
+    case aiChatContextualUnifiedToggleInput
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212388316840466?focus=true
     case showWhatsNewPromptOnDemand
 
@@ -741,6 +744,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(DuckAiChatHistorySubfeature.nativeChatHistory))
         case .aiChatContextualSheetImprovements:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.contextualSheetImprovements))
+        case .aiChatContextualUnifiedToggleInput:
+            Config(source: .remoteReleasable(AIChatSubfeature.contextualUnifiedToggleInput))
         case .showWhatsNewPromptOnDemand:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.showWhatsNewPromptOnDemand))
         case .unifiedToggleInput:

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -2189,7 +2189,9 @@
 		CB6D17A22FA397FC00ECD5AE /* UnifiedToggleInputPageContextChipViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17A12FA397FC00ECD5AE /* UnifiedToggleInputPageContextChipViewModelTests.swift */; };
 		CB6D17A42FA3983100ECD5AE /* UnifiedToggleInputPageContextChipViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17A32FA3983100ECD5AE /* UnifiedToggleInputPageContextChipViewModel.swift */; };
 		CB6D17A82FA39FC900ECD5AE /* AIChatContextualUTIHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17A72FA39FC900ECD5AE /* AIChatContextualUTIHost.swift */; };
+		DEC0DE0000000000000000A2 /* ContextualUnifiedToggleInputFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0DE0000000000000000A1 /* ContextualUnifiedToggleInputFeature.swift */; };
 		CB6D17AA2FA4B57900ECD5AE /* AIChatContextualUTIHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17A92FA4B57900ECD5AE /* AIChatContextualUTIHostTests.swift */; };
+		DEC0DE0000000000000000B2 /* ContextualUnifiedToggleInputFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0DE0000000000000000B1 /* ContextualUnifiedToggleInputFeatureTests.swift */; };
 		CB6D17B02FA2138200ECD5AE /* AIChatSyncPromoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B12FA2138200ECD5AE /* AIChatSyncPromoView.swift */; };
 		CB6D17B22FA2138200ECD5AE /* AIChatSyncIntroSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B32FA2138200ECD5AE /* AIChatSyncIntroSheetView.swift */; };
 		CB6D17B42FB000000ECD5AE /* AIChatSyncPromoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B52FB000000ECD5AE /* AIChatSyncPromoViewModel.swift */; };
@@ -4937,7 +4939,9 @@
 		CB6D17A12FA397FC00ECD5AE /* UnifiedToggleInputPageContextChipViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputPageContextChipViewModelTests.swift; sourceTree = "<group>"; };
 		CB6D17A32FA3983100ECD5AE /* UnifiedToggleInputPageContextChipViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputPageContextChipViewModel.swift; sourceTree = "<group>"; };
 		CB6D17A72FA39FC900ECD5AE /* AIChatContextualUTIHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualUTIHost.swift; sourceTree = "<group>"; };
+		DEC0DE0000000000000000A1 /* ContextualUnifiedToggleInputFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualUnifiedToggleInputFeature.swift; sourceTree = "<group>"; };
 		CB6D17A92FA4B57900ECD5AE /* AIChatContextualUTIHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualUTIHostTests.swift; sourceTree = "<group>"; };
+		DEC0DE0000000000000000B1 /* ContextualUnifiedToggleInputFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualUnifiedToggleInputFeatureTests.swift; sourceTree = "<group>"; };
 		CB6D17B12FA2138200ECD5AE /* AIChatSyncPromoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSyncPromoView.swift; sourceTree = "<group>"; };
 		CB6D17B32FA2138200ECD5AE /* AIChatSyncIntroSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSyncIntroSheetView.swift; sourceTree = "<group>"; };
 		CB6D17B52FB000000ECD5AE /* AIChatSyncPromoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSyncPromoViewModel.swift; sourceTree = "<group>"; };
@@ -6022,6 +6026,7 @@
 				97D99E632F7420A900EE34E7 /* AIVoiceChatIntentTests.swift */,
 				97B908642F75457100372B50 /* DuckAIVoiceControlWidgetTests.swift */,
 				CB6D17A92FA4B57900ECD5AE /* AIChatContextualUTIHostTests.swift */,
+				DEC0DE0000000000000000B1 /* ContextualUnifiedToggleInputFeatureTests.swift */,
 				B4E5D6C7A8F9012345678901 /* AIChatTabChatHeaderViewTests.swift */,
 				5AB12C3D4E5F60718293A4C0 /* MockChatHistoryReader.swift */,
 				80E2BDAF2FDB693A00441FDF /* DuckAIGridItemTests.swift */,
@@ -9429,6 +9434,7 @@
 				C1AIREPO2F2E000000E35AD5 /* AIChatPageContextHandler.swift */,
 				CB6D179C2FA38CAF00ECD5AE /* Logger+ContextualUTI.swift */,
 				CB6D17A72FA39FC900ECD5AE /* AIChatContextualUTIHost.swift */,
+				DEC0DE0000000000000000A1 /* ContextualUnifiedToggleInputFeature.swift */,
 			);
 			path = ContextualMode;
 			sourceTree = "<group>";
@@ -13680,6 +13686,7 @@
 				C1A1AEDC2EBCF97400D49A2F /* AutofillExtensionPromptViewController.swift in Sources */,
 				C1A1AEDD2EBCF97400D49A2F /* AutofillExtensionPromptViewModel.swift in Sources */,
 				CB6D17A82FA39FC900ECD5AE /* AIChatContextualUTIHost.swift in Sources */,
+				DEC0DE0000000000000000A2 /* ContextualUnifiedToggleInputFeature.swift in Sources */,
 				C11F41132F2CCBD800C126C3 /* AIChatContextualChatSessionState.swift in Sources */,
 				C1A1AEDE2EBCF97400D49A2F /* AutofillExtensionPromptView.swift in Sources */,
 				C1E28C2E2F50F2D3007B8230 /* OnboardingView+RestorePromptDialogContent.swift in Sources */,
@@ -14469,6 +14476,7 @@
 				6AC98419288055C1005FA9CA /* BarsAnimatorTests.swift in Sources */,
 				8536A1CA209AF6490050739E /* HomeRowReminderTests.swift in Sources */,
 				CB6D17AA2FA4B57900ECD5AE /* AIChatContextualUTIHostTests.swift in Sources */,
+				DEC0DE0000000000000000B2 /* ContextualUnifiedToggleInputFeatureTests.swift in Sources */,
 				9FA0AF1E2EB4894A00713387 /* RemoteMessagingPixelReporterTests.swift in Sources */,
 				5650E36F2D3E8E5900D41ECF /* PageRefreshMonitorExtensionTests.swift in Sources */,
 				9FE59CDD2E31AD9D00C4B65D /* DefaultBrowserPiPTutorialURLProviderTests.swift in Sources */,

--- a/iOS/DuckDuckGo/AIChat/AIChatContentHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatContentHandler.swift
@@ -99,9 +99,7 @@ protocol AIChatContentHandling: AnyObject {
     /// Submits a prompt to the AI Chat with optional page context.
     func submitPrompt(_ prompt: String, pageContext: AIChatPageContextData?)
 
-    /// Submits a prompt carrying the full unified-toggle-input payload (model, tools, reasoning,
-    /// attachments) plus a frozen page-context snapshot. Used for the contextual sheet's first
-    /// UTI-driven prompt, which is delivered through the web view's readiness queue.
+    /// Submits a prompt with the full UTI payload + a frozen page-context snapshot (the contextual sheet's first prompt).
     func submitPrompt(_ prompt: String, images: [AIChatNativePrompt.NativePromptImage]?, files: [AIChatNativePrompt.NativePromptFile]?, modelId: String?, tools: [AIChatRAGTool]?, pageContext: AIChatPageContextData?, reasoningEffort: AIChatReasoningEffort?)
 
     /// Submits a start chat action to initiate a new AI Chat conversation.

--- a/iOS/DuckDuckGo/AIChat/AIChatContentHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatContentHandler.swift
@@ -39,6 +39,7 @@ protocol AIChatUserScriptProviding: AnyObject {
     func setContextualModePixelHandler(_ pixelHandler: AIChatContextualModePixelFiring)
     func setDisplayMode(_ displayMode: AIChatDisplayMode)
     func submitPrompt(_ prompt: String, pageContext: AIChatPageContextData?)
+    func submitPrompt(_ prompt: String, images: [AIChatNativePrompt.NativePromptImage]?, files: [AIChatNativePrompt.NativePromptFile]?, modelId: String?, tools: [AIChatRAGTool]?, pageContext: AIChatPageContextData?, reasoningEffort: AIChatReasoningEffort?)
     func submitStartChatAction()
     func submitOpenSettingsAction()
     func submitPageContext(_ context: AIChatPageContextData?)
@@ -98,6 +99,10 @@ protocol AIChatContentHandling: AnyObject {
     /// Submits a prompt to the AI Chat with optional page context.
     func submitPrompt(_ prompt: String, pageContext: AIChatPageContextData?)
 
+    /// Submits a prompt carrying the full unified-toggle-input payload (model, tools, reasoning,
+    /// attachments) plus a frozen page-context snapshot. Used for the contextual sheet's first
+    /// UTI-driven prompt, which is delivered through the web view's readiness queue.
+    func submitPrompt(_ prompt: String, images: [AIChatNativePrompt.NativePromptImage]?, files: [AIChatNativePrompt.NativePromptFile]?, modelId: String?, tools: [AIChatRAGTool]?, pageContext: AIChatPageContextData?, reasoningEffort: AIChatReasoningEffort?)
 
     /// Submits a start chat action to initiate a new AI Chat conversation.
     func submitStartChatAction()
@@ -260,6 +265,15 @@ final class AIChatContentHandler: AIChatContentHandling {
             Logger.aiChat.debug("[PageContext] Prompt submitted without context")
         }
         userScript?.submitPrompt(prompt, pageContext: pageContext)
+    }
+
+    func submitPrompt(_ prompt: String, images: [AIChatNativePrompt.NativePromptImage]?, files: [AIChatNativePrompt.NativePromptFile]?, modelId: String?, tools: [AIChatRAGTool]?, pageContext: AIChatPageContextData?, reasoningEffort: AIChatReasoningEffort?) {
+        if let context = pageContext {
+            Logger.aiChat.debug("[PageContext] Rich prompt submitted with context - title: \(context.title.prefix(50))")
+        } else {
+            Logger.aiChat.debug("[PageContext] Rich prompt submitted without context")
+        }
+        userScript?.submitPrompt(prompt, images: images, files: files, modelId: modelId, tools: tools, pageContext: pageContext, reasoningEffort: reasoningEffort)
     }
 
     /// Submits a start chat action to initiate a new AI Chat conversation.

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -177,22 +177,36 @@ final class AIChatContextualChatSessionState {
 
     // MARK: - Frontend Chat State Transitions
 
-    /// Call when user submits a prompt from native input
+    /// Call when user submits a prompt from native input.
     func handlePromptSubmission(_ prompt: String, url: URL? = nil) {
         guard frontendState != .restoredChat else {
             Logger.aiChat.debug("[SessionState] Chat start request ignored - preserving .restoredChat state")
             return
         }
+        let contextData = beginChatForUTISubmission(url: url)
+        emit(.submitPrompt(prompt: prompt, context: contextData))
+    }
 
-        let contextData: AIChatPageContextData?
+    /// Flips the frontend into an active chat for a UTI-driven first submit **without** emitting
+    /// `.submitPrompt`. The immediate-UTI host delivers its own rich payload straight into the web
+    /// view's readiness queue, so emitting here would double-send. This is the flip half of
+    /// `handlePromptSubmission` (native→web swap, submission pixel, chip-hide via `hasActiveChat`);
+    /// it returns the page context that was attached at flip time so the caller can freeze it into
+    /// the delivered prompt. No-op (returns nil) while a chat is already restored/active.
+    @discardableResult
+    func beginChatForUTISubmission(url: URL? = nil) -> AIChatPageContextData? {
+        guard frontendState != .restoredChat else {
+            Logger.aiChat.debug("[SessionState] UTI chat start ignored - preserving .restoredChat state")
+            return nil
+        }
+
+        let contextData = intendedAttachedContext?.contextData
         switch chipState {
-        case .attached(let context):
-            contextData = context.contextData
+        case .attached:
             frontendState = .chatWithInitialContext
             pixelHandler.firePromptSubmittedWithContext()
             Logger.aiChat.debug("[SessionState] Chat started WITH initial context (chip was attached)")
         case .placeholder:
-            contextData = nil
             frontendState = .chatWithoutInitialContext
             pixelHandler.firePromptSubmittedWithoutContext()
             Logger.aiChat.debug("[SessionState] Chat started WITHOUT initial context (chip was placeholder)")
@@ -203,7 +217,7 @@ final class AIChatContextualChatSessionState {
         }
 
         rebuildViewState()
-        emit(.submitPrompt(prompt: prompt, context: contextData))
+        return contextData
     }
 
     /// Call when starting a new chat (resetting frontend)

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -47,12 +47,12 @@ enum FrontendChatState: CustomStringConvertible {
 
 /// Manages the current state of the context chip
 enum ChipState: CustomStringConvertible, Equatable {
-    case placeholder
+    case noContext
     case attached(AIChatPageContext)
 
     var description: String {
         switch self {
-        case .placeholder: return "placeholder"
+        case .noContext: return "noContext"
         case .attached: return "attached"
         }
     }
@@ -93,7 +93,7 @@ final class AIChatContextualChatSessionState {
     // MARK: - Core State (private(set) - mutations happen via methods)
 
     private(set) var frontendState: FrontendChatState = .noChat
-    private(set) var chipState: ChipState = .placeholder
+    private(set) var chipState: ChipState = .noContext
     private(set) var contextualChatURL: URL?
     private(set) var latestContext: AIChatPageContext?
 
@@ -101,7 +101,7 @@ final class AIChatContextualChatSessionState {
         content: .nativeInput,
         isExpandButtonEnabled: true,
         shouldShowNewChatButton: false,
-        chipState: .placeholder,
+        chipState: .noContext,
         quickActions: [.summarize]
     )
 
@@ -159,9 +159,15 @@ final class AIChatContextualChatSessionState {
         latestContext != nil
     }
 
+    /// When set (immediate UTI active), overrides `chipState` as the source of "what's attached".
+    var attachedContextOverrideProvider: (() -> AIChatPageContext?)?
+
     /// User-attached context (nil if opted out / never attached). Unlike `latestContext`,
     /// this respects X-tap downgrades — `latestContext` keeps the last collected payload regardless.
     var intendedAttachedContext: AIChatPageContext? {
+        if let attachedContextOverrideProvider {
+            return attachedContextOverrideProvider()
+        }
         if case .attached(let context) = chipState { return context }
         return nil
     }
@@ -187,12 +193,7 @@ final class AIChatContextualChatSessionState {
         emit(.submitPrompt(prompt: prompt, context: contextData))
     }
 
-    /// Flips the frontend into an active chat for a UTI-driven first submit **without** emitting
-    /// `.submitPrompt`. The immediate-UTI host delivers its own rich payload straight into the web
-    /// view's readiness queue, so emitting here would double-send. This is the flip half of
-    /// `handlePromptSubmission` (native→web swap, submission pixel, chip-hide via `hasActiveChat`);
-    /// it returns the page context that was attached at flip time so the caller can freeze it into
-    /// the delivered prompt. No-op (returns nil) while a chat is already restored/active.
+    /// Flip half of `handlePromptSubmission` for a UTI first submit: flips frontend state without emitting `.submitPrompt` (the host delivers); returns the attached context, no-op if restored/active.
     @discardableResult
     func beginChatForUTISubmission(url: URL? = nil) -> AIChatPageContextData? {
         guard frontendState != .restoredChat else {
@@ -201,12 +202,11 @@ final class AIChatContextualChatSessionState {
         }
 
         let contextData = intendedAttachedContext?.contextData
-        switch chipState {
-        case .attached:
+        if intendedAttachedContext != nil {
             frontendState = .chatWithInitialContext
             pixelHandler.firePromptSubmittedWithContext()
             Logger.aiChat.debug("[SessionState] Chat started WITH initial context (chip was attached)")
-        case .placeholder:
+        } else {
             frontendState = .chatWithoutInitialContext
             pixelHandler.firePromptSubmittedWithoutContext()
             Logger.aiChat.debug("[SessionState] Chat started WITHOUT initial context (chip was placeholder)")
@@ -223,7 +223,7 @@ final class AIChatContextualChatSessionState {
     /// Call when starting a new chat (resetting frontend)
     func resetToNoChat() {
         frontendState = .noChat
-        chipState = .placeholder
+        chipState = .noContext
         contextualChatURL = nil
         userDowngradedToPlaceholder = false
         isManualAttachInProgress = false
@@ -260,7 +260,7 @@ final class AIChatContextualChatSessionState {
     func handleChipRemoval() -> Bool {
         guard case .attached = chipState else { return false }
 
-        chipState = .placeholder
+        chipState = .noContext
         userDowngradedToPlaceholder = true
         pixelHandler.firePageContextRemovedNative()
         rebuildViewState()
@@ -271,7 +271,7 @@ final class AIChatContextualChatSessionState {
     /// Downgrades an attached chip to placeholder state.
     func downgradeToPlaceholder() {
         guard case .attached = chipState else { return }
-        chipState = .placeholder
+        chipState = .noContext
         userDowngradedToPlaceholder = true
         pixelHandler.firePageContextRemovedNative()
         rebuildViewState()
@@ -325,7 +325,7 @@ final class AIChatContextualChatSessionState {
         guard let context = context else {
             Logger.aiChat.debug("[SessionState] Context collection returned nil - clearing context and downgrading to placeholder")
             latestContext = nil
-            chipState = .placeholder
+            chipState = .noContext
             cleanupFlags()
             rebuildViewState()
             return
@@ -363,6 +363,24 @@ final class AIChatContextualChatSessionState {
     func requestWebViewReload() {
         emit(.reloadWebView)
     }
+
+    func rebuildViewState() {
+        let content: SheetViewState.ContentMode
+        switch frontendState {
+        case .noChat:
+            content = .nativeInput
+        case .chatWithInitialContext, .chatWithoutInitialContext, .restoredChat:
+            content = .webView(restoreURL: contextualChatURL)
+        }
+
+        viewState = SheetViewState(
+            content: content,
+            isExpandButtonEnabled: frontendState == .noChat || contextualChatURL != nil,
+            shouldShowNewChatButton: frontendState != .noChat,
+            chipState: chipState,
+            quickActions: resolveQuickActions()
+        )
+    }
 }
 
 // MARK: - Private
@@ -394,7 +412,7 @@ private extension AIChatContextualChatSessionState {
     func handleAutoAttach(_ context: AIChatPageContext) {
         if isShowingNativeInput {
             switch chipState {
-            case .placeholder:
+            case .noContext:
                 if shouldAllowAutomaticUpgrade() {
                     chipState = .attached(context)
                     userDowngradedToPlaceholder = false
@@ -453,31 +471,7 @@ private extension AIChatContextualChatSessionState {
     }
 
     private func resolveQuickActions() -> [AIChatContextualQuickAction] {
-        guard featureFlagger.isFeatureOn(.aiChatContextualSheetImprovements) else {
-            return [.summarize]
-        }
-        switch chipState {
-        case .placeholder: return [.askAboutPage]
-        case .attached: return [.summarizePage]
-        }
-    }
-
-    func rebuildViewState() {
-        let content: SheetViewState.ContentMode
-        switch frontendState {
-        case .noChat:
-            content = .nativeInput
-        case .chatWithInitialContext, .chatWithoutInitialContext, .restoredChat:
-            content = .webView(restoreURL: contextualChatURL)
-        }
-
-        viewState = SheetViewState(
-            content: content,
-            isExpandButtonEnabled: frontendState == .noChat || contextualChatURL != nil,
-            shouldShowNewChatButton: frontendState != .noChat,
-            chipState: chipState,
-            quickActions: resolveQuickActions()
-        )
+        intendedAttachedContext != nil ? [.summarizePage] : [.askAboutPage]
     }
 
     func emit(_ effect: SheetEffect) {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualInputViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualInputViewController.swift
@@ -32,6 +32,34 @@ protocol AIChatContextualInputViewControllerDelegate: AnyObject {
     func contextualInputViewControllerDidRemoveContextChip(_ viewController: AIChatContextualInputViewController)
 }
 
+// MARK: - Input Surface
+
+/// The subset of the native input the contextual container drives, so the immediate-UTI variant can substitute a no-op surface instead of guarding every call on `showsNativeInput`.
+protocol AIChatContextualInputSurface {
+    @discardableResult func becomeFirstResponder() -> Bool
+    @discardableResult func resignFirstResponder() -> Bool
+    var isContextChipVisible: Bool { get }
+    func setText(_ text: String)
+    func appendText(_ text: String)
+    func showContextChip(_ chipView: UIView)
+    func hideContextChip()
+    func updateContextChipState(_ state: AIChatContextChipView.State)
+    func setChipTapCallback(_ callback: @escaping () -> Void)
+}
+
+/// No-op input surface for the immediate-UTI sheet, where the sheet-level UTI is the input.
+struct NoContextualInputSurface: AIChatContextualInputSurface {
+    var isContextChipVisible: Bool { false }
+    func becomeFirstResponder() -> Bool { false }
+    func resignFirstResponder() -> Bool { false }
+    func setText(_ text: String) {}
+    func appendText(_ text: String) {}
+    func showContextChip(_ chipView: UIView) {}
+    func hideContextChip() {}
+    func updateContextChipState(_ state: AIChatContextChipView.State) {}
+    func setChipTapCallback(_ callback: @escaping () -> Void) {}
+}
+
 // MARK: - View Controller
 
 /// Container view controller that hosts the native input and handles keyboard adjustments.
@@ -50,12 +78,13 @@ final class AIChatContextualInputViewController: UIViewController {
 
     weak var delegate: AIChatContextualInputViewControllerDelegate?
 
-    private let isContextualSheetImprovementsEnabled: Bool
-    /// When false (immediate-UTI sheet), the native input box is omitted — the sheet-level UTI is the
-    /// input — and only the hero + quick actions are shown.
+    /// When false (immediate-UTI sheet), the native input box is omitted (the sheet-level UTI is the input) — only hero + quick actions show.
     private let showsNativeInput: Bool
     private let voiceSearchHelper: VoiceSearchHelperProtocol
     private lazy var nativeInputViewController = AIChatNativeInputViewController(voiceSearchHelper: voiceSearchHelper)
+
+    /// Drives the input; the native VC when present, otherwise a no-op surface (immediate-UTI sheet).
+    private lazy var inputSurface: AIChatContextualInputSurface = showsNativeInput ? nativeInputViewController : NoContextualInputSurface()
 
     private lazy var quickActionsScrollView: UIScrollView = {
         let scrollView = UIScrollView()
@@ -85,8 +114,7 @@ final class AIChatContextualInputViewController: UIViewController {
 
     // MARK: - Initialization
 
-    init(voiceSearchHelper: VoiceSearchHelperProtocol, isContextualSheetImprovementsEnabled: Bool = false, showsNativeInput: Bool = true) {
-        self.isContextualSheetImprovementsEnabled = isContextualSheetImprovementsEnabled
+    init(voiceSearchHelper: VoiceSearchHelperProtocol, showsNativeInput: Bool = true) {
         self.showsNativeInput = showsNativeInput
         self.voiceSearchHelper = voiceSearchHelper
         super.init(nibName: nil, bundle: nil)
@@ -133,49 +161,40 @@ final class AIChatContextualInputViewController: UIViewController {
 
     @discardableResult
     override func becomeFirstResponder() -> Bool {
-        guard showsNativeInput else { return false }
-        return nativeInputViewController.becomeFirstResponder()
+        inputSurface.becomeFirstResponder()
     }
 
     @discardableResult
     override func resignFirstResponder() -> Bool {
-        guard showsNativeInput else { return false }
-        return nativeInputViewController.resignFirstResponder()
+        inputSurface.resignFirstResponder()
     }
 
     var isContextChipVisible: Bool {
-        guard showsNativeInput else { return false }
-        return nativeInputViewController.isContextChipVisible
+        inputSurface.isContextChipVisible
     }
 
     func setText(_ text: String) {
-        guard showsNativeInput else { return }
-        nativeInputViewController.setText(text)
+        inputSurface.setText(text)
     }
 
     func appendText(_ text: String) {
-        guard showsNativeInput else { return }
-        nativeInputViewController.appendText(text)
+        inputSurface.appendText(text)
     }
 
     func showContextChip(_ chipView: UIView) {
-        guard showsNativeInput else { return }
-        nativeInputViewController.showContextChip(chipView)
+        inputSurface.showContextChip(chipView)
     }
 
     func hideContextChip() {
-        guard showsNativeInput else { return }
-        nativeInputViewController.hideContextChip()
+        inputSurface.hideContextChip()
     }
 
     func updateContextChipState(_ state: AIChatContextChipView.State) {
-        guard showsNativeInput else { return }
-        nativeInputViewController.updateContextChipState(state)
+        inputSurface.updateContextChipState(state)
     }
 
     func setChipTapCallback(_ callback: @escaping () -> Void) {
-        guard showsNativeInput else { return }
-        nativeInputViewController.setChipTapCallback(callback)
+        inputSurface.setChipTapCallback(callback)
     }
 
     func updateQuickActions(with actions: [AIChatContextualQuickAction]) {
@@ -192,38 +211,9 @@ private extension AIChatContextualInputViewController {
 
         if !showsNativeInput {
             setupImmediateUTIUI()
-        } else if isContextualSheetImprovementsEnabled {
-            setupImprovedUI()
         } else {
-            setupOriginalUI()
+            setupImprovedUI()
         }
-    }
-
-    func setupOriginalUI() {
-        view.addSubview(quickActionsScrollView)
-        quickActionsScrollView.addSubview(quickActionsView)
-        embedNativeInputViewController()
-
-        bottomConstraint = nativeInputViewController.view.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor)
-
-        NSLayoutConstraint.activate([
-            quickActionsScrollView.topAnchor.constraint(equalTo: view.topAnchor),
-            quickActionsScrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.horizontalPadding),
-            quickActionsScrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Constants.horizontalPadding),
-            quickActionsScrollView.bottomAnchor.constraint(equalTo: nativeInputViewController.view.topAnchor, constant: -Constants.quickActionsBottomSpacing),
-
-            quickActionsView.topAnchor.constraint(equalTo: quickActionsScrollView.contentLayoutGuide.topAnchor),
-            quickActionsView.leadingAnchor.constraint(equalTo: quickActionsScrollView.contentLayoutGuide.leadingAnchor),
-            quickActionsView.trailingAnchor.constraint(equalTo: quickActionsScrollView.contentLayoutGuide.trailingAnchor),
-            quickActionsView.bottomAnchor.constraint(equalTo: quickActionsScrollView.contentLayoutGuide.bottomAnchor),
-            quickActionsView.widthAnchor.constraint(equalTo: quickActionsScrollView.frameLayoutGuide.widthAnchor),
-            quickActionsView.heightAnchor.constraint(greaterThanOrEqualTo: quickActionsScrollView.frameLayoutGuide.heightAnchor),
-
-            nativeInputViewController.view.topAnchor.constraint(greaterThanOrEqualTo: quickActionsView.bottomAnchor, constant: Constants.quickActionsBottomSpacing),
-            nativeInputViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.horizontalPadding),
-            nativeInputViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Constants.horizontalPadding),
-            bottomConstraint!,
-        ])
     }
 
     func setupImprovedUI() {
@@ -264,8 +254,7 @@ private extension AIChatContextualInputViewController {
         ])
     }
 
-    /// Immediate-UTI layout: hero + quick-actions only. The input itself is the sheet-level UTI, so
-    /// there is no native box here; quick actions pin to the bottom of the content area above the UTI.
+    /// Immediate-UTI layout: hero + quick-actions only (no native box — the sheet-level UTI is the input).
     func setupImmediateUTIUI() {
         view.addSubview(quickActionsScrollView)
         quickActionsScrollView.addSubview(quickActionsView)
@@ -346,7 +335,6 @@ private extension AIChatContextualInputViewController {
     }
 
     func updateWelcomeLabelCentering() {
-        guard isContextualSheetImprovementsEnabled || !showsNativeInput else { return }
         let scrollViewTop = quickActionsScrollView.frame.minY
         guard scrollViewTop > 0 else { return }
         welcomeCenterYConstraint?.constant = scrollViewTop / 2
@@ -414,3 +402,7 @@ extension AIChatContextualInputViewController: AIChatNativeInputViewControllerDe
         scrollQuickActionsToBottom()
     }
 }
+
+// MARK: - AIChatContextualInputSurface
+
+extension AIChatNativeInputViewController: AIChatContextualInputSurface {}

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualInputViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualInputViewController.swift
@@ -51,6 +51,9 @@ final class AIChatContextualInputViewController: UIViewController {
     weak var delegate: AIChatContextualInputViewControllerDelegate?
 
     private let isContextualSheetImprovementsEnabled: Bool
+    /// When false (immediate-UTI sheet), the native input box is omitted — the sheet-level UTI is the
+    /// input — and only the hero + quick actions are shown.
+    private let showsNativeInput: Bool
     private let voiceSearchHelper: VoiceSearchHelperProtocol
     private lazy var nativeInputViewController = AIChatNativeInputViewController(voiceSearchHelper: voiceSearchHelper)
 
@@ -82,8 +85,9 @@ final class AIChatContextualInputViewController: UIViewController {
 
     // MARK: - Initialization
 
-    init(voiceSearchHelper: VoiceSearchHelperProtocol, isContextualSheetImprovementsEnabled: Bool = false) {
+    init(voiceSearchHelper: VoiceSearchHelperProtocol, isContextualSheetImprovementsEnabled: Bool = false, showsNativeInput: Bool = true) {
         self.isContextualSheetImprovementsEnabled = isContextualSheetImprovementsEnabled
+        self.showsNativeInput = showsNativeInput
         self.voiceSearchHelper = voiceSearchHelper
         super.init(nibName: nil, bundle: nil)
     }
@@ -101,9 +105,11 @@ final class AIChatContextualInputViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
-        configureNativeInput()
+        if showsNativeInput {
+            configureNativeInput()
+            setupKeyboardObservers()
+        }
         configureQuickActions()
-        setupKeyboardObservers()
     }
 
     override func viewDidLayoutSubviews() {
@@ -127,39 +133,48 @@ final class AIChatContextualInputViewController: UIViewController {
 
     @discardableResult
     override func becomeFirstResponder() -> Bool {
+        guard showsNativeInput else { return false }
         return nativeInputViewController.becomeFirstResponder()
     }
 
     @discardableResult
     override func resignFirstResponder() -> Bool {
+        guard showsNativeInput else { return false }
         return nativeInputViewController.resignFirstResponder()
     }
 
     var isContextChipVisible: Bool {
-        nativeInputViewController.isContextChipVisible
+        guard showsNativeInput else { return false }
+        return nativeInputViewController.isContextChipVisible
     }
 
     func setText(_ text: String) {
+        guard showsNativeInput else { return }
         nativeInputViewController.setText(text)
     }
 
     func appendText(_ text: String) {
+        guard showsNativeInput else { return }
         nativeInputViewController.appendText(text)
     }
 
     func showContextChip(_ chipView: UIView) {
+        guard showsNativeInput else { return }
         nativeInputViewController.showContextChip(chipView)
     }
 
     func hideContextChip() {
+        guard showsNativeInput else { return }
         nativeInputViewController.hideContextChip()
     }
 
     func updateContextChipState(_ state: AIChatContextChipView.State) {
+        guard showsNativeInput else { return }
         nativeInputViewController.updateContextChipState(state)
     }
 
     func setChipTapCallback(_ callback: @escaping () -> Void) {
+        guard showsNativeInput else { return }
         nativeInputViewController.setChipTapCallback(callback)
     }
 
@@ -175,7 +190,9 @@ private extension AIChatContextualInputViewController {
     func setupUI() {
         view.backgroundColor = .clear
 
-        if isContextualSheetImprovementsEnabled {
+        if !showsNativeInput {
+            setupImmediateUTIUI()
+        } else if isContextualSheetImprovementsEnabled {
             setupImprovedUI()
         } else {
             setupOriginalUI()
@@ -247,6 +264,37 @@ private extension AIChatContextualInputViewController {
         ])
     }
 
+    /// Immediate-UTI layout: hero + quick-actions only. The input itself is the sheet-level UTI, so
+    /// there is no native box here; quick actions pin to the bottom of the content area above the UTI.
+    func setupImmediateUTIUI() {
+        view.addSubview(quickActionsScrollView)
+        quickActionsScrollView.addSubview(quickActionsView)
+        view.addSubview(welcomeLabel)
+
+        configureWelcomeLabel()
+
+        let centerY = welcomeLabel.centerYAnchor.constraint(equalTo: view.topAnchor)
+        welcomeCenterYConstraint = centerY
+
+        NSLayoutConstraint.activate([
+            quickActionsScrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.horizontalPadding),
+            quickActionsScrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Constants.horizontalPadding),
+            quickActionsScrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -Constants.quickActionsBottomSpacing),
+
+            quickActionsView.topAnchor.constraint(equalTo: quickActionsScrollView.contentLayoutGuide.topAnchor),
+            quickActionsView.leadingAnchor.constraint(equalTo: quickActionsScrollView.contentLayoutGuide.leadingAnchor),
+            quickActionsView.trailingAnchor.constraint(equalTo: quickActionsScrollView.contentLayoutGuide.trailingAnchor),
+            quickActionsView.bottomAnchor.constraint(equalTo: quickActionsScrollView.contentLayoutGuide.bottomAnchor),
+            quickActionsView.widthAnchor.constraint(equalTo: quickActionsScrollView.frameLayoutGuide.widthAnchor),
+            quickActionsScrollView.frameLayoutGuide.heightAnchor.constraint(equalTo: quickActionsScrollView.contentLayoutGuide.heightAnchor),
+
+            centerY,
+            welcomeLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            welcomeLabel.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: Constants.horizontalPadding),
+            welcomeLabel.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -Constants.horizontalPadding),
+        ])
+    }
+
     func embedNativeInputViewController() {
         addChild(nativeInputViewController)
         nativeInputViewController.view.translatesAutoresizingMaskIntoConstraints = false
@@ -298,7 +346,7 @@ private extension AIChatContextualInputViewController {
     }
 
     func updateWelcomeLabelCentering() {
-        guard isContextualSheetImprovementsEnabled else { return }
+        guard isContextualSheetImprovementsEnabled || !showsNativeInput else { return }
         let scrollViewTop = quickActionsScrollView.frame.minY
         guard scrollViewTop > 0 else { return }
         welcomeCenterYConstraint?.constant = scrollViewTop / 2

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -396,6 +396,10 @@ private extension AIChatContextualSheetCoordinator {
             self.sheetViewController?.expandForUTISubmission()
             return frozenContext
         }
+        // Recover to a clean pre-submit sheet if the queued first prompt can't be delivered.
+        host.onFirstPromptFailed = { [weak self] in
+            self?.resetToNativeInputState()
+        }
         return host
     }
 
@@ -452,6 +456,11 @@ private extension AIChatContextualSheetCoordinator {
         Logger.aiChat.debug("[Contextual] Resetting to native input")
 
         sessionState.resetToNoChat()
+
+        // Immediate-UTI: the persistent host + web view are reused across a New-Chat/timeout reset,
+        // so return the host to a clean pre-submit state (unbind + re-arm) — otherwise the next
+        // first prompt would take the bound branch and never flip to the web view.
+        persistentUTIHost?.prepareForNewChat()
 
         Logger.aiChat.debug("[PageContext] New chat - collecting fresh context")
         pageContextHandler.triggerContextCollection()

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -78,6 +78,8 @@ final class AIChatContextualSheetCoordinator {
     private let featureDiscovery: FeatureDiscovery
     private let featureFlagger: FeatureFlagger
     private let unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding
+    /// Gate for the immediate-UTI contextual surface; injected so tests can stub the host-vs-nil fork.
+    private let contextualUTIFeature: ContextualUnifiedToggleInputFeatureProviding
     private let duckAiNativeStorageHandler: DuckAiNativeStorageHandling?
     private let duckAiFireModeStorageHandler: DuckAiNativeStorageHandling?
     private let debugSettings: AIChatDebugSettingsHandling
@@ -97,8 +99,7 @@ final class AIChatContextualSheetCoordinator {
     /// The retained sheet view controller for this tab's active chat session.
     private(set) var sheetViewController: AIChatContextualSheetViewController?
 
-    /// Immediate-UTI: the persistent UTI host mounted once at the sheet level (nil on the legacy path).
-    /// Retained here so both the sheet VC (mount) and the web VC installer (reuse) share one host.
+    /// Immediate-UTI: the persistent sheet-level UTI host (nil on the legacy path), shared by the sheet VC + web VC installer.
     private var persistentUTIHost: AIChatContextualUTIHost?
 
     /// Session timer for auto-resetting the chat after inactivity
@@ -121,10 +122,7 @@ final class AIChatContextualSheetCoordinator {
 
     /// Immediate-UTI availability: the base UTI must be available AND the contextual feature flag on.
     private var isImmediateUTIEnabled: Bool {
-        ContextualUnifiedToggleInputFeature(
-            featureFlagger: featureFlagger,
-            unifiedToggleInputFeature: unifiedToggleInputFeature
-        ).isAvailable
+        contextualUTIFeature.isAvailable
     }
 
     // MARK: - Initialization
@@ -136,6 +134,7 @@ final class AIChatContextualSheetCoordinator {
          featureDiscovery: FeatureDiscovery,
          featureFlagger: FeatureFlagger,
          unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature(),
+         contextualUTIFeature: ContextualUnifiedToggleInputFeatureProviding? = nil,
          pageContextHandler: AIChatPageContextHandling,
          tabURLPublishers: AIChatTabURLPublishers,
          isFireTab: Bool = false,
@@ -150,6 +149,10 @@ final class AIChatContextualSheetCoordinator {
         self.featureDiscovery = featureDiscovery
         self.featureFlagger = featureFlagger
         self.unifiedToggleInputFeature = unifiedToggleInputFeature
+        self.contextualUTIFeature = contextualUTIFeature ?? ContextualUnifiedToggleInputFeature(
+            featureFlagger: featureFlagger,
+            unifiedToggleInputFeature: unifiedToggleInputFeature
+        )
         self.pageContextHandler = pageContextHandler
         self.tabURLPublishers = tabURLPublishers
         self.isFireTab = isFireTab
@@ -263,8 +266,13 @@ private extension AIChatContextualSheetCoordinator {
             sessionState.restoreChat(with: restoreURL)
         }
 
-        let suggestionsReader = makeSuggestionsReaderIfEnabled()
+        let suggestionsReader = makeSuggestionsReader()
         persistentUTIHost = makePersistentUTIHostIfEnabled()
+        if let persistentUTIHost {
+            // The chip VM becomes sessionState's source of truth for "what's attached" while the UTI is active.
+            sessionState.attachedContextOverrideProvider = { [weak persistentUTIHost] in persistentUTIHost?.chipViewModel.attachedContext }
+            persistentUTIHost.onAttachedContextChanged = { [weak sessionState] in sessionState?.rebuildViewState() }
+        }
 
         let sheetVC = AIChatContextualSheetViewController(
             sessionState: sessionState,
@@ -286,8 +294,7 @@ private extension AIChatContextualSheetCoordinator {
         isSheetPresented = true
     }
 
-    func makeSuggestionsReaderIfEnabled() -> AIChatSuggestionsReading? {
-        guard featureFlagger.isFeatureOn(.aiChatContextualSheetImprovements) else { return nil }
+    func makeSuggestionsReader() -> AIChatSuggestionsReading {
         let reader = SuggestionsReader(
             featureFlagger: featureFlagger,
             privacyConfig: privacyConfigurationManager,
@@ -347,15 +354,12 @@ private extension AIChatContextualSheetCoordinator {
             pixelHandler: pixelHandler,
             utiHostInstaller: { [weak self] contextualChatViewController in
                 guard let self else { return nil }
-                // Immediate-UTI: the sheet already mounts one persistent UTI. Point it at the web view
-                // (for context push, delivery telemetry, and the deferred bind) without installing a
-                // second UTI inside the web VC. The host itself keeps the coordinator UNBOUND until
-                // the first submit (`bindToUserScript` defers) — so the first prompt still takes the
-                // unbound → queue path — and binds right after.
+                // Immediate-UTI: point the already-mounted persistent host at the web view (no second UTI); it stays unbound until first submit.
                 if let persistentUTIHost = self.persistentUTIHost {
                     persistentUTIHost.setContextualChatViewController(contextualChatViewController)
                     return persistentUTIHost
                 }
+                // Legacy (immediate-UTI off): mount a web-view-owned host post-flip. Delete this branch when `aiChatContextualUnifiedToggleInput` is removed.
                 let host = self.makeContextualUTIHost(startsPreSubmit: false)
                 host.install(in: contextualChatViewController)
                 return host
@@ -365,8 +369,7 @@ private extension AIChatContextualSheetCoordinator {
         return webVC
     }
 
-    /// Builds a contextual UTI host with the shared configuration. `startsPreSubmit` gates the
-    /// coordinator's pre-submit boot (true only for the immediate-UTI sheet on a fresh chat).
+    /// Builds a contextual UTI host; `startsPreSubmit` gates the pre-submit boot (true only for the immediate-UTI fresh chat).
     private func makeContextualUTIHost(startsPreSubmit: Bool) -> AIChatContextualUTIHost {
         let initialUTIAttachment = self.initialUTIAttachment
         return AIChatContextualUTIHost(
@@ -387,16 +390,11 @@ private extension AIChatContextualSheetCoordinator {
     private func makePersistentUTIHostIfEnabled() -> AIChatContextualUTIHost? {
         guard isImmediateUTIEnabled else { return nil }
         let host = makeContextualUTIHost(startsPreSubmit: !sessionState.hasActiveChat)
-        // The host delivers the first UTI prompt itself; this closure performs the lifecycle flip
-        // (native→web swap + expand) that the native `.submitPrompt` effect would otherwise drive,
-        // and hands back the page context frozen at flip time for the host to deliver.
+        // Flip only — not `handlePromptSubmission` (that emits a text-only submit + double-sends); the host freezes the chip context and delivers.
         host.onFirstPromptSubmitted = { [weak self] in
-            guard let self else { return nil }
-            let frozenContext = self.sessionState.beginChatForUTISubmission()
-            self.sheetViewController?.expandForUTISubmission()
-            return frozenContext
+            self?.sessionState.beginChatForUTISubmission()
+            self?.sheetViewController?.expandForUTISubmission()
         }
-        // Recover to a clean pre-submit sheet if the queued first prompt can't be delivered.
         host.onFirstPromptFailed = { [weak self] in
             self?.resetToNativeInputState()
         }
@@ -457,13 +455,14 @@ private extension AIChatContextualSheetCoordinator {
 
         sessionState.resetToNoChat()
 
-        // Immediate-UTI: the persistent host + web view are reused across a New-Chat/timeout reset,
-        // so return the host to a clean pre-submit state (unbind + re-arm) — otherwise the next
-        // first prompt would take the bound branch and never flip to the web view.
+        // Immediate-UTI: the host + web view are reused across reset, so return the host to clean pre-submit (unbind + re-arm).
         persistentUTIHost?.prepareForNewChat()
 
-        Logger.aiChat.debug("[PageContext] New chat - collecting fresh context")
-        pageContextHandler.triggerContextCollection()
+        // Only auto-collect fresh context when auto-attach is on — otherwise a New Chat / session-timer reset would silently re-attach in manual mode (the immediate-UTI host listener isn't auto-gated).
+        if sessionState.shouldAutoCollectContext {
+            Logger.aiChat.debug("[PageContext] New chat - collecting fresh context")
+            pageContextHandler.triggerContextCollection()
+        }
 
         delegate?.aiChatContextualSheetCoordinator(self, didUpdateContextualChatURL: nil)
     }
@@ -512,6 +511,8 @@ extension AIChatContextualSheetCoordinator: AIChatContextualSheetViewControllerD
 
     func aiChatContextualSheetViewControllerDidRequestAttachPage(_ viewController: AIChatContextualSheetViewController) {
         sessionState.beginManualAttach()
+        // This quick-action attach collects via the page-context handler, so clear the host's post-remove suppression or the re-collected context won't reach the chip.
+        persistentUTIHost?.clearExternalContextSuppression()
         let didTrigger = pageContextHandler.triggerContextCollection()
         if !didTrigger {
             sessionState.cancelManualAttach()

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -97,6 +97,10 @@ final class AIChatContextualSheetCoordinator {
     /// The retained sheet view controller for this tab's active chat session.
     private(set) var sheetViewController: AIChatContextualSheetViewController?
 
+    /// Immediate-UTI: the persistent UTI host mounted once at the sheet level (nil on the legacy path).
+    /// Retained here so both the sheet VC (mount) and the web VC installer (reuse) share one host.
+    private var persistentUTIHost: AIChatContextualUTIHost?
+
     /// Session timer for auto-resetting the chat after inactivity
     private var sessionTimer: AIChatSessionTimer?
 
@@ -113,6 +117,14 @@ final class AIChatContextualSheetCoordinator {
     /// Publishes the URL of the page that originated the contextual chat session, with replay of the last value.
     var originatingURLPublisher: AnyPublisher<URL?, Never> {
         tabURLPublishers.originating
+    }
+
+    /// Immediate-UTI availability: the base UTI must be available AND the contextual feature flag on.
+    private var isImmediateUTIEnabled: Bool {
+        ContextualUnifiedToggleInputFeature(
+            featureFlagger: featureFlagger,
+            unifiedToggleInputFeature: unifiedToggleInputFeature
+        ).isAvailable
     }
 
     // MARK: - Initialization
@@ -252,6 +264,7 @@ private extension AIChatContextualSheetCoordinator {
         }
 
         let suggestionsReader = makeSuggestionsReaderIfEnabled()
+        persistentUTIHost = makePersistentUTIHostIfEnabled()
 
         let sheetVC = AIChatContextualSheetViewController(
             sessionState: sessionState,
@@ -263,7 +276,8 @@ private extension AIChatContextualSheetCoordinator {
             },
             pixelHandler: pixelHandler,
             featureFlagger: featureFlagger,
-            suggestionsReader: suggestionsReader
+            suggestionsReader: suggestionsReader,
+            persistentUTIHost: persistentUTIHost
         )
         sheetVC.delegate = self
         sheetViewController = sheetVC
@@ -333,24 +347,44 @@ private extension AIChatContextualSheetCoordinator {
             pixelHandler: pixelHandler,
             utiHostInstaller: { [weak self] contextualChatViewController in
                 guard let self else { return nil }
-                let initialUTIAttachment = self.initialUTIAttachment
-                let host = AIChatContextualUTIHost(
-                    originatingURLPublisher: self.originatingURLPublisher,
-                    didFinishURLPublisher: self.tabURLPublishers.didFinish,
-                    initialAttachedContext: initialUTIAttachment.context,
-                    initialAttachmentDeliveryState: initialUTIAttachment.deliveryState,
-                    hasActiveChat: { [weak self] in self?.sessionState.hasActiveChat ?? false },
-                    isAutoAttachEnabled: { [weak self] in self?.sessionState.shouldAutoCollectContext ?? false },
-                    pageContextHandler: self.pageContextHandler,
-                    isFireTab: self.isFireTab,
-                    lastUsedModelProvider: self.duckAiLastUsedModelProvider
-                )
+                // Immediate-UTI: the sheet already mounts one persistent UTI. Point it at the web view
+                // (for context push / later bind) but do NOT install a second UTI in the web VC, and do
+                // NOT return it for binding — the host stays unbound until the first submit.
+                if let persistentUTIHost = self.persistentUTIHost {
+                    persistentUTIHost.setContextualChatViewController(contextualChatViewController)
+                    return nil
+                }
+                let host = self.makeContextualUTIHost(startsPreSubmit: false)
                 host.install(in: contextualChatViewController)
                 return host
             }
         )
 
         return webVC
+    }
+
+    /// Builds a contextual UTI host with the shared configuration. `startsPreSubmit` gates the
+    /// coordinator's pre-submit boot (true only for the immediate-UTI sheet on a fresh chat).
+    private func makeContextualUTIHost(startsPreSubmit: Bool) -> AIChatContextualUTIHost {
+        let initialUTIAttachment = self.initialUTIAttachment
+        return AIChatContextualUTIHost(
+            originatingURLPublisher: originatingURLPublisher,
+            didFinishURLPublisher: tabURLPublishers.didFinish,
+            initialAttachedContext: initialUTIAttachment.context,
+            initialAttachmentDeliveryState: initialUTIAttachment.deliveryState,
+            hasActiveChat: { [weak self] in self?.sessionState.hasActiveChat ?? false },
+            isAutoAttachEnabled: { [weak self] in self?.sessionState.shouldAutoCollectContext ?? false },
+            pageContextHandler: pageContextHandler,
+            isFireTab: isFireTab,
+            contextualStartsPreSubmit: startsPreSubmit,
+            lastUsedModelProvider: duckAiLastUsedModelProvider
+        )
+    }
+
+    /// Immediate-UTI: builds the persistent sheet-level host (pre-submit unless restoring an active chat).
+    private func makePersistentUTIHostIfEnabled() -> AIChatContextualUTIHost? {
+        guard isImmediateUTIEnabled else { return nil }
+        return makeContextualUTIHost(startsPreSubmit: !sessionState.hasActiveChat)
     }
 
     var initialUTIAttachment: (context: AIChatPageContext?, deliveryState: PageContextAttachmentDeliveryState) {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -348,11 +348,13 @@ private extension AIChatContextualSheetCoordinator {
             utiHostInstaller: { [weak self] contextualChatViewController in
                 guard let self else { return nil }
                 // Immediate-UTI: the sheet already mounts one persistent UTI. Point it at the web view
-                // (for context push / later bind) but do NOT install a second UTI in the web VC, and do
-                // NOT return it for binding — the host stays unbound until the first submit.
+                // (for context push, delivery telemetry, and the deferred bind) without installing a
+                // second UTI inside the web VC. The host itself keeps the coordinator UNBOUND until
+                // the first submit (`bindToUserScript` defers) — so the first prompt still takes the
+                // unbound → queue path — and binds right after.
                 if let persistentUTIHost = self.persistentUTIHost {
                     persistentUTIHost.setContextualChatViewController(contextualChatViewController)
-                    return nil
+                    return persistentUTIHost
                 }
                 let host = self.makeContextualUTIHost(startsPreSubmit: false)
                 host.install(in: contextualChatViewController)
@@ -384,7 +386,17 @@ private extension AIChatContextualSheetCoordinator {
     /// Immediate-UTI: builds the persistent sheet-level host (pre-submit unless restoring an active chat).
     private func makePersistentUTIHostIfEnabled() -> AIChatContextualUTIHost? {
         guard isImmediateUTIEnabled else { return nil }
-        return makeContextualUTIHost(startsPreSubmit: !sessionState.hasActiveChat)
+        let host = makeContextualUTIHost(startsPreSubmit: !sessionState.hasActiveChat)
+        // The host delivers the first UTI prompt itself; this closure performs the lifecycle flip
+        // (native→web swap + expand) that the native `.submitPrompt` effect would otherwise drive,
+        // and hands back the page context frozen at flip time for the host to deliver.
+        host.onFirstPromptSubmitted = { [weak self] in
+            guard let self else { return nil }
+            let frozenContext = self.sessionState.beginChatForUTISubmission()
+            self.sheetViewController?.expandForUTISubmission()
+            return frozenContext
+        }
+        return host
     }
 
     var initialUTIAttachment: (context: AIChatPageContext?, deliveryState: PageContextAttachmentDeliveryState) {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
@@ -122,18 +122,26 @@ final class AIChatContextualSheetViewController: UIViewController {
     private let appSettings: AppSettings
     private let featureFlagger: FeatureFlagger
     private let suggestionsReader: AIChatSuggestionsReading?
+    /// Immediate-UTI: a persistent UTI owned at the sheet level, mounted once and spanning the
+    /// presubmission→postsubmission swap. Nil on the legacy path (the web VC mounts its own UTI).
+    private let persistentUTIHost: AIChatContextualUTIHost?
     private var recentChatsPopup: AIChatRecentChatsPopupViewController?
     private var popupWindow: UIWindow?
     private var isFetchingRecentChats = false
 
     private lazy var contextualInputViewController = AIChatContextualInputViewController(
         voiceSearchHelper: voiceSearchHelper,
-        isContextualSheetImprovementsEnabled: featureFlagger.isFeatureOn(.aiChatContextualSheetImprovements)
+        isContextualSheetImprovementsEnabled: featureFlagger.isFeatureOn(.aiChatContextualSheetImprovements),
+        showsNativeInput: persistentUTIHost == nil
     )
     private var cancellables = Set<AnyCancellable>()
 
     /// The single web view controller for this sheet, created once and reused
     private var webViewController: AIChatContextualWebViewController?
+
+    /// Content area bottom. Pinned to the sheet bottom on the legacy path; re-anchored to the
+    /// persistent UTI's top on the immediate-UTI path so the content sits above the stationary input.
+    private var contentContainerBottomConstraint: NSLayoutConstraint?
 
     /// Whether the web view is currently visible (vs native input being visible)
     private var isWebViewVisible = false
@@ -274,7 +282,8 @@ final class AIChatContextualSheetViewController: UIViewController {
          pixelHandler: AIChatContextualModePixelFiring,
          appSettings: AppSettings = AppDependencyProvider.shared.appSettings,
          featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
-         suggestionsReader: AIChatSuggestionsReading? = nil) {
+         suggestionsReader: AIChatSuggestionsReading? = nil,
+         persistentUTIHost: AIChatContextualUTIHost? = nil) {
         self.sessionState = sessionState
         self.aiChatSettings = aiChatSettings
         self.voiceSearchHelper = voiceSearchHelper
@@ -283,6 +292,7 @@ final class AIChatContextualSheetViewController: UIViewController {
         self.appSettings = appSettings
         self.featureFlagger = featureFlagger
         self.suggestionsReader = suggestionsReader
+        self.persistentUTIHost = persistentUTIHost
         super.init(nibName: nil, bundle: nil)
         configureModalPresentation()
     }
@@ -305,8 +315,20 @@ final class AIChatContextualSheetViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
+        mountPersistentUTIHostIfNeeded()
         createAndConfigureWebViewController(restoreURL: sessionState.contextualChatURL)
         bindViewModel()
+    }
+
+    /// Immediate-UTI: mount the persistent UTI once at the sheet level and re-anchor the content
+    /// area above it, so the input stays put across the presubmission→postsubmission content swap.
+    private func mountPersistentUTIHostIfNeeded() {
+        guard let persistentUTIHost else { return }
+        let utiView = persistentUTIHost.mountAtSheetLevel(in: self)
+        contentContainerBottomConstraint?.isActive = false
+        let newBottom = contentContainerView.bottomAnchor.constraint(equalTo: utiView.topAnchor)
+        contentContainerBottomConstraint = newBottom
+        newBottom.isActive = true
     }
 
     /// Creates a web VC and starts loading the appropriate URL.
@@ -457,6 +479,10 @@ private extension AIChatContextualSheetViewController {
 
     func removeCurrentChildViewController() {
         children.forEach { child in
+            // Only the swappable content (input / web VC) lives in `contentContainerView`. The
+            // immediate-UTI bar is mounted directly on the sheet and must survive the swap —
+            // removing it would also drop the content's `bottom == UTI.top` anchor and collapse it.
+            guard child.view.superview === contentContainerView else { return }
             child.willMove(toParent: nil)
             child.view.removeFromSuperview()
             child.removeFromParent()
@@ -989,6 +1015,8 @@ private extension AIChatContextualSheetViewController {
     }
 
     func setupConstraints() {
+        let contentBottom = contentContainerView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        contentContainerBottomConstraint = contentBottom
         NSLayoutConstraint.activate([
 
             topSeparator.topAnchor.constraint(equalTo: view.topAnchor),
@@ -1029,7 +1057,7 @@ private extension AIChatContextualSheetViewController {
             contentContainerView.topAnchor.constraint(equalTo: headerView.bottomAnchor, constant: Constants.contentTopPadding),
             contentContainerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             contentContainerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            contentContainerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            contentBottom,
         ])
     }
     

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
@@ -122,8 +122,7 @@ final class AIChatContextualSheetViewController: UIViewController {
     private let appSettings: AppSettings
     private let featureFlagger: FeatureFlagger
     private let suggestionsReader: AIChatSuggestionsReading?
-    /// Immediate-UTI: a persistent UTI owned at the sheet level, mounted once and spanning the
-    /// presubmission→postsubmission swap. Nil on the legacy path (the web VC mounts its own UTI).
+    /// Immediate-UTI: a sheet-level UTI mounted once, spanning the content swap. Nil on the legacy path (web VC mounts its own).
     private let persistentUTIHost: AIChatContextualUTIHost?
     private var recentChatsPopup: AIChatRecentChatsPopupViewController?
     private var popupWindow: UIWindow?
@@ -131,7 +130,6 @@ final class AIChatContextualSheetViewController: UIViewController {
 
     private lazy var contextualInputViewController = AIChatContextualInputViewController(
         voiceSearchHelper: voiceSearchHelper,
-        isContextualSheetImprovementsEnabled: featureFlagger.isFeatureOn(.aiChatContextualSheetImprovements),
         showsNativeInput: persistentUTIHost == nil
     )
     private var cancellables = Set<AnyCancellable>()
@@ -139,8 +137,7 @@ final class AIChatContextualSheetViewController: UIViewController {
     /// The single web view controller for this sheet, created once and reused
     private var webViewController: AIChatContextualWebViewController?
 
-    /// Content area bottom. Pinned to the sheet bottom on the legacy path; re-anchored to the
-    /// persistent UTI's top on the immediate-UTI path so the content sits above the stationary input.
+    /// Content-area bottom: pinned to the sheet bottom (legacy) or re-anchored to the persistent UTI's top (immediate-UTI).
     private var contentContainerBottomConstraint: NSLayoutConstraint?
 
     /// Whether the web view is currently visible (vs native input being visible)
@@ -320,8 +317,7 @@ final class AIChatContextualSheetViewController: UIViewController {
         bindViewModel()
     }
 
-    /// Immediate-UTI: mount the persistent UTI once at the sheet level and re-anchor the content
-    /// area above it, so the input stays put across the presubmission→postsubmission content swap.
+    /// Immediate-UTI: mount the persistent UTI at sheet level + re-anchor content above it, so the input stays put across the swap.
     private func mountPersistentUTIHostIfNeeded() {
         guard let persistentUTIHost else { return }
         let utiView = persistentUTIHost.mountAtSheetLevel(in: self)
@@ -479,9 +475,7 @@ private extension AIChatContextualSheetViewController {
 
     func removeCurrentChildViewController() {
         children.forEach { child in
-            // Only the swappable content (input / web VC) lives in `contentContainerView`. The
-            // immediate-UTI bar is mounted directly on the sheet and must survive the swap —
-            // removing it would also drop the content's `bottom == UTI.top` anchor and collapse it.
+            // Only the swappable content (input / web VC) lives here; the sheet-level immediate-UTI bar must survive the swap.
             guard child.view.superview === contentContainerView else { return }
             child.willMove(toParent: nil)
             child.view.removeFromSuperview()
@@ -583,33 +577,9 @@ private extension AIChatContextualSheetViewController {
 
     func updateChipUI(chipState: ChipState) {
         switch chipState {
-        case .placeholder:
-            if featureFlagger.isFeatureOn(.aiChatContextualSheetImprovements) {
-                if contextualInputViewController.isContextChipVisible {
-                    contextualInputViewController.hideContextChip()
-                }
-            } else {
-                if contextualInputViewController.isContextChipVisible {
-                    contextualInputViewController.updateContextChipState(.placeholder)
-                    contextualInputViewController.setChipTapCallback { [weak self] in
-                        guard let self else { return }
-                        self.pixelHandler.firePageContextPlaceholderTapped()
-                        self.delegate?.aiChatContextualSheetViewControllerDidRequestAttachPage(self)
-                    }
-                } else {
-                    let chipView = createPlaceholderChipView(
-                        onTapToAttach: { [weak self] in
-                            guard let self else { return }
-                            self.pixelHandler.firePageContextPlaceholderTapped()
-                            self.delegate?.aiChatContextualSheetViewControllerDidRequestAttachPage(self)
-                        },
-                        onRemove: { [weak self] in
-                            self?.handleChipRemoved()
-                        }
-                    )
-                    contextualInputViewController.showContextChip(chipView)
-                    pixelHandler.firePageContextPlaceholderShown()
-                }
+        case .noContext:
+            if contextualInputViewController.isContextChipVisible {
+                contextualInputViewController.hideContextChip()
             }
         case .attached(let context):
             if contextualInputViewController.isContextChipVisible {
@@ -621,14 +591,6 @@ private extension AIChatContextualSheetViewController {
                 contextualInputViewController.showContextChip(chipView)
             }
         }
-    }
-
-    func createPlaceholderChipView(onTapToAttach: @escaping () -> Void, onRemove: @escaping () -> Void) -> AIChatContextChipView {
-        let chipView = AIChatContextChipView()
-        chipView.configure(state: .placeholder)
-        chipView.onTapToAttach = onTapToAttach
-        chipView.onRemove = onRemove
-        return chipView
     }
 
     func createContextChipView(context: AIChatPageContext, onRemove: @escaping () -> Void) -> AIChatContextChipView {
@@ -783,7 +745,13 @@ extension AIChatContextualSheetViewController: AIChatContextualInputViewControll
         case .askAboutPage:
             pixelHandler.fireQuickActionAskAboutPageSelected()
             delegate?.aiChatContextualSheetViewControllerDidRequestAttachPage(self)
-            contextualInputViewController.becomeFirstResponder()
+            // Immediate-UTI: focus the sheet-mounted UTI (the native input is a no-op surface) and grow the sheet so the keyboard has room; native path just raises its own keyboard.
+            if let persistentUTIHost {
+                persistentUTIHost.activateInput()
+                expandToLargeDetent()
+            } else {
+                contextualInputViewController.becomeFirstResponder()
+            }
         case .summarize:
             pixelHandler.fireQuickActionSummarizeSelected()
             delegate?.aiChatContextualSheetViewControllerDidRequestAttachPage(self)
@@ -792,7 +760,12 @@ extension AIChatContextualSheetViewController: AIChatContextualInputViewControll
             }
         case .summarizePage:
             pixelHandler.fireQuickActionSummarizeSelected()
-            delegate?.aiChatContextualSheetViewController(self, didSubmitPrompt: action.prompt)
+            // Immediate-UTI: route through the real submit funnel so it can't strand the coordinator unbound; native path is unaffected.
+            if let persistentUTIHost {
+                persistentUTIHost.submitQuickActionPrompt(action.prompt)
+            } else {
+                delegate?.aiChatContextualSheetViewController(self, didSubmitPrompt: action.prompt)
+            }
         }
     }
 
@@ -1152,9 +1125,7 @@ extension AIChatContextualSheetViewController {
         webViewController?.notifyInitialNativePromptSubmitted(hasPageContext: hasPageContext)
     }
 
-    /// Immediate-UTI: expand the sheet to the large detent on the first UTI submit. Mirrors the
-    /// `expandToLargeDetent()` that the native `.submitPrompt` effect drives via `showWebViewWithPrompt`,
-    /// which the UTI path bypasses (the host delivers the prompt directly).
+    /// Immediate-UTI: expand to the large detent on first submit (the native `.submitPrompt` path does this via `showWebViewWithPrompt`).
     func expandForUTISubmission() {
         expandToLargeDetent()
     }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
@@ -1151,4 +1151,11 @@ extension AIChatContextualSheetViewController {
     func notifyInitialNativePromptSubmitted(hasPageContext: Bool) {
         webViewController?.notifyInitialNativePromptSubmitted(hasPageContext: hasPageContext)
     }
+
+    /// Immediate-UTI: expand the sheet to the large detent on the first UTI submit. Mirrors the
+    /// `expandToLargeDetent()` that the native `.submitPrompt` effect drives via `showWebViewWithPrompt`,
+    /// which the UTI path bypasses (the host delivers the prompt directly).
+    func expandForUTISubmission() {
+        expandToLargeDetent()
+    }
 }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -233,6 +233,37 @@ final class AIChatContextualUTIHost {
         Logger.contextualUTI.info("Installed at bottom of contextual chat")
     }
 
+    /// Immediate-UTI path: mounts the persistent UTI at the sheet level so it outlives the
+    /// presubmission→postsubmission content swap. Returns the UTI view so the sheet can anchor its
+    /// content above it. Mounted expanded but keyboard-down (parity); the chat web view is set later
+    /// via `setContextualChatViewController`, and binding is deferred until the first submit.
+    @discardableResult
+    func mountAtSheetLevel(in sheetViewController: UIViewController) -> UIView {
+        coordinator.attachmentPresentingViewController = sheetViewController
+        UIView.performWithoutAnimation {
+            sheetViewController.addChild(coordinator.viewController)
+            sheetViewController.view.addSubview(coordinator.viewController.view)
+            coordinator.viewController.view.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                coordinator.viewController.view.leadingAnchor.constraint(equalTo: sheetViewController.view.leadingAnchor),
+                coordinator.viewController.view.trailingAnchor.constraint(equalTo: sheetViewController.view.trailingAnchor),
+                coordinator.viewController.view.bottomAnchor.constraint(equalTo: sheetViewController.view.keyboardLayoutGuide.topAnchor),
+            ])
+            coordinator.viewController.didMove(toParent: sheetViewController)
+            coordinator.showExpanded(activatesInput: false)
+            applyCurrentRenderState()
+            sheetViewController.view.layoutIfNeeded()
+        }
+        Logger.contextualUTI.info("Mounted UTI at sheet level (immediate-UTI)")
+        return coordinator.viewController.view
+    }
+
+    /// Sets the chat web view the host pushes page context into / binds to, without mounting the UTI
+    /// inside it (sheet-level mount path).
+    func setContextualChatViewController(_ webViewController: AIChatContextualWebViewController) {
+        self.contextualChatViewController = webViewController
+    }
+
     private func applyCurrentRenderState() {
         coordinator.viewController.apply(coordinator.computeRenderState().viewConfig, animated: false)
         contextualChatViewController?.view.layoutIfNeeded()

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -32,6 +32,8 @@ final class AIChatContextualUTIHost {
     let chipViewModel: UnifiedToggleInputPageContextChipViewModel
     private let isAutoAttachEnabled: () -> Bool
     private let hasActiveChat: () -> Bool
+    /// Live phase source handed to the coordinator (weak there) so the model chip survives a rebind.
+    private let hostAdapter: ContextualChatHostAdapter
     private weak var contextualChatViewController: AIChatContextualWebViewController?
     private var pendingChipAttachCancellable: AnyCancellable?
     private var suppressExternalContextUntilNextAttach = false
@@ -49,11 +51,13 @@ final class AIChatContextualUTIHost {
         isAutoAttachEnabled: @escaping () -> Bool,
         pageContextHandler: AIChatPageContextHandling,
         isFireTab: Bool,
+        contextualStartsPreSubmit: Bool = false,
         lastUsedModelProvider: DuckAiLastUsedModelProviding? = nil
     ) {
         self.pageContextHandler = pageContextHandler
         self.isAutoAttachEnabled = isAutoAttachEnabled
         self.hasActiveChat = hasActiveChat
+        self.hostAdapter = ContextualChatHostAdapter(hasActiveChat: hasActiveChat)
         let wideEventInstrumentation = DefaultDuckAIWideEventInstrumentation(
             wideEvent: AppDependencyProvider.shared.wideEvent
         )
@@ -62,6 +66,7 @@ final class AIChatContextualUTIHost {
             host: .contextualChat,
             isToggleEnabled: false,
             isFireTab: isFireTab,
+            contextualStartsPreSubmit: contextualStartsPreSubmit,
             lastUsedModelProvider: lastUsedModelProvider,
             duckAIWideEventInstrumentation: wideEventInstrumentation,
             duckAIWideEventFlowScope: duckAIWideEventFlowScope
@@ -73,6 +78,7 @@ final class AIChatContextualUTIHost {
             isAutoAttachEnabled: isAutoAttachEnabled
         )
         coordinator.viewController.bindPageContextChip(to: chipViewModel)
+        coordinator.hostAdapter = hostAdapter
         chipViewModel.onAttachActionRequested = { [weak self] url in
             self?.handleChipAttachRequest(originatingURL: url)
         }
@@ -264,4 +270,17 @@ extension AIChatContextualUTIHost {
             hasPageContext: hasPageContext
         )
     }
+}
+
+/// Live view of the contextual chat's submission phase for the coordinator's model-chip logic.
+/// Reads `hasActiveChat` on each access so it reflects the current phase even after a user-script
+/// rebind (which resets `hasSubmittedPrompt` but not the chat's active state).
+private final class ContextualChatHostAdapter: UnifiedToggleInputHostAdapter {
+    private let hasActiveChat: () -> Bool
+
+    init(hasActiveChat: @escaping () -> Bool) {
+        self.hasActiveChat = hasActiveChat
+    }
+
+    var isPreSubmitPhase: Bool { !hasActiveChat() }
 }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -37,23 +37,22 @@ final class AIChatContextualUTIHost {
     private weak var contextualChatViewController: AIChatContextualWebViewController?
     private var pendingChipAttachCancellable: AnyCancellable?
     private var suppressExternalContextUntilNextAttach = false
+    /// URL of the context last confirmed delivered in a prompt — an auto-update for this same URL must not reopen the chip.
+    private var lastDeliveredContextURL: URL?
     private var isBoundToUserScript = false
-    /// True for the immediate-UTI fresh-chat host: the coordinator stays unbound until the first
-    /// submit so that prompt takes the unbound → web-VC-queue path (a bound first submit would skip
-    /// the frontend-state flip → invisible chat). Restored/legacy hosts bind immediately.
+    /// Immediate-UTI fresh chat: keep the coordinator unbound until first submit so that prompt takes the unbound path.
     private let startsPreSubmit: Bool
     /// Set once the first UTI prompt is delivered; gates rapid re-submit and flips a deferred bind to immediate.
     private var hasDeliveredFirstPrompt = false
     /// User script stashed at `bindToUserScript` while pre-submit; bound after the first submit.
     private weak var pendingUserScriptToBind: AIChatUserScript?
-    /// The web view's user script, remembered across binds so a New-Chat reset can re-arm the
-    /// deferred bind against the same (still-alive) script without waiting for a fresh install.
+    /// The web view's user script, remembered across binds so a New-Chat reset can re-arm the deferred bind.
     private weak var lastKnownUserScript: AIChatUserScript?
-    /// Flips the session into an active chat (native→web swap + expand) on the first UTI submit and
-    /// returns the page context frozen at flip time. Wired by the sheet coordinator, which owns session state.
-    var onFirstPromptSubmitted: (() -> AIChatPageContextData?)?
-    /// Fired when the queued first prompt can no longer be delivered (page load failed) so the sheet
-    /// can recover to a clean pre-submit state for retry. Wired by the sheet coordinator.
+    /// Flip-only (native→web swap + expand); the host freezes the chip context itself, so this returns nothing.
+    var onFirstPromptSubmitted: (() -> Void)?
+    /// Fired whenever the chip's effective attachment changes, so `sessionState` can recompute its view state.
+    var onAttachedContextChanged: (() -> Void)?
+    /// Recover to a clean pre-submit sheet when the queued first prompt can't be delivered (page load failed).
     var onFirstPromptFailed: (() -> Void)?
     private var cancellables = Set<AnyCancellable>()
     private let duckAIWideEventInstrumentation: DuckAIWideEventInstrumentation
@@ -89,8 +88,7 @@ final class AIChatContextualUTIHost {
             duckAIWideEventInstrumentation: wideEventInstrumentation,
             duckAIWideEventFlowScope: duckAIWideEventFlowScope
         )
-        // Immediate pre-submit: a carried-over attachment hasn't been delivered yet (it rides the
-        // first prompt), so seed the chip as pending → visible, matching the legacy native chip.
+        // Immediate pre-submit: a carried-over attachment rides the first prompt, so seed it pending → visible.
         let seedDeliveryState: PageContextAttachmentDeliveryState =
             (contextualStartsPreSubmit && initialAttachedContext != nil) ? .pendingSubmit : initialAttachmentDeliveryState
         self.chipViewModel = UnifiedToggleInputPageContextChipViewModel(
@@ -108,7 +106,7 @@ final class AIChatContextualUTIHost {
             self?.handleChipRemoveRequest()
         }
 
-        // Page context is attached via the "Ask About Page" attach-menu item (no placeholder chip).
+        // Page context is attached via the "Ask About Page" attach-menu item.
         coordinator.canAttachPageContext = { [weak self] in
             self?.chipViewModel.canAttachPageContext ?? false
         }
@@ -118,6 +116,12 @@ final class AIChatContextualUTIHost {
         chipViewModel.$canAttachPageContext
             .removeDuplicates()
             .sink { [weak self] _ in self?.coordinator.refreshAttachmentMenu() }
+            .store(in: &cancellables)
+
+        // Lets `sessionState` recompute its view state whenever the chip's effective attachment changes.
+        chipViewModel.$state
+            .dropFirst()
+            .sink { [weak self] _ in self?.onAttachedContextChanged?() }
             .store(in: &cancellables)
 
         Logger.contextualUTI.debug("UTIHost init — carryOver=\(initialAttachedContext != nil, privacy: .public) auto=\(isAutoAttachEnabled(), privacy: .public)")
@@ -141,17 +145,16 @@ final class AIChatContextualUTIHost {
                 guard context != self.chipViewModel.attachedContext else { return }
                 Logger.contextualUTI.debug("UTIHost contextPublisher emission → \(context != nil ? "context" : "nil", privacy: .public) — syncing chip")
                 if let context {
-                    self.chipViewModel.setAttached(context, deliveryState: self.externalContextDeliveryState)
+                    // The same page continuing to load/settle after its context was already delivered must not reopen the chip — only a genuine navigation (handled by the didFinish listener below) should.
+                    let alreadyDeliveredThisPage = URL(string: context.contextData.url) != nil && URL(string: context.contextData.url) == self.lastDeliveredContextURL
+                    self.chipViewModel.setAttached(context, deliveryState: alreadyDeliveredThisPage ? .delivered : self.externalContextDeliveryState)
                 } else {
                     self.chipViewModel.clearAttached()
                 }
             }
             .store(in: &cancellables)
 
-        // didFinish (not didCommit) so the new DOM is ready when JS reads it. `dropFirst`
-        // skips the synchronous replay of the URL the half-sheet was opened on — the
-        // half-sheet is the user's attach/skip decision point. Only subsequent in-chat
-        // navigations should trigger auto-attach.
+        // `didFinish` (not `didCommit`) so the new page's DOM is ready when JS reads it — collecting at didCommit reads the outgoing page (off-by-one). `dropFirst` skips the sheet-open replay (the half-sheet is the attach/skip decision point); only subsequent navigations re-collect.
         didFinishURLPublisher
             .dropFirst()
             .removeDuplicates()
@@ -163,19 +166,22 @@ final class AIChatContextualUTIHost {
                     Logger.contextualUTI.debug("UTIHost didFinish skip — auto disabled")
                     return
                 }
+                // The user explicitly removed context this chat — respect that across navigation (don't silently re-attach); cleared by an explicit re-attach or a new chat.
+                guard !self.suppressExternalContextUntilNextAttach else {
+                    Logger.contextualUTI.debug("UTIHost didFinish skip — user removed context; not re-attaching on nav")
+                    return
+                }
                 if let attached = self.chipViewModel.attachedContext,
                    URL(string: attached.contextData.url) == url {
                     Logger.contextualUTI.debug("UTIHost didFinish skip — already attached to same URL")
                     return
                 }
-                Logger.contextualUTI.info("Auto-attach on page load — triggering for \(url.shortDescription, privacy: .private)")
+                Logger.contextualUTI.info("Auto-attach on navigation — triggering for \(url.shortDescription, privacy: .private)")
                 self.handleChipAttachRequest(originatingURL: url)
             }
             .store(in: &cancellables)
 
-        // The host receives the first (unbound) UTI submit through the coordinator delegate; once
-        // bound, subsequent prompts go direct. Legacy/restored hosts bind immediately, so the
-        // delegate submit path never fires for them.
+        // The host receives the first (unbound) UTI submit through the coordinator delegate; bound prompts go direct.
         coordinator.delegate = self
     }
 
@@ -220,18 +226,15 @@ final class AIChatContextualUTIHost {
     /// the chip says is currently attached — no duplicate state, single source of truth.
     func bindToUserScript(_ userScript: AIChatUserScript) {
         lastKnownUserScript = userScript
-        // Wire the page-context provider + submission callback right away — safe pre-submit, and
-        // subsequent (bound) prompts pull their context from the provider.
+        // Wire the provider + submission callback right away — safe pre-submit; bound prompts read context from it.
         userScript.attachedPageContextProvider = { [weak self] in
             self?.chipViewModel.pendingAttachedContextData
         }
         userScript.onPromptSubmitted = { [weak self] in
-            self?.chipViewModel.markPromptSubmitted()
+            self?.recordDeliveryAndMarkSubmitted()
         }
 
-        // Immediate-UTI fresh chat: defer the coordinator bind until the first submit so that first
-        // prompt takes the unbound → web-VC-queue path (a bound first submit would skip the
-        // frontend-state flip → invisible chat). Legacy/restored hosts bind immediately.
+        // Immediate-UTI fresh chat: defer the bind until first submit so that prompt takes the unbound path.
         guard startsPreSubmit, !hasDeliveredFirstPrompt else {
             commitBind(to: userScript)
             return
@@ -250,33 +253,28 @@ final class AIChatContextualUTIHost {
         }
     }
 
-    /// Binds the user script stashed during the pre-submit window (called right after the first submit).
-    /// No-op if the web view hasn't installed its user script yet — a later `bindToUserScript` will
-    /// bind immediately because `hasDeliveredFirstPrompt` is now set.
+    /// Binds the user script stashed during the pre-submit window, called right after the first submit.
     private func commitDeferredBindIfNeeded() {
         guard let userScript = pendingUserScriptToBind else { return }
         pendingUserScriptToBind = nil
         commitBind(to: userScript)
     }
 
-    /// Returns the persistent host to a clean pre-submit state for a new chat (New-Chat / session
-    /// timeout), reusing the same sheet + web view. Unbinds the coordinator so the next first prompt
-    /// takes the unbound → flip path (a bound first submit would skip the frontend-state flip and the
-    /// chat would never become visible), re-arms the deferred bind against the still-alive user
-    /// script, resets the chip, and restores the expanded pre-submit bar (keyboard down).
+    /// Resets the reused host to a clean pre-submit state for a new chat: unbind, re-arm the deferred bind, reset chip, re-expand.
     func prepareForNewChat() {
         coordinator.unbind()
         isBoundToUserScript = false
         hasDeliveredFirstPrompt = false
         pendingUserScriptToBind = lastKnownUserScript
+        // A new chat is a fresh start — clear any post-remove suppression from the prior chat so the new chat's auto-attach isn't silently dropped.
+        suppressExternalContextUntilNextAttach = false
+        lastDeliveredContextURL = nil
         chipViewModel.clearAttached()
         coordinator.showExpanded(activatesInput: false)
         Logger.contextualUTI.info("Host reset for new chat — unbound, re-armed deferred bind")
     }
 
-    /// Called when the web view fails to load while a first prompt is queued for delivery. The web
-    /// VC queue is the sole first-prompt buffer, so a failed load would strand it — recover to a
-    /// clean pre-submit state (via the sheet) so the user can retry.
+    /// Web view failed to load while a first prompt was queued (the sole buffer) — recover to pre-submit for retry.
     func firstPromptDeliveryFailed() {
         Logger.contextualUTI.error("First prompt delivery failed (page load) — recovering to pre-submit")
         onFirstPromptFailed?()
@@ -286,15 +284,33 @@ final class AIChatContextualUTIHost {
         coordinator.observeChatUpdates(publisher)
     }
 
+    /// Raises the keyboard / focuses the sheet-mounted UTI (mounted keyboard-down); used when a quick action attaches context and should hand off to typing.
+    func activateInput() {
+        coordinator.activateInput()
+    }
+
+    /// Clears the post-remove context suppression so a fresh externally-triggered attach reaches the chip. The sheet's "Ask about page" quick action collects via the page-context handler (not the chip's own attach path, which clears this itself), so without this the out-of-band listener would drop the re-collected context and the chip would never reappear.
+    func clearExternalContextSuppression() {
+        suppressExternalContextUntilNextAttach = false
+    }
+
     func markPromptSubmitted() {
+        recordDeliveryAndMarkSubmitted()
+    }
+
+    /// Records which page's context was just delivered, then marks the chip's attachment delivered.
+    private func recordDeliveryAndMarkSubmitted() {
+        lastDeliveredContextURL = chipViewModel.attachedContext.flatMap { URL(string: $0.contextData.url) }
         chipViewModel.markPromptSubmitted()
     }
 
+    /// Routes a quick-action prompt through the same submit funnel as a typed UTI prompt, so it can't strand the coordinator unbound.
+    func submitQuickActionPrompt(_ prompt: String) {
+        coordinator.submitProgrammatic(text: prompt)
+    }
+
     private var externalContextDeliveryState: PageContextAttachmentDeliveryState {
-        // Immediate pre-submit: context collected on sheet open (via the external publisher) rides
-        // the first prompt, so show the chip as pending — parity with the legacy native chip and the
-        // manual-attach / post-nav paths, which are already pending. Without this, the sheet-open
-        // auto-attach would arrive `.delivered` and the chip would be silently hidden pre-submit.
+        // Immediate pre-submit: sheet-open context rides the first prompt, so show it pending (parity with manual/post-nav), not silently delivered.
         if startsPreSubmit && !hasDeliveredFirstPrompt {
             return .pendingSubmit
         }
@@ -327,10 +343,7 @@ final class AIChatContextualUTIHost {
         Logger.contextualUTI.info("Installed at bottom of contextual chat")
     }
 
-    /// Immediate-UTI path: mounts the persistent UTI at the sheet level so it outlives the
-    /// presubmission→postsubmission content swap. Returns the UTI view so the sheet can anchor its
-    /// content above it. Mounted expanded but keyboard-down (parity); the chat web view is set later
-    /// via `setContextualChatViewController`, and binding is deferred until the first submit.
+    /// Immediate-UTI: mounts the persistent UTI at sheet level (expanded, keyboard-down) so it outlives the content swap; returns its view to anchor content above.
     @discardableResult
     func mountAtSheetLevel(in sheetViewController: UIViewController) -> UIView {
         coordinator.attachmentPresentingViewController = sheetViewController
@@ -352,8 +365,7 @@ final class AIChatContextualUTIHost {
         return coordinator.viewController.view
     }
 
-    /// Sets the chat web view the host pushes page context into / binds to, without mounting the UTI
-    /// inside it (sheet-level mount path).
+    /// Sets the chat web view the host pushes context into / binds to, without mounting the UTI inside it.
     func setContextualChatViewController(_ webViewController: AIChatContextualWebViewController) {
         self.contextualChatViewController = webViewController
     }
@@ -401,26 +413,24 @@ extension AIChatContextualUTIHost {
 
 extension AIChatContextualUTIHost: UnifiedToggleInputDelegate {
 
-    /// The first (unbound) UTI prompt lands here; subsequent prompts go direct via the bound user
-    /// script. Flips the session into an active chat, freezes the attached page context, delivers
-    /// the rich payload into the web view's readiness queue, then binds so later prompts skip this.
+    /// The first (unbound) UTI prompt: flip the session, freeze the chip context, deliver the rich payload to the web-VC queue, then bind.
     func unifiedToggleInputDidSubmitPrompt(_ prompt: String,
                                            modelId: String?,
                                            tools: [AIChatRAGTool]?,
                                            reasoningEffort: AIChatReasoningEffort?,
                                            images: [AIChatNativePrompt.NativePromptImage]?,
                                            files: [AIChatNativePrompt.NativePromptFile]?) {
-        // Gate a rapid re-submit during the loading/bind window — the web view queue holds one
-        // prompt, so a second would overwrite the first. Once bound, prompts skip this path entirely.
+        // Gate a rapid re-submit during the loading/bind window — the web-VC queue holds only one prompt.
         guard !hasDeliveredFirstPrompt else {
             Logger.contextualUTI.info("Ignoring UTI re-submit before first prompt delivered")
             return
         }
         hasDeliveredFirstPrompt = true
 
-        // Flip session state (native→web swap + expand) and freeze the page context attached at
-        // flip time — the chip can change during the async swap.
-        let frozenContext = onFirstPromptSubmitted?() ?? nil
+        // Freeze the context from the chip (authoritative — matches the chip + bound prompts), before delivery marks it delivered.
+        let frozenContext = chipViewModel.pendingAttachedContextData
+        // Flip session state (native→web swap + expand).
+        onFirstPromptSubmitted?()
         Logger.contextualUTI.info("Delivering first UTI prompt — hasContext=\(frozenContext != nil, privacy: .public) model=\(modelId ?? "nil", privacy: .public)")
 
         contextualChatViewController?.submitPrompt(
@@ -437,10 +447,7 @@ extension AIChatContextualUTIHost: UnifiedToggleInputDelegate {
     }
 
     func unifiedToggleInputDidChangeHeight() {
-        // The sheet-level mount is bottom-anchored to the keyboard guide and the content above
-        // re-anchors to the UTI's top, so height changes are resolved by constraints — no explicit
-        // container-height recompute (that's an omnibar concern). Kept a no-op to leave the legacy
-        // embedded host byte-for-byte unchanged.
+        // No-op: the sheet-level mount is constraint-driven, so height changes need no explicit recompute (an omnibar concern).
     }
 
     // Remaining actions are omnibar-only surfaces; the contextual sheet never presents them.
@@ -453,9 +460,7 @@ extension AIChatContextualUTIHost: UnifiedToggleInputDelegate {
     func unifiedToggleInputDidRequestAppMenu() {}
 }
 
-/// Live view of the contextual chat's submission phase for the coordinator's model-chip logic.
-/// Reads `hasActiveChat` on each access so it reflects the current phase even after a user-script
-/// rebind (which resets `hasSubmittedPrompt` but not the chat's active state).
+/// Live submission-phase view for the coordinator's model-chip logic; reads `hasActiveChat` each access so it survives a rebind.
 private final class ContextualChatHostAdapter: UnifiedToggleInputHostAdapter {
     private let hasActiveChat: () -> Bool
 

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -83,10 +83,14 @@ final class AIChatContextualUTIHost {
             duckAIWideEventInstrumentation: wideEventInstrumentation,
             duckAIWideEventFlowScope: duckAIWideEventFlowScope
         )
+        // Immediate pre-submit: a carried-over attachment hasn't been delivered yet (it rides the
+        // first prompt), so seed the chip as pending → visible, matching the legacy native chip.
+        let seedDeliveryState: PageContextAttachmentDeliveryState =
+            (contextualStartsPreSubmit && initialAttachedContext != nil) ? .pendingSubmit : initialAttachmentDeliveryState
         self.chipViewModel = UnifiedToggleInputPageContextChipViewModel(
             originatingURLPublisher: originatingURLPublisher,
             initialAttachedContext: initialAttachedContext,
-            initialAttachmentDeliveryState: initialAttachmentDeliveryState,
+            initialAttachmentDeliveryState: seedDeliveryState,
             isAutoAttachEnabled: isAutoAttachEnabled
         )
         coordinator.viewController.bindPageContextChip(to: chipViewModel)
@@ -245,9 +249,16 @@ final class AIChatContextualUTIHost {
     }
 
     private var externalContextDeliveryState: PageContextAttachmentDeliveryState {
+        // Immediate pre-submit: context collected on sheet open (via the external publisher) rides
+        // the first prompt, so show the chip as pending — parity with the legacy native chip and the
+        // manual-attach / post-nav paths, which are already pending. Without this, the sheet-open
+        // auto-attach would arrive `.delivered` and the chip would be silently hidden pre-submit.
+        if startsPreSubmit && !hasDeliveredFirstPrompt {
+            return .pendingSubmit
+        }
         // These states can differ during preload/restore: the user script may be bound before
         // `sessionState` records an active chat, while restored chats may be active before bind.
-        isBoundToUserScript || hasActiveChat() ? .pendingSubmit : .delivered
+        return isBoundToUserScript || hasActiveChat() ? .pendingSubmit : .delivered
     }
 
     func install(in contextualChatViewController: AIChatContextualWebViewController) {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -46,9 +46,15 @@ final class AIChatContextualUTIHost {
     private var hasDeliveredFirstPrompt = false
     /// User script stashed at `bindToUserScript` while pre-submit; bound after the first submit.
     private weak var pendingUserScriptToBind: AIChatUserScript?
+    /// The web view's user script, remembered across binds so a New-Chat reset can re-arm the
+    /// deferred bind against the same (still-alive) script without waiting for a fresh install.
+    private weak var lastKnownUserScript: AIChatUserScript?
     /// Flips the session into an active chat (native→web swap + expand) on the first UTI submit and
     /// returns the page context frozen at flip time. Wired by the sheet coordinator, which owns session state.
     var onFirstPromptSubmitted: (() -> AIChatPageContextData?)?
+    /// Fired when the queued first prompt can no longer be delivered (page load failed) so the sheet
+    /// can recover to a clean pre-submit state for retry. Wired by the sheet coordinator.
+    var onFirstPromptFailed: (() -> Void)?
     private var cancellables = Set<AnyCancellable>()
     private let duckAIWideEventInstrumentation: DuckAIWideEventInstrumentation
     private let duckAIWideEventFlowScope = DuckAIWideEventFlowScope.contextual(UUID())
@@ -201,6 +207,7 @@ final class AIChatContextualUTIHost {
     /// Also wires the user script's page-context provider so every prompt payload carries whatever
     /// the chip says is currently attached — no duplicate state, single source of truth.
     func bindToUserScript(_ userScript: AIChatUserScript) {
+        lastKnownUserScript = userScript
         // Wire the page-context provider + submission callback right away — safe pre-submit, and
         // subsequent (bound) prompts pull their context from the provider.
         userScript.attachedPageContextProvider = { [weak self] in
@@ -238,6 +245,29 @@ final class AIChatContextualUTIHost {
         guard let userScript = pendingUserScriptToBind else { return }
         pendingUserScriptToBind = nil
         commitBind(to: userScript)
+    }
+
+    /// Returns the persistent host to a clean pre-submit state for a new chat (New-Chat / session
+    /// timeout), reusing the same sheet + web view. Unbinds the coordinator so the next first prompt
+    /// takes the unbound → flip path (a bound first submit would skip the frontend-state flip and the
+    /// chat would never become visible), re-arms the deferred bind against the still-alive user
+    /// script, resets the chip, and restores the expanded pre-submit bar (keyboard down).
+    func prepareForNewChat() {
+        coordinator.unbind()
+        isBoundToUserScript = false
+        hasDeliveredFirstPrompt = false
+        pendingUserScriptToBind = lastKnownUserScript
+        chipViewModel.clearAttached()
+        coordinator.showExpanded(activatesInput: false)
+        Logger.contextualUTI.info("Host reset for new chat — unbound, re-armed deferred bind")
+    }
+
+    /// Called when the web view fails to load while a first prompt is queued for delivery. The web
+    /// VC queue is the sole first-prompt buffer, so a failed load would strand it — recover to a
+    /// clean pre-submit state (via the sheet) so the user can retry.
+    func firstPromptDeliveryFailed() {
+        Logger.contextualUTI.error("First prompt delivery failed (page load) — recovering to pre-submit")
+        onFirstPromptFailed?()
     }
 
     func observeChatUpdates(_ publisher: AnyPublisher<String, Never>) {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -108,6 +108,18 @@ final class AIChatContextualUTIHost {
             self?.handleChipRemoveRequest()
         }
 
+        // Page context is attached via the "Ask About Page" attach-menu item (no placeholder chip).
+        coordinator.canAttachPageContext = { [weak self] in
+            self?.chipViewModel.canAttachPageContext ?? false
+        }
+        coordinator.onAttachPageContextRequested = { [weak self] in
+            self?.chipViewModel.tapToAttach()
+        }
+        chipViewModel.$canAttachPageContext
+            .removeDuplicates()
+            .sink { [weak self] _ in self?.coordinator.refreshAttachmentMenu() }
+            .store(in: &cancellables)
+
         Logger.contextualUTI.debug("UTIHost init — carryOver=\(initialAttachedContext != nil, privacy: .public) auto=\(isAutoAttachEnabled(), privacy: .public)")
 
         coordinator.intentPublisher

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -38,6 +38,17 @@ final class AIChatContextualUTIHost {
     private var pendingChipAttachCancellable: AnyCancellable?
     private var suppressExternalContextUntilNextAttach = false
     private var isBoundToUserScript = false
+    /// True for the immediate-UTI fresh-chat host: the coordinator stays unbound until the first
+    /// submit so that prompt takes the unbound → web-VC-queue path (a bound first submit would skip
+    /// the frontend-state flip → invisible chat). Restored/legacy hosts bind immediately.
+    private let startsPreSubmit: Bool
+    /// Set once the first UTI prompt is delivered; gates rapid re-submit and flips a deferred bind to immediate.
+    private var hasDeliveredFirstPrompt = false
+    /// User script stashed at `bindToUserScript` while pre-submit; bound after the first submit.
+    private weak var pendingUserScriptToBind: AIChatUserScript?
+    /// Flips the session into an active chat (native→web swap + expand) on the first UTI submit and
+    /// returns the page context frozen at flip time. Wired by the sheet coordinator, which owns session state.
+    var onFirstPromptSubmitted: (() -> AIChatPageContextData?)?
     private var cancellables = Set<AnyCancellable>()
     private let duckAIWideEventInstrumentation: DuckAIWideEventInstrumentation
     private let duckAIWideEventFlowScope = DuckAIWideEventFlowScope.contextual(UUID())
@@ -57,6 +68,7 @@ final class AIChatContextualUTIHost {
         self.pageContextHandler = pageContextHandler
         self.isAutoAttachEnabled = isAutoAttachEnabled
         self.hasActiveChat = hasActiveChat
+        self.startsPreSubmit = contextualStartsPreSubmit
         self.hostAdapter = ContextualChatHostAdapter(hasActiveChat: hasActiveChat)
         let wideEventInstrumentation = DefaultDuckAIWideEventInstrumentation(
             wideEvent: AppDependencyProvider.shared.wideEvent
@@ -138,6 +150,11 @@ final class AIChatContextualUTIHost {
                 self.handleChipAttachRequest(originatingURL: url)
             }
             .store(in: &cancellables)
+
+        // The host receives the first (unbound) UTI submit through the coordinator delegate; once
+        // bound, subsequent prompts go direct. Legacy/restored hosts bind immediately, so the
+        // delegate submit path never fires for them.
+        coordinator.delegate = self
     }
 
     private func handleChipAttachRequest(originatingURL: URL) {
@@ -180,6 +197,27 @@ final class AIChatContextualUTIHost {
     /// Also wires the user script's page-context provider so every prompt payload carries whatever
     /// the chip says is currently attached — no duplicate state, single source of truth.
     func bindToUserScript(_ userScript: AIChatUserScript) {
+        // Wire the page-context provider + submission callback right away — safe pre-submit, and
+        // subsequent (bound) prompts pull their context from the provider.
+        userScript.attachedPageContextProvider = { [weak self] in
+            self?.chipViewModel.pendingAttachedContextData
+        }
+        userScript.onPromptSubmitted = { [weak self] in
+            self?.chipViewModel.markPromptSubmitted()
+        }
+
+        // Immediate-UTI fresh chat: defer the coordinator bind until the first submit so that first
+        // prompt takes the unbound → web-VC-queue path (a bound first submit would skip the
+        // frontend-state flip → invisible chat). Legacy/restored hosts bind immediately.
+        guard startsPreSubmit, !hasDeliveredFirstPrompt else {
+            commitBind(to: userScript)
+            return
+        }
+        Logger.contextualUTI.info("Deferring coordinator bind until first submit (pre-submit immediate UTI)")
+        pendingUserScriptToBind = userScript
+    }
+
+    private func commitBind(to userScript: AIChatUserScript) {
         Logger.contextualUTI.info("Binding coordinator to AIChatUserScript")
         isBoundToUserScript = true
         let chatID = userScript.webView?.url?.duckAIChatID
@@ -187,12 +225,15 @@ final class AIChatContextualUTIHost {
         if let chatID {
             coordinator.restoreLastUsedModel(forChatID: chatID)
         }
-        userScript.attachedPageContextProvider = { [weak self] in
-            self?.chipViewModel.pendingAttachedContextData
-        }
-        userScript.onPromptSubmitted = { [weak self] in
-            self?.chipViewModel.markPromptSubmitted()
-        }
+    }
+
+    /// Binds the user script stashed during the pre-submit window (called right after the first submit).
+    /// No-op if the web view hasn't installed its user script yet — a later `bindToUserScript` will
+    /// bind immediately because `hasDeliveredFirstPrompt` is now set.
+    private func commitDeferredBindIfNeeded() {
+        guard let userScript = pendingUserScriptToBind else { return }
+        pendingUserScriptToBind = nil
+        commitBind(to: userScript)
     }
 
     func observeChatUpdates(_ publisher: AnyPublisher<String, Never>) {
@@ -301,6 +342,62 @@ extension AIChatContextualUTIHost {
             hasPageContext: hasPageContext
         )
     }
+}
+
+// MARK: - UnifiedToggleInputDelegate
+
+extension AIChatContextualUTIHost: UnifiedToggleInputDelegate {
+
+    /// The first (unbound) UTI prompt lands here; subsequent prompts go direct via the bound user
+    /// script. Flips the session into an active chat, freezes the attached page context, delivers
+    /// the rich payload into the web view's readiness queue, then binds so later prompts skip this.
+    func unifiedToggleInputDidSubmitPrompt(_ prompt: String,
+                                           modelId: String?,
+                                           tools: [AIChatRAGTool]?,
+                                           reasoningEffort: AIChatReasoningEffort?,
+                                           images: [AIChatNativePrompt.NativePromptImage]?,
+                                           files: [AIChatNativePrompt.NativePromptFile]?) {
+        // Gate a rapid re-submit during the loading/bind window — the web view queue holds one
+        // prompt, so a second would overwrite the first. Once bound, prompts skip this path entirely.
+        guard !hasDeliveredFirstPrompt else {
+            Logger.contextualUTI.info("Ignoring UTI re-submit before first prompt delivered")
+            return
+        }
+        hasDeliveredFirstPrompt = true
+
+        // Flip session state (native→web swap + expand) and freeze the page context attached at
+        // flip time — the chip can change during the async swap.
+        let frozenContext = onFirstPromptSubmitted?() ?? nil
+        Logger.contextualUTI.info("Delivering first UTI prompt — hasContext=\(frozenContext != nil, privacy: .public) model=\(modelId ?? "nil", privacy: .public)")
+
+        contextualChatViewController?.submitPrompt(
+            prompt,
+            images: images,
+            files: files,
+            modelId: modelId,
+            tools: tools,
+            reasoningEffort: reasoningEffort,
+            pageContext: frozenContext
+        )
+
+        commitDeferredBindIfNeeded()
+    }
+
+    func unifiedToggleInputDidChangeHeight() {
+        // The sheet-level mount is bottom-anchored to the keyboard guide and the content above
+        // re-anchors to the UTI's top, so height changes are resolved by constraints — no explicit
+        // container-height recompute (that's an omnibar concern). Kept a no-op to leave the legacy
+        // embedded host byte-for-byte unchanged.
+    }
+
+    // Remaining actions are omnibar-only surfaces; the contextual sheet never presents them.
+    func unifiedToggleInputDidSubmitQuery(_ query: String) {}
+    func unifiedToggleInputDidRequestVoiceSearch() {}
+    func unifiedToggleInputDidRequestAIVoiceChat() {}
+    func unifiedToggleInputDidRequestAIChat(prefilledText: String) {}
+    func unifiedToggleInputDidCommitMode(_ mode: TextEntryMode) {}
+    func unifiedToggleInputDidRequestFire() {}
+    func unifiedToggleInputDidRequestAppMenu() {}
 }
 
 /// Live view of the contextual chat's submission phase for the coordinator's model-chip logic.

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
@@ -67,9 +67,25 @@ final class AIChatContextualWebViewController: UIViewController {
         set { aiChatContentHandler.delegate = newValue }
     }
 
-    private var pendingPrompt: String?
-    /// Page context bundled with a pending prompt submission (consumed together in `submitPromptNow`).
-    private var pendingPageContext: AIChatPageContextData?
+    /// A prompt submission buffered until the web view + content handler are ready. Carries the
+    /// full unified-toggle-input payload when the prompt came from the UTI (`payload != nil`), or
+    /// just text + context for the legacy native-input path (`payload == nil`).
+    private struct PendingPromptSubmission {
+        let prompt: String
+        let pageContext: AIChatPageContextData?
+        let payload: RichPayload?
+
+        struct RichPayload {
+            let images: [AIChatNativePrompt.NativePromptImage]?
+            let files: [AIChatNativePrompt.NativePromptFile]?
+            let modelId: String?
+            let tools: [AIChatRAGTool]?
+            let reasoningEffort: AIChatReasoningEffort?
+        }
+    }
+
+    /// Prompt buffered when the web view isn't ready yet (consumed in `submitPendingIfReady`).
+    private var pendingPrompt: PendingPromptSubmission?
     /// Standalone page context for the "Attach Page Content" chip, buffered when WebView isn't ready yet.
     private var pendingChipContext: AIChatPageContextData?
     private var hasPendingChipContext = false
@@ -197,23 +213,56 @@ final class AIChatContextualWebViewController: UIViewController {
 
     // MARK: - Public Methods
 
-    /// Queues prompt if web view not ready yet; otherwise submits immediately.
+    /// Queues prompt if web view not ready yet; otherwise submits immediately. Legacy native-input path.
     func submitPrompt(_ prompt: String, pageContext: AIChatPageContextData? = nil) {
-        Logger.aiChat.debug("[ContextualWebVC] submitPrompt called - isPageReady: \(self.isPageReady), isContentHandlerReady: \(self.isContentHandlerReady)")
-        if pageContext != nil {
+        submit(PendingPromptSubmission(prompt: prompt, pageContext: pageContext, payload: nil))
+    }
+
+    /// Queues or submits a prompt carrying the full unified-toggle-input payload. Used for the
+    /// immediate-UTI sheet's first prompt, which the host delivers directly (bypassing the native
+    /// `.submitPrompt` effect) with a frozen page-context snapshot.
+    func submitPrompt(_ prompt: String,
+                      images: [AIChatNativePrompt.NativePromptImage]?,
+                      files: [AIChatNativePrompt.NativePromptFile]?,
+                      modelId: String?,
+                      tools: [AIChatRAGTool]?,
+                      reasoningEffort: AIChatReasoningEffort?,
+                      pageContext: AIChatPageContextData?) {
+        let payload = PendingPromptSubmission.RichPayload(images: images, files: files, modelId: modelId, tools: tools, reasoningEffort: reasoningEffort)
+        submit(PendingPromptSubmission(prompt: prompt, pageContext: pageContext, payload: payload))
+    }
+
+    private func submit(_ pending: PendingPromptSubmission) {
+        Logger.aiChat.debug("[ContextualWebVC] submitPrompt called - isPageReady: \(self.isPageReady), isContentHandlerReady: \(self.isContentHandlerReady), rich: \(pending.payload != nil)")
+        if pending.pageContext != nil {
             utiHost?.markPromptSubmitted()
         }
         if isPageReady && isContentHandlerReady {
             Logger.aiChat.debug("[ContextualWebVC] Submitting prompt immediately")
-            let didSendBridgeMessage = aiChatContentHandler.canDispatchBridgeMessages
-            aiChatContentHandler.submitPrompt(prompt, pageContext: pageContext)
-            utiHost?.promptDeliveryUpdated(wasQueued: false, didSendBridgeMessage: didSendBridgeMessage)
+            deliver(pending, wasQueued: false)
         } else {
             Logger.aiChat.debug("[ContextualWebVC] Queuing prompt as pending")
             utiHost?.promptDeliveryUpdated(wasQueued: true, didSendBridgeMessage: nil)
-            pendingPrompt = prompt
-            pendingPageContext = pageContext
+            pendingPrompt = pending
         }
+    }
+
+    /// Dispatches a ready prompt to the content handler, routing rich payloads through the widened
+    /// overload and native ones through the text+context overload (unchanged for the legacy path).
+    private func deliver(_ pending: PendingPromptSubmission, wasQueued: Bool?) {
+        let didSendBridgeMessage = aiChatContentHandler.canDispatchBridgeMessages
+        if let payload = pending.payload {
+            aiChatContentHandler.submitPrompt(pending.prompt,
+                                              images: payload.images,
+                                              files: payload.files,
+                                              modelId: payload.modelId,
+                                              tools: payload.tools,
+                                              pageContext: pending.pageContext,
+                                              reasoningEffort: payload.reasoningEffort)
+        } else {
+            aiChatContentHandler.submitPrompt(pending.prompt, pageContext: pending.pageContext)
+        }
+        utiHost?.promptDeliveryUpdated(wasQueued: wasQueued, didSendBridgeMessage: didSendBridgeMessage)
     }
 
     /// Called by the delegate chain when the Frontend requests content, indicating it has initialized.
@@ -259,7 +308,6 @@ final class AIChatContextualWebViewController: UIViewController {
         isPageReady = false
         isFrontendReady = false
         pendingPrompt = nil
-        pendingPageContext = nil
         hasPendingChipContext = false
         pendingChipContext = nil
         loadingView.startAnimating()
@@ -345,11 +393,10 @@ final class AIChatContextualWebViewController: UIViewController {
         Logger.aiChat.debug("[ContextualWebVC] submitPendingIfReady - pendingPrompt: \(self.pendingPrompt != nil), hasPendingChipContext: \(self.hasPendingChipContext), isPageReady: \(self.isPageReady), isContentHandlerReady: \(self.isContentHandlerReady), isFrontendReady: \(self.isFrontendReady)")
         guard isPageReady, isContentHandlerReady else { return }
 
-        if let prompt = pendingPrompt {
-            let pageContext = pendingPageContext
+        if let pending = pendingPrompt {
             pendingPrompt = nil
-            pendingPageContext = nil
-            submitPromptNow(prompt, pageContext: pageContext)
+            Logger.aiChat.debug("[ContextualWebVC] Submitting pending prompt now")
+            deliver(pending, wasQueued: nil)
         }
 
         if hasPendingChipContext, isFrontendReady {
@@ -358,13 +405,6 @@ final class AIChatContextualWebViewController: UIViewController {
             pendingChipContext = nil
             aiChatContentHandler.submitPageContext(context)
         }
-    }
-
-    private func submitPromptNow(_ prompt: String, pageContext: AIChatPageContextData?) {
-        Logger.aiChat.debug("[ContextualWebVC] Submitting pending prompt now")
-        let didSendBridgeMessage = aiChatContentHandler.canDispatchBridgeMessages
-        aiChatContentHandler.submitPrompt(prompt, pageContext: pageContext)
-        utiHost?.promptDeliveryUpdated(wasQueued: nil, didSendBridgeMessage: didSendBridgeMessage)
     }
 
     // MARK: - URL Observation

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
@@ -24,6 +24,8 @@ import Common
 import FoundationExtensions
 import Core
 import os.log
+import os.log
+import os.log
 import PrivacyConfig
 import UIKit
 import UserScript
@@ -56,6 +58,7 @@ final class AIChatContextualWebViewController: UIViewController {
     private let debugSettings: AIChatDebugSettingsHandling
     private let userAgentManager: UserAgentManaging
     private let utiHostInstaller: ((AIChatContextualWebViewController) -> AIChatContextualUTIHost?)?
+    /// The contextual UTI host driving delivery for this web view. Immediate-UTI on: aliases the sheet coordinator's persistent, sheet-mounted host; off (legacy): a host mounted at the bottom of this web view.
     private var utiHost: AIChatContextualUTIHost?
     private var webViewBottomConstraint: NSLayoutConstraint?
 
@@ -67,9 +70,7 @@ final class AIChatContextualWebViewController: UIViewController {
         set { aiChatContentHandler.delegate = newValue }
     }
 
-    /// A prompt submission buffered until the web view + content handler are ready. Carries the
-    /// full unified-toggle-input payload when the prompt came from the UTI (`payload != nil`), or
-    /// just text + context for the legacy native-input path (`payload == nil`).
+    /// A buffered prompt submission: rich UTI payload when `payload != nil`, else text + context (legacy native path).
     private struct PendingPromptSubmission {
         let prompt: String
         let pageContext: AIChatPageContextData?
@@ -218,9 +219,7 @@ final class AIChatContextualWebViewController: UIViewController {
         submit(PendingPromptSubmission(prompt: prompt, pageContext: pageContext, payload: nil))
     }
 
-    /// Queues or submits a prompt carrying the full unified-toggle-input payload. Used for the
-    /// immediate-UTI sheet's first prompt, which the host delivers directly (bypassing the native
-    /// `.submitPrompt` effect) with a frozen page-context snapshot.
+    /// Queues or submits a prompt with the full UTI payload — the immediate-UTI first prompt, delivered directly by the host with a frozen context.
     func submitPrompt(_ prompt: String,
                       images: [AIChatNativePrompt.NativePromptImage]?,
                       files: [AIChatNativePrompt.NativePromptFile]?,
@@ -247,8 +246,7 @@ final class AIChatContextualWebViewController: UIViewController {
         }
     }
 
-    /// Dispatches a ready prompt to the content handler, routing rich payloads through the widened
-    /// overload and native ones through the text+context overload (unchanged for the legacy path).
+    /// Dispatches a ready prompt: rich payloads via the widened overload, native ones via the text+context overload (unchanged).
     private func deliver(_ pending: PendingPromptSubmission, wasQueued: Bool?) {
         let didSendBridgeMessage = aiChatContentHandler.canDispatchBridgeMessages
         if let payload = pending.payload {
@@ -509,8 +507,7 @@ extension AIChatContextualWebViewController: WKNavigationDelegate {
         let nsError = error as NSError
         guard nsError.code != NSURLErrorCancelled || nsError.domain != NSURLErrorDomain else { return }
 
-        // The readiness queue is the sole first-prompt buffer; a failed load means it will never
-        // flush, so drain the stuck prompt and let the host recover to a clean pre-submit for retry.
+        // The readiness queue is the sole first-prompt buffer; a failed load strands it, so drain it and let the host recover.
         if pendingPrompt != nil {
             pendingPrompt = nil
             utiHost?.firstPromptDeliveryFailed()

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
@@ -509,6 +509,13 @@ extension AIChatContextualWebViewController: WKNavigationDelegate {
         let nsError = error as NSError
         guard nsError.code != NSURLErrorCancelled || nsError.domain != NSURLErrorDomain else { return }
 
+        // The readiness queue is the sole first-prompt buffer; a failed load means it will never
+        // flush, so drain the stuck prompt and let the host recover to a clean pre-submit for retry.
+        if pendingPrompt != nil {
+            pendingPrompt = nil
+            utiHost?.firstPromptDeliveryFailed()
+        }
+
         utiHost?.pageLoadFailed(error: error)
     }
 }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualUnifiedToggleInputFeature.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualUnifiedToggleInputFeature.swift
@@ -1,0 +1,47 @@
+//
+//  ContextualUnifiedToggleInputFeature.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Core
+import PrivacyConfig
+
+protocol ContextualUnifiedToggleInputFeatureProviding {
+    /// True when the presubmission contextual sheet should show the unified toggle input in place of
+    /// the basic native input.
+    var isAvailable: Bool { get }
+}
+
+/// Gates the presubmission contextual UTI. AND-gates the contextual feature flag on top of the
+/// unified toggle input's own availability (iPhone-only + grant-gated, via `UnifiedToggleInputFeature`),
+/// so turning the flag off restores today's native input while the UTI stays available elsewhere.
+struct ContextualUnifiedToggleInputFeature: ContextualUnifiedToggleInputFeatureProviding {
+
+    private let unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding
+    private let featureFlagger: FeatureFlagger
+
+    init(featureFlagger: FeatureFlagger,
+         unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature()) {
+        self.featureFlagger = featureFlagger
+        self.unifiedToggleInputFeature = unifiedToggleInputFeature
+    }
+
+    var isAvailable: Bool {
+        unifiedToggleInputFeature.isAvailable && featureFlagger.isFeatureOn(.aiChatContextualUnifiedToggleInput)
+    }
+}

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualUnifiedToggleInputFeature.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualUnifiedToggleInputFeature.swift
@@ -22,14 +22,11 @@ import Core
 import PrivacyConfig
 
 protocol ContextualUnifiedToggleInputFeatureProviding {
-    /// True when the presubmission contextual sheet should show the unified toggle input in place of
-    /// the basic native input.
+    /// True when the presubmission contextual sheet should show the UTI in place of the basic native input.
     var isAvailable: Bool { get }
 }
 
-/// Gates the presubmission contextual UTI. AND-gates the contextual feature flag on top of the
-/// unified toggle input's own availability (iPhone-only + grant-gated, via `UnifiedToggleInputFeature`),
-/// so turning the flag off restores today's native input while the UTI stays available elsewhere.
+/// Gates the presubmission contextual UTI: the contextual flag AND-gated on top of `UnifiedToggleInputFeature` availability (iPhone-only + grant-gated).
 struct ContextualUnifiedToggleInputFeature: ContextualUnifiedToggleInputFeatureProviding {
 
     private let unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding

--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
@@ -333,10 +333,7 @@ final class AIChatUserScript: NSObject, Subfeature {
     }
 
     func submitPrompt(_ prompt: String, images: [AIChatNativePrompt.NativePromptImage]?, files: [AIChatNativePrompt.NativePromptFile]? = nil, modelId: String?, tools: [AIChatRAGTool]?, pageContext: AIChatPageContextData? = nil, reasoningEffort: AIChatReasoningEffort? = nil) {
-        // `attachedPageContextProvider` returns the single current-page form on iOS; wrap it
-        // in the `.single` variant of the union the schema now accepts. An explicit `pageContext`
-        // (the contextual sheet's frozen first-prompt snapshot) takes precedence over the live
-        // provider; omnibar/full-tab callers pass nil and fall back to the provider, unchanged.
+        // Explicit `pageContext` (contextual frozen snapshot) takes precedence, else the live provider (omnibar passes nil); wrapped in `.single`.
         let resolvedPageContext = pageContext ?? attachedPageContextProvider?()
         let promptPayload = AIChatNativePrompt.queryPrompt(
             prompt,

--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
@@ -332,9 +332,12 @@ final class AIChatUserScript: NSObject, Subfeature {
         submitPrompt(prompt, images: images, files: files, modelId: modelId, tools: nil, reasoningEffort: reasoningEffort)
     }
 
-    func submitPrompt(_ prompt: String, images: [AIChatNativePrompt.NativePromptImage]?, files: [AIChatNativePrompt.NativePromptFile]? = nil, modelId: String?, tools: [AIChatRAGTool]?, reasoningEffort: AIChatReasoningEffort? = nil) {
+    func submitPrompt(_ prompt: String, images: [AIChatNativePrompt.NativePromptImage]?, files: [AIChatNativePrompt.NativePromptFile]? = nil, modelId: String?, tools: [AIChatRAGTool]?, pageContext: AIChatPageContextData? = nil, reasoningEffort: AIChatReasoningEffort? = nil) {
         // `attachedPageContextProvider` returns the single current-page form on iOS; wrap it
-        // in the `.single` variant of the union the schema now accepts.
+        // in the `.single` variant of the union the schema now accepts. An explicit `pageContext`
+        // (the contextual sheet's frozen first-prompt snapshot) takes precedence over the live
+        // provider; omnibar/full-tab callers pass nil and fall back to the provider, unchanged.
+        let resolvedPageContext = pageContext ?? attachedPageContextProvider?()
         let promptPayload = AIChatNativePrompt.queryPrompt(
             prompt,
             autoSubmit: true,
@@ -342,7 +345,7 @@ final class AIChatUserScript: NSObject, Subfeature {
             images: images,
             files: files,
             modelId: modelId,
-            pageContext: attachedPageContextProvider?().map(AIChatPageContextPayload.single),
+            pageContext: resolvedPageContext.map(AIChatPageContextPayload.single),
             reasoningEffort: reasoningEffort
         )
         push(.submitPrompt(promptPayload))

--- a/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
@@ -41,17 +41,14 @@ enum PageContextAttachmentDeliveryState {
 ///   - attached + URL doesn't match + auto ON → `.attached` only if pending; if delivered,
 ///     stay hidden until the new page's context lands (otherwise a silent old chip briefly
 ///     reappears during nav transition).
-///   - no attachment → hidden. The chip never renders the placeholder state in the UTI;
-///     attaching is offered through the "Ask About Page" attach-menu item (`canAttachPageContext`).
+///   - no attachment → hidden (attaching is offered via the "Ask About Page" menu item, not a placeholder chip).
 @MainActor
 final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
 
     @Published private(set) var state: AIChatContextChipView.State = .placeholder
     @Published private(set) var isVisible: Bool = false
 
-    /// Whether the "Ask About Page" attach-menu item should be offered. True whenever there's a
-    /// page URL to attach — the action stays available even while context is already attached, in
-    /// which case tapping it re-collects and replaces the attachment with the latest page content.
+    /// Whether the "Ask About Page" menu item is offered — true whenever there's a page URL (even while attached: tapping re-collects + replaces).
     @Published private(set) var canAttachPageContext: Bool = false
 
     /// Invoked when the "Ask About Page" attach-menu item is tapped and an originating URL is available.
@@ -161,9 +158,7 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
     }
 
     private func recompute() {
-        // The chip never shows a placeholder in the UTI — attaching is offered through the
-        // "Ask About Page" attach-menu item, which stays available whenever there's a page to
-        // attach (even while already attached: tapping re-collects and replaces with the latest).
+        // No placeholder chip in the UTI — attaching is offered via the "Ask About Page" menu item whenever there's a page.
         canAttachPageContext = originatingURL != nil
 
         let isMatching = attachedURL != nil && attachedURL == originatingURL
@@ -180,9 +175,7 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
             isVisible = attachmentDeliveryState == .pendingSubmit
             branch = "autoTransition(deliveryState=\(attachmentDeliveryState))"
         } else {
-            // No attachment: keep the logical empty (.placeholder) state but hide the chip —
-            // attaching is offered via the "Ask About Page" attach-menu item, not a tappable
-            // placeholder chip.
+            // No attachment: keep the logical-empty (.placeholder) state but hide the chip (attach via the menu item).
             state = .placeholder
             isVisible = false
             branch = "noAttachment"

--- a/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
@@ -41,15 +41,20 @@ enum PageContextAttachmentDeliveryState {
 ///   - attached + URL doesn't match + auto ON → `.attached` only if pending; if delivered,
 ///     stay hidden until the new page's context lands (otherwise a silent old chip briefly
 ///     reappears during nav transition).
-///   - no attachment → placeholder. The half-sheet is the user's attach/skip gate; once
-///     they're in the chat, an empty state always offers a tap target.
+///   - no attachment → hidden. The chip never renders the placeholder state in the UTI;
+///     attaching is offered through the "Ask About Page" attach-menu item (`canAttachPageContext`).
 @MainActor
 final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
 
     @Published private(set) var state: AIChatContextChipView.State = .placeholder
     @Published private(set) var isVisible: Bool = false
 
-    /// Invoked when the user taps the placeholder chip and an originating URL is available.
+    /// Whether the "Ask About Page" attach-menu item should be offered. True whenever there's a
+    /// page URL to attach — the action stays available even while context is already attached, in
+    /// which case tapping it re-collects and replaces the attachment with the latest page content.
+    @Published private(set) var canAttachPageContext: Bool = false
+
+    /// Invoked when the "Ask About Page" attach-menu item is tapped and an originating URL is available.
     var onAttachActionRequested: ((URL) -> Void)?
 
     /// Invoked when the user taps the X on the attached chip.
@@ -104,7 +109,7 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
             Logger.contextualUTI.debug("PageContextChip tapped but no originating URL — ignoring")
             return
         }
-        Logger.contextualUTI.info("PageContextChip placeholder tapped — attaching \(url.shortDescription, privacy: .private)")
+        Logger.contextualUTI.info("PageContextChip attach requested — attaching \(url.shortDescription, privacy: .private)")
         onAttachActionRequested?(url)
     }
 
@@ -156,6 +161,11 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
     }
 
     private func recompute() {
+        // The chip never shows a placeholder in the UTI — attaching is offered through the
+        // "Ask About Page" attach-menu item, which stays available whenever there's a page to
+        // attach (even while already attached: tapping re-collects and replaces with the latest).
+        canAttachPageContext = originatingURL != nil
+
         let isMatching = attachedURL != nil && attachedURL == originatingURL
         let branch: String
 
@@ -170,8 +180,11 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
             isVisible = attachmentDeliveryState == .pendingSubmit
             branch = "autoTransition(deliveryState=\(attachmentDeliveryState))"
         } else {
+            // No attachment: keep the logical empty (.placeholder) state but hide the chip —
+            // attaching is offered via the "Ask About Page" attach-menu item, not a tappable
+            // placeholder chip.
             state = .placeholder
-            isVisible = true
+            isVisible = false
             branch = "noAttachment"
         }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIToolsController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIToolsController.swift
@@ -66,9 +66,10 @@ final class UTIToolsController {
 
     func presentation(
         displayState: UnifiedToggleInputDisplayState,
-        modelStore: UTIModelStore
+        modelStore: UTIModelStore,
+        includesCustomizeResponses: Bool = true
     ) -> Presentation {
-        let toolsMenu = buildToolsMenu(displayState: displayState, modelStore: modelStore)
+        let toolsMenu = buildToolsMenu(displayState: displayState, modelStore: modelStore, includesCustomizeResponses: includesCustomizeResponses)
         guard canShowTools(displayState: displayState),
               hasActionableMenuItem(modelStore: modelStore, toolsMenu: toolsMenu) else {
             return .hidden
@@ -101,12 +102,13 @@ private extension UTIToolsController {
 
     func buildToolsMenu(
         displayState: UnifiedToggleInputDisplayState,
-        modelStore: UTIModelStore
+        modelStore: UTIModelStore,
+        includesCustomizeResponses: Bool
     ) -> UTIToolsMenu {
         var items: [UTIToolsMenu.Item] = []
 
-        // Customize Responses is an AI-tab-only action; it has no model-tool gating.
-        if case .aiTab = displayState {
+        // Customize Responses is an AI-tab-only action (no model-tool gating), suppressed pre-submit on the contextual sheet where there's no chat to customize yet.
+        if case .aiTab = displayState, includesCustomizeResponses {
             items.append(.customizeResponses)
         }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentPresenter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentPresenter.swift
@@ -91,9 +91,7 @@ final class UnifiedToggleInputAttachmentPresenter: NSObject {
             )
         }
 
-        // Appended last so they sit at the bottom of the menu, below the photo/file options.
-        // The attach button sets `preferredMenuElementOrder = .fixed`, so this array order is
-        // preserved top-to-bottom regardless of whether the menu opens up or down.
+        // Appended last (bottom of the menu); the attach button's `.fixed` order preserves this regardless of open direction.
         actions.append(contentsOf: additionalActions)
 
         guard !actions.isEmpty else { return nil }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentPresenter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentPresenter.swift
@@ -48,10 +48,10 @@ final class UnifiedToggleInputAttachmentPresenter: NSObject {
         presenterProvider: @escaping () -> UIViewController?,
         photoSelectionLimit: Int,
         canAttachFile: Bool,
-        allowedFileTypes: [UTType]
+        allowedFileTypes: [UTType],
+        additionalActions: [UIAction] = []
     ) -> UIMenu? {
         let canAttachPhoto = photoSelectionLimit > 0
-        guard canAttachPhoto || canAttachFile else { return nil }
 
         var actions = [UIAction]()
 
@@ -91,6 +91,12 @@ final class UnifiedToggleInputAttachmentPresenter: NSObject {
             )
         }
 
+        // Appended last so they sit at the bottom of the menu, below the photo/file options.
+        // The attach button sets `preferredMenuElementOrder = .fixed`, so this array order is
+        // preserved top-to-bottom regardless of whether the menu opens up or down.
+        actions.append(contentsOf: additionalActions)
+
+        guard !actions.isEmpty else { return nil }
         return UIMenu(children: actions)
     }
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentsStripView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentsStripView.swift
@@ -33,8 +33,7 @@ final class UnifiedToggleInputAttachmentsStripView: UIView {
     var onAttachmentRemoved: ((UUID, UnifiedToggleInputAttachment, Bool) -> Void)?
     var onAttachmentsChanged: (() -> Void)?
 
-    /// The page-context chip, pinned as the leading item of the row when present. Owned by the
-    /// caller; the strip only positions it. Hidden chips collapse automatically in the stack.
+    /// The caller-owned page-context chip, pinned as the leading item of the row (hidden chips collapse in the stack).
     private weak var contextChipView: UIView?
 
     private let scrollView: UIScrollView = {
@@ -65,8 +64,7 @@ final class UnifiedToggleInputAttachmentsStripView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    /// Pins the given page-context chip as the leading item of the row. Idempotent. Toggle the
-    /// chip's `isHidden` to show/hide it — a hidden arranged subview collapses in the stack.
+    /// Pins the page-context chip as the leading item (idempotent); toggle its `isHidden` to show/hide.
     func setContextChip(_ chip: UIView) {
         guard contextChipView !== chip else { return }
         contextChipView?.removeFromSuperview()
@@ -172,9 +170,7 @@ final class UnifiedToggleInputAttachmentsStripView: UIView {
         }
     }
 
-    /// Reveals the leading item (the page-context chip lives there). Called when the chip becomes
-    /// visible while the strip is scrolled to the trailing edge, so its remove/confirm control
-    /// isn't left off-screen. Mirrors `scheduleScrollToTrailingEdge`.
+    /// Reveals the leading item (the page-context chip) so its remove control isn't off-screen when it appears mid-scroll.
     func scheduleScrollToLeadingEdge() {
         setNeedsLayout()
         DispatchQueue.main.async { [weak self] in

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentsStripView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentsStripView.swift
@@ -33,6 +33,10 @@ final class UnifiedToggleInputAttachmentsStripView: UIView {
     var onAttachmentRemoved: ((UUID, UnifiedToggleInputAttachment, Bool) -> Void)?
     var onAttachmentsChanged: (() -> Void)?
 
+    /// The page-context chip, pinned as the leading item of the row when present. Owned by the
+    /// caller; the strip only positions it. Hidden chips collapse automatically in the stack.
+    private weak var contextChipView: UIView?
+
     private let scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
@@ -59,6 +63,16 @@ final class UnifiedToggleInputAttachmentsStripView: UIView {
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Pins the given page-context chip as the leading item of the row. Idempotent. Toggle the
+    /// chip's `isHidden` to show/hide it — a hidden arranged subview collapses in the stack.
+    func setContextChip(_ chip: UIView) {
+        guard contextChipView !== chip else { return }
+        contextChipView?.removeFromSuperview()
+        chip.translatesAutoresizingMaskIntoConstraints = false
+        contextChipView = chip
+        stackView.insertArrangedSubview(chip, at: 0)
     }
 
     func addAttachment(_ attachment: UnifiedToggleInputAttachment) {
@@ -98,10 +112,12 @@ final class UnifiedToggleInputAttachmentsStripView: UIView {
 
     func removeAllAttachments() {
         attachments.removeAll()
-        stackView.arrangedSubviews.forEach {
-            stackView.removeArrangedSubview($0)
-            $0.removeFromSuperview()
-        }
+        stackView.arrangedSubviews
+            .filter { $0 is UnifiedToggleInputAttachmentThumbnailView }
+            .forEach {
+                stackView.removeArrangedSubview($0)
+                $0.removeFromSuperview()
+            }
         onAttachmentsChanged?()
     }
 
@@ -153,6 +169,18 @@ final class UnifiedToggleInputAttachmentsStripView: UIView {
             self?.superview?.layoutIfNeeded()
             self?.layoutIfNeeded()
             self?.scrollToTrailingEdge()
+        }
+    }
+
+    /// Reveals the leading item (the page-context chip lives there). Called when the chip becomes
+    /// visible while the strip is scrolled to the trailing edge, so its remove/confirm control
+    /// isn't left off-screen. Mirrors `scheduleScrollToTrailingEdge`.
+    func scheduleScrollToLeadingEdge() {
+        setNeedsLayout()
+        DispatchQueue.main.async { [weak self] in
+            self?.superview?.layoutIfNeeded()
+            self?.layoutIfNeeded()
+            self?.scrollView.setContentOffset(.zero, animated: true)
         }
     }
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -22,6 +22,7 @@ import BrowserServicesKit
 import Combine
 import Core
 import DDGSync
+import DesignResourcesKitIcons
 import os.log
 import Subscription
 import UIKit
@@ -247,6 +248,12 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
 
     private(set) var host: UnifiedToggleInputHost
     private(set) var isToggleEnabled: Bool
+
+    /// Contextual-host hooks for the "Ask About Page" attach-menu item. Set by `AIChatContextualUTIHost`.
+    /// `canAttachPageContext` decides whether the item is offered; `onAttachPageContextRequested`
+    /// triggers the attach. Both nil on the omnibar host (no page context there).
+    var canAttachPageContext: (() -> Bool)?
+    var onAttachPageContextRequested: (() -> Void)?
     /// Snapshot of `UnifiedToggleInputFeatureProviding.isToggleHiddenOnDuckAITab` at init.
     private let hidesToggleOnDuckAITab: Bool
     private(set) var isOnboardingLocked: Bool = false
@@ -2078,6 +2085,12 @@ extension UnifiedToggleInputCoordinator {
         updateModelChipVisibility()
     }
 
+    /// Rebuilds the attach button/menu so the contextual "Ask About Page" item appears or
+    /// disappears as the page-context attach state changes. Called by `AIChatContextualUTIHost`.
+    func refreshAttachmentMenu() {
+        updateAttachButtonPresentation()
+    }
+
 }
 
 private extension UnifiedToggleInputCoordinator {
@@ -2298,16 +2311,36 @@ private extension UnifiedToggleInputCoordinator {
             },
             photoSelectionLimit: attachmentPolicy.canAttachImages ? remainingImagesForPicker : 0,
             canAttachFile: canPresentFilePicker,
-            allowedFileTypes: allowedFileUTTypes
+            allowedFileTypes: allowedFileUTTypes,
+            additionalActions: [makePageContextMenuAction()].compactMap { $0 }
         )
+    }
+
+    /// "Ask About Page" — the contextual-host way to attach page content (replaces the old
+    /// dotted placeholder chip). Offered only when the host can attach context right now.
+    private func makePageContextMenuAction() -> UIAction? {
+        guard host == .contextualChat,
+              !viewController.isGenerating,
+              canAttachPageContext?() == true else { return nil }
+        return UIAction(
+            title: UserText.aiChatQuickActionAskAboutPage,
+            image: DesignSystemImages.Glyphs.Size24.pageContentAttach
+        ) { [weak self] _ in
+            self?.onAttachPageContextRequested?()
+        }
+    }
+
+    private var canAskAboutPage: Bool {
+        host == .contextualChat && !viewController.isGenerating && canAttachPageContext?() == true
     }
 
     func updateAttachButtonPresentation() {
         let supportsAttachments = selectedModelSupportsImageUpload || !allowedFileUTTypes.isEmpty
-        let canAttachMore = (attachmentPolicy.canAttachImages || canPresentFilePicker) && !viewController.isGenerating
-        viewController.isImageButtonHidden = !supportsAttachments
+        let canAttachMore = ((attachmentPolicy.canAttachImages || canPresentFilePicker) && !viewController.isGenerating) || canAskAboutPage
+        let showButton = supportsAttachments || canAskAboutPage
+        viewController.isImageButtonHidden = !showButton
         viewController.isImageButtonEnabled = canAttachMore
-        viewController.attachmentMenu = supportsAttachments && canAttachMore ? makeAttachmentMenu() : nil
+        viewController.attachmentMenu = showButton && canAttachMore ? makeAttachmentMenu() : nil
     }
 
     func presentAttachmentValidationError(_ message: String) {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -751,7 +751,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         intentSubject.send(.showCollapsed(from: previousDisplayState))
     }
 
-    func showExpanded(prefilledText: String? = nil, inputMode: TextEntryMode = .aiChat) {
+    func showExpanded(prefilledText: String? = nil, inputMode: TextEntryMode = .aiChat, activatesInput: Bool = true) {
         guard !isOnboardingLocked else { return }
         cancelTopOmnibarKeyboardPresentationFallback()
         isAwaitingTopOmnibarKeyboardPresentation = false
@@ -780,12 +780,16 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         DispatchQueue.main.async { [weak self] in
             guard let self, case .aiTab(.expanded) = self.displayState else { return }
             guard !self.isOnboardingLocked else { return }
-            self.viewController.activateInput()
-            if !self.viewController.isInputFirstResponder {
-                DispatchQueue.main.async { [weak self] in
-                    guard let self, case .aiTab(.expanded) = self.displayState else { return }
-                    guard !self.isOnboardingLocked else { return }
-                    self.viewController.activateInput()
+            // Immediate-UTI mounts expanded but keyboard-down (parity with the native box): the caller
+            // passes activatesInput: false, so we skip raising the keyboard until the user taps in.
+            if activatesInput {
+                self.viewController.activateInput()
+                if !self.viewController.isInputFirstResponder {
+                    DispatchQueue.main.async { [weak self] in
+                        guard let self, case .aiTab(.expanded) = self.displayState else { return }
+                        guard !self.isOnboardingLocked else { return }
+                        self.viewController.activateInput()
+                    }
                 }
             }
             if self.textState == .prefilledSelected {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -241,6 +241,10 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     private(set) var floatingReturnKeyViewController: UnifiedToggleInputFloatingReturnKeyViewController
     weak var delegate: UnifiedToggleInputDelegate?
 
+    /// Live view of the contextual host's submission phase, used to keep the model chip correct across
+    /// a user-script rebind (which resets `hasSubmittedPrompt` but not the phase). Held weak; the host owns it.
+    weak var hostAdapter: UnifiedToggleInputHostAdapter?
+
     private(set) var host: UnifiedToggleInputHost
     private(set) var isToggleEnabled: Bool
     /// Snapshot of `UnifiedToggleInputFeatureProviding.isToggleHiddenOnDuckAITab` at init.
@@ -375,6 +379,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         host: UnifiedToggleInputHost,
         isToggleEnabled: Bool,
         isFireTab: Bool = false,
+        contextualStartsPreSubmit: Bool = false,
         hidesToggleOnDuckAITab: Bool = false,
         duckAiNativeStorageHandler: DuckAiNativeStorageHandling? = nil,
         duckAiNativeStoragePixelFiring: DuckAiNativeStoragePixelFiring = DuckAiNativeStoragePixelAdapter(),
@@ -474,11 +479,14 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         }
 
         // Contextual chat boots in expanded form; no collapsed/inactive states are reachable.
-        // The chat is already post-submit by the time the contextual UTI installs, so
-        // `hasSubmittedPrompt` should reflect that — drives follow-up placeholder + model chip hide.
+        // Legacy/restored contextual installs post-submit and forces `hasSubmittedPrompt`; the
+        // pre-submit immediate-UTI sheet leaves it false so the normal first-submit flow flips it
+        // (drives follow-up placeholder + model chip). The boot decision is a static caller arg.
         if host == .contextualChat {
             displayState = .aiTab(.expanded)
-            hasSubmittedPrompt = true
+            if !contextualStartsPreSubmit {
+                hasSubmittedPrompt = true
+            }
             syncHasSubmittedPromptToHandler()
             updateModelChipVisibility()
         }
@@ -2051,6 +2059,12 @@ extension UnifiedToggleInputCoordinator {
         viewController.insertNewlineAtCursor()
     }
 
+    /// Re-derive model-chip visibility after a host-driven phase change (first submit / rebind).
+    /// Reads `hostAdapter` for the live phase, so the chip is correct even after a user-script rebind.
+    func refreshModelChipVisibility() {
+        updateModelChipVisibility()
+    }
+
 }
 
 private extension UnifiedToggleInputCoordinator {
@@ -2350,12 +2364,15 @@ private extension UnifiedToggleInputCoordinator {
     }
 
     func updateModelChipVisibility() {
-        // Contextual chat picks the model upstream (in the half-sheet); the model chip is permanently hidden here.
-        // Image generation has no model picker either — when active, the chip is hidden until the tool is deselected.
+        // Legacy contextual chat picks the model upstream (in the half-sheet) so its chip stays hidden;
+        // the pre-submit immediate-UTI sheet picks the model in the bar, so the chip shows until the
+        // first prompt. `hostAdapter` is the live phase source and survives a user-script rebind that
+        // resets `hasSubmittedPrompt`; before it is wired (during init) we fall back to `!hasSubmittedPrompt`.
+        // Image generation has no model picker either — when active, the chip is hidden until deselected.
         let isImageGenActive = toolsController.selectedTool == .imageGeneration
-        // `isModelPickerForcedVisible` only relaxes the `hasSubmittedPrompt` hide reason — contextual
-        // chat and image generation stay hidden regardless.
-        let shouldHideModelChip = host == .contextualChat || isImageGenActive || (hasSubmittedPrompt && !isModelPickerForcedVisible)
+        let contextualIsPreSubmit = hostAdapter?.isPreSubmitPhase ?? !hasSubmittedPrompt
+        let contextualHidesModelChip = host == .contextualChat && !contextualIsPreSubmit
+        let shouldHideModelChip = contextualHidesModelChip || isImageGenActive || (hasSubmittedPrompt && !isModelPickerForcedVisible)
         viewController.isModelChipHidden = shouldHideModelChip
         updateReasoningPicker()
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1933,11 +1933,15 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
             )
 
             let configuration = promptSubmissionConfiguration
+            // The contextual sheet's unbound first prompt is delivered into the web view's queue
+            // (via the host), not a URL autosubmit — record that path so the wide event is accurate.
+            let unboundDeliveryPath: DuckAIPromptWideEventData.FrontendDeliveryPath =
+                host == .contextualChat ? .contextualNativeInput : .urlAutoSubmit
             recordDuckAISubmissionStarted(
                 modelId: configuration.modelId,
                 reasoningEffort: configuration.reasoningEffort,
                 inputMode: .keyboard,
-                frontendDeliveryPath: userScript != nil ? .userScript : .urlAutoSubmit,
+                frontendDeliveryPath: userScript != nil ? .userScript : unboundDeliveryPath,
                 hasPageContext: userScript?.attachedPageContextProvider?() != nil,
                 toolsSelected: !(tools?.isEmpty ?? true),
                 attachmentsSelected: !viewController.currentAttachments.isEmpty
@@ -1970,7 +1974,12 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
                 recordDuckAIPromptDelivered(wasQueued: false, didSendBridgeMessage: didSendBridgeMessage)
             } else {
                 delegate?.unifiedToggleInputDidSubmitPrompt(text, modelId: configuration.modelId, tools: tools, reasoningEffort: configuration.reasoningEffort, images: images, files: files)
-                recordDuckAIPromptDelivered(wasQueued: false, didSendBridgeMessage: nil)
+                // The contextual host delivers via the web view's queue, which records the real
+                // delivery (queued/bridge) itself — firing here too would double-count. Omnibar's
+                // URL-autosubmit handoff has no such signal, so it still records delivery here.
+                if host != .contextualChat {
+                    recordDuckAIPromptDelivered(wasQueued: false, didSendBridgeMessage: nil)
+                }
             }
         }
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -242,16 +242,13 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     private(set) var floatingReturnKeyViewController: UnifiedToggleInputFloatingReturnKeyViewController
     weak var delegate: UnifiedToggleInputDelegate?
 
-    /// Live view of the contextual host's submission phase, used to keep the model chip correct across
-    /// a user-script rebind (which resets `hasSubmittedPrompt` but not the phase). Held weak; the host owns it.
+    /// Live contextual submission-phase view, used to keep the model chip correct across a rebind. Held weak; the host owns it.
     weak var hostAdapter: UnifiedToggleInputHostAdapter?
 
     private(set) var host: UnifiedToggleInputHost
     private(set) var isToggleEnabled: Bool
 
-    /// Contextual-host hooks for the "Ask About Page" attach-menu item. Set by `AIChatContextualUTIHost`.
-    /// `canAttachPageContext` decides whether the item is offered; `onAttachPageContextRequested`
-    /// triggers the attach. Both nil on the omnibar host (no page context there).
+    /// Contextual-host hooks for the "Ask About Page" attach-menu item (set by the host; nil on omnibar).
     var canAttachPageContext: (() -> Bool)?
     var onAttachPageContextRequested: (() -> Void)?
     /// Snapshot of `UnifiedToggleInputFeatureProviding.isToggleHiddenOnDuckAITab` at init.
@@ -486,9 +483,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         }
 
         // Contextual chat boots in expanded form; no collapsed/inactive states are reachable.
-        // Legacy/restored contextual installs post-submit and forces `hasSubmittedPrompt`; the
-        // pre-submit immediate-UTI sheet leaves it false so the normal first-submit flow flips it
-        // (drives follow-up placeholder + model chip). The boot decision is a static caller arg.
+        // Legacy/restored installs post-submit (forces `hasSubmittedPrompt`); the pre-submit immediate-UTI sheet leaves it false. Static caller arg.
         if host == .contextualChat {
             displayState = .aiTab(.expanded)
             if !contextualStartsPreSubmit {
@@ -787,8 +782,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         DispatchQueue.main.async { [weak self] in
             guard let self, case .aiTab(.expanded) = self.displayState else { return }
             guard !self.isOnboardingLocked else { return }
-            // Immediate-UTI mounts expanded but keyboard-down (parity with the native box): the caller
-            // passes activatesInput: false, so we skip raising the keyboard until the user taps in.
+            // Immediate-UTI mounts expanded but keyboard-down (parity): `activatesInput: false` skips raising the keyboard until the user taps in.
             if activatesInput {
                 self.viewController.activateInput()
                 if !self.viewController.isInputFirstResponder {
@@ -1899,6 +1893,11 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
         insertNewlineFromFloatingReturnKey()
     }
 
+    /// Submits text through the real UTI text-submit path (pixels, wide-event, tools reset, bound/unbound delivery) without the user having typed it, e.g. a quick action.
+    func submitProgrammatic(text: String) {
+        unifiedToggleInputVC(viewController, didSubmitText: text, mode: .aiChat)
+    }
+
     func unifiedToggleInputVC(_ vc: UnifiedToggleInputViewController, didSubmitText text: String, mode: TextEntryMode) {
         commitCurrentToggleState()
 
@@ -1940,8 +1939,7 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
             )
 
             let configuration = promptSubmissionConfiguration
-            // The contextual sheet's unbound first prompt is delivered into the web view's queue
-            // (via the host), not a URL autosubmit — record that path so the wide event is accurate.
+            // The contextual unbound first prompt goes to the web-VC queue (via the host), not URL autosubmit — record that path.
             let unboundDeliveryPath: DuckAIPromptWideEventData.FrontendDeliveryPath =
                 host == .contextualChat ? .contextualNativeInput : .urlAutoSubmit
             recordDuckAISubmissionStarted(
@@ -1960,6 +1958,10 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
             let files = selectedModelSupportsFileUpload
                 ? UnifiedToggleInputFileEncoder.encode(viewController.currentAttachments)
                 : nil
+
+            if host == .contextualChat {
+                Logger.contextualUTI.debug("Submit encode → attachments=\(self.viewController.currentAttachments.count, privacy: .public) supportsImageUpload=\(self.selectedModelSupportsImageUpload, privacy: .public) images=\(images?.count ?? 0, privacy: .public) files=\(files?.count ?? 0, privacy: .public) model=\(self.modelStore.selectedModel?.id ?? "nil", privacy: .public) bound=\(self.boundUserScript != nil, privacy: .public)")
+            }
 
             resetToolsSelection()
             clearStoreEntryAfterSubmission()
@@ -1981,9 +1983,7 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
                 recordDuckAIPromptDelivered(wasQueued: false, didSendBridgeMessage: didSendBridgeMessage)
             } else {
                 delegate?.unifiedToggleInputDidSubmitPrompt(text, modelId: configuration.modelId, tools: tools, reasoningEffort: configuration.reasoningEffort, images: images, files: files)
-                // The contextual host delivers via the web view's queue, which records the real
-                // delivery (queued/bridge) itself — firing here too would double-count. Omnibar's
-                // URL-autosubmit handoff has no such signal, so it still records delivery here.
+                // The contextual host's web-VC queue records the real delivery itself; firing here too would double-count (omnibar has no such signal).
                 if host != .contextualChat {
                     recordDuckAIPromptDelivered(wasQueued: false, didSendBridgeMessage: nil)
                 }
@@ -2079,14 +2079,12 @@ extension UnifiedToggleInputCoordinator {
         viewController.insertNewlineAtCursor()
     }
 
-    /// Re-derive model-chip visibility after a host-driven phase change (first submit / rebind).
-    /// Reads `hostAdapter` for the live phase, so the chip is correct even after a user-script rebind.
+    /// Test seam exposing the fileprivate `updateModelChipVisibility()` so coordinator tests can re-derive model-chip visibility after simulating a host phase change (e.g. a rebind).
     func refreshModelChipVisibility() {
         updateModelChipVisibility()
     }
 
-    /// Rebuilds the attach button/menu so the contextual "Ask About Page" item appears or
-    /// disappears as the page-context attach state changes. Called by `AIChatContextualUTIHost`.
+    /// Rebuilds the attach button/menu so the contextual "Ask About Page" item tracks the page-context attach state.
     func refreshAttachmentMenu() {
         updateAttachButtonPresentation()
     }
@@ -2316,8 +2314,7 @@ private extension UnifiedToggleInputCoordinator {
         )
     }
 
-    /// "Ask About Page" — the contextual-host way to attach page content (replaces the old
-    /// dotted placeholder chip). Offered only when the host can attach context right now.
+    /// "Ask About Page" — the contextual-host way to attach page content; offered only when the host can attach right now.
     private func makePageContextMenuAction() -> UIAction? {
         guard host == .contextualChat,
               !viewController.isGenerating,
@@ -2410,16 +2407,15 @@ private extension UnifiedToggleInputCoordinator {
     }
 
     func updateModelChipVisibility() {
-        // Legacy contextual chat picks the model upstream (in the half-sheet) so its chip stays hidden;
-        // the pre-submit immediate-UTI sheet picks the model in the bar, so the chip shows until the
-        // first prompt. `hostAdapter` is the live phase source and survives a user-script rebind that
-        // resets `hasSubmittedPrompt`; before it is wired (during init) we fall back to `!hasSubmittedPrompt`.
-        // Image generation has no model picker either — when active, the chip is hidden until deselected.
+        // Contextual chip shows pre-submit (model picked in the bar) and hides once active; `hostAdapter` gives the live phase (rebind-proof), falling back to `!hasSubmittedPrompt` before it's wired. Image-gen has no picker, so it hides the chip too.
         let isImageGenActive = toolsController.selectedTool == .imageGeneration
         let contextualIsPreSubmit = hostAdapter?.isPreSubmitPhase ?? !hasSubmittedPrompt
         let contextualHidesModelChip = host == .contextualChat && !contextualIsPreSubmit
         let shouldHideModelChip = contextualHidesModelChip || isImageGenActive || (hasSubmittedPrompt && !isModelPickerForcedVisible)
         viewController.isModelChipHidden = shouldHideModelChip
+        if host == .contextualChat {
+            Logger.contextualUTI.debug("Model chip visibility → hidden=\(shouldHideModelChip, privacy: .public) preSubmit=\(contextualIsPreSubmit, privacy: .public) hasSubmitted=\(self.hasSubmittedPrompt, privacy: .public) imageGen=\(isImageGenActive, privacy: .public) forced=\(self.isModelPickerForcedVisible, privacy: .public)")
+        }
         updateReasoningPicker()
     }
 
@@ -2489,9 +2485,13 @@ private extension UnifiedToggleInputCoordinator {
     }
 
     func refreshToolsPresentation() {
+        // Contextual sheet hides Customize Responses pre-submit (no chat to customize yet); `hostAdapter` gives the live phase, falling back to `!hasSubmittedPrompt` before it's wired.
+        let contextualIsPreSubmit = hostAdapter?.isPreSubmitPhase ?? !hasSubmittedPrompt
+        let includesCustomizeResponses = !(host == .contextualChat && contextualIsPreSubmit)
         let presentation = toolsController.presentation(
             displayState: displayState,
-            modelStore: modelStore
+            modelStore: modelStore,
+            includesCustomizeResponses: includesCustomizeResponses
         )
         let toolsMenu = presentation.toolsMenu.map { [weak self] menu in
             self?.toolsMenuFactory.makeMenu(menu) { identifier in

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHost.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHost.swift
@@ -29,10 +29,7 @@ enum UnifiedToggleInputHost: Equatable {
     case contextualChat
 }
 
-/// A live, host-owned view of the contextual chat's submission phase, consulted by
-/// `UnifiedToggleInputCoordinator` to keep the model chip correct across a user-script rebind
-/// (which resets `hasSubmittedPrompt` but not the underlying phase). Held `weak` by the coordinator;
-/// the host retains it.
+/// Host-owned live view of the contextual chat's submission phase; consulted by the coordinator to keep the model chip correct across a rebind. Held `weak` there.
 protocol UnifiedToggleInputHostAdapter: AnyObject {
     /// True while the contextual chat is pre-submit (no active chat yet) — the model chip should show.
     var isPreSubmitPhase: Bool { get }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHost.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHost.swift
@@ -28,3 +28,12 @@ enum UnifiedToggleInputHost: Equatable {
     /// Hosted by `AIChatContextualWebViewController` — the post-submit contextual chat surface.
     case contextualChat
 }
+
+/// A live, host-owned view of the contextual chat's submission phase, consulted by
+/// `UnifiedToggleInputCoordinator` to keep the model chip correct across a user-script rebind
+/// (which resets `hasSubmittedPrompt` but not the underlying phase). Held `weak` by the coordinator;
+/// the host retains it.
+protocol UnifiedToggleInputHostAdapter: AnyObject {
+    /// True while the contextual chat is pre-submit (no active chat yet) — the model chip should show.
+    var isPreSubmitPhase: Bool { get }
+}

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
@@ -208,9 +208,7 @@ final class UnifiedToggleInputToolbarView: UIView {
             accessibilityLabel: UserText.aiChatToolbarAttachButtonAccessibilityLabel,
             action: nil
         )
-        // Keep the attach menu in its declared order (Take Photo / Add Image / Add File / Ask
-        // About Page) instead of letting iOS reverse it when the menu opens upward — matches the
-        // reasoning and model-chip buttons.
+        // Keep the attach menu in declared order (not reversed when it opens upward) — matches the reasoning/model buttons.
         if #available(iOS 16.0, *) {
             button.preferredMenuElementOrder = .fixed
         }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
@@ -202,11 +202,20 @@ final class UnifiedToggleInputToolbarView: UIView {
         action: nil
     )
 
-    private(set) lazy var imageButton: UIButton = makeToolButton(
-        image: DesignSystemImages.Glyphs.Size24.attach,
-        accessibilityLabel: UserText.aiChatToolbarAttachButtonAccessibilityLabel,
-        action: nil
-    )
+    private(set) lazy var imageButton: UIButton = {
+        let button = makeToolButton(
+            image: DesignSystemImages.Glyphs.Size24.attach,
+            accessibilityLabel: UserText.aiChatToolbarAttachButtonAccessibilityLabel,
+            action: nil
+        )
+        // Keep the attach menu in its declared order (Take Photo / Add Image / Add File / Ask
+        // About Page) instead of letting iOS reverse it when the menu opens upward — matches the
+        // reasoning and model-chip buttons.
+        if #available(iOS 16.0, *) {
+            button.preferredMenuElementOrder = .fixed
+        }
+        return button
+    }()
 
     private lazy var reasoningButton: UIButton = {
         let button = makeToolButton(

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -98,9 +98,6 @@ final class UnifiedToggleInputView: UIView {
         /// Outer horizontal margin for the expanded card at the bottom-bar position.
         static let cardHorizontalMarginBottom: CGFloat = 8
         static let cardVerticalMarginBottom: CGFloat = 8
-        /// Page-context chip's leading inset within the card. Decoupled from `cardHorizontalMargin`
-        /// so the card's outer margin can change without shifting the chip.
-        static let pageContextChipLeadingInset: CGFloat = 16
         /// Omnibar pill's horizontal inset; the card's hand-off start width so it animates to the
         /// narrower editing margins. Mirrors `DefaultOmniBarView`'s portrait value (landscape/iPad differ).
         static let omnibarMatchingHorizontalMargin: CGFloat = 16
@@ -386,10 +383,17 @@ final class UnifiedToggleInputView: UIView {
     private var isPageContextChipPresent: Bool = false {
         didSet {
             guard oldValue != isPageContextChipPresent else { return }
+            // The chip lives inside the attachments strip's horizontal stack; hiding it collapses
+            // it there. Re-evaluate strip visibility so the row shows when the chip is its only item.
             pageContextChip.isHidden = !isPageContextChipPresent
-            pageContextChipHeightConstraint.isActive = !isPageContextChipPresent
+            updateAttachmentsStripLayout()
             layoutIfNeeded()
             onNeedsHierarchyLayout?()
+            // The chip inserts at the leading edge; if the strip was scrolled to the trailing edge
+            // (a couple of attachments in), reveal it so its remove control isn't off-screen.
+            if isPageContextChipPresent {
+                attachmentsStrip.scheduleScrollToLeadingEdge()
+            }
         }
     }
 
@@ -522,7 +526,6 @@ final class UnifiedToggleInputView: UIView {
     private var textEntryViewTrailingConstraint: NSLayoutConstraint!
     private var toolbarBottomConstraint: NSLayoutConstraint!
     private var attachmentsStripHeightConstraint: NSLayoutConstraint!
-    private var pageContextChipHeightConstraint: NSLayoutConstraint!
     private var toolbarHeightConstraint: NSLayoutConstraint!
 
     // MARK: - Initialization
@@ -1131,8 +1134,8 @@ final class UnifiedToggleInputView: UIView {
     }
 
     private func updateAttachmentsStripLayout() {
-        let hasAttachments = !attachmentsStrip.attachments.isEmpty
-        let showStrip = hasAttachments && isExpanded && handler.currentToggleState == .aiChat
+        let hasContent = !attachmentsStrip.attachments.isEmpty || isPageContextChipPresent
+        let showStrip = hasContent && isExpanded && handler.currentToggleState == .aiChat
         attachmentsStripHeightConstraint.constant = showStrip ? UnifiedToggleInputAttachmentsStripView.Constants.stripHeight : 0
         attachmentsStrip.alpha = showStrip ? 1 : 0
     }
@@ -1344,7 +1347,6 @@ private extension UnifiedToggleInputView {
 
         pageContextChip.translatesAutoresizingMaskIntoConstraints = false
         pageContextChip.isHidden = true
-        addSubview(pageContextChip)
 
         attachmentsStrip.translatesAutoresizingMaskIntoConstraints = false
         attachmentsStrip.clipsToBounds = false
@@ -1361,6 +1363,8 @@ private extension UnifiedToggleInputView {
             self?.onAttachmentRemoved?(id, attachment, isUserInitiated)
         }
         addSubview(attachmentsStrip)
+        // The page-context chip rides as the leading item of the attachments row.
+        attachmentsStrip.setContextChip(pageContextChip)
 
         toolsToolbar.translatesAutoresizingMaskIntoConstraints = false
         toolsToolbar.clipsToBounds = true
@@ -1427,12 +1431,11 @@ private extension UnifiedToggleInputView {
         inlineDismissTopConstraint = inlineDismissButton.topAnchor.constraint(equalTo: cardView.topAnchor, constant: Constants.toggleTopPadding)
         inlineDismissCenterYConstraint = inlineDismissButton.centerYAnchor.constraint(equalTo: textEntryView.centerYAnchor)
         inputTopConstraint = textEntryView.topAnchor.constraint(equalTo: toggleView.bottomAnchor, constant: 0)
-        inputBottomConstraint = pageContextChip.topAnchor.constraint(equalTo: textEntryView.bottomAnchor)
+        inputBottomConstraint = attachmentsStrip.topAnchor.constraint(equalTo: textEntryView.bottomAnchor)
         textEntryViewLeadingConstraint = textEntryView.leadingAnchor.constraint(equalTo: cardView.leadingAnchor)
         textEntryViewTrailingConstraint = textEntryView.trailingAnchor.constraint(equalTo: cardView.trailingAnchor)
         toolbarBottomConstraint = toolsToolbar.bottomAnchor.constraint(equalTo: cardView.bottomAnchor)
         attachmentsStripHeightConstraint = attachmentsStrip.heightAnchor.constraint(equalToConstant: 0)
-        pageContextChipHeightConstraint = pageContextChip.heightAnchor.constraint(equalToConstant: 0)
         toolbarHeightConstraint = toolsToolbar.heightAnchor.constraint(equalToConstant: 0)
 
         NSLayoutConstraint.activate([
@@ -1456,10 +1459,6 @@ private extension UnifiedToggleInputView {
             textEntryViewTrailingConstraint,
 
             inputBottomConstraint,
-            pageContextChip.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: Constants.pageContextChipLeadingInset),
-            pageContextChipHeightConstraint,
-
-            attachmentsStrip.topAnchor.constraint(equalTo: pageContextChip.bottomAnchor),
             attachmentsStrip.leadingAnchor.constraint(equalTo: cardView.leadingAnchor),
             attachmentsStrip.trailingAnchor.constraint(equalTo: cardView.trailingAnchor),
             attachmentsStripHeightConstraint,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -383,14 +383,12 @@ final class UnifiedToggleInputView: UIView {
     private var isPageContextChipPresent: Bool = false {
         didSet {
             guard oldValue != isPageContextChipPresent else { return }
-            // The chip lives inside the attachments strip's horizontal stack; hiding it collapses
-            // it there. Re-evaluate strip visibility so the row shows when the chip is its only item.
+            // The chip lives in the attachments strip's stack; re-evaluate strip visibility so the row shows when it's the only item.
             pageContextChip.isHidden = !isPageContextChipPresent
             updateAttachmentsStripLayout()
             layoutIfNeeded()
             onNeedsHierarchyLayout?()
-            // The chip inserts at the leading edge; if the strip was scrolled to the trailing edge
-            // (a couple of attachments in), reveal it so its remove control isn't off-screen.
+            // Reveal the leading edge so the chip's remove control isn't off-screen if the strip was scrolled away.
             if isPageContextChipPresent {
                 attachmentsStrip.scheduleScrollToLeadingEdge()
             }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContentHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContentHandlerTests.swift
@@ -583,7 +583,52 @@ final class AIChatContentHandlerTests: XCTestCase {
         XCTAssertEqual(mockUserScript.lastSubmittedPrompt, "Hello")
         XCTAssertNil(mockUserScript.lastSubmittedPageContext)
     }
-    
+
+    func testRichSubmitPromptPassesFullPayloadToUserScript() throws {
+        // Given
+        let mockUserScript = MockAIChatUserScript()
+        handler.setup(with: mockUserScript, webView: WKWebView(), displayMode: .contextual)
+
+        let pageContext = AIChatPageContextData(
+            title: "Frozen Page",
+            favicon: [],
+            url: "https://example.com",
+            content: "Frozen content",
+            truncated: false,
+            fullContentLength: 14
+        )
+
+        // When
+        handler.submitPrompt("Ask about this",
+                             images: nil,
+                             files: nil,
+                             modelId: "gpt-5.4-mini",
+                             tools: [.webSearch],
+                             pageContext: pageContext,
+                             reasoningEffort: nil)
+
+        // Then — routes through the rich overload carrying the frozen context + model/tools.
+        XCTAssertEqual(mockUserScript.richSubmitPromptCallCount, 1)
+        XCTAssertEqual(mockUserScript.submitPromptCallCount, 0)
+        XCTAssertEqual(mockUserScript.lastSubmittedPrompt, "Ask about this")
+        XCTAssertEqual(mockUserScript.lastRichSubmittedModelId, "gpt-5.4-mini")
+        XCTAssertEqual(mockUserScript.lastRichSubmittedTools, [.webSearch])
+        XCTAssertEqual(mockUserScript.lastRichSubmittedPageContext?.title, "Frozen Page")
+    }
+
+    func testNativeSubmitPromptDoesNotUseRichOverload() throws {
+        // Given
+        let mockUserScript = MockAIChatUserScript()
+        handler.setup(with: mockUserScript, webView: WKWebView(), displayMode: .contextual)
+
+        // When
+        handler.submitPrompt("Hello", pageContext: nil)
+
+        // Then — legacy native-input path stays on the text+context overload, unchanged.
+        XCTAssertEqual(mockUserScript.submitPromptCallCount, 1)
+        XCTAssertEqual(mockUserScript.richSubmitPromptCallCount, 0)
+    }
+
     // MARK: - Delegate Notifications
 
     func testDidReceiveMessageGetAIChatPageContextNotifiesDelegate() throws {
@@ -752,6 +797,11 @@ final class MockAIChatUserScript: AIChatUserScriptProviding {
     var submitPromptCallCount = 0
     var lastSubmittedPrompt: String?
     var lastSubmittedPageContext: AIChatPageContextData?
+    var richSubmitPromptCallCount = 0
+    var lastRichSubmittedModelId: String?
+    var lastRichSubmittedTools: [AIChatRAGTool]?
+    var lastRichSubmittedReasoningEffort: AIChatReasoningEffort?
+    var lastRichSubmittedPageContext: AIChatPageContextData?
     var submitStartChatActionCallCount = 0
     var submitOpenSettingsActionCallCount = 0
     var submitToggleSidebarActionCallCount = 0
@@ -784,6 +834,15 @@ final class MockAIChatUserScript: AIChatUserScriptProviding {
         submitPromptCallCount += 1
         lastSubmittedPrompt = prompt
         lastSubmittedPageContext = pageContext
+    }
+
+    func submitPrompt(_ prompt: String, images: [AIChatNativePrompt.NativePromptImage]?, files: [AIChatNativePrompt.NativePromptFile]?, modelId: String?, tools: [AIChatRAGTool]?, pageContext: AIChatPageContextData?, reasoningEffort: AIChatReasoningEffort?) {
+        richSubmitPromptCallCount += 1
+        lastSubmittedPrompt = prompt
+        lastRichSubmittedModelId = modelId
+        lastRichSubmittedTools = tools
+        lastRichSubmittedReasoningEffort = reasoningEffort
+        lastRichSubmittedPageContext = pageContext
     }
 
     func submitStartChatAction() {

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -57,7 +57,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
 
     func testInitialState() {
         XCTAssertEqual(sessionState.frontendState, .noChat)
-        XCTAssertEqual(sessionState.chipState, .placeholder)
+        XCTAssertEqual(sessionState.chipState, .noContext)
         XCTAssertFalse(sessionState.userDowngradedToPlaceholder)
         XCTAssertTrue(sessionState.isShowingNativeInput)
         XCTAssertNil(sessionState.contextualChatURL)
@@ -68,7 +68,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         let viewState = sessionState.viewState
         XCTAssertTrue(viewState.isExpandButtonEnabled)
         XCTAssertFalse(viewState.shouldShowNewChatButton)
-        XCTAssertEqual(viewState.chipState, .placeholder)
+        XCTAssertEqual(viewState.chipState, .noContext)
         if case .nativeInput = viewState.content {
             // Expected
         } else {
@@ -132,8 +132,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
     // MARK: - beginChatForUTISubmission (immediate-UTI flip-only path)
 
     func testBeginChatForUTISubmissionFlipsWithoutEmittingSubmitEffect() {
-        // Given - the immediate-UTI host delivers its own rich payload, so the flip must NOT
-        // emit `.submitPrompt` (that would double-send).
+        // The immediate-UTI host delivers its own payload, so the flip must NOT emit `.submitPrompt` (double-send).
         var receivedEffects: [SheetEffect] = []
         sessionState.effects
             .sink { receivedEffects.append($0) }
@@ -184,9 +183,37 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         XCTAssertEqual(sessionState.frontendState, .restoredChat)
     }
 
+    // MARK: - attachedContextOverrideProvider (chip VM as source of truth)
+
+    func testIntendedAttachedContextUsesOverrideWhenSet() {
+        sessionState.attachedContextOverrideProvider = { self.makeTestContext(title: "Overridden") }
+        XCTAssertEqual(sessionState.intendedAttachedContext?.title, "Overridden")
+    }
+
+    func testIntendedAttachedContextFallsBackToChipStateWhenOverrideNil() {
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        sessionState.updateContext(makeTestContext())
+        XCTAssertEqual(sessionState.intendedAttachedContext?.title, "Test Page")
+    }
+
+    func testBeginChatForUTISubmissionClassifiesUsingOverrideNotRawChipState() {
+        // chipState itself is still .noContext, but the override says something is attached — classification must follow the override.
+        sessionState.attachedContextOverrideProvider = { self.makeTestContext(title: "Overridden") }
+        let frozenContext = sessionState.beginChatForUTISubmission()
+        XCTAssertEqual(sessionState.chipState, .noContext)
+        XCTAssertEqual(sessionState.frontendState, .chatWithInitialContext)
+        XCTAssertEqual(frozenContext?.title, "Overridden")
+        XCTAssertTrue(mockPixelHandler.promptSubmittedWithContextFired)
+    }
+
+    func testResolveQuickActionsUsesOverrideNotRawChipState() {
+        sessionState.attachedContextOverrideProvider = { self.makeTestContext(title: "Overridden") }
+        sessionState.updateContextualChatURL(nil) // forces a rebuildViewState() without touching chipState
+        XCTAssertEqual(sessionState.viewState.quickActions, [.summarizePage])
+    }
+
     func testHandlePromptSubmissionStillEmitsSubmitEffectAfterSplit() {
-        // Regression: the native-input path must keep emitting `.submitPrompt` even though the flip
-        // was extracted into `beginChatForUTISubmission`.
+        // Regression: the native-input path must still emit `.submitPrompt` after the flip was extracted.
         var receivedEffects: [SheetEffect] = []
         sessionState.effects
             .sink { receivedEffects.append($0) }
@@ -211,7 +238,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
 
         // Then
         XCTAssertEqual(sessionState.frontendState, .noChat)
-        XCTAssertEqual(sessionState.chipState, .placeholder)
+        XCTAssertEqual(sessionState.chipState, .noContext)
         XCTAssertNil(sessionState.contextualChatURL)
         XCTAssertFalse(sessionState.userDowngradedToPlaceholder)
         XCTAssertTrue(sessionState.isShowingNativeInput)
@@ -241,7 +268,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result)
-        XCTAssertEqual(sessionState.chipState, .placeholder)
+        XCTAssertEqual(sessionState.chipState, .noContext)
         XCTAssertTrue(sessionState.userDowngradedToPlaceholder)
         XCTAssertTrue(mockPixelHandler.pageContextRemovedNativeFired)
     }
@@ -254,7 +281,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
 
         // Then
         XCTAssertFalse(result)
-        XCTAssertEqual(sessionState.chipState, .placeholder)
+        XCTAssertEqual(sessionState.chipState, .noContext)
         XCTAssertFalse(sessionState.userDowngradedToPlaceholder)
     }
 
@@ -268,7 +295,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         sessionState.downgradeToPlaceholder()
 
         // Then
-        XCTAssertEqual(sessionState.chipState, .placeholder)
+        XCTAssertEqual(sessionState.chipState, .noContext)
         XCTAssertTrue(sessionState.userDowngradedToPlaceholder)
     }
 
@@ -302,7 +329,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
 
         // Then
         XCTAssertEqual(sessionState.latestContext?.title, context.title)
-        XCTAssertEqual(sessionState.chipState, .placeholder)
+        XCTAssertEqual(sessionState.chipState, .noContext)
         XCTAssertFalse(mockPixelHandler.pageContextAutoAttachedFired)
     }
 
@@ -316,7 +343,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
 
         // Then
         XCTAssertNil(sessionState.latestContext)
-        XCTAssertEqual(sessionState.chipState, .placeholder)
+        XCTAssertEqual(sessionState.chipState, .noContext)
     }
 
     func testUpdateContextDoesNotAutoAttachWhenUserDowngraded() {
@@ -333,7 +360,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
 
         // Then
         XCTAssertEqual(sessionState.latestContext?.title, "Page 2")
-        XCTAssertEqual(sessionState.chipState, .placeholder) // Still placeholder
+        XCTAssertEqual(sessionState.chipState, .noContext) // Still placeholder
         XCTAssertFalse(mockPixelHandler.pageContextAutoAttachedFired)
     }
 
@@ -702,7 +729,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         // User removes chip
         let shouldShowPlaceholder = sessionState.handleChipRemoval()
         XCTAssertTrue(shouldShowPlaceholder)
-        XCTAssertEqual(sessionState.chipState, .placeholder)
+        XCTAssertEqual(sessionState.chipState, .noContext)
         XCTAssertTrue(sessionState.userDowngradedToPlaceholder)
 
         // Navigation clears downgrade flag
@@ -729,7 +756,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
 
         // Then
         XCTAssertEqual(sessionState.frontendState, .noChat)
-        XCTAssertEqual(sessionState.chipState, .placeholder)
+        XCTAssertEqual(sessionState.chipState, .noContext)
         XCTAssertFalse(sessionState.userDowngradedToPlaceholder)
         XCTAssertTrue(sessionState.isShowingNativeInput)
     }
@@ -893,75 +920,32 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
 
     // MARK: - Quick Actions Tests
 
-    func testQuickActionsDefaultsToSummarizeWhenFFOff() {
-        // Feature flag is off by default in MockFeatureFlagger
-        XCTAssertEqual(sessionState.viewState.quickActions, [.summarize])
-    }
-
-    func testQuickActionsIsAskAboutPageWhenFFOnAndPlaceholder() {
-        // Given
-        mockFeatureFlagger.enabledFeatureFlags = [.aiChatContextualSheetImprovements]
-        sessionState = AIChatContextualChatSessionState(
-            aiChatSettings: mockSettings,
-            pixelHandler: mockPixelHandler,
-            featureFlagger: mockFeatureFlagger
-        )
-
-        // Then
+    func testQuickActionsIsAskAboutPageWhenNoContext() {
         XCTAssertEqual(sessionState.viewState.quickActions, [.askAboutPage])
     }
 
-    func testQuickActionsIsSummarizePageWhenFFOnAndAttached() {
-        // Given
-        mockFeatureFlagger.enabledFeatureFlags = [.aiChatContextualSheetImprovements]
+    func testQuickActionsIsSummarizePageWhenAttached() {
         mockSettings.isAutomaticContextAttachmentEnabled = true
-        sessionState = AIChatContextualChatSessionState(
-            aiChatSettings: mockSettings,
-            pixelHandler: mockPixelHandler,
-            featureFlagger: mockFeatureFlagger
-        )
-
-        // When
         sessionState.updateContext(makeTestContext())
-
-        // Then
         XCTAssertEqual(sessionState.viewState.quickActions, [.summarizePage])
     }
 
     func testQuickActionsTransitionsOnAttach() {
-        // Given
-        mockFeatureFlagger.enabledFeatureFlags = [.aiChatContextualSheetImprovements]
         mockSettings.isAutomaticContextAttachmentEnabled = true
-        sessionState = AIChatContextualChatSessionState(
-            aiChatSettings: mockSettings,
-            pixelHandler: mockPixelHandler,
-            featureFlagger: mockFeatureFlagger
-        )
         XCTAssertEqual(sessionState.viewState.quickActions, [.askAboutPage])
 
-        // When
         sessionState.updateContext(makeTestContext())
 
-        // Then
         XCTAssertEqual(sessionState.viewState.quickActions, [.summarizePage])
     }
 
     func testQuickActionsTransitionsOnChipRemoval() {
-        // Given
-        mockFeatureFlagger.enabledFeatureFlags = [.aiChatContextualSheetImprovements]
         mockSettings.isAutomaticContextAttachmentEnabled = true
-        sessionState = AIChatContextualChatSessionState(
-            aiChatSettings: mockSettings,
-            pixelHandler: mockPixelHandler,
-            featureFlagger: mockFeatureFlagger
-        )
         sessionState.updateContext(makeTestContext())
         XCTAssertEqual(sessionState.viewState.quickActions, [.summarizePage])
 
-        // When
         sessionState.downgradeToPlaceholder()
 
-        // Then
         XCTAssertEqual(sessionState.viewState.quickActions, [.askAboutPage])
     }
 

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -129,6 +129,76 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         XCTAssertEqual(sessionState.frontendState, .restoredChat)
     }
 
+    // MARK: - beginChatForUTISubmission (immediate-UTI flip-only path)
+
+    func testBeginChatForUTISubmissionFlipsWithoutEmittingSubmitEffect() {
+        // Given - the immediate-UTI host delivers its own rich payload, so the flip must NOT
+        // emit `.submitPrompt` (that would double-send).
+        var receivedEffects: [SheetEffect] = []
+        sessionState.effects
+            .sink { receivedEffects.append($0) }
+            .store(in: &cancellables)
+
+        // When
+        sessionState.beginChatForUTISubmission()
+
+        // Then - frontend flipped to an active chat, but no submit effect was emitted.
+        XCTAssertEqual(sessionState.frontendState, .chatWithoutInitialContext)
+        XCTAssertFalse(sessionState.isShowingNativeInput)
+        XCTAssertTrue(mockPixelHandler.promptSubmittedWithoutContextFired)
+        XCTAssertFalse(receivedEffects.contains { if case .submitPrompt = $0 { return true } else { return false } })
+    }
+
+    func testBeginChatForUTISubmissionReturnsAttachedContextAndFlipsWithContext() {
+        // Given
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        sessionState.updateContext(makeTestContext())
+
+        // When
+        let frozenContext = sessionState.beginChatForUTISubmission()
+
+        // Then - returns the attached context (frozen for delivery) and flips with-context.
+        XCTAssertEqual(sessionState.frontendState, .chatWithInitialContext)
+        XCTAssertEqual(frozenContext?.title, "Test Page")
+        XCTAssertTrue(mockPixelHandler.promptSubmittedWithContextFired)
+    }
+
+    func testBeginChatForUTISubmissionReturnsNilForPlaceholder() {
+        // When
+        let frozenContext = sessionState.beginChatForUTISubmission()
+
+        // Then
+        XCTAssertNil(frozenContext)
+        XCTAssertEqual(sessionState.frontendState, .chatWithoutInitialContext)
+    }
+
+    func testBeginChatForUTISubmissionIgnoredInRestoredState() {
+        // Given
+        sessionState.restoreChat(with: URL(string: "https://duck.ai/chat/123")!)
+
+        // When
+        let frozenContext = sessionState.beginChatForUTISubmission()
+
+        // Then - restored chats are preserved (no re-flip, no context).
+        XCTAssertNil(frozenContext)
+        XCTAssertEqual(sessionState.frontendState, .restoredChat)
+    }
+
+    func testHandlePromptSubmissionStillEmitsSubmitEffectAfterSplit() {
+        // Regression: the native-input path must keep emitting `.submitPrompt` even though the flip
+        // was extracted into `beginChatForUTISubmission`.
+        var receivedEffects: [SheetEffect] = []
+        sessionState.effects
+            .sink { receivedEffects.append($0) }
+            .store(in: &cancellables)
+
+        // When
+        sessionState.handlePromptSubmission("Hello world")
+
+        // Then
+        XCTAssertTrue(receivedEffects.contains { if case .submitPrompt(let prompt, _) = $0 { return prompt == "Hello world" } else { return false } })
+    }
+
     // MARK: - Reset Tests
 
     func testResetToNoChat() {

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -348,7 +348,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
 
         sut.aiChatContextualSheetViewControllerDidRequestRemoveChip(sut.sheetViewController!)
 
-        XCTAssertEqual(sut.sessionState.chipState, .placeholder)
+        XCTAssertEqual(sut.sessionState.chipState, .noContext)
         XCTAssertEqual(mockPageContextHandler.clearAttachedContextCallCount, 1)
     }
 

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
@@ -433,6 +433,50 @@ final class AIChatContextualUTIHostTests: XCTestCase {
         XCTAssertNotNil(userScript.inputBoxHandler)
     }
 
+    // MARK: - Pre-submit chip visibility (slice 5)
+
+    func test_preSubmit_sheetOpenAutoAttach_showsChipAsPendingNotSilentlyDelivered() {
+        // On sheet open the initial context arrives via the external publisher (the didFinish path
+        // is dropped for the opening URL). Pre-submit it must show as pending (visible) — it rides
+        // the first prompt — matching the legacy native chip, not silently delivered/hidden.
+        autoAttachEnabled = true
+        let url = URL(string: "https://example.com/a")!
+        originatingURL.send(url)
+        makeSUT(contextualStartsPreSubmit: true)
+
+        pageContextHandler.sendContext(makeContext(title: "Page A", url: url.absoluteString))
+
+        XCTAssertTrue(sut.chipViewModel.isVisible)
+        XCTAssertEqualState(sut.chipViewModel.state, .attached(title: "Page A", favicon: nil))
+        XCTAssertNotNil(sut.chipViewModel.pendingAttachedContextData)
+    }
+
+    func test_preSubmit_carriedOverAttachment_seedsChipVisible() {
+        // A carried-over attachment (seeded at construction as .delivered on the legacy path) must
+        // show pre-submit on the immediate UTI, since it hasn't been delivered in this chat yet.
+        let url = URL(string: "https://example.com/a")!
+        originatingURL.send(url)
+        makeSUT(initialAttachedContext: makeContext(title: "Page A", url: url.absoluteString),
+                initialAttachmentDeliveryState: .delivered,
+                contextualStartsPreSubmit: true)
+
+        XCTAssertTrue(sut.chipViewModel.isVisible)
+        XCTAssertNotNil(sut.chipViewModel.pendingAttachedContextData)
+    }
+
+    func test_activeChat_sheetOpenContext_staysDelivered_notForcedPending() {
+        // Regression: the pre-submit override must NOT leak into restored/active hosts — their
+        // carried-over context stays silent (delivered) as before.
+        hasActiveChat = true
+        let url = URL(string: "https://example.com/a")!
+        originatingURL.send(url)
+        makeSUT(initialAttachedContext: makeContext(title: "Page A", url: url.absoluteString),
+                initialAttachmentDeliveryState: .delivered,
+                contextualStartsPreSubmit: false)
+
+        XCTAssertFalse(sut.chipViewModel.isVisible)
+    }
+
     // MARK: - Helpers
 
     private func makeContext(title: String, url: String) -> AIChatPageContext {

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
@@ -433,6 +433,48 @@ final class AIChatContextualUTIHostTests: XCTestCase {
         XCTAssertNotNil(userScript.inputBoxHandler)
     }
 
+    // MARK: - New-chat reset (slice 6)
+
+    func test_prepareForNewChat_unbindsAndReArms_soNextFirstPromptStillFlips() {
+        makeSUT(contextualStartsPreSubmit: true)
+        let userScript = makeTestUserScript()
+        sut.bindToUserScript(userScript)
+
+        var flipCount = 0
+        sut.onFirstPromptSubmitted = { [weak self] in
+            flipCount += 1
+            self?.hasActiveChat = true
+            return nil
+        }
+
+        // First chat: submit flips + binds.
+        sut.unifiedToggleInputDidSubmitPrompt("First", modelId: nil, tools: nil, reasoningEffort: nil, images: nil, files: nil)
+        XCTAssertEqual(flipCount, 1)
+        XCTAssertNotNil(userScript.inputBoxHandler)
+
+        // New-chat reset: must unbind so the next first prompt doesn't take the bound branch.
+        hasActiveChat = false
+        sut.prepareForNewChat()
+        XCTAssertNil(userScript.inputBoxHandler)
+
+        // Second chat's first prompt must flip again (the post-reset invisible-chat regression) and re-bind.
+        sut.unifiedToggleInputDidSubmitPrompt("Second", modelId: nil, tools: nil, reasoningEffort: nil, images: nil, files: nil)
+        XCTAssertEqual(flipCount, 2)
+        XCTAssertNotNil(userScript.inputBoxHandler)
+    }
+
+    // MARK: - First-prompt failure recovery (slice 7)
+
+    func test_firstPromptDeliveryFailed_firesRecoveryCallback() {
+        makeSUT(contextualStartsPreSubmit: true)
+        var recovered = false
+        sut.onFirstPromptFailed = { recovered = true }
+
+        sut.firstPromptDeliveryFailed()
+
+        XCTAssertTrue(recovered)
+    }
+
     // MARK: - Pre-submit chip visibility (slice 5)
 
     func test_preSubmit_sheetOpenAutoAttach_showsChipAsPendingNotSilentlyDelivered() {

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
@@ -51,7 +51,8 @@ final class AIChatContextualUTIHostTests: XCTestCase {
 
     private func makeSUT(
         initialAttachedContext: AIChatPageContext? = nil,
-        initialAttachmentDeliveryState: PageContextAttachmentDeliveryState = .delivered
+        initialAttachmentDeliveryState: PageContextAttachmentDeliveryState = .delivered,
+        contextualStartsPreSubmit: Bool = false
     ) {
         sut = AIChatContextualUTIHost(
             originatingURLPublisher: originatingURL.eraseToAnyPublisher(),
@@ -61,7 +62,8 @@ final class AIChatContextualUTIHostTests: XCTestCase {
             hasActiveChat: { [weak self] in self?.hasActiveChat ?? false },
             isAutoAttachEnabled: { [weak self] in self?.autoAttachEnabled ?? false },
             pageContextHandler: pageContextHandler,
-            isFireTab: false
+            isFireTab: false,
+            contextualStartsPreSubmit: contextualStartsPreSubmit
         )
     }
 
@@ -361,6 +363,74 @@ final class AIChatContextualUTIHostTests: XCTestCase {
         sut.markPromptSubmitted()
 
         XCTAssertNil(userScript.attachedPageContextProvider?() ?? nil)
+    }
+
+    // MARK: - Immediate-UTI first-submit (flip + rich deliver + deferred bind)
+
+    func test_preSubmitHost_bindToUserScript_defersBind() {
+        // Pre-submit immediate UTI: binding is deferred so the first prompt takes the unbound path.
+        makeSUT(contextualStartsPreSubmit: true)
+        let userScript = makeTestUserScript()
+
+        sut.bindToUserScript(userScript)
+
+        // `bindToTab` (which wires `inputBoxHandler`) is deferred; provider is still wired up-front.
+        XCTAssertNil(userScript.inputBoxHandler)
+    }
+
+    func test_restoredOrLegacyHost_bindToUserScript_bindsImmediately() {
+        // Non-pre-submit hosts (restored chat / legacy post-submit UTI) bind straight away.
+        makeSUT(contextualStartsPreSubmit: false)
+        let userScript = makeTestUserScript()
+
+        sut.bindToUserScript(userScript)
+
+        XCTAssertNotNil(userScript.inputBoxHandler)
+    }
+
+    func test_firstUTISubmit_firesFlipOnce_andCommitsDeferredBind() {
+        makeSUT(contextualStartsPreSubmit: true)
+        let userScript = makeTestUserScript()
+        sut.bindToUserScript(userScript)
+        XCTAssertNil(userScript.inputBoxHandler)
+
+        var flipCount = 0
+        sut.onFirstPromptSubmitted = { [weak self] in
+            flipCount += 1
+            self?.hasActiveChat = true
+            return nil
+        }
+
+        sut.unifiedToggleInputDidSubmitPrompt("Hello", modelId: "m", tools: nil, reasoningEffort: nil, images: nil, files: nil)
+
+        XCTAssertEqual(flipCount, 1)
+        // The deferred bind is committed right after the flip, so subsequent prompts go direct.
+        XCTAssertNotNil(userScript.inputBoxHandler)
+    }
+
+    func test_rapidSecondUTISubmit_beforeDelivery_isGated() {
+        makeSUT(contextualStartsPreSubmit: true)
+        var flipCount = 0
+        sut.onFirstPromptSubmitted = { flipCount += 1; return nil }
+
+        sut.unifiedToggleInputDidSubmitPrompt("First", modelId: nil, tools: nil, reasoningEffort: nil, images: nil, files: nil)
+        sut.unifiedToggleInputDidSubmitPrompt("Second", modelId: nil, tools: nil, reasoningEffort: nil, images: nil, files: nil)
+
+        // Only the first prompt flips/delivers; the rapid second is dropped (the queue holds one).
+        XCTAssertEqual(flipCount, 1)
+    }
+
+    func test_bindAfterFirstSubmit_bindsImmediately() {
+        // If the web view installs its user script AFTER the first submit, the bind is no longer
+        // deferred — it commits immediately.
+        makeSUT(contextualStartsPreSubmit: true)
+        sut.onFirstPromptSubmitted = { [weak self] in self?.hasActiveChat = true; return nil }
+        sut.unifiedToggleInputDidSubmitPrompt("Hello", modelId: nil, tools: nil, reasoningEffort: nil, images: nil, files: nil)
+
+        let userScript = makeTestUserScript()
+        sut.bindToUserScript(userScript)
+
+        XCTAssertNotNil(userScript.inputBoxHandler)
     }
 
     // MARK: - Helpers

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
@@ -116,6 +116,22 @@ final class AIChatContextualUTIHostTests: XCTestCase {
         XCTAssertEqualState(sut.chipViewModel.state, .placeholder)
     }
 
+    func test_attachThenRemove_firesOnAttachedContextChanged() {
+        // sessionState reads through the chip VM now, so it needs to know when to recompute.
+        let url = URL(string: "https://example.com/a")!
+        originatingURL.send(url)
+        makeSUT()
+        var changeCount = 0
+        sut.onAttachedContextChanged = { changeCount += 1 }
+
+        sut.chipViewModel.tapToAttach()
+        pageContextHandler.sendContext(makeContext(title: "Page A", url: url.absoluteString))
+        XCTAssertEqual(changeCount, 1)
+
+        sut.chipViewModel.tapToRemove()
+        XCTAssertGreaterThan(changeCount, 1)
+    }
+
     func test_chipRemove_whileCollectionPending_lateResultDoesNotOverwriteClear() {
         // Regression: user taps attach (kicks off async collection) then quickly taps X. The
         // pending collection result must NOT land after the clear and re-attach the chip.
@@ -133,7 +149,9 @@ final class AIChatContextualUTIHostTests: XCTestCase {
         XCTAssertNil(sut.chipViewModel.attachedContext)
     }
 
-    func test_chipRemove_lateResultIgnoredUntilNextAutoAttachRequest() {
+    func test_chipRemove_thenNavigation_doesNotReattach() {
+        // Explicit removal opts out of auto-attach for the rest of the chat: neither a late
+        // collection result nor a subsequent navigation may silently re-attach context.
         autoAttachEnabled = true
         let urlA = URL(string: "https://example.com/a")!
         let urlB = URL(string: "https://example.com/b")!
@@ -147,11 +165,13 @@ final class AIChatContextualUTIHostTests: XCTestCase {
         XCTAssertEqualState(sut.chipViewModel.state, .placeholder)
         XCTAssertNil(sut.chipViewModel.attachedContext)
 
+        // Navigating to a new page must NOT re-attach after an explicit removal.
         originatingURL.send(urlB)
         didFinishURL.send(urlB)
         pageContextHandler.sendContext(makeContext(title: "Page B", url: urlB.absoluteString))
 
-        XCTAssertEqualState(sut.chipViewModel.state, .attached(title: "Page B", favicon: nil))
+        XCTAssertEqualState(sut.chipViewModel.state, .placeholder)
+        XCTAssertNil(sut.chipViewModel.attachedContext)
     }
 
     func test_chipRemove_attachRequestFails_keepsIgnoringLateExternalContext() {
@@ -398,7 +418,6 @@ final class AIChatContextualUTIHostTests: XCTestCase {
         sut.onFirstPromptSubmitted = { [weak self] in
             flipCount += 1
             self?.hasActiveChat = true
-            return nil
         }
 
         sut.unifiedToggleInputDidSubmitPrompt("Hello", modelId: "m", tools: nil, reasoningEffort: nil, images: nil, files: nil)
@@ -411,7 +430,7 @@ final class AIChatContextualUTIHostTests: XCTestCase {
     func test_rapidSecondUTISubmit_beforeDelivery_isGated() {
         makeSUT(contextualStartsPreSubmit: true)
         var flipCount = 0
-        sut.onFirstPromptSubmitted = { flipCount += 1; return nil }
+        sut.onFirstPromptSubmitted = { flipCount += 1 }
 
         sut.unifiedToggleInputDidSubmitPrompt("First", modelId: nil, tools: nil, reasoningEffort: nil, images: nil, files: nil)
         sut.unifiedToggleInputDidSubmitPrompt("Second", modelId: nil, tools: nil, reasoningEffort: nil, images: nil, files: nil)
@@ -421,16 +440,81 @@ final class AIChatContextualUTIHostTests: XCTestCase {
     }
 
     func test_bindAfterFirstSubmit_bindsImmediately() {
-        // If the web view installs its user script AFTER the first submit, the bind is no longer
-        // deferred — it commits immediately.
+        // A user script installed AFTER the first submit binds immediately (no longer deferred).
         makeSUT(contextualStartsPreSubmit: true)
-        sut.onFirstPromptSubmitted = { [weak self] in self?.hasActiveChat = true; return nil }
+        sut.onFirstPromptSubmitted = { [weak self] in self?.hasActiveChat = true }
         sut.unifiedToggleInputDidSubmitPrompt("Hello", modelId: nil, tools: nil, reasoningEffort: nil, images: nil, files: nil)
 
         let userScript = makeTestUserScript()
         sut.bindToUserScript(userScript)
 
         XCTAssertNotNil(userScript.inputBoxHandler)
+    }
+
+    // MARK: - Quick-action submission funnel
+
+    func test_submitQuickActionPrompt_routesThroughRealFunnel_firesFlipAndBinds() {
+        // A quick action must go through the same funnel as a typed submit, not bypass the flip/bind.
+        makeSUT(contextualStartsPreSubmit: true)
+        let userScript = makeTestUserScript()
+        sut.bindToUserScript(userScript)
+        XCTAssertNil(userScript.inputBoxHandler)
+
+        var flipCount = 0
+        sut.onFirstPromptSubmitted = { [weak self] in
+            flipCount += 1
+            self?.hasActiveChat = true
+        }
+
+        sut.submitQuickActionPrompt("Summarize this page")
+
+        XCTAssertEqual(flipCount, 1)
+        XCTAssertNotNil(userScript.inputBoxHandler)
+    }
+
+    func test_firstUTISubmit_thenSamePageContextUpdate_doesNotReopenChip() {
+        // Regression: the same page continuing to load/settle after its context was already
+        // delivered must not reopen the chip (only a real navigation should).
+        autoAttachEnabled = true
+        let url = URL(string: "https://example.com/a")!
+        makeSUT(contextualStartsPreSubmit: true)
+        originatingURL.send(url)
+        pageContextHandler.sendContext(makeContext(title: "Page A", url: url.absoluteString))
+        XCTAssertTrue(sut.chipViewModel.isVisible)
+
+        let userScript = makeTestUserScript()
+        sut.bindToUserScript(userScript)
+        sut.onFirstPromptSubmitted = { [weak self] in self?.hasActiveChat = true }
+        sut.unifiedToggleInputDidSubmitPrompt("Hello", modelId: nil, tools: nil, reasoningEffort: nil, images: nil, files: nil)
+        sut.markPromptSubmitted()
+        XCTAssertFalse(sut.chipViewModel.isVisible)
+
+        // The same page's context is re-collected (e.g. lazy-loaded content finishing) — must stay hidden.
+        pageContextHandler.sendContext(makeContext(title: "Page A (updated)", url: url.absoluteString))
+
+        XCTAssertFalse(sut.chipViewModel.isVisible)
+    }
+
+    func test_firstUTISubmit_thenDifferentPageContext_stillShowsPending() {
+        // A genuinely different page's auto-collected context must still show as pending (unaffected by the fix above).
+        autoAttachEnabled = true
+        let urlA = URL(string: "https://example.com/a")!
+        let urlB = URL(string: "https://example.com/b")!
+        makeSUT(contextualStartsPreSubmit: true)
+        originatingURL.send(urlA)
+        pageContextHandler.sendContext(makeContext(title: "Page A", url: urlA.absoluteString))
+
+        let userScript = makeTestUserScript()
+        sut.bindToUserScript(userScript)
+        sut.onFirstPromptSubmitted = { [weak self] in self?.hasActiveChat = true }
+        sut.unifiedToggleInputDidSubmitPrompt("Hello", modelId: nil, tools: nil, reasoningEffort: nil, images: nil, files: nil)
+        sut.markPromptSubmitted()
+        XCTAssertFalse(sut.chipViewModel.isVisible)
+
+        originatingURL.send(urlB)
+        pageContextHandler.sendContext(makeContext(title: "Page B", url: urlB.absoluteString))
+
+        XCTAssertTrue(sut.chipViewModel.isVisible)
     }
 
     // MARK: - New-chat reset (slice 6)
@@ -444,7 +528,6 @@ final class AIChatContextualUTIHostTests: XCTestCase {
         sut.onFirstPromptSubmitted = { [weak self] in
             flipCount += 1
             self?.hasActiveChat = true
-            return nil
         }
 
         // First chat: submit flips + binds.
@@ -478,9 +561,7 @@ final class AIChatContextualUTIHostTests: XCTestCase {
     // MARK: - Pre-submit chip visibility (slice 5)
 
     func test_preSubmit_sheetOpenAutoAttach_showsChipAsPendingNotSilentlyDelivered() {
-        // On sheet open the initial context arrives via the external publisher (the didFinish path
-        // is dropped for the opening URL). Pre-submit it must show as pending (visible) — it rides
-        // the first prompt — matching the legacy native chip, not silently delivered/hidden.
+        // Sheet-open context (external publisher; the opening URL's replay is dropped) must show pending/visible, not silently delivered.
         autoAttachEnabled = true
         let url = URL(string: "https://example.com/a")!
         originatingURL.send(url)
@@ -494,8 +575,7 @@ final class AIChatContextualUTIHostTests: XCTestCase {
     }
 
     func test_preSubmit_carriedOverAttachment_seedsChipVisible() {
-        // A carried-over attachment (seeded at construction as .delivered on the legacy path) must
-        // show pre-submit on the immediate UTI, since it hasn't been delivered in this chat yet.
+        // A carried-over attachment (seeded `.delivered`) must show pre-submit on the immediate UTI — not yet delivered in this chat.
         let url = URL(string: "https://example.com/a")!
         originatingURL.send(url)
         makeSUT(initialAttachedContext: makeContext(title: "Page A", url: url.absoluteString),
@@ -507,8 +587,7 @@ final class AIChatContextualUTIHostTests: XCTestCase {
     }
 
     func test_activeChat_sheetOpenContext_staysDelivered_notForcedPending() {
-        // Regression: the pre-submit override must NOT leak into restored/active hosts — their
-        // carried-over context stays silent (delivered) as before.
+        // Regression: the pre-submit override must NOT leak into restored/active hosts (context stays silent/delivered).
         hasActiveChat = true
         let url = URL(string: "https://example.com/a")!
         originatingURL.send(url)

--- a/iOS/DuckDuckGoTests/AIChat/ContextualUnifiedToggleInputFeatureTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/ContextualUnifiedToggleInputFeatureTests.swift
@@ -1,0 +1,59 @@
+//
+//  ContextualUnifiedToggleInputFeatureTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Core
+@testable import DuckDuckGo
+
+final class ContextualUnifiedToggleInputFeatureTests: XCTestCase {
+
+    // The presubmission contextual UTI is available only when BOTH the UTI itself is available
+    // (iPhone + grant-gated) AND the contextual feature flag is on. Exercise the full 2x2.
+
+    func test_isAvailable_trueOnlyWhenUTIAvailableAndFlagOn() {
+        XCTAssertTrue(makeFeature(utiAvailable: true, flagOn: true).isAvailable)
+    }
+
+    func test_isAvailable_falseWhenFlagOff() {
+        XCTAssertFalse(makeFeature(utiAvailable: true, flagOn: false).isAvailable)
+    }
+
+    func test_isAvailable_falseWhenUTIUnavailable() {
+        XCTAssertFalse(makeFeature(utiAvailable: false, flagOn: true).isAvailable)
+    }
+
+    func test_isAvailable_falseWhenNeither() {
+        XCTAssertFalse(makeFeature(utiAvailable: false, flagOn: false).isAvailable)
+    }
+
+    // MARK: - Helpers
+
+    private func makeFeature(utiAvailable: Bool, flagOn: Bool) -> ContextualUnifiedToggleInputFeature {
+        let flagger = MockFeatureFlagger(enabledFeatureFlags: flagOn ? [.aiChatContextualUnifiedToggleInput] : [])
+        return ContextualUnifiedToggleInputFeature(
+            featureFlagger: flagger,
+            unifiedToggleInputFeature: MockUnifiedToggleInputFeatureProviding(isAvailable: utiAvailable)
+        )
+    }
+}
+
+private struct MockUnifiedToggleInputFeatureProviding: UnifiedToggleInputFeatureProviding {
+    let isAvailable: Bool
+    var isToggleHiddenOnDuckAITab: Bool = false
+}

--- a/iOS/DuckDuckGoTests/AIChat/ContextualUnifiedToggleInputFeatureTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/ContextualUnifiedToggleInputFeatureTests.swift
@@ -23,8 +23,7 @@ import Core
 
 final class ContextualUnifiedToggleInputFeatureTests: XCTestCase {
 
-    // The presubmission contextual UTI is available only when BOTH the UTI itself is available
-    // (iPhone + grant-gated) AND the contextual feature flag is on. Exercise the full 2x2.
+    // Available only when BOTH the UTI (iPhone + grant-gated) AND the contextual flag are on — exercise the 2x2.
 
     func test_isAvailable_trueOnlyWhenUTIAvailableAndFlagOn() {
         XCTAssertTrue(makeFeature(utiAvailable: true, flagOn: true).isAvailable)

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -71,6 +71,55 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         XCTAssertFalse(sut.hasActiveChat)
     }
 
+    // MARK: - Contextual model-chip phase (immediate UTI)
+
+    func test_contextualChat_preSubmit_bootsUnsubmitted_andShowsModelChip() {
+        let coordinator = makeContextualCoordinator(preSubmit: true)
+        XCTAssertFalse(coordinator.hasSubmittedPrompt)
+        XCTAssertFalse(coordinator.viewController.isModelChipHidden)
+    }
+
+    func test_contextualChat_legacyActive_bootsPostSubmit_andHidesModelChip() {
+        let coordinator = makeContextualCoordinator(preSubmit: false)
+        XCTAssertTrue(coordinator.hasSubmittedPrompt)
+        XCTAssertTrue(coordinator.viewController.isModelChipHidden)
+    }
+
+    func test_contextualChat_modelChipStaysHidden_whenAdapterReportsActive_evenIfPromptFlagReset() {
+        // Regression lock: a user-script rebind resets `hasSubmittedPrompt` to false while the chat is
+        // still active. The live host adapter must keep the model chip hidden despite the stale flag.
+        let coordinator = makeContextualCoordinator(preSubmit: true)
+        XCTAssertFalse(coordinator.viewController.isModelChipHidden, "pre-submit shows the model chip")
+
+        let adapter = StubHostAdapter(isPreSubmitPhase: false) // simulates active chat after a rebind
+        coordinator.hostAdapter = adapter
+        coordinator.refreshModelChipVisibility()
+
+        XCTAssertTrue(coordinator.viewController.isModelChipHidden, "adapter overrides the stale prompt flag")
+    }
+
+    func test_omnibarHost_modelChipUnaffectedByContextualLogic() {
+        // The omnibar host has no adapter and is not contextual; the contextual hide must not touch it.
+        sut.refreshModelChipVisibility()
+        XCTAssertFalse(sut.viewController.isModelChipHidden)
+    }
+
+    private func makeContextualCoordinator(preSubmit: Bool) -> UnifiedToggleInputCoordinator {
+        UnifiedToggleInputCoordinator(
+            host: .contextualChat,
+            isToggleEnabled: false,
+            contextualStartsPreSubmit: preSubmit,
+            preferences: mockPreferences,
+            toggleModeStorage: mockToggleModeStorage,
+            switchBarSubmissionMetrics: mockSubmissionMetrics
+        )
+    }
+
+    private final class StubHostAdapter: UnifiedToggleInputHostAdapter {
+        let isPreSubmitPhase: Bool
+        init(isPreSubmitPhase: Bool) { self.isPreSubmitPhase = isPreSubmitPhase }
+    }
+
     // MARK: - Display State: showCollapsed
 
     func test_showCollapsed_setsDisplayState() {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -86,8 +86,7 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
     }
 
     func test_contextualChat_modelChipStaysHidden_whenAdapterReportsActive_evenIfPromptFlagReset() {
-        // Regression lock: a user-script rebind resets `hasSubmittedPrompt` to false while the chat is
-        // still active. The live host adapter must keep the model chip hidden despite the stale flag.
+        // Regression lock: a rebind resets `hasSubmittedPrompt`, but the live host adapter must keep the model chip hidden.
         let coordinator = makeContextualCoordinator(preSubmit: true)
         XCTAssertFalse(coordinator.viewController.isModelChipHidden, "pre-submit shows the model chip")
 
@@ -570,6 +569,21 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
 
         sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "hello", mode: .aiChat)
         XCTAssertEqual(sut.displayState, .aiTab(.collapsed))
+    }
+
+    // MARK: - submitProgrammatic (quick-action submission funnel)
+
+    func test_submitProgrammatic_noBoundScript_callsDelegatePromptMethod() {
+        sut.submitProgrammatic(text: "Summarize this page")
+        XCTAssertEqual(mockDelegate.submittedPrompt, "Summarize this page")
+    }
+
+    func test_submitProgrammatic_withBoundScript_doesNotCallDelegatePromptMethod() {
+        let userScript = makeTestUserScript()
+        sut.bindToTab(userScript)
+
+        sut.submitProgrammatic(text: "Summarize this page")
+        XCTAssertNil(mockDelegate.submittedPrompt)
     }
 
     // MARK: - Omnibar Editing Lifecycle

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPageContextChipViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPageContextChipViewModelTests.swift
@@ -80,9 +80,7 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
     }
 
     func test_autoAttachOff_navigationAway_invokesRemoveCallback() {
-        // A delivered attachment (default) cleared on nav-away must propagate through
-        // onRemoveActionRequested so the host clears the FE-side cached page context — otherwise
-        // the next prompt on the new page would ship the previous page's already-sent context.
+        // A delivered attachment cleared on nav-away must propagate via onRemoveActionRequested so stale context isn't kept.
         let attachedUrl = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: attachedUrl))
         makeSUT(initialAttachedContext: makeContext(title: "Cat", url: attachedUrl))
@@ -164,8 +162,7 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
     // MARK: - Visibility (manual mode)
 
     func test_visibility_manual_coldStart_noCarryOver_hiddenOffersAttach() {
-        // 1. Open chat fresh on page X with no carry-over → chip hidden; attach is offered
-        // through the "Ask About Page" menu item.
+        // Fresh chat, no carry-over → chip hidden; attach offered via the "Ask About Page" menu item.
         let url = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: url))
         makeSUT()
@@ -198,8 +195,7 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
     }
 
     func test_visibility_manual_pendingAttachment_navigateAway_isRemoved() {
-        // Manual mode: navigating away removes the attachment (chip + context), even when it was
-        // pending and unsent. The chip hides and the clear propagates so stale context isn't kept.
+        // Manual mode: navigating away removes the attachment even when pending/unsent, and the clear propagates.
         let url = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: url))
         makeSUT(initialAttachedContext: makeContext(title: "Cat", url: url), initialAttachmentDeliveryState: .pendingSubmit)
@@ -253,8 +249,7 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
     }
 
     func test_visibility_manual_userDetachesViaX_hiddenOffersAttach() {
-        // 5. After X-tap (host calls clearAttached()) → no attachment → chip hidden; attach
-        // offered so the user can re-attach if they change their mind.
+        // After X-tap (clearAttached) → no attachment → chip hidden; attach still offered.
         let url = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: url))
         makeSUT(initialAttachedContext: makeContext(title: "Cat", url: url))
@@ -268,8 +263,7 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
     // MARK: - Visibility (auto mode)
 
     func test_visibility_auto_optedOutInHalfSheet_hiddenOffersAttach() {
-        // Auto mode + user opted out at the half-sheet (no carry-over) → chip hidden; attach
-        // offered via the "Ask About Page" menu item.
+        // Auto mode + opted out at the half-sheet (no carry-over) → chip hidden; attach offered.
         autoAttachEnabled = true
         let url = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: url))
@@ -333,8 +327,7 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
     }
 
     func test_visibility_auto_userDetachesViaX_hiddenOffersAttach() {
-        // Auto mode + user X-taps after at least one attachment in the session → chip hidden;
-        // attach offered so they can re-attach manually.
+        // Auto mode + X-tap after an attachment → chip hidden; attach offered to re-attach.
         autoAttachEnabled = true
         let url = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: url))
@@ -346,8 +339,7 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
     }
 
     func test_visibility_auto_attachThenSubmitThenDetach_hiddenOffersAttach() {
-        // After auto-attach lands and the user submits, then X-taps, the chip stays hidden and
-        // attach is offered so they can re-attach manually.
+        // After auto-attach + submit + X-tap, the chip stays hidden and attach is offered.
         autoAttachEnabled = true
         let url = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: url))
@@ -440,8 +432,7 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
     }
 
     func test_canAttachPageContext_whileAttached_isTrue() {
-        // Always available in the contextual scenario — tapping re-collects and replaces the
-        // attachment with the latest page content.
+        // Always available in the contextual scenario — tapping re-collects + replaces with the latest.
         let url = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: url))
         makeSUT(initialAttachedContext: makeContext(title: "Cat", url: url))

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPageContextChipViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPageContextChipViewModelTests.swift
@@ -70,18 +70,19 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         XCTAssertEqualState(sut.state, .attached(title: "Cat", favicon: nil))
     }
 
-    func test_clearAttached_flipsToPlaceholder() {
+    func test_clearAttached_hidesChipAndOffersAttach() {
         let url = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: url))
         makeSUT(initialAttachedContext: makeContext(title: "Cat", url: url))
         sut.clearAttached()
-        XCTAssertEqualState(sut.state, .placeholder)
+        XCTAssertFalse(sut.isVisible)
+        XCTAssertTrue(sut.canAttachPageContext)
     }
 
     func test_autoAttachOff_navigationAway_invokesRemoveCallback() {
-        // Regression: nav-away clearing must propagate through onRemoveActionRequested so the
-        // host clears the FE-side cached page context. Otherwise the next prompt would ship
-        // stale context even though the chip displays placeholder.
+        // A delivered attachment (default) cleared on nav-away must propagate through
+        // onRemoveActionRequested so the host clears the FE-side cached page context — otherwise
+        // the next prompt on the new page would ship the previous page's already-sent context.
         let attachedUrl = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: attachedUrl))
         makeSUT(initialAttachedContext: makeContext(title: "Cat", url: attachedUrl))
@@ -123,17 +124,19 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
 
     func test_autoAttachOff_originatingURLAwayThenBack_doesNotRestoreAttached() {
         // Manual mode: leaving the page clears the attachment. Navigating back does NOT restore
-        // — the user must tap the placeholder to re-attach.
+        // — the user must re-attach via the "Ask About Page" menu item.
         let attachedUrl = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: attachedUrl))
         makeSUT(initialAttachedContext: makeContext(title: "Cat", url: attachedUrl))
         XCTAssertEqualState(sut.state, .attached(title: "Cat", favicon: nil))
 
         originatingURL.send(URL(string: "https://en.wikipedia.org/wiki/Dog"))
-        XCTAssertEqualState(sut.state, .placeholder)
+        XCTAssertFalse(sut.isVisible)
+        XCTAssertTrue(sut.canAttachPageContext)
 
         originatingURL.send(URL(string: attachedUrl))
-        XCTAssertEqualState(sut.state, .placeholder)
+        XCTAssertFalse(sut.isVisible)
+        XCTAssertTrue(sut.canAttachPageContext)
     }
 
     // MARK: - Tap handling
@@ -160,13 +163,14 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
 
     // MARK: - Visibility (manual mode)
 
-    func test_visibility_manual_coldStart_noCarryOver_visiblePlaceholder() {
-        // 1. Open chat fresh on page X with no carry-over → show placeholder so user can attach.
+    func test_visibility_manual_coldStart_noCarryOver_hiddenOffersAttach() {
+        // 1. Open chat fresh on page X with no carry-over → chip hidden; attach is offered
+        // through the "Ask About Page" menu item.
         let url = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: url))
         makeSUT()
-        XCTAssertTrue(sut.isVisible)
-        XCTAssertEqualState(sut.state, .placeholder)
+        XCTAssertFalse(sut.isVisible)
+        XCTAssertTrue(sut.canAttachPageContext)
     }
 
     func test_visibility_manual_coldStart_carryOverMatchingURL_hidden() {
@@ -176,19 +180,35 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         makeSUT(initialAttachedContext: makeContext(title: "Cat", url: url))
         XCTAssertFalse(sut.isVisible)
         XCTAssertEqualState(sut.state, .attached(title: "Cat", favicon: nil))
+        XCTAssertTrue(sut.canAttachPageContext)
     }
 
     func test_visibility_manual_attachLands_visibleAttachedAsFeedback() {
-        // 3. User taps placeholder, host pushes the collected context. Show .attached as
+        // 3. User attaches via the menu, host pushes the collected context. Show .attached as
         // feedback so the user sees what they just attached, until they submit.
         let url = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: url))
         makeSUT()
-        XCTAssertTrue(sut.isVisible)
+        XCTAssertFalse(sut.isVisible)
 
         sut.setAttached(makeContext(title: "Cat", url: url))
         XCTAssertTrue(sut.isVisible)
         XCTAssertEqualState(sut.state, .attached(title: "Cat", favicon: nil))
+        XCTAssertTrue(sut.canAttachPageContext)
+    }
+
+    func test_visibility_manual_pendingAttachment_navigateAway_isRemoved() {
+        // Manual mode: navigating away removes the attachment (chip + context), even when it was
+        // pending and unsent. The chip hides and the clear propagates so stale context isn't kept.
+        let url = "https://en.wikipedia.org/wiki/Cat"
+        originatingURL.send(URL(string: url))
+        makeSUT(initialAttachedContext: makeContext(title: "Cat", url: url), initialAttachmentDeliveryState: .pendingSubmit)
+        XCTAssertTrue(sut.isVisible)
+
+        originatingURL.send(URL(string: "https://en.wikipedia.org/wiki/Dog"))
+        XCTAssertEqual(removeCalls, 1)
+        XCTAssertFalse(sut.isVisible)
+        XCTAssertNil(sut.attachedContext)
     }
 
     func test_visibility_manual_afterSubmit_hidden() {
@@ -220,43 +240,42 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         XCTAssertTrue(sut.isVisible)
     }
 
-    func test_visibility_manual_navigateAway_visiblePlaceholder() {
-        // 4. Navigate away → manual clears attachment → show placeholder for the new page.
+    func test_visibility_manual_navigateAway_hiddenOffersAttach() {
+        // 4. Navigate away → manual clears attachment → chip hidden; attach offered for the new page.
         let url = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: url))
         makeSUT(initialAttachedContext: makeContext(title: "Cat", url: url))
         XCTAssertFalse(sut.isVisible)
 
         originatingURL.send(URL(string: "https://en.wikipedia.org/wiki/Dog"))
-        XCTAssertTrue(sut.isVisible)
-        XCTAssertEqualState(sut.state, .placeholder)
+        XCTAssertFalse(sut.isVisible)
+        XCTAssertTrue(sut.canAttachPageContext)
     }
 
-    func test_visibility_manual_userDetachesViaX_visiblePlaceholder() {
-        // 5. After X-tap (host calls clearAttached()) → no attachment → show placeholder so
-        // the user can re-attach if they change their mind.
+    func test_visibility_manual_userDetachesViaX_hiddenOffersAttach() {
+        // 5. After X-tap (host calls clearAttached()) → no attachment → chip hidden; attach
+        // offered so the user can re-attach if they change their mind.
         let url = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: url))
         makeSUT(initialAttachedContext: makeContext(title: "Cat", url: url))
         XCTAssertFalse(sut.isVisible)
 
         sut.clearAttached()
-        XCTAssertTrue(sut.isVisible)
-        XCTAssertEqualState(sut.state, .placeholder)
+        XCTAssertFalse(sut.isVisible)
+        XCTAssertTrue(sut.canAttachPageContext)
     }
 
     // MARK: - Visibility (auto mode)
 
-    func test_visibility_auto_optedOutInHalfSheet_visiblePlaceholder() {
-        // Auto mode + user opted out at the half-sheet (no carry-over) → show placeholder.
-        // The half-sheet is where the user exercises their attach/skip agency; the chat is
-        // not a "waiting for first attach" surface, so we never hide an empty auto state.
+    func test_visibility_auto_optedOutInHalfSheet_hiddenOffersAttach() {
+        // Auto mode + user opted out at the half-sheet (no carry-over) → chip hidden; attach
+        // offered via the "Ask About Page" menu item.
         autoAttachEnabled = true
         let url = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: url))
         makeSUT()
-        XCTAssertTrue(sut.isVisible)
-        XCTAssertEqualState(sut.state, .placeholder)
+        XCTAssertFalse(sut.isVisible)
+        XCTAssertTrue(sut.canAttachPageContext)
     }
 
     func test_visibility_auto_coldStart_carryOverMatchingURL_hidden() {
@@ -313,23 +332,22 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         XCTAssertFalse(sut.isVisible)
     }
 
-    func test_visibility_auto_userDetachesViaX_visiblePlaceholder() {
-        // Auto mode + user X-taps after at least one attachment in the session → show
-        // placeholder so they can re-attach manually. (The initial cold-start wait is the
-        // only time we hide auto + no attachment.)
+    func test_visibility_auto_userDetachesViaX_hiddenOffersAttach() {
+        // Auto mode + user X-taps after at least one attachment in the session → chip hidden;
+        // attach offered so they can re-attach manually.
         autoAttachEnabled = true
         let url = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: url))
         makeSUT(initialAttachedContext: makeContext(title: "Cat", url: url))
 
         sut.clearAttached()
-        XCTAssertTrue(sut.isVisible)
-        XCTAssertEqualState(sut.state, .placeholder)
+        XCTAssertFalse(sut.isVisible)
+        XCTAssertTrue(sut.canAttachPageContext)
     }
 
-    func test_visibility_auto_attachThenSubmitThenDetach_returnsToPlaceholder() {
-        // After auto-attach lands and the user submits, then X-taps, the placeholder reappears
-        // so they can re-attach manually.
+    func test_visibility_auto_attachThenSubmitThenDetach_hiddenOffersAttach() {
+        // After auto-attach lands and the user submits, then X-taps, the chip stays hidden and
+        // attach is offered so they can re-attach manually.
         autoAttachEnabled = true
         let url = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: url))
@@ -340,8 +358,8 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         XCTAssertFalse(sut.isVisible)
 
         sut.clearAttached()
-        XCTAssertTrue(sut.isVisible)
-        XCTAssertEqualState(sut.state, .placeholder)
+        XCTAssertFalse(sut.isVisible)
+        XCTAssertTrue(sut.canAttachPageContext)
     }
 
     // MARK: - Pending attached context (provider for prompt payload)
@@ -406,6 +424,38 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         sut.clearAttached()
         sut.setAttached(makeContext(title: "Cat", url: url))
         XCTAssertEqual(sut.pendingAttachedContextData?.title, "Cat")
+    }
+
+    // MARK: - canAttachPageContext (drives the "Ask About Page" menu item)
+
+    func test_canAttachPageContext_noOriginatingURL_isFalse() {
+        makeSUT()
+        XCTAssertFalse(sut.canAttachPageContext)
+    }
+
+    func test_canAttachPageContext_originatingURLNoAttachment_isTrue() {
+        originatingURL.send(URL(string: "https://en.wikipedia.org/wiki/Cat"))
+        makeSUT()
+        XCTAssertTrue(sut.canAttachPageContext)
+    }
+
+    func test_canAttachPageContext_whileAttached_isTrue() {
+        // Always available in the contextual scenario — tapping re-collects and replaces the
+        // attachment with the latest page content.
+        let url = "https://en.wikipedia.org/wiki/Cat"
+        originatingURL.send(URL(string: url))
+        makeSUT(initialAttachedContext: makeContext(title: "Cat", url: url))
+        XCTAssertTrue(sut.canAttachPageContext)
+    }
+
+    func test_canAttachPageContext_staysTrueThroughAttachAndClear() {
+        let url = "https://en.wikipedia.org/wiki/Cat"
+        originatingURL.send(URL(string: url))
+        makeSUT(initialAttachedContext: makeContext(title: "Cat", url: url))
+        XCTAssertTrue(sut.canAttachPageContext)
+
+        sut.clearAttached()
+        XCTAssertTrue(sut.canAttachPageContext)
     }
 
     // MARK: - Helpers

--- a/rework-plan.md
+++ b/rework-plan.md
@@ -1,0 +1,207 @@
+# Plan — Contextual UTI (part 1): a persistent UTI that *is* the native flow, just richer
+
+**Status: PARKED (2026-06-30)** — design converged + **twice red-teamed**, plan complete, **no code written**.
+Paused pending **#5596 (web-view-immediate)** merging: that port deletes the transitional *swap glue* (see §10),
+so rather than build glue we'd immediately bin, we resume on the web-view-immediate base. Pete is moving to a
+different worktree meanwhile. **Resume trigger: #5596 merged.**
+**Base:** clean `origin/main` `dc6da9d607` (branch `pete/ios/uti-contextual-part-1`, reset; prototype preserved
+at `uti-part-1-prototype` + PR #5602). **Standalone — no dependency on #5596** (forward-compatible).
+**Grounded in:** the 5 deep-dive references (`review-artifacts/deep-dives/01–05`) + `understanding.md`.
+
+> This is a **build**, not a delete: on clean main the *pre-submit* contextual UTI does not exist (only the
+> active-chat UTI does). We add the pre-submit capability **without** ever introducing the prototype's soup.
+
+---
+
+## 1. Goal
+Behind the kill-switch flag, replace the basic native input box on the **presubmission** contextual Duck.ai
+sheet with the unified toggle input (UTI), as a **drop-in over the existing native flow**. Parity bar: open at
+`.medium`, keyboard down, expanded bar (not the collapsed pill), expand to `.large` on first submit. Subsequent
+behaviour = the active-chat UTI on main. Nav-chip re-attach + attach-menu + voice-tap are **out** (later parts).
+
+## 2. The converged design (one breath)
+**One UTI** is mounted at sheet level and **persists** across the native→web swap (seamless, no input jump).
+Pre-submit it is **unbound**; its first submit rides the **existing native submit road**
+(`handlePromptSubmission` → `.submitPrompt` effect → web-VC readiness queue), which we **widen to carry the
+UTI's rich payload** (model/tools/reasoning/images/files). The web view then **binds** the UTI; subsequent
+prompts go through the bound user script — exactly the active-chat path on main. The page-context chip is fed
+from **`sessionState.chipState`** pre-submit and hands off to the UTI's `chipViewModel` at bind (the existing
+`initialUTIAttachment` seed). Model-chip visibility derives from a **host adapter reading live `frontendState`**.
+
+## 3. Ground truth that constrains the design (from the dives)
+- **`frontendState` is the synchronous single source of truth**, zero consumers outside its file. Safe to read
+  for phase; **cannot** derive `chipState`/context/detent from it.
+- **The web view loads from sheet open**; `webVC.submitPrompt` already queues (`pendingPrompt`, gated on
+  `isPageReady && isContentHandlerReady`, `:201`) — the proven first-prompt buffer.
+- **On main the contextual UTI is post-submit only** — embedded in the web VC, `hasSubmittedPrompt = true`,
+  model chip **permanently hidden** (`host == .contextualChat`, coordinator `:2358`).
+- **The unbound submit silently drops** — coordinator unbound branch (`:1959`) calls a `delegate` the contextual
+  host never sets. Must be wired.
+- **The page-context chip is independent of `frontendState`**; the nav re-attach fork (`notifyPageChanged`
+  early-return `:211`) is part-3 — do not disturb.
+
+## 4. Target architecture
+
+### 4a. Persistent sheet-level UTI mount
+- Mount one UTI at sheet level (expanded bar, keyboard down — call `showExpanded(activatesInput: false)`).
+- Re-anchor the content-container bottom to the UTI top; add the `superview ===` **survival guard** in
+  `transitionToWebView()` so the UTI is NOT torn down at the swap (reference: prototype `mountAtSheetLevel`).
+- The coordinator stays **UNBOUND until the first submit** — do NOT let the web view auto-bind it at sheet open.
+  This is what makes the first prompt reliably take the unbound→funnel path (§4b) and honors the pre-submit-unbound
+  parity bar. It **binds right after** the first submit; subsequent prompts then go direct via the bound script.
+
+### 4b. First prompt = ONE funnel (the widened native flow) — no separate buffer
+**Verified contextual-only (2026-06-30):** `contentHandler.submitPrompt` is called *only* by the contextual web
+VC (`AIChatContextualWebViewController.swift:209/:366`). The full Duck.ai tab instantiates `AIChatContentHandler`
+(`TabViewController.swift:706`) but **never calls `submitPrompt`** on it — it submits via the omnibar UTI straight
+to `userScript.submitPrompt` (`UnifiedToggleInputCoordinator.swift:1957`). So widening the funnel is
+**contextual-only; the full tab is untouched.** (Resolves the Codex/Claude disagreement — Claude was right.)
+
+**The widened funnel is the DURABLE primary flow (Pete, 2026-06-30).** The basic native input is only the
+flag-OFF (kill-switch) fallback, destined for removal once the UTI ships unflagged — then the funnel is the
+**sole** path (the UTI's first prompt keeps using it). So widening it is a durable investment, not a transitional
+hack. *Part-1 caveat:* flag-OFF must still run the native box exactly as today → keep the rich params
+**optional/defaulted `nil`** so flag-off is byte-for-byte unchanged (kill-switch safety), and flag-on is the
+widened flow.
+
+- **Split the first submit into FLIP + DELIVER — do NOT widen `SheetEffect`/session-state/SheetVC** (red-team v2
+  C1: that threads model/tools/images/files through UTI-ignorant lifecycle/UI layers across ~9 sites). On the
+  unbound first submit, `coordinator.delegate = contextualHost` receives it and the host does two things:
+  1. **Flip (lifecycle):** `sessionState.beginChatForUTISubmission()` — flips `frontendState` (native→web swap +
+     expand + chip-hide) and **does NOT emit `.submitPrompt`** (so nothing double-delivers). **KEEP this method**
+     (v2 reversed the earlier decision to delete it).
+  2. **Deliver (the one buffer):** the host calls a **single rich `webVC.submitPrompt(rich, pageContext: frozen)`**
+     overload that reuses the web VC's **existing readiness queue** (`pendingPrompt`, gated on
+     `isPageReady && isContentHandlerReady`, flushed by `submitPendingIfReady`). Widen ONLY the web-VC-and-below
+     layers: `webVC.submitPrompt` (`:201`) + its pending storage (`String?`→rich) + `submitPendingIfReady`/
+     `submitPromptNow` (`:344/:363`) + `contentHandler.submitPrompt` (`:256`) → the rich `userScript.submitPrompt`
+     (`:335`). Add an optional explicit `pageContext` there (`pageContext ?? attachedPageContextProvider?()`) so the
+     **frozen** snapshot rides through (additive; omnibar passes nil → provider, unchanged).
+- **The web VC queue is the ONLY buffer.** No host buffer, no `PendingFirstPrompt`, no provider-swap, **no
+  `.submitPrompt`-effect widening.**
+- **Telemetry (red-team v2 C2):** the unbound contextual submit must NOT fire the dead `promptDelivery` (`:1961`)
+  and must record the correct `frontendDeliveryPath` (it goes via userScript, NOT `.urlAutoSubmit` `:1924`).
+  The delivery pixel fires **once**, from the webVC path (`:210`).
+- **Rapid second submit (red-team v2 Codex):** because the UTI persists (unlike the vanishing native box), the user
+  can submit again during the loading window → overwrite/loss/out-of-order in the queue. **Gate the UTI submit
+  until the first prompt is delivered.**
+- **Why first ≠ subsequent:** unbound first submit → flip + queue (above). Subsequent (bound) prompts go direct via
+  `userScript.submitPrompt(rich)` — never early, never buffered. One buffer; the first prompt uses it, the rest don't.
+
+### 4c. Model-chip visibility — host adapter, live phase, drift-proof
+- New `UnifiedToggleInputHostAdapter { var isPreSubmitPhase: Bool }` (shared module); contextual conformance
+  `ContextualChatHostAdapter` (ContextualMode) reads `sessionState.hasActiveChat` live. Coordinator holds it
+  **`weak`**; the host **retains it strongly**.
+- Replace the permanent hide term (`:2358`) with `host.isContextualChat && !hostAdapter.isPreSubmitPhase`.
+- **Re-trigger (NO publisher exists — red-team C3):** `frontendState` is `private(set)`, not `@Published`, so
+  there is nothing to subscribe to. Drive it **synchronously**: the host calls `handlePromptSubmission` on the
+  first submit (flips `frontendState`), then synchronously calls `coordinator.updateModelChipVisibility()` on the
+  same call path. The adapter reads live `frontendState` (rebind-proof — rebind clears `hasSubmittedPrompt` but
+  not `frontendState`); `hasSubmittedPrompt` (set by `markActiveChatPromptSubmitted` before the fork) gives the
+  immediate hide. Clean replacement for the `hasSubmittedContextualPrompt` latch — no subscription, no latch.
+- Boot (red-team v2 H1): `.contextualChat` stays **bare** (no associated value → preserves `host ==` at ~11
+  sites). Pass the pre-submit-vs-active boot decision as **static init args** — the host knows `hasActiveChat()`
+  before it builds the coordinator (a `let` inside the host's own init, so a live adapter can't be consulted
+  mid-init). The **live adapter is for the runtime re-trigger ONLY** (model-chip after submit/rebind); the
+  immediate hide is `hasSubmittedPrompt`, the adapter is purely the rebind-survival backstop (red-team v2 M2).
+
+### 4d. Context chip — `sessionState.chipState` pre-submit, hand off at bind
+- Pre-submit: feed `viewState.chipState` into the UTI bar's chip view (bypass the UTI's `chipViewModel`).
+- **Provider-wiring resolution (the consequence of the submission asymmetry):** subsequent bound submits pull
+  context from `attachedPageContextProvider` (UTI host `:184` → `chipViewModel`). So the chip *source* transitions
+  with phase, and context-for-submit follows it at each phase — **no mismatch**:
+  - Pre-submit: chip = `sessionState.chipState`; first-prompt context = `sessionState.chipState` (read by
+    `handlePromptSubmission`). **Match.**
+  - At bind: seed `chipViewModel` from `sessionState`. **NOTE (red-team H1):** the existing `initialUTIAttachment`
+    seed is read at **host construction**, not bind (`AIChatContextualSheetCoordinator.swift:336/356`), so it
+    misses late context — **re-seed explicitly at bind**, don't rely on the construction-time read.
+  - Post-submit: chip = `chipViewModel`; subsequent context = `chipViewModel` (via provider). **Match.**
+  - Net: chip source is sessionState pre-submit (drop-in) → chipViewModel post-bind (as main), bridged by an
+    explicit **re-seed at bind**. *(Validate the handoff has no gap/flicker during slice 5.)*
+
+### 4e. What this design ELIMINATES (never introduce)
+`PendingFirstPrompt` host buffer · `flushPendingFirstPromptIfNeeded` · `hasNotifiedFirstPrompt` ·
+`hasSubmittedContextualPrompt` latch · **the `.submitPrompt`-effect widening** (red-team v2 C1). The web VC queue
+(reached via a direct rich `webVC.submitPrompt`) + the adapter replace them.
+**KEEP `beginChatForUTISubmission`** (flip-only) — v2 reversed the earlier delete; it's the lifecycle flip that
+lets the host deliver the rich payload itself without double-sending.
+
+### 4f. Remaining red-team-v2 must-dos (fold into the slices)
+- **Reset must `coordinator.unbind()` + clear the script identifier** on New-Chat / fire / timeout — else the
+  *next* first prompt takes the BOUND branch and never flips `frontendState` (v1's invisible-chat bug, post-reset).
+  Plus clear pending-first-submit, attachments/tools/text, and re-seed the chip.
+- **Shown-but-unbound gating:** while unbound, hide/disable the active-chat toolbar actions (Customize-Responses,
+  voice, generation controls) and route `DidChangeHeight` to the **sheet-level mount** owner, not the web VC
+  (`DidChangeHeight` is a *mandatory* delegate method — the mount's height signal, not a no-op).
+- **Deferring the bind also defers** `attachedPageContextProvider`/`onPromptSubmitted`/`restoreLastUsedModel`
+  (wired at web VC `:412`). **Wire model-restore + the chip's model label pre-submit** independently, so the
+  pre-submit model chip isn't empty/cached until first submit.
+- **Delegate conformance:** `coordinator.delegate = host` requires the full `UnifiedToggleInputDelegate` (~9
+  mandatory methods, only 3 defaulted); implement them (mostly contextual no-ops) + keep the bound-submit-drop guard.
+- **Failure-path drain** (slice 7): the web VC queue is now the *sole* first-prompt buffer — add a timeout /
+  error-clear if readiness never fires.
+
+## 5. Implementation slices (each: build + sim light/dark + tests before the next)
+1. **Flag + gate carry-forward** — `aiChatContextualUnifiedToggleInput` + subfeature + `ContextualUnifiedToggleInputFeature`
+   AND-gate (iPhone-only/grant-gated). No behaviour yet. Tests: gate matrix.
+2. **Host adapter + model-chip derivation** — protocol + `ContextualChatHostAdapter`, coordinator consults it,
+   bare `.contextualChat`, the phase-change re-trigger. Tests: chip shown pre-submit / hidden active /
+   **stays hidden across a simulated rebind** / omnibar unaffected.
+3. **Persistent sheet-level mount** — mount expanded/keyboard-down, survival guard, content re-anchor. Sim parity
+   (medium, keyboard down, expanded bar). No submit yet (or native submit still).
+4. **Extended submit path** — widen `.submitPrompt`/`webVC.submitPrompt`/`contentHandler.submitPrompt` (optional
+   params) + wire `coordinator.delegate`; unbound submit → `handlePromptSubmission(rich)`. Tests: first submit
+   delivers rich payload once via the queue; native box path unchanged (nil params); no double-send.
+5. **Chip source + handoff** — `sessionState.chipState` pre-submit, `initialUTIAttachment` seed at bind. Tests +
+   sim: chip parity pre-submit; context matches on first and subsequent prompts.
+6. **Reset completeness** — New-Chat/fire/timeout return the persistent UTI to clean pre-submit (unbound, chip
+   shown). Tests for each reset path.
+7. **Failure path** — stuck-first-prompt policy in the web-VC queue (timeout/error-clear).
+
+## 6. Tests (regression-lock the bug class)
+- **Rebind-stays-hidden** (the original bug, locked). · First submit flips `frontendState` synchronously +
+  delivers rich payload exactly once via the queue. · Native-box path byte-for-byte unchanged (nil rich params).
+  · Omnibar model-chip unaffected (no adapter). · Reset completeness across the 3 paths. · Provider/chip context
+  parity on first vs subsequent prompts.
+
+## 7. Watch-outs (landmines)
+1. **Model-chip hide timing** — needs the phase-change re-trigger (§4c), else the chip lags a runloop.
+2. **Signature-widening reach** — optional/defaulted params; **verify whether `AIChatContentHandler` is shared
+   with the full Duck.ai tab** (overload vs additive).
+3. **Unbound-delegate silent drop** — wire `coordinator.delegate = host` (§4b) or the first prompt vanishes (`:1959`).
+4. **Survival guard + re-anchor** — or `transitionToWebView()` tears the UTI down.
+5. **Failure path** — no timeout/drain on main; the queued first prompt is the conversation start.
+6. **Do-not-disturb** — `notifyPageChanged` early-return `:211`, `canPushToFrontend()` `:416`, the UTI chip
+   publishers / `suppressExternalContextUntilNextAttach` guards (part-3). Preserve `frontendState`'s 4 internal uses.
+7. **Adapter init ordering / weak-ref retention** — adapter built before the coordinator's init boot block;
+   coordinator holds it weak, host retains it strong; no retain cycle.
+
+## 8. Open questions (resolve during slices)
+- Is `AIChatContentHandler.submitPrompt` shared with the full Duck.ai tab? (→ additive vs overload)
+- Exact failure-path policy (timeout value? error surface? clear + re-enable input?).
+- Chip-source handoff at bind — any flicker between `sessionState.chipState` and `chipViewModel`?
+
+## 9. Carry-forward + do-not-disturb
+- **Carry:** flag + subfeature + AND-gate, voice availability wiring, the test set; reuse the
+  `initialUTIAttachment` seed. **Reference patterns** (prototype): `coordinator.delegate = self`, mount survival
+  guard, content re-anchor.
+- **Untouched:** the omnibar path; the active-chat UTI's post-submit behaviour; the context nav-fork (part-3).
+
+## 10. Forward-compat with #5596 — and the PARKED resume guide
+**Decision (Pete, 2026-06-30): PARK until #5596 (web-view-immediate) merges, then build on it.** Web-view-immediate
+shows the web view from sheet open, which **deletes the swap glue** — so we don't build glue we'd immediately bin.
+
+**Deleted at the convergence (transitional glue — do NOT gold-plate if built early):** `transitionToWebView()` ·
+the `superview ===` **survival guard** · the content-bottom **re-anchor** · the `viewState.content`
+`.nativeInput`/`.webView` fork + `rebuildViewState`'s native-vs-web mapping · the native input box itself (it's
+the flag-off fallback). **Expand** (`.medium→.large`) is a *separate* detent UX choice — survives unless we open `.large`.
+
+**Survives untouched (the durable core — implement THIS on the web-view-immediate base):** persistent UTI mounted
+with the web view (no survival guard needed once there's no swap) · the **flip** `beginChatForUTISubmission`, now
+**chip-only** (drives model-chip hide + `hasActiveChat`, not a content swap) · **direct delivery**
+`host → webVC.submitPrompt(rich)` into the web-VC queue (the one buffer) · the host-**adapter** (immediate
+`hasSubmittedPrompt` + live-`frontendState` rebind backstop) · chip from `sessionState.chipState` re-seeded at bind ·
+**unbound-until-first-submit** · all red-team-v2 must-dos (§4f).
+
+**On resume:** rebase the worktree onto merged #5596 → implement the durable core on the web-view-immediate sheet
+(skip the swap glue) → the §5 slices minus slice 3's swap/re-anchor work.


### PR DESCRIPTION
## Description

Behind the off-by-default `aiChatContextualUnifiedToggleInput` feature flag, replace the basic native input box on the **presubmission** contextual Duck.ai sheet with the unified toggle input (UTI). Flag-off (and iPad) keep today's native input byte-for-byte.

> **Draft / work-in-progress.** This delivers the input *rendering* (slices 1–3 of a 7-slice plan). The first-prompt *submit* path (transition + rich delivery) is slice 4 and is **not** included yet, so submitting from the UTI does not transition to the web view yet. Opening early for visibility.

### Included in this PR
- **Feature flag + gate** — `aiChatContextualUnifiedToggleInput` (off by default) + `ContextualUnifiedToggleInputFeature`, which AND-gates the flag on the existing UTI availability (iPhone + grant-gated). The contextual flag alone can never enable it.
- **Pre-submit model-chip phase** — `UnifiedToggleInputHostAdapter` / `ContextualChatHostAdapter` derive contextual model-chip visibility from the live pre-submit phase, surviving a user-script rebind (regression-locked by a test). `.contextualChat` stays a bare enum case.
- **Sheet-level UTI mount** — the UTI is mounted once at the sheet level so it persists across the presubmission→postsubmission content swap; it opens **expanded but keyboard-down** (parity with the native box) and stays unbound until the first submit.

### Not included yet (follow-ups)
- Slice 4 — first-prompt flip + rich-deliver submit path (makes submitting work end to end).
- Slice 5 — page-context chip source handoff at bind.
- Slice 6 — reset completeness (New Chat / fire / timeout).
- Slice 7 — stuck-first-prompt failure path.
- Later parts — dashed "Attach Page Content" placeholder removal, "Ask about page" attach-menu item, AI voice button, Figma visual-parity polish.

## Testing

- **Unit tests** — feature-gate matrix + coordinator pre-submit / rebind-stays-hidden matrix. 251 tests green.
- **Simulator** (iPhone Air, light + dark) — flag-on: the presubmission sheet opens at `.medium`, keyboard down, expanded UTI bar with the model chip visible, hero + "Ask about page" above; restored chat reuses the same persistent UTI. Flag-off: today's native input, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches contextual chat submit, page-context attachment, and JS bridge payloads on a user-visible AI path; mitigated by a remote off-by-default flag and legacy branch retention.
> 
> **Overview**
> **Replaces** the presubmission contextual Duck.ai sheet’s basic native text box with the **unified toggle input (UTI)** when `aiChatContextualUnifiedToggleInput` is on (AND-gated on existing UTI availability). Flag off keeps the legacy native input path.
> 
> The UTI is **mounted once at sheet level** (expanded, keyboard-down) so it survives the swap to the chat web view. The content area sits above the bar; with the flag on, hero + quick actions only—no duplicate native field (`AIChatContextualInputSurface` / `NoContextualInputSurface`).
> 
> **First prompt from UTI:** deferred user-script bind until submit, then session flip via `beginChatForUTISubmission` (no double text-only submit), frozen page context, and **rich** bridge delivery (model, tools, attachments) through new `submitPrompt` overloads. Quick actions route through the same funnel (`submitProgrammatic` / `submitQuickActionPrompt`). Web load failure drains the single prompt buffer and recovers via `onFirstPromptFailed`.
> 
> **Page context:** renames `contextualSheetImprovements` → `contextualUnifiedToggleInput`; chip state `.placeholder` → `.noContext`; session/quick actions follow `attachedContextOverrideProvider` from the UTI chip VM. Placeholder attach chip removed—**“Ask About Page”** on the attach menu; chip lives in the attachments strip. Stricter post-remove / same-URL / nav auto-attach behavior on the UTI host; `prepareForNewChat` and manual attach suppression clearing.
> 
> **UTI polish:** pre-submit model chip via `UnifiedToggleInputHostAdapter`; contextual tools menu hides “Customize Responses” pre-submit; wide-event delivery path tweak for unbound contextual submits.
> 
> Extensive unit tests for feature gate, session state, UTI host, coordinator, and content handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8604884f6bb5b20b4dfdc994c607fa1759287db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->