### PR TITLE
macOS: Add Customize Responses entry point to the NTP omnibar

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatURLParameters.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatURLParameters.swift
@@ -46,9 +46,9 @@ public enum AIChatURLParameters {
     public static let settingsName = "settings"
     public static let settingsOpenValue = "open"
 
-    /// Selects which Duck.ai shell the FE renders; `native-customize-modal` renders only the customize card.
-    public static let placementName = "placement"
-    public static let nativeCustomizeModalPlacementValue = "native-customize-modal"
+    /// Tells the Duck.ai FE to render only the Customize Responses card.
+    public static let forceCustomizeName = "forceCustomize"
+    public static let forceCustomizeValue = "true"
 
     /// Appends `?mode=voice` to the given base URL.
     public static func voiceModeURL(from baseURL: URL) -> URL {
@@ -70,9 +70,9 @@ public enum AIChatURLParameters {
         baseURL.addingOrReplacing(URLQueryItem(name: settingsName, value: settingsOpenValue))
     }
 
-    /// Appends `?placement=native-customize-modal` to the given base URL.
+    /// Appends `?forceCustomize=true` to the given base URL.
     public static func nativeCustomizeModalURL(from baseURL: URL) -> URL {
-        baseURL.addingOrReplacing(URLQueryItem(name: placementName, value: nativeCustomizeModalPlacementValue))
+        baseURL.addingOrReplacing(URLQueryItem(name: forceCustomizeName, value: forceCustomizeValue))
     }
 
     /// Appends `?native-input=true` to the given base URL.

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatURLParametersTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatURLParametersTests.swift
@@ -114,6 +114,24 @@ final class AIChatURLParametersTests: XCTestCase {
         XCTAssertEqual(settingsItems.first?.value, "open")
     }
 
+    // MARK: - nativeCustomizeModalURL
+
+    func testNativeCustomizeModalURLAppendsForceCustomizeParam() {
+        let baseURL = URL(string: "https://duck.ai")!
+        let result = AIChatURLParameters.nativeCustomizeModalURL(from: baseURL)
+        XCTAssertEqual(result.absoluteString, "https://duck.ai?forceCustomize=true")
+    }
+
+    func testNativeCustomizeModalURLPreservesExistingQueryItems() {
+        let baseURL = URL(string: "https://duck.ai?q=hello")!
+        let result = AIChatURLParameters.nativeCustomizeModalURL(from: baseURL)
+
+        let components = URLComponents(url: result, resolvingAgainstBaseURL: false)!
+        let queryItems = components.queryItems ?? []
+        XCTAssertTrue(queryItems.contains(URLQueryItem(name: "q", value: "hello")))
+        XCTAssertTrue(queryItems.contains(URLQueryItem(name: "forceCustomize", value: "true")))
+    }
+
     func testNativeInputURLAppendsNativeInputParameter() {
         let baseURL = URL(string: "https://duck.ai/chat")!
         let result = AIChatURLParameters.nativeInputURL(from: baseURL)

--- a/macOS/DuckDuckGo/AIChat/CustomizeResponsesModalController.swift
+++ b/macOS/DuckDuckGo/AIChat/CustomizeResponsesModalController.swift
@@ -31,7 +31,7 @@ final class CustomizeResponsesModalController: NSObject {
     var onClose: (() -> Void)?
 
     private enum Constants {
-        static let width: CGFloat = 520
+        static let width: CGFloat = 620
         static let height: CGFloat = 680
     }
 

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageActionsManagerExtension.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageActionsManagerExtension.swift
@@ -123,7 +123,8 @@ extension NewTabPageActionsManager {
             aiChatShortcutSettingProvider: newTabPageAIChatShortcutSettingProvider,
             featureFlagger: featureFlagger,
             aiChatPreferencesPersistor: NSApp.delegateTyped.aiChatPreferencesPersistor,
-            searchPreferences: NSApp.delegateTyped.searchPreferences
+            searchPreferences: NSApp.delegateTyped.searchPreferences,
+            windowControllersManager: windowControllersManager
         )
         let aiChatsProvider = NewTabPageOmnibarAiChatsProvider(
             featureFlagger: featureFlagger,

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageActionsManagerExtension.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageActionsManagerExtension.swift
@@ -126,6 +126,9 @@ extension NewTabPageActionsManager {
             searchPreferences: NSApp.delegateTyped.searchPreferences,
             windowControllersManager: windowControllersManager
         )
+        omnibarActionHandler.onCustomizeResponsesChanged = { [weak omnibarConfigProvider] in
+            omnibarConfigProvider?.notifyCustomizeResponsesChanged()
+        }
         let aiChatsProvider = NewTabPageOmnibarAiChatsProvider(
             featureFlagger: featureFlagger,
             configProvider: omnibarConfigProvider,

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarActionsHandler.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarActionsHandler.swift
@@ -245,6 +245,7 @@ final class NewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandling {
 
     @MainActor
     func openCustomizeResponses() {
+        guard customizeResponsesModal == nil else { return }
         guard let mainWindowController = windowControllersManager.lastKeyMainWindowController,
               let window = mainWindowController.window else {
             Logger.newTabPageOmnibar.error("Failed to get key window in openCustomizeResponses")

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarActionsHandler.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarActionsHandler.swift
@@ -257,6 +257,13 @@ final class NewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandling {
         modal.present(over: window)
     }
 
+    @MainActor
+    func setCustomizeResponsesActive(_ active: Bool) {
+        let burnerMode = windowControllersManager.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel.burnerMode ?? .regular
+        let handler = NSApp.delegateTyped.burnerDuckAiStorageRegistry?.handler(for: burnerMode) ?? NSApp.delegateTyped.duckAiNativeStorageHandler
+        CustomizeResponsesStore(storageHandler: handler).setActive(active)
+    }
+
     private func linkOpenBehavior(for target: NewTabPageDataModel.OpenTarget, using tabsPreferences: TabsPreferences) -> LinkOpenBehavior {
         switch target {
         case .sameTab:

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarActionsHandler.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarActionsHandler.swift
@@ -34,6 +34,9 @@ final class NewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandling {
     private let isCommandPressed: () -> Bool
     private let firePixel: (PixelKitEvent) -> Void
 
+    /// Retains the Customize Responses modal host while it is presented over the NTP window.
+    private var customizeResponsesModal: CustomizeResponsesModalController?
+
     init(promptHandler: AIChatPromptHandler = AIChatPromptHandler.shared,
          windowControllersManager: WindowControllersManagerProtocol & AIChatTabManaging,
          tabsPreferences: TabsPreferences,
@@ -238,6 +241,19 @@ final class NewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandling {
         }
 
         tabOpener.openNewAIChat(in: behavior)
+    }
+
+    @MainActor
+    func openCustomizeResponses() {
+        guard let mainWindowController = windowControllersManager.lastKeyMainWindowController,
+              let window = mainWindowController.window else {
+            Logger.newTabPageOmnibar.error("Failed to get key window in openCustomizeResponses")
+            return
+        }
+        let modal = CustomizeResponsesModalController(burnerMode: mainWindowController.mainViewController.tabCollectionViewModel.burnerMode)
+        modal.onClose = { [weak self] in self?.customizeResponsesModal = nil }
+        customizeResponsesModal = modal
+        modal.present(over: window)
     }
 
     private func linkOpenBehavior(for target: NewTabPageDataModel.OpenTarget, using tabsPreferences: TabsPreferences) -> LinkOpenBehavior {

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarActionsHandler.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarActionsHandler.swift
@@ -34,6 +34,10 @@ final class NewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandling {
     private let isCommandPressed: () -> Bool
     private let firePixel: (PixelKitEvent) -> Void
 
+    /// Called after the Customize Responses modal closes or the toggle is set, so the NTP config
+    /// (sub-label + toggle state) is re-pushed to open New Tab Pages.
+    var onCustomizeResponsesChanged: () -> Void = {}
+
     /// Retains the Customize Responses modal host while it is presented over the NTP window.
     private var customizeResponsesModal: CustomizeResponsesModalController?
 
@@ -252,7 +256,10 @@ final class NewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandling {
             return
         }
         let modal = CustomizeResponsesModalController(burnerMode: mainWindowController.mainViewController.tabCollectionViewModel.burnerMode)
-        modal.onClose = { [weak self] in self?.customizeResponsesModal = nil }
+        modal.onClose = { [weak self] in
+            self?.customizeResponsesModal = nil
+            self?.onCustomizeResponsesChanged()
+        }
         customizeResponsesModal = modal
         modal.present(over: window)
     }
@@ -262,6 +269,7 @@ final class NewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandling {
         let burnerMode = windowControllersManager.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel.burnerMode ?? .regular
         let handler = NSApp.delegateTyped.burnerDuckAiStorageRegistry?.handler(for: burnerMode) ?? NSApp.delegateTyped.duckAiNativeStorageHandler
         CustomizeResponsesStore(storageHandler: handler).setActive(active)
+        onCustomizeResponsesChanged()
     }
 
     private func linkOpenBehavior(for target: NewTabPageDataModel.OpenTarget, using tabsPreferences: TabsPreferences) -> LinkOpenBehavior {

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
@@ -236,6 +236,11 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
         featureFlagger.isFeatureOn(.aiChatNtpWebSearch)
     }
 
+    var isCustomizeResponsesEnabled: Bool {
+        // Gated by the dedicated Customize Responses flag, matching the native omnibar entry point.
+        featureFlagger.isFeatureOn(.aiChatCustomizeResponses)
+    }
+
     var isAttachTabsEnabled: Bool {
         featureFlagger.isFeatureOn(.aiChatNtpAttachMoreTabs)
     }

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
@@ -18,6 +18,7 @@
 
 import AIChat
 import AppKit
+import WebKit
 import Combine
 import FeatureFlags
 import NewTabPage
@@ -96,6 +97,7 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
     private let firePixel: (PixelKitEvent) -> Void
     private var aiChatPreferencesPersistor: AIChatPreferencesPersisting
     private let searchPreferences: SearchPreferences
+    private let windowControllersManager: WindowControllersManagerProtocol?
     private let showCustomizePopoverSubject = PassthroughSubject<Bool, Never>()
     private let modeSubject = PassthroughSubject<NewTabPageDataModel.OmnibarMode, Never>()
     @Published private var hasExcessChats = false
@@ -106,12 +108,14 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
          featureFlagger: FeatureFlagger,
          aiChatPreferencesPersistor: AIChatPreferencesPersisting = AIChatPreferencesPersistor(),
          searchPreferences: SearchPreferences,
+         windowControllersManager: WindowControllersManagerProtocol? = nil,
          firePixel: @escaping (PixelKitEvent) -> Void = { PixelKit.fire($0, frequency: .dailyAndStandard) }) {
         self.keyValueStore = keyValueStore
         self.aiChatShortcutSettingProvider = aiChatShortcutSettingProvider
         self.featureFlagger = featureFlagger
         self.aiChatPreferencesPersistor = aiChatPreferencesPersistor
         self.searchPreferences = searchPreferences
+        self.windowControllersManager = windowControllersManager
         self.firePixel = firePixel
 
         Self.migrateLegacySelectedModelIdIfNeeded(from: keyValueStore, into: &self.aiChatPreferencesPersistor)
@@ -239,6 +243,15 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
     var isCustomizeResponsesEnabled: Bool {
         // Gated by the dedicated Customize Responses flag, matching the native omnibar entry point.
         featureFlagger.isFeatureOn(.aiChatCustomizeResponses)
+    }
+
+    @MainActor
+    func customizeResponsesState(requestingWebView: WKWebView?) -> NewTabPageDataModel.OmnibarCustomizeResponsesState {
+        guard let windowControllersManager else { return .none }
+        let burnerMode = AIChatTabPickerSource.originTabCollectionViewModel(for: requestingWebView, in: windowControllersManager)?.burnerMode ?? .regular
+        let handler = NSApp.delegateTyped.burnerDuckAiStorageRegistry?.handler(for: burnerMode) ?? NSApp.delegateTyped.duckAiNativeStorageHandler
+        let state = CustomizeResponsesStore(storageHandler: handler).currentState(clarifiesLabel: UserText.aiChatCustomizeResponsesClarifies)
+        return NewTabPageDataModel.OmnibarCustomizeResponsesState(subLabel: state.subLabel, hasCustomization: state.hasCustomization, active: state.isActive)
     }
 
     var isAttachTabsEnabled: Bool {

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
@@ -100,6 +100,7 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
     private let windowControllersManager: WindowControllersManagerProtocol?
     private let showCustomizePopoverSubject = PassthroughSubject<Bool, Never>()
     private let modeSubject = PassthroughSubject<NewTabPageDataModel.OmnibarMode, Never>()
+    private let customizeResponsesChangedSubject = PassthroughSubject<Void, Never>()
     @Published private var hasExcessChats = false
     private var aiChatsProviderCancellable: AnyCancellable?
 
@@ -252,6 +253,14 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
         let handler = NSApp.delegateTyped.burnerDuckAiStorageRegistry?.handler(for: burnerMode) ?? NSApp.delegateTyped.duckAiNativeStorageHandler
         let state = CustomizeResponsesStore(storageHandler: handler).currentState(clarifiesLabel: UserText.aiChatCustomizeResponsesClarifies)
         return NewTabPageDataModel.OmnibarCustomizeResponsesState(subLabel: state.subLabel, hasCustomization: state.hasCustomization, active: state.isActive)
+    }
+
+    var customizeResponsesStatePublisher: AnyPublisher<Void, Never> {
+        customizeResponsesChangedSubject.eraseToAnyPublisher()
+    }
+
+    func notifyCustomizeResponsesChanged() {
+        customizeResponsesChangedSubject.send(())
     }
 
     var isAttachTabsEnabled: Bool {

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageDataModel+Omnibar.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageDataModel+Omnibar.swift
@@ -117,6 +117,13 @@ public extension NewTabPageDataModel {
         /// When true, the omnibar shows the "Customize Responses" tool in the Tools menu. Selecting
         /// it sends `omnibar_openCustomizeResponses` so native opens the Customize Responses modal.
         let enableCustomizeResponses: Bool?
+        /// Summary of the user's current customization (e.g. "Professional, Concise"), shown under
+        /// the Customize Responses row. Omitted when responses haven't been customized.
+        let customizeSubLabel: String?
+        /// True once the user has customized responses; gates the row's on/off toggle.
+        let hasCustomization: Bool?
+        /// Whether the stored customization is currently applied; drives the toggle's checked state.
+        let customizationActive: Bool?
         /// When true, the omnibar shows a 1-click voice-chat button. Driven by the native
         /// `aiChatOmnibarVoiceChatAccess` feature flag and reactive over `omnibar_onConfigUpdate`
         /// so the affordance appears/disappears without a page reload when the flag flips.
@@ -421,6 +428,25 @@ public extension NewTabPageDataModel {
 
     struct ViewAllAiChatsAction: Codable, Equatable {
         let target: OpenTarget
+    }
+
+    struct SetCustomizeResponsesActiveAction: Codable, Equatable {
+        let active: Bool
+    }
+
+    /// Customize Responses row state resolved for a specific window (sub-label + toggle).
+    struct OmnibarCustomizeResponsesState: Equatable {
+        let subLabel: String?
+        let hasCustomization: Bool
+        let active: Bool
+
+        public init(subLabel: String?, hasCustomization: Bool, active: Bool) {
+            self.subLabel = subLabel
+            self.hasCustomization = hasCustomization
+            self.active = active
+        }
+
+        public static let none = OmnibarCustomizeResponsesState(subLabel: nil, hasCustomization: false, active: false)
     }
 
     // MARK: - omnibar_getAiChats

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageDataModel+Omnibar.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageDataModel+Omnibar.swift
@@ -114,6 +114,9 @@ public extension NewTabPageDataModel {
         let enableAiChatTools: Bool?
         let enableImageGeneration: Bool?
         let enableWebSearch: Bool?
+        /// When true, the omnibar shows the "Customize Responses" tool in the Tools menu. Selecting
+        /// it sends `omnibar_openCustomizeResponses` so native opens the Customize Responses modal.
+        let enableCustomizeResponses: Bool?
         /// When true, the omnibar shows a 1-click voice-chat button. Driven by the native
         /// `aiChatOmnibarVoiceChatAccess` feature flag and reactive over `omnibar_onConfigUpdate`
         /// so the affordance appears/disappears without a page reload when the flag flips.

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarActionsHandling.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarActionsHandling.swift
@@ -41,4 +41,8 @@ public protocol NewTabPageOmnibarActionsHandling: AnyObject {
     @MainActor
     func viewAllAiChats(target: NewTabPageDataModel.OpenTarget)
 
+    /// Opens the Duck.ai Customize Responses modal from the NTP omnibar Tools menu.
+    @MainActor
+    func openCustomizeResponses()
+
 }

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarActionsHandling.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarActionsHandling.swift
@@ -45,4 +45,8 @@ public protocol NewTabPageOmnibarActionsHandling: AnyObject {
     @MainActor
     func openCustomizeResponses()
 
+    /// Persists whether the stored response customization is applied (from the row's toggle).
+    @MainActor
+    func setCustomizeResponsesActive(_ active: Bool)
+
 }

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
@@ -71,7 +71,8 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             configProvider.selectedReasoningEffortPublisher.map { _ in () }.eraseToAnyPublisher(),
             configProvider.isVoiceChatAccessEnabledPublisher.map { _ in () }.eraseToAnyPublisher(),
             configProvider.showAskAiSuggestionPublisher.map { _ in () }.eraseToAnyPublisher(),
-            configProvider.isAttachTabsEnabledPublisher.map { _ in () }.eraseToAnyPublisher()
+            configProvider.isAttachTabsEnabledPublisher.map { _ in () }.eraseToAnyPublisher(),
+            configProvider.customizeResponsesStatePublisher.map { _ in () }.eraseToAnyPublisher()
         )
         .sink { [weak self] _ in
             Task { @MainActor in

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
@@ -35,6 +35,7 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
         case openAiChat = "omnibar_openAiChat"
         case viewAllAIChats = "omnibar_viewAllAIChats"
         case openCustomizeResponses = "omnibar_openCustomizeResponses"
+        case setCustomizeResponsesActive = "omnibar_setCustomizeResponsesActive"
         case getOpenTabs = "omnibar_getOpenTabs"
         case getTabContent = "omnibar_getTabContent"
     }
@@ -101,6 +102,7 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             MessageName.openAiChat.rawValue: { [weak self] in try await self?.openAiChat(params: $0, original: $1) },
             MessageName.viewAllAIChats.rawValue: { [weak self] in try await self?.viewAllAIChats(params: $0, original: $1) },
             MessageName.openCustomizeResponses.rawValue: { [weak self] in try await self?.openCustomizeResponses(params: $0, original: $1) },
+            MessageName.setCustomizeResponsesActive.rawValue: { [weak self] in try await self?.setCustomizeResponsesActive(params: $0, original: $1) },
             MessageName.getOpenTabs.rawValue: { [weak self] in try await self?.getOpenTabs(params: $0, original: $1) },
             MessageName.getTabContent.rawValue: { [weak self] in try await self?.getTabContent(params: $0, original: $1) }
         ])
@@ -109,6 +111,7 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
     @MainActor
     private func getConfig(params: Any, original: WKScriptMessage) async throws -> Encodable? {
         let aiModelSections = await modelsProvider?.fetchAIModelSections()
+        let customize = configProvider.customizeResponsesState(requestingWebView: original.webView)
         return NewTabPageDataModel.OmnibarConfig(
             mode: configProvider.mode,
             enableAi: configProvider.isAIChatShortcutEnabled,
@@ -120,6 +123,9 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             enableImageGeneration: configProvider.isImageGenerationEnabled,
             enableWebSearch: configProvider.isWebSearchEnabled,
             enableCustomizeResponses: configProvider.isCustomizeResponsesEnabled,
+            customizeSubLabel: customize.hasCustomization ? customize.subLabel : nil,
+            hasCustomization: customize.hasCustomization,
+            customizationActive: customize.active,
             enableVoiceChatAccess: configProvider.isVoiceChatAccessEnabled,
             enableAskAiSuggestion: configProvider.showAskAiSuggestion,
             selectedModelId: configProvider.selectedModelId,
@@ -185,6 +191,7 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
 
     @MainActor
     private func notifyConfigUpdated() {
+        let customize = configProvider.customizeResponsesState(requestingWebView: nil)
         let config = NewTabPageDataModel.OmnibarConfig(
             mode: configProvider.mode,
             enableAi: configProvider.isAIChatShortcutEnabled,
@@ -196,6 +203,9 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             enableImageGeneration: configProvider.isImageGenerationEnabled,
             enableWebSearch: configProvider.isWebSearchEnabled,
             enableCustomizeResponses: configProvider.isCustomizeResponsesEnabled,
+            customizeSubLabel: customize.hasCustomization ? customize.subLabel : nil,
+            hasCustomization: customize.hasCustomization,
+            customizationActive: customize.active,
             enableVoiceChatAccess: configProvider.isVoiceChatAccessEnabled,
             enableAskAiSuggestion: configProvider.showAskAiSuggestion,
             selectedModelId: configProvider.selectedModelId,
@@ -329,6 +339,15 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
     @MainActor
     private func openCustomizeResponses(params: Any, original: WKScriptMessage) async throws -> Encodable? {
         actionHandler.openCustomizeResponses()
+        return nil
+    }
+
+    @MainActor
+    private func setCustomizeResponsesActive(params: Any, original: WKScriptMessage) async throws -> Encodable? {
+        guard let action: NewTabPageDataModel.SetCustomizeResponsesActiveAction = DecodableHelper.decode(from: params) else {
+            return nil
+        }
+        actionHandler.setCustomizeResponsesActive(action.active)
         return nil
     }
 

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
@@ -34,6 +34,7 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
         case getAiChats = "omnibar_getAiChats"
         case openAiChat = "omnibar_openAiChat"
         case viewAllAIChats = "omnibar_viewAllAIChats"
+        case openCustomizeResponses = "omnibar_openCustomizeResponses"
         case getOpenTabs = "omnibar_getOpenTabs"
         case getTabContent = "omnibar_getTabContent"
     }
@@ -99,6 +100,7 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             MessageName.getAiChats.rawValue: { [weak self] in try await self?.getAiChats(params: $0, original: $1) },
             MessageName.openAiChat.rawValue: { [weak self] in try await self?.openAiChat(params: $0, original: $1) },
             MessageName.viewAllAIChats.rawValue: { [weak self] in try await self?.viewAllAIChats(params: $0, original: $1) },
+            MessageName.openCustomizeResponses.rawValue: { [weak self] in try await self?.openCustomizeResponses(params: $0, original: $1) },
             MessageName.getOpenTabs.rawValue: { [weak self] in try await self?.getOpenTabs(params: $0, original: $1) },
             MessageName.getTabContent.rawValue: { [weak self] in try await self?.getTabContent(params: $0, original: $1) }
         ])
@@ -117,6 +119,7 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             enableAiChatTools: configProvider.isAIChatToolsEnabled,
             enableImageGeneration: configProvider.isImageGenerationEnabled,
             enableWebSearch: configProvider.isWebSearchEnabled,
+            enableCustomizeResponses: configProvider.isCustomizeResponsesEnabled,
             enableVoiceChatAccess: configProvider.isVoiceChatAccessEnabled,
             enableAskAiSuggestion: configProvider.showAskAiSuggestion,
             selectedModelId: configProvider.selectedModelId,
@@ -192,6 +195,7 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             enableAiChatTools: configProvider.isAIChatToolsEnabled,
             enableImageGeneration: configProvider.isImageGenerationEnabled,
             enableWebSearch: configProvider.isWebSearchEnabled,
+            enableCustomizeResponses: configProvider.isCustomizeResponsesEnabled,
             enableVoiceChatAccess: configProvider.isVoiceChatAccessEnabled,
             enableAskAiSuggestion: configProvider.showAskAiSuggestion,
             selectedModelId: configProvider.selectedModelId,
@@ -319,6 +323,12 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             return nil
         }
         await actionHandler.viewAllAiChats(target: action.target)
+        return nil
+    }
+
+    @MainActor
+    private func openCustomizeResponses(params: Any, original: WKScriptMessage) async throws -> Encodable? {
+        actionHandler.openCustomizeResponses()
         return nil
     }
 

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarConfigProviding.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarConfigProviding.swift
@@ -43,6 +43,9 @@ public protocol NewTabPageOmnibarConfigProviding: AnyObject {
 
     var isWebSearchEnabled: Bool { get }
 
+    /// Whether the "Customize Responses" tool is shown in the NTP omnibar Tools menu.
+    var isCustomizeResponsesEnabled: Bool { get }
+
     /// Whether the attach-tabs (and files) affordance is enabled. Driven by the
     /// `aiChatNtpAttachMoreTabs` feature flag. Published so the client can push an
     /// `omnibar_onConfigUpdate` when the flag flips at runtime, keeping an open NTP in sync.

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarConfigProviding.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarConfigProviding.swift
@@ -52,6 +52,9 @@ public protocol NewTabPageOmnibarConfigProviding: AnyObject {
     @MainActor
     func customizeResponsesState(requestingWebView: WKWebView?) -> NewTabPageDataModel.OmnibarCustomizeResponsesState
 
+    /// Fires when the stored response customization changes, so the client re-pushes the config.
+    var customizeResponsesStatePublisher: AnyPublisher<Void, Never> { get }
+
     /// Whether the attach-tabs (and files) affordance is enabled. Driven by the
     /// `aiChatNtpAttachMoreTabs` feature flag. Published so the client can push an
     /// `omnibar_onConfigUpdate` when the flag flips at runtime, keeping an open NTP in sync.

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarConfigProviding.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarConfigProviding.swift
@@ -17,6 +17,7 @@
 //
 
 import Combine
+import WebKit
 
 public protocol NewTabPageOmnibarConfigProviding: AnyObject {
 
@@ -45,6 +46,11 @@ public protocol NewTabPageOmnibarConfigProviding: AnyObject {
 
     /// Whether the "Customize Responses" tool is shown in the NTP omnibar Tools menu.
     var isCustomizeResponsesEnabled: Bool { get }
+
+    /// Customize Responses row state (sub-label + toggle) for the window hosting `requestingWebView`;
+    /// pass `nil` to resolve the current key window.
+    @MainActor
+    func customizeResponsesState(requestingWebView: WKWebView?) -> NewTabPageDataModel.OmnibarCustomizeResponsesState
 
     /// Whether the attach-tabs (and files) affordance is enabled. Driven by the
     /// `aiChatNtpAttachMoreTabs` feature flag. Published so the client can push an

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarActionsHandler.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarActionsHandler.swift
@@ -23,6 +23,7 @@ final class MockNewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandlin
     var openSuggestionHandler: ((NewTabPageDataModel.Suggestion, NewTabPageDataModel.OpenTarget) -> Void)?
     var submitChatHandler: ((String, NewTabPageDataModel.OpenTarget, String?, [NewTabPageDataModel.SubmitChatImage]?, String?, [String]?, String?, [NewTabPageDataModel.OmnibarPageContext]?, [NewTabPageDataModel.OmnibarPromptFile]?) -> Void)?
     var openAiChatHandler: ((String, Bool, NewTabPageDataModel.OpenAiChatTrigger, NewTabPageDataModel.OpenTarget) -> Void)?
+    var openCustomizeResponsesHandler: (() -> Void)?
 
     @MainActor
     func submitSearch(_ term: String, target: NewTabPageDataModel.OpenTarget) {
@@ -59,6 +60,6 @@ final class MockNewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandlin
 
     @MainActor
     func openCustomizeResponses() {
-
+        openCustomizeResponsesHandler?()
     }
 }

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarActionsHandler.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarActionsHandler.swift
@@ -56,4 +56,9 @@ final class MockNewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandlin
     func viewAllAiChats(target: NewTabPage.NewTabPageDataModel.OpenTarget) {
 
     }
+
+    @MainActor
+    func openCustomizeResponses() {
+
+    }
 }

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarActionsHandler.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarActionsHandler.swift
@@ -24,6 +24,7 @@ final class MockNewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandlin
     var submitChatHandler: ((String, NewTabPageDataModel.OpenTarget, String?, [NewTabPageDataModel.SubmitChatImage]?, String?, [String]?, String?, [NewTabPageDataModel.OmnibarPageContext]?, [NewTabPageDataModel.OmnibarPromptFile]?) -> Void)?
     var openAiChatHandler: ((String, Bool, NewTabPageDataModel.OpenAiChatTrigger, NewTabPageDataModel.OpenTarget) -> Void)?
     var openCustomizeResponsesHandler: (() -> Void)?
+    var setCustomizeResponsesActiveHandler: ((Bool) -> Void)?
 
     @MainActor
     func submitSearch(_ term: String, target: NewTabPageDataModel.OpenTarget) {
@@ -61,5 +62,10 @@ final class MockNewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandlin
     @MainActor
     func openCustomizeResponses() {
         openCustomizeResponsesHandler?()
+    }
+
+    @MainActor
+    func setCustomizeResponsesActive(_ active: Bool) {
+        setCustomizeResponsesActiveHandler?(active)
     }
 }

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarConfigProvider.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarConfigProvider.swift
@@ -18,6 +18,7 @@
 
 import Combine
 import NewTabPage
+import WebKit
 
 final class MockNewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
 
@@ -57,6 +58,12 @@ final class MockNewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProvidin
     var isWebSearchEnabled: Bool = false
 
     var isCustomizeResponsesEnabled: Bool = false
+
+    var customizeResponsesStateResult = NewTabPageDataModel.OmnibarCustomizeResponsesState.none
+    @MainActor
+    func customizeResponsesState(requestingWebView: WKWebView?) -> NewTabPageDataModel.OmnibarCustomizeResponsesState {
+        customizeResponsesStateResult
+    }
 
     @Published var isAttachTabsEnabled: Bool = false
 

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarConfigProvider.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarConfigProvider.swift
@@ -65,6 +65,11 @@ final class MockNewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProvidin
         customizeResponsesStateResult
     }
 
+    let customizeResponsesStateSubject = PassthroughSubject<Void, Never>()
+    var customizeResponsesStatePublisher: AnyPublisher<Void, Never> {
+        customizeResponsesStateSubject.eraseToAnyPublisher()
+    }
+
     @Published var isAttachTabsEnabled: Bool = false
 
     var isAttachTabsEnabledPublisher: AnyPublisher<Bool, Never> {

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarConfigProvider.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarConfigProvider.swift
@@ -56,6 +56,8 @@ final class MockNewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProvidin
 
     var isWebSearchEnabled: Bool = false
 
+    var isCustomizeResponsesEnabled: Bool = false
+
     @Published var isAttachTabsEnabled: Bool = false
 
     var isAttachTabsEnabledPublisher: AnyPublisher<Bool, Never> {

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
@@ -74,11 +74,21 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
         XCTAssertEqual(config.enableCustomizeResponses, configProvider.isCustomizeResponsesEnabled)
     }
 
+    @MainActor
+    func testGetConfigIncludesCustomizeResponsesStateFromProvider() async throws {
+        configProvider.customizeResponsesStateResult = .init(subLabel: "Professional", hasCustomization: true, active: true)
+        let config: NewTabPageDataModel.OmnibarConfig = try await messageHelper.handleMessage(named: .getConfig)
+
+        XCTAssertEqual(config.hasCustomization, true)
+        XCTAssertEqual(config.customizationActive, true)
+        XCTAssertEqual(config.customizeSubLabel, "Professional")
+    }
+
     // MARK: - setConfig
 
     @MainActor
     func testSetConfigUpdatesModeAndSettings() async throws {
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: false, showAiSetting: true, showCustomizePopover: true, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: nil, aiModelSections: nil, selectedReasoningEffort: nil, enableAttachTabs: nil, attachmentLimits: nil)
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: false, showAiSetting: true, showCustomizePopover: true, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, customizeSubLabel: nil, hasCustomization: nil, customizationActive: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: nil, aiModelSections: nil, selectedReasoningEffort: nil, enableAttachTabs: nil, attachmentLimits: nil)
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
         XCTAssertEqual(configProvider.mode, .ai)
         XCTAssertEqual(configProvider.isAIChatShortcutEnabled, false)
@@ -87,7 +97,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
 
     @MainActor
     func testWhenSetConfigWithSelectedModelIdThenModelIdIsPersisted() async throws {
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "gpt-4o-mini", aiModelSections: nil, selectedReasoningEffort: nil, enableAttachTabs: nil, attachmentLimits: nil)
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, customizeSubLabel: nil, hasCustomization: nil, customizationActive: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "gpt-4o-mini", aiModelSections: nil, selectedReasoningEffort: nil, enableAttachTabs: nil, attachmentLimits: nil)
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
         XCTAssertEqual(configProvider.selectedModelId, "gpt-4o-mini")
     }
@@ -100,7 +110,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
                 NewTabPageDataModel.AIModelItem(id: "maverick", name: "Maverick", shortName: "Maverick", isEnabled: true, supportsImageUpload: false, supportedTools: [])
             ])
         ]
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "maverick", aiModelSections: nil, selectedReasoningEffort: nil, enableAttachTabs: nil, attachmentLimits: nil)
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, customizeSubLabel: nil, hasCustomization: nil, customizationActive: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "maverick", aiModelSections: nil, selectedReasoningEffort: nil, enableAttachTabs: nil, attachmentLimits: nil)
 
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
 
@@ -116,7 +126,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
                 NewTabPageDataModel.AIModelItem(id: "gpt-4o-mini", name: "GPT-4o mini", shortName: "G4m", isEnabled: true, supportsImageUpload: false, supportedTools: [])
             ])
         ]
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "brand-new-model", aiModelSections: nil, selectedReasoningEffort: nil, enableAttachTabs: nil, attachmentLimits: nil)
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, customizeSubLabel: nil, hasCustomization: nil, customizationActive: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "brand-new-model", aiModelSections: nil, selectedReasoningEffort: nil, enableAttachTabs: nil, attachmentLimits: nil)
 
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
 
@@ -132,7 +142,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
         modelsProvider.lastFetchedSections = nil
 
         // When — web echoes back the same id (typical on launch)
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "gpt-4o-mini", aiModelSections: nil, selectedReasoningEffort: nil, enableAttachTabs: nil, attachmentLimits: nil)
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, customizeSubLabel: nil, hasCustomization: nil, customizationActive: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "gpt-4o-mini", aiModelSections: nil, selectedReasoningEffort: nil, enableAttachTabs: nil, attachmentLimits: nil)
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
 
         // Then — cached short name is preserved (not wiped by a failed lookup)
@@ -234,7 +244,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
                                                  supportedReasoningEffort: ["none", "low", "medium"])
             ])
         ]
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "reasoning-model", aiModelSections: nil, selectedReasoningEffort: "low", enableAttachTabs: nil, attachmentLimits: nil)
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, customizeSubLabel: nil, hasCustomization: nil, customizationActive: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "reasoning-model", aiModelSections: nil, selectedReasoningEffort: "low", enableAttachTabs: nil, attachmentLimits: nil)
 
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
 
