### PR TITLE
Remove calls to fire Sync experiment pixels that have been removed

### DIFF
--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -715,11 +715,9 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
                 .failedToFetchExchangeRecoveryKey,
                 .failedToTransmitConnectRecoveryKey:
             sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
-            fireCodeHandlingFailedExperimentPixel(setupRole: setupRole)
             await handleError(.unableToSyncWithDevice, error: underlyingError, event: .syncLoginError)
         case .failedToTransmitExchangeRecoveryKey:
             sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
-            fireCodeHandlingFailedExperimentPixel(setupRole: setupRole)
             await handleError(.unableToSyncWithDevice, error: underlyingError, event: .syncLoginError)
         case .accountUpgradeFailed,
                 .transportFailure,
@@ -744,7 +742,6 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
             await handleError(.unableToSyncWithDevice, error: underlyingError, event: .syncSignupError)
         case .accountCreationFailed:
             sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)
-            fireCodeHandlingFailedExperimentPixel(setupRole: setupRole)
             await handleError(.unableToSyncWithDevice, error: underlyingError, event: .syncSignupError)
         case .pollingForRecoveryKeyTimedOut:
             sendSetupEndedFailedPixel(setupRole: setupRole, reason: error.syncSetupFailureReason)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1216245606912259?focus=true
Tech Design URL:
CC:

### Description
Experiment pixels for Sync were removed on main earlier in the week; merge from internal brought back some stale calls as part of Sync pixel updates

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Confirm CI is green

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only cleanup with no change to sync logic or user-visible error handling.
> 
> **Overview**
> Removes **four** calls to `fireCodeHandlingFailedExperimentPixel` from sync setup error handling in `SyncSettingsViewController` after that experiment pixel was deleted elsewhere.
> 
> Failed setup paths still fire **`sendSetupEndedFailedPixel`** and show the same user-facing errors; only the extra experiment telemetry on login/signup-related failures is dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c00ba2a8e8bd981ccd60b75b3380f31cc6ebf6fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->