### PR TITLE
Onboarding (macOS): detect foreground return after Set Default prompt and notify frontend

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "b08079e6b77c160fcc9a3ad1237c1338cb76e984",
-        "version" : "15.8.0"
+        "branch" : "pr-releases/cursor/onboarding-auto-advance-default-browser-bb92",
+        "revision" : "2c5d89fe13f6314987e9435adb2a7d80eccf30b9"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
         .package(url: "https://github.com/1024jp/GzipSwift.git", exact: "6.0.1"),
         .package(url: "https://github.com/vapor/jwt-kit.git", exact: "4.13.5"),
         .package(url: "https://github.com/pointfreeco/swift-clocks.git", exact: "1.0.6"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts.git", exact: "15.8.0"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts.git", branch: "pr-releases/cursor/onboarding-auto-advance-default-browser-bb92"),
         .package(path: "../URLPredictor"),
         .package(path: "../Infrastructure/SystemFrameworksExtensions"),
     ],

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "5735b061ee14708ca17bc5b72b8eb9d21eb7f830",
-        "version" : "15.3.0"
+        "branch" : "pr-releases/cursor/onboarding-auto-advance-default-browser-bb92",
+        "revision" : "2c5d89fe13f6314987e9435adb2a7d80eccf30b9"
       }
     },
     {

--- a/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
@@ -17,6 +17,7 @@
 //
 
 import AIChat
+import AppKit
 import Combine
 import Common
 import DuckPlayer
@@ -75,6 +76,10 @@ protocol OnboardingActionsManaging {
     /// At user imput shows the system prompt to change default browser
     func setAsDefault()
 
+    /// Emits once each time the user finishes (best-effort) the Set Default OS flow:
+    /// armed by `setAsDefault()`, fires when the app resigns active and then becomes active again.
+    var setAsDefaultCompletePublisher: AnyPublisher<Void, Never> { get }
+
     /// At user imput shows the bookmarks bar
     func setBookmarkBar(enabled: Bool)
 
@@ -123,7 +128,12 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
     private let featureFlagger: FeatureFlagger
     private let onboardingSharedPixelHandler: OnboardingSharedPixelHandling
     private let chromeExtensionInstaller: ThirdPartyBrowserExtensionInstalling
+    private let notificationCenter: NotificationCenter
     private var cancellables = Set<AnyCancellable>()
+
+    private let setAsDefaultCompleteSubject = PassthroughSubject<Void, Never>()
+    var setAsDefaultCompletePublisher: AnyPublisher<Void, Never> { setAsDefaultCompleteSubject.eraseToAnyPublisher() }
+    private var setAsDefaultReturnCancellable: AnyCancellable?
 
     @UserDefaultsWrapper(key: .onboardingFinished, defaultValue: false)
     static var isOnboardingFinished: Bool
@@ -149,7 +159,8 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         }
         let stepDefinitions = StepDefinitions(
             systemSettings: systemSettings,
-            getStarted: GetStarted(options: getStartedOptions)
+            getStarted: GetStarted(options: getStartedOptions),
+            makeDefaultSingle: MakeDefaultSingle(autoAdvance: true)
         )
         let preferredLocale = Bundle.main.preferredLocalizations.first ?? "en"
         var env: String
@@ -199,7 +210,8 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         pinningManager: PinningManager,
         featureFlagger: FeatureFlagger,
         reinstallUserDetection: ReinstallingUserDetecting,
-        installDateProvider: @escaping () -> Date
+        installDateProvider: @escaping () -> Date,
+        notificationCenter: NotificationCenter = .default
     ) {
         let chromeExtensionInstaller = ChromeExtensionInstaller(
             featureFlagger: featureFlagger,
@@ -225,7 +237,8 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
                 },
                 installDateProvider: installDateProvider
              ),
-            chromeExtensionInstaller: chromeExtensionInstaller
+            chromeExtensionInstaller: chromeExtensionInstaller,
+            notificationCenter: notificationCenter
         )
     }
 