@@ -253,7 +263,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
                                                  supportedReasoningEffort: ["low"])
             ])
         ]
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "limited-model", aiModelSections: nil, selectedReasoningEffort: "medium", enableAttachTabs: nil, attachmentLimits: nil)
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, customizeSubLabel: nil, hasCustomization: nil, customizationActive: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "limited-model", aiModelSections: nil, selectedReasoningEffort: "medium", enableAttachTabs: nil, attachmentLimits: nil)
 
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
 
@@ -271,7 +281,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
                                                  supportedReasoningEffort: ["low"])
             ])
         ]
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "reasoning-model", aiModelSections: nil, selectedReasoningEffort: "low", enableAttachTabs: nil, attachmentLimits: nil)
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, customizeSubLabel: nil, hasCustomization: nil, customizationActive: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "reasoning-model", aiModelSections: nil, selectedReasoningEffort: "low", enableAttachTabs: nil, attachmentLimits: nil)
 
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
 
@@ -420,6 +430,18 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
         }
 
         try await messageHelper.handleMessageExpectingNilResponse(named: .openCustomizeResponses)
+        await fulfillment(of: [expectation], timeout: 1)
+    }
+
+    func testSetCustomizeResponsesActiveIsForwardedToHandler() async throws {
+        let expectation = expectation(description: "setCustomizeResponsesActiveCalled")
+        (actionHandler as? MockNewTabPageOmnibarActionsHandler)?.setCustomizeResponsesActiveHandler = { active in
+            XCTAssertTrue(active)
+            expectation.fulfill()
+        }
+
+        let action = NewTabPageDataModel.SetCustomizeResponsesActiveAction(active: true)
+        try await messageHelper.handleMessageExpectingNilResponse(named: .setCustomizeResponsesActive, parameters: action)
         await fulfillment(of: [expectation], timeout: 1)
     }
 

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
@@ -64,12 +64,14 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
         configProvider.isAIChatShortcutEnabled = true
         configProvider.isAIChatSettingVisible = false
         configProvider.isWebSearchEnabled = true
