### PR TITLE
Fix omnibar ui test

### DIFF
--- a/iOS/AtbUITests/AtbIntegrationTests.swift
+++ b/iOS/AtbUITests/AtbIntegrationTests.swift
@@ -98,36 +98,39 @@ class AtbIntegrationTests: XCTestCase {
     func backgroundRelaunch() {
         XCUIDevice.shared.press(.home)
         app.activate()
-        if !app.searchFields["searchEntry"].waitForExistence(timeout: Constants.defaultTimeout) {
+        if !app.descendants(matching: .any)["searchEntry"].waitForExistence(timeout: Constants.defaultTimeout) {
             fatalError("Can not find search field. Has the app launched?")
         }
     }
 
     private func search(forText text: String) {
 
-        let searchentrySearchField = app.searchFields["searchEntry"]
-        XCTAssertTrue(searchentrySearchField.waitForExistence(timeout: Constants.defaultTimeout))
+        // Match by identifier across any element type: the omnibar's field can be
+        // reported as a search field or a plain text field depending on its editing
+        // state, and a type-specific query (e.g. `searchFields`) intermittently fails
+        // to resolve it while the omnibar is transitioning.
+        let searchentrySearchField = app.descendants(matching: .any)["searchEntry"]
         focus(searchentrySearchField)
         searchentrySearchField.typeText("\(text)\r")
         Snapshot.waitForLoadingIndicatorToDisappear(within: Constants.defaultTimeout)
 
     }
 
+    /// Focuses the omnibar by tapping it.
+    ///
+    /// `hasKeyboardFocus` is intentionally not asserted: the omnibar's search field
+    /// never reports keyboard focus to XCUITest even while it is actively being
+    /// edited, so gating on it makes `focus` fail every time. Instead we retry the
+    /// tap itself — the element can briefly drop out of the accessibility hierarchy
+    /// as the omnibar lays out — and let the subsequent `typeText` surface any real
+    /// focus failure.
     private func focus(_ element: XCUIElement, file: StaticString = #filePath, line: UInt = #line) {
-        let hasKeyboardFocus = NSPredicate(format: "hasKeyboardFocus == true")
-
         for _ in 0..<3 {
-            app.typeKey("l", modifierFlags: .command)
-            let keyCommandFocusExpectation = XCTNSPredicateExpectation(predicate: hasKeyboardFocus, object: element)
-            if XCTWaiter.wait(for: [keyCommandFocusExpectation], timeout: 2) == .completed {
-                return
+            guard element.waitForExistence(timeout: Constants.defaultTimeout), element.isHittable else {
+                continue
             }
-
             element.tap()
-            let tapFocusExpectation = XCTNSPredicateExpectation(predicate: hasKeyboardFocus, object: element)
-            if XCTWaiter.wait(for: [tapFocusExpectation], timeout: 2) == .completed {
-                return
-            }
+            return
         }
 
         XCTFail("Could not focus \(element)", file: file, line: line)

--- a/iOS/AtbUITests/AtbIntegrationTests.swift
+++ b/iOS/AtbUITests/AtbIntegrationTests.swift
@@ -120,17 +120,21 @@ class AtbIntegrationTests: XCTestCase {
     ///
     /// `hasKeyboardFocus` is intentionally not asserted: the omnibar's search field
     /// never reports keyboard focus to XCUITest even while it is actively being
-    /// edited, so gating on it makes `focus` fail every time. Instead we retry the
-    /// tap itself — the element can briefly drop out of the accessibility hierarchy
-    /// as the omnibar lays out — and let the subsequent `typeText` surface any real
-    /// focus failure.
+    /// edited (the real first responder is a separate overlaid text view), so gating
+    /// on it makes `focus` fail every time. We also can't gate on existence alone —
+    /// the identifier appears before the omnibar finishes laying out, so the element
+    /// can exist while it is not yet tappable. Wait for it to become *hittable* (the
+    /// predicate re-evaluates over time, and also covers existence) before tapping,
+    /// and let the subsequent `typeText` surface any real focus failure.
     private func focus(_ element: XCUIElement, file: StaticString = #filePath, line: UInt = #line) {
+        let isHittable = NSPredicate(format: "isHittable == true")
+
         for _ in 0..<3 {
-            guard element.waitForExistence(timeout: Constants.defaultTimeout), element.isHittable else {
-                continue
+            let hittableExpectation = XCTNSPredicateExpectation(predicate: isHittable, object: element)
+            if XCTWaiter.wait(for: [hittableExpectation], timeout: Constants.defaultTimeout) == .completed {
+                element.tap()
+                return
             }
-            element.tap()
-            return
         }
 
         XCTFail("Could not focus \(element)", file: file, line: line)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1216277538553620?focus=true
Tech Design URL:
CC:

### Description
Fix omnibar UI test by making it not rely on the focus state, and change to look at more elements than just searchFields. This is because omnibar isn't really a search field anymore

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Ensure UI tests pass
2.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to ATB integration UI helpers; no production app behavior.
> 
> **Overview**
> **ATB integration UI tests** no longer treat the omnibar as a `searchFields` element or assert `hasKeyboardFocus`, which were flaky as the omnibar’s accessibility type and focus reporting changed.
> 
> `backgroundRelaunch` and `search(forText:)` now resolve `searchEntry` via `descendants(matching: .any)` so the field is found whether XCUITest reports it as a search field or plain text during transitions. **`focus`** waits for `isHittable` (with retries and `Constants.defaultTimeout`), taps the element, and drops Cmd+L and keyboard-focus expectations; comments document that the real first responder is an overlaid text view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f06343235e597cc0d3ceb97908172a2214ad7fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->