### PR TITLE
[macOS] Duck.ai: show the open-source icon for Tinfoil models (Gemma)

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatModelsService.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatModelsService.swift
@@ -176,12 +176,15 @@ public final class AIChatModelsService: AIChatModelsProviding {
         }
     }
 
+    /// The production AI Chat API origin, built from the canonical `URL.duckAIHost`.
+    public static let defaultBaseURL = URL(string: "https://\(URL.duckAIHost)")!
+
     private let baseURL: URL
     private let session: URLSession
     private let cookieProvider: AIChatCookieProviding
 
     public init(
-        baseURL: URL = URL(string: "https://duck.ai")!,
+        baseURL: URL = AIChatModelsService.defaultBaseURL,
         session: URLSession = .shared,
         cookieProvider: AIChatCookieProviding = WKHTTPCookieStoreProvider()
     ) {
@@ -264,7 +267,7 @@ extension AIChatModel.ModelProvider {
             return .meta
         } else if isMistralProvider {
             return .mistral
-        } else if id.contains("gpt-oss") {
+        } else if id.contains("gpt-oss") || normalizedProviderString == "tinfoil" {
             return .oss
         } else if normalizedProviderString == "anthropic" {
             return .anthropic

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatModelsServiceTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatModelsServiceTests.swift
@@ -762,6 +762,11 @@ final class AIChatModelsServiceTests: XCTestCase {
         XCTAssertEqual(provider, .oss)
     }
 
+    func testWhenProviderIsTinfoilForNonGptOssModel_ThenMapsToOSS() {
+        let provider = AIChatModel.ModelProvider.from(id: "tinfoil/gemma4-31b", providerString: "tinfoil")
+        XCTAssertEqual(provider, .oss)
+    }
+
     func testWhenProviderIsOpenAIString_ThenMapsToOpenAI() {
         let provider = AIChatModel.ModelProvider.from(id: "gpt-5", providerString: "openai")
         XCTAssertEqual(provider, .openAI)

--- a/iOS/DuckDuckGo/IPadOmnibarModelPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarModelPickerController.swift
@@ -36,12 +36,15 @@ final class IPadOmnibarModelPickerController {
     var onModelsUpdated: (() -> Void)?
 
     init(
-        modelsService: AIChatModelsProviding = AIChatModelsService(),
+        modelsService: AIChatModelsProviding? = nil,
         preferences: AIChatPreferencesPersisting = AIChatPreferencesPersistor(),
-        subscriptionManager: any SubscriptionManager = AppDependencyProvider.shared.subscriptionManager
+        subscriptionManager: any SubscriptionManager = AppDependencyProvider.shared.subscriptionManager,
+        aiChatSettings: AIChatSettingsProvider = AIChatSettings()
     ) {
         store = UTIModelStore(
-            modelsService: modelsService,
+            modelsService: modelsService ?? AIChatModelsService(
+                baseURL: aiChatModelsBaseURL(forChatURL: aiChatSettings.aiChatURL)
+            ),
             preferences: preferences,
             subscriptionManager: subscriptionManager
         )

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -380,7 +380,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         duckAiNativeStoragePixelFiring: DuckAiNativeStoragePixelFiring = DuckAiNativeStoragePixelAdapter(),
         lastUsedModelProvider: DuckAiLastUsedModelProviding? = nil,
         lastUsedReasoningModeProvider: DuckAiLastUsedReasoningModeProviding? = nil,
-        modelsService: AIChatModelsProviding = AIChatModelsService(),
+        modelsService: AIChatModelsProviding? = nil,
         preferences: AIChatPreferencesPersisting = AIChatPreferencesPersistor(),
         subscriptionManager: any SubscriptionManager = AppDependencyProvider.shared.subscriptionManager,
         toggleModeStorage: ToggleModeStoring = ToggleModeStorage(),
@@ -404,7 +404,9 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             toggleModeStorage: toggleModeStorage
         )
         self.modelStore = UTIModelStore(
-            modelsService: modelsService,
+            modelsService: modelsService ?? AIChatModelsService(
+                baseURL: aiChatModelsBaseURL(forChatURL: aiChatSettings.aiChatURL)
+            ),
             preferences: preferences,
             subscriptionManager: subscriptionManager
         )
@@ -2706,4 +2708,17 @@ extension UnifiedToggleInputCoordinator {
             }
             .store(in: &cancellables)
     }
+}
+
+/// Derives the AI Chat models API base (scheme + host) from the resolved chat URL, so `/models` is fetched
+/// from the same origin the chat loads from — production `duck.ai`, or a debug/dev host when the chat URL is
+/// overridden via Debug → "Set Custom AI Chat URL". Falls back to `AIChatModelsService.defaultBaseURL` if the
+/// chat URL lacks a host.
+func aiChatModelsBaseURL(forChatURL chatURL: URL) -> URL {
+    guard let scheme = chatURL.scheme, let host = chatURL.host else { return AIChatModelsService.defaultBaseURL }
+    var components = URLComponents()
+    components.scheme = scheme
+    components.host = host
+    components.port = chatURL.port
+    return components.url ?? AIChatModelsService.defaultBaseURL
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1216119027620409?focus=true

### Description
Cherry pick from https://github.com/duckduckgo/apple-browsers/pull/5600

### Testing Steps
1. Already reviewed 
2.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI mapping and debug/dev URL alignment only; production behavior is unchanged aside from correct OSS icons for Tinfoil models.
> 
> **Overview**
> **Tinfoil models (e.g. Gemma) now use the open-source provider icon** in Duck.ai pickers by treating any model whose API `provider` is `tinfoil` as `.oss`, not only IDs containing `gpt-oss`.
> 
> **Models list fetching on iOS** is wired to the same origin as the loaded chat: `UnifiedToggleInputCoordinator` and `IPadOmnibarModelPickerController` build `AIChatModelsService` with a base URL derived from `aiChatSettings.aiChatURL` (via new `aiChatModelsBaseURL(forChatURL:)`), so Debug custom AI Chat URLs hit matching `/duckchat/v1/models` hosts. Shared `AIChatModelsService.defaultBaseURL` now uses `URL.duckAIHost` instead of a hardcoded `duck.ai` string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9538e03aa5a5516062bbc986810dd830b0a8e503. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->