### PR TITLE
iPad: Hide Duck.ai clear button when the field is empty

### DIFF
--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -343,7 +343,7 @@ final class DefaultOmniBarViewController: OmniBarViewController {
 
         omniBarView.setLayoutMode(newMode, animated: isExpandedPhone)
 
-        let clearButtonHidden = isClearButtonHidden(for: state)
+        let clearButtonHidden = shouldHideClearButton(for: state)
         omniBarView.isClearButtonHidden = clearButtonHidden
 
         let hasTrailingAccessory = state.showAIChatButton || state.showAIChatModeToggle
@@ -354,7 +354,7 @@ final class DefaultOmniBarViewController: OmniBarViewController {
     }
 
     /// Whether the clear button should be hidden for `state`.
-    func isClearButtonHidden(for state: any OmniBarState) -> Bool {
+    func shouldHideClearButton(for state: any OmniBarState) -> Bool {
         if omniBarView.isSearchAreaExpanded {
             return (omniBarView.aiChatTextView.text ?? "").isEmpty
         }

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -343,11 +343,22 @@ final class DefaultOmniBarViewController: OmniBarViewController {
 
         omniBarView.setLayoutMode(newMode, animated: isExpandedPhone)
 
+        let clearButtonHidden = isClearButtonHidden(for: state)
+        omniBarView.isClearButtonHidden = clearButtonHidden
+
         let hasTrailingAccessory = state.showAIChatButton || state.showAIChatModeToggle
-        let hasAdjacentButton = state.showClear || state.showVoiceSearch || state.showRefresh || state.showAbort || state.showCustomizableButton
+        let hasAdjacentButton = !clearButtonHidden || state.showVoiceSearch || state.showRefresh || state.showAbort || state.showCustomizableButton
         omniBarView.isShowingSeparator = hasTrailingAccessory && hasAdjacentButton
 
         updateShadowAppearanceByApplyingLayerMask()
+    }
+
+    /// Whether the clear button should be hidden for `state`.
+    func isClearButtonHidden(for state: any OmniBarState) -> Bool {
+        if omniBarView.isSearchAreaExpanded {
+            return (omniBarView.aiChatTextView.text ?? "").isEmpty
+        }
+        return !state.showClear
     }
 
     override func useSmallTopSpacing() {

--- a/iOS/DuckDuckGoTests/QuerySubmittedTests.swift
+++ b/iOS/DuckDuckGoTests/QuerySubmittedTests.swift
@@ -130,6 +130,47 @@ class QuerySubmittedTests: XCTestCase {
         XCTAssertFalse(mock.wasOnOmniQuerySubmittedCalled)
     }
 
+    // MARK: - Clear button visibility (iPad duck.ai expanded panel)
+
+    func testWhenSearchAreaExpandedAndDuckAIFieldEmptyThenClearButtonIsHidden() throws {
+        sut.loadViewIfNeeded()
+        let expandable = try XCTUnwrap(sut.expandableBarView, "iPad omni bar should expose an expandable bar view")
+
+        expandable.aiChatTextView.text = ""
+        expandable.setSearchAreaExpanded(true, animated: false)
+
+        // A text-editing state reports showClear == true; before the fix the clear button followed
+        // the state machine and lingered over the empty duck.ai field (the reported bug).
+        let textEditingState = LargeOmniBarState.BrowsingTextEditingState(dependencies: MockOmnibarDependency(), isLoading: false)
+        XCTAssertTrue(textEditingState.showClear)
+        XCTAssertTrue(sut.isClearButtonHidden(for: textEditingState))
+    }
+
+    func testWhenSearchAreaExpandedAndDuckAIFieldHasTextThenClearButtonIsVisible() throws {
+        sut.loadViewIfNeeded()
+        let expandable = try XCTUnwrap(sut.expandableBarView)
+
+        expandable.aiChatTextView.text = "best places to visit in japan"
+        expandable.setSearchAreaExpanded(true, animated: false)
+
+        let textEditingState = LargeOmniBarState.BrowsingTextEditingState(dependencies: MockOmnibarDependency(), isLoading: false)
+        XCTAssertFalse(sut.isClearButtonHidden(for: textEditingState))
+    }
+
+    func testWhenSearchAreaNotExpandedThenClearButtonFollowsStateShowClear() throws {
+        sut.loadViewIfNeeded()
+        let expandable = try XCTUnwrap(sut.expandableBarView)
+
+        // Not expanded: the search text field governs, so the state machine's showClear is
+        // authoritative regardless of the (unused) aiChatTextView content.
+        expandable.aiChatTextView.text = "stale text"
+        expandable.setSearchAreaExpanded(false, animated: false)
+
+        let dependencies = MockOmnibarDependency()
+        XCTAssertFalse(sut.isClearButtonHidden(for: LargeOmniBarState.BrowsingTextEditingState(dependencies: dependencies, isLoading: false)))
+        XCTAssertTrue(sut.isClearButtonHidden(for: LargeOmniBarState.BrowsingEmptyEditingState(dependencies: dependencies, isLoading: false)))
+    }
+
     // MARK: - Helper Methods
 
     private func assertQuerySubmission(query: String, expected: String) {

--- a/iOS/DuckDuckGoTests/QuerySubmittedTests.swift
+++ b/iOS/DuckDuckGoTests/QuerySubmittedTests.swift
@@ -136,25 +136,31 @@ class QuerySubmittedTests: XCTestCase {
         sut.loadViewIfNeeded()
         let expandable = try XCTUnwrap(sut.expandableBarView, "iPad omni bar should expose an expandable bar view")
 
-        expandable.aiChatTextView.text = ""
+        // Set the text after expanding: expansion transfers the (empty) search field text into the
+        // aiChatTextView, so seeding it beforehand would be overwritten.
         expandable.setSearchAreaExpanded(true, animated: false)
+        expandable.aiChatTextView.text = ""
+        XCTAssertTrue(expandable.isSearchAreaExpanded, "Precondition: the duck.ai panel must be expanded")
 
         // A text-editing state reports showClear == true; before the fix the clear button followed
         // the state machine and lingered over the empty duck.ai field (the reported bug).
         let textEditingState = LargeOmniBarState.BrowsingTextEditingState(dependencies: MockOmnibarDependency(), isLoading: false)
         XCTAssertTrue(textEditingState.showClear)
-        XCTAssertTrue(sut.isClearButtonHidden(for: textEditingState))
+        XCTAssertTrue(sut.shouldHideClearButton(for: textEditingState))
     }
 
     func testWhenSearchAreaExpandedAndDuckAIFieldHasTextThenClearButtonIsVisible() throws {
         sut.loadViewIfNeeded()
         let expandable = try XCTUnwrap(sut.expandableBarView)
 
-        expandable.aiChatTextView.text = "best places to visit in japan"
+        // Set the text after expanding: expansion transfers the (empty) search field text into the
+        // aiChatTextView, so seeding it beforehand would be overwritten.
         expandable.setSearchAreaExpanded(true, animated: false)
+        expandable.aiChatTextView.text = "best places to visit in japan"
+        XCTAssertTrue(expandable.isSearchAreaExpanded, "Precondition: the duck.ai panel must be expanded")
 
         let textEditingState = LargeOmniBarState.BrowsingTextEditingState(dependencies: MockOmnibarDependency(), isLoading: false)
-        XCTAssertFalse(sut.isClearButtonHidden(for: textEditingState))
+        XCTAssertFalse(sut.shouldHideClearButton(for: textEditingState))
     }
 
     func testWhenSearchAreaNotExpandedThenClearButtonFollowsStateShowClear() throws {
@@ -167,8 +173,8 @@ class QuerySubmittedTests: XCTestCase {
         expandable.setSearchAreaExpanded(false, animated: false)
 
         let dependencies = MockOmnibarDependency()
-        XCTAssertFalse(sut.isClearButtonHidden(for: LargeOmniBarState.BrowsingTextEditingState(dependencies: dependencies, isLoading: false)))
-        XCTAssertTrue(sut.isClearButtonHidden(for: LargeOmniBarState.BrowsingEmptyEditingState(dependencies: dependencies, isLoading: false)))
+        XCTAssertFalse(sut.shouldHideClearButton(for: LargeOmniBarState.BrowsingTextEditingState(dependencies: dependencies, isLoading: false)))
+        XCTAssertTrue(sut.shouldHideClearButton(for: LargeOmniBarState.BrowsingEmptyEditingState(dependencies: dependencies, isLoading: false)))
     }
 
     // MARK: - Helper Methods


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216429247611215?focus=true
Tech Design URL:
CC:

### Description
In the expanded iPad Duck.ai panel the clear (✕) button could appear over an empty field. Its visibility was driven by the omnibar state machine (which tracks the search text field via `showClear`), so paths that emptied the Duck.ai `aiChatTextView` without a text change — e.g. auto-clearing an unedited page URL when switching to Duck.ai — left the button showing. It now derives from the text view's content while the panel is expanded.

### Testing Steps
1. On iPad, enable **Settings → AI Features → "Search & Duck.ai"**.
2. Load a web page, tap the address bar (URL appears and ✕ shows), then tap the Duck.ai toggle **without editing** the URL.
3. Confirm the expanded "Ask anything privately" panel shows **no** ✕ clear button; typing shows it and clearing the text hides it again.

### Impact and Risks
Low — visual-only change scoped to the iPad Duck.ai expanded omnibar.

#### What could go wrong?
The clear button could regress for the non-empty case, but its derivation reads the live text view and is covered by the added unit tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only omnibar logic on iPad Duck.ai expansion, with unit test coverage and unchanged non-expanded behavior.
> 
> **Overview**
> Fixes the iPad **Duck.ai** expanded omnibar showing a clear (✕) control over an **empty** prompt when the omnibar state still reports `showClear` (e.g. after switching from an auto-filled page URL without editing).
> 
> **`DefaultOmniBarViewController`** now drives clear-button visibility via `shouldHideClearButton(for:)`: while `isSearchAreaExpanded`, hide when `aiChatTextView` is empty; otherwise keep using `state.showClear`. The trailing accessory separator uses the same derived visibility instead of `state.showClear` alone.
> 
> Unit tests in **`QuerySubmittedTests`** cover expanded empty/has-text and collapsed state-machine behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9848e3b41600a5ea7b335f4b628855281439bf30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->