### PR TITLE
[iOS] floating UI: use obscured insets where possible

### DIFF
--- a/iOS/DuckDuckGo/BrowserChromeManager.swift
+++ b/iOS/DuckDuckGo/BrowserChromeManager.swift
@@ -40,6 +40,10 @@ protocol BrowserChromeDelegate: AnyObject {
     /// of whatever is on screen (toolbar -> capsule -> safe area).
     func floatingWebViewBottomObscuredHeight(for barsVisibilityPercent: CGFloat) -> CGFloat
 
+    /// Chrome-obscured insets (measured from the full-bleed web view's edges) for the given chrome
+    /// visibility, used to drive `WKWebView.obscuredContentInsets` on iOS 26.
+    func floatingWebViewObscuredInsets(for barsVisibilityPercent: CGFloat) -> UIEdgeInsets
+
     var omniBar: any OmniBar { get }
     var tabBarContainer: UIView { get }
 }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3984,6 +3984,22 @@ extension MainViewController: BrowserChromeDelegate {
         )
     }
 
+    func floatingWebViewObscuredInsets(for barsVisibilityPercent: CGFloat) -> UIEdgeInsets {
+        UIEdgeInsets(top: floatingWebViewTopObscuredHeight(for: barsVisibilityPercent),
+                     left: 0,
+                     bottom: floatingWebViewBottomObscuredHeight(for: barsVisibilityPercent),
+                     right: 0)
+    }
+
+    /// Height (from the screen top) obscured by the top chrome. Content rests below the status bar,
+    /// and below the omnibar too when the address bar is at the top. Constant for now (doesn't yet
+    /// shrink to the top capsule as the omnibar hides on scroll).
+    private func floatingWebViewTopObscuredHeight(for barsVisibilityPercent: CGFloat) -> CGFloat {
+        let safeAreaTop = view.safeAreaInsets.top
+        guard appSettings.currentAddressBarPosition == .top else { return safeAreaTop }
+        return safeAreaTop + omniBar.barView.expectedHeight
+    }
+
     var minimalChromeBottomHeight: CGFloat {
         toolbarHeight + view.safeAreaInsets.bottom
     }

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -892,24 +892,51 @@ class TabViewController: UIViewController {
             webViewBottomAnchorConstraint?.constant = 0
         }
         if FloatingUIManager(featureFlagger: featureFlagger).isFloatingUIEnabled {
-            // Physically resize the web view so its bottom edge sits at the top of the visible bottom
-            // chrome (toolbar -> capsule -> safe area). Resizing the frame lays out page `position: fixed`
-            // footers reliably, including on load, unlike `additionalSafeAreaInsets` which WebKit only
-            // reflows on a subsequent scroll. AI tabs with the unified toggle input keep the full-bleed
-            // web view since that feature owns its own bottom layout.
-            let isUnifiedToggleInputAffectingLayout = isAITab && unifiedToggleInputFeature.isAvailable
-            let bottomObscuredHeight = isUnifiedToggleInputAffectingLayout
-                ? 0
-                : (chromeDelegate?.floatingWebViewBottomObscuredHeight(for: barsVisibilityPercent) ?? 0)
-            webViewBottomAnchorConstraint?.constant = -bottomObscuredHeight
             borderView.bottomAlpha = 0
             borderView.isHidden = true
             borderView.isTopVisible = false
             borderView.isBottomVisible = false
-            updateFloatingUISafeAreaInsets()
+
+            // AI tabs with the unified toggle input own their own bottom layout, so keep the web view
+            // full-bleed with no obscured region there.
+            let isUnifiedToggleInputAffectingLayout = isAITab && unifiedToggleInputFeature.isAvailable
+            if #available(iOS 26, *) {
+                // Keep the web view full-bleed and reserve the chrome region via WebKit's public
+                // `obscuredContentInsets`, which positions page fixed/sticky elements and the layout
+                // viewport reliably (including on load) and lets content scroll behind the glass.
+                webViewBottomAnchorConstraint?.constant = 0
+                let obscuredInsets: UIEdgeInsets = isUnifiedToggleInputAffectingLayout
+                    ? .zero
+                    : (chromeDelegate?.floatingWebViewObscuredInsets(for: barsVisibilityPercent) ?? .zero)
+                webView?.obscuredContentInsets = obscuredInsets
+                // `obscuredContentInsets` does not adjust the scroll view's content/indicator insets in
+                // UIKit, so scrollable content would rest behind the bars. Feed the chrome region
+                // (beyond the device safe area, which the scroll view already accounts for) into
+                // `additionalSafeAreaInsets` so at-rest content and scroll indicators clear the bars too.
+                let deviceSafeArea = view.window?.safeAreaInsets ?? .zero
+                additionalSafeAreaInsets = UIEdgeInsets(
+                    top: max(0, obscuredInsets.top - deviceSafeArea.top),
+                    left: 0,
+                    bottom: max(0, obscuredInsets.bottom - deviceSafeArea.bottom),
+                    right: 0
+                )
+            } else {
+                // iOS 18 fallback: physically resize the web view so its bottom edge sits at the top of
+                // the visible bottom chrome (toolbar -> capsule -> safe area), and inset the top via
+                // `additionalSafeAreaInsets`.
+                let bottomObscuredHeight = isUnifiedToggleInputAffectingLayout
+                    ? 0
+                    : (chromeDelegate?.floatingWebViewBottomObscuredHeight(for: barsVisibilityPercent) ?? 0)
+                webViewBottomAnchorConstraint?.constant = -bottomObscuredHeight
+                updateFloatingUISafeAreaInsets()
+            }
         } else {
             borderView.isHidden = false
             borderView.bottomAlpha = AppWidthObserver.shared.isLargeWidth ? 0 : barsVisibilityPercent
+            // Defensive: clear any obscured insets left over if floating UI was toggled off at runtime.
+            if #available(iOS 26, *) {
+                webView?.obscuredContentInsets = .zero
+            }
         }
     }
 

