### PR TITLE
Add native NetworkProtectionPixelEvent enum with legacy wire-name parity test

### DIFF
--- a/iOS/Core/NetworkProtectionPixelEvent.swift
+++ b/iOS/Core/NetworkProtectionPixelEvent.swift
@@ -1,0 +1,184 @@
+//
+//  NetworkProtectionPixelEvent.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import PixelKit
+
+/// Native `PixelKitEvent` definitions for the pixels fired by the iOS VPN packet tunnel.
+///
+/// This is the source of truth for these pixels' wire names as the tunnel migrates from the legacy
+/// `Pixel` / `DailyPixel` stack to `PixelKit`. Every case here mirrors a `Pixel.Event` case fired by
+/// `NetworkProtectionPacketTunnelProvider`, and `NetworkProtectionPixelEventTests` asserts each
+/// `name` equals the current `Pixel.Event` wire name so nothing forks during the migration.
+///
+/// Nothing fires these events yet — the tunnel call sites move over in a follow-up. `parameters`,
+/// `standardParameters` and error passthrough are therefore left at their defaults here and are
+/// populated alongside the call-site migration.
+public enum NetworkProtectionPixelEvent: PixelKitEvent {
+
+    case networkProtectionActiveUser
+    case networkProtectionAdapterEndTemporaryShutdownStateAttemptFailure
+    case networkProtectionAdapterEndTemporaryShutdownStateRecoveryFailure
+    case networkProtectionAdapterEndTemporaryShutdownStateRecoverySuccess
+    case networkProtectionClientFailedToEncodeRegisterKeyRequest
+    case networkProtectionClientFailedToFetchRegisteredServers
+    case networkProtectionClientFailedToFetchServerList
+    case networkProtectionClientFailedToFetchServerStatus
+    case networkProtectionClientFailedToParseRegisteredServersResponse
+    case networkProtectionClientFailedToParseServerListResponse
+    case networkProtectionClientFailedToParseServerStatusResponse
+    case networkProtectionClientInvalidAuthToken
+    case networkProtectionConnectionFailureLoopDetected
+    case networkProtectionConnectionTesterExtendedFailureDetected
+    case networkProtectionConnectionTesterExtendedFailureRecovered
+    case networkProtectionConnectionTesterFailureDetected
+    case networkProtectionConnectionTesterFailureRecovered
+    case networkProtectionDisconnected
+    case networkProtectionEnableAttemptConnecting
+    case networkProtectionEnableAttemptFailure
+    case networkProtectionEnableAttemptSuccess
+    case networkProtectionFailureRecoveryCompletedHealthy
+    case networkProtectionFailureRecoveryCompletedUnhealthy
+    case networkProtectionFailureRecoveryFailed
+    case networkProtectionFailureRecoveryStarted
+    case networkProtectionKeychainDeleteError
+    case networkProtectionKeychainErrorFailedToCastKeychainValueToData
+    case networkProtectionKeychainReadError
+    case networkProtectionKeychainUpdateError
+    case networkProtectionKeychainWriteError
+    case networkProtectionLatency(quality: String)
+    case networkProtectionLatencyError
+    case networkProtectionMemoryCritical
+    case networkProtectionMemoryWarning
+    case networkProtectionNoAccessTokenFoundError
+    case networkProtectionPixelStorageSetupFailure
+    case networkProtectionRekeyAttempt
+    case networkProtectionRekeyCompleted
+    case networkProtectionRekeyFailure
+    case networkProtectionServerMigrationAttempt
+    case networkProtectionServerMigrationAttemptFailure
+    case networkProtectionServerMigrationAttemptSuccess
+    case networkProtectionTunnelConfigurationCouldNotGetInterfaceAddressRange
+    case networkProtectionTunnelConfigurationCouldNotGetPeerHostName
+    case networkProtectionTunnelConfigurationCouldNotGetPeerPublicKey
+    case networkProtectionTunnelConfigurationCouldNotSelectClosestServer
+    case networkProtectionTunnelConfigurationNoServerRegistrationInfo
+    case networkProtectionTunnelFailureDetected
+    case networkProtectionTunnelFailureRecovered
+    case networkProtectionTunnelStartAttempt
+    case networkProtectionTunnelStartAttemptOnDemandWithoutAccessToken
+    case networkProtectionTunnelStartFailure
+    case networkProtectionTunnelStartSuccess
+    case networkProtectionTunnelStopAttempt
+    case networkProtectionTunnelStopFailure
+    case networkProtectionTunnelStopSuccess
+    case networkProtectionTunnelUpdateAttempt
+    case networkProtectionTunnelUpdateFailure
+    case networkProtectionTunnelUpdateSuccess
+    case networkProtectionTunnelWakeFailure
+    case networkProtectionUnhandledError
+    case networkProtectionUnmanagedSubscriptionError
+    case networkProtectionVPNAccessRevoked
+    case networkProtectionWireguardErrorCannotLocateTunnelFileDescriptor
+    case networkProtectionWireguardErrorCannotSetNetworkSettings
+    case networkProtectionWireguardErrorCannotSetWireguardConfig
+    case networkProtectionWireguardErrorCannotStartWireguardBackend
+    case networkProtectionWireguardErrorFailedDNSResolution
+    case networkProtectionWireguardErrorInvalidState
+    case subscriptionKeychainAccessError
+
+    public var name: String {
+        switch self {
+        case .networkProtectionActiveUser: return "m_netp_daily_active_d"
+        case .networkProtectionAdapterEndTemporaryShutdownStateAttemptFailure: return "m_netp_adapter_end_temporary_shutdown_state_attempt_failure"
+        case .networkProtectionAdapterEndTemporaryShutdownStateRecoveryFailure: return "m_netp_adapter_end_temporary_shutdown_state_recovery_failure"
+        case .networkProtectionAdapterEndTemporaryShutdownStateRecoverySuccess: return "m_netp_adapter_end_temporary_shutdown_state_recovery_success"
+        case .networkProtectionClientFailedToEncodeRegisterKeyRequest: return "m_netp_backend_api_error_encoding_register_request_body_failed"
+        case .networkProtectionClientFailedToFetchRegisteredServers: return "m_netp_backend_api_error_failed_to_fetch_registered_servers"
+        case .networkProtectionClientFailedToFetchServerList: return "m_netp_backend_api_error_failed_to_fetch_server_list"
+        case .networkProtectionClientFailedToFetchServerStatus: return "m_netp_server_migration_failed_to_fetch_status"
+        case .networkProtectionClientFailedToParseRegisteredServersResponse: return "m_netp_backend_api_error_parsing_device_registration_response_failed"
+        case .networkProtectionClientFailedToParseServerListResponse: return "m_netp_backend_api_error_parsing_server_list_response_failed"
+        case .networkProtectionClientFailedToParseServerStatusResponse: return "m_netp_server_migration_failed_to_parse_response"
+        case .networkProtectionClientInvalidAuthToken: return "m_netp_backend_api_error_invalid_auth_token"
+        case .networkProtectionConnectionFailureLoopDetected: return "m_netp_connection_failure_loop_detected"
+        case .networkProtectionConnectionTesterExtendedFailureDetected: return "m_netp_connection_tester_extended_failure"
+        case .networkProtectionConnectionTesterExtendedFailureRecovered: return "m_netp_connection_tester_extended_failure_recovered"
+        case .networkProtectionConnectionTesterFailureDetected: return "m_netp_connection_tester_failure"
+        case .networkProtectionConnectionTesterFailureRecovered: return "m_netp_connection_tester_failure_recovered"
+        case .networkProtectionDisconnected: return "m_netp_vpn_disconnect"
+        case .networkProtectionEnableAttemptConnecting: return "m_netp_ev_enable_attempt"
+        case .networkProtectionEnableAttemptFailure: return "m_netp_ev_enable_attempt_failure"
+        case .networkProtectionEnableAttemptSuccess: return "m_netp_ev_enable_attempt_success"
+        case .networkProtectionFailureRecoveryCompletedHealthy: return "m_netp_ev_failure_recovery_completed_server_healthy"
+        case .networkProtectionFailureRecoveryCompletedUnhealthy: return "m_netp_ev_failure_recovery_completed_server_unhealthy"
+        case .networkProtectionFailureRecoveryFailed: return "m_netp_ev_failure_recovery_failed"
+        case .networkProtectionFailureRecoveryStarted: return "m_netp_ev_failure_recovery_started"
+        case .networkProtectionKeychainDeleteError: return "m_netp_keychain_error_delete_failed"
+        case .networkProtectionKeychainErrorFailedToCastKeychainValueToData: return "m_netp_keychain_error_failed_to_cast_keychain_value_to_data"
+        case .networkProtectionKeychainReadError: return "m_netp_keychain_error_read_failed"
+        case .networkProtectionKeychainUpdateError: return "m_netp_keychain_error_update_failed"
+        case .networkProtectionKeychainWriteError: return "m_netp_keychain_error_write_failed"
+        case .networkProtectionLatency(let quality): return "m_netp_ev_\(quality)_latency"
+        case .networkProtectionLatencyError: return "m_netp_ev_latency_error_d"
+        case .networkProtectionMemoryCritical: return "m_netp_vpn_memory_critical"
+        case .networkProtectionMemoryWarning: return "m_netp_vpn_memory_warning"
+        case .networkProtectionNoAccessTokenFoundError: return "m_netp_no_access_token_found_error"
+        case .networkProtectionPixelStorageSetupFailure: return "m_netp_vpn_pixel_storage_setup_failure"
+        case .networkProtectionRekeyAttempt: return "m_netp_rekey_attempt"
+        case .networkProtectionRekeyCompleted: return "m_netp_rekey_completed"
+        case .networkProtectionRekeyFailure: return "m_netp_rekey_failure"
+        case .networkProtectionServerMigrationAttempt: return "m_netp_ev_server_migration_attempt"
+        case .networkProtectionServerMigrationAttemptFailure: return "m_netp_ev_server_migration_attempt_failed"
+        case .networkProtectionServerMigrationAttemptSuccess: return "m_netp_ev_server_migration_attempt_success"
+        case .networkProtectionTunnelConfigurationCouldNotGetInterfaceAddressRange: return "m_netp_tunnel_config_error_could_not_get_interface_address_range"
+        case .networkProtectionTunnelConfigurationCouldNotGetPeerHostName: return "m_netp_tunnel_config_error_could_not_get_peer_host_name"
+        case .networkProtectionTunnelConfigurationCouldNotGetPeerPublicKey: return "m_netp_tunnel_config_error_could_not_get_peer_public_key"
+        case .networkProtectionTunnelConfigurationCouldNotSelectClosestServer: return "m_netp_tunnel_config_error_could_not_select_closest_server"
+        case .networkProtectionTunnelConfigurationNoServerRegistrationInfo: return "m_netp_tunnel_config_error_no_server_registration_info"
+        case .networkProtectionTunnelFailureDetected: return "m_netp_ev_tunnel_failure"
+        case .networkProtectionTunnelFailureRecovered: return "m_netp_ev_tunnel_failure_recovered"
+        case .networkProtectionTunnelStartAttempt: return "m_netp_tunnel_start_attempt"
+        case .networkProtectionTunnelStartAttemptOnDemandWithoutAccessToken: return "m_netp_tunnel_start_attempt_on_demand_without_access_token"
+        case .networkProtectionTunnelStartFailure: return "m_netp_tunnel_start_failure"
+        case .networkProtectionTunnelStartSuccess: return "m_netp_tunnel_start_success"
+        case .networkProtectionTunnelStopAttempt: return "m_netp_tunnel_stop_attempt"
+        case .networkProtectionTunnelStopFailure: return "m_netp_tunnel_stop_failure"
+        case .networkProtectionTunnelStopSuccess: return "m_netp_tunnel_stop_success"
+        case .networkProtectionTunnelUpdateAttempt: return "m_netp_tunnel_update_attempt"
+        case .networkProtectionTunnelUpdateFailure: return "m_netp_tunnel_update_failure"
+        case .networkProtectionTunnelUpdateSuccess: return "m_netp_tunnel_update_success"
+        case .networkProtectionTunnelWakeFailure: return "m_netp_tunnel_wake_failure"
+        case .networkProtectionUnhandledError: return "m_netp_unhandled_error"
+        case .networkProtectionUnmanagedSubscriptionError: return "m_vpn_access_unmanaged_error"
+        case .networkProtectionVPNAccessRevoked: return "m_vpn_access_revoked"
+        case .networkProtectionWireguardErrorCannotLocateTunnelFileDescriptor: return "m_netp_wireguard_error_cannot_locate_tunnel_file_descriptor"
+        case .networkProtectionWireguardErrorCannotSetNetworkSettings: return "m_netp_wireguard_error_cannot_set_network_settings"
+        case .networkProtectionWireguardErrorCannotSetWireguardConfig: return "m_netp_wireguard_error_cannot_set_wireguard_config"
+        case .networkProtectionWireguardErrorCannotStartWireguardBackend: return "m_netp_wireguard_error_cannot_start_wireguard_backend"
+        case .networkProtectionWireguardErrorFailedDNSResolution: return "m_netp_wireguard_error_failed_dns_resolution"
+        case .networkProtectionWireguardErrorInvalidState: return "m_netp_wireguard_error_invalid_state"
+        case .subscriptionKeychainAccessError: return "m_privacy-pro_keychain_access_error"
+        }
+    }
+
+    public var parameters: [String: String]? { nil }
+
+    public var standardParameters: [PixelKitStandardParameter]? { nil }
+}

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 		4B27FBB12C9252F4007E21A7 /* DefaultPersistentPixelStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B27FBAF2C9251B2007E21A7 /* DefaultPersistentPixelStorageTests.swift */; };
 		4B27FBB32C926E51007E21A7 /* PersistentPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B27FBB22C926E51007E21A7 /* PersistentPixel.swift */; };
 		4B27FBB52C927435007E21A7 /* PersistentPixelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B27FBB42C927435007E21A7 /* PersistentPixelTests.swift */; };
