### PR TITLE
[macOS] Update Next Steps stack behavior and ordering

### DIFF
--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -578,6 +578,12 @@ extension AppDelegate {
     }
 
     @objc func debugResetContinueSetup(_ sender: Any?) {
+        homePageSetUpDependencies.clearAll()
+
+        NewTabPageNextStepsCardsDebugPersistor().debugVisibleCards = []
+
+        NotificationCenter.default.post(name: .nextStepsCardsDebugDidReset, object: nil)
+
         let persistor = AppearancePreferencesUserDefaultsPersistor(keyValueStore: keyValueStore)
         persistor.continueSetUpCardsLastDemonstrated = nil
         persistor.continueSetUpCardsNumberOfDaysDemonstrated = 0
@@ -588,7 +594,8 @@ extension AppDelegate {
         duckPlayer.preferences.youtubeOverlayAnyButtonPressed = false
         duckPlayer.preferences.duckPlayerMode = .alwaysAsk
         UserDefaultsWrapper<Bool>(key: .homePageContinueSetUpImport, defaultValue: false).clear()
-        homePageSetUpDependencies.clearAll()
+
+        NotificationCenter.default.post(name: .newTabPageWebViewDidAppear, object: nil)
     }
 
     @MainActor
@@ -1652,7 +1659,7 @@ extension MainViewController {
         let debugPersistor = NewTabPageNextStepsCardsDebugPersistor()
         guard let card = debugPersistor.debugVisibleCards.first else { return }
         persistor.setTimesShown(NewTabPageNextStepsSingleCardProvider.Constants.maxTimesCardShown, for: card)
-        NotificationCenter.default.post(name: NSWindow.didBecomeKeyNotification, object: nil)
+        NotificationCenter.default.post(name: .newTabPageWebViewDidAppear, object: nil)
     }
 
     @objc func debugShiftNewTabOpeningDate(_ sender: Any?) {

--- a/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsPersistor.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsPersistor.swift
@@ -22,6 +22,8 @@ import Persistence
 
 protocol NewTabPageNextStepsCardsPersisting {
     var orderedCardIDs: [NewTabPageDataModel.CardID]? { get set }
+    var dailyVisibleStack: [NewTabPageDataModel.CardID]? { get set }
+    var visibleStackDayIdentifier: Int? { get set }
     var firstCardLevel: NewTabPageDataModel.CardLevel { get set }
     var isFirstSession: Bool { get set }
     var ntpImpressionCount: Int { get set }
@@ -44,6 +46,8 @@ final class NewTabPageNextStepsCardsPersistor: NewTabPageNextStepsCardsPersistin
 
     enum Keys {
         static let cardOrder = "new.tab.page.next.steps.card.order"
+        static let dailyVisibleStack = "new.tab.page.next.steps.daily.visible.stack"
+        static let visibleStackDayIdentifier = "new.tab.page.next.steps.visible.stack.day.identifier"
         static let firstCardLevel = "new.tab.page.next.steps.first.card.level"
         static let isFirstSession = "new.tab.page.next.steps.is.first.session"
         static let ntpImpressionCount = "new.tab.page.next.steps.ntp.impression.count"
@@ -80,6 +84,44 @@ final class NewTabPageNextStepsCardsPersistor: NewTabPageNextStepsCardsPersistin
                 lock.unlock()
             }
             try? keyValueStore.set(newValue?.map { $0.rawValue }, forKey: Keys.cardOrder)
+        }
+    }
+
+    var dailyVisibleStack: [NewTabPageDataModel.CardID]? {
+        get {
+            lock.lock()
+            defer {
+                lock.unlock()
+            }
+            if let rawCardIDs = (try? keyValueStore.object(forKey: Keys.dailyVisibleStack) as? [String]) {
+                return rawCardIDs.compactMap { NewTabPageDataModel.CardID(rawValue: $0) }
+            } else {
+                return nil
+            }
+        }
+        set {
+            lock.lock()
+            defer {
+                lock.unlock()
+            }
+            try? keyValueStore.set(newValue?.map { $0.rawValue }, forKey: Keys.dailyVisibleStack)
+        }
+    }
+
+    var visibleStackDayIdentifier: Int? {
+        get {
+            lock.lock()
+            defer {
+                lock.unlock()
+            }
+            return try? keyValueStore.object(forKey: Keys.visibleStackDayIdentifier) as? Int
+        }
+        set {
+            lock.lock()
+            defer {
+                lock.unlock()
+            }
+            try? keyValueStore.set(newValue, forKey: Keys.visibleStackDayIdentifier)
         }
     }
 
@@ -178,6 +220,8 @@ final class NewTabPageNextStepsCardsPersistor: NewTabPageNextStepsCardsPersistin
             try? keyValueStore.removeObject(forKey: dismissedKey(for: card))
         }
         try? keyValueStore.removeObject(forKey: Keys.cardOrder)
