### PR TITLE
[iOS] Prevent Duck.ai sync promo from clashing with launch modals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ buildServer.json
 content-scope-scripts/
 privacy-configuration/
 .xcodebuildmcp/config.yaml
+.claude/worktrees

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/AIChatSyncPromoViewModel.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/AIChatSyncPromoViewModel.swift
@@ -19,6 +19,14 @@
 
 import Core
 
+/// Reports whether a coordinated launch modal (subscription reinstaller promo, default-browser
+/// prompt, What's New, etc.) was presented earlier in the current session. The Duck.ai sync promo
+/// uses this to yield so the two don't appear back-to-back in the same session. See Asana 1216108902675922.
+@MainActor
+protocol RecentModalPromptStatusProviding {
+    var wasModalPromptRecentlyPresented: Bool { get }
+}
+
 @MainActor
 final class AIChatSyncPromoViewModel {
 
@@ -27,17 +35,23 @@ final class AIChatSyncPromoViewModel {
     }
 
     private let syncPromoManager: SyncPromoManaging
+    private let recentModalPromptStatusProvider: RecentModalPromptStatusProviding?
     private let pixelFiring: any PixelFiring.Type
     private var impressionRecorded = false
 
     init(syncPromoManager: SyncPromoManaging,
+         recentModalPromptStatusProvider: RecentModalPromptStatusProviding? = nil,
          pixelFiring: any PixelFiring.Type = Pixel.self) {
         self.syncPromoManager = syncPromoManager
+        self.recentModalPromptStatusProvider = recentModalPromptStatusProvider
         self.pixelFiring = pixelFiring
     }
 
     func shouldShowPromo(isQueryActive: Bool, chatCount: Int) -> Bool {
         guard !isQueryActive else { return false }
+        // Yield to a launch modal shown within the coordination cooldown window so we don't stack
+        // two promos back-to-back in the same session (e.g. the subscription reinstaller sheet).
+        guard recentModalPromptStatusProvider?.wasModalPromptRecentlyPresented != true else { return false }
         return syncPromoManager.shouldPresentPromoFor(.aiChat, count: chatCount)
     }
 

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/AIChatSyncPromoViewModel.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/AIChatSyncPromoViewModel.swift
@@ -19,9 +19,8 @@
 
 import Core
 
-/// Reports whether a coordinated launch modal (subscription reinstaller promo, default-browser
-/// prompt, What's New, etc.) was presented earlier in the current session. The Duck.ai sync promo
-/// uses this to yield so the two don't appear back-to-back in the same session. See Asana 1216108902675922.
+/// Whether a coordinated launch modal was already shown earlier in this session, so the Duck.ai
+/// sync promo can yield to it. See Asana 1216108902675922.
 @MainActor
 protocol RecentModalPromptStatusProviding {
     var wasModalPromptRecentlyPresented: Bool { get }
@@ -49,8 +48,6 @@ final class AIChatSyncPromoViewModel {
 
     func shouldShowPromo(isQueryActive: Bool, chatCount: Int) -> Bool {
         guard !isQueryActive else { return false }
-        // Yield to a launch modal shown within the coordination cooldown window so we don't stack
-        // two promos back-to-back in the same session (e.g. the subscription reinstaller sheet).
         guard recentModalPromptStatusProvider?.wasModalPromptRecentlyPresented != true else { return false }
         return syncPromoManager.shouldPresentPromoFor(.aiChat, count: chatCount)
     }

--- a/iOS/DuckDuckGo/AppServices/ModalPromptCoordinationService.swift
+++ b/iOS/DuckDuckGo/AppServices/ModalPromptCoordinationService.swift
@@ -95,8 +95,6 @@ final class ModalPromptCoordinationService {
         self.modalPromptCoordinationManager = modalPromptCoordinationManager
     }
 
-    /// Whether a coordinated launch modal was presented during the current app session. Resets on
-    /// each cold launch (in-memory), letting lower-priority in-context promos yield to it same-session.
     var wasModalPromptPresentedThisSession: Bool {
         modalPromptCoordinationManager.didPresentModalPromptThisSession
     }

--- a/iOS/DuckDuckGo/AppServices/ModalPromptCoordinationService.swift
+++ b/iOS/DuckDuckGo/AppServices/ModalPromptCoordinationService.swift
@@ -95,10 +95,6 @@ final class ModalPromptCoordinationService {
         self.modalPromptCoordinationManager = modalPromptCoordinationManager
     }
 
-    var wasModalPromptPresentedThisSession: Bool {
-        modalPromptCoordinationManager.didPresentModalPromptThisSession
-    }
-
     func presentModalPromptIfNeeded(from viewController: ModalPromptPresenter) {
         guard launchSourceManager.source == .standard else {
             Logger.modalPrompt.info("[Modal Prompt Coordination] - Skipping modal prompt - Launched from non-standard source.")
@@ -131,4 +127,8 @@ final class ModalPromptCoordinationService {
         modalPromptCoordinationManager.presentModalPromptIfNeeded(from: viewController)
     }
 
+}
+
+extension ModalPromptCoordinationService: RecentModalPromptStatusProviding {
+    var wasModalPromptRecentlyPresented: Bool { modalPromptCoordinationManager.didPresentModalPromptThisSession }
 }

--- a/iOS/DuckDuckGo/AppServices/ModalPromptCoordinationService.swift
+++ b/iOS/DuckDuckGo/AppServices/ModalPromptCoordinationService.swift
@@ -95,6 +95,12 @@ final class ModalPromptCoordinationService {
         self.modalPromptCoordinationManager = modalPromptCoordinationManager
     }
 
+    /// Whether a coordinated launch modal was presented during the current app session. Resets on
+    /// each cold launch (in-memory), letting lower-priority in-context promos yield to it same-session.
+    var wasModalPromptPresentedThisSession: Bool {
+        modalPromptCoordinationManager.didPresentModalPromptThisSession
+    }
+
     func presentModalPromptIfNeeded(from viewController: ModalPromptPresenter) {
         guard launchSourceManager.source == .standard else {
             Logger.modalPrompt.info("[Modal Prompt Coordination] - Skipping modal prompt - Launched from non-standard source.")

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -327,6 +327,9 @@ class MainViewController: UIViewController {
 
     let themeManager: ThemeManaging
     let keyValueStore: ThrowingKeyValueStoring
+    /// Reports whether a coordinated launch modal was presented this session, so the Duck.ai sync
+    /// promo can yield to it. Injected by MainCoordinator from the modal prompt coordination service.
+    let recentModalPromptStatusProvider: RecentModalPromptStatusProviding?
     let systemSettingsPiPTutorialManager: SystemSettingsPiPTutorialManaging
     let onboardingResumeStepStore: any KeyedStoring<OnboardingStoringKeys>
     var adBlockingAvailability: AdBlockingAvailabilityProviding { tabManager.adBlockingAvailability }
@@ -461,7 +464,8 @@ class MainViewController: UIViewController {
         voiceShortcutFeature: DuckAIVoiceShortcutFeatureProviding = DuckAIVoiceShortcutFeature(),
         toggleModeStorage: ToggleModeStoring = ToggleModeStorage(),
         onboardingResumeStepStore: (any KeyedStoring<OnboardingStoringKeys>)? = nil,
-        onboardingManager: OnboardingManaging
+        onboardingManager: OnboardingManaging,
+        recentModalPromptStatusProvider: RecentModalPromptStatusProviding? = nil
     ) {
         self.remoteMessagingActionHandler = remoteMessagingActionHandler
         self.remoteMessagingImageLoader = remoteMessagingImageLoader
@@ -516,6 +520,7 @@ class MainViewController: UIViewController {
         self.maliciousSiteProtectionPreferencesManager = maliciousSiteProtectionPreferencesManager
         self.contentScopeExperimentsManager = contentScopeExperimentsManager
         self.keyValueStore = keyValueStore
+        self.recentModalPromptStatusProvider = recentModalPromptStatusProvider
         self.onboardingResumeStepStore = if let onboardingResumeStepStore { onboardingResumeStepStore } else { UserDefaults.app.keyedStoring() }
         self.customConfigurationURLProvider = customConfigurationURLProvider
         self.systemSettingsPiPTutorialManager = systemSettingsPiPTutorialManager

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -327,8 +327,6 @@ class MainViewController: UIViewController {
 
     let themeManager: ThemeManaging
     let keyValueStore: ThrowingKeyValueStoring
-    /// Reports whether a coordinated launch modal was presented this session, so the Duck.ai sync
-    /// promo can yield to it. Injected by MainCoordinator from the modal prompt coordination service.
     let recentModalPromptStatusProvider: RecentModalPromptStatusProviding?
     let systemSettingsPiPTutorialManager: SystemSettingsPiPTutorialManaging
     let onboardingResumeStepStore: any KeyedStoring<OnboardingStoringKeys>

--- a/iOS/DuckDuckGo/ModalPromptCoordination/ModalPromptCoordinationManager.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/ModalPromptCoordinationManager.swift
@@ -21,8 +21,6 @@ import UIKit
 
 @MainActor
 protocol ModalPromptCoordinationManaging {
-    /// Whether a coordinated modal prompt has been presented during the current app session.
-    /// In-memory only (not persisted), so it resets on each cold launch.
     var didPresentModalPromptThisSession: Bool { get }
 
     func presentModalPromptIfNeeded(from presenter: ModalPromptPresenter)
@@ -42,9 +40,6 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
     private let cooldownManager: PromptCooldownManaging
     private let scheduler: ModalPromptScheduling
 
-    /// Set to `true` the first time any coordinated modal is presented this session. Lower-priority
-    /// in-context promos (e.g. the Duck.ai sync banner) read this to avoid appearing back-to-back
-    /// with a launch modal in the same session. See Asana 1216108902675922.
     private(set) var didPresentModalPromptThisSession = false
 
     /// Creates a new modal prompts coordination manager.
@@ -83,10 +78,8 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
         for provider in providers {
             guard let modalPromptConfiguration = provider.provideModalPrompt() else { continue }
 
-            // Mark the session as having shown a modal the moment we commit to presenting — before
-            // the scheduling delay and present animation — so a lower-priority in-context promo (the
-            // Duck.ai sync banner) can't slip in during that window. The cooldown timestamp and
-            // `didPresentModal()` stay in the completion since they should reflect actual presentation.
+            // Set at commit time (not in the present completion) so the sync banner can't slip in
+            // during the schedule + present-animation window; the completion reflects actual presentation.
             didPresentModalPromptThisSession = true
             Logger.modalPrompt.debug("[Modal Prompt Coordination] - Presenting modal from \(type(of: provider))")
             presentModalPrompt(modalPromptConfiguration: modalPromptConfiguration, from: presenter) { [weak self] in

--- a/iOS/DuckDuckGo/ModalPromptCoordination/ModalPromptCoordinationManager.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/ModalPromptCoordinationManager.swift
@@ -21,6 +21,10 @@ import UIKit
 
 @MainActor
 protocol ModalPromptCoordinationManaging {
+    /// Whether a coordinated modal prompt has been presented during the current app session.
+    /// In-memory only (not persisted), so it resets on each cold launch.
+    var didPresentModalPromptThisSession: Bool { get }
+
     func presentModalPromptIfNeeded(from presenter: ModalPromptPresenter)
 }
 
@@ -37,6 +41,11 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
     private let providers: [any ModalPromptProvider]
     private let cooldownManager: PromptCooldownManaging
     private let scheduler: ModalPromptScheduling
+
+    /// Set to `true` the first time any coordinated modal is presented this session. Lower-priority
+    /// in-context promos (e.g. the Duck.ai sync banner) read this to avoid appearing back-to-back
+    /// with a launch modal in the same session. See Asana 1216108902675922.
+    private(set) var didPresentModalPromptThisSession = false
 
     /// Creates a new modal prompts coordination manager.
     ///
@@ -74,6 +83,11 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
         for provider in providers {
             guard let modalPromptConfiguration = provider.provideModalPrompt() else { continue }
 
+            // Mark the session as having shown a modal the moment we commit to presenting — before
+            // the scheduling delay and present animation — so a lower-priority in-context promo (the
+            // Duck.ai sync banner) can't slip in during that window. The cooldown timestamp and
+            // `didPresentModal()` stay in the completion since they should reflect actual presentation.
+            didPresentModalPromptThisSession = true
             Logger.modalPrompt.debug("[Modal Prompt Coordination] - Presenting modal from \(type(of: provider))")
             presentModalPrompt(modalPromptConfiguration: modalPromptConfiguration, from: presenter) { [weak self] in
                 self?.saveModalPromptLastPresentationDate()

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -308,7 +308,6 @@ final class MainCoordinator {
                                         whatsNewRepository: whatsNewRepository,
                                         darkReaderFeatureSettings: darkReaderFeatureSettings,
                                         toggleModeStorage: toggleModeStorage,
-                                        fireModePromotionEligibility: fireModePromotionsCoordinator,
                                         onboardingManager: onboardingManager,
                                         recentModalPromptStatusProvider: modalPromptCoordinationService)
 

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -308,7 +308,9 @@ final class MainCoordinator {
                                         whatsNewRepository: whatsNewRepository,
                                         darkReaderFeatureSettings: darkReaderFeatureSettings,
                                         toggleModeStorage: toggleModeStorage,
-                                        onboardingManager: onboardingManager)
+                                        fireModePromotionEligibility: fireModePromotionsCoordinator,
+                                        onboardingManager: onboardingManager,
+                                        recentModalPromptStatusProvider: modalPromptCoordinationService)
 
         setupWebExtensions(privacyConfigurationManager: privacyConfigurationManager)
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1425,7 +1425,3 @@ extension MainViewController: UnifiedToggleInputFloatingReturnKeyDelegate {
     }
 
 }
-
-extension ModalPromptCoordinationService: RecentModalPromptStatusProviding {
-    var wasModalPromptRecentlyPresented: Bool { wasModalPromptPresentedThisSession }
-}

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1426,12 +1426,6 @@ extension MainViewController: UnifiedToggleInputFloatingReturnKeyDelegate {
 
 }
 
-// MARK: - Modal prompt coordination
-
-/// Bridges the modal prompt coordinator's per-session presentation flag to the Duck.ai sync promo,
-/// so the banner yields to any launch modal shown earlier in the same session (subscription
-/// reinstaller sheet, Win-back, address-bar picker, default browser, What's New). In-memory, so it
-/// resets on the next cold launch. See Asana 1216108902675922.
 extension ModalPromptCoordinationService: RecentModalPromptStatusProviding {
     var wasModalPromptRecentlyPresented: Bool { wasModalPromptPresentedThisSession }
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -83,6 +83,7 @@ extension MainViewController {
             stateStore: stateStore,
             syncService: syncService,
             aiChatSyncCleaner: aiChatSyncCleaner,
+            recentModalPromptStatusProvider: recentModalPromptStatusProvider,
             duckAIWideEventInstrumentation: duckAIWideEventInstrumentation
         )
         coordinator.delegate = self
@@ -1423,4 +1424,14 @@ extension MainViewController: UnifiedToggleInputFloatingReturnKeyDelegate {
         coordinator.insertNewlineFromFloatingReturnKey()
     }
 
+}
+
+// MARK: - Modal prompt coordination
+
+/// Bridges the modal prompt coordinator's per-session presentation flag to the Duck.ai sync promo,
+/// so the banner yields to any launch modal shown earlier in the same session (subscription
+/// reinstaller sheet, Win-back, address-bar picker, default browser, What's New). In-memory, so it
+/// resets on the next cold launch. See Asana 1216108902675922.
+extension ModalPromptCoordinationService: RecentModalPromptStatusProviding {
+    var wasModalPromptRecentlyPresented: Bool { wasModalPromptPresentedThisSession }
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -91,6 +91,7 @@ final class UnifiedInputContentContainerViewController: UIViewController {
     private let syncService: DDGSyncing?
     private let syncPromoManager: SyncPromoManaging?
     private let aiChatSyncIntroSheetPresenter: AIChatSyncIntroSheetPresenting
+    private let recentModalPromptStatusProvider: RecentModalPromptStatusProviding?
 
     // MARK: - Manager Components
 
@@ -118,7 +119,8 @@ final class UnifiedInputContentContainerViewController: UIViewController {
     private var searchDataSource: AutocompleteSuggestionsDataSource?
     /// Duck.ai sync-promo presenter; nil when there's no sync service.
     private lazy var aiChatSyncPromoViewModel: AIChatSyncPromoViewModel? =
-        syncPromoManager.map { AIChatSyncPromoViewModel(syncPromoManager: $0) }
+        syncPromoManager.map { AIChatSyncPromoViewModel(syncPromoManager: $0,
+                                                        recentModalPromptStatusProvider: recentModalPromptStatusProvider) }
     /// Built once and rebound into the pinned chrome by `updatePinnedChrome`; its show/hide rides
     /// `isSyncPromoCardVisible`, so there's no need to reconstruct it each time.
     private lazy var syncPromoView = AnyView(AIChatSyncPromoView(
@@ -155,6 +157,7 @@ final class UnifiedInputContentContainerViewController: UIViewController {
          duckAiNativeStorageHandler: DuckAiNativeStorageHandling? = nil,
          syncService: DDGSyncing? = nil,
          aiChatSyncCleaner: AIChatSyncCleaning? = nil,
+         recentModalPromptStatusProvider: RecentModalPromptStatusProviding? = nil,
          aiChatSyncIntroSheetPresenter: AIChatSyncIntroSheetPresenting = AIChatSyncIntroSheetPresenter()) {
         self.switchBarHandler = switchBarHandler
         self.appSettings = appSettings
@@ -168,6 +171,7 @@ final class UnifiedInputContentContainerViewController: UIViewController {
                                                                   featureFlagger: featureFlagger,
                                                                   privacyConfigurationManager: privacyConfigurationManager) }
         self.aiChatSyncIntroSheetPresenter = aiChatSyncIntroSheetPresenter
+        self.recentModalPromptStatusProvider = recentModalPromptStatusProvider
         self.isUsingTopBarPosition = appSettings.currentAddressBarPosition == .top
         self.isAdjustedForTopBar = self.isUsingTopBarPosition
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -392,6 +392,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         switchBarSubmissionMetrics: SwitchBarSubmissionMetricsProviding = SwitchBarSubmissionMetrics(),
         aiChatSettings: AIChatSettingsProvider = AIChatSettings(),
         aiChatSyncCleaner: AIChatSyncCleaning? = nil,
+        recentModalPromptStatusProvider: RecentModalPromptStatusProviding? = nil,
         sessionStateMetrics: SessionStateMetricsProviding = SessionStateMetrics(storage: UserDefaults.standard),
         duckAIWideEventInstrumentation: DuckAIWideEventInstrumentation? = nil,
         duckAIWideEventFlowScope: DuckAIWideEventFlowScope? = nil
@@ -424,7 +425,8 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             switchBarHandler: viewController.handler,
             duckAiNativeStorageHandler: duckAiNativeStorageHandler,
             syncService: syncService,
-            aiChatSyncCleaner: aiChatSyncCleaner
+            aiChatSyncCleaner: aiChatSyncCleaner,
+            recentModalPromptStatusProvider: recentModalPromptStatusProvider
         )
         floatingReturnKeyViewController = UnifiedToggleInputFloatingReturnKeyViewController()
         super.init()

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerTests.swift
@@ -346,7 +346,7 @@ final class ModalPromptCoordinationManagerTests {
         // WHEN
         sut.presentModalPromptIfNeeded(from: presenterMock)
 
-        // THEN - set synchronously at commit time, before the scheduled present block runs
+        // THEN
         #expect(sut.didPresentModalPromptThisSession)
     }
 

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerTests.swift
@@ -330,6 +330,46 @@ final class ModalPromptCoordinationManagerTests {
         #expect(cooldownManagerMock.didCallRecordLastPromptPresentationTimestamp)
     }
 
+    @available(iOS 16, *)
+    @Test("Check Session Flag Is Set After Successful Presentation", .timeLimit(.minutes(1)))
+    func whenModalIsPresentedThenSessionFlagIsSet() {
+        // GIVEN
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            modalPromptScheduling: schedulerMock
+        )
+        #expect(!sut.didPresentModalPromptThisSession)
+
+        // WHEN
+        sut.presentModalPromptIfNeeded(from: presenterMock)
+
+        // THEN - set synchronously at commit time, before the scheduled present block runs
+        #expect(sut.didPresentModalPromptThisSession)
+    }
+
+    @available(iOS 16, *)
+    @Test("Check Session Flag Is Not Set When No Modal Is Presented", .timeLimit(.minutes(1)))
+    func whenNoModalIsPresentedThenSessionFlagIsNotSet() {
+        // GIVEN
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider(shouldReturnPrompt: false)
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            modalPromptScheduling: schedulerMock
+        )
+
+        // WHEN
+        sut.presentModalPromptIfNeeded(from: presenterMock)
+        schedulerMock.executeScheduledBlock()
+
+        // THEN
+        #expect(!sut.didPresentModalPromptThisSession)
+    }
+
     @Test("Check Cooldown Is Not Recorded When No Modal Is Presented")
     func whenNoModalIsPresentedThenCooldownIsNotRecorded() {
         // GIVEN

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/AIChatSyncPromoViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/AIChatSyncPromoViewModelTests.swift
@@ -59,6 +59,33 @@ final class AIChatSyncPromoViewModelTests {
 
     @available(iOS 16, *)
     @Test(.timeLimit(.minutes(1)))
+    func shouldShowPromo_whenModalPromptRecentlyPresented_returnsFalseWithoutAskingManager() {
+        let manager = MockSyncPromoManager()
+        manager.shouldPresentForTouchpoint[.aiChat] = true
+        let viewModel = AIChatSyncPromoViewModel(
+            syncPromoManager: manager,
+            recentModalPromptStatusProvider: MockRecentModalPromptStatusProvider(wasModalPromptRecentlyPresented: true))
+
+        #expect(!viewModel.shouldShowPromo(isQueryActive: false, chatCount: 2))
+        #expect(manager.shouldPresentRequests.isEmpty)
+    }
+
+    @available(iOS 16, *)
+    @Test(.timeLimit(.minutes(1)))
+    func shouldShowPromo_whenModalPromptNotRecentlyPresented_usesManager() {
+        let manager = MockSyncPromoManager()
+        manager.shouldPresentForTouchpoint[.aiChat] = true
+        let viewModel = AIChatSyncPromoViewModel(
+            syncPromoManager: manager,
+            recentModalPromptStatusProvider: MockRecentModalPromptStatusProvider(wasModalPromptRecentlyPresented: false))
+
+        #expect(viewModel.shouldShowPromo(isQueryActive: false, chatCount: 2))
+        #expect(manager.shouldPresentRequests.count == 1)
+        #expect(manager.shouldPresentRequests.first?.touchpoint == .aiChat)
+    }
+
+    @available(iOS 16, *)
+    @Test(.timeLimit(.minutes(1)))
     func recordImpressionIfNeeded_whenVisibleAndPromoVisible_firesDisplayedPixelAndRecordsImpression() {
         let manager = MockSyncPromoManager()
         let viewModel = AIChatSyncPromoViewModel(syncPromoManager: manager, pixelFiring: PixelFiringMock.self)
@@ -152,4 +179,13 @@ private final class MockSyncPromoManager: SyncPromoManaging {
     }
 
     func resetPromos() {}
+}
+
+@MainActor
+private final class MockRecentModalPromptStatusProvider: RecentModalPromptStatusProviding {
+    var wasModalPromptRecentlyPresented: Bool
+
+    init(wasModalPromptRecentlyPresented: Bool) {
+        self.wasModalPromptRecentlyPresented = wasModalPromptRecentlyPresented
+    }
 }

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptCoordinationManager.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptCoordinationManager.swift
@@ -25,6 +25,7 @@ final class MockModalPromptCoordinationManager: ModalPromptCoordinationManaging 
     private(set) var didCallPresentModalPromptIfNeeded = false
     private(set) var capturedPresenter: ModalPromptPresenter?
     private(set) var callCount = 0
+    var didPresentModalPromptThisSession = false
 
     func presentModalPromptIfNeeded(from presenter: ModalPromptPresenter) {
         didCallPresentModalPromptIfNeeded = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216108902675922
CC:

### Description

The Duck.ai sync-promo banner (shown in the unified input / Duck.ai chat list) and the coordinated launch modals sequenced by `ModalPromptCoordinationManager` — subscription reinstaller sheet, Win-back, address-bar picker, default browser, What's New — had no awareness of each other, so both could fire in the same session and users saw two promos back-to-back ([reported here](https://app.asana.com/1/137249556945/task/1216084825209587)).

The sync banner now **yields to any launch modal shown earlier in the same session**:
- `ModalPromptCoordinationManager` sets an in-memory `didPresentModalPromptThisSession` flag when it presents any of the five modals (alongside the existing cooldown-timestamp save).
- That flag is surfaced on `ModalPromptCoordinationService` and injected (via `MainCoordinator → MainViewController`) into `AIChatSyncPromoViewModel`, which returns `false` from `shouldShowPromo` when it's set.

Because the flag is **in-memory**, it resets on the next cold launch — so the banner reappears on later launches even while the modals' own multi-day cooldown is still active. Suppression is scoped to the single session a modal actually showed, **not** the cooldown window.

- Covers all five coordinated launch modals — subscription is presented *through* this manager, so no per-promo code (incl. `SubscriptionPromoCoordinator`) is touched.
- iOS only (macOS `SyncPromoManager` has no `aiChat` touchpoint).
- **Known gap:** RMFs (new-tab-page remote-message banners) aren't routed through this coordinator and can still co-occur with the banner — out of scope until the Promo Queue project ([1214299397742171](https://app.asana.com/1/137249556945/task/1214299397742171)).

### Testing Steps
1. Turn on the two feature flags:
   - **`unifiedToggleInput`** — enables the unified input surface the banner lives in (snapshotted once per launch, so enable it and relaunch).
   - **`aiChatSyncPromo`** — the sync-promo flag currently disabled remotely (the stopgap).

2. Ask something to duck.ai to create a chat history. Make sure sync is off.
3. Confirm the banner shows when no launch modal has appeared this session.
4. Go to Debug screen -> Onboarding and “Set Subscription Promo Cooldown Passed"
5. Kill and relaunch the app. The subscription bottom sheet should appear and then when going to duck.ai the sync promo should be hidden.
6. Kill and relaunch **without** a modal presenting (e.g. the modal cooldown is still active, so none shows) → open the Duck.ai input → the banner **shows again**. This proves suppression is scoped to the session a modal actually appeared, not the multi-day cooldown window.

### Impact and Risks
Low. Adds one in-memory gating condition to a promo that is currently disabled remotely (`aiChatSyncPromo`). Backward-compatible: the injected provider is optional and defaults to `nil` (no suppression) wherever it isn't wired.

#### What could go wrong?
Over-suppression is bounded to a single session, and the banner's 3-impression cap is unaffected (impressions are only consumed when it actually shows). Worst case is the banner not showing in a session where a launch modal appeared — which is the intended behavior.

### Notes to Reviewer
- Session scoping is deliberate: the flag is in-memory on the coordinator and resets each cold launch, so the modals' multi-day cooldown doesn't hide the banner across later sessions.
- The flag lives on `ModalPromptCoordinationManager` — the single choke point all five modals route through — so it covers them uniformly without per-promo changes.
- **Follow-up in a separate repo:** re-enable `aiChatSyncPromo` in privacy-configuration after this ships (it was disabled remotely as the stopgap).

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Low Risk**
> Optional dependency injection with in-memory session gating on a remotely disabled promo; no changes to individual launch-modal providers or sync impression logic beyond an extra guard.
> 
> **Overview**
> Adds **same-session coordination** so the Duck.ai sync promo banner does not show right after a coordinated launch modal (subscription reinstaller, default browser, What's New, etc.).
> 
> `ModalPromptCoordinationManager` now sets an in-memory **`didPresentModalPromptThisSession`** when any coordinated modal is presented. That state is exposed through `ModalPromptCoordinationService` and wired via `MainCoordinator` → `MainViewController` → unified input into `AIChatSyncPromoViewModel`, which **skips** `shouldShowPromo` when a launch modal already appeared this session. The provider is optional (`nil` = no extra gating).
> 
> Suppression is **session-scoped only** (resets on cold launch), not tied to the multi-day modal cooldown. Unit tests cover the session flag on the coordinator and the promo view model’s yield behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bff5a83d83228e49776c3dd73c11cc7fa8e1bdbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional injection with in-memory promo gating only; no changes to individual modal providers or sync impression logic beyond an extra guard on a remotely disabled promo.
> 
> **Overview**
> Prevents the **Duck.ai sync promo banner** from appearing in the same session as a **coordinated launch modal** (subscription, Win-back, address bar, default browser, What's New).
> 
> `ModalPromptCoordinationManager` now tracks **`didPresentModalPromptThisSession`** in memory and sets it when a modal is committed for presentation (before the animation completes, so the banner cannot slip in during the present window). `ModalPromptCoordinationService` exposes that via **`RecentModalPromptStatusProviding`**, wired through **`MainCoordinator` → `MainViewController` → unified input** into **`AIChatSyncPromoViewModel`**, which adds a guard in **`shouldShowPromo`**. The provider is optional (`nil` leaves prior behavior).
> 
> Suppression is **session-only** (resets on cold launch), not tied to the multi-day modal cooldown. Unit tests cover the session flag and promo gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dbb2e64ff65958447db5ed373ed1772079c3464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->