### PR TITLE
[iOS] re-add "Tab Switcher" accessibility label

### DIFF
--- a/iOS/DuckDuckGo/ToolbarButtons/TabSwitcherStaticButton.swift
+++ b/iOS/DuckDuckGo/ToolbarButtons/TabSwitcherStaticButton.swift
@@ -58,6 +58,7 @@ final class TabSwitcherStaticButton: BrowserChromeButton, TabSwitcherButton {
         configureLongPressBehavior()
         setUpSubviews()
         self.isPointerInteractionEnabled = true
+        self.accessibilityLabel = UserText.tabSwitcherAccessibilityLabel
     }
 
     @available(*, unavailable)

--- a/iOS/DuckDuckGoTests/TabSwitcherStaticButtonTests.swift
+++ b/iOS/DuckDuckGoTests/TabSwitcherStaticButtonTests.swift
@@ -29,6 +29,11 @@ class TabSwitcherStaticButtonTests: XCTestCase {
         XCTAssertNil(button.text)
     }
 
+    func testWhenInitializedThenAccessibilityLabelIsTabSwitcher() {
+        let button = TabSwitcherStaticButton(showMenuOnLongPress: false)
+        XCTAssertEqual(UserText.tabSwitcherAccessibilityLabel, button.accessibilityLabel)
+    }
+
     func testWhenAnimateCalledThenCountIsNotIncremented() {
         let button = TabSwitcherStaticButton(showMenuOnLongPress: false)
         button.animateUpdate { }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1216262693560413?focus=true
Tech Design URL:
CC:

### Description
Re-adds "Tab Switcher" accessibility label. 

### Testing Steps
1. Check that E2E tests have passed. https://github.com/duckduckgo/apple-browsers/actions/runs/28653727227
2. OR run some of the missing tests locally and validate they pass

e.g. 
<img width="654" height="186" alt="Screenshot 2026-07-03 at 11 10 26" src="https://github.com/user-attachments/assets/991ece10-3945-491d-8af3-dac2f0edbf85" />

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single accessibility property and a test; no behavior or security impact beyond assistive tech labeling.
> 
> **Overview**
> Restores **`UserText.tabSwitcherAccessibilityLabel`** on **`TabSwitcherStaticButton`** during initialization so VoiceOver and UI tests can identify the toolbar tab switcher consistently with other tab switcher entry points.
> 
> Adds **`testWhenInitializedThenAccessibilityLabelIsTabSwitcher`** to lock in that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2c31cab35c58d57816389e9515a9d75a88cc8c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->