### PR TITLE
[CI] Revert to main branch for sync_crypto action

### DIFF
--- a/.github/workflows/macos_sync_end_to_end.yml
+++ b/.github/workflows/macos_sync_end_to_end.yml
@@ -143,7 +143,7 @@ jobs:
         echo $! > log_stream.pid
 
     - name: Create test account for Sync and return the recovery code
-      uses: duckduckgo/sync_crypto/action@chore/github-action-node24-runtime
+      uses: duckduckgo/sync_crypto/action@main
       id: sync-recovery-code
       with:
         debug: true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1216397628843922?focus=true

### Description
Just reverting a change I forgot to revert before merging https://github.com/duckduckgo/apple-browsers/pull/5726

### Testing Steps
N/A

### Impact
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI action ref change with no application or security impact; behavior should match the stable main action again.
> 
> **Overview**
> Reverts the macOS Sync end-to-end workflow to use **`duckduckgo/sync_crypto/action@main`** instead of the temporary **`@chore/github-action-node24-runtime`** ref for the step that creates the Sync test account and recovery code.
> 
> No other workflow steps or inputs change; this undoes a branch pin that was left in after an earlier merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aead982e183a02e0ac6e7aeb450793743594105a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->