### PR TITLE
Allow saving bookmarks with an empty name from the Add Bookmark dialog

### DIFF
--- a/macOS/DuckDuckGo/Bookmarks/ViewModel/AddEditBookmarkDialogViewModel.swift
+++ b/macOS/DuckDuckGo/Bookmarks/ViewModel/AddEditBookmarkDialogViewModel.swift
@@ -68,7 +68,7 @@ final class AddEditBookmarkDialogViewModel: BookmarkDialogEditing {
 
     private var hasValidInput: Bool {
         guard let url = bookmarkURLPath.url else { return false }
-        return !bookmarkName.trimmingWhitespace().isEmpty && url.isValid
+        return url.isValid
     }
 
     let isOtherActionDisabled: Bool = false

--- a/macOS/UnitTests/Bookmarks/ViewModels/AddEditBookmarkDialogViewModelTests.swift
+++ b/macOS/UnitTests/Bookmarks/ViewModels/AddEditBookmarkDialogViewModelTests.swift
@@ -363,7 +363,7 @@ final class AddEditBookmarkDialogViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testReturnIsDefaultActionButtonDisabledTrueWhenBookmarkNameIsEmptyAndModeIsAdd() {
+    func testReturnIsDefaultActionButtonDisabledFalseWhenBookmarkNameIsEmptyAndModeIsAdd() {
         // GIVEN
         let sut = AddEditBookmarkDialogViewModel(mode: .add(), bookmarkManager: bookmarkManager)
         sut.bookmarkName = ""
@@ -373,11 +373,11 @@ final class AddEditBookmarkDialogViewModelTests: XCTestCase {
         let result = sut.isDefaultActionDisabled
 
         // THEN
-        XCTAssertTrue(result)
+        XCTAssertFalse(result)
     }
 
     @MainActor
-    func testReturnIsDefaultActionButtonDisabledTrueWhenBookmarkNameIsEmptyAndModeIsEdit() {
+    func testReturnIsDefaultActionButtonDisabledFalseWhenBookmarkNameIsEmptyAndModeIsEdit() {
         // GIVEN
         let sut = AddEditBookmarkDialogViewModel(mode: .edit(bookmark: .mock), bookmarkManager: bookmarkManager)
         sut.bookmarkName = ""
@@ -387,7 +387,7 @@ final class AddEditBookmarkDialogViewModelTests: XCTestCase {
         let result = sut.isDefaultActionDisabled
 
         // THEN
-        XCTAssertTrue(result)
+        XCTAssertFalse(result)
     }
 
     @MainActor


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1215999088012162?focus=true

### Description

Drops the non-empty-name requirement in the Add Bookmark dialog (bookmarks manager / bookmarks shortcut). `AddEditBookmarkDialogViewModel.hasValidInput` now gates the default action on a valid URL only, so a bookmark can be saved with an empty name — matching the address-bar star popover, which already allowed it.

### Testing Steps
1. Bookmarks manager → New Bookmark (or the bookmarks shortcut panel).
2. Leave Name empty, enter a valid URL.
3. Confirm the Add Bookmark button is enabled and saves the bookmark.

### Impact and Risks
Low. Validation-only change; the bookmark store already accepted empty titles (the bookmarks-bar path did too).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Validation-only UI change; persistence already accepted empty titles and save behavior is unchanged aside from when the button is enabled.
> 
> **Overview**
> The bookmarks manager and shortcut **Add/Edit Bookmark** dialog no longer requires a non-empty name before enabling save. **`hasValidInput`** in `AddEditBookmarkDialogViewModel` now depends only on a parseable, valid URL, so Add/Save stays enabled when the name field is empty—aligned with the address-bar star flow.
> 
> Unit tests for **`isDefaultActionDisabled`** with an empty name in add and edit modes were updated to expect the default action to remain **enabled** when the URL is valid. Save still passes a trimmed title (including an empty string) through existing **`addOrSave`** logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8b75c433789d4c6866f9ba32ec612394bca34e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->