+		7A3F1C0E9B2D4856A1E0F003 /* NetworkProtectionPixelEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3F1C0E9B2D4856A1E0F004 /* NetworkProtectionPixelEventTests.swift */; };
 		4B2855352E3825000085D31D /* privacy-reference-tests in Resources */ = {isa = PBXBuildFile; fileRef = EA39B7E1268A1A35000C62CD /* privacy-reference-tests */; };
 		4B2C79612C5B27AC00A240CC /* VPNSnoozeActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD96E082C4DCDD2003BC32C /* VPNSnoozeActivityAttributes.swift */; };
 		4B2DF8A42E64BBF800FBF11E /* WideEventService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2DF8A32E64BBF400FBF11E /* WideEventService.swift */; };
@@ -2157,6 +2158,7 @@
 		CB258D1F29A52B2500DEBA24 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB258D0C29A4CD0500DEBA24 /* Configuration.swift */; };
 		CB2A7EEF283D185100885F67 /* RulesCompilationMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2A7EEE283D185100885F67 /* RulesCompilationMonitor.swift */; };
 		CB2A7EF128410DF700885F67 /* PixelEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2A7EF028410DF700885F67 /* PixelEvent.swift */; };
+		7A3F1C0E9B2D4856A1E0F001 /* NetworkProtectionPixelEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3F1C0E9B2D4856A1E0F002 /* NetworkProtectionPixelEvent.swift */; };
 		CB2A7EF4285383B300885F67 /* AppLastCompiledRulesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2A7EF3285383B300885F67 /* AppLastCompiledRulesStore.swift */; };
 		CB3B4D442D5F757A006DAD63 /* StatisticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3B4D432D5F757A006DAD63 /* StatisticsService.swift */; };
 		CB3B4D4A2D5FA4A3006DAD63 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3B4D492D5FA4A3006DAD63 /* AppConfiguration.swift */; };
