### PR TITLE
iPad suggestions: align popover to address bar and fix spacing

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2655,7 +2655,7 @@ class MainViewController: UIViewController {
 
     private func applyWidthToTrayController() {
         if AppWidthObserver.shared.isLargeWidth {
-            self.suggestionTrayController?.float(withWidth: self.viewCoordinator.omniBar.barView.searchContainerWidth + 32)
+            self.suggestionTrayController?.float(withWidth: self.viewCoordinator.omniBar.barView.searchContainerWidth)
         } else {
             self.suggestionTrayController?.coversFullScreen = isInMinimalChromeLayout
             let bottomOmniBarHeight = appSettings.currentAddressBarPosition.isBottom ? omniBar.barView.expectedHeight : 0

--- a/iOS/DuckDuckGo/SuggestionTrayViewController.swift
+++ b/iOS/DuckDuckGo/SuggestionTrayViewController.swift
@@ -379,10 +379,11 @@ class SuggestionTrayViewController: UIViewController {
     }
 
     func float(withWidth width: CGFloat) {
-        containerView.layer.cornerRadius = 24
+        let cornerRadius = Constant.popoverCornerRadius
+        containerView.layer.cornerRadius = cornerRadius
         containerView.layer.masksToBounds = true
 
-        backgroundView.layer.cornerRadius = 24
+        backgroundView.layer.cornerRadius = cornerRadius
         backgroundView.backgroundColor = UIColor(designSystemColor: .background)
         backgroundView.clipsToBounds = false
         backgroundView.applyActiveShadow()
@@ -836,6 +837,7 @@ private extension SuggestionTrayViewController {
         static let suggestionTrayInitialHeight = 380.0
         static let fillTopInset: CGFloat = 0
         static let floatingTopInset: CGFloat = 4
+        static let popoverCornerRadius: CGFloat = 36
     }
 
     func applyTopConstraintForLayoutMode() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/PopoverSuggestionsController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/PopoverSuggestionsController.swift
@@ -114,7 +114,7 @@ final class PopoverSuggestionsController: UIViewController {
     }
 
     private func installHostingController() {
-        let listView = SuggestionsListView(viewModel: listViewModel, isAddressBarAtBottom: isAddressBarAtBottom)
+        let listView = SuggestionsListView(viewModel: listViewModel, isAddressBarAtBottom: isAddressBarAtBottom, isFloatingPopover: true)
         let hosting = UIHostingController(rootView: listView)
         hosting.view.backgroundColor = .clear
         hosting.view.translatesAutoresizingMaskIntoConstraints = false

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/SuggestionsListHeightCalculator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/SuggestionsListHeightCalculator.swift
@@ -26,8 +26,7 @@ import CoreGraphics
 enum SuggestionsListHeightCalculator {
 
     private enum Metrics {
-        /// `listTopInset` (6) per `SuggestionsListView`, top-bar only.
-        static let topContentInset: CGFloat = 6
+        static let verticalContentInset: CGFloat = 12
         /// `rowVerticalPaddingSingleLine` (15) ×2 + 24pt icon row.
         static let singleLineRowHeight: CGFloat = 54
         /// `rowVerticalPaddingWithSubtitle` (14) ×2 + title line + 21pt subtitle.
@@ -35,7 +34,7 @@ enum SuggestionsListHeightCalculator {
         /// `.listSectionSpacing(.compact)` gap between adjacent sections.
         static let interSectionSpacing: CGFloat = 10
         /// Slack below the last row so the rounded popover doesn't clip it.
-        static let bottomPadding: CGFloat = 12
+        static let bottomPadding: CGFloat = 6
     }
 
     static func height(for sections: [SuggestionSection], isAddressBarAtBottom: Bool) -> CGFloat {
@@ -45,9 +44,9 @@ enum SuggestionsListHeightCalculator {
             runningTotal + section.rows.reduce(CGFloat.zero) { $0 + rowHeight(for: $1) }
         }
         let spacing = CGFloat(max(0, sections.count - 1)) * Metrics.interSectionSpacing
-        let topInset = isAddressBarAtBottom ? 0 : Metrics.topContentInset
+        let verticalInsets = Metrics.verticalContentInset * 2
 
-        return rowsHeight + spacing + topInset + Metrics.bottomPadding
+        return rowsHeight + spacing + verticalInsets + Metrics.bottomPadding
     }
 
     private static func rowHeight(for row: SuggestionRow) -> CGFloat {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/SuggestionsListView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/SuggestionsListView.swift
@@ -27,10 +27,13 @@ struct SuggestionsListView: View {
 
     @ObservedObject var viewModel: SuggestionsListViewModel
     let isAddressBarAtBottom: Bool
+    var isFloatingPopover: Bool = false
 
     private enum Metrics {
         /// Per Figma: the list table sits 6pt below the top-positioned input's bottom margin.
         static let listTopInset: CGFloat = 6
+        static let popoverVerticalInset: CGFloat = 12
+        static let popoverSectionSpacing: CGFloat = 10
         /// Per Figma: single-line rows use 15pt top/bottom padding; rows with a subtitle use 14pt
         static let rowVerticalPaddingSingleLine: CGFloat = 15
         static let rowVerticalPaddingWithSubtitle: CGFloat = 14
@@ -53,11 +56,13 @@ struct SuggestionsListView: View {
                 }
             }
             .listStyle(.insetGrouped)
-            .modifier(CompactSectionSpacingModifier())
+            .modifier(SectionSpacingModifier(isFloatingPopover: isFloatingPopover,
+                                             popoverSpacing: Metrics.popoverSectionSpacing))
             // Replace insetGrouped's variable top margin with the design's list top inset (6pt below the
             // input on the top bar; 0 on the bottom bar, where the input sits below the list).
-            .modifier(ListTopContentMarginModifier(top: isAddressBarAtBottom ? 0 : Metrics.listTopInset,
-                                                   horizontal: Metrics.listHorizontalContentMargin))
+            .modifier(ListContentMarginsModifier(top: isFloatingPopover ? Metrics.popoverVerticalInset : (isAddressBarAtBottom ? 0 : Metrics.listTopInset),
+                                                 bottom: isFloatingPopover ? Metrics.popoverVerticalInset : nil,
+                                                 horizontal: Metrics.listHorizontalContentMargin))
             .hideScrollContentBackground()
             .background(Color(designSystemColor: .background))
             .scrollDismissesKeyboardIfAvailable()
@@ -111,7 +116,8 @@ struct SuggestionsListView: View {
     /// the rows aligned with the input's text + X clear button.
     private func rowInsets(for row: SuggestionRow) -> EdgeInsets {
         let vertical = row.subtitle == nil ? Metrics.rowVerticalPaddingSingleLine : Metrics.rowVerticalPaddingWithSubtitle
-        return EdgeInsets(top: vertical, leading: Metrics.rowLeftInset, bottom: vertical, trailing: Metrics.rowRightInset)
+        let trailing = isFloatingPopover ? Metrics.rowLeftInset : Metrics.rowRightInset
+        return EdgeInsets(top: vertical, leading: Metrics.rowLeftInset, bottom: vertical, trailing: trailing)
     }
 
     @ViewBuilder
@@ -129,23 +135,49 @@ struct SuggestionsListView: View {
 /// insetGrouped reserves a large variable top inset above the first section; replace it with the
 /// design's `top` inset, and set the `horizontal` content margin (the cell edge) explicitly so the
 /// rows align with the escape hatch and favorites grid in every orientation.
-private struct ListTopContentMarginModifier: ViewModifier {
+private struct ListContentMarginsModifier: ViewModifier {
     let top: CGFloat
+    let bottom: CGFloat?
     let horizontal: CGFloat
+
+    @ViewBuilder
     func body(content: Content) -> some View {
         if #available(iOS 17, *) {
-            content
-                .contentMargins(.top, top, for: .scrollContent)
-                .contentMargins(.horizontal, horizontal, for: .scrollContent)
+            applyMargins(to: content)
         } else {
             content
         }
     }
+
+    @available(iOS 17, *)
+    @ViewBuilder
+    private func applyMargins(to content: Content) -> some View {
+        let base = content
+            .contentMargins(.top, top, for: .scrollContent)
+            .contentMargins(.horizontal, horizontal, for: .scrollContent)
+        if let bottom {
+            base.contentMargins(.bottom, bottom, for: .scrollContent)
+        } else {
+            base
+        }
+    }
 }
 
-private struct CompactSectionSpacingModifier: ViewModifier {
+private struct SectionSpacingModifier: ViewModifier {
+    let isFloatingPopover: Bool
+    let popoverSpacing: CGFloat
+
+    @ViewBuilder
     func body(content: Content) -> some View {
-        if #available(iOS 17, *) { content.listSectionSpacing(.compact) } else { content }
+        if #available(iOS 17, *) {
+            if isFloatingPopover {
+                content.listSectionSpacing(popoverSpacing)
+            } else {
+                content.listSectionSpacing(.compact)
+            }
+        } else {
+            content
+        }
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216333358792107?focus=true
Tech Design URL:
CC:

### Description
Polishes the iPad search/Duck.ai suggestions popover: its width now matches the address-bar pill, the corner radius is opened up to match the design mock, and the top/bottom and row insets are symmetric and roomier. All changes are scoped to the iPad floating popover via `isFloatingPopover` / the large-width `float()` path, so iPhone's suggestions list is byte-identical.

### Testing Steps
1. On iPad, tap the address bar and type a query; confirm the popover width and corner radius match the address bar and the top/bottom spacing looks even.
2. Switch to Duck.ai mode and confirm the recents popover looks the same.
3. On iPhone, type a query and confirm the suggestions list is unchanged.

### Impact and Risks
Low — cosmetic layout of an existing iPad-only surface.

#### What could go wrong?
The arithmetic content-height calculator could mis-size the popover, clipping the last row or leaving a gap at the bottom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> iPad-only cosmetic layout; the main failure mode is the height calculator disagreeing with the new insets and clipping or leaving a gap at the bottom of the popover.
> 
> **Overview**
> Polishes the **iPad large-width floating suggestions popover** so it lines up with the address-bar pill and matches updated Figma spacing, without changing the iPhone suggestions list (gated by `isFloatingPopover: true` on the popover path only).
> 
> **Width & chrome:** `applyWidthToTrayController()` stops adding 32pt to the popover width so it matches `searchContainerWidth` exactly. `float(withWidth:)` uses a **36pt** corner radius (was 24pt) via `popoverCornerRadius`.
> 
> **List layout (popover only):** `SuggestionsListView` gets symmetric **12pt** top/bottom content margins, custom **10pt** section spacing, and symmetric row trailing inset when `isFloatingPopover` is set. `SuggestionsListHeightCalculator` is updated in parallel (symmetric vertical insets, tweaked bottom padding) so the tray height still fits the content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 204fc693aeba8e1d3173f3356d0f4a471d8a22e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->