### PR TITLE
Fix: UTI ignores Search Suggestions setting

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/DuckAISuggestionsSurfaceProvider.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/DuckAISuggestionsSurfaceProvider.swift
@@ -140,7 +140,8 @@ final class DuckAISuggestionsSurfaceProvider {
             // The "View all chats" row opens the native history page — an iPhone-only experience gated on the same flag.
             viewAllChatsEnabled: { [featureFlagger] in
                 featureFlagger.isFeatureOn(.aiChatNativeChatHistory) && UIDevice.current.userInterfaceIdiom != .pad
-            }
+            },
+            searchSuggestionsEnabled: { [weak self] in self?.dependencies.appSettings.autocomplete ?? true }
         )
         chatManager.onFetchCompleted = { [weak self] query, hasSuggestions in
             // Only an unfiltered (empty-query) fetch defines "has any recent chats". Filtered fetches
@@ -188,7 +189,8 @@ final class DuckAISuggestionsSurfaceProvider {
             chatManager?.refreshSuggestions(query: self?.switchBarHandler.currentText ?? "")
         }
         refreshURLSuggestionsAction = { [weak self] in
-            source.fetchURLSuggestions(query: self?.switchBarHandler.currentText ?? "")
+            guard let self, self.dependencies.appSettings.autocomplete else { return }
+            source.fetchURLSuggestions(query: self.switchBarHandler.currentText)
         }
         refreshCachesAction = { [weak dataSource] in dataSource?.refreshCaches() }
         recentsCountReader = { [weak chatViewModel] in chatViewModel?.filteredSuggestions.count ?? 0 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/SuggestionsSource.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/SuggestionsSource.swift
@@ -40,17 +40,21 @@ final class DuckAISuggestionsSource: SuggestionsSource {
     private let urlLoader: DuckAIURLSuggestionsLoader
     private let chatManager: AIChatHistoryManager
     private let query: () -> String
+    /// Gates the URL-hits sub-source only (the "Search Suggestions" setting); chat history is unaffected.
+    private let searchSuggestionsEnabled: () -> Bool
 
     init(chatViewModel: AIChatSuggestionsViewModel,
          urlLoader: DuckAIURLSuggestionsLoader,
          chatManager: AIChatHistoryManager,
          query: @escaping () -> String,
          deleteEnabled: @escaping () -> Bool = { false },
-         viewAllChatsEnabled: @escaping () -> Bool = { false }) {
+         viewAllChatsEnabled: @escaping () -> Bool = { false },
+         searchSuggestionsEnabled: @escaping () -> Bool = { true }) {
         self.chatViewModel = chatViewModel
         self.urlLoader = urlLoader
         self.chatManager = chatManager
         self.query = query
+        self.searchSuggestionsEnabled = searchSuggestionsEnabled
 
         let pipeline = DuckAISuggestionsPipeline(
             chatsPublisher: chatViewModel.$filteredSuggestions.eraseToAnyPublisher(),
@@ -67,7 +71,12 @@ final class DuckAISuggestionsSource: SuggestionsSource {
 
     func start(textPublisher: AnyPublisher<String, Never>) {
         chatManager.subscribeToTextChanges(textPublisher)
-        urlLoader.subscribeToTextChanges(textPublisher)
+        // Empty when "Search Suggestions" is off, so URL hits are suppressed without touching chat history.
+        let urlTextPublisher = textPublisher
+            .map { [searchSuggestionsEnabled] text in searchSuggestionsEnabled() ? text : "" }
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+        urlLoader.subscribeToTextChanges(urlTextPublisher)
         chatManager.refreshSuggestions(query: query())
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -257,7 +257,19 @@ final class UnifiedInputContentContainerViewController: UIViewController {
             // Re-resolve now (synchronously, before the host is shown) so the prior session's stale
             // content isn't flashed. Runs after `prepareForActivation` clears the dismiss freeze.
             activationResolveTrigger.send(())
+            syncDuckAISurfaceWithSettings()
             duckAISurface?.refreshRecents()
+        }
+    }
+
+    /// Re-checks the Chat Suggestions gate on every focus: this VC is built once per browser session
+    /// (`viewWillAppear` only fires once), so without this, toggling the setting wouldn't take effect
+    /// until the app restarts.
+    private func syncDuckAISurfaceWithSettings() {
+        if featureFlagger.isFeatureOn(.aiChatSuggestions) && aiChatSettings.isChatSuggestionsEnabled {
+            attachDuckAISurfaceIfNeeded()
+        } else {
+            detachDuckAISurfaceFromSingleHost()
         }
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -524,7 +524,8 @@ final class UnifiedInputContentContainerViewController: UIViewController {
 
         let source = SearchSuggestionsSource(
             loader: loader,
-            query: { [weak self] in self?.switchBarHandler.currentText ?? "" },
+            // Empty when "Search Suggestions" is off, else `effectiveTopHits` falls back to a phrase row.
+            query: { [weak self] in self?.appSettings.autocomplete == true ? (self?.switchBarHandler.currentText ?? "") : "" },
             showAskAIChat: aiChatSettings.isAIChatEnabled
         )
 
@@ -604,7 +605,7 @@ final class UnifiedInputContentContainerViewController: UIViewController {
             switchBarHandler.toggleStatePublisher,
             switchBarHandler.currentTextPublisher)
             .filter { mode, _ in mode == .search }
-            .map { _, text in text }
+            .map { [weak self] _, text in self?.appSettings.autocomplete == true ? text : "" }
             .removeDuplicates()
             .eraseToAnyPublisher()
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/Suggestions/DuckAISuggestionsSelectionTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/Suggestions/DuckAISuggestionsSelectionTests.swift
@@ -84,6 +84,63 @@ final class DuckAISuggestionsSelectionTests: XCTestCase {
         let source = makeSource(query: "")
         XCTAssertNil(source.selection(forRowID: "does-not-exist"))
     }
+
+    // MARK: - Search Suggestions gating
+
+    func test_urlHits_areSuppressed_whenSearchSuggestionsDisabled() async {
+        let urlLoader = DuckAIURLSuggestionsLoader(dataSource: StubSuggestionLoadingDataSource())
+        let chatViewModel = AIChatSuggestionsViewModel()
+        let chatManager = AIChatHistoryManager(
+            suggestionsReader: NilSuggestionsReader(),
+            aiChatSettings: MockAIChatSettingsProvider(),
+            aiChatDeleter: StubAIChatDeleter(),
+            viewModel: chatViewModel,
+            isFireTab: false
+        )
+        let source = DuckAISuggestionsSource(
+            chatViewModel: chatViewModel,
+            urlLoader: urlLoader,
+            chatManager: chatManager,
+            query: { "hotmail" },
+            searchSuggestionsEnabled: { false }
+        )
+        let textSubject = PassthroughSubject<String, Never>()
+        source.start(textPublisher: textSubject.eraseToAnyPublisher())
+        textSubject.send("hotmail")
+
+        let predicate = NSPredicate { _, _ in urlLoader.lastCompletedFetchQuery != nil }
+        await fulfillment(of: [expectation(for: predicate, evaluatedWith: nil)], timeout: 5.0)
+
+        XCTAssertEqual(urlLoader.lastCompletedFetchQuery, "")
+        XCTAssertTrue(urlLoader.topURLs.isEmpty)
+    }
+
+    func test_urlHits_fetch_whenSearchSuggestionsEnabled() async {
+        let urlLoader = DuckAIURLSuggestionsLoader(dataSource: StubSuggestionLoadingDataSource())
+        let chatViewModel = AIChatSuggestionsViewModel()
+        let chatManager = AIChatHistoryManager(
+            suggestionsReader: NilSuggestionsReader(),
+            aiChatSettings: MockAIChatSettingsProvider(),
+            aiChatDeleter: StubAIChatDeleter(),
+            viewModel: chatViewModel,
+            isFireTab: false
+        )
+        let source = DuckAISuggestionsSource(
+            chatViewModel: chatViewModel,
+            urlLoader: urlLoader,
+            chatManager: chatManager,
+            query: { "hotmail" },
+            searchSuggestionsEnabled: { true }
+        )
+        let textSubject = PassthroughSubject<String, Never>()
+        source.start(textPublisher: textSubject.eraseToAnyPublisher())
+        textSubject.send("hotmail")
+
+        let predicate = NSPredicate { _, _ in urlLoader.lastCompletedFetchQuery != nil }
+        await fulfillment(of: [expectation(for: predicate, evaluatedWith: nil)], timeout: 5.0)
+
+        XCTAssertEqual(urlLoader.lastCompletedFetchQuery, "hotmail")
+    }
 }
 
 // MARK: - Stubs

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/Suggestions/DuckAISuggestionsSelectionTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/Suggestions/DuckAISuggestionsSelectionTests.swift
@@ -154,7 +154,10 @@ private final class StubSuggestionLoadingDataSource: SuggestionLoadingDataSource
     func suggestionLoading(_ suggestionLoading: SuggestionLoading,
                            suggestionDataFromUrl url: URL,
                            withParameters parameters: [String: String],
-                           completion: @escaping (Data?, Error?) -> Void) {}
+                           completion: @escaping (Data?, Error?) -> Void) {
+        // Must call completion or SuggestionLoader's DispatchGroup never leaves and getSuggestions hangs forever.
+        completion(nil, nil)
+    }
 }
 
 @MainActor


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1216235587380278
Tech Design URL:
CC:

### Description

The Unified Toggle Input (UTI) suggestion surfaces were not respecting the "Search Suggestions" and "Chat Suggestions" settings (Settings → General → Private Search and Chat) the way the legacy omnibar did. Three separate gaps, found while validating against manual testing:

1. **Search-mode suggestions ignored "Search Suggestions" entirely.** Fixed by gating the suggestion loader's text stream and the source's query on `appSettings.autocomplete` in `UnifiedInputContentContainerViewController.installUnifiedSuggestionsHost()`, matching the pattern already used for Duck.ai chat suggestions (`aiChatSettings.isChatSuggestionsEnabled` in `attachDuckAISurfaceIfNeeded()`). The query itself is gated (not just the fetch) because `SearchSuggestionsSource.effectiveTopHits` falls back to a single phrase suggestion for a non-empty query against an empty result — gating only the fetch would still leave one suggestion row visible.

2. **Duck.ai-mode URL/website suggestions also ignored "Search Suggestions".** Legacy's iPhone omnibar gated these URL-fallback suggestions (shown while typing in Duck.ai mode) on the same `appSettings.autocomplete` setting; UTI's `DuckAISuggestionsSource` never did. Added a `searchSuggestionsEnabled` closure (same DI pattern as the existing `deleteEnabled`/`viewAllChatsEnabled`) that maps the URL loader's text stream to empty when the setting is off — chat history suggestions (governed by the separate Chat Suggestions setting) are untouched.

3. **"Chat Suggestions" required an app restart to take effect.** The Duck.ai surface's attach/detach decision (`attachDuckAISurfaceIfNeeded`) was only evaluated once, from `viewWillAppear` — but `UnifiedInputContentContainerViewController` is built once per browser session (`UnifiedToggleInputCoordinator.init`), not per omnibar focus, so `viewWillAppear` effectively only fires once. The real per-focus hook, `setActive(true)`, never re-ran the check. Added `syncDuckAISurfaceWithSettings()`, called from `setActive(true)`, which re-attaches/detaches against the live setting on every focus.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Ensure Unified Toggle Input is enabled (internal/experiment flag) so the address bar shows the Search / Duck.ai toggle.
2. **Search Suggestions, Search mode:** Settings → General → Private Search and Chat → turn **Search Suggestions** OFF. From a new tab, tap the address bar (Search mode) and type e.g. "apple".
   - **Expected:** no suggestions appear at all — not even a single row echoing the typed text.
3. Turn **Search Suggestions** back ON, repeat step 2.
   - **Expected:** suggestions appear as normal (e.g. apple.com, apple music, apple tv, apple store, apple watch, Ask AI Chat) — no restart needed.
4. **Search Suggestions, Duck.ai mode:** with Search Suggestions OFF, visit a site (e.g. apple.com) so it's in history. Open a new tab, switch the address bar to **Duck.ai** mode, and type a prefix of that site's name.
   - **Expected:** no URL/website suggestion row for that site (the "Search DuckDuckGo" row and chat recents may still show — those are separate).
5. Turn Search Suggestions back ON and repeat step 4 without restarting.
   - **Expected:** the URL suggestion for the visited site now appears.
6. **Chat Suggestions live toggle:** with some Duck.ai chat history present, turn **Chat Suggestions** OFF (Settings → General → Private Search and Chat). Without restarting the app, switch the address bar to Duck.ai mode.
   - **Expected:** no recent-chat suggestions appear.
7. Turn **Chat Suggestions** back ON and refocus the Duck.ai address bar without restarting.
   - **Expected:** recent chats reappear.

### Impact and Risks
<!--
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low — restores existing settings toggles' effects within a feature (UTI) that is currently mid-rollout; no change to default suggestion behavior when both settings are on.

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
- If the gate were applied inconsistently between the loader and the query closure, a stale/fallback suggestion could still leak through with the setting off — addressed by gating both the fetch and the query used for rendering/fallback (Search mode), and by gating the URL loader's own text stream directly (Duck.ai mode).
- The `syncDuckAISurfaceWithSettings()` re-check runs on every omnibar focus (`setActive(true)`), which is more frequent than the previous one-time `viewWillAppear` check, but it's a cheap boolean check with an attach/detach that's already idempotent (both guard on current state).

### Quality Considerations
<!--
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->
- Edge case covered: the single-phrase fallback row (`effectiveTopHits`) that renders even when the network result is empty — now suppressed by gating the query, not just the fetch (Search mode).
- Edge case covered: a URL-history deletion's post-delete refetch (`refreshURLSuggestionsAction`) also respects the setting now, so it can't bypass the gate.
- Automated test added for the Duck.ai URL-gating logic (`DuckAISuggestionsSelectionTests`). No automated test for the `syncDuckAISurfaceWithSettings()` live-toggle fix or the original Search-mode fix — both would require new `SuggestionTrayDependencies`/VC-level test scaffolding that doesn't exist anywhere in the suite yet. All three fixes verified manually on simulator (see Testing Steps).

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->
The three fixes touch the same underlying asymmetry: Search's setting is read live per-keystroke (a `Combine` `.map`), so it never needed a restart; Duck.ai's chat-suggestions setting was only checked once, at attach time. Worth double-checking `syncDuckAISurfaceWithSettings()`'s placement in `setActive(true)` is the right/only place this needs to happen — I didn't find another per-focus hook, but I'm not deeply familiar with the rest of the UTI focus lifecycle.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to UTI mid-rollout that restores existing user preferences; default behavior when both settings are on is unchanged.
>
> **Overview**
> **Unified Toggle Input** suggestions previously ignored **Settings → Search Suggestions** (`appSettings.autocomplete`) and required an app restart for **Chat Suggestions** to take effect.
>
> In `installUnifiedSuggestionsHost()`, both the search query and text publisher are now gated on `appSettings.autocomplete`. `DuckAISuggestionsSource` gained a `searchSuggestionsEnabled` closure gating its URL-hits sub-source only (chat history is unaffected). `setActive(true)` now calls `syncDuckAISurfaceWithSettings()` to re-attach/detach the Duck.ai surface against the live Chat Suggestions setting on every omnibar focus, instead of only once at `viewWillAppear`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 122fa80c9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
