### PR TITLE
[iOS] add retries for x-safari loads

### DIFF
--- a/iOS/DuckDuckGo/SafariRedirectHandler.swift
+++ b/iOS/DuckDuckGo/SafariRedirectHandler.swift
@@ -31,7 +31,7 @@ protocol SafariRedirectHandling: AnyObject {
     @discardableResult
     func handleRedirect(to url: URL) -> Bool
 
-    /// Full reset including the redirect-detected flag. Called on new top-level navigation.
+    /// Full reset including converted load attempts. Called on new top-level navigation.
     func reset()
 }
 
@@ -44,11 +44,15 @@ final class SafariRedirectHandler: SafariRedirectHandling {
 
     private enum Constants {
         static let safariHTTPSRedirectScheme = "x-safari-https"
+        static let maximumConvertedLoadAttempts = 3
     }
 
     private struct HostState {
-        var isSafariRedirectSuppressed: Bool = false
-        var loopErrorPageShown: Bool = false
+        var convertedLoadAttemptCount: Int = 0
+
+        var isSafariRedirectSuppressed: Bool {
+            convertedLoadAttemptCount > 0
+        }
     }
 
     private let tld: TLD
@@ -71,14 +75,12 @@ final class SafariRedirectHandler: SafariRedirectHandling {
         guard let host = domain(for: url) else { return false }
         var state = hostStates[host, default: HostState()]
 
-        if state.isSafariRedirectSuppressed {
-            // Second time through we're obviously in a loop
+        if state.convertedLoadAttemptCount >= Constants.maximumConvertedLoadAttempts {
             delegate?.safariRedirectHandler(self, didRequestShowSafariRedirectLoopErrorForURL: url)
         } else {
-            state.isSafariRedirectSuppressed = true
+            state.convertedLoadAttemptCount += 1
             hostStates[host] = state
 
-            // First time through try to show the https version
             convertAndLoad(url: url)
         }
         

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -1848,6 +1848,7 @@ class TabViewController: UIViewController {
     }
 
     func stopLoading() {
+        safariRedirectHandler.reset()
         webView.stopLoading()
         wasLoadingStoppedExternally = true
 

--- a/iOS/DuckDuckGoTests/SafariRedirectHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/SafariRedirectHandlerTests.swift
@@ -64,44 +64,45 @@ final class SafariRedirectHandlerTests: XCTestCase {
 
     // MARK: - Loop handling
 
-    func testSecondRedirectRequestsLoopError() {
-        _ = handler.handleRedirect(to: xSafariHTTPSURL)
-        _ = handler.handleRedirect(to: xSafariHTTPSURL)
+    func testFirstThreeRedirectsConvertToHTTPSAndLoad() {
+        for _ in 0..<3 {
+            XCTAssertTrue(handler.handleRedirect(to: xSafariHTTPSURL))
+        }
 
-        XCTAssertEqual(delegate.loadedURLs.count, 1)
+        XCTAssertEqual(delegate.loadedURLs.count, 3)
+        XCTAssertTrue(delegate.loadedURLs.allSatisfy { $0.scheme == "https" })
+        XCTAssertTrue(delegate.loadedURLs.allSatisfy { $0.host == "example.com" })
+        XCTAssertTrue(delegate.loopErrorURLs.isEmpty)
+    }
+
+    func testFourthRedirectRequestsLoopError() {
+        for _ in 0..<3 {
+            _ = handler.handleRedirect(to: xSafariHTTPSURL)
+        }
+        XCTAssertTrue(handler.handleRedirect(to: xSafariHTTPSURL))
+
+        XCTAssertEqual(delegate.loadedURLs.count, 3)
         XCTAssertEqual(delegate.loopErrorURLs.count, 1)
         XCTAssertEqual(delegate.loopErrorURLs.first?.scheme, "x-safari-https")
         XCTAssertEqual(delegate.loopErrorURLs.first?.host, "example.com")
     }
 
-    func testAdditionalRedirectsKeepRequestingLoopError() {
-        _ = handler.handleRedirect(to: xSafariHTTPSURL)
-        _ = handler.handleRedirect(to: xSafariHTTPSURL) // loop callback #1
-        _ = handler.handleRedirect(to: xSafariHTTPSURL) // loop callback #2
-        _ = handler.handleRedirect(to: xSafariHTTPSURL) // loop callback #3
+    func testAdditionalRedirectsAfterMaximumAttemptsKeepRequestingLoopError() {
+        for _ in 0..<3 {
+            _ = handler.handleRedirect(to: xSafariHTTPSURL)
+        }
 
-        XCTAssertEqual(delegate.loadedURLs.count, 1)
+        XCTAssertTrue(handler.handleRedirect(to: xSafariHTTPSURL))
+        XCTAssertTrue(handler.handleRedirect(to: xSafariHTTPSURL))
+        XCTAssertTrue(handler.handleRedirect(to: xSafariHTTPSURL))
+
+        XCTAssertEqual(delegate.loadedURLs.count, 3)
         XCTAssertEqual(delegate.loopErrorURLs.count, 3)
-        XCTAssertEqual(delegate.loopErrorURLs.first?.scheme, "x-safari-https")
-        XCTAssertEqual(delegate.loopErrorURLs.first?.host, "example.com")
-    }
-
-    func testAdditionalRedirectsAfterLoopStillCallLoopErrorCallback() {
-        _ = handler.handleRedirect(to: xSafariHTTPSURL)
-        _ = handler.handleRedirect(to: xSafariHTTPSURL) // loop callback #1
-        _ = handler.handleRedirect(to: xSafariHTTPSURL) // loop callback #2
-        _ = handler.handleRedirect(to: xSafariHTTPSURL) // loop callback #3
-
-        XCTAssertTrue(handler.handleRedirect(to: xSafariHTTPSURL))
-        XCTAssertTrue(handler.handleRedirect(to: xSafariHTTPSURL))
-
-        XCTAssertEqual(delegate.loopErrorURLs.count, 5)
-        XCTAssertEqual(delegate.loadedURLs.count, 1)
     }
 
     // MARK: - Per-host scoping
 
-    func testDifferentHostGetsFreshAlert() {
+    func testDifferentHostGetsFreshRetryBudget() {
         _ = handler.handleRedirect(to: xSafariHTTPSURL)
 
         let otherHostURL = URL(string: "x-safari-https://other.com/page")!
@@ -140,16 +141,17 @@ final class SafariRedirectHandlerTests: XCTestCase {
         XCTAssertFalse(handler.isAfterSuppressedXSafariRedirect(for: httpsURL))
     }
 
-    func testResetMidLoopStartsFresh() {
-        _ = handler.handleRedirect(to: xSafariHTTPSURL)
-        _ = handler.handleRedirect(to: xSafariHTTPSURL)
+    func testResetAfterMaximumAttemptsStartsFresh() {
+        for _ in 0..<3 {
+            _ = handler.handleRedirect(to: xSafariHTTPSURL)
+        }
         _ = handler.handleRedirect(to: xSafariHTTPSURL)
 
         handler.reset()
 
         _ = handler.handleRedirect(to: xSafariHTTPSURL)
-        XCTAssertEqual(delegate.loadedURLs.count, 2)
-        XCTAssertEqual(delegate.loopErrorURLs.count, 2)
+        XCTAssertEqual(delegate.loadedURLs.count, 4)
+        XCTAssertEqual(delegate.loopErrorURLs.count, 1)
     }
 
     // MARK: - isAfterSuppressedXSafariRedirect


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1216385010536160?focus=true
Tech Design URL:
CC:

### Description
When x-safari URLs are loaded try reloading them up to 3 times before showing the error page

### Testing Steps
1. Visit some links from https://grafana.duckduckgo.com/d/afq3b0y9349hcf/site-breakage3a-safari-redirect-flag?orgId=1&refresh=1h
2. Visit some links from https://privacy-test-pages.site/x-safari-scheme/index.html
3. Smoke test regular browsing 

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Could break navigation when x-safari URLs are loaded

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes main-frame navigation for x-safari URLs; mis-tuned retries could delay the loop error or cause extra reload attempts on broken sites.
> 
> **Overview**
> **x-safari redirect handling** no longer treats the second `x-safari-https` hit as an immediate loop. Per host, the handler now converts and reloads as HTTPS up to **three** times; only the fourth (and later) redirects trigger the Safari redirect loop error page. Breakage reporting still treats loads as “after suppressed redirect” once any conversion attempt has happened (`convertedLoadAttemptCount > 0`).
> 
> **Tab lifecycle:** `stopLoading()` now calls `safariRedirectHandler.reset()` so stopping a load clears per-host retry state (aligned with existing resets on new loads/reload).
> 
> Unit tests were updated for the new retry budget and per-host behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d800e271dd67cdcd3fae84f06cd75950b9fcecd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->