### PR TITLE
macOS: Add Customize Responses popup to the Duck.ai omnibar tools menu

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatNotification.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatNotification.swift
@@ -25,4 +25,5 @@ public extension NSNotification.Name {
     static let aiChatVoiceSessionEnded: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.aiChat.voiceSessionEnded")
     static let aiChatNewImageGenerationChatStarted: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.aiChat.newImageGenerationChatStarted")
     static let aiChatShowModelPicker: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.aiChat.showModelPicker")
+    static let aiChatCustomizeResponsesModalClosed: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.aiChat.customizeResponsesModalClosed")
 }

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatURLParameters.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatURLParameters.swift
@@ -46,6 +46,10 @@ public enum AIChatURLParameters {
     public static let settingsName = "settings"
     public static let settingsOpenValue = "open"
 
+    /// Selects which Duck.ai shell the FE renders; `native-customize-modal` renders only the customize card.
+    public static let placementName = "placement"
+    public static let nativeCustomizeModalPlacementValue = "native-customize-modal"
+
     /// Appends `?mode=voice` to the given base URL.
     public static func voiceModeURL(from baseURL: URL) -> URL {
         modeURL(from: baseURL, mode: voiceModeValue)
@@ -64,6 +68,11 @@ public enum AIChatURLParameters {
     /// Appends `?settings=open` to the given base URL.
     public static func settingsOpenURL(from baseURL: URL) -> URL {
         baseURL.addingOrReplacing(URLQueryItem(name: settingsName, value: settingsOpenValue))
+    }
+
+    /// Appends `?placement=native-customize-modal` to the given base URL.
+    public static func nativeCustomizeModalURL(from baseURL: URL) -> URL {
+        baseURL.addingOrReplacing(URLQueryItem(name: placementName, value: nativeCustomizeModalPlacementValue))
     }
 
     /// Appends `?native-input=true` to the given base URL.

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatUserScriptMessages.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatUserScriptMessages.swift
@@ -103,5 +103,8 @@ public enum AIChatUserScriptMessages: String, CaseIterable {
 
     /// Pushed to the duck.ai page to open the Duck.ai Settings modal.
     case submitOpenSettingsAction
+
+    /// Posted by the native-customize-modal placement when the user dismisses the Customize Responses card.
+    case customizeResponsesModalClosed
 }
 // swiftlint:enable inclusive_language

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -433,6 +433,8 @@
 		31BFDB7A2ECA5FCD00ADFABD /* AIChatOmnibarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BFDB782ECA5FCD00ADFABD /* AIChatOmnibarController.swift */; };
 		CA57DE500000000000000011 /* CustomizeResponsesMenuRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA57DE500000000000000010 /* CustomizeResponsesMenuRowView.swift */; };
 		CA57DE500000000000000012 /* CustomizeResponsesMenuRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA57DE500000000000000010 /* CustomizeResponsesMenuRowView.swift */; };
+		CA57DE500000000000000021 /* CustomizeResponsesModalController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA57DE500000000000000020 /* CustomizeResponsesModalController.swift */; };
+		CA57DE500000000000000022 /* CustomizeResponsesModalController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA57DE500000000000000020 /* CustomizeResponsesModalController.swift */; };
 		31C26A0A2CBE9D2700FFF462 /* PreferencesAIChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C26A092CBE9D2200FFF462 /* PreferencesAIChat.swift */; };
 		31C26A0B2CBE9D2700FFF462 /* PreferencesAIChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C26A092CBE9D2200FFF462 /* PreferencesAIChat.swift */; };
 		31C26A0D2CBE9DFE00FFF462 /* AIChatPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C26A0C2CBE9DFA00FFF462 /* AIChatPreferences.swift */; };
