### PR TITLE
Update SwitchBarTextEntryView corner radius for app rebranding

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryViewController.swift
@@ -22,6 +22,7 @@ import SwiftUI
 import Combine
 import UIComponents
 import DesignResourcesKitIcons
+import MetricBuilder
 
 final class SwitchBarTextEntryButtonsContainerView: UIView {
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
@@ -130,7 +131,8 @@ class SwitchBarTextEntryViewController: UIViewController {
     }
 
     private func updateContainerCornerRadius() {
-        let radius = Metrics.containerCornerRadius(forHeight: containerView.bounds.height)
+        let radius = Metrics.containerCornerRadius(forHeight: containerView.bounds.height,
+                                                   maximum: ContainerMetrics.cornerRadius)
         containerView.layer.cornerRadius = radius
         textEntryView.layer.cornerRadius = radius
     }
@@ -208,11 +210,10 @@ class SwitchBarTextEntryViewController: UIViewController {
 
     private struct Metrics {
         static let legacyCornerRadius: CGFloat = 16
-        static let rebrandedMaxCornerRadius: CGFloat = 26
 
-        static func containerCornerRadius(forHeight height: CGFloat) -> CGFloat {
+        static func containerCornerRadius(forHeight height: CGFloat, maximum: CGFloat) -> CGFloat {
             guard AppRebrand.isAppRebranded() else { return legacyCornerRadius }
-            return min(height / 2, rebrandedMaxCornerRadius)
+            return min(height / 2, maximum)
         }
     }
 }

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryViewController.swift
@@ -21,6 +21,7 @@ import UIKit
 import SwiftUI
 import Combine
 import UIComponents
+import DesignResourcesKitIcons
 
 final class SwitchBarTextEntryButtonsContainerView: UIView {
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
@@ -83,6 +84,11 @@ class SwitchBarTextEntryViewController: UIViewController {
         setupPasteAndGo()
     }
 
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        updateContainerCornerRadius()
+    }
+
     func refreshFireMode(fireMode: Bool) {
         applyContainerBackground(isFireTab: fireMode)
         textEntryView.refreshFireMode(fireMode: fireMode)
@@ -115,14 +121,18 @@ class SwitchBarTextEntryViewController: UIViewController {
 
     private func setupContainerViewAppearance() {
 
-        containerView.layer.cornerRadius = Metrics.containerCornerRadius
         containerView.layer.masksToBounds = false
-
-        textEntryView.layer.cornerRadius = Metrics.containerCornerRadius
         textEntryView.layer.masksToBounds = true
+        updateContainerCornerRadius()
 
         applyContainerBackground(isFireTab: handler.isFireTab)
         containerView.applyActiveShadow()
+    }
+
+    private func updateContainerCornerRadius() {
+        let radius = Metrics.containerCornerRadius(forHeight: containerView.bounds.height)
+        containerView.layer.cornerRadius = radius
+        textEntryView.layer.cornerRadius = radius
     }
 
     private func applyContainerBackground(isFireTab: Bool) {
@@ -197,6 +207,12 @@ class SwitchBarTextEntryViewController: UIViewController {
     }
 
     private struct Metrics {
-        static let containerCornerRadius: CGFloat = 16
+        static let legacyCornerRadius: CGFloat = 16
+        static let rebrandedMaxCornerRadius: CGFloat = 26
+
+        static func containerCornerRadius(forHeight height: CGFloat) -> CGFloat {
+            guard AppRebrand.isAppRebranded() else { return legacyCornerRadius }
+            return min(height / 2, rebrandedMaxCornerRadius)
+        }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1216271937140064?focus=true
Tech Design URL:
CC:

### Description

This PR updates the corner radius of `SwitchBarTextEntryView` when the appRebranding feature flag is enabled. It uses half the bar’s height when collapsed to a single line (to give fully rounded corners), and 26 (the standard rebranding corner radius) when expanded.

<img width="396" height="175" alt="image" src="https://github.com/user-attachments/assets/9760d9cd-c8df-4cc8-a18b-44bab078114b" />
<br />
<img width="393" height="126" alt="image" src="https://github.com/user-attachments/assets/78784f1d-6e2b-4fc0-bd9d-117ae5592e04" />
<br />
<img width="394" height="143" alt="image" src="https://github.com/user-attachments/assets/bd1b2fc1-200b-46ab-92af-e7d0aab065ac" />


### Testing Steps

1. Disable the `unifiedToggleInput` feature flag and restart the app
2. Verify that the corner radius of the address bar looks good when expanded and collapsed
3. Verify that with the appRebranding feature flag is disabled, the original tighter corner radius is used

### Impact

Low: Minor visual changes, small bug fixes, improvement to existing features

Just visual tweaks.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only layout change behind the app rebrand flag with unchanged legacy styling when the flag is disabled.
> 
> **Overview**
> Updates the **SwitchBar** address/text entry container so corner radius is no longer fixed at **16pt**. When **`AppRebrand.isAppRebranded()`** is on, radius is **`min(bar height / 2, ContainerMetrics.cornerRadius)`** so a single-line bar gets fully rounded ends and a taller expanded bar caps at the standard rebrand radius (~26). With rebrand off, behavior stays at the legacy **16pt** value.
> 
> Radius is applied in **`updateContainerCornerRadius()`** from **`viewDidLayoutSubviews`** (and initial setup) so it tracks layout as the bar grows or shrinks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 918c7f3b4b012e7e192f3b51b25920ace22d76da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->