### PR TITLE
[iOS] Simplify onboarding subscription bailout

### DIFF
--- a/iOS/DuckDuckGo/MainViewController+Segues.swift
+++ b/iOS/DuckDuckGo/MainViewController+Segues.swift
@@ -662,7 +662,6 @@ class SettingsUINavigationController: UINavigationController {
         // Bail out to home instead of popping to the Settings root
         // when leaving the onboarding subscription flow without a purchase.
         if dismissesModalOnSubscriptionBailout,
-           viewControllers.count == 2,
            !didAcquireSubscription {
             dismiss(animated: true)
             return nil


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216308700603582
Tech Design URL: N/A
CC: N/A

### Description
This PR removes redundant check when backing out of the onboarding subscription flow without purchase.

### Testing Steps
No purchase path:
1. Install the app and go through onboarding to reach the subscription promo (final step)
2. Dismiss the modal without purchasing -> Confirm that the Settings root view is not shown

Purchase path:
1. Install the app and go through onboarding to reach the subscription promo (final step)
2. Purchase a subscription and navigate back -> Confirm that the Settings root view is shown

### Impact and Risks
Low. Removes a redundant check.

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small navigation-condition change in a scoped onboarding subscription path; intended to remove a redundant guard with manual test coverage for purchase vs no-purchase back navigation.
> 
> **Overview**
> **Simplifies** when backing out of the onboarding subscription promo dismisses the whole Settings sheet instead of popping to the Settings root.
> 
> In `SettingsUINavigationController.popViewController`, the bailout path no longer requires `viewControllers.count == 2`. It now runs whenever **`dismissesModalOnSubscriptionBailout`** is set and the user **has not** acquired a subscription (`!didAcquireSubscription`), then dismisses the modal and skips the normal pop.
> 
> Behavior for onboarding subscription entry is still gated by setting `dismissesModalOnSubscriptionBailout` from `deepLinkTarget?.isOnboardingSubscriptionFlow` when Settings is launched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb3de339dc5cab25be32a4da2755e53dcd465d9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->