@@ -5026,6 +5028,7 @@
 		31BFDB6F2ECA46DD00ADFABD /* AIChatOmnibarTextContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatOmnibarTextContainerViewController.swift; sourceTree = "<group>"; };
 		31BFDB782ECA5FCD00ADFABD /* AIChatOmnibarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatOmnibarController.swift; sourceTree = "<group>"; };
 		CA57DE500000000000000010 /* CustomizeResponsesMenuRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizeResponsesMenuRowView.swift; sourceTree = "<group>"; };
+		CA57DE500000000000000020 /* CustomizeResponsesModalController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizeResponsesModalController.swift; sourceTree = "<group>"; };
 		31C26A092CBE9D2200FFF462 /* PreferencesAIChat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesAIChat.swift; sourceTree = "<group>"; };
 		31C26A0C2CBE9DFA00FFF462 /* AIChatPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatPreferences.swift; sourceTree = "<group>"; };
 		31C3CE0128EDC1E70002C24A /* CustomRoundedCornersShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRoundedCornersShape.swift; sourceTree = "<group>"; };
@@ -7815,6 +7818,7 @@
 				31BFDB692ECA420E00ADFABD /* AIChatOmnibarContainerViewController.swift */,
 				31BFDB782ECA5FCD00ADFABD /* AIChatOmnibarController.swift */,
 				CA57DE500000000000000010 /* CustomizeResponsesMenuRowView.swift */,
+				CA57DE500000000000000020 /* CustomizeResponsesModalController.swift */,
 				31BFDB6F2ECA46DD00ADFABD /* AIChatOmnibarTextContainerViewController.swift */,
 				31E3FD712CE39C4600A392C8 /* Debug */,
 				1E4EDA262DE9ED1C0019B6E8 /* Sidebar */,
@@ -15158,6 +15162,7 @@
 				C1935A1C2C88F9ED001AD72D /* SyncPromoViewModel.swift in Sources */,
 				31BFDB7A2ECA5FCD00ADFABD /* AIChatOmnibarController.swift in Sources */,
 				CA57DE500000000000000011 /* CustomizeResponsesMenuRowView.swift in Sources */,
+				CA57DE500000000000000021 /* CustomizeResponsesModalController.swift in Sources */,
 				4D5E6F708192A3B4C5D6E7F8 /* BookmarksBarMenuCustomPopover.swift in Sources */,
 				84F1C8D02C7705B500716446 /* BookmarksBarMenuPopover.swift in Sources */,
 				2B3C4D5E6F708192A3B4C5D6 /* BookmarksBarMenuPopoverPresenting.swift in Sources */,
@@ -17705,6 +17710,7 @@
 				566B73692BECBF8400FF1959 /* SyncAlertsPresenter.swift in Sources */,
 				31BFDB792ECA5FCD00ADFABD /* AIChatOmnibarController.swift in Sources */,
 				CA57DE500000000000000012 /* CustomizeResponsesMenuRowView.swift in Sources */,
+				CA57DE500000000000000022 /* CustomizeResponsesModalController.swift in Sources */,
 				BDD13E222D8BD47A00FBC383 /* VPNBypassServiceExtensions.swift in Sources */,
 				EE1886532EB3BA4900A46272 /* NewImportSummaryView.swift in Sources */,
 				B6F41031264D2B23003DA42C /* ProgressExtension.swift in Sources */,

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -1146,6 +1146,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
                 icon: DesignSystemImages.Glyphs.Size16.glasses,
                 showsToggle: state.hasCustomization,
                 isActive: state.isActive,
+                isEnabled: !omnibarController.isImageGenerationMode,
                 onOpen: { [weak self] in self?.presentCustomizeResponsesModal() },
                 onToggle: { active in store.setActive(active) }
             )

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -139,6 +139,8 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     /// attachments error label and cleared when the user next changes attachments or the model.
     private var lastAttachmentError: String?
 
+    private var customizeResponsesModal: CustomizeResponsesModalController?
+
     let themeManager: ThemeManaging
     let omnibarController: AIChatOmnibarController
     private let duckAiNativeStorageHandler: DuckAiNativeStorageHandling?
@@ -1141,7 +1143,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
                 icon: DesignSystemImages.Glyphs.Size16.glasses,
                 showsToggle: state.hasCustomization,
                 isActive: state.isActive,
-                onOpen: {},
+                onOpen: { [weak self] in self?.presentCustomizeResponsesModal() },
                 onToggle: { active in store.setActive(active) }
             )
             let customizeItem = NSMenuItem()
