### PR TITLE
Document Cloud Agent (Linux) dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,12 @@ Detailed rules live in `.cursor/rules/`. Read from the list below when the reque
 | `anti-patterns.mdc` | What NOT to do: singletons, async mistakes, SwiftUI pitfalls, testing mistakes |
 | `user-defaults-storage.mdc` | Storing settings or preferences via `KeyValueStore` |
 | `pixels.mdc` | Defining, naming, or firing pixel events |
+
+## Cursor Cloud specific instructions
+
+Cloud Agent VMs run **Linux x86_64**, but this is a native **Apple (iOS + macOS)** codebase.
+
+- **The iOS and macOS browser apps cannot be built, run, or unit-tested in the Cloud Agent VM.** They require macOS + Xcode (`.xcode-version` pins the version) and Apple frameworks (UIKit/AppKit/WebKit). Every `xcodebuild`/Swift build, unit test, and UI test in CI runs on `macos-*` runners only. `swiftlint` also needs the Swift toolchain (not installed here) — see `README.md` / `development-commands.mdc` for the macOS build/lint/test commands.
+- **What DOES run on Linux:** the Node/JS + pixel tooling exposed as npm scripts in `package.json`, `iOS/package.json`, and `macOS/package.json`. The startup update script (`npm install`) installs all workspace deps. Useful commands (run from `iOS/` or `macOS/`): `npm run rebuild-autoconsent` (rollup JS bundle), `npm run validate-pixel-defs` / `validate-defs-without-formatting`, `npm run check-wide-events`, `npm run pixel-lint`. The root `scripts/*.mjs` wide-event checkers are also Node-based.
+- Running `validate-pixel-defs` / `rebuild-autoconsent` regenerates artifacts: `PixelDefinitions/wide_events/generated_schemas/` (gitignored) and `DuckDuckGo/Autoconsent/autoconsent-bundle.js` (tracked; output is normally identical). Verify `git status` is clean before committing.
+- `npm run rebuild-autoconsent` from the repo root fails (no root `rollup.config.js`); the config lives in the `iOS/` and `macOS/` workspaces, so run it from there.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL:
Tech Design URL:
CC:

### Description

Sets up and documents the Cloud Agent (Linux) development environment for this Apple (iOS + macOS) monorepo.

This is a native Apple codebase: the iOS and macOS browser apps require macOS + Xcode (`.xcode-version`) and Apple frameworks (UIKit/AppKit/WebKit), so **they cannot be built, run, or unit-tested in the Linux Cloud Agent VM** — every `xcodebuild`/Swift build, unit test, and UI test in CI runs on `macos-*` runners only. `swiftlint` likewise needs the Swift toolchain, which is not present on Linux.

What this PR does:
- **Update script** (via Cloud Agent env setup): `npm install` — installs all npm workspace deps (root + `iOS/` + `macOS/`).
- **AGENTS.md**: adds a `## Cursor Cloud specific instructions` section describing the platform constraint and the Node/JS + pixel tooling that *does* run on Linux, plus non-obvious gotchas (generated artifacts, the root-vs-workspace `rollup.config.js` caveat).

No application code changed.

### Testing Steps
1. `npm install` from the repo root.
2. From `iOS/` (and `macOS/`): `npm run rebuild-autoconsent`, `npm run validate-pixel-defs`, `npm run check-wide-events`, `npm run pixel-lint` — all succeed on Linux.
3. Confirm `git status` is clean afterward (generated `wide_events/generated_schemas` is gitignored; the regenerated `autoconsent-bundle.js` is byte-identical).

Verified proof run (Ubuntu 24.04 x86_64, node v22.14.0):
```
===> [1/5] iOS: rebuild autoconsent JS bundle (rollup)   -> created autoconsent-bundle.js
===> [2/5] iOS: validate pixel definitions + wide events -> All matched files use Prettier code style!
===> [3/5] iOS: wide-event consistency + immutability     -> checks passed
===> [4/5] macOS: validate pixel definitions              -> schemas generated
===> [5/5] macOS: wide-event checks + prettier pixel-lint -> checks passed
===> DONE: all Linux-runnable dev tasks passed.
```

### Impact and Risks
None — documentation only plus a minimal, idempotent `npm install` startup script. No product/application code is touched.

#### What could go wrong?
Nothing user-facing. The update script is `npm install`, which is idempotent and valid against the repo's current state.

### Notes to Reviewer
The full iOS/macOS app build/run/test remains a macOS + Xcode workflow (see `README.md` and `development-commands.mdc`); it is intentionally out of scope for the Linux Cloud Agent VM.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e458a70e-dc98-4c45-beea-88e2246110c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e458a70e-dc98-4c45-beea-88e2246110c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

