### PR TITLE
iPad: Add Duck.ai control pixels

### DIFF
--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -515,6 +515,10 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
     /// Fired when the badge's clear (✕) button is tapped, so the host can deselect the tool.
     var onSelectedToolClearTapped: (() -> Void)?
 
+    var onModelPickerMenuOpened: (() -> Void)?
+
+    var onReasoningPickerMenuOpened: (() -> Void)?
+
     private var canShowToolPicker: Bool {
         isToolPickerEnabled && toolPickerButton.menu != nil
     }
@@ -592,6 +596,16 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
 
     @objc private func selectedToolClearButtonTapped() {
         onSelectedToolClearTapped?()
+    }
+
+    @objc private func modelPickerButtonTouchedDown() {
+        guard modelPickerButton.menu != nil else { return }
+        onModelPickerMenuOpened?()
+    }
+
+    @objc private func reasoningPickerButtonTouchedDown() {
+        guard reasoningPickerButton.menu != nil else { return }
+        onReasoningPickerMenuOpened?()
     }
 
     let attachButton: UIButton = {
@@ -1155,6 +1169,8 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
 
         aiChatLeftButton.addTarget(self, action: #selector(aiChatLeftButtonTap), for: .touchUpInside)
         aiChatSendButton.addTarget(self, action: #selector(aiChatSendButtonTap), for: .primaryActionTriggered)
+        modelPickerButton.addTarget(self, action: #selector(modelPickerButtonTouchedDown), for: .touchDown)
+        reasoningPickerButton.addTarget(self, action: #selector(reasoningPickerButtonTouchedDown), for: .touchDown)
     }
 
     private func updateFireModeAppearance() {

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -515,10 +515,6 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
     /// Fired when the badge's clear (✕) button is tapped, so the host can deselect the tool.
     var onSelectedToolClearTapped: (() -> Void)?
 
-    var onModelPickerMenuOpened: (() -> Void)?
-
-    var onReasoningPickerMenuOpened: (() -> Void)?
-
     private var canShowToolPicker: Bool {
         isToolPickerEnabled && toolPickerButton.menu != nil
     }
@@ -596,16 +592,6 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
 
     @objc private func selectedToolClearButtonTapped() {
         onSelectedToolClearTapped?()
-    }
-
-    @objc private func modelPickerButtonTouchedDown() {
-        guard modelPickerButton.menu != nil else { return }
-        onModelPickerMenuOpened?()
-    }
-
-    @objc private func reasoningPickerButtonTouchedDown() {
-        guard reasoningPickerButton.menu != nil else { return }
-        onReasoningPickerMenuOpened?()
     }
 
     let attachButton: UIButton = {
@@ -1169,8 +1155,6 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
 
         aiChatLeftButton.addTarget(self, action: #selector(aiChatLeftButtonTap), for: .touchUpInside)
         aiChatSendButton.addTarget(self, action: #selector(aiChatSendButtonTap), for: .primaryActionTriggered)
-        modelPickerButton.addTarget(self, action: #selector(modelPickerButtonTouchedDown), for: .touchDown)
-        reasoningPickerButton.addTarget(self, action: #selector(reasoningPickerButtonTouchedDown), for: .touchDown)
     }
 
     private func updateFireModeAppearance() {

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -641,12 +641,6 @@ extension DefaultOmniBarViewController {
         omniBarView.onSelectedToolClearTapped = { [weak self] in
             self?.toolPickerController?.resetSelection(isUserInitiated: true)
         }
-        omniBarView.onModelPickerMenuOpened = {
-            UnifiedToggleInputCoordinatorPixelHelper.fireModelPickerShownPixel(isAITabState: false)
-        }
-        omniBarView.onReasoningPickerMenuOpened = {
-            UnifiedToggleInputCoordinatorPixelHelper.fireReasoningPickerShownPixel(isAITabState: false)
-        }
 
         // The attach button shares the same store so its limits and accepted types track the selected
         // model. The strip view owns the pending attachments; the controller reads and mutates it.
@@ -703,7 +697,7 @@ extension DefaultOmniBarViewController {
         if let shortName = controller.currentModelLabel {
             omniBarView.aiChatModelName = shortName
         }
-        omniBarView.aiChatModelPickerMenu = controller.makeMenu { [weak self] modelId in
+        let menu = controller.makeMenu { [weak self] modelId in
             guard let self else { return }
             self.modelPickerController?.handleModelSelection(modelId)
             self.toolPickerController?.handleModelChanged()
@@ -713,6 +707,9 @@ extension DefaultOmniBarViewController {
             self.refreshToolPicker()
             self.refreshAttachButton()
         }
+        omniBarView.aiChatModelPickerMenu = menuFiringShownPixel(menu) {
+            UnifiedToggleInputCoordinatorPixelHelper.fireModelPickerShownPixel(isAITabState: false)
+        }
     }
 
     private func refreshReasoningPicker() {
@@ -721,11 +718,22 @@ extension DefaultOmniBarViewController {
         let hiddenByTool = toolPickerController?.selectedToolHidesReasoningPicker ?? false
         if controller.isReasoningPickerAvailable, !hiddenByTool {
             omniBarView.aiChatReasoningIcon = controller.currentReasoningMode?.unifiedToggleInputButtonImage
-            omniBarView.aiChatReasoningPickerMenu = controller.makeMenu()
+            omniBarView.aiChatReasoningPickerMenu = menuFiringShownPixel(controller.makeMenu()) {
+                UnifiedToggleInputCoordinatorPixelHelper.fireReasoningPickerShownPixel(isAITabState: false)
+            }
         } else {
             omniBarView.aiChatReasoningIcon = nil
             omniBarView.aiChatReasoningPickerMenu = nil
         }
+    }
+
+    private func menuFiringShownPixel(_ menu: UIMenu?, onShow: @escaping () -> Void) -> UIMenu? {
+        guard let menu else { return nil }
+        let deferred = UIDeferredMenuElement.uncached { completion in
+            onShow()
+            completion(menu.children)
+        }
+        return UIMenu(title: menu.title, options: menu.options, children: [deferred])
     }
 
     private func refreshToolPicker() {

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -516,6 +516,7 @@ extension DefaultOmniBarViewController {
                 omniDelegate?.onOmniQuerySubmitted(query)
             } else {
                 DailyPixel.fireDailyAndCount(pixel: .aiChatIPadTogglePromptSubmitted)
+                fireIPadUnifiedPromptSubmittedPixels(hasText: !query.isEmpty)
                 /// Collapse and resign instantly so a quick re-tap doesn't race the post-submit
                 /// collapse animation.
                 /// https://app.asana.com/1/137249556945/project/1201011656765697/task/1215084286493408?focus=true
@@ -638,7 +639,13 @@ extension DefaultOmniBarViewController {
             self?.refreshReasoningPicker()
         }
         omniBarView.onSelectedToolClearTapped = { [weak self] in
-            self?.toolPickerController?.resetSelection()
+            self?.toolPickerController?.resetSelection(isUserInitiated: true)
+        }
+        omniBarView.onModelPickerMenuOpened = {
+            UnifiedToggleInputCoordinatorPixelHelper.fireModelPickerShownPixel(isAITabState: false)
+        }
+        omniBarView.onReasoningPickerMenuOpened = {
+            UnifiedToggleInputCoordinatorPixelHelper.fireReasoningPickerShownPixel(isAITabState: false)
         }
 
         // The attach button shares the same store so its limits and accepted types track the selected
@@ -736,6 +743,29 @@ extension DefaultOmniBarViewController {
     private func refreshAttachButton() {
         // A nil menu hides the button — i.e. when the selected model accepts no attachments.
         omniBarView.aiChatAttachmentMenu = attachmentController?.makeMenu()
+    }
+
+    private func fireIPadUnifiedPromptSubmittedPixels(hasText: Bool) {
+        guard modelPickerController != nil else { return }
+        let attachments = attachmentController?.pendingAttachments ?? []
+        let selectedTool = toolPickerController?.selectedTool
+        UnifiedToggleInputCoordinatorPixelHelper.fireUnifiedPromptSubmittedPixel(
+            hasText: hasText,
+            selectedTool: selectedTool,
+            attachments: attachments,
+            reasoningMode: iPadReasoningModeForSubmitPixel,
+            modelId: modelPickerController?.currentModelId
+        )
+        UnifiedToggleInputCoordinatorPixelHelper.fireToolSubmittedPixelIfNeeded(
+            selectedTool: selectedTool,
+            attachments: attachments
+        )
+    }
+
+    private var iPadReasoningModeForSubmitPixel: AIChatReasoningMode? {
+        if toolPickerController?.selectedToolHidesReasoningPicker == true { return nil }
+        guard reasoningPickerController?.isReasoningPickerAvailable == true else { return nil }
+        return reasoningPickerController?.currentReasoningMode
     }
 
     /// Called when the strip's attachments change (add / remove / clear): rebuilds the attach menu

--- a/iOS/DuckDuckGo/IPadOmnibarAttachmentController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarAttachmentController.swift
@@ -37,7 +37,14 @@ final class IPadOmnibarAttachmentController {
 
     /// The strip that renders and owns the pending attachments. Set by the omnibar view controller
     /// once its view is loaded.
-    weak var attachmentsStripView: UnifiedToggleInputAttachmentsStripView?
+    weak var attachmentsStripView: UnifiedToggleInputAttachmentsStripView? {
+        didSet {
+            attachmentsStripView?.onAttachmentRemoved = { _, attachment, isUserInitiated in
+                guard isUserInitiated else { return }
+                UnifiedToggleInputCoordinatorPixelHelper.fireAttachmentRemovedPixel(for: attachment)
+            }
+        }
+    }
 
     /// Supplies the view controller used to present the photo / camera / document pickers.
     var presenterProvider: (() -> UIViewController?)?
@@ -100,6 +107,10 @@ final class IPadOmnibarAttachmentController {
 
     var hasAttachments: Bool {
         !currentAttachments.isEmpty
+    }
+
+    var pendingAttachments: [UnifiedToggleInputAttachment] {
+        currentAttachments
     }
 
     /// Whether at least one pending attachment is valid (submittable). Mirrors the iPhone unified

--- a/iOS/DuckDuckGo/IPadOmnibarModelPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarModelPickerController.swift
@@ -99,7 +99,11 @@ final class IPadOmnibarModelPickerController {
 
         if model.entityHasAccess {
             pendingGatedModelId = nil
+            let isNewSelection = modelId != store.persistedModelId
             store.updateSelectedModel(modelId, isNewChatContext: true)
+            if isNewSelection {
+                UnifiedToggleInputCoordinatorPixelHelper.fireModelSelectedPixel(modelId: modelId)
+            }
         } else if routeGatedModelSelection(model) {
             // Remember the gated model so a post-purchase `/models` refresh can apply it.
             pendingGatedModelId = modelId
@@ -131,6 +135,10 @@ final class IPadOmnibarModelPickerController {
             return
         }
         pendingGatedModelId = nil
+        let isNewSelection = modelId != store.persistedModelId
         store.updateSelectedModel(modelId, isNewChatContext: true)
+        if isNewSelection {
+            UnifiedToggleInputCoordinatorPixelHelper.fireModelSelectedPixel(modelId: modelId)
+        }
     }
 }

--- a/iOS/DuckDuckGo/IPadOmnibarToolPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarToolPickerController.swift
@@ -88,9 +88,12 @@ final class IPadOmnibarToolPickerController {
         onToolsUpdated?()
     }
 
-    func resetSelection() {
-        guard toolsController.selectedTool != nil else { return }
+    func resetSelection(isUserInitiated: Bool = false) {
+        guard let previousTool = toolsController.selectedTool else { return }
         toolsController.clearSelection()
+        if isUserInitiated {
+            UnifiedToggleInputCoordinatorPixelHelper.fireToolDeselectedPixel(for: previousTool)
+        }
         onToolsUpdated?()
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1565,7 +1565,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     }
 
     private func fireModelSelectedPixel(modelId: String) {
-        Pixel.fire(pixel: .unifiedToggleInputModelSelected, withAdditionalParameters: ["model_id": modelId ])
+        UnifiedToggleInputCoordinatorPixelHelper.fireModelSelectedPixel(modelId: modelId)
     }
 
     private func fireReasoningEffortSelectedPixel(mode: AIChatReasoningMode) {
@@ -1573,15 +1573,11 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     }
 
     private func fireModelPickerShown() {
-        Pixel.fire(pixel: .unifiedToggleInputModelPickerShown, withAdditionalParameters: [
-            AttributionParameter.origin: UnifiedToggleInputCoordinatorPixelHelper.measurementOrigin(for: .modelPicker, isAITabState: isAITabState).rawValue
-        ])
+        UnifiedToggleInputCoordinatorPixelHelper.fireModelPickerShownPixel(isAITabState: isAITabState)
     }
 
     private func fireReasoningPickerShown() {
-        Pixel.fire(pixel: .unifiedToggleInputReasoningEffortPickerShown, withAdditionalParameters: [
-            AttributionParameter.origin: UnifiedToggleInputCoordinatorPixelHelper.measurementOrigin(for: .reasoningPicker, isAITabState: isAITabState).rawValue
-        ])
+        UnifiedToggleInputCoordinatorPixelHelper.fireReasoningPickerShownPixel(isAITabState: isAITabState)
     }
     
     private func requiredPublicTier(for mode: AIChatReasoningMode, model: AIChatModel) -> AIChatModelPublicAccessTier? {
@@ -1842,7 +1838,7 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
             switchBarSubmissionMetrics.process(text, for: .aiChat)
             processSessionActivity(mode: .aiChat)
             UnifiedToggleInputCoordinatorPixelHelper.fireUnifiedPromptSubmittedPixel(
-                text: text,
+                hasText: !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
                 selectedTool: toolsController.selectedTool,
                 attachments: viewController.currentAttachments,
                 reasoningMode: reasoningModeForSubmitPixel,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinatorPixelHelper.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinatorPixelHelper.swift
@@ -147,14 +147,13 @@ final class UnifiedToggleInputCoordinatorPixelHelper {
     }
 
     static func fireUnifiedPromptSubmittedPixel(
-        text: String,
+        hasText: Bool,
         selectedTool: AIChatRAGTool?,
         attachments: [UnifiedToggleInputAttachment],
         reasoningMode: AIChatReasoningMode?,
         modelId: String?
     ) {
         let selectedToolValue = UnifiedPromptSubmittedSelectedToolPixelValue(selectedTool: selectedTool).rawValue
-        let hasText = !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let reasoningEffort = reasoningMode?.rawValue ?? "none"
         let modelId = modelId ?? ""
 
@@ -173,6 +172,22 @@ final class UnifiedToggleInputCoordinatorPixelHelper {
 
     static func fireShowModelPickerPixel() {
         DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputShowModelPicker)
+    }
+
+    static func fireModelSelectedPixel(modelId: String) {
+        Pixel.fire(pixel: .unifiedToggleInputModelSelected, withAdditionalParameters: ["model_id": modelId])
+    }
+
+    static func fireModelPickerShownPixel(isAITabState: Bool) {
+        Pixel.fire(pixel: .unifiedToggleInputModelPickerShown, withAdditionalParameters: [
+            AttributionParameter.origin: measurementOrigin(for: .modelPicker, isAITabState: isAITabState).rawValue
+        ])
+    }
+
+    static func fireReasoningPickerShownPixel(isAITabState: Bool) {
+        Pixel.fire(pixel: .unifiedToggleInputReasoningEffortPickerShown, withAdditionalParameters: [
+            AttributionParameter.origin: measurementOrigin(for: .reasoningPicker, isAITabState: isAITabState).rawValue
+        ])
     }
 
     static func fireSubmitChangeModelPixel(modelId: String) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216447011980472?focus=true
Tech Design URL:
CC:

### Description
Adds pixels to the iPad Duck.ai bar controls (model, reasoning, tool, and attachment pickers, behind `iPadDuckAIBarControls`) so they reach parity with the iPhone unified toggle input. It reuses the existing `unifiedToggleInput*` pixels

### Testing Steps
1. On an iPad as an internal user with `iPadDuckAIBarControls` on, enter Duck.ai mode; open the model picker and pick a different model → `m_aichat_unified_input_model_picker_shown` and `m_aichat_unified_input_model_selected` fire (with `_ios_tablet` form factor).
2. Select a tool, attach an image and a file, then submit a prompt → tool-selected, image/file-attached, `m_aichat_unified_input_prompt_submitted`, and the tool-submitted pixel fire.
3. Clear the selected-tool badge (✕) and remove an attachment via its ✕ → the tool-deselected and attachment-removed pixels fire.
4. Validate no regression on iPhone pixels for UTI

### Impact and Risks
Low 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes behind the iPad bar-controls flag; iPhone paths mostly delegate to the same helper without altering submission behavior.
> 
> **Overview**
> **iPad Duck.ai omnibar** now emits the same `unifiedToggleInput*` analytics as iPhone’s unified toggle input when `iPadDuckAIBarControls` is on.
> 
> On prompt submit, the omnibar fires **`fireUnifiedPromptSubmittedPixel`** and **`fireToolSubmittedPixelIfNeeded`** with model, reasoning, tool, and attachment context. Model and reasoning menus use **`menuFiringShownPixel`** (`UIDeferredMenuElement`) so picker-shown pixels fire when those menus open. Model changes on iPad call **`fireModelSelectedPixel`** only when the selection actually changes.
> 
> User-driven clears are distinguished from programmatic resets: clearing the selected-tool badge passes **`isUserInitiated: true`** into **`resetSelection`** for **`fireToolDeselectedPixel`**, and attachment strip removals wire **`fireAttachmentRemovedPixel`** for user-initiated removes only.
> 
> **`UnifiedToggleInputCoordinatorPixelHelper`** gains shared helpers for model selected, model/reasoning picker shown, and **`fireUnifiedPromptSubmittedPixel`** now takes **`hasText`** instead of raw text (iPhone submit path updated the same way).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79fa9435cc825afc95e6f23e2ac446d5063069be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->