### PR TITLE
[iOS][Onboarding] Move Dax animation selection into OnboardingIntroContentProvider

### DIFF
--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroContentProvider.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroContentProvider.swift
@@ -86,6 +86,7 @@ struct OnboardingIntroStepContent: Equatable {
     let secondaryCTA: String
     let restorePromptStepContent: RestorePromptStepContent
     let skipFlowStepContent: SkipFlowStepContent
+    let daxAnimation: DaxAnimation
 }
 
 extension OnboardingIntroContentProvider {
@@ -121,7 +122,8 @@ extension OnboardingIntroContentProvider {
             primaryCTA: UserText.Onboarding.Intro.continueCTA,
             secondaryCTA: UserText.Onboarding.Intro.skipCTA,
             restorePromptStepContent: restoreOnboardingContent,
-            skipFlowStepContent: skipOnboardingContent
+            skipFlowStepContent: skipOnboardingContent,
+            daxAnimation: .thumbUp
         )
     }
 
@@ -134,6 +136,7 @@ struct OnboardingBrowserComparisonContent: Equatable {
     let features: [RebrandedComparisonTableModel.Feature]
     let primaryCTA: String
     let secondaryCTA: String
+    let daxAnimation: DaxAnimation
 }
 
 extension OnboardingIntroContentProvider {
@@ -148,7 +151,8 @@ extension OnboardingIntroContentProvider {
             title: title,
             features: RebrandedComparisonTableModel.defaultBrowserFeatures,
             primaryCTA: UserText.Onboarding.BrowsersComparison.cta,
-            secondaryCTA: UserText.onboardingSkip
+            secondaryCTA: UserText.onboardingSkip,
+            daxAnimation: .wingBottom
         )
     }
 
@@ -161,6 +165,7 @@ struct OnboardingAIComparisonContent: Equatable {
     let subHeader: String
     let features: [RebrandedComparisonTableModel.Feature]
     let primaryCTA: String
+    let daxAnimation: DaxAnimation
 }
 
 extension OnboardingIntroContentProvider {
@@ -171,6 +176,7 @@ extension OnboardingIntroContentProvider {
             subHeader: UserText.Onboarding.DuckAICPP.AIComparison.subHeader,
             features: RebrandedComparisonTableModel.defaultAIFeatures,
             primaryCTA: UserText.Onboarding.DuckAICPP.AIComparison.cta,
+            daxAnimation: .wingBottom
         )
     }
 
@@ -190,6 +196,7 @@ struct OnboardingAddToDockContent: Equatable {
     let primaryCTA: String
     let secondaryCTA: String
     let tutorialStepContent: TutorialStepContent
+    let daxAnimation: DaxAnimation
 }
 
 extension OnboardingIntroContentProvider {
@@ -211,7 +218,8 @@ extension OnboardingIntroContentProvider {
             message: promoMessage,
             primaryCTA: UserText.AddToDockOnboarding.Buttons.tutorial,
             secondaryCTA: UserText.AddToDockOnboarding.Buttons.skip,
-            tutorialStepContent: tutorial
+            tutorialStepContent: tutorial,
+            daxAnimation: .wingLeft
         )
     }
 
@@ -223,6 +231,7 @@ struct OnboardingAppIconColorContent: Equatable {
     let title: String
     let message: String
     let primaryCTA: String
+    let daxAnimation: DaxAnimation
 }
 
 extension OnboardingIntroContentProvider {
@@ -231,7 +240,8 @@ extension OnboardingIntroContentProvider {
         OnboardingAppIconColorContent(
             title: UserText.Onboarding.AppIconSelection.title,
             message: UserText.Onboarding.AppIconSelection.message,
-            primaryCTA: UserText.Onboarding.AppIconSelection.cta
+            primaryCTA: UserText.Onboarding.AppIconSelection.cta,
+            daxAnimation: .wingRight
         )
     }
 
@@ -250,6 +260,7 @@ struct OnboardingAddressBarPositionContent: Equatable {
     let bottomOption: OptionContent
     let defaultIndicator: String
     let primaryCTA: String
+    let daxAnimation: DaxAnimation?
 }
 
 extension OnboardingIntroContentProvider {
@@ -266,7 +277,8 @@ extension OnboardingIntroContentProvider {
                 message: UserText.Onboarding.AddressBarPosition.bottomMessage
             ),
             defaultIndicator: UserText.Onboarding.AddressBarPosition.defaultOption,
-            primaryCTA: UserText.Onboarding.AddressBarPosition.cta
+            primaryCTA: UserText.Onboarding.AddressBarPosition.cta,
+            daxAnimation: nil // Dax-Floating is embedded in ScrollableOnboardingBackground
         )
     }
 