--- a/iOS/DuckDuckGoTests/BarsAnimatorTests.swift
+++ b/iOS/DuckDuckGoTests/BarsAnimatorTests.swift
@@ -273,6 +273,8 @@ private class BrowserChromeDelegateMock: BrowserChromeDelegate {
 
     func floatingWebViewBottomObscuredHeight(for barsVisibilityPercent: CGFloat) -> CGFloat { 0 }
 
+    func floatingWebViewObscuredInsets(for barsVisibilityPercent: CGFloat) -> UIEdgeInsets { .zero }
+
     var omniBar: OmniBar = {
         let omniBar = MockOmniBar()
         omniBar.mockBarView.expectedHeight = 52

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/DuckPlayerMocks.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/DuckPlayerMocks.swift
@@ -626,6 +626,8 @@ final class DuckPlayerBrowserChromeDelegateMock: BrowserChromeDelegate {
 
     func floatingWebViewBottomObscuredHeight(for barsVisibilityPercent: CGFloat) -> CGFloat { 0 }
 
+    func floatingWebViewObscuredInsets(for barsVisibilityPercent: CGFloat) -> UIEdgeInsets { .zero }
+
     var omniBar: OmniBar = DefaultOmniBarViewController(
         dependencies: MockOmnibarDependency(
             voiceSearchHelper: MockVoiceSearchHelper(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216279782099801?focus=true
Tech Design URL:
CC:

### Description
Uses obscured insets where possible for improved webview with floating glass support.

### Testing Steps
1. Check floatingUI flag leakage
2. Validate iPad
3. Review new floatingUI code (bearing in mind known list of things https://app.asana.com/1/137249556945/project/72649045549333/task/1216248709747126?focus=true)

### Impact
Medium: Could disrupt specific features or user flows

#### What could go wrong?
Could break browsing / scrolling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core browsing layout and scroll/inset behavior for floating UI across iOS versions; regressions could affect fixed/sticky web content, scrolling, and AI-tab exceptions.
> 
> **Overview**
> On **iOS 26+** with floating UI enabled, the tab web view stays **full-bleed** and chrome overlap is expressed through **`WKWebView.obscuredContentInsets`** instead of shrinking the web view’s bottom anchor. **`MainViewController`** now supplies full **`UIEdgeInsets`** (top: status bar plus omnibar when the address bar is at the top; bottom: existing floating chrome height) via a new **`floatingWebViewObscuredInsets`** delegate API.
> 
> **`TabViewController`** sets those insets on the web view and mirrors the chrome region beyond the device safe area into **`additionalSafeAreaInsets`** so scrollable content and indicators still clear the bars, since obscured insets alone do not adjust UIKit scroll insets. **AI tabs** with unified toggle input still skip obscured regions. **Pre–iOS 26** keeps the prior bottom-anchor resize plus **`updateFloatingUISafeAreaInsets`**, and obscured insets are cleared when floating UI is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d2eb0bd0b4ad3384955570246faf5b5c5d2fb7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->