### PR TITLE
[iOS] Cookie Pop-up Protection opt-in dialog translations

### DIFF
--- a/.github/workflows/smartling.yml
+++ b/.github/workflows/smartling.yml
@@ -25,6 +25,11 @@ on:
         description: "Smartling job ID"
         required: false
         type: string
+      allow-unfinished:
+        description: "Allow downloading unfinished (non-COMPLETED) translations"
+        required: false
+        type: boolean
+        default: false
   pull_request:
     types: [labeled]
 
@@ -56,6 +61,7 @@ jobs:
           INPUT_PLATFORM: ${{ github.event.inputs.platform }}
           INPUT_ACTION: ${{ github.event.inputs.action }}
           INPUT_JOB_ID: ${{ github.event.inputs['job-id'] }}
+          INPUT_ALLOW_UNFINISHED: ${{ github.event.inputs['allow-unfinished'] }}
         run: |
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
             # Label trigger
@@ -80,6 +86,8 @@ jobs:
             fi
             echo "is_pr_trigger=true" >> $GITHUB_OUTPUT
             echo "branch=$HEAD_REF" >> $GITHUB_OUTPUT
+            # Label triggers never allow unfinished downloads
+            echo "allow_unfinished=false" >> $GITHUB_OUTPUT
           else
             # Manual workflow dispatch
             echo "platform=$INPUT_PLATFORM" >> $GITHUB_OUTPUT
@@ -87,6 +95,7 @@ jobs:
             echo "job_id=$INPUT_JOB_ID" >> $GITHUB_OUTPUT
             echo "is_pr_trigger=false" >> $GITHUB_OUTPUT
             echo "branch=$REF_NAME" >> $GITHUB_OUTPUT
+            echo "allow_unfinished=$INPUT_ALLOW_UNFINISHED" >> $GITHUB_OUTPUT
           fi
 
       - name: Assert not main or release branch
@@ -124,6 +133,7 @@ jobs:
           echo "PLATFORM=${{ steps.params.outputs.platform || steps.parse_comment.outputs.platform }}" >> $GITHUB_ENV
           echo "JOB_ID=${{ steps.params.outputs.job_id || steps.parse_comment.outputs.job_id }}" >> $GITHUB_ENV
           echo "BRANCH=${{ steps.params.outputs.branch }}" >> $GITHUB_ENV
+          echo "ALLOW_UNFINISHED=${{ steps.params.outputs.allow_unfinished }}" >> $GITHUB_ENV
           echo "WORKFLOW_URL=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}" >> $GITHUB_ENV
 
       - name: Set Smartling credentials
@@ -190,7 +200,7 @@ jobs:
         if: ${{ env.ACTION == 'download' }}
         id: download
         run: |
-          ./scripts/smartling/smartling_download.sh "$JOB_ID" "$PLATFORM"
+          ./scripts/smartling/smartling_download.sh "$JOB_ID" "$PLATFORM" "$ALLOW_UNFINISHED"
           cat download_message.txt >> $GITHUB_STEP_SUMMARY
 
       - name: Check Status and Update Labels

