### PR TITLE
[iOS] Add impression pixel for Freemium PIR settings entry point

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1934,6 +1934,7 @@ extension Pixel {
         case subscriptionExpirationReminderSchedulingError
 
         // MARK: - Freemium Personal Information Removal
+        case freemiumPIRSettingsEntryPointImpression
         case freemiumPIRSettingsEntryPointClicked
 
         // MARK: - Data Broker Protection Notifications
@@ -3899,6 +3900,7 @@ extension Pixel.Event {
         case .subscriptionExpirationReminderSchedulingError: return "push-notification_subscription-expiration-reminder_scheduling-error"
 
         // MARK: Freemium Personal Information Removal
+        case .freemiumPIRSettingsEntryPointImpression: return "m_dbp_freemium_settings_entry_point_impression"
         case .freemiumPIRSettingsEntryPointClicked: return "m_dbp_freemium_settings_entry_point_clicked"
 
         // MARK: Data Broker Protection Notifications

--- a/iOS/DuckDuckGo/SettingsSubscriptionView.swift
+++ b/iOS/DuckDuckGo/SettingsSubscriptionView.swift
@@ -198,6 +198,9 @@ struct SettingsSubscriptionView: View {
                     .hidden()
                 )
             }
+            .onFirstAppear {
+                Pixel.fire(pixel: .freemiumPIRSettingsEntryPointImpression)
+            }
         }
     }
 

--- a/iOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -1162,6 +1162,13 @@
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource"]
     },
+    "m_dbp_freemium_settings_entry_point_impression": {
+        "description": "Fires when the freemium Personal Information Removal entry point is shown to an eligible user in Settings. Used to count entry-point exposure for the freemium funnel dashboard.",
+        "owners": ["jozsef-vesza"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
     "m_dbp_freemium_settings_entry_point_clicked": {
         "description": "Fires when the user taps the freemium Personal Information Removal entry point CTA in Settings.",
         "owners": ["jozsef-vesza"],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215162983789006
Tech Design URL:
CC:

### Description
Adds an impression pixel for the Freemium PIR entry point in Settings.

### Testing Steps
1. Force Freemium eligibility via Debug > PIR > Force Freemium PIR Eligibility
2. Open Settings and scroll to the "Other Protections" section so the Freemium PIR entry point becomes visible → `m_dbp_freemium_settings_entry_point_impression` fires once.

### Impact
Low


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only addition with no changes to eligibility, navigation, or PIR behavior.
> 
> **Overview**
> Adds **impression** analytics for the freemium Personal Information Removal row in Settings, complementing the existing tap pixel so funnel dashboards can measure exposure vs clicks.
> 
> Registers `freemiumPIRSettingsEntryPointImpression` (`m_dbp_freemium_settings_entry_point_impression`) in `PixelEvent` and `data_broker_protection.json5`, and fires it once when the eligible **Other Protections** section first appears via `.onFirstAppear` on `freemiumPIRSettingsEntryPointSection` in `SettingsSubscriptionView`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a54950e5b7eaa5e5c0f1658db17d710346d831a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->