### PR TITLE
[iOS] Suppress file protection errors in the VPN

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Configuration/Configuration+FileReadError.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Configuration/Configuration+FileReadError.swift
@@ -1,0 +1,30 @@
+//
+//  Configuration+FileReadError.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+extension Configuration {
+
+    /// Whether a file-read error hit while loading a configuration file is an expected, transient condition rather than a genuine load failure worth investigating.
+    public static func isExpectedFileReadError(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        guard nsError.domain == NSCocoaErrorDomain else { return false }
+        return nsError.code == NSFileReadNoSuchFileError
+            || nsError.code == NSFileReadNoPermissionError
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Tests/ConfigurationTests/ConfigurationFileReadErrorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/ConfigurationTests/ConfigurationFileReadErrorTests.swift
@@ -1,0 +1,47 @@
+//
+//  ConfigurationFileReadErrorTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import Configuration
+
+final class ConfigurationFileReadErrorTests: XCTestCase {
+
+    func testWhenFileDoesNotExistThenErrorIsExpected() {
+        // The configuration simply hasn't been downloaded yet.
+        let error = NSError(domain: NSCocoaErrorDomain, code: NSFileReadNoSuchFileError)
+        XCTAssertTrue(Configuration.isExpectedFileReadError(error))
+    }
+
+    func testWhenFileIsUnreadableDueToDataProtectionThenErrorIsExpected() {
+        // A background reader (e.g. the VPN extension) hit the file while iOS Data
+        // Protection had it locked - device locked or before first unlock. Transient.
+        let error = NSError(domain: NSCocoaErrorDomain, code: NSFileReadNoPermissionError)
+        XCTAssertTrue(Configuration.isExpectedFileReadError(error))
+    }
+
+    func testWhenFileIsCorruptThenErrorIsNotExpected() {
+        // A genuine load failure the reporting exists to catch.
+        let error = NSError(domain: NSCocoaErrorDomain, code: NSFileReadCorruptFileError)
+        XCTAssertFalse(Configuration.isExpectedFileReadError(error))
+    }
+
+    func testWhenErrorIsNotACocoaErrorThenItIsNotExpected() {
+        let error = NSError(domain: NSPOSIXErrorDomain, code: 1)
+        XCTAssertFalse(Configuration.isExpectedFileReadError(error))
+    }
+}

--- a/iOS/PacketTunnelProvider/NetworkProtection/ConfigurationStore.swift
+++ b/iOS/PacketTunnelProvider/NetworkProtection/ConfigurationStore.swift
@@ -60,9 +60,7 @@ struct ConfigurationStore: ConfigurationStoring {
             do {
                 data = try Data(contentsOf: fileUrl)
             } catch {
-                let nserror = error as NSError
-
-                if nserror.domain != NSCocoaErrorDomain || nserror.code != NSFileReadNoSuchFileError {
+                if !Configuration.isExpectedFileReadError(error) {
                     let pixel = Pixel.Event.couldNotLoadConfiguration(configuration: configuration, target: .vpn)
                     DailyPixel.fireDailyAndCount(pixel: pixel, error: error)
                 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1216280385065820?focus=true
Tech Design URL:
CC:

### Description

This PR updates the VPN to filter out an error that happens when the device is locked. This happens most often after an OS update, where the user's device restarts automatically.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that the VPN connects and works as expected

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only error classification and pixel firing in the VPN extension; genuine load failures (e.g. corrupt files) still report.
> 
> **Overview**
> Reduces noisy VPN telemetry when configuration files cannot be read for **transient, expected** reasons (not yet downloaded, or blocked by iOS Data Protection while the device is locked).
> 
> Adds shared **`Configuration.isExpectedFileReadError`** in BrowserServicesKit, treating `NSFileReadNoSuchFileError` and `NSFileReadNoPermissionError` as expected. The VPN **`ConfigurationStore.loadData`** now skips firing `couldNotLoadConfiguration` pixels for those cases instead of only ignoring missing files. Unit tests document which Cocoa errors are filtered vs still reported (e.g. corrupt files).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cb1b875ecb1c718ecaeeeeb981cc6449133b8ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->