### PR TITLE
[iOS] Show the VPN error banner in more scenarios

### DIFF
--- a/SharedPackages/VPN/Tests/VPNTests/WideEvent/VPNConnectionWideEventTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/WideEvent/VPNConnectionWideEventTests.swift
@@ -17,7 +17,9 @@
 //
 
 import XCTest
+import Networking
 import PixelKit
+import Subscription
 @testable import VPN
 
 final class VPNConnectionWideEventTests: XCTestCase {
@@ -312,6 +314,25 @@ final class VPNConnectionWideEventTests: XCTestCase {
         // Second underlying error
         XCTAssertEqual(parameters["feature.data.ext.controller_start_error.underlying_domain2"], "Domain2")
         XCTAssertEqual(parameters["feature.data.ext.controller_start_error.underlying_code2"], "2")
+    }
+
+    func testAddStepError_withSubscriptionManagerTokenRetrievalErrorIncludesWrappedUnderlyingError() {
+        let eventData = VPNConnectionWideEventData(
+            extensionType: .app,
+            startupMethod: .manualByMainApp,
+            contextData: WideEventContextData(name: "Test-Context")
+        )
+
+        let wrappedError = OAuthClientError.unauthenticated
+        let error = SubscriptionManagerError.errorRetrievingTokenContainer(error: wrappedError)
+        eventData.oauthError = WideEventErrorData(error: error)
+
+        let parameters = eventData.pixelParameters()
+
+        XCTAssertEqual(parameters["feature.data.ext.oauth_error.domain"], "com.duckduckgo.subscription.SubscriptionManagerError")
+        XCTAssertEqual(parameters["feature.data.ext.oauth_error.code"], "12001")
+        XCTAssertEqual(parameters["feature.data.ext.oauth_error.underlying_domain"], "com.duckduckgo.networking.OAuthClientError")
+        XCTAssertEqual(parameters["feature.data.ext.oauth_error.underlying_code"], "11002")
     }
 
     // MARK: - transformErrorKey

--- a/iOS/DuckDuckGo/NetworkProtectionRootView.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionRootView.swift
@@ -31,11 +31,13 @@ struct NetworkProtectionRootView: View {
     init() {
         let subscriptionManager = AppDependencyProvider.shared.subscriptionManager
         let locationListRepository = NetworkProtectionLocationListCompositeRepository()
+        let tunnelController = AppDependencyProvider.shared.networkProtectionTunnelController
         _statusViewModel = StateObject(wrappedValue: NetworkProtectionStatusViewModel(
-            tunnelController: AppDependencyProvider.shared.networkProtectionTunnelController,
+            tunnelController: tunnelController,
             settings: AppDependencyProvider.shared.vpnSettings,
             statusObserver: AppDependencyProvider.shared.connectionObserver,
             serverInfoObserver: AppDependencyProvider.shared.serverInfoObserver,
+            controllerErrorPublisher: tunnelController.controllerErrorPublisher,
             locationListRepository: locationListRepository,
             enablesUnifiedFeedbackForm: subscriptionManager.isUserAuthenticated))
 

--- a/iOS/DuckDuckGo/NetworkProtectionStatusViewModel.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionStatusViewModel.swift
@@ -97,6 +97,7 @@ final class NetworkProtectionStatusViewModel: ObservableObject {
     private let statusObserver: ConnectionStatusObserver
     private let serverInfoObserver: ConnectionServerInfoObserver
     private let errorObserver: ConnectionErrorObserver
+    private let controllerErrorPublisher: AnyPublisher<String?, Never>
     private var cancellables: Set<AnyCancellable> = []
 
     /// Whether the "Add Widget" education sheet should be presented to the user.
@@ -177,6 +178,7 @@ final class NetworkProtectionStatusViewModel: ObservableObject {
                 statusObserver: ConnectionStatusObserver,
                 serverInfoObserver: ConnectionServerInfoObserver,
                 errorObserver: ConnectionErrorObserver = ConnectionErrorObserverThroughSession(),
+                controllerErrorPublisher: AnyPublisher<String?, Never> = Empty(completeImmediately: false).eraseToAnyPublisher(),
                 timeLapsedFormatter: VPNTimeFormatting = VPNTimeFormatter(),
                 locationListRepository: NetworkProtectionLocationListRepository,
                 enablesUnifiedFeedbackForm: Bool,
@@ -186,6 +188,7 @@ final class NetworkProtectionStatusViewModel: ObservableObject {
         self.statusObserver = statusObserver
         self.serverInfoObserver = serverInfoObserver
         self.errorObserver = errorObserver
+        self.controllerErrorPublisher = controllerErrorPublisher
         self.timeLapsedFormatter = timeLapsedFormatter
         self.enablesUnifiedFeedbackForm = enablesUnifiedFeedbackForm
         self.featureDiscovery = featureDiscovery
@@ -224,6 +227,7 @@ final class NetworkProtectionStatusViewModel: ObservableObject {
         setUpDNSSettingsPublisher()
         setUpThroughputRefreshTimer()
         setUpErrorPublishers()
+        setUpControllerErrorPublisher()
 
         // Prefetching this now for snappy load times on the locations screens
         Task {
@@ -402,6 +406,27 @@ final class NetworkProtectionStatusViewModel: ObservableObject {
                         self.error = errorItem
                     }
                 }
+            }
+            .store(in: &cancellables)
+    }
+
+    /// Surfaces controller-side (pre-session) start failures in the same banner as session errors.
+    ///
+    /// These failures abort before a tunnel session exists, so `errorObserver` (which reads errors
+    /// through the session) never sees them. The controller maps them to the existing VPN error copy;
+    /// here we only wrap the message in an `ErrorItem`, or clear it when the controller reports `nil`.
+    private func setUpControllerErrorPublisher() {
+        controllerErrorPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] message in
+                guard let self else { return }
+
+                guard let message else {
+                    self.error = nil
+                    return
+                }
+
+                self.error = ErrorItem(title: UserText.netPStatusViewErrorConnectionFailedTitle, message: message)
             }
             .store(in: &cancellables)
     }

--- a/iOS/DuckDuckGo/NetworkProtectionStatusViewModel.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionStatusViewModel.swift
@@ -123,6 +123,12 @@ final class NetworkProtectionStatusViewModel: ObservableObject {
     @Published public var shouldShowError: Bool = false
     private var errorTask: Task<Void, Never>?
 
+    // The banner shows a single error, but two independent sources feed it: controller (pre-session)
+    // start failures and session errors. We track each separately so a session update that resolves to
+    // no error can't clear a live start failure. See `refreshErrorBanner()` for the precedence rule.
+    private var controllerErrorMessage: String?
+    private var sessionErrorItem: ErrorItem?
+
     // MARK: Header
 
     @Published public var statusImageID: String
@@ -250,6 +256,8 @@ final class NetworkProtectionStatusViewModel: ObservableObject {
                 case .connected:
                     self?.isNetPEnabled = true
                     self?.errorTask?.cancel()
+                    self?.controllerErrorMessage = nil
+                    self?.sessionErrorItem = nil
                     self?.error = nil
                 case .connecting:
                     self?.isNetPEnabled = true
@@ -394,7 +402,8 @@ final class NetworkProtectionStatusViewModel: ObservableObject {
                 guard let self else { return }
 
                 guard let errorMessage else {
-                    self.error = nil
+                    self.sessionErrorItem = nil
+                    self.refreshErrorBanner()
                     return
                 }
 
@@ -403,7 +412,8 @@ final class NetworkProtectionStatusViewModel: ObservableObject {
                     let errorItem = await self.createErrorItem(fallbackMessage: errorMessage)
                     guard !Task.isCancelled else { return }
                     await MainActor.run {
-                        self.error = errorItem
+                        self.sessionErrorItem = errorItem
+                        self.refreshErrorBanner()
                     }
                 }
             }
@@ -414,7 +424,7 @@ final class NetworkProtectionStatusViewModel: ObservableObject {
     ///
     /// These failures abort before a tunnel session exists, so `errorObserver` (which reads errors
     /// through the session) never sees them. The controller maps them to the existing VPN error copy;
-    /// here we only wrap the message in an `ErrorItem`, or clear it when the controller reports `nil`.
+    /// here we store the message and recompute the banner, or clear it when the controller reports `nil`.
     private func setUpControllerErrorPublisher() {
         controllerErrorPublisher
             .receive(on: DispatchQueue.main)
@@ -422,13 +432,29 @@ final class NetworkProtectionStatusViewModel: ObservableObject {
                 guard let self else { return }
 
                 guard let message else {
-                    self.error = nil
+                    // A nil controller message signals a fresh connection attempt; clear any stale error
+                    // from a previous attempt (session errors included) so the banner starts clean.
+                    self.controllerErrorMessage = nil
+                    self.sessionErrorItem = nil
+                    self.refreshErrorBanner()
                     return
                 }
 
-                self.error = ErrorItem(title: UserText.netPStatusViewErrorConnectionFailedTitle, message: message)
+                self.controllerErrorMessage = message
+                self.refreshErrorBanner()
             }
             .store(in: &cancellables)
+    }
+
+    /// Recomputes the single banner error from the two independent sources. Controller (pre-session)
+    /// start failures take precedence: only when there is no controller error do we fall back to the
+    /// session error, so a session update resolving to no error can't clear a live start failure.
+    private func refreshErrorBanner() {
+        if let controllerErrorMessage {
+            error = ErrorItem(title: UserText.netPStatusViewErrorConnectionFailedTitle, message: controllerErrorMessage)
+        } else {
+            error = sessionErrorItem
+        }
     }
 
     private func createErrorItem(fallbackMessage: String) async -> ErrorItem? {

--- a/iOS/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -208,8 +208,10 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
                 withAdditionalParameters: [:],
                 onComplete: { _ in })
         } catch {
-            // Top level catch-all
-            controllerErrorSubject.send(userFacingControllerErrorMessage(for: error))
+            if let message = userFacingControllerErrorMessage(for: error) {
+                controllerErrorSubject.send(message)
+            }
+
             completeAndCleanupConnectionWideEvent(with: error, description: error.contextualizedDescription())
             if case StartError.configSystemPermissionsDenied = error {
                 return

--- a/iOS/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -377,13 +377,8 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
         
         do {
             self.connectionWideEventData?.oauthDuration = WideEvent.MeasuredInterval.startingNow()
-            #if DEBUG
-            // TEMP: reproduce SubscriptionManagerError 12000 (noTokenAvailable) at the oauth step. Revert before merge.
-            throw SubscriptionManagerError.noTokenAvailable
-            #else
             try await tokenHandler.getToken()
             self.connectionWideEventData?.oauthDuration?.complete()
-            #endif
         } catch {
             switch error {
             case SubscriptionManagerError.noTokenAvailable:

--- a/iOS/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -50,7 +50,17 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
     private let settings: VPNSettings
     private lazy var startupMonitor = VPNStartupMonitor()
     private var cancellables = Set<AnyCancellable>()
-    
+
+    /// Carries user-facing messages for controller-side (pre-session) start failures.
+    ///
+    /// The status view surfaces connection errors through the tunnel session, but failures that abort
+    /// before the session is created (e.g. a missing auth token) never reach that observer. This subject
+    /// gives those pre-session failures a channel to the UI; `nil` means "no error to show".
+    private let controllerErrorSubject = CurrentValueSubject<String?, Never>(nil)
+    var controllerErrorPublisher: AnyPublisher<String?, Never> {
+        controllerErrorSubject.eraseToAnyPublisher()
+    }
+
     // Wide Event
     private let wideEvent: WideEventManaging
     private var connectionWideEventData: VPNConnectionWideEventData?
@@ -179,6 +189,7 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
     ///
     func start() async {
         setupAndStartConnectionWideEvent()
+        controllerErrorSubject.send(nil)
         persistentPixel.fire(
             pixel: .networkProtectionControllerStartAttempt,
             error: nil,
@@ -198,6 +209,7 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
                 onComplete: { _ in })
         } catch {
             // Top level catch-all
+            controllerErrorSubject.send(userFacingControllerErrorMessage(for: error))
             completeAndCleanupConnectionWideEvent(with: error, description: error.contextualizedDescription())
             if case StartError.configSystemPermissionsDenied = error {
                 return
@@ -214,6 +226,29 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
             errorStore.lastErrorMessage = error.localizedDescription
             #endif
         }
+    }
+
+    /// Maps a start failure to the user-facing message the status view should show, reusing the existing
+    /// `VPNConnectionError` copy. Returns `nil` for failures the user should not see a banner for:
+    /// `configSystemPermissionsDenied` (the user deliberately declined the system prompt) and
+    /// `startVPNFailed` (which happens after the tunnel session exists, so the session-based error
+    /// observer already surfaces it).
+    private func userFacingControllerErrorMessage(for error: Error) -> String? {
+        guard let startError = error as? StartError else {
+            return nil
+        }
+
+        let connectionError: VPNConnectionError
+        switch startError {
+        case .noAuthToken, .failedToFetchAuthToken:
+            connectionError = .authenticationFailed
+        case .loadFromPreferencesFailed, .saveToPreferencesFailed, .simulateControllerFailureError:
+            connectionError = .connectionFailed
+        case .configSystemPermissionsDenied, .startVPNFailed:
+            return nil
+        }
+
+        return connectionError.localizedMessage
     }
 
     func stop() async {
@@ -340,8 +375,13 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
         
         do {
             self.connectionWideEventData?.oauthDuration = WideEvent.MeasuredInterval.startingNow()
+            #if DEBUG
+            // TEMP: reproduce SubscriptionManagerError 12000 (noTokenAvailable) at the oauth step. Revert before merge.
+            throw SubscriptionManagerError.noTokenAvailable
+            #else
             try await tokenHandler.getToken()
             self.connectionWideEventData?.oauthDuration?.complete()
+            #endif
         } catch {
             switch error {
             case SubscriptionManagerError.noTokenAvailable:

--- a/iOS/DuckDuckGoTests/NetworkProtectionStatusViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/NetworkProtectionStatusViewModelTests.swift
@@ -18,6 +18,7 @@
 //
 
 import XCTest
+import Combine
 import VPN
 import NetworkExtension
 import VPNTestUtils
@@ -194,7 +195,42 @@ import Subscription
         }
     }
 
+    // MARK: - Controller (pre-session) errors
+
+    func testControllerError_message_setsErrorBannerWithExistingCopy() async {
+        let subject = CurrentValueSubject<String?, Never>(nil)
+        let viewModel = makeViewModel(controllerErrorPublisher: subject.eraseToAnyPublisher())
+
+        subject.send(UserText.vpnErrorAuthenticationFailed)
+
+        await waitFor(condition: viewModel.error != nil)
+        XCTAssertEqual(viewModel.error?.title, UserText.netPStatusViewErrorConnectionFailedTitle)
+        XCTAssertEqual(viewModel.error?.message, UserText.vpnErrorAuthenticationFailed)
+    }
+
+    func testControllerError_nil_clearsErrorBanner() async {
+        let subject = CurrentValueSubject<String?, Never>(nil)
+        let viewModel = makeViewModel(controllerErrorPublisher: subject.eraseToAnyPublisher())
+
+        subject.send(UserText.vpnErrorAuthenticationFailed)
+        await waitFor(condition: viewModel.error != nil)
+
+        subject.send(nil)
+        await waitFor(condition: viewModel.error == nil)
+        XCTAssertNil(viewModel.error)
+    }
+
     // MARK: - Helpers
+
+    private func makeViewModel(controllerErrorPublisher: AnyPublisher<String?, Never>) -> NetworkProtectionStatusViewModel {
+        NetworkProtectionStatusViewModel(tunnelController: tunnelController,
+                                         settings: VPNSettings(defaults: .networkProtectionGroupDefaults),
+                                         statusObserver: statusObserver,
+                                         serverInfoObserver: serverInfoObserver,
+                                         controllerErrorPublisher: controllerErrorPublisher,
+                                         locationListRepository: MockNetworkProtectionLocationListRepository(),
+                                         enablesUnifiedFeedbackForm: false)
+    }
 
     private func whenStatusUpdate_connected() async {
         statusObserver.subject.send(.connected(connectedDate: Date()))

--- a/iOS/DuckDuckGoTests/NetworkProtectionStatusViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/NetworkProtectionStatusViewModelTests.swift
@@ -238,6 +238,23 @@ import Subscription
         XCTAssertEqual(viewModel.error?.message, UserText.vpnErrorAuthenticationFailed)
     }
 
+    func testControllerError_takesPrecedenceOverLiveSessionError() async {
+        let controllerErrorSubject = CurrentValueSubject<String?, Never>(nil)
+        let errorObserver = MockConnectionErrorObserver()
+        let viewModel = makeViewModel(controllerErrorPublisher: controllerErrorSubject.eraseToAnyPublisher(),
+                                      errorObserver: errorObserver)
+
+        // A real (non-nil) session error is showing in the banner first.
+        errorObserver.subject.send("VPN disconnected due to expired subscription")
+        await waitFor(condition: viewModel.error?.message == UserText.vpnErrorSubscriptionExpired)
+
+        // With a controller (pre-session) start failure also present, the controller message wins.
+        controllerErrorSubject.send(UserText.vpnErrorAuthenticationFailed)
+        await waitFor(condition: viewModel.error?.message == UserText.vpnErrorAuthenticationFailed)
+        XCTAssertEqual(viewModel.error?.title, UserText.netPStatusViewErrorConnectionFailedTitle)
+        XCTAssertEqual(viewModel.error?.message, UserText.vpnErrorAuthenticationFailed)
+    }
+
     // MARK: - Helpers
 
     private func makeViewModel(controllerErrorPublisher: AnyPublisher<String?, Never>,

--- a/iOS/DuckDuckGoTests/NetworkProtectionStatusViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/NetworkProtectionStatusViewModelTests.swift
@@ -220,13 +220,33 @@ import Subscription
         XCTAssertNil(viewModel.error)
     }
 
+    func testControllerError_isNotClearedBySessionErrorObserverEmittingNil() async {
+        let controllerErrorSubject = CurrentValueSubject<String?, Never>(nil)
+        let errorObserver = MockConnectionErrorObserver()
+        let viewModel = makeViewModel(controllerErrorPublisher: controllerErrorSubject.eraseToAnyPublisher(),
+                                      errorObserver: errorObserver)
+
+        controllerErrorSubject.send(UserText.vpnErrorAuthenticationFailed)
+        await waitFor(condition: viewModel.error != nil)
+
+        // A session status change that resolves to no error must not clear a live controller start failure.
+        errorObserver.subject.send(nil)
+
+        // Give the sink a chance to run, then confirm the controller error is still showing.
+        await waitFor(condition: viewModel.error?.message == UserText.vpnErrorAuthenticationFailed)
+        XCTAssertEqual(viewModel.error?.title, UserText.netPStatusViewErrorConnectionFailedTitle)
+        XCTAssertEqual(viewModel.error?.message, UserText.vpnErrorAuthenticationFailed)
+    }
+
     // MARK: - Helpers
 
-    private func makeViewModel(controllerErrorPublisher: AnyPublisher<String?, Never>) -> NetworkProtectionStatusViewModel {
+    private func makeViewModel(controllerErrorPublisher: AnyPublisher<String?, Never>,
+                               errorObserver: ConnectionErrorObserver = MockConnectionErrorObserver()) -> NetworkProtectionStatusViewModel {
         NetworkProtectionStatusViewModel(tunnelController: tunnelController,
                                          settings: VPNSettings(defaults: .networkProtectionGroupDefaults),
                                          statusObserver: statusObserver,
                                          serverInfoObserver: serverInfoObserver,
+                                         errorObserver: errorObserver,
                                          controllerErrorPublisher: controllerErrorPublisher,
                                          locationListRepository: MockNetworkProtectionLocationListRepository(),
                                          enablesUnifiedFeedbackForm: false)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1216271792395742?focus=true
Tech Design URL:
CC:

### Description

This PR updates the VPN error banner to show in more scenarios.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Install this branch on a physical device and try to connect the VPN.
2. Check that an error banner appears - this is because there is a hardcoded failure that forces token fetch to fail. Before this branch, no error UI would appear, but the VPN would silently fail to connect.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
3. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
4. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes VPN connection UX and error-state merging on the main status screen; logic is well-tested but incorrect precedence or clearing could hide or duplicate errors during connect flows.
> 
> **Overview**
> **Pre-session VPN start failures** (e.g. missing or failed auth token, preferences load/save) now show in the same Network Protection error banner instead of failing silently when no tunnel session exists.
> 
> `NetworkProtectionTunnelController` publishes user-facing messages via `controllerErrorPublisher`, mapping `StartError` cases to existing `VPNConnectionError` copy and skipping banner-worthy cases the session observer already handles (`startVPNFailed`) or that are intentional user actions (`configSystemPermissionsDenied`). Each new `start()` clears the controller error channel.
> 
> `NetworkProtectionStatusViewModel` merges controller and session error sources: controller messages take precedence, and a session observer emitting `nil` no longer clears an active controller failure. `NetworkProtectionRootView` wires the publisher into the status view model.
> 
> Tests cover banner precedence/clearing behavior and wide-event pixel parameters for wrapped subscription token errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a55da54a938e8803381cfbe1024fbe27892c42ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->