### PR TITLE
macOS: Enable sidebar suggestions for external users

### DIFF
--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -693,7 +693,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .aiChatSidebarFloating:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.sidebarFloating), category: .duckAI)
         case .sidebarSuggestedPrompts:
-            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.sidebarSuggestedPrompts), category: .duckAI)
+            Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.sidebarSuggestedPrompts), category: .duckAI)
         case .aiChatChromeSidebar:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.sidebar), category: .duckAI)
         case .webViewLookUpAction:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216365672355908?focus=true
Tech Design URL:
CC:

### Description
Enables the feature flag for external users (it has been turned on for internal for some time)

### Testing Steps
Nothing specific

### Impact
Low

#### What could go wrong?
Nothing specific

### Quality Considerations
Nothing specific

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single feature-flag default change for an already-shipped Duck.ai sidebar capability; remote config can still disable it.
> 
> **Overview**
> Changes the **default** for `sidebarSuggestedPrompts` from **internal-only** to **enabled**, so external macOS users can get Duck.ai sidebar suggested prompts when remote privacy config allows it (still gated by `AIChatSubfeature.sidebarSuggestedPrompts`).
> 
> That flag already drives `supportsSuggestions` in the AI chat native bridge and optional signals-only page-context collection for shortcut prompts when page context is on but auto-attach is off—this PR only widens who sees it by default, with no new UI or protocol code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36993657204e81fdbf240773ba227c4eb461052d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->