@@ -3032,6 +3034,7 @@
 		4B27FBAF2C9251B2007E21A7 /* DefaultPersistentPixelStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultPersistentPixelStorageTests.swift; sourceTree = "<group>"; };
 		4B27FBB22C926E51007E21A7 /* PersistentPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentPixel.swift; sourceTree = "<group>"; };
 		4B27FBB42C927435007E21A7 /* PersistentPixelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentPixelTests.swift; sourceTree = "<group>"; };
+		7A3F1C0E9B2D4856A1E0F004 /* NetworkProtectionPixelEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionPixelEventTests.swift; sourceTree = "<group>"; };
 		4B2DF8A32E64BBF400FBF11E /* WideEventService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WideEventService.swift; sourceTree = "<group>"; };
 		4B2DF8A52E64C67000FBF11E /* WideEventServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WideEventServiceTests.swift; sourceTree = "<group>"; };
 		4B359FD22FB52B810020D70F /* PrivacyStatsDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyStatsDatabase.swift; sourceTree = "<group>"; };
@@ -4879,6 +4882,7 @@
 		CB29792D2AF6D5C1006C461D /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		CB2A7EEE283D185100885F67 /* RulesCompilationMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesCompilationMonitor.swift; sourceTree = "<group>"; };
 		CB2A7EF028410DF700885F67 /* PixelEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelEvent.swift; sourceTree = "<group>"; };
+		7A3F1C0E9B2D4856A1E0F002 /* NetworkProtectionPixelEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionPixelEvent.swift; sourceTree = "<group>"; };
 		CB2A7EF3285383B300885F67 /* AppLastCompiledRulesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLastCompiledRulesStore.swift; sourceTree = "<group>"; };
 		CB2C47822AF6D55800AEDCD9 /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		CB3B4D432D5F757A006DAD63 /* StatisticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsService.swift; sourceTree = "<group>"; };
@@ -10696,6 +10700,7 @@
 				F1134EAE1F40AB2300B73467 /* Parser */,
 				F1134EA91F3E2BA700B73467 /* Store */,
 				CB2A7EF028410DF700885F67 /* PixelEvent.swift */,
