### PR TITLE
Add Maestro test for iPad Duck.ai omnibar controls

### DIFF
--- a/.github/workflows/ios_end_to_end.yml
+++ b/.github/workflows/ios_end_to_end.yml
@@ -189,7 +189,8 @@ jobs:
           {"test-tag":"device_info","exclude-tags":"ipad","device-model":"iPhone-16","device":"iphone"},
           {"test-tag":"device_info","exclude-tags":"iphone","device-model":"iPad-10th-generation","device":"ipad"},
           {"test-tag":"duckplayer_classic","exclude-tags":"iphone","device-model":"iPad-10th-generation","device":"ipad"},
-          {"test-tag":"duckai_chrome_shortcut","exclude-tags":"iphone","device-model":"iPad-10th-generation","device":"ipad"}
+          {"test-tag":"duckai_chrome_shortcut","exclude-tags":"iphone","device-model":"iPad-10th-generation","device":"ipad"},
+          {"test-tag":"ipad_duckai","exclude-tags":"iphone","device-model":"iPad-10th-generation","device":"ipad"}
         ]'
         # Comma-separated suite tags from dispatch -> trimmed JSON array; empty = all suites.
         tags=$(jq -nc --arg s "$input_tags" '$s | split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length > 0))')

--- a/.maestro/ipad_duckai/ipad_duckai_bar_controls.yaml
+++ b/.maestro/ipad_duckai/ipad_duckai_bar_controls.yaml
@@ -26,6 +26,7 @@
 appId: com.duckduckgo.mobile.ios
 tags:
     - ipad
+    - ipad_duckai
 
 ---
 

--- a/.maestro/unified_toggle_input/ipad_duckai_bar_controls.yaml
+++ b/.maestro/unified_toggle_input/ipad_duckai_bar_controls.yaml
@@ -1,0 +1,98 @@
+# ipad_duckai_bar_controls.yaml
+#
+# Validates the iPad Duck.ai omnibar controls that are gated behind the
+# `iPadDuckAIBarControls` feature flag: the model picker, reasoning picker, tool
+# picker and attach button that appear in the expanded Duck.ai input area.
+#
+# Coverage:
+#   1. State gating - the four chips are hidden while the omnibar is in Search
+#      mode, and only appear once it is switched to Duck.ai mode (expanded).
+#   2. Positive     - with the flag on, switching to Duck.ai mode renders them.
+#
+# Requirements / notes:
+#   * Runs on iPad only (the controls require the iPad idiom).
+#   * `iPadDuckAIBarControls` defaults to .internalOnly, so `isInternalUser` must
+#     be true for the `ff.` override to take effect.
+#   * The inline Search/Duck.ai mode toggle is gated by the AI Features
+#     "Search & Duck.ai" setting, so the flow enables it first. The picker sits
+#     at the bottom of the iPad Settings form sheet, so it must be scrolled fully
+#     into view before tapping - otherwise the tap lands on the sheet backdrop
+#     and dismisses it without selecting.
+#   * The chips only render after the model list is fetched from the Duck.ai
+#     backend (there is no bundled default model), so this flow needs network for
+#     the model list. It does NOT submit a chat message. The model picker is the
+#     reliable "did the stack render" signal; reasoning/tool/attach additionally
+#     depend on the default model's capabilities.
+appId: com.duckduckgo.mobile.ios
+tags:
+    - ipad
+
+---
+
+- launchApp:
+    appId: "com.duckduckgo.mobile.ios"
+    clearState: true
+    clearKeychain: true
+    arguments:
+        isOnboardingCompleted: ${ONBOARDING_COMPLETED}
+        currentAppVariant: ${APP_VARIANT}
+        isRunningUITests: true
+        isInternalUser: "true"
+        ff.iPadDuckAIBarControls: "true"
+
+# Enable the Search/Duck.ai mode toggle via AI Features -> "Search & Duck.ai".
+- tapOn:
+    id: "Browser.OmniBar.Button.BrowsingMenu"
+- tapOn: "Settings"
+- scrollUntilVisible:
+    element:
+        text: "AI Features"
+    direction: DOWN
+- tapOn: "AI Features"
+# Scroll the picker fully into view and center it so the tap lands on the card,
+# not on the form-sheet backdrop (which would dismiss it without selecting).
+- scrollUntilVisible:
+    element:
+        id: "Settings.AIFeatures.Picker.SearchAndDuckAI"
+    direction: DOWN
+    centerElement: true
+- tapOn:
+    id: "Settings.AIFeatures.Picker.SearchAndDuckAI"
+- tapOn: "Settings"
+- tapOn: "Done"
+
+# Focus the omnibar - starts in Search mode; the mode toggle appears once focused.
+- tapOn:
+    id: "searchEntry"
+- assertVisible:
+    id: "Browser.OmniBar.Button.ModeToggle.Search"
+- assertVisible:
+    id: "Browser.OmniBar.Button.ModeToggle.AIChat"
+
+# State gating: in Search mode the input is not expanded, so none of the iPad
+# Duck.ai chips are shown yet.
+- assertNotVisible:
+    id: "AIChat.Omnibar.iPad.ModelPicker"
+- assertNotVisible:
+    id: "AIChat.Omnibar.iPad.ReasoningPicker"
+- assertNotVisible:
+    id: "AIChat.Omnibar.iPad.ToolPicker"
+- assertNotVisible:
+    id: "AIChat.Omnibar.iPad.Attach"
+
+# Switch to Duck.ai mode -> expands the input area and triggers the /models fetch.
+- tapOn:
+    id: "Browser.OmniBar.Button.ModeToggle.AIChat"
+
+# Positive: once the model list loads the controls appear. Allow time for the
+# network round-trip before asserting.
+- extendedWaitUntil:
+    visible:
+        id: "AIChat.Omnibar.iPad.ModelPicker"
+    timeout: 20000
+- assertVisible:
+    id: "AIChat.Omnibar.iPad.ReasoningPicker"
+- assertVisible:
+    id: "AIChat.Omnibar.iPad.ToolPicker"
+- assertVisible:
+    id: "AIChat.Omnibar.iPad.Attach"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1216167780655218?focus=true
Tech Design URL:
CC:

### Description
Adds an iPad Maestro UI test for the Duck.ai omnibar controls gated by the `iPadDuckAIBarControls` flag 

### Testing Steps
1. Run maestro test locally
2. See results of https://github.com/duckduckgo/apple-browsers/actions/runs/28938991236

### Impact and Risks
Low — adds a UI test only; no product code changes.

#### What could go wrong?
The reasoning/tool/attach assertions depend on the backend default model advertising those capabilities, so a future model-config change could make those three (not the model-picker) flaky.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI matrix changes only; no app logic. Possible E2E flake if backend default model stops advertising reasoning/tool/attach capabilities.
> 
> **Overview**
> Adds **iPad-only Maestro E2E** coverage for Duck.ai omnibar controls behind **`iPadDuckAIBarControls`**, and wires that suite into the iOS nightly/dispatch matrix.
> 
> The new flow **`ipad_duckai_bar_controls.yaml`** launches as an internal user with the flag on, turns on **Search & Duck.ai** in AI Features, then checks that model/reasoning/tool/attach chips stay hidden in Search mode and appear after switching to Duck.ai (with a wait for the remote model list). CI gains a matrix leg tagged **`ipad_duckai`** on **iPad-10th-generation**, alongside existing iPad suites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e010cd8b97c5acba40655cf5ff4a4b7a8c896cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->