### PR TITLE
Fix fire-button tab bar and titlebar visual glitches

### DIFF
--- a/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
@@ -270,13 +270,24 @@ final class MainWindowController: NSWindowController {
 
     private var burningDataCancellable: AnyCancellable?
     private var delayedBlockingWorkItem: DispatchWorkItem?
+    private var didMoveTabBarForFireAnimation = false
 
     private func subscribeToBurningData() {
         burningDataCancellable = fireViewModel.fire.burningDataPublisher
             .dropFirst()
             .removeDuplicates()
             .sink { [weak self] burningData in
-                self?.moveTabBarView(toTitlebarView: burningData == nil)
+                guard let self else { return }
+                // The tab bar is only moved out of the titlebar so the fire animation can cover it.
+                // Site-level burns (e.g. from the New Tab Page) don't play the animation, so leave the
+                // tab bar in place to avoid a flash from needlessly reparenting it.
+                if let burningData, burningData.shouldPlayFireAnimation(decider: fireViewModel.fire.visualizeFireAnimationDecider) {
+                    moveTabBarView(toTitlebarView: false)
+                    didMoveTabBarForFireAnimation = true
+                } else if burningData == nil, didMoveTabBarForFireAnimation {
+                    moveTabBarView(toTitlebarView: true)
+                    didMoveTabBarForFireAnimation = false
+                }
             }
     }
 

--- a/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
@@ -279,13 +279,18 @@ final class MainWindowController: NSWindowController {
             .sink { [weak self] burningData in
                 guard let self else { return }
                 // The tab bar is only moved out of the titlebar so the fire animation can cover it.
-                // Site-level burns (e.g. from the New Tab Page) don't play the animation, so leave the
-                // tab bar in place to avoid a flash from needlessly reparenting it.
+                // Site-level burns (e.g. from the New Tab Page) don't play the full-screen animation, so
+                // we're leaving the tab bar in place to avoid a flash from needlessly reparenting it.
                 if let burningData, burningData.shouldPlayFireAnimation(decider: fireViewModel.fire.visualizeFireAnimationDecider) {
                     moveTabBarView(toTitlebarView: false)
+                    // The titlebar has an opaque background (see applyThemeStyle) and sits above the
+                    // full-window fire animation. With the tab bar moved out, that leaves a blank bar
+                    // over the animation — clear it so the animation shows through, and restore it after.
+                    setTitlebarBackgroundColor(.clear)
                     didMoveTabBarForFireAnimation = true
                 } else if burningData == nil, didMoveTabBarForFireAnimation {
                     moveTabBarView(toTitlebarView: true)
+                    setTitlebarBackgroundColor(theme.colorsProvider.baseBackgroundColor)
                     didMoveTabBarForFireAnimation = false
                 }
             }
@@ -349,6 +354,17 @@ final class MainWindowController: NSWindowController {
         NSLayoutConstraint.activate(constraints)
     }
 
+    /// Sets the titlebar view's layer background color on Liquid Glass, where the titlebar has an
+    /// opaque background (see `applyThemeStyle`). Used both to apply the theme background and to
+    /// clear it during the fire animation so the full-window animation shows through the titlebar.
+    private func setTitlebarBackgroundColor(_ color: NSColor) {
+        guard AppVersion.isLiquidGlassSupported, let titlebarView = window?.titlebarView else { return }
+        titlebarView.wantsLayer = true
+        titlebarView.effectiveAppearance.performAsCurrentDrawingAppearance {
+            titlebarView.layer?.backgroundColor = color.cgColor
+        }
+    }
+
     override func showWindow(_ sender: Any?) {
         window?.makeKeyAndOrderFront(sender)
         register()
@@ -391,12 +407,7 @@ extension MainWindowController: ThemeUpdateListening {
         // leaving a thin strip above it that shows through to whatever is behind the titlebarView.
         // In fullscreen the titlebarView lives in an auxiliary window whose contentView is opaque
         // white, so coloring the titlebarView's layer itself is the only way to fill that strip.
-        if AppVersion.isLiquidGlassSupported, let titlebarView = window?.titlebarView {
-            titlebarView.wantsLayer = true
-            titlebarView.effectiveAppearance.performAsCurrentDrawingAppearance {
-                titlebarView.layer?.backgroundColor = theme.colorsProvider.baseBackgroundColor.cgColor
-            }
-        }
+        setTitlebarBackgroundColor(theme.colorsProvider.baseBackgroundColor)
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1216246789222832?focus=true

### Description
Two related fixes to visual glitches in the tab bar / titlebar around the fire button:

1. **Tabs briefly disappearing when burning a site from the New Tab Page.** Don't adjust the title bar
for NTP-originated fire actions – they don't play the full screen animation, so no need to fiddle with the title bar.

3. **Blank titlebar strip over the full-screen fire animation.** Liquid Glass uses an opaque background of
the title bar, and that was causing the title bar to be profoundly displayed above the fire animation. Make
the title bar background clear for the duration of the fire animation.

### Testing Steps
1. Open a New Tab Page and make sure the recent activity / privacy feed shows at least one site; open a couple of tabs so the tab bar is visible.
2. Use the site-level fire button to burn a site from the New Tab Page → the site is cleared and the tabs in the tab bar stay visible (no flash / disappearing tabs).
5. Click the main fire button (top-right) with the fire animation setting enabled and burn → the fire animation plays and fills the whole window, with no blank bar across the titlebar.
6. With the fire animation setting disabled, repeat step 3 → burn completes without the tab bar flashing.

### Impact
Low — visual-only fixes to existing behavior; no change to what data is cleared.

### Quality Considerations
- The tab-bar move and the titlebar background clear are both gated on the same `shouldPlayFireAnimation` decision used to trigger the animation, and are only reverted if they were applied, so the views stay consistent.
- The titlebar coloring is guarded on Liquid Glass (matching the existing `applyThemeStyle` logic), so older macOS behavior is unchanged.
- Worth an extra look in fullscreen, where the titlebar lives in an auxiliary window; the titlebar is normally auto-hidden there during the animation.
- UI reparenting/titlebar behavior on `MainWindowController` isn't practically unit-testable (requires a live window/titlebar), so this was verified by a full app build and by tracing the burn flows (main button animation on/off, and New Tab Page site burn).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only window chrome changes gated on existing fire-animation logic; no data-clearing behavior changes.
> 
> **Overview**
> Fixes two **Liquid Glass / fire-button** UI glitches in `MainWindowController` by tying tab-bar reparenting and titlebar styling to the same **`shouldPlayFireAnimation`** gate used for the full-window animation.
> 
> **Site burns from the New Tab Page** no longer move the tab bar out of the titlebar (those burns don’t play the animation), which avoids a brief tab-bar flash from unnecessary reparenting.
> 
> When the **full-screen fire animation** runs, the tab bar is still moved so the animation can cover it, but the titlebar’s opaque layer background is set to **clear** for the burn and restored afterward—so the animation isn’t covered by a blank strip. A `didMoveTabBarForFireAnimation` flag ensures restore only happens when those animation-specific changes were applied.
> 
> Titlebar layer coloring is centralized in **`setTitlebarBackgroundColor`**, shared by theme updates and the burn flow (Liquid Glass only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0330d09bf7b2f8bdb25cfafc40e216adeb794bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->