### PR TITLE
Add error pixels for AI chat history load/pin/download failures

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1778,6 +1778,9 @@ extension Pixel {
         case aiChatHistoryDownloadStarted
         case aiChatHistoryEditModeEntered
         case aiChatHistoryNewChatTapped
+        case aiChatHistoryLoadFailed
+        case aiChatHistoryPinToggleFailed
+        case aiChatHistoryDownloadFailed
 
         // MARK: AI Chat Recent Chats
         case aiChatRecentChatSelectedPinned
@@ -3677,6 +3680,9 @@ extension Pixel.Event {
         case .aiChatHistoryDownloadStarted: return "aichat_history_download_started"
         case .aiChatHistoryEditModeEntered: return "aichat_history_edit_mode_entered"
         case .aiChatHistoryNewChatTapped: return "aichat_history_new_chat_tapped"
+        case .aiChatHistoryLoadFailed: return "aichat_history_load_failed"
+        case .aiChatHistoryPinToggleFailed: return "aichat_history_pin_toggle_failed"
+        case .aiChatHistoryDownloadFailed: return "aichat_history_download_failed"
 
         // MARK: AI Chat Recent Chats
         case .aiChatRecentChatSelectedPinned: return "m_aichat_recent_chat_selected_pinned"

--- a/iOS/DuckDuckGo/AIChat/AIChatHistoryInstrumentation.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatHistoryInstrumentation.swift
@@ -40,6 +40,9 @@ protocol AIChatHistoryInstrumentation {
     func downloadStarted()
     func editModeEntered()
     func newChatTapped()
+    func loadFailed(error: Error)
+    func pinToggleFailed(error: Error)
+    func downloadFailed(error: Error)
 }
 
 final class DefaultAIChatHistoryInstrumentation: AIChatHistoryInstrumentation {
@@ -100,7 +103,19 @@ final class DefaultAIChatHistoryInstrumentation: AIChatHistoryInstrumentation {
         fire(.aiChatHistoryNewChatTapped)
     }
 
-    private func fire(_ pixel: Pixel.Event) {
-        dailyPixelFiring.fireDailyAndCount(pixel, error: nil, withAdditionalParameters: [:])
+    func loadFailed(error: Error) {
+        fire(.aiChatHistoryLoadFailed, error: error)
+    }
+
+    func pinToggleFailed(error: Error) {
+        fire(.aiChatHistoryPinToggleFailed, error: error)
+    }
+
+    func downloadFailed(error: Error) {
+        fire(.aiChatHistoryDownloadFailed, error: error)
+    }
+
+    private func fire(_ pixel: Pixel.Event, error: Error? = nil) {
+        dailyPixelFiring.fireDailyAndCount(pixel, error: error, withAdditionalParameters: [:])
     }
 }

--- a/iOS/DuckDuckGo/AIChat/AIChatHistoryViewModel.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatHistoryViewModel.swift
@@ -113,7 +113,10 @@ final class AIChatHistoryViewModel: ObservableObject {
             totalChatCount = allChats.count
             pinned = filtered.filter(\.pinned)
             recent = filtered.filter { !$0.pinned }
-        case .failure:
+        case .failure(let error):
+            if !loadFailed {
+                instrumentation.loadFailed(error: error)
+            }
             loadFailed = true
             totalChatCount = 0
             pinned = []
@@ -218,6 +221,7 @@ final class AIChatHistoryViewModel: ObservableObject {
         // Image-gen exports do enough I/O to freeze the sheet — dispatch off-main.
         guard let downloader else { return }
         instrumentation.downloadStarted()
+        let instrumentation = instrumentation
         mutationQueue.async { [weak self] in
             do {
                 let url = try downloader.downloadChat(chatId: chatId)
@@ -226,7 +230,7 @@ final class AIChatHistoryViewModel: ObservableObject {
                 }
             } catch {
                 Logger.aiChat.debug("Chat export failed: \(error.localizedDescription)")
-                // Failure-state toast pairs with the pixels-pass follow-up (task #28).
+                instrumentation.downloadFailed(error: error)
             }
         }
     }
@@ -247,11 +251,13 @@ final class AIChatHistoryViewModel: ObservableObject {
         } else {
             instrumentation.pinRemoved()
         }
+        let instrumentation = instrumentation
         mutationQueue.async {
             do {
                 try pinner.setPinned(chatId: chatId, pinned: newPinned)
             } catch {
                 Logger.aiChat.debug("Pin toggle failed: \(error.localizedDescription)")
+                instrumentation.pinToggleFailed(error: error)
             }
         }
         return move

--- a/iOS/DuckDuckGoTests/AIChat/AIChatHistoryViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatHistoryViewModelTests.swift
@@ -101,6 +101,28 @@ final class AIChatHistoryViewModelTests: XCTestCase {
         XCTAssertTrue(sut.loadFailed, "Storage failure should set loadFailed so the UI can show an error, not the empty state")
     }
 
+    func testReaderFailure_firesLoadFailedPixelOncePerTransition() {
+        let reader = MockChatHistoryReader(chats: [chat(id: "p1", pinned: true)])
+        let instrumentation = MockAIChatHistoryInstrumentation()
+        let sut = AIChatHistoryViewModel(reader: reader, instrumentation: instrumentation)
+        processMainQueue()
+        XCTAssertTrue(instrumentation.loadFailedErrors.isEmpty)
+
+        let error = NSError(domain: "test", code: 1)
+        reader.subject.send(completion: .failure(error))
+        processMainQueue()
+
+        XCTAssertEqual(instrumentation.loadFailedErrors.count, 1, "The load-failure pixel should fire on the failure transition")
+
+        // A later query keystroke recombines the cached failure through CombineLatest, re-running
+        // `apply(.failure:)`. Since `loadFailed` is already true, the pixel must not re-fire.
+        sut.updateQuery("hello")
+        waitForDebounce()
+
+        XCTAssertTrue(sut.loadFailed)
+        XCTAssertEqual(instrumentation.loadFailedErrors.count, 1, "Re-emitted cached failures should not re-count")
+    }
+
     func testNewChatTapped_notifiesDelegate() {
         let sut = makeSUT(chats: [])
         let delegate = MockDelegate()
@@ -625,6 +647,9 @@ final class AIChatHistoryViewModelTests: XCTestCase {
         private(set) var downloadStartedCount = 0
         private(set) var editModeEnteredCount = 0
         private(set) var newChatTappedCount = 0
+        private(set) var loadFailedErrors: [Error] = []
+        private(set) var pinToggleFailedErrors: [Error] = []
+        private(set) var downloadFailedErrors: [Error] = []
 
         func screenShown(source: AIChatHistorySource) { screenShownSources.append(source) }
         func chatOpened() { chatOpenedCount += 1 }
@@ -638,5 +663,8 @@ final class AIChatHistoryViewModelTests: XCTestCase {
         func downloadStarted() { downloadStartedCount += 1 }
         func editModeEntered() { editModeEnteredCount += 1 }
         func newChatTapped() { newChatTappedCount += 1 }
+        func loadFailed(error: Error) { loadFailedErrors.append(error) }
+        func pinToggleFailed(error: Error) { pinToggleFailedErrors.append(error) }
+        func downloadFailed(error: Error) { downloadFailedErrors.append(error) }
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/aichat_history.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/aichat_history.json5
@@ -92,5 +92,26 @@
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "platform"],
         "parameters": ["appVersion"]
+    },
+    "aichat_history_load_failed": {
+        "description": "The chat history list failed to load (native storage unavailable or an observer error). This is what drives the load-error alert shown on the chat history screen; use it to gauge how often the error surfaces and how many users are affected",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform"],
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode"]
+    },
+    "aichat_history_pin_toggle_failed": {
+        "description": "Persisting a pin/unpin toggle failed after the optimistic in-memory move on the chat history screen",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform"],
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode"]
+    },
+    "aichat_history_download_failed": {
+        "description": "Exporting a chat for download failed on the chat history screen",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform"],
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216245682220673?focus=true
Tech Design URL:
CC:

### Description
Instruments the three currently-silent failure points on the native Duck.ai chat history screen via the `AIChatHistoryInstrumentation

### Testing Steps
1. Best way to test this is to change the related code to force the trigger of the pixels and check the console to see if the correct pixel was fired. 
2. Add this line `let result: Result<[DuckAiChat], Error> = .failure(ChatHistoryError.storageUnavailable)` right after the line ` private func apply(result: Result<[DuckAiChat], Error>, query: String) {` to force the error to happen


### Impact and Risks
Low — adds telemetry only; no user-facing behavior changes.

#### What could go wrong?
A misattached or mis-bucketed error parameter could reduce the diagnostic value of a pixel, but cannot affect app behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8b25d52161be07b6355c622032c3f5d0a5166324. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->