@@ -240,7 +253,8 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         homepageSearchModeSeedPersistor: HomepageSearchModeSeedPersistor = HomepageSearchModeSeedUserDefaultsPersistor(),
         featureFlagger: FeatureFlagger,
         onboardingSharedPixelHandler: OnboardingSharedPixelHandling,
-        chromeExtensionInstaller: ThirdPartyBrowserExtensionInstalling
+        chromeExtensionInstaller: ThirdPartyBrowserExtensionInstalling,
+        notificationCenter: NotificationCenter = .default
     ) {
         self.navigation = navigationDelegate
         self.dockCustomization = dockCustomization
@@ -253,6 +267,7 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         self.featureFlagger = featureFlagger
         self.onboardingSharedPixelHandler = onboardingSharedPixelHandler
         self.chromeExtensionInstaller = chromeExtensionInstaller
+        self.notificationCenter = notificationCenter
     }
 
     func onboardingStarted() {
@@ -307,6 +322,23 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         try? defaultBrowserProvider.presentDefaultBrowserPrompt()
         onboardingSharedPixelHandler.fire(.setDefault(.clicked(.engage)))
         didRequestDefaultBrowser = true
+        armSetAsDefaultReturnDetection()
+    }
+
+    /// The system default-browser prompt belongs to another process, so interacting with it
+    /// deactivates the app. Requiring resign-then-activate (rather than just the next
+    /// activation) avoids firing on unrelated focus churn right after the click.
+    private func armSetAsDefaultReturnDetection() {
+        setAsDefaultReturnCancellable = notificationCenter
+            .publisher(for: NSApplication.didResignActiveNotification)
+            .first()
+            .flatMap { [notificationCenter] _ in
+                notificationCenter.publisher(for: NSApplication.didBecomeActiveNotification).first()
+            }
+            .sink { [weak self] _ in
+                self?.setAsDefaultReturnCancellable = nil
+                self?.setAsDefaultCompleteSubject.send()
+            }
     }
 
     func setBookmarkBar(enabled: Bool) {

--- a/macOS/DuckDuckGo/Onboarding/OnboardingConfiguration.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingConfiguration.swift
@@ -32,10 +32,20 @@ struct OnboardingConfiguration: Codable, Equatable {
 struct StepDefinitions: Codable, Equatable {
     var systemSettings: SystemSettings
     var getStarted: GetStarted
+    var makeDefaultSingle: MakeDefaultSingle
 }
 
 struct GetStarted: Codable, Equatable {
     var options: [String]
+}
+
+/// Advertises the "Set Default" step capabilities to the FE.
+///
+/// macOS never learns which option the user picked in the system prompt, so `autoAdvance`
+/// tells the FE it can rely on the best-effort `onSetAsDefaultComplete` push (fired on the
+/// first app resign-then-become-active cycle after the request) to move past the step.
+struct MakeDefaultSingle: Codable, Equatable {
+    var autoAdvance: Bool
 }
 
 struct SystemSettings: Codable, Equatable {

--- a/macOS/DuckDuckGo/Onboarding/OnboardingUserScript.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingUserScript.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import Combine
 import Common
 import FoundationExtensions
 import Foundation
@@ -29,6 +30,9 @@ final class OnboardingUserScript: NSObject, Subfeature {
     var messageOriginPolicy: MessageOriginPolicy = .only(rules: [.exact(hostname: "onboarding")])
     let featureName: String = "onboarding"
     weak var broker: UserScriptMessageBroker?
+    weak var webView: WKWebView?
+
+    private var cancellables = Set<AnyCancellable>()
 
     // MARK: - MessageNames
     enum MessageNames: String, CaseIterable {
@@ -52,8 +56,21 @@ final class OnboardingUserScript: NSObject, Subfeature {
         case telemetryEvent
     }
 
+    /// Subscription events pushed from native to the onboarding page.
+    enum SubscriptionMethodNames: String {
+        case onSetAsDefaultComplete
+    }
+
     init(onboardingActionsManager: OnboardingActionsManaging) {
         self.onboardingActionsManager = onboardingActionsManager
+        super.init()
+
+        onboardingActionsManager.setAsDefaultCompletePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
+                self?.pushSetAsDefaultComplete()
+            }
+            .store(in: &cancellables)
     }
 
     public func with(broker: UserScriptMessageBroker) {
@@ -95,6 +112,7 @@ final class OnboardingUserScript: NSObject, Subfeature {
 extension OnboardingUserScript {
     @MainActor
     private func setInit(params: Any, original: WKScriptMessage) async throws -> Encodable? {
+        webView = original.webView
         onboardingActionsManager.onboardingStarted()
         return onboardingActionsManager.configuration
     }
@@ -131,6 +149,13 @@ extension OnboardingUserScript {
     private func requestSetAsDefault(params: Any, original: WKScriptMessage) async throws -> Encodable? {
         onboardingActionsManager.setAsDefault()
         return Result()
+    }
+
+    /// Pushed to the page at most once per `requestSetAsDefault`, on the first app
+    /// resign-active → become-active cycle afterwards (see `setAsDefaultCompletePublisher`).
+    func pushSetAsDefaultComplete() {
+        guard let webView else { return }
+        broker?.push(method: SubscriptionMethodNames.onSetAsDefaultComplete.rawValue, params: [String: String](), for: self, into: webView)
     }
 
     @MainActor

--- a/macOS/UnitTests/Onboarding/Mocks/CapturingOnboardingActionsManager.swift
+++ b/macOS/UnitTests/Onboarding/Mocks/CapturingOnboardingActionsManager.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import Combine
 import Foundation
 @testable import DuckDuckGo_Privacy_Browser
 
@@ -24,7 +25,8 @@ class CapturingOnboardingActionsManager: OnboardingActionsManaging {
     var configuration: OnboardingConfiguration = OnboardingConfiguration(
         stepDefinitions: StepDefinitions(
             systemSettings: SystemSettings(rows: []),
-            getStarted: GetStarted(options: [])
+            getStarted: GetStarted(options: []),
+            makeDefaultSingle: MakeDefaultSingle(autoAdvance: true)
         ),
         exclude: [],
         order: "",
@@ -32,6 +34,9 @@ class CapturingOnboardingActionsManager: OnboardingActionsManaging {
         locale: "en",
         platform: .init(name: "")
     )
+
+    let setAsDefaultCompleteSubject = PassthroughSubject<Void, Never>()
+    var setAsDefaultCompletePublisher: AnyPublisher<Void, Never> { setAsDefaultCompleteSubject.eraseToAnyPublisher() }
 
     var goToAddressBarCalled = false
     var goToSettingsCalled = false

--- a/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
+++ b/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
@@ -17,6 +17,8 @@
 //
 
 import AIChat
+import AppKit
+import Combine
 import FeatureFlags
 import Onboarding
 import Persistence
@@ -101,7 +103,8 @@ class OnboardingManagerTests: XCTestCase {
         let systemSettings = SystemSettings(rows: ["dock", "import"])
         let stepDefinitions = StepDefinitions(
             systemSettings: systemSettings,
-            getStarted: GetStarted(options: [])
+            getStarted: GetStarted(options: []),
+            makeDefaultSingle: MakeDefaultSingle(autoAdvance: true)
         )
         let expectedConfig = OnboardingConfiguration(
             stepDefinitions: stepDefinitions,
@@ -182,7 +185,8 @@ class OnboardingManagerTests: XCTestCase {
         )
         let stepDefinitions = StepDefinitions(
             systemSettings: SystemSettings(rows: ["dock-instructions", "import"]),
-            getStarted: GetStarted(options: [])
+            getStarted: GetStarted(options: []),
+            makeDefaultSingle: MakeDefaultSingle(autoAdvance: true)
         )
         let expectedConfig = OnboardingConfiguration(
             stepDefinitions: stepDefinitions,
@@ -216,7 +220,8 @@ class OnboardingManagerTests: XCTestCase {
         let systemSettings = SystemSettings(rows: ["dock", "import"])
         let stepDefinitions = StepDefinitions(
             systemSettings: systemSettings,
-            getStarted: GetStarted(options: [])
+            getStarted: GetStarted(options: []),
+            makeDefaultSingle: MakeDefaultSingle(autoAdvance: true)
         )
         let expectedConfig = OnboardingConfiguration(
             stepDefinitions: stepDefinitions,
@@ -250,7 +255,8 @@ class OnboardingManagerTests: XCTestCase {
         let systemSettings = SystemSettings(rows: ["dock", "import"])
         let stepDefinitions = StepDefinitions(
             systemSettings: systemSettings,
-            getStarted: GetStarted(options: [])
+            getStarted: GetStarted(options: []),
+            makeDefaultSingle: MakeDefaultSingle(autoAdvance: true)
         )
         let expectedConfig = OnboardingConfiguration(
             stepDefinitions: stepDefinitions,
@@ -284,7 +290,8 @@ class OnboardingManagerTests: XCTestCase {
         let systemSettings = SystemSettings(rows: ["dock", "import"])
         let stepDefinitions = StepDefinitions(
             systemSettings: systemSettings,
-            getStarted: GetStarted(options: [])
+            getStarted: GetStarted(options: []),
+            makeDefaultSingle: MakeDefaultSingle(autoAdvance: true)
         )
         let expectedConfig = OnboardingConfiguration(
             stepDefinitions: stepDefinitions,
@@ -401,6 +408,105 @@ class OnboardingManagerTests: XCTestCase {
 
         // Then
         XCTAssertTrue(defaultBrowserProvider.presentDefaultBrowserPromptCalled)
+    }
+
+    // MARK: setAsDefaultCompletePublisher — foreground return detection
+
+    func testConfiguration_AdvertisesMakeDefaultSingleAutoAdvance() {
+        // Then
+        XCTAssertTrue(manager.configuration.stepDefinitions.makeDefaultSingle.autoAdvance)
+    }
+
+    func testSetAsDefaultCompletePublisher_EmitsOnce_WhenAppResignsThenBecomesActive() {
+        // Given
+        let notificationCenter = NotificationCenter()
+        let manager = makeManagerWithNotificationCenter(notificationCenter)
+        var emissionCount = 0
+        let cancellable = manager.setAsDefaultCompletePublisher.sink { emissionCount += 1 }
+
+        // When
+        manager.setAsDefault()
+        notificationCenter.post(name: NSApplication.didResignActiveNotification, object: nil)
+        notificationCenter.post(name: NSApplication.didBecomeActiveNotification, object: nil)
+
+        // Then
+        XCTAssertEqual(emissionCount, 1)
+        cancellable.cancel()
+    }
+
+    func testSetAsDefaultCompletePublisher_DoesNotEmit_WhenBecomeActiveWithoutPriorResign() {
+        // Given
+        let notificationCenter = NotificationCenter()
+        let manager = makeManagerWithNotificationCenter(notificationCenter)
+        var emissionCount = 0
+        let cancellable = manager.setAsDefaultCompletePublisher.sink { emissionCount += 1 }
+
+        // When
+        manager.setAsDefault()
+        notificationCenter.post(name: NSApplication.didBecomeActiveNotification, object: nil)
+
+        // Then
+        XCTAssertEqual(emissionCount, 0)
+        cancellable.cancel()
+    }
+
+    func testSetAsDefaultCompletePublisher_EmitsOnlyOnce_ForResignBecomeResignBecomeSingleArm() {
+        // Given
+        let notificationCenter = NotificationCenter()
+        let manager = makeManagerWithNotificationCenter(notificationCenter)
+        var emissionCount = 0
+        let cancellable = manager.setAsDefaultCompletePublisher.sink { emissionCount += 1 }
+
+        // When
+        manager.setAsDefault()
+        notificationCenter.post(name: NSApplication.didResignActiveNotification, object: nil)
+        notificationCenter.post(name: NSApplication.didBecomeActiveNotification, object: nil)
+        notificationCenter.post(name: NSApplication.didResignActiveNotification, object: nil)
+        notificationCenter.post(name: NSApplication.didBecomeActiveNotification, object: nil)
+
+        // Then
+        XCTAssertEqual(emissionCount, 1)
+        cancellable.cancel()
+    }
+
+    func testSetAsDefaultCompletePublisher_ReArmsAndEmitsAgain_OnSecondSetAsDefaultCall() {
+        // Given
+        let notificationCenter = NotificationCenter()
+        let manager = makeManagerWithNotificationCenter(notificationCenter)
+        var emissionCount = 0
+        let cancellable = manager.setAsDefaultCompletePublisher.sink { emissionCount += 1 }
+
+        // When: first click completes a full cycle
+        manager.setAsDefault()
+        notificationCenter.post(name: NSApplication.didResignActiveNotification, object: nil)
+        notificationCenter.post(name: NSApplication.didBecomeActiveNotification, object: nil)
+
+        // Then
+        XCTAssertEqual(emissionCount, 1)
+
+        // When: second click re-arms and completes another cycle
+        manager.setAsDefault()
+        notificationCenter.post(name: NSApplication.didResignActiveNotification, object: nil)
+        notificationCenter.post(name: NSApplication.didBecomeActiveNotification, object: nil)
+
+        // Then
+        XCTAssertEqual(emissionCount, 2)
+        cancellable.cancel()
+    }
+
+    private func makeManagerWithNotificationCenter(_ notificationCenter: NotificationCenter) -> OnboardingActionsManager {
+        OnboardingActionsManager(
+            navigationDelegate: navigationDelegate,
+            dockCustomization: dockCustomization,
+            defaultBrowserProvider: defaultBrowserProvider,
+            appearancePreferences: appearancePreferences,
+            startupPreferences: startupPreferences,
+            dataImportProvider: importProvider,
+            featureFlagger: MockFeatureFlagger(),
+            onboardingSharedPixelHandler: onboardingSharedPixelHandler,
+            chromeExtensionInstaller: chromeExtensionInstaller,
+            notificationCenter: notificationCenter
+        )
     }
 
     func testOnSetBookmarksBar_andBarNotShown_ThenBarIsShown() {

--- a/macOS/UnitTests/Onboarding/OnboardingUserScriptTests.swift
+++ b/macOS/UnitTests/Onboarding/OnboardingUserScriptTests.swift
@@ -17,6 +17,7 @@
 //
 
 import BrowserServicesKitTestsUtils
+import Combine
 import WebKit
 import XCTest
 
@@ -101,6 +102,39 @@ final class OnboardingUserScriptTests: XCTestCase {
         let result = try await handler([""], WKScriptMessage.mock())
         XCTAssertTrue(mockManager.setAsDefaultCalled)
         XCTAssertNotNil(result)
+    }
+
+    // MARK: - onSetAsDefaultComplete push
+
+    @MainActor
+    func testSetInit_CapturesWebView_ForLaterPush() async throws {
+        let webView = WKWebView()
+        let handler = try XCTUnwrap(script.handler(forMethodNamed: "init"))
+
+        _ = try await handler([""], WKScriptMessage.mock(webView: webView))
+
+        XCTAssertTrue(script.webView === webView)
+    }
+
+    @MainActor
+    func testPushSetAsDefaultComplete_DoesNothing_WhenInitHasNotCapturedAWebView() {
+        // Given: "init" has never been handled, so no webView has been captured.
+        XCTAssertNil(script.webView)
+
+        // Then: the guard on `webView` must prevent any push attempt (no crash, no-op).
+        script.pushSetAsDefaultComplete()
+    }
+
+    @MainActor
+    func testPushSetAsDefaultComplete_DoesNothing_WhenWebViewCapturedButNoBrokerAttached() async throws {
+        // Given: "init" captured a webView, but `with(broker:)` was never called.
+        let webView = WKWebView()
+        let handler = try XCTUnwrap(script.handler(forMethodNamed: "init"))
+        _ = try await handler([""], WKScriptMessage.mock(webView: webView))
+        XCTAssertNil(script.broker)
+
+        // Then: `broker?.push` is a safe no-op without a broker.
+        script.pushSetAsDefaultComplete()
     }
 
     @MainActor


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216255322063714 (parent: 1215435204288345)
Tech Design URL:
CC:

### Description

During HTML onboarding, after the user clicks "Make DuckDuckGo Your Default" (`requestSetAsDefault` → `presentDefaultBrowserPrompt()`), we now push a new `onSetAsDefaultComplete` subscription event to the onboarding page the first time the app returns to the foreground afterwards. The frontend uses that to auto-advance the Comparison Chart screen. The `init` response also advertises the capability via `stepDefinitions.makeDefaultSingle.autoAdvance`.

macOS never learns which option the user picked in the system prompt, so foreground return (resign-active → become-active) is used as a best-effort proxy for "done" — accepted trade-off per the project thread. It can misfire if the user switches to another app mid-flow; that's an accepted limitation.

Changes:
- `OnboardingConfiguration.swift`: adds `MakeDefaultSingle` / `StepDefinitions.makeDefaultSingle`.
- `OnboardingActionsManager.swift`: adds `setAsDefaultCompletePublisher` to `OnboardingActionsManaging`; `setAsDefault()` arms a one-shot resign-active → become-active detector (re-armed on each click) that emits on the publisher; `configuration` now sets `makeDefaultSingle.autoAdvance = true`. `NotificationCenter` is injectable for tests.
- `OnboardingUserScript.swift`: captures the `webView` from the `init` message, subscribes to `setAsDefaultCompletePublisher`, and pushes `onSetAsDefaultComplete` (empty params) through the broker — mirroring the weak-webView + `broker.push` pattern used by `AIChatUserScript`.
- Temporarily pins `content-scope-scripts` to `pr-releases/cursor/onboarding-auto-advance-default-browser-bb92` (the branch containing the matching frontend changes) so this can be exercised end-to-end. **Must be reverted to a tagged release once that C-S-S PR merges.**

No new pixels, no new strings. Existing pixels (`setDefault` engage; dismiss-on-skip logic keyed off `didRequestDefaultBrowser`) are unchanged. iOS is untouched — this flow is desktop-only.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Run the macOS unit tests for `OnboardingUserScriptTests` and `OnboardingManagerTests` (I was unable to build/run tests in this sandbox — no Xcode/Swift toolchain available in the cloud agent environment; please run these before merging).
2. Manual (needs a C-S-S build containing the frontend half): fresh profile → onboarding → Comparison Chart → "Make DuckDuckGo Your Default" → interact with the system prompt (either choice) → app regains focus → screen advances without tapping Next. Also verify Skip, and that clicking Make Default then staying in the app doesn't advance until you actually leave and return.

### Impact and Risks
Low — additive change behind a best-effort foreground-return heuristic; existing onboarding flows and pixels are unaffected if the frontend doesn't yet act on the new push/flag.

#### What could go wrong?
- If the user alt-tabs away and back without touching the system prompt, the push could fire early. This is an accepted trade-off since macOS has no API to observe the user's actual choice.
- The `content-scope-scripts` branch pin is temporary and must be swapped back to a tagged release before this ships.

### Quality Considerations
- `setAsDefaultCompletePublisher` is one-shot per `setAsDefault()` call: re-clicking re-arms; a stray `didBecomeActive` without a preceding `didResignActive` does not fire it.
- Params are pushed as `{}` (empty `[String: String]`), matching the broker's own default for nil params.

### Notes to Reviewer
I could not run `xcodebuild`/`swift test` in this environment (no Xcode/Swift toolchain on the Linux cloud-agent sandbox), so please run the Onboarding unit test suites locally before merging.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b9bf6d4-03f2-4b20-9879-76e4642d0b0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b9bf6d4-03f2-4b20-9879-76e4642d0b0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

