### PR TITLE
iOS: Add contextual UTI part one

### DIFF
--- a/.maestro/unified_toggle_input/test_contextual_immediate_uti_manual_sticky_context.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_immediate_uti_manual_sticky_context.yaml
@@ -7,10 +7,11 @@ name: test_contextual_immediate_uti_manual_sticky_context
 
 ---
 
-# With the immediate contextual UTI flag on and automatic attachment off, manual
-# context is sticky across navigation before and after the first prompt. Post-submit
-# navigation with no pending chip shows the add affordance; navigation with a pending
-# manually attached chip keeps that chip attached.
+# With the immediate contextual UTI flag on and automatic attachment off, empty
+# context, removed context, and manual context are sticky across navigation before
+# and after the first prompt. Post-submit navigation with no pending chip shows the
+# add affordance; navigation with a pending manually attached chip keeps that chip
+# attached.
 
 - launchApp:
     appId: "com.duckduckgo.mobile.ios"
@@ -51,6 +52,11 @@ name: test_contextual_immediate_uti_manual_sticky_context
     timeout: 10000
 
 - tapOn:
+    id: "AIChat.ContextChip.RemoveButton"
+- assertVisible:
+    id: "AIChat.ContextChip.Placeholder"
+
+- tapOn:
     id: "AIChat.ContextualSheet.CloseButton"
 - waitForAnimationToEnd:
     timeout: 3000
@@ -60,6 +66,31 @@ name: test_contextual_immediate_uti_manual_sticky_context
 - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/index.html"
 - pressKey: Enter
 - assertVisible: ".*Address Bar Spoofing.*"
+
+- tapOn:
+    id: "Browser.OmniBar.Button.AIChat"
+- assertVisible:
+    id: "AIChat.ContextualSheet"
+- assertVisible:
+    id: "AIChat.ContextChip.Placeholder"
+
+- tapOn:
+    id: "AIChat.ContextChip.Placeholder"
+- extendedWaitUntil:
+    visible:
+        id: "AIChat.ContextChip.AttachedTitle"
+    timeout: 10000
+
+- tapOn:
+    id: "AIChat.ContextualSheet.CloseButton"
+- waitForAnimationToEnd:
+    timeout: 3000
+
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://privacy-test-pages.site/privacy-protections/geolocation/"
+- pressKey: Enter
+- assertVisible: ".*Geolocation.*"
 
 - tapOn:
     id: "Browser.OmniBar.Button.AIChat"

--- a/.maestro/unified_toggle_input/test_contextual_immediate_uti_manual_sticky_context.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_immediate_uti_manual_sticky_context.yaml
@@ -7,9 +7,10 @@ name: test_contextual_immediate_uti_manual_sticky_context
 
 ---
 
-# With the immediate contextual UTI flag on and automatic attachment off, the first
-# sheet show uses UTI before submit. Manually attached pre-submit context is sticky
-# across navigation and does not auto-update or clear.
+# With the immediate contextual UTI flag on and automatic attachment off, manual
+# context is sticky across navigation before and after the first prompt. Post-submit
+# navigation with no pending chip shows the add affordance; navigation with a pending
+# manually attached chip keeps that chip attached.
 
 - launchApp:
     appId: "com.duckduckgo.mobile.ios"
@@ -59,6 +60,64 @@ name: test_contextual_immediate_uti_manual_sticky_context
 - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/index.html"
 - pressKey: Enter
 - assertVisible: ".*Address Bar Spoofing.*"
+
+- tapOn:
+    id: "Browser.OmniBar.Button.AIChat"
+- assertVisible:
+    id: "AIChat.ContextualSheet"
+- assertVisible:
+    id: "AIChat.ContextChip.AttachedTitle"
+- assertNotVisible:
+    id: "AIChat.ContextChip.Placeholder"
+
+- tapOn:
+    id: "searchEntry"
+- inputText: "First contextual UTI prompt"
+- tapOn:
+    id: "AIChat.Toolbar.Button.Submit"
+
+- runFlow:
+    file: ../shared/dismiss_chat_open_modals.yaml
+- extendedWaitUntil:
+    notVisible:
+        id: "AIChat.ContextChip.AttachedTitle"
+    timeout: 30000
+
+- tapOn:
+    id: "AIChat.ContextualSheet.CloseButton"
+- waitForAnimationToEnd:
+    timeout: 3000
+
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://example.com"
+- pressKey: Enter
+- assertVisible: ".*Example Domain.*"
+
+- tapOn:
+    id: "Browser.OmniBar.Button.AIChat"
+- assertVisible:
+    id: "AIChat.ContextualSheet"
+- assertVisible:
+    id: "AIChat.ContextChip.Placeholder"
+
+- tapOn:
+    id: "AIChat.ContextChip.Placeholder"
+- extendedWaitUntil:
+    visible:
+        id: "AIChat.ContextChip.AttachedTitle"
+    timeout: 10000
+
+- tapOn:
+    id: "AIChat.ContextualSheet.CloseButton"
+- waitForAnimationToEnd:
+    timeout: 3000
+
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://example.org"
+- pressKey: Enter
+- assertVisible: ".*Example Domain.*"
 
 - tapOn:
     id: "Browser.OmniBar.Button.AIChat"

--- a/.maestro/unified_toggle_input/test_contextual_immediate_uti_manual_sticky_context.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_immediate_uti_manual_sticky_context.yaml
@@ -3,13 +3,13 @@ tags:
     - iphone
     - release
     - unified_toggle_input
-name: test_contextual_web_uti_manual_attach_regression
+name: test_contextual_immediate_uti_manual_sticky_context
 
 ---
 
-# With the immediate contextual UTI flag off, contextual chat still starts with the
-# basic native input, then shows the web UTI after the first prompt. In manual mode,
-# placeholder and manually attached context stay sticky across navigation.
+# With the immediate contextual UTI flag on and automatic attachment off, the first
+# sheet show uses UTI before submit. Manually attached pre-submit context is sticky
+# across navigation and does not auto-update or clear.
 
 - launchApp:
     appId: "com.duckduckgo.mobile.ios"
@@ -21,7 +21,7 @@ name: test_contextual_web_uti_manual_attach_regression
         isRunningUITests: true
         ff.unifiedToggleInput: "true"
         ff.contextualDuckAIMode: "true"
-        ff.aiChatContextualUnifiedToggleInput: "false"
+        ff.aiChatContextualUnifiedToggleInput: "true"
         ff.aiChatAutoAttachContextByDefault: "false"
 
 - runFlow:
@@ -38,20 +38,16 @@ name: test_contextual_web_uti_manual_attach_regression
 - assertVisible:
     id: "AIChat.ContextualSheet"
 - assertVisible:
+    id: "AIChat.ContextChip.Placeholder"
+- assertNotVisible:
     id: "AIChatNativeInputView.submitButton"
 
 - tapOn:
-    id: "AIChatNativeInputView.textView"
-- inputText: "First contextual prompt"
-- tapOn:
-    id: "AIChatNativeInputView.submitButton"
-
-- runFlow:
-    file: ../shared/dismiss_chat_open_modals.yaml
+    id: "AIChat.ContextChip.Placeholder"
 - extendedWaitUntil:
     visible:
-        text: "Attach Page Content"
-    timeout: 30000
+        id: "AIChat.ContextChip.AttachedTitle"
+    timeout: 10000
 
 - tapOn:
     id: "AIChat.ContextualSheet.CloseButton"
@@ -69,29 +65,6 @@ name: test_contextual_web_uti_manual_attach_regression
 - assertVisible:
     id: "AIChat.ContextualSheet"
 - assertVisible:
-    text: "Attach Page Content"
-
-- tapOn:
-    text: "Attach Page Content"
-- extendedWaitUntil:
-    notVisible: "Attach Page Content"
-    timeout: 10000
-
-- tapOn:
-    id: "AIChat.ContextualSheet.CloseButton"
-- waitForAnimationToEnd:
-    timeout: 3000
-
-- tapOn:
-    id: "searchEntry"
-- inputText: "https://privacy-test-pages.site/privacy-protections/geolocation/"
-- pressKey: Enter
-- assertVisible: ".*Geolocation.*"
-
-- tapOn:
-    id: "Browser.OmniBar.Button.AIChat"
-- assertVisible:
-    id: "AIChat.ContextualSheet"
-- extendedWaitUntil:
-    notVisible: "Attach Page Content"
-    timeout: 10000
+    id: "AIChat.ContextChip.AttachedTitle"
+- assertNotVisible:
+    id: "AIChat.ContextChip.Placeholder"

--- a/.maestro/unified_toggle_input/test_contextual_immediate_uti_pre_submit_context.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_immediate_uti_pre_submit_context.yaml
@@ -1,6 +1,7 @@
 appId: com.duckduckgo.mobile.ios
 tags:
     - iphone
+    - release
     - unified_toggle_input
 name: test_contextual_immediate_uti_pre_submit_context
 

--- a/.maestro/unified_toggle_input/test_contextual_immediate_uti_pre_submit_context.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_immediate_uti_pre_submit_context.yaml
@@ -1,0 +1,77 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - iphone
+    - unified_toggle_input
+name: test_contextual_immediate_uti_pre_submit_context
+
+---
+
+# With the immediate contextual UTI flag on, the first sheet show uses UTI before
+# submit. Removing pre-submit context keeps the placeholder across navigation, and
+# tapping the placeholder manually attaches again.
+
+- launchApp:
+    appId: "com.duckduckgo.mobile.ios"
+    clearState: true
+    clearKeychain: true
+    arguments:
+        isOnboardingCompleted: ${ONBOARDING_COMPLETED}
+        currentAppVariant: ${APP_VARIANT}
+        isRunningUITests: true
+        ff.unifiedToggleInput: "true"
+        ff.contextualDuckAIMode: "true"
+        ff.aiChatContextualUnifiedToggleInput: "true"
+        ff.aiChatAutoAttachContextByDefault: "true"
+
+- runFlow:
+    file: ../shared/dismiss_chat_open_modals.yaml
+
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://privacy-test-pages.site"
+- pressKey: Enter
+- assertVisible: ".*Privacy Test Pages.*"
+
+- tapOn:
+    id: "Browser.OmniBar.Button.AIChat"
+- assertVisible:
+    id: "AIChat.ContextualSheet"
+- assertVisible: "Summarize page"
+- assertNotVisible:
+    id: "AIChatNativeInputView.submitButton"
+- extendedWaitUntil:
+    visible:
+        id: "AIChat.ContextChip.AttachedTitle"
+    timeout: 10000
+
+- tapOn:
+    id: "AIChat.ContextChip.RemoveButton"
+- assertVisible:
+    id: "AIChat.ContextChip.Placeholder"
+
+- tapOn:
+    id: "AIChat.ContextualSheet.CloseButton"
+- waitForAnimationToEnd:
+    timeout: 3000
+
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/index.html"
+- pressKey: Enter
+- assertVisible: ".*Address Bar Spoofing.*"
+
+- tapOn:
+    id: "Browser.OmniBar.Button.AIChat"
+- assertVisible:
+    id: "AIChat.ContextualSheet"
+- assertVisible:
+    id: "AIChat.ContextChip.Placeholder"
+- assertNotVisible:
+    id: "AIChat.ContextChip.AttachedTitle"
+
+- tapOn:
+    id: "AIChat.ContextChip.Placeholder"
+- extendedWaitUntil:
+    visible:
+        id: "AIChat.ContextChip.AttachedTitle"
+    timeout: 10000

--- a/.maestro/unified_toggle_input/test_contextual_immediate_uti_pre_submit_context.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_immediate_uti_pre_submit_context.yaml
@@ -79,9 +79,6 @@ name: test_contextual_immediate_uti_pre_submit_context
 
 - runFlow:
     file: ../shared/dismiss_chat_open_modals.yaml
-- extendedWaitUntil:
-    visible: "Address Bar Spoofing.*"
-    timeout: 30000
 
 - tapOn:
     id: "AIChat.ContextualSheet.CloseButton"
@@ -90,9 +87,9 @@ name: test_contextual_immediate_uti_pre_submit_context
 
 - tapOn:
     id: "searchEntry"
-- inputText: "https://privacy-test-pages.site/privacy-protections/geolocation/"
+- inputText: "https://example.com"
 - pressKey: Enter
-- assertVisible: ".*Geolocation.*"
+- assertVisible: ".*Example Domain.*"
 
 - tapOn:
     id: "Browser.OmniBar.Button.AIChat"

--- a/.maestro/unified_toggle_input/test_contextual_immediate_uti_pre_submit_context.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_immediate_uti_pre_submit_context.yaml
@@ -7,8 +7,8 @@ name: test_contextual_immediate_uti_pre_submit_context
 ---
 
 # With the immediate contextual UTI flag on, the first sheet show uses UTI before
-# submit. Removing pre-submit context keeps the placeholder across navigation, and
-# tapping the placeholder manually attaches again.
+# submit. Removing pre-submit context clears the current chip, and a real navigation
+# with auto-attach enabled attaches the current page again.
 
 - launchApp:
     appId: "com.duckduckgo.mobile.ios"
@@ -64,13 +64,6 @@ name: test_contextual_immediate_uti_pre_submit_context
     id: "Browser.OmniBar.Button.AIChat"
 - assertVisible:
     id: "AIChat.ContextualSheet"
-- assertVisible:
-    id: "AIChat.ContextChip.Placeholder"
-- assertNotVisible:
-    id: "AIChat.ContextChip.AttachedTitle"
-
-- tapOn:
-    id: "AIChat.ContextChip.Placeholder"
 - extendedWaitUntil:
     visible:
         id: "AIChat.ContextChip.AttachedTitle"

--- a/.maestro/unified_toggle_input/test_contextual_immediate_uti_pre_submit_context.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_immediate_uti_pre_submit_context.yaml
@@ -9,8 +9,9 @@ name: test_contextual_immediate_uti_pre_submit_context
 
 # With the immediate contextual UTI flag on, the first sheet show uses UTI before
 # submit. Removing pre-submit context clears the current chip, and a real navigation
-# with auto-attach enabled attaches the current page again. After first submit,
-# dismissed-sheet navigation also auto-attaches the current page when reopened.
+# with auto-attach enabled attaches the current page again. After first submit, a
+# same-page reopen does not reattach; dismissed-sheet navigation still auto-attaches
+# the current page when reopened.
 
 - launchApp:
     appId: "com.duckduckgo.mobile.ios"
@@ -79,6 +80,18 @@ name: test_contextual_immediate_uti_pre_submit_context
 
 - runFlow:
     file: ../shared/dismiss_chat_open_modals.yaml
+
+- tapOn:
+    id: "AIChat.ContextualSheet.CloseButton"
+- waitForAnimationToEnd:
+    timeout: 3000
+
+- tapOn:
+    id: "Browser.OmniBar.Button.AIChat"
+- assertVisible:
+    id: "AIChat.ContextualSheet"
+- assertNotVisible:
+    id: "AIChat.ContextChip.AttachedTitle"
 
 - tapOn:
     id: "AIChat.ContextualSheet.CloseButton"

--- a/.maestro/unified_toggle_input/test_contextual_immediate_uti_pre_submit_context.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_immediate_uti_pre_submit_context.yaml
@@ -8,7 +8,8 @@ name: test_contextual_immediate_uti_pre_submit_context
 
 # With the immediate contextual UTI flag on, the first sheet show uses UTI before
 # submit. Removing pre-submit context clears the current chip, and a real navigation
-# with auto-attach enabled attaches the current page again.
+# with auto-attach enabled attaches the current page again. After first submit,
+# dismissed-sheet navigation also auto-attaches the current page when reopened.
 
 - launchApp:
     appId: "com.duckduckgo.mobile.ios"
@@ -59,6 +60,38 @@ name: test_contextual_immediate_uti_pre_submit_context
 - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/index.html"
 - pressKey: Enter
 - assertVisible: ".*Address Bar Spoofing.*"
+
+- tapOn:
+    id: "Browser.OmniBar.Button.AIChat"
+- assertVisible:
+    id: "AIChat.ContextualSheet"
+- extendedWaitUntil:
+    visible:
+        id: "AIChat.ContextChip.AttachedTitle"
+    timeout: 10000
+
+- tapOn:
+    id: "searchEntry"
+- inputText: "First contextual UTI prompt"
+- tapOn:
+    id: "AIChat.Toolbar.Button.Submit"
+
+- runFlow:
+    file: ../shared/dismiss_chat_open_modals.yaml
+- extendedWaitUntil:
+    visible: "Address Bar Spoofing.*"
+    timeout: 30000
+
+- tapOn:
+    id: "AIChat.ContextualSheet.CloseButton"
+- waitForAnimationToEnd:
+    timeout: 3000
+
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://privacy-test-pages.site/privacy-protections/geolocation/"
+- pressKey: Enter
+- assertVisible: ".*Geolocation.*"
 
 - tapOn:
     id: "Browser.OmniBar.Button.AIChat"

--- a/.maestro/unified_toggle_input/test_contextual_web_uti_auto_attach_regression.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_web_uti_auto_attach_regression.yaml
@@ -1,6 +1,7 @@
 appId: com.duckduckgo.mobile.ios
 tags:
     - iphone
+    - release
     - unified_toggle_input
 name: test_contextual_web_uti_auto_attach_regression
 

--- a/.maestro/unified_toggle_input/test_contextual_web_uti_auto_attach_regression.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_web_uti_auto_attach_regression.yaml
@@ -1,0 +1,71 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - iphone
+    - unified_toggle_input
+name: test_contextual_web_uti_auto_attach_regression
+
+---
+
+# Same first-submit web UTI setup as the manual-attach regression, but with automatic
+# context attachment enabled. After navigating and reopening the active contextual
+# chat, the UTI chip should attach the new page automatically.
+
+- launchApp:
+    appId: "com.duckduckgo.mobile.ios"
+    clearState: true
+    clearKeychain: true
+    arguments:
+        isOnboardingCompleted: ${ONBOARDING_COMPLETED}
+        currentAppVariant: ${APP_VARIANT}
+        isRunningUITests: true
+        ff.unifiedToggleInput: "true"
+        ff.contextualDuckAIMode: "true"
+        ff.aiChatContextualUnifiedToggleInput: "false"
+        ff.aiChatAutoAttachContextByDefault: "true"
+
+- runFlow:
+    file: ../shared/dismiss_chat_open_modals.yaml
+
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://privacy-test-pages.site"
+- pressKey: Enter
+- assertVisible: ".*Privacy Test Pages.*"
+
+- tapOn:
+    id: "Browser.OmniBar.Button.AIChat"
+- assertVisible:
+    id: "AIChat.ContextualSheet"
+- assertVisible:
+    id: "AIChatNativeInputView.submitButton"
+
+- tapOn:
+    id: "AIChatNativeInputView.textView"
+- inputText: "First contextual prompt"
+- tapOn:
+    id: "AIChatNativeInputView.submitButton"
+
+- runFlow:
+    file: ../shared/dismiss_chat_open_modals.yaml
+- extendedWaitUntil:
+    visible: "We don't track you.*"
+    timeout: 30000
+
+- tapOn:
+    id: "AIChat.ContextualSheet.CloseButton"
+- waitForAnimationToEnd:
+    timeout: 3000
+
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/index.html"
+- pressKey: Enter
+- assertVisible: ".*Address Bar Spoofing.*"
+
+- tapOn:
+    id: "Browser.OmniBar.Button.AIChat"
+- assertVisible:
+    id: "AIChat.ContextualSheet"
+- extendedWaitUntil:
+    notVisible: "Attach Page Content"
+    timeout: 10000

--- a/.maestro/unified_toggle_input/test_contextual_web_uti_manual_attach_regression.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_web_uti_manual_attach_regression.yaml
@@ -1,0 +1,77 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - iphone
+    - unified_toggle_input
+name: test_contextual_web_uti_manual_attach_regression
+
+---
+
+# With the immediate contextual UTI flag off, contextual chat still starts with the
+# basic native input, then shows the web UTI after the first prompt. After navigating,
+# the web UTI placeholder chip must manually attach page context.
+
+- launchApp:
+    appId: "com.duckduckgo.mobile.ios"
+    clearState: true
+    clearKeychain: true
+    arguments:
+        isOnboardingCompleted: ${ONBOARDING_COMPLETED}
+        currentAppVariant: ${APP_VARIANT}
+        isRunningUITests: true
+        ff.unifiedToggleInput: "true"
+        ff.contextualDuckAIMode: "true"
+        ff.aiChatContextualUnifiedToggleInput: "false"
+        ff.aiChatAutoAttachContextByDefault: "false"
+
+- runFlow:
+    file: ../shared/dismiss_chat_open_modals.yaml
+
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://privacy-test-pages.site"
+- pressKey: Enter
+- assertVisible: ".*Privacy Test Pages.*"
+
+- tapOn:
+    id: "Browser.OmniBar.Button.AIChat"
+- assertVisible:
+    id: "AIChat.ContextualSheet"
+- assertVisible:
+    id: "AIChatNativeInputView.submitButton"
+
+- tapOn:
+    id: "AIChatNativeInputView.textView"
+- inputText: "First contextual prompt"
+- tapOn:
+    id: "AIChatNativeInputView.submitButton"
+
+- runFlow:
+    file: ../shared/dismiss_chat_open_modals.yaml
+- extendedWaitUntil:
+    visible:
+        text: "Attach Page Content"
+    timeout: 30000
+
+- tapOn:
+    id: "AIChat.ContextualSheet.CloseButton"
+- waitForAnimationToEnd:
+    timeout: 3000
+
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/index.html"
+- pressKey: Enter
+- assertVisible: ".*Address Bar Spoofing.*"
+
+- tapOn:
+    id: "Browser.OmniBar.Button.AIChat"
+- assertVisible:
+    id: "AIChat.ContextualSheet"
+- assertVisible:
+    text: "Attach Page Content"
+
+- tapOn:
+    text: "Attach Page Content"
+- extendedWaitUntil:
+    notVisible: "Attach Page Content"
+    timeout: 10000

--- a/.maestro/unified_toggle_input/test_contextual_web_uti_manual_attach_regression.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_web_uti_manual_attach_regression.yaml
@@ -1,6 +1,7 @@
 appId: com.duckduckgo.mobile.ios
 tags:
     - iphone
+    - release
     - unified_toggle_input
 name: test_contextual_web_uti_manual_attach_regression
 

--- a/SharedPackages/AIChat/Sources/AIChat/iOS/Views/ContextChip/AIChatContextChipView.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/iOS/Views/ContextChip/AIChatContextChipView.swift
@@ -193,6 +193,7 @@ private extension AIChatContextChipView {
         switch state {
         case .placeholder:
             titleLabel.text = UserText.attachPageContent
+            titleLabel.accessibilityIdentifier = "AIChat.ContextChip.Placeholder"
             titleLabel.textColor = UIColor(designSystemColor: .textPlaceholder)
             faviconView.image = DesignSystemImages.Glyphs.Size24.pageContentAttach.withRenderingMode(.alwaysTemplate)
             faviconView.tintColor = UIColor(designSystemColor: .textTertiary)
@@ -208,6 +209,7 @@ private extension AIChatContextChipView {
 
         case .attached(let title, let favicon):
             titleLabel.text = title
+            titleLabel.accessibilityIdentifier = "AIChat.ContextChip.AttachedTitle"
             titleLabel.textColor = UIColor(designSystemColor: .textPrimary)
             removeButton.isHidden = false
             faviconView.image = favicon ?? placeholderFavicon()
@@ -291,6 +293,7 @@ private extension AIChatContextChipView {
     func setupAccessibility() {
         isAccessibilityElement = false
         removeButton.accessibilityLabel = "Remove"
+        removeButton.accessibilityIdentifier = "AIChat.ContextChip.RemoveButton"
         removeButton.accessibilityTraits = .button
     }
 

--- a/SharedPackages/AIChat/Sources/AIChat/iOS/Views/NativeInput/AIChatNativeInputView.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/iOS/Views/NativeInput/AIChatNativeInputView.swift
@@ -123,6 +123,7 @@ public final class AIChatNativeInputView: UIView {
         textView.textContainerInset = Constants.textContainerInset
         textView.isScrollEnabled = false
         textView.delegate = self
+        textView.accessibilityIdentifier = "AIChatNativeInputView.textView"
         textView.translatesAutoresizingMaskIntoConstraints = false
         return textView
     }()

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -464,6 +464,9 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// roll out the new Duck.ai-tab nav UI (no toggle on chat) independently of the master flag.
     case aiChatTabHideToggle
 
+    /// Enables Unified Toggle Input inside the iOS contextual AI chat sheet.
+    case contextualUnifiedToggleInput
+
     /// Signals that the iOS app should display duck.ai chats in "contextual mode" when opened from specific entry points
     case contextualDuckAIMode
 
@@ -518,9 +521,6 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
 
     /// Enables voice chat shortcut in the focused address bar
     case voiceShortcut
-
-    /// Enables improved contextual sheet UX (welcome message, ask about page, etc.)
-    case contextualSheetImprovements
 
     /// Enables removing individual AI chat suggestions
     case removeSuggestion

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -308,9 +308,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1204186595873227/task/1213651297612976?focus=true
     case aiChatNativeChatHistory
 
-    /// https://app.asana.com/1/137249556945/project/1208671677432066/task/1213651262338059
-    case aiChatContextualSheetImprovements
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212388316840466?focus=true
     case showWhatsNewPromptOnDemand
 
@@ -329,6 +326,9 @@ public enum FeatureFlag: String {
     /// `UnifiedToggleInputFeatureProviding.isToggleHiddenOnDuckAITab`.
     /// https://app.asana.com/1/137249556945/project/1206488453854252/task/1214995978971487?focus=true
     case aiChatTabHideToggle
+
+    /// https://app.asana.com/1/137249556945/project/1206488453854252/task/1212289671815991
+    case aiChatContextualUnifiedToggleInput
 
     /// Failsafe flag for whether the free trial conversion wide event is enabled
     case freeTrialConversionWideEvent
@@ -714,8 +714,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(DuckAiChatHistorySubfeature.featureEnabled))
         case .aiChatNativeChatHistory:
             Config(defaultValue: .enabled, source: .remoteReleasable(DuckAiChatHistorySubfeature.nativeChatHistory))
-        case .aiChatContextualSheetImprovements:
-            Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.contextualSheetImprovements))
         case .showWhatsNewPromptOnDemand:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.showWhatsNewPromptOnDemand))
         case .unifiedToggleInput:
@@ -726,6 +724,8 @@ extension FeatureFlag: FeatureFlagDescribing {
                    supportsLocalOverriding: false)
         case .aiChatTabHideToggle:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.aiChatTabHideToggle))
+        case .aiChatContextualUnifiedToggleInput:
+            Config(source: .remoteReleasable(AIChatSubfeature.contextualUnifiedToggleInput))
         case .freeTrialConversionWideEvent:
             Config(defaultValue: .enabled, source: .remoteReleasable(PrivacyProSubfeature.freeTrialConversionWideEvent))
         case .tabSwitcherTrackerCount:

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -327,7 +327,7 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1206488453854252/task/1214995978971487?focus=true
     case aiChatTabHideToggle
 
-    /// https://app.asana.com/1/137249556945/project/1206488453854252/task/1212289671815991
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216049537026986
     case aiChatContextualUnifiedToggleInput
 
     /// Failsafe flag for whether the free trial conversion wide event is enabled

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1991,7 +1991,7 @@
 		C18390BB2F4F6F54001939B9 /* UnifiedToggleInputCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18390BA2F4F6F54001939B9 /* UnifiedToggleInputCoordinator.swift */; };
 		C18390BD2F4F6F57001939B9 /* UnifiedToggleInputDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18390BC2F4F6F57001939B9 /* UnifiedToggleInputDelegate.swift */; };
 		C18390BF2F4F6F5E001939B9 /* UnifiedToggleInputFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18390BE2F4F6F5E001939B9 /* UnifiedToggleInputFeature.swift */; };
-		C18390C22F4F712A001939B9 /* AIChatNativeInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18390C12F4F712A001939B9 /* AIChatNativeInputViewController.swift */; };
+		C18390C22F4F712A001939B9 /* AIChatBasicNativeInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18390C12F4F712A001939B9 /* AIChatBasicNativeInputViewController.swift */; };
 		C18390C42F4F73AE001939B9 /* UnifiedToggleInputHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18390C32F4F73AE001939B9 /* UnifiedToggleInputHandler.swift */; };
 		C18390C72F5078ED001939B9 /* MainViewController+UnifiedToggleInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18390C62F5078ED001939B9 /* MainViewController+UnifiedToggleInput.swift */; };
 		C18390CA2F5099D8001939B9 /* UnifiedToggleInputHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18390C92F5099D8001939B9 /* UnifiedToggleInputHandlerTests.swift */; };
