### PR TITLE
[CI] Fix Danger

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
       - name: Danger

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -14,9 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
       - name: Danger
-        uses: danger/danger-js@13.0.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: "--dangerfile duckduckgo/danger-settings/org/allPRs.ts@main"
+        run: |
+          npx --yes -p danger@13.0.4 -p typescript@6 -- \
+            danger ci --dangerfile duckduckgo/danger-settings/org/allPRs.ts@main


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1216411675645252?focus=true
Tech Design URL:
CC:

### Description
The danger/danger-js@13.0.4 Docker action rebuilds its image each run and uns an unpinned `yarn add typescript`, which started resolving to typescript@7.0.2 (the native Go rewrite) after it was promoted to the npm
`latest` tag on 2026-07-08. TS7 dropped the classic compiler API, so Danger's transpiler crashed with:
    `TypeError: ts.getDefaultCompilerOptions is not a function`

This PR replaces the container action with a plain Node 24 step running `npx danger ci` with typescript@6 pinned, restoring the last-known-good compiler (6.0.3) that retains the classic API.


### Testing Steps
1. Ensure Danger Check passes.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal CI-only change; no app runtime, auth, or data paths affected.
> 
> **Overview**
> Fixes the **Danger JS** GitHub Action failing after **TypeScript 7** landed on npm `latest` and broke Danger’s classic compiler API (`ts.getDefaultCompilerOptions`).
> 
> The workflow stops using the **`danger/danger-js@13.0.4` container action** (which rebuilt each run and pulled an unpinned TypeScript). It now uses **`actions/setup-node@v5` (Node 24)** and runs **`npx danger ci`** with **`danger@13.0.4`** and **`typescript@6`** pinned, keeping the same remote dangerfile (`duckduckgo/danger-settings/org/allPRs.ts@main`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c6f6074c3f8473c70884735494305846c584904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->