+        try? keyValueStore.removeObject(forKey: Keys.dailyVisibleStack)
+        try? keyValueStore.removeObject(forKey: Keys.visibleStackDayIdentifier)
         try? keyValueStore.removeObject(forKey: Keys.firstCardLevel)
         try? keyValueStore.removeObject(forKey: Keys.isFirstSession)
         try? keyValueStore.removeObject(forKey: Keys.ntpImpressionCount)

--- a/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
@@ -115,12 +115,12 @@ final class NewTabPageNextStepsSingleCardProvider: NewTabPageNextStepsCardsProvi
     /// This is used for advanced card ordering with the feature flag `nextStepsListAdvancedCardOrdering`.
     private let defaultAdvancedCards = [
         LeveledCard(cardID: .personalizeBrowser, level: .level1),
-        LeveledCard(cardID: .sync, level: .level1),
         LeveledCard(cardID: .emailProtection, level: .level1),
         LeveledCard(cardID: .defaultApp, level: .level2),
-        LeveledCard(cardID: .addAppToDockMac, level: .level2),
         LeveledCard(cardID: .youtubeAdBlocking, level: .level2),
+        LeveledCard(cardID: .addAppToDockMac, level: .level2),
         LeveledCard(cardID: .bringStuff, level: .level2),
+        LeveledCard(cardID: .sync, level: .level1),
         LeveledCard(cardID: .subscription, level: .level2)
     ]
 
@@ -222,6 +222,7 @@ final class NewTabPageNextStepsSingleCardProvider: NewTabPageNextStepsCardsProvi
         observeNewTabPageWebViewDidAppear()
         observeNewTabPageOpen()
         observeFeatureFlagChanges()
+        observeNextStepsCardsDebugReset()
     }
 
     @MainActor
@@ -282,7 +283,11 @@ private extension NewTabPageNextStepsSingleCardProvider {
         if updateOrder {
             return buildVisibleStackWithAdvancedOrdering()
         } else {
-            return cardList.filter(shouldShowCard)
+            let prunedStack = cardList.filter(shouldShowCard)
+            if !cardList.isEmpty, prunedStack != persistor.dailyVisibleStack {
+                persistor.dailyVisibleStack = prunedStack
+            }
+            return prunedStack
         }
     }
 
