### PR TITLE
Sync V2 pixel improvements

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -323,7 +323,7 @@ public class DDGSync: DDGSyncing {
                 try updateAccount(result.account)
             } catch {
                 Logger.sync.error("3party account upgrade failed to persist the native account: \(String(reflecting: error), privacy: .public)")
-                throw error
+                throw ThirdPartyAccountUpgradeError.localStorageFailed
             }
             cacheScopedPasswordInBackground(result.scopedPassword)
             updateProtectedKeysCache(with: result.protectedKeys)

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
@@ -68,7 +68,7 @@ public enum SyncConnectionError: Error {
     case protocolError
 
     case pollingForRecoveryKeyTimedOut
-    case pairingV2SessionTimedOut
+    case pairingV2SessionTimedOut(timeoutStage: SyncSetupTimeoutStage?)
 
     case unexpectedSecondHello
     case unexpectedEvent
@@ -84,6 +84,14 @@ public enum SyncConnectionError: Error {
     case missingThirdPartyKey
     case localStorageFailed
     case invalidCredentials
+}
+
+public enum SyncSetupTimeoutStage: String {
+    case waitingForPeerHello = "waiting_for_peer_hello"
+    case waitingForPeerStatus = "waiting_for_peer_status"
+    case waitingForConfirmation = "waiting_for_confirmation"
+    case waitingForRecoveryCode = "waiting_for_recovery_code"
+    case loggingIn = "logging_in"
 }
 
 public protocol SyncConnectionControlling {
@@ -493,11 +501,33 @@ public class SyncConnectionController: SyncConnectionControlling {
     private func handlePairingV2SyncError(_ error: SyncError, coordinator: PairingV2Coordinator, setupRole: SyncSetupRole) async {
         switch error {
         case .pollingDidTimeOut:
-            await delegate?.controllerDidError(.pairingV2SessionTimedOut, underlyingError: nil, setupRole: setupRole)
+            await delegate?.controllerDidError(.pairingV2SessionTimedOut(timeoutStage: timeoutStage(for: coordinator.state)), underlyingError: nil, setupRole: setupRole)
         case .accountAlreadyExists:
             await handlePairingV2AccountAlreadyExists(coordinator, setupRole: setupRole)
         default:
             await delegate?.controllerDidError(.transportFailure, underlyingError: error, setupRole: setupRole)
+        }
+    }
+
+    private func timeoutStage(for state: PairingV2State) -> SyncSetupTimeoutStage? {
+        switch state {
+        case .waitingForPeerHello:
+            return .waitingForPeerHello
+        case .waitingForPeerStatus:
+            return .waitingForPeerStatus
+        case .hostWaitingForConfirmation,
+                .joinerWaitingForConfirmation:
+            return .waitingForConfirmation
+        case .hostPreparingRecoveryCode,
+                .hostSendingRecoveryCode,
+                .joinerWaitingForRecoveryCode:
+            return .waitingForRecoveryCode
+        case .joinerLoggingIn:
+            return .loggingIn
+        case .idle,
+                .completed,
+                .failed:
+            return nil
         }
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
@@ -94,6 +94,106 @@ public enum SyncSetupTimeoutStage: String, Equatable {
     case loggingIn = "logging_in"
 }
 
+enum SyncSetupFailureReason {
+    static let v1Failure = "v1_failure"
+    static let sessionTimeout = "session_timeout"
+    static let needsUpgrade = "needs_upgrade"
+    static let incompatibleCode = "incompatible_code"
+    static let alreadyUpgraded = "already_upgraded"
+    static let unrecognizedCode = "unrecognized_code"
+    static let accountCreationFailed = "account_creation_failed"
+    static let accountUpgradeFailed = "account_upgrade_failed"
+    static let invalidCredentials = "invalid_credentials"
+    static let protocolError = "protocol_error"
+    static let transportFailure = "transport_failure"
+    static let unexpectedSecondHello = "unexpected_second_hello"
+    static let unexpectedEvent = "unexpected_event"
+    static let pairingSessionNotReady = "pairing_session_not_ready"
+    static let relayChannelUnavailable = "relay_channel_unavailable"
+    static let recoveryCodePreparationFailed = "recovery_code_preparation_failed"
+    static let peerRecoveryCodeUnavailable = "peer_recovery_code_unavailable"
+    static let unexpectedFailure = "unexpected_failure"
+    static let missingThirdPartyCredential = "missing_3party_credential"
+    static let undecryptableThirdPartyCredential = "undecryptable_3party_credential"
+    static let accountExtendFailed = "account_extend_failed"
+    static let missingThirdPartyKey = "missing_3party_key"
+    static let localStorageFailed = "local_storage_failed"
+}
+
+public extension SyncConnectionError {
+
+    var syncSetupFailureReason: String? {
+        switch self {
+        // These cases are emitted by the legacy V1 exchange/connect flow and are intentionally bucketed together.
+        case .failedToLogIn,
+                .failedToFetchPublicKey,
+                .failedToTransmitExchangeRecoveryKey,
+                .failedToFetchConnectRecoveryKey,
+                .failedToTransmitExchangeKey,
+                .failedToFetchExchangeRecoveryKey,
+                .failedToTransmitConnectRecoveryKey,
+                .pollingForRecoveryKeyTimedOut,
+                .failedToCreateAccount:
+            return SyncSetupFailureReason.v1Failure
+        case .invalidCredentials:
+            return SyncSetupFailureReason.invalidCredentials
+        case .pairingV2SessionTimedOut:
+            return SyncSetupFailureReason.sessionTimeout
+        case .updateRequired:
+            return SyncSetupFailureReason.needsUpgrade
+        case .unsupportedThirdPartyRecoveryCode:
+            return SyncSetupFailureReason.incompatibleCode
+        case .thirdPartyAccountAlreadyUpgraded:
+            return SyncSetupFailureReason.alreadyUpgraded
+        case .unableToRecognizeCode:
+            return SyncSetupFailureReason.unrecognizedCode
+        case .accountCreationFailed:
+            return SyncSetupFailureReason.accountCreationFailed
+        case .accountUpgradeFailed:
+            return SyncSetupFailureReason.accountUpgradeFailed
+        case .transportFailure:
+            return SyncSetupFailureReason.transportFailure
+        case .protocolError:
+            return SyncSetupFailureReason.protocolError
+        case .syncCancelledFromOtherDevice:
+            return nil
+        case .unexpectedSecondHello:
+            return SyncSetupFailureReason.unexpectedSecondHello
+        case .unexpectedEvent:
+            return SyncSetupFailureReason.unexpectedEvent
+        case .pairingSessionNotReady:
+            return SyncSetupFailureReason.pairingSessionNotReady
+        case .relayChannelUnavailable:
+            return SyncSetupFailureReason.relayChannelUnavailable
+        case .recoveryCodePreparationFailed:
+            return SyncSetupFailureReason.recoveryCodePreparationFailed
+        case .peerRecoveryCodeUnavailable:
+            return SyncSetupFailureReason.peerRecoveryCodeUnavailable
+        case .unexpectedFailure:
+            return SyncSetupFailureReason.unexpectedFailure
+        case .missingThirdPartyCredential:
+            return SyncSetupFailureReason.missingThirdPartyCredential
+        case .undecryptableThirdPartyCredential:
+            return SyncSetupFailureReason.undecryptableThirdPartyCredential
+        case .accountExtendFailed:
+            return SyncSetupFailureReason.accountExtendFailed
+        case .missingThirdPartyKey:
+            return SyncSetupFailureReason.missingThirdPartyKey
+        case .localStorageFailed:
+            return SyncSetupFailureReason.localStorageFailed
+        }
+    }
+
+    var syncSetupTimeoutStage: String? {
+        switch self {
+        case .pairingV2SessionTimedOut(let timeoutStage):
+            return timeoutStage?.rawValue
+        default:
+            return nil
+        }
+    }
+}
+
 public protocol SyncConnectionControlling {
     /**
      Returns a device ID, public key and secret key ready for display and allows callers attempt to fetch the transmitted public key

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
@@ -63,10 +63,12 @@ public enum SyncConnectionError: Error {
     case failedToCreateAccount
     case failedToTransmitConnectRecoveryKey
 
+    case accountCreationFailed
     case accountUpgradeFailed
     case protocolError
 
     case pollingForRecoveryKeyTimedOut
+    case pairingV2SessionTimedOut
 
     case unexpectedSecondHello
     case unexpectedEvent
@@ -74,7 +76,14 @@ public enum SyncConnectionError: Error {
     case relayChannelUnavailable
     case recoveryCodePreparationFailed
     case peerRecoveryCodeUnavailable
+    case transportFailure
     case unexpectedFailure
+    case missingThirdPartyCredential
+    case undecryptableThirdPartyCredential
+    case accountExtendFailed
+    case missingThirdPartyKey
+    case localStorageFailed
+    case invalidCredentials
 }
 
 public protocol SyncConnectionControlling {
@@ -484,11 +493,11 @@ public class SyncConnectionController: SyncConnectionControlling {
     private func handlePairingV2SyncError(_ error: SyncError, coordinator: PairingV2Coordinator, setupRole: SyncSetupRole) async {
         switch error {
         case .pollingDidTimeOut:
-            await delegate?.controllerDidError(.pollingForRecoveryKeyTimedOut, underlyingError: nil, setupRole: setupRole)
+            await delegate?.controllerDidError(.pairingV2SessionTimedOut, underlyingError: nil, setupRole: setupRole)
         case .accountAlreadyExists:
             await handlePairingV2AccountAlreadyExists(coordinator, setupRole: setupRole)
         default:
-            await delegate?.controllerDidError(.unexpectedFailure, underlyingError: error, setupRole: setupRole)
+            await delegate?.controllerDidError(.transportFailure, underlyingError: error, setupRole: setupRole)
         }
     }
 
@@ -612,7 +621,7 @@ public class SyncConnectionController: SyncConnectionControlling {
             do {
                 try await loginAndShowDeviceConnected(recoveryKey: recoveryKey, isRecovery: false, setupRole: .sharer)
             } catch {
-                await delegate?.controllerDidError(.failedToLogIn, underlyingError: error, setupRole: .sharer)
+                await delegate?.controllerDidError(loginConnectionError(for: error), underlyingError: error, setupRole: .sharer)
             }
         }
     }
@@ -719,7 +728,7 @@ public class SyncConnectionController: SyncConnectionControlling {
                 setupRole: setupRole,
                 shouldPromptBeforeSwitchingAccounts: true)
         } else {
-            await delegate?.controllerDidError(.failedToLogIn, underlyingError: error, setupRole: setupRole)
+            await delegate?.controllerDidError(loginConnectionError(for: error), underlyingError: error, setupRole: setupRole)
         }
     }
 
@@ -743,10 +752,24 @@ public class SyncConnectionController: SyncConnectionControlling {
         switch error {
         case .recoveryCodePreparationFailed:
             return .recoveryCodePreparationFailed
+        case .missingThirdPartyCredential:
+            return .missingThirdPartyCredential
+        case .undecryptableThirdPartyCredential:
+            return .undecryptableThirdPartyCredential
+        case .accountCreationFailed:
+            return .accountCreationFailed
+        case .accountExtendFailed:
+            return .accountExtendFailed
         case .recoveryCodeSendFailed:
-            return .failedToTransmitExchangeRecoveryKey
+            return .transportFailure
+        case .missingThirdPartyKey:
+            return .missingThirdPartyKey
+        case .localStorageFailed:
+            return .localStorageFailed
+        case .invalidCredentials:
+            return .invalidCredentials
         case .loginFailed:
-            return .failedToLogIn
+            return .transportFailure
         case .upgradeFailed:
             return .accountUpgradeFailed
         case .nativeCredentialAlreadyPresent:
@@ -770,6 +793,20 @@ public class SyncConnectionController: SyncConnectionControlling {
         case .cancelled:
             return .syncCancelledFromOtherDevice
         }
+    }
+
+    private func loginConnectionError(for error: Error) -> SyncConnectionError {
+        if let error = error as? SyncError {
+            switch error {
+            case .unexpectedStatusCode(let statusCode) where statusCode == 401:
+                return .invalidCredentials
+            case .failedToWriteSecureStore:
+                return .localStorageFailed
+            default:
+                break
+            }
+        }
+        return .failedToLogIn
     }
 
     private func syncCodeDecodingConnectionError(for error: Error) -> SyncConnectionError {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
@@ -45,7 +45,7 @@ public protocol SyncConnectionControllerDelegate: AnyObject {
     func controllerDidError(_ error: SyncConnectionError, underlyingError: Error?, setupRole: SyncSetupRole) async
 }
 
-public enum SyncConnectionError: Error {
+public enum SyncConnectionError: Error, Equatable {
     case unableToRecognizeCode
     case updateRequired
     case unsupportedThirdPartyRecoveryCode
@@ -86,7 +86,7 @@ public enum SyncConnectionError: Error {
     case invalidCredentials
 }
 
-public enum SyncSetupTimeoutStage: String {
+public enum SyncSetupTimeoutStage: String, Equatable {
     case waitingForPeerHello = "waiting_for_peer_hello"
     case waitingForPeerStatus = "waiting_for_peer_status"
     case waitingForConfirmation = "waiting_for_confirmation"

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
@@ -67,6 +67,14 @@ public enum SyncConnectionError: Error {
     case protocolError
 
     case pollingForRecoveryKeyTimedOut
+
+    case unexpectedSecondHello
+    case unexpectedEvent
+    case pairingSessionNotReady
+    case relayChannelUnavailable
+    case recoveryCodePreparationFailed
+    case peerRecoveryCodeUnavailable
+    case unexpectedFailure
 }
 
 public protocol SyncConnectionControlling {
@@ -467,7 +475,7 @@ public class SyncConnectionController: SyncConnectionControlling {
         } else if let cryptoError = error as? PairingV2MessageCryptoError {
             await delegate?.controllerDidError(pairingV2CryptoConnectionError(for: cryptoError), underlyingError: cryptoError, setupRole: setupRole)
         } else {
-            await delegate?.controllerDidError(.failedToFetchExchangeRecoveryKey, underlyingError: error, setupRole: setupRole)
+            await delegate?.controllerDidError(.unexpectedFailure, underlyingError: error, setupRole: setupRole)
         }
 
         await coordinator.cancel()
@@ -480,7 +488,7 @@ public class SyncConnectionController: SyncConnectionControlling {
         case .accountAlreadyExists:
             await handlePairingV2AccountAlreadyExists(coordinator, setupRole: setupRole)
         default:
-            await delegate?.controllerDidError(.failedToFetchExchangeRecoveryKey, underlyingError: error, setupRole: setupRole)
+            await delegate?.controllerDidError(.unexpectedFailure, underlyingError: error, setupRole: setupRole)
         }
     }
 
@@ -733,7 +741,9 @@ public class SyncConnectionController: SyncConnectionControlling {
 
     private func pairingV2ConnectionError(for error: PairingV2Error) -> SyncConnectionError {
         switch error {
-        case .recoveryCodePreparationFailed, .recoveryCodeSendFailed:
+        case .recoveryCodePreparationFailed:
+            return .recoveryCodePreparationFailed
+        case .recoveryCodeSendFailed:
             return .failedToTransmitExchangeRecoveryKey
         case .loginFailed:
             return .failedToLogIn
@@ -744,15 +754,19 @@ public class SyncConnectionController: SyncConnectionControlling {
         case .recoveryCodeDenied:
             return .syncCancelledFromOtherDevice
         case .recoveryCodeUnavailable:
-            return .failedToFetchExchangeRecoveryKey
+            return .peerRecoveryCodeUnavailable
         case .unsupportedVersion(let version):
             return unsupportedVersionConnectionError(for: version, supportedMajor: PairingV2ProtocolVersion.supportedMajor)
         case .v2ScanningDisabled, .unknownCode, .unsupportedFlow:
             return .unableToRecognizeCode
-        case .secondHello, .unexpectedEvent, .pairingSessionNotReady:
-            return .protocolError
+        case .secondHello:
+            return .unexpectedSecondHello
+        case .unexpectedEvent:
+            return .unexpectedEvent
+        case .pairingSessionNotReady:
+            return .pairingSessionNotReady
         case .relayChannelUnavailable, .relayChannelExpired:
-            return .failedToFetchExchangeRecoveryKey
+            return .relayChannelUnavailable
         case .cancelled:
             return .syncCancelledFromOtherDevice
         }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/PairingV2/PairingV2Coordinator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/PairingV2/PairingV2Coordinator.swift
@@ -32,7 +32,7 @@ protocol PairingV2ConfirmationDelegate: AnyObject {
 /// Default timing for the polling loop in `pollUntilFinished`.
 enum PairingV2PollingDefaults {
     /// Give up on the pairing session after this many seconds (5 minutes).
-    static let sessionTimeout: TimeInterval = 300
+    static let sessionTimeout: TimeInterval = 10
     /// Wait this long between relay polls (1 second, in nanoseconds).
     static let pollIntervalNanoseconds: UInt64 = 1_000_000_000
 }
@@ -338,6 +338,9 @@ final class PairingV2Coordinator {
             } catch SyncError.unexpectedStatusCode(let statusCode) where statusCode == 401 {
                 try await execute(stateMachine.handle(.failed(.invalidCredentials)))
                 throw PairingV2Error.invalidCredentials
+            } catch SyncError.failedToWriteSecureStore {
+                try await execute(stateMachine.handle(.failed(.localStorageFailed)))
+                throw PairingV2Error.localStorageFailed
             } catch {
                 try await execute(stateMachine.handle(.failed(.loginFailed)))
                 throw PairingV2Error.loginFailed

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/PairingV2/PairingV2Coordinator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/PairingV2/PairingV2Coordinator.swift
@@ -300,13 +300,21 @@ final class PairingV2Coordinator {
             let recoveryCode: String
             do {
                 recoveryCode = try await prepareRecoveryCode(credentialKind: credentialKind, purpose: purpose)
-            } catch {
+            } catch let error as PairingV2Error {
                 do {
-                    try await execute(stateMachine.handle(.failed(.recoveryCodePreparationFailed)))
+                    try await execute(stateMachine.handle(.failed(error)))
                 } catch {
                     await closeLocalChannel()
                 }
-                throw PairingV2Error.recoveryCodePreparationFailed
+                throw error
+            } catch {
+                let pairingError = pairingV2RecoveryCodePreparationError(for: error)
+                do {
+                    try await execute(stateMachine.handle(.failed(pairingError)))
+                } catch {
+                    await closeLocalChannel()
+                }
+                throw pairingError
             }
             try await execute(stateMachine.handle(.recoveryCodePrepared(recoveryCode)))
 
@@ -327,6 +335,9 @@ final class PairingV2Coordinator {
                 try await login(with: recoveryCode)
             } catch SyncError.accountAlreadyExists {
                 throw SyncError.accountAlreadyExists
+            } catch SyncError.unexpectedStatusCode(let statusCode) where statusCode == 401 {
+                try await execute(stateMachine.handle(.failed(.invalidCredentials)))
+                throw PairingV2Error.invalidCredentials
             } catch {
                 try await execute(stateMachine.handle(.failed(.loginFailed)))
                 throw PairingV2Error.loginFailed
@@ -337,13 +348,7 @@ final class PairingV2Coordinator {
             do {
                 try await upgradeThirdPartyAccount(with: recoveryCode)
             } catch let error as ThirdPartyAccountUpgradeError {
-                let pairingError: PairingV2Error
-                switch error {
-                case .nativeCredentialAlreadyPresent:
-                    pairingError = .nativeCredentialAlreadyPresent
-                default:
-                    pairingError = .upgradeFailed
-                }
+                let pairingError = pairingV2AccountUpgradeError(for: error)
                 try await execute(stateMachine.handle(.failed(pairingError)))
                 throw pairingError
             } catch let error as PairingV2Error {
@@ -408,7 +413,11 @@ final class PairingV2Coordinator {
             return
         }
 
-        try await syncService.createAccount(deviceName: deviceName, deviceType: deviceType)
+        do {
+            try await syncService.createAccount(deviceName: deviceName, deviceType: deviceType)
+        } catch {
+            throw PairingV2Error.accountCreationFailed
+        }
         await confirmationDelegate?.pairingV2CoordinatorDidCreateSyncAccount(credentialKind: credentialKind)
     }
 
@@ -437,6 +446,39 @@ final class PairingV2Coordinator {
         } catch {
             Logger.sync.error("Pairing V2 3party account upgrade failed: \(String(reflecting: error))")
             throw error
+        }
+    }
+
+    private func pairingV2RecoveryCodePreparationError(for error: Error) -> PairingV2Error {
+        guard let error = error as? ScopedAccessCredentialError else {
+            return .recoveryCodePreparationFailed
+        }
+
+        switch error {
+        case .missingThirdPartyCredential:
+            return .missingThirdPartyCredential
+        case .undecryptableThirdPartyCredential:
+            return .undecryptableThirdPartyCredential
+        case .accountExtendFailed:
+            return .accountExtendFailed
+        }
+    }
+
+    private func pairingV2AccountUpgradeError(for error: ThirdPartyAccountUpgradeError) -> PairingV2Error {
+        switch error {
+        case .nativeCredentialAlreadyPresent:
+            return .nativeCredentialAlreadyPresent
+        case .noUsableThirdPartyProtectedKeys:
+            return .missingThirdPartyKey
+        case .localStorageFailed:
+            return .localStorageFailed
+        case .invalidCredentials:
+            return .invalidCredentials
+        case .finalNativeLoginFailed,
+                .invalidFinalNativeLoginResponse:
+            return .loginFailed
+        default:
+            return .upgradeFailed
         }
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/PairingV2/PairingV2Coordinator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/PairingV2/PairingV2Coordinator.swift
@@ -32,7 +32,7 @@ protocol PairingV2ConfirmationDelegate: AnyObject {
 /// Default timing for the polling loop in `pollUntilFinished`.
 enum PairingV2PollingDefaults {
     /// Give up on the pairing session after this many seconds (5 minutes).
-    static let sessionTimeout: TimeInterval = 10
+    static let sessionTimeout: TimeInterval = 300
     /// Wait this long between relay polls (1 second, in nanoseconds).
     static let pollIntervalNanoseconds: UInt64 = 1_000_000_000
 }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/PairingV2/PairingV2StateMachine.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/PairingV2/PairingV2StateMachine.swift
@@ -171,8 +171,15 @@ enum PairingV2Error: Error, Equatable {
     case unexpectedEvent(PairingV2UnexpectedEvent)
     case pairingSessionNotReady(PairingV2MissingSessionData)
     case nativeCredentialAlreadyPresent
+    case accountCreationFailed
     case recoveryCodePreparationFailed
+    case missingThirdPartyCredential
+    case undecryptableThirdPartyCredential
+    case accountExtendFailed
     case recoveryCodeSendFailed
+    case missingThirdPartyKey
+    case localStorageFailed
+    case invalidCredentials
     case loginFailed
     case upgradeFailed
     case recoveryCodeDenied
@@ -565,7 +572,7 @@ struct PairingV2StateMachine {
 
     private mutating func fail(with error: PairingV2Error) -> [PairingV2Command] {
         let commands: [PairingV2Command]
-        if case .hostPreparingRecoveryCode = state, error == .recoveryCodePreparationFailed {
+        if case .hostPreparingRecoveryCode = state, error.shouldNotifyRecoveryCodeUnavailable {
             commands = [.sendRecoveryCodeUnavailable, .abort(error)]
         } else {
             commands = [.abort(error)]
@@ -591,4 +598,20 @@ struct PairingV2StateMachine {
         PairingV2ProtocolVersion.supports(version)
     }
 
+}
+
+private extension PairingV2Error {
+
+    var shouldNotifyRecoveryCodeUnavailable: Bool {
+        switch self {
+        case .accountCreationFailed,
+                .recoveryCodePreparationFailed,
+                .missingThirdPartyCredential,
+                .undecryptableThirdPartyCredential,
+                .accountExtendFailed:
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
@@ -19,6 +19,12 @@
 import CryptoKit
 import Foundation
 
+enum ScopedAccessCredentialError: Error, Equatable {
+    case missingThirdPartyCredential
+    case undecryptableThirdPartyCredential
+    case accountExtendFailed
+}
+
 /// Creates and recovers the scoped ("3party") access credential and its protected keys that let a limited client share a sync account.
 struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
 
@@ -33,29 +39,39 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
             return nil
         }
         guard let encryptedCredential = thirdPartyCredential.encrypted3PartyCredential, !encryptedCredential.isEmpty else {
-            throw SyncError.invalidDataInResponse("3P access credential missing encrypted_3party_credential")
+            throw ScopedAccessCredentialError.missingThirdPartyCredential
         }
         let defaultCredentialMainKey = ScopedAccessKeyDerivation.mainKey(from: primaryKey, userID: userID)
-        return try scopedAccessCredentialEnvelope.decryptScopedPassword(from: encryptedCredential, using: defaultCredentialMainKey)
+        do {
+            return try scopedAccessCredentialEnvelope.decryptScopedPassword(from: encryptedCredential, using: defaultCredentialMainKey)
+        } catch {
+            throw ScopedAccessCredentialError.undecryptableThirdPartyCredential
+        }
     }
 
     func ensureThirdPartyScopedPassword(for account: SyncAccount,
                                         purpose: String,
                                         cachedScopedPassword: () throws -> Data?) async throws -> EnsuredThirdPartyCredential {
-        let accessCredentials = try await fetchAccessCredentials(account)
-        if let scopedPassword = try recoverScopedPassword(from: accessCredentials, primaryKey: account.primaryKey, userID: account.userId) {
-            return EnsuredThirdPartyCredential(scopedPassword: scopedPassword, protectedKeysToCache: [])
-        }
+        do {
+            let accessCredentials = try await fetchAccessCredentials(account)
+            if let scopedPassword = try recoverScopedPassword(from: accessCredentials, primaryKey: account.primaryKey, userID: account.userId) {
+                return EnsuredThirdPartyCredential(scopedPassword: scopedPassword, protectedKeysToCache: [])
+            }
 
-        let scopedPassword = try scopedPasswordForNewThirdPartyCredential(cachedScopedPassword: cachedScopedPassword)
-        let keyPreparation = try await protectedKeysForThirdPartyCredential(purpose: purpose,
-                                                                            account: account)
-        let ensuredScopedPassword = try await ensureThirdPartyAccessCredential(for: account,
-                                                                              scopedPassword: scopedPassword,
-                                                                              keys: keyPreparation.protectedKeys,
-                                                                              shouldUploadDefaultCredentialKeys: keyPreparation.shouldUploadDefaultCredentialKeys)
-        return EnsuredThirdPartyCredential(scopedPassword: ensuredScopedPassword,
-                                           protectedKeysToCache: keyPreparation.protectedKeysToCache)
+            let scopedPassword = try scopedPasswordForNewThirdPartyCredential(cachedScopedPassword: cachedScopedPassword)
+            let keyPreparation = try await protectedKeysForThirdPartyCredential(purpose: purpose,
+                                                                                account: account)
+            let ensuredScopedPassword = try await ensureThirdPartyAccessCredential(for: account,
+                                                                                  scopedPassword: scopedPassword,
+                                                                                  keys: keyPreparation.protectedKeys,
+                                                                                  shouldUploadDefaultCredentialKeys: keyPreparation.shouldUploadDefaultCredentialKeys)
+            return EnsuredThirdPartyCredential(scopedPassword: ensuredScopedPassword,
+                                               protectedKeysToCache: keyPreparation.protectedKeysToCache)
+        } catch let error as ScopedAccessCredentialError {
+            throw error
+        } catch {
+            throw ScopedAccessCredentialError.accountExtendFailed
+        }
     }
 
     func makeRecoveryCode(for account: SyncAccount, scopedPassword: Data) -> String? {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ThirdPartyAccountUpgradeCoordinator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ThirdPartyAccountUpgradeCoordinator.swift
@@ -46,8 +46,10 @@ enum ThirdPartyAccountUpgradeError: Error, Equatable {
     case nativeCredentialCreationRequestFailed
     case nativeCredentialCreationFailed(statusCode: Int)
     case invalidTemporaryLoginResponse
+    case invalidCredentials
     case finalNativeLoginFailed
     case invalidFinalNativeLoginResponse
+    case localStorageFailed
 }
 
 /// Performs the third-party-to-native account upgrade: temporary 3party login, native credential creation, then final native login.
@@ -240,7 +242,12 @@ struct ThirdPartyAccountUpgradeCoordinator: ThirdPartyAccountUpgradeCoordinating
                                                scope: LoginScope.thirdPartyAccountManagement)
         let requestJson = try JSONEncoder.snakeCaseKeys.encode(params)
         let request = api.createUnauthenticatedJSONRequest(url: endpoints.login, method: .post, json: requestJson)
-        let result = try await request.execute()
+        let result: HTTPResult
+        do {
+            result = try await request.execute()
+        } catch SyncError.unexpectedStatusCode(let statusCode) where statusCode == 401 {
+            throw ThirdPartyAccountUpgradeError.invalidCredentials
+        }
         guard let body = result.data else {
             throw ThirdPartyAccountUpgradeError.invalidTemporaryLoginResponse
         }
@@ -270,6 +277,8 @@ struct ThirdPartyAccountUpgradeCoordinator: ThirdPartyAccountUpgradeCoordinating
                 return try await loginDefaultCredential(userId: userId, accountKeys: accountKeys, deviceName: deviceName, deviceType: deviceType)
             } catch let error as ThirdPartyAccountUpgradeError {
                 throw error
+            } catch SyncError.unexpectedStatusCode(let statusCode) where statusCode == 401 {
+                throw ThirdPartyAccountUpgradeError.invalidCredentials
             } catch {
                 guard shouldRetryFinalNativeLogin(after: error), !retryDelays.isEmpty else {
                     throw ThirdPartyAccountUpgradeError.finalNativeLoginFailed

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/PairingV2/PairingV2CoordinatorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/PairingV2/PairingV2CoordinatorTests.swift
@@ -432,13 +432,13 @@ final class PairingV2CoordinatorTests: XCTestCase {
 
         do {
             try await coordinator.pollOnce()
-            XCTFail("Expected PairingV2Error.recoveryCodePreparationFailed")
-        } catch PairingV2Error.recoveryCodePreparationFailed {
+            XCTFail("Expected PairingV2Error.accountCreationFailed")
+        } catch PairingV2Error.accountCreationFailed {
         } catch {
-            XCTFail("Expected PairingV2Error.recoveryCodePreparationFailed, got \(error)")
+            XCTFail("Expected PairingV2Error.accountCreationFailed, got \(error)")
         }
 
-        XCTAssertEqual(coordinator.state, .failed(.recoveryCodePreparationFailed))
+        XCTAssertEqual(coordinator.state, .failed(.accountCreationFailed))
         XCTAssertEqual(accountManager.createAccountCalls.map(\.deviceName), ["Mac"])
         XCTAssertNil(syncService.account)
         XCTAssertTrue(confirmationDelegate.didCreateSyncAccountCalls.isEmpty)
@@ -762,19 +762,19 @@ final class PairingV2CoordinatorTests: XCTestCase {
         XCTAssertEqual(setup.coordinator.state, .failed(.nativeCredentialAlreadyPresent))
     }
 
-    func testWhenThirdPartyUpgradeReportsGenericUpgradeErrorThenPairingFailsWithUpgradeFailed() async throws {
+    func testWhenThirdPartyUpgradeHasNoUsableProtectedKeysThenPairingFailsWithMissingThirdPartyKey() async throws {
         let setup = try await makeNativeJoinerReadyForThirdPartyUpgrade(upgradeError: ThirdPartyAccountUpgradeError.noUsableThirdPartyProtectedKeys)
 
         do {
             try await setup.coordinator.pollOnce()
-            XCTFail("Expected upgrade failure to abort pairing")
-        } catch PairingV2Error.upgradeFailed {
+            XCTFail("Expected missing third-party key to abort pairing")
+        } catch PairingV2Error.missingThirdPartyKey {
         } catch {
             XCTFail("Unexpected error: \(error)")
         }
 
         XCTAssertEqual(setup.upgradeCoordinator.upgradeThirdPartyAccountCalls.map(\.recoveryCode), ["third-party-recovery-code"])
-        XCTAssertEqual(setup.coordinator.state, .failed(.upgradeFailed))
+        XCTAssertEqual(setup.coordinator.state, .failed(.missingThirdPartyKey))
     }
 
     func testWhenNativeJoinerConfirmationIsDeniedThenDoesNotLoginIfRecoveryCodeArrives() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
@@ -278,7 +278,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         ])
     }
 
-    func testWhenDefaultCredentialProtectedKeyIsDirectJWEThenThrowsInvalidDataInResponse() async throws {
+    func testWhenDefaultCredentialProtectedKeyIsDirectJWEThenThrowsAccountExtendFailed() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
         var crypter = CryptingMock()
@@ -305,8 +305,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                                                  purpose: "ai_chats",
                                                                  cachedScopedPassword: { scopedPassword })
             XCTFail("Expected direct-JWE ddg source key to be rejected")
-        } catch SyncError.invalidDataInResponse(let message) {
-            XCTAssertTrue(message.contains("encrypted_private_key"))
+        } catch ScopedAccessCredentialError.accountExtendFailed {
         } catch {
             XCTFail("Unexpected error: \(error)")
         }
@@ -500,9 +499,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
             _ = try await manager.ensureThirdPartyScopedPassword(for: account,
                                                                  purpose: "ai_chats",
                                                                  cachedScopedPassword: { Data((32..<64).map(UInt8.init)) })
-            XCTFail("Expected fetchProtectedKeys failure to be propagated")
-        } catch SyncError.unexpectedStatusCode(let statusCode) {
-            XCTAssertEqual(statusCode, 500)
+            XCTFail("Expected fetchProtectedKeys failure to become account extend failure")
+        } catch ScopedAccessCredentialError.accountExtendFailed {
         } catch {
             XCTFail("Unexpected error: \(error)")
         }

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ThirdPartyAccountUpgradeCoordinatorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ThirdPartyAccountUpgradeCoordinatorTests.swift
@@ -190,8 +190,8 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
                 recoveryCode(),
                 deviceName: "Mac",
                 deviceType: "desktop")
-            XCTFail("Expected unauthorized final native login failure")
-        } catch ThirdPartyAccountUpgradeError.finalNativeLoginFailed {
+            XCTFail("Expected invalid credentials final native login failure")
+        } catch ThirdPartyAccountUpgradeError.invalidCredentials {
         } catch {
             XCTFail("Unexpected error: \(error)")
         }

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SyncConnectionControllerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SyncConnectionControllerTests.swift
@@ -1292,6 +1292,40 @@ final class SyncConnectionControllerTests: XCTestCase {
     }
 
     @MainActor
+    func test_syncCodeEntered_withV2NativeLoginSecureStoreFailure_notifiesLocalStorageFailed() async throws {
+        let mockAccountManager = AccountManagingMock()
+        mockAccountManager.loginError = SyncError.failedToWriteSecureStore(status: -1)
+        dependencies.account = mockAccountManager
+        let messageExchanger = PairingV2MessageExchangingMock()
+        dependencies.createPairingV2MessageExchangerStub = messageExchanger
+        let peerKeyPair = try makePeerKeyPair()
+        messageExchanger.fetchMessagesHandler = { _, _ in
+            try self.encryptedPeerMessages(
+                [
+                    .recoveryCodeAvailable(
+                        .init(type: PairingV2ApplicationMessage.MessageType.recoveryCodeAvailable,
+                              name: "Peer",
+                              kind: .ddg,
+                              userId: "other-user")
+                    ),
+                    .recoveryCodeResponse(.init(recoveryCode: Self.validRecoveryCode))
+                ],
+                messageExchanger: messageExchanger,
+                peerKeyPair: peerKeyPair
+            )
+        }
+        let payload = PairingV2QRCodePayload(channelId: peerKeyPair.channelID, publicKey: peerKeyPair.publicKey)
+        let url = try payload.toURL(baseURL: URL(string: "https://duckduckgo.com")!)
+
+        let result = await controller.syncCodeEntered(code: url.absoluteString, canScanLegacyURLBarcodes: true, codeSource: .pastedCode)
+
+        XCTAssertFalse(result)
+        XCTAssertTrue(mockAccountManager.loginCalled)
+        XCTAssertEqual(delegate.didErrorErrors?.error, .localStorageFailed)
+        XCTAssertNil(delegate.didErrorErrors?.underlyingError)
+    }
+
+    @MainActor
     func test_syncCodeEntered_withValidExchangeCode_notifiesDelegate() async {
         let expectation = self.expectation(description: "Exchanger poll completes")
         delegate.didRecognizeScannedCodeCalled = {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SyncConnectionControllerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SyncConnectionControllerTests.swift
@@ -1040,7 +1040,7 @@ final class SyncConnectionControllerTests: XCTestCase {
     }
 
     @MainActor
-    func test_syncCodeEntered_withV2UrlAndRelayUnavailableOnSend_notifiesFetchError() async throws {
+    func test_syncCodeEntered_withV2UrlAndRelayUnavailableOnSend_notifiesRelayChannelUnavailable() async throws {
         let messageExchanger = PairingV2MessageExchangingMock()
         messageExchanger.sendError = PairingV2Error.relayChannelUnavailable
         dependencies.createPairingV2MessageExchangerStub = messageExchanger
@@ -1051,7 +1051,7 @@ final class SyncConnectionControllerTests: XCTestCase {
         let result = await controller.syncCodeEntered(code: url.absoluteString, canScanLegacyURLBarcodes: true, codeSource: .pastedCode)
 
         XCTAssertFalse(result)
-        XCTAssertEqual(delegate.didErrorErrors?.error, .failedToFetchExchangeRecoveryKey)
+        XCTAssertEqual(delegate.didErrorErrors?.error, .relayChannelUnavailable)
         XCTAssertNil(delegate.didErrorErrors?.underlyingError)
     }
 
@@ -1067,7 +1067,7 @@ final class SyncConnectionControllerTests: XCTestCase {
         let result = await controller.syncCodeEntered(code: url.absoluteString, canScanLegacyURLBarcodes: true, codeSource: .pastedCode)
 
         XCTAssertFalse(result)
-        XCTAssertEqual(delegate.didErrorErrors?.error, .failedToFetchExchangeRecoveryKey)
+        XCTAssertEqual(delegate.didErrorErrors?.error, .relayChannelUnavailable)
         XCTAssertNil(delegate.didErrorErrors?.underlyingError)
     }
 
@@ -1193,7 +1193,7 @@ final class SyncConnectionControllerTests: XCTestCase {
     }
 
     @MainActor
-    func test_syncCodeEntered_withV2RecoveryCodePreparationFailure_notifiesTransmitError() async throws {
+    func test_syncCodeEntered_withV2RecoveryCodePreparationFailure_notifiesPreparationError() async throws {
         try dependencies.secureStore.persistAccount(SyncAccount.mock)
         let scopedAccess = try XCTUnwrap(dependencies.scopedAccess as? ScopedAccessCredentialManagingMock)
         scopedAccess.ensureThirdPartyScopedPasswordError = SyncError.failedToEncryptValue("")
@@ -1220,12 +1220,12 @@ final class SyncConnectionControllerTests: XCTestCase {
         let result = await controller.syncCodeEntered(code: url.absoluteString, canScanLegacyURLBarcodes: true, codeSource: .pastedCode)
 
         XCTAssertFalse(result)
-        XCTAssertEqual(delegate.didErrorErrors?.error, .failedToTransmitExchangeRecoveryKey)
+        XCTAssertEqual(delegate.didErrorErrors?.error, .recoveryCodePreparationFailed)
         XCTAssertNil(delegate.didErrorErrors?.underlyingError)
     }
 
     @MainActor
-    func test_syncCodeEntered_withV2RecoveryCodeSendFailure_notifiesTransmitError() async throws {
+    func test_syncCodeEntered_withV2RecoveryCodeSendFailure_notifiesUnexpectedFailure() async throws {
         try dependencies.secureStore.persistAccount(SyncAccount.mock)
         let messageExchanger = PairingV2MessageExchangingMock()
         messageExchanger.sendHandler = { _, _ in
@@ -1255,7 +1255,7 @@ final class SyncConnectionControllerTests: XCTestCase {
         let result = await controller.syncCodeEntered(code: url.absoluteString, canScanLegacyURLBarcodes: true, codeSource: .pastedCode)
 
         XCTAssertFalse(result)
-        XCTAssertEqual(delegate.didErrorErrors?.error, .failedToTransmitExchangeRecoveryKey)
+        XCTAssertEqual(delegate.didErrorErrors?.error, .unexpectedFailure)
         XCTAssertNil(delegate.didErrorErrors?.underlyingError)
     }
 

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SyncConnectionControllerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SyncConnectionControllerTests.swift
@@ -152,17 +152,7 @@ final class SyncConnectionControllerTests: XCTestCase {
     @MainActor
     override func setUp() {
         super.setUp()
-        dependencies = MockSyncDependencies()
-        dependencies.isPairingV2CodeEnabled = { false }
-        syncService = DDGSync(dataProvidersSource: MockDataProvidersSource(), dependencies: dependencies)
-        delegate = MockSyncConnectionControllerDelegate()
-        controller = SyncConnectionController(deviceName: Self.deviceName,
-                                              deviceType: Self.deviceType,
-                                              delegate: delegate,
-                                              syncService: syncService,
-                                              dependencies: dependencies,
-                                              pairingV2PollingTimeout: Self.pairingV2PollingTimeout,
-                                              pairingV2PollIntervalNanoseconds: Self.pairingV2PollIntervalNanoseconds)
+        resetControllerUnderTest()
     }
 
     override func tearDown() {
@@ -1072,6 +1062,118 @@ final class SyncConnectionControllerTests: XCTestCase {
     }
 
     @MainActor
+    func test_syncCodeEntered_withPairingV2Errors_notifiesExpectedPixelContractError() async throws {
+        let testCases: [(error: PairingV2Error, expectedError: SyncConnectionError, description: String)] = [
+            (.recoveryCodePreparationFailed, .recoveryCodePreparationFailed, "recovery code preparation failure"),
+            (.missingThirdPartyCredential, .missingThirdPartyCredential, "missing 3party credential"),
+            (.undecryptableThirdPartyCredential, .undecryptableThirdPartyCredential, "undecryptable 3party credential"),
+            (.accountCreationFailed, .accountCreationFailed, "account creation failure"),
+            (.accountExtendFailed, .accountExtendFailed, "account extend failure"),
+            (.recoveryCodeSendFailed, .transportFailure, "recovery code send failure"),
+            (.missingThirdPartyKey, .missingThirdPartyKey, "missing 3party key"),
+            (.localStorageFailed, .localStorageFailed, "local storage failure"),
+            (.invalidCredentials, .invalidCredentials, "invalid credentials"),
+            (.loginFailed, .transportFailure, "login failure"),
+            (.upgradeFailed, .accountUpgradeFailed, "account upgrade failure"),
+            (.nativeCredentialAlreadyPresent, .thirdPartyAccountAlreadyUpgraded, "native credential already present"),
+            (.recoveryCodeDenied, .syncCancelledFromOtherDevice, "recovery code denied"),
+            (.recoveryCodeUnavailable, .peerRecoveryCodeUnavailable, "peer recovery code unavailable"),
+            (.unsupportedVersion("3.0"), .updateRequired, "unsupported future version"),
+            (.unsupportedVersion("not-a-version"), .unableToRecognizeCode, "malformed version"),
+            (.v2ScanningDisabled, .unableToRecognizeCode, "V2 scanning disabled"),
+            (.unknownCode, .unableToRecognizeCode, "unknown code"),
+            (.unsupportedFlow("unsupported-flow"), .unableToRecognizeCode, "unsupported flow"),
+            (.secondHello, .unexpectedSecondHello, "second hello"),
+            (.unexpectedEvent(.helloAfterPeerStatus), .unexpectedEvent, "unexpected event"),
+            (.pairingSessionNotReady(.peerPublicKey), .pairingSessionNotReady, "pairing session not ready"),
+            (.relayChannelUnavailable, .relayChannelUnavailable, "relay channel unavailable"),
+            (.relayChannelExpired, .relayChannelUnavailable, "relay channel expired")
+        ]
+
+        for testCase in testCases {
+            resetControllerUnderTest()
+            let messageExchanger = PairingV2MessageExchangingMock()
+            messageExchanger.fetchMessagesError = testCase.error
+            dependencies.createPairingV2MessageExchangerStub = messageExchanger
+            let peerKeyPair = try makePeerKeyPair()
+            let payload = PairingV2QRCodePayload(channelId: peerKeyPair.channelID, publicKey: peerKeyPair.publicKey)
+            let url = try payload.toURL(baseURL: URL(string: "https://duckduckgo.com")!)
+
+            let result = await controller.syncCodeEntered(code: url.absoluteString, canScanLegacyURLBarcodes: true, codeSource: .pastedCode)
+
+            XCTAssertFalse(result, testCase.description)
+            XCTAssertEqual(delegate.didErrorErrors?.error, testCase.expectedError, testCase.description)
+            XCTAssertNil(delegate.didErrorErrors?.underlyingError, testCase.description)
+        }
+    }
+
+    func test_syncSetupFailureReason_forConnectionErrors_matchesPixelContract() {
+        let testCases: [(error: SyncConnectionError, expectedReason: String?, description: String)] = [
+            (.failedToLogIn, SyncSetupFailureReason.v1Failure, "legacy login failure"),
+            (.failedToFetchPublicKey, SyncSetupFailureReason.v1Failure, "legacy public key fetch failure"),
+            (.failedToTransmitExchangeRecoveryKey, SyncSetupFailureReason.v1Failure, "legacy exchange recovery key transmit failure"),
+            (.failedToFetchConnectRecoveryKey, SyncSetupFailureReason.v1Failure, "legacy connect recovery key fetch failure"),
+            (.failedToTransmitExchangeKey, SyncSetupFailureReason.v1Failure, "legacy exchange key transmit failure"),
+            (.failedToFetchExchangeRecoveryKey, SyncSetupFailureReason.v1Failure, "legacy exchange recovery key fetch failure"),
+            (.failedToTransmitConnectRecoveryKey, SyncSetupFailureReason.v1Failure, "legacy connect recovery key transmit failure"),
+            (.pollingForRecoveryKeyTimedOut, SyncSetupFailureReason.v1Failure, "legacy recovery key polling timeout"),
+            (.failedToCreateAccount, SyncSetupFailureReason.v1Failure, "legacy account creation failure"),
+            (.invalidCredentials, SyncSetupFailureReason.invalidCredentials, "invalid credentials"),
+            (.pairingV2SessionTimedOut(timeoutStage: .loggingIn), SyncSetupFailureReason.sessionTimeout, "Pairing V2 session timeout"),
+            (.updateRequired, SyncSetupFailureReason.needsUpgrade, "update required"),
+            (.unsupportedThirdPartyRecoveryCode, SyncSetupFailureReason.incompatibleCode, "unsupported 3party recovery code"),
+            (.thirdPartyAccountAlreadyUpgraded, SyncSetupFailureReason.alreadyUpgraded, "3party account already upgraded"),
+            (.unableToRecognizeCode, SyncSetupFailureReason.unrecognizedCode, "unable to recognize code"),
+            (.accountCreationFailed, SyncSetupFailureReason.accountCreationFailed, "Pairing V2 account creation failure"),
+            (.accountUpgradeFailed, SyncSetupFailureReason.accountUpgradeFailed, "Pairing V2 account upgrade failure"),
+            (.transportFailure, SyncSetupFailureReason.transportFailure, "Pairing V2 transport failure"),
+            (.protocolError, SyncSetupFailureReason.protocolError, "Pairing V2 protocol error"),
+            (.syncCancelledFromOtherDevice, nil, "sync cancelled from other device"),
+            (.unexpectedSecondHello, SyncSetupFailureReason.unexpectedSecondHello, "unexpected second hello"),
+            (.unexpectedEvent, SyncSetupFailureReason.unexpectedEvent, "unexpected event"),
+            (.pairingSessionNotReady, SyncSetupFailureReason.pairingSessionNotReady, "pairing session not ready"),
+            (.relayChannelUnavailable, SyncSetupFailureReason.relayChannelUnavailable, "relay channel unavailable"),
+            (.recoveryCodePreparationFailed, SyncSetupFailureReason.recoveryCodePreparationFailed, "recovery code preparation failure"),
+            (.peerRecoveryCodeUnavailable, SyncSetupFailureReason.peerRecoveryCodeUnavailable, "peer recovery code unavailable"),
+            (.unexpectedFailure, SyncSetupFailureReason.unexpectedFailure, "unexpected failure"),
+            (.missingThirdPartyCredential, SyncSetupFailureReason.missingThirdPartyCredential, "missing 3party credential"),
+            (.undecryptableThirdPartyCredential, SyncSetupFailureReason.undecryptableThirdPartyCredential, "undecryptable 3party credential"),
+            (.accountExtendFailed, SyncSetupFailureReason.accountExtendFailed, "account extend failure"),
+            (.missingThirdPartyKey, SyncSetupFailureReason.missingThirdPartyKey, "missing 3party key"),
+            (.localStorageFailed, SyncSetupFailureReason.localStorageFailed, "local storage failure")
+        ]
+
+        for testCase in testCases {
+            XCTAssertEqual(testCase.error.syncSetupFailureReason, testCase.expectedReason, testCase.description)
+        }
+    }
+
+    func test_syncSetupTimeoutStage_forConnectionErrors_matchesPixelContract() {
+        XCTAssertEqual(
+            SyncConnectionError.pairingV2SessionTimedOut(timeoutStage: .waitingForPeerHello).syncSetupTimeoutStage,
+            SyncSetupTimeoutStage.waitingForPeerHello.rawValue
+        )
+        XCTAssertEqual(
+            SyncConnectionError.pairingV2SessionTimedOut(timeoutStage: .waitingForPeerStatus).syncSetupTimeoutStage,
+            SyncSetupTimeoutStage.waitingForPeerStatus.rawValue
+        )
+        XCTAssertEqual(
+            SyncConnectionError.pairingV2SessionTimedOut(timeoutStage: .waitingForConfirmation).syncSetupTimeoutStage,
+            SyncSetupTimeoutStage.waitingForConfirmation.rawValue
+        )
+        XCTAssertEqual(
+            SyncConnectionError.pairingV2SessionTimedOut(timeoutStage: .waitingForRecoveryCode).syncSetupTimeoutStage,
+            SyncSetupTimeoutStage.waitingForRecoveryCode.rawValue
+        )
+        XCTAssertEqual(
+            SyncConnectionError.pairingV2SessionTimedOut(timeoutStage: .loggingIn).syncSetupTimeoutStage,
+            SyncSetupTimeoutStage.loggingIn.rawValue
+        )
+        XCTAssertNil(SyncConnectionError.pairingV2SessionTimedOut(timeoutStage: nil).syncSetupTimeoutStage)
+        XCTAssertNil(SyncConnectionError.transportFailure.syncSetupTimeoutStage)
+    }
+
+    @MainActor
     func test_syncCodeEntered_withV2SameAccount_notifiesAlreadyConnected() async throws {
         try dependencies.secureStore.persistAccount(SyncAccount.mock)
         let messageExchanger = PairingV2MessageExchangingMock()
@@ -1729,5 +1831,20 @@ final class SyncConnectionControllerTests: XCTestCase {
         try await action()
         await fulfillment(of: [errorExpectation], timeout: 5)
         return try XCTUnwrap(delegate.didErrorErrors?.error, file: file, line: line)
+    }
+
+    @MainActor
+    private func resetControllerUnderTest() {
+        dependencies = MockSyncDependencies()
+        dependencies.isPairingV2CodeEnabled = { false }
+        syncService = DDGSync(dataProvidersSource: MockDataProvidersSource(), dependencies: dependencies)
+        delegate = MockSyncConnectionControllerDelegate()
+        controller = SyncConnectionController(deviceName: Self.deviceName,
+                                              deviceType: Self.deviceType,
+                                              delegate: delegate,
+                                              syncService: syncService,
+                                              dependencies: dependencies,
+                                              pairingV2PollingTimeout: Self.pairingV2PollingTimeout,
+                                              pairingV2PollIntervalNanoseconds: Self.pairingV2PollIntervalNanoseconds)
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SyncConnectionControllerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SyncConnectionControllerTests.swift
@@ -1225,7 +1225,7 @@ final class SyncConnectionControllerTests: XCTestCase {
     }
 
     @MainActor
-    func test_syncCodeEntered_withV2RecoveryCodeSendFailure_notifiesUnexpectedFailure() async throws {
+    func test_syncCodeEntered_withV2RecoveryCodeSendFailure_notifiesTransportFailure() async throws {
         try dependencies.secureStore.persistAccount(SyncAccount.mock)
         let messageExchanger = PairingV2MessageExchangingMock()
         messageExchanger.sendHandler = { _, _ in
@@ -1255,7 +1255,7 @@ final class SyncConnectionControllerTests: XCTestCase {
         let result = await controller.syncCodeEntered(code: url.absoluteString, canScanLegacyURLBarcodes: true, codeSource: .pastedCode)
 
         XCTAssertFalse(result)
-        XCTAssertEqual(delegate.didErrorErrors?.error, .unexpectedFailure)
+        XCTAssertEqual(delegate.didErrorErrors?.error, .transportFailure)
         XCTAssertNil(delegate.didErrorErrors?.underlyingError)
     }
 

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -1010,7 +1010,6 @@ private enum SyncSetupPixelValue {
     static let pairing = "pairing"
     static let linking = "linking"
     static let sessionTimeout = "session_timeout"
-    static let transportFailure = "transport_failure"
     static let needsUpgrade = "needs_upgrade"
     static let incompatibleCode = "incompatible_code"
     static let unrecognizedCode = "unrecognized_code"
@@ -1028,6 +1027,12 @@ private enum SyncSetupPixelValue {
     static let recoveryCodePreparationFailed = "recovery_code_preparation_failed"
     static let peerRecoveryCodeUnavailable = "peer_recovery_code_unavailable"
     static let unexpectedFailure = "unexpected_failure"
+    static let fetchPublicKeyFailed = "fetch_public_key_failed"
+    static let transmitExchangeKeyFailed = "transmit_exchange_key_failed"
+    static let fetchExchangeRecoveryKeyFailed = "fetch_exchange_recovery_key_failed"
+    static let transmitExchangeRecoveryKeyFailed = "transmit_exchange_recovery_key_failed"
+    static let fetchConnectRecoveryKeyFailed = "fetch_connect_recovery_key_failed"
+    static let transmitConnectRecoveryKeyFailed = "transmit_connect_recovery_key_failed"
     static let host = "host"
     static let joiner = "joiner"
 }
@@ -1092,13 +1097,18 @@ private extension SyncConnectionError {
         switch self {
         case .failedToLogIn:
             return SyncSetupPixelValue.invalidCredentials
-        case .failedToFetchPublicKey,
-                .failedToTransmitExchangeRecoveryKey,
-                .failedToFetchConnectRecoveryKey,
-                .failedToTransmitExchangeKey,
-                .failedToFetchExchangeRecoveryKey,
-                .failedToTransmitConnectRecoveryKey:
-            return SyncSetupPixelValue.transportFailure
+        case .failedToFetchPublicKey:
+            return SyncSetupPixelValue.fetchPublicKeyFailed
+        case .failedToTransmitExchangeRecoveryKey:
+            return SyncSetupPixelValue.transmitExchangeRecoveryKeyFailed
+        case .failedToFetchConnectRecoveryKey:
+            return SyncSetupPixelValue.fetchConnectRecoveryKeyFailed
+        case .failedToTransmitExchangeKey:
+            return SyncSetupPixelValue.transmitExchangeKeyFailed
+        case .failedToFetchExchangeRecoveryKey:
+            return SyncSetupPixelValue.fetchExchangeRecoveryKeyFailed
+        case .failedToTransmitConnectRecoveryKey:
+            return SyncSetupPixelValue.transmitConnectRecoveryKeyFailed
         case .pollingForRecoveryKeyTimedOut:
             return SyncSetupPixelValue.sessionTimeout
         case .updateRequired:

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -808,7 +808,7 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
             handleRecoveryKeyPollingTimeout(setupRole: setupRole)
             await handleError(.unableToSyncWithDevice, error: underlyingError, event: nil)
         case .pairingV2SessionTimedOut:
-            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason, timeoutStage: error.syncSetupTimeoutStage)
             await dismissPresentedViewController()
             await handleError(.unableToSyncWithDevice, error: underlyingError, event: nil)
         }
@@ -877,9 +877,9 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         }
     }
 
-    private func sendSetupEndedFailedPixel(setupRole: SyncSetupRole, reason: String?) {
+    private func sendSetupEndedFailedPixel(setupRole: SyncSetupRole, reason: String?, timeoutStage: String? = nil) {
         Pixel.fire(pixel: .syncSetupEndedFailed,
-                   withAdditionalParameters: syncSetupPixelParameters(setupRole: setupRole, reason: reason),
+                   withAdditionalParameters: syncSetupPixelParameters(setupRole: setupRole, reason: reason, timeoutStage: timeoutStage),
                    includedParameters: [.appVersion])
         pairingV2PeerKind = nil
     }
@@ -911,18 +911,20 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         syncSetupExperimentPixels.fireDeepLinkFlowAbandoned()
     }
 
-    private func syncSetupPixelParameters(setupRole: SyncSetupRole, reason: String?) -> [String: String] {
+    private func syncSetupPixelParameters(setupRole: SyncSetupRole, reason: String?, timeoutStage: String? = nil) -> [String: String] {
         switch setupRole {
         case .receiver(let setupSource, _):
             return syncSetupPixelParameters(setupSource: setupSource,
                                             path: setupSource.syncSetupPath,
                                             reason: reason,
+                                            timeoutStage: timeoutStage,
                                             peerKind: pairingV2PeerKind?.syncSetupPeerKind,
                                             myRole: setupSource.syncSetupMyRole)
         case .sharer:
             return syncSetupPixelParameters(setupSource: .exchange,
                                             path: SyncSetupPixelValue.pairing,
                                             reason: reason,
+                                            timeoutStage: timeoutStage,
                                             peerKind: pairingV2PeerKind?.syncSetupPeerKind,
                                             myRole: SyncSetupPixelValue.host)
         }
@@ -934,6 +936,7 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
                                           path: String? = nil,
                                           flowVersion: String? = nil,
                                           reason: String? = nil,
+                                          timeoutStage: String? = nil,
                                           peerKind: String? = nil,
                                           myRole: String? = nil) -> [String: String] {
         var parameters = source.map { [PixelParameters.source: $0] } ?? [PixelParameters.source: setupSource.rawValue]
@@ -943,6 +946,7 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         parameters[SyncSetupPixelParameter.path] = path
         parameters[SyncSetupPixelParameter.flowVersion] = flowVersion ?? syncSetupPixelFlowVersion
         parameters[SyncSetupPixelParameter.reason] = reason
+        parameters[SyncSetupPixelParameter.timeoutStage] = timeoutStage
         parameters[SyncSetupPixelParameter.peerKind] = peerKind
         parameters[SyncSetupPixelParameter.myRole] = myRole
         return parameters
@@ -1021,6 +1025,7 @@ private enum SyncSetupPixelParameter {
     static let codeVersion = "code_version"
     static let path = "path"
     static let reason = "reason"
+    static let timeoutStage = "timeout_stage"
     static let peerKind = "peer_kind"
     static let myRole = "my_role"
 }
@@ -1175,6 +1180,15 @@ private extension SyncConnectionError {
             return SyncSetupPixelValue.missingThirdPartyKey
         case .localStorageFailed:
             return SyncSetupPixelValue.localStorageFailed
+        }
+    }
+
+    var syncSetupTimeoutStage: String? {
+        switch self {
+        case .pairingV2SessionTimedOut(let timeoutStage):
+            return timeoutStage?.rawValue
+        default:
+            return nil
         }
     }
 }

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -810,6 +810,7 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         case .pairingV2SessionTimedOut:
             sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason, timeoutStage: error.syncSetupTimeoutStage)
             await dismissPresentedViewController()
+            handleRecoveryKeyPollingTimeout(setupRole: setupRole)
             await handleError(.unableToSyncWithDevice, error: underlyingError, event: nil)
         }
 

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -1036,32 +1036,9 @@ private enum SyncSetupPixelValue {
     static let recovery = "recovery"
     static let pairing = "pairing"
     static let linking = "linking"
-    static let v1Failure = "v1_failure"
-    static let sessionTimeout = "session_timeout"
-    static let needsUpgrade = "needs_upgrade"
-    static let incompatibleCode = "incompatible_code"
-    static let unrecognizedCode = "unrecognized_code"
     static let scanningCancelled = "scanning_cancelled"
     static let syncConfirmationDenied = "sync_confirmation_denied"
-    static let invalidCredentials = "invalid_credentials"
-    static let alreadyUpgraded = "already_upgraded"
     static let alreadyPaired = "already_paired"
-    static let accountCreationFailed = "account_creation_failed"
-    static let accountUpgradeFailed = "account_upgrade_failed"
-    static let protocolError = "protocol_error"
-    static let transportFailure = "transport_failure"
-    static let unexpectedSecondHello = "unexpected_second_hello"
-    static let unexpectedEvent = "unexpected_event"
-    static let pairingSessionNotReady = "pairing_session_not_ready"
-    static let relayChannelUnavailable = "relay_channel_unavailable"
-    static let recoveryCodePreparationFailed = "recovery_code_preparation_failed"
-    static let peerRecoveryCodeUnavailable = "peer_recovery_code_unavailable"
-    static let unexpectedFailure = "unexpected_failure"
-    static let missingThirdPartyCredential = "missing_3party_credential"
-    static let undecryptableThirdPartyCredential = "undecryptable_3party_credential"
-    static let accountExtendFailed = "account_extend_failed"
-    static let missingThirdPartyKey = "missing_3party_key"
-    static let localStorageFailed = "local_storage_failed"
     static let host = "host"
     static let joiner = "joiner"
 }
@@ -1117,79 +1094,5 @@ private extension PairingV2DeviceKind {
 
     var syncSetupPeerKind: String {
         rawValue
-    }
-}
-
-private extension SyncConnectionError {
-
-    var syncSetupFailureReason: String? {
-        switch self {
-        // These cases are emitted by the legacy V1 exchange/connect flow and are intentionally bucketed together.
-        case .failedToLogIn,
-                .failedToFetchPublicKey,
-                .failedToTransmitExchangeRecoveryKey,
-                .failedToFetchConnectRecoveryKey,
-                .failedToTransmitExchangeKey,
-                .failedToFetchExchangeRecoveryKey,
-                .failedToTransmitConnectRecoveryKey,
-                .pollingForRecoveryKeyTimedOut,
-                .failedToCreateAccount:
-            return SyncSetupPixelValue.v1Failure
-        case .invalidCredentials:
-            return SyncSetupPixelValue.invalidCredentials
-        case .pairingV2SessionTimedOut:
-            return SyncSetupPixelValue.sessionTimeout
-        case .updateRequired:
-            return SyncSetupPixelValue.needsUpgrade
-        case .unsupportedThirdPartyRecoveryCode:
-            return SyncSetupPixelValue.incompatibleCode
-        case .thirdPartyAccountAlreadyUpgraded:
-            return SyncSetupPixelValue.alreadyUpgraded
-        case .unableToRecognizeCode:
-            return SyncSetupPixelValue.unrecognizedCode
-        case .accountCreationFailed:
-            return SyncSetupPixelValue.accountCreationFailed
-        case .accountUpgradeFailed:
-            return SyncSetupPixelValue.accountUpgradeFailed
-        case .transportFailure:
-            return SyncSetupPixelValue.transportFailure
-        case .protocolError:
-            return SyncSetupPixelValue.protocolError
-        case .syncCancelledFromOtherDevice:
-            return nil
-        case .unexpectedSecondHello:
-            return SyncSetupPixelValue.unexpectedSecondHello
-        case .unexpectedEvent:
-            return SyncSetupPixelValue.unexpectedEvent
-        case .pairingSessionNotReady:
-            return SyncSetupPixelValue.pairingSessionNotReady
-        case .relayChannelUnavailable:
-            return SyncSetupPixelValue.relayChannelUnavailable
-        case .recoveryCodePreparationFailed:
-            return SyncSetupPixelValue.recoveryCodePreparationFailed
-        case .peerRecoveryCodeUnavailable:
-            return SyncSetupPixelValue.peerRecoveryCodeUnavailable
-        case .unexpectedFailure:
-            return SyncSetupPixelValue.unexpectedFailure
-        case .missingThirdPartyCredential:
-            return SyncSetupPixelValue.missingThirdPartyCredential
-        case .undecryptableThirdPartyCredential:
-            return SyncSetupPixelValue.undecryptableThirdPartyCredential
-        case .accountExtendFailed:
-            return SyncSetupPixelValue.accountExtendFailed
-        case .missingThirdPartyKey:
-            return SyncSetupPixelValue.missingThirdPartyKey
-        case .localStorageFailed:
-            return SyncSetupPixelValue.localStorageFailed
-        }
-    }
-
-    var syncSetupTimeoutStage: String? {
-        switch self {
-        case .pairingV2SessionTimedOut(let timeoutStage):
-            return timeoutStage?.rawValue
-        default:
-            return nil
-        }
     }
 }

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -763,7 +763,22 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         case .syncCancelledFromOtherDevice:
             sendSyncConfirmationDeniedSetupEndedAbandonedPixel(setupRole: setupRole)
             await handleError(.syncCancelledFromOtherDevice, error: nil, event: nil)
-        case .failedToFetchPublicKey, .failedToTransmitExchangeRecoveryKey, .failedToFetchConnectRecoveryKey, .failedToLogIn, .failedToTransmitExchangeKey, .failedToFetchExchangeRecoveryKey, .failedToTransmitConnectRecoveryKey, .accountUpgradeFailed, .protocolError:
+        case .failedToFetchPublicKey,
+                .failedToTransmitExchangeRecoveryKey,
+                .failedToFetchConnectRecoveryKey,
+                .failedToLogIn,
+                .failedToTransmitExchangeKey,
+                .failedToFetchExchangeRecoveryKey,
+                .failedToTransmitConnectRecoveryKey,
+                .accountUpgradeFailed,
+                .protocolError,
+                .unexpectedSecondHello,
+                .unexpectedEvent,
+                .pairingSessionNotReady,
+                .relayChannelUnavailable,
+                .recoveryCodePreparationFailed,
+                .peerRecoveryCodeUnavailable,
+                .unexpectedFailure:
             sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             fireCodeHandlingFailedExperimentPixel(setupRole: setupRole)
             await handleError(.unableToSyncWithDevice, error: underlyingError, event: .syncLoginError)
@@ -1006,7 +1021,13 @@ private enum SyncSetupPixelValue {
     static let alreadyPaired = "already_paired"
     static let accountCreationFailed = "account_creation_failed"
     static let accountUpgradeFailed = "account_upgrade_failed"
-    static let protocolError = "protocol_error"
+    static let unexpectedSecondHello = "unexpected_second_hello"
+    static let unexpectedEvent = "unexpected_event"
+    static let pairingSessionNotReady = "pairing_session_not_ready"
+    static let relayChannelUnavailable = "relay_channel_unavailable"
+    static let recoveryCodePreparationFailed = "recovery_code_preparation_failed"
+    static let peerRecoveryCodeUnavailable = "peer_recovery_code_unavailable"
+    static let unexpectedFailure = "unexpected_failure"
     static let host = "host"
     static let joiner = "joiner"
 }
@@ -1093,9 +1114,23 @@ private extension SyncConnectionError {
         case .accountUpgradeFailed:
             return SyncSetupPixelValue.accountUpgradeFailed
         case .protocolError:
-            return SyncSetupPixelValue.protocolError
+            return SyncSetupPixelValue.unexpectedFailure
         case .syncCancelledFromOtherDevice:
             return nil
+        case .unexpectedSecondHello:
+            return SyncSetupPixelValue.unexpectedSecondHello
+        case .unexpectedEvent:
+            return SyncSetupPixelValue.unexpectedEvent
+        case .pairingSessionNotReady:
+            return SyncSetupPixelValue.pairingSessionNotReady
+        case .relayChannelUnavailable:
+            return SyncSetupPixelValue.relayChannelUnavailable
+        case .recoveryCodePreparationFailed:
+            return SyncSetupPixelValue.recoveryCodePreparationFailed
+        case .peerRecoveryCodeUnavailable:
+            return SyncSetupPixelValue.peerRecoveryCodeUnavailable
+        case .unexpectedFailure:
+            return SyncSetupPixelValue.unexpectedFailure
         }
     }
 }

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -764,13 +764,20 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
             sendSyncConfirmationDeniedSetupEndedAbandonedPixel(setupRole: setupRole)
             await handleError(.syncCancelledFromOtherDevice, error: nil, event: nil)
         case .failedToFetchPublicKey,
-                .failedToTransmitExchangeRecoveryKey,
                 .failedToFetchConnectRecoveryKey,
                 .failedToLogIn,
                 .failedToTransmitExchangeKey,
                 .failedToFetchExchangeRecoveryKey,
-                .failedToTransmitConnectRecoveryKey,
-                .accountUpgradeFailed,
+                .failedToTransmitConnectRecoveryKey:
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
+            fireCodeHandlingFailedExperimentPixel(setupRole: setupRole)
+            await handleError(.unableToSyncWithDevice, error: underlyingError, event: .syncLoginError)
+        case .failedToTransmitExchangeRecoveryKey:
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
+            fireCodeHandlingFailedExperimentPixel(setupRole: setupRole)
+            await handleError(.unableToSyncWithDevice, error: underlyingError, event: .syncLoginError)
+        case .accountUpgradeFailed,
+                .transportFailure,
                 .protocolError,
                 .unexpectedSecondHello,
                 .unexpectedEvent,
@@ -778,17 +785,31 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
                 .relayChannelUnavailable,
                 .recoveryCodePreparationFailed,
                 .peerRecoveryCodeUnavailable,
-                .unexpectedFailure:
+                .unexpectedFailure,
+                .missingThirdPartyCredential,
+                .undecryptableThirdPartyCredential,
+                .accountExtendFailed,
+                .missingThirdPartyKey,
+                .localStorageFailed,
+                .invalidCredentials:
             sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             fireCodeHandlingFailedExperimentPixel(setupRole: setupRole)
             await handleError(.unableToSyncWithDevice, error: underlyingError, event: .syncLoginError)
         case .failedToCreateAccount:
             sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             await handleError(.unableToSyncWithDevice, error: underlyingError, event: .syncSignupError)
+        case .accountCreationFailed:
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
+            fireCodeHandlingFailedExperimentPixel(setupRole: setupRole)
+            await handleError(.unableToSyncWithDevice, error: underlyingError, event: .syncSignupError)
         case .pollingForRecoveryKeyTimedOut:
             sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             await dismissPresentedViewController()
             handleRecoveryKeyPollingTimeout(setupRole: setupRole)
+            await handleError(.unableToSyncWithDevice, error: underlyingError, event: nil)
+        case .pairingV2SessionTimedOut:
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
+            await dismissPresentedViewController()
             await handleError(.unableToSyncWithDevice, error: underlyingError, event: nil)
         }
 
@@ -1009,6 +1030,7 @@ private enum SyncSetupPixelValue {
     static let recovery = "recovery"
     static let pairing = "pairing"
     static let linking = "linking"
+    static let v1Failure = "v1_failure"
     static let sessionTimeout = "session_timeout"
     static let needsUpgrade = "needs_upgrade"
     static let incompatibleCode = "incompatible_code"
@@ -1020,6 +1042,8 @@ private enum SyncSetupPixelValue {
     static let alreadyPaired = "already_paired"
     static let accountCreationFailed = "account_creation_failed"
     static let accountUpgradeFailed = "account_upgrade_failed"
+    static let protocolError = "protocol_error"
+    static let transportFailure = "transport_failure"
     static let unexpectedSecondHello = "unexpected_second_hello"
     static let unexpectedEvent = "unexpected_event"
     static let pairingSessionNotReady = "pairing_session_not_ready"
@@ -1027,12 +1051,11 @@ private enum SyncSetupPixelValue {
     static let recoveryCodePreparationFailed = "recovery_code_preparation_failed"
     static let peerRecoveryCodeUnavailable = "peer_recovery_code_unavailable"
     static let unexpectedFailure = "unexpected_failure"
-    static let fetchPublicKeyFailed = "fetch_public_key_failed"
-    static let transmitExchangeKeyFailed = "transmit_exchange_key_failed"
-    static let fetchExchangeRecoveryKeyFailed = "fetch_exchange_recovery_key_failed"
-    static let transmitExchangeRecoveryKeyFailed = "transmit_exchange_recovery_key_failed"
-    static let fetchConnectRecoveryKeyFailed = "fetch_connect_recovery_key_failed"
-    static let transmitConnectRecoveryKeyFailed = "transmit_connect_recovery_key_failed"
+    static let missingThirdPartyCredential = "missing_3party_credential"
+    static let undecryptableThirdPartyCredential = "undecryptable_3party_credential"
+    static let accountExtendFailed = "account_extend_failed"
+    static let missingThirdPartyKey = "missing_3party_key"
+    static let localStorageFailed = "local_storage_failed"
     static let host = "host"
     static let joiner = "joiner"
 }
@@ -1095,21 +1118,20 @@ private extension SyncConnectionError {
 
     var syncSetupFailureReason: String? {
         switch self {
-        case .failedToLogIn:
+        // These cases are emitted by the legacy V1 exchange/connect flow and are intentionally bucketed together.
+        case .failedToLogIn,
+                .failedToFetchPublicKey,
+                .failedToTransmitExchangeRecoveryKey,
+                .failedToFetchConnectRecoveryKey,
+                .failedToTransmitExchangeKey,
+                .failedToFetchExchangeRecoveryKey,
+                .failedToTransmitConnectRecoveryKey,
+                .pollingForRecoveryKeyTimedOut,
+                .failedToCreateAccount:
+            return SyncSetupPixelValue.v1Failure
+        case .invalidCredentials:
             return SyncSetupPixelValue.invalidCredentials
-        case .failedToFetchPublicKey:
-            return SyncSetupPixelValue.fetchPublicKeyFailed
-        case .failedToTransmitExchangeRecoveryKey:
-            return SyncSetupPixelValue.transmitExchangeRecoveryKeyFailed
-        case .failedToFetchConnectRecoveryKey:
-            return SyncSetupPixelValue.fetchConnectRecoveryKeyFailed
-        case .failedToTransmitExchangeKey:
-            return SyncSetupPixelValue.transmitExchangeKeyFailed
-        case .failedToFetchExchangeRecoveryKey:
-            return SyncSetupPixelValue.fetchExchangeRecoveryKeyFailed
-        case .failedToTransmitConnectRecoveryKey:
-            return SyncSetupPixelValue.transmitConnectRecoveryKeyFailed
-        case .pollingForRecoveryKeyTimedOut:
+        case .pairingV2SessionTimedOut:
             return SyncSetupPixelValue.sessionTimeout
         case .updateRequired:
             return SyncSetupPixelValue.needsUpgrade
@@ -1119,12 +1141,14 @@ private extension SyncConnectionError {
             return SyncSetupPixelValue.alreadyUpgraded
         case .unableToRecognizeCode:
             return SyncSetupPixelValue.unrecognizedCode
-        case .failedToCreateAccount:
+        case .accountCreationFailed:
             return SyncSetupPixelValue.accountCreationFailed
         case .accountUpgradeFailed:
             return SyncSetupPixelValue.accountUpgradeFailed
+        case .transportFailure:
+            return SyncSetupPixelValue.transportFailure
         case .protocolError:
-            return SyncSetupPixelValue.unexpectedFailure
+            return SyncSetupPixelValue.protocolError
         case .syncCancelledFromOtherDevice:
             return nil
         case .unexpectedSecondHello:
@@ -1141,6 +1165,16 @@ private extension SyncConnectionError {
             return SyncSetupPixelValue.peerRecoveryCodeUnavailable
         case .unexpectedFailure:
             return SyncSetupPixelValue.unexpectedFailure
+        case .missingThirdPartyCredential:
+            return SyncSetupPixelValue.missingThirdPartyCredential
+        case .undecryptableThirdPartyCredential:
+            return SyncSetupPixelValue.undecryptableThirdPartyCredential
+        case .accountExtendFailed:
+            return SyncSetupPixelValue.accountExtendFailed
+        case .missingThirdPartyKey:
+            return SyncSetupPixelValue.missingThirdPartyKey
+        case .localStorageFailed:
+            return SyncSetupPixelValue.localStorageFailed
         }
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -319,6 +319,18 @@
                     "missing_3party_key",
                     "local_storage_failed"
                 ]
+            },
+            {
+                "key": "timeout_stage",
+                "type": "string",
+                "description": "The last Pairing V2 stage before a session_timeout failure, when known.",
+                "enum": [
+                    "waiting_for_peer_hello",
+                    "waiting_for_peer_status",
+                    "waiting_for_confirmation",
+                    "waiting_for_recovery_code",
+                    "logging_in"
+                ]
             }
         ]
     },

--- a/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -297,6 +297,7 @@
                 "type": "string",
                 "description": "The reason Sync setup failed, when it can be mapped safely.",
                 "enum": [
+                    "v1_failure",
                     "session_timeout",
                     "invalid_credentials",
                     "already_upgraded",
@@ -304,6 +305,7 @@
                     "account_creation_failed",
                     "account_upgrade_failed",
                     "protocol_error",
+                    "transport_failure",
                     "unexpected_second_hello",
                     "unexpected_event",
                     "pairing_session_not_ready",
@@ -311,12 +313,11 @@
                     "recovery_code_preparation_failed",
                     "peer_recovery_code_unavailable",
                     "unexpected_failure",
-                    "fetch_public_key_failed",
-                    "transmit_exchange_key_failed",
-                    "fetch_exchange_recovery_key_failed",
-                    "transmit_exchange_recovery_key_failed",
-                    "fetch_connect_recovery_key_failed",
-                    "transmit_connect_recovery_key_failed"
+                    "missing_3party_credential",
+                    "undecryptable_3party_credential",
+                    "account_extend_failed",
+                    "missing_3party_key",
+                    "local_storage_failed"
                 ]
             }
         ]

--- a/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -298,7 +298,6 @@
                 "description": "The reason Sync setup failed, when it can be mapped safely.",
                 "enum": [
                     "session_timeout",
-                    "transport_failure",
                     "invalid_credentials",
                     "already_upgraded",
                     "already_paired",
@@ -311,7 +310,13 @@
                     "relay_channel_unavailable",
                     "recovery_code_preparation_failed",
                     "peer_recovery_code_unavailable",
-                    "unexpected_failure"
+                    "unexpected_failure",
+                    "fetch_public_key_failed",
+                    "transmit_exchange_key_failed",
+                    "fetch_exchange_recovery_key_failed",
+                    "transmit_exchange_recovery_key_failed",
+                    "fetch_connect_recovery_key_failed",
+                    "transmit_connect_recovery_key_failed"
                 ]
             }
         ]

--- a/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -304,7 +304,14 @@
                     "already_paired",
                     "account_creation_failed",
                     "account_upgrade_failed",
-                    "protocol_error"
+                    "protocol_error",
+                    "unexpected_second_hello",
+                    "unexpected_event",
+                    "pairing_session_not_ready",
+                    "relay_channel_unavailable",
+                    "recovery_code_preparation_failed",
+                    "peer_recovery_code_unavailable",
+                    "unexpected_failure"
                 ]
             }
         ]

--- a/macOS/DuckDuckGo/Preferences/Model/LegacySyncPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/LegacySyncPreferences.swift
@@ -1102,7 +1102,22 @@ extension LegacySyncPreferences: SyncConnectionControllerDelegate {
         case .syncCancelledFromOtherDevice:
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .syncCancelledFromOtherDevice)
             sendSetupEndedAbandonedPixel(setupRole: setupRole, reason: SyncSetupPixelKitEvent.ParameterValue.syncConfirmationDenied)
-        case .failedToFetchPublicKey, .failedToTransmitExchangeRecoveryKey, .failedToFetchConnectRecoveryKey, .failedToLogIn, .failedToTransmitExchangeKey, .failedToFetchExchangeRecoveryKey, .failedToTransmitConnectRecoveryKey, .accountUpgradeFailed, .protocolError:
+        case .failedToFetchPublicKey,
+                .failedToTransmitExchangeRecoveryKey,
+                .failedToFetchConnectRecoveryKey,
+                .failedToLogIn,
+                .failedToTransmitExchangeKey,
+                .failedToFetchExchangeRecoveryKey,
+                .failedToTransmitConnectRecoveryKey,
+                .accountUpgradeFailed,
+                .protocolError,
+                .unexpectedSecondHello,
+                .unexpectedEvent,
+                .pairingSessionNotReady,
+                .relayChannelUnavailable,
+                .recoveryCodePreparationFailed,
+                .peerRecoveryCodeUnavailable,
+                .unexpectedFailure:
             sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             handleError(.unableToSyncToOtherDevice, error: underlyingError, pixelEvent: GeneralPixel.syncLoginError(error: underlyingError ?? error))
         case .failedToCreateAccount:

--- a/macOS/DuckDuckGo/Preferences/Model/LegacySyncPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/LegacySyncPreferences.swift
@@ -1141,7 +1141,7 @@ extension LegacySyncPreferences: SyncConnectionControllerDelegate {
             sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unableToSyncToOtherDevice)
         case .pairingV2SessionTimedOut:
-            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason, timeoutStage: error.syncSetupTimeoutStage)
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unableToSyncToOtherDevice)
         }
     }
@@ -1165,21 +1165,23 @@ extension LegacySyncPreferences: SyncConnectionControllerDelegate {
         PixelKit.fire(SyncSetupPixelKitEvent.syncSetupManualCodeEnteredFailed(setupSource, flowVersion: syncSetupFlowVersion, reason: reason), doNotEnforcePrefix: true)
     }
 
-    private func sendSetupEndedFailedPixel(setupRole: SyncSetupRole, reason: String?) {
+    private func sendSetupEndedFailedPixel(setupRole: SyncSetupRole, reason: String?, timeoutStage: String? = nil) {
         switch setupRole {
         case .receiver(let setupSource, _):
             PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedFailed(setupSource,
                                                                       flowVersion: syncSetupFlowVersion,
                                                                       peerKind: pairingV2PeerKind?.syncSetupPeerKind,
                                                                       myRole: setupSource.syncSetupMyRole,
-                                                                      reason: reason),
+                                                                      reason: reason,
+                                                                      timeoutStage: timeoutStage),
                           doNotEnforcePrefix: true)
         case .sharer:
             PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedFailed(.exchange,
                                                                       flowVersion: syncSetupFlowVersion,
                                                                       peerKind: pairingV2PeerKind?.syncSetupPeerKind,
                                                                       myRole: SyncSetupPixelKitEvent.ParameterValue.host,
-                                                                      reason: reason),
+                                                                      reason: reason,
+                                                                      timeoutStage: timeoutStage),
                           doNotEnforcePrefix: true)
         }
         pairingV2PeerKind = nil

--- a/macOS/DuckDuckGo/Preferences/Model/LegacySyncPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/LegacySyncPreferences.swift
@@ -1103,13 +1103,18 @@ extension LegacySyncPreferences: SyncConnectionControllerDelegate {
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .syncCancelledFromOtherDevice)
             sendSetupEndedAbandonedPixel(setupRole: setupRole, reason: SyncSetupPixelKitEvent.ParameterValue.syncConfirmationDenied)
         case .failedToFetchPublicKey,
-                .failedToTransmitExchangeRecoveryKey,
                 .failedToFetchConnectRecoveryKey,
                 .failedToLogIn,
                 .failedToTransmitExchangeKey,
                 .failedToFetchExchangeRecoveryKey,
-                .failedToTransmitConnectRecoveryKey,
-                .accountUpgradeFailed,
+                .failedToTransmitConnectRecoveryKey:
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
+            handleError(.unableToSyncToOtherDevice, error: underlyingError, pixelEvent: GeneralPixel.syncLoginError(error: underlyingError ?? error))
+        case .failedToTransmitExchangeRecoveryKey:
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
+            handleError(.unableToSyncToOtherDevice, error: underlyingError, pixelEvent: GeneralPixel.syncLoginError(error: underlyingError ?? error))
+        case .accountUpgradeFailed,
+                .transportFailure,
                 .protocolError,
                 .unexpectedSecondHello,
                 .unexpectedEvent,
@@ -1117,13 +1122,25 @@ extension LegacySyncPreferences: SyncConnectionControllerDelegate {
                 .relayChannelUnavailable,
                 .recoveryCodePreparationFailed,
                 .peerRecoveryCodeUnavailable,
-                .unexpectedFailure:
+                .unexpectedFailure,
+                .missingThirdPartyCredential,
+                .undecryptableThirdPartyCredential,
+                .accountExtendFailed,
+                .missingThirdPartyKey,
+                .localStorageFailed,
+                .invalidCredentials:
             sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             handleError(.unableToSyncToOtherDevice, error: underlyingError, pixelEvent: GeneralPixel.syncLoginError(error: underlyingError ?? error))
         case .failedToCreateAccount:
             sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             handleError(.unableToSyncToOtherDevice, error: underlyingError, pixelEvent: GeneralPixel.syncSignupError(error: underlyingError ?? error))
+        case .accountCreationFailed:
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
+            handleError(.unableToSyncToOtherDevice, error: underlyingError, pixelEvent: GeneralPixel.syncSignupError(error: underlyingError ?? error))
         case .pollingForRecoveryKeyTimedOut:
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
+            managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unableToSyncToOtherDevice)
+        case .pairingV2SessionTimedOut:
             sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unableToSyncToOtherDevice)
         }

--- a/macOS/DuckDuckGo/Preferences/Model/SyncDialogController.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/SyncDialogController.swift
@@ -776,7 +776,7 @@ extension SyncDialogController: SyncConnectionControllerDelegate {
             sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unableToSyncToOtherDevice)
         case .pairingV2SessionTimedOut:
-            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason, timeoutStage: error.syncSetupTimeoutStage)
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unableToSyncToOtherDevice)
         }
     }
@@ -812,21 +812,23 @@ extension SyncDialogController: SyncConnectionControllerDelegate {
         PixelKit.fire(SyncSetupPixelKitEvent.syncSetupManualCodeEnteredFailed(setupSource, flowVersion: syncSetupFlowVersion, reason: reason), doNotEnforcePrefix: true)
     }
 
-    private func sendSetupEndedFailedPixel(setupRole: SyncSetupRole, reason: String?) {
+    private func sendSetupEndedFailedPixel(setupRole: SyncSetupRole, reason: String?, timeoutStage: String? = nil) {
         switch setupRole {
         case .receiver(let setupSource, _):
             PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedFailed(setupSource,
                                                                       flowVersion: syncSetupFlowVersion,
                                                                       peerKind: pairingV2PeerKind?.syncSetupPeerKind,
                                                                       myRole: setupSource.syncSetupMyRole,
-                                                                      reason: reason),
+                                                                      reason: reason,
+                                                                      timeoutStage: timeoutStage),
                           doNotEnforcePrefix: true)
         case .sharer:
             PixelKit.fire(SyncSetupPixelKitEvent.syncSetupEndedFailed(.exchange,
                                                                       flowVersion: syncSetupFlowVersion,
                                                                       peerKind: pairingV2PeerKind?.syncSetupPeerKind,
                                                                       myRole: SyncSetupPixelKitEvent.ParameterValue.host,
-                                                                      reason: reason),
+                                                                      reason: reason,
+                                                                      timeoutStage: timeoutStage),
                           doNotEnforcePrefix: true)
         }
         pairingV2PeerKind = nil

--- a/macOS/DuckDuckGo/Preferences/Model/SyncDialogController.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/SyncDialogController.swift
@@ -732,7 +732,22 @@ extension SyncDialogController: SyncConnectionControllerDelegate {
         case .syncCancelledFromOtherDevice:
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .syncCancelledFromOtherDevice)
             sendSetupEndedAbandonedPixel(setupRole: setupRole, reason: SyncSetupPixelKitEvent.ParameterValue.syncConfirmationDenied)
-        case .failedToFetchPublicKey, .failedToTransmitExchangeRecoveryKey, .failedToFetchConnectRecoveryKey, .failedToLogIn, .failedToTransmitExchangeKey, .failedToFetchExchangeRecoveryKey, .failedToTransmitConnectRecoveryKey, .accountUpgradeFailed, .protocolError:
+        case .failedToFetchPublicKey,
+                .failedToTransmitExchangeRecoveryKey,
+                .failedToFetchConnectRecoveryKey,
+                .failedToLogIn,
+                .failedToTransmitExchangeKey,
+                .failedToFetchExchangeRecoveryKey,
+                .failedToTransmitConnectRecoveryKey,
+                .accountUpgradeFailed,
+                .protocolError,
+                .unexpectedSecondHello,
+                .unexpectedEvent,
+                .pairingSessionNotReady,
+                .relayChannelUnavailable,
+                .recoveryCodePreparationFailed,
+                .peerRecoveryCodeUnavailable,
+                .unexpectedFailure:
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unableToSyncToOtherDevice, description: underlyingError?.localizedDescription)
             sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             PixelKit.fire(DebugEvent(GeneralPixel.syncLoginError(error: underlyingError ?? error)))

--- a/macOS/DuckDuckGo/Preferences/Model/SyncDialogController.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/SyncDialogController.swift
@@ -733,13 +733,20 @@ extension SyncDialogController: SyncConnectionControllerDelegate {
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .syncCancelledFromOtherDevice)
             sendSetupEndedAbandonedPixel(setupRole: setupRole, reason: SyncSetupPixelKitEvent.ParameterValue.syncConfirmationDenied)
         case .failedToFetchPublicKey,
-                .failedToTransmitExchangeRecoveryKey,
                 .failedToFetchConnectRecoveryKey,
                 .failedToLogIn,
                 .failedToTransmitExchangeKey,
                 .failedToFetchExchangeRecoveryKey,
-                .failedToTransmitConnectRecoveryKey,
-                .accountUpgradeFailed,
+                .failedToTransmitConnectRecoveryKey:
+            managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unableToSyncToOtherDevice, description: underlyingError?.localizedDescription)
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
+            PixelKit.fire(DebugEvent(GeneralPixel.syncLoginError(error: underlyingError ?? error)))
+        case .failedToTransmitExchangeRecoveryKey:
+            managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unableToSyncToOtherDevice, description: underlyingError?.localizedDescription)
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
+            PixelKit.fire(DebugEvent(GeneralPixel.syncLoginError(error: underlyingError ?? error)))
+        case .accountUpgradeFailed,
+                .transportFailure,
                 .protocolError,
                 .unexpectedSecondHello,
                 .unexpectedEvent,
@@ -747,7 +754,13 @@ extension SyncDialogController: SyncConnectionControllerDelegate {
                 .relayChannelUnavailable,
                 .recoveryCodePreparationFailed,
                 .peerRecoveryCodeUnavailable,
-                .unexpectedFailure:
+                .unexpectedFailure,
+                .missingThirdPartyCredential,
+                .undecryptableThirdPartyCredential,
+                .accountExtendFailed,
+                .missingThirdPartyKey,
+                .localStorageFailed,
+                .invalidCredentials:
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unableToSyncToOtherDevice, description: underlyingError?.localizedDescription)
             sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             PixelKit.fire(DebugEvent(GeneralPixel.syncLoginError(error: underlyingError ?? error)))
@@ -755,7 +768,14 @@ extension SyncDialogController: SyncConnectionControllerDelegate {
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unableToSyncToOtherDevice, description: underlyingError?.localizedDescription)
             sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             PixelKit.fire(DebugEvent(GeneralPixel.syncSignupError(error: underlyingError ?? error)))
+        case .accountCreationFailed:
+            managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unableToSyncToOtherDevice, description: underlyingError?.localizedDescription)
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
+            PixelKit.fire(DebugEvent(GeneralPixel.syncSignupError(error: underlyingError ?? error)))
         case .pollingForRecoveryKeyTimedOut:
+            sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
+            managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unableToSyncToOtherDevice)
+        case .pairingV2SessionTimedOut:
             sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
             managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unableToSyncToOtherDevice)
         }

--- a/macOS/DuckDuckGo/Sync/SyncPixels.swift
+++ b/macOS/DuckDuckGo/Sync/SyncPixels.swift
@@ -110,32 +110,9 @@ enum SyncSetupPixelKitEvent: PixelKitEvent {
         static let linking = "linking"
         static let v1 = "v1"
         static let v2 = "v2"
-        static let v1Failure = "v1_failure"
         static let alreadyPaired = "already_paired"
-        static let accountCreationFailed = "account_creation_failed"
-        static let accountUpgradeFailed = "account_upgrade_failed"
-        static let invalidCredentials = "invalid_credentials"
-        static let protocolError = "protocol_error"
-        static let transportFailure = "transport_failure"
-        static let sessionTimeout = "session_timeout"
-        static let needsUpgrade = "needs_upgrade"
-        static let incompatibleCode = "incompatible_code"
-        static let alreadyUpgraded = "already_upgraded"
-        static let unrecognizedCode = "unrecognized_code"
         static let scanningCancelled = "scanning_cancelled"
         static let syncConfirmationDenied = "sync_confirmation_denied"
-        static let unexpectedSecondHello = "unexpected_second_hello"
-        static let unexpectedEvent = "unexpected_event"
-        static let pairingSessionNotReady = "pairing_session_not_ready"
-        static let relayChannelUnavailable = "relay_channel_unavailable"
-        static let recoveryCodePreparationFailed = "recovery_code_preparation_failed"
-        static let peerRecoveryCodeUnavailable = "peer_recovery_code_unavailable"
-        static let unexpectedFailure = "unexpected_failure"
-        static let missingThirdPartyCredential = "missing_3party_credential"
-        static let undecryptableThirdPartyCredential = "undecryptable_3party_credential"
-        static let accountExtendFailed = "account_extend_failed"
-        static let missingThirdPartyKey = "missing_3party_key"
-        static let localStorageFailed = "local_storage_failed"
         static let host = "host"
         static let joiner = "joiner"
     }
@@ -337,79 +314,5 @@ extension PairingV2DeviceKind {
 
     var syncSetupPeerKind: String {
         rawValue
-    }
-}
-
-extension SyncConnectionError {
-
-    var syncSetupFailureReason: String? {
-        switch self {
-        // These cases are emitted by the legacy V1 exchange/connect flow and are intentionally bucketed together.
-        case .failedToLogIn,
-                .failedToFetchPublicKey,
-                .failedToTransmitExchangeRecoveryKey,
-                .failedToFetchConnectRecoveryKey,
-                .failedToTransmitExchangeKey,
-                .failedToFetchExchangeRecoveryKey,
-                .failedToTransmitConnectRecoveryKey,
-                .pollingForRecoveryKeyTimedOut,
-                .failedToCreateAccount:
-            return SyncSetupPixelKitEvent.ParameterValue.v1Failure
-        case .invalidCredentials:
-            return SyncSetupPixelKitEvent.ParameterValue.invalidCredentials
-        case .pairingV2SessionTimedOut:
-            return SyncSetupPixelKitEvent.ParameterValue.sessionTimeout
-        case .updateRequired:
-            return SyncSetupPixelKitEvent.ParameterValue.needsUpgrade
-        case .unsupportedThirdPartyRecoveryCode:
-            return SyncSetupPixelKitEvent.ParameterValue.incompatibleCode
-        case .thirdPartyAccountAlreadyUpgraded:
-            return SyncSetupPixelKitEvent.ParameterValue.alreadyUpgraded
-        case .unableToRecognizeCode:
-            return SyncSetupPixelKitEvent.ParameterValue.unrecognizedCode
-        case .accountCreationFailed:
-            return SyncSetupPixelKitEvent.ParameterValue.accountCreationFailed
-        case .accountUpgradeFailed:
-            return SyncSetupPixelKitEvent.ParameterValue.accountUpgradeFailed
-        case .transportFailure:
-            return SyncSetupPixelKitEvent.ParameterValue.transportFailure
-        case .protocolError:
-            return SyncSetupPixelKitEvent.ParameterValue.protocolError
-        case .syncCancelledFromOtherDevice:
-            return nil
-        case .unexpectedSecondHello:
-            return SyncSetupPixelKitEvent.ParameterValue.unexpectedSecondHello
-        case .unexpectedEvent:
-            return SyncSetupPixelKitEvent.ParameterValue.unexpectedEvent
-        case .pairingSessionNotReady:
-            return SyncSetupPixelKitEvent.ParameterValue.pairingSessionNotReady
-        case .relayChannelUnavailable:
-            return SyncSetupPixelKitEvent.ParameterValue.relayChannelUnavailable
-        case .recoveryCodePreparationFailed:
-            return SyncSetupPixelKitEvent.ParameterValue.recoveryCodePreparationFailed
-        case .peerRecoveryCodeUnavailable:
-            return SyncSetupPixelKitEvent.ParameterValue.peerRecoveryCodeUnavailable
-        case .unexpectedFailure:
-            return SyncSetupPixelKitEvent.ParameterValue.unexpectedFailure
-        case .missingThirdPartyCredential:
-            return SyncSetupPixelKitEvent.ParameterValue.missingThirdPartyCredential
-        case .undecryptableThirdPartyCredential:
-            return SyncSetupPixelKitEvent.ParameterValue.undecryptableThirdPartyCredential
-        case .accountExtendFailed:
-            return SyncSetupPixelKitEvent.ParameterValue.accountExtendFailed
-        case .missingThirdPartyKey:
-            return SyncSetupPixelKitEvent.ParameterValue.missingThirdPartyKey
-        case .localStorageFailed:
-            return SyncSetupPixelKitEvent.ParameterValue.localStorageFailed
-        }
-    }
-
-    var syncSetupTimeoutStage: String? {
-        switch self {
-        case .pairingV2SessionTimedOut(let timeoutStage):
-            return timeoutStage?.rawValue
-        default:
-            return nil
-        }
     }
 }

--- a/macOS/DuckDuckGo/Sync/SyncPixels.swift
+++ b/macOS/DuckDuckGo/Sync/SyncPixels.swift
@@ -112,7 +112,6 @@ enum SyncSetupPixelKitEvent: PixelKitEvent {
         static let alreadyPaired = "already_paired"
         static let accountCreationFailed = "account_creation_failed"
         static let accountUpgradeFailed = "account_upgrade_failed"
-        static let protocolError = "protocol_error"
         static let invalidCredentials = "invalid_credentials"
         static let transportFailure = "transport_failure"
         static let sessionTimeout = "session_timeout"
@@ -122,6 +121,13 @@ enum SyncSetupPixelKitEvent: PixelKitEvent {
         static let unrecognizedCode = "unrecognized_code"
         static let scanningCancelled = "scanning_cancelled"
         static let syncConfirmationDenied = "sync_confirmation_denied"
+        static let unexpectedSecondHello = "unexpected_second_hello"
+        static let unexpectedEvent = "unexpected_event"
+        static let pairingSessionNotReady = "pairing_session_not_ready"
+        static let relayChannelUnavailable = "relay_channel_unavailable"
+        static let recoveryCodePreparationFailed = "recovery_code_preparation_failed"
+        static let peerRecoveryCodeUnavailable = "peer_recovery_code_unavailable"
+        static let unexpectedFailure = "unexpected_failure"
         static let host = "host"
         static let joiner = "joiner"
     }
@@ -344,9 +350,23 @@ extension SyncConnectionError {
         case .accountUpgradeFailed:
             return SyncSetupPixelKitEvent.ParameterValue.accountUpgradeFailed
         case .protocolError:
-            return SyncSetupPixelKitEvent.ParameterValue.protocolError
+            return SyncSetupPixelKitEvent.ParameterValue.unexpectedFailure
         case .syncCancelledFromOtherDevice:
             return nil
+        case .unexpectedSecondHello:
+            return SyncSetupPixelKitEvent.ParameterValue.unexpectedSecondHello
+        case .unexpectedEvent:
+            return SyncSetupPixelKitEvent.ParameterValue.unexpectedEvent
+        case .pairingSessionNotReady:
+            return SyncSetupPixelKitEvent.ParameterValue.pairingSessionNotReady
+        case .relayChannelUnavailable:
+            return SyncSetupPixelKitEvent.ParameterValue.relayChannelUnavailable
+        case .recoveryCodePreparationFailed:
+            return SyncSetupPixelKitEvent.ParameterValue.recoveryCodePreparationFailed
+        case .peerRecoveryCodeUnavailable:
+            return SyncSetupPixelKitEvent.ParameterValue.peerRecoveryCodeUnavailable
+        case .unexpectedFailure:
+            return SyncSetupPixelKitEvent.ParameterValue.unexpectedFailure
         }
     }
 }

--- a/macOS/DuckDuckGo/Sync/SyncPixels.swift
+++ b/macOS/DuckDuckGo/Sync/SyncPixels.swift
@@ -109,10 +109,13 @@ enum SyncSetupPixelKitEvent: PixelKitEvent {
         static let linking = "linking"
         static let v1 = "v1"
         static let v2 = "v2"
+        static let v1Failure = "v1_failure"
         static let alreadyPaired = "already_paired"
         static let accountCreationFailed = "account_creation_failed"
         static let accountUpgradeFailed = "account_upgrade_failed"
         static let invalidCredentials = "invalid_credentials"
+        static let protocolError = "protocol_error"
+        static let transportFailure = "transport_failure"
         static let sessionTimeout = "session_timeout"
         static let needsUpgrade = "needs_upgrade"
         static let incompatibleCode = "incompatible_code"
@@ -127,12 +130,11 @@ enum SyncSetupPixelKitEvent: PixelKitEvent {
         static let recoveryCodePreparationFailed = "recovery_code_preparation_failed"
         static let peerRecoveryCodeUnavailable = "peer_recovery_code_unavailable"
         static let unexpectedFailure = "unexpected_failure"
-        static let fetchPublicKeyFailed = "fetch_public_key_failed"
-        static let transmitExchangeKeyFailed = "transmit_exchange_key_failed"
-        static let fetchExchangeRecoveryKeyFailed = "fetch_exchange_recovery_key_failed"
-        static let transmitExchangeRecoveryKeyFailed = "transmit_exchange_recovery_key_failed"
-        static let fetchConnectRecoveryKeyFailed = "fetch_connect_recovery_key_failed"
-        static let transmitConnectRecoveryKeyFailed = "transmit_connect_recovery_key_failed"
+        static let missingThirdPartyCredential = "missing_3party_credential"
+        static let undecryptableThirdPartyCredential = "undecryptable_3party_credential"
+        static let accountExtendFailed = "account_extend_failed"
+        static let missingThirdPartyKey = "missing_3party_key"
+        static let localStorageFailed = "local_storage_failed"
         static let host = "host"
         static let joiner = "joiner"
     }
@@ -331,21 +333,20 @@ extension SyncConnectionError {
 
     var syncSetupFailureReason: String? {
         switch self {
-        case .failedToLogIn:
+        // These cases are emitted by the legacy V1 exchange/connect flow and are intentionally bucketed together.
+        case .failedToLogIn,
+                .failedToFetchPublicKey,
+                .failedToTransmitExchangeRecoveryKey,
+                .failedToFetchConnectRecoveryKey,
+                .failedToTransmitExchangeKey,
+                .failedToFetchExchangeRecoveryKey,
+                .failedToTransmitConnectRecoveryKey,
+                .pollingForRecoveryKeyTimedOut,
+                .failedToCreateAccount:
+            return SyncSetupPixelKitEvent.ParameterValue.v1Failure
+        case .invalidCredentials:
             return SyncSetupPixelKitEvent.ParameterValue.invalidCredentials
-        case .failedToFetchPublicKey:
-            return SyncSetupPixelKitEvent.ParameterValue.fetchPublicKeyFailed
-        case .failedToTransmitExchangeRecoveryKey:
-            return SyncSetupPixelKitEvent.ParameterValue.transmitExchangeRecoveryKeyFailed
-        case .failedToFetchConnectRecoveryKey:
-            return SyncSetupPixelKitEvent.ParameterValue.fetchConnectRecoveryKeyFailed
-        case .failedToTransmitExchangeKey:
-            return SyncSetupPixelKitEvent.ParameterValue.transmitExchangeKeyFailed
-        case .failedToFetchExchangeRecoveryKey:
-            return SyncSetupPixelKitEvent.ParameterValue.fetchExchangeRecoveryKeyFailed
-        case .failedToTransmitConnectRecoveryKey:
-            return SyncSetupPixelKitEvent.ParameterValue.transmitConnectRecoveryKeyFailed
-        case .pollingForRecoveryKeyTimedOut:
+        case .pairingV2SessionTimedOut:
             return SyncSetupPixelKitEvent.ParameterValue.sessionTimeout
         case .updateRequired:
             return SyncSetupPixelKitEvent.ParameterValue.needsUpgrade
@@ -355,12 +356,14 @@ extension SyncConnectionError {
             return SyncSetupPixelKitEvent.ParameterValue.alreadyUpgraded
         case .unableToRecognizeCode:
             return SyncSetupPixelKitEvent.ParameterValue.unrecognizedCode
-        case .failedToCreateAccount:
+        case .accountCreationFailed:
             return SyncSetupPixelKitEvent.ParameterValue.accountCreationFailed
         case .accountUpgradeFailed:
             return SyncSetupPixelKitEvent.ParameterValue.accountUpgradeFailed
+        case .transportFailure:
+            return SyncSetupPixelKitEvent.ParameterValue.transportFailure
         case .protocolError:
-            return SyncSetupPixelKitEvent.ParameterValue.unexpectedFailure
+            return SyncSetupPixelKitEvent.ParameterValue.protocolError
         case .syncCancelledFromOtherDevice:
             return nil
         case .unexpectedSecondHello:
@@ -377,6 +380,16 @@ extension SyncConnectionError {
             return SyncSetupPixelKitEvent.ParameterValue.peerRecoveryCodeUnavailable
         case .unexpectedFailure:
             return SyncSetupPixelKitEvent.ParameterValue.unexpectedFailure
+        case .missingThirdPartyCredential:
+            return SyncSetupPixelKitEvent.ParameterValue.missingThirdPartyCredential
+        case .undecryptableThirdPartyCredential:
+            return SyncSetupPixelKitEvent.ParameterValue.undecryptableThirdPartyCredential
+        case .accountExtendFailed:
+            return SyncSetupPixelKitEvent.ParameterValue.accountExtendFailed
+        case .missingThirdPartyKey:
+            return SyncSetupPixelKitEvent.ParameterValue.missingThirdPartyKey
+        case .localStorageFailed:
+            return SyncSetupPixelKitEvent.ParameterValue.localStorageFailed
         }
     }
 }

--- a/macOS/DuckDuckGo/Sync/SyncPixels.swift
+++ b/macOS/DuckDuckGo/Sync/SyncPixels.swift
@@ -98,6 +98,7 @@ enum SyncSetupPixelKitEvent: PixelKitEvent {
         static let codeVersion = "code_version"
         static let path = "path"
         static let reason = "reason"
+        static let timeoutStage = "timeout_stage"
         static let peerKind = "peer_kind"
         static let myRole = "my_role"
     }
@@ -145,7 +146,7 @@ enum SyncSetupPixelKitEvent: PixelKitEvent {
     case syncSetupManualCodeEnteredSuccess(SyncSetupSource, flowVersion: String?, codeVersion: String?)
     case syncSetupManualCodeEnteredFailed(SyncSetupSource?, flowVersion: String?, reason: String?)
     case syncSetupEndedAbandoned(SyncSetupSource, flowVersion: String?, reason: String? = nil)
-    case syncSetupEndedFailed(SyncSetupSource?, flowVersion: String?, peerKind: String?, myRole: String?, reason: String?)
+    case syncSetupEndedFailed(SyncSetupSource?, flowVersion: String?, peerKind: String?, myRole: String?, reason: String?, timeoutStage: String?)
     case syncSetupEndedSuccessful(SyncSetupSource, flowVersion: String?, peerKind: String?, myRole: String?)
 
     var name: String {
@@ -169,6 +170,7 @@ enum SyncSetupPixelKitEvent: PixelKitEvent {
         parameters[ParameterKey.codeVersion] = codeVersion
         parameters[ParameterKey.path] = path
         parameters[ParameterKey.reason] = reason
+        parameters[ParameterKey.timeoutStage] = timeoutStage
         parameters[ParameterKey.peerKind] = peerKind
         parameters[ParameterKey.myRole] = myRole
         return parameters
@@ -185,7 +187,7 @@ enum SyncSetupPixelKitEvent: PixelKitEvent {
             return source
         case
             .syncSetupManualCodeEnteredFailed(let source, _, _),
-            .syncSetupEndedFailed(let source, _, _, _, _):
+            .syncSetupEndedFailed(let source, _, _, _, _, _):
             return source
         case
             .syncSetupManualCodeEntryScreenShown:
@@ -201,7 +203,7 @@ enum SyncSetupPixelKitEvent: PixelKitEvent {
                 .syncSetupManualCodeEnteredSuccess(_, let flowVersion, _),
                 .syncSetupManualCodeEnteredFailed(_, let flowVersion, _),
                 .syncSetupEndedAbandoned(_, let flowVersion, _),
-                .syncSetupEndedFailed(_, let flowVersion, _, _, _),
+                .syncSetupEndedFailed(_, let flowVersion, _, _, _, _),
                 .syncSetupEndedSuccessful(_, let flowVersion, _, _):
             return flowVersion
         }
@@ -229,7 +231,7 @@ enum SyncSetupPixelKitEvent: PixelKitEvent {
         switch self {
         case .syncSetupEndedSuccessful(let source, _, _, _):
             return source.syncSetupPath
-        case .syncSetupEndedFailed(let source, _, _, _, _):
+        case .syncSetupEndedFailed(let source, _, _, _, _, _):
             return source?.syncSetupPath
         default:
             return nil
@@ -240,7 +242,7 @@ enum SyncSetupPixelKitEvent: PixelKitEvent {
         switch self {
         case .syncSetupManualCodeEnteredFailed(_, _, let reason),
                 .syncSetupEndedAbandoned(_, _, let reason),
-                .syncSetupEndedFailed(_, _, _, _, let reason):
+                .syncSetupEndedFailed(_, _, _, _, let reason, _):
             return reason
         default:
             return nil
@@ -250,7 +252,7 @@ enum SyncSetupPixelKitEvent: PixelKitEvent {
     private var peerKind: String? {
         switch self {
         case .syncSetupEndedSuccessful(_, _, let peerKind, _),
-                .syncSetupEndedFailed(_, _, let peerKind, _, _):
+                .syncSetupEndedFailed(_, _, let peerKind, _, _, _):
             return peerKind
         default:
             return nil
@@ -260,8 +262,17 @@ enum SyncSetupPixelKitEvent: PixelKitEvent {
     private var myRole: String? {
         switch self {
         case .syncSetupEndedSuccessful(_, _, _, let myRole),
-                .syncSetupEndedFailed(_, _, _, let myRole, _):
+                .syncSetupEndedFailed(_, _, _, let myRole, _, _):
             return myRole
+        default:
+            return nil
+        }
+    }
+
+    private var timeoutStage: String? {
+        switch self {
+        case .syncSetupEndedFailed(_, _, _, _, _, let timeoutStage):
+            return timeoutStage
         default:
             return nil
         }
@@ -390,6 +401,15 @@ extension SyncConnectionError {
             return SyncSetupPixelKitEvent.ParameterValue.missingThirdPartyKey
         case .localStorageFailed:
             return SyncSetupPixelKitEvent.ParameterValue.localStorageFailed
+        }
+    }
+
+    var syncSetupTimeoutStage: String? {
+        switch self {
+        case .pairingV2SessionTimedOut(let timeoutStage):
+            return timeoutStage?.rawValue
+        default:
+            return nil
         }
     }
 }

--- a/macOS/DuckDuckGo/Sync/SyncPixels.swift
+++ b/macOS/DuckDuckGo/Sync/SyncPixels.swift
@@ -113,7 +113,6 @@ enum SyncSetupPixelKitEvent: PixelKitEvent {
         static let accountCreationFailed = "account_creation_failed"
         static let accountUpgradeFailed = "account_upgrade_failed"
         static let invalidCredentials = "invalid_credentials"
-        static let transportFailure = "transport_failure"
         static let sessionTimeout = "session_timeout"
         static let needsUpgrade = "needs_upgrade"
         static let incompatibleCode = "incompatible_code"
@@ -128,6 +127,12 @@ enum SyncSetupPixelKitEvent: PixelKitEvent {
         static let recoveryCodePreparationFailed = "recovery_code_preparation_failed"
         static let peerRecoveryCodeUnavailable = "peer_recovery_code_unavailable"
         static let unexpectedFailure = "unexpected_failure"
+        static let fetchPublicKeyFailed = "fetch_public_key_failed"
+        static let transmitExchangeKeyFailed = "transmit_exchange_key_failed"
+        static let fetchExchangeRecoveryKeyFailed = "fetch_exchange_recovery_key_failed"
+        static let transmitExchangeRecoveryKeyFailed = "transmit_exchange_recovery_key_failed"
+        static let fetchConnectRecoveryKeyFailed = "fetch_connect_recovery_key_failed"
+        static let transmitConnectRecoveryKeyFailed = "transmit_connect_recovery_key_failed"
         static let host = "host"
         static let joiner = "joiner"
     }
@@ -328,13 +333,18 @@ extension SyncConnectionError {
         switch self {
         case .failedToLogIn:
             return SyncSetupPixelKitEvent.ParameterValue.invalidCredentials
-        case .failedToFetchPublicKey,
-                .failedToTransmitExchangeRecoveryKey,
-                .failedToFetchConnectRecoveryKey,
-                .failedToTransmitExchangeKey,
-                .failedToFetchExchangeRecoveryKey,
-                .failedToTransmitConnectRecoveryKey:
-            return SyncSetupPixelKitEvent.ParameterValue.transportFailure
+        case .failedToFetchPublicKey:
+            return SyncSetupPixelKitEvent.ParameterValue.fetchPublicKeyFailed
+        case .failedToTransmitExchangeRecoveryKey:
+            return SyncSetupPixelKitEvent.ParameterValue.transmitExchangeRecoveryKeyFailed
+        case .failedToFetchConnectRecoveryKey:
+            return SyncSetupPixelKitEvent.ParameterValue.fetchConnectRecoveryKeyFailed
+        case .failedToTransmitExchangeKey:
+            return SyncSetupPixelKitEvent.ParameterValue.transmitExchangeKeyFailed
+        case .failedToFetchExchangeRecoveryKey:
+            return SyncSetupPixelKitEvent.ParameterValue.fetchExchangeRecoveryKeyFailed
+        case .failedToTransmitConnectRecoveryKey:
+            return SyncSetupPixelKitEvent.ParameterValue.transmitConnectRecoveryKeyFailed
         case .pollingForRecoveryKeyTimedOut:
             return SyncSetupPixelKitEvent.ParameterValue.sessionTimeout
         case .updateRequired:

--- a/macOS/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -228,7 +228,14 @@
                     "already_paired",
                     "account_creation_failed",
                     "account_upgrade_failed",
-                    "protocol_error"
+                    "protocol_error",
+                    "unexpected_second_hello",
+                    "unexpected_event",
+                    "pairing_session_not_ready",
+                    "relay_channel_unavailable",
+                    "recovery_code_preparation_failed",
+                    "peer_recovery_code_unavailable",
+                    "unexpected_failure"
                 ]
             }
         ]

--- a/macOS/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -222,7 +222,6 @@
                 "description": "The reason Sync setup failed, when it can be mapped safely.",
                 "enum": [
                     "session_timeout",
-                    "transport_failure",
                     "invalid_credentials",
                     "already_upgraded",
                     "already_paired",
@@ -235,7 +234,13 @@
                     "relay_channel_unavailable",
                     "recovery_code_preparation_failed",
                     "peer_recovery_code_unavailable",
-                    "unexpected_failure"
+                    "unexpected_failure",
+                    "fetch_public_key_failed",
+                    "transmit_exchange_key_failed",
+                    "fetch_exchange_recovery_key_failed",
+                    "transmit_exchange_recovery_key_failed",
+                    "fetch_connect_recovery_key_failed",
+                    "transmit_connect_recovery_key_failed"
                 ]
             }
         ]

--- a/macOS/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -243,6 +243,18 @@
                     "missing_3party_key",
                     "local_storage_failed"
                 ]
+            },
+            {
+                "key": "timeout_stage",
+                "type": "string",
+                "description": "The last Pairing V2 stage before a session_timeout failure, when known.",
+                "enum": [
+                    "waiting_for_peer_hello",
+                    "waiting_for_peer_status",
+                    "waiting_for_confirmation",
+                    "waiting_for_recovery_code",
+                    "logging_in"
+                ]
             }
         ]
     },

--- a/macOS/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -221,6 +221,7 @@
                 "type": "string",
                 "description": "The reason Sync setup failed, when it can be mapped safely.",
                 "enum": [
+                    "v1_failure",
                     "session_timeout",
                     "invalid_credentials",
                     "already_upgraded",
@@ -228,6 +229,7 @@
                     "account_creation_failed",
                     "account_upgrade_failed",
                     "protocol_error",
+                    "transport_failure",
                     "unexpected_second_hello",
                     "unexpected_event",
                     "pairing_session_not_ready",
@@ -235,12 +237,11 @@
                     "recovery_code_preparation_failed",
                     "peer_recovery_code_unavailable",
                     "unexpected_failure",
-                    "fetch_public_key_failed",
-                    "transmit_exchange_key_failed",
-                    "fetch_exchange_recovery_key_failed",
-                    "transmit_exchange_recovery_key_failed",
-                    "fetch_connect_recovery_key_failed",
-                    "transmit_connect_recovery_key_failed"
+                    "missing_3party_credential",
+                    "undecryptable_3party_credential",
+                    "account_extend_failed",
+                    "missing_3party_key",
+                    "local_storage_failed"
                 ]
             }
         ]


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216211575338678?focus=true
Tech Design URL:
CC:

### Description
Breaks down existing `sync_setup_ended_failed` reason buckets to more specific failure reasons 

### Testing Steps
1. Confirm CI is green

### Impact and Risks
What's the impact on users if something goes wrong?

Low: Minor visual changes, small bug fixes, improvement to existing features


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync pairing/login error classification and analytics contracts across iOS/macOS; user-visible flows stay similar but mis-mapped errors could skew metrics or mask rare auth/storage failures.
> 
> **Overview**
> **Sync setup failure telemetry** is split into many specific `sync_setup_ended_failed` **reason** values instead of broad buckets like generic transport failures. Legacy V1 errors are grouped under **`v1_failure`**, while Pairing V2 paths emit distinct reasons (relay, credentials, 3party credential/key issues, account create/extend, protocol edge cases, etc.).
> 
> **`SyncConnectionError`** gains Equatable, many new cases, and centralized **`syncSetupFailureReason`** / **`syncSetupTimeoutStage`** on DDGSync (removed duplicate mappings from iOS/macOS UI). Pairing V2 polling timeouts map to **`pairingV2SessionTimedOut`** with an optional **`timeout_stage`** pixel parameter. Lower layers (**`PairingV2Error`**, **`ScopedAccessCredentialError`**, upgrade/login flows) propagate finer errors (401 → invalid credentials, secure store → local storage, etc.) through the coordinator and connection controller.
> 
> iOS and macOS settings/controllers handle the new error cases and pass **`timeout_stage`** into failed-setup pixels; pixel definitions on both platforms document the expanded **reason** enum and **timeout_stage**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d9ec3763261e6040386a5a01e1fab0af4ac840c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->