+				7A3F1C0E9B2D4856A1E0F002 /* NetworkProtectionPixelEvent.swift */,
 				BDC234F62B27F51100D3C798 /* UniquePixel.swift */,
 				853A717520F62FE800FE60BC /* Pixel.swift */,
 				6F03CB062C32F173004179A8 /* PixelFiring.swift */,
@@ -10746,6 +10751,7 @@
 				F1134ED31F40F12B00B73467 /* Store */,
 				85C11E4020904BBE00BFFEB4 /* VariantManagerTests.swift */,
 				4B27FBB42C927435007E21A7 /* PersistentPixelTests.swift */,
+				7A3F1C0E9B2D4856A1E0F004 /* NetworkProtectionPixelEventTests.swift */,
 				4B27FBAF2C9251B2007E21A7 /* DefaultPersistentPixelStorageTests.swift */,
 			);
 			name = Statistics;
@@ -14112,6 +14118,7 @@
 				97FCCDD72F60ACA200EDB025 /* MockAIChatContentHandlingDelegate.swift in Sources */,
 				5694372B2BE3F2D900C0881B /* SyncErrorHandlerTests.swift in Sources */,
 				4B27FBB52C927435007E21A7 /* PersistentPixelTests.swift in Sources */,
+				7A3F1C0E9B2D4856A1E0F003 /* NetworkProtectionPixelEventTests.swift in Sources */,
 				987130C7294AAB9F00AB05E0 /* MenuBookmarksViewModelTests.swift in Sources */,
 				9FFDA83D2DFA8F6F007923F7 /* MockAudioSessionManager.swift in Sources */,
 				C1A74BB02EC2618D00870321 /* AutofillServiceTests.swift in Sources */,