@@ -1179,6 +1181,18 @@ final class AIChatOmnibarContainerViewController: NSViewController {
             PixelKit.fire(AIChatPixel.aiChatAddressBarWebSearchActivated, frequency: .dailyAndCount, includeAppVersionParameter: true)
         }
         omnibarController.toggleWebSearchMode()
+    }
+
+    private func presentCustomizeResponsesModal() {
+        guard customizeResponsesModal == nil else { return }
+        guard let parentWindow = view.window else {
+            omnibarController.openCustomizeResponses()
+            return
+        }
+        let modal = CustomizeResponsesModalController()
+        modal.onClose = { [weak self] in self?.customizeResponsesModal = nil }
+        customizeResponsesModal = modal
+        modal.present(over: parentWindow)
     }
 
     /// Routes the attach-button click. When the omnibar tab picker is enabled, opens a menu

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -144,6 +144,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     let themeManager: ThemeManaging
     let omnibarController: AIChatOmnibarController
     private let duckAiNativeStorageHandler: DuckAiNativeStorageHandling?
+    private let burnerMode: BurnerMode
     var themeUpdateCancellable: AnyCancellable?
     private var appearanceCancellable: AnyCancellable?
     private var textChangeCancellable: AnyCancellable?
@@ -307,10 +308,12 @@ final class AIChatOmnibarContainerViewController: NSViewController {
 
     required init(themeManager: ThemeManaging,
                   omnibarController: AIChatOmnibarController,
-                  duckAiNativeStorageHandler: DuckAiNativeStorageHandling?) {
+                  duckAiNativeStorageHandler: DuckAiNativeStorageHandling?,
+                  burnerMode: BurnerMode) {
         self.themeManager = themeManager
         self.omnibarController = omnibarController
         self.duckAiNativeStorageHandler = duckAiNativeStorageHandler
+        self.burnerMode = burnerMode
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -1189,7 +1192,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
             omnibarController.openCustomizeResponses()
             return
         }
-        let modal = CustomizeResponsesModalController()
+        let modal = CustomizeResponsesModalController(burnerMode: burnerMode)
         modal.onClose = { [weak self] in self?.customizeResponsesModal = nil }
         customizeResponsesModal = modal
         modal.present(over: parentWindow)

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -929,6 +929,12 @@ final class AIChatOmnibarController {
         aiChatTabOpener.openNewAIChat(in: .newTab(selected: true))
     }
 
+    /// Fallback when no window can host the modal: opens the customize URL in a tab.
+    func openCustomizeResponses() {
+        let url = AIChatURLParameters.nativeCustomizeModalURL(from: AIChatRemoteSettings().aiChatURL)
+        aiChatTabOpener.openAIChatTab(with: .url(url), behavior: .newTab(selected: true))
+    }
+
     func submit() {
         guard !currentText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return

--- a/macOS/DuckDuckGo/AIChat/CustomizeResponsesMenuRowView.swift
+++ b/macOS/DuckDuckGo/AIChat/CustomizeResponsesMenuRowView.swift
@@ -53,6 +53,7 @@ final class CustomizeResponsesMenuRowView: NSView {
     private var trackingArea: NSTrackingArea?
 
     private let showsToggle: Bool
+    private let isEnabled: Bool
     private let onOpen: () -> Void
     private let onToggle: (Bool) -> Void
 
@@ -71,9 +72,11 @@ final class CustomizeResponsesMenuRowView: NSView {
          icon: NSImage?,
          showsToggle: Bool,
          isActive: Bool,
+         isEnabled: Bool,
          onOpen: @escaping () -> Void,
          onToggle: @escaping (Bool) -> Void) {
         self.showsToggle = showsToggle
+        self.isEnabled = isEnabled
         self.onOpen = onOpen
         self.onToggle = onToggle
         super.init(frame: NSRect(x: 0, y: 0, width: Layout.width, height: Layout.height))
@@ -96,6 +99,7 @@ final class CustomizeResponsesMenuRowView: NSView {
 
         switchControl.state = isActive ? .on : .off
         switchControl.isHidden = !showsToggle
+        switchControl.isEnabled = isEnabled
         let switchSize = switchControl.intrinsicContentSize
         let switchX = Layout.width - Layout.trailingPadding - switchSize.width
         switchControl.frame = NSRect(x: switchX, y: (Layout.height - switchSize.height) / 2, width: switchSize.width, height: switchSize.height)
@@ -140,6 +144,12 @@ final class CustomizeResponsesMenuRowView: NSView {
     }
 
     private func updateColors() {
+        guard isEnabled else {
+            titleLabel.textColor = .disabledControlTextColor
+            iconView.contentTintColor = .disabledControlTextColor
+            subtitleLabel.textColor = .tertiaryLabelColor
+            return
+        }
         let foreground: NSColor = isHovering ? .alternateSelectedControlTextColor : .labelColor
         titleLabel.textColor = foreground
         iconView.contentTintColor = foreground
@@ -156,7 +166,7 @@ final class CustomizeResponsesMenuRowView: NSView {
         trackingArea = area
     }
 
-    override func mouseEntered(with event: NSEvent) { isHovering = true }
+    override func mouseEntered(with event: NSEvent) { guard isEnabled else { return }; isHovering = true }
     override func mouseExited(with event: NSEvent) { isHovering = false }
 
     override func hitTest(_ point: NSPoint) -> NSView? {
@@ -167,6 +177,7 @@ final class CustomizeResponsesMenuRowView: NSView {
     override func mouseDown(with event: NSEvent) {}
 
     override func mouseUp(with event: NSEvent) {
+        guard isEnabled else { return }
         let point = convert(event.locationInWindow, from: nil)
         guard bounds.contains(point) else { return }
 

--- a/macOS/DuckDuckGo/AIChat/CustomizeResponsesMenuRowView.swift
+++ b/macOS/DuckDuckGo/AIChat/CustomizeResponsesMenuRowView.swift
@@ -22,7 +22,10 @@ final class CustomizeResponsesMenuRowView: NSView {
 
     private enum Layout {
         static let width: CGFloat = 300
-        static let height: CGFloat = 44
+        // Height matches the native two-line Tools-menu items (title + subtitle) so the hover
+        // highlight is the same size — the two-line text block (~32pt) plus the same ~6pt total
+        // padding the single-line AIChatTabPickerMenuRowView uses around its block.
+        static let height: CGFloat = 38
         static let leadingPadding: CGFloat = 16
         static let trailingPadding: CGFloat = 14
         static let iconSize: CGFloat = 16
@@ -35,6 +38,18 @@ final class CustomizeResponsesMenuRowView: NSView {
     private let titleLabel = NSTextField(labelWithString: "")
     private let subtitleLabel = NSTextField(labelWithString: "")
     private let switchControl = NSSwitch()
+    private let selectionView: NSVisualEffectView = {
+        let view = NSVisualEffectView()
+        view.material = .selection
+        view.blendingMode = .withinWindow
+        view.state = .active
+        view.isEmphasized = true
+        view.wantsLayer = true
+        view.layer?.cornerRadius = 5
+        view.layer?.masksToBounds = true
+        view.isHidden = true
+        return view
+    }()
     private var trackingArea: NSTrackingArea?
 
     private let showsToggle: Bool
@@ -44,8 +59,8 @@ final class CustomizeResponsesMenuRowView: NSView {
     private var isHovering = false {
         didSet {
             guard oldValue != isHovering else { return }
+            selectionView.isHidden = !isHovering
             updateColors()
-            needsDisplay = true
         }
     }
 
@@ -63,6 +78,13 @@ final class CustomizeResponsesMenuRowView: NSView {
         self.onToggle = onToggle
         super.init(frame: NSRect(x: 0, y: 0, width: Layout.width, height: Layout.height))
         autoresizesSubviews = true
+
+        // Native menu-selection background (vibrant, emphasized accent) shown on hover — an opaque
+        // selectedContentBackgroundColor fill reads brighter than the system menu highlight. Added
+        // first so it sits behind the icon/labels/switch.
+        selectionView.frame = bounds.insetBy(dx: 5, dy: 0)
+        selectionView.autoresizingMask = [.width, .height]
+        addSubview(selectionView)
 
         let iconY = (Layout.height - Layout.iconSize) / 2
         iconView.frame = NSRect(x: Layout.leadingPadding, y: iconY, width: Layout.iconSize, height: Layout.iconSize)
@@ -136,15 +158,6 @@ final class CustomizeResponsesMenuRowView: NSView {
 
     override func mouseEntered(with event: NSEvent) { isHovering = true }
     override func mouseExited(with event: NSEvent) { isHovering = false }
-
-    override func draw(_ dirtyRect: NSRect) {
-        super.draw(dirtyRect)
-        if isHovering {
-            let selectionRect = bounds.insetBy(dx: 5, dy: 0)
-            NSColor.selectedContentBackgroundColor.setFill()
-            NSBezierPath(roundedRect: selectionRect, xRadius: 5, yRadius: 5).fill()
-        }
-    }
 
     override func hitTest(_ point: NSPoint) -> NSView? {
         let local = convert(point, from: superview)

--- a/macOS/DuckDuckGo/AIChat/CustomizeResponsesModalController.swift
+++ b/macOS/DuckDuckGo/AIChat/CustomizeResponsesModalController.swift
@@ -102,22 +102,23 @@ final class CustomizeResponsesModalController: NSObject {
             return nil
         }
 
-        // Tie the modal's lifetime to the parent: dismiss when it closes, and keep the scrim covering
-        // it if it moves or resizes.
+        // Tie the modal's lifetime to the parent: dismiss when it closes; re-cover it on resize
+        // (moves are handled automatically by the child-window attachment below).
         NotificationCenter.default.publisher(for: NSWindow.willCloseNotification, object: parentWindow)
             .sink { [weak self] _ in self?.dismiss() }
             .store(in: &parentCancellables)
-        Publishers.Merge(
-            NotificationCenter.default.publisher(for: NSWindow.didResizeNotification, object: parentWindow),
-            NotificationCenter.default.publisher(for: NSWindow.didMoveNotification, object: parentWindow)
-        )
-        .sink { [weak self] _ in
-            guard let self, let parentWindow = self.parentWindow else { return }
-            self.modalWindow?.setFrame(parentWindow.frame, display: true)
-        }
-        .store(in: &parentCancellables)
+        NotificationCenter.default.publisher(for: NSWindow.didResizeNotification, object: parentWindow)
+            .sink { [weak self] _ in
+                guard let self, let parentWindow = self.parentWindow else { return }
+                self.modalWindow?.setFrame(parentWindow.frame, display: true)
+            }
+            .store(in: &parentCancellables)
 
         window.setFrame(coverFrame, display: true)
+        // Attach as a child window so it stays ordered above the parent — otherwise, on app
+        // re-activation part of the parent composites in front of the scrim (un-dimmed band) — and
+        // follows the parent as it moves.
+        parentWindow.addChildWindow(window, ordered: .above)
         window.makeKeyAndOrderFront(nil)
     }
 
@@ -139,6 +140,7 @@ final class CustomizeResponsesModalController: NSObject {
         tab.webView.uiDelegate = nil
         webViewContainer?.removeFromSuperview()
         webViewContainer = nil
+        parentWindow?.removeChildWindow(window)
         window.orderOut(nil)
         modalWindow = nil
 

--- a/macOS/DuckDuckGo/AIChat/CustomizeResponsesModalController.swift
+++ b/macOS/DuckDuckGo/AIChat/CustomizeResponsesModalController.swift
@@ -47,12 +47,20 @@ final class CustomizeResponsesModalController: NSObject {
         if let escMonitor {
             NSEvent.removeMonitor(escMonitor)
         }
+        // Safety net if released without dismiss(): detach and hide the child overlay so it (and its
+        // web view) doesn't outlive the controller.
+        if let modalWindow {
+            parentWindow?.removeChildWindow(modalWindow)
+            modalWindow.orderOut(nil)
+        }
     }
 
-    override init() {
+    init(burnerMode: BurnerMode) {
         let url = AIChatURLParameters.nativeCustomizeModalURL(from: AIChatRemoteSettings().aiChatURL)
         // NOT a sidebar tab: isLoadedInSidebar makes the FE report a sidebar host and render the full chat.
-        tab = Tab(content: .url(url, source: .ui), burnerMode: .regular, isLoadedInSidebar: false)
+        // Match the presenting window's burnerMode so the native-storage bridge shares the menu row's
+        // handler (persistent for regular, the burner-scoped in-memory store in a Fire window).
+        tab = Tab(content: .url(url, source: .ui), burnerMode: burnerMode, isLoadedInSidebar: false)
         super.init()
     }
 

--- a/macOS/DuckDuckGo/AIChat/CustomizeResponsesModalController.swift
+++ b/macOS/DuckDuckGo/AIChat/CustomizeResponsesModalController.swift
@@ -1,0 +1,190 @@
+//
+//  CustomizeResponsesModalController.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Cocoa
+import Combine
+import WebKit
+import AIChat
+import BrowserServicesKit
+import Carbon.HIToolbox
+
+/// Hosts the Duck.ai Customize Responses card in a modal over the browser window: a borderless
+/// window with a dimming scrim and a centered Duck.ai web view at `?placement=native-customize-modal`.
+@MainActor
+final class CustomizeResponsesModalController: NSObject {
+
+    var onClose: (() -> Void)?
+
+    private enum Constants {
+        static let width: CGFloat = 520
+        static let height: CGFloat = 680
+    }
+
+    private let tab: Tab
+    private var modalWindow: NSWindow?
+    private var webViewContainer: WebViewContainerView?
+    private weak var parentWindow: NSWindow?
+    private var closeCancellable: AnyCancellable?
+    private var parentCancellables = Set<AnyCancellable>()
+    private var escMonitor: Any?
+
+    deinit {
+        if let escMonitor {
+            NSEvent.removeMonitor(escMonitor)
+        }
+    }
+
+    override init() {
+        let url = AIChatURLParameters.nativeCustomizeModalURL(from: AIChatRemoteSettings().aiChatURL)
+        // NOT a sidebar tab: isLoadedInSidebar makes the FE report a sidebar host and render the full chat.
+        tab = Tab(content: .url(url, source: .ui), burnerMode: .regular, isLoadedInSidebar: false)
+        super.init()
+    }
+
+    func present(over parentWindow: NSWindow) {
+        self.parentWindow = parentWindow
+
+        // One window (scrim background + centered card) avoids the z-order glitch a separate scrim window caused.
+        let coverFrame = parentWindow.frame
+        let window = CustomizeResponsesModalWindow(contentRect: coverFrame, styleMask: .borderless, backing: .buffered, defer: false)
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.hasShadow = false
+        window.isReleasedWhenClosed = false
+
+        let scrim = CustomizeResponsesScrimView(frame: NSRect(origin: .zero, size: coverFrame.size))
+        scrim.autoresizingMask = [.width, .height]
+        scrim.onBackdropClick = { [weak self] in self?.dismiss() }
+        window.contentView = scrim
+
+        let card = WebViewContainerView(tab: tab, webView: tab.webView, frame: .zero)
+        card.translatesAutoresizingMaskIntoConstraints = false
+        card.wantsLayer = true
+        card.layer?.cornerRadius = 12
+        card.layer?.masksToBounds = true
+        scrim.addSubview(card)
+        NSLayoutConstraint.activate([
+            card.centerXAnchor.constraint(equalTo: scrim.centerXAnchor),
+            card.centerYAnchor.constraint(equalTo: scrim.centerYAnchor),
+            card.widthAnchor.constraint(equalToConstant: Constants.width),
+            card.heightAnchor.constraint(equalToConstant: Constants.height)
+        ])
+        tab.webView.allowsMagnification = false
+        tab.setDelegate(self)
+        modalWindow = window
+        webViewContainer = card
+
+        closeCancellable = NotificationCenter.default.publisher(for: .aiChatCustomizeResponsesModalClosed)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] note in
+                guard let self, (note.object as AnyObject?) === self.tab.webView else { return }
+                self.dismiss()
+            }
+
+        escMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self, self.modalWindow?.isKeyWindow == true, Int(event.keyCode) == kVK_Escape else { return event }
+            self.dismiss()
+            return nil
+        }
+
+        // Tie the modal's lifetime to the parent: dismiss when it closes, and keep the scrim covering
+        // it if it moves or resizes.
+        NotificationCenter.default.publisher(for: NSWindow.willCloseNotification, object: parentWindow)
+            .sink { [weak self] _ in self?.dismiss() }
+            .store(in: &parentCancellables)
+        Publishers.Merge(
+            NotificationCenter.default.publisher(for: NSWindow.didResizeNotification, object: parentWindow),
+            NotificationCenter.default.publisher(for: NSWindow.didMoveNotification, object: parentWindow)
+        )
+        .sink { [weak self] _ in
+            guard let self, let parentWindow = self.parentWindow else { return }
+            self.modalWindow?.setFrame(parentWindow.frame, display: true)
+        }
+        .store(in: &parentCancellables)
+
+        window.setFrame(coverFrame, display: true)
+        window.makeKeyAndOrderFront(nil)
+    }
+
+    private func dismiss() {
+        teardown()
+    }
+
+    private func teardown() {
+        guard let window = modalWindow else { return } // idempotent
+
+        if let escMonitor {
+            NSEvent.removeMonitor(escMonitor)
+            self.escMonitor = nil
+        }
+        closeCancellable = nil
+        parentCancellables.removeAll()
+        tab.webView.stopLoading()
+        tab.webView.navigationDelegate = nil
+        tab.webView.uiDelegate = nil
+        webViewContainer?.removeFromSuperview()
+        webViewContainer = nil
+        window.orderOut(nil)
+        modalWindow = nil
+
+        onClose?()
+        onClose = nil
+    }
+}
+
+/// Borderless window that can still become key so the hosted web view accepts input.
+private final class CustomizeResponsesModalWindow: NSWindow {
+    override var canBecomeKey: Bool { true }
+}
+
+/// Dimming backdrop; clicking outside the centered card dismisses the modal.
+private final class CustomizeResponsesScrimView: NSView {
+    var onBackdropClick: (() -> Void)?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.black.withAlphaComponent(0.4).cgColor
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        onBackdropClick?()
+    }
+}
+
+extension CustomizeResponsesModalController: TabDelegate {
+
+    var isInPopUpWindow: Bool { true }
+
+    func tab(_ tab: Tab, createdChild childTab: Tab, of kind: NewWindowPolicy) {
+        // Route FE-opened links to a normal browser tab.
+        guard let windowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController else { return }
+        windowController.mainViewController.tabCollectionViewModel.insertOrAppend(tab: childTab, selected: true)
+    }
+
+    func tabWillStartNavigation(_ tab: Tab, isUserInitiated: Bool) {}
+    func tabDidStartNavigation(_ tab: Tab) {}
+    func tabPageDOMLoaded(_ tab: Tab) {}
+    func closeTab(_ tab: Tab) { dismiss() }
+    func websiteAutofillUserScriptCloseOverlay(_ websiteAutofillUserScript: BrowserServicesKit.WebsiteAutofillUserScript?) {}
+    func websiteAutofillUserScript(_ websiteAutofillUserScript: BrowserServicesKit.WebsiteAutofillUserScript, willDisplayOverlayAtClick: CGPoint?, serializedInputContext: String, inputPosition: CGRect) {}
+}

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
@@ -236,6 +236,8 @@ final class AIChatUserScript: NSObject, Subfeature {
             return handler.voiceChatStartFailed
         case .dictationStartFailed:
             return handler.dictationStartFailed
+        case .customizeResponsesModalClosed:
+            return handler.customizeResponsesModalClosed
         default:
             return nil
         }

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -155,6 +155,9 @@ protocol AIChatUserScriptHandling: AnyObject {
     /// Posted by Duck.ai when `getUserMedia()` rejects while starting dictation. Mirrors
     /// `voiceChatStartFailed` but surfaces dictation-specific remediation copy.
     @MainActor func dictationStartFailed(params: Any, message: UserScriptMessage) async -> Encodable?
+
+    /// Posted by the native-customize-modal placement when the user dismisses the Customize Responses card.
+    @MainActor func customizeResponsesModalClosed(params: Any, message: UserScriptMessage) async -> Encodable?
 }
 
 final class AIChatUserScriptHandler: AIChatUserScriptHandling {
@@ -883,6 +886,12 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
         // handled. The carried `reason` drives the same OS-mic-denied check as voice chat;
         // only the remediation copy differs.
         voiceChatFailureHandler.handleDictationStartFailed(reason: Self.failureReason(from: params), sourceWebView: message.messageWebView)
+        return nil
+    }
+
+    @MainActor
+    func customizeResponsesModalClosed(params: Any, message: UserScriptMessage) async -> Encodable? {
+        notificationCenter.post(name: .aiChatCustomizeResponsesModalClosed, object: message.messageWebView)
         return nil
     }
 

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -334,7 +334,8 @@ final class MainViewController: NSViewController {
             themeManager: themeManager,
             omnibarController: aiChatOmnibarController,
             duckAiNativeStorageHandler: NSApp.delegateTyped.burnerDuckAiStorageRegistry?.handler(for: tabCollectionViewModel.burnerMode)
-                ?? NSApp.delegateTyped.duckAiNativeStorageHandler
+                ?? NSApp.delegateTyped.duckAiNativeStorageHandler,
+            burnerMode: tabCollectionViewModel.burnerMode
         )
         aiChatOmnibarTextContainerViewController = AIChatOmnibarTextContainerViewController(
             omnibarController: aiChatOmnibarController,

--- a/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
@@ -473,6 +473,9 @@ final class MockAIChatUserScriptHandler: AIChatUserScriptHandling {
         didClearMigrationData = true
         return nil
     }
+    func customizeResponsesModalClosed(params: Any, message: any UserScriptMessage) async -> (any Encodable)? {
+        return nil
+    }
 }
 // swiftlint:enable inclusive_language
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1215104157301832
Tech Design URL:
CC:

### Description
Follow-up to #5687, which added the "Customize Responses" row to the native Duck.ai omnibar Tools menu with a no-op open action. This PR makes that row open a popup.

Clicking the row now presents the Duck.ai Customize Responses card in a dimmed, centered panel over the browser window. The card is a fully-wired Duck.ai web view loaded with a new `?placement=native-customize-modal` parameter, which tells the frontend to render only the customize card (mirrors the Windows browser wire format). Customizations persist through the existing native storage bridge, so reopening the Tools menu reflects the updated summary/toggle. The popup closes when the frontend dismisses the card, on Escape, or on a click outside the card.

Behind the same internal-only feature flag as the entry point; there is no release entry point.

### Testing Steps
1. Internal build. Enable the omnibar tools flag and open the Duck.ai omnibar Tools menu → the "Customize Responses" row appears.
2. Set `https://euw-serp-dev-testing8.duck.ai` as the URL for AI Chat (Debug -> AI Chat -> Web Communication -> Set URL)
3. Click the row → a popup opens over the window showing the Duck.ai Customize Responses card.
4. Change and save a customization → it persists. Reopen the Tools menu → the summary sub-label and toggle reflect the change.
5. Open the popup again and tap reset (which should reset the customize response to default); the toggle should not appear in the row.
6. Dismiss via the card's own close, the Escape key, or by clicking outside the card → the popup closes.

### Impact
Low. Behind an internal-only feature flag, and it reuses native-storage bridge keys the frontend already owns.

#### What could go wrong?
The popup depends on the deployed frontend supporting the `native-customize-modal` placement → gated to internal builds behind the omnibar-tools flag while the frontend rolls out.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behind the existing internal omnibar-tools flag; reuses the native storage bridge and adds a self-contained modal web view with tab fallback if no window is available. Depends on frontend support for `native-customize-modal` placement.
> 
> **Overview**
> Wires the omnibar **Customize Responses** tools row to open a native overlay instead of a no-op: **`CustomizeResponsesModalController`** presents a dimmed, child-window modal with a centered Duck.ai web view at **`?placement=native-customize-modal`**, using the window’s **`burnerMode`** so native storage matches the menu row (including Fire windows). Dismissal is handled via FE **`customizeResponsesModalClosed`**, Escape, backdrop click, or parent window close; without a hosting window it falls back to **`openCustomizeResponses()`** in a new tab.
> 
> Shared **AIChat** adds the placement URL helper, notification, and user-script message; macOS routes the script through **`AIChatUserScriptHandler`** to **`NSNotification`**. The menu row gains **`isEnabled`** (off in image-generation mode), system-style hover selection, and **`onOpen`** → **`presentCustomizeResponsesModal()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit feeab1f2fcd2062259e430bfad5f82408b40b91b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->