### PR TITLE
[iOS] skip the localized strings step if SKIP_STRINGS is set

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -12604,7 +12604,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"$SOURCE_ROOT/scripts/loc_update.sh\"\n";
+			shellScript = "if [ -n \"${SKIP_STRINGS:-}\" ]; then\n    echo \"Skipping Localizable.strings update because SKIP_STRINGS is set\"\n    exit 0\nfi\n\n\"$SOURCE_ROOT/scripts/loc_update.sh\"\n";
 		};
 		B6409DC62BC7D9BF00D66F9E /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1216248709747072?focus=true
Tech Design URL:
CC:

### Description
setting SKIP_STRINGS anywhere in the xcconfig will skip the generate localised strings step

### Testing Steps
1. Run a build, localised strings step should run
2. Add SKIP_STRINGS=1 to ExternalDeveloper.xcconfig and run build - it should be skipped
3. Comment out SKIP_STRINGS and build again, and step should be run

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Could break the build


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-phase-only change for internal tooling; default builds still run localization updates, with minor risk if SKIP_STRINGS is set unintentionally in release configs.
> 
> **Overview**
> The **Update Localizable.strings** Xcode build phase now exits early when **`SKIP_STRINGS`** is defined (for example in an xcconfig), so **`loc_update.sh`** does not run during that build.
> 
> When the variable is unset, behavior is unchanged: the phase still invokes **`loc_update.sh`** as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f7b669ed161182982ad5eb623774414984caa7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->