@@ -15007,6 +15014,7 @@
 				EE00D2D82DFC3A3300B79E9D /* UserDefaults+Autofill.swift in Sources */,
 				6F03CB092C32F331004179A8 /* PixelFiringAsync.swift in Sources */,
 				CB2A7EF128410DF700885F67 /* PixelEvent.swift in Sources */,
+				7A3F1C0E9B2D4856A1E0F001 /* NetworkProtectionPixelEvent.swift in Sources */,
 				98B000532915C46E0034BCA0 /* LegacyBookmarksStoreMigration.swift in Sources */,
 				C1C23C3A2D4C349D00B6BDF6 /* DataImportManager.swift in Sources */,
 				9FEA22322C3270BD006B03BF /* TimerInterface.swift in Sources */,

--- a/iOS/DuckDuckGoTests/NetworkProtectionPixelEventTests.swift
+++ b/iOS/DuckDuckGoTests/NetworkProtectionPixelEventTests.swift
@@ -1,0 +1,119 @@
+//
+//  NetworkProtectionPixelEventTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import PixelKit
+@testable import Core
+
+/// Wire-name parity oracle for the iOS VPN tunnel pixel migration.
+///
+/// For every pixel the tunnel fires, this asserts that the native `NetworkProtectionPixelEvent`
+/// definition emits exactly the same wire name the legacy `Pixel.Event` emits today. It compares the
+/// two enums at runtime — no hand-typed expected strings — so the native definitions cannot drift
+/// from the shipping names, and the follow-up that migrates the call sites can rely on this parity.
+final class NetworkProtectionPixelEventTests: XCTestCase {
+
+    func testNativeNamesMatchLegacyWireNames() {
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionActiveUser, Pixel.Event.networkProtectionActiveUser)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionAdapterEndTemporaryShutdownStateAttemptFailure, Pixel.Event.networkProtectionAdapterEndTemporaryShutdownStateAttemptFailure)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionAdapterEndTemporaryShutdownStateRecoveryFailure, Pixel.Event.networkProtectionAdapterEndTemporaryShutdownStateRecoveryFailure)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionAdapterEndTemporaryShutdownStateRecoverySuccess, Pixel.Event.networkProtectionAdapterEndTemporaryShutdownStateRecoverySuccess)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionClientFailedToEncodeRegisterKeyRequest, Pixel.Event.networkProtectionClientFailedToEncodeRegisterKeyRequest)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionClientFailedToFetchRegisteredServers, Pixel.Event.networkProtectionClientFailedToFetchRegisteredServers)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionClientFailedToFetchServerList, Pixel.Event.networkProtectionClientFailedToFetchServerList)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionClientFailedToFetchServerStatus, Pixel.Event.networkProtectionClientFailedToFetchServerStatus)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionClientFailedToParseRegisteredServersResponse, Pixel.Event.networkProtectionClientFailedToParseRegisteredServersResponse)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionClientFailedToParseServerListResponse, Pixel.Event.networkProtectionClientFailedToParseServerListResponse)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionClientFailedToParseServerStatusResponse, Pixel.Event.networkProtectionClientFailedToParseServerStatusResponse)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionClientInvalidAuthToken, Pixel.Event.networkProtectionClientInvalidAuthToken)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionConnectionFailureLoopDetected, Pixel.Event.networkProtectionConnectionFailureLoopDetected)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionConnectionTesterExtendedFailureDetected, Pixel.Event.networkProtectionConnectionTesterExtendedFailureDetected)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionConnectionTesterExtendedFailureRecovered, Pixel.Event.networkProtectionConnectionTesterExtendedFailureRecovered(failureCount: 0))
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionConnectionTesterFailureDetected, Pixel.Event.networkProtectionConnectionTesterFailureDetected)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionConnectionTesterFailureRecovered, Pixel.Event.networkProtectionConnectionTesterFailureRecovered(failureCount: 0))
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionDisconnected, Pixel.Event.networkProtectionDisconnected)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionEnableAttemptConnecting, Pixel.Event.networkProtectionEnableAttemptConnecting)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionEnableAttemptFailure, Pixel.Event.networkProtectionEnableAttemptFailure)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionEnableAttemptSuccess, Pixel.Event.networkProtectionEnableAttemptSuccess)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionFailureRecoveryCompletedHealthy, Pixel.Event.networkProtectionFailureRecoveryCompletedHealthy)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionFailureRecoveryCompletedUnhealthy, Pixel.Event.networkProtectionFailureRecoveryCompletedUnhealthy)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionFailureRecoveryFailed, Pixel.Event.networkProtectionFailureRecoveryFailed)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionFailureRecoveryStarted, Pixel.Event.networkProtectionFailureRecoveryStarted)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionKeychainDeleteError, Pixel.Event.networkProtectionKeychainDeleteError)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionKeychainErrorFailedToCastKeychainValueToData, Pixel.Event.networkProtectionKeychainErrorFailedToCastKeychainValueToData)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionKeychainReadError, Pixel.Event.networkProtectionKeychainReadError)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionKeychainUpdateError, Pixel.Event.networkProtectionKeychainUpdateError)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionKeychainWriteError, Pixel.Event.networkProtectionKeychainWriteError)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionLatency(quality: "excellent"), Pixel.Event.networkProtectionLatency(quality: "excellent"))
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionLatencyError, Pixel.Event.networkProtectionLatencyError)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionMemoryCritical, Pixel.Event.networkProtectionMemoryCritical)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionMemoryWarning, Pixel.Event.networkProtectionMemoryWarning)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionNoAccessTokenFoundError, Pixel.Event.networkProtectionNoAccessTokenFoundError)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionPixelStorageSetupFailure, Pixel.Event.networkProtectionPixelStorageSetupFailure)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionRekeyAttempt, Pixel.Event.networkProtectionRekeyAttempt)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionRekeyCompleted, Pixel.Event.networkProtectionRekeyCompleted)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionRekeyFailure, Pixel.Event.networkProtectionRekeyFailure)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionServerMigrationAttempt, Pixel.Event.networkProtectionServerMigrationAttempt)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionServerMigrationAttemptFailure, Pixel.Event.networkProtectionServerMigrationAttemptFailure)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionServerMigrationAttemptSuccess, Pixel.Event.networkProtectionServerMigrationAttemptSuccess)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionTunnelConfigurationCouldNotGetInterfaceAddressRange, Pixel.Event.networkProtectionTunnelConfigurationCouldNotGetInterfaceAddressRange)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionTunnelConfigurationCouldNotGetPeerHostName, Pixel.Event.networkProtectionTunnelConfigurationCouldNotGetPeerHostName)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionTunnelConfigurationCouldNotGetPeerPublicKey, Pixel.Event.networkProtectionTunnelConfigurationCouldNotGetPeerPublicKey)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionTunnelConfigurationCouldNotSelectClosestServer, Pixel.Event.networkProtectionTunnelConfigurationCouldNotSelectClosestServer)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionTunnelConfigurationNoServerRegistrationInfo, Pixel.Event.networkProtectionTunnelConfigurationNoServerRegistrationInfo)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionTunnelFailureDetected, Pixel.Event.networkProtectionTunnelFailureDetected)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionTunnelFailureRecovered, Pixel.Event.networkProtectionTunnelFailureRecovered)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionTunnelStartAttempt, Pixel.Event.networkProtectionTunnelStartAttempt)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionTunnelStartAttemptOnDemandWithoutAccessToken, Pixel.Event.networkProtectionTunnelStartAttemptOnDemandWithoutAccessToken)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionTunnelStartFailure, Pixel.Event.networkProtectionTunnelStartFailure)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionTunnelStartSuccess, Pixel.Event.networkProtectionTunnelStartSuccess)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionTunnelStopAttempt, Pixel.Event.networkProtectionTunnelStopAttempt)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionTunnelStopFailure, Pixel.Event.networkProtectionTunnelStopFailure)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionTunnelStopSuccess, Pixel.Event.networkProtectionTunnelStopSuccess)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionTunnelUpdateAttempt, Pixel.Event.networkProtectionTunnelUpdateAttempt)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionTunnelUpdateFailure, Pixel.Event.networkProtectionTunnelUpdateFailure)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionTunnelUpdateSuccess, Pixel.Event.networkProtectionTunnelUpdateSuccess)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionTunnelWakeFailure, Pixel.Event.networkProtectionTunnelWakeFailure)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionUnhandledError, Pixel.Event.networkProtectionUnhandledError)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionUnmanagedSubscriptionError, Pixel.Event.networkProtectionUnmanagedSubscriptionError)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionVPNAccessRevoked, Pixel.Event.networkProtectionVPNAccessRevoked)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionWireguardErrorCannotLocateTunnelFileDescriptor, Pixel.Event.networkProtectionWireguardErrorCannotLocateTunnelFileDescriptor)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionWireguardErrorCannotSetNetworkSettings, Pixel.Event.networkProtectionWireguardErrorCannotSetNetworkSettings)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionWireguardErrorCannotSetWireguardConfig, Pixel.Event.networkProtectionWireguardErrorCannotSetWireguardConfig)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionWireguardErrorCannotStartWireguardBackend, Pixel.Event.networkProtectionWireguardErrorCannotStartWireguardBackend)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionWireguardErrorFailedDNSResolution, Pixel.Event.networkProtectionWireguardErrorFailedDNSResolution)
+        assertNameParity(NetworkProtectionPixelEvent.networkProtectionWireguardErrorInvalidState, Pixel.Event.networkProtectionWireguardErrorInvalidState)
+        assertNameParity(NetworkProtectionPixelEvent.subscriptionKeychainAccessError, Pixel.Event.subscriptionKeychainAccessError)
+    }
+
+    // MARK: - Reusable helper
+
+    /// Asserts a native `PixelKitEvent` emits the same wire name as a legacy `Pixel.Event`.
+    ///
+    /// Generic on purpose: any legacy→PixelKit pixel migration can reuse this to lock name parity.
+    /// A good candidate to promote to `SharedTestUtils` once a second migration needs it.
+    private func assertNameParity(_ native: PixelKitEvent,
+                                  _ legacy: Pixel.Event,
+                                  file: StaticString = #filePath,
+                                  line: UInt = #line) {
+        XCTAssertEqual(native.name, legacy.name,
+                       "Wire-name parity broken: native '\(native.name)' vs legacy '\(legacy.name)'",
+                       file: file, line: line)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216380234619094

### Description

Introduces `NetworkProtectionPixelEvent`, a native `PixelKitEvent` enum that will become the source of truth for the iOS VPN tunnel's pixel wire names, and a test that pins each case to its current legacy `Pixel.Event` name. This is the groundwork for migrating the tunnel off the legacy Pixel stack onto PixelKit; it is purely additive and changes no runtime behaviour.

The tunnel currently fires ~70 pixels through the legacy in-app Pixel/DailyPixel stack. Migrating the call sites in one step is risky because a mistyped wire name silently forks a metric. Landing the native definitions plus a parity oracle first lets the follow-up call-site migration rely on a green build to prove names are unchanged.

### Testing Steps

1. Run the `NetworkProtectionPixelEventTests` suite.
   - Every case's native name matches its legacy `Pixel.Event` name.

### Impact and Risks

None. Nothing fires the new enum yet and `PixelEvent.swift` is untouched, so no pixel changes. The only risk is a wrong literal in a new case, which the parity test catches at build time.

#### What could go wrong?

A native case could carry a wire name that doesn't match the legacy one. The added test asserts `native.name == Pixel.Event.<legacy>.name` for every migrated case, so any drift fails.

### Notes to Reviewer

The enum keeps all 70 tunnel pixels together for now; a semantic split can come later. The parity helper is written generically so it can move to a shared test utility if other migrations reuse it.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
