### PR TITLE
[macOS] Split UI Tests matrix by user mode to stay under 256-config limit

### DIFF
--- a/.github/workflows/macos_run_ui_test.yml
+++ b/.github/workflows/macos_run_ui_test.yml
@@ -327,11 +327,15 @@ jobs:
       working-directory: macOS
       run: |
         test_id="${{ inputs.test }} (macOS ${{ inputs.os-version }}${{ inputs.user-mode == 'internal' && ' / internal' || '' }})"
-        file="${test_id}.xml"
+        # The report filename must not contain '/', which is a path separator: the internal-mode
+        # suffix (' / internal') would otherwise make xcbeautify write to a non-existent directory.
+        # Sanitize the filename while keeping '/' in test_id for the human-readable suite name below.
+        file="${test_id//\//-}.xml"
         echo "file=$file" >> $GITHUB_OUTPUT
         xcbeautify --report junit --report-path . --junit-report-filename "$file" < ui-tests.log
-        # Replace the default test suite name with the test id for better grouping in the test report
-        sed -i '' "s/Selected tests/${test_id}/" "$file"
+        # Replace the default test suite name with the test id for better grouping in the test report.
+        # Use '#' as the sed delimiter since test_id may contain '/'.
+        sed -i '' "s#Selected tests#${test_id}#" "$file"
 
     # Upload test report as artifact for the test-report job
     # that publishes a combined report for all test cases

