### PR TITLE
[macOS] Fix address bar spoofing UI tests

### DIFF
--- a/macOS/UITests/AddressBarSpoofingUITests.swift
+++ b/macOS/UITests/AddressBarSpoofingUITests.swift
@@ -246,9 +246,13 @@ class AddressBarSpoofingUITests: UITestCase {
 
         let addressBarEmpty = addressBarValue.isEmpty
         let addressBarIsData = addressBarValue.starts(with: "data:text/html")
+        // data: URL popups are now blocked outright, so window.open() of the base64 payload
+        // opens no window and the address bar stays on the legitimate source page. That is a
+        // safe, non-spoofed outcome alongside an empty bar or an honestly-shown data: URL.
+        let addressBarOnSourcePage = addressBarValue.contains("privacy-test-pages.site")
 
-        XCTAssertTrue(addressBarEmpty || addressBarIsData,
-                      "Address bar should be empty or show data URL, got: \(addressBarValue)")
+        XCTAssertTrue(addressBarEmpty || addressBarIsData || addressBarOnSourcePage,
+                      "Address bar should be empty, show a data URL, or stay on the source page, got: \(addressBarValue)")
     }
 
     func testUrlBarSpoofingWithUnsupportedScheme() {

--- a/macOS/UITests/AddressBarSpoofingUITests.swift
+++ b/macOS/UITests/AddressBarSpoofingUITests.swift
@@ -246,9 +246,6 @@ class AddressBarSpoofingUITests: UITestCase {
 
         let addressBarEmpty = addressBarValue.isEmpty
         let addressBarIsData = addressBarValue.starts(with: "data:text/html")
-        // data: URL popups are now blocked outright, so window.open() of the base64 payload
-        // opens no window and the address bar stays on the legitimate source page. That is a
-        // safe, non-spoofed outcome alongside an empty bar or an honestly-shown data: URL.
         let addressBarOnSourcePage = addressBarValue.contains("privacy-test-pages.site")
 
         XCTAssertTrue(addressBarEmpty || addressBarIsData || addressBarOnSourcePage,


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1216138542122220?focus=true
Tech Design URL:
CC:

### Description

This PR fixes address bar spoofing UI tests.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that the address bar spoofing tests succeeded in [this workflow run](https://github.com/duckduckgo/apple-browsers/actions/runs/28420034152) - note that other tests like Duck Player may fail as they are currently experiencing issues unrelated to this PR

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion change in macOS UI tests; no production browser or security logic is modified.
> 
> **Overview**
> Updates **`testUrlBarSpoofingWithOpenB64Html`** so a passing result can include the address bar **still showing the privacy test page**, not only an empty bar or a `data:text/html` URL.
> 
> This adds `addressBarOnSourcePage` and folds it into the existing `XCTAssertTrue`, with an updated failure message—matching patterns used in other spoofing tests when the browser keeps the original URL instead of navigating to base64 HTML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3099d7c4a4313d6b10d45e370ec4a52f07b08a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->