+        configProvider.isCustomizeResponsesEnabled = true
         let config: NewTabPageDataModel.OmnibarConfig = try await messageHelper.handleMessage(named: .getConfig)
 
         XCTAssertEqual(config.mode, configProvider.mode)
         XCTAssertEqual(config.enableAi, configProvider.isAIChatShortcutEnabled)
         XCTAssertEqual(config.showAiSetting, configProvider.isAIChatSettingVisible)
         XCTAssertEqual(config.enableWebSearch, configProvider.isWebSearchEnabled)
+        XCTAssertEqual(config.enableCustomizeResponses, configProvider.isCustomizeResponsesEnabled)
     }
 
     // MARK: - setConfig
@@ -406,6 +408,18 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
 
         let action = NewTabPageDataModel.OpenSuggestionAction(suggestion: suggestion, target: .newTab)
         try await messageHelper.handleMessageExpectingNilResponse(named: .openSuggestion, parameters: action)
+        await fulfillment(of: [expectation], timeout: 1)
+    }
+
+    // MARK: - openCustomizeResponses
+
+    func testOpenCustomizeResponsesIsForwardedToHandler() async throws {
+        let expectation = expectation(description: "openCustomizeResponsesCalled")
+        (actionHandler as? MockNewTabPageOmnibarActionsHandler)?.openCustomizeResponsesHandler = {
+            expectation.fulfill()
+        }
+
+        try await messageHelper.handleMessageExpectingNilResponse(named: .openCustomizeResponses)
         await fulfillment(of: [expectation], timeout: 1)
     }
 

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
@@ -76,7 +76,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
 
     @MainActor
     func testSetConfigUpdatesModeAndSettings() async throws {
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: false, showAiSetting: true, showCustomizePopover: true, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: nil, aiModelSections: nil, selectedReasoningEffort: nil, enableAttachTabs: nil, attachmentLimits: nil)
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: false, showAiSetting: true, showCustomizePopover: true, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: nil, aiModelSections: nil, selectedReasoningEffort: nil, enableAttachTabs: nil, attachmentLimits: nil)
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
         XCTAssertEqual(configProvider.mode, .ai)
         XCTAssertEqual(configProvider.isAIChatShortcutEnabled, false)
