### PR TITLE
Fix ConfigurationStore data race causing loadData crash (Sentry 713934)

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Configuration/ConfigurationFetching.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Configuration/ConfigurationFetching.swift
@@ -39,7 +39,7 @@ public final class ConfigurationFetcher: ConfigurationFetching {
 
     }
 
-    private var store: ConfigurationStoring
+    private let store: ConfigurationStoring
     private let validator: ConfigurationValidating
     private let configurationURLProvider: ConfigurationURLProviding
     private let sessionProvider: () -> URLSession

--- a/SharedPackages/BrowserServicesKit/Sources/Configuration/ConfigurationStoring.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Configuration/ConfigurationStoring.swift
@@ -24,8 +24,8 @@ public protocol ConfigurationStoring {
     func loadEtag(for configuration: Configuration) -> String?
     func loadEmbeddedEtag(for configuration: Configuration) -> String?
 
-    mutating func saveData(_ data: Data, for configuration: Configuration) throws
-    mutating func saveEtag(_ etag: String, for configuration: Configuration) throws
+    func saveData(_ data: Data, for configuration: Configuration) throws
+    func saveEtag(_ etag: String, for configuration: Configuration) throws
 
     func fileUrl(for configuration: Configuration) -> URL
 

--- a/SharedPackages/BrowserServicesKit/Tests/ConfigurationTests/ConfigurationFetcherTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/ConfigurationTests/ConfigurationFetcherTests.swift
@@ -386,4 +386,97 @@ final class ConfigurationFetcherTests: XCTestCase {
         XCTAssertEqual(MockURLProtocol.lastRequest?.url, expectedURL)
     }
 
+    // MARK: - Concurrency
+
+    // Regression for the ConfigurationStore.loadData use-after-free (Sentry 713934): concurrent
+    // fetches on one fetcher must not race on `store`. Under TSan this fails pre-fix, passes after.
+    func testConcurrentFetchesOnSharedFetcherDoNotRaceOnStore() async {
+        let sessionConfiguration = URLSessionConfiguration.ephemeral
+        sessionConfiguration.protocolClasses = [CannedURLProtocol.self]
+        let store = BoxedExistentialConfigurationStore(backing: LockedConfigurationBacking())
+        let fetcher = ConfigurationFetcher(store: store,
+                                           validator: NoopConfigurationValidator(),
+                                           sessionProvider: { URLSession(configuration: sessionConfiguration) },
+                                           configurationURLProvider: StaticConfigurationURLProvider())
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<500 {
+                group.addTask { try? await fetcher.fetch(.privacyConfiguration) }
+            }
+        }
+
+        XCTAssertEqual(store.loadData(for: .privacyConfiguration), CannedURLProtocol.responseData)
+        XCTAssertEqual(store.loadEtag(for: .privacyConfiguration), CannedURLProtocol.etag)
+    }
+
+}
+
+private struct StaticConfigurationURLProvider: ConfigurationURLProviding {
+    let endpoint = URL(string: "https://config.test.example")!
+    func url(for configuration: Configuration) -> URL { endpoint }
+}
+
+private struct NoopConfigurationValidator: ConfigurationValidating {
+    func validate(_ data: Data, for configuration: Configuration) throws {}
+}
+
+// Returns a fixed response with no shared mutable state, so concurrent requests can't race here.
+private final class CannedURLProtocol: URLProtocol {
+    static let responseData = Data("canned-config".utf8)
+    static let etag = "canned-etag"
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil,
+                                       headerFields: ["Etag": Self.etag])!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Self.responseData)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+// Non-class protocol so the conforming struct is heap-boxed (like the real ConfigurationStore).
+private protocol ConfigurationBacking {
+    func loadData(for configuration: Configuration) -> Data?
+    func save(_ data: Data, for configuration: Configuration)
+    func loadEtag(for configuration: Configuration) -> String?
+    func saveEtag(_ etag: String, for configuration: Configuration)
+}
+
+private final class LockedConfigurationBacking: ConfigurationBacking {
+    private let lock = NSLock()
+    private var data: [Configuration: Data] = [:]
+    private var etags: [Configuration: String] = [:]
+
+    func loadData(for configuration: Configuration) -> Data? {
+        lock.lock(); defer { lock.unlock() }
+        return data[configuration]
+    }
+    func save(_ data: Data, for configuration: Configuration) {
+        lock.lock(); defer { lock.unlock() }
+        self.data[configuration] = data
+    }
+    func loadEtag(for configuration: Configuration) -> String? {
+        lock.lock(); defer { lock.unlock() }
+        return etags[configuration]
+    }
+    func saveEtag(_ etag: String, for configuration: Configuration) {
+        lock.lock(); defer { lock.unlock() }
+        etags[configuration] = etag
+    }
+}
+
+private struct BoxedExistentialConfigurationStore: ConfigurationStoring {
+    let backing: ConfigurationBacking
+
+    func loadData(for configuration: Configuration) -> Data? { backing.loadData(for: configuration) }
+    func loadEtag(for configuration: Configuration) -> String? { backing.loadEtag(for: configuration) }
+    func loadEmbeddedEtag(for configuration: Configuration) -> String? { nil }
+    func saveData(_ data: Data, for configuration: Configuration) throws { backing.save(data, for: configuration) }
+    func saveEtag(_ etag: String, for configuration: Configuration) throws { backing.saveEtag(etag, for: configuration) }
+    func fileUrl(for configuration: Configuration) -> URL { URL(fileURLWithPath: "/dev/null") }
 }

--- a/iOS/DuckDuckGo/Configuration/ConfigurationStore.swift
+++ b/iOS/DuckDuckGo/Configuration/ConfigurationStore.swift
@@ -47,11 +47,11 @@ struct ConfigurationStore: ConfigurationStoring {
         }
     }
     