--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "83590c802b17708ff1dbc5df3e760fed809d90190bbdced50a6929247e9be35e",
+  "originHash" : "8e95463b1743b61b9696512cf002a29cc4979e7d17079884d0e515362fab23e9",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scinfu/SwiftSoup",
       "state" : {
-        "revision" : "49dcadd93161f4a44b4994d3a3e8de9f085aface",
-        "version" : "2.13.5"
+        "revision" : "ead56133a693d0184d8c2db1a6d6394410cacfd6",
+        "version" : "2.13.6"
       }
     },
     {

--- a/iOS/DuckDuckGo/Autoconsent/CookiePopupProtectionOptInView.swift
+++ b/iOS/DuckDuckGo/Autoconsent/CookiePopupProtectionOptInView.swift
@@ -132,7 +132,7 @@ struct CookiePopupProtectionOptInView: View {
 
                     HStack(spacing: 8) {
                         BadgeView(text: UserText.cookiePopupProtectionOptInBadge)
-                        Text(UserText.cookiePopupProtectionOptInHeader.uppercased())
+                        Text(verbatim: "DuckDuckGo".uppercased())
                             .font(.system(size: 13, weight: .semibold))
                             .tracking(0.6)
                             .foregroundColor(Color(designSystemColor: .textSecondary))

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -494,7 +494,6 @@ public struct UserText {
 
     // MARK: - Cookie Pop-up Protection Opt-In Dialog
     public static let cookiePopupProtectionOptInBadge = NSLocalizedString("cookie-popup-protection.opt-in.badge", value: "New", comment: "Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header")
-    public static let cookiePopupProtectionOptInHeader = NSLocalizedString("cookie-popup-protection.opt-in.header", value: "Cookie Pop-up Protection", comment: "Header of the Cookie Pop-up Protection opt-in dialog")
     public static let cookiePopupProtectionOptInConfirm = NSLocalizedString("cookie-popup-protection.opt-in.confirm", value: "Confirm", comment: "Confirm button in the Cookie Pop-up Protection opt-in dialog")
     public static let cookiePopupProtectionOptInFooter = NSLocalizedString("cookie-popup-protection.opt-in.footer", value: "You can always adjust later in\n**Settings** > **Cookie Pop-Up Protection**.", comment: "Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold.")
     // Variant shown when Cookie Pop-up Protection is already ON

--- a/iOS/DuckDuckGo/bg.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/bg.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Натиснете **Добавяне на управление** в долната част на екрана";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Ново";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Потвърждаване";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "Ще се стремим да избираме възможно най-поверителните опции за бисквитки и да ги затваряме вместо Вас. Ако няма опция за отказ от тях, ще Ви спестим едно кликване и ще приемем тези бисквитки вместо Вас.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Управление или приемане на бисквитки вместо мен";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Ще продължа да ги управлявам самостоятелно";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Омръзнаха ли Ви изскачащите прозорци за бисквитки, които не Ви оставят на мира?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "Можем да Ви спестим едно кликване и да приемем тези бисквитки вместо Вас.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Приемане на бисквитки без опция за отказ вместо мен";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Ще продължа да ги управлявам самостоятелно";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Омръзнаха ли Ви изскачащите прозорци за бисквитки без опция за отказ?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "Винаги можете да коригирате това по-късно в\n**Настройки** > **Защита от изскачащи прозорци за бисквитки**.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Винаги да се изпращат доклади за сривове";
 

--- a/iOS/DuckDuckGo/cs.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/cs.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Klepni na **Add a Control** [Přidat ovládací prvek] v dolní části obrazovky";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Novinka";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Potvrdit";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "Pokusíme se vybrat ty možnosti cookies, které nejlépe chrání soukromí, a okna za tebe zavřeme. Pokud možnost odmítnutí neexistuje, ušetříme ti kliknutí a tyto cookies za tebe přijmeme.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Spravovat nebo přijímat cookies za mě";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Budu je dál řešit já";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Už tě nebaví vyskakovací okna o cookies, která ti nedají pokoj?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "Můžeme ti ušetřit klikání a cookies přijímat za tebe.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Přijímat za mě cookies, které nelze odmítnout";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Budu je dál řešit já";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Štvou tě vyskakovací okna s cookies, která ti nedovolí je odmítnout?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "Později to můžeš kdykoli upravit v **Nastavení** > **Ochrana před vyskakovacími okny o cookies**.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Vždycky odesílat hlášení o selhání";
 

--- a/iOS/DuckDuckGo/da.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/da.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Tryk på **Tilføj en kontrol** nederst på skærmen";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Ny";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Bekræft";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "Vi vil forsøge at vælge de mest private cookieindstillinger og lukke disse for dig. Hvis de ikke har fravalgsmuligheder, sparer vi dig for et klik og accepterer disse cookies for dig.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Administrer eller accepter cookies for mig";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Jeg vil fortsætte med at håndtere dem selv";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Er du træt af pop op-vinduer om cookies, der ikke vil lade dig være i fred?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "Vi kan spare dig for et klik og acceptere disse cookies for dig.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Acceptér cookies uden fravalg for mig";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Jeg vil fortsætte med at håndtere dem selv";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Træt af cookie-pop-ups, der ikke lader dig fravælge?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "Du kan altid justere det senere i\n**Indstillinger** > **Beskyttelse mod pop op-beskeder om cookies**.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Send altid fejlrapporter";
 

--- a/iOS/DuckDuckGo/de.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/de.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Tippe unten auf dem Bildschirm auf **Steuerelement hinzufügen**";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Neu";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Bestätigen";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "Wir werden versuchen, die strengsten verfügbaren Cookie-Einstellungen auszuwählen und diese für dich zu deaktivieren. Falls es keine Opt-out-Möglichkeit gibt, ersparen wir dir einen Klick und akzeptieren diese Cookies für dich.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Verwalte oder akzeptiere Cookies für mich";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Ich kümmere mich weiter selbst darum";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Hast du genug von Cookie-Pop-ups, die dich nicht in Ruhe lassen?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "Wir können dir einen Klick ersparen und diese Cookies für dich akzeptieren.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Akzeptiere für mich Cookies, bei denen kein Opt-out möglich ist";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Ich kümmere mich weiter selbst darum";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Hast du genug von Cookie-Pop-ups, bei denen du dich nicht abmelden kannst?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "Du kannst das später jederzeit unter **Einstellungen** > **Cookie-Pop-up-Schutz** anpassen.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Absturzberichte immer senden";
 

--- a/iOS/DuckDuckGo/el.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/el.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Πάτησε **Προσθήκη ελέγχου** στο κάτω μέρος της οθόνης";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Νέο";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Επιβεβαίωση";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "Θα στοχεύσουμε στην επιλογή των πιο ιδιωτικών διαθέσιμων επιλογών cookie και θα τα κλείσουμε για εσένα. Εάν δεν έχουν εξαιρέσεις, θα σας γλιτώσουμε ένα κλικ και θα αποδεχτούμε αυτά τα cookie για εσάς.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Διαχειριστείτε ή αποδεχθείτε cookie για εμένα";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Θα συνεχίσω να τα διαχειρίζομαι εγώ προσωπικά";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Κουραστήκατε από τα αναδυόμενα παράθυρα για cookie που δεν σας αφήνουν σε ησυχία;";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "Μπορούμε να σας γλιτώσουμε ένα κλικ και να αποδεχτούμε αυτά τα cookie για εσάς.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Αποδοχή cookie χωρίς δυνατότητα εξαίρεσης για μένα";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Θα συνεχίσω να τα διαχειρίζομαι εγώ προσωπικά";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Κουραστήκατε από τα αναδυόμενα παράθυρα για cookie που δεν σας επιτρέπουν να εξαιρεθείτε;";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "Μπορείτε πάντα να κάνετε τις απαραίτητες ρυθμίσεις αργότερα\n **Ρυθμίσεις** > **Προστασία αναδυόμενων παραθύρων για cookie**.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Να αποστέλλονται πάντα αναφορές σφαλμάτων";
 

--- a/iOS/DuckDuckGo/en.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/en.lproj/Localizable.strings
@@ -1420,9 +1420,6 @@
 /* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
 "cookie-popup-protection.opt-in.footer" = "You can always adjust later in\n**Settings** > **Cookie Pop-Up Protection**.";
 
-/* Header of the Cookie Pop-up Protection opt-in dialog */
-"cookie-popup-protection.opt-in.header" = "Cookie Pop-up Protection";
-
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Always Send Crash Reports";
 

--- a/iOS/DuckDuckGo/es.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/es.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Toca **Añadir un control** en la parte inferior de la pantalla";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Nuevo";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Confirmar";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "Intentaremos seleccionar las opciones de cookies más privadas disponibles y cerrarlas por ti. Si no permiten rechazarlas, te ahorraremos un clic y aceptaremos estas cookies por ti.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Gestionar o aceptar las cookies por mí";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Seguiré gestionándolas por mi cuenta";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "¿Cansado de las ventanas emergentes de cookies que no te dejan en paz?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "Podemos ahorrarte un clic y aceptar estas cookies por ti.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Aceptar cookies sin opción de rechazarlas por mí";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Seguiré gestionándolas por mi cuenta";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "¿Cansado de las ventanas emergentes de cookies que no te dejan rechazarlas?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "Puedes ajustar esta configuración más tarde en \n**Ajustes** > **Protección contra ventanas emergentes de cookies**.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Enviar siempre informes de fallos";
 

--- a/iOS/DuckDuckGo/et.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/et.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Puuduta ekraani allosas nuppu **Lisa juhtelement**";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Uus";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Kinnita";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "Püüame valida kõige privaatsemad saadaolevad küpsisevalikud ja sulgeda need sinu eest. Kui neil pole loobumisvõimalust, säästame sulle ühe klõpsu ja nõustume nende küpsistega sinu eest.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Halda või nõustu küpsistega minu eest";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Ma jätkan nende haldamist ise";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Oled väsinud küpsiste hüpikakendest, mis ei jäta sind rahule?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "Saame säästa sind ühest klõpsust ja nõustuda nende küpsistega sinu eest.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Nõustu minu eest küpsistega, millest ei saa loobuda";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Ma jätkan nende haldamist ise";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Oled väsinud küpsiste hüpikakendest, mis ei lase sul neist keelduda?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "Saad seda hiljem alati muuta jaotises\n**Seaded** > **Küpsiste hüpikakna kaitse**.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Saada krahhiaruanded alati";
 

--- a/iOS/DuckDuckGo/fi.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fi.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Napauta **Lisää valvonta** näytön alareunasta.";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Uusi";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Vahvista";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "Pyrimme valitsemaan käytettävissä olevista evästeasetuksista ne, jotka takaavat parhaan yksityisyyden, ja ottamaan ne käyttöön puolestasi. Jos sivustolla ei ole mahdollisuutta kieltäytyä evästeistä, säästämme sinulta yhden klikkauksen ja hyväksymme nämä evästeet puolestasi.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Hallinnoi evästeitä puolestani tai hyväksy ne";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Hoidan ne jatkossakin itse";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Oletko kyllästynyt evästeponnahdusikkunoihin, jotka eivät jätä sinua rauhaan?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "Voimme säästää sinulta yhden klikkauksen ja hyväksyä nämä evästeet puolestasi.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Hyväksy puolestani evästeet, joista ei voi kieltäytyä";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Hoidan ne jatkossakin itse";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Oletko kyllästynyt evästeikkunoihin, joista ei voi kieltäytyä?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "Voit muuttaa tätä myöhemmin kohdassa\n**Asetukset** > **Evästeiden ponnahdusikkuna -suojaus**.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Lähetä aina virheraportit";
 

--- a/iOS/DuckDuckGo/fr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fr.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Appuyez sur **Ajouter un contrôle** en bas de l'écran";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Nouveau";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Confirmer";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "Nous nous efforcerons de sélectionner les options de cookies les plus respectueuses de la vie privée et de les désactiver pour vous. Si aucune option de désactivation n'est proposée, nous vous épargnerons un clic et accepterons ces cookies à votre place.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Gérer ou accepter les cookies à ma place";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Je les gérerai moi-même";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Vous en avez assez des fenêtres contextuelles sur les cookies qui ne vous laissent pas tranquille ?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "Nous pouvons vous épargner un clic et accepter ces cookies à votre place.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Accepter les cookies sans option de désactivation pour moi";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Je les gérerai moi-même";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Vous en avez assez des fenêtres contextuelles de cookies qui ne vous permettent pas de refuser leur utilisation ?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "Vous pouvez toujours modifier ces paramètres ultérieurement dans\n**Réglages** > **Protection contre les fenêtres contextuelles des cookies**.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Toujours envoyer des rapports de plantage";
 

--- a/iOS/DuckDuckGo/hr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hr.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Dodirni **Dodaj kontrolu** na dnu zaslona.";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Novo";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Potvrdi";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "Pokušat ćemo za tebe odabrati najprivatnije dostupne opcije kolačića i zatvoriti ih. Ako nemaju mogućnost isključivanja, uštedjet ćemo ti klik i umjesto tebe prihvatiti te kolačiće.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Upravljaj kolačićima ili ih prihvati umjesto mene";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Nastavit ću njima upravljati sam";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Umoran si od skočnih prozora kolačića koji te ne ostavljaju na miru?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "Možemo ti uštedjeti klik i prihvatiti ove kolačiće umjesto tebe.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Prihvati kolačiće bez mogućnosti isključivanja umjesto mene";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Nastavit ću njima upravljati sam";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Umoran si od skočnih prozora s kolačićima koji ti ne dopuštaju odjavu?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "To uvijek možeš prilagoditi kasnije opcijama\n**Postavke** > **Zaštita od skočnih prozora kolačića**.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Uvijek šalji izvješća o padu programa";
 

--- a/iOS/DuckDuckGo/hu.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hu.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Koppints a képernyő alján található **Vezérlő hozzáadása** gombra";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Új";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Megerősítés";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "Igyekszünk kiválasztani az elérhető legdiszkrétebb sütibeállításokat, és bezárni őket. Ha nincs lehetőség a leiratkozásra, egy kattintást megspórolva elfogadjuk helyetted ezeket a sütiket.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Sütik helyettem való kezelése, illetve elfogadása";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Továbbra is magam kezelem őket";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Eleged van már a folyton felugró sütiablakokból?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "Egy kattintást megspórolva elfogadhatjuk helyetted ezeket a sütiket.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Nem letiltható sütik helyettem való elfogadása";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Továbbra is magam kezelem őket";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Eleged van már a folyton felugró sütiablakokból, amelyek nem tilthatók le?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "Ezt később bármikor módosíthatod\na **Beállítások** > **Felugró sütiablak elleni védelem** alatt.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Mindig küldjön hibajelentést";
 

--- a/iOS/DuckDuckGo/it.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/it.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Tocca **Aggiungi un controllo** nella parte inferiore dello schermo";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Nuova";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Conferma";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "Cercheremo di selezionare le opzioni sui cookie più riservate disponibili e di chiuderle per te. Se non sono previste opzioni di rifiuto, ti risparmieremo un clic accettando i cookie al posto tuo.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Gestisci o accetta i cookie per me";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Continuerò a occuparmene io";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Non vuoi più vedere popup sui cookie che non ti lasciano in pace?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "Possiamo farti risparmiare un clic e accettare questi cookie per te.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Accetta per me i cookie che non prevedono il rifiuto";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Continuerò a occuparmene io";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Non vuoi più vedere pop-up sui cookie che non ti permettono di rifiutare?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "Puoi sempre modificare questa scelta in un secondo momento in\n**Impostazioni** > **Protezione pop-up dei cookie**.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Invia sempre segnalazioni di arresto anomalo";
 

--- a/iOS/DuckDuckGo/ja.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ja.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "画面下部の**コントロールを追加**をタップします";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "新規";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "確認";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "選択可能な中で最もプライバシー保護を強化したCookieオプションが選択され、ポップアップは自動的に閉じます。オプトアウトできないCookieは、ユーザーがクリックしなくても、自動的に受け入れられます。";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "自動的にCookieを管理し、同意する";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "自分で継続的に管理する";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "しつこいCookieポップアップにうんざりしていませんか？";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "クリックしなくても、Cookieオプションを受け入れることができます。";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "オプトアウトできないCookieを受け入れる";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "自分で継続的に管理する";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "オプトアウトできないCookieポップアップにうんざりしていませんか？";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "後からいつでも **設定** > **Cookieポップアップ保護** で調整できます。";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "クラッシュレポートを常に送信";
 

--- a/iOS/DuckDuckGo/lt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lt.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Ekrano apačioje bakstelėkite **Pridėti valdiklį**";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Naujas";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Patvirtinti";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "Stengsimės parinkti privačiausias galimas slapukų parinktis ir jas už jus uždaryti. Jei nėra atsisakymo parinkčių, sutaupysime jums paspaudimą ir priimsime šiuos slapukus už jus.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Tvarkyti arba priimti slapukus už mane";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Aš ir toliau juos tvarkysiu";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Ar pavargote nuo slapukų iškylančiųjų langų, kurie niekaip neduoda ramybės?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "Galime išlaisvinti jus nuo paspaudimo ir priimti šiuos slapukus už jus.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Priimti neatsisakomus slapukus už mane";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Aš ir toliau juos tvarkysiu";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Ar pavargote nuo slapukų iškylančiųjų langų, kurie neleidžia jų atsisakyti?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "Vėliau visada galite pakoreguoti nuėję \n**Nustatymai** > **Apsauga nuo slapukų iškylančiųjų langų**.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Visada siųsti strigčių ataskaitas";
 

--- a/iOS/DuckDuckGo/lv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lv.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Ekrāna apakšā pieskaries pogai **Pievienot vadīklu**";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "New";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Confirm";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "We'll aim to select the most private cookie options available and close these for you. If they don't have opt-outs, we'll save you a click and accept these cookies for you.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Manage or accept cookies for me";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "I'll keep handling them myself";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Tired of cookie pop-ups that won't leave you alone?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "We can save you a click and accept these cookies for you.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Accept no-opt-out cookies for me";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "I'll keep handling them myself";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Tired of cookie pop-ups that don't let you opt out?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "You can always adjust later in\n**Settings** > **Cookie Pop-Up Protection**.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Vienmēr sūtīt avārijas ziņojumus";
 

--- a/iOS/DuckDuckGo/nb.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nb.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Trykk på **Legg til en kontroll** nederst på skjermen";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Ny";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Bekreft";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "Vi prøver å velge de mest private alternativene for informasjonskapsler som er tilgjengelige, og lukker disse for deg. Hvis de ikke tilbyr muligheten til å reservere seg, sparer vi deg for et klikk ved å godta disse informasjonskapslene for deg.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Administrer eller godta informasjonskapsler for meg";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Jeg vil fortsette å håndtere dem selv";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Er du lei av popup-vinduer om informasjonskapsler?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "Vi kan spare deg for et klikk og godta disse kapslene for deg.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Godta informasjonskapsler som ikke gir muligheten til å reservere seg, for meg";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Jeg vil fortsette å håndtere dem selv";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Lei av popup-vinduer om informasjonskapsler som ikke gir deg muligheten til å reservere deg mot dem?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "Du kan når som helst gjøre endringer senere i\n**Innstillinger** > **Beskyttelse mot popup-vinduer om informasjonskapsler**.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Send alltid krasjrapporter";
 

--- a/iOS/DuckDuckGo/nl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nl.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Tik op **Een besturingselement toevoegen** onderaan het scherm";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Nieuw";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Bevestigen";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "We proberen de meest privacyvriendelijke cookie-opties te selecteren en deze voor je te sluiten. Als afmelden niet mogelijk is, besparen we je een klik en accepteren we deze cookies voor je.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Beheer of accepteer cookies voor mij";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Ik blijf ze zelf beheren";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Ben je de cookiepop-ups zat die je maar blijven lastigvallen?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "We kunnen je een klik besparen en deze cookies voor je accepteren.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Accepteer cookies zonder afmeldoptie voor me";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Ik blijf ze zelf beheren";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Ben je de cookiepop-ups zat waarbij je je niet kunt afmelden?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "Je kunt dit altijd later aanpassen in\n**Instellingen** > **Bescherming tegen cookiepop-ups**.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Crashrapporten altijd verzenden";
 

--- a/iOS/DuckDuckGo/pl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pl.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Stuknij **Dodaj kontrolkę** na dole ekranu";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Nowa";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Potwierdź";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "Postaramy się wybrać najbardziej prywatne dostępne opcje plików cookie i zamknąć je za Ciebie. Jeśli nie mają opcji rezygnacji, zaoszczędzimy Ci kliknięcia i zaakceptujemy te pliki cookie za Ciebie.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Zarządzaj plikami cookie lub zaakceptuj je za mnie";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Będę się nimi zajmować samodzielnie";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Masz dość wyskakujących okienek z informacją o plikach cookie, które nie dają ci spokoju?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "Możemy zaoszczędzić Ci kliknięcia i zaakceptować te pliki cookie za Ciebie.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Akceptuj za mnie pliki cookie niewymagające rezygnacji";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Będę się nimi zajmować samodzielnie";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Masz dość wyskakujących okienek z plikami cookie, z których nie możesz zrezygnować?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "Możesz to zawsze później zmienić, wybierając kolejno **Ustawienia** > **Ochrona przed wyskakującymi okienkami dotyczącymi plików cookie**.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Zawsze wysyłaj raporty o awariach";
 

--- a/iOS/DuckDuckGo/pt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pt.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Toca em **Adicionar um controlo** na parte inferior do ecrã";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Novo";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Confirmar";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "Vamos tentar selecionar as opções de cookies mais privadas disponíveis e fechá-las por ti. Se não tiverem opções de exclusão, vamos poupar-te um clique e aceitar estes cookies por ti.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Gerir ou aceitar cookies por mim";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Prefiro continuar eu a geri-los";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Cansado de pop-ups de cookies que não te deixam em paz?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "Podemos poupar-te um clique e aceitar estes cookies por ti.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Aceitar cookies sem opção de exclusão por mim";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Prefiro continuar eu a geri-los";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Cansado de pop-ups de cookies sem opção de exclusão?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "Podes sempre ajustar mais tarde em\n**Definições** > **Proteção contra pop-ups de cookies**.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Enviar sempre relatórios de falhas";
 

--- a/iOS/DuckDuckGo/ro.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ro.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Atinge **Adaugă un control** în partea de jos a ecranului";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Nou";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Confirmă";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "Vom încerca să selectăm cele mai private opțiuni disponibile privind modulele cookie și să le închidem pentru tine. Dacă nu au opțiuni de renunțare, te vom scuti de un click și vom accepta aceste module cookie pentru tine.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Gestionează sau acceptă modulele cookie pentru mine";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Le voi gestiona în continuare personal";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Te-ai săturat de ferestrele pop-up privind modulele cookie care nu îți dau pace?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "Te putem scuti de un click și putem accepta aceste module cookie pentru tine.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Accept modulele cookie fără opțiune de renunțare pentru mine";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Le voi gestiona în continuare personal";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Te-ai săturat de ferestrele pop-up cu module cookie care nu îți permit să renunți la ele?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "Poți oricând să modifici ulterior din\n**Setări** > **Protecție pentru ferestre pop-up aferente modulelor cookie**.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Trimite întotdeauna rapoarte de cădere";
 

--- a/iOS/DuckDuckGo/ru.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ru.lproj/Localizable.strings
@@ -1412,7 +1412,7 @@
 "control.center.widget.education.paragraph.3" = "Внизу экрана нажмите **Добавить элемент управления**.";
 
 /* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
-"cookie-popup-protection.opt-in.badge" = "Создать";
+"cookie-popup-protection.opt-in.badge" = "Новое";
 
 /* Confirm button in the Cookie Pop-up Protection opt-in dialog */
 "cookie-popup-protection.opt-in.confirm" = "Подтвердить";

--- a/iOS/DuckDuckGo/ru.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ru.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Внизу экрана нажмите **Добавить элемент управления**.";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Создать";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Подтвердить";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "Мы постараемся выбрать максимально конфиденциальные настройки файлов cookie и закроем эти окна за вас. Если во всплывающих окнах нет возможности отказаться от отслеживания, мы сэкономим ваше время и примем эти файлы cookie за вас.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Настраивать или принимать файлы cookie за меня";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Я продолжу управлять файлами cookie самостоятельно";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Устали от всплывающих окон с уведомлениями о файлах cookie, которые не дают вам покоя?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "Мы можем сэкономить вам время и примем эти файлы cookie за вас.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Принимать за меня файлы cookie, от которых нельзя отказаться";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Я продолжу управлять файлами cookie самостоятельно";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Устали от всплывающих окон с уведомлениями о файлах cookie, от которых вы не можете отказаться?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "Эту настройку всегда можно изменить позже в разделе\n**«Настройки»** > **«Защита от всплывающих окон cookie»**.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Всегда отправлять отчеты о сбоях";
 

--- a/iOS/DuckDuckGo/sk.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sk.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Ťukni na tlačidlo **Pridať ovládací prvok** v spodnej časti obrazovky";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Nové";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Potvrdiť";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "Budeme sa snažiť vybrať dostupné možnosti súborov cookie s najväčšou ochranou súkromia a zatvoríme ich za teba. Ak neponúkajú možnosť odmietnutia, ušetríme ti kliknutie a tieto súbory cookie za teba prijmeme.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Spravuj alebo prijmi súbory cookie za mňa";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Budem ich naďalej spravovať sám/sama";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Už ťa nebavia vyskakovacie okná o súboroch cookie, ktoré ti nedajú pokoj?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "Ušetríme ti kliknutie a tieto súbory cookie prijmeme za teba.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Prijímaj za mňa súbory cookie, ktoré nevyžadujú odhlásenie";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Budem ich naďalej spravovať sám/sama";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Už ťa unavujú vyskakovacie okná s cookies, ktoré ti neumožňujú nesúhlasiť?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "Neskôr to môžeš kedykoľvek upraviť v časti **Nastavenia** > **Ochrana proti automatickému otváraniu okien o súboroch cookie**.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Vždy odosielať správy o zlyhaní";
 

--- a/iOS/DuckDuckGo/sl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sl.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Tapnite **Dodaj kontrolnik** na dnu zaslona.";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Novo";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Potrdi";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "Poskušali bomo izbrati najbolj zasebne možnosti piškotkov, ki so na voljo, in jih zapreti namesto vas. Če nimajo možnosti zavrnitve, vam bomo prihranili klik in te piškotke sprejeli namesto vas.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Upravljaj ali sprejmi piškotke zame";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Upravljanje bom še naprej urejal/-a sam/-a";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Vas motijo pojavna okna za piškotke, ki vam ne dajo miru?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "Prihranimo vam lahko klik in te piškotke sprejmemo namesto vas.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Zame sprejmi piškotke brez možnosti zavrnitve";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Upravljanje bom še naprej urejal/-a sam/-a";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Ste naveličani pojavnih oken s piškotki, ki vam ne omogočajo, da jih zavrnete?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "To lahko pozneje kadar koli prilagodite v razdelku\n**Nastavitve** > **Zaščita pred pojavnimi okni piškotkov**.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Vedno pošlji poročila o zrušitvah";
 

--- a/iOS/DuckDuckGo/sv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sv.lproj/Localizable.strings
@@ -1430,7 +1430,7 @@
 "cookie-popup-protection.opt-in.disabled.title" = "Är du trött på att ständigt se popup-fönster för cookies?";
 
 /* Body of the opt-in dialog when cookie pop-up protection is already enabled */
-"cookie-popup-protection.opt-in.enabled.body" = "Vi kan spara dig ett klick och acceptera dessa cookies år dig.";
+"cookie-popup-protection.opt-in.enabled.body" = "Vi kan spara dig ett klick och acceptera dessa cookies åt dig.";
 
 /* Primary (recommended) option when cookie pop-up protection is already enabled */
 "cookie-popup-protection.opt-in.enabled.primary-option" = "Acceptera cookies som inte kan väljas bort åt mig";

--- a/iOS/DuckDuckGo/sv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sv.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Tryck på **Lägg till en kontroll** längst ned på skärmen";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Ny";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Bekräfta";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "Vi kommer att försöka välja de mest privata cookiealternativen som finns tillgängliga och stänga dessa åt dig. Om de inte har alternativ för att välja bort, sparar vi ett klick för dig och accepterar dessa cookies åt dig.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Hantera eller acceptera cookies åt mig";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Jag fortsätter att hantera dem själv";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Är du trött på att ständigt se popup-fönster för cookies?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "Vi kan spara dig ett klick och acceptera dessa cookies år dig.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Acceptera cookies som inte kan väljas bort åt mig";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Jag fortsätter att hantera dem själv";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Trött på popup-fönster för cookies som inte låter dig tacka nej?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "Du kan alltid justera det här senare i\n**Inställningar** > **Skydd mot popup-fönster för cookies**.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Skicka alltid kraschrapporter";
 

--- a/iOS/DuckDuckGo/tr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/tr.lproj/Localizable.strings
@@ -1411,6 +1411,39 @@
 /* Third paragraph of the Control Center Widget Education screen */
 "control.center.widget.education.paragraph.3" = "Ekranın en altındaki **Kontrol Ekle** seçeneğine dokunun";
 
+/* Small 'NEW' badge shown above the Cookie Pop-up Protection opt-in dialog header */
+"cookie-popup-protection.opt-in.badge" = "Yeni";
+
+/* Confirm button in the Cookie Pop-up Protection opt-in dialog */
+"cookie-popup-protection.opt-in.confirm" = "Onayla";
+
+/* Body of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.body" = "Mümkün olan en gizli çerez seçeneklerini belirlemeyi ve bunları sizin için kapatmayı hedefleyeceğiz. Devre dışı bırakma seçeneği yoksa, sizin için bu çerezleri otomatik olarak kabul edeceğiz.";
+
+/* Primary (recommended) option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.primary-option" = "Çerezleri benim için yönet veya kabul et";
+
+/* Secondary option when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.secondary-option" = "Bunları kendim yönetmeye devam edeceğim";
+
+/* Title of the opt-in dialog when cookie pop-up protection is off */
+"cookie-popup-protection.opt-in.disabled.title" = "Sizi rahat bırakmayan çerez bildirimlerinden bıktınız mı?";
+
+/* Body of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.body" = "Sizi bir tıklama zahmetinden kurtarıp bu çerezleri sizin yerinize kabul edebiliriz.";
+
+/* Primary (recommended) option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.primary-option" = "Devre dışı bırakılamayan çerezleri benim için kabul et";
+
+/* Secondary option when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.secondary-option" = "Bunları kendim yönetmeye devam edeceğim";
+
+/* Title of the opt-in dialog when cookie pop-up protection is already enabled */
+"cookie-popup-protection.opt-in.enabled.title" = "Çıkış yapmana izin vermeyen çerez açılır pencerelerinden bıktın mı?";
+
+/* Footer text in the Cookie Pop-up Protection opt-in dialog. The text between ** ** is rendered bold. */
+"cookie-popup-protection.opt-in.footer" = "Bunu daha sonra **Ayarlar** > **Çerez Açılır Pencere Engelleyici** kısmından her zaman değiştirebilirsiniz.";
+
 /* Crash Report always send button title */
 "crash.report.dialog.always.send" = "Kilitlenme Raporlarını Her Zaman Gönder";
 

--- a/scripts/smartling/loc_tool.sh
+++ b/scripts/smartling/loc_tool.sh
@@ -102,18 +102,21 @@ case "$cmd" in
 	download)
 		JOB_ID=$(parse_job_id "$@")
 
-		# Parse optional output directory
+		# Parse optional output directory and allow-unfinished flag
 		OUT_DIR=""
 		if [ "${3:-}" = "--out-dir" ] && [ -n "${4:-}" ]; then
 			OUT_DIR="$4"
 		fi
+		ALLOW_UNFINISHED=""
+		for arg in "$@"; do
+			[ "$arg" = "--allow-unfinished" ] && ALLOW_UNFINISHED="--allow-unfinished"
+		done
 
 		# Run download
-		if [ -n "$OUT_DIR" ]; then
-			python3 "$PYTHON_TOOL" download --job-id "$JOB_ID" --out-dir "$OUT_DIR"
-		else
-			python3 "$PYTHON_TOOL" download --job-id "$JOB_ID"
-		fi
+		DOWNLOAD_ARGS=(download --job-id "$JOB_ID")
+		[ -n "$OUT_DIR" ] && DOWNLOAD_ARGS+=(--out-dir "$OUT_DIR")
+		[ -n "$ALLOW_UNFINISHED" ] && DOWNLOAD_ARGS+=("$ALLOW_UNFINISHED")
+		python3 "$PYTHON_TOOL" "${DOWNLOAD_ARGS[@]}"
 		;;
 	*)
 		usage; exit 1;;

--- a/scripts/smartling/localization_tool.py
+++ b/scripts/smartling/localization_tool.py
@@ -313,9 +313,11 @@ async def download_command(args):
         print(f"📊 Status: {job['jobStatus']}")
 
         if job['jobStatus'] != "COMPLETED":
-            print("DOWNLOADED=0")
-            print(f"⚠️  Job not completed (status: {job['jobStatus']})")
-            return
+            if not args.allow_unfinished:
+                print("DOWNLOADED=0")
+                print(f"⚠️  Job not completed (status: {job['jobStatus']})")
+                return
+            print(f"⚠️  Job not completed (status: {job['jobStatus']}), downloading anyway (--allow-unfinished)")
 
         file_uris = await client.get_job_files(args.job_id)
         if not file_uris:
@@ -375,6 +377,8 @@ def main():
     download_parser = subparsers.add_parser('download')
     download_parser.add_argument('--job-id', required=True)
     download_parser.add_argument('--out-dir', default='./downloads')
+    download_parser.add_argument('--allow-unfinished', action='store_true',
+                                 help='Download even if the job is not COMPLETED (defaults to False)')
 
     args = parser.parse_args()
     if not args.command:

--- a/scripts/smartling/smartling_download.sh
+++ b/scripts/smartling/smartling_download.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 JOB_ID="$1"
 PLATFORM="$2"
+ALLOW_UNFINISHED="${3:-false}"
 
 if [ -z "$JOB_ID" ]; then
 	echo "Error: Job ID is required"
@@ -28,8 +29,13 @@ DOWNLOAD_DIR="$(mktemp -d)/smartling_downloads"
 mkdir -p "$DOWNLOAD_DIR"
 
 # Download translated files
+ALLOW_FLAG=""
+if [ "$ALLOW_UNFINISHED" = "true" ]; then
+	echo "⚠️  allow-unfinished enabled: downloading even if the Smartling job is not COMPLETED"
+	ALLOW_FLAG="--allow-unfinished"
+fi
 echo "Downloading translations from Smartling job $JOB_ID..."
-./scripts/smartling/loc_tool.sh download --job-id "$JOB_ID" --out-dir "$DOWNLOAD_DIR" || download_failed=1
+./scripts/smartling/loc_tool.sh download --job-id "$JOB_ID" --out-dir "$DOWNLOAD_DIR" $ALLOW_FLAG || download_failed=1
 
 # Handle download failure gracefully and set step outputs
 if [ "${download_failed:-0}" = "1" ]; then


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216386097324617
Tech Design URL: N/A
CC:

### Description
Adds localized translations for the Cookie Pop-up Protection opt-in dialog across ~24 languages, sets the dialog header to a static uppercased "DuckDuckGo", and adds an `allow-unfinished` option to the Smartling download workflow so a maintainer can manually pull translations from a not-yet-`COMPLETED` job (defaults to off; label-triggered downloads stay `COMPLETED`-only).

### Testing Steps
1. In a non-English locale, trigger the CPM opt-in dialog and confirm the title/options/body are localized and the header reads "DUCKDUCKGO".
2. (Tooling) Run the Smartling workflow via manual dispatch with `allow-unfinished` enabled against an in-progress job; confirm it downloads instead of reporting "no changes". With it disabled, confirm the `COMPLETED` gate still holds.

### Impact and Risks
Low — user-facing translations plus a static header string; the Smartling change is internal CI tooling.

#### What could go wrong?
Mistranslated or misaligned strings in a locale; mitigated by vendor translation and the workflow's existing integrity check. The `allow-unfinished` path can import partial/source-fallback strings, but only via deliberate manual dispatch (off by default, unreachable from the label flow).

### Quality Considerations
Translations only add keys for the new dialog; no logic changes. The tooling flag is off by default and cannot be triggered from the label flow.

### Notes to Reviewer
The Smartling `allow-unfinished` tooling change rides along on this branch — let me know if you'd prefer it split into its own PR.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly strings and CI tooling; the unfinished-download path can land partial translations but is off by default and blocked for label-triggered runs.
> 
> **Overview**
> Ships **Cookie Pop-up Protection opt-in** copy in many iOS `Localizable.strings` locales and drops the localized `cookie-popup-protection.opt-in.header` key in favor of a fixed uppercased **DUCKDUCKGO** label in `CookiePopupProtectionOptInView` (via `Text(verbatim:)`).
> 
> Extends the **Smartling** GitHub workflow and download scripts with an optional **`allow-unfinished`** flag (manual `workflow_dispatch` only; PR label downloads still require a `COMPLETED` job) so maintainers can pull in-progress translations. Also bumps **SwiftSoup** in `Package.resolved` (2.13.5 → 2.13.6).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cb43d6ce1dfec1a600163603075f081d2dd7dfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->