@@ -85,7 +85,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
 
     @MainActor
     func testWhenSetConfigWithSelectedModelIdThenModelIdIsPersisted() async throws {
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "gpt-4o-mini", aiModelSections: nil, selectedReasoningEffort: nil, enableAttachTabs: nil, attachmentLimits: nil)
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "gpt-4o-mini", aiModelSections: nil, selectedReasoningEffort: nil, enableAttachTabs: nil, attachmentLimits: nil)
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
         XCTAssertEqual(configProvider.selectedModelId, "gpt-4o-mini")
     }
@@ -98,7 +98,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
                 NewTabPageDataModel.AIModelItem(id: "maverick", name: "Maverick", shortName: "Maverick", isEnabled: true, supportsImageUpload: false, supportedTools: [])
             ])
         ]
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "maverick", aiModelSections: nil, selectedReasoningEffort: nil, enableAttachTabs: nil, attachmentLimits: nil)
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "maverick", aiModelSections: nil, selectedReasoningEffort: nil, enableAttachTabs: nil, attachmentLimits: nil)
 
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
 
@@ -114,7 +114,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
                 NewTabPageDataModel.AIModelItem(id: "gpt-4o-mini", name: "GPT-4o mini", shortName: "G4m", isEnabled: true, supportsImageUpload: false, supportedTools: [])
             ])
         ]
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "brand-new-model", aiModelSections: nil, selectedReasoningEffort: nil, enableAttachTabs: nil, attachmentLimits: nil)
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "brand-new-model", aiModelSections: nil, selectedReasoningEffort: nil, enableAttachTabs: nil, attachmentLimits: nil)
 
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
 
