### PR TITLE
Update GitHub Actions pinned to Node 20 to Node 24-compatible versions

### DIFF
--- a/.github/actions/asana-failed-pr-checks/action.yml
+++ b/.github/actions/asana-failed-pr-checks/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
     - id: get-asana-user-id
       if: inputs.action == 'create-task'
-      uses: duckduckgo/native-github-asana-sync@v1.9
+      uses: duckduckgo/native-github-asana-sync@v2.5.1
       with:
         action: 'get-asana-user-id'
         github-username: ${{ inputs.commit-author }}

--- a/.github/actions/send-release-notification-task/action.yml
+++ b/.github/actions/send-release-notification-task/action.yml
@@ -58,7 +58,7 @@ runs:
         echo "task-desc=${DESC}" >> "$GITHUB_OUTPUT"
 
     - name: Create Asana task
-      uses: duckduckgo/native-github-asana-sync@v1.1
+      uses: duckduckgo/native-github-asana-sync@v2.5.1
       with:
         action: create-asana-task
         asana-pat: ${{ inputs.asana-access-token }}

--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -16,7 +16,7 @@ runs:
       uses: ruby/setup-ruby@v1
 
     - name: Cache Ruby dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ inputs.working-directory }}/vendor/bundle
         key: ${{ runner.os }}-${{ inputs.cache-key-prefix }}-${{ hashFiles(format('{0}/Gemfile.lock', inputs.working-directory)) }}

--- a/.github/workflows/add_asana_comment_on_pr_review.yml
+++ b/.github/workflows/add_asana_comment_on_pr_review.yml
@@ -69,7 +69,7 @@ jobs:
             echo "text=${prefix} by @${REVIEWER} — see review: ${REVIEW_URL}" >> "$GITHUB_OUTPUT"
 
         - name: Post review comment
-          uses: duckduckgo/native-github-asana-sync@v2.4
+          uses: duckduckgo/native-github-asana-sync@v2.5.1
           with:
             action: 'post-comment-asana-task'
             asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
@@ -79,7 +79,7 @@ jobs:
 
         - name: Mark subtask complete on approve
           if: ${{ github.event.review.state == 'approved' }}
-          uses: duckduckgo/native-github-asana-sync@v2.4
+          uses: duckduckgo/native-github-asana-sync@v2.5.1
           with:
             action: 'mark-asana-task-complete'
             asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
@@ -90,7 +90,7 @@ jobs:
         # completed) and submits a non-approve review, reopen the subtask.
         - name: Mark subtask incomplete on non-approve review
           if: ${{ github.event.review.state != 'approved' }}
-          uses: duckduckgo/native-github-asana-sync@v2.4
+          uses: duckduckgo/native-github-asana-sync@v2.5.1
           with:
             action: 'mark-asana-task-complete'
             asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/bsk_pr_checks.yml
+++ b/.github/workflows/bsk_pr_checks.yml
@@ -50,7 +50,7 @@ jobs:
       steps:
 
       - name: Register SSH keys for private repos
-        uses: webfactory/ssh-agent@v0.9.1
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_DUCKSANS_FONT }}
 
@@ -77,7 +77,7 @@ jobs:
 
       - name: Cache SPM
         if: env.cache_key_hash
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: SharedPackages/BrowserServicesKit/DerivedData/SourcePackages
           key: ${{ runner.os }}-bsk-spm-${{ env.cache_key_hash }}
@@ -131,7 +131,7 @@ jobs:
           test-outcome: ${{ steps.run-unit-tests.outcome }}
 
       - name: Upload JUnit XML as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: bsk-macos-unittests.xml
@@ -141,7 +141,7 @@ jobs:
           retention-days: 7
 
       - name: Publish Unit Tests Report
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@v6
         if: always()
         with:
           check_name: BSK Test Report (macOS)
@@ -163,14 +163,14 @@ jobs:
             | xargs -L 1 ${{ github.workspace }}/scripts/report-failed-unit-test.sh -s ${{ vars.APPLE_CI_FAILING_TESTS_BSK_FAILED_TESTS_SECTION_ID }}
 
       - name: Upload logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: build-log.txt
           path: SharedPackages/BrowserServicesKit/build-log.txt
 
       - name: Upload xcresult bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: bsk-macos-xcresult
@@ -202,7 +202,7 @@ jobs:
       steps:
 
       - name: Register SSH keys for private repos
-        uses: webfactory/ssh-agent@v0.9.1
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_DUCKSANS_FONT }}
 
@@ -228,7 +228,7 @@ jobs:
 
       - name: Cache SPM
         if: env.cache_key_hash
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: SharedPackages/BrowserServicesKit/DerivedData/SourcePackages
           key: ${{ runner.os }}-bsk-spm-ios-${{ env.cache_key_hash }}
@@ -303,7 +303,7 @@ jobs:
           test-outcome: ${{ steps.run-unit-tests-ios.outcome }}
 
       - name: Upload JUnit XML as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: bsk-ios-unittests.xml
@@ -313,7 +313,7 @@ jobs:
           retention-days: 7
 
       - name: Publish Unit Tests Report
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@v6
         if: always()
         with:
           check_name: BSK Test Report (iOS)
@@ -335,14 +335,14 @@ jobs:
             | xargs -L 1 ${{ github.workspace }}/scripts/report-failed-unit-test.sh -s ${{ vars.APPLE_CI_FAILING_TESTS_BSK_FAILED_TESTS_SECTION_ID }}
 
       - name: Upload logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: ios-build-log.txt
           path: SharedPackages/BrowserServicesKit/ios-build-log.txt
 
       - name: Upload xcresult bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: bsk-ios-xcresult
@@ -357,7 +357,7 @@ jobs:
           ls -l ~/Library/Logs/DiagnosticReports
 
       - name: Upload crash reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: "bsk-crash-reports-iOS"

--- a/.github/workflows/close_asana_pr_subtasks.yml
+++ b/.github/workflows/close_asana_pr_subtasks.yml
@@ -46,7 +46,7 @@ jobs:
 
         steps:
         - name: Mark PR review subtask as complete
-          uses: duckduckgo/native-github-asana-sync@v2.4
+          uses: duckduckgo/native-github-asana-sync@v2.5.1
           with:
             action: 'mark-asana-task-complete'
             asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/conflict_watch.yml
+++ b/.github/workflows/conflict_watch.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload run logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: conflict-watch-logs
           path: ${{ runner.temp }}/conflict-watch/logs/

--- a/.github/workflows/dbp_pr_checks.yml
+++ b/.github/workflows/dbp_pr_checks.yml
@@ -50,7 +50,7 @@ jobs:
       steps:
 
       - name: Register SSH keys for private repos
-        uses: webfactory/ssh-agent@v0.9.1
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_DUCKSANS_FONT }}
 
@@ -77,7 +77,7 @@ jobs:
 
       - name: Cache SPM
         if: env.cache_key_hash
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: SharedPackages/DataBrokerProtectionCore/DerivedData/SourcePackages
           key: ${{ runner.os }}-dbp-spm-${{ env.cache_key_hash }}
