### PR TITLE
Keep iPad Duck.ai address bar text across rotation

### DIFF
--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -557,8 +557,8 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         return strip
     }()
 
-    let aiChatTextView: UITextView = {
-        let textView = UITextView()
+    let aiChatTextView: ResignSuppressingTextView = {
+        let textView = ResignSuppressingTextView()
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.isHidden = true
         textView.backgroundColor = .clear
@@ -2104,6 +2104,20 @@ extension DefaultOmniBarView {
         } else {
             updateMaskLayer()
         }
+    }
+}
+
+/// A `UITextView` that can be prevented from resigning first responder,
+final class ResignSuppressingTextView: UITextView {
+
+    /// When true, prevents the text view from resigning first responder.
+    /// Used during device rotation to keep the keyboard visible.
+    var suppressResignFirstResponder: Bool = false
+
+    @discardableResult
+    override func resignFirstResponder() -> Bool {
+        if suppressResignFirstResponder { return false }
+        return super.resignFirstResponder()
     }
 }
 

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -162,6 +162,18 @@ final class DefaultOmniBarViewController: OmniBarViewController {
         updateShadowAppearanceByApplyingLayerMask()
     }
 
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+
+        /// Keep the inline duck.ai field first responder across the rotation
+        guard omniBarView.aiChatTextView.isFirstResponder else { return }
+
+        omniBarView.aiChatTextView.suppressResignFirstResponder = true
+        coordinator.animate(alongsideTransition: nil) { [weak self] _ in
+            self?.omniBarView.aiChatTextView.suppressResignFirstResponder = false
+        }
+    }
+
     // MARK: - Text Field Delegate Overrides
 
     override func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {

--- a/iOS/DuckDuckGo/OmniBarView.swift
+++ b/iOS/DuckDuckGo/OmniBarView.swift
@@ -146,7 +146,7 @@ protocol ExpandableOmniBarView: OmniBarView {
     var selectedModeToggleState: TextEntryMode { get set }
     var isModeToggleHidden: Bool { get set }
     func setSearchAreaExpanded(_ expanded: Bool, animated: Bool)
-    var aiChatTextView: UITextView { get }
+    var aiChatTextView: ResignSuppressingTextView { get }
     var onAIChatSendPressed: (() -> Void)? { get set }
     func updateTextFieldPlaceholderVisibility(hasText: Bool)
     func updateAIChatSendButton(hasText: Bool)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1216387751669995?focus=true
Tech Design URL:
CC:

### Description
On iPad, rotating the device while editing in Duck.ai mode collapsed the expanded address bar and cleared the in-progress prompt, so the user had to retype. The inline `aiChatTextView` now uses a `suppressResignFirstResponder` flag (mirroring the search field's `TextFieldWithInsets`) so it stays first responder through the rotation and the expanded bar is not torn down.

### Testing Steps
1. On iPad, tap the address bar, switch to Duck.ai mode, and type a partial prompt.
2. Rotate the device between portrait and landscape.
3. Confirm the typed text and keyboard focus are preserved (they were lost before); repeat in search mode to confirm it still behaves.

### Impact and Risks
Low — scoped to the iPad inline Duck.ai address bar during rotation, with no change on iPhone or in search mode.

#### What could go wrong?
Holding first responder through the iPad size-class layout change could in theory misbehave, but it was verified on device and only applies during the brief rotation window.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, rotation-window UIKit first-responder tweak on iPad Duck.ai only; mirrors an existing search-field pattern with no auth or data changes.
> 
> **Overview**
> Fixes **iPad Duck.ai** editing where rotation used to drop keyboard focus, collapse the expanded address bar, and lose in-progress prompt text.
> 
> The inline **`aiChatTextView`** is now a **`ResignSuppressingTextView`** (same resign-blocking idea as search’s **`TextFieldWithInsets`**). **`DefaultOmniBarViewController`** turns **`suppressResignFirstResponder`** on for the rotation transition when that text view is first responder, then clears it when the transition finishes. **`ExpandableOmniBarView`** exposes the new type.
> 
> Scope is limited to the iPad inline Duck.ai field during rotation; iPhone and search mode are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1490ceda9701be1023fed0601d115304576b473. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->