@@ -130,7 +130,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
         modelsProvider.lastFetchedSections = nil
 
         // When — web echoes back the same id (typical on launch)
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "gpt-4o-mini", aiModelSections: nil, selectedReasoningEffort: nil, enableAttachTabs: nil, attachmentLimits: nil)
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "gpt-4o-mini", aiModelSections: nil, selectedReasoningEffort: nil, enableAttachTabs: nil, attachmentLimits: nil)
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
 
         // Then — cached short name is preserved (not wiped by a failed lookup)
@@ -232,7 +232,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
                                                  supportedReasoningEffort: ["none", "low", "medium"])
             ])
         ]
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "reasoning-model", aiModelSections: nil, selectedReasoningEffort: "low", enableAttachTabs: nil, attachmentLimits: nil)
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "reasoning-model", aiModelSections: nil, selectedReasoningEffort: "low", enableAttachTabs: nil, attachmentLimits: nil)
 
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
 
@@ -251,7 +251,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
                                                  supportedReasoningEffort: ["low"])
             ])
         ]
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "limited-model", aiModelSections: nil, selectedReasoningEffort: "medium", enableAttachTabs: nil, attachmentLimits: nil)
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "limited-model", aiModelSections: nil, selectedReasoningEffort: "medium", enableAttachTabs: nil, attachmentLimits: nil)
 
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
 
