### PR TITLE
macOS: Add aiChatCustomizeResponses feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -592,6 +592,9 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// Enables the native Duck.ai bar controls (model picker) in the iPad address bar's
     /// expanded Duck.ai input area.
     case iPadDuckAIBarControls
+
+    /// Enables the macOS native "Customize Responses" UI (omnibar + New Tab Page entry points).
+    case customizeResponses
 }
 
 public enum HtmlNewTabPageSubfeature: String, Equatable, PrivacySubfeature {

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -407,6 +407,11 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214025222413375
     case aiChatNativeDataAccess
 
+    /// Gates the macOS "Customize Responses" native UI (omnibar + New Tab Page entry points).
+    /// Internal-only while in development.
+    /// https://app.asana.com/1/137249556945/project/1204006570077678/task/1216299435808476
+    case aiChatCustomizeResponses
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215798415697847
     /// Replaces the web-link Search Assist and Hide AI-Generated Images rows on the AI Features
     /// settings screen with native controls, regroups the main AI settings at the top, and adds the
@@ -710,6 +715,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(AIChatSubfeature.nativeStorage), category: .duckAI)
         case .aiChatNativeDataAccess:
             Config(source: .remoteReleasable(AIChatSubfeature.nativeDataAccess), category: .duckAI)
+        case .aiChatCustomizeResponses:
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.customizeResponses), category: .duckAI)
         case .aiFeaturesNativeControls:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.aiFeaturesNativeControls), category: .duckAI)
         case .aiChatNativeVoicePermissionFlow:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1216299435808476
Tech Design URL:
CC:

### Description

Adds the `aiChatCustomizeResponses` feature flag (`.internalOnly`, remote-releasable via `AIChatSubfeature.customizeResponses`) to gate the upcoming macOS native Customize Responses UI on the omnibar and New Tab Page. Flag only — no entry points consume it yet, so there's no user-visible behavior.

### Impact and Risks

Low. Unused internal-only flag; nothing reads it yet.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Unused internal-only flag registration only; no runtime behavior or user-visible changes.
> 
> **Overview**
> Adds remote-releasable feature-flag plumbing for the upcoming macOS native **Customize Responses** UI (omnibar and New Tab Page).
> 
> Introduces `AIChatSubfeature.customizeResponses` in shared privacy config and wires macOS `FeatureFlag.aiChatCustomizeResponses` to it with **internal-only** default and Duck AI category—matching other in-development Duck.ai flags. **No call sites** use the flag yet, so behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 145969da791ea6eb346981b2113a28d55875ac32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->