### PR TITLE
[macOS] Update mac sync setup pixels to include normalized _mac suffix

### DIFF
--- a/macOS/DuckDuckGo/Sync/SyncPixels.swift
+++ b/macOS/DuckDuckGo/Sync/SyncPixels.swift
@@ -137,14 +137,14 @@ enum SyncSetupPixelKitEvent: PixelKitEvent {
 
     var name: String {
         switch self {
-        case .syncSetupBarcodeScreenShown: return "sync_setup_barcode_screen_shown"
-        case .syncSetupBarcodeCodeCopied: return "sync_setup_barcode_code_copied"
-        case .syncSetupManualCodeEntryScreenShown: return "sync_setup_manual_code_entry_screen_shown"
-        case .syncSetupManualCodeEnteredSuccess: return "sync_setup_manual_code_entered_success"
-        case .syncSetupManualCodeEnteredFailed: return "sync_setup_manual_code_entered_failed"
-        case .syncSetupEndedAbandoned: return "sync_setup_ended_abandoned"
-        case .syncSetupEndedFailed: return "sync_setup_ended_failed"
-        case .syncSetupEndedSuccessful: return "sync_setup_ended_successful"
+        case .syncSetupBarcodeScreenShown: return "sync_setup_barcode_screen_shown_mac"
+        case .syncSetupBarcodeCodeCopied: return "sync_setup_barcode_code_copied_mac"
+        case .syncSetupManualCodeEntryScreenShown: return "sync_setup_manual_code_entry_screen_shown_mac"
+        case .syncSetupManualCodeEnteredSuccess: return "sync_setup_manual_code_entered_success_mac"
+        case .syncSetupManualCodeEnteredFailed: return "sync_setup_manual_code_entered_failed_mac"
+        case .syncSetupEndedAbandoned: return "sync_setup_ended_abandoned_mac"
+        case .syncSetupEndedFailed: return "sync_setup_ended_failed_mac"
+        case .syncSetupEndedSuccessful: return "sync_setup_ended_successful_mac"
         }
     }
 

--- a/macOS/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -1,5 +1,5 @@
 {
-    "sync_setup_barcode_screen_shown": {
+    "sync_setup_barcode_screen_shown_mac": {
         "description": "Fired when the Sync setup QR/code screen is shown.",
         "owners": ["amddg44"],
         "triggers": ["other"],
@@ -25,7 +25,7 @@
             }
         ]
     },
-    "sync_setup_barcode_code_copied": {
+    "sync_setup_barcode_code_copied_mac": {
         "description": "Fired when the user copies the Sync setup code.",
         "owners": ["amddg44"],
         "triggers": ["other"],
@@ -51,7 +51,7 @@
             }
         ]
     },
-    "sync_setup_manual_code_entry_screen_shown": {
+    "sync_setup_manual_code_entry_screen_shown_mac": {
         "description": "Fired when the Sync setup manual code-entry screen is shown.",
         "owners": ["amddg44"],
         "triggers": ["other"],
@@ -72,7 +72,7 @@
             }
         ]
     },
-    "sync_setup_manual_code_entered_success": {
+    "sync_setup_manual_code_entered_success_mac": {
         "description": "Fired when Sync setup recognizes a manually entered or pasted code.",
         "owners": ["amddg44"],
         "triggers": ["other"],
@@ -110,7 +110,7 @@
             }
         ]
     },
-    "sync_setup_manual_code_entered_failed": {
+    "sync_setup_manual_code_entered_failed_mac": {
         "description": "Fired when Sync setup rejects a manually entered or pasted code.",
         "owners": ["amddg44"],
         "triggers": ["other"],
@@ -142,7 +142,7 @@
             }
         ]
     },
-    "sync_setup_ended_abandoned": {
+    "sync_setup_ended_abandoned_mac": {
         "description": "Fired when the user abandons Sync setup before completion.",
         "owners": ["amddg44"],
         "triggers": ["other"],
@@ -174,7 +174,7 @@
             }
         ]
     },
-    "sync_setup_ended_failed": {
+    "sync_setup_ended_failed_mac": {
         "description": "Fired when Sync setup started from a recognized code but failed before completion.",
         "owners": ["amddg44"],
         "triggers": ["other"],
@@ -233,7 +233,7 @@
             }
         ]
     },
-    "sync_setup_ended_successful": {
+    "sync_setup_ended_successful_mac": {
         "description": "Fired when Sync setup completes successfully.",
         "owners": ["amddg44"],
         "triggers": ["other"],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203822806345703/task/1216168380934815?focus=true
Tech Design URL:
CC:

### Description
Update Sync pixels on macOS to follow O-I pixel naming conventions

### Testing Steps
1. Click “Sync with Another Device”, confirm pixel `sync_setup_barcode_screen_shown_mac` contains `_mac` suffix

### Impact and Risks
What's the impact on users if something goes wrong?

Low: Minor visual changes, small bug fixes, improvement to existing features

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only renames; dashboards or queries keyed on the old pixel names will need updating, but app Sync behavior is unaffected.
> 
> **Overview**
> Renames **eight macOS Sync setup analytics pixels** to use the normalized `_mac` suffix so mac events align with O-I pixel naming and can be distinguished from other platforms.
> 
> **`SyncSetupPixelKitEvent`** string IDs now end in `_mac` (e.g. `sync_setup_barcode_screen_shown_mac`, `sync_setup_ended_successful_mac`). Event payloads and parameters are unchanged.
> 
> **`sync_setup.json5`** pixel definition keys are updated to the same `_mac` names so runtime firing matches the schema registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9322add2edc887442dfb836fd7b79bafeed3f1ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->