### PR TITLE
Add diagnostics to SERP settings keyvalue store read-error pixel

### DIFF
--- a/SharedPackages/SERPSettings/Sources/SERPSettings/SERPSettingsError.swift
+++ b/SharedPackages/SERPSettings/Sources/SERPSettings/SERPSettingsError.swift
@@ -48,3 +48,22 @@ public enum SERPSettingsError: Error {
     /// range the native side recognizes. The native getter falls back to its default.
     case unrecognizedValue
 }
+
+/// Distinguishes which operation produced a `keyValueStoreReadError`.
+///
+/// The read path does two very different things under one error case: it reads the raw value
+/// from the key-value store, then decodes that value's JSON blob into `[String: String]`. This is
+/// surfaced as the `reason` pixel parameter so the two failure modes can be told apart in analytics.
+enum SERPSettingsReadFailure: String {
+
+    /// The underlying key-value store threw while reading the raw stored value.
+    case storeRead
+
+    /// The stored blob was read successfully but failed to decode into `[String: String]`.
+    case decode
+
+    static let parameterKey = "reason"
+
+    /// Pixel parameters describing this failure, keyed by ``parameterKey``.
+    var pixelParameters: [String: String] { [Self.parameterKey: rawValue] }
+}

--- a/SharedPackages/SERPSettings/Sources/SERPSettings/SERPSettingsProviding.swift
+++ b/SharedPackages/SERPSettings/Sources/SERPSettings/SERPSettingsProviding.swift
@@ -116,20 +116,25 @@ public extension SERPSettingsProviding {
     ///
     /// - Returns: Encoded settings blob, or an empty JSON object if no data exists, or `nil` if an error occurs
     func getSERPSettings() -> Encodable? {
+        let storedString: String?
         do {
-            if let stringData = try keyValueStore?.object(forKey: SERPSettingsConstants.serpSettingsStorage) as? String,
-                let data = stringData.data(using: .utf8) {
-                let dict = try JSONDecoder().decode([String: String].self, from: data)
-                return dict
-            } else {
-                // First-time access: return empty JSON object
-                return EmptyPayload()
-            }
+            storedString = try keyValueStore?.object(forKey: SERPSettingsConstants.serpSettingsStorage) as? String
         } catch {
-            eventMapper?.fire(.keyValueStoreReadError, error: error)
+            eventMapper?.fire(.keyValueStoreReadError, error: error, parameters: SERPSettingsReadFailure.storeRead.pixelParameters)
+            return nil
         }
 
-        return nil
+        guard let storedString, let data = storedString.data(using: .utf8) else {
+            // First-time access: return empty JSON object
+            return EmptyPayload()
+        }
+
+        do {
+            return try JSONDecoder().decode([String: String].self, from: data)
+        } catch {
+            eventMapper?.fire(.keyValueStoreReadError, error: error, parameters: SERPSettingsReadFailure.decode.pixelParameters)
+            return nil
+        }
     }
 
     /// Stores SERP settings in a thread-safe manner.
@@ -264,14 +269,22 @@ public extension SERPSettingsProviding {
     // MARK: - Blob read/write helpers
 
     private func readSERPSettingsDictionary() -> [String: String]? {
+        let storedString: String?
         do {
-            guard let stringData = try keyValueStore?.object(forKey: SERPSettingsConstants.serpSettingsStorage) as? String,
-                  let data = stringData.data(using: .utf8) else {
-                return nil
-            }
+            storedString = try keyValueStore?.object(forKey: SERPSettingsConstants.serpSettingsStorage) as? String
+        } catch {
+            eventMapper?.fire(.keyValueStoreReadError, error: error, parameters: SERPSettingsReadFailure.storeRead.pixelParameters)
+            return nil
+        }
+
+        guard let storedString, let data = storedString.data(using: .utf8) else {
+            return nil
+        }
+
+        do {
             return try JSONDecoder().decode([String: String].self, from: data)
         } catch {
-            eventMapper?.fire(.keyValueStoreReadError, error: error)
+            eventMapper?.fire(.keyValueStoreReadError, error: error, parameters: SERPSettingsReadFailure.decode.pixelParameters)
             return nil
         }
     }

--- a/iOS/DuckDuckGo/SERP/SERPSettingsEventHandler.swift
+++ b/iOS/DuckDuckGo/SERP/SERPSettingsEventHandler.swift
@@ -68,14 +68,18 @@ final class SERPSettingsEventHandler: EventMapping<SERPSettingsError> {
     /// This initializer configures the event-to-pixel mappings for all
     /// supported error types.
     init() {
-        super.init { event, _, _, _ in
+        super.init { event, error, parameters, _ in
             switch event {
             case .serializationFailed:
                 // Fires when converting settings dictionary to JSON fails.
                 PixelKit.fire(SERPSettingsPixel.serpSettingsSerializationFailed, frequency: .dailyAndCount)
             case .keyValueStoreReadError:
                 // Fires when reading from persistent storage fails.
-                PixelKit.fire(SERPSettingsPixel.serpSettingsKeyValueStoreReadError, frequency: .dailyAndCount)
+                // DebugEvent attaches the underlying error's domain/code; `parameters` carries the `reason`
+                // (store read vs JSON decode) so the two failure modes can be distinguished in analytics.
+                PixelKit.fire(DebugEvent(SERPSettingsPixel.serpSettingsKeyValueStoreReadError, error: error),
+                              frequency: .dailyAndCount,
+                              withAdditionalParameters: parameters)
             case .keyValueStoreWriteError:
                 // Fires when writing to persistent storage fails.
                 PixelKit.fire(SERPSettingsPixel.serpSettingsKeyValueStoreWriteError, frequency: .dailyAndCount)

--- a/iOS/PixelDefinitions/pixels/definitions/serp_settings_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/serp_settings_pixels.json5
@@ -12,7 +12,20 @@
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "errorDomain",
+            "errorCode",
+            "underlyingErrorDomain",
+            "underlyingErrorCode",
+            {
+                "key": "reason",
+                "description": "Which read operation failed: reading the raw value from the key-value store, or decoding the stored JSON blob into [String: String]",
+                "type": "string",
+                "enum": ["storeRead", "decode"]
+            }
+        ]
     },
     "m_serp_settings_keyvalue_store_write_error": {
         "description": "Fired when writing SERP settings to persistent storage fails",

--- a/macOS/DuckDuckGo/Tab/UserScripts/SERPSettingsEventHandler.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/SERPSettingsEventHandler.swift
@@ -50,14 +50,18 @@ final class SERPSettingsEventHandler: EventMapping<SERPSettingsError> {
     /// This initializer configures the event-to-pixel mappings for all
     /// supported error types.
     init() {
-        super.init { event, _, _, _ in
+        super.init { event, error, parameters, _ in
             switch event {
             case .serializationFailed:
                 // Fires when converting settings dictionary to JSON fails.
                 PixelKit.fire(GeneralPixel.serpSettingsSerializationFailed, frequency: .dailyAndCount)
             case .keyValueStoreReadError:
                 // Fires when reading from persistent storage fails.
-                PixelKit.fire(GeneralPixel.serpSettingsKeyValueStoreReadError, frequency: .dailyAndCount)
+                // DebugEvent attaches the underlying error's domain/code; `parameters` carries the `reason`
+                // (store read vs JSON decode) so the two failure modes can be distinguished in analytics.
+                PixelKit.fire(DebugEvent(GeneralPixel.serpSettingsKeyValueStoreReadError, error: error),
+                              frequency: .dailyAndCount,
+                              withAdditionalParameters: parameters)
             case .keyValueStoreWriteError:
                 // Fires when writing to persistent storage fails.
                 PixelKit.fire(GeneralPixel.serpSettingsKeyValueStoreWriteError, frequency: .dailyAndCount)

--- a/macOS/PixelDefinitions/pixels/definitions/serp_settings_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/serp_settings_pixels.json5
@@ -12,7 +12,21 @@
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
-        "parameters": ["appVersion", "pixelSource", "channel"]
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            "errorDomain",
+            "errorCode",
+            "underlyingErrorDomain",
+            "underlyingErrorCode",
+            {
+                "key": "reason",
+                "description": "Which read operation failed: reading the raw value from the key-value store, or decoding the stored JSON blob into [String: String]",
+                "type": "string",
+                "enum": ["storeRead", "decode"]
+            }
+        ]
     },
     "m_mac_serp_settings_keyvalue_store_write_error": {
         "description": "Fired when writing SERP settings to persistent storage fails",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1216390075631186?focus=true
Tech Design URL:
CC:

### Description

Adds diagnostic data to the SERP settings read-error pixel (`…keyvalue_store_read_error`), which previously carried no error info because both platform event handlers discarded it. Now attaches the underlying error's domain/code plus a `reason` param distinguishing a key-value store read failure from a JSON-decode failure of the stored blob (the likelier cause). macOS and iOS; telemetry-only, no behavior change.

### Impact

Low. Telemetry-only; read/return behavior unchanged, only error attribution added.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only changes to error reporting and pixel metadata; SERP settings read/write semantics and user-visible behavior are unchanged.
> 
> **Overview**
> Improves **SERP settings read-error** telemetry on iOS and macOS so `…keyvalue_store_read_error` carries actionable detail instead of firing with no underlying error context.
> 
> The shared read path now **splits key-value store reads from JSON decoding** and passes a `reason` parameter (`storeRead` vs `decode`) when firing `keyValueStoreReadError`. A new `SERPSettingsReadFailure` enum supplies those pixel parameters. Platform `SERPSettingsEventHandler` implementations forward the caught `error` through **`DebugEvent`** (domain/code fields) and merge in the `reason` map.
> 
> Pixel definitions for iOS and macOS are updated to document **`errorDomain`**, **`errorCode`**, underlying error fields, and the **`reason`** enum. **Read/return behavior is unchanged**—only error attribution and analytics payloads differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5043d84b11fb75c46b470b8f675cff6bb63e27cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->