@@ -124,7 +124,7 @@ jobs:
           test-outcome: ${{ steps.run-unit-tests.outcome }}
 
       - name: Publish Unit Tests Report
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@v6
         if: always()
         with:
           check_name: DBP Test Report (macOS)
@@ -153,7 +153,7 @@ jobs:
             | xargs -L 1 ${{ github.workspace }}/scripts/report-failed-unit-test.sh -s ${{ vars.APPLE_CI_FAILING_TESTS_DBP_FAILED_TESTS_SECTION_ID }}
 
       - name: Upload logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: BuildLogs
@@ -184,7 +184,7 @@ jobs:
       steps:
 
       - name: Register SSH keys for private repos
-        uses: webfactory/ssh-agent@v0.9.1
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_DUCKSANS_FONT }}
 
@@ -210,7 +210,7 @@ jobs:
 
       - name: Cache SPM
         if: env.cache_key_hash
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: SharedPackages/DataBrokerProtectionCore/DerivedData/SourcePackages
           key: ${{ runner.os }}-dbp-spm-ios-${{ env.cache_key_hash }}
@@ -279,7 +279,7 @@ jobs:
           test-outcome: ${{ steps.run-unit-tests.outcome }}
 
       - name: Publish Unit Tests Report
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@v6
         if: always()
         with:
           check_name: DBP Test Report (iOS)
@@ -308,7 +308,7 @@ jobs:
             | xargs -L 1 ${{ github.workspace }}/scripts/report-failed-unit-test.sh -s ${{ vars.APPLE_CI_FAILING_TESTS_DBP_FAILED_TESTS_SECTION_ID }}
 
       - name: Upload logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: ios-build-log.txt
@@ -321,7 +321,7 @@ jobs:
           ls -l ~/Library/Logs/DiagnosticReports
 
       - name: Upload crash reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: "dbp-crash-reports-iOS"