@@ -269,7 +269,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
                                                  supportedReasoningEffort: ["low"])
             ])
         ]
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "reasoning-model", aiModelSections: nil, selectedReasoningEffort: "low", enableAttachTabs: nil, attachmentLimits: nil)
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableCustomizeResponses: nil, enableVoiceChatAccess: nil, enableAskAiSuggestion: nil, selectedModelId: "reasoning-model", aiModelSections: nil, selectedReasoningEffort: "low", enableAttachTabs: nil, attachmentLimits: nil)
 
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
 

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarAiChatsProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarAiChatsProviderTests.swift
@@ -18,6 +18,7 @@
 
 import XCTest
 import AIChat
+import WebKit
 import Combine
 import PrivacyConfig
 import FeatureFlags
@@ -344,6 +345,8 @@ private final class MockAiChatsConfigProvider: NewTabPageOmnibarConfigProviding 
     var isImageGenerationEnabled: Bool = false
     var isWebSearchEnabled: Bool = false
     var isCustomizeResponsesEnabled: Bool = false
+    @MainActor
+    func customizeResponsesState(requestingWebView: WKWebView?) -> NewTabPageDataModel.OmnibarCustomizeResponsesState { .none }
     var isAttachTabsEnabled: Bool = false
     var isAttachTabsEnabledPublisher: AnyPublisher<Bool, Never> { Just(false).eraseToAnyPublisher() }
     var selectedModelId: String?

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarAiChatsProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarAiChatsProviderTests.swift
@@ -343,6 +343,7 @@ private final class MockAiChatsConfigProvider: NewTabPageOmnibarConfigProviding 
     var isAIChatToolsEnabled: Bool = false
     var isImageGenerationEnabled: Bool = false
     var isWebSearchEnabled: Bool = false
