### PR TITLE
iOS: Respect Duck AI settings for Chats menu item

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -552,6 +552,7 @@
 		6F40D15B2C34423800BF22F0 /* HomePageDisplayDailyPixelBucket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F40D15A2C34423800BF22F0 /* HomePageDisplayDailyPixelBucket.swift */; };
 		6F40D15E2C34436500BF22F0 /* HomePageDisplayDailyPixelBucketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F40D15C2C34436200BF22F0 /* HomePageDisplayDailyPixelBucketTests.swift */; };
 		6F45B7012F1A677400883A86 /* BrowsingMenuSheetCapabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F45B6FF2F1A677400883A86 /* BrowsingMenuSheetCapabilityTests.swift */; };
+		6F45B7022F1A677400883A86 /* BrowsingMenuBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F45B7032F1A677400883A86 /* BrowsingMenuBuilderTests.swift */; };
 		6F45B70D2F1E60AE00883A86 /* BrowsingMenuHeaderDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F45B70C2F1E60AA00883A86 /* BrowsingMenuHeaderDataSource.swift */; };
 		6F45B70F2F1E616600883A86 /* BrowsingMenuSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F45B70E2F1E616600883A86 /* BrowsingMenuSheetViewController.swift */; };
 		6F45B7102F1F8A0000883A86 /* BrowsingMenuHeaderStateProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F45B70F2F1F8A0000883A86 /* BrowsingMenuHeaderStateProviderTests.swift */; };
@@ -3222,6 +3223,7 @@
 		6F40D15A2C34423800BF22F0 /* HomePageDisplayDailyPixelBucket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePageDisplayDailyPixelBucket.swift; sourceTree = "<group>"; };
 		6F40D15C2C34436200BF22F0 /* HomePageDisplayDailyPixelBucketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePageDisplayDailyPixelBucketTests.swift; sourceTree = "<group>"; };
 		6F45B6FF2F1A677400883A86 /* BrowsingMenuSheetCapabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowsingMenuSheetCapabilityTests.swift; sourceTree = "<group>"; };
+		6F45B7032F1A677400883A86 /* BrowsingMenuBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowsingMenuBuilderTests.swift; sourceTree = "<group>"; };
 		6F45B70C2F1E60AA00883A86 /* BrowsingMenuHeaderDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowsingMenuHeaderDataSource.swift; sourceTree = "<group>"; };
 		6F45B70E2F1E616600883A86 /* BrowsingMenuSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowsingMenuSheetViewController.swift; sourceTree = "<group>"; };
 		6F45B70F2F1F8A0000883A86 /* BrowsingMenuHeaderStateProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowsingMenuHeaderStateProviderTests.swift; sourceTree = "<group>"; };
@@ -7072,6 +7074,7 @@
 			children = (
 				6F45B70F2F1F8A0000883A86 /* BrowsingMenuHeaderStateProviderTests.swift */,
 				6F81F61E2F1FB0790007CADD /* BrowsingMenuHeaderDataSourceTests.swift */,
+				6F45B7032F1A677400883A86 /* BrowsingMenuBuilderTests.swift */,
 				6F45B6FF2F1A677400883A86 /* BrowsingMenuSheetCapabilityTests.swift */,
 			);
 			path = BrowsingMenu;
@@ -14253,6 +14256,7 @@
 				98E564062DE8B32D00E6E75F /* MockTabDelegate.swift in Sources */,
 				98E564072DE8B32D00E6E75F /* MockTutorialSettings.swift in Sources */,
 				98E564082DE8B32D00E6E75F /* OnboardingPixelReporterMock.swift in Sources */,
+				6F45B7022F1A677400883A86 /* BrowsingMenuBuilderTests.swift in Sources */,
 				6F45B7012F1A677400883A86 /* BrowsingMenuSheetCapabilityTests.swift in Sources */,
 				80E2BDB02FDB693A00441FDF /* DuckAIGridItemTests.swift in Sources */,
 				80E5CA032FE0F17800B8F0A0 /* DuckAIVoiceSessionTrackerTests.swift in Sources */,

