### PR TITLE
feat(opt-out-email): add native mail providers

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/UIWeb/DBPUICommunicationLayer.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/UIWeb/DBPUICommunicationLayer.swift
@@ -38,6 +38,13 @@ public struct DBPUIFeatureConfigurationResponse: Encodable {
     }
 }
 
+public struct DBPUIOptOutEmail: Codable {
+    public let brokerName: String
+    public let to: String
+    public let subject: String
+    public let body: String
+}
+
 public protocol DBPUICommunicationDelegate: AnyObject {
     func getHandshakeUserData() async -> DBPUIHandshakeUserData?
     func saveProfile() async throws
@@ -56,6 +63,7 @@ public protocol DBPUICommunicationDelegate: AnyObject {
     func getDataBrokers() async -> [DBPUIDataBroker]
     func getBackgroundAgentMetadata() async -> DBPUIDebugMetadata
     func openSendFeedbackModal() async
+    func openOptOutEmail(_ payload: DBPUIOptOutEmail) async -> Bool
     func applyVPNBypassSetting(_ bypass: Bool) async
     func removeOptOutFromDashboard(_ id: Int64) async
     func needBackgroundAppRefresh() async -> Bool
@@ -81,6 +89,7 @@ public enum DBPUIReceivedMethodName: String {
     case getBackgroundAgentMetadata
     case getFeatureConfig
     case openSendFeedbackModal
+    case openOptOutEmail
     case getVPNBypassSetting = "getVpnExclusionSetting"
     case setVPNBypassSetting = "setVpnExclusionSetting"
     case removeOptOutFromDashboard
@@ -106,7 +115,7 @@ public struct DBPUICommunicationLayer: Subfeature {
     weak public var delegate: DBPUICommunicationDelegate?
 
     private enum Constants {
-        static let version = 12
+        static let version = 13
     }
 
     public init(webURLSettings: DataBrokerProtectionWebUIURLSettingsRepresentable,
@@ -145,6 +154,7 @@ public struct DBPUICommunicationLayer: Subfeature {
         case .getBackgroundAgentMetadata: return getBackgroundAgentMetadata
         case .getFeatureConfig: return getFeatureConfig
         case .openSendFeedbackModal: return openSendFeedbackModal
+        case .openOptOutEmail: return openOptOutEmail
         case .getVPNBypassSetting: return getVPNBypassSetting
         case .setVPNBypassSetting: return setVPNBypassSetting
         case .removeOptOutFromDashboard: return removeOptOutFromDashboard
@@ -358,6 +368,17 @@ public struct DBPUICommunicationLayer: Subfeature {
     func openSendFeedbackModal(params: Any, original: WKScriptMessage) async throws -> Encodable? {
         await delegate?.openSendFeedbackModal()
         return nil
+    }
+
+    func openOptOutEmail(params: Any, original: WKScriptMessage) async throws -> Encodable? {
+        guard let data = try? JSONSerialization.data(withJSONObject: params),
+              let payload = try? JSONDecoder().decode(DBPUIOptOutEmail.self, from: data) else {
+            Logger.dataBrokerProtection.error("openOptOutEmail: malformed payload")
+            return DBPUIStandardResponse(version: Constants.version, success: false)
+        }
+
+        let opened = await delegate?.openOptOutEmail(payload) ?? false
+        return DBPUIStandardResponse(version: Constants.version, success: opened)
     }
 
     func getVPNBypassSetting(params: Any, original: WKScriptMessage) async throws -> Encodable? {

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/UIWeb/DBPUICommunicationModel.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/UIWeb/DBPUICommunicationModel.swift
@@ -254,6 +254,7 @@ public struct DBPUIDataBrokerProfileMatch: Codable {
     public let addresses: [DBPUIUserProfileAddress]
     public let alternativeNames: [String]
     public let relatives: [String]
+    public let profileUrl: String?
     public let foundDate: Double
     /// The moment the broker acknowledged the opt-out for email-confirming brokers, or the moment our
     /// form submission completed for brokers that don't email-confirm. For a value that consistently
@@ -266,13 +267,14 @@ public struct DBPUIDataBrokerProfileMatch: Codable {
     public let removedDate: Double?
     public let hasMatchingRecordOnParentBroker: Bool
 
-    public init(id: Int64?, dataBroker: DBPUIDataBroker, name: String, addresses: [DBPUIUserProfileAddress], alternativeNames: [String], relatives: [String], foundDate: Double, optOutSubmittedDate: Double? = nil, optOutFormSubmittedDate: Double? = nil, estimatedRemovalDate: Double? = nil, removedDate: Double? = nil, hasMatchingRecordOnParentBroker: Bool) {
+    public init(id: Int64?, dataBroker: DBPUIDataBroker, name: String, addresses: [DBPUIUserProfileAddress], alternativeNames: [String], relatives: [String], profileUrl: String? = nil, foundDate: Double, optOutSubmittedDate: Double? = nil, optOutFormSubmittedDate: Double? = nil, estimatedRemovalDate: Double? = nil, removedDate: Double? = nil, hasMatchingRecordOnParentBroker: Bool) {
         self.id = id
         self.dataBroker = dataBroker
         self.name = name
         self.addresses = addresses
         self.alternativeNames = alternativeNames
         self.relatives = relatives
+        self.profileUrl = profileUrl
         self.foundDate = foundDate
         self.optOutSubmittedDate = optOutSubmittedDate
         self.optOutFormSubmittedDate = optOutFormSubmittedDate
@@ -339,6 +341,7 @@ extension DBPUIDataBrokerProfileMatch {
                   addresses: extractedProfile.addresses?.map { DBPUIUserProfileAddress(addressCityState: $0) } ?? [],
                   alternativeNames: extractedProfile.alternativeNames ?? [String](),
                   relatives: extractedProfile.relatives ?? [String](),
+                  profileUrl: extractedProfile.profileUrl,
                   foundDate: foundDate.timeIntervalSince1970,
                   optOutSubmittedDate: optOutSubmittedDate?.timeIntervalSince1970,
                   optOutFormSubmittedDate: optOutFormSubmittedDate?.timeIntervalSince1970,

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/UINative/DBPUIViewModel.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/UINative/DBPUIViewModel.swift
@@ -227,6 +227,11 @@ extension DBPUIViewModel: DBPUICommunicationDelegate {
         feedbackFormDelegate?.openSendFeedbackForm()
     }
 
+    public func openOptOutEmail(_ payload: DBPUIOptOutEmail) async -> Bool {
+        // Opt-out email prefill is macOS only for now.
+        return false
+    }
+
     public func getBackgroundAgentMetadata() async -> DBPUIDebugMetadata {
         // Return no information as we think this is unused
         DBPUIDebugMetadata(lastRunAppVersion: "")

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/DataCaching/DataBrokerProtectionDataManager.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/DataCaching/DataBrokerProtectionDataManager.swift
@@ -65,6 +65,7 @@ public protocol DataBrokerProtectionDataManagerDelegate: AnyObject {
 
 public class DataBrokerProtectionDataManager: DataBrokerProtectionDataManaging {
     private let profileSavedNotifier: DBPProfileSavedNotifier?
+    private let optOutEmailOpener: DBPUIOptOutEmailOpening
 
     public let communicator = DBPUICommunicator()
 
@@ -79,6 +80,17 @@ public class DataBrokerProtectionDataManager: DataBrokerProtectionDataManaging {
                          profileSavedNotifier: DBPProfileSavedNotifier? = nil) {
         self.database = database
         self.profileSavedNotifier = profileSavedNotifier
+        self.optOutEmailOpener = DBPUIOptOutEmailOpener()
+        self.onProfileSaved = nil
+        communicator.delegate = self
+    }
+
+    init(database: DataBrokerProtectionRepository,
+         profileSavedNotifier: DBPProfileSavedNotifier? = nil,
+         optOutEmailOpener: DBPUIOptOutEmailOpening) {
+        self.database = database
+        self.profileSavedNotifier = profileSavedNotifier
+        self.optOutEmailOpener = optOutEmailOpener
         self.onProfileSaved = nil
         communicator.delegate = self
     }
@@ -222,6 +234,12 @@ extension DataBrokerProtectionDataManager: DBPUICommunicatorDelegate {
         delegate?.dataBrokerProtectionDataManagerWillOpenSendFeedbackForm()
     }
 
+    @MainActor
+    public func willOpenOptOutEmail(_ payload: DBPUIOptOutEmail) -> Bool {
+        let result = optOutEmailOpener.open(payload)
+        return result.didOpen
+    }
+
     public func willApplyVPNBypassSetting(_ bypass: Bool) async {
         await delegate?.dataBrokerProtectionDataManagerWillApplyVPNBypassSetting(bypass)
     }
@@ -262,6 +280,8 @@ public protocol UserProfileDelegate: AnyObject {
 
 public protocol UserActionDelegate: AnyObject {
     func willOpenSendFeedbackForm()
+    @MainActor
+    func willOpenOptOutEmail(_ payload: DBPUIOptOutEmail) -> Bool
     func willApplyVPNBypassSetting(_ bypass: Bool) async
     func willRemoveOptOutFromDashboard(_ id: Int64)
 }
@@ -401,6 +421,10 @@ extension DBPUICommunicator: DBPUICommunicationDelegate {
 
     public func openSendFeedbackModal() async {
         delegate?.willOpenSendFeedbackForm()
+    }
+
+    public func openOptOutEmail(_ payload: DBPUIOptOutEmail) async -> Bool {
+        return await delegate?.willOpenOptOutEmail(payload) ?? false
     }
 
     public func applyVPNBypassSetting(_ bypass: Bool) async {

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/OptOutEmail/DBPUIOptOutEmailOpenResult.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/OptOutEmail/DBPUIOptOutEmailOpenResult.swift
@@ -1,0 +1,56 @@
+//
+//  DBPUIOptOutEmailOpenResult.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+enum DBPUIOptOutEmailOpenFailure: Equatable {
+    case noMailHandler
+    case unsupportedMailHandler(String)
+    case appleMailComposeUnavailable
+    case composeURLBuildFailed(providerName: String)
+    case workspaceOpenFailed(providerName: String)
+}
+
+enum DBPUIOptOutEmailOpenResult: Equatable {
+    case opened(providerName: String)
+    case failed(providerName: String, failure: DBPUIOptOutEmailOpenFailure)
+
+    var didOpen: Bool {
+        switch self {
+        case .opened:
+            return true
+        case .failed:
+            return false
+        }
+    }
+
+    var providerName: String {
+        switch self {
+        case .opened(let providerName),
+             .failed(let providerName, _):
+            return providerName
+        }
+    }
+
+    var failure: DBPUIOptOutEmailOpenFailure? {
+        switch self {
+        case .opened:
+            return nil
+        case .failed(_, let failure):
+            return failure
+        }
+    }
+}

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/OptOutEmail/DBPUIOptOutEmailOpener.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/OptOutEmail/DBPUIOptOutEmailOpener.swift
@@ -1,0 +1,52 @@
+//
+//  DBPUIOptOutEmailOpener.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import DataBrokerProtectionCore
+
+final class DBPUIOptOutEmailOpener: DBPUIOptOutEmailOpening {
+    private let workspace: DBPUIOptOutEmailWorkspace
+    private let providers: [DBPUIOptOutEmailProvider]
+
+    init(workspace: DBPUIOptOutEmailWorkspace = DBPUIOptOutEmailNSWorkspace(),
+         appleMailComposer: DBPUIAppleMailComposing = DBPUIAppleMailComposer()) {
+        self.workspace = workspace
+        self.providers = [
+            DBPUIAppleMailOptOutEmailProvider(composer: appleMailComposer),
+            DBPUIGmailOptOutEmailProvider(),
+            DBPUIOutlookOptOutEmailProvider()
+        ]
+    }
+
+    init(workspace: DBPUIOptOutEmailWorkspace, providers: [DBPUIOptOutEmailProvider]) {
+        self.workspace = workspace
+        self.providers = providers
+    }
+
+    @MainActor
+    func open(_ payload: DBPUIOptOutEmail) -> DBPUIOptOutEmailOpenResult {
+        guard let bundleIdentifier = workspace.defaultMailAppBundleIdentifier() else {
+            return .failed(providerName: "none", failure: .noMailHandler)
+        }
+
+        guard let provider = providers.first(where: { $0.canHandle(mailHandlerBundleIdentifier: bundleIdentifier) }) else {
+            return .failed(providerName: "unsupported", failure: .unsupportedMailHandler(bundleIdentifier))
+        }
+
+        return provider.open(payload, using: workspace)
+    }
+}

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/OptOutEmail/DBPUIOptOutEmailOpening.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/OptOutEmail/DBPUIOptOutEmailOpening.swift
@@ -1,0 +1,24 @@
+//
+//  DBPUIOptOutEmailOpening.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import DataBrokerProtectionCore
+
+protocol DBPUIOptOutEmailOpening {
+    @MainActor
+    func open(_ payload: DBPUIOptOutEmail) -> DBPUIOptOutEmailOpenResult
+}

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/OptOutEmail/DBPUIOptOutEmailProvider.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/OptOutEmail/DBPUIOptOutEmailProvider.swift
@@ -1,0 +1,33 @@
+//
+//  DBPUIOptOutEmailProvider.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import DataBrokerProtectionCore
+
+protocol DBPUIOptOutEmailProvider {
+    var providerName: String { get }
+    var supportedMailHandlerBundleIdentifiers: Set<String> { get }
+
+    @MainActor
+    func open(_ payload: DBPUIOptOutEmail, using workspace: DBPUIOptOutEmailWorkspace) -> DBPUIOptOutEmailOpenResult
+}
+
+extension DBPUIOptOutEmailProvider {
+    func canHandle(mailHandlerBundleIdentifier: String) -> Bool {
+        supportedMailHandlerBundleIdentifiers.contains(mailHandlerBundleIdentifier)
+    }
+}

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/OptOutEmail/DBPUIOptOutEmailWorkspace.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/OptOutEmail/DBPUIOptOutEmailWorkspace.swift
@@ -1,0 +1,50 @@
+//
+//  DBPUIOptOutEmailWorkspace.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppKit
+import Foundation
+
+protocol DBPUIOptOutEmailWorkspace {
+    @MainActor
+    func defaultMailAppBundleIdentifier() -> String?
+    @MainActor
+    func open(_ url: URL) -> Bool
+}
+
+final class DBPUIOptOutEmailNSWorkspace: DBPUIOptOutEmailWorkspace {
+    private let workspace: NSWorkspace
+
+    init(workspace: NSWorkspace = .shared) {
+        self.workspace = workspace
+    }
+
+    @MainActor
+    func defaultMailAppBundleIdentifier() -> String? {
+        guard let mailtoURL = URL(string: "mailto:test@example.com"),
+              let applicationURL = workspace.urlForApplication(toOpen: mailtoURL) else {
+            return nil
+        }
+
+        return Bundle(url: applicationURL)?.bundleIdentifier
+    }
+
+    @MainActor
+    func open(_ url: URL) -> Bool {
+        workspace.open(url)
+    }
+}

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/OptOutEmail/Providers/AppleMail/DBPUIAppleMailComposer.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/OptOutEmail/Providers/AppleMail/DBPUIAppleMailComposer.swift
@@ -1,0 +1,43 @@
+//
+//  DBPUIAppleMailComposer.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppKit
+import DataBrokerProtectionCore
+
+protocol DBPUIAppleMailComposing {
+    @MainActor
+    func open(_ payload: DBPUIOptOutEmail) -> DBPUIOptOutEmailOpenResult
+}
+
+final class DBPUIAppleMailComposer: DBPUIAppleMailComposing {
+    @MainActor
+    func open(_ payload: DBPUIOptOutEmail) -> DBPUIOptOutEmailOpenResult {
+        let items = [payload.body]
+
+        guard let emailService = NSSharingService(named: .composeEmail),
+              emailService.canPerform(withItems: items) else {
+            return .failed(providerName: "Apple Mail", failure: .appleMailComposeUnavailable)
+        }
+
+        emailService.recipients = [payload.to]
+        emailService.subject = payload.subject
+        emailService.perform(withItems: items)
+
+        return .opened(providerName: "Apple Mail")
+    }
+}

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/OptOutEmail/Providers/AppleMail/DBPUIAppleMailOptOutEmailProvider.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/OptOutEmail/Providers/AppleMail/DBPUIAppleMailOptOutEmailProvider.swift
@@ -1,0 +1,35 @@
+//
+//  DBPUIAppleMailOptOutEmailProvider.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import DataBrokerProtectionCore
+
+final class DBPUIAppleMailOptOutEmailProvider: DBPUIOptOutEmailProvider {
+    let providerName = "Apple Mail"
+    let supportedMailHandlerBundleIdentifiers: Set<String> = ["com.apple.mail"]
+
+    private let composer: DBPUIAppleMailComposing
+
+    init(composer: DBPUIAppleMailComposing) {
+        self.composer = composer
+    }
+
+    @MainActor
+    func open(_ payload: DBPUIOptOutEmail, using workspace: DBPUIOptOutEmailWorkspace) -> DBPUIOptOutEmailOpenResult {
+        composer.open(payload)
+    }
+}

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/OptOutEmail/Providers/Gmail/DBPUIGmailOptOutEmailProvider.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/OptOutEmail/Providers/Gmail/DBPUIGmailOptOutEmailProvider.swift
@@ -1,0 +1,61 @@
+//
+//  DBPUIGmailOptOutEmailProvider.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import DataBrokerProtectionCore
+import Foundation
+
+final class DBPUIGmailOptOutEmailProvider: DBPUIOptOutEmailProvider {
+    let providerName = "Gmail"
+    let supportedMailHandlerBundleIdentifiers: Set<String> = [
+        "com.google.Chrome",
+        "com.google.Chrome.beta",
+        "com.google.Chrome.canary",
+        "com.brave.Browser",
+        "company.thebrowser.Browser"
+    ]
+
+    @MainActor
+    func open(_ payload: DBPUIOptOutEmail, using workspace: DBPUIOptOutEmailWorkspace) -> DBPUIOptOutEmailOpenResult {
+        guard let composeURL = composeURL(for: payload) else {
+            return .failed(providerName: providerName, failure: .composeURLBuildFailed(providerName: providerName))
+        }
+
+        if workspace.open(composeURL) {
+            return .opened(providerName: providerName)
+        }
+
+        return .failed(providerName: providerName, failure: .workspaceOpenFailed(providerName: providerName))
+    }
+
+    private func composeURL(for payload: DBPUIOptOutEmail) -> URL? {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "mail.google.com"
+        components.path = "/mail/"
+        components.queryItems = [
+            URLQueryItem(name: "view", value: "cm"),
+            URLQueryItem(name: "fs", value: "1"),
+            URLQueryItem(name: "to", value: payload.to),
+            URLQueryItem(name: "su", value: payload.subject),
+            URLQueryItem(name: "body", value: payload.body)
+        ]
+        components.percentEncodedQuery = components.percentEncodedQuery?.replacingOccurrences(of: "+", with: "%2B")
+
+        return components.url
+    }
+}

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/OptOutEmail/Providers/Outlook/DBPUIOutlookOptOutEmailProvider.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/OptOutEmail/Providers/Outlook/DBPUIOutlookOptOutEmailProvider.swift
@@ -1,0 +1,58 @@
+//
+//  DBPUIOutlookOptOutEmailProvider.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import DataBrokerProtectionCore
+import Foundation
+
+final class DBPUIOutlookOptOutEmailProvider: DBPUIOptOutEmailProvider {
+    let providerName = "Outlook"
+    let supportedMailHandlerBundleIdentifiers: Set<String> = [
+        "com.microsoft.Outlook",
+        "com.microsoft.edgemac",
+        "com.microsoft.edgemac.Beta",
+        "com.microsoft.edgemac.Canary"
+    ]
+
+    @MainActor
+    func open(_ payload: DBPUIOptOutEmail, using workspace: DBPUIOptOutEmailWorkspace) -> DBPUIOptOutEmailOpenResult {
+        guard let composeURL = composeURL(for: payload) else {
+            return .failed(providerName: providerName, failure: .composeURLBuildFailed(providerName: providerName))
+        }
+
+        if workspace.open(composeURL) {
+            return .opened(providerName: providerName)
+        }
+
+        return .failed(providerName: providerName, failure: .workspaceOpenFailed(providerName: providerName))
+    }
+
+    private func composeURL(for payload: DBPUIOptOutEmail) -> URL? {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "outlook.office.com"
+        components.path = "/mail/deeplink/compose"
+        components.queryItems = [
+            URLQueryItem(name: "to", value: payload.to),
+            URLQueryItem(name: "subject", value: payload.subject),
+            URLQueryItem(name: "body", value: payload.body)
+        ]
+        components.percentEncodedQuery = components.percentEncodedQuery?.replacingOccurrences(of: "+", with: "%2B")
+
+        return components.url
+    }
+}

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/DBPUICommunicationLayerTests.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/DBPUICommunicationLayerTests.swift
@@ -177,6 +177,61 @@ final class DBPUICommunicationLayerTests: XCTestCase {
         XCTAssertEqual(featureConfig.useUnifiedFeedback, true)
         XCTAssertEqual(featureConfig.excludeVpnTraffic, true)
     }
+
+    func testWhenOpenOptOutEmailCalled_andPayloadIsWellFormed_thenDelegateIsCalledAndSuccessMatchesDelegate() async throws {
+        // Given
+        let mockDelegate = MockDelegate()
+        mockDelegate.openOptOutEmailResult = true
+        var sut = DBPUICommunicationLayer(webURLSettings: MockWebSettings(), privacyConfig: PrivacyConfigurationManagingMock())
+        sut.delegate = mockDelegate
+        let params: [String: Any] = [
+            "brokerName": "MyLife",
+            "to": "privacy@mylife.com",
+            "subject": "Removal request for Daniel Silva (Los Angeles, CA)",
+            "body": "Hello,\n\nPlease remove the following listing...\n"
+        ]
+        let scriptMessage = WKScriptMessage.mock()
+
+        // When
+        let handler = sut.handler(forMethodNamed: DBPUIReceivedMethodName.openOptOutEmail.rawValue)
+        let result = try await handler?(params, scriptMessage)
+
+        // Then
+        XCTAssertTrue(mockDelegate.openOptOutEmailCalled)
+        XCTAssertEqual(mockDelegate.openOptOutEmailPayload?.brokerName, "MyLife")
+        XCTAssertEqual(mockDelegate.openOptOutEmailPayload?.to, "privacy@mylife.com")
+
+        guard let response = result as? DBPUIStandardResponse else {
+            XCTFail("Expected DBPUIStandardResponse to be returned")
+            return
+        }
+
+        XCTAssertTrue(response.success)
+    }
+
+    func testWhenOpenOptOutEmailCalled_andPayloadIsMalformed_thenSuccessIsFalseAndDelegateNotCalled() async throws {
+        // Given
+        let mockDelegate = MockDelegate()
+        var sut = DBPUICommunicationLayer(webURLSettings: MockWebSettings(), privacyConfig: PrivacyConfigurationManagingMock())
+        sut.delegate = mockDelegate
+        // Missing required fields (only brokerName provided)
+        let params: [String: Any] = ["brokerName": "MyLife"]
+        let scriptMessage = WKScriptMessage.mock()
+
+        // When
+        let handler = sut.handler(forMethodNamed: DBPUIReceivedMethodName.openOptOutEmail.rawValue)
+        let result = try await handler?(params, scriptMessage)
+
+        // Then
+        XCTAssertFalse(mockDelegate.openOptOutEmailCalled)
+
+        guard let response = result as? DBPUIStandardResponse else {
+            XCTFail("Expected DBPUIStandardResponse to be returned")
+            return
+        }
+
+        XCTAssertFalse(response.success)
+    }
 }
 
 // MARK: - Mock Classes
@@ -224,6 +279,16 @@ private final class MockDelegate: DBPUICommunicationDelegate {
     }
 
     func openSendFeedbackModal() async {}
+
+    var openOptOutEmailCalled = false
+    var openOptOutEmailPayload: DBPUIOptOutEmail?
+    var openOptOutEmailResult = true
+
+    func openOptOutEmail(_ payload: DBPUIOptOutEmail) async -> Bool {
+        openOptOutEmailCalled = true
+        openOptOutEmailPayload = payload
+        return openOptOutEmailResult
+    }
 
     func applyVPNBypassSetting(_ bypass: Bool) async {}
 

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/DBPUICommunicationModelTests.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/DBPUICommunicationModelTests.swift
@@ -63,6 +63,21 @@ final class DBPUICommunicationModelTests: XCTestCase {
         XCTAssertEqual(profileMatch.optOutSubmittedDate, submittedDate.timeIntervalSince1970)
     }
 
+    func testProfileMatchInit_whenExtractedProfileHasProfileUrl_thenProfileUrlIsExposed() {
+        // Given
+        let profileUrl = "https://example.com/profile/123"
+        let extractedProfile = ExtractedProfile(id: 1, name: "Sample Name", profileUrl: profileUrl)
+        let optOut = OptOutJobData.mock(with: extractedProfile)
+
+        // When
+        let profileMatch = DBPUIDataBrokerProfileMatch(optOutJobData: optOut,
+                                                       dataBroker: makeUIBroker(),
+                                                       parentBrokerOptOutJobData: nil)
+
+        // Then
+        XCTAssertEqual(profileMatch.profileUrl, profileUrl)
+    }
+
     func testProfileMatchInit_whenCreatedDateIsDefault_thenResultingProfileMatchDatesAreBothBasedOnEventDates() {
 
         // Given

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/DBPUIOptOutEmailOpenerTests.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/DBPUIOptOutEmailOpenerTests.swift
@@ -1,0 +1,207 @@
+//
+//  DBPUIOptOutEmailOpenerTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DataBrokerProtection_macOS
+import DataBrokerProtectionCore
+
+@MainActor
+final class DBPUIOptOutEmailOpenerTests: XCTestCase {
+
+    func testWhenMailHandlerIsMissingThenNoMailHandlerFailureIsReturned() throws {
+        let workspace = MockOptOutEmailWorkspace(bundleIdentifier: nil)
+        let opener = DBPUIOptOutEmailOpener(workspace: workspace, appleMailComposer: MockAppleMailComposer())
+
+        let result = try opener.open(makePayload())
+
+        XCTAssertFalse(result.didOpen)
+        XCTAssertEqual(result.providerName, "none")
+        XCTAssertEqual(result.failure, .noMailHandler)
+        XCTAssertNil(workspace.openedURL)
+    }
+
+    func testWhenMailHandlerIsUnsupportedThenUnsupportedFailureIsReturned() throws {
+        let workspace = MockOptOutEmailWorkspace(bundleIdentifier: "com.example.mail")
+        let opener = DBPUIOptOutEmailOpener(workspace: workspace, appleMailComposer: MockAppleMailComposer())
+
+        let result = try opener.open(makePayload())
+
+        XCTAssertFalse(result.didOpen)
+        XCTAssertEqual(result.providerName, "unsupported")
+        XCTAssertEqual(result.failure, .unsupportedMailHandler("com.example.mail"))
+        XCTAssertNil(workspace.openedURL)
+    }
+
+    func testWhenMailHandlerIsAppleMailThenAppleMailComposerIsUsed() throws {
+        let composer = MockAppleMailComposer()
+        let workspace = MockOptOutEmailWorkspace(bundleIdentifier: "com.apple.mail")
+        let opener = DBPUIOptOutEmailOpener(workspace: workspace, appleMailComposer: composer)
+        let payload = try makePayload()
+
+        let result = opener.open(payload)
+
+        XCTAssertTrue(result.didOpen)
+        XCTAssertEqual(result.providerName, "Apple Mail")
+        XCTAssertEqual(composer.openedPayload?.to, payload.to)
+        XCTAssertNil(workspace.openedURL)
+    }
+
+    func testWhenAppleMailComposerFailsThenFailureIsReturned() throws {
+        let composer = MockAppleMailComposer()
+        composer.result = .failed(providerName: "Apple Mail", failure: .appleMailComposeUnavailable)
+        let workspace = MockOptOutEmailWorkspace(bundleIdentifier: "com.apple.mail")
+        let opener = DBPUIOptOutEmailOpener(workspace: workspace, appleMailComposer: composer)
+
+        let result = try opener.open(makePayload())
+
+        XCTAssertFalse(result.didOpen)
+        XCTAssertEqual(result.providerName, "Apple Mail")
+        XCTAssertEqual(result.failure, .appleMailComposeUnavailable)
+        XCTAssertNil(workspace.openedURL)
+    }
+
+    func testWhenMailHandlerIsChromeThenGmailComposeURLIsOpened() throws {
+        let workspace = MockOptOutEmailWorkspace(bundleIdentifier: "com.google.Chrome")
+        let opener = DBPUIOptOutEmailOpener(workspace: workspace, appleMailComposer: MockAppleMailComposer())
+
+        let result = try opener.open(makePayload())
+
+        XCTAssertTrue(result.didOpen)
+        XCTAssertEqual(result.providerName, "Gmail")
+        XCTAssertEqual(workspace.openedURL?.host, "mail.google.com")
+        XCTAssertEqual(workspace.openedURL?.path, "/mail/")
+        XCTAssertEqual(queryValue("view", in: workspace.openedURL), "cm")
+        XCTAssertEqual(queryValue("fs", in: workspace.openedURL), "1")
+        XCTAssertEqual(queryValue("to", in: workspace.openedURL), "support@example.com")
+        XCTAssertEqual(queryValue("su", in: workspace.openedURL), "Removal request")
+        XCTAssertEqual(queryValue("body", in: workspace.openedURL), "Please remove me.")
+    }
+
+    func testWhenMailHandlerIsChromeThenGmailComposeURLPercentEncodesPlusSigns() throws {
+        let workspace = MockOptOutEmailWorkspace(bundleIdentifier: "com.google.Chrome")
+        let opener = DBPUIOptOutEmailOpener(workspace: workspace, appleMailComposer: MockAppleMailComposer())
+
+        let result = try opener.open(makePayload(to: "privacy+requests@example.com",
+                                                 subject: "Removal + identity request",
+                                                 body: "Profile https://example.com/a+b"))
+
+        XCTAssertTrue(result.didOpen)
+        let absoluteString = try XCTUnwrap(workspace.openedURL?.absoluteString)
+        XCTAssertTrue(absoluteString.contains("to=privacy%2Brequests@example.com"))
+        XCTAssertTrue(absoluteString.contains("su=Removal%20%2B%20identity%20request"))
+        XCTAssertTrue(absoluteString.contains("body=Profile%20https://example.com/a%2Bb"))
+    }
+
+    func testWhenMailHandlerIsOutlookThenOutlookComposeURLIsOpened() throws {
+        let workspace = MockOptOutEmailWorkspace(bundleIdentifier: "com.microsoft.Outlook")
+        let opener = DBPUIOptOutEmailOpener(workspace: workspace, appleMailComposer: MockAppleMailComposer())
+
+        let result = try opener.open(makePayload())
+
+        XCTAssertTrue(result.didOpen)
+        XCTAssertEqual(result.providerName, "Outlook")
+        XCTAssertEqual(workspace.openedURL?.host, "outlook.office.com")
+        XCTAssertEqual(workspace.openedURL?.path, "/mail/deeplink/compose")
+        XCTAssertEqual(queryValue("to", in: workspace.openedURL), "support@example.com")
+        XCTAssertEqual(queryValue("subject", in: workspace.openedURL), "Removal request")
+        XCTAssertEqual(queryValue("body", in: workspace.openedURL), "Please remove me.")
+    }
+
+    func testWhenMailHandlerIsOutlookThenOutlookComposeURLPercentEncodesPlusSigns() throws {
+        let workspace = MockOptOutEmailWorkspace(bundleIdentifier: "com.microsoft.Outlook")
+        let opener = DBPUIOptOutEmailOpener(workspace: workspace, appleMailComposer: MockAppleMailComposer())
+
+        let result = try opener.open(makePayload(to: "privacy+requests@example.com",
+                                                 subject: "Removal + identity request",
+                                                 body: "Profile https://example.com/a+b"))
+
+        XCTAssertTrue(result.didOpen)
+        let absoluteString = try XCTUnwrap(workspace.openedURL?.absoluteString)
+        XCTAssertTrue(absoluteString.contains("to=privacy%2Brequests@example.com"))
+        XCTAssertTrue(absoluteString.contains("subject=Removal%20%2B%20identity%20request"))
+        XCTAssertTrue(absoluteString.contains("body=Profile%20https://example.com/a%2Bb"))
+    }
+
+    func testWhenWebComposeURLCannotOpenThenWorkspaceFailureIsReturned() throws {
+        let workspace = MockOptOutEmailWorkspace(bundleIdentifier: "com.google.Chrome")
+        workspace.openResult = false
+        let opener = DBPUIOptOutEmailOpener(workspace: workspace, appleMailComposer: MockAppleMailComposer())
+
+        let result = try opener.open(makePayload())
+
+        XCTAssertFalse(result.didOpen)
+        XCTAssertEqual(result.providerName, "Gmail")
+        XCTAssertEqual(result.failure, .workspaceOpenFailed(providerName: "Gmail"))
+    }
+
+    private func makePayload(to: String = "support@example.com",
+                             subject: String = "Removal request",
+                             body: String = "Please remove me.") throws -> DBPUIOptOutEmail {
+        let data = try XCTUnwrap("""
+        {
+            "brokerName": "Example Broker",
+            "to": "\(to)",
+            "subject": "\(subject)",
+            "body": "\(body)"
+        }
+        """.data(using: .utf8))
+
+        return try JSONDecoder().decode(DBPUIOptOutEmail.self, from: data)
+    }
+
+    private func queryValue(_ name: String, in url: URL?) -> String? {
+        guard let url,
+              let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems else {
+            return nil
+        }
+
+        return queryItems.first(where: { $0.name == name })?.value
+    }
+}
+
+private final class MockOptOutEmailWorkspace: DBPUIOptOutEmailWorkspace {
+    private let bundleIdentifier: String?
+    var openResult = true
+    private(set) var openedURL: URL?
+
+    init(bundleIdentifier: String?) {
+        self.bundleIdentifier = bundleIdentifier
+    }
+
+    @MainActor
+    func defaultMailAppBundleIdentifier() -> String? {
+        bundleIdentifier
+    }
+
+    @MainActor
+    func open(_ url: URL) -> Bool {
+        openedURL = url
+        return openResult
+    }
+}
+
+private final class MockAppleMailComposer: DBPUIAppleMailComposing {
+    var result = DBPUIOptOutEmailOpenResult.opened(providerName: "Apple Mail")
+    private(set) var openedPayload: DBPUIOptOutEmail?
+
+    @MainActor
+    func open(_ payload: DBPUIOptOutEmail) -> DBPUIOptOutEmailOpenResult {
+        openedPayload = payload
+        return result
+    }
+}

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/DataBrokerProtectionDataManagingTests.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/DataBrokerProtectionDataManagingTests.swift
@@ -149,9 +149,40 @@ final class DataBrokerProtectionDataManagingTests: XCTestCase {
         // Then
         XCTAssertFalse(mockDBPProfileSavedNotifier.didCallPostProfileSavedNotificationIfPermitted)
     }
+
+    @MainActor
+    func testWhenOpeningOptOutEmailThenOpenerResultIsReturned() throws {
+        // Given
+        let opener = MockOptOutEmailOpener()
+        opener.result = .failed(providerName: "Gmail", failure: .workspaceOpenFailed(providerName: "Gmail"))
+        let sut = DataBrokerProtectionDataManager(database: mockDatabase,
+                                                  profileSavedNotifier: mockDBPProfileSavedNotifier,
+                                                  optOutEmailOpener: opener)
+        let payload = try makeOptOutEmailPayload()
+
+        // When
+        let didOpen = sut.willOpenOptOutEmail(payload)
+
+        // Then
+        XCTAssertFalse(didOpen)
+        XCTAssertEqual(opener.openedPayload?.brokerName, payload.brokerName)
+    }
 }
 
 private extension DataBrokerProtectionDataManagingTests {
+
+    func makeOptOutEmailPayload() throws -> DBPUIOptOutEmail {
+        let data = try XCTUnwrap("""
+        {
+            "brokerName": "Example Broker",
+            "to": "support@example.com",
+            "subject": "Removal request",
+            "body": "Please remove me."
+        }
+        """.data(using: .utf8))
+
+        return try JSONDecoder().decode(DBPUIOptOutEmail.self, from: data)
+    }
 
     var mockProfile: DataBrokerProtectionProfile {
         let name = DataBrokerProtectionProfile.Name(
@@ -325,5 +356,16 @@ private extension DataBrokerProtectionDataManagingTests {
                 deprecated: false
             )
         ]
+    }
+}
+
+@MainActor
+private final class MockOptOutEmailOpener: DBPUIOptOutEmailOpening {
+    var result = DBPUIOptOutEmailOpenResult.opened(providerName: "Apple Mail")
+    private(set) var openedPayload: DBPUIOptOutEmail?
+
+    func open(_ payload: DBPUIOptOutEmail) -> DBPUIOptOutEmailOpenResult {
+        openedPayload = payload
+        return result
     }
 }


### PR DESCRIPTION
### Summary

Asana: https://app.asana.com/1/137249556945/project/1206054067224240/task/1214756559881755?focus=true

This PR:

* adds native macOS opt-out email opening for Apple Mail, Gmail, and Outlook.
* wires the native bridge to return typed open results and expose `profileUrl` to the UI payload.
* adds unit coverage for provider selection, bridge handling, and data-manager delegation.

## Test plan

* [x] Built `DataBrokerProtection-macOS` with `xcodebuild build -workspace "DuckDuckGo.xcworkspace" -scheme "DataBrokerProtection-macOS" -destination "platform=macOS"`.