### PR TITLE
Remove eager full-screen tab snapshot that crashed in drawHierarchy

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -887,27 +887,6 @@ class MainViewController: UIViewController {
         swipeTabsCoordinator?.swipeOverlayView = overlay
     }
 
-    func captureCurrentTabScreenSnapshotIfPossible(tabUID: String) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-            guard let self else { return }
-            guard (self.tabSwipeOverlayView?.alpha ?? 0) == 0 else {
-                return
-            }
-            guard let currentTab = self.tabManager.currentTabsModel.currentTab,
-                  currentTab.uid == tabUID else {
-                return
-            }
-            guard self.view.window != nil,
-                  self.view.bounds.width > 0,
-                  self.view.bounds.height > 0 else { return }
-            let renderer = UIGraphicsImageRenderer(size: self.view.bounds.size)
-            let image = renderer.image { _ in
-                self.view.drawHierarchy(in: self.view.bounds, afterScreenUpdates: false)
-            }
-            self.previewsSource.updateFullScreenSnapshot(image, forTab: currentTab)
-        }
-    }
-
     func updatePreviewForCurrentTab(completion: (() -> Void)? = nil) {
         assert(Thread.isMainThread)
         

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -224,15 +224,6 @@ extension MainViewController {
             return
         }
 
-        // Capture the current tab's screen snapshot regardless of which refresh branch we
-        // take — `.unbindInactiveNonAITab` early-returns without falling through, but we
-        // still want a fresh snapshot for the swipe overlay every time the tab becomes the
-        // active one. `captureCurrentTabScreenSnapshotIfPossible` defers to the next runloop
-        // so any layout changes the branches apply have settled by capture time.
-        defer {
-            captureCurrentTabScreenSnapshotIfPossible(tabUID: tab.tabModel.uid)
-        }
-
         coordinator.activateForTab(tab.tabModel.uid)
 
         let action = refreshAction(for: tab, coordinator: coordinator)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214294661819890/task/1216237756104396?focus=true
Tech Design URL:
CC:

### Description
The Unified Toggle Input feature captured a full-screen snapshot of the current tab on every tab activation, and that snapshot rendered the whole view — including the live web view — via a synchronous bitmap render that crashed while reading the web content's graphics surface. This removes that eager per-activation capture. The swipe-between-tabs overlay is unaffected: it still captures the current tab the moment a swipe begins, and adjacent tabs fall back to the existing tab preview.

### Testing Steps
1. With Unified Toggle Input enabled, open several tabs and switch between them rapidly → no crash, tabs switch normally.
2. Swipe left/right between tabs → the tab you're swiping from animates correctly; adjacent tabs slide in (incoming tab may show the plain page preview without chrome the first time).
3. Load heavy/media-rich pages, background/foreground the app, and switch tabs → no crash.

### Impact
Low

#### What could go wrong?
On the first swipe toward a tab, the incoming tab shows a webview-only preview without chrome until it has been a swipe source once — cosmetic and transient, mitigated by the source tab always being captured fresh at swipe start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted removal of a crash-prone capture path with no auth or data changes; main tradeoff is a possible first-swipe preview without chrome until that tab is captured at swipe start.
> 
> **Overview**
> **Removes the per-tab-activation full-screen snapshot** that ran on every Unified Toggle Input refresh via `refreshUnifiedToggleInput`. That path deferred a `UIGraphicsImageRenderer` + `view.drawHierarchy` capture of the entire `MainViewController` (including the live web view) into `previewsSource.updateFullScreenSnapshot`, which could crash when reading the web content graphics surface.
> 
> The **`captureCurrentTabScreenSnapshotIfPossible`** helper is deleted from `MainViewController`, along with the **`defer` block** that invoked it on each tab activation. Tab switching no longer triggers that synchronous render.
> 
> **Swipe-between-tabs behavior is unchanged at swipe time**: `onSwipeStarted` still calls `updatePreviewForCurrentTab()`, and the swipe coordinator continues to capture the source tab when a gesture begins. Adjacent tabs may show an existing webview-only preview until they have been a swipe source once—a transient cosmetic difference called out in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00bbfd42e61ad0a6a304e14b594805ab7d3acce9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->