### PR TITLE
macOS: Route Duck.ai image generation to an image-capable model

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -497,7 +497,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     }
 
     private var isImageGenerationItemVisible: Bool {
-        omnibarController.isImageGenerationEnabled
+        omnibarController.isImageGenerationEnabled && omnibarController.selectedModelSupportsImageGeneration
     }
 
     private var isWebSearchItemVisible: Bool {
@@ -1106,7 +1106,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         let menu = NSMenu()
         menu.autoenablesItems = false
 
-        if omnibarController.isImageGenerationEnabled {
+        if isImageGenerationItemVisible {
             let createImageItem = NSMenuItem()
             createImageItem.attributedTitle = toolsMenuItemAttributedTitle(
                 title: UserText.aiChatImageGenButtonLabel,

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -310,6 +310,7 @@ final class AIChatOmnibarController {
                 self.clearStaleModelSelectionIfNeeded()
                 self.clearStaleReasoningEffortIfNeeded()
                 self.deactivateWebSearchIfUnsupported()
+                self.deactivateImageGenerationIfUnsupported()
             } catch is CancellationError {
                 return
             } catch {
@@ -423,6 +424,14 @@ final class AIChatOmnibarController {
     var selectedModelSupportsWebSearch: Bool {
         guard !models.isEmpty else { return true }
         return models.first(where: { $0.id == persistedModelId })?.supportsTool(.webSearch) ?? true
+    }
+
+    /// Whether the currently selected model supports the GenerateImage tool.
+    /// Returns true when models are unavailable (conservative default — Create Image menu item
+    /// remains visible until the model list is known).
+    var selectedModelSupportsImageGeneration: Bool {
+        guard !models.isEmpty else { return true }
+        return models.first(where: { $0.id == persistedModelId })?.supportsTool(.imageGeneration) ?? true
     }
 
     /// Image formats supported by the currently selected model (e.g. ["png", "jpeg", "webp"]).
@@ -558,20 +567,39 @@ final class AIChatOmnibarController {
         preferences.selectedReasoningEffort = effort?.rawValue
     }
 
-    /// The model ID to use for the current submission.
-    /// Returns nil when image generation mode is active — the mode field handles routing.
+    /// The model used for image-generation submissions: the selected model when it supports
+    /// GenerateImage, otherwise the first accessible model that does. `nil` while models
+    /// haven't loaded (or none supports the tool).
+    ///
+    /// Resolving the model natively matters: a handoff without `modelId` makes the duck.ai
+    /// page fall back to its own saved model, which may not support image generation (e.g.
+    /// Mistral) — the chat then starts on that model and no image is produced.
+    var imageGenerationModel: AIChatModel? {
+        if let selectedModel, selectedModel.supportsTool(.imageGeneration) {
+            return selectedModel
+        }
+        return models.first(where: { $0.entityHasAccess && $0.supportsTool(.imageGeneration) })
+    }
+
+    /// The model ID to use for the current submission. In image-generation mode an
+    /// image-capable model is sent explicitly, matching iOS.
     var effectiveModelId: String? {
-        isImageGenerationMode ? nil : currentModelId
+        isImageGenerationMode ? imageGenerationModel?.id : currentModelId
     }
 
-    /// The mode to include in the prompt payload (e.g., "image-generation").
+    /// The mode to include in the prompt payload. Only used as the image-generation fallback
+    /// when no image-capable model could be resolved (models not loaded) — the duck.ai page
+    /// then routes the request itself.
     var effectiveMode: String? {
-        isImageGenerationMode ? AIChatNativePrompt.imageGenerationMode : nil
+        isImageGenerationMode && imageGenerationModel == nil ? AIChatNativePrompt.imageGenerationMode : nil
     }
 
-    /// The tool choice to include in the prompt payload (e.g., ["WebSearch"]).
+    /// The tool choice to include in the prompt payload (e.g., ["GenerateImage"], ["WebSearch"]).
     var effectiveToolChoice: [String]? {
-        isWebSearchMode ? [AIChatRAGTool.webSearch.rawValue] : nil
+        if isImageGenerationMode {
+            return imageGenerationModel != nil ? [AIChatRAGTool.imageGeneration.rawValue] : nil
+        }
+        return isWebSearchMode ? [AIChatRAGTool.webSearch.rawValue] : nil
     }
 
     /// The reasoning effort to include in the prompt payload.
@@ -593,6 +621,7 @@ final class AIChatOmnibarController {
         // Clearing here keeps stale-effort handling in one place (see `clearStaleReasoningEffortIfNeeded`).
         clearStaleReasoningEffortIfNeeded()
         deactivateWebSearchIfUnsupported()
+        deactivateImageGenerationIfUnsupported()
     }
 
     /// Clears Web Search mode if the currently selected model doesn't support the WebSearch tool.
@@ -600,6 +629,14 @@ final class AIChatOmnibarController {
     /// mode must not remain active across a switch into such a model.
     private func deactivateWebSearchIfUnsupported() {
         guard isWebSearchMode, !selectedModelSupportsWebSearch else { return }
+        activeToolMode = nil
+    }
+
+    /// Clears image-generation mode if the currently selected model doesn't support the
+    /// GenerateImage tool. Mirrors `deactivateWebSearchIfUnsupported` so the tool can't stay
+    /// armed for a model that can't generate images (e.g. Mistral).
+    private func deactivateImageGenerationIfUnsupported() {
+        guard isImageGenerationMode, !selectedModelSupportsImageGeneration else { return }
         activeToolMode = nil
     }
 

--- a/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
@@ -971,6 +971,197 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         XCTAssertFalse(controller.isWebSearchMode)
     }
 
+    // MARK: - Image Generation Model Support Tests
+
+    func testWhenModelsNotLoaded_ThenSelectedModelSupportsImageGenerationDefaultsToTrue() {
+        // Then — conservative default keeps the Tools menu item visible until we know otherwise
+        XCTAssertTrue(controller.models.isEmpty)
+        XCTAssertTrue(controller.selectedModelSupportsImageGeneration)
+    }
+
+    func testWhenSelectedModelSupportsGenerateImage_ThenSelectedModelSupportsImageGenerationReturnsTrue() async {
+        // Given
+        mockModelsService.modelsToReturn = [
+            makeRemoteModel(id: "img-model", supportedTools: ["GenerateImage"])
+        ]
+        mockPreferences.selectedModelId = "img-model"
+
+        // When
+        controller.onOmnibarActivated()
+        await waitForModels()
+
+        // Then
+        XCTAssertTrue(controller.selectedModelSupportsImageGeneration)
+    }
+
+    func testWhenSelectedModelDoesNotSupportGenerateImage_ThenSelectedModelSupportsImageGenerationReturnsFalse() async {
+        // Given — model advertises other tools but not GenerateImage
+        mockModelsService.modelsToReturn = [
+            makeRemoteModel(id: "mistral", supportedTools: ["NewsSearch"])
+        ]
+        mockPreferences.selectedModelId = "mistral"
+
+        // When
+        controller.onOmnibarActivated()
+        await waitForModels()
+
+        // Then
+        XCTAssertFalse(controller.selectedModelSupportsImageGeneration)
+    }
+
+    func testWhenSwitchingToUnsupportedModel_ThenImageGenerationModeIsDeactivated() async {
+        // Given
+        mockModelsService.modelsToReturn = [
+            makeRemoteModel(id: "img-supported", supportedTools: ["GenerateImage"]),
+            makeRemoteModel(id: "img-unsupported", supportedTools: [])
+        ]
+        mockPreferences.selectedModelId = "img-supported"
+        controller.onOmnibarActivated()
+        await waitForModels()
+        controller.toggleImageGenerationMode()
+        XCTAssertTrue(controller.isImageGenerationMode)
+
+        // When
+        controller.updateSelectedModel("img-unsupported")
+
+        // Then
+        XCTAssertFalse(controller.isImageGenerationMode)
+    }
+
+    func testWhenSwitchingBetweenSupportingModels_ThenImageGenerationModeIsPreserved() async {
+        // Given
+        mockModelsService.modelsToReturn = [
+            makeRemoteModel(id: "img-a", supportedTools: ["GenerateImage"]),
+            makeRemoteModel(id: "img-b", supportedTools: ["GenerateImage"])
+        ]
+        mockPreferences.selectedModelId = "img-a"
+        controller.onOmnibarActivated()
+        await waitForModels()
+        controller.toggleImageGenerationMode()
+        XCTAssertTrue(controller.isImageGenerationMode)
+
+        // When
+        controller.updateSelectedModel("img-b")
+
+        // Then
+        XCTAssertTrue(controller.isImageGenerationMode)
+    }
+
+    func testWhenFetchModelsRevealsUnsupportedPersistedModel_ThenImageGenerationModeIsDeactivated() async {
+        // Given — user toggled Create Image before models loaded (conservative default allowed it),
+        // persisted model turns out not to support it
+        mockModelsService.modelsToReturn = [
+            makeRemoteModel(id: "no-img", supportedTools: [])
+        ]
+        mockPreferences.selectedModelId = "no-img"
+        controller.toggleImageGenerationMode()
+        XCTAssertTrue(controller.isImageGenerationMode)
+
+        // When
+        controller.onOmnibarActivated()
+        await waitForModels()
+
+        // Then
+        XCTAssertFalse(controller.isImageGenerationMode)
+    }
+
+    // MARK: - Image Generation Submission Parameter Tests
+
+    func testWhenImageGenerationModeWithCapableSelectedModel_ThenSubmissionUsesSelectedModelAndToolChoice() async {
+        // Given
+        mockModelsService.modelsToReturn = [
+            makeRemoteModel(id: "img-model", supportedTools: ["GenerateImage"])
+        ]
+        mockPreferences.selectedModelId = "img-model"
+        controller.onOmnibarActivated()
+        await waitForModels()
+
+        // When
+        controller.toggleImageGenerationMode()
+
+        // Then — explicit model + GenerateImage tool choice, no legacy mode handoff
+        XCTAssertEqual(controller.effectiveModelId, "img-model")
+        XCTAssertEqual(controller.effectiveToolChoice, [AIChatRAGTool.imageGeneration.rawValue])
+        XCTAssertNil(controller.effectiveMode)
+    }
+
+    func testWhenImageGenerationModeWithIncapableSelectedModel_ThenSubmissionFallsBackToFirstCapableModel() async {
+        // Given — image mode active with a non-capable model selected. Gating normally prevents
+        // this, but the tool mode can be restored from a tab's saved state, so submission must
+        // still resolve an image-capable model.
+        mockModelsService.modelsToReturn = [
+            makeRemoteModel(id: "mistral", supportedTools: []),
+            makeRemoteModel(id: "premium-img", entityHasAccess: false, supportedTools: ["GenerateImage"]),
+            makeRemoteModel(id: "free-img", supportedTools: ["GenerateImage"])
+        ]
+        mockPreferences.selectedModelId = "mistral"
+        controller.onOmnibarActivated()
+        await waitForModels()
+
+        // When
+        controller.toggleImageGenerationMode()
+
+        // Then — inaccessible capable model is skipped, first accessible capable one wins
+        XCTAssertEqual(controller.effectiveModelId, "free-img")
+        XCTAssertEqual(controller.effectiveToolChoice, [AIChatRAGTool.imageGeneration.rawValue])
+        XCTAssertNil(controller.effectiveMode)
+    }
+
+    func testWhenImageGenerationModeAndModelsNotLoaded_ThenSubmissionFallsBackToModeHandoff() {
+        // Given — no models fetched
+
+        // When
+        controller.toggleImageGenerationMode()
+
+        // Then — legacy shape: duck.ai routes the request from the mode field
+        XCTAssertNil(controller.effectiveModelId)
+        XCTAssertNil(controller.effectiveToolChoice)
+        XCTAssertEqual(controller.effectiveMode, AIChatNativePrompt.imageGenerationMode)
+    }
+
+    func testWhenNotInImageGenerationMode_ThenModeAndImageToolChoiceAreNotSent() async {
+        // Given
+        mockModelsService.modelsToReturn = [
+            makeRemoteModel(id: "img-model", supportedTools: ["GenerateImage"])
+        ]
+        mockPreferences.selectedModelId = "img-model"
+        controller.onOmnibarActivated()
+        await waitForModels()
+
+        // Then
+        XCTAssertEqual(controller.effectiveModelId, "img-model")
+        XCTAssertNil(controller.effectiveToolChoice)
+        XCTAssertNil(controller.effectiveMode)
+    }
+
+    func testWhenSubmitInImageGenerationMode_ThenPromptCarriesModelIdAndToolChoice() async {
+        // Given
+        mockModelsService.modelsToReturn = [
+            makeRemoteModel(id: "img-model", supportedTools: ["GenerateImage"])
+        ]
+        mockPreferences.selectedModelId = "img-model"
+        controller.onOmnibarActivated()
+        await waitForModels()
+        controller.toggleImageGenerationMode()
+        controller.updateText("a war potato")
+
+        // When
+        controller.submit()
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // Then
+        XCTAssertTrue(mockTabOpener.openAIChatTabCalled, "Submit opens the duck.ai tab")
+        let prompt = AIChatPromptHandler.shared.consumeData()
+        guard case .query(let query) = prompt?.tool else {
+            XCTFail("Expected a `.query` tool in the submitted prompt")
+            return
+        }
+        XCTAssertEqual(query.prompt, "a war potato")
+        XCTAssertEqual(query.modelId, "img-model")
+        XCTAssertEqual(query.toolChoice, [AIChatRAGTool.imageGeneration.rawValue])
+        XCTAssertNil(query.mode)
+    }
+
     // MARK: - Reasoning Effort Tests
 
     func testWhenReasoningEffortFeatureFlagEnabled_ThenIsReasoningEffortEnabledIsTrue() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1216424911867409?focus=true

### Description

Duck.ai image generation from the macOS address-bar omnibar could start the chat on a model that can't generate images (e.g. Mistral) and produce no image.

- Root cause: image-generation submissions were handed off with `mode: image-generation` and no model, leaving model choice to the duck.ai page — which falls back to the user's web-side saved model, even when that model can't generate images.
- Fix: resolve an image-capable model natively (the selected model when it supports image generation, otherwise the first accessible one that does) and hand off an explicit model + `GenerateImage` tool choice, matching iOS. The mode-based handoff remains only as a fallback while the models list hasn't loaded.
- Also gates the Create Image tools-menu item on the selected model's image-generation support and clears the armed tool when switching to an unsupported model — mirroring the existing Web Search gating (and iOS).

Out of scope, same bug class: the NTP omnibar builds the same no-model handoff in content-scope-scripts and needs the equivalent change there (or in the duck.ai FE model resolution).

### Testing Steps

1. Open duck.ai in a tab, switch the model to Mistral in the page's model picker, and send a message (this sets the web-side saved model that used to leak into image generation).
2. Click the address bar, toggle to Duck.ai, Tools → Create Image, type a prompt, press Enter → the new chat starts on an image-capable model and an image is generated.
3. In the Duck.ai address-bar panel, select Mistral in the native model picker and open Tools → "Create Image" is hidden. Switch back to an image-capable model → it reappears.
4. With Create Image armed (chip visible), switch the model to Mistral → the tool clears itself.
5. Plain prompts and Web Search prompts from the omnibar behave as before.

### Impact

Low — scoped to the parameters of Duck.ai image-generation submissions from the macOS address-bar omnibar.

#### What could go wrong?

- Models endpoint unreachable at submit time → falls back to the previous `mode` handoff (unchanged behavior); covered by a unit test.
- Image tool armed while a non-capable model is selected (restored per-tab state) → submission resolves the first accessible image-capable model; covered by a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to macOS Duck.ai omnibar image-generation parameters and tools menu gating; legacy mode handoff remains when models are unavailable.
> 
> **Overview**
> Fixes Duck.ai **Create Image** from the macOS address-bar omnibar starting chats on models that cannot generate images (e.g. Mistral) when the web-side saved model was incompatible.
> 
> **Submission handoff** now resolves an image-capable model in-app—the selected model when it supports `GenerateImage`, otherwise the first accessible model that does—and sends an explicit `modelId` plus `GenerateImage` in `toolChoice`, aligned with iOS. The previous `mode: image-generation` with no model is kept only when the models list has not loaded yet.
> 
> **UI gating** mirrors Web Search: the Tools **Create Image** entry and omnibar tools button visibility require `selectedModelSupportsImageGeneration`, and image-generation mode is cleared after models load or on model switch when the selection does not support the tool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b334b0cfdae4e9eb63cae469efc97a74c1fc6a05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->