### PR TITLE
Send broken site report config version as camelCase remoteConfigVersion

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
@@ -285,7 +285,7 @@ public struct BrokenSiteReport {
             "siteUrl": siteUrl.trimmingQueryItemsAndFragment().absoluteString,
             "upgradedHttps": upgradedHttps.description,
             "tds": tdsETag?.trimmingCharacters(in: CharacterSet(charactersIn: "\"")) ?? "",
-            "remote_config_version": configVersion ?? "",
+            "remoteConfigVersion": configVersion ?? "",
             "blockedTrackers": blockedTrackerDomains.joined(separator: ","),
             "surrogates": installedSurrogates.joined(separator: ","),
             "gpc": isGPCEnabled.description,

--- a/iOS/PixelDefinitions/pixels/definitions/broken_site_reporting.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/broken_site_reporting.json5
@@ -54,7 +54,7 @@
                 "description": "Tracker data set ETag"
             },
             {
-                "key": "remote_config_version",
+                "key": "remoteConfigVersion",
                 "type": "string",
                 "description": "Privacy remote config version"
             },
@@ -428,7 +428,7 @@
                 "description": "Tracker data set ETag"
             },
             {
-                "key": "remote_config_version",
+                "key": "remoteConfigVersion",
                 "type": "string",
                 "description": "Privacy remote config version"
             },

--- a/macOS/PixelDefinitions/pixels/definitions/broken_site_reporting.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/broken_site_reporting.json5
@@ -64,7 +64,7 @@
                 "description": "Tracker data set ETag"
             },
             {
-                "key": "remote_config_version",
+                "key": "remoteConfigVersion",
                 "type": "string",
                 "description": "Privacy remote config version"
             },
@@ -444,7 +444,7 @@
                 "description": "Tracker data set ETag"
             },
             {
-                "key": "remote_config_version",
+                "key": "remoteConfigVersion",
                 "type": "string",
                 "description": "Privacy remote config version"
             },


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1213659555956031/task/1216231983130506
CC:

### Description

The site breakage pixel sent the privacy remote config version under different parameter names per platform: Apple (iOS + macOS) sent `remote_config_version` (snake_case) while Android and the browser extension send `remoteConfigVersion` (camelCase). This created duplicate keys in `metrics.pixels` / `metrics.broken_site_reports`.

This PR renames the emitted parameter key to `remoteConfigVersion` on Apple so it matches the other platforms:

- `BrokenSiteReport.getRequestParameters()` in BrowserServicesKit now emits `remoteConfigVersion`.
- The `iOS` and `macOS` `broken_site_reporting.json5` pixel definitions are updated to match.

The internal `configVersion` property and all call sites are unchanged — only the emitted parameter key string changes.

Scope note: this is the rename only. The `remoteConfigEtag` parity item mentioned in the task is intentionally **not** included.

### Testing Steps
Green CI

### Impact and Risks

Low, no user-facing changes.

#### What could go wrong?

N/A

### Notes to Reviewer

N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only key rename with no user-facing or behavioral change; downstream dashboards may need to expect the new key for Apple traffic after release.
> 
> **Overview**
> Apple broken-site reports now send the privacy remote config version under **`remoteConfigVersion`** instead of **`remote_config_version`**, matching Android and the browser extension and avoiding duplicate metric keys.
> 
> **`BrokenSiteReport.getRequestParameters()`** only changes the dictionary key string; the value still comes from **`configVersion`**. iOS and macOS **`broken_site_reporting.json5`** definitions for user-submitted and protection-toggled-off pixels are updated to the same key name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca83c2dd3fd3297121a6fe6e9e098ab04f448f54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->