### PR TITLE
[iOS] Show after-idle RMF card in focused unified-toggle-input mode

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1690,6 +1690,7 @@ class MainViewController: UIViewController {
         let narrowLayoutInLandscape = aiChatSettings.isAIChatSearchInputUserSettingsEnabled
 
         let controller = NewTabPageViewController(isFocussedState: false,
+                                                  openedAfterIdle: hatch != nil,
                                                   dismissKeyboardOnScroll: true,
                                                   tab: tabModel,
                                                   interactionModel: favoritesViewModel,

--- a/iOS/DuckDuckGo/NewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPageViewController.swift
@@ -85,6 +85,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
     var onViewDidAppear: (() -> Void)?
 
     init(isFocussedState: Bool,
+         openedAfterIdle: Bool = false,
          dismissKeyboardOnScroll: Bool,
          tab: Tab,
          interactionModel: FavoritesListInteracting,
@@ -117,6 +118,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
         self.tutorialSettings = tutorialSettings
 
         newTabPageViewModel = NewTabPageViewModel(fireTab: tab.fireTab)
+        newTabPageViewModel.openedAfterIdle = openedAfterIdle
         favoritesModel = FavoritesViewModel(isFocussedState: isFocussedState,
                                             favoriteDataSource: FavoritesListInteractingAdapter(favoritesListInteracting: interactionModel),
                                             faviconLoader: faviconLoader,
@@ -128,7 +130,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
                                                 imageLoader: remoteMessagingImageLoader,
                                                 pixelReporter: remoteMessagingPixelReporter,
                                                 fireModePromotionEligibility: fireModePromotionEligibility,
-                                                isOpenedAfterIdle: { [weak viewModel] in viewModel?.escapeHatch != nil })
+                                                isOpenedAfterIdle: { [weak viewModel] in viewModel?.openedAfterIdle ?? false })
 
         super.init(rootView: NewTabPageView(isFocussedState: isFocussedState,
                                             narrowLayoutInLandscape: narrowLayoutInLandscape,
@@ -147,8 +149,14 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
 
     func setEscapeHatch(_ model: EscapeHatchModel?) {
         newTabPageViewModel.escapeHatch = model
+        newTabPageViewModel.openedAfterIdle = (model != nil)
         messagesModel.refresh()
         updateBorderView()
+    }
+
+    func setOpenedAfterIdle(_ openedAfterIdle: Bool) {
+        newTabPageViewModel.openedAfterIdle = openedAfterIdle
+        messagesModel.refresh()
     }
 
     func setChromeLayoutContext(isBorderSuppressed: Bool) {

--- a/iOS/DuckDuckGo/NewTabPageViewModel.swift
+++ b/iOS/DuckDuckGo/NewTabPageViewModel.swift
@@ -27,6 +27,7 @@ final class NewTabPageViewModel: ObservableObject {
     @Published var canEditFavorites = true
     @Published private(set) var isOnboarding: Bool
     @Published var escapeHatch: EscapeHatchModel?
+    var openedAfterIdle: Bool = false
     @Published var sectionTitle: String?
     @Published var isLogoHidden: Bool = false
     /// Hides the favorites grid (without removing it) so the UTI defocus handoff can keep the embedded

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/UnifiedSuggestionsHost.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/UnifiedSuggestionsHost.swift
@@ -52,6 +52,10 @@ final class UnifiedSuggestionsHost {
         return cachedFavoritesController
     }
 
+    func updateOpenedAfterIdle(_ openedAfterIdle: Bool) {
+        cachedFavoritesController?.setOpenedAfterIdle(openedAfterIdle)
+    }
+
     init(config: UnifiedSuggestionsHostConfig) {
         self.config = config
         self.isAddressBarAtBottom = config.isAddressBarAtBottom

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -285,9 +285,14 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         refreshVisibleContent(animateContentUpdates: false)
     }
 
+    private var sessionOpenedAfterIdle: Bool {
+        suggestionTrayDependencies?.tabsModelProvider().currentTab?.openedAfterIdle ?? false
+    }
+
     func setEscapeHatch(_ model: EscapeHatchModel?) {
         let hatchPresenceChanged = (escapeHatchModel != nil) != (model != nil)
         escapeHatchModel = model
+        unifiedSuggestionsHost?.updateOpenedAfterIdle(sessionOpenedAfterIdle)
         // The chrome (hatch + sync-promo) is pinned to the bar (see below), not rendered in the host.
         updatePinnedChrome()
         updateSingleHostTopOffset()
@@ -700,6 +705,7 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         let ntpDeps = dependencies.newTabPageDependencies
         let controller = NewTabPageViewController(
             isFocussedState: true,
+            openedAfterIdle: sessionOpenedAfterIdle,
             dismissKeyboardOnScroll: aiChatSettings.isAIChatSearchInputUserSettingsEnabled,
             tab: Tab(fireTab: dependencies.tabsModelProvider().shouldCreateFireTabs),
             interactionModel: ntpDeps.favoritesModel,
@@ -723,8 +729,7 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         // standalone NTP (the embedded controller has no owner to set this otherwise).
         controller.delegate = self
         // The escape hatch and the empty-state logo are UTI chrome (bar-pinned hatch + the host's
-        // `FocusedDaxLogoView`), not the NTP's — suppress the NTP's own so we never get two.
-        controller.setEscapeHatch(nil)
+        // `FocusedDaxLogoView`), not the NTP's — leave the NTP's own hatch unset so we never get two.
         controller.setLogoHidden(true)
         return controller
     }

--- a/iOS/SharedStateTests/NewTabPageControllerDaxDialogTests.swift
+++ b/iOS/SharedStateTests/NewTabPageControllerDaxDialogTests.swift
@@ -98,6 +98,82 @@ final class NewTabPageControllerDaxDialogTests: XCTestCase {
         hvc = nil
     }
 
+    // MARK: - After-idle remote message signal
+
+    /// Builds an NTP the way the focused UTI embedded surface does: a shared messages config and the
+    /// after-idle signal passed in (the embedded surface suppresses its own escape hatch, so the
+    /// signal can't be derived from it).
+    private func makeNewTabPage(openedAfterIdle: Bool,
+                                homePageMessagesConfiguration: HomePageMessagesConfiguration) -> NewTabPageViewController {
+        NewTabPageViewController(
+            isFocussedState: true,
+            openedAfterIdle: openedAfterIdle,
+            dismissKeyboardOnScroll: false,
+            tab: Tab(),
+            interactionModel: MockFavoritesListInteracting(),
+            homePageMessagesConfiguration: homePageMessagesConfiguration,
+            newTabDialogFactory: dialogFactory,
+            daxDialogsManager: specProvider,
+            onboardingFlowProvider: flowProvider,
+            faviconLoader: EmptyFaviconLoading(),
+            remoteMessagingActionHandler: MockRemoteMessagingActionHandler(),
+            remoteMessagingImageLoader: MockRemoteMessagingImageLoader(),
+            appSettings: AppSettingsMock(),
+            faviconsCache: Favicons(),
+            subscriptionManager: SubscriptionManagerMock(),
+            internalUserCommands: MockURLBasedDebugCommands(),
+            tutorialSettings: tutorialSettings)
+    }
+
+    private func makeConfiguration(withScheduledMessage: Bool) -> (HomePageConfiguration, MockRemoteMessagingStore) {
+        let store = MockRemoteMessagingStore()
+        if withScheduledMessage {
+            store.scheduledRemoteMessage = RemoteMessageModel(
+                id: "idle-msg", surfaces: .newTabPage, content: nil, matchingRules: [], exclusionRules: [], isMetricsEnabled: false)
+        }
+        let config = HomePageConfiguration(remoteMessagingStore: store,
+                                           subscriptionDataReporter: MockSubscriptionDataReporter(),
+                                           isStillOnboarding: { false })
+        return (config, store)
+    }
+
+    func testWhenOpenedAfterIdleTrueThenMessagesConfigFetchesWithAfterIdleTrigger() {
+        // GIVEN a shared config with a scheduled after-idle message
+        let (config, store) = makeConfiguration(withScheduledMessage: true)
+
+        // WHEN an embedded (hatch-suppressed) NTP is built seeded with the after-idle signal
+        _ = makeNewTabPage(openedAfterIdle: true, homePageMessagesConfiguration: config)
+
+        // THEN its first refresh fetches the after-idle message (not .noTrigger) and keeps it in the
+        // shared config the focused-content gate reads
+        XCTAssertEqual(store.capturedTriggerFilter, .specific(.afterIdle))
+        XCTAssertFalse(config.homeMessages.isEmpty)
+    }
+
+    func testWhenOpenedAfterIdleFalseThenMessagesConfigFetchesWithNoTrigger() {
+        // GIVEN
+        let (config, store) = makeConfiguration(withScheduledMessage: true)
+
+        // WHEN a non-after-idle NTP is built
+        _ = makeNewTabPage(openedAfterIdle: false, homePageMessagesConfiguration: config)
+
+        // THEN it fetches the standard (.noTrigger) message, not the after-idle one
+        XCTAssertEqual(store.capturedTriggerFilter, .noTrigger)
+    }
+
+    func testWhenSetOpenedAfterIdleTrueThenMessagesConfigRefetchesWithAfterIdleTrigger() {
+        // GIVEN a cached NTP originally built without the after-idle signal
+        let (config, store) = makeConfiguration(withScheduledMessage: true)
+        let controller = makeNewTabPage(openedAfterIdle: false, homePageMessagesConfiguration: config)
+        store.capturedTriggerFilter = nil
+
+        // WHEN a later after-idle session pushes the signal into the cached controller
+        controller.setOpenedAfterIdle(true)
+
+        // THEN it re-fetches with the after-idle trigger
+        XCTAssertEqual(store.capturedTriggerFilter, .specific(.afterIdle))
+    }
+
     func testWhenViewDidAppear_CorrectTypePassedToDialogFactory() throws {
         // GIVEN
         let expectedSpec = randomDialogType()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1215849325724845/task/1216034379142824?focus=true
Tech Design URL:
CC:

### Description
Show after-idle RMF card in focused unified-toggle-input mode

### Testing Steps
Same as https://github.com/duckduckgo/apple-browsers/pull/5570
1. Got to Settings -> General -> Make sure after idle is set to NTP and  idle time is none
2. From debug menu -> Configuration URL ->  override remote message config with https://pastebin.com/raw/kHdXWw8T
3. Debug menu -> Remote messaging ->  Press delete all and then Refresh config
4. Open a site and then background and foreground the app
5. check the RMF is visible in both focussed and unfocussed mode
6. Open a new tab manually and check the RMF is not visible.

### Impact and Risks
Low.

#### What could go wrong?
The after-idle signal is now seeded per surface, but every NTP call site either passes it at init or sets it via the escape hatch, so no surface is left without a signal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized NTP/UTI messaging wiring with explicit idle signaling at existing call sites; no auth or data-layer changes.
> 
> **Overview**
> Fixes **after-idle Remote Message Framework (RMF) cards** missing when the omnibar is focused with **unified toggle input (UTI)**. The embedded NTP keeps its escape hatch unset so chrome isn’t duplicated, but message refresh used to infer “opened after idle” from `escapeHatch != nil`, so it fetched with `.noTrigger` and cleared the shared home-message cache the focused UI reads.
> 
> The PR introduces a first-class **`openedAfterIdle`** on `NewTabPageViewModel`, wired at **`NewTabPageViewController` init** (standalone NTP from `MainViewController` when a hatch exists; UTI from the current tab’s `openedAfterIdle`). **`NewTabPageMessagesModel`** now uses that flag for `HomePageConfiguration.refresh`. **`setOpenedAfterIdle`** and **`UnifiedSuggestionsHost.updateOpenedAfterIdle`** keep cached embedded NTPs in sync when the session signal changes; **`setEscapeHatch`** still sets the flag when a hatch is shown. UTI stops forcing **`setEscapeHatch(nil)`** on the embedded favorites NTP so the hatch stays unset without losing the idle signal. Tests cover init seeding and late updates to the after-idle trigger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cff386c6845c5f83ee6a4a16265cef4495195516. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->