--- a/.github/workflows/dependabot_pr_body.yml
+++ b/.github/workflows/dependabot_pr_body.yml
@@ -10,7 +10,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Prepend CI instructions to PR body
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prefix = `> **Dependabot SSH access Workaround:**

--- a/.github/workflows/ios_adhoc.yml
+++ b/.github/workflows/ios_adhoc.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
 
       - name: Register SSH keys for private repos
-        uses: webfactory/ssh-agent@v0.9.1
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: |
             ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
@@ -132,13 +132,13 @@ jobs:
           echo "dsyms_path=${{ github.workspace }}/iOS/${{ env.dsyms_filename }}" >> $GITHUB_ENV
 
       - name: Upload IPA artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.ipa_filename }}
           path: ${{ env.ipa_path }}
 
       - name: Upload dSYMs artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.dsyms_filename }}
           path: ${{ env.dsyms_path }}

--- a/.github/workflows/ios_alpha.yml
+++ b/.github/workflows/ios_alpha.yml
@@ -51,7 +51,7 @@ jobs:
         fi
 
     - name: Register SSH keys for private repos
-      uses: webfactory/ssh-agent@v0.9.1
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: |
           ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache SPM
       if: env.cache_key_hash
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: iOS/DerivedData/SourcePackages
         key: ${{ runner.os }}-ios-${{ env.cache_key_hash }}
@@ -114,7 +114,7 @@ jobs:
       id: build-alpha
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: alpha-build-${{ steps.build-alpha.outputs.app_version }}-${{ steps.build-alpha.outputs.build_version }}
         path: |
@@ -142,7 +142,7 @@ jobs:
         submodules: recursive
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: alpha-build-${{ needs.build-alpha.outputs.app_version }}-${{ needs.build-alpha.outputs.build_version }}
         path: iOS/
@@ -162,7 +162,7 @@ jobs:
         bundle exec fastlane upload_alpha groups:["${{ env.destination }}"] ipa_path:"${{ needs.build-alpha.outputs.ipa_path }}"
 
     - name: Upload dSYMs artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: DuckDuckGo-Alpha-dSYM-${{ needs.build-alpha.outputs.app_version }}
         path: ${{ needs.build-alpha.outputs.dsyms_path }}

--- a/.github/workflows/ios_end_to_end.yml
+++ b/.github/workflows/ios_end_to_end.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Register SSH keys for private repos
-      uses: webfactory/ssh-agent@v0.9.1
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_DUCKSANS_FONT }}
 
@@ -64,7 +64,7 @@ jobs:
 
     - name: Cache SPM
       if: env.cache_key_hash
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: iOS/DerivedData/SourcePackages
         key: ${{ runner.os }}-ios-${{ env.cache_key_hash }}
@@ -81,7 +81,7 @@ jobs:
         preferred-versions: "26.4"
 
     - name: Restore Xcode Compilation Cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: iOS/DerivedData/CompilationCache.noindex
         key: xcode-compilation-cache-ios-e2e
@@ -117,7 +117,7 @@ jobs:
 
     - name: Save Xcode Compilation Cache
       if: github.ref == 'refs/heads/main' && steps.compilation-cache-hash.outputs.hash
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: iOS/DerivedData/CompilationCache.noindex
         key: xcode-compilation-cache-ios-e2e-${{ steps.compilation-cache-hash.outputs.hash }}
@@ -133,13 +133,13 @@ jobs:
           runner: ${{ env.RUNS_ON }}
 
     - name: Store Binary
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: duckduckgo-ios-app
         path: iOS/DerivedData/Build/Products/Debug-iphonesimulator/DuckDuckGo.app
 
     - name: Upload logs when workflow failed
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: failure() || cancelled()
       with:
         name: BuildLogs
@@ -244,7 +244,7 @@ jobs:
         mode: start
 
     - name: Retrieve Binary
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: duckduckgo-ios-app
         path: iOS/DerivedData/Build/Products/Debug-iphonesimulator/DuckDuckGo.app
@@ -380,7 +380,7 @@ jobs:
         echo "e2e:${{ matrix.user-mode }}:${{ matrix.test-tag }}:${{ matrix.device }}" > failure-marker/marker.txt
     - name: Upload failure marker (e2e)
       if: (failure() || cancelled()) && github.ref_name == 'main'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: failure-marker-e2e-${{ matrix.user-mode }}-${{ matrix.test-tag }}-${{ matrix.device }}
         path: failure-marker/

--- a/.github/workflows/ios_experimental.yml
+++ b/.github/workflows/ios_experimental.yml
@@ -44,7 +44,7 @@ jobs:
         submodules: recursive
 
     - name: Register SSH keys for private repos
-      uses: webfactory/ssh-agent@v0.9.1
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: |
           ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
@@ -64,7 +64,7 @@ jobs:
 
     - name: Cache SPM
       if: env.cache_key_hash
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: iOS/DerivedData/SourcePackages
         key: ${{ runner.os }}-ios-${{ env.cache_key_hash }}
@@ -107,7 +107,7 @@ jobs:
       id: build-experimental
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: experimental-build-${{ steps.build-experimental.outputs.app_version }}-${{ steps.build-experimental.outputs.build_version }}
         path: |
@@ -135,7 +135,7 @@ jobs:
         submodules: recursive
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: experimental-build-${{ needs.build-experimental.outputs.app_version }}-${{ needs.build-experimental.outputs.build_version }}
         path: iOS/
@@ -155,7 +155,7 @@ jobs:
         bundle exec fastlane upload_experimental groups:["${{ env.destination }}"] ipa_path:"${{ needs.build-experimental.outputs.ipa_path }}"
 
     - name: Upload dSYMs artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: DuckDuckGo-Experimental-dSYM-${{ needs.build-experimental.outputs.app_version }}
         path: ${{ needs.build-experimental.outputs.dsyms_path }}

--- a/.github/workflows/ios_nightly.yml
+++ b/.github/workflows/ios_nightly.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
     - name: Register SSH keys for private repos
-      uses: webfactory/ssh-agent@v0.9.1
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_DUCKSANS_FONT }}
 
@@ -86,7 +86,7 @@ jobs:
 
     - name: Cache SPM
       if: env.cache_key_hash
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: iOS/DerivedData/SourcePackages
         key: ${{ runner.os }}-ios-${{ matrix.user-mode }}-${{ env.cache_key_hash }}
@@ -134,7 +134,7 @@ jobs:
         device-id: ${{ steps.boot-simulator.outputs.device-id }}
 
     - name: Upload logs if workflow failed
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: failure() || cancelled()
       with:
         name: ATBBuildLogs-${{ matrix.user-mode }}
@@ -145,7 +145,7 @@ jobs:
         retention-days: 7
 
     - name: Upload crash reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: failure() || cancelled()
       with:
         name: ios-nightly-crash-reports-${{ matrix.user-mode }}
@@ -163,7 +163,7 @@ jobs:
         echo "atb:${{ matrix.user-mode }}" > failure-marker/marker.txt
     - name: Upload failure marker
       if: (failure() || cancelled()) && github.ref_name == 'main'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: failure-marker-atb-${{ matrix.user-mode }}
         path: failure-marker/
@@ -180,7 +180,7 @@ jobs:
         test-outcome: ${{ steps.run-unit-tests.outcome }}
 
     - name: Publish unit tests report
-      uses: mikepenz/action-junit-report@v3
+      uses: mikepenz/action-junit-report@v6
       if: always()
       with:
         report_paths: iOS/unittests.xml
@@ -216,7 +216,7 @@ jobs:
 
     - name: Create Asana task for production-mode failure
       if: steps.detect.outputs.has_production == 'true'
-      uses: duckduckgo/native-github-asana-sync@v1.1
+      uses: duckduckgo/native-github-asana-sync@v2.5.1
       with:
         action: create-asana-task
         asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
@@ -226,7 +226,7 @@ jobs:
 
     - name: Create Asana task for internal-mode failure
       if: steps.detect.outputs.has_internal == 'true'
-      uses: duckduckgo/native-github-asana-sync@v1.1
+      uses: duckduckgo/native-github-asana-sync@v2.5.1
       with:
         action: create-asana-task
         asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/ios_pr_checks.yml
+++ b/.github/workflows/ios_pr_checks.yml
@@ -113,7 +113,7 @@ jobs:
     steps:
 
     - name: Register SSH keys for private repos
-      uses: webfactory/ssh-agent@v0.9.1
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_DUCKSANS_FONT }}
 
@@ -148,7 +148,7 @@ jobs:
 
     - name: Cache SPM
       if: env.cache_key_hash
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: iOS/DerivedData/SourcePackages
         key: ${{ runner.os }}-ios-${{ env.cache_key_hash }}
@@ -159,7 +159,7 @@ jobs:
       uses: ./.github/actions/select-xcode-version
 
     - name: Restore Xcode Compilation Cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: iOS/DerivedData/CompilationCache.noindex
         key: xcode-compilation-cache-ios-unit-tests
@@ -205,7 +205,7 @@ jobs:
 
     - name: Save Xcode Compilation Cache
       if: github.ref == 'refs/heads/main' && steps.compilation-cache-hash.outputs.hash
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: iOS/DerivedData/CompilationCache.noindex
         key: xcode-compilation-cache-ios-unit-tests-${{ steps.compilation-cache-hash.outputs.hash }}
@@ -221,7 +221,7 @@ jobs:
         test-outcome: ${{ steps.run-unit-tests.outcome }}
 
     - name: Upload JUnit XML as artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: always()
       with:
         name: ios-unittests.xml
@@ -231,7 +231,7 @@ jobs:
         retention-days: 7
 
     - name: Upload logs if workflow failed
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: failure() || cancelled()
       with:
         name: BuildLogs
@@ -241,7 +241,7 @@ jobs:
         retention-days: 7
 
     - name: Upload crash reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: failure() || cancelled()
       with:
         name: ios-pr-crash-reports
@@ -252,7 +252,7 @@ jobs:
         retention-days: 7
 
     - name: Publish unit tests report
-      uses: mikepenz/action-junit-report@v3
+      uses: mikepenz/action-junit-report@v6
       if: always()
       with:
         report_paths: iOS/unittests.xml
@@ -319,7 +319,7 @@ jobs:
     steps:
 
     - name: Register SSH keys for private repos
-      uses: webfactory/ssh-agent@v0.9.1
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: |
           ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
@@ -352,7 +352,7 @@ jobs:
 
     - name: Cache SPM
       if: env.cache_key_hash
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: iOS/DerivedData/SourcePackages
         key: ${{ runner.os }}-ios-release-${{ env.cache_key_hash }}
@@ -363,7 +363,7 @@ jobs:
       uses: ./.github/actions/select-xcode-version
 
     - name: Restore Xcode Compilation Cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: iOS/DerivedData/CompilationCache.noindex
         key: xcode-compilation-cache-ios-release
@@ -418,7 +418,7 @@ jobs:
 
     - name: Save Xcode Compilation Cache
       if: github.ref == 'refs/heads/main' && steps.compilation-cache-hash.outputs.hash
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: iOS/DerivedData/CompilationCache.noindex
         key: xcode-compilation-cache-ios-release-${{ steps.compilation-cache-hash.outputs.hash }}
@@ -467,7 +467,7 @@ jobs:
           fetch-depth: 0 # Allows scripts to diff against the base branch
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/ios_release.yml
+++ b/.github/workflows/ios_release.yml
@@ -97,7 +97,7 @@ jobs:
         esac
 
     - name: Register SSH keys for private repos
-      uses: webfactory/ssh-agent@v0.9.1
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: |
           ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
@@ -143,7 +143,7 @@ jobs:
 
     - name: Upload dSYMs artifact
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: DuckDuckGo-${{ steps.destination.outputs.destination }}-dSYM-${{ env.app_version }}.${{ env.build_number }}
         path: ${{ env.dsyms_path }}

--- a/.github/workflows/ios_sync_end_to_end.yml
+++ b/.github/workflows/ios_sync_end_to_end.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Register SSH keys for private repos
-      uses: webfactory/ssh-agent@v0.9.1
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_DUCKSANS_FONT }}
 
@@ -50,7 +50,7 @@ jobs:
 
     - name: Cache SPM
       if: env.cache_key_hash
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: iOS/DerivedData/SourcePackages
         key: ${{ runner.os }}-ios-${{ env.cache_key_hash }}
@@ -67,7 +67,7 @@ jobs:
         preferred-versions: "26.4"
 
     - name: Restore Xcode Compilation Cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: iOS/DerivedData/CompilationCache.noindex
         key: xcode-compilation-cache-ios-sync-e2e
@@ -103,7 +103,7 @@ jobs:
 
     - name: Save Xcode Compilation Cache
       if: github.ref == 'refs/heads/main' && steps.compilation-cache-hash.outputs.hash
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: iOS/DerivedData/CompilationCache.noindex
         key: xcode-compilation-cache-ios-sync-e2e-${{ steps.compilation-cache-hash.outputs.hash }}
@@ -119,13 +119,13 @@ jobs:
           runner: ${{ env.RUNS_ON }}
 
     - name: Store Binary
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: duckduckgo-ios-app
         path: iOS/DerivedData/Build/Products/Debug-iphonesimulator/DuckDuckGo.app
 
     - name: Upload logs when workflow failed
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: failure() || cancelled()
       with:
         name: BuildLogs
@@ -161,7 +161,7 @@ jobs:
         debug: true
 
     - name: Retrieve Binary
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: duckduckgo-ios-app
         path: iOS/DerivedData/Build/Products/Debug-iphonesimulator/DuckDuckGo.app
@@ -172,7 +172,7 @@ jobs:
 
     - name: Sync e2e tests
       id: upload
-      uses: mobile-dev-inc/action-maestro-cloud@v1.9.8
+      uses: mobile-dev-inc/action-maestro-cloud@v3.0.1
       with:
         api-key: ${{ secrets.ROBIN_API_KEY }}
         project-id: ${{ vars.ROBIN_PROJECT_KEY }}

--- a/.github/workflows/ios_sync_end_to_end.yml
+++ b/.github/workflows/ios_sync_end_to_end.yml
@@ -155,7 +155,7 @@ jobs:
         mode: start
 
     - name: Create test account for Sync and return the recovery code
-      uses: duckduckgo/sync_crypto/action@main
+      uses: duckduckgo/sync_crypto/action@chore/github-action-node24-runtime
       id: sync-recovery-code
       with:
         debug: true

--- a/.github/workflows/ios_tag_release.yml
+++ b/.github/workflows/ios_tag_release.yml
@@ -134,7 +134,7 @@ jobs:
       run: touch ${{ github.workspace }}/.github/stop_workflow
 
     - name: Upload stop_workflow flag artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: steps.tag-release.outputs.stop_workflow == 'true'
       with:
         name: stop_workflow
@@ -145,7 +145,7 @@ jobs:
       run: echo ${{ steps.tag-release.outputs.tag }} > ${{ github.workspace }}/.github/tag
 
     - name: Upload tag artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: tag
         path: ${{ github.workspace }}/.github/tag

--- a/.github/workflows/ios_tag_release_update_asana.yml
+++ b/.github/workflows/ios_tag_release_update_asana.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Download stop_workflow flag artifact
         id: download-stop-workflow
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: stop_workflow
           path: .github
@@ -137,7 +137,7 @@ jobs:
         # Only look for the tag artifact when the tag input is empty
         if: github.event.inputs.tag == null || github.event.inputs.tag == ''
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: tag
           path: .github

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -116,7 +116,7 @@ jobs:
 
     steps:
       - name: Download DMG URL artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dmg_url
 

--- a/.github/workflows/macos_build_appstore.yml
+++ b/.github/workflows/macos_build_appstore.yml
@@ -104,7 +104,7 @@ jobs:
         esac
 
     - name: Register SSH keys for private repos
-      uses: webfactory/ssh-agent@v0.9.1
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: |
           ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
@@ -154,7 +154,7 @@ jobs:
       run: bundle exec fastlane build_${{ env.destination }}
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: appstore-artifacts
         path: |
@@ -196,7 +196,7 @@ jobs:
         cache-key-prefix: macos-ruby
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: appstore-artifacts
         path: macOS/
@@ -234,7 +234,7 @@ jobs:
 
     - name: Upload dSYMs artifact
       if: steps.upload-app-to-appstore.conclusion == 'success'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: DuckDuckGo-${{ env.destination }}-dSYM-${{ env.app-version }}
         path: ${{ env.dsym-path }}

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -103,7 +103,7 @@ jobs:
 
     steps:
     - name: Register SSH keys for private repos
-      uses: webfactory/ssh-agent@v0.9.1
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: |
           ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
@@ -252,13 +252,13 @@ jobs:
         echo "dsym-name=${dsym_name}" >> $GITHUB_OUTPUT
 
     - name: Upload app artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: DuckDuckGo-${{ env.release-type }}-${{ env.app-version }}.app.tar.xz
         path: ${{ github.workspace }}/macOS/release/DuckDuckGo-${{ env.app-version }}.app.tar.xz
 
     - name: Upload dSYMs artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: DuckDuckGo-${{ env.release-type }}-dSYM-${{ env.app-version }}
         path: ${{ github.workspace }}/macOS/release/${{ steps.set-outputs.outputs.dsym-name }}
@@ -382,7 +382,7 @@ jobs:
         cache-key-prefix: macos-ruby
 
     - name: Fetch app bundle
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: DuckDuckGo-${{ env.release-type }}-${{ env.app-version }}.app.tar.xz
         path: ${{ github.workspace }}/macOS/dmg
@@ -446,7 +446,7 @@ jobs:
           runner: ${{ env.RUNS_ON }}
 
     - name: Upload DMG artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: DuckDuckGo-${{ env.release-type }}-${{ env.app-version }}.dmg
         path: ${{ github.workspace }}/macOS/${{ steps.create-dmg.outputs.dmg }}
@@ -485,7 +485,7 @@ jobs:
 
     - name: Upload DMG URL artifact
       if: ${{ env.release-type == 'alpha' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: dmg_url
         path: ${{ github.workspace }}/macOS/dmg_url.txt

--- a/.github/workflows/macos_check_sparkle_update.yml
+++ b/.github/workflows/macos_check_sparkle_update.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Create draft Pull Request
         id: create-pr
         if: steps.dedupe.outputs.should_create == 'true'
-        uses: peter-evans/create-pull-request@88bf0de51c7487d91e1abbb4899332e602c58bbf
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "Update Sparkle to ${{ steps.check.outputs.latest_version }}"
           committer: Dax the Duck <dax@duckduckgo.com>

--- a/.github/workflows/macos_create_variant.yml
+++ b/.github/workflows/macos_create_variant.yml
@@ -77,7 +77,7 @@ jobs:
       id: download-dmg-artifact
       if: ${{ !env.DMG_URL }}
       continue-on-error: true
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: duckduckgo-dmg
         path: ${{ github.workspace }}/macOS
@@ -170,7 +170,7 @@ jobs:
 
     - name: Upload variant DMG as artifact
       if: ${{ env.DRY_RUN == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: variant-dmg-${{ steps.set-variant-name.outputs.variant-name }}
         path: ${{ github.workspace }}/macOS/duckduckgo.dmg

--- a/.github/workflows/macos_create_variants.yml
+++ b/.github/workflows/macos_create_variants.yml
@@ -79,7 +79,7 @@ jobs:
           curl -fLSs "${DMG_URL}" --output duckduckgo.dmg
 
       - name: Upload DMG artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: duckduckgo-dmg
           path: ${{ github.workspace }}/macOS/duckduckgo.dmg

--- a/.github/workflows/macos_performance_tests.yml
+++ b/.github/workflows/macos_performance_tests.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
     - name: Register SSH keys for private repos
-      uses: webfactory/ssh-agent@v0.9.1
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: |
           ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
@@ -116,7 +116,7 @@ jobs:
         bundle exec fastlane sync_signing_ci
 
     - name: Download and unzip artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         path: macOS
 
@@ -131,7 +131,7 @@ jobs:
 
     - name: Cache SPM
       if: env.cache_key_hash
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: macOS/DerivedData/SourcePackages
         key: ${{ runner.os }}-macos-${{ env.cache_key_hash }}
@@ -156,7 +156,7 @@ jobs:
         echo $! > log_stream.pid
 
     - name: Restore Xcode Compilation Cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: macOS/DerivedData/CompilationCache.noindex
         key: xcode-compilation-cache-perf-tests
@@ -189,7 +189,7 @@ jobs:
 
     - name: Save Xcode Compilation Cache
       if: github.ref == 'refs/heads/main' && steps.compilation-cache-hash.outputs.hash
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: macOS/DerivedData/CompilationCache.noindex
         key: xcode-compilation-cache-perf-tests-${{ steps.compilation-cache-hash.outputs.hash }}
@@ -275,7 +275,7 @@ jobs:
 
     - name: Upload memory metrics
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: memory-metrics
         path: macOS/insert-statements-memory.sql
@@ -283,7 +283,7 @@ jobs:
 
     - name: Upload startup metrics
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: startup-metrics
         path: macOS/insert-statements-startup-metrics.sql
@@ -326,7 +326,7 @@ jobs:
         xcbeautify --report junit --report-path . --junit-report-filename ui-tests.xml < ui-tests.log
 
     - name: Publish tests report
-      uses: mikepenz/action-junit-report@v4
+      uses: mikepenz/action-junit-report@v6
       if: always() && steps.run-ui-tests.outcome != 'skipped'
       with:
         check_name: "Test Report ${{ matrix.runner }}"
@@ -334,7 +334,7 @@ jobs:
         check_retries: true
 
     - name: Upload xcresult files (passed on retry)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: always() && steps.check-failures.outputs.had_failures == 'true' && steps.run-ui-tests.outcome == 'success'
       with:
         name: "xcresult-${{ matrix.runner }}"
@@ -342,7 +342,7 @@ jobs:
         retention-days: 1
 
     - name: Upload app console log (passed on retry)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: always() && steps.check-failures.outputs.had_failures == 'true' && steps.run-ui-tests.outcome == 'success'
       with:
         name: "app-console-${{ matrix.runner }}-macos${{ matrix.os-version }}"
@@ -374,7 +374,7 @@ jobs:
         echo "ARCHIVE_NAME=$archive_name" >> $GITHUB_ENV
 
     - name: Upload logs when workflow failed
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: failure() || cancelled()
       with:
         name: "${{ env.ARCHIVE_NAME }}"
@@ -389,12 +389,12 @@ jobs:
 
     steps:
       - name: Download startup metrics
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: startup-metrics
 
       - name: Download memory metrics
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: memory-metrics
 
@@ -431,7 +431,7 @@ jobs:
         ref: ${{ inputs.branch || github.sha }}
 
     - name: Create Asana task when workflow failed
-      uses: duckduckgo/native-github-asana-sync@v1.1
+      uses: duckduckgo/native-github-asana-sync@v2.5.1
       with:
         action: create-asana-task
         asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/macos_pir_end_to_end_tests.yml
+++ b/.github/workflows/macos_pir_end_to_end_tests.yml
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 32
     steps:
     - name: Register SSH keys for private repos
-      uses: webfactory/ssh-agent@v0.9.1
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: |
           ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
@@ -123,7 +123,7 @@ jobs:
         bundle exec fastlane sync_signing_ci
 
     - name: Download and unzip artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
 
     - name: Set cache key hash
       run: |
@@ -136,7 +136,7 @@ jobs:
 
     - name: Cache SPM
       if: env.cache_key_hash
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: macOS/DerivedData/SourcePackages
         key: ${{ runner.os }}-macos-${{ env.cache_key_hash }}
@@ -149,7 +149,7 @@ jobs:
         xcode-version: ${{ matrix.xcode-version }}
 
     - name: Restore Xcode Compilation Cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: macOS/DerivedData/CompilationCache.noindex
         key: xcode-compilation-cache-pir-e2e
@@ -210,7 +210,7 @@ jobs:
 
     - name: Save Xcode Compilation Cache
       if: github.ref == 'refs/heads/main' && steps.compilation-cache-hash.outputs.hash
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: macOS/DerivedData/CompilationCache.noindex
         key: xcode-compilation-cache-pir-e2e-${{ steps.compilation-cache-hash.outputs.hash }}
@@ -238,7 +238,7 @@ jobs:
         xcbeautify --report junit --report-path . --junit-report-filename pir-e2e-tests.xml < pir-e2e-tests.log
 
     - name: Publish tests report
-      uses: mikepenz/action-junit-report@v4
+      uses: mikepenz/action-junit-report@v6
       if: always()
       with:
         check_name: "Test Report ${{ matrix.runner }}"
@@ -251,7 +251,7 @@ jobs:
         log show --predicate 'processImagePath CONTAINS "DuckDuckGo Personal Information Removal"' --last 1h > pir-process.log 2>&1 || true
 
     - name: Upload logs when workflow failed
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: failure() || cancelled()
       with:
         name: "BuildLogs ${{ matrix.runner }}"
@@ -271,7 +271,7 @@ jobs:
 
     steps:
     - name: Create Asana task when workflow failed
-      uses: duckduckgo/native-github-asana-sync@v1.1
+      uses: duckduckgo/native-github-asana-sync@v2.5.1
       with:
         action: create-asana-task
         asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -124,7 +124,7 @@ jobs:
       run: bats --formatter junit scripts/tests/* > bats-tests.xml
 
     - name: Publish unit tests report
-      uses: mikepenz/action-junit-report@v4
+      uses: mikepenz/action-junit-report@v6
       if: always() # always run even if the previous step fails
       with:
         check_name: "Test Report: Shell Scripts"
@@ -175,7 +175,7 @@ jobs:
 
     steps:
     - name: Register SSH keys for private repos
-      uses: webfactory/ssh-agent@v0.9.1
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: |
           ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
@@ -241,7 +241,7 @@ jobs:
 
     - name: Cache SPM
       if: env.cache_key_hash
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: macOS/DerivedData/SourcePackages
         key: ${{ runner.os }}-macos-${{ matrix.cache-key }}${{ env.cache_key_hash }}
@@ -252,7 +252,7 @@ jobs:
       uses: ./.github/actions/select-xcode-version
 
     - name: Restore Xcode Compilation Cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: macOS/DerivedData/CompilationCache.noindex
         key: xcode-compilation-cache-${{ matrix.flavor }}
@@ -321,7 +321,7 @@ jobs:
 
     - name: Save Xcode Compilation Cache
       if: github.ref == 'refs/heads/main' && steps.compilation-cache-hash.outputs.hash
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: macOS/DerivedData/CompilationCache.noindex
         key: xcode-compilation-cache-${{ matrix.flavor }}-${{ steps.compilation-cache-hash.outputs.hash }}
@@ -375,7 +375,7 @@ jobs:
         test-outcome: ${{ steps.run-integration-tests.outcome }}
 
     - name: Upload JUnit XML as artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: always()
       with:
         name: macos-${{ matrix.flavor }}-unittests.xml
@@ -385,7 +385,7 @@ jobs:
         retention-days: 7
 
     - name: Publish unit tests report
-      uses: mikepenz/action-junit-report@v4
+      uses: mikepenz/action-junit-report@v6
       if: always() # always run even if the previous step fails
       with:
         check_name: "Test Report: ${{ matrix.flavor }}"
@@ -431,7 +431,7 @@ jobs:
         pixel-name: m_ci_apple_status_mac_main_${{ matrix.flavor }}_integration_tests_${{ steps.run-integration-tests.outcome }}
 
     - name: Upload failed unit tests log
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: failure() || cancelled()
       with:
         name: ${{ matrix.flavor }}-unittests-xcodebuild.log
@@ -439,7 +439,7 @@ jobs:
         retention-days: 7
 
     - name: Upload failed unit tests xcresult
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: failure() || cancelled()
       with:
         name: ${{ matrix.flavor }}-unittests.xcresult
@@ -447,7 +447,7 @@ jobs:
         retention-days: 7
 
     - name: Upload failed integration tests log
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: failure() || cancelled()
       with:
         name: ${{ matrix.flavor }}-integrationtests-xcodebuild.log
@@ -455,7 +455,7 @@ jobs:
         retention-days: 7
 
     - name: Upload failed integration tests xcresult
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: failure() || cancelled()
       with:
         name: ${{ matrix.flavor }}-integrationtests.xcresult
@@ -463,7 +463,7 @@ jobs:
         retention-days: 7
 
     - name: Upload crash reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: failure() || cancelled()
       with:
         name: ${{ matrix.flavor }}-crash-reports
@@ -512,7 +512,7 @@ jobs:
 
     steps:
     - name: Register SSH keys for private repos
-      uses: webfactory/ssh-agent@v0.9.1
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: |
           ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
@@ -569,7 +569,7 @@ jobs:
 
     - name: Cache SPM
       if: env.cache_key_hash
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: macOS/DerivedData/SourcePackages
         key: ${{ runner.os }}-mac-release-build-${{ env.cache_key_hash }}
@@ -580,7 +580,7 @@ jobs:
       uses: ./.github/actions/select-xcode-version
 
     - name: Restore Xcode Compilation Cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: macOS/DerivedData/CompilationCache.noindex
         key: xcode-compilation-cache-release
@@ -613,7 +613,7 @@ jobs:
 
     - name: Save Xcode Compilation Cache
       if: github.ref == 'refs/heads/main' && steps.compilation-cache-hash.outputs.hash
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: macOS/DerivedData/CompilationCache.noindex
         key: xcode-compilation-cache-release-${{ steps.compilation-cache-hash.outputs.hash }}
@@ -638,7 +638,7 @@ jobs:
         echo "EOF" >> $GITHUB_OUTPUT
 
     - name: Upload failed test log
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: failure()
       with:
         name: release-xcodebuild.log
@@ -657,7 +657,7 @@ jobs:
         working-directory: .
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 18
           cache: 'npm'
@@ -701,7 +701,7 @@ jobs:
           fetch-depth: 0 # Allows scripts to diff against the base branch
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/macos_private_api_report.yml
+++ b/.github/workflows/macos_private_api_report.yml
@@ -31,14 +31,14 @@ jobs:
 
     - name: Comment on the PR
       if: ${{ inputs.report != '' }}
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@v3
       with:
         header: status
         path: message.txt
 
     - name: Delete comment on the PR
       if: ${{ inputs.report == '' }}
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@v3
       with:
         header: status
         delete: true

--- a/.github/workflows/macos_publish_dmg_release.yml
+++ b/.github/workflows/macos_publish_dmg_release.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Download stop_workflow flag artifact
         id: download-stop-workflow
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: stop_workflow
           path: .github
@@ -133,7 +133,7 @@ jobs:
         # Only look for the tag artifact when the tag input is empty
         if: github.event.inputs.tag == null || github.event.inputs.tag == ''
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: tag
           path: .github
@@ -258,7 +258,7 @@ jobs:
           echo "appcast-patch-name=${appcast_patch_name}" >> $GITHUB_OUTPUT
 
       - name: Upload appcast diff artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ steps.appcast.outputs.appcast-patch-name }}
           path: ${{ env.SPARKLE_DIR }}/${{ steps.appcast.outputs.appcast-patch-name }}

--- a/.github/workflows/macos_run_ui_test.yml
+++ b/.github/workflows/macos_run_ui_test.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
     - name: Register SSH keys for private repos
-      uses: webfactory/ssh-agent@v0.9.1
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: |
           ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
@@ -179,7 +179,7 @@ jobs:
 
     - name: Cache SPM
       if: env.cache_key_hash
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: macOS/DerivedData/SourcePackages
         key: ${{ runner.os }}-macos-${{ env.cache_key_hash }}
@@ -228,7 +228,7 @@ jobs:
         exit 1
 
     - name: Restore Xcode Compilation Cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: macOS/DerivedData/CompilationCache.noindex
         key: xcode-compilation-cache-ui-tests
@@ -262,7 +262,7 @@ jobs:
 
     - name: Save Xcode Compilation Cache
       if: github.ref == 'refs/heads/main' && steps.compilation-cache-hash.outputs.hash
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: macOS/DerivedData/CompilationCache.noindex
         key: xcode-compilation-cache-ui-tests-${{ steps.compilation-cache-hash.outputs.hash }}
@@ -338,7 +338,7 @@ jobs:
     # Upload test report as artifact for the test-report job
     # that publishes a combined report for all test cases
     - name: Upload test report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: always() && steps.run-ui-tests.outcome != 'skipped'
       with:
         name: "testreport-${{ inputs.test }}-macos${{ inputs.os-version }}-${{ inputs.user-mode }}"
@@ -346,7 +346,7 @@ jobs:
         retention-days: 1
 
     - name: Upload xcresult files (passed on retry)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: always() && steps.check-failures.outputs.had_failures == 'true' && steps.run-ui-tests.outcome == 'success'
       with:
         name: "xcresult-${{ inputs.test }}-macos${{ inputs.os-version }}-${{ inputs.user-mode }}"
@@ -354,7 +354,7 @@ jobs:
         retention-days: 1
 
     - name: Upload app console log (passed on retry)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: always() && steps.check-failures.outputs.had_failures == 'true' && steps.run-ui-tests.outcome == 'success'
       with:
         name: "app-console-${{ inputs.test }}-macos${{ inputs.os-version }}-${{ inputs.user-mode }}"
@@ -370,7 +370,7 @@ jobs:
         echo "macos-ui:${{ inputs.user-mode }}:${{ inputs.test }}:${{ inputs.os-version }}" > failure-marker/marker.txt
     - name: Upload failure marker
       if: failure() || cancelled()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: failure-marker-macos-ui-${{ inputs.user-mode }}-${{ inputs.test }}-${{ inputs.os-version }}
         path: failure-marker/
@@ -398,7 +398,7 @@ jobs:
         echo "ARCHIVE_NAME=$archive_name" >> $GITHUB_ENV
 
     - name: Upload logs when workflow failed
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: failure() || cancelled()
       with:
         name: "${{ env.ARCHIVE_NAME }}"

--- a/.github/workflows/macos_sync_end_to_end.yml
+++ b/.github/workflows/macos_sync_end_to_end.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
     - name: Register SSH keys for private repos
-      uses: webfactory/ssh-agent@v0.9.1
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: |
           ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
@@ -103,7 +103,7 @@ jobs:
         bundle exec fastlane sync_signing_ci
 
     - name: Download and unzip artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         path: macOS
 
@@ -118,7 +118,7 @@ jobs:
 
     - name: Cache SPM
       if: env.cache_key_hash
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: macOS/DerivedData/SourcePackages
         key: ${{ runner.os }}-macos-${{ env.cache_key_hash }}
@@ -149,7 +149,7 @@ jobs:
         debug: true
 
     - name: Restore Xcode Compilation Cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: macOS/DerivedData/CompilationCache.noindex
         key: xcode-compilation-cache-sync-e2e
@@ -182,7 +182,7 @@ jobs:
 
     - name: Save Xcode Compilation Cache
       if: github.ref == 'refs/heads/main' && steps.compilation-cache-hash.outputs.hash
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: macOS/DerivedData/CompilationCache.noindex
         key: xcode-compilation-cache-sync-e2e-${{ steps.compilation-cache-hash.outputs.hash }}
@@ -278,7 +278,7 @@ jobs:
         xcbeautify --report junit --report-path . --junit-report-filename ui-tests.xml < ui-tests.log
 
     - name: Publish tests report
-      uses: mikepenz/action-junit-report@v4
+      uses: mikepenz/action-junit-report@v6
       if: always() && steps.run-ui-tests.outcome != 'skipped'
       with:
         check_name: "Test Report ${{ matrix.runner }}"
@@ -286,7 +286,7 @@ jobs:
         check_retries: true
 
     - name: Upload xcresult files (passed on retry)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: always() && steps.check-failures.outputs.had_failures == 'true' && steps.run-ui-tests.outcome == 'success'
       with:
         name: "xcresult-${{ matrix.runner }}"
@@ -294,7 +294,7 @@ jobs:
         retention-days: 1
 
     - name: Upload app console log (passed on retry)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: always() && steps.check-failures.outputs.had_failures == 'true' && steps.run-ui-tests.outcome == 'success'
       with:
         name: "app-console-${{ matrix.runner }}-macos${{ matrix.os-version }}"
@@ -326,7 +326,7 @@ jobs:
         echo "ARCHIVE_NAME=$archive_name" >> $GITHUB_ENV
 
     - name: Upload logs when workflow failed
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: failure() || cancelled()
       with:
         name: "${{ env.ARCHIVE_NAME }}"
@@ -343,7 +343,7 @@ jobs:
     - name: Check out the code
       uses: actions/checkout@v6
     - name: Create Asana task when workflow failed
-      uses: duckduckgo/native-github-asana-sync@v1.1
+      uses: duckduckgo/native-github-asana-sync@v2.5.1
       with:
         action: create-asana-task
         asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/macos_sync_end_to_end.yml
+++ b/.github/workflows/macos_sync_end_to_end.yml
@@ -143,7 +143,7 @@ jobs:
         echo $! > log_stream.pid
 
     - name: Create test account for Sync and return the recovery code
-      uses: duckduckgo/sync_crypto/action@main
+      uses: duckduckgo/sync_crypto/action@chore/github-action-node24-runtime
       id: sync-recovery-code
       with:
         debug: true

--- a/.github/workflows/macos_tag_release.yml
+++ b/.github/workflows/macos_tag_release.yml
@@ -154,7 +154,7 @@ jobs:
       run: touch ${{ github.workspace }}/.github/stop_workflow
 
     - name: Upload stop_workflow flag artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: steps.tag-release.outputs.stop_workflow == 'true'
       with:
         name: stop_workflow
@@ -165,7 +165,7 @@ jobs:
       run: echo ${{ steps.tag-release.outputs.tag }} > ${{ github.workspace }}/.github/tag
 
     - name: Upload tag artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: tag
         path: ${{ github.workspace }}/.github/tag

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -280,14 +280,14 @@ jobs:
         ref: ${{ inputs.branch || github.sha }}
 
     - name: Download test reports
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       if: always()
       with:
         pattern: "testreport-*"
         merge-multiple: true
 
     - name: Publish tests report
-      uses: mikepenz/action-junit-report@v5
+      uses: mikepenz/action-junit-report@v6
       if: always()
       with:
         check_name: Tests Report
@@ -338,7 +338,7 @@ jobs:
 
     - name: Create Asana task for production-mode failure
       if: steps.detect.outputs.has_production == 'true'
-      uses: duckduckgo/native-github-asana-sync@v1.1
+      uses: duckduckgo/native-github-asana-sync@v2.5.1
       with:
         action: create-asana-task
         asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
@@ -348,7 +348,7 @@ jobs:
 
     - name: Create Asana task for internal-mode failure
       if: steps.detect.outputs.has_internal == 'true'
-      uses: duckduckgo/native-github-asana-sync@v1.1
+      uses: duckduckgo/native-github-asana-sync@v2.5.1
       with:
         action: create-asana-task
         asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/macos_update_phishing_detection_data.yml
+++ b/.github/workflows/macos_update_phishing_detection_data.yml
@@ -26,7 +26,7 @@ jobs:
           echo "$PR_BODY_MACOS" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
       - name: Create PR for macOS
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         id: create-pr
         with:
           path: apple-monorepo/
@@ -42,14 +42,14 @@ jobs:
         id: asana-assignee
         if: failure() && github.event_name == 'schedule'
         continue-on-error: true  # Fall back to an unassigned task if the lookup fails.
-        uses: duckduckgo/native-github-asana-sync@v1.9
+        uses: duckduckgo/native-github-asana-sync@v2.5.1
         with:
           action: get-asana-user-id
           github-username: alessandroboron
           github-pat: ${{ secrets.APPLE_GH_RO_PAT }}
       - name: Create Asana task on failure
         if: failure() && github.event_name == 'schedule'
-        uses: duckduckgo/native-github-asana-sync@v1.9
+        uses: duckduckgo/native-github-asana-sync@v2.5.1
         with:
           action: create-asana-task
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/pixel_validation.yml
+++ b/.github/workflows/pixel_validation.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Use Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20.x
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/shared_web_tests.yml
+++ b/.github/workflows/shared_web_tests.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
 
     - name: Register SSH keys for private repos
-      uses: webfactory/ssh-agent@v0.9.1
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_DUCKSANS_FONT }}
 
@@ -99,7 +99,7 @@ jobs:
         fi
 
     - name: Upload logs when workflow failed
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: failure() || cancelled()
       with:
         name: iOS-BuildLogs
@@ -119,7 +119,7 @@ jobs:
     steps:
 
     - name: Register SSH keys for private repos
-      uses: webfactory/ssh-agent@v0.9.1
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_DUCKSANS_FONT }}
 
@@ -219,7 +219,7 @@ jobs:
         ls -la DerivedData/Build/Products/Debug/ > tmp/diagnostics/macos_build_products.log 2>&1 || true
 
     - name: Upload logs when workflow failed
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: failure() || cancelled()
       with:
         name: macOS-BuildLogs
@@ -242,7 +242,7 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@v6
       - name: Create Asana task when workflow failed
-        uses: duckduckgo/native-github-asana-sync@v1.1
+        uses: duckduckgo/native-github-asana-sync@v2.5.1
         with:
           action: create-asana-task
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/smartling.yml
+++ b/.github/workflows/smartling.yml
@@ -100,7 +100,7 @@ jobs:
           echo "✅ Running on branch: $BRANCH"
 
       - name: Register SSH keys for private repos
-        uses: webfactory/ssh-agent@v0.9.1
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_DUCKSANS_FONT }}
 
@@ -146,7 +146,7 @@ jobs:
         uses: ./.github/actions/select-xcode-version
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/stale_pr.yml
+++ b/.github/workflows/stale_pr.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close stale pull requests
-        uses: actions/stale@v9
+        uses: actions/stale@v10
         with:
           stale-pr-message: 'This PR has been inactive for more than 7 days and will be automatically closed 7 days from now.'
           days-before-pr-stale: 7

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Cache Mint packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.mint
           key: ${{ runner.os }}-mint-${{ hashFiles('Mintfile') }}

--- a/.github/workflows/update_code_signing.yml
+++ b/.github/workflows/update_code_signing.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
 
       - name: Register SSH keys for access to certificates
-        uses: webfactory/ssh-agent@v0.9.1
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1216397628843922?focus=true

### Description

GitHub is deprecating the Node 20 runtime for JavaScript-based Actions. This bumps every action in `.github/workflows` and `.github/actions` that was pinned to a Node 20 (or older) release up to the lowest major version that runs on Node 24.

Each target version was verified against the action's upstream `action.yml` (`runs.using: node24`) rather than assumed — a few actions needed a higher bump than expected because their first `vN` release still defaulted to Node 20:

| Action | Was | Now | Note |
|---|---|---|---|
| `actions/upload-artifact` | v4 | **v6** | v5 still defaults to node20 |
| `actions/download-artifact` | v4 | **v7** | v5/v6 still default to node20 |
| `actions/cache` (+ `save`/`restore`) | v4 | v5 | |
| `actions/setup-node` | v4 | v5 | adds auto package-manager caching |
| `actions/setup-python` | v5 | v6 | |
| `actions/github-script` | v7 | v8 | |
| `actions/stale` | v9 | v10 | |
| `webfactory/ssh-agent` | v0.9.1 | v0.10.0 | |
| `mikepenz/action-junit-report` | v3/v4/v5 | v6 | v3 was node16 |
| `marocchino/sticky-pull-request-comment` | v2 | v3 | |
| `peter-evans/create-pull-request` | v7 / SHA | v8 / v8.1.1 SHA | SHA-pin preserved |
| `mobile-dev-inc/action-maestro-cloud` | v1.9.8 | v3.0.1 | now a composite action |
| `duckduckgo/native-github-asana-sync` | v1.1/v1.9/v2.4 | v2.5.1 | |

Pure version-string swaps only — 189 insertions / 189 deletions across 41 files, no structural changes. Input/`action:` compatibility was verified for the cross-major third-party bumps (asana-sync v2.5.1 documents all four `action:` values we use and its inputs are a superset of v1.x; maestro-cloud v3 inputs are a superset of v1.9.8 and no `steps.upload.outputs.*` are consumed).

**Not changed (intentionally):**
- `actions/checkout@v6` and `ruby/setup-ruby@v1` — already on Node 24.
- Docker / composite actions (no Node runtime): `danger/danger-js`, `yogevbd/enforce-label-action`, `ludeeus/action-shellcheck`, `duckduckgo/apple-toolbox/*`, `docker://rhysd/actionlint`.
- `duckduckgo/sync_crypto/action@main` — **still Node 20**, but it's pinned to a branch and has no Node 24 tag to move to. It needs an upstream fix in the `sync_crypto` repo (used in `macos_sync_end_to_end.yml` and `ios_sync_end_to_end.yml`).

### Testing Steps
1. CI runs on this PR → all workflows that were bumped should resolve their actions and run without "action not found" / runtime errors.
2. `actionlint` on the changed workflows introduces zero new findings vs. base (verified locally).
3. Verify that [macOS Sync E2E tests workflow](https://github.com/duckduckgo/apple-browsers/actions/runs/29008863249) that uses an updated sync-crypto runs fine.

### Impact
Low — CI infrastructure only; no product code.

#### What could go wrong?
- Node 24 actions require **Actions Runner ≥ 2.327.1**. GitHub-hosted runners already satisfy this; the **`[self-hosted, apple]`** runner used by `macos_performance_tests.yml` (upload-artifact step) must be on ≥ 2.327.1 → otherwise the node24 action fails to start.
- `mobile-dev-inc/action-maestro-cloud` is a v1 → v3 jump (internal rewrite to the Maestro CLI). Inputs are compatible, but the `ios_sync_end_to_end.yml` Robin upload should be watched on its next run.

### Quality Considerations
- Follow-up needed: bump `duckduckgo/sync_crypto` to Node 24 upstream, then it can be picked up here automatically (it's `@main`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only version pin updates; main watchouts are self-hosted runners below Actions 2.327.1 and the Maestro cloud v1→v3 jump on iOS sync e2e.
> 
> **Overview**
> Prepares CI for GitHub’s Node 20 deprecation by **only changing action version pins** across `.github/workflows` and `.github/actions`—no workflow logic or inputs were restructured.
> 
> **Core GitHub actions** move to majors that declare `node24`: `actions/cache` (including `save`/`restore`) **v4 → v5**, `actions/upload-artifact` **v4 → v6**, `actions/download-artifact` **v4 → v7**, `actions/setup-python` **v5 → v6**, `actions/setup-node` **v4 → v5**, `actions/github-script` **v7 → v8**, and `actions/stale` **v9 → v10**.
> 
> **Third-party pins** are aligned the same way: `webfactory/ssh-agent` **v0.10.0**, `mikepenz/action-junit-report` **v6** (from mixed v3/v4/v5), `marocchino/sticky-pull-request-comment` **v3**, `peter-evans/create-pull-request` **v8** (SHA updated on the Sparkle automation workflow), `mobile-dev-inc/action-maestro-cloud` **v3.0.1** in iOS sync e2e, and **`duckduckgo/native-github-asana-sync` unified at v2.5.1** (replacing v1.x/v2.4) for Asana task/comment flows.
> 
> **Intentionally unchanged:** `duckduckgo/sync_crypto/action@main` (still Node 20 until upstream tags Node 24).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e6b8f01b115d1e6f417628a6a65528a859ffbd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->