--- a/.github/workflows/macos_run_ui_test.yml
+++ b/.github/workflows/macos_run_ui_test.yml
@@ -1,0 +1,404 @@
+name: macOS - Run UI Test
+
+# Reusable helper that runs a single UITestCase class, on one runner, in one user mode.
+# Called by macos_ui_tests.yml once per (runner × test) matrix combination, per user-mode leg.
+# Splitting the UI Tests matrix into per-user-mode legs that each call this workflow keeps every
+# leg under GitHub's 256-configuration matrix limit (3 runners × ~55 tests = 165 per leg) while
+# defining the run steps only once.
+
+defaults:
+  run:
+    working-directory: macOS
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: "Runner label to run on (e.g. 'macos-26-xlarge')"
+        required: true
+        type: string
+      os-version:
+        description: "macOS version of the runner (e.g. '26'). Used for names and conditional steps."
+        required: true
+        type: string
+      xcode-version:
+        description: "Xcode version to select (e.g. '26.4')"
+        required: true
+        type: string
+      test:
+        description: "The UITestCase class to run"
+        required: true
+        type: string
+      user-mode:
+        description: "'production' = production behaviour (release-gating). 'internal' = isInternalUser=true (advance warning, non-gating)."
+        required: true
+        type: string
+      build-type:
+        description: "Build type: 'dmg' for Developer ID DMG app, 'appstore' for sandboxed App Store app"
+        required: false
+        type: string
+        default: dmg
+      branch:
+        description: "Ref to check out. Caller should pass its own 'inputs.branch || github.sha'."
+        required: true
+        type: string
+
+jobs:
+  run-ui-test:
+    name: ${{ inputs.test }} (macOS ${{ inputs.os-version }}${{ inputs.user-mode == 'internal' && ' / internal' || '' }})
+    runs-on: ${{ inputs.runner }}
+
+    # Internal-mode failures are advance warning for features still gated to internal users; they
+    # must not fail the overall workflow. Setting continue-on-error here (a normal job inside the
+    # reusable workflow) is what makes the calling leg pass on internal failures — a job that
+    # `uses:` a reusable workflow cannot set continue-on-error itself.
+    continue-on-error: ${{ inputs.user-mode == 'internal' }}
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.runner }}-${{ inputs.test }}-${{ inputs.user-mode }}-${{ inputs.build-type }}
+      cancel-in-progress: true
+
+    timeout-minutes: 120
+
+    env:
+      scheme: ${{ inputs.build-type == 'appstore' && 'macOS UI Tests App Store CI' || 'macOS UI Tests CI' }}
+      app-name: ${{ inputs.build-type == 'appstore' && 'DuckDuckGo App Store Review' || 'DuckDuckGo Review' }}
+      app-bundle-id: ${{ inputs.build-type == 'appstore' && 'com.duckduckgo.mobile.ios.review' || 'com.duckduckgo.macos.browser.review' }}
+      release-type: ${{ inputs.build-type == 'appstore' && 'sandbox-review' || 'review' }}
+      extra-xcargs: ${{ inputs.build-type == 'appstore' && 'UI_TESTS_TARGET_APP=sandbox' || '' }}
+
+    steps:
+    - name: Register SSH keys for private repos
+      uses: webfactory/ssh-agent@v0.9.1
+      with:
+        ssh-private-key: |
+          ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
+          ${{ secrets.SSH_PRIVATE_KEY_DUCKSANS_FONT }}
+
+    - name: Check out the code
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ inputs.branch }}
+
+    - name: Initialize submodules with retry
+      run: |
+        max_attempts=3
+        retry_delay=15
+        for attempt in $(seq 1 $max_attempts); do
+          echo "Submodule init attempt $attempt of $max_attempts"
+          if git submodule update --init --recursive; then
+            echo "Submodules initialized successfully"
+            exit 0
+          fi
+          if [[ $attempt -lt $max_attempts ]]; then
+            echo "Failed, retrying in ${retry_delay}s..."
+            sleep $retry_delay
+          fi
+        done
+        echo "All submodule init attempts failed"
+        exit 1
+
+    - name: Install screenresolution
+      if: inputs.os-version != '14'
+      run: brew install screenresolution
+
+    - name: Change screen resolution
+      if: inputs.os-version != '14'
+      run: screenresolution set 1920x1080x32@60
+
+    - name: Setup Ruby and dependencies
+      uses: ./.github/actions/setup-ruby
+      with:
+        working-directory: macOS
+        cache-key-prefix: macos-ruby
+
+    - name: Create Default Keychain
+      run: bundle exec fastlane create_keychain_ui_tests
+
+    - name: Sync code signing assets
+      id: sync-signing-first-attempt
+      continue-on-error: true
+      env:
+        APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+        APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+        APPLE_API_KEY_ISSUER: ${{ secrets.APPLE_API_KEY_ISSUER }}
+        MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+        SSH_PRIVATE_KEY_FASTLANE_MATCH: ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
+      run: |
+        bundle exec fastlane sync_signing_ci
+
+    - name: Retry sync code signing assets
+      if: steps.sync-signing-first-attempt.outcome == 'failure'
+      env:
+        APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+        APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+        APPLE_API_KEY_ISSUER: ${{ secrets.APPLE_API_KEY_ISSUER }}
+        MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+        SSH_PRIVATE_KEY_FASTLANE_MATCH: ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
+      run: |
+        echo "First attempt to sync code signing assets failed. Retrying..."
+        bundle exec fastlane sync_signing_ci
+
+    - name: Download and unzip artifact
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        max_attempts=3
+        retry_delay=10
+
+        for attempt in $(seq 1 $max_attempts); do
+          echo "Attempt $attempt of $max_attempts"
+          rm -rf build-download-temp
+          mkdir build-download-temp
+          if gh run download "${{ github.run_id }}" --dir build-download-temp; then
+            echo "Download successful"
+            mv build-download-temp/* .
+            rm -rf build-download-temp
+            exit 0
+          fi
+          rm -rf build-download-temp
+          if [[ $attempt -lt $max_attempts ]]; then
+            echo "Download failed, retrying in ${retry_delay}s..."
+            sleep $retry_delay
+            retry_delay=$((retry_delay * 2))
+          fi
+        done
+        echo "All download attempts failed"
+        exit 1
+
+    - name: Set cache key hash
+      run: |
+        has_only_tags=$(jq '[ .pins[].state | has("version") ] | all' DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved)
+        if [[ "$has_only_tags" == "true" ]]; then
+          echo "cache_key_hash=${{ hashFiles('macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}" >> $GITHUB_ENV
+        else
+          echo "Package.resolved contains dependencies specified by branch or commit, skipping cache."
+        fi
+
+    - name: Cache SPM
+      if: env.cache_key_hash
+      uses: actions/cache@v4
+      with:
+        path: macOS/DerivedData/SourcePackages
+        key: ${{ runner.os }}-macos-${{ env.cache_key_hash }}
+        restore-keys: |
+          ${{ runner.os }}-macos-
+
+    - name: Select Xcode
+      uses: ./.github/actions/select-xcode-version
+      with:
+        xcode-version: ${{ inputs.xcode-version }}
+
+    - name: Configure system logging
+      working-directory: SharedPackages/BrowserServicesKit
+      run: |
+        sudo cp com.apple.system.logging.plist /Library/Preferences/Logging/com.apple.system.logging.plist
+        sudo killall logd || true
+
+    - name: Start log stream in background
+      working-directory: macOS
+      run: |
+        log stream --debug --info --predicate 'process == "${{ env.app-name }}" OR process == "UI Tests-Runner"' --style syslog > app-console.log 2>&1 &
+        echo $! > log_stream.pid
+
+    - name: Resolve package dependencies
+      working-directory: macOS
+      run: |
+        max_attempts=5
+        retry_delay=10
+
+        for attempt in $(seq 1 $max_attempts); do
+          echo "Attempt $attempt of $max_attempts"
+          if xcodebuild -resolvePackageDependencies \
+            -scheme "${{ env.scheme }}" \
+            -derivedDataPath DerivedData \
+            2>&1 | tee resolve.log; then
+            echo "Package resolution succeeded"
+            exit 0
+          fi
+
+          if [[ $attempt -lt $max_attempts ]]; then
+            echo "Package resolution failed (attempt $attempt), retrying in ${retry_delay}s..."
+            sleep $retry_delay
+          fi
+        done
+        echo "Package resolution failed after $max_attempts attempts"
+        exit 1
+
+    - name: Restore Xcode Compilation Cache
+      uses: actions/cache/restore@v4
+      with:
+        path: macOS/DerivedData/CompilationCache.noindex
+        key: xcode-compilation-cache-ui-tests
+        restore-keys: |
+          xcode-compilation-cache-ui-tests-
+
+    - name: Build for testing
+      working-directory: macOS
+      run: |
+        set -o pipefail && xcodebuild build-for-testing \
+          -scheme "${{ env.scheme }}" \
+          -derivedDataPath DerivedData \
+          -skipPackagePluginValidation \
+          -skipMacroValidation \
+          COMPILATION_CACHE_ENABLE_CACHING=YES \
+          OTHER_CODE_SIGN_FLAGS=--timestamp=none \
+          ${{ env.extra-xcargs }} \
+        | tee xcodebuild.log \
+        | xcbeautify
+
+    - name: Compute Compilation Cache hash
+      if: github.ref == 'refs/heads/main'
+      id: compilation-cache-hash
+      run: |
+        if [ -d "DerivedData/CompilationCache.noindex" ]; then
+          hash=$(find DerivedData/CompilationCache.noindex -type f \( -name "*.index" -o -name "*.actions" \) 2>/dev/null | sort | xargs cat | shasum -a 256 | cut -d' ' -f1)
+          echo "hash=${hash}" >> $GITHUB_OUTPUT
+        else
+          echo "No compilation cache directory found (Xcode version may not support compilation caching)"
+        fi
+
+    - name: Save Xcode Compilation Cache
+      if: github.ref == 'refs/heads/main' && steps.compilation-cache-hash.outputs.hash
+      uses: actions/cache/save@v4
+      with:
+        path: macOS/DerivedData/CompilationCache.noindex
+        key: xcode-compilation-cache-ui-tests-${{ steps.compilation-cache-hash.outputs.hash }}
+
+    - name: Extract and Copy app to /DerivedData
+      working-directory: macOS
+      run: |
+        cd DuckDuckGo-${{ env.release-type }}-*.app.tar.xz && tar -xf DuckDuckGo-*.app.tar.xz
+
+        # Find the extracted app bundle and rename if needed
+        extracted_app=$(find . -maxdepth 1 -name "*.app" -type d | head -1)
+        if [[ -n "${extracted_app}" ]]; then
+          extracted_app_name=$(basename "${extracted_app}")
+          if [[ "${extracted_app_name}" != "${{ env.app-name }}.app" ]]; then
+            echo "Renaming extracted app from '${extracted_app_name}' to '${{ env.app-name }}.app'"
+            mv "${extracted_app}" "${{ env.app-name }}.app"
+          fi
+        fi
+
+        mv -f "${{ env.app-name }}.app" "../DerivedData/Build/Products/Review/${{ env.app-name }}.app"
+
+    - name: Run UI Tests
+      id: run-ui-tests
+      working-directory: macOS
+      run: |
+        defaults write ${{ env.app-bundle-id }} moveToApplicationsFolderAlertSuppress 1
+        set -o pipefail && xcodebuild test-without-building \
+          -scheme "${{ env.scheme }}" \
+          -derivedDataPath DerivedData \
+          -skipPackagePluginValidation \
+          -skipMacroValidation \
+          -test-iterations 2 \
+          -retry-tests-on-failure \
+          -test-repetition-relaunch-enabled YES \
+          '-only-testing:UI Tests/${{ inputs.test }}' \
+          ${{ env.extra-xcargs }} \
+          "TEST_RUNNER_INTERNAL_USER_MODE=${{ inputs.user-mode == 'internal' && 'true' || 'false' }}" \
+        | tee -a xcodebuild.log \
+        | tee ui-tests.log
+
+    - name: Stop log stream
+      if: always()
+      working-directory: macOS
+      run: |
+        if [ -f log_stream.pid ]; then
+          kill $(cat log_stream.pid) || true
+        fi
+
+    - name: Check for test failures
+      id: check-failures
+      if: always()
+      working-directory: macOS
+      run: |
+        if grep -Eq 'XCTAssert.*failed|Test Case.*failed|Testing failed:' ui-tests.log; then
+          echo "had_failures=true" >> $GITHUB_OUTPUT
+          echo "⚠️ Detected test failures in the log (may have passed on retry)"
+        else
+          echo "had_failures=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Prepare test report
+      id: prepare-test-report
+      if: always() && steps.run-ui-tests.outcome != 'skipped'
+      working-directory: macOS
+      run: |
+        test_id="${{ inputs.test }} (macOS ${{ inputs.os-version }}${{ inputs.user-mode == 'internal' && ' / internal' || '' }})"
+        file="${test_id}.xml"
+        echo "file=$file" >> $GITHUB_OUTPUT
+        xcbeautify --report junit --report-path . --junit-report-filename "$file" < ui-tests.log
+        # Replace the default test suite name with the test id for better grouping in the test report
+        sed -i '' "s/Selected tests/${test_id}/" "$file"
+
+    # Upload test report as artifact for the test-report job
+    # that publishes a combined report for all test cases
+    - name: Upload test report
+      uses: actions/upload-artifact@v4
+      if: always() && steps.run-ui-tests.outcome != 'skipped'
+      with:
+        name: "testreport-${{ inputs.test }}-macos${{ inputs.os-version }}-${{ inputs.user-mode }}"
+        path: "macOS/${{ steps.prepare-test-report.outputs.file }}"
+        retention-days: 1
+
+    - name: Upload xcresult files (passed on retry)
+      uses: actions/upload-artifact@v4
+      if: always() && steps.check-failures.outputs.had_failures == 'true' && steps.run-ui-tests.outcome == 'success'
+      with:
+        name: "xcresult-${{ inputs.test }}-macos${{ inputs.os-version }}-${{ inputs.user-mode }}"
+        path: "macOS/DerivedData/Logs/Test/*.xcresult"
+        retention-days: 1
+
+    - name: Upload app console log (passed on retry)
+      uses: actions/upload-artifact@v4
+      if: always() && steps.check-failures.outputs.had_failures == 'true' && steps.run-ui-tests.outcome == 'success'
+      with:
+        name: "app-console-${{ inputs.test }}-macos${{ inputs.os-version }}-${{ inputs.user-mode }}"
+        path: "macOS/app-console.log"
+        if-no-files-found: warn
+        retention-days: 1
+
+    - name: Mark user-mode failure
+      if: failure() || cancelled()
+      working-directory: ${{ github.workspace }}
+      run: |
+        mkdir -p failure-marker
+        echo "macos-ui:${{ inputs.user-mode }}:${{ inputs.test }}:${{ inputs.os-version }}" > failure-marker/marker.txt
+    - name: Upload failure marker
+      if: failure() || cancelled()
+      uses: actions/upload-artifact@v4
+      with:
+        name: failure-marker-macos-ui-${{ inputs.user-mode }}-${{ inputs.test }}-${{ inputs.os-version }}
+        path: failure-marker/
+        retention-days: 1
+
+    - name: Organize logs for upload
+      if: failure() || cancelled()
+      working-directory: macOS
+      run: |
+        echo "Current working directory: $(pwd)"
+
+        # Create staging directory with timestamp, OS version and failing test name
+        timestamp=$(date +"%Y-%m-%d_%H-%M-%S")
+        archive_name="BuildLogs ${{ inputs.test }} (macOS ${{ inputs.os-version }}${{ inputs.user-mode == 'internal' && ' internal' || '' }}) ${timestamp}"
+        echo "Creating archive directory: $archive_name"
+        mkdir -p "$archive_name"
+
+        # locate and copy all files, flattening the structure with verbose output
+        cp "xcodebuild.log" "$archive_name/" || echo "No xcodebuild.log found"
+        cp "app-console.log" "$archive_name/" || echo "No app-console.log found"
+        find DerivedData/Logs/Test -name "*.xcresult" -print -exec cp -rf {} "$archive_name/" \; 2>&1 || echo "No .xcresult files found"
+        cp -rf ~/Library/Logs/DiagnosticReports "$archive_name/" || echo "No DiagnosticReports found"
+
+        # Store archive name for upload step
+        echo "ARCHIVE_NAME=$archive_name" >> $GITHUB_ENV
+
+    - name: Upload logs when workflow failed
+      uses: actions/upload-artifact@v4
+      if: failure() || cancelled()
+      with:
+        name: "${{ env.ARCHIVE_NAME }}"
+        path: "macOS/${{ env.ARCHIVE_NAME }}"
+        retention-days: 7

--- a/.github/workflows/macos_run_ui_test.yml
+++ b/.github/workflows/macos_run_ui_test.yml
@@ -3,8 +3,7 @@ name: macOS - Run UI Test
 # Reusable helper that runs a single UITestCase class, on one runner, in one user mode.
 # Called by macos_ui_tests.yml once per (runner × test) matrix combination, per user-mode leg.
 # Splitting the UI Tests matrix into per-user-mode legs that each call this workflow keeps every
-# leg under GitHub's 256-configuration matrix limit (3 runners × ~55 tests = 165 per leg) while
-# defining the run steps only once.
+# leg under GitHub's 256-configuration matrix limit while defining the run steps only once.
 
 defaults:
   run:

--- a/.github/workflows/macos_run_ui_test.yml
+++ b/.github/workflows/macos_run_ui_test.yml
@@ -45,7 +45,10 @@ on:
 
 jobs:
   run-ui-test:
-    name: ${{ inputs.test }} (macOS ${{ inputs.os-version }}${{ inputs.user-mode == 'internal' && ' / internal' || '' }})
+    # Avoid '/' in the job name: GitHub joins the reusable-workflow job name onto the caller with
+    # ' / ' and the UI splits that path on ' / ', so a '/' here would break the name into fake tree
+    # nodes. It is also used to build the report filename, where '/' is a path separator.
+    name: ${{ inputs.test }} (macOS ${{ inputs.os-version }}${{ inputs.user-mode == 'internal' && ', internal' || '' }})
     runs-on: ${{ inputs.runner }}
 
     # Internal-mode failures are advance warning for features still gated to internal users; they
@@ -326,16 +329,12 @@ jobs:
       if: always() && steps.run-ui-tests.outcome != 'skipped'
       working-directory: macOS
       run: |
-        test_id="${{ inputs.test }} (macOS ${{ inputs.os-version }}${{ inputs.user-mode == 'internal' && ' / internal' || '' }})"
-        # The report filename must not contain '/', which is a path separator: the internal-mode
-        # suffix (' / internal') would otherwise make xcbeautify write to a non-existent directory.
-        # Sanitize the filename while keeping '/' in test_id for the human-readable suite name below.
-        file="${test_id//\//-}.xml"
+        test_id="${{ inputs.test }} (macOS ${{ inputs.os-version }}${{ inputs.user-mode == 'internal' && ', internal' || '' }})"
+        file="${test_id}.xml"
         echo "file=$file" >> $GITHUB_OUTPUT
         xcbeautify --report junit --report-path . --junit-report-filename "$file" < ui-tests.log
-        # Replace the default test suite name with the test id for better grouping in the test report.
-        # Use '#' as the sed delimiter since test_id may contain '/'.
-        sed -i '' "s#Selected tests#${test_id}#" "$file"
+        # Replace the default test suite name with the test id for better grouping in the test report
+        sed -i '' "s/Selected tests/${test_id}/" "$file"
 
     # Upload test report as artifact for the test-report job
     # that publishes a combined report for all test cases

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -171,9 +171,8 @@ jobs:
               ;;
           esac
           # Each user mode runs as its own job (ui-tests-production / ui-tests-internal). Running
-          # both in a single matrix would produce 3 runners x ~55 tests x 2 modes = 330 configs,
-          # over GitHub's 256 limit, so they are split; each job is gated on whether its mode was
-          # requested.
+          # both in a single matrix would produce more configs than GitHub's 256 limit, so they are split;
+          # each job is gated on whether its mode was requested.
           run_production=$(jq -r 'any(.[]; . == "production")' <<< "$user_modes")
           run_internal=$(jq -r 'any(.[]; . == "internal")' <<< "$user_modes")
           echo "run-production=${run_production}" >> $GITHUB_OUTPUT
@@ -222,7 +221,7 @@ jobs:
 
   # UI Tests run as two jobs, one per user mode, each calling the reusable macos_run_ui_test.yml
   # helper once per (runner x test) combination. Both modes in a single matrix would exceed GitHub's
-  # 256-configuration limit; splitting by user mode keeps each job at 3 runners x ~55 tests = 165.
+  # 256-configuration limit.
   # Each job runs only when its mode was requested (production by default; internal for
   # user_modes=internal/both and the scheduled run). Internal-mode failures stay non-gating via
   # continue-on-error inside the helper's job.

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -111,11 +111,11 @@ jobs:
       test: ${{ steps.list-tests.outputs.test }}
       all-os-versions: ${{ steps.define-runners.outputs.all-os-versions }}
       start-timestamp: ${{ steps.start-duration.outputs.start-timestamp }}
-      # The UI Tests matrix runs each user mode as a separate leg (ui-tests-1 / ui-tests-2) so that
-      # a single matrix never exceeds GitHub's 256-configuration limit. user-mode-2 is empty when
-      # only one mode should run, in which case the ui-tests-2 leg is skipped.
-      user-mode-1: ${{ steps.define-user-modes.outputs.user-mode-1 }}
-      user-mode-2: ${{ steps.define-user-modes.outputs.user-mode-2 }}
+      # The UI Tests matrix runs each user mode as a separate job (ui-tests-production /
+      # ui-tests-internal) so that a single matrix never exceeds GitHub's 256-configuration limit.
+      # Each flag says whether that mode was requested; the matching job is skipped when it is false.
+      run-production: ${{ steps.define-user-modes.outputs.run-production }}
+      run-internal: ${{ steps.define-user-modes.outputs.run-internal }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -170,14 +170,15 @@ jobs:
               user_modes='["production"]'
               ;;
           esac
-          # Emit one user mode per leg. Two modes in a single matrix would produce
-          # 3 runners x ~55 tests x 2 modes = 330 configs, over GitHub's 256 limit, so each mode
-          # runs as its own leg (ui-tests-1 / ui-tests-2). user-mode-2 is empty for a single mode.
-          mode1=$(jq -r '.[0]' <<< "$user_modes")
-          mode2=$(jq -r '.[1] // ""' <<< "$user_modes")
-          echo "user-mode-1=${mode1}" >> $GITHUB_OUTPUT
-          echo "user-mode-2=${mode2}" >> $GITHUB_OUTPUT
-          echo "Resolved user modes: leg 1='${mode1}', leg 2='${mode2:-<none>}'"
+          # Each user mode runs as its own job (ui-tests-production / ui-tests-internal). Running
+          # both in a single matrix would produce 3 runners x ~55 tests x 2 modes = 330 configs,
+          # over GitHub's 256 limit, so they are split; each job is gated on whether its mode was
+          # requested.
+          run_production=$(jq -r 'any(.[]; . == "production")' <<< "$user_modes")
+          run_internal=$(jq -r 'any(.[]; . == "internal")' <<< "$user_modes")
+          echo "run-production=${run_production}" >> $GITHUB_OUTPUT
+          echo "run-internal=${run_internal}" >> $GITHUB_OUTPUT
+          echo "Resolved user modes: ${user_modes} (production=${run_production}, internal=${run_internal})"
 
       - name: List tests
         id: list-tests
@@ -219,15 +220,16 @@ jobs:
 
           echo "test=${test}" >> $GITHUB_OUTPUT
 
-  # UI Tests run as two legs, one per user mode, each calling the reusable macos_run_ui_test.yml
-  # helper once per (runner x test) combination. Two modes in a single matrix would exceed GitHub's
-  # 256-configuration limit; splitting by user mode keeps each leg at 3 runners x ~55 tests = 165.
-  # Leg 1 always runs; leg 2 only runs when a second user mode was requested (e.g. user_modes=both
-  # or the scheduled run). Internal-mode failures stay non-gating via continue-on-error inside the
-  # helper's job.
-  ui-tests-1:
+  # UI Tests run as two jobs, one per user mode, each calling the reusable macos_run_ui_test.yml
+  # helper once per (runner x test) combination. Both modes in a single matrix would exceed GitHub's
+  # 256-configuration limit; splitting by user mode keeps each job at 3 runners x ~55 tests = 165.
+  # Each job runs only when its mode was requested (production by default; internal for
+  # user_modes=internal/both and the scheduled run). Internal-mode failures stay non-gating via
+  # continue-on-error inside the helper's job.
+  ui-tests-production:
     name: UI Tests
     needs: [create-notarized-app, setup-tests]
+    if: needs.setup-tests.outputs.run-production == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -240,15 +242,15 @@ jobs:
       os-version: ${{ matrix.os-version }}
       xcode-version: ${{ matrix.xcode-version }}
       test: ${{ matrix.test }}
-      user-mode: ${{ needs.setup-tests.outputs.user-mode-1 }}
+      user-mode: production
       build-type: ${{ inputs.build-type || 'dmg' }}
       branch: ${{ inputs.branch || github.sha }}
     secrets: inherit
 
-  ui-tests-2:
+  ui-tests-internal:
     name: UI Tests
     needs: [create-notarized-app, setup-tests]
-    if: needs.setup-tests.outputs.user-mode-2 != ''
+    if: needs.setup-tests.outputs.run-internal == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -261,7 +263,7 @@ jobs:
       os-version: ${{ matrix.os-version }}
       xcode-version: ${{ matrix.xcode-version }}
       test: ${{ matrix.test }}
-      user-mode: ${{ needs.setup-tests.outputs.user-mode-2 }}
+      user-mode: internal
       build-type: ${{ inputs.build-type || 'dmg' }}
       branch: ${{ inputs.branch || github.sha }}
     secrets: inherit
@@ -269,7 +271,7 @@ jobs:
   test-report:
     name: Report test results
     if: always() && needs.should-run-checks.outputs.should_run == 'true'
-    needs: [should-run-checks, setup-tests, ui-tests-1, ui-tests-2]
+    needs: [should-run-checks, setup-tests, ui-tests-production, ui-tests-internal]
     runs-on: ubuntu-latest
 
     steps:
@@ -309,7 +311,7 @@ jobs:
   notify-failure:
     name: Notify on failure
     if: ${{ always() && github.event_name == 'schedule' }}
-    needs: [ui-tests-1, ui-tests-2]
+    needs: [ui-tests-production, ui-tests-internal]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -97,7 +97,7 @@ jobs:
       skip-notify: true
     secrets: inherit
 
-  # This job sets up the matrix strategy arguments for the ui-tests job
+  # This job sets up the matrix strategy arguments for the ui-tests jobs
   setup-tests:
     name: Set up tests list
     runs-on: macos-26
@@ -111,7 +111,11 @@ jobs:
       test: ${{ steps.list-tests.outputs.test }}
       all-os-versions: ${{ steps.define-runners.outputs.all-os-versions }}
       start-timestamp: ${{ steps.start-duration.outputs.start-timestamp }}
-      user-modes: ${{ steps.define-user-modes.outputs.user-modes }}
+      # The UI Tests matrix runs each user mode as a separate leg (ui-tests-1 / ui-tests-2) so that
+      # a single matrix never exceeds GitHub's 256-configuration limit. user-mode-2 is empty when
+      # only one mode should run, in which case the ui-tests-2 leg is skipped.
+      user-mode-1: ${{ steps.define-user-modes.outputs.user-mode-1 }}
+      user-mode-2: ${{ steps.define-user-modes.outputs.user-mode-2 }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -166,8 +170,14 @@ jobs:
               user_modes='["production"]'
               ;;
           esac
-          echo "user-modes=${user_modes}" >> $GITHUB_OUTPUT
-          echo "Resolved user-modes: ${user_modes}"
+          # Emit one user mode per leg. Two modes in a single matrix would produce
+          # 3 runners x ~55 tests x 2 modes = 330 configs, over GitHub's 256 limit, so each mode
+          # runs as its own leg (ui-tests-1 / ui-tests-2). user-mode-2 is empty for a single mode.
+          mode1=$(jq -r '.[0]' <<< "$user_modes")
+          mode2=$(jq -r '.[1] // ""' <<< "$user_modes")
+          echo "user-mode-1=${mode1}" >> $GITHUB_OUTPUT
+          echo "user-mode-2=${mode2}" >> $GITHUB_OUTPUT
+          echo "Resolved user modes: leg 1='${mode1}', leg 2='${mode2:-<none>}'"
 
       - name: List tests
         id: list-tests
@@ -209,373 +219,57 @@ jobs:
 
           echo "test=${test}" >> $GITHUB_OUTPUT
 
-  ui-tests:
-    name: ${{ matrix.test }} (macOS ${{ matrix.os-version }}${{ matrix.user-mode == 'internal' && ' / internal' || '' }})
+  # UI Tests run as two legs, one per user mode, each calling the reusable macos_run_ui_test.yml
+  # helper once per (runner x test) combination. Two modes in a single matrix would exceed GitHub's
+  # 256-configuration limit; splitting by user mode keeps each leg at 3 runners x ~55 tests = 165.
+  # Leg 1 always runs; leg 2 only runs when a second user mode was requested (e.g. user_modes=both
+  # or the scheduled run). Internal-mode failures stay non-gating via continue-on-error inside the
+  # helper's job.
+  ui-tests-1:
+    name: UI Tests
     needs: [create-notarized-app, setup-tests]
-    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         runner: ${{ fromJSON(needs.setup-tests.outputs.runner) }}
         test: ${{ fromJSON(needs.setup-tests.outputs.test) }}
-        user-mode: ${{ fromJSON(needs.setup-tests.outputs.user-modes) }}
         include: ${{ fromJSON(needs.setup-tests.outputs.include) }}
+    uses: ./.github/workflows/macos_run_ui_test.yml
+    with:
+      runner: ${{ matrix.runner }}
+      os-version: ${{ matrix.os-version }}
+      xcode-version: ${{ matrix.xcode-version }}
+      test: ${{ matrix.test }}
+      user-mode: ${{ needs.setup-tests.outputs.user-mode-1 }}
+      build-type: ${{ inputs.build-type || 'dmg' }}
+      branch: ${{ inputs.branch || github.sha }}
+    secrets: inherit
 
-    continue-on-error: ${{ matrix.user-mode == 'internal' }}
-
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.runner }}-${{ matrix.test }}-${{ matrix.user-mode }}-${{ inputs.build-type }}
-      cancel-in-progress: true
-
-    timeout-minutes: 120
-
-    env:
-      scheme: ${{ inputs.build-type == 'appstore' && 'macOS UI Tests App Store CI' || 'macOS UI Tests CI' }}
-      app-name: ${{ inputs.build-type == 'appstore' && 'DuckDuckGo App Store Review' || 'DuckDuckGo Review' }}
-      app-bundle-id: ${{ inputs.build-type == 'appstore' && 'com.duckduckgo.mobile.ios.review' || 'com.duckduckgo.macos.browser.review' }}
-      release-type: ${{ inputs.build-type == 'appstore' && 'sandbox-review' || 'review' }}
-      extra-xcargs: ${{ inputs.build-type == 'appstore' && 'UI_TESTS_TARGET_APP=sandbox' || '' }}
-
-    steps:
-    - name: Register SSH keys for private repos
-      uses: webfactory/ssh-agent@v0.9.1
-      with:
-        ssh-private-key: |
-          ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
-          ${{ secrets.SSH_PRIVATE_KEY_DUCKSANS_FONT }}
-
-    - name: Check out the code
-      uses: actions/checkout@v6
-      with:
-        ref: ${{ inputs.branch || github.sha }}
-
-    - name: Initialize submodules with retry
-      run: |
-        max_attempts=3
-        retry_delay=15
-        for attempt in $(seq 1 $max_attempts); do
-          echo "Submodule init attempt $attempt of $max_attempts"
-          if git submodule update --init --recursive; then
-            echo "Submodules initialized successfully"
-            exit 0
-          fi
-          if [[ $attempt -lt $max_attempts ]]; then
-            echo "Failed, retrying in ${retry_delay}s..."
-            sleep $retry_delay
-          fi
-        done
-        echo "All submodule init attempts failed"
-        exit 1
-
-    - name: Install screenresolution
-      if: matrix.os-version != '14'
-      run: brew install screenresolution
-
-    - name: Change screen resolution
-      if: matrix.os-version != '14'
-      run: screenresolution set 1920x1080x32@60
-
-    - name: Setup Ruby and dependencies
-      uses: ./.github/actions/setup-ruby
-      with:
-        working-directory: macOS
-        cache-key-prefix: macos-ruby
-
-    - name: Create Default Keychain
-      run: bundle exec fastlane create_keychain_ui_tests
-
-    - name: Sync code signing assets
-      id: sync-signing-first-attempt
-      continue-on-error: true
-      env:
-        APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
-        APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-        APPLE_API_KEY_ISSUER: ${{ secrets.APPLE_API_KEY_ISSUER }}
-        MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-        SSH_PRIVATE_KEY_FASTLANE_MATCH: ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
-      run: |
-        bundle exec fastlane sync_signing_ci
-
-    - name: Retry sync code signing assets
-      if: steps.sync-signing-first-attempt.outcome == 'failure'
-      env:
-        APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
-        APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-        APPLE_API_KEY_ISSUER: ${{ secrets.APPLE_API_KEY_ISSUER }}
-        MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-        SSH_PRIVATE_KEY_FASTLANE_MATCH: ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
-      run: |
-        echo "First attempt to sync code signing assets failed. Retrying..."
-        bundle exec fastlane sync_signing_ci
-
-    - name: Download and unzip artifact
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        max_attempts=3
-        retry_delay=10
-
-        for attempt in $(seq 1 $max_attempts); do
-          echo "Attempt $attempt of $max_attempts"
-          rm -rf build-download-temp
-          mkdir build-download-temp
-          if gh run download "${{ github.run_id }}" --dir build-download-temp; then
-            echo "Download successful"
-            mv build-download-temp/* .
-            rm -rf build-download-temp
-            exit 0
-          fi
-          rm -rf build-download-temp
-          if [[ $attempt -lt $max_attempts ]]; then
-            echo "Download failed, retrying in ${retry_delay}s..."
-            sleep $retry_delay
-            retry_delay=$((retry_delay * 2))
-          fi
-        done
-        echo "All download attempts failed"
-        exit 1
-
-    - name: Set cache key hash
-      run: |
-        has_only_tags=$(jq '[ .pins[].state | has("version") ] | all' DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved)
-        if [[ "$has_only_tags" == "true" ]]; then
-          echo "cache_key_hash=${{ hashFiles('macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}" >> $GITHUB_ENV
-        else
-          echo "Package.resolved contains dependencies specified by branch or commit, skipping cache."
-        fi
-
-    - name: Cache SPM
-      if: env.cache_key_hash
-      uses: actions/cache@v4
-      with:
-        path: macOS/DerivedData/SourcePackages
-        key: ${{ runner.os }}-macos-${{ env.cache_key_hash }}
-        restore-keys: |
-          ${{ runner.os }}-macos-
-
-    - name: Select Xcode
-      uses: ./.github/actions/select-xcode-version
-      with:
-        xcode-version: ${{ matrix.xcode-version }}
-
-    - name: Configure system logging
-      working-directory: SharedPackages/BrowserServicesKit
-      run: |
-        sudo cp com.apple.system.logging.plist /Library/Preferences/Logging/com.apple.system.logging.plist
-        sudo killall logd || true
-
-    - name: Start log stream in background
-      working-directory: macOS
-      run: |
-        log stream --debug --info --predicate 'process == "${{ env.app-name }}" OR process == "UI Tests-Runner"' --style syslog > app-console.log 2>&1 &
-        echo $! > log_stream.pid
-
-    - name: Resolve package dependencies
-      working-directory: macOS
-      run: |
-        max_attempts=5
-        retry_delay=10
-
-        for attempt in $(seq 1 $max_attempts); do
-          echo "Attempt $attempt of $max_attempts"
-          if xcodebuild -resolvePackageDependencies \
-            -scheme "${{ env.scheme }}" \
-            -derivedDataPath DerivedData \
-            2>&1 | tee resolve.log; then
-            echo "Package resolution succeeded"
-            exit 0
-          fi
-
-          if [[ $attempt -lt $max_attempts ]]; then
-            echo "Package resolution failed (attempt $attempt), retrying in ${retry_delay}s..."
-            sleep $retry_delay
-          fi
-        done
-        echo "Package resolution failed after $max_attempts attempts"
-        exit 1
-
-    - name: Restore Xcode Compilation Cache
-      uses: actions/cache/restore@v4
-      with:
-        path: macOS/DerivedData/CompilationCache.noindex
-        key: xcode-compilation-cache-ui-tests
-        restore-keys: |
-          xcode-compilation-cache-ui-tests-
-
-    - name: Build for testing
-      working-directory: macOS
-      run: |
-        set -o pipefail && xcodebuild build-for-testing \
-          -scheme "${{ env.scheme }}" \
-          -derivedDataPath DerivedData \
-          -skipPackagePluginValidation \
-          -skipMacroValidation \
-          COMPILATION_CACHE_ENABLE_CACHING=YES \
-          OTHER_CODE_SIGN_FLAGS=--timestamp=none \
-          ${{ env.extra-xcargs }} \
-        | tee xcodebuild.log \
-        | xcbeautify
-
-    - name: Compute Compilation Cache hash
-      if: github.ref == 'refs/heads/main'
-      id: compilation-cache-hash
-      run: |
-        if [ -d "DerivedData/CompilationCache.noindex" ]; then
-          hash=$(find DerivedData/CompilationCache.noindex -type f \( -name "*.index" -o -name "*.actions" \) 2>/dev/null | sort | xargs cat | shasum -a 256 | cut -d' ' -f1)
-          echo "hash=${hash}" >> $GITHUB_OUTPUT
-        else
-          echo "No compilation cache directory found (Xcode version may not support compilation caching)"
-        fi
-
-    - name: Save Xcode Compilation Cache
-      if: github.ref == 'refs/heads/main' && steps.compilation-cache-hash.outputs.hash
-      uses: actions/cache/save@v4
-      with:
-        path: macOS/DerivedData/CompilationCache.noindex
-        key: xcode-compilation-cache-ui-tests-${{ steps.compilation-cache-hash.outputs.hash }}
-
-    - name: Extract and Copy app to /DerivedData
-      working-directory: macOS
-      run: |
-        cd DuckDuckGo-${{ env.release-type }}-*.app.tar.xz && tar -xf DuckDuckGo-*.app.tar.xz
-
-        # Find the extracted app bundle and rename if needed
-        extracted_app=$(find . -maxdepth 1 -name "*.app" -type d | head -1)
-        if [[ -n "${extracted_app}" ]]; then
-          extracted_app_name=$(basename "${extracted_app}")
-          if [[ "${extracted_app_name}" != "${{ env.app-name }}.app" ]]; then
-            echo "Renaming extracted app from '${extracted_app_name}' to '${{ env.app-name }}.app'"
-            mv "${extracted_app}" "${{ env.app-name }}.app"
-          fi
-        fi
-
-        mv -f "${{ env.app-name }}.app" "../DerivedData/Build/Products/Review/${{ env.app-name }}.app"
-
-    - name: Run UI Tests
-      id: run-ui-tests
-      working-directory: macOS
-      run: |
-        defaults write ${{ env.app-bundle-id }} moveToApplicationsFolderAlertSuppress 1
-        set -o pipefail && xcodebuild test-without-building \
-          -scheme "${{ env.scheme }}" \
-          -derivedDataPath DerivedData \
-          -skipPackagePluginValidation \
-          -skipMacroValidation \
-          -test-iterations 2 \
-          -retry-tests-on-failure \
-          -test-repetition-relaunch-enabled YES \
-          '-only-testing:UI Tests/${{ matrix.test }}' \
-          ${{ env.extra-xcargs }} \
-          "TEST_RUNNER_INTERNAL_USER_MODE=${{ matrix.user-mode == 'internal' && 'true' || 'false' }}" \
-        | tee -a xcodebuild.log \
-        | tee ui-tests.log
-
-    - name: Stop log stream
-      if: always()
-      working-directory: macOS
-      run: |
-        if [ -f log_stream.pid ]; then
-          kill $(cat log_stream.pid) || true
-        fi
-
-    - name: Check for test failures
-      id: check-failures
-      if: always()
-      working-directory: macOS
-      run: |
-        if grep -Eq 'XCTAssert.*failed|Test Case.*failed|Testing failed:' ui-tests.log; then
-          echo "had_failures=true" >> $GITHUB_OUTPUT
-          echo "⚠️ Detected test failures in the log (may have passed on retry)"
-        else
-          echo "had_failures=false" >> $GITHUB_OUTPUT
-        fi
-
-    - name: Prepare test report
-      id: prepare-test-report
-      if: always() && steps.run-ui-tests.outcome != 'skipped'
-      working-directory: macOS
-      run: |
-        test_id="${{ matrix.test }} (macOS ${{ matrix.os-version }}${{ matrix.user-mode == 'internal' && ' / internal' || '' }})"
-        file="${test_id}.xml"
-        echo "file=$file" >> $GITHUB_OUTPUT
-        xcbeautify --report junit --report-path . --junit-report-filename "$file" < ui-tests.log
-        # Replace the default test suite name with the test id for better grouping in the test report
-        sed -i '' "s/Selected tests/${test_id}/" "$file"
-
-    # Upload test report as artifact for the test-report job
-    # that publishes a combined report for all test cases
-    - name: Upload test report
-      uses: actions/upload-artifact@v4
-      if: always() && steps.run-ui-tests.outcome != 'skipped'
-      with:
-        name: "testreport-${{ matrix.test }}-macos${{ matrix.os-version }}-${{ matrix.user-mode }}"
-        path: "macOS/${{ steps.prepare-test-report.outputs.file }}"
-        retention-days: 1
-
-    - name: Upload xcresult files (passed on retry)
-      uses: actions/upload-artifact@v4
-      if: always() && steps.check-failures.outputs.had_failures == 'true' && steps.run-ui-tests.outcome == 'success'
-      with:
-        name: "xcresult-${{ matrix.test }}-macos${{ matrix.os-version }}-${{ matrix.user-mode }}"
-        path: "macOS/DerivedData/Logs/Test/*.xcresult"
-        retention-days: 1
-
-    - name: Upload app console log (passed on retry)
-      uses: actions/upload-artifact@v4
-      if: always() && steps.check-failures.outputs.had_failures == 'true' && steps.run-ui-tests.outcome == 'success'
-      with:
-        name: "app-console-${{ matrix.test }}-macos${{ matrix.os-version }}-${{ matrix.user-mode }}"
-        path: "macOS/app-console.log"
-        if-no-files-found: warn
-        retention-days: 1
-
-    - name: Mark user-mode failure
-      if: failure() || cancelled()
-      working-directory: ${{ github.workspace }}
-      run: |
-        mkdir -p failure-marker
-        echo "macos-ui:${{ matrix.user-mode }}:${{ matrix.test }}:${{ matrix.os-version }}" > failure-marker/marker.txt
-    - name: Upload failure marker
-      if: failure() || cancelled()
-      uses: actions/upload-artifact@v4
-      with:
-        name: failure-marker-macos-ui-${{ matrix.user-mode }}-${{ matrix.test }}-${{ matrix.os-version }}
-        path: failure-marker/
-        retention-days: 1
-
-    - name: Organize logs for upload
-      if: failure() || cancelled()
-      working-directory: macOS
-      run: |
-        echo "Current working directory: $(pwd)"
-
-        # Create staging directory with timestamp, OS version and failing test name
-        timestamp=$(date +"%Y-%m-%d_%H-%M-%S")
-        archive_name="BuildLogs ${{ matrix.test }} (macOS ${{ matrix.os-version }}${{ matrix.user-mode == 'internal' && ' internal' || '' }}) ${timestamp}"
-        echo "Creating archive directory: $archive_name"
-        mkdir -p "$archive_name"
-
-        # locate and copy all files, flattening the structure with verbose output
-        cp "xcodebuild.log" "$archive_name/" || echo "No xcodebuild.log found"
-        cp "app-console.log" "$archive_name/" || echo "No app-console.log found"
-        find DerivedData/Logs/Test -name "*.xcresult" -print -exec cp -rf {} "$archive_name/" \; 2>&1 || echo "No .xcresult files found"
-        cp -rf ~/Library/Logs/DiagnosticReports "$archive_name/" || echo "No DiagnosticReports found"
-
-        # Store archive name for upload step
-        echo "ARCHIVE_NAME=$archive_name" >> $GITHUB_ENV
-
-    - name: Upload logs when workflow failed
-      uses: actions/upload-artifact@v4
-      if: failure() || cancelled()
-      with:
-        name: "${{ env.ARCHIVE_NAME }}"
-        path: "macOS/${{ env.ARCHIVE_NAME }}"
-        retention-days: 7
+  ui-tests-2:
+    name: UI Tests
+    needs: [create-notarized-app, setup-tests]
+    if: needs.setup-tests.outputs.user-mode-2 != ''
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ${{ fromJSON(needs.setup-tests.outputs.runner) }}
+        test: ${{ fromJSON(needs.setup-tests.outputs.test) }}
+        include: ${{ fromJSON(needs.setup-tests.outputs.include) }}
+    uses: ./.github/workflows/macos_run_ui_test.yml
+    with:
+      runner: ${{ matrix.runner }}
+      os-version: ${{ matrix.os-version }}
+      xcode-version: ${{ matrix.xcode-version }}
+      test: ${{ matrix.test }}
+      user-mode: ${{ needs.setup-tests.outputs.user-mode-2 }}
+      build-type: ${{ inputs.build-type || 'dmg' }}
+      branch: ${{ inputs.branch || github.sha }}
+    secrets: inherit
 
   test-report:
     name: Report test results
     if: always() && needs.should-run-checks.outputs.should_run == 'true'
-    needs: [should-run-checks, setup-tests, ui-tests]
+    needs: [should-run-checks, setup-tests, ui-tests-1, ui-tests-2]
     runs-on: ubuntu-latest
 
     steps:
@@ -615,7 +309,7 @@ jobs:
   notify-failure:
     name: Notify on failure
     if: ${{ always() && github.event_name == 'schedule' }}
-    needs: [ui-tests]
+    needs: [ui-tests-1, ui-tests-2]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1216305204896743
Tech Design URL:
CC:

### Description

Running the **macOS - UI Tests** workflow with two user modes fails before any test executes:

```
Strategy for job 'ui-tests' produced 330 configurations which exceeds the maximum of 256 configurations
```

The `ui-tests` job built its matrix from `runner × test × user-mode` (+ `include`). With all OS versions that is **3 runners × ~55 UITestCase classes × 2 user-modes = 330** — over GitHub Actions' hard cap of **256** configurations per matrix. One user-mode is 165 (fine); two blow the limit. This happens on `user_modes: both` and on the nightly scheduled run (which always runs both modes).

This PR mirrors the existing variants pattern (`macos_create_variants.yml` → `macos_create_variant.yml`): the per-test run steps are extracted into a reusable helper workflow, driven by **one job per user mode**.

- **New `.github/workflows/macos_run_ui_test.yml`** — a `workflow_call` helper that runs a *single* test class, on one runner, in one user-mode. It owns everything that used to live in the `ui-tests` job (job-level `env`, `concurrency`, `timeout-minutes`, `continue-on-error`, and all steps).
- **`macos_ui_tests.yml`** — the single `ui-tests` job is replaced by two jobs, each with a `runner × test` matrix that calls the helper:
  - `ui-tests-production` — runs the production leg; `if: run-production == 'true'`.
  - `ui-tests-internal` — runs the internal leg; `if: run-internal == 'true'`.
  - `setup-tests` emits per-mode flags `run-production` / `run-internal` (from the resolved user-modes list) instead of the old `user-modes` array, so each job maps to a fixed mode and runs only when that mode was requested.
  - `test-report` and `notify-failure` now depend on both jobs.

### Testing Steps
1. Verify that [this UI tests workflow run](https://github.com/duckduckgo/apple-browsers/actions/runs/28790130547) (running just Autocomplete Tests on all OS versions for both internal and production.

### Impact and Risks

**Low / None** — CI infrastructure only; no product code changes.

#### What could go wrong?
- **Job/check display names change** with reusable-workflow nesting (`ui-tests-production / <matrix> / <leaf>`). If any branch-protection *required status checks* referenced the old `ui-tests` job names, they'd need updating. Worth confirming during review.
- **Single-job headroom**: `3 × 55 = 165`. If the UITestCase count grows beyond ~85 a single job would itself exceed 256 — out of scope here (this fix addresses the 2-user-mode case), but noted for the future.

### Notes to Reviewer
- The helper is a verbatim move of the old `ui-tests` steps with every `matrix.*` swapped for `inputs.*`; the `defaults.run.working-directory: macOS` block is duplicated into the helper because several `run:` steps rely on it.
- Includes a fix for a **pre-existing latent bug** exposed by running the internal leg. The internal-mode suffix was ` / internal`; the `/` is both a path separator (so `xcbeautify` failed to write the JUnit report — `The file " internal).xml" doesn't exist` — producing no report artifact) and the delimiter GitHub uses to join a reusable-workflow job name onto its caller (so the Actions UI split the leaf job name into two fake tree nodes). The suffix is now `, internal`, which fixes both; production names are unchanged.
- Verified with `actionlint 1.7.12`: no workflow/expression/structural errors. The only findings are `shellcheck` info/style notes on `run:` scripts copied verbatim from the original (they fire identically on `origin/main`).




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow refactor only; main operational risk is branch-protection required checks if they referenced the old `ui-tests` job name.
> 
> **Overview**
> Fixes **macOS UI Tests** failing at matrix expansion when both user modes run (`runner × test × user-mode` exceeded GitHub’s **256** config cap).
> 
> Adds reusable **`macos_run_ui_test.yml`** with the former `ui-tests` job steps (signing, artifact download, build-for-testing, run one class, reports/artifacts). **`macos_ui_tests.yml`** replaces the single `ui-tests` matrix with **`ui-tests-production`** and **`ui-tests-internal`**, each `runner × test` calling that helper with a fixed `user-mode`. **`setup-tests`** now outputs **`run-production`** / **`run-internal`** gates instead of a `user-modes` matrix axis; **`test-report`** and **`notify-failure`** depend on both jobs. Internal legs stay non-gating via **`continue-on-error`** on the helper job.
> 
> Also changes the internal label suffix from **` / internal`** to **`, internal`** so JUnit/report paths and nested job names don’t break on `/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc80d101820e6aa758251a11f31904a5ddea096c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->