### PR TITLE
[iOS] Fix iPad Duck.ai suggestions panel showing without focus

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4951,6 +4951,18 @@ extension MainViewController: PopoverSuggestionsHosting {
     }
 
     func showPopoverDuckAIList(query: String) {
+        // The Duck.ai popover is anchored under the *expanded* Duck.ai input and is only valid while
+        // that input is focused. The async recents/URL content callback (and restoration paths) can
+        // drive a present() while the bar is collapsed and unfocused — e.g. after submitting a Duck.ai
+        // prompt the toggle mode persists as .aiChat, so on relaunch the recents popover would appear
+        // over an unselected, collapsed address bar. `IPadOmnibarFocusModel` decides the surface purely
+        // from the toggle mode (no focus input), so gate the actual reveal on the input being expanded.
+        let isDuckAIInputExpanded = (viewCoordinator.omniBar as? OmniBarViewController)?
+            .expandableBarView?.isSearchAreaExpanded ?? false
+        guard isDuckAIInputExpanded else {
+            hidePopover()
+            return
+        }
         suggestionTrayController?.setAdditionalTopInset(duckAIPopoverTopInset(), animated: isPopoverVisible)
         tryToShowSuggestionTray(.duckAISuggestions(query: query))
     }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4951,12 +4951,6 @@ extension MainViewController: PopoverSuggestionsHosting {
     }
 
     func showPopoverDuckAIList(query: String) {
-        // The Duck.ai popover is anchored under the *expanded* Duck.ai input and is only valid while
-        // that input is focused. The async recents/URL content callback (and restoration paths) can
-        // drive a present() while the bar is collapsed and unfocused — e.g. after submitting a Duck.ai
-        // prompt the toggle mode persists as .aiChat, so on relaunch the recents popover would appear
-        // over an unselected, collapsed address bar. `IPadOmnibarFocusModel` decides the surface purely
-        // from the toggle mode (no focus input), so gate the actual reveal on the input being expanded.
         let isDuckAIInputExpanded = (viewCoordinator.omniBar as? OmniBarViewController)?
             .expandableBarView?.isSearchAreaExpanded ?? false
         guard isDuckAIInputExpanded else {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1216315715687106?focus=true
Tech Design URL:
CC:

### Description
Since the model-driven iPad suggestions popover (#5411), `IPadOmnibarFocusModel` decides the Duck.ai surface purely from the toggle mode, with no focus check. Because submitting a Duck.ai prompt persists the toggle as `.aiChat`, on relaunch the recents panel could appear over a collapsed, unfocused address bar. This gates the popover reveal (`showPopoverDuckAIList`) on the Duck.ai input actually being expanded/focused.

### Testing Steps
1. On iPad, submit a Duck.ai prompt from the address bar so the toggle is left in Duck.ai mode.
2. Fully quit and relaunch the app.
3. Confirm it opens with no suggestions panel showing while the address bar is unselected; tapping the address bar in Duck.ai mode still shows recents as expected. Search-mode suggestions are unchanged.

### Impact and Risks
Low — iPad-only address-bar suggestions visibility; no change to Search-mode behaviour.

#### What could go wrong?
The gate could hide the panel in a legitimate focus case, but `isSearchAreaExpanded` is set true before the reveal fires, so the focused flow is unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> iPad-only visibility guard for Duck.ai popover; search suggestions unchanged and expansion is set before legitimate reveals.
> 
> **Overview**
> Fixes the iPad Duck.ai suggestions popover appearing over a collapsed, unfocused address bar after relaunch when the toggle was left in Duck.ai mode.
> 
> **`showPopoverDuckAIList`** now checks **`isSearchAreaExpanded`** on the omnibar’s expandable search area. If the Duck.ai input is not expanded, it calls **`hidePopover()`** and skips showing recents; the existing inset and tray logic runs only when the bar is actually expanded/focused. Search-mode popover behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a78b346392e3000b99e8f64142a0344c7f5ea64a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->