@@ -291,66 +296,103 @@ private extension NewTabPageNextStepsSingleCardProvider {
     /// - Limiting the visible stack to a maximum number of cards, to avoid card overwhelm.
     /// - Rotating the top card in the visible stack after a maximum number of impressions, to avoid card blindness.
     func buildVisibleStackWithAdvancedOrdering() -> [NewTabPageDataModel.CardID] {
-        let baseOrder = persistor.orderedCardIDs ?? defaultAdvancedCards.map(\.cardID)
-        var resolvedOrder = applyLevelSwapIfNeeded(to: baseOrder)
+        let currentDayIdentifier = appearancePreferences.nextStepsCardsDemonstrationDays
+        var resolvedOrder = persistor.orderedCardIDs ?? defaultAdvancedCards.map(\.cardID)
+        let didLevelSwap = applyLevelSwapIfNeeded(to: &resolvedOrder)
 
-        var visibleStack = Array(
-            resolvedOrder
+        let isNewDay = persistor.visibleStackDayIdentifier != currentDayIdentifier
+        var visibleStack: [NewTabPageDataModel.CardID]
+        if isNewDay {
+            if didLevelSwap {
+                visibleStack = topEligibleVisibleCards(from: resolvedOrder)
+            } else {
+                visibleStack = (persistor.dailyVisibleStack ?? [])
+                    .filter(shouldShowCard)
+                if visibleStack.isEmpty {
+                    visibleStack = topEligibleVisibleCards(from: resolvedOrder)
+                } else {
+                    refillVisibleStack(&visibleStack, from: resolvedOrder)
+                }
+            }
+        } else {
+            visibleStack = (persistor.dailyVisibleStack ?? [])
                 .filter(shouldShowCard)
-                .prefix(Constants.maxVisibleCards)
-        )
-
-        if let rotatedVisibleStack = applyVisibleStackRotationIfNeeded(to: visibleStack) {
-            visibleStack = rotatedVisibleStack
-            resolvedOrder = rebuildOrderedCardIDs(resolvedOrder, applyingVisibleOrder: visibleStack)
         }
 
+        applyRotationIfNeeded(to: &visibleStack, orderedCardIDs: &resolvedOrder)
+
+        persistor.dailyVisibleStack = visibleStack
+        if isNewDay {
+            persistor.visibleStackDayIdentifier = currentDayIdentifier
+        }
         if persistor.orderedCardIDs != resolvedOrder {
             persistor.orderedCardIDs = resolvedOrder
         }
 
         persistDebugVisibleCardsIfNeeded(visibleStack)
-
         return visibleStack
     }
 
-    func applyLevelSwapIfNeeded(to orderedCards: [NewTabPageDataModel.CardID]) -> [NewTabPageDataModel.CardID] {
+    func applyLevelSwapIfNeeded(to orderedCards: inout [NewTabPageDataModel.CardID]) -> Bool {
         guard firstCardLevel == .level1,
               appearancePreferences.nextStepsCardsDemonstrationDays >= Constants.cardLevel1PriorityDays else {
-            return orderedCards
+            return false
         }
 
         firstCardLevel = .level2
-        return orderedCards
+        orderedCards = orderedCards
             .compactMap { cardID in defaultAdvancedCards.first(where: { $0.cardID == cardID }) }
             .sorted { $0.level.rawValue > $1.level.rawValue }
             .map(\.cardID)
+        return true
     }
 
-    func applyVisibleStackRotationIfNeeded(to visibleStack: [NewTabPageDataModel.CardID]) -> [NewTabPageDataModel.CardID]? {
-        guard let topCard = visibleStack.first else { return nil }
+    func topEligibleVisibleCards(from orderedCardIDs: [NewTabPageDataModel.CardID]) -> [NewTabPageDataModel.CardID] {
+        Array(
+            orderedCardIDs
+                .filter(shouldShowCard)
+                .prefix(Constants.maxVisibleCards)
+        )
+    }
+
+    func applyRotationIfNeeded(to visibleStack: inout [NewTabPageDataModel.CardID],
+                               orderedCardIDs: inout [NewTabPageDataModel.CardID]) {
+        guard let topCard = visibleStack.first else { return }
 
         let impressions = persistor.timesShown(for: topCard)
-        guard impressions > 0, impressions % Constants.maxTimesCardShown == 0 else {
-            return nil
+        guard impressions > 0, impressions.isMultiple(of: Constants.maxTimesCardShown) else { return }
+
+        visibleStack.removeFirst()
+        orderedCardIDs.removeAll { $0 == topCard }
+        orderedCardIDs.append(topCard)
+
+        if visibleStack.count < Constants.maxVisibleCards {
+            pullNextEligibleCard(into: &visibleStack, from: orderedCardIDs)
         }
 
-        var rotatedStack = visibleStack
-        let card = rotatedStack.removeFirst()
-        rotatedStack.append(card)
-
-        return rotatedStack
+        let visibleSet = Set(visibleStack)
+        let backlog = orderedCardIDs.filter { !visibleSet.contains($0) }
+        orderedCardIDs = visibleStack + backlog
     }
 
-    func rebuildOrderedCardIDs(_ orderedCardIDs: [NewTabPageDataModel.CardID],
-                               applyingVisibleOrder visibleOrder: [NewTabPageDataModel.CardID]) -> [NewTabPageDataModel.CardID] {
-        let visibleSet = Set(visibleOrder)
-        var visibleIterator = visibleOrder.makeIterator()
-
-        return orderedCardIDs.map { cardID in
-            guard visibleSet.contains(cardID) else { return cardID }
-            return visibleIterator.next() ?? cardID
+    func refillVisibleStack(_ visibleStack: inout [NewTabPageDataModel.CardID],
+                            from orderedCardIDs: [NewTabPageDataModel.CardID]) {
+        while visibleStack.count < Constants.maxVisibleCards {
+            guard pullNextEligibleCard(into: &visibleStack, from: orderedCardIDs) else {
+                break
+            }
         }
+    }
+
+    @discardableResult
+    func pullNextEligibleCard(into visibleStack: inout [NewTabPageDataModel.CardID],
+                              from orderedCardIDs: [NewTabPageDataModel.CardID]) -> Bool {
+        let visibleSet = Set(visibleStack)
+        guard let nextCard = orderedCardIDs.first(where: { shouldShowCard($0) && !visibleSet.contains($0) }) else {
+            return false
+        }
+        visibleStack.append(nextCard)
+        return true
     }
 
     func persistDebugVisibleCardsIfNeeded(_ visibleCards: [NewTabPageDataModel.CardID]) {
@@ -478,6 +520,9 @@ private extension NewTabPageNextStepsSingleCardProvider {
                         standardCards = defaultStandardCards
                     }
                 }
+                if !isNextStepsCardsComplete {
+                    appearancePreferences.continueSetUpCardsViewDidAppear()
+                }
                 // We record an impression for the visible card unconditionally when the New Tab Page is opened,
                 // not only when a new card is visible due to the card list refresh.
                 refreshCardList(updateOrder: true, recordNewCardImpression: false)
@@ -523,8 +568,18 @@ private extension NewTabPageNextStepsSingleCardProvider {
             }
             .store(in: &cancellables)
     }
+
+    func observeNextStepsCardsDebugReset() {
+        NotificationCenter.default.publisher(for: .nextStepsCardsDebugDidReset)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.cardList = []
+            }
+            .store(in: &cancellables)
+    }
 }
 
 extension Notification.Name {
     static let newTabPageOpen = Notification.Name("newTabPageOpen")
+    static let nextStepsCardsDebugDidReset = Notification.Name("nextStepsCardsDebugDidReset")
 }

--- a/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
@@ -68,13 +68,14 @@ final class NewTabPageNextStepsSingleCardProvider: NewTabPageNextStepsCardsProvi
         /// This value can be increased to allow cards to resurface after being dismissed.
         static let maxTimesCardDismissed = 1
 
-        /// Maximum times a card can be shown before it is moved to the back of the card list.
+        /// Maximum times a card can be shown before it is moved to the back of the card list, to avoid card blindness.
         static let maxTimesCardShown = 5
 
         /// How many days to prioritize Level 1 cards before highlighting Level 2 cards.
+        /// This is used with advanced ordering to swap the card order, to highlight higher impact, higher effort cards.
         static let cardLevel1PriorityDays = 2
 
-        /// Maximum number of Next Steps cards shown in the visible stack at once (advanced ordering).
+        /// Maximum number of Next Steps cards shown in the visible stack at once (advanced ordering), to avoid overwhelm.
         static let maxVisibleCards = 3
     }
 
@@ -259,8 +260,7 @@ private extension NewTabPageNextStepsSingleCardProvider {
     /// Refreshes the card list based on card visibility conditions and ordering logic.
     ///
     /// - Parameters:
-    ///   - updateOrder: When true, runs the full advanced-ordering pipeline (level swap, slice to 3, rotation).
-    ///     Only set from `newTabPageWebViewDidAppear`. Mid-session refreshes prune the current stack only.
+    ///   - updateOrder: When true, refreshes the full advanced-ordering stack (NTP appear only). Mid-session refreshes prune the current stack without reordering.
     ///   - recordNewCardImpression: Whether to record an impression for the newly visible card if the first card in the list has changed after the refresh. Defaults to true.
     func refreshCardList(updateOrder: Bool = false, recordNewCardImpression: Bool = true) {
         let cards = visibleCards(updateOrder: updateOrder)
@@ -276,12 +276,13 @@ private extension NewTabPageNextStepsSingleCardProvider {
         cardList = cards
     }
 
+    /// Returns visible cards. When `updateOrder` is true and advanced ordering is enabled, refreshes the visible stack with advanced ordering.
     func visibleCards(updateOrder: Bool) -> [NewTabPageDataModel.CardID] {
         guard shouldUseAdvancedCardOrdering else {
             return standardCards.filter(shouldShowCard)
         }
         if updateOrder {
-            return buildVisibleStackWithAdvancedOrdering()
+            return refreshVisibleStackWithAdvancedOrdering()
         } else {
             let prunedStack = cardList.filter(shouldShowCard)
             if !cardList.isEmpty, prunedStack != persistor.dailyVisibleStack {
@@ -291,11 +292,11 @@ private extension NewTabPageNextStepsSingleCardProvider {
         }
     }
 
-    /// Builds the visible stack of cards for the New Tab Page load, applying advanced ordering logic:
-    /// - Swapping card levels after a certain number of days have passed, to highlight higher impact/effort cards.
-    /// - Limiting the visible stack to a maximum number of cards, to avoid card overwhelm.
-    /// - Rotating the top card in the visible stack after a maximum number of impressions, to avoid card blindness.
-    func buildVisibleStackWithAdvancedOrdering() -> [NewTabPageDataModel.CardID] {
+    /// Refreshes the persisted visible stack for a New Tab Page appear.
+    /// Applies level swap, rotation, and day-boundary rules to reduce card blindness and overwhelm.
+    /// Reconciles stored order and `dailyVisibleStack` with current eligibility, then writes
+    /// the updated stack and order back to the persistor.
+    func refreshVisibleStackWithAdvancedOrdering() -> [NewTabPageDataModel.CardID] {
         let currentDayIdentifier = appearancePreferences.nextStepsCardsDemonstrationDays
         var resolvedOrder = persistor.orderedCardIDs ?? defaultAdvancedCards.map(\.cardID)
         let didLevelSwap = applyLevelSwapIfNeeded(to: &resolvedOrder)
@@ -303,17 +304,7 @@ private extension NewTabPageNextStepsSingleCardProvider {
         let isNewDay = persistor.visibleStackDayIdentifier != currentDayIdentifier
         var visibleStack: [NewTabPageDataModel.CardID]
         if isNewDay {
-            if didLevelSwap {
-                visibleStack = topEligibleVisibleCards(from: resolvedOrder)
-            } else {
-                visibleStack = (persistor.dailyVisibleStack ?? [])
-                    .filter(shouldShowCard)
-                if visibleStack.isEmpty {
-                    visibleStack = topEligibleVisibleCards(from: resolvedOrder)
-                } else {
-                    refillVisibleStack(&visibleStack, from: resolvedOrder)
-                }
-            }
+            visibleStack = buildStackForNewDay(didLevelSwap, resolvedOrder)
         } else {
             visibleStack = (persistor.dailyVisibleStack ?? [])
                 .filter(shouldShowCard)
@@ -345,6 +336,23 @@ private extension NewTabPageNextStepsSingleCardProvider {
             .sorted { $0.level.rawValue > $1.level.rawValue }
             .map(\.cardID)
         return true
+    }
+
+    func buildStackForNewDay(_ didLevelSwap: Bool, _ resolvedOrder: [NewTabPageDataModel.CardID]) -> [NewTabPageDataModel.CardID] {
+        guard !didLevelSwap else {
+            return topEligibleVisibleCards(from: resolvedOrder)
+        }
+
+        var visibleStack = (persistor.dailyVisibleStack ?? [])
+            .filter(shouldShowCard)
+
+        if visibleStack.isEmpty {
+            visibleStack = topEligibleVisibleCards(from: resolvedOrder)
+        } else {
+            refillVisibleStack(&visibleStack, from: resolvedOrder)
+        }
+
+        return visibleStack
     }
 
     func topEligibleVisibleCards(from orderedCardIDs: [NewTabPageDataModel.CardID]) -> [NewTabPageDataModel.CardID] {

--- a/macOS/UnitTests/NewTabPage/MockNewTabPageNextStepsCardsPersistor.swift
+++ b/macOS/UnitTests/NewTabPage/MockNewTabPageNextStepsCardsPersistor.swift
@@ -25,6 +25,8 @@ final class MockNewTabPageNextStepsCardsPersistor: NewTabPageNextStepsCardsPersi
     private var timesDismissedStorage: [NewTabPageDataModel.CardID: Int] = [:]
 
     var orderedCardIDs: [NewTabPageDataModel.CardID]?
+    var dailyVisibleStack: [NewTabPageDataModel.CardID]?
+    var visibleStackDayIdentifier: Int?
     var firstCardLevel: NewTabPageDataModel.CardLevel = .level1
     var isFirstSession: Bool = true
     var ntpImpressionCount: Int = 0
@@ -59,6 +61,8 @@ final class MockNewTabPageNextStepsCardsPersistor: NewTabPageNextStepsCardsPersi
         timesShownStorage.removeAll()
         timesDismissedStorage.removeAll()
         orderedCardIDs = nil
+        dailyVisibleStack = nil
+        visibleStackDayIdentifier = nil
         firstCardLevel = .level1
         isFirstSession = true
         ntpImpressionCount = 0

--- a/macOS/UnitTests/NewTabPage/NewTabPageNextStepsCardsPersistorTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageNextStepsCardsPersistorTests.swift
@@ -332,4 +332,38 @@ final class NewTabPageNextStepsCardsPersistorTests: XCTestCase {
         try keyValueStore.set(3, forKey: "new.tab.page.next.steps.ntp.impression.count")
         XCTAssertEqual(persistor.ntpImpressionCount, 3)
     }
+
+    // MARK: - Daily Visible Stack Tests
+
+    func testWhenNoValuesAreStoredThenDailyVisibleStackIsNil() {
+        XCTAssertNil(persistor.dailyVisibleStack)
+    }
+
+    func testWhenNoValuesAreStoredThenVisibleStackDayIdentifierIsNil() {
+        XCTAssertNil(persistor.visibleStackDayIdentifier)
+    }
+
+    func testWhenDailyVisibleStackIsSetThenValueIsStored() throws {
+        persistor.dailyVisibleStack = [.personalizeBrowser, .sync, .emailProtection]
+        XCTAssertEqual(
+            try keyValueStore.object(forKey: "new.tab.page.next.steps.daily.visible.stack") as? [String],
+            ["personalizeBrowser", "sync", "emailProtection"]
+        )
+    }
+
+    func testWhenVisibleStackDayIdentifierIsSetThenValueIsStored() throws {
+        persistor.visibleStackDayIdentifier = 3
+        XCTAssertEqual(
+            try keyValueStore.object(forKey: "new.tab.page.next.steps.visible.stack.day.identifier") as? Int,
+            3
+        )
+    }
+
+    func testWhenClearIsCalledThenDailyVisibleStackAndDayIdentifierAreRemoved() {
+        persistor.dailyVisibleStack = [.sync]
+        persistor.visibleStackDayIdentifier = 2
+        persistor.clear()
+        XCTAssertNil(persistor.dailyVisibleStack)
+        XCTAssertNil(persistor.visibleStackDayIdentifier)
+    }
 }

--- a/macOS/UnitTests/NewTabPage/NewTabPageNextStepsSingleCardProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageNextStepsSingleCardProviderTests.swift
@@ -690,10 +690,9 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
 
         triggerNewTabPageView(on: testProvider)
 
-        XCTAssertEqual(
-            testProvider.cards,
-            [.personalizeBrowser, .sync, .emailProtection]
-        )
+        XCTAssertEqual(testProvider.cards, [.personalizeBrowser, .emailProtection, .defaultApp])
+        XCTAssertEqual(persistor.dailyVisibleStack, [.personalizeBrowser, .emailProtection, .defaultApp])
+        XCTAssertEqual(persistor.visibleStackDayIdentifier, 1)
     }
 
     @MainActor
@@ -706,48 +705,46 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
         )
         triggerNewTabPageView(on: testProvider)
 
-        XCTAssertEqual(testProvider.cards, [.personalizeBrowser, .sync, .emailProtection])
+        XCTAssertEqual(testProvider.cards, [.personalizeBrowser, .emailProtection, .defaultApp])
 
         testProvider.dismiss(.personalizeBrowser)
 
-        XCTAssertEqual(testProvider.cards, [.sync, .emailProtection])
+        XCTAssertEqual(testProvider.cards, [.emailProtection, .defaultApp])
+        XCTAssertEqual(persistor.dailyVisibleStack, [.emailProtection, .defaultApp])
     }
 
     @MainActor
-    func testWhenAdvancedOrderingEnabledThenTopCardRotatesWithinVisibleStack() {
+    func testWhenAdvancedOrderingEnabledThenTopCardRotatesToBackOfFullListAndPullsNextCard() {
         featureFlagger.enabledFeatureFlags = [.nextStepsListAdvancedCardOrdering]
-        persistor.orderedCardIDs = [.personalizeBrowser, .sync, .emailProtection]
+        persistor.orderedCardIDs = [.personalizeBrowser, .sync, .emailProtection, .defaultApp, .addAppToDockMac]
         persistor.setTimesShown(NewTabPageNextStepsSingleCardProvider.Constants.maxTimesCardShown, for: .personalizeBrowser)
-        let testProvider = createProvider()
+        let testProvider = createProvider(defaultBrowserIsDefault: false, isAppStoreBuild: false)
 
         triggerNewTabPageView(on: testProvider)
 
-        XCTAssertEqual(testProvider.cards, [.sync, .emailProtection, .personalizeBrowser])
-        XCTAssertEqual(
-            persistor.orderedCardIDs,
-            [.sync, .emailProtection, .personalizeBrowser]
-        )
+        XCTAssertEqual(testProvider.cards, [.sync, .emailProtection, .defaultApp])
+        XCTAssertEqual(persistor.orderedCardIDs, [.sync, .emailProtection, .defaultApp, .addAppToDockMac, .personalizeBrowser])
+        XCTAssertEqual(persistor.dailyVisibleStack, [.sync, .emailProtection, .defaultApp])
     }
 
     @MainActor
-    func testWhenAdvancedOrderingEnabledThenTwoCardStackRotatesInPlace() {
+    func testWhenAdvancedOrderingEnabledThenTwoCardStackRotationPullsFromBacklog() {
         featureFlagger.enabledFeatureFlags = [.nextStepsListAdvancedCardOrdering]
-        persistor.orderedCardIDs = [.sync, .emailProtection, .personalizeBrowser]
+        persistor.orderedCardIDs = [.sync, .emailProtection, .personalizeBrowser, .defaultApp]
+        persistor.dailyVisibleStack = [.sync, .emailProtection]
+        persistor.visibleStackDayIdentifier = 1
         persistor.setTimesDismissed(1, for: .personalizeBrowser)
         persistor.setTimesShown(NewTabPageNextStepsSingleCardProvider.Constants.maxTimesCardShown, for: .sync)
-        let testProvider = createProvider()
+        let testProvider = createProvider(defaultBrowserIsDefault: false)
 
         triggerNewTabPageView(on: testProvider)
 
-        XCTAssertEqual(testProvider.cards, [.emailProtection, .sync])
-        XCTAssertEqual(
-            persistor.orderedCardIDs,
-            [.emailProtection, .sync, .personalizeBrowser]
-        )
+        XCTAssertEqual(testProvider.cards, [.emailProtection, .defaultApp])
+        XCTAssertEqual(persistor.orderedCardIDs, [.emailProtection, .defaultApp, .personalizeBrowser, .sync])
     }
 
     @MainActor
-    func testWhenAdvancedOrderingEnabledThenNTPLoadRefillsToThreeCards() {
+    func testWhenAdvancedOrderingEnabledThenSameDayNTPRevisitDoesNotRefillDismissedSlots() {
         featureFlagger.enabledFeatureFlags = [.nextStepsListAdvancedCardOrdering]
         persistor.orderedCardIDs = nil
         let testProvider = createProvider(
@@ -758,11 +755,45 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
         triggerNewTabPageView(on: testProvider)
         testProvider.dismiss(.personalizeBrowser)
 
-        XCTAssertEqual(testProvider.cards, [.sync, .emailProtection])
+        XCTAssertEqual(testProvider.cards, [.emailProtection, .defaultApp])
 
         triggerNewTabPageView(on: testProvider)
 
-        XCTAssertEqual(testProvider.cards, [.sync, .emailProtection, .defaultApp])
+        XCTAssertEqual(testProvider.cards, [.emailProtection, .defaultApp])
+    }
+
+    @MainActor
+    func testWhenAdvancedOrderingEnabledThenNewActiveUsageDayRefillsToThreeCards() {
+        featureFlagger.enabledFeatureFlags = [.nextStepsListAdvancedCardOrdering]
+        persistor.orderedCardIDs = nil
+        persistor.firstCardLevel = .level2
+        let mockAppearancePersistor = MockAppearancePreferencesPersistor(
+            continueSetUpCardsLastDemonstrated: Date(),
+            continueSetUpCardsNumberOfDaysDemonstrated: 2
+        )
+        let testAppearancePreferences = AppearancePreferences(
+            persistor: mockAppearancePersistor,
+            privacyConfigurationManager: MockPrivacyConfigurationManager(),
+            dateTimeProvider: { Date() },
+            featureFlagger: MockFeatureFlagger(),
+            aiChatMenuConfig: MockAIChatConfig()
+        )
+        let testProvider = createProvider(
+            defaultBrowserIsDefault: false,
+            appearancePreferences: testAppearancePreferences,
+            adBlockingAvailability: MockAdBlockingAvailability(isFeatureSupported: true, isEnabledByUser: true),
+            isAppStoreBuild: false
+        )
+        triggerNewTabPageView(on: testProvider)
+        testProvider.dismiss(.personalizeBrowser)
+
+        XCTAssertEqual(testProvider.cards, [.emailProtection, .defaultApp])
+
+        mockAppearancePersistor.continueSetUpCardsNumberOfDaysDemonstrated = 3
+        triggerNewTabPageView(on: testProvider)
+
+        XCTAssertEqual(testProvider.cards, [.emailProtection, .defaultApp, .youtubeAdBlocking])
+        XCTAssertEqual(persistor.visibleStackDayIdentifier, 3)
     }
 
     @MainActor
@@ -775,8 +806,8 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
         )
         triggerNewTabPageView(on: testProvider)
         testProvider.dismiss(.personalizeBrowser)
-        testProvider.dismiss(.sync)
         testProvider.dismiss(.emailProtection)
+        testProvider.dismiss(.defaultApp)
 
         XCTAssertTrue(testProvider.cards.isEmpty)
         XCTAssertFalse(appearancePreferences.continueSetUpCardsClosed)
@@ -811,7 +842,7 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
             isAppStoreBuild: false
         )
         triggerNewTabPageView(on: testProvider)
-        let expectedCards: [NewTabPageDataModel.CardID] = [.personalizeBrowser, .sync, .emailProtection]
+        let expectedCards: [NewTabPageDataModel.CardID] = [.personalizeBrowser, .emailProtection, .defaultApp]
 
         XCTAssertEqual(testProvider.cards, expectedCards)
     }
@@ -824,7 +855,7 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
             isAppStoreBuild: true
         )
         triggerNewTabPageView(on: testProvider)
-        let expectedCards: [NewTabPageDataModel.CardID] = [.personalizeBrowser, .sync, .emailProtection]
+        let expectedCards: [NewTabPageDataModel.CardID] = [.personalizeBrowser, .emailProtection, .defaultApp]
 
         XCTAssertEqual(testProvider.cards, expectedCards)
     }
@@ -862,7 +893,7 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
         triggerNewTabPageView(on: testProvider)
 
         let cards = testProvider.cards
-        XCTAssertEqual(cards, [.personalizeBrowser, .sync, .emailProtection])
+        XCTAssertEqual(cards, [.personalizeBrowser, .emailProtection, .defaultApp])
     }
 
     func testWhenFirstCardLevelIsLevel1AndDaysGreaterThanOrEqualToMaxDays_WithAdvancedOrderingEnabled_ThenLevel2CardsFirst() throws {
@@ -872,12 +903,14 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
         let testProvider = createProvider(
             defaultBrowserIsDefault: false,
             appearancePreferences: testAppearancePrefs,
-            adBlockingAvailability: MockAdBlockingAvailability(isFeatureSupported: true, isEnabledByUser: true)
+            adBlockingAvailability: MockAdBlockingAvailability(isFeatureSupported: true, isEnabledByUser: true),
+            isAppStoreBuild: false
         )
         triggerNewTabPageView(on: testProvider)
 
-        XCTAssertEqual(testProvider.cards.first, .defaultApp)
-        XCTAssertEqual(persistor.firstCardLevel, .level2, "firstCardLevel should be updated when swap occurs")
+        XCTAssertEqual(testProvider.cards, [.defaultApp, .youtubeAdBlocking, .addAppToDockMac])
+        XCTAssertEqual(persistor.dailyVisibleStack, [.defaultApp, .youtubeAdBlocking, .addAppToDockMac])
+        XCTAssertEqual(persistor.firstCardLevel, .level2)
     }
 
     func testWhenLevelOrderSwaps_WithAdvancedOrderingEnabled_ThenOrderIsPersisted() {
@@ -892,9 +925,10 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
 
         triggerNewTabPageView(on: testProvider)
 
-        let expectedCards: [NewTabPageDataModel.CardID] = [.defaultApp, .addAppToDockMac, .youtubeAdBlocking, .bringStuff, .subscription, .personalizeBrowser, .sync, .emailProtection]
+        let expectedCards: [NewTabPageDataModel.CardID] = [.defaultApp, .youtubeAdBlocking, .addAppToDockMac, .bringStuff, .subscription, .personalizeBrowser, .emailProtection, .sync]
 
         XCTAssertEqual(persistor.orderedCardIDs, expectedCards, "Order should be persisted after swap")
+        XCTAssertEqual(testProvider.cards, [.defaultApp, .youtubeAdBlocking, .addAppToDockMac])
     }
 
     func testWhenDefaultOrderIsUsed_WithAdvancedOrderingEnabled_ThenOrderIsPersisted() {
@@ -1211,5 +1245,5 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
 extension NewTabPageNextStepsSingleCardProvider {
     static let defaultStandardCards: [NewTabPageDataModel.CardID] = [.emailProtection, .defaultApp, .addAppToDockMac, .bringStuff, .subscription, .personalizeBrowser, .sync]
 
-    static let defaultAdvancedCards: [NewTabPageDataModel.CardID] = [.personalizeBrowser, .sync, .emailProtection, .defaultApp, .addAppToDockMac, .youtubeAdBlocking, .bringStuff, .subscription]
+    static let defaultAdvancedCards: [NewTabPageDataModel.CardID] = [.personalizeBrowser, .emailProtection, .defaultApp, .youtubeAdBlocking, .addAppToDockMac, .bringStuff, .sync, .subscription]
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1216275443603476?focus=true
Tech Design URL:
CC:

### Description

Changes to Next Steps cards based on ship review feedback:

1. Only 3 cards are included in the card list **per active usage day** (previously per New Tab Page load). If all cards are dismissed or the call to action is performed, the list remains empty until the next day.
   - The active card stack and its corresponding active usage day are persisted across app launches
   - When the current active usage day changes, the active stack is refilled to 3 cards
   - When the card levels swap, the active card stack is replaced with the first 3 eligible level 2 cards
3. When the visible card has 5 impressions, it is moved to the back of the complete card stack (and the next eligible card is added to the current day's stack).
   - This rotation retains the current number of cards left in the active card stack (there will always be 3 cards available for the user to interact with per active usage day)
   - This prevents the same 3 cards from rotating endlessly within a day (eventually it will rotate through all eligible cards)
5. The default card order is updated (no change to card levels): _Personalize, Email Protection, Set Default, Youtube Ad Blocking, Add to Dock, Import, Sync, Subscription_

Debug menu actions are also updated to facilitate manual testing.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Go to Debug menu → New Tab Page → Reset Next Steps.
2. Open the New Tab Page and the first 3 Next Steps cards will be in the stack (Personalize, Email Protection, Set Default).
3. Open a new window, or open a website and then reopen the New Tab Page. This reloads the New Tab Page with the same stack of Next Steps cards.
4. Dismiss all 3 cards and confirm no new cards appear after the first 3.
5. Open a new window, or open a website and then reopen the New Tab Page. Confirm no new cards appear.
6. Go to Debug menu → New Tab Page → Shift New Tab daily impression. Confirm a new stack of the next 3 eligible cards appears.
7. Use the Debug menu → New Tab Page items to simulate other behavior:
   - Shift top card by 5 impressions: Simulates viewing the same card 5 times in a row. The top card is rotated to the end of the full stack of eligible cards and the next card is shown.
   - Shift New Tab daily impression: Simulates time moving forward a day, i.e. using the New Tab Page on another day. On the third day, the cards are reordered to highlight level 2 cards. (Reset Next Steps first before testing this, to see the reordering clearly.)
   - Shift 14 days: Simulates 14 days of using the New Tab Page, after which any visible cards are permanently hidden. You can use _Shift New Tab daily impression_ to confirm the cards don't reappear on any subsequent days after this.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Medium: Could disrupt specific features or user flows

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
- New card ordering logic is covered with unit tests and debug menu actions match production behavior (with time travel) for manually testing expected results.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes onboarding UX and persisted NTP card state across launches; logic is covered by unit tests but wrong day/stack behavior could confuse users or hide cards incorrectly.
> 
> **Overview**
> **Next Steps (advanced ordering)** now keeps a **fixed stack of up to three cards per active usage day**, persisted via `dailyVisibleStack` and `visibleStackDayIdentifier`, instead of rebuilding the visible three on every New Tab Page load. Mid-session dismissals only prune that stack; refills to three happen on a **new usage day** (or when level-2 swap replaces the day’s stack). After **five impressions** on the top card, it moves to the **back of the full ordered list** and the next eligible card is pulled in so the daily stack stays at three when possible.
> 
> The **default advanced card order** changes (e.g. Sync later; Personalize → Email → Set Default as the initial trio). **Debug reset** clears debug overrides earlier, posts `nextStepsCardsDebugDidReset`, and triggers NTP refresh via `newTabPageWebViewDidAppear`; **shift card impression** uses the same appear signal instead of window key.
> 
> Unit tests and the mock persistor are updated for the new persistence and rotation/day-boundary behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ced8fd2773645f106446475fc4770dc544d48d87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->