### PR TITLE
[iOS] Always include the model ID in the Duck.ai wide event

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1184,7 +1184,6 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         guard let userScript = boundUserScript else { return }
         let configuration = voicePromptSubmissionConfiguration
         recordDuckAISubmissionStarted(
-            modelId: configuration.modelId,
             reasoningEffort: configuration.reasoningEffort,
             inputMode: .voice,
             frontendDeliveryPath: .userScript,
@@ -1922,7 +1921,6 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
 
             let configuration = promptSubmissionConfiguration
             recordDuckAISubmissionStarted(
-                modelId: configuration.modelId,
                 reasoningEffort: configuration.reasoningEffort,
                 inputMode: .keyboard,
                 frontendDeliveryPath: userScript != nil ? .userScript : .urlAutoSubmit,
@@ -2634,8 +2632,7 @@ extension UnifiedToggleInputCoordinator {
 
     /// Records a submission for the user's primary input path (voice or keyboard) - opens the
     /// wide-event flow with the snapshot of state at submit time.
-    func recordDuckAISubmissionStarted(modelId: String?,
-                                       reasoningEffort: AIChatReasoningEffort?,
+    func recordDuckAISubmissionStarted(reasoningEffort: AIChatReasoningEffort?,
                                        inputMode: DuckAIPromptWideEventData.InputMode,
                                        frontendDeliveryPath: DuckAIPromptWideEventData.FrontendDeliveryPath,
                                        hasPageContext: Bool,
@@ -2644,7 +2641,7 @@ extension UnifiedToggleInputCoordinator {
         guard let scope = currentDuckAIWideEventFlowScope else { return }
         duckAIWideEventInstrumentation?.submissionStarted(
             scope: scope,
-            modelId: modelId,
+            modelId: persistedModelId,
             userTier: subscriptionState.userTier,
             reasoningEffort: reasoningEffort,
             entryPoint: duckAIEntryPoint,

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -283,6 +283,27 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "follow-up", mode: .aiChat)
     }
 
+    func test_duckAIWideEvent_recordsEffectiveModelId_onFollowUpPrompts() {
+        // Follow-ups previously dropped model_id by reusing the submission-config value.
+        let instrumentation = MockDuckAIWideEventInstrumentation()
+        let coordinator = UnifiedToggleInputCoordinator(
+            host: .omnibar,
+            isToggleEnabled: true,
+            preferences: mockPreferences,
+            toggleModeStorage: mockToggleModeStorage,
+            switchBarSubmissionMetrics: mockSubmissionMetrics,
+            duckAIWideEventInstrumentation: instrumentation
+        )
+        coordinator.activateForTab("tab-A")
+        coordinator.modelStore.models = [makeModel(id: "gpt-5", access: true)]
+
+        coordinator.unifiedToggleInputVC(coordinator.viewController, didSubmitText: "first prompt", mode: .aiChat)
+        coordinator.unifiedToggleInputVC(coordinator.viewController, didSubmitText: "follow-up", mode: .aiChat)
+
+        XCTAssertEqual(instrumentation.submissionStartedModelIds, ["gpt-5", "gpt-5"],
+                       "Both the first and follow-up prompts should record the effective model id in the wide event")
+    }
+
     func test_hide_clearsRecoveryBlock() {
         sut.isSubmitBlockedByRecoveryCard = true
         sut.hide()
@@ -3624,6 +3645,7 @@ final class MockSwitchBarSubmissionMetrics: SwitchBarSubmissionMetricsProviding 
 @MainActor
 private final class MockDuckAIWideEventInstrumentation: DuckAIWideEventInstrumentation {
     private(set) var submissionStartedScopes: [DuckAIWideEventFlowScope] = []
+    private(set) var submissionStartedModelIds: [String?] = []
     private(set) var tabSwitchedAwayCalls: [TabUID] = []
     private(set) var promptInterpretedAsURLScopes: [DuckAIWideEventFlowScope] = []
 
@@ -3640,6 +3662,7 @@ private final class MockDuckAIWideEventInstrumentation: DuckAIWideEventInstrumen
                            toolsSelected: Bool,
                            attachmentsSelected: Bool) {
         submissionStartedScopes.append(scope)
+        submissionStartedModelIds.append(modelId)
     }
     func promptDeliveryUpdated(scope: DuckAIWideEventFlowScope, wasQueued: Bool?, didSendBridgeMessage: Bool?) {}
     func frontendSubmissionAcknowledged(scope: DuckAIWideEventFlowScope) {}


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1216171814812404?focus=true
Tech Design URL:
CC:

### Description

This PR updates the Duck.ai wide event to correctly include the model ID.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Send a Duck.ai prompt from the unified input and check that the wide event in the logs includes the model ID

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only change to wide-event payload sourcing; prompt submission to the frontend still uses the existing configuration rules.
> 
> **Overview**
> Duck.ai **wide-event** instrumentation now always records **`model_id`** from **`persistedModelId`**, instead of reusing **`promptSubmissionConfiguration.modelId`**.
> 
> That submission config intentionally sets **`modelId` to `nil` after the first prompt** (follow-ups rely on the active chat model on the bridge). Wide events were inheriting that rule, so **follow-up keyboard and voice submits** could omit the model in logs.
> 
> Call sites no longer pass **`modelId`** into **`recordDuckAISubmissionStarted`**; reasoning effort and other submit-time fields are unchanged. A unit test asserts both the first prompt and a follow-up emit the same effective model id in **`submissionStarted`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1dde0aece7e428e56411456012c27105bd8ad53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->