### PR TITLE
[CI] Handle unrequested PR reviews

### DIFF
--- a/.github/workflows/add_asana_comment_on_pr_review.yml
+++ b/.github/workflows/add_asana_comment_on_pr_review.yml
@@ -1,98 +1,119 @@
 name: Shared - Add Asana Comment on PR Review
 
 on:
-    pull_request_review:
-        types: [submitted]
+  pull_request_review:
+    types: [submitted]
 
 jobs:
+  add-pr-review-comment:
+    # Skip this job when:
+    #   - The review submitter is the PR author themselves (self-review,
+    #     or AI/automation tools posting via the author's GitHub token).
+    #   - The review submitter is a Bot account (e.g. cursor[bot],
+    #     dependabot[bot]) posting under its own [bot] identity. No
+    #     Asana subtask exists for bots.
+    #   - The review state is 'commented' with an empty body. GitHub
+    #     wraps every "Add single comment" inline reply in a review with
+    #     state=commented and an empty body; filtering by body excludes
+    #     those noisy inline-reply events while keeping deliberate
+    #     "Submit review → Comment" submissions that include a summary.
+    if: |
+      contains(fromJSON('["approved","changes_requested","commented"]'), github.event.review.state)
+      && github.event.review.user.login != github.event.pull_request.user.login
+      && github.event.review.user.type != 'Bot'
+      && (github.event.review.state != 'commented' || github.event.review.body != '')
+    name: "Add Asana comment on PR review"
+    runs-on: ubuntu-latest
 
-    add-pr-review-comment:
-        # Skip this job when:
-        #   - The review submitter is the PR author themselves (self-review,
-        #     or AI/automation tools posting via the author's GitHub token).
-        #   - The review submitter is a Bot account (e.g. cursor[bot],
-        #     dependabot[bot]) posting under its own [bot] identity. No
-        #     Asana subtask exists for bots.
-        #   - The review state is 'commented' with an empty body. GitHub
-        #     wraps every "Add single comment" inline reply in a review with
-        #     state=commented and an empty body; filtering by body excludes
-        #     those noisy inline-reply events while keeping deliberate
-        #     "Submit review → Comment" submissions that include a summary.
-        if: |
-            contains(fromJSON('["approved","changes_requested","commented"]'), github.event.review.state)
-            && github.event.review.user.login != github.event.pull_request.user.login
-            && github.event.review.user.type != 'Bot'
-            && (github.event.review.state != 'commented' || github.event.review.body != '')
-        name: "Add Asana comment on PR review"
-        runs-on: ubuntu-latest
+    steps:
+      - name: Get Task ID
+        id: get-task-id
+        uses: duckduckgo/apple-toolbox/actions/asana-extract-task-id@main
+        with:
+          text: ${{ github.event.pull_request.body }}
 
-        steps:
-        - name: Get Task ID
-          id: get-task-id
-          uses: duckduckgo/apple-toolbox/actions/asana-extract-task-id@main
-          with:
-            text: ${{ github.event.pull_request.body }}
+      - name: Fail if no Asana task URL in PR body
+        if: ${{ steps.get-task-id.outputs.task-id == '' }}
+        run: |
+          echo "::error::No Asana task URL found in the PR body. Add a 'Task/Issue URL: https://app.asana.com/...' line to enable PR review subtask comments."
+          exit 1
 
-        - name: Fail if no Asana task URL in PR body
-          if: ${{ steps.get-task-id.outputs.task-id == '' }}
-          run: |
-            echo "::error::No Asana task URL found in the PR body. Add a 'Task/Issue URL: https://app.asana.com/...' line to enable PR review subtask comments."
-            exit 1
+      - name: Find PR review subtask for the reviewer
+        id: find-subtask
+        uses: duckduckgo/apple-toolbox/actions/asana-fetch-pr-subtasks@main
+        with:
+          access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-task-id: ${{ steps.get-task-id.outputs.task-id }}
+          github-reviewer-user: ${{ github.event.review.user.login }}
+          github-token: ${{ secrets.APPLE_GH_RO_PAT }}
 
