### PR TITLE
Make AIChat model/cookie fetch chain @MainActor to fix iOS 15 SIGTRAP

### DIFF
--- a/SharedPackages/AIChat/Package.swift
+++ b/SharedPackages/AIChat/Package.swift
@@ -65,6 +65,7 @@ let package = Package(
                 .product(name: "PrivacyConfig", package: "BrowserServicesKit"),
                 .product(name: "UserScript", package: "BrowserServicesKit"),
                 .product(name: "DuckAiDataStore", package: "BrowserServicesKit"),
+                .product(name: "WKAbstractions", package: "BrowserServicesKit"),
                 .product(name: "DDGSyncCrypto", package: "sync_crypto")
             ],
             resources: [
@@ -92,7 +93,8 @@ let package = Package(
                 "AIChatTestingUtilities",
                 .product(name: "BrowserServicesKitTestsUtils", package: "BrowserServicesKit"),
                 .product(name: "PersistenceTestingUtils", package: "BrowserServicesKit"),
-                .product(name: "PrivacyConfigTestsUtils", package: "BrowserServicesKit")
+                .product(name: "PrivacyConfigTestsUtils", package: "BrowserServicesKit"),
+                .product(name: "WKAbstractions", package: "BrowserServicesKit")
             ]
         )
     ]

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatModelsService.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatModelsService.swift
@@ -19,17 +19,20 @@
 import Foundation
 import os.log
 import WebKit
+import WKAbstractions
 
 // MARK: - Cookie Providing
 
+@MainActor
 public protocol AIChatCookieProviding {
     func cookies(for url: URL) async -> [HTTPCookie]
 }
 
