### PR TITLE
Remove aiChatRemoveSuggestion feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -529,9 +529,6 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// Enables improved contextual sheet UX (welcome message, ask about page, etc.)
     case contextualSheetImprovements
 
-    /// Enables removing individual AI chat suggestions
-    case removeSuggestion
-
     /// Enables the fire button in the contextual AI chat sheet
     case contextualFireButton
 

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -886,34 +886,31 @@ final class AIChatOmnibarContainerViewController: NSViewController {
             )
         }
 
-        // Handle suggestion deletions (gated by feature flag)
-        let canRemoveSuggestions = NSApp.delegateTyped.featureFlagger.isFeatureOn(.aiChatRemoveSuggestion)
-        suggestionsView.canDeleteSuggestions = canRemoveSuggestions
-        if canRemoveSuggestions {
-            suggestionsView.onSuggestionDeleted = { [weak self] suggestion in
-                guard let self, let window = self.view.window else { return }
+        // Handle suggestion deletions
+        suggestionsView.canDeleteSuggestions = true
+        suggestionsView.onSuggestionDeleted = { [weak self] suggestion in
+            guard let self, let window = self.view.window else { return }
 
-                PixelKit.fire(AIChatPixel.aiChatRecentChatDeleteButtonClicked, frequency: .dailyAndCount, includeAppVersionParameter: true)
+            PixelKit.fire(AIChatPixel.aiChatRecentChatDeleteButtonClicked, frequency: .dailyAndCount, includeAppVersionParameter: true)
 
-                let alert = NSAlert()
-                alert.messageText = UserText.removeRecentChatConfirmationTitle
-                alert.informativeText = String(format: UserText.removeRecentChatConfirmationMessage, suggestion.title)
-                alert.addButton(withTitle: UserText.removeRecentChatConfirmationButton, response: .OK)
-                alert.buttons.first?.hasDestructiveAction = true
-                alert.addButton(withTitle: UserText.cancel, response: .cancel, keyEquivalent: .escape)
+            let alert = NSAlert()
+            alert.messageText = UserText.removeRecentChatConfirmationTitle
+            alert.informativeText = String(format: UserText.removeRecentChatConfirmationMessage, suggestion.title)
+            alert.addButton(withTitle: UserText.removeRecentChatConfirmationButton, response: .OK)
+            alert.buttons.first?.hasDestructiveAction = true
+            alert.addButton(withTitle: UserText.cancel, response: .cancel, keyEquivalent: .escape)
 
-                alert.beginSheetModal(for: window) { [weak self] response in
-                    guard let self else { return }
-                    guard response == .OK else {
-                        PixelKit.fire(AIChatPixel.aiChatRecentChatDeleteCancelled, frequency: .dailyAndCount, includeAppVersionParameter: true)
-                        return
-                    }
-                    PixelKit.fire(AIChatPixel.aiChatRecentChatDeleteConfirmed, frequency: .dailyAndCount, includeAppVersionParameter: true)
-                    self.omnibarController.suggestionsViewModel.removeSuggestion(suggestion)
-                    Task { @MainActor in
-                        _ = await self.historyCleaner.deleteAIChat(chatID: suggestion.chatId)
-                        self.omnibarController.refreshSuggestions()
-                    }
+            alert.beginSheetModal(for: window) { [weak self] response in
+                guard let self else { return }
+                guard response == .OK else {
+                    PixelKit.fire(AIChatPixel.aiChatRecentChatDeleteCancelled, frequency: .dailyAndCount, includeAppVersionParameter: true)
+                    return
+                }
+                PixelKit.fire(AIChatPixel.aiChatRecentChatDeleteConfirmed, frequency: .dailyAndCount, includeAppVersionParameter: true)
+                self.omnibarController.suggestionsViewModel.removeSuggestion(suggestion)
+                Task { @MainActor in
+                    _ = await self.historyCleaner.deleteAIChat(chatID: suggestion.chatId)
+                    self.omnibarController.refreshSuggestions()
                 }
             }
         }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -373,10 +373,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Defers menu population to NSMenuDelegate.menuNeedsUpdate(_:) to avoid expensive eager rebuilds
     case lazyMenuRebuild
 
-    /// Enables removing individual AI chat suggestions from the omnibar
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213761882751264?focus=true
-    case aiChatRemoveSuggestion
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213813585476250?focus=true
     case screenTimeCleaning
 
@@ -687,8 +683,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.websitesHistoryFirstTimeQuitSurvey))
         case .lazyMenuRebuild:
             Config(defaultValue: .enabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.lazyMenuRebuild))
-        case .aiChatRemoveSuggestion:
-            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.removeSuggestion), category: .duckAI)
         case .screenTimeCleaning:
             Config(defaultValue: .enabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.screenTimeCleaning))
         case .tabSuspension:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1213761882751264?focus=true
Tech Design URL:
CC:

### Description

The `aiChatRemoveSuggestion` feature was accepted, so this PR removes the feature flag and treats all conditional paths that checked it as always enabled.

Changes:
- Removed the `aiChatRemoveSuggestion` case and its `Config` entry from the macOS `FeatureFlag` package.
- Removed the now-orphaned `removeSuggestion` subfeature from `AIChatSubfeature` in `PrivacyFeature.swift` (it was only referenced by the removed flag).
- Inlined the always-enabled behavior in `AIChatOmnibarContainerViewController`: `canDeleteSuggestions` is now always `true` and the `onSuggestionDeleted` handler is always installed.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Open the Duck.ai omnibar so recent chat suggestions are shown.
2. Hover over a suggestion and use the delete affordance; confirm the removal confirmation alert appears.
3. Confirm deletion and verify the chat is removed from suggestions and history.

### Impact and Risks

Low: Removes an internal-only gate for an accepted feature. The suggestion-deletion behavior is now always available.

#### What could go wrong?

The suggestion-deletion feature is now enabled for all users regardless of remote configuration. This is intended since the feature was accepted.

### Notes to Reviewer

The removed subfeature had no remaining code references after removing the flag.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c424df3-c271-4bb4-a9b0-b88587e54d91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c424df3-c271-4bb4-a9b0-b88587e54d91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

