### PR TITLE
iOS: Keep native storage debug server running until Stop Server is tapped

### DIFF
--- a/iOS/DuckDuckGo/AIChatDebugView.swift
+++ b/iOS/DuckDuckGo/AIChatDebugView.swift
@@ -305,7 +305,7 @@ private struct AIChatDebugSessionTimerEntryView: View {
 
 private struct AIChatStorageServerSection: View {
     let duckAiNativeStorageHandler: DuckAiNativeStorageHandling?
-    @StateObject private var serverState = StorageServerState()
+    @ObservedObject private var serverState = StorageServerState.shared
 
     var body: some View {
         Section(header: Text(verbatim: "Native Storage Server")) {
@@ -339,19 +339,22 @@ private struct AIChatStorageServerSection: View {
     }
 }
 
+/// Owns the native-storage debug server for the app session.
 @MainActor
 private final class StorageServerState: ObservableObject {
+    /// Deliberate singleton: keeps the server alive across the debug view's lifecycle.
+    /// A DI-based owner would mean threading this through production code, which isn't
+    /// warranted for debug-only tooling.
+    static let shared = StorageServerState()
+
     @Published var errorMessage: String?
     @Published var localIPAddress: String?
 
     var isRunning: Bool { server != nil }
 
     @Published private var server: DuckAiStorageDebugServer?
-    private nonisolated(unsafe) var serverForDeinit: DuckAiStorageDebugServer?
 
-    deinit {
-        serverForDeinit?.stop()
-    }
+    private init() {}
 
     func start(handler: DuckAiNativeStorageHandling?) {
         guard let handler else {
@@ -368,7 +371,6 @@ private final class StorageServerState: ObservableObject {
             }
             try server.start()
             self.server = server
-            self.serverForDeinit = server
             self.errorMessage = nil
             self.localIPAddress = DebugServerNetworkInterface.wiFiAddress()
         } catch {
@@ -381,7 +383,6 @@ private final class StorageServerState: ObservableObject {
         case .failed(let message):
             errorMessage = message
             server = nil
-            serverForDeinit = nil
             localIPAddress = nil
         default:
             break
@@ -391,7 +392,6 @@ private final class StorageServerState: ObservableObject {
     func stop() {
         server?.stop()
         server = nil
-        serverForDeinit = nil
         localIPAddress = nil
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1216390044812724?focus=true
Tech Design URL:
CC:

### Description
The native storage debug server stopped as soon as you navigated away from Settings → AI Chat, because it was owned by a view-scoped `@StateObject` whose `deinit` stopped it. Ownership now lives on a session-lived shared holder, so the server keeps running until Stop Server is tapped. Change is contained to the debug screen with no production-code changes.

### Testing Steps
1. On an internal build, go to Settings → Debug → AI Chat and tap Start Server; confirm the server URL is reachable in a browser.
2. Navigate back out of the AI Chat debug screen (and dismiss the debug UI), then reload the server URL → it should still respond.
3. Return to the AI Chat debug screen and tap Stop Server → the URL should stop responding.

### Impact
None

#### What could go wrong?
The server (and its port 8473 binding) now persists for the whole app session until Stop Server is tapped → intended, and it is internal debug-only tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Debug-only UI in `AIChatDebugView`; no production paths change, only when port 8473 stays bound until explicit stop.
> 
> **Overview**
> The native storage debug server no longer stops when you leave **Settings → Debug → AI Chat**. It used to be tied to a view-scoped `@StateObject`, whose teardown stopped the server on navigation.
> 
> **`StorageServerState`** is now a session-lived singleton (`StorageServerState.shared`), observed from the debug section instead of owned per view. The extra `serverForDeinit` hook and `deinit` stop logic are removed; shutdown is only via **Stop Server**. Comments document that this is intentional debug-only tooling (no production DI).
> 
> When you return to the screen, UI still reflects running/stopped state from the shared holder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 430a2440d0e49404a3478ded7693c209f4cf463f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->