+@MainActor
 public struct WKHTTPCookieStoreProvider: AIChatCookieProviding {
-    private let cookieStore: WKHTTPCookieStore
+    private let cookieStore: any DDGHTTPCookieStore
 
-    public init(cookieStore: WKHTTPCookieStore = WKWebsiteDataStore.default().httpCookieStore) {
+    public nonisolated init(cookieStore: any DDGHTTPCookieStore = HTTPCookieStoreWrapper(wrapped: WKWebsiteDataStore.default().httpCookieStore)) {
         self.cookieStore = cookieStore
     }
 
@@ -156,12 +159,14 @@ public struct AIChatRemoteModel: Decodable, Equatable {
 
 // MARK: - Service Protocol
 
+@MainActor
 public protocol AIChatModelsProviding {
     func fetchModels() async throws -> AIChatModelsResponse
 }
 
 // MARK: - Service Implementation
 
+@MainActor
 public final class AIChatModelsService: AIChatModelsProviding {
 
     public enum ServiceError: Error, LocalizedError {
@@ -183,7 +188,7 @@ public final class AIChatModelsService: AIChatModelsProviding {
     private let session: URLSession
     private let cookieProvider: AIChatCookieProviding
 
-    public init(
+    public nonisolated init(
         baseURL: URL = AIChatModelsService.defaultBaseURL,
         session: URLSession = .shared,
         cookieProvider: AIChatCookieProviding = WKHTTPCookieStoreProvider()

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatModelsServiceTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatModelsServiceTests.swift
@@ -19,6 +19,7 @@
 import XCTest
 import AIChat
 
+@MainActor
 final class AIChatModelsServiceTests: XCTestCase {
 
     // MARK: - JSON Decoding Tests
@@ -810,6 +811,7 @@ final class AIChatModelsServiceTests: XCTestCase {
 
 // MARK: - Mocks
 
+@MainActor
 private final class MockCookieProvider: AIChatCookieProviding {
     var cookiesToReturn: [HTTPCookie] = []
 

--- a/SharedPackages/AIChat/Tests/AIChatTests/WKHTTPCookieStoreProviderTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/WKHTTPCookieStoreProviderTests.swift
@@ -1,0 +1,85 @@
+//
+//  WKHTTPCookieStoreProviderTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import AIChat
+import BrowserServicesKitTestsUtils
+
+@MainActor
+final class WKHTTPCookieStoreProviderTests: XCTestCase {
+
+    private func makeCookie(name: String, domain: String) -> HTTPCookie {
+        HTTPCookie(properties: [
+            .name: name,
+            .value: "value",
+            .domain: domain,
+            .path: "/"
+        ])!
+    }
+
+    func testWhenCookieDomainExactlyMatchesHost_ThenCookieIsReturned() async {
+        let cookie = makeCookie(name: "a", domain: "duck.ai")
+        let store = MockHTTPCookieStore(allCookiesReturnValue: [cookie])
+        let provider = WKHTTPCookieStoreProvider(cookieStore: store)
+
+        let result = await provider.cookies(for: URL(string: "https://duck.ai/chat")!)
+
+        XCTAssertEqual(result.map(\.name), ["a"])
+    }
+
+    func testWhenCookieDomainHasLeadingDot_ThenSubdomainMatches() async {
+        let cookie = makeCookie(name: "a", domain: ".duck.ai")
+        let store = MockHTTPCookieStore(allCookiesReturnValue: [cookie])
+        let provider = WKHTTPCookieStoreProvider(cookieStore: store)
+
+        let result = await provider.cookies(for: URL(string: "https://chat.duck.ai/")!)
+
+        XCTAssertEqual(result.map(\.name), ["a"])
+    }
+
+    func testWhenCookieDomainDoesNotMatchHost_ThenCookieIsFilteredOut() async {
+        let cookie = makeCookie(name: "a", domain: "example.com")
+        let store = MockHTTPCookieStore(allCookiesReturnValue: [cookie])
+        let provider = WKHTTPCookieStoreProvider(cookieStore: store)
+
+        let result = await provider.cookies(for: URL(string: "https://duck.ai/")!)
+
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testWhenStoreHasMixOfMatchingAndNonMatchingCookies_ThenOnlyMatchingAreReturned() async {
+        let matching = makeCookie(name: "matching", domain: "duck.ai")
+        let matchingSubdomain = makeCookie(name: "matchingSubdomain", domain: ".duck.ai")
+        let nonMatching = makeCookie(name: "nonMatching", domain: "example.com")
+        let store = MockHTTPCookieStore(allCookiesReturnValue: [matching, matchingSubdomain, nonMatching])
+        let provider = WKHTTPCookieStoreProvider(cookieStore: store)
+
+        let result = await provider.cookies(for: URL(string: "https://duck.ai/")!)
+
+        XCTAssertEqual(result.map(\.name), ["matching", "matchingSubdomain"])
+    }
+
+    func testWhenStoreIsEmpty_ThenNoCookiesAreReturned() async {
+        let store = MockHTTPCookieStore(allCookiesReturnValue: [])
+        let provider = WKHTTPCookieStoreProvider(cookieStore: store)
+
+        let result = await provider.cookies(for: URL(string: "https://duck.ai/")!)
+
+        XCTAssertTrue(result.isEmpty)
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Sources/WKAbstractions/WKAbstractions.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/WKAbstractions/WKAbstractions.swift
@@ -79,7 +79,7 @@ public struct HTTPCookieStoreWrapper: DDGHTTPCookieStore {
     //  bridge between this wrapper and another for subscriptions
     public let wrapped: WKHTTPCookieStore
 
-    public init(wrapped: WKHTTPCookieStore) {
+    public nonisolated init(wrapped: WKHTTPCookieStore) {
         self.wrapped = wrapped
     }
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarModelPickerControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarModelPickerControllerTests.swift
@@ -278,6 +278,7 @@ private final class StubPreferences: AIChatPreferencesPersisting {
     var selectedReasoningEffortPublisher: AnyPublisher<String?, Never> { Empty().eraseToAnyPublisher() }
 }
 
+@MainActor
 private final class StubModelsService: AIChatModelsProviding {
     var result: Result<AIChatModelsResponse, Error> = .success(AIChatModelsResponse(models: []))
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarReasoningPickerControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarReasoningPickerControllerTests.swift
@@ -258,6 +258,7 @@ private final class StubReasoningPreferences: AIChatPreferencesPersisting {
     var selectedReasoningEffortPublisher: AnyPublisher<String?, Never> { Empty().eraseToAnyPublisher() }
 }
 
+@MainActor
 private final class StubModelsService: AIChatModelsProviding {
     var result: Result<AIChatModelsResponse, Error> = .success(AIChatModelsResponse(models: []))
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarToolPickerControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarToolPickerControllerTests.swift
@@ -236,6 +236,7 @@ private final class StubToolPreferences: AIChatPreferencesPersisting {
     var selectedReasoningEffortPublisher: AnyPublisher<String?, Never> { Empty().eraseToAnyPublisher() }
 }
 
+@MainActor
 private final class StubModelsService: AIChatModelsProviding {
     var result: Result<AIChatModelsResponse, Error> = .success(AIChatModelsResponse(models: []))
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIModelStoreTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIModelStoreTests.swift
@@ -467,6 +467,7 @@ private final class StubPreferences: AIChatPreferencesPersisting {
     var selectedReasoningEffortPublisher: AnyPublisher<String?, Never> { Empty().eraseToAnyPublisher() }
 }
 
+@MainActor
 private final class StubModelsService: AIChatModelsProviding {
     enum StubError: Error {
         case fetchFailed

--- a/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
@@ -1471,6 +1471,7 @@ private class MockAIChatPreferencesPersisting: AIChatPreferencesPersisting {
 
 // MARK: - Mock Models Service
 
+@MainActor
 private class MockAIChatModelsProviding: AIChatModelsProviding {
     var modelsToReturn: [AIChatRemoteModel] = []
     var errorToThrow: Error?

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarModelsProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarModelsProviderTests.swift
@@ -293,6 +293,7 @@ final class NewTabPageOmnibarModelsProviderTests: XCTestCase {
 
 // MARK: - Mocks
 
+@MainActor
 private final class MockModelsService: AIChatModelsProviding {
     var modelsToReturn: [AIChatRemoteModel] = []
     var errorToThrow: Error?


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1216258354437824?focus=true

### Description

This PR marks the whole chain (AIChatCookieProviding → WKHTTPCookieStoreProvider → AIChatModelsProviding → AIChatModelsService) @MainActor, so it is now impossible to reach allCookies() from off the main actor. The hop, which caused the exception, is removed. 

I also swapped the raw WKHTTPCookieStore for the existing @MainActor DDGHTTPCookieStore abstraction, which finally makes the cookie-filtering logic testable.

### Testing Steps
1. Open the AI Chat omnibar on macOS or iOS (`onOmnibarActivated → fetchModels → cookies(for:)`) → Duck.ai model list loads with no crash.
2. `AIChatOmnibarControllerTests` / `NewTabPageOmnibarModelsProviderTests` (macOS) and `UTIModelStoreTests` / `IPadOmnibarModelPickerControllerTests` / `IPadOmnibarReasoningPickerControllerTests` / `IPadOmnibarToolPickerControllerTests` (iOS) all pass unchanged.

### Impact
Low — isolation-only refactor of a single call chain; no behavior change for any existing caller.

#### What could go wrong?
- The iOS-15-specific crash can't be reproduced locally (no deterministic repro exists, even on-device) → mitigated by the compile-time actor-isolation guarantee: the compiler statically proves there's no cross-actor call anywhere between any caller and `allCookies()`, rather than relying on a runtime hop working correctly.

### Quality Considerations
The `AIChatTests` SPM test target (`AIChatModelsServiceTests`, plus a new `WKHTTPCookieStoreProviderTests` added here to cover the previously-untestable cookie domain-filtering logic) isn't wired into either app's test plan/scheme — a pre-existing gap, unrelated to this change. Both files were hand-verified against the real APIs; worth wiring up separately.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolation and abstraction swap on a single omnibar fetch path; intended behavior unchanged, with compile-time guarantees against cross-actor WebKit cookie access.
> 
> **Overview**
> Fixes an **iOS 15 SIGTRAP** when loading Duck.ai models by making the full path **`AIChatCookieProviding` → `WKHTTPCookieStoreProvider` → `AIChatModelsProviding` / `AIChatModelsService`** **`@MainActor`**, so **`allCookies()`** is never reached from a background actor.
> 
> **`WKHTTPCookieStoreProvider`** now depends on **`DDGHTTPCookieStore`** (`WKAbstractions`) instead of raw **`WKHTTPCookieStore`**, with **`nonisolated`** initializers where defaults still touch WebKit. **`HTTPCookieStoreWrapper`**’s initializer is **`nonisolated`** for the same pattern.
> 
> Adds **`WKHTTPCookieStoreProviderTests`** for host/domain cookie filtering via **`MockHTTPCookieStore`**, wires **`WKAbstractions`** into the **AIChat** SPM target and tests, and marks related **`AIChatModelsProviding`** test doubles **`@MainActor`** on iOS and macOS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 958f8d13d954a565637f02c1fa84436a0488a93c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->