-        - name: Find PR review subtask for the reviewer
-          id: find-subtask
-          uses: duckduckgo/apple-toolbox/actions/asana-fetch-pr-subtasks@main
-          with:
-            access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
-            asana-task-id: ${{ steps.get-task-id.outputs.task-id }}
-            github-reviewer-user: ${{ github.event.review.user.login }}
-            github-token: ${{ secrets.APPLE_GH_RO_PAT }}
+      - name: Create PR review subtask if missing
+        if: ${{ steps.find-subtask.outputs.subtask-ids == '[]' }}
+        uses: duckduckgo/apple-toolbox/actions/asana-create-pr-subtask@main
+        with:
+          access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-task-id: ${{ steps.get-task-id.outputs.task-id }}
+          github-reviewer-user: ${{ github.event.review.user.login }}
+          github-pr-author-user: ${{ github.event.pull_request.user.login }}
+          github-pr-author-type: ${{ github.event.pull_request.user.type }}
+          github-token: ${{ secrets.APPLE_GH_RO_PAT }}
+          asana-project-id: ${{ vars.APPLE_TEAM_CODE_REVIEWS_ASANA_PROJECT_ID }}
+          asana-section-id: ${{ vars.APPLE_TEAM_CODE_REVIEWS_SECTION_ID }}
 
-        - name: Fail if reviewer's Asana mapping is missing
-          if: ${{ steps.find-subtask.outputs.subtask-ids == '[]' }}
-          run: |
-            echo "::error::No PR review subtask found for @${{ github.event.review.user.login }}. They may not be in the GitHub→Asana mapping. Add them in duckduckgo/native-github-asana-sync and re-run."
-            exit 1
+      - name: Resolve PR review subtask for the reviewer
+        id: resolve-subtask
+        uses: duckduckgo/apple-toolbox/actions/asana-fetch-pr-subtasks@main
+        with:
+          access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-task-id: ${{ steps.get-task-id.outputs.task-id }}
+          github-reviewer-user: ${{ github.event.review.user.login }}
+          github-token: ${{ secrets.APPLE_GH_RO_PAT }}
 
-        - name: Build comment text
-          id: comment
-          env:
-            STATE: ${{ github.event.review.state }}
-            REVIEWER: ${{ github.event.review.user.login }}
-            REVIEW_URL: ${{ github.event.review.html_url }}
-          run: |
-            case "$STATE" in
-              approved)          prefix="✅ Approved" ;;
-              changes_requested) prefix="🔄 Changes requested" ;;
-              commented)         prefix="💬 Comment" ;;
-            esac
-            echo "text=${prefix} by @${REVIEWER} — see review: ${REVIEW_URL}" >> "$GITHUB_OUTPUT"
+      - name: Fail if PR review subtask could not be resolved
+        if: ${{ steps.resolve-subtask.outputs.subtask-ids == '[]' }}
+        run: |
+          echo "::error::No PR review subtask could be found or created for @${{ github.event.review.user.login }}. Check their GitHub→Asana mapping and the parent Asana task, then re-run."
+          exit 1
 
-        - name: Post review comment
-          uses: duckduckgo/native-github-asana-sync@v2.4
-          with:
-            action: 'post-comment-asana-task'
-            asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-            asana-task-id: ${{ fromJSON(steps.find-subtask.outputs.subtask-ids)[0] }}
-            asana-task-comment: ${{ steps.comment.outputs.text }}
-            asana-task-comment-pinned: false
+      - name: Build comment text
+        id: comment
+        env:
+          STATE: ${{ github.event.review.state }}
+          REVIEWER: ${{ github.event.review.user.login }}
+          REVIEW_URL: ${{ github.event.review.html_url }}
+        run: |
+          case "$STATE" in
+            approved)          prefix="✅ Approved" ;;
+            changes_requested) prefix="🔄 Changes requested" ;;
+            commented)         prefix="💬 Comment" ;;
+          esac
+          echo "text=${prefix} by @${REVIEWER} — see review: ${REVIEW_URL}" >> "$GITHUB_OUTPUT"
 
-        - name: Mark subtask complete on approve
-          if: ${{ github.event.review.state == 'approved' }}
-          uses: duckduckgo/native-github-asana-sync@v2.4
-          with:
-            action: 'mark-asana-task-complete'
-            asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-            asana-task-id: ${{ fromJSON(steps.find-subtask.outputs.subtask-ids)[0] }}
-            is-complete: true
+      - name: Post review comment
+        uses: duckduckgo/native-github-asana-sync@v2.4
+        with:
+          action: "post-comment-asana-task"
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-task-id: ${{ fromJSON(steps.resolve-subtask.outputs.subtask-ids)[0] }}
+          asana-task-comment: ${{ steps.comment.outputs.text }}
+          asana-task-comment-pinned: false
 
