### PR TITLE
macOS: Remove aiChatOmnibarToggle feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -439,9 +439,6 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// Enables Duck.ai query experiment with tracker-blocking demo during onboarding
     case onboardingDuckAIQueryTrackersDemoExperiment
 
-    /// Enables the omnibar toggle for AI Chat
-    case omnibarToggle
-
     /// Enables the omnibar onboarding for AI Chat
     case omnibarOnboarding
 

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -1064,13 +1064,13 @@ final class MainViewController: NSViewController {
         /// the panel (unfocused + prompt preserved). Skip the panel tear-down and the address-bar focus grab
         /// below — otherwise we'd reset the tab's shared duck.ai flag and exit back to search.
         let isIncomingTabInDuckAIMode = selectedTabViewModel.addressBarSharedTextState.isInDuckAIMode
-        if isIncomingTabInDuckAIMode, featureFlagger.isFeatureOn(.aiChatOmnibarToggle) {
+        if isIncomingTabInDuckAIMode {
             return
         }
 
         /// Close AI Chat omnibar if visible before adjusting first responder
         /// https://app.asana.com/1/137249556945/project/1204167627774280/task/1212252449969913?focus=true
-        if mainView.isAIChatOmnibarContainerShown && featureFlagger.isFeatureOn(.aiChatOmnibarToggle) {
+        if mainView.isAIChatOmnibarContainerShown {
             updateAIChatOmnibarContainerVisibility(visible: false, shouldKeepSelection: false)
             aiChatOmnibarContainerViewController.cleanup()
         }
@@ -1168,7 +1168,6 @@ extension MainViewController {
         }
 
         if flags.contains(.option) || flags.contains(.shift),
-           featureFlagger.isFeatureOn(.aiChatOmnibarToggle),
            let buttonsViewController = navigationBarViewController.addressBarViewController?.addressBarButtonsViewController {
             let isSwitchingToAIChatMode = buttonsViewController.searchModeToggleControl?.selectedSegment == 0
             buttonsViewController.toggleSearchMode()
@@ -1177,8 +1176,7 @@ extension MainViewController {
                 self.aiChatOmnibarTextContainerViewController.insertNewlineIfHasContent(addressBarText: currentText)
             }
             return true
-        } else if flags.contains(.control),
-                  featureFlagger.isFeatureOn(.aiChatOmnibarToggle) {
+        } else if flags.contains(.control) {
             addressBarTextField.openAIChatWithPrompt()
             return true
         } else if flags.contains(.shift) && aiChatMenuConfig.shouldDisplayAddressBarShortcutWhenTyping {

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -83,7 +83,6 @@ final class AddressBarButtonsViewController: NSViewController {
 
     /// Struct to keep track of some Toggle conditions to avoid expensive operations like checking user defaults
     private struct AIChatOmnibarToggleConditions {
-        let isFeatureOn: Bool
         let hasUserInteractedWithToggle: Bool
     }
 
@@ -297,8 +296,7 @@ final class AddressBarButtonsViewController: NSViewController {
     private let aiChatCoordinator: AIChatCoordinating
     private let aiChatSettings: AIChatPreferencesStorage
     private lazy var aiChatToggleConditions: AIChatOmnibarToggleConditions = {
-        AIChatOmnibarToggleConditions(isFeatureOn: featureFlagger.isFeatureOn(.aiChatOmnibarToggle),
-                                      hasUserInteractedWithToggle: UserDefaults.standard.hasInteractedWithSearchDuckAIToggle)
+        AIChatOmnibarToggleConditions(hasUserInteractedWithToggle: UserDefaults.standard.hasInteractedWithSearchDuckAIToggle)
     }()
     private var isChromeSidebarFeatureEnabled: Bool {
         featureFlagger.isFeatureOn(.aiChatChromeSidebar)
@@ -1330,7 +1328,7 @@ final class AddressBarButtonsViewController: NSViewController {
             return
         }
 
-        if isTextFieldEditorFirstResponder && featureFlagger.isFeatureOn(.aiChatOmnibarToggle) {
+        if isTextFieldEditorFirstResponder {
             bookmarkButton.isShown = false
             updateAIChatDividerVisibility()
             return
@@ -1425,7 +1423,7 @@ final class AddressBarButtonsViewController: NSViewController {
     private var isAskAIChatButtonExpanded: Bool = false
 
     private func updateAskAIChatButtonVisibility(isSidebarOpen: Bool? = nil) {
-        let isToggleFeatureEnabled = isTextFieldEditorFirstResponder && featureFlagger.isFeatureOn(.aiChatOmnibarToggle) && aiChatSettings.isAIFeaturesEnabled
+        let isToggleFeatureEnabled = isTextFieldEditorFirstResponder && aiChatSettings.isAIFeaturesEnabled
 
         if isTextFieldEditorFirstResponder {
             if isToggleFeatureEnabled {
@@ -1900,7 +1898,7 @@ final class AddressBarButtonsViewController: NSViewController {
     /// Per the new design the toggle is visible in all selection states (focused and unfocused) so the user can
     /// always see / change the tab's current mode — previously it was gated on the address bar being first responder.
     private var isSearchModeToggleFeatureActive: Bool {
-        featureFlagger.isFeatureOn(.aiChatOmnibarToggle) && aiChatSettings.isAIFeaturesEnabled
+        aiChatSettings.isAIFeaturesEnabled
     }
 
     /// True when the toggle should be shown (feature active + user setting enabled).
@@ -2262,8 +2260,7 @@ final class AddressBarButtonsViewController: NSViewController {
     }
 
     private func updateAIChatToggleConditions() {
-        aiChatToggleConditions = AIChatOmnibarToggleConditions(isFeatureOn: featureFlagger.isFeatureOn(.aiChatOmnibarToggle),
-                                                                hasUserInteractedWithToggle: UserDefaults.standard.hasInteractedWithSearchDuckAIToggle)
+        aiChatToggleConditions = AIChatOmnibarToggleConditions(hasUserInteractedWithToggle: UserDefaults.standard.hasInteractedWithSearchDuckAIToggle)
     }
 
     @objc private func searchModeToggleDidChange(_ sender: CustomToggleControl) {

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -225,8 +225,7 @@ final class AddressBarTextField: NSTextField {
         perfAIModeTerminatorCancellable?.cancel()
         perfAIModeTerminatorCancellable = nil
 
-        guard Application.appDelegate.featureFlagger.isFeatureOn(.aiChatOmnibarToggle),
-              let sharedTextState else { return }
+        guard let sharedTextState else { return }
 
         perfAIModeTerminatorCancellable = sharedTextState.$isInDuckAIMode
             .dropFirst()
@@ -744,25 +743,19 @@ final class AddressBarTextField: NSTextField {
     enum SuggestionWindowSizes {
 
         private enum ToggleAlignmentOffset {
-            static let rebrandedWithToggle: CGFloat = 2
-            static let rebrandedWithoutToggle: CGFloat = 1
-            static let legacyWithToggle: CGFloat = 4
-            static let legacyWithoutToggle: CGFloat = 0
+            static let rebranded: CGFloat = 2
+            static let legacy: CGFloat = 4
         }
 
         private static let padding = CGPoint(x: -20, y: 1)
 
-        static func verticalOffset(isAppRebranded: Bool, aiChatOmnibarToggleEnabled: Bool) -> CGFloat {
-            if isAppRebranded {
-                return aiChatOmnibarToggleEnabled ? ToggleAlignmentOffset.rebrandedWithToggle : ToggleAlignmentOffset.rebrandedWithoutToggle
-            }
-
-            return aiChatOmnibarToggleEnabled ? ToggleAlignmentOffset.legacyWithToggle : ToggleAlignmentOffset.legacyWithoutToggle
+        static func verticalOffset(isAppRebranded: Bool) -> CGFloat {
+            isAppRebranded ? ToggleAlignmentOffset.rebranded : ToggleAlignmentOffset.legacy
         }
 
-        static func padding(isAppRebranded: Bool, aiChatOmnibarToggleEnabled: Bool) -> CGPoint {
+        static func padding(isAppRebranded: Bool) -> CGPoint {
             var output = padding
-            output.y += verticalOffset(isAppRebranded: isAppRebranded, aiChatOmnibarToggleEnabled: aiChatOmnibarToggleEnabled)
+            output.y += verticalOffset(isAppRebranded: isAppRebranded)
             return output
         }
     }
@@ -860,8 +853,7 @@ final class AddressBarTextField: NSTextField {
         }
 
         /// Shift the panel so its top edge clears the AI Chat omnibar toggle / aligns with the focused bar.
-        let isOmnibarEnabled = Application.appDelegate.featureFlagger.isFeatureOn(.aiChatOmnibarToggle)
-        let padding = SuggestionWindowSizes.padding(isAppRebranded: themeManager.isAppRebranded, aiChatOmnibarToggleEnabled: isOmnibarEnabled)
+        let padding = SuggestionWindowSizes.padding(isAppRebranded: themeManager.isAppRebranded)
 
         suggestionWindow.setFrame(NSRect(x: 0, y: 0, width: superview.frame.width - 2 * padding.x, height: 0), display: true)
 
@@ -1421,7 +1413,6 @@ extension AddressBarTextField: NSTextViewDelegate {
         }
 
         let featureFlagger = Application.appDelegate.featureFlagger
-        let isAIChatOmnibarToggleEnabled = featureFlagger.isFeatureOn(.aiChatOmnibarToggle)
         let isChromeSidebarEnabled = featureFlagger.isFeatureOn(.aiChatChromeSidebar)
         let isGlobalAIEnabled = AIChatPreferences().isAIFeaturesEnabled
 
@@ -1431,10 +1422,10 @@ extension AddressBarTextField: NSTextViewDelegate {
         ]
 
         if isGlobalAIEnabled && !isChromeSidebarEnabled {
-            additionalMenuItems.append(.toggleAIChatAddressMenuItem(isOmnibarToggleEnabled: isAIChatOmnibarToggleEnabled))
+            additionalMenuItems.append(.toggleAIChatAddressMenuItem())
         }
 
-        if isGlobalAIEnabled && isAIChatOmnibarToggleEnabled {
+        if isGlobalAIEnabled {
             additionalMenuItems.append(.toggleAIChatToggleMenuItem)
         }
 
@@ -1513,8 +1504,8 @@ private extension NSMenuItem {
         return menuItem
     }
 
-    static func toggleAIChatAddressMenuItem(isOmnibarToggleEnabled: Bool) -> NSMenuItem {
-        let title = isOmnibarToggleEnabled ? UserText.showAIChatShortcutInAddress : UserText.showAIChatInAddress
+    static func toggleAIChatAddressMenuItem() -> NSMenuItem {
+        let title = UserText.showAIChatShortcutInAddress
         let menuItem = NSMenuItem(
             title: title,
             action: #selector(AddressBarTextField.toggleAIChatAddress(_:)),

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -916,8 +916,7 @@ final class AddressBarViewController: NSViewController {
         var frame = superview.convert(winFrame, from: nil)
 
         /// Keep the suggestions shadow aligned with the panel by applying the same vertical offset.
-        let isOmnibarEnabled = featureFlagger.isFeatureOn(.aiChatOmnibarToggle)
-        let offset = AddressBarTextField.SuggestionWindowSizes.verticalOffset(isAppRebranded: themeManager.isAppRebranded, aiChatOmnibarToggleEnabled: isOmnibarEnabled)
+        let offset = AddressBarTextField.SuggestionWindowSizes.verticalOffset(isAppRebranded: themeManager.isAppRebranded)
         frame.origin.y += offset
         frame.size.height -= offset
 
@@ -1020,7 +1019,7 @@ final class AddressBarViewController: NSViewController {
         /// When the toggle feature is on, all editing states have no left icon, so we pin the text at a constant
         /// padding that matches the Duck.ai prompt panel's leading inset. When the buttons container is wider
         /// (e.g. browsing with the privacy dashboard showing), we respect that width so the text clears the button.
-        let isToggleFeatureEnabled = featureFlagger.isFeatureOn(.aiChatOmnibarToggle) && aiChatSettings.isAIFeaturesEnabled
+        let isToggleFeatureEnabled = aiChatSettings.isAIFeaturesEnabled
         let isToggleVisible = isToggleFeatureEnabled && aiChatSettings.showSearchAndDuckAIToggle
 
         let styleProvider = theme.addressBarStyleProvider
@@ -1040,9 +1039,8 @@ final class AddressBarViewController: NSViewController {
         /// The negative offset compensates for the leading padding of the search icon so the typed text sits
         /// flush against it (the buttons side sets a matching positive pad on the privacy-shield constraint —
         /// see `AddressBarButtonsViewController.IconLeadingTuning`). With the redesign, editing states
-        /// (`.text`, `.url`, `.openTabSuggestion`, `.aiChat`) no longer render a leading icon regardless of
-        /// the `aiChatOmnibarToggle` flag — skip the offset so the text isn't pushed past the (now-narrower)
-        /// buttons container's left edge on that path.
+        /// (`.text`, `.url`, `.openTabSuggestion`, `.aiChat`) no longer render a leading icon — skip the
+        /// offset so the text isn't pushed past the (now-narrower) buttons container's left edge on that path.
         if styleProvider.shouldShowNewSearchIcon && !self.mode.isEditing {
             let pullback = isAddressBarFocused
                 ? AddressBarButtonsViewController.IconLeadingTuning.textFieldPullback.focused
@@ -1123,8 +1121,7 @@ final class AddressBarViewController: NSViewController {
     }
 
     private func fireAddressBarActivatedPixelIfNeeded() {
-        guard featureFlagger.isFeatureOn(.aiChatOmnibarToggle),
-              aiChatSettings.isAIFeaturesEnabled else {
+        guard aiChatSettings.isAIFeaturesEnabled else {
             return
         }
 

--- a/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
@@ -173,10 +173,9 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
     private func buildExcludedSteps() -> [String] {
         var excludedSteps: [String] = [OnboardingExcludedStep.duckPlayerSingle.rawValue]
 
-        let isAIChatOmnibarToggleEnabled = featureFlagger.isFeatureOn(.aiChatOmnibarToggle)
         let isAIChatOmnibarOnboardingEnabled = featureFlagger.isFeatureOn(.aiChatOmnibarOnboarding)
 
-        if !(isAIChatOmnibarToggleEnabled && isAIChatOmnibarOnboardingEnabled) {
+        if !isAIChatOmnibarOnboardingEnabled {
             excludedSteps.append(OnboardingExcludedStep.addressBarMode.rawValue)
         }
 
@@ -497,11 +496,9 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
     }
 
     /// Returns true if the toggle onboarding step was shown to the user.
-    /// The step is only shown when both aiChatOmnibarToggle AND aiChatOmnibarOnboarding flags are enabled.
+    /// The step is only shown when the aiChatOmnibarOnboarding flag is enabled.
     private func wasToggleOnboardingStepShown() -> Bool {
-        let isAIChatOmnibarToggleEnabled = featureFlagger.isFeatureOn(.aiChatOmnibarToggle)
-        let isAIChatOmnibarOnboardingEnabled = featureFlagger.isFeatureOn(.aiChatOmnibarOnboarding)
-        return isAIChatOmnibarToggleEnabled && isAIChatOmnibarOnboardingEnabled
+        return featureFlagger.isFeatureOn(.aiChatOmnibarOnboarding)
     }
 
     private func fireOnboardingFinishedPixels(userSawToggleOnboarding: Bool) {

--- a/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
@@ -136,10 +136,6 @@ final class AIChatPreferences: ObservableObject {
         featureFlagger.isFeatureOn(.aiChatSettingsLinkInAiFeatures)
     }
 
-    var shouldShowSearchAndDuckAIToggleOption: Bool {
-        featureFlagger.isFeatureOn(.aiChatOmnibarToggle)
-    }
-
     var shouldShowTabBarButtonVisibilityOptions: Bool {
         featureFlagger.isFeatureOn(.aiChatChromeSidebar)
     }

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
@@ -161,26 +161,9 @@ extension Preferences {
                     }
                     .visibility(model.shouldShowNewTabPageToggle ? .visible : .gone)
 
-                    if model.shouldShowSearchAndDuckAIToggleOption {
-                        ToggleMenuItem(UserText.aiChatShowSearchAndDuckAIToggleLabel,
-                                       isOn: $model.showSearchAndDuckAIToggle)
-                        .accessibilityIdentifier("Preferences.AIChat.showSearchAndDuckAIToggleToggle")
-                    } else {
-                        ToggleMenuItem(UserText.aiChatShowInAddressBarWhenTypingLabel,
-                                       isOn: $model.showShortcutInAddressBarWhenTyping)
-                        .accessibilityIdentifier("Preferences.AIChat.showInAddressBarWhenTypingToggle")
-                        .onChange(of: model.showShortcutInAddressBarWhenTyping) { newValue in
-                            if newValue {
-                                PixelKit.fire(AIChatPixel.aiChatSettingsAddressBarTypingShortcutTurnedOn,
-                                              frequency: .dailyAndCount,
-                                              includeAppVersionParameter: true)
-                            } else {
-                                PixelKit.fire(AIChatPixel.aiChatSettingsAddressBarTypingShortcutTurnedOff,
-                                              frequency: .dailyAndCount,
-                                              includeAppVersionParameter: true)
-                            }
-                        }
-                    }
+                    ToggleMenuItem(UserText.aiChatShowSearchAndDuckAIToggleLabel,
+                                   isOn: $model.showSearchAndDuckAIToggle)
+                    .accessibilityIdentifier("Preferences.AIChat.showSearchAndDuckAIToggleToggle")
 
                     if model.shouldShowTabBarButtonVisibilityOptions {
                         ToggleMenuItem(UserText.aiChatShowDuckAIButtonInTabBarLabel,

--- a/macOS/DuckDuckGo/Suggestions/View/SuggestionViewController.swift
+++ b/macOS/DuckDuckGo/Suggestions/View/SuggestionViewController.swift
@@ -98,13 +98,11 @@ final class SuggestionViewController: NSViewController {
         subscribeToThemeChanges()
         applyThemeStyle()
 
-        if Application.appDelegate.featureFlagger.isFeatureOn(.aiChatOmnibarToggle) {
-            topSeparatorView?.isHidden = true
-        }
+        topSeparatorView?.isHidden = true
     }
 
     private func updateAIChatToggleFlag() {
-        let isToggleFeatureEnabled = Application.appDelegate.featureFlagger.isFeatureOn(.aiChatOmnibarToggle) && aiChatPreferencesStorage.isAIFeaturesEnabled
+        let isToggleFeatureEnabled = aiChatPreferencesStorage.isAIFeaturesEnabled
         isAIChatToggleBeingDisplayed = isToggleFeatureEnabled && aiChatPreferencesStorage.showSearchAndDuckAIToggle
     }
 

--- a/macOS/DuckDuckGo/Suggestions/ViewModel/SuggestionContainerViewModel.swift
+++ b/macOS/DuckDuckGo/Suggestions/ViewModel/SuggestionContainerViewModel.swift
@@ -148,7 +148,6 @@ final class SuggestionContainerViewModel {
     }
 
     private var shouldShowAIChatCellBase: Bool {
-        guard featureFlagger.isFeatureOn(.aiChatOmnibarToggle) else { return false }
         guard aiChatPreferencesStorage.isAIFeaturesEnabled else { return false }
         guard let userStringValue, !userStringValue.isEmpty else { return false }
         return true

--- a/macOS/DuckDuckGo/VisualRefresh/AddressBarStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/AddressBarStyleProviding.swift
@@ -73,10 +73,10 @@ struct AddressBarStyleProvidingFactory {
 
     static func buildStyleProvider(featureFlagger: FeatureFlagger) -> AddressBarStyleProviding {
         if featureFlagger.isFeatureOn(.appRebranding) {
-            return CurrentAddressBarStyleProvider(featureFlagger: featureFlagger)
+            return CurrentAddressBarStyleProvider()
         }
 
-        return LegacyAddressBarStyleProvider(featureFlagger: featureFlagger)
+        return LegacyAddressBarStyleProvider()
     }
 }
 
@@ -114,16 +114,6 @@ final class LegacyAddressBarStyleProvider: AddressBarStyleProviding {
     private let addressBarTrailingStackViewOmnibarPadding: CGFloat = 4
     private let addressBarTrailingStackViewFocusedPadding: CGFloat = 4
     private let addressBarTrailingStackViewDefaultPadding: CGFloat = 3
-
-    private let featureFlagger: FeatureFlagger
-
-    private var isAIChatOmnibarEnabled: Bool {
-        featureFlagger.isFeatureOn(.aiChatOmnibarToggle)
-    }
-
-    init(featureFlagger: FeatureFlagger) {
-        self.featureFlagger = featureFlagger
-    }
 
     let defaultAddressBarFontSize: CGFloat = 13
     let newTabOrHomePageAddressBarFontSize: CGFloat = 13
@@ -167,12 +157,12 @@ final class LegacyAddressBarStyleProvider: AddressBarStyleProviding {
         switch type {
         case .default:
             if focused {
-                return isAIChatOmnibarEnabled ? addressBarTopPaddingForDefaultFocusedWithAIChat : addressBarTopPaddingForDefault - 1
+                return addressBarTopPaddingForDefaultFocusedWithAIChat
             }
             return addressBarTopPaddingForDefault
         case .homePage:
             if focused {
-                return isAIChatOmnibarEnabled ? addressBarTopPaddingForHomePageFocusedWithAIChat : addressBarTopPaddingForHomePage - 1
+                return addressBarTopPaddingForHomePageFocusedWithAIChat
             }
             return addressBarTopPaddingForHomePage
         case .popUpWindow:
@@ -184,12 +174,12 @@ final class LegacyAddressBarStyleProvider: AddressBarStyleProviding {
         switch type {
         case .default:
             if focused {
-                return isAIChatOmnibarEnabled ? addressBarBottomPaddingForDefaultFocusedWithAIChat : addressBarBottomPaddingForDefault - 1
+                return addressBarBottomPaddingForDefaultFocusedWithAIChat
             }
             return addressBarBottomPaddingForDefault
         case .homePage:
             if focused {
-                return isAIChatOmnibarEnabled ? addressBarBottomPaddingForHomePageFocusedWithAIChat : addressBarBottomPaddingForHomePage - 1
+                return addressBarBottomPaddingForHomePageFocusedWithAIChat
             }
             return addressBarBottomPaddingForHomePage
         case .popUpWindow:
@@ -206,11 +196,7 @@ final class LegacyAddressBarStyleProvider: AddressBarStyleProviding {
     }
 
     func addressBarTrailingStackViewPadding(focused: Bool, showsToggle: Bool) -> CGFloat {
-        if featureFlagger.isFeatureOn(.aiChatOmnibarToggle) {
-            return addressBarTrailingStackViewOmnibarPadding
-        }
-
-        return focused ? addressBarTrailingStackViewFocusedPadding : addressBarTrailingStackViewDefaultPadding
+        return addressBarTrailingStackViewOmnibarPadding
     }
 
     func shouldShowOutlineBorder(isHomePage: Bool) -> Bool {
@@ -289,15 +275,6 @@ final class CurrentAddressBarStyleProvider: AddressBarStyleProviding {
         return 0
     }()
 
-    // MARK: - Feature Flag Helpers
-    private let featureFlagger: FeatureFlagger
-
-    /// Designated Initializer
-    ///
-    init(featureFlagger: FeatureFlagger) {
-        self.featureFlagger = featureFlagger
-    }
-
     // MARK: - Public API(s)
 
     func navigationBarHeight(for type: AddressBarSizeClass, focused: Bool) -> CGFloat {
@@ -338,11 +315,7 @@ final class CurrentAddressBarStyleProvider: AddressBarStyleProviding {
     }
 
     func addressBarTrailingStackViewPadding(focused: Bool, showsToggle: Bool) -> CGFloat {
-        if featureFlagger.isFeatureOn(.aiChatOmnibarToggle) {
-            return showsToggle ? addressBarTrailingStackViewOmnibarPadding : addressBarTrailingStackViewDefaultPadding
-        }
-
-        return focused ? addressBarTrailingStackViewFocusedPadding : addressBarTrailingStackViewDefaultPadding
+        return showsToggle ? addressBarTrailingStackViewOmnibarPadding : addressBarTrailingStackViewDefaultPadding
     }
 
     func shouldShowOutlineBorder(isHomePage: Bool) -> Bool {

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -144,9 +144,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866617328244
     case aiChatKeepSession
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212016242789291
-    case aiChatOmnibarToggle
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212745919983886?focus=true
     case aiChatSuggestions
 
@@ -557,8 +554,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.selectionContext), category: .duckAI)
         case .aiChatKeepSession:
             Config(source: .remoteReleasable(AIChatSubfeature.keepSession), category: .duckAI)
-        case .aiChatOmnibarToggle:
-            Config(source: .remoteReleasable(AIChatSubfeature.omnibarToggle), category: .duckAI)
         case .aiChatSuggestions:
             Config(defaultValue: .enabled, source: .remoteReleasable(DuckAiChatHistorySubfeature.featureEnabled), category: .duckAI)
         case .aiChatOmnibarTools:

--- a/macOS/UITests/AIChatMultilinePasteTests.swift
+++ b/macOS/UITests/AIChatMultilinePasteTests.swift
@@ -30,7 +30,7 @@ class AIChatMultilinePasteTests: UITestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         continueAfterFailure = false
-        app = XCUIApplication.setUp(featureFlags: ["aiChatOmnibarToggle": true])
+        app = XCUIApplication.setUp()
 
         addressBarTextField = app.addressBar
         app.enforceSingleWindow()
@@ -38,7 +38,6 @@ class AIChatMultilinePasteTests: UITestCase {
 
     override func tearDownWithError() throws {
         try super.tearDownWithError()
-        app = XCUIApplication.setUp(featureFlags: ["aiChatOmnibarToggle": false])
         app.terminate()
     }
 
@@ -75,7 +74,7 @@ class AIChatMultilinePasteTests: UITestCase {
         )
     }
 
-    /// Tests that pressing SHIFT + ENTER in the address bar toggles to Duck.ai mode when the aiChatOmnibarToggle feature flag is ON
+    /// Tests that pressing SHIFT + ENTER in the address bar toggles to Duck.ai mode when the Search/Duck.ai toggle setting is ON
     func test_shiftEnter_withToggleSettingON_togglesToDuckAIMode() throws {
         // Navigate to AI Chat settings and enable the Search/Duck.ai toggle
         addressBarTextField.typeURL(URL(string: "duck://settings/aichat")!)

--- a/macOS/UITests/AIChatOmnibarTests.swift
+++ b/macOS/UITests/AIChatOmnibarTests.swift
@@ -18,9 +18,9 @@
 
 import XCTest
 
-/// UI tests for the Duck.ai address-bar mode (the per-tab Search ↔ Duck.ai toggle introduced by the
-/// `aiChatOmnibarToggle` feature). Covers the high-traffic state transitions: tab-switch draft
-/// preservation, Cmd+T from Duck.ai, two-step ESC, and refocus from the unfocused Duck.ai state.
+/// UI tests for the Duck.ai address-bar mode (the per-tab Search ↔ Duck.ai toggle). Covers the
+/// high-traffic state transitions: tab-switch draft preservation, Cmd+T from Duck.ai, two-step ESC,
+/// and refocus from the unfocused Duck.ai state.
 class AIChatOmnibarTests: UITestCase {
 
     private var addressBarTextField: XCUIElement!
@@ -35,7 +35,7 @@ class AIChatOmnibarTests: UITestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         continueAfterFailure = false
-        app = XCUIApplication.setUp(featureFlags: ["aiChatOmnibarToggle": true])
+        app = XCUIApplication.setUp()
 
         addressBarTextField = app.addressBar
         app.enforceSingleWindow()

--- a/macOS/UITests/AIChatSettingsTests.swift
+++ b/macOS/UITests/AIChatSettingsTests.swift
@@ -34,7 +34,7 @@ class AIChatSettingsTests: UITestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         continueAfterFailure = false
-        app = XCUIApplication.setUp(featureFlags: ["aiChatOmnibarToggle": true, "aiChatChromeSidebar": true, "aiChatSidebarFloating": true])
+        app = XCUIApplication.setUp(featureFlags: ["aiChatChromeSidebar": true, "aiChatSidebarFloating": true])
 
         addressBarTextField = app.addressBar
         app.enforceSingleWindow()

--- a/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
+++ b/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
@@ -197,10 +197,10 @@ class OnboardingManagerTests: XCTestCase {
         XCTAssertEqual(appStoreManager.configuration, expectedConfig)
     }
 
-    func testReturnsExpectedOnboardingConfig_WhenOnlyOmnibarToggleIsOn_ExcludesAddressBarMode() {
+    func testReturnsExpectedOnboardingConfig_WhenOmnibarOnboardingIsOff_ExcludesAddressBarMode() {
         // Given
         let featureFlagger = MockFeatureFlagger()
-        featureFlagger.enabledFeatureFlags = [.aiChatOmnibarToggle]
+        featureFlagger.enabledFeatureFlags = []
         let managerWithFlagOn = OnboardingActionsManager(
             navigationDelegate: navigationDelegate,
             dockCustomization: dockCustomization,
@@ -231,44 +231,10 @@ class OnboardingManagerTests: XCTestCase {
         XCTAssertEqual(managerWithFlagOn.configuration, expectedConfig)
     }
 
-    func testReturnsExpectedOnboardingConfig_WhenOnlyOmnibarOnboardingIsOn_ExcludesAddressBarMode() {
+    func testReturnsExpectedOnboardingConfig_WhenOmnibarOnboardingIsOn_DoesNotExcludeAddressBarMode() {
         // Given
         let featureFlagger = MockFeatureFlagger()
         featureFlagger.enabledFeatureFlags = [.aiChatOmnibarOnboarding]
-        let managerWithFlagOn = OnboardingActionsManager(
-            navigationDelegate: navigationDelegate,
-            dockCustomization: dockCustomization,
-            defaultBrowserProvider: defaultBrowserProvider,
-            appearancePreferences: appearancePreferences,
-            startupPreferences: startupPreferences,
-            dataImportProvider: importProvider,
-            featureFlagger: featureFlagger,
-            onboardingSharedPixelHandler: onboardingSharedPixelHandler,
-            chromeExtensionInstaller: chromeExtensionInstaller
-        )
-
-        let systemSettings = SystemSettings(rows: ["dock", "import"])
-        let stepDefinitions = StepDefinitions(
-            systemSettings: systemSettings,
-            getStarted: GetStarted(options: [])
-        )
-        let expectedConfig = OnboardingConfiguration(
-            stepDefinitions: stepDefinitions,
-            exclude: [OnboardingExcludedStep.duckPlayerSingle.rawValue, OnboardingExcludedStep.addressBarMode.rawValue],
-            order: "v3",
-            env: "development",
-            locale: "en",
-            platform: .init(name: "macos")
-        )
-
-        // Then
-        XCTAssertEqual(managerWithFlagOn.configuration, expectedConfig)
-    }
-
-    func testReturnsExpectedOnboardingConfig_WhenBothFlagsAreOn_DoesNotExcludeAddressBarMode() {
-        // Given
-        let featureFlagger = MockFeatureFlagger()
-        featureFlagger.enabledFeatureFlags = [.aiChatOmnibarToggle, .aiChatOmnibarOnboarding]
         let managerWithFlagsOn = OnboardingActionsManager(
             navigationDelegate: navigationDelegate,
             dockCustomization: dockCustomization,
@@ -665,7 +631,7 @@ class OnboardingManagerTests: XCTestCase {
     func testSearchExperienceClickedPixelFired_WithAddressBarSetting_WhenAddressBarModeIsFinalStep() {
         // Given
         let featureFlagger = MockFeatureFlagger()
-        featureFlagger.enabledFeatureFlags = [.aiChatOmnibarToggle, .aiChatOmnibarOnboarding]
+        featureFlagger.enabledFeatureFlags = [.aiChatOmnibarOnboarding]
         let manager = OnboardingActionsManager(
             navigationDelegate: navigationDelegate,
             dockCustomization: dockCustomization,

--- a/macOS/UnitTests/Suggestions/ViewModel/SuggestionContainerViewModelTests.swift
+++ b/macOS/UnitTests/Suggestions/ViewModel/SuggestionContainerViewModelTests.swift
@@ -382,9 +382,8 @@ final class SuggestionContainerViewModelTests: XCTestCase {
     // MARK: - AI Chat Footer Cell Tests
 
     @MainActor
-    func testWhenAIChatToggleAndFeaturesEnabled_ThenAIChatCellAppearsInFooter() {
+    func testWhenAIFeaturesEnabled_ThenAIChatCellAppearsInFooter() {
         // Cluster removed: the AI chat cell only ever appears in the footer, never at the top
-        featureFlagger.enabledFeatureFlags = [.aiChatOmnibarToggle]
         let aiChatStorage = MockAIChatPreferencesStorage()
         aiChatStorage.isAIFeaturesEnabled = true
 
@@ -411,8 +410,10 @@ final class SuggestionContainerViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testWhenAIChatToggleDisabled_ThenListShowsOnlySuggestions() {
-        // Setup without AI chat toggle
+    func testWhenAIFeaturesDisabled_ThenListShowsOnlySuggestions() {
+        // Setup with AI features disabled
+        let aiChatStorage = MockAIChatPreferencesStorage()
+        aiChatStorage.isAIFeaturesEnabled = false
 
         suggestionContainerViewModel = SuggestionContainerViewModel(
             isHomePage: false,
@@ -424,14 +425,14 @@ final class SuggestionContainerViewModelTests: XCTestCase {
             ),
             themeManager: MockThemeManager(),
             featureFlagger: featureFlagger,
-            aiChatPreferencesStorage: MockAIChatPreferencesStorage()
+            aiChatPreferencesStorage: aiChatStorage
         )
 
         suggestionContainerViewModel.setUserStringValue("test query", userAppendedStringToTheEnd: false)
         suggestionLoadingMock.completion?(SuggestionResult.noTopHitsResult, nil)
 
-        // No AI chat cell should appear when the toggle is disabled
-        XCTAssertEqual(suggestionContainerViewModel.numberOfFooterRows, 0, "Footer should have no rows when toggle disabled")
+        // No AI chat cell should appear when AI features are disabled
+        XCTAssertEqual(suggestionContainerViewModel.numberOfFooterRows, 0, "Footer should have no rows when AI features disabled")
 
         // First row should be a suggestion
         XCTAssertEqual(suggestionContainerViewModel.rowContent(at: 0), .suggestion(index: 0))
@@ -439,8 +440,7 @@ final class SuggestionContainerViewModelTests: XCTestCase {
 
     @MainActor
     func testWhenAIFeaturesDisabledAfterInit_ThenAIChatCellFooterIsHidden() {
-        // AI chat toggle enabled: AI chat always appears in the footer
-        featureFlagger.enabledFeatureFlags = [.aiChatOmnibarToggle]
+        // AI features enabled: AI chat always appears in the footer
         let aiChatStorage = MockAIChatPreferencesStorage()
         aiChatStorage.isAIFeaturesEnabled = true
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1209671977594486/task/1212016242789291?focus=true
Tech Design URL:
CC:

### Description
Remove aiChatOmnibarToggle feature flag

### Testing Steps
1. Launch macOS with Duck.ai enabled and confirm the Search/Duck.ai toggle behavior in the address bar
2. Open Settings → AI Features and confirm the "Show Search and Duck.ai toggle" option is present.


### Impact and Risks
Low — behavior matches the flag's already-shipped enabled state; only the disabled path is removed.

#### What could go wrong?
A gate that previously depended on the flag being off could now always take the enabled path in an unexpected UI state.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk if omnibar toggle was already fully rolled out; main concern is users or builds that still relied on the flag-off path now always get omnibar toggle UX.
> 
> **Overview**
> Removes the **`aiChatOmnibarToggle`** privacy/feature flag and its macOS **`FeatureFlag.aiChatOmnibarToggle`** mapping so the Search ↔ Duck.ai address bar experience is no longer remotely kill-switchable.
> 
> **Runtime behavior** now always follows the former “flag on” path: tab-switch first-responder logic, omnibar panel teardown, Shift/Option/Ctrl+Return shortcuts, shared text sync, suggestion footer AI cells, toggle visibility, and address bar layout/padding no longer consult the flag—only **`aiChatSettings.isAIFeaturesEnabled`** and user prefs such as **`showSearchAndDuckAIToggle`**.
> 
> **Settings & onboarding**: AI Features always shows the **“Show Search and Duck.ai toggle”** preference (the legacy “shortcut when typing” branch is dropped). Onboarding’s address-bar mode step depends solely on **`aiChatOmnibarOnboarding`**, not the removed toggle flag.
> 
> **Styling cleanup**: **`AddressBarStyleProviding`** factories and legacy/current providers drop **`FeatureFlagger`** injection and always use omnibar-focused padding/trailing insets.
> 
> **Tests** drop flag bootstrapping and rename cases to match AI-features-only gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cb25042dd3b2a0d8f5b9344d947343c53fad8e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->