### PR TITLE
iPad: Add selected-tool mode badge to Duck.ai address bar

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1757,6 +1757,7 @@
 		A1B2C3D4E5F60002A1B2C3D4 /* UnifiedInputContentContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001A1B2C3D4 /* UnifiedInputContentContainerViewController.swift */; };
 		A1B2C3D4E5F60002AABBA001 /* IdleReturnTabCountInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60002AABBA002 /* IdleReturnTabCountInstrumentationTests.swift */; };
 		A1B2C3D4E5F60012A1B2C3D4 /* AIChatReasoningMode+UnifiedToggleInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60011A1B2C3D4 /* AIChatReasoningMode+UnifiedToggleInput.swift */; };
+		FE1A2B3C0001000100010001 /* AIChatRAGTool+ToolbarChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE1A2B3C0001000100010002 /* AIChatRAGTool+ToolbarChip.swift */; };
 		A1B2C3D4E5F60014A1B2C3D4 /* UnifiedToggleInputReasoningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60013A1B2C3D4 /* UnifiedToggleInputReasoningTests.swift */; };
 		A1B2C3D72F7F111100ABCDEF /* SyncSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D62F7F111100ABCDEF /* SyncSettingsViewModelTests.swift */; };
 		A1D1C0E72F8CB3A400B1D001 /* DataImportUserActivityHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D1C0E62F8CB3A400B1D001 /* DataImportUserActivityHandler.swift */; };
@@ -4473,6 +4474,7 @@
 		A1B2C3D4E5F60001AABB0002 /* NTPAfterIdleInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPAfterIdleInstrumentationTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60002AABBA002 /* IdleReturnTabCountInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleReturnTabCountInstrumentationTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60011A1B2C3D4 /* AIChatReasoningMode+UnifiedToggleInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AIChatReasoningMode+UnifiedToggleInput.swift"; sourceTree = "<group>"; };
+		FE1A2B3C0001000100010002 /* AIChatRAGTool+ToolbarChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AIChatRAGTool+ToolbarChip.swift"; sourceTree = "<group>"; };
 		A1B2C3D4E5F60013A1B2C3D4 /* UnifiedToggleInputReasoningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputReasoningTests.swift; sourceTree = "<group>"; };
 		A1B2C3D62F7F111100ABCDEF /* SyncSettingsViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncSettingsViewModelTests.swift; sourceTree = "<group>"; };
 		A1D1C0E62F8CB3A400B1D001 /* DataImportUserActivityHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataImportUserActivityHandler.swift; sourceTree = "<group>"; };
@@ -9643,6 +9645,7 @@
 			children = (
 				F1CCC14F2F642109007AB0A5 /* UnifiedToggleInputOmnibarActivating.swift */,
 				A1B2C3D4E5F60011A1B2C3D4 /* AIChatReasoningMode+UnifiedToggleInput.swift */,
+				FE1A2B3C0001000100010002 /* AIChatRAGTool+ToolbarChip.swift */,
 				C18390B62F4F6F16001939B9 /* UnifiedToggleInputView.swift */,
 				C18390B82F4F6F19001939B9 /* UnifiedToggleInputViewController.swift */,
 				C18390B22F4F6EB6001939B9 /* UnifiedToggleInputToggleView.swift */,
@@ -12755,6 +12758,7 @@
 				80437D692EFACF2D00D3E896 /* AutoClearSettingsViewModel.swift in Sources */,
 				C18390B52F4F6ED0001939B9 /* UnifiedToggleInputToolbarView.swift in Sources */,
 				A1B2C3D4E5F60012A1B2C3D4 /* AIChatReasoningMode+UnifiedToggleInput.swift in Sources */,
+				FE1A2B3C0001000100010001 /* AIChatRAGTool+ToolbarChip.swift in Sources */,
 				C17B59592A03AAD30055F2D1 /* PasswordGenerationPromptViewModel.swift in Sources */,
 				9F254B082CF9FC270063B308 /* SpecialErrorModel.swift in Sources */,
 				BDE91CDE2C62B90F0005CB74 /* UnifiedFeedbackRootView.swift in Sources */,

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -17,6 +17,7 @@
 //  limitations under the License.
 //
 