-        # If a reviewer returns to a previously approved PR (subtask already
-        # completed) and submits a non-approve review, reopen the subtask.
-        - name: Mark subtask incomplete on non-approve review
-          if: ${{ github.event.review.state != 'approved' }}
-          uses: duckduckgo/native-github-asana-sync@v2.4
-          with:
-            action: 'mark-asana-task-complete'
-            asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-            asana-task-id: ${{ fromJSON(steps.find-subtask.outputs.subtask-ids)[0] }}
-            is-complete: false
+      - name: Mark subtask complete on approve
+        if: ${{ github.event.review.state == 'approved' }}
+        uses: duckduckgo/native-github-asana-sync@v2.4
+        with:
+          action: "mark-asana-task-complete"
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-task-id: ${{ fromJSON(steps.resolve-subtask.outputs.subtask-ids)[0] }}
+          is-complete: true
+
+      # If a reviewer returns to a previously approved PR (subtask already
+      # completed) and submits a non-approve review, reopen the subtask.
+      - name: Mark subtask incomplete on non-approve review
+        if: ${{ github.event.review.state != 'approved' }}
+        uses: duckduckgo/native-github-asana-sync@v2.4
+        with:
+          action: "mark-asana-task-complete"
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-task-id: ${{ fromJSON(steps.resolve-subtask.outputs.subtask-ids)[0] }}
+          is-complete: false

--- a/.github/workflows/add_asana_comment_on_pr_review.yml
+++ b/.github/workflows/add_asana_comment_on_pr_review.yml
@@ -1,119 +1,120 @@
 name: Shared - Add Asana Comment on PR Review
 
 on:
-  pull_request_review:
-    types: [submitted]
+    pull_request_review:
+        types: [submitted]
 
 jobs:
-  add-pr-review-comment:
-    # Skip this job when:
-    #   - The review submitter is the PR author themselves (self-review,
-    #     or AI/automation tools posting via the author's GitHub token).
-    #   - The review submitter is a Bot account (e.g. cursor[bot],
-    #     dependabot[bot]) posting under its own [bot] identity. No
-    #     Asana subtask exists for bots.
-    #   - The review state is 'commented' with an empty body. GitHub
-    #     wraps every "Add single comment" inline reply in a review with
-    #     state=commented and an empty body; filtering by body excludes
-    #     those noisy inline-reply events while keeping deliberate
-    #     "Submit review → Comment" submissions that include a summary.
-    if: |
-      contains(fromJSON('["approved","changes_requested","commented"]'), github.event.review.state)
-      && github.event.review.user.login != github.event.pull_request.user.login
-      && github.event.review.user.type != 'Bot'
-      && (github.event.review.state != 'commented' || github.event.review.body != '')
-    name: "Add Asana comment on PR review"
-    runs-on: ubuntu-latest
 
-    steps:
-      - name: Get Task ID
-        id: get-task-id
-        uses: duckduckgo/apple-toolbox/actions/asana-extract-task-id@main
-        with:
-          text: ${{ github.event.pull_request.body }}
+    add-pr-review-comment:
+        # Skip this job when:
+        #   - The review submitter is the PR author themselves (self-review,
+        #     or AI/automation tools posting via the author's GitHub token).
+        #   - The review submitter is a Bot account (e.g. cursor[bot],
+        #     dependabot[bot]) posting under its own [bot] identity. No
+        #     Asana subtask exists for bots.
+        #   - The review state is 'commented' with an empty body. GitHub
+        #     wraps every "Add single comment" inline reply in a review with
+        #     state=commented and an empty body; filtering by body excludes
+        #     those noisy inline-reply events while keeping deliberate
+        #     "Submit review → Comment" submissions that include a summary.
+        if: |
+            contains(fromJSON('["approved","changes_requested","commented"]'), github.event.review.state)
+            && github.event.review.user.login != github.event.pull_request.user.login
+            && github.event.review.user.type != 'Bot'
+            && (github.event.review.state != 'commented' || github.event.review.body != '')
+        name: "Add Asana comment on PR review"
+        runs-on: ubuntu-latest
 
-      - name: Fail if no Asana task URL in PR body
-        if: ${{ steps.get-task-id.outputs.task-id == '' }}
-        run: |
-          echo "::error::No Asana task URL found in the PR body. Add a 'Task/Issue URL: https://app.asana.com/...' line to enable PR review subtask comments."
-          exit 1
+        steps:
+        - name: Get Task ID
+          id: get-task-id
+          uses: duckduckgo/apple-toolbox/actions/asana-extract-task-id@main
+          with:
+            text: ${{ github.event.pull_request.body }}
 