--- a/iOS/DuckDuckGo/BrowsingMenu/SheetPresentationMenu/BrowsingMenuBuilder.swift
+++ b/iOS/DuckDuckGo/BrowsingMenu/SheetPresentationMenu/BrowsingMenuBuilder.swift
@@ -90,10 +90,10 @@ final class BrowsingMenuBuilder: BrowsingMenuBuilding {
         // With Unified Toggle Input on, the Duck.ai "Chats" row moves into its own Duck.ai cluster below.
         let duckAIItems = entryBuilder.makeDuckAIMenuItems()
         let shortcutsItems: [BrowsingMenuModel.Entry] = [
-            .init(duckAIItems.isEmpty ? entryBuilder.makeDuckAiChatsEntry() : nil),
             .init(entryBuilder.makeOpenBookmarksEntry()),
             .init(entryBuilder.makeAutoFillEntry()),
-            .init(entryBuilder.makeDownloadsEntry())
+            .init(entryBuilder.makeDownloadsEntry()),
+            .init(duckAIItems.isEmpty ? entryBuilder.makeDuckAiChatsEntry() : nil)
         ].compactMap { $0 }
 
         // MARK: Privacy group
@@ -181,10 +181,10 @@ final class BrowsingMenuBuilder: BrowsingMenuBuilding {
         // With Unified Toggle Input on, the Duck.ai "Chats" row moves into its own Duck.ai cluster below.
         let duckAIItems = entryBuilder.makeDuckAIMenuItems()
         let shortcutItems: [BrowsingMenuModel.Entry] = [
-            .init(duckAIItems.isEmpty ? entryBuilder.makeDuckAiChatsEntry() : nil),
             .init(entryBuilder.makeOpenBookmarksEntry()),
             .init(entryBuilder.makeAutoFillEntry()),
-            .init(entryBuilder.makeDownloadsEntry())
+            .init(entryBuilder.makeDownloadsEntry()),
+            .init(duckAIItems.isEmpty ? entryBuilder.makeDuckAiChatsEntry() : nil)
         ].compactMap { $0 }
 
         appendSection(shortcutItems, to: &sections)

--- a/iOS/DuckDuckGo/TabViewControllerMenuBuilderExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerMenuBuilderExtension.swift
@@ -1045,7 +1045,7 @@ extension TabViewController: BrowsingMenuEntryBuilding {
     }
 
     func makeDuckAiChatsEntry() -> BrowsingMenuEntry? {
-        guard isNativeChatHistoryAvailable else { return nil }
+        guard shouldShowAIChatInMenu, isNativeChatHistoryAvailable else { return nil }
         return buildDuckAiChatsEntry(withSmallIcon: false)
     }
 

--- a/iOS/DuckDuckGoTests/AIChat/AIChatSettingsTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatSettingsTests.swift
@@ -102,6 +102,18 @@ class AIChatSettingsTests: XCTestCase {
         XCTAssertTrue(settings.isAIChatBrowsingMenuUserSettingsEnabled)
     }
 
+    func testAIChatBrowsingMenuUserSettingsDisabledWhenAIChatIsDisabled() {
+        let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
+                                      debugSettings: mockAIChatDebugSettings,
+                                      keyValueStore: mockKeyValueStore,
+                                      notificationCenter: mockNotificationCenter)
+
+        settings.enableAIChatBrowsingMenuUserSettings(enable: true)
+        settings.enableAIChat(enable: false)
+
+        XCTAssertFalse(settings.isAIChatBrowsingMenuUserSettingsEnabled)
+    }
+
     func testEnableAIChatAddressBarUserSettings() {
         let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
                                       debugSettings: mockAIChatDebugSettings,

--- a/iOS/DuckDuckGoTests/BrowsingMenu/BrowsingMenuBuilderTests.swift
+++ b/iOS/DuckDuckGoTests/BrowsingMenu/BrowsingMenuBuilderTests.swift
@@ -1,0 +1,142 @@
+//
+//  BrowsingMenuBuilderTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Bookmarks
+import PersistenceTestingUtils
+import UIKit
+import XCTest
+@testable import DuckDuckGo
+
+final class BrowsingMenuBuilderTests: XCTestCase {
+
+    func testNewTabPageMenuOmitsChatsWhenFallbackChatsEntryIsUnavailable() {
+        let entryBuilder = MockBrowsingMenuEntryBuilder(chatsEntry: nil)
+        let model = makeBuilder(entryBuilder: entryBuilder).buildMenu(
+            context: .newTabPage,
+            bookmarksInterface: MockMenuBookmarksInteractor(),
+            mobileCustomization: makeMobileCustomization(),
+            clearTabsAndData: {}
+        )
+
+        XCTAssertEqual(model?.sections.first?.items.map(\.name), [
+            MockBrowsingMenuEntryBuilder.openBookmarksName,
+            MockBrowsingMenuEntryBuilder.downloadsName
+        ])
+    }
+
+    func testNewTabPageMenuPlacesFallbackChatsAfterBookmarksAndDownloads() {
+        let entryBuilder = MockBrowsingMenuEntryBuilder(chatsEntry: .named(MockBrowsingMenuEntryBuilder.chatsName))
+        let model = makeBuilder(entryBuilder: entryBuilder).buildMenu(
+            context: .newTabPage,
+            bookmarksInterface: MockMenuBookmarksInteractor(),
+            mobileCustomization: makeMobileCustomization(),
+            clearTabsAndData: {}
+        )
+
+        XCTAssertEqual(model?.sections.first?.items.map(\.name), [
+            MockBrowsingMenuEntryBuilder.openBookmarksName,
+            MockBrowsingMenuEntryBuilder.downloadsName,
+            MockBrowsingMenuEntryBuilder.chatsName
+        ])
+    }
+
+    func testWebsiteMenuPlacesFallbackChatsAfterBookmarksAndDownloads() {
+        let entryBuilder = MockBrowsingMenuEntryBuilder(chatsEntry: .named(MockBrowsingMenuEntryBuilder.chatsName))
+        let model = makeBuilder(entryBuilder: entryBuilder).buildMenu(
+            context: .website,
+            bookmarksInterface: MockMenuBookmarksInteractor(),
+            mobileCustomization: makeMobileCustomization(),
+            clearTabsAndData: {}
+        )
+
+        XCTAssertEqual(model?.sections.first?.items.map(\.name), [
+            MockBrowsingMenuEntryBuilder.openBookmarksName,
+            MockBrowsingMenuEntryBuilder.downloadsName,
+            MockBrowsingMenuEntryBuilder.chatsName
+        ])
+    }
+
+    private func makeBuilder(entryBuilder: BrowsingMenuEntryBuilding) -> BrowsingMenuBuilder {
+        BrowsingMenuBuilder(entryBuilder: entryBuilder)
+    }
+
+    private func makeMobileCustomization() -> MobileCustomization {
+        MobileCustomization(keyValueStore: MockKeyValueStore(), isPad: false)
+    }
+}
+
+private final class MockBrowsingMenuEntryBuilder: BrowsingMenuEntryBuilding {
+
+    static let chatsName = "Chats"
+    static let downloadsName = "Downloads"
+    static let openBookmarksName = "Bookmarks"
+
+    private let chatsEntry: BrowsingMenuEntry?
+
+    init(chatsEntry: BrowsingMenuEntry?) {
+        self.chatsEntry = chatsEntry
+    }
+
+    func makeShortcutsMenu() -> [BrowsingMenuEntry] { [] }
+    func makeAITabMenu() -> [BrowsingMenuEntry] { [] }
+    func makeAITabMenuHeaderContent() -> [BrowsingMenuEntry] { [] }
+    func makeBrowsingMenu(with bookmarksInterface: MenuBookmarksInteracting,
+                          mobileCustomization: MobileCustomization,
+                          clearTabsAndData: @escaping () -> Void) -> [BrowsingMenuEntry] { [] }
+    func makeBrowsingMenuHeaderContent() -> [BrowsingMenuEntry] { [] }
+    func makeNewTabEntry() -> BrowsingMenuEntry { .named("New Tab") }
+    func makeChatEntry() -> BrowsingMenuEntry? { nil }
+    func makeDuckAiChatsEntry() -> BrowsingMenuEntry? { chatsEntry }
+    func makeDuckAIMenuItems() -> [BrowsingMenuEntry] { [] }
+    func makeSettingsEntry() -> BrowsingMenuEntry { .named("Settings") }
+    func makeShareEntry() -> BrowsingMenuEntry { .named("Share") }
+    func makePrintEntry() -> BrowsingMenuEntry { .named("Print") }
+    func makeDownloadsEntry() -> BrowsingMenuEntry { .named(Self.downloadsName) }
+    func makeAutoFillEntry() -> BrowsingMenuEntry? { nil }
+    func makeVPNEntry() -> BrowsingMenuEntry? { nil }
+    func makeOpenBookmarksEntry() -> BrowsingMenuEntry { .named(Self.openBookmarksName) }
+    func makeBookmarkEntries(with bookmarksInterface: MenuBookmarksInteracting) -> (bookmark: BrowsingMenuEntry, favorite: BrowsingMenuEntry)? { nil }
+    func makeFindInPageEntry() -> BrowsingMenuEntry? { nil }
+    func makeZoomEntry() -> BrowsingMenuEntry? { nil }
+    func makeDesktopSiteEntry() -> BrowsingMenuEntry? { nil }
+    func makeReloadEntry() -> BrowsingMenuEntry? { nil }
+    func makeToggleProtectionEntry() -> BrowsingMenuEntry? { nil }
+    func makeReportBrokenSiteEntry() -> BrowsingMenuEntry? { nil }
+    func makeClearDataEntry(mobileCustomization: MobileCustomization, clearTabsAndData: @escaping () -> Void) -> BrowsingMenuEntry? { nil }
+    func makeUseNewDuckAddressEntry() -> BrowsingMenuEntry? { nil }
+    func makeKeepSignInEntry() -> BrowsingMenuEntry? { nil }
+    func makeYouTubeAdBlockToggleEntry() -> BrowsingMenuEntry? { nil }
+}
+
+private final class MockMenuBookmarksInteractor: MenuBookmarksInteracting {
+
+    var favoritesDisplayMode: FavoritesDisplayMode = .displayNative(.mobile)
+
+    func createOrToggleFavorite(title: String, url: URL) {}
+    func createBookmark(title: String, url: URL) {}
+    func favorite(for url: URL) -> BookmarkEntity? { nil }
+    func bookmark(for url: URL) -> BookmarkEntity? { nil }
+}
+
+private extension BrowsingMenuEntry {
+
+    static func named(_ name: String) -> BrowsingMenuEntry {
+        .regular(name: name, image: UIImage(), action: {})
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1216279693242465

### Description
Fixes the app menu Chats row so it follows Duck AI user settings and no longer displaces Bookmarks. When Duck AI is disabled, Chats is removed from the menu. When Duck AI is enabled, Chats appears after Bookmarks, Passwords, and Downloads instead of above them.

### Testing Steps
1. Enable the `unifiedToggleInput` FF & restart. Enabled Duck AI in settings. Open a webpage.
2. Tap the bottom-right app menu button → Bookmarks, Passwords, and Downloads appear above the Duck AI menu entries (a separate section of duck.ai items)
3. Disable the Unified Input feature flag & restart while keeping Duck AI enabled.
4. Tap the bottom-right app menu button → Bookmarks, Passwords, and Downloads appear above Chats.
5. Disable Duck AI fully (Settings -> AI Features -> Duck.ai)
6. Tap the bottom-right app menu button → Chats is not shown.
7. Re-enable Duck AI and disable only the browser menu shortcut.
8. Tap the bottom-right app menu button → Chats is not shown.

### Impact
Medium: This affects the app menu ordering and Duck AI opt-out behavior for iOS users.

#### What could go wrong?
Duck AI menu entries could be hidden when the user expects them → mitigated by keeping Chats visible when Duck AI and the browser menu shortcut are enabled, and by adding menu builder coverage for the fallback Chats row.

### Quality Considerations
Added focused unit coverage for the app menu builder ordering and the Duck AI master setting suppressing browser menu visibility.

Validation performed locally:
- `git diff --check`
- `plutil -lint iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj`

Target branch: `release/ios/7.228.0`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-visible app menu ordering and Duck AI visibility on iOS; behavior is constrained by existing settings gates and new unit tests, but regressions could hide or misplace AI menu entries.
> 
> **Overview**
> Fixes the iOS sheet app menu so the fallback **Chats** row respects Duck AI opt-out and no longer sits above core shortcuts.
> 
> **Chats** is only built when `shouldShowAIChatInMenu` passes (same gate as the header Duck.ai tile), so disabling Duck AI or the browser-menu shortcut removes **Chats** from the shortcuts section. On new tab page and website menus, when Unified Toggle Input is off and the fallback **Chats** row is used, it is ordered **after** Bookmarks, Passwords (when present), and Downloads instead of leading that group.
> 
> Adds `BrowsingMenuBuilderTests` for omission vs placement of the fallback **Chats** row, plus an `AIChatSettings` test that browsing-menu visibility is false when global AI chat is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2829f9d2c3d658f7d6abc82110b994b509b54c00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->