### PR TITLE
Fix pinned tab SSL error navigation

### DIFF
--- a/macOS/DuckDuckGo/Tab/TabExtensions/PopupHandlingTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PopupHandlingTabExtension.swift
@@ -437,7 +437,16 @@ extension PopupHandlingTabExtension: NavigationResponder {
         // Links clicked in a pinned tab navigating to another domain should open in a new tab
         let canOpenLinkInCurrentTab: Bool = {
             let isNavigatingToAnotherDomain = navigationAction.url.host != targetFrame.url.host && !targetFrame.url.isEmpty
-            let isNavigatingAwayFromPinnedTab = isLinkActivated && self.isTabPinned() && isNavigatingToAnotherDomain && navigationAction.isForMainFrame
+            // Don't treat leaving an internal error page as navigating away from a pinned tab: the SSL
+            // "Accept risk and visit site" reload navigates from duck://error back to the failing site,
+            // whose host differs from the error page's, so it would otherwise wrongly spawn a new tab
+            // (which re-shows the warning, as the SSL bypass flag lives only on the original tab).
+            let isLeavingErrorPage = targetFrame.url.isErrorURL
+            let isNavigatingAwayFromPinnedTab = isLinkActivated
+                && self.isTabPinned()
+                && isNavigatingToAnotherDomain
+                && navigationAction.isForMainFrame
+                && !isLeavingErrorPage
             return !isNavigatingAwayFromPinnedTab
         }()
 

--- a/macOS/UnitTests/TabExtensionsTests/PopupHandlingTabExtensionTests.swift
+++ b/macOS/UnitTests/TabExtensionsTests/PopupHandlingTabExtensionTests.swift
@@ -1256,6 +1256,38 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
         XCTAssertNil(policy, "Pinned tab same-domain navigation should return .next (nil)")
     }
 
+    @MainActor
+    func testWhenPinnedTabNavigatesFromErrorPageToAnotherDomain_ThenStaysInCurrentTab() async {
+        // GIVEN - Tab is pinned and currently showing an internal error page
+        popupHandlingExtension = createExtension(isTabPinned: true)
+
+        // WHEN - Navigate from the error page to a different domain
+        let targetURL = URL(string: "https://different.com")!
+        let errorFrame = FrameInfo(webView: webView,
+                                   handle: FrameHandle(rawValue: 1),
+                                   isMainFrame: true,
+                                   url: URL.error,
+                                   securityOrigin: URL.error.securityOrigin)
+
+        let navigationAction = NavigationAction(
+            request: URLRequest(url: targetURL),
+            navigationType: .linkActivated(isMiddleClick: false),
+            currentHistoryItemIdentity: nil,
+            redirectHistory: nil,
+            isUserInitiated: true,
+            sourceFrame: errorFrame,
+            targetFrame: errorFrame,
+            shouldDownload: false,
+            mainFrameNavigation: nil
+        )
+
+        var prefs = NavigationPreferences.default
+        let policy = await popupHandlingExtension.decidePolicy(for: navigationAction, preferences: &prefs)
+
+        // THEN - Should allow navigation in current tab (.next is nil)
+        XCTAssertNil(policy, "Pinned tab error-page navigation should return .next (nil)")
+    }
+
     // MARK: - pageInitiatedPopupOpened Flag Tests
 
     @MainActor


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1216240737348676
Tech Design URL:
CC: @ayoy 

### Description

Pinned tabs open cross-domain link clicks in a new unpinned tab. SSL error pages are a special case because the current frame is the internal `duck://error` page, and accepting the SSL risk navigates back to the failing site from that internal URL.

This keeps navigations that leave an internal error page in the current pinned tab so the tab-local SSL bypass flag remains available. It also adds a regression test for the pinned-tab error-page navigation path.

### Testing Steps
1. Visit an insecure website in a pinned tab (`wrong.host.badssl.com` works)
2. Click on “Advanced…”
3. Click on “Accept risk and visit site”

### Impact and Risks

Low: this changes pinned-tab navigation policy only when the current target frame is an internal error page.

#### What could go wrong?

Pinned-tab cross-domain navigations from normal web pages could accidentally stay in the pinned tab. The existing condition is preserved for normal pages, and the regression test covers the new `duck://error` exception.

### Quality Considerations

N/A

### Notes to Reviewer

N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to pinned-tab link policy only when the frame is an internal error page; normal cross-domain pinned-tab behavior is unchanged aside from that exception.
> 
> **Overview**
> Fixes **pinned-tab SSL “Accept risk and visit site”** failing because cross-domain link policy treated the reload from `duck://error` as leaving the pin and opened a **new unpinned tab**, where the tab-local SSL bypass is missing and the warning reappears.
> 
> **`PopupHandlingTabExtension.decidePolicy`** now skips the “navigate away from pinned tab → new tab” rule when the current main frame is an internal error URL (`targetFrame.url.isErrorURL`), so that navigation stays in the pinned tab.
> 
> Adds **`testWhenPinnedTabNavigatesFromErrorPageToAnotherDomain_ThenStaysInCurrentTab`** to lock in the error-page exception.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba28943eb7249d4f51dda2688768af997f959cb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->