-      - name: Find PR review subtask for the reviewer
-        id: find-subtask
-        uses: duckduckgo/apple-toolbox/actions/asana-fetch-pr-subtasks@main
-        with:
-          access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana-task-id: ${{ steps.get-task-id.outputs.task-id }}
-          github-reviewer-user: ${{ github.event.review.user.login }}
-          github-token: ${{ secrets.APPLE_GH_RO_PAT }}
+        - name: Fail if no Asana task URL in PR body
+          if: ${{ steps.get-task-id.outputs.task-id == '' }}
+          run: |
+            echo "::error::No Asana task URL found in the PR body. Add a 'Task/Issue URL: https://app.asana.com/...' line to enable PR review subtask comments."
+            exit 1
 
-      - name: Create PR review subtask if missing
-        if: ${{ steps.find-subtask.outputs.subtask-ids == '[]' }}
-        uses: duckduckgo/apple-toolbox/actions/asana-create-pr-subtask@main
-        with:
-          access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana-task-id: ${{ steps.get-task-id.outputs.task-id }}
-          github-reviewer-user: ${{ github.event.review.user.login }}
-          github-pr-author-user: ${{ github.event.pull_request.user.login }}
-          github-pr-author-type: ${{ github.event.pull_request.user.type }}
-          github-token: ${{ secrets.APPLE_GH_RO_PAT }}
-          asana-project-id: ${{ vars.APPLE_TEAM_CODE_REVIEWS_ASANA_PROJECT_ID }}
-          asana-section-id: ${{ vars.APPLE_TEAM_CODE_REVIEWS_SECTION_ID }}
+        - name: Find PR review subtask for the reviewer
+          id: find-subtask
+          uses: duckduckgo/apple-toolbox/actions/asana-fetch-pr-subtasks@main
+          with:
+            access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
+            asana-task-id: ${{ steps.get-task-id.outputs.task-id }}
+            github-reviewer-user: ${{ github.event.review.user.login }}
+            github-token: ${{ secrets.APPLE_GH_RO_PAT }}
 
-      - name: Resolve PR review subtask for the reviewer
-        id: resolve-subtask
-        uses: duckduckgo/apple-toolbox/actions/asana-fetch-pr-subtasks@main
-        with:
-          access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana-task-id: ${{ steps.get-task-id.outputs.task-id }}
-          github-reviewer-user: ${{ github.event.review.user.login }}
-          github-token: ${{ secrets.APPLE_GH_RO_PAT }}
+        - name: Create PR review subtask if missing
+          if: ${{ steps.find-subtask.outputs.subtask-ids == '[]' }}
+          uses: duckduckgo/apple-toolbox/actions/asana-create-pr-subtask@main
+          with:
+            access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
+            asana-task-id: ${{ steps.get-task-id.outputs.task-id }}
+            github-reviewer-user: ${{ github.event.review.user.login }}
+            github-pr-author-user: ${{ github.event.pull_request.user.login }}
+            github-pr-author-type: ${{ github.event.pull_request.user.type }}
+            github-token: ${{ secrets.APPLE_GH_RO_PAT }}
+            asana-project-id: ${{ vars.APPLE_TEAM_CODE_REVIEWS_ASANA_PROJECT_ID }}
+            asana-section-id: ${{ vars.APPLE_TEAM_CODE_REVIEWS_SECTION_ID }}
 
-      - name: Fail if PR review subtask could not be resolved
-        if: ${{ steps.resolve-subtask.outputs.subtask-ids == '[]' }}
-        run: |
-          echo "::error::No PR review subtask could be found or created for @${{ github.event.review.user.login }}. Check their GitHub→Asana mapping and the parent Asana task, then re-run."
-          exit 1
+        - name: Resolve PR review subtask for the reviewer
+          id: resolve-subtask
+          uses: duckduckgo/apple-toolbox/actions/asana-fetch-pr-subtasks@main
+          with:
+            access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
+            asana-task-id: ${{ steps.get-task-id.outputs.task-id }}
+            github-reviewer-user: ${{ github.event.review.user.login }}
+            github-token: ${{ secrets.APPLE_GH_RO_PAT }}
 
-      - name: Build comment text
-        id: comment
-        env:
-          STATE: ${{ github.event.review.state }}
-          REVIEWER: ${{ github.event.review.user.login }}
-          REVIEW_URL: ${{ github.event.review.html_url }}
-        run: |
-          case "$STATE" in
-            approved)          prefix="✅ Approved" ;;
-            changes_requested) prefix="🔄 Changes requested" ;;
-            commented)         prefix="💬 Comment" ;;
-          esac
-          echo "text=${prefix} by @${REVIEWER} — see review: ${REVIEW_URL}" >> "$GITHUB_OUTPUT"
+        - name: Fail if PR review subtask could not be resolved
+          if: ${{ steps.resolve-subtask.outputs.subtask-ids == '[]' }}
+          run: |
+            echo "::error::No PR review subtask could be found or created for @${{ github.event.review.user.login }}. Check their GitHub→Asana mapping and the parent Asana task, then re-run."
+            exit 1
 
