### PR TITLE
Add Duck.ai userDidViewSuggestions metric pixel (macOS)

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatMetricName.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatMetricName.swift
@@ -27,6 +27,7 @@ public enum AIChatMetricName: String, Codable {
     case userDidTapKeyboardReturnKey
     case userDidAcceptTermsAndConditions
     case userDidSelectSuggestion
+    case userDidViewSuggestions
 }
 
 // Model tier for AI Chat metrics
@@ -43,14 +44,17 @@ public struct AIChatMetric: Codable {
     /// Fixed catalog key identifying the tapped suggestion (e.g. `summarize-page`). Carried by `userDidSelectSuggestion`.
     public let suggestionId: String?
     /// Coarse page classification the FE derived from JSON-LD/OpenGraph. Decoded as a plain string so a new FE
-    /// page type never breaks decoding. Carried by `userDidSelectSuggestion`.
+    /// page type never breaks decoding. Carried by `userDidSelectSuggestion` and `userDidViewSuggestions`.
     public let pageType: String?
+    /// Whether the shown suggestions were smart (page-tailored) rather than generic. Carried by `userDidViewSuggestions`.
+    public let isSmart: Bool?
 
-     public init(metricName: AIChatMetricName, modelTier: AIChatModelTier? = nil, suggestionId: String? = nil, pageType: String? = nil) {
+     public init(metricName: AIChatMetricName, modelTier: AIChatModelTier? = nil, suggestionId: String? = nil, pageType: String? = nil, isSmart: Bool? = nil) {
          self.metricName = metricName
          self.modelTier = modelTier
          self.suggestionId = suggestionId
          self.pageType = pageType
+         self.isSmart = isSmart
      }
 }
 

--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -348,6 +348,10 @@ enum AIChatPixel: PixelKitEvent {
     /// `suggestionId` is the FE's fixed catalog key; `pageType` is the FE's coarse page classification.
     case aiChatSuggestionSelected(suggestionId: String, pageType: String)
 
+    /// Event Trigger: The Duck.ai sidebar presents page-suggestion chips to the user.
+    /// `isSmart` indicates whether the suggestions were smart (page-tailored); `pageType` is the FE's coarse page classification.
+    case aiChatSuggestionsViewed(isSmart: Bool, pageType: String)
+
     // MARK: - Onboarding
 
     /// Event Trigger: User enables the Duck.ai toggle during onboarding
@@ -648,6 +652,8 @@ enum AIChatPixel: PixelKitEvent {
             return "aichat_sent_prompt_ongoing_chat"
         case .aiChatSuggestionSelected:
             return "aichat_suggestion_selected"
+        case .aiChatSuggestionsViewed:
+            return "aichat_suggestions_viewed"
         case .aiChatOpenDuckAiMainMenu:
             return "aichat_open_duck_ai_main_menu"
         case .aiChatNewChatMainMenu:
@@ -862,6 +868,8 @@ enum AIChatPixel: PixelKitEvent {
             return ["reason": reason.rawValue]
         case .aiChatSuggestionSelected(let suggestionId, let pageType):
             return ["suggestionId": suggestionId, "pageType": pageType]
+        case .aiChatSuggestionsViewed(let isSmart, let pageType):
+            return ["isSmart": String(isSmart), "pageType": pageType]
         }
     }
 
@@ -957,6 +965,7 @@ enum AIChatPixel: PixelKitEvent {
                 .aiChatMetricStartNewConversation,
                 .aiChatMetricSentPromptOngoingChat,
                 .aiChatSuggestionSelected,
+                .aiChatSuggestionsViewed,
                 .aiChatTermsAcceptedDuplicateSyncOff,
                 .aiChatTermsAcceptedDuplicateSyncOn,
                 .aiChatReportMetricDecodeError,

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -985,6 +985,15 @@ extension AIChatUserScriptHandler: AIChatMetricReportingHandling {
                 frequency: .dailyAndStandard
             )
             completion?()
+        case .userDidViewSuggestions:
+            pixelFiring?.fire(
+                AIChatPixel.aiChatSuggestionsViewed(
+                    isSmart: metric.isSmart ?? false,
+                    pageType: metric.pageType ?? "none"
+                ),
+                frequency: .dailyAndStandard
+            )
+            completion?()
         default:
             completion?()
             return

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_pixels.json5
@@ -134,6 +134,45 @@
             "channel"
         ]
     },
+    "m_mac_aichat_suggestions_viewed": {
+        "description": "Fired when the Duck.ai sidebar presents page-suggestion chips to the user",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "isSmart",
+                "description": "Whether the shown suggestions were smart (page-tailored) rather than generic.",
+                "type": "boolean"
+            },
+            {
+                "key": "pageType",
+                "description": "Coarse page-type bucket the frontend computes from page-type signals. Never a URL, domain or page content.",
+                "type": "string",
+                "enum": [
+                    "recipe",
+                    "product",
+                    "article",
+                    "video",
+                    "job",
+                    "book",
+                    "event",
+                    "place",
+                    "forum",
+                    "code",
+                    "course",
+                    "review",
+                    "person",
+                    "howto",
+                    "faq",
+                    "none"
+                ]
+            },
+            "channel"
+        ]
+    },
     "m_mac_aichat_sidebar_resized": {
         "description": "Fired when user finishes dragging the sidebar resize grip (after 500 ms debounce)",
         "owners": ["jaceklyp"],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1216365672355903
Tech Design URL:
CC:

### Description

Adds a `userDidViewSuggestions` reportMetric case (carrying `isSmart` + `pageType`) to the shared Duck.ai `AIChatMetric`, and fires a new `m_mac_aichat_suggestions_viewed` pixel on macOS when the sidebar presents page-suggestion chips. Mirrors the existing `userDidSelectSuggestion` / `aiChatSuggestionSelected` path.

### Testing Steps
1. Run the macOS app with pixel debugging on.
2. Go to Debug -> AI Chat -> Web Communication -> Set URL, and set `https://euw-serp-dev-testing21.duck.ai`
3. Open https://www.imdb.com/title/tt32093575 and then open the sidebar
4. Filter pixels in Xcode and check`aichat_suggestions_viewed` fires with `isSmart` + `pageType`.

### Impact
Low. Telemetry-only; new pixel, no user-visible behavior change.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Low Risk**
> Telemetry-only changes with no user-facing behavior; follows the established suggestion-selection pixel path.
> 
> **Overview**
> Adds telemetry when the Duck.ai sidebar **shows** page-suggestion chips (complementing the existing tap metric).
> 
> The shared `AIChatMetric` gains `userDidViewSuggestions` plus optional `isSmart` and extended `pageType` on the payload. On macOS, `AIChatUserScriptHandler` maps that metric to **`aiChatSuggestionsViewed`** (`m_mac_aichat_suggestions_viewed`) with `isSmart` and `pageType`, fired at **daily + standard** frequency—the same pattern as `userDidSelectSuggestion` / `aiChatSuggestionSelected`.
> 
> Pixel catalog entry documents boolean `isSmart` and the same coarse `pageType` enum as suggestion selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9dc69dc9f91e53f203c0b008bf7fc16ba07835f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only; no user-facing behavior. Follows the established suggestion-selection pixel path with backward-compatible optional fields on `AIChatMetric`.
> 
> **Overview**
> Adds **impression** telemetry for Duck.ai sidebar page-suggestion chips, alongside the existing tap metric.
> 
> The shared `AIChatMetric` gains **`userDidViewSuggestions`** and an optional **`isSmart`** field on the payload (with **`pageType`** also documented for this metric). On macOS, **`AIChatUserScriptHandler`** maps that metric to **`aiChatSuggestionsViewed`** (`m_mac_aichat_suggestions_viewed`) with `isSmart` and `pageType`, fired at **daily + standard** frequency—the same pattern as suggestion selection.
> 
> The pixel catalog entry documents boolean **`isSmart`** and the same coarse **`pageType`** enum as **`m_mac_aichat_suggestion_selected`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6deaade586da808c50bf0a70ce26b0bf46c8342. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->