### PR TITLE
iOS: Fix tab switcher Done button width in floating UI

### DIFF
--- a/iOS/DuckDuckGo/BrowserChromeButton.swift
+++ b/iOS/DuckDuckGo/BrowserChromeButton.swift
@@ -241,6 +241,9 @@ extension BrowserChromeButton {
         let button = BrowserChromeButton(.toolbar)
         if let image {
             button.setImage(image)
+        } else {
+            // Text buttons (no icon) render `title` as their visible label; icon buttons use it only for accessibility.
+            button.setTitle(title, for: .normal)
         }
 
         if let action {

--- a/iOS/DuckDuckGo/BrowserChromeButton.swift
+++ b/iOS/DuckDuckGo/BrowserChromeButton.swift
@@ -237,7 +237,7 @@ private extension UIButton.Configuration {
 
 extension BrowserChromeButton {
 
-    static func createToolbarButton(title: String, image: UIImage?, action: (() -> Void)? = nil) -> BrowserChromeButton {
+    static func createToolbarButton(title: String, image: UIImage?, fixedWidth: CGFloat? = 34, action: (() -> Void)? = nil) -> BrowserChromeButton {
         let button = BrowserChromeButton(.toolbar)
         if let image {
             button.setImage(image)
@@ -251,16 +251,17 @@ extension BrowserChromeButton {
 
         button.accessibilityLabel = title
         button.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            button.widthAnchor.constraint(equalToConstant: 34),
-            button.heightAnchor.constraint(equalToConstant: 44),
-        ])
+        button.heightAnchor.constraint(equalToConstant: 44).isActive = true
+        // Icon buttons use a fixed width; text buttons pass nil and size to their title (see applyTextConstraints).
+        if let fixedWidth {
+            button.widthAnchor.constraint(equalToConstant: fixedWidth).isActive = true
+        }
 
         return button
     }
 
-    static func createToolbarButtonItem(title: String, image: UIImage?, action: (() -> Void)? = nil) -> UIBarButtonItem {
-        let button = createToolbarButton(title: title, image: image, action: action)
+    static func createToolbarButtonItem(title: String, image: UIImage?, fixedWidth: CGFloat? = 34, action: (() -> Void)? = nil) -> UIBarButtonItem {
+        let button = createToolbarButton(title: title, image: image, fixedWidth: fixedWidth, action: action)
 
         let barItem = UIBarButtonItem(customView: button)
 

--- a/iOS/DuckDuckGo/TabSwitcherBarsStateHandler.swift
+++ b/iOS/DuckDuckGo/TabSwitcherBarsStateHandler.swift
@@ -112,7 +112,6 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
         let item = BrowserChromeButton.createToolbarButtonItem(title: UserText.navigationTitleDone, image: nil, fixedWidth: nil) { [weak self] in
             self?.onDoneButtonTapped?()
         }
-        (item.customView as? BrowserChromeButton)?.setTitle(UserText.navigationTitleDone, for: .normal)
         Self.applyTextConstraints(to: item)
         return item
     }()

--- a/iOS/DuckDuckGo/TabSwitcherBarsStateHandler.swift
+++ b/iOS/DuckDuckGo/TabSwitcherBarsStateHandler.swift
@@ -109,7 +109,7 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
     }()
 
     lazy var doneTextButton: UIBarButtonItem = {
-        let item = BrowserChromeButton.createToolbarButtonItem(title: UserText.navigationTitleDone, image: nil) { [weak self] in
+        let item = BrowserChromeButton.createToolbarButtonItem(title: UserText.navigationTitleDone, image: nil, fixedWidth: nil) { [weak self] in
             self?.onDoneButtonTapped?()
         }
         (item.customView as? BrowserChromeButton)?.setTitle(UserText.navigationTitleDone, for: .normal)
@@ -143,7 +143,7 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
     }()
 
     lazy var selectAllButton: UIBarButtonItem = {
-        let item = BrowserChromeButton.createToolbarButtonItem(title: UserText.selectAllTabs, image: nil) { [weak self] in
+        let item = BrowserChromeButton.createToolbarButtonItem(title: UserText.selectAllTabs, image: nil, fixedWidth: nil) { [weak self] in
             self?.onSelectAllTapped?()
         }
         Self.applyTextConstraints(to: item)
@@ -151,7 +151,7 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
     }()
 
     lazy var deselectAllButton: UIBarButtonItem = {
-        let item = BrowserChromeButton.createToolbarButtonItem(title: UserText.deselectAllTabs, image: nil) { [weak self] in
+        let item = BrowserChromeButton.createToolbarButtonItem(title: UserText.deselectAllTabs, image: nil, fixedWidth: nil) { [weak self] in
             self?.onDeselectAllTapped?()
         }
         Self.applyTextConstraints(to: item)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1216450665288210?focus=true

Tech Design URL:
CC: @jaceklyp 

### Description
In tab switcher, the "Done" button rendered too narrow and wrapped its title vertically, caused by recent width constraint added. This adds an option in the factory method to fix the size or skip the width constraint.

### Testing Steps
1. Open the tab switcher on an iPad or large layout (where the text "Done" button is shown).
2. Verify the "Done" button shows the full word on one line, not wrapped or truncated.
3. Enter multi-select/edit mode, verify "Select All" / "Deselect All" text buttons also size to their titles.
4. Verify all icon buttons (new tab, fire, menu, grid/list toggle, Duck.ai) keep their normal 34pt width and alignment.

### Impact and Risks
Low. Layout-only change to toolbar button sizing, scoped to `BrowserChromeButton` and the tab switcher bar handler.

#### What could go wrong?
- Other BrowserChromeButton instances with broken layout. Should not happen, since it falls back to previous default.
- Text button instance too wide.

### Quality Considerations
— 

### Notes to Reviewer
— 

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only change with default 34pt width preserved for existing icon toolbar buttons; only explicit nil fixedWidth callers change sizing.
> 
> **Overview**
> Fixes **Done** and other label-only tab switcher toolbar buttons being squeezed to **34pt** (title wrapping vertically) after a fixed width was applied to all `BrowserChromeButton` toolbar items.
> 
> `createToolbarButton` / `createToolbarButtonItem` now take an optional **`fixedWidth`** (default **34** for icon buttons). Width is constrained only when that value is set; **nil** lets the button grow with its title. Icon-less buttons also get **`setTitle`** in the factory so callers don’t duplicate that setup.
> 
> **Done**, **Select All**, and **Deselect All** in `TabSwitcherBarsStateHandler` pass **`fixedWidth: nil`** and rely on existing `applyTextConstraints` for a minimum touch target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00ef80b8c9629b753e5ce5589a27128283deddef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->