### PR TITLE
Suppress pixel validation failures for legacy _monthly version of os_distribution pixels

### DIFF
--- a/iOS/PixelDefinitions/pixels/definitions/os_distribution_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/os_distribution_pixels.json5
@@ -19,10 +19,7 @@
             },
             "platform",
             "form_factor",
-            {
-                "description": "Calendar month frequency marker",
-                "enum": ["monthly"]
-            }
+            "monthly"
         ]
     },
     "os_distribution_searches_major_version": {
@@ -44,7 +41,8 @@
                 "pattern": "^[0-9]{1,2}$"
             },
             "platform",
-            "form_factor"
+            "form_factor",
+            "monthly" // Legacy: present only to suppress pixel validation warnings for the deprecated monthly version of this pixel
         ]
     },
     "os_distribution_active_subscriptions_major_version": {
@@ -67,10 +65,7 @@
             },
             "platform",
             "form_factor",
-            {
-                "description": "Calendar month frequency marker",
-                "enum": ["monthly"]
-            }
+            "monthly"
         ]
     }
 }

--- a/iOS/PixelDefinitions/pixels/suffixes_dictionary.json5
+++ b/iOS/PixelDefinitions/pixels/suffixes_dictionary.json5
@@ -17,6 +17,11 @@
         "description": "Daily pixel suffix",
         "enum": ["daily"]
     },
+    "monthly": {
+        "type": "string",
+        "description": "Monthly pixel suffix",
+        "enum": ["monthly"]
+    },
     "daily_standard": {
         "type": "string",
         "description": "Daily and standard pixel suffixes",

--- a/macOS/PixelDefinitions/pixels/definitions/os_distribution_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/os_distribution_pixels.json5
@@ -20,10 +20,7 @@
             },
             "platform",
             "form_factor",
-            {
-                "description": "Calendar month frequency marker",
-                "enum": ["monthly"]
-            }
+            "monthly"
         ]
     },
     "os_distribution_searches_major_version": {
@@ -46,7 +43,8 @@
                 "pattern": "^[0-9]{1,2}$"
             },
             "platform",
-            "form_factor"
+            "form_factor",
+            "monthly" // Legacy: present only to suppress pixel validation warnings for the deprecated monthly version of this pixel
         ]
     },
     "os_distribution_active_subscriptions_major_version": {
@@ -70,10 +68,7 @@
             },
             "platform",
             "form_factor",
-            {
-                "description": "Calendar month frequency marker",
-                "enum": ["monthly"]
-            }
+            "monthly"
         ]
     }
 }

--- a/macOS/PixelDefinitions/pixels/suffixes_dictionary.json5
+++ b/macOS/PixelDefinitions/pixels/suffixes_dictionary.json5
@@ -7,6 +7,11 @@
         "description": "Daily pixel schedule type",
         "enum": ["daily"]
     },
+    "monthly": {
+        "type": "string",
+        "description": "Monthly pixel schedule type",
+        "enum": ["monthly"]
+    },
     "daily_standard": {
         "type": "string",
         "description": "Pixel schedule type",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216277405273191?focus=true
Tech Design URL:
CC:

### Description
Move definition of the `monthly` suffix to `suffixes_dictionary.json5`, and add the legacy monthly suffix (with clarifying comment) to `os_distribution_searches_major_version` to suppress a pixel validation failure that won't go away unitl the original app ersions are 100% out of usage.  The timeline for this is unclear, but likely to be a very long tail.

### Testing Steps
All existing automated pixel tests for os_distribution pixels still pass.  Further testing _can_ be done manually, but I’m not sure it’s worth the effort in this case.

### Impact
Risk: Low

#### What could go wrong?
Just changing some pixel definition files, so the potential failure mode is new/different validation failures once this goes to production.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only pixel definition updates; the main failure mode is incorrect validation behavior, not runtime app logic.
> 
> **Overview**
> Centralizes the **`monthly`** pixel suffix in **`suffixes_dictionary.json5`** on iOS and macOS, and updates **`os_distribution_*_major_version`** definitions to reference that key instead of inline `enum: ["monthly"]` blocks.
> 
> For **`os_distribution_searches_major_version`**, the PR also adds the **`monthly`** suffix (documented as legacy-only) so validators accept deprecated `_monthly` events still sent by older app builds until that traffic dies off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81ce3e0dd0f37e26fb65c8683da138370704e776. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->