### PR TITLE
[iOS] correct call menu opened product surface telementry

### DIFF
--- a/iOS/DuckDuckGo/BrowsingMenu/BrowsingMenuViewController.swift
+++ b/iOS/DuckDuckGo/BrowsingMenu/BrowsingMenuViewController.swift
@@ -73,27 +73,24 @@ final class BrowsingMenuViewController: UIViewController {
     private let menuEntries: [BrowsingMenuEntry]
     private let daxDialogsManager: DaxDialogsManaging
     private let appSettings: AppSettings
-    private let productSurfaceTelemetry: ProductSurfaceTelemetry
     private var wasActionSelected: Bool = false
 
     var onDismiss: ((_ wasActionSelected: Bool) -> Void)?
 
     var isUsingSingleBar: Bool = false
 
-    class func instantiate(headerEntries: [BrowsingMenuEntry], menuEntries: [BrowsingMenuEntry], daxDialogsManager: DaxDialogsManaging, appSettings: AppSettings = AppDependencyProvider.shared.appSettings, productSurfaceTelemetry: ProductSurfaceTelemetry) -> BrowsingMenuViewController {
+    class func instantiate(headerEntries: [BrowsingMenuEntry], menuEntries: [BrowsingMenuEntry], daxDialogsManager: DaxDialogsManaging, appSettings: AppSettings = AppDependencyProvider.shared.appSettings) -> BrowsingMenuViewController {
         BrowsingMenuViewController(headerEntries: headerEntries,
                                    menuEntries: menuEntries,
                                    daxDialogsManager: daxDialogsManager,
-                                   appSettings: appSettings,
-                                   productSurfaceTelemetry: productSurfaceTelemetry)
+                                   appSettings: appSettings)
     }
 
-    init(headerEntries: [BrowsingMenuEntry], menuEntries: [BrowsingMenuEntry], daxDialogsManager: DaxDialogsManaging, appSettings: AppSettings, productSurfaceTelemetry: ProductSurfaceTelemetry) {
+    init(headerEntries: [BrowsingMenuEntry], menuEntries: [BrowsingMenuEntry], daxDialogsManager: DaxDialogsManaging, appSettings: AppSettings) {
         self.headerEntries = headerEntries
         self.menuEntries = menuEntries
         self.daxDialogsManager = daxDialogsManager
         self.appSettings = appSettings
-        self.productSurfaceTelemetry = productSurfaceTelemetry
         super.init(nibName: nil, bundle: nil)
         self.transitioningDelegate = self
     }

--- a/iOS/DuckDuckGo/BrowsingMenu/BrowsingMenuViewController.swift
+++ b/iOS/DuckDuckGo/BrowsingMenu/BrowsingMenuViewController.swift
@@ -239,11 +239,6 @@ final class BrowsingMenuViewController: UIViewController {
         tableView.register(BrowsingMenuSeparatorViewCell.self, forCellReuseIdentifier: Contants.separatorCellReuseIdentifier)
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        productSurfaceTelemetry.menuUsed()
-    }
-
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         if isBeingDismissed {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4236,8 +4236,7 @@ extension MainViewController: OmniBarDelegate {
         let browsingMenu: BrowsingMenuViewController =
         BrowsingMenuViewController.instantiate(headerEntries: headerEntries,
                                                menuEntries: menuEntries,
-                                               daxDialogsManager: daxDialogsManager,
-                                               productSurfaceTelemetry: productSurfaceTelemetry)
+                                               daxDialogsManager: daxDialogsManager)
         browsingMenu.isUsingSingleBar = isUsingSingleBar
         browsingMenu.onDismiss = { wasActionSelected in
             self.showMenuHighlighterIfNeeded()

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4210,6 +4210,7 @@ extension MainViewController: OmniBarDelegate {
                 Pixel.fire(pixel: .browsingMenuOpenedError)
             }
         }
+        productSurfaceTelemetry.menuUsed()
     }
 
     private func launchDefaultBrowsingMenu(in context: BrowsingMenuContext, tabController tab: TabViewController) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1216248709747078?focus=true
Tech Design URL:
CC:

### Description
Move the call to the menu opened part of the product surface telemetry to the right place.

### Testing Steps
1. Break point on ProductSurfaceTelemetry.menuOpened()
2. Launch the app and open the browser menu from a web page, new tab page and ai chat, ensure breakpoint is hit

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
??

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry timing/placement only; no auth, data, or user-facing behavior changes.
> 
> **Overview**
> Moves **`productSurfaceTelemetry.menuUsed()`** from **`BrowsingMenuViewController.viewDidAppear`** to **`MainViewController`** in the shared browser-menu launch path, alongside the existing **`browsingMenuOpened`** pixels for new tab, AI chat, and website contexts.
> 
> **`BrowsingMenuViewController`** no longer takes or stores **`ProductSurfaceTelemetry`**; **`instantiate`** / **`init`** drop that parameter and the **`viewDidAppear`** hook is removed.
> 
> Menu-open product surface telemetry now runs when the menu is opened from the main coordinator (default and sheet menu paths), not only after the legacy menu UI appears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 318e85adc066dedc2acfc2c9f144e8d2cd1eedeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->