-    mutating func saveData(_ data: Data, for configuration: Configuration) throws {
+    func saveData(_ data: Data, for configuration: Configuration) throws {
         try fileStore.persist(data, for: configuration)
     }
-    
-    mutating func saveEtag(_ etag: String, for configuration: Configuration) throws {
+
+    func saveEtag(_ etag: String, for configuration: Configuration) throws {
         etagStorage.saveEtag(etag, for: configuration)
     }
 

--- a/iOS/PacketTunnelProvider/NetworkProtection/ConfigurationStore.swift
+++ b/iOS/PacketTunnelProvider/NetworkProtection/ConfigurationStore.swift
@@ -29,7 +29,7 @@ struct ConfigurationStore: ConfigurationStoring {
         case unsupportedConfig
     }
 
-    private var defaults: KeyValueStoring
+    private let defaults: KeyValueStoring
 
     private var privacyConfigurationEtagKey: String {
         return "privacyConfiguration"
@@ -38,7 +38,7 @@ struct ConfigurationStore: ConfigurationStoring {
         get {
             defaults.object(forKey: privacyConfigurationEtagKey) as? String
         }
-        set {
+        nonmutating set {
             defaults.set(newValue, forKey: privacyConfigurationEtagKey)
         }
     }
@@ -87,7 +87,7 @@ struct ConfigurationStore: ConfigurationStoring {
         return AppPrivacyConfigurationDataProvider.Constants.embeddedDataETag
     }
     
-    mutating func saveData(_ data: Data, for configuration: Configuration) throws {
+    func saveData(_ data: Data, for configuration: Configuration) throws {
         guard configuration == .privacyConfiguration else { throw Error.unsupportedConfig }
         let file = fileUrl(for: configuration)
         var coordinatorError: NSError?
@@ -105,7 +105,7 @@ struct ConfigurationStore: ConfigurationStoring {
         }
     }
     
-    mutating func saveEtag(_ etag: String, for configuration: Configuration) throws {
+    func saveEtag(_ etag: String, for configuration: Configuration) throws {
         guard configuration == .privacyConfiguration else { throw Error.unsupportedConfig }
 
         privacyConfigurationEtag = etag

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/DataBrokerProtectionAgentManagerTests.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/DataBrokerProtectionAgentManagerTests.swift
@@ -765,11 +765,11 @@ struct MockConfigurationStore: ConfigurationStoring {
         return nil
     }
 
-    mutating func saveData(_ data: Data, for configuration: Configuration) throws {
+    func saveData(_ data: Data, for configuration: Configuration) throws {
         return
     }
 
-    mutating func saveEtag(_ etag: String, for configuration: Configuration) throws {
+    func saveEtag(_ etag: String, for configuration: Configuration) throws {
         return
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211737940275488/task/1213468073551980

### Description
Fixes a recurring background-thread crash (EXC_BAD_ACCESS / SIGSEGV) that surfaces during configuration and remote-message refresh (Sentry 713934). The shared configuration store was reached from several concurrent refreshes without synchronization. Because the store value is heap-boxed, a copy-on-write reassignment of the store handle raced across threads and freed memory that was still referenced, so a later read faulted.

The store's "save" operations never actually mutate in-memory state — they write to files and UserDefaults, which are already thread-safe. The fix removes the spurious mutability so the store handle is immutable and only ever read concurrently, eliminating the race at its root with no behaviour change.

### Testing Steps
This is a concurrency crash with no reliable manual reproduction; it is verified with automated tests:
1. Build the iOS app → succeeds.
2. Run BrowserServicesKit `ConfigurationTests` → all pass (96/96).
3. Run the new `testConcurrentFetchesOnSharedFetcherDoNotRaceOnStore` under Thread Sanitizer → passes clean. Temporarily reverting the fix makes the same test fail with a TSan "Swift access race" report and abort, confirming it catches the regression.

### Impact
Medium–High: removes a production crash occurring on background configuration / remote-message refresh (spikes on RMF rollouts). If the fix were somehow wrong, the only affected behaviour would be config persistence — but writes still go through the same thread-safe file / UserDefaults path as before, unchanged.

#### What could go wrong?
Relaxing the store's save methods to non-mutating could break a conformer that relied on struct mutation → none do (every conformer writes to reference-backed file/UserDefaults storage); verified by building iOS + all conformers and running the Configuration suite.

### Quality Considerations
Concurrency: the configuration layer now relies on immutable handles plus already-thread-safe sinks (NSFileCoordinator, UserDefaults). Benign last-writer-wins on concurrent same-config writes is unchanged (coordinated writes, no corruption). No privacy or data-loss impact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared configuration fetch/persist paths used during background privacy-config and remote-message refresh; persistence still goes through the same file/UserDefaults/NSFileCoordinator sinks, but incorrect API adoption could break a conformer that relied on in-struct mutation.
> 
> **Overview**
> Fixes a **background crash** from concurrent configuration refreshes racing on a heap-boxed `ConfigurationStoring` handle when `mutating` save methods triggered copy-on-write reassignment while other threads still read the store.
> 
> **`ConfigurationStoring`** drops `mutating` on `saveData` / `saveEtag` so saves are non-mutating at the protocol level; **`ConfigurationFetcher`** holds `store` as `let` instead of `var`. iOS app, VPN packet tunnel, and test mocks adopt the same API. VPN tunnel store uses `nonmutating set` on the etag property and `let` for `defaults` so etag writes no longer imply struct mutation.
> 
> Adds **`testConcurrentFetchesOnSharedFetcherDoNotRaceOnStore`** (500 parallel fetches, boxed existential store, TSan regression for Sentry 713934).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4804efee72924c9ffe1104dc133991530014e3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->