+import AIChat
 import UIKit
 import DesignResourcesKit
 import DesignResourcesKitIcons
@@ -502,15 +503,95 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         }
     }
 
-    /// Whether a tool is currently selected — tints the chip to signal the active state.
-    var isToolSelected: Bool = false {
+    var selectedTool: AIChatRAGTool? {
         didSet {
-            toolPickerButton.tintColor = UIColor(designSystemColor: isToolSelected ? .accentPrimary : .iconsSecondary)
+            selectedToolIconView.image = selectedTool?.toolbarChipIcon
+            selectedToolTitleLabel.text = selectedTool?.toolbarChipTitle
+            selectedToolChipView.accessibilityLabel = selectedTool?.toolbarChipAccessibilityLabel
+            refreshSelectedToolBadgeVisibility()
         }
     }
 
+    /// Fired when the badge's clear (✕) button is tapped, so the host can deselect the tool.
+    var onSelectedToolClearTapped: (() -> Void)?
+
     private var canShowToolPicker: Bool {
         isToolPickerEnabled && toolPickerButton.menu != nil
+    }
+
+    private var canShowSelectedToolBadge: Bool {
+        canShowToolPicker && selectedTool != nil
+    }
+
+    private lazy var selectedToolIconView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.tintColor = UIColor(designSystemColor: .textPrimary)
+        imageView.contentMode = .scaleAspectFit
+        imageView.setContentHuggingPriority(.required, for: .horizontal)
+        imageView.setContentCompressionResistancePriority(.required, for: .horizontal)
+        NSLayoutConstraint.activate([
+            imageView.widthAnchor.constraint(equalToConstant: Metrics.selectedToolIconSize),
+            imageView.heightAnchor.constraint(equalToConstant: Metrics.selectedToolIconSize),
+        ])
+        return imageView
+    }()
+
+    private lazy var selectedToolTitleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.daxSubheadSemibold()
+        label.textColor = UIColor(designSystemColor: .textPrimary)
+        label.lineBreakMode = .byTruncatingTail
+        // Let the label truncate rather than push into the trailing controls when width is tight.
+        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        return label
+    }()
+
+    private lazy var selectedToolClearButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setImage(DesignSystemImages.Glyphs.Size16.close, for: .normal)
+        button.tintColor = UIColor(designSystemColor: .textPrimary)
+        button.accessibilityLabel = UserText.aiChatToolbarClearSelectedToolAccessibilityLabel
+        button.accessibilityIdentifier = "AIChat.Omnibar.iPad.SelectedToolBadge.Clear"
+        button.setContentHuggingPriority(.required, for: .horizontal)
+        button.setContentCompressionResistancePriority(.required, for: .horizontal)
+        button.addTarget(self, action: #selector(selectedToolClearButtonTapped), for: .primaryActionTriggered)
+        NSLayoutConstraint.activate([
+            button.widthAnchor.constraint(equalToConstant: Metrics.selectedToolClearButtonSize),
+            button.heightAnchor.constraint(equalToConstant: Metrics.selectedToolClearButtonSize),
+        ])
+        return button
+    }()
+
+    private lazy var selectedToolChipView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = UIColor(designSystemColor: .controlsFillPrimary)
+        view.layer.cornerRadius = Metrics.selectedToolChipHeight / 2
+        view.isHidden = true
+        view.accessibilityIdentifier = "AIChat.Omnibar.iPad.SelectedToolBadge"
+
+        let stackView = UIStackView(arrangedSubviews: [selectedToolIconView, selectedToolTitleLabel, selectedToolClearButton])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.spacing = Metrics.selectedToolChipSpacing
+        view.addSubview(stackView)
+
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Metrics.selectedToolChipHorizontalPadding),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Metrics.selectedToolChipHorizontalPadding),
+            stackView.topAnchor.constraint(equalTo: view.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+        return view
+    }()
+
+    @objc private func selectedToolClearButtonTapped() {
+        onSelectedToolClearTapped?()
     }
 
     let attachButton: UIButton = {
@@ -775,6 +856,7 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         chromeContentContainerView.addSubview(modelPickerButton)
         chromeContentContainerView.addSubview(reasoningPickerButton)
         chromeContentContainerView.addSubview(toolPickerButton)
+        chromeContentContainerView.addSubview(selectedToolChipView)
         chromeContentContainerView.addSubview(attachButton)
         chromeContentContainerView.addSubview(attachmentsStripView)
         chromeContentContainerView.addSubview(aiChatLeftButton)
@@ -1211,7 +1293,7 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         guard isSearchAreaExpanded else { return nil }
         // The strip and attach button sit above the text view (which is brought to front for typing),
         // so route taps to them before falling back to the text view.
-        let candidates: [UIView] = [aiChatSendButton, modelPickerButton, reasoningPickerButton, toolPickerButton, attachButton, attachmentsStripView, aiChatTextView]
+        let candidates: [UIView] = [aiChatSendButton, modelPickerButton, reasoningPickerButton, toolPickerButton, selectedToolChipView, attachButton, attachmentsStripView, aiChatTextView]
         return candidates.first { candidate in
             guard !candidate.isHidden else { return false }
             let localPoint = candidate.convert(point, from: self)
@@ -1380,6 +1462,15 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         static let reasoningPickerChipSize: CGFloat = 40.0
         static let reasoningToModelPickerSpacing: CGFloat = 4.0
         static let toolPickerChipSize: CGFloat = 40.0
+
+        // Duck.ai selected-tool badge (iPad): capsule with icon + name + clear, to the trailing edge
+        // of the tool picker. Sizing matches the iOS selected-tool / attachment chip family.
+        static let selectedToolChipHeight: CGFloat = 40.0
+        static let selectedToolChipHorizontalPadding: CGFloat = 16.0
+        static let selectedToolChipSpacing: CGFloat = 4.0
+        static let selectedToolIconSize: CGFloat = 24.0
+        static let selectedToolClearButtonSize: CGFloat = 24.0
+        static let toolPickerToSelectedToolChipSpacing: CGFloat = 4.0
 
         // Duck.ai attach button (iPad), sits on the far left, to the left of the tool picker.
         static let attachButtonSize: CGFloat = 40.0
@@ -1714,6 +1805,11 @@ extension DefaultOmniBarView {
             toolPickerButton.widthAnchor.constraint(equalToConstant: Metrics.toolPickerChipSize),
             toolPickerButton.heightAnchor.constraint(equalToConstant: Metrics.toolPickerChipSize),
 
+            selectedToolChipView.centerYAnchor.constraint(equalTo: aiChatSendButton.centerYAnchor),
+            selectedToolChipView.heightAnchor.constraint(equalToConstant: Metrics.selectedToolChipHeight),
+            selectedToolChipView.leadingAnchor.constraint(equalTo: toolPickerButton.trailingAnchor, constant: Metrics.toolPickerToSelectedToolChipSpacing),
+            selectedToolChipView.trailingAnchor.constraint(lessThanOrEqualTo: reasoningPickerButton.leadingAnchor, constant: -Metrics.toolPickerToSelectedToolChipSpacing),
+
             attachmentsStripView.leadingAnchor.constraint(equalTo: searchAreaContainerView.leadingAnchor),
             attachmentsStripView.trailingAnchor.constraint(equalTo: searchAreaContainerView.trailingAnchor),
             attachmentsStripView.bottomAnchor.constraint(equalTo: aiChatSendButton.topAnchor, constant: -Metrics.attachmentsStripToButtonRowSpacing),
@@ -1779,12 +1875,14 @@ extension DefaultOmniBarView {
             modelPickerButton.alpha = (isSearchAreaExpanded && canShowModelPicker) ? 1 : 0
             reasoningPickerButton.alpha = (isSearchAreaExpanded && canShowReasoningPicker) ? 1 : 0
             toolPickerButton.alpha = (isSearchAreaExpanded && canShowToolPicker) ? 1 : 0
+            selectedToolChipView.alpha = (isSearchAreaExpanded && canShowSelectedToolBadge) ? 1 : 0
             attachButton.alpha = (isSearchAreaExpanded && canShowAttachButton) ? 1 : 0
             if !isSearchAreaExpanded {
                 aiChatSendButton.isHidden = true
                 modelPickerButton.isHidden = true
                 reasoningPickerButton.isHidden = true
                 toolPickerButton.isHidden = true
+                selectedToolChipView.isHidden = true
                 attachButton.isHidden = true
             }
             applyExpansionConstraints()
@@ -1827,6 +1925,7 @@ extension DefaultOmniBarView {
                 self.modelPickerButton.alpha = self.canShowModelPicker ? 1 : 0
                 self.reasoningPickerButton.alpha = self.canShowReasoningPicker ? 1 : 0
                 self.toolPickerButton.alpha = self.canShowToolPicker ? 1 : 0
+                self.selectedToolChipView.alpha = self.canShowSelectedToolBadge ? 1 : 0
                 self.attachButton.alpha = self.canShowAttachButton ? 1 : 0
             } else {
                 self.searchAreaShadowView?.applyShadowOpacityMultiplier(0)
@@ -1834,6 +1933,7 @@ extension DefaultOmniBarView {
                 self.modelPickerButton.alpha = 0
                 self.reasoningPickerButton.alpha = 0
                 self.toolPickerButton.alpha = 0
+                self.selectedToolChipView.alpha = 0
                 self.attachButton.alpha = 0
             }
             self.attachmentsStripView.alpha = showStrip ? 1 : 0
@@ -1849,6 +1949,7 @@ extension DefaultOmniBarView {
                 self.modelPickerButton.isHidden = true
                 self.reasoningPickerButton.isHidden = true
                 self.toolPickerButton.isHidden = true
+                self.selectedToolChipView.isHidden = true
                 self.attachButton.isHidden = true
                 self.onCollapseAnimationCompleted?()
                 self.onCollapseAnimationCompleted = nil
@@ -1891,6 +1992,12 @@ extension DefaultOmniBarView {
                 toolPickerButton.isHidden = false
                 toolPickerButton.alpha = 0
                 searchAreaContainerView.bringSubviewToFront(toolPickerButton)
+            }
+
+            if canShowSelectedToolBadge {
+                selectedToolChipView.isHidden = false
+                selectedToolChipView.alpha = 0
+                searchAreaContainerView.bringSubviewToFront(selectedToolChipView)
             }
 
             if canShowAttachButton {
@@ -1951,6 +2058,20 @@ extension DefaultOmniBarView {
         searchAreaContainerView.bringSubviewToFront(toolPickerButton)
         UIView.animate(withDuration: Metrics.expansionAnimationDuration) {
             self.toolPickerButton.alpha = 1
+        }
+    }
+
+    private func refreshSelectedToolBadgeVisibility() {
+        guard isSearchAreaExpanded, canShowSelectedToolBadge else {
+            selectedToolChipView.isHidden = true
+            return
+        }
+        guard selectedToolChipView.isHidden else { return }
+        selectedToolChipView.isHidden = false
+        selectedToolChipView.alpha = 0
+        searchAreaContainerView.bringSubviewToFront(selectedToolChipView)
+        UIView.animate(withDuration: Metrics.expansionAnimationDuration) {
+            self.selectedToolChipView.alpha = 1
         }
     }
 

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -614,6 +614,9 @@ extension DefaultOmniBarViewController {
             self?.refreshToolPicker()
             self?.refreshReasoningPicker()
         }
+        omniBarView.onSelectedToolClearTapped = { [weak self] in
+            self?.toolPickerController?.resetSelection()
+        }
 
         // The attach button shares the same store so its limits and accepted types track the selected
         // model. The strip view owns the pending attachments; the controller reads and mutates it.
@@ -700,10 +703,10 @@ extension DefaultOmniBarViewController {
 
         if controller.isToolPickerAvailable {
             omniBarView.aiChatToolPickerMenu = controller.makeMenu()
-            omniBarView.isToolSelected = controller.isToolSelected
+            omniBarView.selectedTool = controller.selectedTool
         } else {
             omniBarView.aiChatToolPickerMenu = nil
-            omniBarView.isToolSelected = false
+            omniBarView.selectedTool = nil
         }
     }
 

--- a/iOS/DuckDuckGo/IPadOmnibarToolPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarToolPickerController.swift
@@ -44,6 +44,11 @@ final class IPadOmnibarToolPickerController {
         toolsController.selectedTool != nil
     }
 
+    /// The currently selected tool, or `nil` when none is active. Drives the iPad selected-tool badge.
+    var selectedTool: AIChatRAGTool? {
+        toolsController.selectedTool
+    }
+
     var selectedToolHidesReasoningPicker: Bool {
         guard let tool = toolsController.selectedTool,
               let identifier = UTIToolsMenu.Item.Identifier(tool: tool) else { return false }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/AIChatRAGTool+ToolbarChip.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/AIChatRAGTool+ToolbarChip.swift
@@ -1,0 +1,65 @@
+//
+//  AIChatRAGTool+ToolbarChip.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import DesignResourcesKitIcons
+import UIKit
+
+/// Display attributes for the selected-tool chip/badge shown in the unified toggle input toolbar
+/// (iPhone) and the iPad address-bar expanded input area. Only `.webSearch` and `.imageGeneration`
+/// are surfaced in the omnibar tools menu; other cases are defensive fallbacks.
+extension AIChatRAGTool {
+
+    var toolbarChipIcon: DesignSystemImage? {
+        switch self {
+        case .webSearch:
+            return DesignSystemImages.Glyphs.Size24.globe
+        case .imageGeneration:
+            return DesignSystemImages.Glyphs.Size24.images
+        case .newsSearch, .videosSearch, .localSearch, .relatedSearchTerms, .weatherForecast:
+            // Not surfaced in the unified-input tools menu — defensive fallback only.
+            return nil
+        }
+    }
+
+    /// Human-readable tool name shown as the badge label (iPad).
+    var toolbarChipTitle: String? {
+        switch self {
+        case .webSearch:
+            return UserText.aiChatToolbarWebSearchToolTitle
+        case .imageGeneration:
+            return UserText.aiChatToolbarImageGenerationToolTitle
+        case .newsSearch, .videosSearch, .localSearch, .relatedSearchTerms, .weatherForecast:
+            // Not surfaced in the unified-input tools menu — defensive fallback only.
+            return nil
+        }
+    }
+
+    var toolbarChipAccessibilityLabel: String? {
+        switch self {
+        case .webSearch:
+            return UserText.aiChatToolbarWebSearchToolTitle
+        case .imageGeneration:
+            return UserText.aiChatToolbarImageGenerationToolTitle
+        case .newsSearch, .videosSearch, .localSearch, .relatedSearchTerms, .weatherForecast:
+            // Not surfaced in the unified-input tools menu — defensive fallback only.
+            return nil
+        }
+    }
+}

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
@@ -548,30 +548,3 @@ private extension UnifiedToggleInputToolbarView {
     }
     @objc private func stopGeneratingTapped() { onStopGeneratingTapped?() }
 }
-
-private extension AIChatRAGTool {
-
-    var toolbarChipIcon: DesignSystemImage? {
-        switch self {
-        case .webSearch:
-            return DesignSystemImages.Glyphs.Size24.globe
-        case .imageGeneration:
-            return DesignSystemImages.Glyphs.Size24.images
-        case .newsSearch, .videosSearch, .localSearch, .relatedSearchTerms, .weatherForecast:
-            // Not surfaced in the unified-input tools menu — defensive fallback only.
-            return nil
-        }
-    }
-
-    var toolbarChipAccessibilityLabel: String? {
-        switch self {
-        case .webSearch:
-            return UserText.aiChatToolbarWebSearchToolTitle
-        case .imageGeneration:
-            return UserText.aiChatToolbarImageGenerationToolTitle
-        case .newsSearch, .videosSearch, .localSearch, .relatedSearchTerms, .weatherForecast:
-            // Not surfaced in the unified-input tools menu — defensive fallback only.
-            return nil
-        }
-    }
-}

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarToolPickerControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarToolPickerControllerTests.swift
@@ -115,6 +115,40 @@ final class IPadOmnibarToolPickerControllerTests: XCTestCase {
         XCTAssertNil(sut.selectedToolsForSubmission)
     }
 
+    // MARK: - Selected tool (drives the iPad badge)
+
+    func testWhenNoToolSelectedThenSelectedToolIsNil() {
+        store.models = [makeModel(id: "gpt-5.2", supportedTools: [.webSearch])]
+
+        XCTAssertNil(sut.selectedTool)
+    }
+
+    func testWhenToolSelectedThenSelectedToolReflectsIt() {
+        store.models = [makeModel(id: "gpt-5.2", supportedTools: [.webSearch, .imageGeneration])]
+
+        sut.handleToolSelection(.imageGeneration)
+
+        XCTAssertEqual(sut.selectedTool, .imageGeneration)
+    }
+
+    func testWhenSelectedToolToggledOffThenSelectedToolIsNil() {
+        store.models = [makeModel(id: "gpt-5.2", supportedTools: [.webSearch])]
+
+        sut.handleToolSelection(.webSearch)
+        sut.handleToolSelection(.webSearch)
+
+        XCTAssertNil(sut.selectedTool)
+    }
+
+    func testWhenResetSelectionThenSelectedToolIsNil() {
+        store.models = [makeModel(id: "gpt-5.2", supportedTools: [.webSearch])]
+        sut.handleToolSelection(.webSearch)
+
+        sut.resetSelection()
+
+        XCTAssertNil(sut.selectedTool)
+    }
+
     // MARK: - Reasoning picker interaction
 
     func testWhenImageGenerationSelectedThenHidesReasoningPicker() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216429247611212?focus=true
Tech Design URL:
CC:

### Description
On iPad, selecting a Duck.ai tool only re-tinted the picker button, making the active mode easy to miss. This adds a capsule badge (tool icon + name + clear) beside the tool picker — matching macOS and the iOS chip family — as the active-mode indicator. iPad only, behind the existing `iPadDuckAIBarControls` flag; iPhone is unchanged.

### Testing Steps
1. On iPad with `iPadDuckAIBarControls` enabled, focus the Duck.ai address bar and open the tool picker.
2. Select "Create Image" (or "Web Search") → a badge with the tool's icon and name appears beside the picker.
3. Tap the badge's clear button → the tool deselects and the badge disappears.

### Impact
Low

#### What could go wrong?
On a narrow split-view width the badge could crowd the trailing controls → mitigated by the trailing `<=` constraint and title truncation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> iPad-only UI behind existing `iPadDuckAIBarControls`; narrow layouts may crowd controls but trailing constraints and title truncation mitigate overlap.
> 
> **Overview**
> On **iPad**, when a Duck.ai RAG tool is active in the expanded address bar, the PR replaces **only tinting the tool picker** with a **capsule badge** (tool icon, localized name, and clear control) placed beside the tool picker, aligned with the iPhone unified-toolbar chip styling.
> 
> **`DefaultOmniBarView`** now binds **`selectedTool: AIChatRAGTool?`** instead of **`isToolSelected`**, drives badge content via shared chip metadata, and shows/hides the badge with the same expand/collapse and hit-testing behavior as other Duck.ai controls. **`DefaultOmniBarViewController`** syncs the badge from **`IPadOmnibarToolPickerController.selectedTool`** and clears selection when the badge’s ✕ is tapped.
> 
> Chip display logic is **centralized** in new **`AIChatRAGTool+ToolbarChip`** (icon, title, accessibility for web search and image generation); the duplicate private extension was **removed** from **`UnifiedToggleInputToolbarView`**. **`IPadOmnibarToolPickerController`** exposes **`selectedTool`** for the UI, with unit tests covering selection, toggle-off, and **`resetSelection`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bd5508ac5b8589f7986fce34d0f94adac9fc725. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->