### PR TITLE
Filter out crash reports older than 7 days from crash pixels

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Crashes/CrashCollection.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Crashes/CrashCollection.swift
@@ -51,6 +51,12 @@ public enum CrashReportPixelParameter: String {
 @available(iOS 13, *)
 public final class CrashCollection {
 
+    /// Crash reports whose crash occurred more than this long ago are excluded from crash pixels.
+    ///
+    /// This prevents old crashes from skewing crash metrics and causing false alarms.
+    /// Such reports are still uploaded to Sentry, only pixel reporting is affected.
+    public static let maxCrashReportAgeForPixels: TimeInterval = .days(7)
+
     public init(crashReportSender: CrashReportSending,
                 crashCollectionStorage: KeyValueStoring = UserDefaults.standard) {
         self.crashHandler = CrashHandler()
@@ -81,7 +87,12 @@ public final class CrashCollection {
 
         crashHandler.crashDiagnosticsPayloadHandler = { payloads in
             Logger.general.log("😵 loaded \(payloads.count, privacy: .public) diagnostic payloads")
+
+            // Exclude crash reports older than `maxCrashReportAgeForPixels` from crash pixels to
+            // avoid skewing metrics with stale crashes. Uploads (`process` below) are unaffected.
+            let pixelReportingCutoffDate = Date().addingTimeInterval(-Self.maxCrashReportAgeForPixels)
             let pixelParameters = payloads
+                .filter { $0.timeStampBegin >= pixelReportingCutoffDate }
                 .compactMap(\.crashDiagnostics)
                 .flatMap { $0 }
                 .map { diagnostic in

--- a/SharedPackages/BrowserServicesKit/Sources/Crashes/CrashCollection.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Crashes/CrashCollection.swift
@@ -82,11 +82,10 @@ public final class CrashCollection {
                                                       _ payloads: [Data],
                                                       _ uploadReports: @escaping () -> Void) -> Void,
                       didFinishHandlingResponse: @escaping (() -> Void) = {}) {
-        let first = isFirstCrash
-        isFirstCrash = false
-
         crashHandler.crashDiagnosticsPayloadHandler = { payloads in
             Logger.general.log("😵 loaded \(payloads.count, privacy: .public) diagnostic payloads")
+
+            let first = self.isFirstCrash
 
             // Exclude crash reports older than `maxCrashReportAgeForPixels` from crash pixels to
             // avoid skewing metrics with stale crashes. Uploads (`process` below) are unaffected.
@@ -111,6 +110,13 @@ public final class CrashCollection {
                     params[.bundle] = metadataJSON?["bundleIdentifier"] as? String
                     return params
                 }
+
+            // Only consume the first-crash flag once we've actually reported a crash pixel, so a
+            // batch of exclusively stale (age-filtered) crashes doesn't clear it before an in-window
+            // crash is reported.
+            if !pixelParameters.isEmpty {
+                self.isFirstCrash = false
+            }
 
             // Only process crash diagnostics
             let processedData = process(payloads.filter({ $0.crashDiagnostics?.isEmpty == false }))

--- a/SharedPackages/BrowserServicesKit/Tests/CrashesTests/CrashCollectionTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/CrashesTests/CrashCollectionTests.swift
@@ -63,6 +63,49 @@ class CrashCollectionTests: XCTestCase {
         XCTAssertFalse(crashCollection.isFirstCrash)
     }
 
+    func testCrashesOlderThanMaxAgeAreExcludedFromCrashPixels() {
+        let crashReportSender = CrashReportSender(platform: .iOS, pixelEvents: nil)
+        let crashCollection = CrashCollection(crashReportSender: crashReportSender,
+                                              crashCollectionStorage: MockKeyValueStore())
+
+        var reportedPixelParameters: [[CrashReportPixelParameter: String]] = []
+        var uploadedPayloadCount = 0
+        crashCollection.start(process: { payloads in
+            uploadedPayloadCount = payloads.count
+            return payloads.map { _ in Data() }
+        }, didFindCrashReports: { pixelParameters, _, _ in
+            reportedPixelParameters = pixelParameters
+        })
+
+        let threeDaysAgo = Date().addingTimeInterval(-3 * 24 * 60 * 60)
+        let tenDaysAgo = Date().addingTimeInterval(-10 * 24 * 60 * 60)
+        crashCollection.crashHandler.didReceive([
+            MockPayload(mockCrashes: [MXCrashDiagnostic()], timeStampBegin: threeDaysAgo),
+            MockPayload(mockCrashes: [MXCrashDiagnostic()], timeStampBegin: tenDaysAgo)
+        ])
+
+        XCTAssertEqual(reportedPixelParameters.count, 1, "Only the crash within the age limit should be reported as a pixel")
+        XCTAssertEqual(uploadedPayloadCount, 2, "Both crashes should still be uploaded regardless of age")
+    }
+
+    func testCrashesWithinMaxAgeAreReportedAsCrashPixels() {
+        let crashReportSender = CrashReportSender(platform: .iOS, pixelEvents: nil)
+        let crashCollection = CrashCollection(crashReportSender: crashReportSender,
+                                              crashCollectionStorage: MockKeyValueStore())
+
+        var reportedPixelParameters: [[CrashReportPixelParameter: String]] = []
+        crashCollection.start { pixelParameters, _, _ in
+            reportedPixelParameters = pixelParameters
+        }
+
+        let sixDaysAgo = Date().addingTimeInterval(-6 * 24 * 60 * 60)
+        crashCollection.crashHandler.didReceive([
+            MockPayload(mockCrashes: [MXCrashDiagnostic()], timeStampBegin: sixDaysAgo)
+        ])
+
+        XCTAssertEqual(reportedPixelParameters.count, 1)
+    }
+
     func testCRCIDIsStoredWhenReceived() {
         let responseCRCIDValue = "CRCID Value"
 
@@ -299,14 +342,20 @@ class CrashCollectionTests: XCTestCase {
 class MockPayload: MXDiagnosticPayload {
 
     var mockCrashes: [MXCrashDiagnostic]?
+    let mockTimeStampBegin: Date
 
-    init(mockCrashes: [MXCrashDiagnostic]?) {
+    init(mockCrashes: [MXCrashDiagnostic]?, timeStampBegin: Date = Date()) {
         self.mockCrashes = mockCrashes
+        self.mockTimeStampBegin = timeStampBegin
         super.init()
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override var timeStampBegin: Date {
+        return mockTimeStampBegin
     }
 
     override var crashDiagnostics: [MXCrashDiagnostic]? {

--- a/SharedPackages/BrowserServicesKit/Tests/CrashesTests/CrashCollectionTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/CrashesTests/CrashCollectionTests.swift
@@ -106,6 +106,34 @@ class CrashCollectionTests: XCTestCase {
         XCTAssertEqual(reportedPixelParameters.count, 1)
     }
 
+    func testFirstCrashFlagIsRetainedUntilAnInWindowCrashIsReported() {
+        let crashReportSender = CrashReportSender(platform: .iOS, pixelEvents: nil)
+        let crashCollection = CrashCollection(crashReportSender: crashReportSender,
+                                              crashCollectionStorage: MockKeyValueStore())
+
+        var reportedPixelParameters: [[CrashReportPixelParameter: String]] = []
+        crashCollection.start { pixelParameters, _, _ in
+            reportedPixelParameters = pixelParameters
+        }
+
+        // A batch of exclusively stale crashes fires no pixel and must not consume the first-crash flag.
+        let tenDaysAgo = Date().addingTimeInterval(-10 * 24 * 60 * 60)
+        crashCollection.crashHandler.didReceive([
+            MockPayload(mockCrashes: [MXCrashDiagnostic()], timeStampBegin: tenDaysAgo)
+        ])
+        XCTAssertTrue(reportedPixelParameters.isEmpty)
+        XCTAssertTrue(crashCollection.isFirstCrash)
+
+        // A later in-window crash should still be reported as the first crash.
+        let oneDayAgo = Date().addingTimeInterval(-1 * 24 * 60 * 60)
+        crashCollection.crashHandler.didReceive([
+            MockPayload(mockCrashes: [MXCrashDiagnostic()], timeStampBegin: oneDayAgo)
+        ])
+        XCTAssertEqual(reportedPixelParameters.count, 1)
+        XCTAssertEqual(reportedPixelParameters.first?[.first], "1")
+        XCTAssertFalse(crashCollection.isFirstCrash)
+    }
+
     func testCRCIDIsStoredWhenReceived() {
         let responseCRCIDValue = "CRCID Value"
 

--- a/macOS/LocalPackages/CrashReporting/Sources/CrashReporting/CrashReport.swift
+++ b/macOS/LocalPackages/CrashReporting/Sources/CrashReporting/CrashReport.swift
@@ -30,6 +30,9 @@ protocol CrashReport: CrashReportPresenting {
     var contentData: Data? { get }
     var appVersion: String? { get }
     var bundleID: String? { get }
+
+    /// The date the crash report file was created, used as a proxy for when the crash occurred.
+    var creationDate: Date? { get }
 }
 
 final class LegacyCrashReport: CrashReport {
@@ -88,6 +91,8 @@ final class LegacyCrashReport: CrashReport {
 
     let appVersion: String? = nil
     let bundleID: String? = nil
+
+    var creationDate: Date? { fileManager.fileCreationDate(url: url) }
 }
 
 final class JSONCrashReport: CrashReport {
@@ -166,4 +171,6 @@ final class JSONCrashReport: CrashReport {
         }
         return version
     }
+
+    var creationDate: Date? { fileManager.fileCreationDate(url: url) }
 }

--- a/macOS/LocalPackages/CrashReporting/Sources/CrashReporting/CrashReporter.swift
+++ b/macOS/LocalPackages/CrashReporting/Sources/CrashReporting/CrashReporter.swift
@@ -94,7 +94,6 @@ public final class CrashReporter: CrashReporting {
 
         if internalUserDecider.isInternalUser {
             await send(crashReports)
-            return
         } else if await promptForConsent(latest) {
             await send(crashReports)
         }

--- a/macOS/LocalPackages/CrashReporting/Sources/CrashReporting/CrashReporter.swift
+++ b/macOS/LocalPackages/CrashReporting/Sources/CrashReporting/CrashReporter.swift
@@ -83,7 +83,8 @@ public final class CrashReporter: CrashReporting {
             return
         }
 
-        for crash in crashReports {
+        // Only fire crash pixels for reports within the age limit; stale reports are still uploaded below.
+        for crash in Self.crashReportsEligibleForPixelReporting(crashReports, now: Date()) {
             if let appVersion = crash.appVersion {
                 fireCrashPixel(crash.bundleID, appVersion, /*failedToReadCrashVersion:*/ false)
             } else {
@@ -108,6 +109,17 @@ public final class CrashReporter: CrashReporting {
             }
             let result = await sender.send(contentData, crcid: crcidManager.crcid)
             crcidManager.handleCrashSenderResult(result: result.result, response: result.response)
+        }
+    }
+
+    /// Filters out crash reports older than `CrashCollection.maxCrashReportAgeForPixels` so that stale
+    /// crashes (for example ones the collector picks up long after they happened) don't skew crash
+    /// metrics. Crashes without a creation date are reported by default.
+    static func crashReportsEligibleForPixelReporting(_ crashReports: [CrashReport], now: Date) -> [CrashReport] {
+        let cutoffDate = now.addingTimeInterval(-CrashCollection.maxCrashReportAgeForPixels)
+        return crashReports.filter { crashReport in
+            guard let creationDate = crashReport.creationDate else { return true }
+            return creationDate >= cutoffDate
         }
     }
 

--- a/macOS/LocalPackages/CrashReporting/Tests/CrashReportingTests/CrashReportTests.swift
+++ b/macOS/LocalPackages/CrashReporting/Tests/CrashReportingTests/CrashReportTests.swift
@@ -54,4 +54,28 @@ struct CrashReportTests {
         #expect(content.contains(#""deviceIdentifierForVendor":"<removed>""#))
     }
 
+    @Test("Legacy crash report exposes the file creation date", .timeLimit(.minutes(1)))
+    func legacyCrashReportExposesFileCreationDate() {
+        let fileManager = MockFileManager()
+        let creationDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let url = FileManager.userDiagnosticReports.appendingPathComponent("DuckDuckGo-legacy.crash")
+        fileManager.registerFile(at: url, in: FileManager.userDiagnosticReports, contents: "Process: DuckDuckGo [123]", creationDate: creationDate)
+
+        let report = LegacyCrashReport(url: url, fileManager: fileManager)
+
+        #expect(report.creationDate == creationDate)
+    }
+
+    @Test("JSON crash report exposes the file creation date", .timeLimit(.minutes(1)))
+    func jsonCrashReportExposesFileCreationDate() {
+        let fileManager = MockFileManager()
+        let creationDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let url = FileManager.userDiagnosticReports.appendingPathComponent("DuckDuckGo-report.ips")
+        fileManager.registerFile(at: url, in: FileManager.userDiagnosticReports, contents: "{}", creationDate: creationDate)
+
+        let report = JSONCrashReport(url: url, fileManager: fileManager)
+
+        #expect(report.creationDate == creationDate)
+    }
+
 }

--- a/macOS/LocalPackages/CrashReporting/Tests/CrashReportingTests/CrashReporterTests.swift
+++ b/macOS/LocalPackages/CrashReporting/Tests/CrashReportingTests/CrashReporterTests.swift
@@ -1,0 +1,57 @@
+//
+//  CrashReporterTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Testing
+
+@testable import CrashReporting
+
+struct CrashReporterTests {
+
+    private let day: TimeInterval = 24 * 60 * 60
+
+    @Test("Crash reports older than the pixel age limit are excluded from pixel reporting", .timeLimit(.minutes(1)))
+    func crashReportsOlderThanAgeLimitAreExcludedFromPixelReporting() {
+        let now = Date()
+        let recent = makeReport(named: "DuckDuckGo-recent.crash", creationDate: now.addingTimeInterval(-3 * day))
+        let stale = makeReport(named: "DuckDuckGo-stale.crash", creationDate: now.addingTimeInterval(-10 * day))
+
+        let eligible = CrashReporter.crashReportsEligibleForPixelReporting([recent, stale], now: now)
+
+        #expect(eligible.map(\.url) == [recent.url])
+    }
+
+    @Test("Crash reports within the pixel age limit are included in pixel reporting", .timeLimit(.minutes(1)))
+    func crashReportsWithinAgeLimitAreIncludedInPixelReporting() {
+        let now = Date()
+        let recent = makeReport(named: "DuckDuckGo-recent.crash", creationDate: now.addingTimeInterval(-6 * day))
+
+        let eligible = CrashReporter.crashReportsEligibleForPixelReporting([recent], now: now)
+
+        #expect(eligible.count == 1)
+    }
+
+    // MARK: - Helpers
+
+    private func makeReport(named name: String, creationDate: Date) -> LegacyCrashReport {
+        let fileManager = MockFileManager()
+        let url = FileManager.userDiagnosticReports.appendingPathComponent(name)
+        fileManager.registerFile(at: url, in: FileManager.userDiagnosticReports, contents: "Process: DuckDuckGo [123]", creationDate: creationDate)
+        return LegacyCrashReport(url: url, fileManager: fileManager)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1216384098622310?focus=true

### Description
We were sending a crash pixel for every crash report we received, including very old ones that MetricKit or the crash report collector only surfaced days or weeks after they actually happened. Those stale crashes skewed our crash metrics and triggered false SLO-breach alarms.

Crashes older than 7 days are now excluded from crash pixels across the board — iOS and macOS App Store (via MetricKit) and the macOS DMG crash report collector. Crash reports are still uploaded regardless of age; only pixel reporting is affected.

### Testing Steps
Covered by unit tests — there's no reliable manual repro because it depends on the OS delivering week-old crash reports.

1. Run `CrashesTests` (BrowserServicesKit) → `testCrashesOlderThanMaxAgeAreExcludedFromCrashPixels` and `testCrashesWithinMaxAgeAreReportedAsCrashPixels` pass.
2. Run `CrashReportingTests` (macOS/LocalPackages/CrashReporting) → the new `CrashReporterTests` and the `creationDate` tests in `CrashReportTests` pass.

### Impact
Low — this only narrows which crashes fire a pixel. Crash report uploads and CRCID handling are unchanged, so no crash data is lost.

#### What could go wrong?
- A legitimate recent crash gets filtered out → mitigated by a generous 7-day window (MetricKit normally delivers within ~24h) plus tests asserting within-window crashes still fire.
- A macOS DMG report without a readable creation date gets dropped → mitigated by failing open (undated reports still fire a pixel).

### Quality Considerations
- Pixels only: the age filter never touches the upload path, so crash reports still reach the dashboard regardless of age.
- Single source of truth: both pipelines use `CrashCollection.maxCrashReportAgeForPixels` (7 days).
- The macOS DMG path keys off the crash file's creation date (≈ crash time) rather than the in-file timestamp, because the existing Legacy `.crash` timestamp regex is end-of-string anchored and does not reliably match real multi-line reports.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows analytics pixel firing only; uploads and CRCID flows are untouched, with fail-open behavior when creation dates are missing.
> 
> **Overview**
> Crash **pixels** now ignore reports older than **7 days** (`CrashCollection.maxCrashReportAgeForPixels`), so late MetricKit or collector deliveries no longer inflate crash metrics or trigger false SLO alarms. **Uploads** (Sentry / server) are unchanged.
> 
> On **iOS (MetricKit)**, pixel parameters are built only from payloads with `timeStampBegin` within the window. The **first-crash** flag is cleared only after at least one in-window crash actually fires a pixel, so a batch of only stale reports no longer consumes it.
> 
> On **macOS DMG** collection, `CrashReport` gains **`creationDate`** (file creation time on legacy `.crash` and `.ips` reports). `CrashReporter` fires pixels only for reports passing the same 7-day filter; reports with no creation date still fire a pixel.
> 
> Unit tests cover age filtering, upload vs pixel behavior, first-crash retention, and creation-date exposure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cb0d91ad805e9557dd0d6ac183310e0f8e769b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->