@@ -278,6 +290,7 @@ struct OnboardingSearchExperienceContent: Equatable {
     let title: String
     let footer: AttributedString
     let primaryCTA: String
+    let daxAnimation: DaxAnimation
 }
 
 extension OnboardingIntroContentProvider {
@@ -286,7 +299,8 @@ extension OnboardingIntroContentProvider {
         OnboardingSearchExperienceContent(
             title: UserText.Onboarding.SearchExperience.title,
             footer: AttributedString(UserText.Onboarding.SearchExperience.footerAttributed()),
-            primaryCTA: UserText.Onboarding.SearchExperience.cta
+            primaryCTA: UserText.Onboarding.SearchExperience.cta,
+            daxAnimation: .wingLeft
         )
     }
 
@@ -298,8 +312,8 @@ struct OnboardingDuckAIQueryContent: Equatable {
     let title: String
     let searchPlaceholder: String
     let aiPlaceholder: String
-
     let isToggleVisible: Bool
+    let daxAnimation: DaxAnimation?
 }
 
 extension OnboardingIntroContentProvider {
@@ -316,7 +330,8 @@ extension OnboardingIntroContentProvider {
             title: title,
             searchPlaceholder: UserText.Onboarding.DuckAIQuery.searchPlaceholder,
             aiPlaceholder: UserText.Onboarding.DuckAIQuery.aiPlaceholder,
-            isToggleVisible: isToggleVisible
+            isToggleVisible: isToggleVisible,
+            daxAnimation: nil
         )
     }
 

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingView+DuckAIQuerySearchContent.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingView+DuckAIQuerySearchContent.swift
@@ -128,7 +128,8 @@ extension OnboardingView {
                 title: UserText.Onboarding.DuckAIQuery.title,
                 searchPlaceholder: UserText.Onboarding.DuckAIQuery.searchPlaceholder,
                 aiPlaceholder: UserText.Onboarding.DuckAIQuery.aiPlaceholder,
-                isToggleVisible: true
+                isToggleVisible: true,
+                daxAnimation: nil
             ),
             defaultMode: DuckAIQueryMode,
             visualStyle: VisualStyle = .legacy,

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/Components/RebrandedOnboardingView+DaxAnimationOverlay.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/Components/RebrandedOnboardingView+DaxAnimationOverlay.swift
@@ -23,10 +23,10 @@ import SwiftUI
 // MARK: - Dax Animation Configuration
 
 /// Configuration for a Dax Lottie animation overlaid between the scrollable background and the dialog bubble.
-struct DaxAnimation {
+struct DaxAnimation: Equatable {
 
     /// Anchoring position relative to the view's bottom edge.
-    enum Position {
+    enum Position: Equatable {
         /// Bottom-leading anchor. `bottomPadding` lifts above the bottom; `xOffset` shifts right (+) / left (−).
         case left(bottomPadding: CGFloat = 0, xOffset: CGFloat = 0)
         /// Bottom-trailing anchor. `bottomPadding` lifts above the bottom; `xOffset` shifts left (+) / right (−).
@@ -101,6 +101,50 @@ struct DaxAnimation {
         self.fadeInTime = fadeInTime
         self.startDelay = startDelay
     }
+}
+
+// MARK: - Dax Animation Presets
+
+extension DaxAnimation {
+
+    /// Dax giving a thumbs up, at full base size.
+    static let thumbUp = DaxAnimation(
+        animationName: "Dax-ThumbUp",
+        size: CGSize(width: 258.0, height: 352.0),
+        position: .left(bottomPadding: 110.0, xOffset: -40.0),
+        largeScreenPosition: .left(bottomPadding: 110.0, xOffset: 200.0),
+        entranceOffset: CGPoint(x: -20.0, y: 0),
+        exitOffset: CGPoint(x: -258.0, y: 0),
+        exitDuration: 0.5,
+        fadeOut: true,
+        startDelay: 0.75
+    )
+
+    /// Dax waving from the bottom center of the screen.
+    static let wingBottom = DaxAnimation(
+        animationName: "Dax-WingBottom",
+        size: CGSize(width: 159.33, height: 180.33),
+        position: .bottom(),
+        twoStagesAnimation: 0.5,
+        exitDuration: 1.0
+    )
+
+    /// Dax waving from the left side of the screen.
+    static let wingLeft = DaxAnimation(
+        animationName: "Dax-WingLeft",
+        size: CGSize(width: 116, height: 208.33),
+        position: .left(bottomPadding: 70.0),
+        twoStagesAnimation: 0.5
+    )
+
+    /// Dax waving from the right side of the screen.
+    static let wingRight = DaxAnimation(
+        animationName: "Dax-WingRight",
+        size: CGSize(width: 116, height: 208.33),
+        position: .right(bottomPadding: 107.0),
+        twoStagesAnimation: 0.5,
+        exitDuration: 0.5
+    )
 }
 
 // MARK: - Dax Animation Overlay

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView+AddToDockContent.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView+AddToDockContent.swift
@@ -26,15 +26,6 @@ extension OnboardingRebranding.OnboardingView {
     /// Figma: https://www.figma.com/design/YPE94Xkcrk2uqiF2l4VmSv/Onboarding--2026-?node-id=12203-26425
     struct AddToDockPromoContent: View {
 
-        static var daxAnimation: DaxAnimation {
-            DaxAnimation(
-                animationName: "Dax-WingLeft",
-                size: CGSize(width: 116, height: 208.33),
-                position: .left(bottomPadding: 70.0),
-                twoStagesAnimation: 0.5
-            )
-        }
-
         @Environment(\.onboardingTheme) private var onboardingTheme
         @Environment(\.accessibilityReduceMotion) private var reduceMotion
 

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView+AppIconPickerContent.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView+AppIconPickerContent.swift
@@ -26,16 +26,6 @@ extension OnboardingRebranding.OnboardingView {
     /// Figma: https://www.figma.com/design/YPE94Xkcrk2uqiF2l4VmSv/Onboarding--2026-?node-id=12191-45897
     struct AppIconPickerContent: View {
 
-        static var daxAnimation: DaxAnimation {
-            DaxAnimation(
-                animationName: "Dax-WingRight",
-                size: CGSize(width: 116, height: 208.33),
-                position: .right(bottomPadding: 107.0),
-                twoStagesAnimation: 0.5,
-                exitDuration: 0.5
-            )
-        }
-
         @Environment(\.onboardingTheme) private var onboardingTheme
         @Environment(\.accessibilityReduceMotion) private var reduceMotion
 

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView+BrowsersComparisonContent.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView+BrowsersComparisonContent.swift
@@ -27,17 +27,6 @@ extension OnboardingRebranding.OnboardingView {
     /// Figma: https://www.figma.com/design/YPE94Xkcrk2uqiF2l4VmSv/Onboarding--2026-?node-id=7419-54020
     struct BrowsersComparisonContent: View {
 
-        /// Dax "Wing Wave Up" animation
-        static var daxAnimation: DaxAnimation {
-            DaxAnimation(
-                animationName: "Dax-WingBottom",
-                size: CGSize(width: 159.33, height: 180.33),
-                position: .bottom(),
-                twoStagesAnimation: 0.5,
-                exitDuration: 1.0
-            )
-        }
-
         @Environment(\.onboardingTheme) private var onboardingTheme
         @Environment(\.accessibilityReduceMotion) private var reduceMotion
 

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView+IntroDialogContent.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView+IntroDialogContent.swift
@@ -26,43 +26,6 @@ extension OnboardingRebranding.OnboardingView {
     /// Figma: https://www.figma.com/design/YPE94Xkcrk2uqiF2l4VmSv/Onboarding--2026-?node-id=12191-31959
     struct IntroDialogContent: View {
 
-        /// Dax "Thumbs Up", sized inversely to the bubble height so the two never overlap.
-        /// Returns `nil` when Dax would shrink below `minDaxHeight`. `bubbleHeight = 0`
-        /// (no measurement yet) renders Dax at full size so the first frame doesn't blink.
-        static func daxAnimation(forBubbleHeight bubbleHeight: CGFloat = 0) -> DaxAnimation? {
-            let baseSize = CGSize(width: 258.0, height: 352.0)
-            let baseBottomPadding: CGFloat = 110.0
-            let baseEntranceXOffset: CGFloat = -20.0
-            let baseLargeScreenXOffset: CGFloat = 200.0
-            let baseLeftXOffset: CGFloat = -40.0
-            /// Threshold above which the bubble starts shrinking Dax 1:1.
-            let referenceBubbleHeight: CGFloat = 280.0
-            /// Below this height Dax is hidden entirely (per design).
-            let minDaxHeight: CGFloat = 170.0
-
-            let extraBubbleHeight = max(0, bubbleHeight - referenceBubbleHeight)
-            let targetHeight = baseSize.height - extraBubbleHeight
-            guard targetHeight >= minDaxHeight else { return nil }
-
-            let scale = targetHeight / baseSize.height
-            let size = CGSize(width: baseSize.width * scale, height: targetHeight)
-            // Scale the bottom inset with Dax so the screen-bottom relationship is preserved.
-            let bottomPadding = baseBottomPadding * scale
-
-            return DaxAnimation(
-                animationName: "Dax-ThumbUp",
-                size: size,
-                position: .left(bottomPadding: bottomPadding, xOffset: baseLeftXOffset),
-                largeScreenPosition: .left(bottomPadding: bottomPadding, xOffset: baseLargeScreenXOffset),
-                entranceOffset: CGPoint(x: baseEntranceXOffset, y: 0),
-                // Slide left by the full (scaled) width so exit fully clears the screen.
-                exitOffset: CGPoint(x: -size.width, y: 0),
-                exitDuration: 0.5,
-                fadeOut: true,
-                startDelay: 0.75
-            )
-        }
-
         @Environment(\.onboardingTheme) private var onboardingTheme
         @Environment(\.accessibilityReduceMotion) private var reduceMotion
 

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView+SearchExperienceContent.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView+SearchExperienceContent.swift
@@ -25,15 +25,6 @@ extension OnboardingRebranding.OnboardingView {
     /// Figma: https://www.figma.com/design/YPE94Xkcrk2uqiF2l4VmSv/Onboarding--2026-?node-id=12192-50600
     struct SearchExperienceContent: View {
 
-        static var daxAnimation: DaxAnimation {
-            DaxAnimation(
-                animationName: "Dax-WingLeft",
-                size: CGSize(width: 116, height: 208.33),
-                position: .left(bottomPadding: 70.0),
-                twoStagesAnimation: 0.5
-            )
-        }
-
         @Environment(\.onboardingTheme) private var onboardingTheme
         @Environment(\.accessibilityReduceMotion) private var reduceMotion
 

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView.swift
@@ -495,7 +495,7 @@ extension OnboardingRebranding {
                     // The background doesn't change here, so animateContentTransition is not called.
                     // Trigger the Dax exit manually: starts simultaneously with the tutorial transition,
                     // then removes the overlay once the exit animation completes.
-                    let exitDuration = AddToDockPromoContent.daxAnimation.effectiveExitDuration
+                    let exitDuration = content.daxAnimation.effectiveExitDuration
                     daxExiting = true
                     DispatchQueue.main.asyncAfter(deadline: .now() + exitDuration) {
                         daxExiting = false
@@ -570,15 +570,54 @@ extension OnboardingRebranding {
             guard !dynamicTypeSize.isAccessibilitySize else { return nil }
             switch type {
             // `lockedIntroBubbleHeight` (not the live value) keeps Dax stable across intro
-            // bubble content swaps.
-            case .startOnboardingDialog: return IntroDialogContent.daxAnimation(forBubbleHeight: lockedIntroBubbleHeight)
-            case .browsersComparisonDialog, .aiComparisonDialog: return BrowsersComparisonContent.daxAnimation
-            case .addToDockPromoDialog: return AddToDockPromoContent.daxAnimation
-            case .chooseAppIconDialog: return AppIconPickerContent.daxAnimation
-            case .chooseAddressBarPositionDialog: return nil // Dax-Floating is embedded in ScrollableOnboardingBackground
-            case .chooseSearchExperienceDialog: return SearchExperienceContent.daxAnimation
-            case .duckAIQueryDialog: return nil
+            // bubble content swaps. Dax is scaled inversely to the bubble so they never overlap.
+            case .startOnboardingDialog(let content, _):
+                return scaledThumbUpAnimation(forBubbleHeight: lockedIntroBubbleHeight, base: content.daxAnimation)
+            case .browsersComparisonDialog(let content):
+                return content.daxAnimation
+            case .aiComparisonDialog(let content):
+                return content.daxAnimation
+            case .addToDockPromoDialog(let content):
+                return content.daxAnimation
+            case .chooseAppIconDialog(let content):
+                return content.daxAnimation
+            case .chooseAddressBarPositionDialog(let content):
+                return content.daxAnimation
+            case .chooseSearchExperienceDialog(let content):
+                return content.daxAnimation
+            case .duckAIQueryDialog(let content, _):
+                return content.daxAnimation
             }
+        }
+
+        /// Scales `base` inversely to the bubble height so Dax and the bubble never overlap.
+        /// Returns `nil` when Dax would shrink below the minimum visible height.
+        /// Only `size`, `position` bottom padding, and `exitOffset` are adjusted; all other
+        /// params (animation name, entrance, timing) are taken from `base` unchanged.
+        private func scaledThumbUpAnimation(forBubbleHeight bubbleHeight: CGFloat, base: DaxAnimation) -> DaxAnimation? {
+            let referenceBubbleHeight: CGFloat = 280.0
+            let minDaxHeight: CGFloat = 170.0
+
+            let extraBubbleHeight = max(0, bubbleHeight - referenceBubbleHeight)
+            let targetHeight = base.size.height - extraBubbleHeight
+            guard targetHeight >= minDaxHeight else { return nil }
+
+            let scale = targetHeight / base.size.height
+            let size = CGSize(width: base.size.width * scale, height: targetHeight)
+
+            guard case .left(let baseBottomPadding, let xOffset) = base.position else { return nil }
+            let bottomPadding = baseBottomPadding * scale
+
+            return DaxAnimation(
+                animationName: base.animationName,
+                size: size,
+                position: .left(bottomPadding: bottomPadding, xOffset: xOffset),
+                entranceOffset: base.entranceOffset,
+                exitOffset: base.exitOffset.map { CGPoint(x: -size.width, y: $0.y) },
+                exitDuration: base.exitDuration,
+                fadeOut: base.fadeOut,
+                startDelay: base.startDelay
+            )
         }
 
         /// Hide → action → show sequence prevents cross-fading between steps.

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView.swift
@@ -612,6 +612,7 @@ extension OnboardingRebranding {
                 animationName: base.animationName,
                 size: size,
                 position: .left(bottomPadding: bottomPadding, xOffset: xOffset),
+                largeScreenPosition: .left(bottomPadding: bottomPadding, xOffset: 200.0),
                 entranceOffset: base.entranceOffset,
                 exitOffset: base.exitOffset.map { CGPoint(x: -size.width, y: $0.y) },
                 exitDuration: base.exitDuration,

--- a/iOS/DuckDuckGoTests/OnboardingIntroContentProviderTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroContentProviderTests.swift
@@ -839,4 +839,81 @@ struct OnboardingIntroContentProviderTests {
 
     }
 
+    @Suite("Dax Animations")
+    struct DaxAnimations {
+
+        @Test(
+            "Check intro step uses thumbUp animation",
+            arguments: [.default, .duckAI] as [OnboardingFlowType]
+        )
+        func introStepDaxAnimation(flow: OnboardingFlowType) {
+            let sut = OnboardingIntroContentProvider(flowType: flow, featureFlagger: MockFeatureFlagger())
+            #expect(sut.introStepContent.daxAnimation == .thumbUp)
+        }
+
+        @Test(
+            "Check browser comparison uses wingBottom animation",
+            arguments: [.default, .duckAI] as [OnboardingFlowType]
+        )
+        func browserComparisonDaxAnimation(flow: OnboardingFlowType) {
+            let sut = OnboardingIntroContentProvider(flowType: flow, featureFlagger: MockFeatureFlagger())
+            #expect(sut.browserComparisonContent.daxAnimation == .wingBottom)
+        }
+
+        @Test(
+            "Check AI comparison uses wingBottom animation",
+            arguments: [.default, .duckAI] as [OnboardingFlowType]
+        )
+        func aiComparisonDaxAnimation(flow: OnboardingFlowType) {
+            let sut = OnboardingIntroContentProvider(flowType: flow, featureFlagger: MockFeatureFlagger())
+            #expect(sut.aiComparisonContent.daxAnimation == .wingBottom)
+        }
+
+        @Test(
+            "Check add to dock uses wingLeft animation",
+            arguments: [.default, .duckAI] as [OnboardingFlowType]
+        )
+        func addToDockDaxAnimation(flow: OnboardingFlowType) {
+            let sut = OnboardingIntroContentProvider(flowType: flow, featureFlagger: MockFeatureFlagger())
+            #expect(sut.addToDockContent.daxAnimation == .wingLeft)
+        }
+
+        @Test(
+            "Check app icon color uses wingRight animation",
+            arguments: [.default, .duckAI] as [OnboardingFlowType]
+        )
+        func appIconColorDaxAnimation(flow: OnboardingFlowType) {
+            let sut = OnboardingIntroContentProvider(flowType: flow, featureFlagger: MockFeatureFlagger())
+            #expect(sut.appIconColorContent.daxAnimation == .wingRight)
+        }
+
+        @Test(
+            "Check address bar position has no overlay animation (Dax is embedded in the background)",
+            arguments: [.default, .duckAI] as [OnboardingFlowType]
+        )
+        func addressBarPositionDaxAnimation(flow: OnboardingFlowType) {
+            let sut = OnboardingIntroContentProvider(flowType: flow, featureFlagger: MockFeatureFlagger())
+            #expect(sut.addressBarPositionContent.daxAnimation == nil)
+        }
+
+        @Test(
+            "Check search experience uses wingLeft animation",
+            arguments: [.default, .duckAI] as [OnboardingFlowType]
+        )
+        func searchExperienceDaxAnimation(flow: OnboardingFlowType) {
+            let sut = OnboardingIntroContentProvider(flowType: flow, featureFlagger: MockFeatureFlagger())
+            #expect(sut.searchExperienceContent.daxAnimation == .wingLeft)
+        }
+
+        @Test(
+            "Check duck.ai query has no animation",
+            arguments: [.default, .duckAI] as [OnboardingFlowType]
+        )
+        func duckAIQueryDaxAnimation(flow: OnboardingFlowType) {
+            let sut = OnboardingIntroContentProvider(flowType: flow, featureFlagger: MockFeatureFlagger())
+            #expect(sut.duckAIQueryContent.daxAnimation == nil)
+        }
+
+    }
+
 }

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/MockOnboardingIntroContentProvider.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/MockOnboardingIntroContentProvider.swift
@@ -58,7 +58,8 @@ extension OnboardingIntroStepContent {
             message: "Skip Message",
             primaryCTA: "Skip Primary",
             secondaryCTA: "Skip Secondary"
-        )
+        ),
+        daxAnimation: .thumbUp
     )
 }
 
@@ -69,7 +70,8 @@ extension OnboardingBrowserComparisonContent {
             .init(type: RebrandedComparisonTableModel.Feature.BrowserFeatureType.privateSearch, competitorAvailability: .unavailable, ddgAvailability: .available)
         ],
         primaryCTA: "Browser Comparison Primary",
-        secondaryCTA: "Browser Comparison Secondary"
+        secondaryCTA: "Browser Comparison Secondary",
+        daxAnimation: .wingLeft
     )
 }
 
@@ -80,7 +82,8 @@ extension OnboardingAIComparisonContent {
         features: [
             .init(type: RebrandedComparisonTableModel.Feature.AIFeatureType.anonymousChats, competitorAvailability: .unavailable, ddgAvailability: .available)
         ],
-        primaryCTA: "AI Comparison Primary"
+        primaryCTA: "AI Comparison Primary",
+        daxAnimation: .wingLeft
     )
 }
 
@@ -94,7 +97,8 @@ extension OnboardingAddToDockContent {
             title: "Tutorial Title",
             message: "Tutorial Message",
             primaryCTA: "Tutorial Primary"
-        )
+        ),
+        daxAnimation: .wingRight
     )
 }
 
@@ -102,7 +106,8 @@ extension OnboardingAppIconColorContent {
     static let mock = OnboardingAppIconColorContent(
         title: "App Icon Title",
         message: "App Icon Message",
-        primaryCTA: "App Icon Primary"
+        primaryCTA: "App Icon Primary",
+        daxAnimation: .wingBottom
     )
 }
 
@@ -112,7 +117,8 @@ extension OnboardingAddressBarPositionContent {
         topOption: .init(title: "Top Title", message: "Top Message"),
         bottomOption: .init(title: "Bottom Title", message: "Bottom Message"),
         defaultIndicator: "(default)",
-        primaryCTA: "Address Bar Primary"
+        primaryCTA: "Address Bar Primary",
+        daxAnimation: nil
     )
 }
 
@@ -120,7 +126,8 @@ extension OnboardingSearchExperienceContent {
     static let mock = OnboardingSearchExperienceContent(
         title: "Search Experience Title",
         footer: AttributedString("Search Experience Footer"),
-        primaryCTA: "Search Experience Primary"
+        primaryCTA: "Search Experience Primary",
+        daxAnimation: .wingRight
     )
 }
 
@@ -129,6 +136,7 @@ extension OnboardingDuckAIQueryContent {
         title: "Duck.ai Query Title",
         searchPlaceholder: "Search Placeholder",
         aiPlaceholder: "AI Placeholder",
-        isToggleVisible: true
+        isToggleVisible: true,
+        daxAnimation: nil
     )
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1215563968127481
Tech Design URL:
CC:

### Description
Moves Dax animation ownership into the content provider so each step declares its animation alongside its text content. Previously the view decided which animation to show per step via a hardcoded switch.

This is groundwork for future experiments where steps that need to show a different animation per variant can now do so purely in the content provider, and steps added for the experiment can re-use existing animations.

### Before

- iPhone 17 Pro

https://github.com/user-attachments/assets/a8510f81-bd44-47bf-928b-04f71d7d69d0

- iPhone SE

https://github.com/user-attachments/assets/952d241a-4e0e-4237-992a-69a3cd9dc5ab


- iPad

https://github.com/user-attachments/assets/6e3f17ec-a9cf-4f1e-829e-3e83087b2de6


### After

- iPhone 17 Pro

https://github.com/user-attachments/assets/4b350f16-1ccb-432c-80c5-c0faf850e2f2

- iPhone SE

https://github.com/user-attachments/assets/9b071309-5678-4cb3-9df7-2b4ca29e1558


- iPad

https://github.com/user-attachments/assets/0a2fe326-9a92-4ab4-a63d-a57131e4efc4


### Testing Steps
1. Ensure CI test pass
2. Check videos before and after

### Impact
**Low:** internal refactor, no change to user-visible behaviour.

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." —>

### Quality Considerations
Unit tests added to `OnboardingIntroContentProviderTests` asserting the correct animation is assigned to each step for both flow types.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-layer refactor with unit tests; intended to preserve user-visible onboarding animations.
> 
> **Overview**
> **Dax animation selection** moves from hardcoded per-step view helpers into `OnboardingIntroContentProvider`: each onboarding step content model now carries a `daxAnimation` (or `nil` where there is no overlay).
> 
> Shared **Lottie presets** (`thumbUp`, `wingBottom`, `wingLeft`, `wingRight`) live on `DaxAnimation` (now `Equatable`). Step-specific `static daxAnimation` blocks are removed from rebranded step views; `RebrandedOnboardingView` reads animations from the associated content and still applies **bubble-height scaling** for the intro thumbs-up via `scaledThumbUpAnimation`. Add-to-dock tutorial exit timing uses `content.daxAnimation.effectiveExitDuration`.
> 
> **Tests** in `OnboardingIntroContentProviderTests` assert the expected preset per step for both flow types; mocks are updated for the new fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dff648d6075e744066ba89c98338abdf0cc1e4f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->