@@ -4719,7 +4719,7 @@
 		C18390BA2F4F6F54001939B9 /* UnifiedToggleInputCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputCoordinator.swift; sourceTree = "<group>"; };
 		C18390BC2F4F6F57001939B9 /* UnifiedToggleInputDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputDelegate.swift; sourceTree = "<group>"; };
 		C18390BE2F4F6F5E001939B9 /* UnifiedToggleInputFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputFeature.swift; sourceTree = "<group>"; };
-		C18390C12F4F712A001939B9 /* AIChatNativeInputViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatNativeInputViewController.swift; sourceTree = "<group>"; };
+		C18390C12F4F712A001939B9 /* AIChatBasicNativeInputViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatBasicNativeInputViewController.swift; sourceTree = "<group>"; };
 		C18390C32F4F73AE001939B9 /* UnifiedToggleInputHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputHandler.swift; sourceTree = "<group>"; };
 		C18390C62F5078ED001939B9 /* MainViewController+UnifiedToggleInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainViewController+UnifiedToggleInput.swift"; sourceTree = "<group>"; };
 		C18390C92F5099D8001939B9 /* UnifiedToggleInputHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputHandlerTests.swift; sourceTree = "<group>"; };
@@ -9534,7 +9534,7 @@
 		C15C85222EEFBA1D0096C9EF /* NativeInput */ = {
 			isa = PBXGroup;
 			children = (
-				C18390C12F4F712A001939B9 /* AIChatNativeInputViewController.swift */,
+				C18390C12F4F712A001939B9 /* AIChatBasicNativeInputViewController.swift */,
 			);
 			path = NativeInput;
 			sourceTree = "<group>";
@@ -13466,7 +13466,7 @@
 				8598D2E22CEB98B500C45685 /* FaviconRequestModifier.swift in Sources */,
 				CBAD0F102D0062A7006267B8 /* ScreenshotService.swift in Sources */,
 				8598D2E42CEB98B500C45685 /* FaviconSourcesProvider.swift in Sources */,
-				C18390C22F4F712A001939B9 /* AIChatNativeInputViewController.swift in Sources */,
+				C18390C22F4F712A001939B9 /* AIChatBasicNativeInputViewController.swift in Sources */,
 				CBB4A8652FD31A0A00A65956 /* SuggestionsFavoritesView.swift in Sources */,
 				317DF60B2D01E7D600DE0145 /* RoundedPageSheetPresentationAnimator.swift in Sources */,
 				85AE6690209724120014CF04 /* NotificationView.swift in Sources */,

--- a/iOS/DuckDuckGo/AIChat/AIChatContentHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatContentHandler.swift
@@ -44,6 +44,7 @@ protocol AIChatUserScriptProviding: AnyObject {
                       files: [AIChatNativePrompt.NativePromptFile]?,
                       modelId: String?,
                       tools: [AIChatRAGTool]?,
+                      pageContext: AIChatPageContextData?,
                       reasoningEffort: AIChatReasoningEffort?)
     func submitStartChatAction()
     func submitOpenSettingsAction()
@@ -110,6 +111,7 @@ protocol AIChatContentHandling: AnyObject {
                       files: [AIChatNativePrompt.NativePromptFile]?,
                       modelId: String?,
                       tools: [AIChatRAGTool]?,
+                      pageContext: AIChatPageContextData?,
                       reasoningEffort: AIChatReasoningEffort?)
 
     /// Submits a start chat action to initiate a new AI Chat conversation.
@@ -280,8 +282,9 @@ final class AIChatContentHandler: AIChatContentHandling {
                       files: [AIChatNativePrompt.NativePromptFile]?,
                       modelId: String?,
                       tools: [AIChatRAGTool]?,
+                      pageContext: AIChatPageContextData?,
                       reasoningEffort: AIChatReasoningEffort?) {
-        userScript?.submitPrompt(prompt, images: images, files: files, modelId: modelId, tools: tools, reasoningEffort: reasoningEffort)
+        userScript?.submitPrompt(prompt, images: images, files: files, modelId: modelId, tools: tools, pageContext: pageContext, reasoningEffort: reasoningEffort)
     }
 
     /// Submits a start chat action to initiate a new AI Chat conversation.

--- a/iOS/DuckDuckGo/AIChat/AIChatContentHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatContentHandler.swift
@@ -39,6 +39,12 @@ protocol AIChatUserScriptProviding: AnyObject {
     func setContextualModePixelHandler(_ pixelHandler: AIChatContextualModePixelFiring)
     func setDisplayMode(_ displayMode: AIChatDisplayMode)
     func submitPrompt(_ prompt: String, pageContext: AIChatPageContextData?)
+    func submitPrompt(_ prompt: String,
+                      images: [AIChatNativePrompt.NativePromptImage]?,
+                      files: [AIChatNativePrompt.NativePromptFile]?,
+                      modelId: String?,
+                      tools: [AIChatRAGTool]?,
+                      reasoningEffort: AIChatReasoningEffort?)
     func submitStartChatAction()
     func submitOpenSettingsAction()
     func submitPageContext(_ context: AIChatPageContextData?)
@@ -98,6 +104,13 @@ protocol AIChatContentHandling: AnyObject {
     /// Submits a prompt to the AI Chat with optional page context.
     func submitPrompt(_ prompt: String, pageContext: AIChatPageContextData?)
 
+    /// Submits a rich native prompt to the AI Chat.
+    func submitPrompt(_ prompt: String,
+                      images: [AIChatNativePrompt.NativePromptImage]?,
+                      files: [AIChatNativePrompt.NativePromptFile]?,
+                      modelId: String?,
+                      tools: [AIChatRAGTool]?,
+                      reasoningEffort: AIChatReasoningEffort?)
 
     /// Submits a start chat action to initiate a new AI Chat conversation.
     func submitStartChatAction()
@@ -260,6 +273,15 @@ final class AIChatContentHandler: AIChatContentHandling {
             Logger.aiChat.debug("[PageContext] Prompt submitted without context")
         }
         userScript?.submitPrompt(prompt, pageContext: pageContext)
+    }
+
+    func submitPrompt(_ prompt: String,
+                      images: [AIChatNativePrompt.NativePromptImage]?,
+                      files: [AIChatNativePrompt.NativePromptFile]?,
+                      modelId: String?,
+                      tools: [AIChatRAGTool]?,
+                      reasoningEffort: AIChatReasoningEffort?) {
+        userScript?.submitPrompt(prompt, images: images, files: files, modelId: modelId, tools: tools, reasoningEffort: reasoningEffort)
     }
 
     /// Submits a start chat action to initiate a new AI Chat conversation.

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -74,8 +74,15 @@ struct SheetViewState {
 enum SheetEffect {
     case submitPrompt(prompt: String, context: AIChatPageContextData?)
     case reloadWebView
-    case deliverPageContext(AIChatPageContextData?)
+    case deliverPageContext(AIChatPageContextData?, targets: PageContextDeliveryTargets)
     case clearPrompt
+}
+
+struct PageContextDeliveryTargets: OptionSet {
+    let rawValue: Int
+
+    static let utiChip = PageContextDeliveryTargets(rawValue: 1 << 0)
+    static let frontendBridge = PageContextDeliveryTargets(rawValue: 1 << 1)
 }
 
 // MARK: - Session State
@@ -343,7 +350,7 @@ final class AIChatContextualChatSessionState {
     /// so the FE can show the "Add page content" button for the new page.
     func notifyFrontendOfMultiContextNavigation() {
         guard supportsMultipleContexts, shouldDeliverToFrontendBridge(nil) else { return }
-        emit(.deliverPageContext(nil))
+        emit(.deliverPageContext(nil, targets: .frontendBridge))
         Logger.aiChat.debug("[SessionState] Sent null context navigation signal to frontend")
     }
 
@@ -545,7 +552,14 @@ private extension AIChatContextualChatSessionState {
     }
 
     func emitDeliveryIfNeeded(_ context: AIChatPageContextData?) {
-        guard shouldDeliverToUTIChip(context) || shouldDeliverToFrontendBridge(context) else { return }
-        emit(.deliverPageContext(context))
+        var targets: PageContextDeliveryTargets = []
+        if shouldDeliverToUTIChip(context) {
+            targets.insert(.utiChip)
+        }
+        if shouldDeliverToFrontendBridge(context) {
+            targets.insert(.frontendBridge)
+        }
+        guard !targets.isEmpty else { return }
+        emit(.deliverPageContext(context, targets: targets))
     }
 }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -374,6 +374,10 @@ final class AIChatContextualChatSessionState {
     /// Updates the latest page context and determines attach behavior based on internal state.
     func updateContext(_ context: AIChatPageContext?) {
         guard let context = context else {
+            guard shouldProcessNilContextUpdate else {
+                Logger.aiChat.debug("[SessionState] Ignoring nil context update without active collection")
+                return
+            }
             Logger.aiChat.debug("[SessionState] Context collection returned nil - clearing context and downgrading to placeholder")
             latestContext = nil
             chipState = .placeholder
@@ -512,6 +516,10 @@ private extension AIChatContextualChatSessionState {
 
     func shouldAllowAutomaticUpgrade() -> Bool {
         return !userDowngradedToPlaceholder
+    }
+
+    var shouldProcessNilContextUpdate: Bool {
+        shouldAutoCollectContext || isManualAttachInProgress || isProcessingNavigation
     }
 
     private func resolveQuickActions() -> [AIChatContextualQuickAction] {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -177,7 +177,7 @@ final class AIChatContextualChatSessionState {
         featureFlagger.isFeatureOn(.multiplePageContexts)
     }
 
-    private var isPreSubmitUnifiedToggleInputOptOutActive: Bool {
+    private var hasUserOptedOutOfPreChatUTIContext: Bool {
         isUnifiedToggleInputActive && frontendState == .noChat && userDowngradedToPlaceholder
     }
 
@@ -327,7 +327,7 @@ final class AIChatContextualChatSessionState {
     /// Notify that page navigation occurred
     func notifyPageChanged(pageURL: URL? = nil) {
         Logger.aiChat.debug("[SessionState] Page navigation detected")
-        if !isPreSubmitUnifiedToggleInputOptOutActive || isNavigationToDifferentPage(pageURL) {
+        if !hasUserOptedOutOfPreChatUTIContext || isNavigationToDifferentPage(pageURL) {
             clearUserDowngradeOnNavigation()
         }
         isProcessingNavigation = true
@@ -339,7 +339,7 @@ final class AIChatContextualChatSessionState {
     }
 
     func shouldTriggerAutoCollect(for pageURL: URL) -> Bool {
-        guard !isPreSubmitUnifiedToggleInputOptOutActive else { return false }
+        guard !hasUserOptedOutOfPreChatUTIContext else { return false }
         guard shouldAutoCollectContext else { return false }
         guard let attachedContext = intendedAttachedContext,
               URL(string: attachedContext.contextData.url) == pageURL else {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -492,9 +492,7 @@ private extension AIChatContextualChatSessionState {
                     lastDeliveredContextURL = nil
                     didUpdateAttachment = true
                     Logger.aiChat.debug("[SessionState] Auto-attached context (setting ON)")
-                    if isShowingNativeInput {
-                        pixelHandler.firePageContextAutoAttached()
-                    }
+                    pixelHandler.firePageContextAutoAttached()
                 }
 
             case .attached:

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -327,6 +327,10 @@ final class AIChatContextualChatSessionState {
     func notifyPageChanged(pageURL: URL? = nil) {
         Logger.aiChat.debug("[SessionState] Page navigation detected")
         isProcessingNavigation = true
+        if shouldAutoCollectContext, userDowngradedToPlaceholder {
+            userDowngradedToPlaceholder = false
+            Logger.aiChat.debug("[SessionState] Page navigation cleared temporary context removal")
+        }
     }
 
     func updateUnifiedToggleInputActive(_ isActive: Bool, isImmediateContextual _: Bool = false) {
@@ -335,8 +339,8 @@ final class AIChatContextualChatSessionState {
     }
 
     func shouldTriggerAutoCollect(for pageURL: URL? = nil) -> Bool {
-        guard !hasUserOptedOutOfContext else { return false }
         guard shouldAutoCollectContext else { return false }
+        guard !hasUserOptedOutOfContext else { return false }
         guard let pageURL else { return true }
         guard let attachedContext = intendedAttachedContext,
               URL(string: attachedContext.contextData.url) == pageURL else {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -111,6 +111,7 @@ final class AIChatContextualChatSessionState {
     private(set) var userDowngradedToPlaceholder = false
     private var wasAutoAttachEnabled: Bool
     private var isUnifiedToggleInputActive = false
+    private var isImmediateContextualUnifiedToggleInputActive = false
     private var lastDeliveredContextURL: URL?
 
     // MARK: - Internal Flags
@@ -178,7 +179,7 @@ final class AIChatContextualChatSessionState {
     }
 
     private var hasUserOptedOutOfPreChatUTIContext: Bool {
-        isUnifiedToggleInputActive && frontendState == .noChat && userDowngradedToPlaceholder
+        isImmediateContextualUnifiedToggleInputActive && frontendState == .noChat && userDowngradedToPlaceholder
     }
 
     private func isNavigationToDifferentPage(_ pageURL: URL?) -> Bool {
@@ -333,8 +334,9 @@ final class AIChatContextualChatSessionState {
         isProcessingNavigation = true
     }
 
-    func updateUnifiedToggleInputActive(_ isActive: Bool) {
+    func updateUnifiedToggleInputActive(_ isActive: Bool, isImmediateContextual: Bool = false) {
         isUnifiedToggleInputActive = isActive
+        isImmediateContextualUnifiedToggleInputActive = isImmediateContextual
         rebuildViewState()
     }
 

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -83,6 +83,7 @@ struct PageContextDeliveryTargets: OptionSet {
 
     static let utiChip = PageContextDeliveryTargets(rawValue: 1 << 0)
     static let frontendBridge = PageContextDeliveryTargets(rawValue: 1 << 1)
+    static let utiAttachAffordance = PageContextDeliveryTargets(rawValue: 1 << 2)
 }
 
 // MARK: - Session State
@@ -118,7 +119,6 @@ final class AIChatContextualChatSessionState {
     private(set) var userDowngradedToPlaceholder = false
     private var wasAutoAttachEnabled: Bool
     private var isUnifiedToggleInputActive = false
-    private var lastDeliveredContextURL: URL?
 
     // MARK: - Internal Flags
 
@@ -250,7 +250,6 @@ final class AIChatContextualChatSessionState {
         frontendState = .noChat
         chipState = .placeholder
         contextualChatURL = nil
-        lastDeliveredContextURL = nil
         userDowngradedToPlaceholder = false
         isManualAttachInProgress = false
         isManualAttachFromFrontend = false
@@ -295,22 +294,10 @@ final class AIChatContextualChatSessionState {
         guard case .attached = chipState else { return }
         chipState = .placeholder
         userDowngradedToPlaceholder = true
-        lastDeliveredContextURL = nil
         pixelHandler.firePageContextRemovedNative()
         rebuildViewState()
         emitDeliveryIfNeeded(nil)
         Logger.aiChat.debug("[SessionState] Chip downgraded to placeholder via coordinator")
-    }
-
-    /// Detaches context because the visible page moved away while auto-attach is off.
-    /// This is not a user opt-out and should not fire user-removal pixels.
-    func detachFromNavigationAway() {
-        guard case .attached = chipState else { return }
-        chipState = .placeholder
-        lastDeliveredContextURL = nil
-        rebuildViewState()
-        emitDeliveryIfNeeded(nil)
-        Logger.aiChat.debug("[SessionState] Chip detached because page navigated away")
     }
 
     // MARK: - Context Management
@@ -349,13 +336,23 @@ final class AIChatContextualChatSessionState {
         return false
     }
 
-    /// Sends a null context to the frontend as a navigation signal.
+    /// Sends a null context as a navigation signal.
     /// Used when auto-collect is OFF but multiple contexts are supported,
     /// so the FE can show the "Add page content" button for the new page.
     func notifyFrontendOfMultiContextNavigation() {
-        guard supportsMultipleContexts, shouldDeliverToFrontendBridge(nil) else { return }
-        emit(.deliverPageContext(nil, targets: .frontendBridge))
-        Logger.aiChat.debug("[SessionState] Sent null context navigation signal to frontend")
+        guard supportsMultipleContexts else { return }
+
+        var targets: PageContextDeliveryTargets = []
+        if shouldDeliverToFrontendBridge(nil) {
+            targets.insert(.frontendBridge)
+        }
+        if shouldShowUTIAttachAffordanceForMultiContextNavigation() {
+            targets.insert(.utiAttachAffordance)
+        }
+
+        guard !targets.isEmpty else { return }
+        emit(.deliverPageContext(nil, targets: targets))
+        Logger.aiChat.debug("[SessionState] Sent null context navigation signal")
     }
 
     /// Clear the navigation processing flag (called when collection can't start)
@@ -443,17 +440,10 @@ final class AIChatContextualChatSessionState {
         return shouldDeliver
     }
 
-    func markPageContextDeliveredInPrompt(_ url: URL?) {
-        lastDeliveredContextURL = url
+    func shouldShowUTIAttachAffordanceForMultiContextNavigation() -> Bool {
+        isUnifiedToggleInputActive && hasActiveChat && !shouldAutoCollectContext
     }
 
-    func hasDeliveredPageContext(_ context: AIChatPageContextData) -> Bool {
-        guard let url = URL(string: context.url),
-              let lastDeliveredContextURL else {
-            return false
-        }
-        return url == lastDeliveredContextURL
-    }
 }
 
 // MARK: - Private
@@ -464,7 +454,6 @@ private extension AIChatContextualChatSessionState {
         if isShowingNativeInput || isUnifiedToggleInputActive {
             chipState = .attached(context)
             userDowngradedToPlaceholder = false
-            lastDeliveredContextURL = nil
             Logger.aiChat.debug("[SessionState] Manually attached context")
         }
 
@@ -490,7 +479,6 @@ private extension AIChatContextualChatSessionState {
                 if shouldAllowAutomaticUpgrade() {
                     chipState = .attached(context)
                     userDowngradedToPlaceholder = false
-                    lastDeliveredContextURL = nil
                     didUpdateAttachment = true
                     Logger.aiChat.debug("[SessionState] Auto-attached context (setting ON)")
                     pixelHandler.firePageContextAutoAttached()

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -327,9 +327,10 @@ final class AIChatContextualChatSessionState {
         rebuildViewState()
     }
 
-    func shouldTriggerAutoCollect(for pageURL: URL) -> Bool {
+    func shouldTriggerAutoCollect(for pageURL: URL? = nil) -> Bool {
         guard !hasUserOptedOutOfContext else { return false }
         guard shouldAutoCollectContext else { return false }
+        guard let pageURL else { return true }
         guard let attachedContext = intendedAttachedContext,
               URL(string: attachedContext.contextData.url) == pageURL else {
             return true

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -182,14 +182,6 @@ final class AIChatContextualChatSessionState {
         isImmediateContextualUnifiedToggleInputActive && frontendState == .noChat && userDowngradedToPlaceholder
     }
 
-    private func isNavigationToDifferentPage(_ pageURL: URL?) -> Bool {
-        guard let pageURL,
-              let latestContextURL = latestContext.flatMap({ URL(string: $0.contextData.url) }) else {
-            return false
-        }
-        return latestContextURL != pageURL
-    }
-
     // MARK: - Frontend Chat State Transitions
 
     /// Call when user submits a prompt from native input
@@ -328,7 +320,7 @@ final class AIChatContextualChatSessionState {
     /// Notify that page navigation occurred
     func notifyPageChanged(pageURL: URL? = nil) {
         Logger.aiChat.debug("[SessionState] Page navigation detected")
-        if !hasUserOptedOutOfPreChatUTIContext || isNavigationToDifferentPage(pageURL) {
+        if !hasUserOptedOutOfPreChatUTIContext {
             clearUserDowngradeOnNavigation()
         }
         isProcessingNavigation = true

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -111,7 +111,6 @@ final class AIChatContextualChatSessionState {
     private(set) var userDowngradedToPlaceholder = false
     private var wasAutoAttachEnabled: Bool
     private var isUnifiedToggleInputActive = false
-    private var isImmediateContextualUnifiedToggleInputActive = false
     private var lastDeliveredContextURL: URL?
 
     // MARK: - Internal Flags
@@ -178,8 +177,8 @@ final class AIChatContextualChatSessionState {
         featureFlagger.isFeatureOn(.multiplePageContexts)
     }
 
-    private var hasUserOptedOutOfPreChatUTIContext: Bool {
-        isImmediateContextualUnifiedToggleInputActive && frontendState == .noChat && userDowngradedToPlaceholder
+    private var hasUserOptedOutOfContext: Bool {
+        userDowngradedToPlaceholder
     }
 
     // MARK: - Frontend Chat State Transitions
@@ -320,20 +319,16 @@ final class AIChatContextualChatSessionState {
     /// Notify that page navigation occurred
     func notifyPageChanged(pageURL: URL? = nil) {
         Logger.aiChat.debug("[SessionState] Page navigation detected")
-        if !hasUserOptedOutOfPreChatUTIContext {
-            clearUserDowngradeOnNavigation()
-        }
         isProcessingNavigation = true
     }
 
-    func updateUnifiedToggleInputActive(_ isActive: Bool, isImmediateContextual: Bool = false) {
+    func updateUnifiedToggleInputActive(_ isActive: Bool, isImmediateContextual _: Bool = false) {
         isUnifiedToggleInputActive = isActive
-        isImmediateContextualUnifiedToggleInputActive = isImmediateContextual
         rebuildViewState()
     }
 
     func shouldTriggerAutoCollect(for pageURL: URL) -> Bool {
-        guard !hasUserOptedOutOfPreChatUTIContext else { return false }
+        guard !hasUserOptedOutOfContext else { return false }
         guard shouldAutoCollectContext else { return false }
         guard let attachedContext = intendedAttachedContext,
               URL(string: attachedContext.contextData.url) == pageURL else {
@@ -517,13 +512,6 @@ private extension AIChatContextualChatSessionState {
 
     func shouldAllowAutomaticUpgrade() -> Bool {
         return !userDowngradedToPlaceholder
-    }
-
-    func clearUserDowngradeOnNavigation() {
-        if userDowngradedToPlaceholder {
-            userDowngradedToPlaceholder = false
-            Logger.aiChat.debug("[SessionState] Cleared user downgrade flag on navigation")
-        }
     }
 
     private func resolveQuickActions() -> [AIChatContextualQuickAction] {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -74,7 +74,7 @@ struct SheetViewState {
 enum SheetEffect {
     case submitPrompt(prompt: String, context: AIChatPageContextData?)
     case reloadWebView
-    case pushContextToFrontend(AIChatPageContextData?)
+    case deliverPageContext(AIChatPageContextData?)
     case clearPrompt
 }
 
@@ -110,6 +110,8 @@ final class AIChatContextualChatSessionState {
     /// Tracks whether the user explicitly downgraded from attached to placeholder
     private(set) var userDowngradedToPlaceholder = false
     private var wasAutoAttachEnabled: Bool
+    private var isUnifiedToggleInputActive = false
+    private var lastDeliveredContextURL: URL?
 
     // MARK: - Internal Flags
 
@@ -175,6 +177,18 @@ final class AIChatContextualChatSessionState {
         featureFlagger.isFeatureOn(.multiplePageContexts)
     }
 
+    private var isPreSubmitUnifiedToggleInputOptOutActive: Bool {
+        isUnifiedToggleInputActive && frontendState == .noChat && userDowngradedToPlaceholder
+    }
+
+    private func isNavigationToDifferentPage(_ pageURL: URL?) -> Bool {
+        guard let pageURL,
+              let latestContextURL = latestContext.flatMap({ URL(string: $0.contextData.url) }) else {
+            return false
+        }
+        return latestContextURL != pageURL
+    }
+
     // MARK: - Frontend Chat State Transitions
 
     /// Call when user submits a prompt from native input
@@ -206,11 +220,38 @@ final class AIChatContextualChatSessionState {
         emit(.submitPrompt(prompt: prompt, context: contextData))
     }
 
+    /// Call when the first prompt is submitted through contextual UTI. The UTI coordinator
+    /// delivers the prompt, so this only performs the contextual session transition and pixels.
+    func beginChatForUTISubmission(url: URL? = nil) {
+        guard frontendState != .restoredChat else {
+            Logger.aiChat.debug("[SessionState] UTI chat start request ignored - preserving .restoredChat state")
+            return
+        }
+
+        switch chipState {
+        case .attached:
+            frontendState = .chatWithInitialContext
+            pixelHandler.firePromptSubmittedWithContext()
+            Logger.aiChat.debug("[SessionState] UTI chat started WITH initial context")
+        case .placeholder:
+            frontendState = .chatWithoutInitialContext
+            pixelHandler.firePromptSubmittedWithoutContext()
+            Logger.aiChat.debug("[SessionState] UTI chat started WITHOUT initial context")
+        }
+
+        if let url {
+            contextualChatURL = url
+        }
+
+        rebuildViewState()
+    }
+
     /// Call when starting a new chat (resetting frontend)
     func resetToNoChat() {
         frontendState = .noChat
         chipState = .placeholder
         contextualChatURL = nil
+        lastDeliveredContextURL = nil
         userDowngradedToPlaceholder = false
         isManualAttachInProgress = false
         isManualAttachFromFrontend = false
@@ -246,11 +287,7 @@ final class AIChatContextualChatSessionState {
     func handleChipRemoval() -> Bool {
         guard case .attached = chipState else { return false }
 
-        chipState = .placeholder
-        userDowngradedToPlaceholder = true
-        pixelHandler.firePageContextRemovedNative()
-        rebuildViewState()
-        Logger.aiChat.debug("[SessionState] Chip downgraded to placeholder (user action)")
+        downgradeToPlaceholder()
         return true
     }
 
@@ -259,9 +296,22 @@ final class AIChatContextualChatSessionState {
         guard case .attached = chipState else { return }
         chipState = .placeholder
         userDowngradedToPlaceholder = true
+        lastDeliveredContextURL = nil
         pixelHandler.firePageContextRemovedNative()
         rebuildViewState()
+        emitDeliveryIfNeeded(nil)
         Logger.aiChat.debug("[SessionState] Chip downgraded to placeholder via coordinator")
+    }
+
+    /// Detaches context because the visible page moved away while auto-attach is off.
+    /// This is not a user opt-out and should not fire user-removal pixels.
+    func detachFromNavigationAway() {
+        guard case .attached = chipState else { return }
+        chipState = .placeholder
+        lastDeliveredContextURL = nil
+        rebuildViewState()
+        emitDeliveryIfNeeded(nil)
+        Logger.aiChat.debug("[SessionState] Chip detached because page navigated away")
     }
 
     // MARK: - Context Management
@@ -275,18 +325,35 @@ final class AIChatContextualChatSessionState {
     }
 
     /// Notify that page navigation occurred
-    func notifyPageChanged() {
+    func notifyPageChanged(pageURL: URL? = nil) {
         Logger.aiChat.debug("[SessionState] Page navigation detected")
-        clearUserDowngradeOnNavigation()
+        if !isPreSubmitUnifiedToggleInputOptOutActive || isNavigationToDifferentPage(pageURL) {
+            clearUserDowngradeOnNavigation()
+        }
         isProcessingNavigation = true
+    }
+
+    func updateUnifiedToggleInputActive(_ isActive: Bool) {
+        isUnifiedToggleInputActive = isActive
+        rebuildViewState()
+    }
+
+    func shouldTriggerAutoCollect(for pageURL: URL) -> Bool {
+        guard !isPreSubmitUnifiedToggleInputOptOutActive else { return false }
+        guard shouldAutoCollectContext else { return false }
+        guard let attachedContext = intendedAttachedContext,
+              URL(string: attachedContext.contextData.url) == pageURL else {
+            return true
+        }
+        return false
     }
 
     /// Sends a null context to the frontend as a navigation signal.
     /// Used when auto-collect is OFF but multiple contexts are supported,
     /// so the FE can show the "Add page content" button for the new page.
     func notifyFrontendOfMultiContextNavigation() {
-        guard supportsMultipleContexts, canPushToFrontend() else { return }
-        emit(.pushContextToFrontend(nil))
+        guard supportsMultipleContexts, shouldDeliverToFrontendBridge(nil) else { return }
+        emit(.deliverPageContext(nil))
         Logger.aiChat.debug("[SessionState] Sent null context navigation signal to frontend")
     }
 
@@ -349,6 +416,43 @@ final class AIChatContextualChatSessionState {
     func requestWebViewReload() {
         emit(.reloadWebView)
     }
+
+    func shouldDeliverToUTIChip(_ context: AIChatPageContextData?) -> Bool {
+        guard isUnifiedToggleInputActive else { return false }
+        guard context != nil || hasActiveChat || userDowngradedToPlaceholder else { return false }
+        return true
+    }
+
+    func shouldDeliverToFrontendBridge(_ context: AIChatPageContextData?) -> Bool {
+        if isUnifiedToggleInputActive, context != nil {
+            Logger.aiChat.debug("[SessionState] shouldDeliverToFrontendBridge=false (non-nil context delivered to UTI)")
+            return false
+        }
+
+        let shouldDeliver: Bool
+        switch frontendState {
+        case .chatWithoutInitialContext, .restoredChat:
+            shouldDeliver = true
+        case .chatWithInitialContext:
+            shouldDeliver = supportsMultipleContexts
+        case .noChat:
+            shouldDeliver = false
+        }
+        Logger.aiChat.debug("[SessionState] shouldDeliverToFrontendBridge=\(shouldDeliver) (frontendState=\(self.frontendState), multipleContexts=\(self.supportsMultipleContexts), uti=\(self.isUnifiedToggleInputActive))")
+        return shouldDeliver
+    }
+
+    func markPageContextDeliveredInPrompt(_ url: URL?) {
+        lastDeliveredContextURL = url
+    }
+
+    func hasDeliveredPageContext(_ context: AIChatPageContextData) -> Bool {
+        guard let url = URL(string: context.url),
+              let lastDeliveredContextURL else {
+            return false
+        }
+        return url == lastDeliveredContextURL
+    }
 }
 
 // MARK: - Private
@@ -356,15 +460,14 @@ final class AIChatContextualChatSessionState {
 private extension AIChatContextualChatSessionState {
 
     func handleManualAttach(_ context: AIChatPageContext) {
-        if isShowingNativeInput {
+        if isShowingNativeInput || isUnifiedToggleInputActive {
             chipState = .attached(context)
             userDowngradedToPlaceholder = false
+            lastDeliveredContextURL = nil
             Logger.aiChat.debug("[SessionState] Manually attached context")
         }
 
-        if canPushToFrontend() {
-            emit(.pushContextToFrontend(context.contextData))
-        }
+        emitDeliveryIfNeeded(context.contextData)
 
         if isManualAttachFromFrontend {
             pixelHandler.firePageContextManuallyAttachedFrontend()
@@ -378,26 +481,33 @@ private extension AIChatContextualChatSessionState {
     }
 
     func handleAutoAttach(_ context: AIChatPageContext) {
-        if isShowingNativeInput {
+        var didUpdateAttachment = false
+
+        if isShowingNativeInput || isUnifiedToggleInputActive {
             switch chipState {
             case .placeholder:
                 if shouldAllowAutomaticUpgrade() {
                     chipState = .attached(context)
                     userDowngradedToPlaceholder = false
+                    lastDeliveredContextURL = nil
+                    didUpdateAttachment = true
                     Logger.aiChat.debug("[SessionState] Auto-attached context (setting ON)")
-                    pixelHandler.firePageContextAutoAttached()
+                    if isShowingNativeInput {
+                        pixelHandler.firePageContextAutoAttached()
+                    }
                 }
 
             case .attached:
                 chipState = .attached(context)
+                didUpdateAttachment = true
                 Logger.aiChat.debug("[SessionState] Updated attached context (setting ON)")
             }
         } else {
             Logger.aiChat.debug("[SessionState] Context updated on navigation (WebView active, chip not updated)")
         }
 
-        if canPushToFrontend() {
-            emit(.pushContextToFrontend(context.contextData))
+        if didUpdateAttachment || shouldDeliverToFrontendBridge(context.contextData) {
+            emitDeliveryIfNeeded(context.contextData)
         }
     }
 
@@ -413,20 +523,6 @@ private extension AIChatContextualChatSessionState {
         }
     }
 
-    func canPushToFrontend() -> Bool {
-        let canPush: Bool
-        switch frontendState {
-        case .chatWithoutInitialContext, .restoredChat:
-            canPush = true
-        case .chatWithInitialContext:
-            canPush = supportsMultipleContexts
-        case .noChat:
-            canPush = false
-        }
-        Logger.aiChat.debug("[SessionState] canPushToFrontend=\(canPush) (frontendState=\(self.frontendState), multipleContexts=\(self.supportsMultipleContexts))")
-        return canPush
-    }
-
     func shouldAllowAutomaticUpgrade() -> Bool {
         return !userDowngradedToPlaceholder
     }
@@ -439,9 +535,6 @@ private extension AIChatContextualChatSessionState {
     }
 
     private func resolveQuickActions() -> [AIChatContextualQuickAction] {
-        guard featureFlagger.isFeatureOn(.aiChatContextualSheetImprovements) else {
-            return [.summarize]
-        }
         switch chipState {
         case .placeholder: return [.askAboutPage]
         case .attached: return [.summarizePage]
@@ -468,5 +561,10 @@ private extension AIChatContextualChatSessionState {
 
     func emit(_ effect: SheetEffect) {
         effects.send(effect)
+    }
+
+    func emitDeliveryIfNeeded(_ context: AIChatPageContextData?) {
+        guard shouldDeliverToUTIChip(context) || shouldDeliverToFrontendBridge(context) else { return }
+        emit(.deliverPageContext(context))
     }
 }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualInputViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualInputViewController.swift
@@ -32,6 +32,34 @@ protocol AIChatContextualInputViewControllerDelegate: AnyObject {
     func contextualInputViewControllerDidRemoveContextChip(_ viewController: AIChatContextualInputViewController)
 }
 
+// MARK: - Input Surface
+
+protocol AIChatContextualInputSurface {
+    @discardableResult func becomeFirstResponder() -> Bool
+    @discardableResult func resignFirstResponder() -> Bool
+    var isContextChipVisible: Bool { get }
+    func setText(_ text: String)
+    func appendText(_ text: String)
+    func showContextChip(_ chipView: UIView)
+    func hideContextChip()
+    func updateContextChipState(_ state: AIChatContextChipView.State)
+    func setChipTapCallback(_ callback: @escaping () -> Void)
+}
+
+private struct NoContextualInputSurface: AIChatContextualInputSurface {
+    var isContextChipVisible: Bool { false }
+    func becomeFirstResponder() -> Bool { false }
+    func resignFirstResponder() -> Bool { false }
+    func setText(_ text: String) {}
+    func appendText(_ text: String) {}
+    func showContextChip(_ chipView: UIView) {}
+    func hideContextChip() {}
+    func updateContextChipState(_ state: AIChatContextChipView.State) {}
+    func setChipTapCallback(_ callback: @escaping () -> Void) {}
+}
+
+extension AIChatNativeInputViewController: AIChatContextualInputSurface {}
+
 // MARK: - View Controller
 
 /// Container view controller that hosts the native input and handles keyboard adjustments.
@@ -50,9 +78,16 @@ final class AIChatContextualInputViewController: UIViewController {
 
     weak var delegate: AIChatContextualInputViewControllerDelegate?
 
-    private let isContextualSheetImprovementsEnabled: Bool
+    private let showsNativeInput: Bool
     private let voiceSearchHelper: VoiceSearchHelperProtocol
     private lazy var nativeInputViewController = AIChatNativeInputViewController(voiceSearchHelper: voiceSearchHelper)
+    private lazy var inputSurface: AIChatContextualInputSurface = {
+        if showsNativeInput {
+            return nativeInputViewController
+        } else {
+            return NoContextualInputSurface()
+        }
+    }()
 
     private lazy var quickActionsScrollView: UIScrollView = {
         let scrollView = UIScrollView()
@@ -82,8 +117,8 @@ final class AIChatContextualInputViewController: UIViewController {
 
     // MARK: - Initialization
 
-    init(voiceSearchHelper: VoiceSearchHelperProtocol, isContextualSheetImprovementsEnabled: Bool = false) {
-        self.isContextualSheetImprovementsEnabled = isContextualSheetImprovementsEnabled
+    init(voiceSearchHelper: VoiceSearchHelperProtocol, showsNativeInput: Bool = true) {
+        self.showsNativeInput = showsNativeInput
         self.voiceSearchHelper = voiceSearchHelper
         super.init(nibName: nil, bundle: nil)
     }
@@ -101,9 +136,11 @@ final class AIChatContextualInputViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
-        configureNativeInput()
+        if showsNativeInput {
+            configureNativeInput()
+            setupKeyboardObservers()
+        }
         configureQuickActions()
-        setupKeyboardObservers()
     }
 
     override func viewDidLayoutSubviews() {
@@ -127,40 +164,40 @@ final class AIChatContextualInputViewController: UIViewController {
 
     @discardableResult
     override func becomeFirstResponder() -> Bool {
-        return nativeInputViewController.becomeFirstResponder()
+        inputSurface.becomeFirstResponder()
     }
 
     @discardableResult
     override func resignFirstResponder() -> Bool {
-        return nativeInputViewController.resignFirstResponder()
+        inputSurface.resignFirstResponder()
     }
 
     var isContextChipVisible: Bool {
-        nativeInputViewController.isContextChipVisible
+        inputSurface.isContextChipVisible
     }
 
     func setText(_ text: String) {
-        nativeInputViewController.setText(text)
+        inputSurface.setText(text)
     }
 
     func appendText(_ text: String) {
-        nativeInputViewController.appendText(text)
+        inputSurface.appendText(text)
     }
 
     func showContextChip(_ chipView: UIView) {
-        nativeInputViewController.showContextChip(chipView)
+        inputSurface.showContextChip(chipView)
     }
 
     func hideContextChip() {
-        nativeInputViewController.hideContextChip()
+        inputSurface.hideContextChip()
     }
 
     func updateContextChipState(_ state: AIChatContextChipView.State) {
-        nativeInputViewController.updateContextChipState(state)
+        inputSurface.updateContextChipState(state)
     }
 
     func setChipTapCallback(_ callback: @escaping () -> Void) {
-        nativeInputViewController.setChipTapCallback(callback)
+        inputSurface.setChipTapCallback(callback)
     }
 
     func updateQuickActions(with actions: [AIChatContextualQuickAction]) {
@@ -175,10 +212,10 @@ private extension AIChatContextualInputViewController {
     func setupUI() {
         view.backgroundColor = .clear
 
-        if isContextualSheetImprovementsEnabled {
+        if showsNativeInput {
             setupImprovedUI()
         } else {
-            setupOriginalUI()
+            setupImmediateUTIUI()
         }
     }
 
@@ -247,6 +284,35 @@ private extension AIChatContextualInputViewController {
         ])
     }
 
+    func setupImmediateUTIUI() {
+        view.addSubview(quickActionsScrollView)
+        quickActionsScrollView.addSubview(quickActionsView)
+        view.addSubview(welcomeLabel)
+
+        configureWelcomeLabel()
+
+        let centerY = welcomeLabel.centerYAnchor.constraint(equalTo: view.topAnchor)
+        welcomeCenterYConstraint = centerY
+
+        NSLayoutConstraint.activate([
+            quickActionsScrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.horizontalPadding),
+            quickActionsScrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Constants.horizontalPadding),
+            quickActionsScrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -Constants.quickActionsBottomSpacing),
+
+            quickActionsView.topAnchor.constraint(equalTo: quickActionsScrollView.contentLayoutGuide.topAnchor),
+            quickActionsView.leadingAnchor.constraint(equalTo: quickActionsScrollView.contentLayoutGuide.leadingAnchor),
+            quickActionsView.trailingAnchor.constraint(equalTo: quickActionsScrollView.contentLayoutGuide.trailingAnchor),
+            quickActionsView.bottomAnchor.constraint(equalTo: quickActionsScrollView.contentLayoutGuide.bottomAnchor),
+            quickActionsView.widthAnchor.constraint(equalTo: quickActionsScrollView.frameLayoutGuide.widthAnchor),
+            quickActionsScrollView.frameLayoutGuide.heightAnchor.constraint(equalTo: quickActionsScrollView.contentLayoutGuide.heightAnchor),
+
+            centerY,
+            welcomeLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            welcomeLabel.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: Constants.horizontalPadding),
+            welcomeLabel.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -Constants.horizontalPadding),
+        ])
+    }
+
     func embedNativeInputViewController() {
         addChild(nativeInputViewController)
         nativeInputViewController.view.translatesAutoresizingMaskIntoConstraints = false
@@ -298,7 +364,6 @@ private extension AIChatContextualInputViewController {
     }
 
     func updateWelcomeLabelCentering() {
-        guard isContextualSheetImprovementsEnabled else { return }
         let scrollViewTop = quickActionsScrollView.frame.minY
         guard scrollViewTop > 0 else { return }
         welcomeCenterYConstraint?.constant = scrollViewTop / 2

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualInputViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualInputViewController.swift
@@ -58,11 +58,11 @@ private struct NoContextualInputSurface: AIChatContextualInputSurface {
     func setChipTapCallback(_ callback: @escaping () -> Void) {}
 }
 
-extension AIChatNativeInputViewController: AIChatContextualInputSurface {}
+extension AIChatBasicNativeInputViewController: AIChatContextualInputSurface {}
 
 // MARK: - View Controller
 
-/// Container view controller that hosts the native input and handles keyboard adjustments.
+/// Container view controller that hosts the basic native input and handles keyboard adjustments.
 final class AIChatContextualInputViewController: UIViewController {
 
     // MARK: - Constants
@@ -78,12 +78,12 @@ final class AIChatContextualInputViewController: UIViewController {
 
     weak var delegate: AIChatContextualInputViewControllerDelegate?
 
-    private let showsNativeInput: Bool
+    private let showsBasicNativeInput: Bool
     private let voiceSearchHelper: VoiceSearchHelperProtocol
-    private lazy var nativeInputViewController = AIChatNativeInputViewController(voiceSearchHelper: voiceSearchHelper)
+    private lazy var basicNativeInputViewController = AIChatBasicNativeInputViewController(voiceSearchHelper: voiceSearchHelper)
     private lazy var inputSurface: AIChatContextualInputSurface = {
-        if showsNativeInput {
-            return nativeInputViewController
+        if showsBasicNativeInput {
+            return basicNativeInputViewController
         } else {
             return NoContextualInputSurface()
         }
@@ -117,8 +117,8 @@ final class AIChatContextualInputViewController: UIViewController {
 
     // MARK: - Initialization
 
-    init(voiceSearchHelper: VoiceSearchHelperProtocol, showsNativeInput: Bool = true) {
-        self.showsNativeInput = showsNativeInput
+    init(voiceSearchHelper: VoiceSearchHelperProtocol, showsBasicNativeInput: Bool = true) {
+        self.showsBasicNativeInput = showsBasicNativeInput
         self.voiceSearchHelper = voiceSearchHelper
         super.init(nibName: nil, bundle: nil)
     }
@@ -136,8 +136,8 @@ final class AIChatContextualInputViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
-        if showsNativeInput {
-            configureNativeInput()
+        if showsBasicNativeInput {
+            configureBasicNativeInput()
             setupKeyboardObservers()
         }
         configureQuickActions()
@@ -212,7 +212,7 @@ private extension AIChatContextualInputViewController {
     func setupUI() {
         view.backgroundColor = .clear
 
-        if showsNativeInput {
+        if showsBasicNativeInput {
             setupImprovedUI()
         } else {
             setupImmediateUTIUI()
@@ -222,15 +222,15 @@ private extension AIChatContextualInputViewController {
     func setupOriginalUI() {
         view.addSubview(quickActionsScrollView)
         quickActionsScrollView.addSubview(quickActionsView)
-        embedNativeInputViewController()
+        embedBasicNativeInputViewController()
 
-        bottomConstraint = nativeInputViewController.view.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor)
+        bottomConstraint = basicNativeInputViewController.view.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor)
 
         NSLayoutConstraint.activate([
             quickActionsScrollView.topAnchor.constraint(equalTo: view.topAnchor),
             quickActionsScrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.horizontalPadding),
             quickActionsScrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Constants.horizontalPadding),
-            quickActionsScrollView.bottomAnchor.constraint(equalTo: nativeInputViewController.view.topAnchor, constant: -Constants.quickActionsBottomSpacing),
+            quickActionsScrollView.bottomAnchor.constraint(equalTo: basicNativeInputViewController.view.topAnchor, constant: -Constants.quickActionsBottomSpacing),
 
             quickActionsView.topAnchor.constraint(equalTo: quickActionsScrollView.contentLayoutGuide.topAnchor),
             quickActionsView.leadingAnchor.constraint(equalTo: quickActionsScrollView.contentLayoutGuide.leadingAnchor),
@@ -239,9 +239,9 @@ private extension AIChatContextualInputViewController {
             quickActionsView.widthAnchor.constraint(equalTo: quickActionsScrollView.frameLayoutGuide.widthAnchor),
             quickActionsView.heightAnchor.constraint(greaterThanOrEqualTo: quickActionsScrollView.frameLayoutGuide.heightAnchor),
 
-            nativeInputViewController.view.topAnchor.constraint(greaterThanOrEqualTo: quickActionsView.bottomAnchor, constant: Constants.quickActionsBottomSpacing),
-            nativeInputViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.horizontalPadding),
-            nativeInputViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Constants.horizontalPadding),
+            basicNativeInputViewController.view.topAnchor.constraint(greaterThanOrEqualTo: quickActionsView.bottomAnchor, constant: Constants.quickActionsBottomSpacing),
+            basicNativeInputViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.horizontalPadding),
+            basicNativeInputViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Constants.horizontalPadding),
             bottomConstraint!,
         ])
     }
@@ -250,11 +250,11 @@ private extension AIChatContextualInputViewController {
         view.addSubview(quickActionsScrollView)
         quickActionsScrollView.addSubview(quickActionsView)
         view.addSubview(welcomeLabel)
-        embedNativeInputViewController()
+        embedBasicNativeInputViewController()
 
         configureWelcomeLabel()
 
-        bottomConstraint = nativeInputViewController.view.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor)
+        bottomConstraint = basicNativeInputViewController.view.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor)
 
         let centerY = welcomeLabel.centerYAnchor.constraint(equalTo: view.topAnchor)
         welcomeCenterYConstraint = centerY
@@ -263,7 +263,7 @@ private extension AIChatContextualInputViewController {
             // Scroll view wraps quick actions at natural size, pinned above input
             quickActionsScrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.horizontalPadding),
             quickActionsScrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Constants.horizontalPadding),
-            quickActionsScrollView.bottomAnchor.constraint(equalTo: nativeInputViewController.view.topAnchor, constant: -Constants.quickActionsBottomSpacing),
+            quickActionsScrollView.bottomAnchor.constraint(equalTo: basicNativeInputViewController.view.topAnchor, constant: -Constants.quickActionsBottomSpacing),
 
             quickActionsView.topAnchor.constraint(equalTo: quickActionsScrollView.contentLayoutGuide.topAnchor),
             quickActionsView.leadingAnchor.constraint(equalTo: quickActionsScrollView.contentLayoutGuide.leadingAnchor),
@@ -278,8 +278,8 @@ private extension AIChatContextualInputViewController {
             welcomeLabel.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: Constants.horizontalPadding),
             welcomeLabel.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -Constants.horizontalPadding),
 
-            nativeInputViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.horizontalPadding),
-            nativeInputViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Constants.horizontalPadding),
+            basicNativeInputViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.horizontalPadding),
+            basicNativeInputViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Constants.horizontalPadding),
             bottomConstraint!,
         ])
     }
@@ -313,16 +313,16 @@ private extension AIChatContextualInputViewController {
         ])
     }
 
-    func embedNativeInputViewController() {
-        addChild(nativeInputViewController)
-        nativeInputViewController.view.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(nativeInputViewController.view)
-        nativeInputViewController.didMove(toParent: self)
+    func embedBasicNativeInputViewController() {
+        addChild(basicNativeInputViewController)
+        basicNativeInputViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(basicNativeInputViewController.view)
+        basicNativeInputViewController.didMove(toParent: self)
     }
 
-    func configureNativeInput() {
-        nativeInputViewController.delegate = self
-        nativeInputViewController.placeholder = UserText.searchInputFieldPlaceholderDuckAI
+    func configureBasicNativeInput() {
+        basicNativeInputViewController.delegate = self
+        basicNativeInputViewController.placeholder = UserText.searchInputFieldPlaceholderDuckAI
     }
 
     func configureQuickActions() {
@@ -411,23 +411,23 @@ private extension AIChatContextualInputViewController {
     }
 }
 
-// MARK: - AIChatNativeInputViewControllerDelegate
+// MARK: - AIChatBasicNativeInputViewControllerDelegate
 
-extension AIChatContextualInputViewController: AIChatNativeInputViewControllerDelegate {
+extension AIChatContextualInputViewController: AIChatBasicNativeInputViewControllerDelegate {
 
-    func nativeInputViewController(_ viewController: AIChatNativeInputViewController, didSubmitPrompt prompt: String) {
+    func basicNativeInputViewController(_ viewController: AIChatBasicNativeInputViewController, didSubmitPrompt prompt: String) {
         delegate?.contextualInputViewController(self, didSubmitPrompt: prompt)
     }
 
-    func nativeInputViewControllerDidTapVoice(_ viewController: AIChatNativeInputViewController) {
+    func basicNativeInputViewControllerDidTapVoice(_ viewController: AIChatBasicNativeInputViewController) {
         delegate?.contextualInputViewControllerDidTapVoice(self)
     }
 
-    func nativeInputViewControllerDidRemoveContextChip(_ viewController: AIChatNativeInputViewController) {
+    func basicNativeInputViewControllerDidRemoveContextChip(_ viewController: AIChatBasicNativeInputViewController) {
         delegate?.contextualInputViewControllerDidRemoveContextChip(self)
     }
 
-    func nativeInputViewController(_ viewController: AIChatNativeInputViewController, didChangeText text: String) {
+    func basicNativeInputViewController(_ viewController: AIChatBasicNativeInputViewController, didChangeText text: String) {
         scrollQuickActionsToBottom()
     }
 }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -234,7 +234,7 @@ final class AIChatContextualSheetCoordinator {
             if !didTrigger {
                 sessionState.clearProcessingNavigationFlag()
             }
-        } else if sessionState.supportsMultipleContexts && sessionState.hasActiveChat && isActivelyObservingContext {
+        } else if sessionState.supportsMultipleContexts && sessionState.hasActiveChat && (isActivelyObservingContext || isImmediateContextualUTIEnabled) {
             sessionState.notifyFrontendOfMultiContextNavigation()
             sessionState.clearProcessingNavigationFlag()
         } else {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -235,7 +235,7 @@ final class AIChatContextualSheetCoordinator {
         if isImmediateContextualUTIEnabled { return }
         sessionState.notifyPageChanged()
 
-        if sessionState.shouldAutoCollectContext {
+        if sessionState.shouldTriggerAutoCollect() {
             let didTrigger = pageContextHandler.triggerContextCollection()
             if !didTrigger {
                 sessionState.clearProcessingNavigationFlag()

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -169,8 +169,8 @@ final class AIChatContextualSheetCoordinator {
         self.sessionState.updateUnifiedToggleInputActive(isWebUTIEnabled, isImmediateContextual: isImmediateContextualUTIEnabled)
         self.sessionEffectCancellable = self.sessionState.effects
             .sink { [weak self] effect in
-                guard case .deliverPageContext(let context) = effect else { return }
-                self?.deliverPageContext(context)
+                guard case .deliverPageContext(let context, let targets) = effect else { return }
+                self?.deliverPageContext(context, targets: targets)
             }
     }
 
@@ -403,12 +403,12 @@ private extension AIChatContextualSheetCoordinator {
             }
     }
 
-    func deliverPageContext(_ context: AIChatPageContextData?) {
-        if let host = persistentUTIHost, sessionState.shouldDeliverToUTIChip(context) {
+    func deliverPageContext(_ context: AIChatPageContextData?, targets: PageContextDeliveryTargets) {
+        if let host = persistentUTIHost, targets.contains(.utiChip) {
             deliverToUTIChip(context, host: host)
         }
 
-        if sessionState.shouldDeliverToFrontendBridge(context) {
+        if targets.contains(.frontendBridge) {
             sheetViewController?.pushPageContext(context)
         }
     }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -166,7 +166,7 @@ final class AIChatContextualSheetCoordinator {
             pixelHandler: pixelHandler,
             featureFlagger: featureFlagger
         )
-        self.sessionState.updateUnifiedToggleInputActive(isImmediateContextualUTIEnabled)
+        self.sessionState.updateUnifiedToggleInputActive(isWebUTIEnabled, isImmediateContextual: isImmediateContextualUTIEnabled)
         self.sessionEffectCancellable = self.sessionState.effects
             .sink { [weak self] effect in
                 guard case .deliverPageContext(let context) = effect else { return }
@@ -180,7 +180,7 @@ final class AIChatContextualSheetCoordinator {
     func presentSheet(from presentingViewController: UIViewController,
                       restoreURL: URL? = nil) async {
         sessionState.refreshAutoAttachSetting()
-        sessionState.updateUnifiedToggleInputActive(isImmediateContextualUTIEnabled)
+        sessionState.updateUnifiedToggleInputActive(isWebUTIEnabled, isImmediateContextual: isImmediateContextualUTIEnabled)
 
         startObservingContextUpdates()
 

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -333,18 +333,10 @@ private extension AIChatContextualSheetCoordinator {
             self.sessionState.downgradeToPlaceholder()
             self.pageContextHandler.clear()
         }
-        host.onNavigationAwayDetachRequested = { [weak self] in
-            guard let self else { return }
-            self.sessionState.detachFromNavigationAway()
-            self.pageContextHandler.clear()
-        }
         host.onPromptSubmitted = { [weak self] in
             guard let self else { return }
             self.sessionState.beginChatForUTISubmission()
             self.sheetViewController?.handleFirstUTISubmission()
-        }
-        host.onPromptContextDelivered = { [weak self] url in
-            self?.sessionState.markPageContextDeliveredInPrompt(url)
         }
         self.persistentUTIHost = host
         return host
@@ -376,6 +368,10 @@ private extension AIChatContextualSheetCoordinator {
             deliverToUTIChip(context, host: host)
         }
 
+        if let host = persistentUTIHost, targets.contains(.utiAttachAffordance) {
+            host.showAttachAffordance()
+        }
+
         if targets.contains(.frontendBridge) {
             sheetViewController?.pushPageContext(context)
         }
@@ -387,12 +383,11 @@ private extension AIChatContextualSheetCoordinator {
             return
         }
 
-        let deliveryState: PageContextAttachmentDeliveryState = sessionState.hasDeliveredPageContext(context) ? .delivered : .pendingSubmit
         let pageContext = sessionState.latestContext?.contextData == context
             ? sessionState.latestContext
             : AIChatPageContext(contextData: context, favicon: nil)
         if let pageContext {
-            host.setAttachedContext(pageContext, deliveryState: deliveryState)
+            host.setAttachedContext(pageContext, deliveryState: .pendingSubmit)
         }
     }
 

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -326,7 +326,7 @@ private extension AIChatContextualSheetCoordinator {
             lastUsedModelProvider: duckAiLastUsedModelProvider,
             startsPreSubmit: startsPreSubmit
         )
-        host.onAttachRequested = { [weak self] _ in
+        host.onAttachRequested = { [weak self] in
             guard let self else { return }
             self.sessionState.beginManualAttach()
             let didTrigger = self.pageContextHandler.triggerContextCollection()

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -29,11 +29,8 @@ import UIKit
 import WebKit
 
 /// Underlying-tab URL publishers the contextual chat needs.
-/// `originating` fires at didCommit (drives chip display state); `didFinish` fires when the new
-/// page is actually loaded (drives auto-attach context collection so JS sees fresh DOM).
 struct AIChatTabURLPublishers {
     let originating: AnyPublisher<URL?, Never>
-    let didFinish: AnyPublisher<URL?, Never>
 }
 
 private struct ContextualUnifiedToggleInputFeature: UnifiedToggleInputFeatureProviding {
@@ -92,7 +89,6 @@ final class AIChatContextualSheetCoordinator {
     let pageContextHandler: AIChatPageContextHandling
     private let tabURLPublishers: AIChatTabURLPublishers
     private var contextUpdateCancellable: AnyCancellable?
-    private var utiNavigationCancellable: AnyCancellable?
     private var sessionEffectCancellable: AnyCancellable?
     private var persistentUTIHost: AIChatContextualUTIHost?
 
@@ -231,8 +227,6 @@ final class AIChatContextualSheetCoordinator {
     /// Called by TabViewController when the page navigates to a new URL.
     func notifyPageChanged() async {
         guard hasActiveSheet else { return }
-        // Native UTI handles nav via the didFinish publisher subscription.
-        if isImmediateContextualUTIEnabled { return }
         sessionState.notifyPageChanged()
 
         if sessionState.shouldTriggerAutoCollect() {
@@ -366,40 +360,15 @@ private extension AIChatContextualSheetCoordinator {
                 self?.handleContextDataUpdate(contextData)
             }
 
-        startObservingUTINavigationIfNeeded()
     }
 
     func stopObservingContextUpdates() {
         contextUpdateCancellable?.cancel()
         contextUpdateCancellable = nil
-        utiNavigationCancellable?.cancel()
-        utiNavigationCancellable = nil
     }
 
     func handleContextDataUpdate(_ context: AIChatPageContext?) {
         sessionState.updateContext(context)
-    }
-
-    func startObservingUTINavigationIfNeeded() {
-        guard isImmediateContextualUTIEnabled, utiNavigationCancellable == nil else { return }
-
-        utiNavigationCancellable = tabURLPublishers.didFinish
-            .dropFirst()
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] url in
-                guard let self, self.hasActiveSheet else { return }
-                guard let url else { return }
-
-                self.sessionState.notifyPageChanged(pageURL: url)
-                if self.sessionState.shouldTriggerAutoCollect(for: url) {
-                    let didTrigger = self.pageContextHandler.triggerContextCollection()
-                    if !didTrigger {
-                        self.sessionState.clearProcessingNavigationFlag()
-                    }
-                } else {
-                    self.sessionState.clearProcessingNavigationFlag()
-                }
-            }
     }
 
     func deliverPageContext(_ context: AIChatPageContextData?, targets: PageContextDeliveryTargets) {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -31,6 +31,7 @@ import WebKit
 /// Underlying-tab URL publishers the contextual chat needs.
 struct AIChatTabURLPublishers {
     let originating: AnyPublisher<URL?, Never>
+    let didFinish: AnyPublisher<URL?, Never>
 }
 
 private struct ContextualUnifiedToggleInputFeature: UnifiedToggleInputFeatureProviding {
@@ -91,6 +92,7 @@ final class AIChatContextualSheetCoordinator {
     private var contextUpdateCancellable: AnyCancellable?
     private var sessionEffectCancellable: AnyCancellable?
     private var currentPageURLCancellable: AnyCancellable?
+    private var didFinishURLCancellable: AnyCancellable?
     private var currentPageURL: URL?
     private var persistentUTIHost: AIChatContextualUTIHost?
 
@@ -173,6 +175,13 @@ final class AIChatContextualSheetCoordinator {
         self.currentPageURLCancellable = tabURLPublishers.originating
             .sink { [weak self] url in
                 self?.currentPageURL = url
+            }
+        self.didFinishURLCancellable = tabURLPublishers.didFinish
+            .dropFirst()
+            .sink { [weak self] _ in
+                Task { [weak self] in
+                    await self?.notifyPageChanged()
+                }
             }
     }
 

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -90,6 +90,8 @@ final class AIChatContextualSheetCoordinator {
     private let tabURLPublishers: AIChatTabURLPublishers
     private var contextUpdateCancellable: AnyCancellable?
     private var sessionEffectCancellable: AnyCancellable?
+    private var currentPageURLCancellable: AnyCancellable?
+    private var currentPageURL: URL?
     private var persistentUTIHost: AIChatContextualUTIHost?
 
     /// Handles all pixel firing for contextual mode.
@@ -168,6 +170,10 @@ final class AIChatContextualSheetCoordinator {
                 guard case .deliverPageContext(let context, let targets) = effect else { return }
                 self?.deliverPageContext(context, targets: targets)
             }
+        self.currentPageURLCancellable = tabURLPublishers.originating
+            .sink { [weak self] url in
+                self?.currentPageURL = url
+            }
     }
 
     // MARK: - Public Methods
@@ -180,7 +186,7 @@ final class AIChatContextualSheetCoordinator {
 
         startObservingContextUpdates()
 
-        if sessionState.shouldAutoCollectContext {
+        if sessionState.shouldTriggerAutoCollect(for: currentPageURL) {
             pageContextHandler.triggerContextCollection()
         }
 

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -385,7 +385,6 @@ private extension AIChatContextualSheetCoordinator {
 
         utiNavigationCancellable = tabURLPublishers.didFinish
             .dropFirst()
-            .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] url in
                 guard let self, self.hasActiveSheet else { return }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -36,6 +36,11 @@ struct AIChatTabURLPublishers {
     let didFinish: AnyPublisher<URL?, Never>
 }
 
+private struct ContextualUnifiedToggleInputFeature: UnifiedToggleInputFeatureProviding {
+    let isAvailable: Bool
+    let isToggleHiddenOnDuckAITab: Bool
+}
+
 /// Delegate protocol for coordinating actions that require interaction with the browser.
 protocol AIChatContextualSheetCoordinatorDelegate: AnyObject {
     /// Called when the user requests to load a URL externally.
@@ -87,6 +92,9 @@ final class AIChatContextualSheetCoordinator {
     let pageContextHandler: AIChatPageContextHandling
     private let tabURLPublishers: AIChatTabURLPublishers
     private var contextUpdateCancellable: AnyCancellable?
+    private var utiNavigationCancellable: AnyCancellable?
+    private var sessionEffectCancellable: AnyCancellable?
+    private var persistentUTIHost: AIChatContextualUTIHost?
 
     /// Handles all pixel firing for contextual mode.
     let pixelHandler: AIChatContextualModePixelFiring
@@ -108,6 +116,14 @@ final class AIChatContextualSheetCoordinator {
     /// Whether the sheet is presented and actively observing page context updates.
     private var isActivelyObservingContext: Bool {
         contextUpdateCancellable != nil
+    }
+
+    private var isWebUTIEnabled: Bool {
+        unifiedToggleInputFeature.isAvailable
+    }
+
+    private var isImmediateContextualUTIEnabled: Bool {
+        isWebUTIEnabled && featureFlagger.isFeatureOn(.aiChatContextualUnifiedToggleInput)
     }
 
     /// Publishes the URL of the page that originated the contextual chat session, with replay of the last value.
@@ -150,6 +166,12 @@ final class AIChatContextualSheetCoordinator {
             pixelHandler: pixelHandler,
             featureFlagger: featureFlagger
         )
+        self.sessionState.updateUnifiedToggleInputActive(isImmediateContextualUTIEnabled)
+        self.sessionEffectCancellable = self.sessionState.effects
+            .sink { [weak self] effect in
+                guard case .deliverPageContext(let context) = effect else { return }
+                self?.deliverPageContext(context)
+            }
     }
 
     // MARK: - Public Methods
@@ -158,6 +180,7 @@ final class AIChatContextualSheetCoordinator {
     func presentSheet(from presentingViewController: UIViewController,
                       restoreURL: URL? = nil) async {
         sessionState.refreshAutoAttachSetting()
+        sessionState.updateUnifiedToggleInputActive(isImmediateContextualUTIEnabled)
 
         startObservingContextUpdates()
 
@@ -194,6 +217,7 @@ final class AIChatContextualSheetCoordinator {
         sheetViewController?.notifySheetDismissed()
         isSheetPresented = false
         sheetViewController = nil
+        persistentUTIHost = nil
         stopObservingContextUpdates()
         pageContextHandler.clear()
         sessionState.resetToNoChat()
@@ -207,8 +231,8 @@ final class AIChatContextualSheetCoordinator {
     /// Called by TabViewController when the page navigates to a new URL.
     func notifyPageChanged() async {
         guard hasActiveSheet else { return }
-        // Native UTI handles nav via the chip view-model's `originatingURLPublisher` subscription.
-        if unifiedToggleInputFeature.isAvailable { return }
+        // Native UTI handles nav via the didFinish publisher subscription.
+        if isImmediateContextualUTIEnabled { return }
         sessionState.notifyPageChanged()
 
         if sessionState.shouldAutoCollectContext {
@@ -252,6 +276,9 @@ private extension AIChatContextualSheetCoordinator {
         }
 
         let suggestionsReader = makeSuggestionsReaderIfEnabled()
+        let persistentUTIHost = isImmediateContextualUTIEnabled
+            ? makePersistentUTIHostIfNeeded(startsPreSubmit: !sessionState.hasActiveChat)
+            : nil
 
         let sheetVC = AIChatContextualSheetViewController(
             sessionState: sessionState,
@@ -263,6 +290,7 @@ private extension AIChatContextualSheetCoordinator {
             },
             pixelHandler: pixelHandler,
             featureFlagger: featureFlagger,
+            persistentUTIHost: persistentUTIHost,
             suggestionsReader: suggestionsReader
         )
         sheetVC.delegate = self
@@ -273,7 +301,6 @@ private extension AIChatContextualSheetCoordinator {
     }
 
     func makeSuggestionsReaderIfEnabled() -> AIChatSuggestionsReading? {
-        guard featureFlagger.isFeatureOn(.aiChatContextualSheetImprovements) else { return nil }
         let reader = SuggestionsReader(
             featureFlagger: featureFlagger,
             privacyConfig: privacyConfigurationManager,
@@ -282,6 +309,51 @@ private extension AIChatContextualSheetCoordinator {
         )
         let settings = AIChatHistorySettings(privacyConfig: privacyConfigurationManager)
         return AIChatSuggestionsReader(suggestionsReader: reader, historySettings: settings)
+    }
+
+    func makePersistentUTIHostIfNeeded(startsPreSubmit: Bool) -> AIChatContextualUTIHost? {
+        guard isWebUTIEnabled else { return nil }
+        if let persistentUTIHost { return persistentUTIHost }
+
+        let initialUTIAttachment = self.initialUTIAttachment
+        let host = AIChatContextualUTIHost(
+            originatingURLPublisher: originatingURLPublisher,
+            initialAttachedContext: initialUTIAttachment.context,
+            initialAttachmentDeliveryState: initialUTIAttachment.deliveryState,
+            hasActiveChat: { [weak self] in self?.sessionState.hasActiveChat ?? false },
+            isAutoAttachEnabled: { [weak self] in self?.sessionState.shouldAutoCollectContext ?? false },
+            isFireTab: isFireTab,
+            lastUsedModelProvider: duckAiLastUsedModelProvider,
+            startsPreSubmit: startsPreSubmit
+        )
+        host.onAttachRequested = { [weak self] _ in
+            guard let self else { return }
+            self.sessionState.beginManualAttach()
+            let didTrigger = self.pageContextHandler.triggerContextCollection()
+            if !didTrigger {
+                self.sessionState.cancelManualAttach()
+            }
+        }
+        host.onRemoveRequested = { [weak self] in
+            guard let self else { return }
+            self.sessionState.downgradeToPlaceholder()
+            self.pageContextHandler.clear()
+        }
+        host.onNavigationAwayDetachRequested = { [weak self] in
+            guard let self else { return }
+            self.sessionState.detachFromNavigationAway()
+            self.pageContextHandler.clear()
+        }
+        host.onPromptSubmitted = { [weak self] in
+            guard let self else { return }
+            self.sessionState.beginChatForUTISubmission()
+            self.sheetViewController?.handleFirstUTISubmission()
+        }
+        host.onPromptContextDelivered = { [weak self] url in
+            self?.sessionState.markPageContextDeliveredInPrompt(url)
+        }
+        self.persistentUTIHost = host
+        return host
     }
 
     func startObservingContextUpdates() {
@@ -293,15 +365,67 @@ private extension AIChatContextualSheetCoordinator {
             .sink { [weak self] contextData in
                 self?.handleContextDataUpdate(contextData)
             }
+
+        startObservingUTINavigationIfNeeded()
     }
 
     func stopObservingContextUpdates() {
         contextUpdateCancellable?.cancel()
         contextUpdateCancellable = nil
+        utiNavigationCancellable?.cancel()
+        utiNavigationCancellable = nil
     }
 
     func handleContextDataUpdate(_ context: AIChatPageContext?) {
         sessionState.updateContext(context)
+    }
+
+    func startObservingUTINavigationIfNeeded() {
+        guard isImmediateContextualUTIEnabled, utiNavigationCancellable == nil else { return }
+
+        utiNavigationCancellable = tabURLPublishers.didFinish
+            .dropFirst()
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] url in
+                guard let self, self.hasActiveSheet else { return }
+                guard let url else { return }
+
+                self.sessionState.notifyPageChanged(pageURL: url)
+                if self.sessionState.shouldTriggerAutoCollect(for: url) {
+                    let didTrigger = self.pageContextHandler.triggerContextCollection()
+                    if !didTrigger {
+                        self.sessionState.clearProcessingNavigationFlag()
+                    }
+                } else {
+                    self.sessionState.clearProcessingNavigationFlag()
+                }
+            }
+    }
+
+    func deliverPageContext(_ context: AIChatPageContextData?) {
+        if let host = persistentUTIHost, sessionState.shouldDeliverToUTIChip(context) {
+            deliverToUTIChip(context, host: host)
+        }
+
+        if sessionState.shouldDeliverToFrontendBridge(context) {
+            sheetViewController?.pushPageContext(context)
+        }
+    }
+
+    func deliverToUTIChip(_ context: AIChatPageContextData?, host: AIChatContextualUTIHost) {
+        guard let context else {
+            host.clearAttachedContext()
+            return
+        }
+
+        let deliveryState: PageContextAttachmentDeliveryState = sessionState.hasDeliveredPageContext(context) ? .delivered : .pendingSubmit
+        let pageContext = sessionState.latestContext?.contextData == context
+            ? sessionState.latestContext
+            : AIChatPageContext(contextData: context, favicon: nil)
+        if let pageContext {
+            host.setAttachedContext(pageContext, deliveryState: deliveryState)
+        }
     }
 
     /// Factory method for creating web view controllers, avoids prop drilling through the Sheet VC.
@@ -310,13 +434,18 @@ private extension AIChatContextualSheetCoordinator {
         downloadsDirectoryHandler.createDownloadsDirectoryIfNeeded()
         let downloadHandler = makeDownloadHandler(downloadsPath: downloadsDirectoryHandler.downloadsDirectory)
 
+        let contextualUTIFeature = ContextualUnifiedToggleInputFeature(
+            isAvailable: isWebUTIEnabled,
+            isToggleHiddenOnDuckAITab: unifiedToggleInputFeature.isToggleHiddenOnDuckAITab
+        )
+
         let webVC = AIChatContextualWebViewController(
             aiChatSettings: aiChatSettings,
             privacyConfigurationManager: privacyConfigurationManager,
             contentBlockingAssetsPublisher: contentBlockingAssetsPublisher,
             featureDiscovery: featureDiscovery,
             featureFlagger: featureFlagger,
-            unifiedToggleInputFeature: unifiedToggleInputFeature,
+            unifiedToggleInputFeature: contextualUTIFeature,
             isFireTab: isFireTab,
             duckAiFireModeStorageHandler: duckAiFireModeStorageHandler,
             downloadHandler: downloadHandler,
@@ -333,19 +462,12 @@ private extension AIChatContextualSheetCoordinator {
             pixelHandler: pixelHandler,
             utiHostInstaller: { [weak self] contextualChatViewController in
                 guard let self else { return nil }
-                let initialUTIAttachment = self.initialUTIAttachment
-                let host = AIChatContextualUTIHost(
-                    originatingURLPublisher: self.originatingURLPublisher,
-                    didFinishURLPublisher: self.tabURLPublishers.didFinish,
-                    initialAttachedContext: initialUTIAttachment.context,
-                    initialAttachmentDeliveryState: initialUTIAttachment.deliveryState,
-                    hasActiveChat: { [weak self] in self?.sessionState.hasActiveChat ?? false },
-                    isAutoAttachEnabled: { [weak self] in self?.sessionState.shouldAutoCollectContext ?? false },
-                    pageContextHandler: self.pageContextHandler,
-                    isFireTab: self.isFireTab,
-                    lastUsedModelProvider: self.duckAiLastUsedModelProvider
-                )
-                host.install(in: contextualChatViewController)
+                guard self.isWebUTIEnabled else { return nil }
+                let host = self.makePersistentUTIHostIfNeeded(startsPreSubmit: self.isImmediateContextualUTIEnabled && !self.sessionState.hasActiveChat)
+                host?.setContextualChatViewController(contextualChatViewController)
+                if !self.isImmediateContextualUTIEnabled {
+                    host?.installInWebView(contextualChatViewController)
+                }
                 return host
             }
         )
@@ -355,6 +477,9 @@ private extension AIChatContextualSheetCoordinator {
 
     var initialUTIAttachment: (context: AIChatPageContext?, deliveryState: PageContextAttachmentDeliveryState) {
         if let context = sessionState.intendedAttachedContext {
+            if isImmediateContextualUTIEnabled, !sessionState.hasActiveChat {
+                return (context, .pendingSubmit)
+            }
             return (context, .delivered)
         }
         if sessionState.hasActiveChat, let context = sessionState.latestContext {
@@ -406,6 +531,7 @@ private extension AIChatContextualSheetCoordinator {
         Logger.aiChat.debug("[Contextual] Resetting to native input")
 
         sessionState.resetToNoChat()
+        persistentUTIHost?.prepareForNewChat()
 
         Logger.aiChat.debug("[PageContext] New chat - collecting fresh context")
         pageContextHandler.triggerContextCollection()
@@ -465,7 +591,7 @@ extension AIChatContextualSheetCoordinator: AIChatContextualSheetViewControllerD
 
     func aiChatContextualSheetViewControllerDidRequestRemoveChip(_ viewController: AIChatContextualSheetViewController) {
         sessionState.downgradeToPlaceholder()
-        pageContextHandler.clearAttachedContext()
+        pageContextHandler.clear()
     }
 
     func aiChatContextualSheetViewController(_ viewController: AIChatContextualSheetViewController, didUpdateContextualChatURL url: URL?) {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
@@ -129,7 +129,7 @@ final class AIChatContextualSheetViewController: UIViewController {
 
     private lazy var contextualInputViewController = AIChatContextualInputViewController(
         voiceSearchHelper: voiceSearchHelper,
-        showsNativeInput: persistentUTIHost == nil
+        showsBasicNativeInput: persistentUTIHost == nil
     )
     private var cancellables = Set<AnyCancellable>()
     private var contentContainerBottomConstraint: NSLayoutConstraint?

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
@@ -122,15 +122,17 @@ final class AIChatContextualSheetViewController: UIViewController {
     private let appSettings: AppSettings
     private let featureFlagger: FeatureFlagger
     private let suggestionsReader: AIChatSuggestionsReading?
+    private let persistentUTIHost: AIChatContextualUTIHost?
     private var recentChatsPopup: AIChatRecentChatsPopupViewController?
     private var popupWindow: UIWindow?
     private var isFetchingRecentChats = false
 
     private lazy var contextualInputViewController = AIChatContextualInputViewController(
         voiceSearchHelper: voiceSearchHelper,
-        isContextualSheetImprovementsEnabled: featureFlagger.isFeatureOn(.aiChatContextualSheetImprovements)
+        showsNativeInput: persistentUTIHost == nil
     )
     private var cancellables = Set<AnyCancellable>()
+    private var contentContainerBottomConstraint: NSLayoutConstraint?
 
     /// The single web view controller for this sheet, created once and reused
     private var webViewController: AIChatContextualWebViewController?
@@ -274,6 +276,7 @@ final class AIChatContextualSheetViewController: UIViewController {
          pixelHandler: AIChatContextualModePixelFiring,
          appSettings: AppSettings = AppDependencyProvider.shared.appSettings,
          featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
+         persistentUTIHost: AIChatContextualUTIHost? = nil,
          suggestionsReader: AIChatSuggestionsReading? = nil) {
         self.sessionState = sessionState
         self.aiChatSettings = aiChatSettings
@@ -282,6 +285,7 @@ final class AIChatContextualSheetViewController: UIViewController {
         self.pixelHandler = pixelHandler
         self.appSettings = appSettings
         self.featureFlagger = featureFlagger
+        self.persistentUTIHost = persistentUTIHost
         self.suggestionsReader = suggestionsReader
         super.init(nibName: nil, bundle: nil)
         configureModalPresentation()
@@ -305,6 +309,7 @@ final class AIChatContextualSheetViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
+        mountPersistentUTIHostIfNeeded()
         createAndConfigureWebViewController(restoreURL: sessionState.contextualChatURL)
         bindViewModel()
     }
@@ -423,6 +428,15 @@ final class AIChatContextualSheetViewController: UIViewController {
         }
     }
 
+    func pushPageContext(_ context: AIChatPageContextData?) {
+        webViewController?.pushPageContext(context)
+    }
+
+    func handleFirstUTISubmission() {
+        transitionToWebView()
+        expandToLargeDetent()
+    }
+
 }
 
 // MARK: - Private Methods
@@ -457,6 +471,7 @@ private extension AIChatContextualSheetViewController {
 
     func removeCurrentChildViewController() {
         children.forEach { child in
+            guard child.view.superview === contentContainerView else { return }
             child.willMove(toParent: nil)
             child.view.removeFromSuperview()
             child.removeFromParent()
@@ -556,34 +571,11 @@ private extension AIChatContextualSheetViewController {
     }
 
     func updateChipUI(chipState: ChipState) {
+        guard persistentUTIHost == nil else { return }
         switch chipState {
         case .placeholder:
-            if featureFlagger.isFeatureOn(.aiChatContextualSheetImprovements) {
-                if contextualInputViewController.isContextChipVisible {
-                    contextualInputViewController.hideContextChip()
-                }
-            } else {
-                if contextualInputViewController.isContextChipVisible {
-                    contextualInputViewController.updateContextChipState(.placeholder)
-                    contextualInputViewController.setChipTapCallback { [weak self] in
-                        guard let self else { return }
-                        self.pixelHandler.firePageContextPlaceholderTapped()
-                        self.delegate?.aiChatContextualSheetViewControllerDidRequestAttachPage(self)
-                    }
-                } else {
-                    let chipView = createPlaceholderChipView(
-                        onTapToAttach: { [weak self] in
-                            guard let self else { return }
-                            self.pixelHandler.firePageContextPlaceholderTapped()
-                            self.delegate?.aiChatContextualSheetViewControllerDidRequestAttachPage(self)
-                        },
-                        onRemove: { [weak self] in
-                            self?.handleChipRemoved()
-                        }
-                    )
-                    contextualInputViewController.showContextChip(chipView)
-                    pixelHandler.firePageContextPlaceholderShown()
-                }
+            if contextualInputViewController.isContextChipVisible {
+                contextualInputViewController.hideContextChip()
             }
         case .attached(let context):
             if contextualInputViewController.isContextChipVisible {
@@ -757,7 +749,11 @@ extension AIChatContextualSheetViewController: AIChatContextualInputViewControll
         case .askAboutPage:
             pixelHandler.fireQuickActionAskAboutPageSelected()
             delegate?.aiChatContextualSheetViewControllerDidRequestAttachPage(self)
-            contextualInputViewController.becomeFirstResponder()
+            if let persistentUTIHost {
+                persistentUTIHost.activateInput()
+            } else {
+                contextualInputViewController.becomeFirstResponder()
+            }
         case .summarize:
             pixelHandler.fireQuickActionSummarizeSelected()
             delegate?.aiChatContextualSheetViewControllerDidRequestAttachPage(self)
@@ -766,7 +762,11 @@ extension AIChatContextualSheetViewController: AIChatContextualInputViewControll
             }
         case .summarizePage:
             pixelHandler.fireQuickActionSummarizeSelected()
-            delegate?.aiChatContextualSheetViewController(self, didSubmitPrompt: action.prompt)
+            if let persistentUTIHost {
+                persistentUTIHost.submitQuickActionPrompt(action.prompt)
+            } else {
+                delegate?.aiChatContextualSheetViewController(self, didSubmitPrompt: action.prompt)
+            }
         }
     }
 
@@ -919,7 +919,7 @@ private extension AIChatContextualSheetViewController {
             if !isWebViewVisible {
                 transitionToWebView()
             }
-            fireButton.isHidden = false
+            fireButton.isHidden = !viewState.shouldShowNewChatButton
         }
 
     }
@@ -930,8 +930,8 @@ private extension AIChatContextualSheetViewController {
             showWebViewWithPrompt(prompt, pageContext: context)
         case .reloadWebView:
             webViewController?.reload()
-        case .pushContextToFrontend(let context):
-            webViewController?.pushPageContext(context)
+        case .deliverPageContext:
+            break
         case .clearPrompt:
             contextualInputViewController.setText("")
         }
@@ -989,6 +989,9 @@ private extension AIChatContextualSheetViewController {
     }
 
     func setupConstraints() {
+        let contentBottomConstraint = contentContainerView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        contentContainerBottomConstraint = contentBottomConstraint
+
         NSLayoutConstraint.activate([
 
             topSeparator.topAnchor.constraint(equalTo: view.topAnchor),
@@ -1029,8 +1032,18 @@ private extension AIChatContextualSheetViewController {
             contentContainerView.topAnchor.constraint(equalTo: headerView.bottomAnchor, constant: Constants.contentTopPadding),
             contentContainerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             contentContainerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            contentContainerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            contentBottomConstraint,
         ])
+    }
+
+    func mountPersistentUTIHostIfNeeded() {
+        guard let persistentUTIHost else { return }
+
+        let utiView = persistentUTIHost.mountAtSheetLevel(in: self)
+        contentContainerBottomConstraint?.isActive = false
+        let bottomConstraint = contentContainerView.bottomAnchor.constraint(equalTo: utiView.topAnchor)
+        contentContainerBottomConstraint = bottomConstraint
+        bottomConstraint.isActive = true
     }
     
     func updateShadowPath() {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -41,9 +41,7 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate {
 
     var onAttachRequested: (() -> Void)?
     var onRemoveRequested: (() -> Void)?
-    var onNavigationAwayDetachRequested: (() -> Void)?
     var onPromptSubmitted: (() -> Void)?
-    var onPromptContextDelivered: ((URL?) -> Void)?
 
     var attachedContextURL: URL? {
         chipViewModel.attachedContext.flatMap { URL(string: $0.contextData.url) }
@@ -89,9 +87,6 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate {
         chipViewModel.onRemoveActionRequested = { [weak self] in
             self?.onRemoveRequested?()
         }
-        chipViewModel.onNavigationAwayDetachRequested = { [weak self] in
-            self?.onNavigationAwayDetachRequested?()
-        }
 
         Logger.contextualUTI.debug("UTIHost init — carryOver=\(initialAttachedContext != nil, privacy: .public) auto=\(isAutoAttachEnabled(), privacy: .public)")
 
@@ -108,6 +103,10 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate {
 
     func clearAttachedContext() {
         chipViewModel.clearAttached()
+    }
+
+    func showAttachAffordance() {
+        chipViewModel.showAttachAffordance()
     }
 
     /// Routes UTI-submitted prompts through the contextual chat's JS message channel (same as the FE).
@@ -239,7 +238,6 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate {
     }
 
     private func handlePromptSubmittedFromUserScript() {
-        onPromptContextDelivered?(attachedContextURL)
         if !hasDeliveredFirstPrompt {
             hasDeliveredFirstPrompt = true
             onPromptSubmitted?()
@@ -257,7 +255,6 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate {
         guard !hasDeliveredFirstPrompt else { return }
         hasDeliveredFirstPrompt = true
         onPromptSubmitted?()
-        onPromptContextDelivered?(attachedContextURL)
         contextualChatViewController?.submitPrompt(prompt,
                                                    images: images,
                                                    files: files,

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -39,7 +39,7 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate {
     private let duckAIWideEventInstrumentation: DuckAIWideEventInstrumentation
     private let duckAIWideEventFlowScope = DuckAIWideEventFlowScope.contextual(UUID())
 
-    var onAttachRequested: ((URL) -> Void)?
+    var onAttachRequested: (() -> Void)?
     var onRemoveRequested: (() -> Void)?
     var onNavigationAwayDetachRequested: (() -> Void)?
     var onPromptSubmitted: (() -> Void)?
@@ -83,8 +83,8 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate {
         )
         coordinator.delegate = self
         coordinator.viewController.bindPageContextChip(to: chipViewModel)
-        chipViewModel.onAttachActionRequested = { [weak self] url in
-            self?.onAttachRequested?(url)
+        chipViewModel.onAttachActionRequested = { [weak self] in
+            self?.onAttachRequested?()
         }
         chipViewModel.onRemoveActionRequested = { [weak self] in
             self?.onRemoveRequested?()

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -22,38 +22,46 @@ import Combine
 import UIKit
 import os.log
 
-/// Owns a `UnifiedToggleInputCoordinator` configured for the contextual chat surface and
-/// embeds its view controller as a child of `AIChatContextualWebViewController`.
+/// Owns a `UnifiedToggleInputCoordinator` configured for the contextual chat surface.
 @MainActor
-final class AIChatContextualUTIHost {
+final class AIChatContextualUTIHost: UnifiedToggleInputDelegate {
 
     private let coordinator: UnifiedToggleInputCoordinator
-    private let pageContextHandler: AIChatPageContextHandling
     let chipViewModel: UnifiedToggleInputPageContextChipViewModel
-    private let isAutoAttachEnabled: () -> Bool
     private let hasActiveChat: () -> Bool
     private weak var contextualChatViewController: AIChatContextualWebViewController?
-    private var pendingChipAttachCancellable: AnyCancellable?
-    private var suppressExternalContextUntilNextAttach = false
+    private weak var currentUserScript: AIChatUserScript?
+    private weak var pendingUserScriptToBind: AIChatUserScript?
     private var isBoundToUserScript = false
+    private var hasDeliveredFirstPrompt = false
+    private let startsPreSubmit: Bool
     private var cancellables = Set<AnyCancellable>()
     private let duckAIWideEventInstrumentation: DuckAIWideEventInstrumentation
     private let duckAIWideEventFlowScope = DuckAIWideEventFlowScope.contextual(UUID())
 
+    var onAttachRequested: ((URL) -> Void)?
+    var onRemoveRequested: (() -> Void)?
+    var onNavigationAwayDetachRequested: (() -> Void)?
+    var onPromptSubmitted: (() -> Void)?
+    var onPromptContextDelivered: ((URL?) -> Void)?
+
+    var attachedContextURL: URL? {
+        chipViewModel.attachedContext.flatMap { URL(string: $0.contextData.url) }
+    }
+
     init(
         originatingURLPublisher: AnyPublisher<URL?, Never>,
-        didFinishURLPublisher: AnyPublisher<URL?, Never>,
         initialAttachedContext: AIChatPageContext?,
         initialAttachmentDeliveryState: PageContextAttachmentDeliveryState = .delivered,
         hasActiveChat: @escaping () -> Bool,
         isAutoAttachEnabled: @escaping () -> Bool,
-        pageContextHandler: AIChatPageContextHandling,
         isFireTab: Bool,
-        lastUsedModelProvider: DuckAiLastUsedModelProviding? = nil
+        lastUsedModelProvider: DuckAiLastUsedModelProviding? = nil,
+        startsPreSubmit: Bool = false
     ) {
-        self.pageContextHandler = pageContextHandler
-        self.isAutoAttachEnabled = isAutoAttachEnabled
         self.hasActiveChat = hasActiveChat
+        self.startsPreSubmit = startsPreSubmit
+        self.hasDeliveredFirstPrompt = !startsPreSubmit
         let wideEventInstrumentation = DefaultDuckAIWideEventInstrumentation(
             wideEvent: AppDependencyProvider.shared.wideEvent
         )
@@ -64,7 +72,8 @@ final class AIChatContextualUTIHost {
             isFireTab: isFireTab,
             lastUsedModelProvider: lastUsedModelProvider,
             duckAIWideEventInstrumentation: wideEventInstrumentation,
-            duckAIWideEventFlowScope: duckAIWideEventFlowScope
+            duckAIWideEventFlowScope: duckAIWideEventFlowScope,
+            contextualStartsPreSubmit: startsPreSubmit
         )
         self.chipViewModel = UnifiedToggleInputPageContextChipViewModel(
             originatingURLPublisher: originatingURLPublisher,
@@ -72,12 +81,16 @@ final class AIChatContextualUTIHost {
             initialAttachmentDeliveryState: initialAttachmentDeliveryState,
             isAutoAttachEnabled: isAutoAttachEnabled
         )
+        coordinator.delegate = self
         coordinator.viewController.bindPageContextChip(to: chipViewModel)
         chipViewModel.onAttachActionRequested = { [weak self] url in
-            self?.handleChipAttachRequest(originatingURL: url)
+            self?.onAttachRequested?(url)
         }
         chipViewModel.onRemoveActionRequested = { [weak self] in
-            self?.handleChipRemoveRequest()
+            self?.onRemoveRequested?()
+        }
+        chipViewModel.onNavigationAwayDetachRequested = { [weak self] in
+            self?.onNavigationAwayDetachRequested?()
         }
 
         Logger.contextualUTI.debug("UTIHost init — carryOver=\(initialAttachedContext != nil, privacy: .public) auto=\(isAutoAttachEnabled(), privacy: .public)")
@@ -87,86 +100,13 @@ final class AIChatContextualUTIHost {
                 self?.applyCurrentRenderState()
             }
             .store(in: &cancellables)
-
-        // Out-of-band context (BEFORECHAT manual attach, FE-driven flows) reaches the chip
-        // here; pick a delivery state from session timing — pre-chat = silent, active-chat =
-        // pending. `dropFirst` skips the cold-start replay. We step aside while a UTI-driven
-        // attach is in flight; that path has its own one-shot subscriber in `handleChipAttachRequest`.
-        pageContextHandler.contextPublisher
-            .dropFirst()
-            .sink { [weak self] context in
-                guard let self else { return }
-                guard self.pendingChipAttachCancellable == nil else { return }
-                guard context == nil || !self.suppressExternalContextUntilNextAttach else { return }
-                guard context != self.chipViewModel.attachedContext else { return }
-                Logger.contextualUTI.debug("UTIHost contextPublisher emission → \(context != nil ? "context" : "nil", privacy: .public) — syncing chip")
-                if let context {
-                    self.chipViewModel.setAttached(context, deliveryState: self.externalContextDeliveryState)
-                } else {
-                    self.chipViewModel.clearAttached()
-                }
-            }
-            .store(in: &cancellables)
-
-        // didFinish (not didCommit) so the new DOM is ready when JS reads it. `dropFirst`
-        // skips the synchronous replay of the URL the half-sheet was opened on — the
-        // half-sheet is the user's attach/skip decision point. Only subsequent in-chat
-        // navigations should trigger auto-attach.
-        didFinishURLPublisher
-            .dropFirst()
-            .removeDuplicates()
-            .sink { [weak self] url in
-                guard let self else { return }
-                Logger.contextualUTI.debug("UTIHost didFinish (post-replay) → \(url?.shortDescription ?? "nil", privacy: .private)")
-                guard let url else { return }
-                guard self.isAutoAttachEnabled() else {
-                    Logger.contextualUTI.debug("UTIHost didFinish skip — auto disabled")
-                    return
-                }
-                if let attached = self.chipViewModel.attachedContext,
-                   URL(string: attached.contextData.url) == url {
-                    Logger.contextualUTI.debug("UTIHost didFinish skip — already attached to same URL")
-                    return
-                }
-                Logger.contextualUTI.info("Auto-attach on page load — triggering for \(url.shortDescription, privacy: .private)")
-                self.handleChipAttachRequest(originatingURL: url)
-            }
-            .store(in: &cancellables)
     }
 
-    private func handleChipAttachRequest(originatingURL: URL) {
-        Logger.contextualUTI.info("Chip onAttach — triggering context collection")
-        guard pageContextHandler.triggerContextCollection() else {
-            Logger.contextualUTI.error("triggerContextCollection returned false")
-            return
-        }
-        suppressExternalContextUntilNextAttach = false
-        pendingChipAttachCancellable = pageContextHandler.contextPublisher
-            .dropFirst()
-            .prefix(1)
-            .sink { [weak self] context in
-                guard let self else { return }
-                self.pendingChipAttachCancellable = nil
-                guard let context else {
-                    Logger.contextualUTI.error("Collection completed with nil context")
-                    return
-                }
-                Logger.contextualUTI.info("Pushing collected context to contextual chat for FE delivery")
-                self.contextualChatViewController?.pushPageContext(context.contextData)
-                self.chipViewModel.setAttached(context)
-            }
+    func setAttachedContext(_ context: AIChatPageContext, deliveryState: PageContextAttachmentDeliveryState = .pendingSubmit) {
+        chipViewModel.setAttached(context, deliveryState: deliveryState)
     }
 
-    private func handleChipRemoveRequest() {
-        Logger.contextualUTI.info("Chip onRemove — clearing attached context")
-        // Cancel any in-flight collection so a late-arriving result doesn't overwrite the clear.
-        pendingChipAttachCancellable = nil
-        suppressExternalContextUntilNextAttach = true
-        // Use `clear()` rather than `clearAttachedContext()` here because CHAT detach must also
-        // cancel the handler's active JS subscription; otherwise a late collection can still
-        // flow through the coordinator and re-push stale context to the frontend.
-        pageContextHandler.clear()
-        contextualChatViewController?.pushPageContext(nil)
+    func clearAttachedContext() {
         chipViewModel.clearAttached()
     }
 
@@ -175,18 +115,20 @@ final class AIChatContextualUTIHost {
     /// the chip says is currently attached — no duplicate state, single source of truth.
     func bindToUserScript(_ userScript: AIChatUserScript) {
         Logger.contextualUTI.info("Binding coordinator to AIChatUserScript")
-        isBoundToUserScript = true
-        let chatID = userScript.webView?.url?.duckAIChatID
-        coordinator.bindToTab(userScript, hasExistingChat: hasActiveChat() || chatID != nil)
-        if let chatID {
-            coordinator.restoreLastUsedModel(forChatID: chatID)
-        }
+        currentUserScript = userScript
         userScript.attachedPageContextProvider = { [weak self] in
             self?.chipViewModel.pendingAttachedContextData
         }
         userScript.onPromptSubmitted = { [weak self] in
-            self?.chipViewModel.markPromptSubmitted()
+            self?.handlePromptSubmittedFromUserScript()
         }
+
+        if startsPreSubmit, !hasDeliveredFirstPrompt {
+            pendingUserScriptToBind = userScript
+            return
+        }
+
+        bindCoordinator(to: userScript)
     }
 
     func observeChatUpdates(_ publisher: AnyPublisher<String, Never>) {
@@ -197,40 +139,143 @@ final class AIChatContextualUTIHost {
         chipViewModel.markPromptSubmitted()
     }
 
-    private var externalContextDeliveryState: PageContextAttachmentDeliveryState {
-        // These states can differ during preload/restore: the user script may be bound before
-        // `sessionState` records an active chat, while restored chats may be active before bind.
-        isBoundToUserScript || hasActiveChat() ? .pendingSubmit : .delivered
-    }
-
-    func install(in contextualChatViewController: AIChatContextualWebViewController) {
+    func setContextualChatViewController(_ contextualChatViewController: AIChatContextualWebViewController) {
         self.contextualChatViewController = contextualChatViewController
         coordinator.attachmentPresentingViewController = contextualChatViewController
-        // Install + lay out without animation. Otherwise the half-sheet's slide-up animation
-        // captures the UTI's first layout pass and interpolates from a zero-frame at (0,0),
-        // making the bar fly in from the top-left.
+    }
+
+    func installInWebView(_ contextualChatViewController: AIChatContextualWebViewController) {
+        setContextualChatViewController(contextualChatViewController)
+
+        let viewController = coordinator.viewController
+        guard viewController.parent !== contextualChatViewController else {
+            return
+        }
+
         UIView.performWithoutAnimation {
-            contextualChatViewController.addChild(coordinator.viewController)
-            contextualChatViewController.view.addSubview(coordinator.viewController.view)
-            coordinator.viewController.view.translatesAutoresizingMaskIntoConstraints = false
+            contextualChatViewController.addChild(viewController)
+            contextualChatViewController.view.addSubview(viewController.view)
+            viewController.view.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
-                coordinator.viewController.view.leadingAnchor.constraint(equalTo: contextualChatViewController.view.leadingAnchor),
-                coordinator.viewController.view.trailingAnchor.constraint(equalTo: contextualChatViewController.view.trailingAnchor),
-                coordinator.viewController.view.bottomAnchor.constraint(equalTo: contextualChatViewController.view.keyboardLayoutGuide.topAnchor),
+                viewController.view.leadingAnchor.constraint(equalTo: contextualChatViewController.view.leadingAnchor),
+                viewController.view.trailingAnchor.constraint(equalTo: contextualChatViewController.view.trailingAnchor),
+                viewController.view.bottomAnchor.constraint(equalTo: contextualChatViewController.view.keyboardLayoutGuide.topAnchor),
             ])
-            contextualChatViewController.anchorWebViewBottom(to: coordinator.viewController.view.topAnchor)
-            coordinator.viewController.didMove(toParent: contextualChatViewController)
+            contextualChatViewController.anchorWebViewBottom(to: viewController.view.topAnchor)
+            viewController.didMove(toParent: contextualChatViewController)
             coordinator.showExpanded()
             applyCurrentRenderState()
             contextualChatViewController.view.layoutIfNeeded()
         }
-        Logger.contextualUTI.info("Installed at bottom of contextual chat")
+        Logger.contextualUTI.info("Installed at bottom of contextual web chat")
+    }
+
+    func mountAtSheetLevel(in sheetViewController: UIViewController) -> UIView {
+        let viewController = coordinator.viewController
+        guard viewController.parent !== sheetViewController else {
+            return viewController.view
+        }
+
+        // Install + lay out without animation. Otherwise the half-sheet's slide-up animation
+        // captures the UTI's first layout pass and interpolates from a zero-frame at (0,0),
+        // making the bar fly in from the top-left.
+        UIView.performWithoutAnimation {
+            sheetViewController.addChild(viewController)
+            sheetViewController.view.addSubview(viewController.view)
+            viewController.view.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                viewController.view.leadingAnchor.constraint(equalTo: sheetViewController.view.leadingAnchor),
+                viewController.view.trailingAnchor.constraint(equalTo: sheetViewController.view.trailingAnchor),
+                viewController.view.bottomAnchor.constraint(equalTo: sheetViewController.view.keyboardLayoutGuide.topAnchor),
+            ])
+            viewController.didMove(toParent: sheetViewController)
+            coordinator.showExpanded(activatesInput: false)
+            applyCurrentRenderState()
+            sheetViewController.view.layoutIfNeeded()
+        }
+        Logger.contextualUTI.info("Mounted at bottom of contextual sheet")
+        return viewController.view
+    }
+
+    func activateInput() {
+        coordinator.showExpanded()
+    }
+
+    func submitQuickActionPrompt(_ prompt: String) {
+        coordinator.submitProgrammatic(text: prompt)
+    }
+
+    func prepareForNewChat() {
+        hasDeliveredFirstPrompt = !startsPreSubmit
+        clearAttachedContext()
+        if startsPreSubmit, let currentUserScript {
+            coordinator.unbind()
+            isBoundToUserScript = false
+            pendingUserScriptToBind = currentUserScript
+        }
+        coordinator.startNewChat()
+        coordinator.showExpanded(activatesInput: false)
+        applyCurrentRenderState()
     }
 
     private func applyCurrentRenderState() {
         coordinator.viewController.apply(coordinator.computeRenderState().viewConfig, animated: false)
         contextualChatViewController?.view.layoutIfNeeded()
     }
+
+    private func bindCoordinator(to userScript: AIChatUserScript) {
+        isBoundToUserScript = true
+        let chatID = userScript.webView?.url?.duckAIChatID
+        coordinator.bindToTab(userScript, hasExistingChat: hasActiveChat() || chatID != nil)
+        if let chatID {
+            coordinator.restoreLastUsedModel(forChatID: chatID)
+        }
+    }
+
+    private func commitDeferredBindIfNeeded() {
+        guard !isBoundToUserScript, let pendingUserScriptToBind else { return }
+        self.pendingUserScriptToBind = nil
+        bindCoordinator(to: pendingUserScriptToBind)
+    }
+
+    private func handlePromptSubmittedFromUserScript() {
+        onPromptContextDelivered?(attachedContextURL)
+        if !hasDeliveredFirstPrompt {
+            hasDeliveredFirstPrompt = true
+            onPromptSubmitted?()
+            commitDeferredBindIfNeeded()
+        }
+        chipViewModel.markPromptSubmitted()
+    }
+
+    func unifiedToggleInputDidSubmitPrompt(_ prompt: String,
+                                           modelId: String?,
+                                           tools: [AIChatRAGTool]?,
+                                           reasoningEffort: AIChatReasoningEffort?,
+                                           images: [AIChatNativePrompt.NativePromptImage]?,
+                                           files: [AIChatNativePrompt.NativePromptFile]?) {
+        guard !hasDeliveredFirstPrompt else { return }
+        hasDeliveredFirstPrompt = true
+        onPromptSubmitted?()
+        onPromptContextDelivered?(attachedContextURL)
+        contextualChatViewController?.submitPrompt(prompt,
+                                                   images: images,
+                                                   files: files,
+                                                   modelId: modelId,
+                                                   tools: tools,
+                                                   reasoningEffort: reasoningEffort)
+        commitDeferredBindIfNeeded()
+        chipViewModel.markPromptSubmitted()
+    }
+
+    func unifiedToggleInputDidSubmitQuery(_ query: String) {}
+    func unifiedToggleInputDidRequestVoiceSearch() {}
+    func unifiedToggleInputDidRequestAIVoiceChat() {}
+    func unifiedToggleInputDidRequestAIChat(prefilledText: String) {}
+    func unifiedToggleInputDidChangeHeight() {}
+    func unifiedToggleInputDidCommitMode(_ mode: TextEntryMode) {}
+    func unifiedToggleInputDidRequestFire() {}
+    func unifiedToggleInputDidRequestAppMenu() {}
 }
 
 // MARK: - Duck.ai Wide Event

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -260,6 +260,7 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate {
                                                    files: files,
                                                    modelId: modelId,
                                                    tools: tools,
+                                                   pageContext: chipViewModel.pendingAttachedContextData,
                                                    reasoningEffort: reasoningEffort)
         commitDeferredBindIfNeeded()
         chipViewModel.markPromptSubmitted()

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
@@ -39,6 +39,15 @@ protocol AIChatContextualWebViewControllerDelegate: AnyObject {
 
 final class AIChatContextualWebViewController: UIViewController {
 
+    private struct PendingRichPrompt {
+        let prompt: String
+        let images: [AIChatNativePrompt.NativePromptImage]?
+        let files: [AIChatNativePrompt.NativePromptFile]?
+        let modelId: String?
+        let tools: [AIChatRAGTool]?
+        let reasoningEffort: AIChatReasoningEffort?
+    }
+
     // MARK: - Properties
 
     weak var delegate: AIChatContextualWebViewControllerDelegate?
@@ -70,6 +79,7 @@ final class AIChatContextualWebViewController: UIViewController {
     private var pendingPrompt: String?
     /// Page context bundled with a pending prompt submission (consumed together in `submitPromptNow`).
     private var pendingPageContext: AIChatPageContextData?
+    private var pendingRichPrompt: PendingRichPrompt?
     /// Standalone page context for the "Attach Page Content" chip, buffered when WebView isn't ready yet.
     private var pendingChipContext: AIChatPageContextData?
     private var hasPendingChipContext = false
@@ -216,6 +226,30 @@ final class AIChatContextualWebViewController: UIViewController {
         }
     }
 
+    func submitPrompt(_ prompt: String,
+                      images: [AIChatNativePrompt.NativePromptImage]?,
+                      files: [AIChatNativePrompt.NativePromptFile]?,
+                      modelId: String?,
+                      tools: [AIChatRAGTool]?,
+                      reasoningEffort: AIChatReasoningEffort?) {
+        Logger.aiChat.debug("[ContextualWebVC] submit rich prompt called - isPageReady: \(self.isPageReady), isContentHandlerReady: \(self.isContentHandlerReady)")
+        if isPageReady && isContentHandlerReady {
+            let didSendBridgeMessage = aiChatContentHandler.canDispatchBridgeMessages
+            aiChatContentHandler.submitPrompt(prompt, images: images, files: files, modelId: modelId, tools: tools, reasoningEffort: reasoningEffort)
+            utiHost?.promptDeliveryUpdated(wasQueued: false, didSendBridgeMessage: didSendBridgeMessage)
+        } else {
+            utiHost?.promptDeliveryUpdated(wasQueued: true, didSendBridgeMessage: nil)
+            pendingRichPrompt = PendingRichPrompt(prompt: prompt,
+                                                  images: images,
+                                                  files: files,
+                                                  modelId: modelId,
+                                                  tools: tools,
+                                                  reasoningEffort: reasoningEffort)
+            pendingPrompt = nil
+            pendingPageContext = nil
+        }
+    }
+
     /// Called by the delegate chain when the Frontend requests content, indicating it has initialized.
     func markFrontendAsReady() {
         guard !isFrontendReady else { return }
@@ -260,6 +294,7 @@ final class AIChatContextualWebViewController: UIViewController {
         isFrontendReady = false
         pendingPrompt = nil
         pendingPageContext = nil
+        pendingRichPrompt = nil
         hasPendingChipContext = false
         pendingChipContext = nil
         loadingView.startAnimating()
@@ -342,10 +377,13 @@ final class AIChatContextualWebViewController: UIViewController {
 
     /// Handles edge case where user submits or pushes context before preloaded web view is fully ready.
     private func submitPendingIfReady() {
-        Logger.aiChat.debug("[ContextualWebVC] submitPendingIfReady - pendingPrompt: \(self.pendingPrompt != nil), hasPendingChipContext: \(self.hasPendingChipContext), isPageReady: \(self.isPageReady), isContentHandlerReady: \(self.isContentHandlerReady), isFrontendReady: \(self.isFrontendReady)")
+        Logger.aiChat.debug("[ContextualWebVC] submitPendingIfReady - pendingPrompt: \(self.pendingPrompt != nil), pendingRichPrompt: \(self.pendingRichPrompt != nil), hasPendingChipContext: \(self.hasPendingChipContext), isPageReady: \(self.isPageReady), isContentHandlerReady: \(self.isContentHandlerReady), isFrontendReady: \(self.isFrontendReady)")
         guard isPageReady, isContentHandlerReady else { return }
 
-        if let prompt = pendingPrompt {
+        if let richPrompt = pendingRichPrompt {
+            pendingRichPrompt = nil
+            submitPromptNow(richPrompt)
+        } else if let prompt = pendingPrompt {
             let pageContext = pendingPageContext
             pendingPrompt = nil
             pendingPageContext = nil
@@ -364,6 +402,18 @@ final class AIChatContextualWebViewController: UIViewController {
         Logger.aiChat.debug("[ContextualWebVC] Submitting pending prompt now")
         let didSendBridgeMessage = aiChatContentHandler.canDispatchBridgeMessages
         aiChatContentHandler.submitPrompt(prompt, pageContext: pageContext)
+        utiHost?.promptDeliveryUpdated(wasQueued: nil, didSendBridgeMessage: didSendBridgeMessage)
+    }
+
+    private func submitPromptNow(_ richPrompt: PendingRichPrompt) {
+        Logger.aiChat.debug("[ContextualWebVC] Submitting pending rich prompt now")
+        let didSendBridgeMessage = aiChatContentHandler.canDispatchBridgeMessages
+        aiChatContentHandler.submitPrompt(richPrompt.prompt,
+                                         images: richPrompt.images,
+                                         files: richPrompt.files,
+                                         modelId: richPrompt.modelId,
+                                         tools: richPrompt.tools,
+                                         reasoningEffort: richPrompt.reasoningEffort)
         utiHost?.promptDeliveryUpdated(wasQueued: nil, didSendBridgeMessage: didSendBridgeMessage)
     }
 

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
@@ -45,6 +45,7 @@ final class AIChatContextualWebViewController: UIViewController {
         let files: [AIChatNativePrompt.NativePromptFile]?
         let modelId: String?
         let tools: [AIChatRAGTool]?
+        let pageContext: AIChatPageContextData?
         let reasoningEffort: AIChatReasoningEffort?
     }
 
@@ -231,11 +232,12 @@ final class AIChatContextualWebViewController: UIViewController {
                       files: [AIChatNativePrompt.NativePromptFile]?,
                       modelId: String?,
                       tools: [AIChatRAGTool]?,
+                      pageContext: AIChatPageContextData? = nil,
                       reasoningEffort: AIChatReasoningEffort?) {
         Logger.aiChat.debug("[ContextualWebVC] submit rich prompt called - isPageReady: \(self.isPageReady), isContentHandlerReady: \(self.isContentHandlerReady)")
         if isPageReady && isContentHandlerReady {
             let didSendBridgeMessage = aiChatContentHandler.canDispatchBridgeMessages
-            aiChatContentHandler.submitPrompt(prompt, images: images, files: files, modelId: modelId, tools: tools, reasoningEffort: reasoningEffort)
+            aiChatContentHandler.submitPrompt(prompt, images: images, files: files, modelId: modelId, tools: tools, pageContext: pageContext, reasoningEffort: reasoningEffort)
             utiHost?.promptDeliveryUpdated(wasQueued: false, didSendBridgeMessage: didSendBridgeMessage)
         } else {
             utiHost?.promptDeliveryUpdated(wasQueued: true, didSendBridgeMessage: nil)
@@ -244,6 +246,7 @@ final class AIChatContextualWebViewController: UIViewController {
                                                   files: files,
                                                   modelId: modelId,
                                                   tools: tools,
+                                                  pageContext: pageContext,
                                                   reasoningEffort: reasoningEffort)
             pendingPrompt = nil
             pendingPageContext = nil
@@ -413,6 +416,7 @@ final class AIChatContextualWebViewController: UIViewController {
                                          files: richPrompt.files,
                                          modelId: richPrompt.modelId,
                                          tools: richPrompt.tools,
+                                         pageContext: richPrompt.pageContext,
                                          reasoningEffort: richPrompt.reasoningEffort)
         utiHost?.promptDeliveryUpdated(wasQueued: nil, didSendBridgeMessage: didSendBridgeMessage)
     }

--- a/iOS/DuckDuckGo/AIChat/NativeInput/AIChatBasicNativeInputViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/NativeInput/AIChatBasicNativeInputViewController.swift
@@ -1,5 +1,5 @@
 //
-//  AIChatNativeInputViewController.swift
+//  AIChatBasicNativeInputViewController.swift
 //  DuckDuckGo
 //
 //  Copyright © 2025 DuckDuckGo. All rights reserved.
@@ -22,31 +22,31 @@ import UIKit
 
 // MARK: - Delegate Protocol
 
-/// Delegate protocol for handling user interactions with the native input view controller.
-protocol AIChatNativeInputViewControllerDelegate: AnyObject {
-    func nativeInputViewController(_ viewController: AIChatNativeInputViewController, didSubmitPrompt prompt: String)
-    func nativeInputViewControllerDidTapVoice(_ viewController: AIChatNativeInputViewController)
-    func nativeInputViewControllerDidTapClear(_ viewController: AIChatNativeInputViewController)
-    func nativeInputViewControllerDidRemoveContextChip(_ viewController: AIChatNativeInputViewController)
-    func nativeInputViewController(_ viewController: AIChatNativeInputViewController, didChangeText text: String)
+/// Delegate protocol for handling user interactions with the basic native input view controller.
+protocol AIChatBasicNativeInputViewControllerDelegate: AnyObject {
+    func basicNativeInputViewController(_ viewController: AIChatBasicNativeInputViewController, didSubmitPrompt prompt: String)
+    func basicNativeInputViewControllerDidTapVoice(_ viewController: AIChatBasicNativeInputViewController)
+    func basicNativeInputViewControllerDidTapClear(_ viewController: AIChatBasicNativeInputViewController)
+    func basicNativeInputViewControllerDidRemoveContextChip(_ viewController: AIChatBasicNativeInputViewController)
+    func basicNativeInputViewController(_ viewController: AIChatBasicNativeInputViewController, didChangeText text: String)
 }
 
 // MARK: - Default Implementations
 
-extension AIChatNativeInputViewControllerDelegate {
-    func nativeInputViewControllerDidTapClear(_ viewController: AIChatNativeInputViewController) {}
-    func nativeInputViewControllerDidRemoveContextChip(_ viewController: AIChatNativeInputViewController) {}
-    func nativeInputViewController(_ viewController: AIChatNativeInputViewController, didChangeText text: String) {}
+extension AIChatBasicNativeInputViewControllerDelegate {
+    func basicNativeInputViewControllerDidTapClear(_ viewController: AIChatBasicNativeInputViewController) {}
+    func basicNativeInputViewControllerDidRemoveContextChip(_ viewController: AIChatBasicNativeInputViewController) {}
+    func basicNativeInputViewController(_ viewController: AIChatBasicNativeInputViewController, didChangeText text: String) {}
 }
 
 // MARK: - View Controller
 
-/// View controller that wraps the native input view and manages voice search availability.
-final class AIChatNativeInputViewController: UIViewController {
+/// View controller that wraps the basic native input view and manages voice search availability.
+final class AIChatBasicNativeInputViewController: UIViewController {
 
     // MARK: - Properties
 
-    weak var delegate: AIChatNativeInputViewControllerDelegate?
+    weak var delegate: AIChatBasicNativeInputViewControllerDelegate?
 
     private let voiceSearchHelper: VoiceSearchHelperProtocol
     private let nativeInputView = AIChatNativeInputView()
@@ -128,7 +128,7 @@ final class AIChatNativeInputViewController: UIViewController {
 
 // MARK: - Private Setup
 
-private extension AIChatNativeInputViewController {
+private extension AIChatBasicNativeInputViewController {
 
     func setupUI() {
         view.backgroundColor = .clear
@@ -152,26 +152,26 @@ private extension AIChatNativeInputViewController {
 
 // MARK: - AIChatNativeInputViewDelegate
 
-extension AIChatNativeInputViewController: AIChatNativeInputViewDelegate {
+extension AIChatBasicNativeInputViewController: AIChatNativeInputViewDelegate {
 
     func nativeInputViewDidChangeText(_ view: AIChatNativeInputView, text: String) {
-        delegate?.nativeInputViewController(self, didChangeText: text)
+        delegate?.basicNativeInputViewController(self, didChangeText: text)
     }
 
     func nativeInputViewDidTapSubmit(_ view: AIChatNativeInputView, text: String) {
-        delegate?.nativeInputViewController(self, didSubmitPrompt: text)
+        delegate?.basicNativeInputViewController(self, didSubmitPrompt: text)
     }
 
     func nativeInputViewDidTapVoice(_ view: AIChatNativeInputView) {
-        delegate?.nativeInputViewControllerDidTapVoice(self)
+        delegate?.basicNativeInputViewControllerDidTapVoice(self)
     }
 
     func nativeInputViewDidTapClear(_ view: AIChatNativeInputView) {
-        delegate?.nativeInputViewControllerDidTapClear(self)
+        delegate?.basicNativeInputViewControllerDidTapClear(self)
     }
 
     func nativeInputViewDidRemoveContextChip(_ view: AIChatNativeInputView) {
-        delegate?.nativeInputViewControllerDidRemoveContextChip(self)
+        delegate?.basicNativeInputViewControllerDidRemoveContextChip(self)
     }
 
     func nativeInputViewNeedsLayout(_ view: AIChatNativeInputView) {

--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
@@ -332,7 +332,13 @@ final class AIChatUserScript: NSObject, Subfeature {
         submitPrompt(prompt, images: images, files: files, modelId: modelId, tools: nil, reasoningEffort: reasoningEffort)
     }
 
-    func submitPrompt(_ prompt: String, images: [AIChatNativePrompt.NativePromptImage]?, files: [AIChatNativePrompt.NativePromptFile]? = nil, modelId: String?, tools: [AIChatRAGTool]?, reasoningEffort: AIChatReasoningEffort? = nil) {
+    func submitPrompt(_ prompt: String,
+                      images: [AIChatNativePrompt.NativePromptImage]?,
+                      files: [AIChatNativePrompt.NativePromptFile]? = nil,
+                      modelId: String?,
+                      tools: [AIChatRAGTool]?,
+                      pageContext: AIChatPageContextData? = nil,
+                      reasoningEffort: AIChatReasoningEffort? = nil) {
         // `attachedPageContextProvider` returns the single current-page form on iOS; wrap it
         // in the `.single` variant of the union the schema now accepts.
         let promptPayload = AIChatNativePrompt.queryPrompt(
@@ -342,7 +348,7 @@ final class AIChatUserScript: NSObject, Subfeature {
             images: images,
             files: files,
             modelId: modelId,
-            pageContext: attachedPageContextProvider?().map(AIChatPageContextPayload.single),
+            pageContext: (pageContext ?? attachedPageContextProvider?()).map(AIChatPageContextPayload.single),
             reasoningEffort: reasoningEffort
         )
         push(.submitPrompt(promptPayload))

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -325,16 +325,6 @@ class TabViewController: UIViewController {
         urlSubject.eraseToAnyPublisher()
     }
 
-    /// Emits the URL of the underlying tab each time a navigation finishes loading. Unlike
-    /// `urlPublisher` (which fires at didCommit, before the new DOM is ready), this is the
-    /// reliable signal for "the new page's content is available to query." Replays the last
-    /// finished URL on subscribe so late subscribers (e.g. a contextual chat opened after
-    /// the page already loaded) still see the current page.
-    private let didFinishURLSubject = CurrentValueSubject<URL?, Never>(nil)
-    var didFinishURLPublisher: AnyPublisher<URL?, Never> {
-        didFinishURLSubject.eraseToAnyPublisher()
-    }
-
     public var url: URL? {
         willSet {
             if newValue != url {
@@ -615,7 +605,7 @@ class TabViewController: UIViewController {
             featureFlagger: featureFlagger,
             unifiedToggleInputFeature: unifiedToggleInputFeature,
             pageContextHandler: pageContextHandler,
-            tabURLPublishers: AIChatTabURLPublishers(originating: urlPublisher, didFinish: didFinishURLPublisher),
+            tabURLPublishers: AIChatTabURLPublishers(originating: urlPublisher),
             isFireTab: tabModel.fireTab,
             duckAiNativeStorageHandler: duckAiNativeStorageHandler,
             duckAiFireModeStorageHandler: duckAiFireModeStorageHandler
@@ -2113,7 +2103,6 @@ extension TabViewController: WKNavigationDelegate {
         navigationPixelResponder.didFinish(navigation)
         self.preventUniversalLinksOnce = false
         self.currentlyLoadedURL = webView.url
-        didFinishURLSubject.send(webView.url)
         onTextZoomChange()
         adClickAttributionDetection.onDidFinishNavigation(url: webView.url)
         adClickExternalOpenDetector.finishNavigation()

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -324,6 +324,10 @@ class TabViewController: UIViewController {
     var urlPublisher: AnyPublisher<URL?, Never> {
         urlSubject.eraseToAnyPublisher()
     }
+    private let didFinishURLSubject = CurrentValueSubject<URL?, Never>(nil)
+    var didFinishURLPublisher: AnyPublisher<URL?, Never> {
+        didFinishURLSubject.eraseToAnyPublisher()
+    }
 
     public var url: URL? {
         willSet {
@@ -605,7 +609,7 @@ class TabViewController: UIViewController {
             featureFlagger: featureFlagger,
             unifiedToggleInputFeature: unifiedToggleInputFeature,
             pageContextHandler: pageContextHandler,
-            tabURLPublishers: AIChatTabURLPublishers(originating: urlPublisher),
+            tabURLPublishers: AIChatTabURLPublishers(originating: urlPublisher, didFinish: didFinishURLPublisher),
             isFireTab: tabModel.fireTab,
             duckAiNativeStorageHandler: duckAiNativeStorageHandler,
             duckAiFireModeStorageHandler: duckAiFireModeStorageHandler
@@ -2098,6 +2102,7 @@ extension TabViewController: WKNavigationDelegate {
         navigationPixelResponder.didFinish(navigation)
         self.preventUniversalLinksOnce = false
         self.currentlyLoadedURL = webView.url
+        didFinishURLSubject.send(webView.url)
         onTextZoomChange()
         adClickAttributionDetection.onDidFinishNavigation(url: webView.url)
         adClickExternalOpenDetector.finishNavigation()
@@ -2109,12 +2114,6 @@ extension TabViewController: WKNavigationDelegate {
         instrumentation.didLoadURL()
         checkLoginDetectionAfterNavigation()
         trackSecondSiteVisitIfNeeded(url: webView.url)
-
-        if aiChatContextualSheetCoordinator.hasActiveSheet {
-            Task { [weak self] in
-                await self?.aiChatContextualSheetCoordinator.notifyPageChanged()
-            }
-        }
 
         fireProductTelemetry(for: webView)
         

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -1937,11 +1937,6 @@ extension TabViewController: WKNavigationDelegate {
         // Check cache for instant logo display during back navigation
         checkDaxEasterEggCacheIfDuckDuckGoSearch(webView)
 
-        if aiChatContextualSheetCoordinator.hasActiveSheet {
-            Task { [weak self] in
-                await self?.aiChatContextualSheetCoordinator.notifyPageChanged()
-            }
-        }
     }
 
     private func onWebpageDidStartLoading(httpsForced: Bool) {
@@ -2114,6 +2109,12 @@ extension TabViewController: WKNavigationDelegate {
         instrumentation.didLoadURL()
         checkLoginDetectionAfterNavigation()
         trackSecondSiteVisitIfNeeded(url: webView.url)
+
+        if aiChatContextualSheetCoordinator.hasActiveSheet {
+            Task { [weak self] in
+                await self?.aiChatContextualSheetCoordinator.notifyPageChanged()
+            }
+        }
 
         fireProductTelemetry(for: webView)
         

--- a/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
@@ -55,6 +55,10 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
     /// Invoked when the user taps the X on the attached chip.
     var onRemoveActionRequested: (() -> Void)?
 
+    /// Invoked when the attached chip is cleared because the tab navigated away while
+    /// auto-attach is off. This is not a user removal.
+    var onNavigationAwayDetachRequested: (() -> Void)?
+
     private let isAutoAttachEnabled: () -> Bool
     private(set) var attachedContext: AIChatPageContext?
     private var attachedURL: URL?
@@ -110,7 +114,7 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
 
     func tapToRemove() {
         Logger.contextualUTI.info("PageContextChip remove tapped — detaching")
-        onRemoveActionRequested?()
+        onNavigationAwayDetachRequested?()
     }
 
     var pendingAttachedContextData: AIChatPageContextData? {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
@@ -49,8 +49,8 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
     @Published private(set) var state: AIChatContextChipView.State = .placeholder
     @Published private(set) var isVisible: Bool = false
 
-    /// Invoked when the user taps the placeholder chip and an originating URL is available.
-    var onAttachActionRequested: ((URL) -> Void)?
+    /// Invoked when the user taps the placeholder chip.
+    var onAttachActionRequested: (() -> Void)?
 
     /// Invoked when the user taps the X on the attached chip.
     var onRemoveActionRequested: (() -> Void)?
@@ -104,17 +104,17 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
     }
 
     func tapToAttach() {
-        guard let url = originatingURL else {
-            Logger.contextualUTI.debug("PageContextChip tapped but no originating URL — ignoring")
-            return
+        if let url = originatingURL {
+            Logger.contextualUTI.info("PageContextChip placeholder tapped — attaching \(url.shortDescription, privacy: .private)")
+        } else {
+            Logger.contextualUTI.info("PageContextChip placeholder tapped — attaching without originating URL")
         }
-        Logger.contextualUTI.info("PageContextChip placeholder tapped — attaching \(url.shortDescription, privacy: .private)")
-        onAttachActionRequested?(url)
+        onAttachActionRequested?()
     }
 
     func tapToRemove() {
         Logger.contextualUTI.info("PageContextChip remove tapped — detaching")
-        onNavigationAwayDetachRequested?()
+        onRemoveActionRequested?()
     }
 
     var pendingAttachedContextData: AIChatPageContextData? {
@@ -140,7 +140,7 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
         clearAttachmentState()
         // Propagate through the host so it also clears the page-context handler — otherwise
         // its cached context survives and the next prompt would carry stale context.
-        onRemoveActionRequested?()
+        onNavigationAwayDetachRequested?()
     }
 
     private func updateAttachment(_ context: AIChatPageContext?, deliveryState: PageContextAttachmentDeliveryState) {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
@@ -114,6 +114,7 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
 
     func tapToRemove() {
         Logger.contextualUTI.info("PageContextChip remove tapped — detaching")
+        clearAttached()
         onRemoveActionRequested?()
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
@@ -100,6 +100,10 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
     }
 
     func showAttachAffordance() {
+        guard pendingAttachedContextData == nil else {
+            Logger.contextualUTI.debug("PageContextChip keeping pending attachment instead of showing attach affordance")
+            return
+        }
         isShowingAttachAffordance = true
         Logger.contextualUTI.debug("PageContextChip showing attach affordance")
         recompute()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
@@ -36,11 +36,9 @@ enum PageContextAttachmentDeliveryState {
 /// `.delivered`, so the chat opens silent.
 ///
 /// Visibility:
-///   - attached + URL matches + delivered → hidden (FE silently uses it).
-///   - attached + URL matches + pending → `.attached` feedback until the user submits.
-///   - attached + URL doesn't match + auto ON → `.attached` only if pending; if delivered,
-///     stay hidden until the new page's context lands (otherwise a silent old chip briefly
-///     reappears during nav transition).
+///   - attach affordance command → placeholder.
+///   - attached + pending → `.attached` feedback until the user submits.
+///   - attached + delivered → hidden (already submitted).
 ///   - no attachment → placeholder. The half-sheet is the user's attach/skip gate; once
 ///     they're in the chat, an empty state always offers a tap target.
 @MainActor
@@ -55,10 +53,6 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
     /// Invoked when the user taps the X on the attached chip.
     var onRemoveActionRequested: (() -> Void)?
 
-    /// Invoked when the attached chip is cleared because the tab navigated away while
-    /// auto-attach is off. This is not a user removal.
-    var onNavigationAwayDetachRequested: (() -> Void)?
-
     private let isAutoAttachEnabled: () -> Bool
     private(set) var attachedContext: AIChatPageContext?
     private var attachedURL: URL?
@@ -66,6 +60,7 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
     /// Whether the current attachment is waiting to be included in a prompt or has already
     /// been delivered. `markPromptSubmitted()` flips pending attachments to delivered.
     private var attachmentDeliveryState: PageContextAttachmentDeliveryState = .pendingSubmit
+    private var isShowingAttachAffordance = false
     private var cancellables = Set<AnyCancellable>()
 
     init(
@@ -84,7 +79,6 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
                 guard let self else { return }
                 Logger.contextualUTI.debug("ChipViewModel originatingURL changed → \(url?.shortDescription ?? "nil", privacy: .private)")
                 self.originatingURL = url
-                if self.shouldClearOnNavigationAway { self.clearAttachedDueToNavigationAway() }
                 self.recompute()
             }
             .store(in: &cancellables)
@@ -92,14 +86,22 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
     }
 
     func setAttached(_ context: AIChatPageContext, deliveryState: PageContextAttachmentDeliveryState = .pendingSubmit) {
+        isShowingAttachAffordance = false
         updateAttachment(context, deliveryState: deliveryState)
         Logger.contextualUTI.debug("PageContextChip attached")
         recompute()
     }
 
     func clearAttached() {
+        isShowingAttachAffordance = false
         clearAttachmentState()
         Logger.contextualUTI.debug("PageContextChip detached")
+        recompute()
+    }
+
+    func showAttachAffordance() {
+        isShowingAttachAffordance = true
+        Logger.contextualUTI.debug("PageContextChip showing attach affordance")
         recompute()
     }
 
@@ -131,19 +133,6 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
         recompute()
     }
 
-    private var shouldClearOnNavigationAway: Bool {
-        guard let attachedURL, attachedURL != originatingURL else { return false }
-        return !isAutoAttachEnabled()
-    }
-
-    private func clearAttachedDueToNavigationAway() {
-        Logger.contextualUTI.debug("PageContextChip clearing attachment — tab navigated away (auto-attach OFF)")
-        clearAttachmentState()
-        // Propagate through the host so it also clears the page-context handler — otherwise
-        // its cached context survives and the next prompt would carry stale context.
-        onNavigationAwayDetachRequested?()
-    }
-
     private func updateAttachment(_ context: AIChatPageContext?, deliveryState: PageContextAttachmentDeliveryState) {
         attachedContext = context
         attachedURL = Self.url(of: context)
@@ -164,16 +153,14 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
         let isMatching = attachedURL != nil && attachedURL == originatingURL
         let branch: String
 
-        if isMatching, let ctx = attachedContext {
+        if isShowingAttachAffordance {
+            state = .placeholder
+            isVisible = true
+            branch = "attachAffordance"
+        } else if let ctx = attachedContext {
             state = .attached(title: ctx.title, favicon: ctx.favicon)
             isVisible = attachmentDeliveryState == .pendingSubmit
-            branch = "matching(deliveryState=\(attachmentDeliveryState))"
-        } else if let ctx = attachedContext, isAutoAttachEnabled() {
-            // Auto-mode nav transition: keep showing the attached site only if it was
-            // pending feedback; if delivered, stay hidden so we don't briefly resurrect it.
-            state = .attached(title: ctx.title, favicon: ctx.favicon)
-            isVisible = attachmentDeliveryState == .pendingSubmit
-            branch = "autoTransition(deliveryState=\(attachmentDeliveryState))"
+            branch = "attached(matching=\(isMatching), deliveryState=\(attachmentDeliveryState))"
         } else {
             state = .placeholder
             isVisible = true

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -394,7 +394,8 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         aiChatSyncCleaner: AIChatSyncCleaning? = nil,
         sessionStateMetrics: SessionStateMetricsProviding = SessionStateMetrics(storage: UserDefaults.standard),
         duckAIWideEventInstrumentation: DuckAIWideEventInstrumentation? = nil,
-        duckAIWideEventFlowScope: DuckAIWideEventFlowScope? = nil
+        duckAIWideEventFlowScope: DuckAIWideEventFlowScope? = nil,
+        contextualStartsPreSubmit: Bool = false
     ) {
         self.host = host
         self.isToggleEnabled = isToggleEnabled
@@ -481,7 +482,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         // `hasSubmittedPrompt` should reflect that — drives follow-up placeholder + model chip hide.
         if host == .contextualChat {
             displayState = .aiTab(.expanded)
-            hasSubmittedPrompt = true
+            hasSubmittedPrompt = !contextualStartsPreSubmit
             syncHasSubmittedPromptToHandler()
             updateModelChipVisibility()
         }
@@ -746,7 +747,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         intentSubject.send(.showCollapsed(from: previousDisplayState))
     }
 
-    func showExpanded(prefilledText: String? = nil, inputMode: TextEntryMode = .aiChat) {
+    func showExpanded(prefilledText: String? = nil, inputMode: TextEntryMode = .aiChat, activatesInput: Bool = true) {
         guard !isOnboardingLocked else { return }
         cancelTopOmnibarKeyboardPresentationFallback()
         isAwaitingTopOmnibarKeyboardPresentation = false
@@ -772,6 +773,8 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         updateFloatingReturnKeyState()
 
         intentSubject.send(.showExpanded(from: previousDisplayState))
+        guard activatesInput else { return }
+
         DispatchQueue.main.async { [weak self] in
             guard let self, case .aiTab(.expanded) = self.displayState else { return }
             guard !self.isOnboardingLocked else { return }
@@ -787,6 +790,10 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
                 self.viewController.selectAllText()
             }
         }
+    }
+
+    func submitProgrammatic(text: String) {
+        unifiedToggleInputVC(viewController, didSubmitText: text, mode: .aiChat)
     }
 
     func hide() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
@@ -342,6 +342,7 @@ final class UnifiedToggleInputToolbarView: UIView {
         button.setContentHuggingPriority(.required, for: .horizontal)
         button.setContentCompressionResistancePriority(.required, for: .horizontal)
         button.accessibilityLabel = UserText.aiChatToolbarSubmitButtonAccessibilityLabel
+        button.accessibilityIdentifier = "AIChat.Toolbar.Button.Submit"
         button.addTarget(self, action: #selector(submitTapped), for: .touchUpInside)
         NSLayoutConstraint.activate([
             button.widthAnchor.constraint(equalToConstant: Constants.toolButtonSize),

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
@@ -202,17 +202,11 @@ final class UnifiedToggleInputToolbarView: UIView {
         action: nil
     )
 
-    private(set) lazy var imageButton: UIButton = {
-        let button = makeToolButton(
-            image: DesignSystemImages.Glyphs.Size24.attach,
-            accessibilityLabel: UserText.aiChatToolbarAttachButtonAccessibilityLabel,
-            action: nil
-        )
-        if #available(iOS 16.0, *) {
-            button.preferredMenuElementOrder = .fixed
-        }
-        return button
-    }()
+    private(set) lazy var imageButton: UIButton = makeToolButton(
+        image: DesignSystemImages.Glyphs.Size24.attach,
+        accessibilityLabel: UserText.aiChatToolbarAttachButtonAccessibilityLabel,
+        action: nil
+    )
 
     private lazy var reasoningButton: UIButton = {
         let button = makeToolButton(

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
@@ -202,11 +202,17 @@ final class UnifiedToggleInputToolbarView: UIView {
         action: nil
     )
 
-    private(set) lazy var imageButton: UIButton = makeToolButton(
-        image: DesignSystemImages.Glyphs.Size24.attach,
-        accessibilityLabel: UserText.aiChatToolbarAttachButtonAccessibilityLabel,
-        action: nil
-    )
+    private(set) lazy var imageButton: UIButton = {
+        let button = makeToolButton(
+            image: DesignSystemImages.Glyphs.Size24.attach,
+            accessibilityLabel: UserText.aiChatToolbarAttachButtonAccessibilityLabel,
+            action: nil
+        )
+        if #available(iOS 16.0, *) {
+            button.preferredMenuElementOrder = .fixed
+        }
+        return button
+    }()
 
     private lazy var reasoningButton: UIButton = {
         let button = makeToolButton(

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContentHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContentHandlerTests.swift
@@ -583,6 +583,33 @@ final class AIChatContentHandlerTests: XCTestCase {
         XCTAssertEqual(mockUserScript.lastSubmittedPrompt, "Hello")
         XCTAssertNil(mockUserScript.lastSubmittedPageContext)
     }
+
+    func testSubmitRichPromptPassesPageContextToUserScript() throws {
+        let mockUserScript = MockAIChatUserScript()
+        let mockWebView = WKWebView()
+        handler.setup(with: mockUserScript, webView: mockWebView, displayMode: .contextual)
+        let pageContext = AIChatPageContextData(
+            title: "Queued Page",
+            favicon: [],
+            url: "https://example.com/queued",
+            content: "Queued content",
+            truncated: false,
+            fullContentLength: 14
+        )
+
+        handler.submitPrompt("Summarize queued page",
+                             images: nil,
+                             files: nil,
+                             modelId: nil,
+                             tools: nil,
+                             pageContext: pageContext,
+                             reasoningEffort: nil)
+
+        XCTAssertEqual(mockUserScript.submitPromptCallCount, 1)
+        XCTAssertEqual(mockUserScript.lastSubmittedPrompt, "Summarize queued page")
+        XCTAssertEqual(mockUserScript.lastSubmittedPageContext?.title, "Queued Page")
+        XCTAssertEqual(mockUserScript.lastSubmittedPageContext?.url, "https://example.com/queued")
+    }
     
     // MARK: - Delegate Notifications
 
@@ -781,9 +808,11 @@ final class MockAIChatUserScript: AIChatUserScriptProviding {
                       files: [AIChatNativePrompt.NativePromptFile]?,
                       modelId: String?,
                       tools: [AIChatRAGTool]?,
+                      pageContext: AIChatPageContextData?,
                       reasoningEffort: AIChatReasoningEffort?) {
         submitPromptCallCount += 1
         lastSubmittedPrompt = prompt
+        lastSubmittedPageContext = pageContext
     }
 
     func submitStartChatAction() {

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContentHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContentHandlerTests.swift
@@ -776,6 +776,16 @@ final class MockAIChatUserScript: AIChatUserScriptProviding {
         lastSubmittedPageContext = pageContext
     }
 
+    func submitPrompt(_ prompt: String,
+                      images: [AIChatNativePrompt.NativePromptImage]?,
+                      files: [AIChatNativePrompt.NativePromptFile]?,
+                      modelId: String?,
+                      tools: [AIChatRAGTool]?,
+                      reasoningEffort: AIChatReasoningEffort?) {
+        submitPromptCallCount += 1
+        lastSubmittedPrompt = prompt
+    }
+
     func submitStartChatAction() {
         submitStartChatActionCallCount += 1
     }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -644,7 +644,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
 
     // MARK: - Complex Scenario Tests
 
-    func testUserDowngradeBlocksAutoAttachUntilManualAttach() {
+    func testUserDowngradeBlocksLateResultUntilNavigationOrManualAttach() {
         // Given
         mockSettings.isAutomaticContextAttachmentEnabled = true
         sessionState.updateContext(makeTestContext())
@@ -655,14 +655,22 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         XCTAssertEqual(sessionState.chipState, .placeholder)
         XCTAssertTrue(sessionState.userDowngradedToPlaceholder)
 
-        // Navigation preserves the opt-out
-        sessionState.notifyPageChanged()
-        XCTAssertTrue(sessionState.userDowngradedToPlaceholder)
-        XCTAssertFalse(sessionState.shouldTriggerAutoCollect(for: URL(string: "https://example.com/new")!))
-
-        // A late or manually triggered context result still does not auto-attach
+        // A late collection result still does not auto-attach
         sessionState.updateContext(makeTestContext(title: "New Page"))
         XCTAssertEqual(sessionState.chipState, .placeholder)
+
+        // A real navigation clears the temporary removal so auto-attach can run again
+        sessionState.notifyPageChanged()
+        XCTAssertFalse(sessionState.userDowngradedToPlaceholder)
+        XCTAssertTrue(sessionState.shouldTriggerAutoCollect(for: URL(string: "https://example.com/new")!))
+        sessionState.updateContext(makeTestContext(title: "Navigated Page"))
+        if case .attached = sessionState.chipState {
+            // Expected
+        } else {
+            XCTFail("Expected attached chip state after navigation auto-attach")
+        }
+
+        XCTAssertTrue(sessionState.handleChipRemoval())
 
         // Manual attach clears the opt-out and attaches again
         sessionState.beginManualAttach()
@@ -675,7 +683,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         }
     }
 
-    func testBaseWebUTIWithoutImmediateContextualModePreservesDowngradeOnNavigation() {
+    func testBaseWebUTIWithoutImmediateContextualModeAllowsAutoAttachAfterNavigation() {
         // Given
         sessionState.updateUnifiedToggleInputActive(true, isImmediateContextual: false)
         mockSettings.isAutomaticContextAttachmentEnabled = true
@@ -687,12 +695,12 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         // When - base web UTI is active and the page changes
         sessionState.notifyPageChanged(pageURL: pageURL)
 
-        // Then - user remove remains an opt-out until manual attach/reset
-        XCTAssertTrue(sessionState.userDowngradedToPlaceholder)
-        XCTAssertFalse(sessionState.shouldTriggerAutoCollect(for: pageURL))
+        // Then - production behavior allows auto-attach after a real navigation/reload
+        XCTAssertFalse(sessionState.userDowngradedToPlaceholder)
+        XCTAssertTrue(sessionState.shouldTriggerAutoCollect(for: pageURL))
     }
 
-    func testPreSubmitUTIOptOutSurvivesSamePageNavigationReplayAndLateContextResult() {
+    func testPreSubmitUTIOptOutBlocksLateContextResultUntilNavigation() {
         // Given
         sessionState.updateUnifiedToggleInputActive(true, isImmediateContextual: true)
         mockSettings.isAutomaticContextAttachmentEnabled = true
@@ -720,18 +728,13 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
             }
             .store(in: &cancellables)
 
-        // Then - replayed didFinish should not clear opt-out or trigger collection
-        sessionState.notifyPageChanged(pageURL: pageURL)
-        XCTAssertTrue(sessionState.userDowngradedToPlaceholder)
-        XCTAssertFalse(sessionState.shouldTriggerAutoCollect(for: pageURL))
-
-        // And a late collection result should not reattach or deliver to the UTI chip
+        // Then - a late collection result should not reattach or deliver to the UTI chip
         sessionState.updateContext(makeTestContext(title: "Late Page", url: pageURL.absoluteString))
         XCTAssertEqual(sessionState.chipState, .placeholder)
         XCTAssertTrue(deliveredContexts.isEmpty)
     }
 
-    func testPreSubmitUTIOptOutSurvivesDifferentPageNavigation() {
+    func testPreSubmitUTIOptOutAllowsAutoCollectAfterDifferentPageNavigation() {
         // Given
         sessionState.updateUnifiedToggleInputActive(true, isImmediateContextual: true)
         mockSettings.isAutomaticContextAttachmentEnabled = true
@@ -744,9 +747,23 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         // When - didFinish reports a real page change
         sessionState.notifyPageChanged(pageURL: newPageURL)
 
-        // Then - production pre-submit behavior keeps the user's opt-out until manual attach/reset
+        // Then - production pre-submit behavior gives auto-attach another chance after navigation
+        XCTAssertFalse(sessionState.userDowngradedToPlaceholder)
+        XCTAssertTrue(sessionState.shouldTriggerAutoCollect(for: newPageURL))
+    }
+
+    func testPreSubmitUTIOptOutAllowsAutoCollectAfterSamePageReload() {
+        sessionState.updateUnifiedToggleInputActive(true, isImmediateContextual: true)
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        let pageURL = URL(string: "https://example.com")!
+        sessionState.updateContext(makeTestContext(url: pageURL.absoluteString))
+        XCTAssertTrue(sessionState.handleChipRemoval())
         XCTAssertTrue(sessionState.userDowngradedToPlaceholder)
-        XCTAssertFalse(sessionState.shouldTriggerAutoCollect(for: newPageURL))
+
+        sessionState.notifyPageChanged(pageURL: pageURL)
+
+        XCTAssertFalse(sessionState.userDowngradedToPlaceholder)
+        XCTAssertTrue(sessionState.shouldTriggerAutoCollect(for: pageURL))
     }
 
     func testNewChatFlowWithAutoAttachOn() {

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -609,8 +609,9 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         waitForExpectations(timeout: 1.0)
 
         // Then
-        if case .deliverPageContext(let contextData) = receivedEffect {
+        if case .deliverPageContext(let contextData, let targets) = receivedEffect {
             XCTAssertEqual(contextData?.title, "Test Page")
+            XCTAssertEqual(targets, .frontendBridge)
         } else {
             XCTFail("Expected deliverPageContext effect")
         }
@@ -713,7 +714,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         var deliveredContexts: [AIChatPageContextData?] = []
         sessionState.effects
             .sink { effect in
-                if case .deliverPageContext(let data) = effect {
+                if case .deliverPageContext(let data, _) = effect {
                     deliveredContexts.append(data)
                 }
             }
@@ -806,7 +807,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         var pushedContexts: [AIChatPageContextData?] = []
         sessionState.effects
             .sink { effect in
-                if case .deliverPageContext(let data) = effect {
+                if case .deliverPageContext(let data, _) = effect {
                     pushedContexts.append(data)
                 }
             }
@@ -856,7 +857,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         var deliveredContexts: [AIChatPageContextData?] = []
         sessionState.effects
             .sink { effect in
-                if case .deliverPageContext(let data) = effect {
+                if case .deliverPageContext(let data, _) = effect {
                     deliveredContexts.append(data)
                 }
             }
@@ -906,7 +907,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         XCTAssertFalse(sessionState.hasDeliveredPageContext(context))
     }
 
-    func testNotifyFrontendOfNavigationEmitsNullContextWhenFlagEnabled() {
+    func testNotifyFrontendOfNavigationEmitsFrontendOnlyNullContextWhenFlagEnabled() {
         // Given - chat with initial context, flag ON
         // Note: auto-attach ON is only needed to reach .chatWithInitialContext state.
         // In production, notifyFrontendOfMultiContextNavigation() is called when auto-collect is OFF.
@@ -933,8 +934,10 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         waitForExpectations(timeout: 1.0)
 
         // Then
-        if case .deliverPageContext(let contextData) = receivedEffect {
+        if case .deliverPageContext(let contextData, let targets) = receivedEffect {
             XCTAssertNil(contextData)
+            XCTAssertEqual(targets, .frontendBridge)
+            XCTAssertFalse(targets.contains(.utiChip))
         } else {
             XCTFail("Expected deliverPageContext effect with nil")
         }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -667,9 +667,25 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         }
     }
 
+    func testBaseWebUTIWithoutImmediateContextualModeUsesLegacyDowngradeNavigation() {
+        // Given
+        sessionState.updateUnifiedToggleInputActive(true, isImmediateContextual: false)
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        let pageURL = URL(string: "https://example.com")!
+        sessionState.updateContext(makeTestContext(url: pageURL.absoluteString))
+        XCTAssertTrue(sessionState.handleChipRemoval())
+        XCTAssertTrue(sessionState.userDowngradedToPlaceholder)
+
+        // When - base web UTI is active, but the immediate pre-submit replay guard is not
+        sessionState.notifyPageChanged(pageURL: pageURL)
+
+        // Then - legacy navigation semantics still clear the opt-out
+        XCTAssertFalse(sessionState.userDowngradedToPlaceholder)
+    }
+
     func testPreSubmitUTIOptOutSurvivesSamePageNavigationReplayAndLateContextResult() {
         // Given
-        sessionState.updateUnifiedToggleInputActive(true)
+        sessionState.updateUnifiedToggleInputActive(true, isImmediateContextual: true)
         mockSettings.isAutomaticContextAttachmentEnabled = true
         let pageURL = URL(string: "https://example.com")!
         sessionState.updateContext(makeTestContext(url: pageURL.absoluteString))
@@ -708,7 +724,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
 
     func testPreSubmitUTIOptOutClearsOnDifferentPageNavigation() {
         // Given
-        sessionState.updateUnifiedToggleInputActive(true)
+        sessionState.updateUnifiedToggleInputActive(true, isImmediateContextual: true)
         mockSettings.isAutomaticContextAttachmentEnabled = true
         let pageURL = URL(string: "https://example.com")!
         let newPageURL = URL(string: "https://example.com/new")!

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -341,7 +341,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
 
     // MARK: - Navigation Tests
 
-    func testNotifyPageChangedPreservesUserDowngradeFlag() {
+    func testNotifyPageChangedClearsTemporaryUserDowngradeWhenAutoAttachIsOn() {
         // Given
         mockSettings.isAutomaticContextAttachmentEnabled = true
         sessionState.updateContext(makeTestContext())
@@ -352,7 +352,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         sessionState.notifyPageChanged()
 
         // Then
-        XCTAssertTrue(sessionState.userDowngradedToPlaceholder)
+        XCTAssertFalse(sessionState.userDowngradedToPlaceholder)
     }
 
     func testUpdateContextAfterNavigationFiresPixel() {
@@ -912,19 +912,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         XCTAssertFalse(sessionState.shouldDeliverToFrontendBridge(context))
     }
 
-    func testDeliveredPageContextTrackingResetsOnNewChat() {
-        let pageURL = URL(string: "https://example.com")!
-        let context = makeTestContext(url: pageURL.absoluteString).contextData
-
-        sessionState.markPageContextDeliveredInPrompt(pageURL)
-        XCTAssertTrue(sessionState.hasDeliveredPageContext(context))
-
-        sessionState.resetToNoChat()
-
-        XCTAssertFalse(sessionState.hasDeliveredPageContext(context))
-    }
-
-    func testNotifyFrontendOfNavigationEmitsFrontendOnlyNullContextWhenFlagEnabled() {
+    func testNotifyFrontendOfNavigationEmitsFrontendOnlyNullContextWhenUTIInactive() {
         // Given - chat with initial context, flag ON
         // Note: auto-attach ON is only needed to reach .chatWithInitialContext state.
         // In production, notifyFrontendOfMultiContextNavigation() is called when auto-collect is OFF.
@@ -954,6 +942,44 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         if case .deliverPageContext(let contextData, let targets) = receivedEffect {
             XCTAssertNil(contextData)
             XCTAssertEqual(targets, .frontendBridge)
+            XCTAssertFalse(targets.contains(.utiChip))
+            XCTAssertFalse(targets.contains(.utiAttachAffordance))
+        } else {
+            XCTFail("Expected deliverPageContext effect with nil")
+        }
+    }
+
+    func testNotifyFrontendOfNavigationEmitsUTIAttachAffordanceWhenUTIActive() {
+        // Given - chat with initial context, multi-context ON, UTI active
+        mockFeatureFlagger.enabledFeatureFlags = [.multiplePageContexts]
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        sessionState.updateUnifiedToggleInputActive(true)
+        sessionState.updateContext(makeTestContext(title: "Page A"))
+        sessionState.handlePromptSubmission("Hello")
+
+        let expectation = expectation(description: "Null context pushed")
+        var receivedEffect: SheetEffect?
+
+        sessionState.effects
+            .sink { effect in
+                if case .deliverPageContext = effect {
+                    receivedEffect = effect
+                    expectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        // When
+        mockSettings.isAutomaticContextAttachmentEnabled = false
+        sessionState.notifyFrontendOfMultiContextNavigation()
+
+        waitForExpectations(timeout: 1.0)
+
+        // Then - nil is a multi-context navigation affordance, not a detach
+        if case .deliverPageContext(let contextData, let targets) = receivedEffect {
+            XCTAssertNil(contextData)
+            XCTAssertTrue(targets.contains(.frontendBridge))
+            XCTAssertTrue(targets.contains(.utiAttachAffordance))
             XCTAssertFalse(targets.contains(.utiChip))
         } else {
             XCTFail("Expected deliverPageContext effect with nil")

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -567,7 +567,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         }
     }
 
-    func testEffectsPublisherEmitsPushContextToFrontend() {
+    func testEffectsPublisherEmitsDeliverPageContext() {
         // Given
         sessionState.handlePromptSubmission("Hello") // Start chat without context
         sessionState.beginManualAttach(fromFrontend: true)
@@ -577,7 +577,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
 
         sessionState.effects
             .sink { effect in
-                if case .pushContextToFrontend = effect {
+                if case .deliverPageContext = effect {
                     receivedEffect = effect
                     expectation.fulfill()
                 }
@@ -590,10 +590,10 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         waitForExpectations(timeout: 1.0)
 
         // Then
-        if case .pushContextToFrontend(let contextData) = receivedEffect {
+        if case .deliverPageContext(let contextData) = receivedEffect {
             XCTAssertEqual(contextData?.title, "Test Page")
         } else {
-            XCTFail("Expected pushContextToFrontend effect")
+            XCTFail("Expected deliverPageContext effect")
         }
     }
 
@@ -648,6 +648,63 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         }
     }
 
+    func testPreSubmitUTIOptOutSurvivesSamePageNavigationReplayAndLateContextResult() {
+        // Given
+        sessionState.updateUnifiedToggleInputActive(true)
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        let pageURL = URL(string: "https://example.com")!
+        sessionState.updateContext(makeTestContext(url: pageURL.absoluteString))
+
+        if case .attached = sessionState.chipState {
+            // Expected
+        } else {
+            XCTFail("Expected initial auto-attached chip state")
+        }
+
+        // When - user opts out before first submit
+        let shouldShowPlaceholder = sessionState.handleChipRemoval()
+        XCTAssertTrue(shouldShowPlaceholder)
+        XCTAssertEqual(sessionState.chipState, .placeholder)
+        XCTAssertTrue(sessionState.userDowngradedToPlaceholder)
+
+        var deliveredContexts: [AIChatPageContextData?] = []
+        sessionState.effects
+            .sink { effect in
+                if case .deliverPageContext(let data) = effect {
+                    deliveredContexts.append(data)
+                }
+            }
+            .store(in: &cancellables)
+
+        // Then - replayed didFinish should not clear opt-out or trigger collection
+        sessionState.notifyPageChanged(pageURL: pageURL)
+        XCTAssertTrue(sessionState.userDowngradedToPlaceholder)
+        XCTAssertFalse(sessionState.shouldTriggerAutoCollect(for: pageURL))
+
+        // And a late collection result should not reattach or deliver to the UTI chip
+        sessionState.updateContext(makeTestContext(title: "Late Page", url: pageURL.absoluteString))
+        XCTAssertEqual(sessionState.chipState, .placeholder)
+        XCTAssertTrue(deliveredContexts.isEmpty)
+    }
+
+    func testPreSubmitUTIOptOutClearsOnDifferentPageNavigation() {
+        // Given
+        sessionState.updateUnifiedToggleInputActive(true)
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        let pageURL = URL(string: "https://example.com")!
+        let newPageURL = URL(string: "https://example.com/new")!
+        sessionState.updateContext(makeTestContext(url: pageURL.absoluteString))
+        XCTAssertTrue(sessionState.handleChipRemoval())
+        XCTAssertTrue(sessionState.userDowngradedToPlaceholder)
+
+        // When - didFinish reports a real page change
+        sessionState.notifyPageChanged(pageURL: newPageURL)
+
+        // Then - immediate UTI matches legacy's fresh opt-in chance on a new page
+        XCTAssertFalse(sessionState.userDowngradedToPlaceholder)
+        XCTAssertTrue(sessionState.shouldTriggerAutoCollect(for: newPageURL))
+    }
+
     func testNewChatFlowWithAutoAttachOn() {
         // Given
         mockSettings.isAutomaticContextAttachmentEnabled = true
@@ -675,7 +732,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         var pushedToFrontend = false
         sessionState.effects
             .sink { effect in
-                if case .pushContextToFrontend = effect {
+                if case .deliverPageContext = effect {
                     pushedToFrontend = true
                 }
             }
@@ -706,7 +763,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         var pushedContexts: [AIChatPageContextData?] = []
         sessionState.effects
             .sink { effect in
-                if case .pushContextToFrontend(let data) = effect {
+                if case .deliverPageContext(let data) = effect {
                     pushedContexts.append(data)
                 }
             }
@@ -731,7 +788,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         var pushedToFrontend = false
         sessionState.effects
             .sink { effect in
-                if case .pushContextToFrontend = effect {
+                if case .deliverPageContext = effect {
                     pushedToFrontend = true
                 }
             }
@@ -743,6 +800,67 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
 
         // Then - no push (backward compatible)
         XCTAssertFalse(pushedToFrontend)
+    }
+
+    func testAutoAttachDeliversContextForUTIChipWhenMultipleContextsFlagDisabled() {
+        // Given - start chat WITH initial context, flag OFF (default), UTI active
+        sessionState.updateUnifiedToggleInputActive(true)
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        sessionState.updateContext(makeTestContext(title: "Page A"))
+        sessionState.handlePromptSubmission("Hello")
+        mockPixelHandler.pageContextAutoAttachedFired = false
+
+        var deliveredContexts: [AIChatPageContextData?] = []
+        sessionState.effects
+            .sink { effect in
+                if case .deliverPageContext(let data) = effect {
+                    deliveredContexts.append(data)
+                }
+            }
+            .store(in: &cancellables)
+
+        // When - navigate and update context
+        sessionState.notifyPageChanged()
+        sessionState.updateContext(makeTestContext(title: "Page B"))
+
+        // Then - gate A emits for the UTI chip even though gate B remains closed
+        XCTAssertEqual(deliveredContexts.count, 1)
+        XCTAssertEqual(deliveredContexts.first??.title, "Page B")
+        XCTAssertTrue(sessionState.shouldDeliverToUTIChip(deliveredContexts.first!))
+        XCTAssertFalse(sessionState.shouldDeliverToFrontendBridge(deliveredContexts.first!))
+        XCTAssertFalse(mockPixelHandler.pageContextAutoAttachedFired)
+    }
+
+    func testUTINonNilContextDoesNotDeliverToFrontendForChatWithoutInitialContext() {
+        sessionState.updateUnifiedToggleInputActive(true)
+        sessionState.handlePromptSubmission("Hello")
+
+        let context = makeTestContext().contextData
+
+        XCTAssertTrue(sessionState.shouldDeliverToUTIChip(context))
+        XCTAssertFalse(sessionState.shouldDeliverToFrontendBridge(context))
+    }
+
+    func testUTINonNilContextDoesNotDeliverToFrontendForRestoredChat() {
+        sessionState.updateUnifiedToggleInputActive(true)
+        sessionState.restoreChat(with: URL(string: "https://duck.ai/chat/abc")!)
+
+        let context = makeTestContext().contextData
+
+        XCTAssertTrue(sessionState.shouldDeliverToUTIChip(context))
+        XCTAssertFalse(sessionState.shouldDeliverToFrontendBridge(context))
+    }
+
+    func testDeliveredPageContextTrackingResetsOnNewChat() {
+        let pageURL = URL(string: "https://example.com")!
+        let context = makeTestContext(url: pageURL.absoluteString).contextData
+
+        sessionState.markPageContextDeliveredInPrompt(pageURL)
+        XCTAssertTrue(sessionState.hasDeliveredPageContext(context))
+
+        sessionState.resetToNoChat()
+
+        XCTAssertFalse(sessionState.hasDeliveredPageContext(context))
     }
 
     func testNotifyFrontendOfNavigationEmitsNullContextWhenFlagEnabled() {
@@ -759,7 +877,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
 
         sessionState.effects
             .sink { effect in
-                if case .pushContextToFrontend = effect {
+                if case .deliverPageContext = effect {
                     receivedEffect = effect
                     expectation.fulfill()
                 }
@@ -772,10 +890,10 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         waitForExpectations(timeout: 1.0)
 
         // Then
-        if case .pushContextToFrontend(let contextData) = receivedEffect {
+        if case .deliverPageContext(let contextData) = receivedEffect {
             XCTAssertNil(contextData)
         } else {
-            XCTFail("Expected pushContextToFrontend effect with nil")
+            XCTFail("Expected deliverPageContext effect with nil")
         }
     }
 
@@ -788,7 +906,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         var pushedToFrontend = false
         sessionState.effects
             .sink { effect in
-                if case .pushContextToFrontend = effect {
+                if case .deliverPageContext = effect {
                     pushedToFrontend = true
                 }
             }
@@ -808,7 +926,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         var pushedToFrontend = false
         sessionState.effects
             .sink { effect in
-                if case .pushContextToFrontend = effect {
+                if case .deliverPageContext = effect {
                     pushedToFrontend = true
                 }
             }
@@ -817,39 +935,19 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         // When
         sessionState.notifyFrontendOfMultiContextNavigation()
 
-        // Then - nothing emitted (no chat = canPushToFrontend false)
+        // Then - nothing emitted (no chat = frontend bridge delivery false)
         XCTAssertFalse(pushedToFrontend)
     }
 
     // MARK: - Quick Actions Tests
 
-    func testQuickActionsDefaultsToSummarizeWhenFFOff() {
-        // Feature flag is off by default in MockFeatureFlagger
-        XCTAssertEqual(sessionState.viewState.quickActions, [.summarize])
-    }
-
-    func testQuickActionsIsAskAboutPageWhenFFOnAndPlaceholder() {
-        // Given
-        mockFeatureFlagger.enabledFeatureFlags = [.aiChatContextualSheetImprovements]
-        sessionState = AIChatContextualChatSessionState(
-            aiChatSettings: mockSettings,
-            pixelHandler: mockPixelHandler,
-            featureFlagger: mockFeatureFlagger
-        )
-
-        // Then
+    func testQuickActionsDefaultsToAskAboutPageWhenPlaceholder() {
         XCTAssertEqual(sessionState.viewState.quickActions, [.askAboutPage])
     }
 
-    func testQuickActionsIsSummarizePageWhenFFOnAndAttached() {
+    func testQuickActionsIsSummarizePageWhenAttached() {
         // Given
-        mockFeatureFlagger.enabledFeatureFlags = [.aiChatContextualSheetImprovements]
         mockSettings.isAutomaticContextAttachmentEnabled = true
-        sessionState = AIChatContextualChatSessionState(
-            aiChatSettings: mockSettings,
-            pixelHandler: mockPixelHandler,
-            featureFlagger: mockFeatureFlagger
-        )
 
         // When
         sessionState.updateContext(makeTestContext())
@@ -860,13 +958,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
 
     func testQuickActionsTransitionsOnAttach() {
         // Given
-        mockFeatureFlagger.enabledFeatureFlags = [.aiChatContextualSheetImprovements]
         mockSettings.isAutomaticContextAttachmentEnabled = true
-        sessionState = AIChatContextualChatSessionState(
-            aiChatSettings: mockSettings,
-            pixelHandler: mockPixelHandler,
-            featureFlagger: mockFeatureFlagger
-        )
         XCTAssertEqual(sessionState.viewState.quickActions, [.askAboutPage])
 
         // When
@@ -878,13 +970,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
 
     func testQuickActionsTransitionsOnChipRemoval() {
         // Given
-        mockFeatureFlagger.enabledFeatureFlags = [.aiChatContextualSheetImprovements]
         mockSettings.isAutomaticContextAttachmentEnabled = true
-        sessionState = AIChatContextualChatSessionState(
-            aiChatSettings: mockSettings,
-            pixelHandler: mockPixelHandler,
-            featureFlagger: mockFeatureFlagger
-        )
         sessionState.updateContext(makeTestContext())
         XCTAssertEqual(sessionState.viewState.quickActions, [.summarizePage])
 
@@ -897,11 +983,11 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func makeTestContext(title: String = "Test Page") -> AIChatPageContext {
+    private func makeTestContext(title: String = "Test Page", url: String = "https://example.com") -> AIChatPageContext {
         let contextData = AIChatPageContextData(
             title: title,
             favicon: [],
-            url: "https://example.com",
+            url: url,
             content: "Test content",
             truncated: false,
             fullContentLength: 12

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -268,6 +268,22 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         XCTAssertEqual(sessionState.chipState, .placeholder)
     }
 
+    func testUpdateContextWithIdleNilDoesNotClearManualAttachmentWhenAutoAttachDisabled() {
+        mockSettings.isAutomaticContextAttachmentEnabled = false
+        let context = makeTestContext(title: "Manually Attached Page")
+        sessionState.beginManualAttach()
+        sessionState.updateContext(context)
+
+        sessionState.updateContext(nil)
+
+        XCTAssertEqual(sessionState.latestContext?.title, context.title)
+        if case .attached(let attachedContext) = sessionState.chipState {
+            XCTAssertEqual(attachedContext.title, context.title)
+        } else {
+            XCTFail("Expected manually attached chip to survive idle nil replay")
+        }
+    }
+
     func testUpdateContextDoesNotAutoAttachWhenUserDowngraded() {
         // Given
         mockSettings.isAutomaticContextAttachmentEnabled = true
@@ -462,6 +478,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
     func testHasContext() {
         XCTAssertFalse(sessionState.hasContext)
 
+        mockSettings.isAutomaticContextAttachmentEnabled = true
         sessionState.updateContext(makeTestContext())
         XCTAssertTrue(sessionState.hasContext)
 

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -722,7 +722,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         XCTAssertTrue(deliveredContexts.isEmpty)
     }
 
-    func testPreSubmitUTIOptOutClearsOnDifferentPageNavigation() {
+    func testPreSubmitUTIOptOutSurvivesDifferentPageNavigation() {
         // Given
         sessionState.updateUnifiedToggleInputActive(true, isImmediateContextual: true)
         mockSettings.isAutomaticContextAttachmentEnabled = true
@@ -735,9 +735,9 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         // When - didFinish reports a real page change
         sessionState.notifyPageChanged(pageURL: newPageURL)
 
-        // Then - immediate UTI matches legacy's fresh opt-in chance on a new page
-        XCTAssertFalse(sessionState.userDowngradedToPlaceholder)
-        XCTAssertTrue(sessionState.shouldTriggerAutoCollect(for: newPageURL))
+        // Then - production pre-submit behavior keeps the user's opt-out until manual attach/reset
+        XCTAssertTrue(sessionState.userDowngradedToPlaceholder)
+        XCTAssertFalse(sessionState.shouldTriggerAutoCollect(for: newPageURL))
     }
 
     func testNewChatFlowWithAutoAttachOn() {

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -341,7 +341,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
 
     // MARK: - Navigation Tests
 
-    func testNotifyPageChangedClearsUserDowngradeFlag() {
+    func testNotifyPageChangedPreservesUserDowngradeFlag() {
         // Given
         mockSettings.isAutomaticContextAttachmentEnabled = true
         sessionState.updateContext(makeTestContext())
@@ -352,7 +352,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         sessionState.notifyPageChanged()
 
         // Then
-        XCTAssertFalse(sessionState.userDowngradedToPlaceholder)
+        XCTAssertTrue(sessionState.userDowngradedToPlaceholder)
     }
 
     func testUpdateContextAfterNavigationFiresPixel() {
@@ -643,7 +643,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
 
     // MARK: - Complex Scenario Tests
 
-    func testCompleteUserDowngradeAndUpgradeCycle() {
+    func testUserDowngradeBlocksAutoAttachUntilManualAttach() {
         // Given
         mockSettings.isAutomaticContextAttachmentEnabled = true
         sessionState.updateContext(makeTestContext())
@@ -654,20 +654,27 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         XCTAssertEqual(sessionState.chipState, .placeholder)
         XCTAssertTrue(sessionState.userDowngradedToPlaceholder)
 
-        // Navigation clears downgrade flag
+        // Navigation preserves the opt-out
         sessionState.notifyPageChanged()
-        XCTAssertFalse(sessionState.userDowngradedToPlaceholder)
+        XCTAssertTrue(sessionState.userDowngradedToPlaceholder)
+        XCTAssertFalse(sessionState.shouldTriggerAutoCollect(for: URL(string: "https://example.com/new")!))
 
-        // New context auto-attaches again
+        // A late or manually triggered context result still does not auto-attach
         sessionState.updateContext(makeTestContext(title: "New Page"))
+        XCTAssertEqual(sessionState.chipState, .placeholder)
+
+        // Manual attach clears the opt-out and attaches again
+        sessionState.beginManualAttach()
+        sessionState.updateContext(makeTestContext(title: "Manual Page"))
+        XCTAssertFalse(sessionState.userDowngradedToPlaceholder)
         if case .attached = sessionState.chipState {
             // Expected
         } else {
-            XCTFail("Expected attached chip state after navigation")
+            XCTFail("Expected attached chip state after manual attach")
         }
     }
 
-    func testBaseWebUTIWithoutImmediateContextualModeUsesLegacyDowngradeNavigation() {
+    func testBaseWebUTIWithoutImmediateContextualModePreservesDowngradeOnNavigation() {
         // Given
         sessionState.updateUnifiedToggleInputActive(true, isImmediateContextual: false)
         mockSettings.isAutomaticContextAttachmentEnabled = true
@@ -676,11 +683,12 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         XCTAssertTrue(sessionState.handleChipRemoval())
         XCTAssertTrue(sessionState.userDowngradedToPlaceholder)
 
-        // When - base web UTI is active, but the immediate pre-submit replay guard is not
+        // When - base web UTI is active and the page changes
         sessionState.notifyPageChanged(pageURL: pageURL)
 
-        // Then - legacy navigation semantics still clear the opt-out
-        XCTAssertFalse(sessionState.userDowngradedToPlaceholder)
+        // Then - user remove remains an opt-out until manual attach/reset
+        XCTAssertTrue(sessionState.userDowngradedToPlaceholder)
+        XCTAssertFalse(sessionState.shouldTriggerAutoCollect(for: pageURL))
     }
 
     func testPreSubmitUTIOptOutSurvivesSamePageNavigationReplayAndLateContextResult() {

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -222,6 +222,25 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         XCTAssertTrue(mockPixelHandler.pageContextAutoAttachedFired)
     }
 
+    func testUpdateContextWithUnifiedToggleInputAutoAttachEnabledFiresPixel() {
+        // Given
+        sessionState.updateUnifiedToggleInputActive(true)
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        let context = makeTestContext()
+
+        // When
+        sessionState.updateContext(context)
+
+        // Then
+        XCTAssertEqual(sessionState.latestContext?.title, context.title)
+        if case .attached(let attachedContext) = sessionState.chipState {
+            XCTAssertEqual(attachedContext.title, context.title)
+        } else {
+            XCTFail("Expected attached chip state")
+        }
+        XCTAssertTrue(mockPixelHandler.pageContextAutoAttachedFired)
+    }
+
     func testUpdateContextWithAutoAttachDisabled() {
         // Given
         mockSettings.isAutomaticContextAttachmentEnabled = false

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -35,6 +35,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         var clearCallCount = 0
         var clearAttachedContextCallCount = 0
         var resubscribeCallCount = 0
+        var onTriggerContextCollection: (() -> Void)?
 
         private let contextSubject = CurrentValueSubject<AIChatPageContext?, Never>(nil)
         var contextPublisher: AnyPublisher<AIChatPageContext?, Never> {
@@ -47,6 +48,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
 
         func triggerContextCollection() -> Bool {
             triggerContextCollectionCallCount += 1
+            onTriggerContextCollection?()
             return triggerContextCollectionReturnValue
         }
 
@@ -499,7 +501,13 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         originatingTabURLSubject.send(URL(string: "https://example.com/did-commit"))
         XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 0)
 
+        let collectionTriggered = expectation(description: "didFinish triggers context collection")
+        mockPageContextHandler.onTriggerContextCollection = {
+            collectionTriggered.fulfill()
+        }
+
         didFinishTabURLSubject.send(URL(string: "https://example.com/finished"))
+        await fulfillment(of: [collectionTriggered], timeout: 1)
 
         XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 1)
     }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -135,6 +135,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
     private var mockPageContextHandler: MockPageContextHandler!
     private var contentBlockingSubject: PassthroughSubject<ContentBlockingUpdating.NewContent, Never>!
     private var originatingTabURLSubject: CurrentValueSubject<URL?, Never>!
+    private var didFinishTabURLSubject: CurrentValueSubject<URL?, Never>!
     private var cancellables: Set<AnyCancellable>!
 
     // MARK: - Setup
@@ -148,6 +149,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         mockPageContextHandler = MockPageContextHandler()
         contentBlockingSubject = PassthroughSubject<ContentBlockingUpdating.NewContent, Never>()
         originatingTabURLSubject = CurrentValueSubject<URL?, Never>(nil)
+        didFinishTabURLSubject = CurrentValueSubject<URL?, Never>(nil)
         sut = AIChatContextualSheetCoordinator(
             voiceSearchHelper: MockVoiceSearchHelper(),
             aiChatSettings: mockSettings,
@@ -158,7 +160,8 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
             unifiedToggleInputFeature: mockUnifiedToggleInputFeature,
             pageContextHandler: mockPageContextHandler,
             tabURLPublishers: AIChatTabURLPublishers(
-                originating: originatingTabURLSubject.eraseToAnyPublisher()
+                originating: originatingTabURLSubject.eraseToAnyPublisher(),
+                didFinish: didFinishTabURLSubject.eraseToAnyPublisher()
             )
         )
         mockDelegate = MockDelegate()
@@ -178,6 +181,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         mockPageContextHandler = nil
         contentBlockingSubject = nil
         originatingTabURLSubject = nil
+        didFinishTabURLSubject = nil
         cancellables = nil
         super.tearDown()
     }
@@ -351,6 +355,46 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         mockPageContextHandler.triggerContextCollectionCallCount = 0
 
         await sut.notifyPageChanged()
+
+        XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 1)
+    }
+
+    @MainActor
+    func testDidFinishURLPublisherTriggersCollectionWhenAutoAttachEnabled() async {
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        await sut.presentSheet(from: mockPresentingVC)
+        mockPageContextHandler.triggerContextCollectionCallCount = 0
+
+        didFinishTabURLSubject.send(URL(string: "https://example.com/page-b")!)
+        await Task.yield()
+
+        XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 1)
+    }
+
+    @MainActor
+    func testDidFinishURLPublisherInitialReplayDoesNotDuplicateCollectionWhenSheetOpens() async {
+        sut = nil
+        mockPageContextHandler = MockPageContextHandler()
+        originatingTabURLSubject = CurrentValueSubject<URL?, Never>(URL(string: "https://example.com/page-a")!)
+        didFinishTabURLSubject = CurrentValueSubject<URL?, Never>(URL(string: "https://example.com/page-a")!)
+        sut = AIChatContextualSheetCoordinator(
+            voiceSearchHelper: MockVoiceSearchHelper(),
+            aiChatSettings: mockSettings,
+            privacyConfigurationManager: MockPrivacyConfigurationManager(),
+            contentBlockingAssetsPublisher: contentBlockingSubject.eraseToAnyPublisher(),
+            featureDiscovery: MockFeatureDiscovery(),
+            featureFlagger: mockFeatureFlagger,
+            unifiedToggleInputFeature: mockUnifiedToggleInputFeature,
+            pageContextHandler: mockPageContextHandler,
+            tabURLPublishers: AIChatTabURLPublishers(
+                originating: originatingTabURLSubject.eraseToAnyPublisher(),
+                didFinish: didFinishTabURLSubject.eraseToAnyPublisher()
+            )
+        )
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+
+        await sut.presentSheet(from: mockPresentingVC)
+        await Task.yield()
 
         XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 1)
     }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -322,7 +322,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
     }
 
     @MainActor
-    func testNotifyPageChangedDoesNotTriggerCollectionAfterUserRemove() async {
+    func testNotifyPageChangedTriggersCollectionAfterUserRemoveWhenAutoAttachEnabled() async {
         mockSettings.isAutomaticContextAttachmentEnabled = true
         await sut.presentSheet(from: mockPresentingVC)
         mockPageContextHandler.sendContext(makeTestContext())
@@ -331,7 +331,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
 
         await sut.notifyPageChanged()
 
-        XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 0)
+        XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 1)
     }
 
     @MainActor
@@ -481,6 +481,36 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
 
         // Then - no null signal sent (sheet not visible)
         XCTAssertFalse(receivedPush)
+    }
+
+    @MainActor
+    func testImmediateUTINotifyPageChangedSendsAttachAffordanceWhenSheetDismissedButRetained() async {
+        // Given - immediate UTI keeps a persistent host while the sheet is dismissed
+        mockUnifiedToggleInputFeature.isAvailable = true
+        mockFeatureFlagger.enabledFeatureFlags = [.aiChatContextualUnifiedToggleInput, .multiplePageContexts]
+        mockSettings.isAutomaticContextAttachmentEnabled = false
+        await sut.presentSheet(from: mockPresentingVC)
+        sut.sessionState.beginChatForUTISubmission()
+
+        sut.aiChatContextualSheetViewControllerDidDismiss(sut.sheetViewController!)
+        XCTAssertTrue(sut.hasActiveSheet)
+        XCTAssertFalse(sut.isSheetPresented)
+
+        var receivedTargets: PageContextDeliveryTargets?
+        sut.sessionState.effects
+            .sink { effect in
+                if case .deliverPageContext(let context, let targets) = effect, context == nil {
+                    receivedTargets = targets
+                }
+            }
+            .store(in: &cancellables)
+
+        // When - navigate while the immediate UTI sheet is dismissed
+        await sut.notifyPageChanged()
+
+        // Then - remember that the next sheet presentation should offer manual attach
+        XCTAssertTrue(receivedTargets?.contains(.utiAttachAffordance) == true)
+        XCTAssertTrue(receivedTargets?.contains(.utiChip) == false)
     }
 
     @MainActor

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -324,6 +324,19 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
     }
 
     @MainActor
+    func testNotifyPageChangedDoesNotTriggerCollectionAfterUserRemove() async {
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        await sut.presentSheet(from: mockPresentingVC)
+        mockPageContextHandler.sendContext(makeTestContext())
+        sut.aiChatContextualSheetViewControllerDidRequestRemoveChip(sut.sheetViewController!)
+        mockPageContextHandler.triggerContextCollectionCallCount = 0
+
+        await sut.notifyPageChanged()
+
+        XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 0)
+    }
+
+    @MainActor
     func testNotifyPageChangedDoesNotTriggerCollectionWhenAutoAttachDisabled() async {
         mockSettings.isAutomaticContextAttachmentEnabled = false
         await sut.presentSheet(from: mockPresentingVC)

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -133,6 +133,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
     private var mockPageContextHandler: MockPageContextHandler!
     private var contentBlockingSubject: PassthroughSubject<ContentBlockingUpdating.NewContent, Never>!
     private var originatingTabURLSubject: CurrentValueSubject<URL?, Never>!
+    private var didFinishTabURLSubject: CurrentValueSubject<URL?, Never>!
     private var cancellables: Set<AnyCancellable>!
 
     // MARK: - Setup
@@ -146,6 +147,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         mockPageContextHandler = MockPageContextHandler()
         contentBlockingSubject = PassthroughSubject<ContentBlockingUpdating.NewContent, Never>()
         originatingTabURLSubject = CurrentValueSubject<URL?, Never>(nil)
+        didFinishTabURLSubject = CurrentValueSubject<URL?, Never>(nil)
         sut = AIChatContextualSheetCoordinator(
             voiceSearchHelper: MockVoiceSearchHelper(),
             aiChatSettings: mockSettings,
@@ -157,7 +159,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
             pageContextHandler: mockPageContextHandler,
             tabURLPublishers: AIChatTabURLPublishers(
                 originating: originatingTabURLSubject.eraseToAnyPublisher(),
-                didFinish: PassthroughSubject<URL?, Never>().eraseToAnyPublisher()
+                didFinish: didFinishTabURLSubject.eraseToAnyPublisher()
             )
         )
         mockDelegate = MockDelegate()
@@ -177,6 +179,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         mockPageContextHandler = nil
         contentBlockingSubject = nil
         originatingTabURLSubject = nil
+        didFinishTabURLSubject = nil
         cancellables = nil
         super.tearDown()
     }
@@ -341,7 +344,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
     }
 
     @MainActor
-    func testRemoveChipRequestClearsAttachedContextFromHandler() async {
+    func testRemoveChipRequestClearsHandler() async {
         mockSettings.isAutomaticContextAttachmentEnabled = true
         await sut.presentSheet(from: mockPresentingVC)
         mockPageContextHandler.sendContext(makeTestContext())
@@ -349,7 +352,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         sut.aiChatContextualSheetViewControllerDidRequestRemoveChip(sut.sheetViewController!)
 
         XCTAssertEqual(sut.sessionState.chipState, .placeholder)
-        XCTAssertEqual(mockPageContextHandler.clearAttachedContextCallCount, 1)
+        XCTAssertEqual(mockPageContextHandler.clearCallCount, 1)
     }
 
     // MARK: - Session Timer Tests
@@ -370,7 +373,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         var receivedNullPush = false
         sut.sessionState.effects
             .sink { effect in
-                if case .pushContextToFrontend(let data) = effect, data == nil {
+                if case .deliverPageContext(let data) = effect, data == nil {
                     receivedNullPush = true
                 }
             }
@@ -395,7 +398,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         var receivedPush = false
         sut.sessionState.effects
             .sink { effect in
-                if case .pushContextToFrontend = effect {
+                if case .deliverPageContext = effect {
                     receivedPush = true
                 }
             }
@@ -427,7 +430,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         var receivedPush = false
         sut.sessionState.effects
             .sink { effect in
-                if case .pushContextToFrontend = effect {
+                if case .deliverPageContext = effect {
                     receivedPush = true
                 }
             }
@@ -456,7 +459,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         var receivedPush = false
         sut.sessionState.effects
             .sink { effect in
-                if case .pushContextToFrontend = effect {
+                if case .deliverPageContext = effect {
                     receivedPush = true
                 }
             }
@@ -467,6 +470,59 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
 
         // Then - no null signal sent (sheet not visible)
         XCTAssertFalse(receivedPush)
+    }
+
+    @MainActor
+    func testUTINavigationUsesDidFinishAndSkipsColdStartReplay() async {
+        mockUnifiedToggleInputFeature.isAvailable = true
+        mockFeatureFlagger.enabledFeatureFlags = [.aiChatContextualUnifiedToggleInput]
+        sut.sessionState.updateUnifiedToggleInputActive(true)
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+
+        didFinishTabURLSubject.send(URL(string: "https://example.com/initial"))
+        await sut.presentSheet(from: mockPresentingVC)
+        mockPageContextHandler.triggerContextCollectionCallCount = 0
+
+        originatingTabURLSubject.send(URL(string: "https://example.com/did-commit"))
+        XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 0)
+
+        didFinishTabURLSubject.send(URL(string: "https://example.com/finished"))
+
+        XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 1)
+    }
+
+    @MainActor
+    func testUTINavigationDoesNotAutoCollectSamePageReplayAfterPreSubmitOptOut() async {
+        mockUnifiedToggleInputFeature.isAvailable = true
+        mockFeatureFlagger.enabledFeatureFlags = [.aiChatContextualUnifiedToggleInput]
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        let pageURL = URL(string: "https://example.com")!
+
+        await sut.presentSheet(from: mockPresentingVC)
+        mockPageContextHandler.sendContext(makeTestContext(url: pageURL.absoluteString))
+        sut.sessionState.downgradeToPlaceholder()
+        mockPageContextHandler.clearCallCount = 0
+        mockPageContextHandler.triggerContextCollectionCallCount = 0
+
+        didFinishTabURLSubject.send(pageURL)
+
+        XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 0)
+        XCTAssertEqual(mockPageContextHandler.clearCallCount, 0)
+    }
+
+    @MainActor
+    func testBaseUTIAvailableWithoutContextualFlagUsesLegacyNavigationPath() async {
+        mockUnifiedToggleInputFeature.isAvailable = true
+        mockFeatureFlagger.enabledFeatureFlags = []
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        await sut.presentSheet(from: mockPresentingVC)
+        mockPageContextHandler.triggerContextCollectionCallCount = 0
+
+        didFinishTabURLSubject.send(URL(string: "https://example.com/finished"))
+        XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 0)
+
+        await sut.notifyPageChanged()
+        XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 1)
     }
 
     // MARK: - Double Present Guard Tests
@@ -522,11 +578,11 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func makeTestContext(title: String = "Test Page") -> AIChatPageContext {
+    private func makeTestContext(title: String = "Test Page", url: String = "https://example.com") -> AIChatPageContext {
         let contextData = AIChatPageContextData(
             title: title,
             favicon: [],
-            url: "https://example.com",
+            url: url,
             content: "Test content",
             truncated: false,
             fullContentLength: 12

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -273,7 +273,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         mockSettings.isAutomaticContextAttachmentEnabled = true
 
         await sut.presentSheet(from: mockPresentingVC)
-        mockPageContextHandler.sendContext(makeTestContext(title: "Page A", url: pageURL.absoluteString))
+        sut.sessionState.updateContext(makeTestContext(title: "Page A", url: pageURL.absoluteString))
         sut.sessionState.beginChatForUTISubmission()
         mockPageContextHandler.triggerContextCollectionCallCount = 0
 
@@ -290,7 +290,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         mockSettings.isAutomaticContextAttachmentEnabled = true
 
         await sut.presentSheet(from: mockPresentingVC)
-        mockPageContextHandler.sendContext(makeTestContext(title: "Page A", url: pageURL.absoluteString))
+        sut.sessionState.updateContext(makeTestContext(title: "Page A", url: pageURL.absoluteString))
         sut.sessionState.beginChatForUTISubmission()
         mockPageContextHandler.triggerContextCollectionCallCount = 0
 

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -266,6 +266,40 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 1)
     }
 
+    @MainActor
+    func testPresentExistingSheetDoesNotCollectSameAttachedURLAfterSubmit() async {
+        let pageURL = URL(string: "https://example.com/page-a")!
+        originatingTabURLSubject.send(pageURL)
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+
+        await sut.presentSheet(from: mockPresentingVC)
+        mockPageContextHandler.sendContext(makeTestContext(title: "Page A", url: pageURL.absoluteString))
+        sut.sessionState.beginChatForUTISubmission()
+        mockPageContextHandler.triggerContextCollectionCallCount = 0
+
+        sut.aiChatContextualSheetViewControllerDidDismiss(sut.sheetViewController!)
+        await sut.presentSheet(from: mockPresentingVC)
+
+        XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 0)
+    }
+
+    @MainActor
+    func testNotifyPageChangedStillCollectsSameURLAfterSubmit() async {
+        let pageURL = URL(string: "https://example.com/page-a")!
+        originatingTabURLSubject.send(pageURL)
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+
+        await sut.presentSheet(from: mockPresentingVC)
+        mockPageContextHandler.sendContext(makeTestContext(title: "Page A", url: pageURL.absoluteString))
+        sut.sessionState.beginChatForUTISubmission()
+        mockPageContextHandler.triggerContextCollectionCallCount = 0
+
+        sut.aiChatContextualSheetViewControllerDidDismiss(sut.sheetViewController!)
+        await sut.notifyPageChanged()
+
+        XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 1)
+    }
+
     // MARK: - Delegate Forwarding Tests
 
     @MainActor

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -388,7 +388,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         var receivedNullPush = false
         sut.sessionState.effects
             .sink { effect in
-                if case .deliverPageContext(let data) = effect, data == nil {
+                if case .deliverPageContext(let data, let targets) = effect, data == nil, targets == .frontendBridge {
                     receivedNullPush = true
                 }
             }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -135,7 +135,6 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
     private var mockPageContextHandler: MockPageContextHandler!
     private var contentBlockingSubject: PassthroughSubject<ContentBlockingUpdating.NewContent, Never>!
     private var originatingTabURLSubject: CurrentValueSubject<URL?, Never>!
-    private var didFinishTabURLSubject: CurrentValueSubject<URL?, Never>!
     private var cancellables: Set<AnyCancellable>!
 
     // MARK: - Setup
@@ -149,7 +148,6 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         mockPageContextHandler = MockPageContextHandler()
         contentBlockingSubject = PassthroughSubject<ContentBlockingUpdating.NewContent, Never>()
         originatingTabURLSubject = CurrentValueSubject<URL?, Never>(nil)
-        didFinishTabURLSubject = CurrentValueSubject<URL?, Never>(nil)
         sut = AIChatContextualSheetCoordinator(
             voiceSearchHelper: MockVoiceSearchHelper(),
             aiChatSettings: mockSettings,
@@ -160,8 +158,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
             unifiedToggleInputFeature: mockUnifiedToggleInputFeature,
             pageContextHandler: mockPageContextHandler,
             tabURLPublishers: AIChatTabURLPublishers(
-                originating: originatingTabURLSubject.eraseToAnyPublisher(),
-                didFinish: didFinishTabURLSubject.eraseToAnyPublisher()
+                originating: originatingTabURLSubject.eraseToAnyPublisher()
             )
         )
         mockDelegate = MockDelegate()
@@ -181,7 +178,6 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         mockPageContextHandler = nil
         contentBlockingSubject = nil
         originatingTabURLSubject = nil
-        didFinishTabURLSubject = nil
         cancellables = nil
         super.tearDown()
     }
@@ -488,38 +484,29 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
     }
 
     @MainActor
-    func testUTINavigationUsesDidFinishAndSkipsColdStartReplay() async {
+    func testImmediateUTINavigationUsesNotifyPageChangedPath() async {
         mockUnifiedToggleInputFeature.isAvailable = true
         mockFeatureFlagger.enabledFeatureFlags = [.aiChatContextualUnifiedToggleInput]
         sut.sessionState.updateUnifiedToggleInputActive(true)
         mockSettings.isAutomaticContextAttachmentEnabled = true
 
-        didFinishTabURLSubject.send(URL(string: "https://example.com/initial"))
         await sut.presentSheet(from: mockPresentingVC)
         mockPageContextHandler.triggerContextCollectionCallCount = 0
 
         originatingTabURLSubject.send(URL(string: "https://example.com/did-commit"))
         XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 0)
 
-        let collectionTriggered = expectation(description: "didFinish triggers context collection")
-        mockPageContextHandler.onTriggerContextCollection = {
-            collectionTriggered.fulfill()
-        }
-
-        didFinishTabURLSubject.send(URL(string: "https://example.com/finished"))
-        await fulfillment(of: [collectionTriggered], timeout: 1)
-
+        await sut.notifyPageChanged()
         XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 1)
     }
 
     @MainActor
-    func testUTINavigationDoesNotAutoCollectSamePageReplayAfterPreSubmitOptOut() async {
+    func testImmediateUTIDoesNotAutoCollectBeforeNavigationAfterPreSubmitOptOut() async {
         mockUnifiedToggleInputFeature.isAvailable = true
         mockFeatureFlagger.enabledFeatureFlags = [.aiChatContextualUnifiedToggleInput]
         mockSettings.isAutomaticContextAttachmentEnabled = true
         let pageURL = URL(string: "https://example.com")!
 
-        didFinishTabURLSubject.send(pageURL)
         await sut.presentSheet(from: mockPresentingVC)
         mockPageContextHandler.sendContext(makeTestContext(url: pageURL.absoluteString))
         sut.sessionState.downgradeToPlaceholder()
@@ -531,56 +518,57 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
     }
 
     @MainActor
-    func testUTINavigationAutoCollectsDifferentPageAfterPreSubmitOptOut() async {
+    func testImmediateUTIAutoCollectsOnNavigationAfterPreSubmitOptOut() async {
         mockUnifiedToggleInputFeature.isAvailable = true
         mockFeatureFlagger.enabledFeatureFlags = [.aiChatContextualUnifiedToggleInput]
         mockSettings.isAutomaticContextAttachmentEnabled = true
         let pageURL = URL(string: "https://example.com")!
-        let newPageURL = URL(string: "https://example.com/new")!
 
-        didFinishTabURLSubject.send(pageURL)
         await sut.presentSheet(from: mockPresentingVC)
         mockPageContextHandler.sendContext(makeTestContext(url: pageURL.absoluteString))
         sut.sessionState.downgradeToPlaceholder()
         mockPageContextHandler.clearCallCount = 0
         mockPageContextHandler.triggerContextCollectionCallCount = 0
 
-        let collectionTriggered = expectation(description: "new page didFinish triggers context collection")
-        mockPageContextHandler.onTriggerContextCollection = {
-            collectionTriggered.fulfill()
-        }
-
-        didFinishTabURLSubject.send(newPageURL)
-        await fulfillment(of: [collectionTriggered], timeout: 1)
-
+        await sut.notifyPageChanged()
         XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 1)
         XCTAssertEqual(mockPageContextHandler.clearCallCount, 0)
     }
 
     @MainActor
-    func testUTINavigationAutoCollectsSamePageReloadAfterPreSubmitOptOut() async {
+    func testImmediateUTIAutoCollectsOnReloadAfterPreSubmitOptOut() async {
         mockUnifiedToggleInputFeature.isAvailable = true
         mockFeatureFlagger.enabledFeatureFlags = [.aiChatContextualUnifiedToggleInput]
         mockSettings.isAutomaticContextAttachmentEnabled = true
         let pageURL = URL(string: "https://example.com")!
 
-        didFinishTabURLSubject.send(pageURL)
         await sut.presentSheet(from: mockPresentingVC)
         mockPageContextHandler.sendContext(makeTestContext(url: pageURL.absoluteString))
         sut.sessionState.downgradeToPlaceholder()
         mockPageContextHandler.clearCallCount = 0
         mockPageContextHandler.triggerContextCollectionCallCount = 0
 
-        let collectionTriggered = expectation(description: "reload didFinish triggers context collection")
-        mockPageContextHandler.onTriggerContextCollection = {
-            collectionTriggered.fulfill()
-        }
-
-        didFinishTabURLSubject.send(pageURL)
-        await fulfillment(of: [collectionTriggered], timeout: 1)
-
+        await sut.notifyPageChanged()
         XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 1)
         XCTAssertEqual(mockPageContextHandler.clearCallCount, 0)
+    }
+
+    @MainActor
+    func testNotifyPageChangedAutoCollectsWhenImmediateUTISheetIsDismissed() async {
+        mockUnifiedToggleInputFeature.isAvailable = true
+        mockFeatureFlagger.enabledFeatureFlags = [.aiChatContextualUnifiedToggleInput, .multiplePageContexts]
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+
+        await sut.presentSheet(from: mockPresentingVC)
+        sut.sessionState.beginChatForUTISubmission()
+        mockPageContextHandler.triggerContextCollectionCallCount = 0
+
+        sut.aiChatContextualSheetViewControllerDidDismiss(sut.sheetViewController!)
+        XCTAssertTrue(sut.hasActiveSheet)
+        XCTAssertFalse(sut.isSheetPresented)
+
+        await sut.notifyPageChanged()
+        XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 1)
     }
 
     @MainActor
@@ -591,7 +579,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         await sut.presentSheet(from: mockPresentingVC)
         mockPageContextHandler.triggerContextCollectionCallCount = 0
 
-        didFinishTabURLSubject.send(URL(string: "https://example.com/finished"))
+        originatingTabURLSubject.send(URL(string: "https://example.com/finished"))
         XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 0)
 
         await sut.notifyPageChanged()

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -525,6 +525,16 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 1)
     }
 
+    @MainActor
+    func testBaseUTIAvailableWithoutContextualFlagStillEnablesUTIChipDelivery() async {
+        mockUnifiedToggleInputFeature.isAvailable = true
+        mockFeatureFlagger.enabledFeatureFlags = []
+
+        await sut.presentSheet(from: mockPresentingVC)
+
+        XCTAssertTrue(sut.sessionState.shouldDeliverToUTIChip(makeTestContext().contextData))
+    }
+
     // MARK: - Double Present Guard Tests
 
     @MainActor

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -519,35 +519,67 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         mockSettings.isAutomaticContextAttachmentEnabled = true
         let pageURL = URL(string: "https://example.com")!
 
+        didFinishTabURLSubject.send(pageURL)
         await sut.presentSheet(from: mockPresentingVC)
         mockPageContextHandler.sendContext(makeTestContext(url: pageURL.absoluteString))
         sut.sessionState.downgradeToPlaceholder()
         mockPageContextHandler.clearCallCount = 0
         mockPageContextHandler.triggerContextCollectionCallCount = 0
-
-        didFinishTabURLSubject.send(pageURL)
 
         XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 0)
         XCTAssertEqual(mockPageContextHandler.clearCallCount, 0)
     }
 
     @MainActor
-    func testUTINavigationDoesNotAutoCollectDifferentPageAfterPreSubmitOptOut() async {
+    func testUTINavigationAutoCollectsDifferentPageAfterPreSubmitOptOut() async {
         mockUnifiedToggleInputFeature.isAvailable = true
         mockFeatureFlagger.enabledFeatureFlags = [.aiChatContextualUnifiedToggleInput]
         mockSettings.isAutomaticContextAttachmentEnabled = true
         let pageURL = URL(string: "https://example.com")!
         let newPageURL = URL(string: "https://example.com/new")!
 
+        didFinishTabURLSubject.send(pageURL)
         await sut.presentSheet(from: mockPresentingVC)
         mockPageContextHandler.sendContext(makeTestContext(url: pageURL.absoluteString))
         sut.sessionState.downgradeToPlaceholder()
         mockPageContextHandler.clearCallCount = 0
         mockPageContextHandler.triggerContextCollectionCallCount = 0
 
-        didFinishTabURLSubject.send(newPageURL)
+        let collectionTriggered = expectation(description: "new page didFinish triggers context collection")
+        mockPageContextHandler.onTriggerContextCollection = {
+            collectionTriggered.fulfill()
+        }
 
-        XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 0)
+        didFinishTabURLSubject.send(newPageURL)
+        await fulfillment(of: [collectionTriggered], timeout: 1)
+
+        XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 1)
+        XCTAssertEqual(mockPageContextHandler.clearCallCount, 0)
+    }
+
+    @MainActor
+    func testUTINavigationAutoCollectsSamePageReloadAfterPreSubmitOptOut() async {
+        mockUnifiedToggleInputFeature.isAvailable = true
+        mockFeatureFlagger.enabledFeatureFlags = [.aiChatContextualUnifiedToggleInput]
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        let pageURL = URL(string: "https://example.com")!
+
+        didFinishTabURLSubject.send(pageURL)
+        await sut.presentSheet(from: mockPresentingVC)
+        mockPageContextHandler.sendContext(makeTestContext(url: pageURL.absoluteString))
+        sut.sessionState.downgradeToPlaceholder()
+        mockPageContextHandler.clearCallCount = 0
+        mockPageContextHandler.triggerContextCollectionCallCount = 0
+
+        let collectionTriggered = expectation(description: "reload didFinish triggers context collection")
+        mockPageContextHandler.onTriggerContextCollection = {
+            collectionTriggered.fulfill()
+        }
+
+        didFinishTabURLSubject.send(pageURL)
+        await fulfillment(of: [collectionTriggered], timeout: 1)
+
+        XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 1)
         XCTAssertEqual(mockPageContextHandler.clearCallCount, 0)
     }
 

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -511,6 +511,26 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
     }
 
     @MainActor
+    func testUTINavigationDoesNotAutoCollectDifferentPageAfterPreSubmitOptOut() async {
+        mockUnifiedToggleInputFeature.isAvailable = true
+        mockFeatureFlagger.enabledFeatureFlags = [.aiChatContextualUnifiedToggleInput]
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        let pageURL = URL(string: "https://example.com")!
+        let newPageURL = URL(string: "https://example.com/new")!
+
+        await sut.presentSheet(from: mockPresentingVC)
+        mockPageContextHandler.sendContext(makeTestContext(url: pageURL.absoluteString))
+        sut.sessionState.downgradeToPlaceholder()
+        mockPageContextHandler.clearCallCount = 0
+        mockPageContextHandler.triggerContextCollectionCallCount = 0
+
+        didFinishTabURLSubject.send(newPageURL)
+
+        XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 0)
+        XCTAssertEqual(mockPageContextHandler.clearCallCount, 0)
+    }
+
+    @MainActor
     func testBaseUTIAvailableWithoutContextualFlagUsesLegacyNavigationPath() async {
         mockUnifiedToggleInputFeature.isAvailable = true
         mockFeatureFlagger.enabledFeatureFlags = []

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
@@ -26,8 +26,6 @@ import XCTest
 final class AIChatContextualUTIHostTests: XCTestCase {
 
     private var originatingURL: CurrentValueSubject<URL?, Never>!
-    private var didFinishURL: CurrentValueSubject<URL?, Never>!
-    private var pageContextHandler: MockPageContextHandler!
     private var autoAttachEnabled = false
     private var hasActiveChat = false
     private var sut: AIChatContextualUTIHost!
@@ -35,16 +33,12 @@ final class AIChatContextualUTIHostTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
         originatingURL = .init(nil)
-        didFinishURL = .init(nil)
-        pageContextHandler = MockPageContextHandler()
         autoAttachEnabled = false
         hasActiveChat = false
     }
 
     override func tearDown() async throws {
         sut = nil
-        pageContextHandler = nil
-        didFinishURL = nil
         originatingURL = nil
         try await super.tearDown()
     }
@@ -55,367 +49,135 @@ final class AIChatContextualUTIHostTests: XCTestCase {
     ) {
         sut = AIChatContextualUTIHost(
             originatingURLPublisher: originatingURL.eraseToAnyPublisher(),
-            didFinishURLPublisher: didFinishURL.eraseToAnyPublisher(),
             initialAttachedContext: initialAttachedContext,
             initialAttachmentDeliveryState: initialAttachmentDeliveryState,
             hasActiveChat: { [weak self] in self?.hasActiveChat ?? false },
             isAutoAttachEnabled: { [weak self] in self?.autoAttachEnabled ?? false },
-            pageContextHandler: pageContextHandler,
             isFireTab: false
         )
     }
 
-    // MARK: - Chip-driven attach flow
-
-    func test_chipAttachAction_triggersContextCollection() {
-        makeSUT()
-        originatingURL.send(URL(string: "https://example.com/a"))
-
-        sut.chipViewModel.tapToAttach()
-
-        XCTAssertEqual(pageContextHandler.triggerContextCollectionCallCount, 1)
-    }
-
-    func test_chipAttach_thenContextEmits_flipsChipToAttached() {
+    func test_chipAttachAction_firesAttachCallbackWithOriginatingURL() {
         let url = URL(string: "https://example.com/a")!
+        var requestedURL: URL?
         makeSUT()
-        originatingURL.send(url)
-        sut.chipViewModel.tapToAttach()
-
-        pageContextHandler.sendContext(makeContext(title: "Page A", url: url.absoluteString))
-
-        guard case .attached(let title, _) = sut.chipViewModel.state else {
-            return XCTFail("Expected .attached, got \(sut.chipViewModel.state)")
-        }
-        XCTAssertEqual(title, "Page A")
-    }
-
-    func test_chipAttach_collectionReturnsFalse_chipStaysPlaceholder() {
-        pageContextHandler.triggerContextCollectionReturnValue = false
-        let url = URL(string: "https://example.com/a")!
-        makeSUT()
+        sut.onAttachRequested = { requestedURL = $0 }
         originatingURL.send(url)
 
         sut.chipViewModel.tapToAttach()
 
-        XCTAssertEqualState(sut.chipViewModel.state, .placeholder)
+        XCTAssertEqual(requestedURL, url)
     }
 
-    // MARK: - Chip-driven remove flow
+    func test_chipAttachAction_withoutOriginatingURL_doesNotFireAttachCallback() {
+        var didRequestAttach = false
+        makeSUT()
+        sut.onAttachRequested = { _ in didRequestAttach = true }
 
-    func test_chipRemoveAction_clearsAttachedContext() {
+        sut.chipViewModel.tapToAttach()
+
+        XCTAssertFalse(didRequestAttach)
+    }
+
+    func test_chipRemoveAction_firesRemoveCallbackOnly() {
+        let url = URL(string: "https://example.com/a")!
+        var removeCallCount = 0
+        originatingURL.send(url)
+        makeSUT(initialAttachedContext: makeContext(title: "Page A", url: url.absoluteString))
+        sut.onRemoveRequested = { removeCallCount += 1 }
+
+        sut.chipViewModel.tapToRemove()
+
+        XCTAssertEqual(removeCallCount, 1)
+    }
+
+    func test_setAttachedContext_updatesChipPresentation() {
+        let url = URL(string: "https://example.com/a")!
+        originatingURL.send(url)
+        makeSUT()
+
+        sut.setAttachedContext(makeContext(title: "Page A", url: url.absoluteString))
+
+        XCTAssertEqualState(sut.chipViewModel.state, .attached(title: "Page A", favicon: nil))
+        XCTAssertEqual(sut.attachedContextURL, url)
+    }
+
+    func test_clearAttachedContext_updatesChipPresentation() {
         let url = URL(string: "https://example.com/a")!
         originatingURL.send(url)
         makeSUT(initialAttachedContext: makeContext(title: "Page A", url: url.absoluteString))
 
-        sut.chipViewModel.tapToRemove()
+        sut.clearAttachedContext()
 
-        XCTAssertEqual(pageContextHandler.clearCallCount, 1)
         XCTAssertEqualState(sut.chipViewModel.state, .placeholder)
+        XCTAssertNil(sut.attachedContextURL)
     }
 
-    func test_chipRemove_whileCollectionPending_lateResultDoesNotOverwriteClear() {
-        // Regression: user taps attach (kicks off async collection) then quickly taps X. The
-        // pending collection result must NOT land after the clear and re-attach the chip.
+    func test_prepareForNewChat_clearsAttachedContextPresentation() {
         let url = URL(string: "https://example.com/a")!
-        makeSUT()
         originatingURL.send(url)
+        makeSUT(initialAttachedContext: makeContext(title: "Page A", url: url.absoluteString))
 
-        sut.chipViewModel.tapToAttach()
-        sut.chipViewModel.tapToRemove()
-
-        // Late collection result arrives after the user already detached.
-        pageContextHandler.sendContext(makeContext(title: "Page A", url: url.absoluteString))
+        sut.prepareForNewChat()
 
         XCTAssertEqualState(sut.chipViewModel.state, .placeholder)
-        XCTAssertNil(sut.chipViewModel.attachedContext)
+        XCTAssertNil(sut.attachedContextURL)
     }
 
-    func test_chipRemove_lateResultIgnoredUntilNextAutoAttachRequest() {
+    func test_autoAttachOn_didCommitURLChangeAlone_doesNotFireAttachCallback() {
         autoAttachEnabled = true
-        let urlA = URL(string: "https://example.com/a")!
-        let urlB = URL(string: "https://example.com/b")!
+        var didRequestAttach = false
         makeSUT()
-        originatingURL.send(urlA)
-
-        sut.chipViewModel.tapToAttach()
-        sut.chipViewModel.tapToRemove()
-        pageContextHandler.sendContext(makeContext(title: "Page A", url: urlA.absoluteString))
-
-        XCTAssertEqualState(sut.chipViewModel.state, .placeholder)
-        XCTAssertNil(sut.chipViewModel.attachedContext)
-
-        originatingURL.send(urlB)
-        didFinishURL.send(urlB)
-        pageContextHandler.sendContext(makeContext(title: "Page B", url: urlB.absoluteString))
-
-        XCTAssertEqualState(sut.chipViewModel.state, .attached(title: "Page B", favicon: nil))
-    }
-
-    func test_chipRemove_attachRequestFails_keepsIgnoringLateExternalContext() {
-        let url = URL(string: "https://example.com/a")!
-        makeSUT()
-        originatingURL.send(url)
-
-        sut.chipViewModel.tapToAttach()
-        sut.chipViewModel.tapToRemove()
-        pageContextHandler.triggerContextCollectionReturnValue = false
-        sut.chipViewModel.tapToAttach()
-        pageContextHandler.sendContext(makeContext(title: "Page A", url: url.absoluteString))
-
-        XCTAssertEqualState(sut.chipViewModel.state, .placeholder)
-        XCTAssertNil(sut.chipViewModel.attachedContext)
-    }
-
-    func test_autoAttachOff_navigationAway_clearsAttachedContextOnHandler() {
-        // Regression: when the chip clears its attachment due to nav-away (auto-attach OFF),
-        // the host must also clear the handler — otherwise the FE-side cached page context
-        // would survive and the next prompt would ship stale context.
-        autoAttachEnabled = false
-        let urlA = URL(string: "https://example.com/a")!
-        originatingURL.send(urlA)
-        makeSUT(initialAttachedContext: makeContext(title: "Page A", url: urlA.absoluteString))
+        sut.onAttachRequested = { _ in didRequestAttach = true }
 
         originatingURL.send(URL(string: "https://example.com/b"))
 
-        XCTAssertEqual(pageContextHandler.clearCallCount, 1)
-        XCTAssertEqualState(sut.chipViewModel.state, .placeholder)
+        XCTAssertFalse(didRequestAttach)
     }
 
-    // MARK: - Auto-attach on page-load (didFinish)
+    func test_autoAttachOff_navigationAwayFiresNavigationDetachCallbackOnly() {
+        let pageAURL = URL(string: "https://example.com/a")!
+        let pageBURL = URL(string: "https://example.com/b")!
+        var removeCallCount = 0
+        var navigationDetachCallCount = 0
+        originatingURL.send(pageAURL)
+        makeSUT(initialAttachedContext: makeContext(title: "Page A", url: pageAURL.absoluteString))
+        sut.onRemoveRequested = { removeCallCount += 1 }
+        sut.onNavigationAwayDetachRequested = { navigationDetachCallCount += 1 }
 
-    func test_autoAttachOff_pageLoadDoesNotTriggerCollection() {
-        autoAttachEnabled = false
-        makeSUT()
+        originatingURL.send(pageBURL)
 
-        didFinishURL.send(URL(string: "https://example.com/b"))
-
-        XCTAssertEqual(pageContextHandler.triggerContextCollectionCallCount, 0)
+        XCTAssertEqual(removeCallCount, 0)
+        XCTAssertEqual(navigationDetachCallCount, 1)
     }
-
-    func test_autoAttachOn_pageLoadTriggersCollection() {
-        autoAttachEnabled = true
-        makeSUT()
-
-        didFinishURL.send(URL(string: "https://example.com/b"))
-
-        XCTAssertEqual(pageContextHandler.triggerContextCollectionCallCount, 1)
-    }
-
-    func test_autoAttachOn_duplicatePageLoadDeduped() {
-        autoAttachEnabled = true
-        makeSUT()
-
-        let same = URL(string: "https://example.com/b")
-        didFinishURL.send(same)
-        didFinishURL.send(same)
-
-        XCTAssertEqual(pageContextHandler.triggerContextCollectionCallCount, 1)
-    }
-
-    func test_autoAttachOn_didCommitURLChangeAlone_doesNotTrigger() {
-        // Regression: triggers must NOT come from urlPublisher (didCommit) — too early, JS
-        // returns stale content from the previous page. Only didFinish should trigger.
-        autoAttachEnabled = true
-        makeSUT()
-
-        originatingURL.send(URL(string: "https://example.com/b"))
-
-        XCTAssertEqual(pageContextHandler.triggerContextCollectionCallCount, 0)
-    }
-
-    func test_autoAttachOn_pageLoadThenContextEmits_flipsChipToAttached() {
-        autoAttachEnabled = true
-        let urlA = URL(string: "https://example.com/a")!
-        let urlB = URL(string: "https://example.com/b")!
-        makeSUT(initialAttachedContext: makeContext(title: "Page A", url: urlA.absoluteString))
-        originatingURL.send(urlA)
-        originatingURL.send(urlB)
-
-        didFinishURL.send(urlB)
-        pageContextHandler.sendContext(makeContext(title: "Page B", url: urlB.absoluteString))
-
-        guard case .attached(let title, _) = sut.chipViewModel.state else {
-            return XCTFail("Expected .attached on Page B, got \(sut.chipViewModel.state)")
-        }
-        XCTAssertEqual(title, "Page B")
-    }
-
-    func test_autoAttachOn_duplicateContextAfterAutoAttach_doesNotMarkAttachmentDelivered() {
-        autoAttachEnabled = true
-        let urlA = URL(string: "https://example.com/a")!
-        let urlB = URL(string: "https://example.com/b")!
-        let contextB = makeContext(title: "Page B", url: urlB.absoluteString)
-        makeSUT(initialAttachedContext: makeContext(title: "Page A", url: urlA.absoluteString))
-        originatingURL.send(urlA)
-        originatingURL.send(urlB)
-
-        didFinishURL.send(urlB)
-        pageContextHandler.sendContext(contextB)
-        XCTAssertTrue(sut.chipViewModel.isVisible)
-
-        pageContextHandler.sendContext(contextB)
-
-        XCTAssertTrue(sut.chipViewModel.isVisible)
-        XCTAssertEqualState(sut.chipViewModel.state, .attached(title: "Page B", favicon: nil))
-    }
-
-    func test_autoAttachOn_contextEmitsAfterChatIsBound_staysVisibleUntilPromptSubmit() {
-        autoAttachEnabled = true
-        hasActiveChat = true
-        let urlA = URL(string: "https://example.com/a")!
-        let urlB = URL(string: "https://example.com/b")!
-        makeSUT(initialAttachedContext: makeContext(title: "Page A", url: urlA.absoluteString))
-        originatingURL.send(urlA)
-        sut.bindToUserScript(makeTestUserScript())
-
-        originatingURL.send(urlB)
-        pageContextHandler.sendContext(makeContext(title: "Page B", url: urlB.absoluteString))
-
-        XCTAssertTrue(sut.chipViewModel.isVisible)
-        XCTAssertEqualState(sut.chipViewModel.state, .attached(title: "Page B", favicon: nil))
-    }
-
-    func test_restoredChat_initialAttachedContext_staysVisibleUntilPromptSubmit() {
-        autoAttachEnabled = true
-        hasActiveChat = true
-        let url = URL(string: "https://example.com/a")!
-        originatingURL.send(url)
-
-        makeSUT(initialAttachedContext: makeContext(title: "Page A", url: url.absoluteString), initialAttachmentDeliveryState: .pendingSubmit)
-
-        XCTAssertTrue(sut.chipViewModel.isVisible)
-        XCTAssertEqualState(sut.chipViewModel.state, .attached(title: "Page A", favicon: nil))
-    }
-
-    func test_activeChatPromptSubmittedWithAttachedContext_marksAttachmentDelivered() {
-        hasActiveChat = true
-        let url = URL(string: "https://example.com/a")!
-        makeSUT()
-        originatingURL.send(url)
-        pageContextHandler.sendContext(makeContext(title: "Page A", url: url.absoluteString))
-        XCTAssertTrue(sut.chipViewModel.isVisible)
-
-        sut.markPromptSubmitted()
-
-        XCTAssertFalse(sut.chipViewModel.isVisible)
-        XCTAssertEqualState(sut.chipViewModel.state, .attached(title: "Page A", favicon: nil))
-    }
-
-    func test_autoAttachOn_coldStart_optedOutAtHalfSheet_doesNotTrigger() {
-        // Cold start with no carry-over means the user opted out at the half-sheet. The chat
-        // must respect that and NOT auto-attach on the replayed didFinish — otherwise the
-        // chip would flip to .attached immediately, overriding the user's skip choice.
-        autoAttachEnabled = true
-        let url = URL(string: "https://example.com/a")!
-        didFinishURL.send(url)
-
-        makeSUT()
-
-        XCTAssertEqual(pageContextHandler.triggerContextCollectionCallCount, 0)
-    }
-
-    func test_autoAttachOn_optedOut_thenInChatNavigation_triggers() {
-        // Once the user navigates within the chat, that's a signal change auto-mode should
-        // act on. The opt-out only sticks for the URL the half-sheet was opened on.
-        autoAttachEnabled = true
-        let urlA = URL(string: "https://example.com/a")!
-        didFinishURL.send(urlA)
-        makeSUT()
-
-        let urlB = URL(string: "https://example.com/b")!
-        didFinishURL.send(urlB)
-
-        XCTAssertEqual(pageContextHandler.triggerContextCollectionCallCount, 1)
-    }
-
-    // MARK: - Bound user-script provider
-
-    func test_bindToUserScript_attachedPageContextProvider_returnsContextWhilePending() {
-        // User taps chip → collection → context lands as .pendingSubmit. The next prompt's
-        // payload must carry it so duck.ai can attribute the initial prompt.
-        let url = URL(string: "https://example.com/a")!
-        originatingURL.send(url)
-        makeSUT()
-        sut.chipViewModel.tapToAttach()
-        pageContextHandler.sendContext(makeContext(title: "Page A", url: url.absoluteString))
-
-        let userScript = makeTestUserScript()
-        sut.bindToUserScript(userScript)
-
-        XCTAssertEqual(userScript.attachedPageContextProvider?()?.title, "Page A")
-    }
-
-    func test_bindToUserScript_attachedPageContextProvider_returnsNilAfterMarkPromptSubmitted() {
-        // Once the chip flips to .delivered, the bound provider must
-        // stop emitting context — otherwise every follow-up prompt's payload carries it and
-        // duck.ai renders "Page content from..." beneath each follow-up.
-        let url = URL(string: "https://example.com/a")!
-        originatingURL.send(url)
-        makeSUT()
-        sut.chipViewModel.tapToAttach()
-        pageContextHandler.sendContext(makeContext(title: "Page A", url: url.absoluteString))
-
-        let userScript = makeTestUserScript()
-        sut.bindToUserScript(userScript)
-        sut.markPromptSubmitted()
-
-        XCTAssertNil(userScript.attachedPageContextProvider?() ?? nil)
-    }
-
-    // MARK: - Helpers
 
     private func makeContext(title: String, url: String) -> AIChatPageContext {
-        let data = AIChatPageContextData(title: title, favicon: [], url: url, content: "", truncated: false, fullContentLength: 0)
-        return AIChatPageContext(contextData: data, favicon: nil)
+        AIChatPageContext(
+            contextData: AIChatPageContextData(
+                title: title,
+                favicon: [],
+                url: url,
+                content: "Content for \(title)",
+                truncated: false,
+                fullContentLength: 12
+            ),
+            favicon: nil
+        )
     }
+}
 
-    private func XCTAssertEqualState(_ lhs: AIChatContextChipView.State, _ rhs: AIChatContextChipView.State, file: StaticString = #filePath, line: UInt = #line) {
-        switch (lhs, rhs) {
-        case (.placeholder, .placeholder):
-            return
-        case (.attached(let lt, _), .attached(let rt, _)) where lt == rt:
-            return
-        default:
-            XCTFail("State mismatch: \(lhs) vs \(rhs)", file: file, line: line)
-        }
-    }
-
-    // MARK: - Mocks
-
-    private final class MockPageContextHandler: AIChatPageContextHandling {
-        var triggerContextCollectionCallCount = 0
-        var triggerContextCollectionReturnValue = true
-        var clearCallCount = 0
-        var clearAttachedContextCallCount = 0
-        var resubscribeCallCount = 0
-
-        private let contextSubject = CurrentValueSubject<AIChatPageContext?, Never>(nil)
-        var contextPublisher: AnyPublisher<AIChatPageContext?, Never> {
-            contextSubject.eraseToAnyPublisher()
-        }
-
-        func sendContext(_ context: AIChatPageContext?) {
-            contextSubject.send(context)
-        }
-
-        func triggerContextCollection() -> Bool {
-            triggerContextCollectionCallCount += 1
-            return triggerContextCollectionReturnValue
-        }
-
-        func clear() {
-            clearCallCount += 1
-            contextSubject.send(nil)
-        }
-
-        func resubscribe() {
-            resubscribeCallCount += 1
-        }
-
-        func clearAttachedContext() {
-            clearAttachedContextCallCount += 1
-            contextSubject.send(nil)
-        }
+private func XCTAssertEqualState(
+    _ actual: AIChatContextChipView.State,
+    _ expected: AIChatContextChipView.State,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    switch (actual, expected) {
+    case (.placeholder, .placeholder):
+        return
+    case let (.attached(actualTitle, _), .attached(expectedTitle, _)):
+        XCTAssertEqual(actualTitle, expectedTitle, file: file, line: line)
+    default:
+        XCTFail("Expected \(expected), got \(actual)", file: file, line: line)
     }
 }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
@@ -82,16 +82,13 @@ final class AIChatContextualUTIHostTests: XCTestCase {
     func test_chipRemoveAction_firesRemoveCallbackOnly() {
         let url = URL(string: "https://example.com/a")!
         var removeCallCount = 0
-        var navigationDetachCallCount = 0
         originatingURL.send(url)
         makeSUT(initialAttachedContext: makeContext(title: "Page A", url: url.absoluteString))
         sut.onRemoveRequested = { removeCallCount += 1 }
-        sut.onNavigationAwayDetachRequested = { navigationDetachCallCount += 1 }
 
         sut.chipViewModel.tapToRemove()
 
         XCTAssertEqual(removeCallCount, 1)
-        XCTAssertEqual(navigationDetachCallCount, 0)
     }
 
     func test_setAttachedContext_updatesChipPresentation() {
@@ -116,6 +113,34 @@ final class AIChatContextualUTIHostTests: XCTestCase {
         XCTAssertNil(sut.attachedContextURL)
     }
 
+    func test_showAttachAffordanceShowsPlaceholderWithoutClearingDeliveredAttachment() {
+        let url = URL(string: "https://example.com/a")!
+        originatingURL.send(url)
+        makeSUT(initialAttachedContext: makeContext(title: "Page A", url: url.absoluteString), initialAttachmentDeliveryState: .delivered)
+
+        sut.showAttachAffordance()
+
+        XCTAssertEqualState(sut.chipViewModel.state, .placeholder)
+        XCTAssertTrue(sut.chipViewModel.isVisible)
+        XCTAssertEqual(sut.attachedContextURL, url)
+        XCTAssertNil(sut.chipViewModel.pendingAttachedContextData)
+    }
+
+    func test_setAttachedContextAfterPromptSubmittedWithSameURL_makesContextPendingAgain() {
+        let url = URL(string: "https://example.com/a")!
+        originatingURL.send(url)
+        let context = makeContext(title: "Page A", url: url.absoluteString)
+        makeSUT(initialAttachedContext: context, initialAttachmentDeliveryState: .pendingSubmit)
+
+        sut.markPromptSubmitted()
+        XCTAssertNil(sut.chipViewModel.pendingAttachedContextData)
+
+        sut.setAttachedContext(context)
+
+        XCTAssertEqual(sut.chipViewModel.pendingAttachedContextData?.url, url.absoluteString)
+        XCTAssertEqualState(sut.chipViewModel.state, .attached(title: "Page A", favicon: nil))
+    }
+
     func test_prepareForNewChat_clearsAttachedContextPresentation() {
         let url = URL(string: "https://example.com/a")!
         originatingURL.send(url)
@@ -138,20 +163,19 @@ final class AIChatContextualUTIHostTests: XCTestCase {
         XCTAssertFalse(didRequestAttach)
     }
 
-    func test_autoAttachOff_navigationAwayFiresNavigationDetachCallbackOnly() {
+    func test_autoAttachOff_navigationAwayKeepsManualAttachmentSticky() {
         let pageAURL = URL(string: "https://example.com/a")!
         let pageBURL = URL(string: "https://example.com/b")!
         var removeCallCount = 0
-        var navigationDetachCallCount = 0
         originatingURL.send(pageAURL)
-        makeSUT(initialAttachedContext: makeContext(title: "Page A", url: pageAURL.absoluteString))
+        makeSUT(initialAttachedContext: makeContext(title: "Page A", url: pageAURL.absoluteString), initialAttachmentDeliveryState: .pendingSubmit)
         sut.onRemoveRequested = { removeCallCount += 1 }
-        sut.onNavigationAwayDetachRequested = { navigationDetachCallCount += 1 }
 
         originatingURL.send(pageBURL)
 
         XCTAssertEqual(removeCallCount, 0)
-        XCTAssertEqual(navigationDetachCallCount, 1)
+        XCTAssertEqualState(sut.chipViewModel.state, .attached(title: "Page A", favicon: nil))
+        XCTAssertEqual(sut.attachedContextURL, pageAURL)
     }
 
     private func makeContext(title: String, url: String) -> AIChatPageContext {

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
@@ -57,38 +57,41 @@ final class AIChatContextualUTIHostTests: XCTestCase {
         )
     }
 
-    func test_chipAttachAction_firesAttachCallbackWithOriginatingURL() {
+    func test_chipAttachAction_firesAttachCallback() {
         let url = URL(string: "https://example.com/a")!
-        var requestedURL: URL?
+        var attachCallCount = 0
         makeSUT()
-        sut.onAttachRequested = { requestedURL = $0 }
+        sut.onAttachRequested = { attachCallCount += 1 }
         originatingURL.send(url)
 
         sut.chipViewModel.tapToAttach()
 
-        XCTAssertEqual(requestedURL, url)
+        XCTAssertEqual(attachCallCount, 1)
     }
 
-    func test_chipAttachAction_withoutOriginatingURL_doesNotFireAttachCallback() {
-        var didRequestAttach = false
+    func test_chipAttachAction_withoutOriginatingURL_stillFiresAttachCallback() {
+        var attachCallCount = 0
         makeSUT()
-        sut.onAttachRequested = { _ in didRequestAttach = true }
+        sut.onAttachRequested = { attachCallCount += 1 }
 
         sut.chipViewModel.tapToAttach()
 
-        XCTAssertFalse(didRequestAttach)
+        XCTAssertEqual(attachCallCount, 1)
     }
 
     func test_chipRemoveAction_firesRemoveCallbackOnly() {
         let url = URL(string: "https://example.com/a")!
         var removeCallCount = 0
+        var navigationDetachCallCount = 0
         originatingURL.send(url)
         makeSUT(initialAttachedContext: makeContext(title: "Page A", url: url.absoluteString))
         sut.onRemoveRequested = { removeCallCount += 1 }
+        sut.onNavigationAwayDetachRequested = { navigationDetachCallCount += 1 }
 
         sut.chipViewModel.tapToRemove()
 
         XCTAssertEqual(removeCallCount, 1)
+        XCTAssertEqual(navigationDetachCallCount, 0)
     }
 
     func test_setAttachedContext_updatesChipPresentation() {
@@ -128,7 +131,7 @@ final class AIChatContextualUTIHostTests: XCTestCase {
         autoAttachEnabled = true
         var didRequestAttach = false
         makeSUT()
-        sut.onAttachRequested = { _ in didRequestAttach = true }
+        sut.onAttachRequested = { didRequestAttach = true }
 
         originatingURL.send(URL(string: "https://example.com/b"))
 

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
@@ -126,6 +126,19 @@ final class AIChatContextualUTIHostTests: XCTestCase {
         XCTAssertNil(sut.chipViewModel.pendingAttachedContextData)
     }
 
+    func test_showAttachAffordanceDoesNotOverridePendingAttachment() {
+        let url = URL(string: "https://example.com/a")!
+        originatingURL.send(url)
+        makeSUT(initialAttachedContext: makeContext(title: "Page A", url: url.absoluteString), initialAttachmentDeliveryState: .pendingSubmit)
+
+        sut.showAttachAffordance()
+
+        XCTAssertEqualState(sut.chipViewModel.state, .attached(title: "Page A", favicon: nil))
+        XCTAssertTrue(sut.chipViewModel.isVisible)
+        XCTAssertEqual(sut.attachedContextURL, url)
+        XCTAssertEqual(sut.chipViewModel.pendingAttachedContextData?.url, url.absoluteString)
+    }
+
     func test_setAttachedContextAfterPromptSubmittedWithSameURL_makesContextPendingAgain() {
         let url = URL(string: "https://example.com/a")!
         originatingURL.send(url)

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -2590,17 +2590,6 @@ final class UnifiedToggleInputToolbarViewTests: XCTestCase {
         }
     }
 
-    func test_attachmentButton_usesFixedMenuElementOrder() {
-        let sut = UnifiedToggleInputToolbarView()
-
-        let attachmentButton = findButton(accessibilityLabel: UserText.aiChatToolbarAttachButtonAccessibilityLabel, in: sut)
-
-        XCTAssertNotNil(attachmentButton)
-        if #available(iOS 16.0, *) {
-            XCTAssertEqual(attachmentButton?.preferredMenuElementOrder, .fixed)
-        }
-    }
-
     private func findButton(accessibilityLabel: String, in view: UIView) -> UIButton? {
         for subview in view.subviews {
             if let button = subview as? UIButton, button.accessibilityLabel == accessibilityLabel {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -2590,6 +2590,17 @@ final class UnifiedToggleInputToolbarViewTests: XCTestCase {
         }
     }
 
+    func test_attachmentButton_usesFixedMenuElementOrder() {
+        let sut = UnifiedToggleInputToolbarView()
+
+        let attachmentButton = findButton(accessibilityLabel: UserText.aiChatToolbarAttachButtonAccessibilityLabel, in: sut)
+
+        XCTAssertNotNil(attachmentButton)
+        if #available(iOS 16.0, *) {
+            XCTAssertEqual(attachmentButton?.preferredMenuElementOrder, .fixed)
+        }
+    }
+
     private func findButton(accessibilityLabel: String, in view: UIView) -> UIButton? {
         for subview in view.subviews {
             if let button = subview as? UIButton, button.accessibilityLabel == accessibilityLabel {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPageContextChipViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPageContextChipViewModelTests.swift
@@ -124,6 +124,18 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         XCTAssertEqual(sut.pendingAttachedContextData?.url, "https://en.wikipedia.org/wiki/Dog")
     }
 
+    func test_showAttachAffordance_doesNotOverridePendingAttachment() {
+        let attachedUrl = "https://en.wikipedia.org/wiki/Cat"
+        originatingURL.send(URL(string: attachedUrl))
+        makeSUT(initialAttachedContext: makeContext(title: "Cat", url: attachedUrl), initialAttachmentDeliveryState: .pendingSubmit)
+
+        sut.showAttachAffordance()
+
+        XCTAssertEqualState(sut.state, .attached(title: "Cat", favicon: nil))
+        XCTAssertTrue(sut.isVisible)
+        XCTAssertEqual(sut.pendingAttachedContextData?.url, attachedUrl)
+    }
+
     func test_autoAttachOn_navigationAway_preservesAttachment() {
         autoAttachEnabled = true
         let attachedUrl = "https://en.wikipedia.org/wiki/Cat"

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPageContextChipViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPageContextChipViewModelTests.swift
@@ -29,7 +29,6 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
     private var sut: UnifiedToggleInputPageContextChipViewModel!
     private var attachCalls: Int = 0
     private var removeCalls: Int = 0
-    private var navigationAwayDetachCalls: Int = 0
     private var autoAttachEnabled = false
 
     override func setUp() async throws {
@@ -37,7 +36,6 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         originatingURL = .init(nil)
         attachCalls = 0
         removeCalls = 0
-        navigationAwayDetachCalls = 0
         autoAttachEnabled = false
     }
 
@@ -53,7 +51,6 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         )
         sut.onAttachActionRequested = { [weak self] in self?.attachCalls += 1 }
         sut.onRemoveActionRequested = { [weak self] in self?.removeCalls += 1 }
-        sut.onNavigationAwayDetachRequested = { [weak self] in self?.navigationAwayDetachCalls += 1 }
     }
 
     // MARK: - State transitions
@@ -81,31 +78,62 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         XCTAssertEqualState(sut.state, .placeholder)
     }
 
-    func test_autoAttachOff_navigationAway_invokesNavigationAwayDetachCallback() {
-        // Regression: nav-away clearing must propagate through the host so it clears the FE-side
-        // cached page context. Otherwise the next prompt would ship stale context even though the
-        // chip displays placeholder.
+    func test_autoAttachOff_navigationAway_keepsManualPendingAttachmentSticky() {
         let attachedUrl = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: attachedUrl))
-        makeSUT(initialAttachedContext: makeContext(title: "Cat", url: attachedUrl))
+        makeSUT(initialAttachedContext: makeContext(title: "Cat", url: attachedUrl), initialAttachmentDeliveryState: .pendingSubmit)
         XCTAssertEqual(removeCalls, 0)
-        XCTAssertEqual(navigationAwayDetachCalls, 0)
+        XCTAssertEqualState(sut.state, .attached(title: "Cat", favicon: nil))
+        XCTAssertTrue(sut.isVisible)
 
         originatingURL.send(URL(string: "https://en.wikipedia.org/wiki/Dog"))
         XCTAssertEqual(removeCalls, 0)
-        XCTAssertEqual(navigationAwayDetachCalls, 1)
+        XCTAssertEqualState(sut.state, .attached(title: "Cat", favicon: nil))
+        XCTAssertTrue(sut.isVisible)
     }
 
-    func test_autoAttachOn_navigationAway_doesNotInvokeDetachCallback() {
-        // With auto-attach ON, the attachment is preserved while the host re-collects, so
-        // the detach callback must NOT fire on nav-away.
+    func test_autoAttachOff_navigationAway_keepsManualDeliveredAttachmentStickyAndHidden() {
+        let attachedUrl = "https://en.wikipedia.org/wiki/Cat"
+        originatingURL.send(URL(string: attachedUrl))
+        makeSUT(initialAttachedContext: makeContext(title: "Cat", url: attachedUrl), initialAttachmentDeliveryState: .delivered)
+        XCTAssertEqualState(sut.state, .attached(title: "Cat", favicon: nil))
+        XCTAssertFalse(sut.isVisible)
+
+        originatingURL.send(URL(string: "https://en.wikipedia.org/wiki/Dog"))
+        XCTAssertEqualState(sut.state, .attached(title: "Cat", favicon: nil))
+        XCTAssertFalse(sut.isVisible)
+    }
+
+    func test_showAttachAffordance_preservesDeliveredAttachmentAndShowsPlaceholder() {
+        let attachedUrl = "https://en.wikipedia.org/wiki/Cat"
+        originatingURL.send(URL(string: attachedUrl))
+        makeSUT(initialAttachedContext: makeContext(title: "Cat", url: attachedUrl), initialAttachmentDeliveryState: .delivered)
+        XCTAssertFalse(sut.isVisible)
+
+        sut.showAttachAffordance()
+
+        XCTAssertEqualState(sut.state, .placeholder)
+        XCTAssertTrue(sut.isVisible)
+        XCTAssertNil(sut.pendingAttachedContextData)
+
+        sut.tapToAttach()
+        XCTAssertEqual(attachCalls, 1)
+
+        sut.setAttached(makeContext(title: "Dog", url: "https://en.wikipedia.org/wiki/Dog"))
+        XCTAssertEqualState(sut.state, .attached(title: "Dog", favicon: nil))
+        XCTAssertEqual(sut.pendingAttachedContextData?.url, "https://en.wikipedia.org/wiki/Dog")
+    }
+
+    func test_autoAttachOn_navigationAway_preservesAttachment() {
         autoAttachEnabled = true
         let attachedUrl = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: attachedUrl))
-        makeSUT(initialAttachedContext: makeContext(title: "Cat", url: attachedUrl))
+        makeSUT(initialAttachedContext: makeContext(title: "Cat", url: attachedUrl), initialAttachmentDeliveryState: .pendingSubmit)
 
         originatingURL.send(URL(string: "https://en.wikipedia.org/wiki/Dog"))
         XCTAssertEqual(removeCalls, 0)
+        XCTAssertEqualState(sut.state, .attached(title: "Cat", favicon: nil))
+        XCTAssertTrue(sut.isVisible)
     }
 
     func test_autoAttachOn_originatingURLChangesAwayThenBack_attachmentPreservedInternally() {
@@ -126,19 +154,17 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         XCTAssertEqualState(sut.state, .attached(title: "Cat", favicon: nil))
     }
 
-    func test_autoAttachOff_originatingURLAwayThenBack_doesNotRestoreAttached() {
-        // Manual mode: leaving the page clears the attachment. Navigating back does NOT restore
-        // — the user must tap the placeholder to re-attach.
+    func test_autoAttachOff_originatingURLAwayThenBack_keepsManualAttachmentSticky() {
         let attachedUrl = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: attachedUrl))
-        makeSUT(initialAttachedContext: makeContext(title: "Cat", url: attachedUrl))
+        makeSUT(initialAttachedContext: makeContext(title: "Cat", url: attachedUrl), initialAttachmentDeliveryState: .pendingSubmit)
         XCTAssertEqualState(sut.state, .attached(title: "Cat", favicon: nil))
 
         originatingURL.send(URL(string: "https://en.wikipedia.org/wiki/Dog"))
-        XCTAssertEqualState(sut.state, .placeholder)
+        XCTAssertEqualState(sut.state, .attached(title: "Cat", favicon: nil))
 
         originatingURL.send(URL(string: attachedUrl))
-        XCTAssertEqualState(sut.state, .placeholder)
+        XCTAssertEqualState(sut.state, .attached(title: "Cat", favicon: nil))
     }
 
     // MARK: - Tap handling
@@ -231,16 +257,16 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         XCTAssertTrue(sut.isVisible)
     }
 
-    func test_visibility_manual_navigateAway_visiblePlaceholder() {
-        // 4. Navigate away → manual clears attachment → show placeholder for the new page.
+    func test_visibility_manual_navigateAway_keepsAttachedState() {
+        // Manual mode is sticky: navigation does not clear or replace an existing attachment.
         let url = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: url))
-        makeSUT(initialAttachedContext: makeContext(title: "Cat", url: url))
-        XCTAssertFalse(sut.isVisible)
+        makeSUT(initialAttachedContext: makeContext(title: "Cat", url: url), initialAttachmentDeliveryState: .pendingSubmit)
+        XCTAssertTrue(sut.isVisible)
 
         originatingURL.send(URL(string: "https://en.wikipedia.org/wiki/Dog"))
         XCTAssertTrue(sut.isVisible)
-        XCTAssertEqualState(sut.state, .placeholder)
+        XCTAssertEqualState(sut.state, .attached(title: "Cat", favicon: nil))
     }
 
     func test_visibility_manual_userDetachesViaX_visiblePlaceholder() {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPageContextChipViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPageContextChipViewModelTests.swift
@@ -157,9 +157,15 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         XCTAssertEqual(attachCalls, 1)
     }
 
-    func test_tapToRemove_callsOnRemove() {
-        makeSUT()
+    func test_tapToRemove_clearsChipAndCallsOnRemove() {
+        let url = "https://en.wikipedia.org/wiki/Cat"
+        originatingURL.send(URL(string: url))
+        makeSUT(initialAttachedContext: makeContext(title: "Cat", url: url))
         sut.tapToRemove()
+
+        XCTAssertEqualState(sut.state, .placeholder)
+        XCTAssertTrue(sut.isVisible)
+        XCTAssertNil(sut.pendingAttachedContextData)
         XCTAssertEqual(removeCalls, 1)
     }
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPageContextChipViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPageContextChipViewModelTests.swift
@@ -27,15 +27,17 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
 
     private var originatingURL: CurrentValueSubject<URL?, Never>!
     private var sut: UnifiedToggleInputPageContextChipViewModel!
-    private var attachCalls: [URL] = []
+    private var attachCalls: Int = 0
     private var removeCalls: Int = 0
+    private var navigationAwayDetachCalls: Int = 0
     private var autoAttachEnabled = false
 
     override func setUp() async throws {
         try await super.setUp()
         originatingURL = .init(nil)
-        attachCalls = []
+        attachCalls = 0
         removeCalls = 0
+        navigationAwayDetachCalls = 0
         autoAttachEnabled = false
     }
 
@@ -49,8 +51,9 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
             initialAttachmentDeliveryState: initialAttachmentDeliveryState,
             isAutoAttachEnabled: { [weak self] in self?.autoAttachEnabled ?? false }
         )
-        sut.onAttachActionRequested = { [weak self] url in self?.attachCalls.append(url) }
+        sut.onAttachActionRequested = { [weak self] in self?.attachCalls += 1 }
         sut.onRemoveActionRequested = { [weak self] in self?.removeCalls += 1 }
+        sut.onNavigationAwayDetachRequested = { [weak self] in self?.navigationAwayDetachCalls += 1 }
     }
 
     // MARK: - State transitions
@@ -78,22 +81,24 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         XCTAssertEqualState(sut.state, .placeholder)
     }
 
-    func test_autoAttachOff_navigationAway_invokesRemoveCallback() {
-        // Regression: nav-away clearing must propagate through onRemoveActionRequested so the
-        // host clears the FE-side cached page context. Otherwise the next prompt would ship
-        // stale context even though the chip displays placeholder.
+    func test_autoAttachOff_navigationAway_invokesNavigationAwayDetachCallback() {
+        // Regression: nav-away clearing must propagate through the host so it clears the FE-side
+        // cached page context. Otherwise the next prompt would ship stale context even though the
+        // chip displays placeholder.
         let attachedUrl = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: attachedUrl))
         makeSUT(initialAttachedContext: makeContext(title: "Cat", url: attachedUrl))
         XCTAssertEqual(removeCalls, 0)
+        XCTAssertEqual(navigationAwayDetachCalls, 0)
 
         originatingURL.send(URL(string: "https://en.wikipedia.org/wiki/Dog"))
-        XCTAssertEqual(removeCalls, 1)
+        XCTAssertEqual(removeCalls, 0)
+        XCTAssertEqual(navigationAwayDetachCalls, 1)
     }
 
-    func test_autoAttachOn_navigationAway_doesNotInvokeRemoveCallback() {
+    func test_autoAttachOn_navigationAway_doesNotInvokeDetachCallback() {
         // With auto-attach ON, the attachment is preserved while the host re-collects, so
-        // the remove callback must NOT fire on nav-away.
+        // the detach callback must NOT fire on nav-away.
         autoAttachEnabled = true
         let attachedUrl = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: attachedUrl))
@@ -143,13 +148,13 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         let url = URL(string: "https://example.com/a")!
         originatingURL.send(url)
         sut.tapToAttach()
-        XCTAssertEqual(attachCalls, [url])
+        XCTAssertEqual(attachCalls, 1)
     }
 
-    func test_tapToAttach_noOriginatingURL_doesNotCallOnAttach() {
+    func test_tapToAttach_noOriginatingURL_callsOnAttach() {
         makeSUT()
         sut.tapToAttach()
-        XCTAssertTrue(attachCalls.isEmpty)
+        XCTAssertEqual(attachCalls, 1)
     }
 
     func test_tapToRemove_callsOnRemove() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1216049537026986?focus=true

### Description

Builds part 1 of contextual Unified Toggle Input for iOS contextual mode behind `aiChatContextualUnifiedToggleInput`.

When the new contextual flag is enabled, opening contextual Duck.ai from a web page shows the contextual sheet with Unified Toggle Input at the bottom before the first prompt. The web chat is still opened after first submit. When the new contextual flag is disabled, the existing first-sheet behavior remains in place and the existing web-bottom UTI still works when the base UTI feature is enabled.

Page-context behavior is owned by contextual session state. Explicitly removing page context clears the current attachment immediately; with automatic page-context attachment enabled, a real reload or navigation can attach the current page again, while reopening the sheet on the same page does not create a duplicate reattachment.

Key changes:

- Add `aiChatContextualUnifiedToggleInput` / `contextualUnifiedToggleInput`.
- Keep base web UTI availability separate from the new immediate contextual UTI flag.
- Remove the old contextual sheet improvements flag.
- Route page-context collection through one coordinator subscription.
- Use the existing contextual `notifyPageChanged()` navigation path for immediate UTI as well as legacy/basic input.
- Keep the UTI host focused on input/presentation; attach/remove policy stays in session state.
- Send first contextual UTI submit through the UTI prompt path.
- Add stable accessibility identifiers for contextual chip and input UI test coverage.

### Manual Testing

Feature flags:
- Existing web UTI tests: enable `unifiedToggleInput`, disable `aiChatContextualUnifiedToggleInput`.
- New first-sheet UTI tests: enable both `unifiedToggleInput` and `aiChatContextualUnifiedToggleInput`.

#### 1. Existing Web UTI: Manual Attach, Automatic Attach OFF

Setup:
1. Enable `unifiedToggleInput`.
2. Disable `aiChatContextualUnifiedToggleInput`.
3. Disable automatic page-context attachment in AI settings.

Steps:
1. Open page A.
2. Open contextual Duck.ai.
   - Expected: the first sheet before submit uses the existing basic input.
3. Submit a first prompt from the sheet.
   - Expected: Duck.ai opens with UTI at the bottom.
4. Close the sheet.
5. Navigate to page B.
6. Reopen contextual Duck.ai.
   - Expected: `Attach Page Content` is visible.
7. Tap `Attach Page Content`.
   - Expected: page B context is attached.

#### 2. Existing Web UTI: Automatic Attach ON

Setup:
1. As above, but enable automatic page-context attachment.

Steps:
1. Open page A.
2. Open contextual Duck.ai.
   - Expected: the first sheet before submit still uses the existing basic input.
3. Submit a first prompt from the sheet.
   - Expected: Duck.ai opens with UTI at the bottom.
4. Close the sheet.
5. Navigate to page B.
6. Reopen contextual Duck.ai.
   - Expected: page B context is attached automatically; the user does not have to tap `Attach Page Content`.

#### 3. New First-Sheet UTI: Manual Attach, Automatic Attach OFF

Setup:
1. Enable `unifiedToggleInput`.
2. Enable `aiChatContextualUnifiedToggleInput`.
3. Disable automatic page-context attachment in AI settings.

Steps:
1. Open page A.
2. Open contextual Duck.ai.
   - Expected: the sheet shows Unified Toggle Input at the bottom immediately.
   - Expected: the old basic input is not shown.
   - Expected: the web chat is not shown before first submit.
   - Expected: the sheet starts in a placeholder/no-context state.
3. Tap the placeholder chip / attach control.
   - Expected: page A context is attached.
4. Tap X on the attached context chip.
   - Expected: the chip returns to placeholder/no-context.
5. Close the sheet without submitting.
6. Navigate to page B.
7. Reopen contextual Duck.ai.
   - Expected: navigating from page A to page B does not auto-attach context; the placeholder/no-context state remains sticky.
8. Tap the placeholder chip / attach control.
   - Expected: page B context is attached.
9. Close the sheet without submitting.
10. Navigate to page C.
11. Reopen contextual Duck.ai.
    - Expected: page B context is still attached; navigating before first submit does not clear or replace it.
12. Submit a first prompt.
    - Expected: the web chat opens after submit.
13. Close the sheet.
14. Navigate to page D.
15. Reopen contextual Duck.ai.
    - Expected: with no pending chip after first submit, the placeholder / attach affordance is shown for the current page.
16. Tap the placeholder chip / attach control.
    - Expected: page D context is attached as a pending manual attachment.
17. Close the sheet.
18. Navigate to page E.
19. Reopen contextual Duck.ai.
    - Expected: page D context is still attached; navigation does not clear or replace the pending manual attachment when automatic attachment is off.

#### 4. New First-Sheet UTI: Automatic Attach ON

Setup:
1. Enable `unifiedToggleInput`.
2. Enable `aiChatContextualUnifiedToggleInput`.
3. Enable automatic page-context attachment in AI settings.

Steps:
1. Open page A.
2. Open contextual Duck.ai.
   - Expected: the sheet shows Unified Toggle Input at the bottom immediately.
   - Expected: the old basic input is not shown.
   - Expected: the web chat is not shown before first submit.
   - Expected: page A context is attached automatically on first open.
3. Tap X on the attached context chip.
   - Expected: the chip changes to placeholder/no-context immediately.
4. Close the sheet.
5. Navigate to page B.
6. Reopen contextual Duck.ai.
   - Expected: a real navigation gives automatic attachment another chance, so page B context is attached.
7. Submit a first prompt.
   - Expected: the web chat opens after submit.
8. Close the sheet.
9. Reopen contextual Duck.ai without navigating.
   - Expected: reopening the sheet on the same page does not reattach the already-submitted page B context.
10. Close the sheet.
11. Navigate to page C.
12. Reopen contextual Duck.ai.
    - Expected: after first submit, navigating while the sheet is closed attaches page C automatically when the sheet is reopened.

#### 5. New First-Sheet UTI: First Submit

Setup:
1. Continue from test 4, or start with both UTI flags enabled.

Steps:
1. Open page A.
2. Open contextual Duck.ai.
   - Expected: the sheet shows Unified Toggle Input before first submit.
3. Submit a first prompt from the UTI shown in the sheet.
   - Expected: the web chat opens only after submit.
   - Expected: the submitted prompt appears once.
   - Expected: the first prompt is sent through the UTI path with the current page context when context is attached.

### Impact and Risks

Medium. This changes contextual Duck.ai input and page-context delivery when the new feature flag is enabled. The flag-off path should preserve current behavior, and existing web UTI remains controlled by the base UTI feature rather than the new contextual flag.

What could go wrong:

- Existing web UTI could disappear when the contextual flag is off.
- Removed page context could fail to reattach after a real reload or navigation.
- Reopening the sheet on the same page could incorrectly attach duplicate page context.
- First submit could skip the UTI prompt path.
- Page context could be attached twice or delivered to the wrong surface.

### Notes to Reviewer

Please focus review on:

- existing web UTI still working when `aiChatContextualUnifiedToggleInput` is off
- first-sheet UTI appearing only when the new contextual flag is on
- explicit context removal clearing immediately while reload/navigation can auto-attach again
- same-page sheet reopen not reattaching already-submitted context
- post-submit dismissed-sheet navigation attaching the current page when automatic attachment is enabled
- UTI host staying input/presentation only
- one page-context collection subscription in the coordinator

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Medium Risk**
> Changes contextual Duck.ai input, page-context routing, and navigation/auto-attach when the new flag is on; flag-off paths are explicitly preserved but coordinator/session-state logic is substantial.
> 
> **Overview**
> Introduces **`aiChatContextualUnifiedToggleInput`** (privacy config **`contextualUnifiedToggleInput`**) so contextual Duck.ai can show **Unified Toggle Input at the bottom of the sheet before the first prompt**, with the web chat still opening after first submit. Base **`unifiedToggleInput`** plus the new flag control immediate sheet UTI; when the contextual flag is off, **web-bottom UTI after first submit** behavior is preserved.
> 
> **Page context** is routed through **`AIChatContextualChatSessionState`** and the coordinator: **`deliverPageContext`** replaces direct frontend pushes, with separate gates for the **UTI chip** vs **web bridge**. User removal clears the current attachment immediately, while real reload/navigation can auto-attach again when automatic attachment is enabled; **`detachFromNavigationAway`** vs user remove is distinguished in the chip view model. **`AIChatContextualUTIHost`** is slimmed to presentation/input (callbacks to coordinator); it can **`mountAtSheetLevel`** or **`installInWebView`**, defer user-script bind until first submit when **`contextualStartsPreSubmit`**, and submit rich prompts via **`AIChatContentHandler`**.
> 
> Renames **`AIChatNativeInputViewController`** → **`AIChatBasicNativeInputViewController`** for the pre-UTI basic input path. Drops **`aiChatContextualSheetImprovements`** / **`contextualSheetImprovements`**; quick actions default to ask-about-page / summarize-page without that flag. Adds **Maestro** regression flows and **accessibility identifiers** on context chip and native input for UI tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bee7ea5818b31df95053e2deae5c3af9b052be0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Substantial changes to contextual sheet input, page-context routing, and navigation/auto-attach when the new flag is on; flag-off paths are intended to preserve current behavior but coordinator and session-state logic is easy to regress.
> 
> **Overview**
> **Part 1 of contextual Unified Toggle Input** for iOS Duck.ai from a web page, gated by **`aiChatContextualUnifiedToggleInput`** (privacy config **`contextualUnifiedToggleInput`**). When both base **`unifiedToggleInput`** and this flag are on, the contextual sheet shows **UTI at the bottom before the first prompt**; the web chat still appears only after first submit. With the new flag off, behavior stays **basic native input first**, then **web-bottom UTI** after submit when base UTI is enabled.
> 
> **Page context** is centralized in session state and the sheet coordinator: **`pushContextToFrontend`** becomes **`deliverPageContext`** with targets for the **UTI chip**, **web bridge**, and **attach affordance**. Attach/remove policy moves out of **`AIChatContextualUTIHost`** (callbacks + **`mountAtSheetLevel`** vs **`installInWebView`**); first-submit binding uses **`contextualStartsPreSubmit`**. Navigation/auto-attach rules change (user opt-out, same-URL reopen, **`didFinish`**-driven collection in the coordinator). **`AIChatNativeInputViewController`** is renamed **`AIChatBasicNativeInputViewController`**.
> 
> Removes **`aiChatContextualSheetImprovements`** / **`contextualSheetImprovements`**; quick actions no longer depend on that flag. Adds **rich prompt** submission through **`AIChatContentHandler`**, **Maestro** regression flows, and **accessibility identifiers** on context chip and input for UI tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3b123aa565b061d8a9e073aa4fe801f2bdc477c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