-      - name: Post review comment
-        uses: duckduckgo/native-github-asana-sync@v2.4
-        with:
-          action: "post-comment-asana-task"
-          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana-task-id: ${{ fromJSON(steps.resolve-subtask.outputs.subtask-ids)[0] }}
-          asana-task-comment: ${{ steps.comment.outputs.text }}
-          asana-task-comment-pinned: false
+        - name: Build comment text
+          id: comment
+          env:
+            STATE: ${{ github.event.review.state }}
+            REVIEWER: ${{ github.event.review.user.login }}
+            REVIEW_URL: ${{ github.event.review.html_url }}
+          run: |
+            case "$STATE" in
+              approved)          prefix="✅ Approved" ;;
+              changes_requested) prefix="🔄 Changes requested" ;;
+              commented)         prefix="💬 Comment" ;;
+            esac
+            echo "text=${prefix} by @${REVIEWER} — see review: ${REVIEW_URL}" >> "$GITHUB_OUTPUT"
 
-      - name: Mark subtask complete on approve
-        if: ${{ github.event.review.state == 'approved' }}
-        uses: duckduckgo/native-github-asana-sync@v2.4
-        with:
-          action: "mark-asana-task-complete"
-          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana-task-id: ${{ fromJSON(steps.resolve-subtask.outputs.subtask-ids)[0] }}
-          is-complete: true
+        - name: Post review comment
+          uses: duckduckgo/native-github-asana-sync@v2.4
+          with:
+            action: 'post-comment-asana-task'
+            asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+            asana-task-id: ${{ fromJSON(steps.resolve-subtask.outputs.subtask-ids)[0] }}
+            asana-task-comment: ${{ steps.comment.outputs.text }}
+            asana-task-comment-pinned: false
 
-      # If a reviewer returns to a previously approved PR (subtask already
-      # completed) and submits a non-approve review, reopen the subtask.
-      - name: Mark subtask incomplete on non-approve review
-        if: ${{ github.event.review.state != 'approved' }}
-        uses: duckduckgo/native-github-asana-sync@v2.4
-        with:
-          action: "mark-asana-task-complete"
-          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana-task-id: ${{ fromJSON(steps.resolve-subtask.outputs.subtask-ids)[0] }}
-          is-complete: false
+        - name: Mark subtask complete on approve
+          if: ${{ github.event.review.state == 'approved' }}
+          uses: duckduckgo/native-github-asana-sync@v2.4
+          with:
+            action: 'mark-asana-task-complete'
+            asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+            asana-task-id: ${{ fromJSON(steps.resolve-subtask.outputs.subtask-ids)[0] }}
+            is-complete: true
+
+        # If a reviewer returns to a previously approved PR (subtask already
+        # completed) and submits a non-approve review, reopen the subtask.
+        - name: Mark subtask incomplete on non-approve review
+          if: ${{ github.event.review.state != 'approved' }}
+          uses: duckduckgo/native-github-asana-sync@v2.4
+          with:
+            action: 'mark-asana-task-complete'
+            asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+            asana-task-id: ${{ fromJSON(steps.resolve-subtask.outputs.subtask-ids)[0] }}
+            is-complete: false


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1216438927332697?focus=true
Tech Design URL:
CC:

### Description

This PR fixes a case where leaving a review on PR without being requested for a review first causes the PR review workflow to fail.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Leave a review on this task without first being requested for review - if you have been requested, remove yourself and delete the PR review task
2. Check that a PR review task is created and the correct action was taken

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal GitHub Actions only; no app or user-facing behavior, with failure still possible if mapping or parent task is invalid after create.
> 
> **Overview**
> **Unrequested PR reviews** no longer fail the Asana sync workflow. When a reviewer submits a review but no matching PR review subtask exists, the job **creates** one via `asana-create-pr-subtask` (same project/section vars as the existing create workflow), **re-fetches** subtasks into `resolve-subtask`, and only then errors if the subtask is still missing.
> 
> Comment posting and approve / reopen subtask steps now target **`resolve-subtask`** instead of the initial lookup, so newly created subtasks get the same behavior as pre-requested reviewers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b8802858c7c2932c21d762d0cce63d66c99514e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->