### PR TITLE
Fix flaky testWhenDidUpdateStorageCacheNotificationNotificationSentThenUserScriptsAreRebuild

### DIFF
--- a/iOS/DuckDuckGoTests/ContentBlockingUpdatingTests.swift
+++ b/iOS/DuckDuckGoTests/ContentBlockingUpdatingTests.swift
@@ -233,7 +233,7 @@ final class ContentBlockingUpdatingTests: XCTestCase {
 
     func testWhenDidUpdateStorageCacheNotificationNotificationSentThenUserScriptsAreRebuild() {
         let e1 = expectation(description: "should post initial update")
-        var e2: XCTestExpectation!
+        var e2: XCTestExpectation?
         var ruleList: WKContentRuleList!
         let c = updating.userContentBlockingAssets.sink { assets in
             if ruleList == nil {
@@ -243,7 +243,8 @@ final class ContentBlockingUpdatingTests: XCTestCase {
                 // ruleList should not be recompiled
                 XCTAssertTrue(assets.rules(withName: "test") === ruleList)
                 XCTAssertTrue(assets.isValid)
-                e2.fulfill()
+                e2?.fulfill()
+                e2 = nil
             }
         }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1202406491309510/task/1216201525692622?focus=true

### Description
- the failed test run: https://github.com/duckduckgo/apple-browsers/actions/runs/28505589907 - indicated there was a double expectation fulfilment call, which is not reproduced locally on 200x text run
- Disabled the 2nd expectation fulfillment to avoid the flakiness in future

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Validate CI is green
2.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
None

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to expectation handling; no production behavior affected.
> 
> **Overview**
> Fixes intermittent CI failures in **`testWhenDidUpdateStorageCacheNotificationNotificationSentThenUserScriptsAreRebuild`** caused by **`e2`** being fulfilled more than once when the content-blocking assets sink emits extra updates.
> 
> **`e2`** is now optional; the rebuild branch calls **`e2?.fulfill()`** and clears **`e2 = nil`** so only the active expectation is satisfied and later emissions are ignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdb368556fd76e58aea185b42c0c59c8c9f88730. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->