### PR TITLE
macOS: Forward attachmentLimits to the NTP omnibar config

### DIFF
--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarModelsProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarModelsProvider.swift
@@ -27,6 +27,7 @@ import Subscription
 final class NewTabPageOmnibarModelsProvider: NewTabPageOmnibarModelsProviding {
 
     private(set) var lastFetchedSections: [NewTabPageDataModel.AIModelSection]?
+    private(set) var attachmentLimits: NewTabPageDataModel.AttachmentLimits?
     private let modelsService: AIChatModelsProviding
     private let subscriptionManager: any SubscriptionManager
 
@@ -42,6 +43,7 @@ final class NewTabPageOmnibarModelsProvider: NewTabPageOmnibarModelsProviding {
         do {
             let response = try await modelsService.fetchModels()
             let userTier = await resolveUserTier()
+            attachmentLimits = Self.mapAttachmentLimits(response.attachmentLimits?.limits(for: userTier))
             let models = response.models.map { AIChatModel(remoteModel: $0, userTier: userTier) }
             let hasActiveSubscription = userTier != .free
 
@@ -75,6 +77,23 @@ final class NewTabPageOmnibarModelsProvider: NewTabPageOmnibarModelsProviding {
             Logger.aiChat.error("Failed to fetch models for NTP: \(error.localizedDescription)")
             return []
         }
+    }
+
+    private static func mapAttachmentLimits(_ limits: AIChatAttachmentTierLimits?) -> NewTabPageDataModel.AttachmentLimits? {
+        guard let limits else { return nil }
+        return NewTabPageDataModel.AttachmentLimits(
+            files: .init(
+                maxPerConversation: limits.files.maxPerConversation,
+                maxFileSizeMB: limits.files.maxFileSizeMB,
+                maxTotalFileSizeBytes: limits.files.maxTotalFileSizeBytes,
+                maxPagesPerFile: limits.files.maxPagesPerFile
+            ),
+            images: .init(
+                maxPerTurn: limits.images.maxPerTurn,
+                maxPerConversation: limits.images.maxPerConversation,
+                maxInputCharsWithAttachments: limits.images.maxInputCharsWithAttachments
+            )
+        )
     }
 
     private func resolveUserTier() async -> AIChatUserTier {

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarModelsProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarModelsProvider.swift
@@ -43,7 +43,7 @@ final class NewTabPageOmnibarModelsProvider: NewTabPageOmnibarModelsProviding {
         do {
             let response = try await modelsService.fetchModels()
             let userTier = await resolveUserTier()
-            attachmentLimits = Self.mapAttachmentLimits(response.attachmentLimits?.limits(for: userTier))
+            attachmentLimits = mapAttachmentLimits(response.attachmentLimits?.limits(for: userTier))
             let models = response.models.map { AIChatModel(remoteModel: $0, userTier: userTier) }
             let hasActiveSubscription = userTier != .free
 
@@ -79,7 +79,7 @@ final class NewTabPageOmnibarModelsProvider: NewTabPageOmnibarModelsProviding {
         }
     }
 
-    private static func mapAttachmentLimits(_ limits: AIChatAttachmentTierLimits?) -> NewTabPageDataModel.AttachmentLimits? {
+    private func mapAttachmentLimits(_ limits: AIChatAttachmentTierLimits?) -> NewTabPageDataModel.AttachmentLimits? {
         guard let limits else { return nil }
         return NewTabPageDataModel.AttachmentLimits(
             files: .init(

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageDataModel+Omnibar.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageDataModel+Omnibar.swift
@@ -64,6 +64,46 @@ public extension NewTabPageDataModel {
         }
     }
 
+    /// Attachment limits sourced from the Duck.ai backend (`/duckchat/v1/models`, field
+    /// `attachmentLimits`), already resolved for the user's tier. Forwarded to the web so the NTP
+    /// omnibar can enforce them instead of hardcoding defaults. Mirrors the resolved shape of
+    /// `AIChat.AIChatAttachmentTierLimits`.
+    struct AttachmentLimits: Codable, Equatable {
+        public struct FileLimits: Codable, Equatable {
+            let maxPerConversation: Int
+            let maxFileSizeMB: Int
+            let maxTotalFileSizeBytes: Int
+            let maxPagesPerFile: Int
+
+            public init(maxPerConversation: Int, maxFileSizeMB: Int, maxTotalFileSizeBytes: Int, maxPagesPerFile: Int) {
+                self.maxPerConversation = maxPerConversation
+                self.maxFileSizeMB = maxFileSizeMB
+                self.maxTotalFileSizeBytes = maxTotalFileSizeBytes
+                self.maxPagesPerFile = maxPagesPerFile
+            }
+        }
+
+        public struct ImageLimits: Codable, Equatable {
+            let maxPerTurn: Int
+            let maxPerConversation: Int
+            let maxInputCharsWithAttachments: Int
+
+            public init(maxPerTurn: Int, maxPerConversation: Int, maxInputCharsWithAttachments: Int) {
+                self.maxPerTurn = maxPerTurn
+                self.maxPerConversation = maxPerConversation
+                self.maxInputCharsWithAttachments = maxInputCharsWithAttachments
+            }
+        }
+
+        let files: FileLimits
+        let images: ImageLimits
+
+        public init(files: FileLimits, images: ImageLimits) {
+            self.files = files
+            self.images = images
+        }
+    }
+
     struct OmnibarConfig: Codable, Equatable {
         let mode: OmnibarMode
         let enableAi: Bool
@@ -95,6 +135,11 @@ public extension NewTabPageDataModel {
         /// `aiChatNtpAttachMoreTabs` feature flag and reactive over `omnibar_onConfigUpdate`.
         /// `nil`/false means the affordances stay hidden and existing flows are unchanged.
         let enableAttachTabs: Bool?
+        /// Backend-provided attachment limits, already tier-resolved. `nil` on older native builds
+        /// or when the backend omits them, in which case the web falls back to its built-in defaults.
+        /// The `= nil` default makes this a trailing optional parameter of the synthesized memberwise
+        /// initializer, so the existing `OmnibarConfig(...)` call sites (and tests) compile unchanged.
+        let attachmentLimits: AttachmentLimits? = nil
     }
 
     // MARK: - omnibar_getSuggestions

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageDataModel+Omnibar.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageDataModel+Omnibar.swift
@@ -139,7 +139,7 @@ public extension NewTabPageDataModel {
         /// or when the backend omits them, in which case the web falls back to its built-in defaults.
         /// The `= nil` default makes this a trailing optional parameter of the synthesized memberwise
         /// initializer, so the existing `OmnibarConfig(...)` call sites (and tests) compile unchanged.
-        let attachmentLimits: AttachmentLimits? = nil
+        var attachmentLimits: AttachmentLimits? = nil
     }
 
     // MARK: - omnibar_getSuggestions

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
@@ -122,7 +122,8 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             selectedModelId: configProvider.selectedModelId,
             aiModelSections: sectionsForWeb(aiModelSections),
             selectedReasoningEffort: configProvider.selectedReasoningEffort,
-            enableAttachTabs: configProvider.isAttachTabsEnabled
+            enableAttachTabs: configProvider.isAttachTabsEnabled,
+            attachmentLimits: modelsProvider?.attachmentLimits
         )
     }
 
@@ -196,7 +197,8 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             selectedModelId: configProvider.selectedModelId,
             aiModelSections: sectionsForWeb(modelsProvider?.lastFetchedSections),
             selectedReasoningEffort: configProvider.selectedReasoningEffort,
-            enableAttachTabs: configProvider.isAttachTabsEnabled
+            enableAttachTabs: configProvider.isAttachTabsEnabled,
+            attachmentLimits: modelsProvider?.attachmentLimits
         )
         pushMessage(named: MessageName.onConfigUpdate.rawValue, params: config)
     }

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarModelsProviding.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarModelsProviding.swift
@@ -19,5 +19,12 @@
 @MainActor
 public protocol NewTabPageOmnibarModelsProviding {
     var lastFetchedSections: [NewTabPageDataModel.AIModelSection]? { get }
+    /// Attachment limits resolved for the user's tier from the most recent duck.ai models fetch.
+    /// `nil` until a fetch succeeds, or when the backend omits them.
+    var attachmentLimits: NewTabPageDataModel.AttachmentLimits? { get }
     func fetchAIModelSections() async -> [NewTabPageDataModel.AIModelSection]
+}
+
+public extension NewTabPageOmnibarModelsProviding {
+    var attachmentLimits: NewTabPageDataModel.AttachmentLimits? { nil }
 }

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarModelsProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarModelsProviderTests.swift
@@ -111,6 +111,54 @@ final class NewTabPageOmnibarModelsProviderTests: XCTestCase {
         XCTAssertFalse(allIds.contains("pro-only"))
     }
 
+    // MARK: - Attachment Limits Tests
+
+    func testWhenResponseHasNoAttachmentLimitsThenProviderLimitsAreNil() async {
+        mockModelsService.modelsToReturn = [makeRemoteModel(id: "free-model", accessTier: ["free"])]
+        mockModelsService.attachmentLimitsToReturn = nil
+
+        _ = await provider.fetchAIModelSections()
+
+        XCTAssertNil(provider.attachmentLimits)
+    }
+
+    func testWhenResponseHasAttachmentLimitsThenTheyAreMappedForFreeTier() async {
+        mockModelsService.modelsToReturn = [makeRemoteModel(id: "free-model", accessTier: ["free"])]
+        mockModelsService.attachmentLimitsToReturn = makeAttachmentLimits()
+
+        _ = await provider.fetchAIModelSections()
+
+        XCTAssertEqual(provider.attachmentLimits, expectedAttachmentLimits(base: freeBase))
+    }
+
+    func testWhenPlusUserThenPlusAttachmentLimitsAreMapped() async {
+        mockSubscriptionManager.resultSubscription = .success(makeSubscription(tier: .plus))
+        mockModelsService.modelsToReturn = [makeRemoteModel(id: "plus-model", accessTier: ["plus"])]
+        mockModelsService.attachmentLimitsToReturn = makeAttachmentLimits()
+
+        _ = await provider.fetchAIModelSections()
+
+        XCTAssertEqual(provider.attachmentLimits, expectedAttachmentLimits(base: plusBase))
+    }
+
+    func testWhenProUserThenProAttachmentLimitsAreMapped() async {
+        mockSubscriptionManager.resultSubscription = .success(makeSubscription(tier: .pro))
+        mockModelsService.modelsToReturn = [makeRemoteModel(id: "pro-model", accessTier: ["pro"])]
+        mockModelsService.attachmentLimitsToReturn = makeAttachmentLimits()
+
+        _ = await provider.fetchAIModelSections()
+
+        XCTAssertEqual(provider.attachmentLimits, expectedAttachmentLimits(base: proBase))
+    }
+
+    func testWhenFetchFailsThenAttachmentLimitsRemainNil() async {
+        mockModelsService.errorToThrow = NSError(domain: "test", code: -1)
+
+        _ = await provider.fetchAIModelSections()
+
+        XCTAssertNil(provider.attachmentLimits)
+    }
+
     // MARK: - Reasoning Effort Tests
 
     func testWhenModelHasSupportedReasoningEffortThenItIsMappedToItem() async {
@@ -274,6 +322,51 @@ final class NewTabPageOmnibarModelsProviderTests: XCTestCase {
         )
     }
 
+    // Distinct base values per tier so tier-specific mapping is verifiable.
+    private let freeBase = 10
+    private let plusBase = 100
+    private let proBase = 1000
+
+    private func makeAttachmentLimits() -> AIChatAttachmentLimits {
+        AIChatAttachmentLimits(
+            free: makeTierLimits(base: freeBase),
+            plus: makeTierLimits(base: plusBase),
+            pro: makeTierLimits(base: proBase)
+        )
+    }
+
+    private func makeTierLimits(base: Int) -> AIChatAttachmentTierLimits {
+        AIChatAttachmentTierLimits(
+            files: AIChatAttachmentFileLimits(
+                maxPerConversation: base + 1,
+                maxFileSizeMB: base + 2,
+                maxTotalFileSizeBytes: base + 3,
+                maxPagesPerFile: base + 4
+            ),
+            images: AIChatAttachmentImageLimits(
+                maxPerTurn: base + 5,
+                maxPerConversation: base + 6,
+                maxInputCharsWithAttachments: base + 7
+            )
+        )
+    }
+
+    private func expectedAttachmentLimits(base: Int) -> NewTabPageDataModel.AttachmentLimits {
+        NewTabPageDataModel.AttachmentLimits(
+            files: .init(
+                maxPerConversation: base + 1,
+                maxFileSizeMB: base + 2,
+                maxTotalFileSizeBytes: base + 3,
+                maxPagesPerFile: base + 4
+            ),
+            images: .init(
+                maxPerTurn: base + 5,
+                maxPerConversation: base + 6,
+                maxInputCharsWithAttachments: base + 7
+            )
+        )
+    }
+
     private func makeSubscription(tier: TierName) -> DuckDuckGoSubscription {
         DuckDuckGoSubscription(
             productId: "test",
@@ -295,10 +388,11 @@ final class NewTabPageOmnibarModelsProviderTests: XCTestCase {
 
 private final class MockModelsService: AIChatModelsProviding {
     var modelsToReturn: [AIChatRemoteModel] = []
+    var attachmentLimitsToReturn: AIChatAttachmentLimits?
     var errorToThrow: Error?
 
     func fetchModels() async throws -> AIChatModelsResponse {
         if let error = errorToThrow { throw error }
-        return AIChatModelsResponse(models: modelsToReturn)
+        return AIChatModelsResponse(models: modelsToReturn, attachmentLimits: attachmentLimitsToReturn)
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671677432066/task/1216131542608713?focus=true
Tech Design URL:
CC:

### Description

- Adds `AttachmentLimits` to the NTP config

### Testing Steps

1. Build
2. Use debugger to confirm the build sends AttachmentLimits field to the NTP config.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
3. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
4. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional config field with nil fallback; no changes to auth or persistence, covered by unit tests.
> 
> **Overview**
> Native macOS now passes **backend attachment limits** (files and images) into the NTP omnibar config so the web layer can enforce caps from `/duckchat/v1/models` instead of hardcoded defaults.
> 
> On each models fetch, limits are resolved for the user’s subscription tier (free/plus/pro), mapped into a new `AttachmentLimits` type on `OmnibarConfig`, and included in both initial `getConfig` and `onConfigUpdate` payloads. When the API omits limits or fetch fails, the field stays `nil` and the web keeps its fallbacks. Unit tests cover tier mapping and error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38745216322f5ccc047800877ae5b682b2f2bb72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->