### PR TITLE
Fix: New Pixel Validation Errors

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/app_settings_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/app_settings_pixels.json5
@@ -33,14 +33,14 @@
         "owners": ["jleandroperez"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource", "channel", "themeChangeSource"]
+        "parameters": ["appVersion", "pixelSource", "channel", "themeChangeSource", "originalPixelTimestamp", "retriedPixel"]
     },
     "m_mac_settings_theme_name_changed": {
         "description": "Fired when Browser Theme Name setting is changed",
         "owners": ["jleandroperez"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource", "channel", "themeChangeSource", "themeName"]
+        "parameters": ["appVersion", "pixelSource", "channel", "themeChangeSource", "themeName", "originalPixelTimestamp", "retriedPixel"]
     },
     "m_mac_settings_add-to-dock_show-me-how-clicked": {
         "description": "Fired when Add to Dock Show Me How link in settings is clicked to open the demo video",

--- a/macOS/PixelDefinitions/pixels/definitions/new_tab_page_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/new_tab_page_pixels.json5
@@ -78,7 +78,7 @@
         "owners": ["jleandroperez"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource", "channel"]
+        "parameters": ["appVersion", "pixelSource", "channel", "originalPixelTimestamp", "retriedPixel"]
     },
     "m_mac_new-tab-page_customizer_shown": {
         "description": "Fires when the user reveals the New Tab Page Customizer UI.",
@@ -93,7 +93,9 @@
                 "key": "themePopoverWasOpen",
                 "type": "boolean",
                 "description": "Whether the Themes Discovery Popover was onscreen, or not"
-            }
+            },
+            "originalPixelTimestamp",
+            "retriedPixel"
         ]
     },
     "m_mac_new-tab-page_loading_time": {

--- a/macOS/PixelDefinitions/pixels/definitions/startup_metrics_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/startup_metrics_pixels.json5
@@ -102,7 +102,9 @@
                 "key": "session_restoration",
                 "type": "boolean",
                 "description": "Whether session restoration was enabled at launch time."
-            }
+            },
+            "originalPixelTimestamp",
+            "retriedPixel"
         ]
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/theme_pixels.json
+++ b/macOS/PixelDefinitions/pixels/definitions/theme_pixels.json
@@ -5,6 +5,6 @@
         "owners": ["jleandroperez"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource", "channel", "themeName"]
+        "parameters": ["appVersion", "pixelSource", "channel", "themeName", "originalPixelTimestamp", "retriedPixel"]
     }
 }

--- a/macOS/PixelDefinitions/pixels/params_dictionary.json5
+++ b/macOS/PixelDefinitions/pixels/params_dictionary.json5
@@ -392,5 +392,18 @@
         "description": "The mode of the consent heuristic feature: '', off, reject, tier1, tier2",
         "type": "string",
         "enum": ["", "off", "reject", "tier1", "tier2"]
+    },
+    "originalPixelTimestamp": {
+        "key": "originalPixelTimestamp",
+        "type": "string",
+        "format": "date-time",
+        "description": "Optional. ISO8601 timestamp of when the pixel was originally fired, attached when the pixel is queued for retry by the pixel retry queue.",
+        "examples": ["2026-06-11T00:00:00Z"]
+    },
+    "retriedPixel": {
+        "key": "retriedPixel",
+        "type": "string",
+        "description": "Optional. Set to '1' when the pixel is being re-sent from the pixel retry queue after an earlier delivery failure.",
+        "enum": ["1"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1216277289207399
Tech Design URL:
CC:

### Description
This PR adds two newly added parameters in the following Pixel Definitions: `originalPixelTimestamp` + `retriedPixel`

- m_mac_startup_performance_metrics
- m_mac_theme_name_daily
- m_mac_new-tab-page_customizer_hidden
- m_mac_new-tab-page_customizer_shown
- m_mac_settings_theme_appearance_changed
- m_mac_settings_theme_name_changed

### Testing Steps
- [ ] Verify the CI is green please!

### Impact
None: Internal tooling, documentation

#### What could go wrong?
Nothing really!

### Quality Considerations
Thanks a lot, in advance!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema/documentation-only updates to pixel JSON definitions; no runtime behavior or analytics pipeline logic changes in this diff.
> 
> **Overview**
> Aligns macOS pixel definition schemas with what the **pixel retry queue** already attaches on resend, fixing validation errors for pixels that can be queued after delivery failure.
> 
> **`params_dictionary.json5`** gains shared definitions for **`originalPixelTimestamp`** (optional ISO8601 time of the original fire) and **`retriedPixel`** (optional `"1"` when the event is a retry).
> 
> Those two parameters are added to six pixels: **`m_mac_startup_performance_metrics`**, **`m_mac_theme_name_daily`**, NTP customizer **hidden/shown**, and settings theme **appearance/name** changed. No app firing logic changes—definitions only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bec2d7a0eb50190d419c71adf242e70105050cd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->