### PR TITLE
NavigationTests: prevent WebContent process accumulation causing flaky session-restoration test

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/NavigationTests/Helpers/DistributedNavigationDelegateTestsHelpers.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/NavigationTests/Helpers/DistributedNavigationDelegateTestsHelpers.swift
@@ -84,6 +84,11 @@ class DistributedNavigationDelegateTestsBase: XCTestCase {
             })
         }
         if let _webView {
+            if let navigationDelegateProxy {
+                let navigationDelegateProxyKey = UnsafeRawPointer(bitPattern: "navigationDelegateProxyKey".hashValue)!
+                objc_setAssociatedObject(_webView, navigationDelegateProxyKey, navigationDelegateProxy, .OBJC_ASSOCIATION_RETAIN)
+            }
+
             // Save the pool before releasing the webView so we can call
             // _terminateAllWebContentProcesses on it after the webView is gone.
             let processPool = _webView.configuration.processPool

--- a/SharedPackages/BrowserServicesKit/Tests/NavigationTests/Helpers/DistributedNavigationDelegateTestsHelpers.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/NavigationTests/Helpers/DistributedNavigationDelegateTestsHelpers.swift
@@ -30,6 +30,12 @@ class DistributedNavigationDelegateTestsBase: XCTestCase {
 
     let standardTimeout: TimeInterval = 15
 
+    // Counts how many tests have accumulated web content processes without a
+    // bulk termination.  We never kill the current test's process directly
+    // (avoids async IPC crash in resetStateAfterProcessTermination); instead
+    // we call _terminateAllWebContentProcesses on the pool once every ~10 tests.
+    private static var accumulatedWebViewCount = 0
+
     var navigationDelegateProxy: NavigationDelegateProxy!
 
     var navigationDelegate: DistributedNavigationDelegate { navigationDelegateProxy.delegate }
@@ -38,7 +44,6 @@ class DistributedNavigationDelegateTestsBase: XCTestCase {
     var currentHistoryItemIdentityCancellable: AnyCancellable!
     var history = [UInt64: HistoryItemIdentity]()
 
-    private static var webContentProcessPIDs = [pid_t]()
     var _webView: WKWebView!
     @discardableResult
     func withWebView<T>(testURLSchemeHandler: TestNavigationSchemeHandler? = nil, do block: (WKWebView) throws -> T) rethrows -> T {
@@ -79,21 +84,19 @@ class DistributedNavigationDelegateTestsBase: XCTestCase {
             })
         }
         if let _webView {
-            if let navigationDelegateProxy {
-                let navigationDelegateProxyKey = UnsafeRawPointer(bitPattern: "navigationDelegateProxyKey".hashValue)!
-                objc_setAssociatedObject(_webView, navigationDelegateProxyKey, navigationDelegateProxy, .OBJC_ASSOCIATION_RETAIN)
-            }
-            if let pid = _webView.pid {
-                Self.webContentProcessPIDs.append(pid)
-            }
-            if Self.webContentProcessPIDs.count > 10 {
-                while Self.webContentProcessPIDs.count > 5 {
-                    let pid = Self.webContentProcessPIDs.removeFirst()
-                    kill(pid, SIGTERM)
-                }
-            }
-            _webView.killWebContentProcess()
+            // Save the pool before releasing the webView so we can call
+            // _terminateAllWebContentProcesses on it after the webView is gone.
+            let processPool = _webView.configuration.processPool
+            // Nil the webView first: WebPageProxy.close() fires, removeWebPage()
+            // empties m_pageMap for this process.  Any subsequent IPC-close
+            // callback from _terminateAllWebContentProcesses finds no pages and
+            // returns early, never reaching resetStateAfterProcessTermination.
             self._webView = nil
+
+            if Self.accumulatedWebViewCount > 10 {
+                Self.accumulatedWebViewCount = 0
+                processPool.perform(Selector(("_terminateAllWebContentProcesses")))
+            }
         }
         navigationDelegateProxy = nil
         currentHistoryItemIdentityCancellable = nil
@@ -114,6 +117,8 @@ extension DistributedNavigationDelegateTestsBase {
     }
 
     func makeWebView(testURLSchemeHandler: TestNavigationSchemeHandler? = nil) -> WKWebView {
+        Self.accumulatedWebViewCount += 1
+
         let configuration = WKWebViewConfiguration()
         configuration.websiteDataStore = .nonPersistent()
         if let testURLSchemeHandler {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202406491309510/task/1206506154943201
Tech Design URL: N/A
CC: N/A

### Description
- Replace per-test `killWebContentProcess()` in `tearDown` with a bounded pool-level cleanup: every ~10 tests `_terminateAllWebContentProcesses` is called on the `WKProcessPool`, preventing unbounded WebContent process accumulation that was starving the test runner and causing `testWhenSessionIsRestored_navigationTypeIsSessionRestoration` to time out
- `_webView` is nil'd **before** the termination call so `WebPageProxy.close()` fires first, emptying `m_pageMap` for that process; any deferred IPC-close callback finds no live pages and returns early, avoiding `EXC_BAD_ACCESS` in `resetStateAfterProcessTermination`
- Counter is incremented in `makeWebView` and reset to zero after each bulk termination, keeping the pool bounded to ~10 processes at any time
- The `killWebContentProcess()` extension (`kill(pid, SIGTERM)`) is left untouched so termination-specific tests continue to work

### Testing Steps
- Validate CI is green

### Impact and Risks
**Impact Level: None**

#### What could go wrong?
- `_terminateAllWebContentProcesses` is a private WebKit API; it is already used broadly throughout WebKit's own test suite (`TestWebKitAPI`) for the same cleanup purpose, so breakage risk is low
- If the pool used by nonPersistent data-store webViews differs between tests, some orphan processes may escape the bulk kill — but the pool is recovered naturally by WebKit's own process count limits

### Quality Considerations
- Change is test infrastructure only; no production code is touched
- Avoids the previous approach of raw `kill(pid, SIGTERM)` on stale PIDs, which had a PID-reuse hazard and deferred IPC crash window

### Notes to Reviewer
The root cause was that each test accumulated a WebContent process in the pool cache (nonPersistent data-store), and the prior tearDown's direct `killWebContentProcess()` call triggered an async IPC close while the `WKWebView` was still alive, causing `resetStateAfterProcessTermination` to run against live page state. Nil-ing first + bulk-terminating old ones every 10 tests sidesteps both issues.

Made with [Cursor](https://cursor.com)