### PR TITLE
[iOS] regression: prevent floating UI feature flag leakage for duck ai hidden chrome state

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1292,6 +1292,7 @@ class MainViewController: UIViewController {
         }
 
         viewCoordinator.updateToolbarLayoutForAddressBarPosition(position)
+        reconcileAIChromeForCurrentTab()
         swipeTabsCoordinator?.refresh(tabsModel: tabManager.currentTabsModel, scrollToSelected: true)
 
         omniBar.adjust(for: position)
@@ -6527,9 +6528,11 @@ extension MainViewController {
     }
 
     private func applyFloatingUIIfNeeded() {
+        guard floatingUIManager.isFloatingUIEnabled else { return }
         viewCoordinator.setFloatingUIEnabled(floatingUIManager.isFloatingUIEnabled)
         FloatingUIChromeStyler().decorateMainViewIfNeeded(manager: floatingUIManager, coordinator: viewCoordinator)
         viewCoordinator.updateToolbarLayoutForAddressBarPosition(appSettings.currentAddressBarPosition)
+        reconcileAIChromeForCurrentTab()
     }
 
 }

--- a/iOS/DuckDuckGo/MainViewCoordinator.swift
+++ b/iOS/DuckDuckGo/MainViewCoordinator.swift
@@ -547,9 +547,9 @@ class MainViewCoordinator {
     /// content container to the safe area, giving voice mode the full height between the AI
     /// header and the home indicator. Idempotent.
     func setAITabBottomChromeHidden(_ hidden: Bool) {
+        isAITabBottomChromeHidden = hidden
         guard navigationBarContainer.isHidden != hidden else { return }
         navigationBarContainer.isHidden = hidden
-        isAITabBottomChromeHidden = hidden
         applyAITabCollapsedTopSeparatorVisibility()
         if hidden {
             setContentContainerBottomAnchorMode(.safeArea)

--- a/iOS/DuckDuckGo/MainViewCoordinator.swift
+++ b/iOS/DuckDuckGo/MainViewCoordinator.swift
@@ -69,9 +69,6 @@ class MainViewCoordinator {
     private var statusBackgroundPresentation: StatusBackgroundPresentation = .standard
     private var statusBackgroundPresentationBeforeOmnibarEditing: StatusBackgroundPresentation?
     private(set) var isNavigationChromeHidden = false
-    /// True when the bottom UTI (`navigationBarContainer`) is intentionally hidden for the current
-    /// AI tab — voice mode or any FE-driven `hideChatInput`. Written only by `setAITabBottomChromeHidden`.
-    private(set) var isAITabBottomChromeHidden = false
     private var isNavBarContainerBottomKeyboardBased = false
     private(set) var isOmnibarInToolbar = false
     private var isFloatingUIEnabled = false
@@ -142,15 +139,11 @@ class MainViewCoordinator {
             toolbar.setOmnibarView(nil, height: 0)
             // Flag-off keeps the original toolbar height so existing chrome is unchanged.
             constraints.toolbarHeight.constant = BrowserToolbarView.legacyButtonsHeight
-            // Voice mode (and any FE-driven hideChatInput) intentionally hides the bottom UTI via
-            // setAITabBottomChromeHidden(true). The flag-off path must not undo that hide.
-            if !isAITabBottomChromeHidden {
-                navigationBarContainer.isHidden = false
-                navigationBarContainer.alpha = 1
-                navigationBarContainer.isUserInteractionEnabled = true
-                if position.isBottom {
-                    setContentContainerBottomAnchorMode(.toolbar)
-                }
+            navigationBarContainer.isHidden = false
+            navigationBarContainer.alpha = 1
+            navigationBarContainer.isUserInteractionEnabled = true
+            if position.isBottom {
+                setContentContainerBottomAnchorMode(.toolbar)
             }
             isOmnibarInToolbar = false
             return
@@ -547,7 +540,6 @@ class MainViewCoordinator {
     /// content container to the safe area, giving voice mode the full height between the AI
     /// header and the home indicator. Idempotent.
     func setAITabBottomChromeHidden(_ hidden: Bool) {
-        isAITabBottomChromeHidden = hidden
         guard navigationBarContainer.isHidden != hidden else { return }
         navigationBarContainer.isHidden = hidden
         applyAITabCollapsedTopSeparatorVisibility()

--- a/iOS/DuckDuckGo/MainViewCoordinator.swift
+++ b/iOS/DuckDuckGo/MainViewCoordinator.swift
@@ -69,6 +69,9 @@ class MainViewCoordinator {
     private var statusBackgroundPresentation: StatusBackgroundPresentation = .standard
     private var statusBackgroundPresentationBeforeOmnibarEditing: StatusBackgroundPresentation?
     private(set) var isNavigationChromeHidden = false
+    /// True when the bottom UTI (`navigationBarContainer`) is intentionally hidden for the current
+    /// AI tab — voice mode or any FE-driven `hideChatInput`. Written only by `setAITabBottomChromeHidden`.
+    private(set) var isAITabBottomChromeHidden = false
     private var isNavBarContainerBottomKeyboardBased = false
     private(set) var isOmnibarInToolbar = false
     private var isFloatingUIEnabled = false
@@ -139,11 +142,15 @@ class MainViewCoordinator {
             toolbar.setOmnibarView(nil, height: 0)
             // Flag-off keeps the original toolbar height so existing chrome is unchanged.
             constraints.toolbarHeight.constant = BrowserToolbarView.legacyButtonsHeight
-            navigationBarContainer.isHidden = false
-            navigationBarContainer.alpha = 1
-            navigationBarContainer.isUserInteractionEnabled = true
-            if position.isBottom {
-                setContentContainerBottomAnchorMode(.toolbar)
+            // Voice mode (and any FE-driven hideChatInput) intentionally hides the bottom UTI via
+            // setAITabBottomChromeHidden(true). The flag-off path must not undo that hide.
+            if !isAITabBottomChromeHidden {
+                navigationBarContainer.isHidden = false
+                navigationBarContainer.alpha = 1
+                navigationBarContainer.isUserInteractionEnabled = true
+                if position.isBottom {
+                    setContentContainerBottomAnchorMode(.toolbar)
+                }
             }
             isOmnibarInToolbar = false
             return
@@ -542,6 +549,7 @@ class MainViewCoordinator {
     func setAITabBottomChromeHidden(_ hidden: Bool) {
         guard navigationBarContainer.isHidden != hidden else { return }
         navigationBarContainer.isHidden = hidden
+        isAITabBottomChromeHidden = hidden
         applyAITabCollapsedTopSeparatorVisibility()
         if hidden {
             setContentContainerBottomAnchorMode(.safeArea)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/inbox/392891325557408/item/1216287701770256/story/1216360852042287
Tech Design URL:
CC:

### Description
Fixes a regression which caused the floatingUI off path to ignore state of navigation chrome set by AI.

### Testing Steps

With `floatingUI` off and `unifiedToggleInput` on.

Problem 1: Duck.ai TOS modal dismisses itself
1. Start with a fresh install
2. Click unified input menu → New Voice Chat

Problem 2: Unified input shows up with the voice chat modal
1. Start with a fresh install
2. Open the sidebar → New Voice Chat 
3. Duck.ai modal shows up. Click "Agree and Continue"
4. Unified native input widget is visible.

Smoke tests
1. Web browsing
2. Tab switcher
3. Browser toolbar

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted chrome/layout reconciliation with an early return on a feature flag; no auth, data, or security surface.
> 
> **Overview**
> Fixes a regression where **floating UI disabled** still ran floating chrome setup and layout updates could **override Duck.ai navigation chrome** (hidden bottom input, voice-session header), causing TOS/voice modals to misbehave and the unified input to show when it should stay hidden.
> 
> **`applyFloatingUIIfNeeded()`** now **returns immediately** when `floatingUIManager.isFloatingUIEnabled` is false, so floating styling and toolbar layout tweaks no longer run on the off path.
> 
> **`reconcileAIChromeForCurrentTab()`** is invoked after address-bar position refresh and after the floating-UI-on layout path, so per-tab AI chrome state is **re-applied** whenever those layout passes run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea73c52d657cedba5e7ba6daa6dc7ff6063828df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->