+    var isCustomizeResponsesEnabled: Bool = false
     var isAttachTabsEnabled: Bool = false
     var isAttachTabsEnabledPublisher: AnyPublisher<Bool, Never> { Just(false).eraseToAnyPublisher() }
     var selectedModelId: String?

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarAiChatsProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarAiChatsProviderTests.swift
@@ -347,6 +347,7 @@ private final class MockAiChatsConfigProvider: NewTabPageOmnibarConfigProviding 
     var isCustomizeResponsesEnabled: Bool = false
     @MainActor
     func customizeResponsesState(requestingWebView: WKWebView?) -> NewTabPageDataModel.OmnibarCustomizeResponsesState { .none }
+    var customizeResponsesStatePublisher: AnyPublisher<Void, Never> { Empty<Void, Never>().eraseToAnyPublisher() }
     var isAttachTabsEnabled: Bool = false
     var isAttachTabsEnabledPublisher: AnyPublisher<Bool, Never> { Just(false).eraseToAnyPublisher() }
     var selectedModelId: String?


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1216299435808475
Tech Design URL:
CC:

### Description

Wires the New Tab Page omnibar to show and open the Customize Responses tool. Adds an `enableCustomizeResponses` config field and an `omnibar_openCustomizeResponses` message; selecting the tool presents the shared Customize Responses modal over the NTP window (using that window's burner mode for storage). Gated by `aiChatCustomizeResponses` (internal-only), matching the native omnibar entry point.

### Testing Steps

1. Internal build; enable `aiChatCustomizeResponses` and the NTP AI-chat-tools flag.
2. Then you need to clone the `c-s-s` package and point to the `feature/anpete/ntp-customize-responses` branch. I’m using the old DBP technique of just dragging the C-S-S package to Xcode; pointing to a specific branch from the package doesn’t work for me.
3. Also, you need to set the AI chat URL to `https://euw-serp-dev-testing20.duck.ai`. You can do this by going to Debug -> AI Chat -> Web Communication -> Set URL.
4. Open a New Tab Page and open the omnibar Tools menu — "Customize Responses” appears.
5. Click it — the Customize Responses modal opens over the NTP window.

<img width="1832" height="1522" alt="Screenshot 2026-07-10 at 2 52 56 PM" src="https://github.com/user-attachments/assets/681e8031-9652-4ac5-9e68-d045d23f7a0f" />
<img width="1832" height="1522" alt="Screenshot 2026-07-10 at 2 53 02 PM" src="https://github.com/user-attachments/assets/911db908-f626-42bd-88ed-896b79b8de23" />


### Impact

Low. Behind an internal-only feature flag; affects the NTP omnibar only.

#### What could go wrong?

The row is web-rendered, so it only appears once the frontend renders `enableCustomizeResponses` and sends `omnibar_openCustomizeResponses`.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Low Risk**
> Changes are behind an internal feature flag and limited to NTP omnibar bridging; the menu row still depends on the web client honoring `enableCustomizeResponses` and sending the new message.
> 
> **Overview**
> Adds a **Customize Responses** path from the New Tab Page omnibar Tools menu, aligned with the native omnibar modal flow.
> 
> Native exposes **`enableCustomizeResponses`** on omnibar config (gated by **`aiChatCustomizeResponses`**) and handles **`omnibar_openCustomizeResponses`** by presenting **`CustomizeResponsesModalController`** over the key NTP window, using that window’s burner mode for storage. The shared Duck.ai URL contract switches from **`?placement=native-customize-modal`** to **`?forceCustomize=true`** via **`nativeCustomizeModalURL`**, with tests for the new query param. The customize modal card width is increased from 520 to 620 pt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b281ab38101f7a7f6098e0c2520c0ea734eb9cf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are behind an internal feature flag and limited to NTP native↔web omnibar bridging; the row and modal still depend on the web client honoring the new config fields and query param.
> 
> **Overview**
> Adds **Customize Responses** to the New Tab Page omnibar Tools menu, wired like the native omnibar: config exposes **`enableCustomizeResponses`** ( **`aiChatCustomizeResponses`** ), sub-label/toggle fields (**`customizeSubLabel`**, **`hasCustomization`**, **`customizationActive`**), and the web bridge handles **`omnibar_openCustomizeResponses`** and **`omnibar_setCustomizeResponsesActive`**.
> 
> Native presents **`CustomizeResponsesModalController`** over the key NTP window (burner-aware storage via **`CustomizeResponsesStore`**), re-pushes **`omnibar_onConfigUpdate`** when the modal closes or the toggle changes, and widens the modal card (**520 → 620** pt).
> 
> The shared Duck.ai URL contract switches from **`?placement=native-customize-modal`** to **`?forceCustomize=true`** in **`nativeCustomizeModalURL`**, with unit tests for the new query param.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e9249f9142ba2e1c4ea4b7301288ad8cf1abe0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->