### PR TITLE
iOS: Add surface param to contextual UTI pixels

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1801,8 +1801,6 @@ extension Pixel {
         case aiChatContextualExpandButtonTapped
         case aiChatContextualNewChatButtonTapped
         case aiChatContextualQuickActionSummarizeSelected
-        case aiChatContextualPageContextPlaceholderShown
-        case aiChatContextualPageContextPlaceholderTapped
         case aiChatContextualPageContextAutoAttached
         case aiChatContextualPageContextUpdatedOnNavigation
         case aiChatContextualPageContextManuallyAttachedNative
@@ -3712,8 +3710,6 @@ extension Pixel.Event {
         case .aiChatContextualExpandButtonTapped: return "m_aichat_contextual_expand_button_tapped"
         case .aiChatContextualNewChatButtonTapped: return "m_aichat_contextual_new_chat_button_tapped"
         case .aiChatContextualQuickActionSummarizeSelected: return "m_aichat_contextual_quick_action_summarize_selected"
-        case .aiChatContextualPageContextPlaceholderShown: return "m_aichat_contextual_page_context_placeholder_shown"
-        case .aiChatContextualPageContextPlaceholderTapped: return "m_aichat_contextual_page_context_placeholder_tapped"
         case .aiChatContextualPageContextAutoAttached: return "m_aichat_contextual_page_context_auto_attached"
         case .aiChatContextualPageContextUpdatedOnNavigation: return "m_aichat_contextual_page_context_updated_on_navigation"
         case .aiChatContextualPageContextManuallyAttachedNative: return "m_aichat_contextual_page_context_manually_attached_native"

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualModePixelHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualModePixelHandler.swift
@@ -41,8 +41,6 @@ protocol AIChatContextualModePixelFiring {
     func fireViewAllChatsTapped()
 
     // MARK: - Page Context Attachment
-    func firePageContextPlaceholderShown()
-    func firePageContextPlaceholderTapped()
     func firePageContextAutoAttached()
     func firePageContextUpdatedOnNavigation(url: String)
     func firePageContextManuallyAttachedNative()
@@ -140,14 +138,6 @@ final class AIChatContextualModePixelHandler: AIChatContextualModePixelFiring {
     }
 
     // MARK: - Page Context Attachment
-
-    func firePageContextPlaceholderShown() {
-        firePixel(.aiChatContextualPageContextPlaceholderShown)
-    }
-
-    func firePageContextPlaceholderTapped() {
-        firePixel(.aiChatContextualPageContextPlaceholderTapped)
-    }
 
     func firePageContextAutoAttached() {
         firePixel(.aiChatContextualPageContextAutoAttached)

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -86,6 +86,9 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate {
         coordinator.onPageContextAttachRequested = { [weak chipViewModel] in
             chipViewModel?.tapToAttach()
         }
+        coordinator.hasPendingPageContextProvider = { [weak chipViewModel] in
+            chipViewModel?.pendingAttachedContextData != nil
+        }
         coordinator.updateImageButtonVisibility()
         coordinator.viewController.bindPageContextChip(to: chipViewModel)
         chipViewModel.onAttachActionRequested = { [weak self] in

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -762,11 +762,13 @@ extension DefaultOmniBarViewController {
             selectedTool: selectedTool,
             attachments: attachments,
             reasoningMode: iPadReasoningModeForSubmitPixel,
-            modelId: modelPickerController?.currentModelId
+            modelId: modelPickerController?.currentModelId,
+            surface: .addressBar
         )
         UnifiedToggleInputCoordinatorPixelHelper.fireToolSubmittedPixelIfNeeded(
             selectedTool: selectedTool,
-            attachments: attachments
+            attachments: attachments,
+            surface: .addressBar
         )
     }
 

--- a/iOS/DuckDuckGo/IPadOmnibarAttachmentController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarAttachmentController.swift
@@ -41,7 +41,7 @@ final class IPadOmnibarAttachmentController {
         didSet {
             attachmentsStripView?.onAttachmentRemoved = { _, attachment, isUserInitiated in
                 guard isUserInitiated else { return }
-                UnifiedToggleInputCoordinatorPixelHelper.fireAttachmentRemovedPixel(for: attachment)
+                UnifiedToggleInputCoordinatorPixelHelper.fireAttachmentRemovedPixel(for: attachment, surface: .addressBar)
             }
         }
     }
@@ -173,7 +173,7 @@ final class IPadOmnibarAttachmentController {
         if let validationError = attachmentPolicy.fileValidationError(for: fileAttachment) {
             DailyPixel.fireDailyAndCount(
                 pixel: .unifiedToggleInputFileValidationFailed,
-                withAdditionalParameters: ["reason": validationError.reason.rawValue]
+                withAdditionalParameters: ["reason": validationError.reason.rawValue, "surface": UnifiedToggleInputPixelSurface.addressBar.rawValue]
             )
             attachmentsStripView?.addAttachment(.invalidFile(
                 UnifiedToggleInputInvalidFileAttachment(
@@ -188,7 +188,7 @@ final class IPadOmnibarAttachmentController {
             return
         }
 
-        DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputFileAttached)
+        DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputFileAttached, withAdditionalParameters: ["surface": UnifiedToggleInputPixelSurface.addressBar.rawValue])
         attachmentsStripView?.addAttachment(.file(fileAttachment))
     }
 
@@ -209,7 +209,7 @@ final class IPadOmnibarAttachmentController {
         }
         DailyPixel.fireDailyAndCount(
             pixel: .unifiedToggleInputFileValidationFailed,
-            withAdditionalParameters: ["reason": reason.rawValue]
+            withAdditionalParameters: ["reason": reason.rawValue, "surface": UnifiedToggleInputPixelSurface.addressBar.rawValue]
         )
         attachmentsStripView?.addAttachment(.invalidFile(
             UnifiedToggleInputInvalidFileAttachment(

--- a/iOS/DuckDuckGo/IPadOmnibarModelPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarModelPickerController.swift
@@ -102,7 +102,7 @@ final class IPadOmnibarModelPickerController {
             let isNewSelection = modelId != store.persistedModelId
             store.updateSelectedModel(modelId, isNewChatContext: true)
             if isNewSelection {
-                UnifiedToggleInputCoordinatorPixelHelper.fireModelSelectedPixel(modelId: modelId)
+                UnifiedToggleInputCoordinatorPixelHelper.fireModelSelectedPixel(modelId: modelId, surface: .addressBar)
             }
         } else if routeGatedModelSelection(model) {
             // Remember the gated model so a post-purchase `/models` refresh can apply it.
@@ -138,7 +138,7 @@ final class IPadOmnibarModelPickerController {
         let isNewSelection = modelId != store.persistedModelId
         store.updateSelectedModel(modelId, isNewChatContext: true)
         if isNewSelection {
-            UnifiedToggleInputCoordinatorPixelHelper.fireModelSelectedPixel(modelId: modelId)
+            UnifiedToggleInputCoordinatorPixelHelper.fireModelSelectedPixel(modelId: modelId, surface: .addressBar)
         }
     }
 }

--- a/iOS/DuckDuckGo/IPadOmnibarReasoningPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarReasoningPickerController.swift
@@ -99,7 +99,7 @@ final class IPadOmnibarReasoningPickerController {
 
     private func select(_ mode: AIChatReasoningMode) {
         store.updateSelectedReasoningMode(mode)
-        Pixel.fire(pixel: .unifiedToggleInputReasoningEffortSelected, withAdditionalParameters: ["effort_level": mode.rawValue])
+        Pixel.fire(pixel: .unifiedToggleInputReasoningEffortSelected, withAdditionalParameters: ["effort_level": mode.rawValue, "surface": UnifiedToggleInputPixelSurface.addressBar.rawValue])
         onReasoningUpdated?()
     }
 

--- a/iOS/DuckDuckGo/IPadOmnibarToolPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarToolPickerController.swift
@@ -92,7 +92,7 @@ final class IPadOmnibarToolPickerController {
         guard let previousTool = toolsController.selectedTool else { return }
         toolsController.clearSelection()
         if isUserInitiated {
-            UnifiedToggleInputCoordinatorPixelHelper.fireToolDeselectedPixel(for: previousTool)
+            UnifiedToggleInputCoordinatorPixelHelper.fireToolDeselectedPixel(for: previousTool, surface: .addressBar)
         }
         onToolsUpdated?()
     }
@@ -110,10 +110,10 @@ final class IPadOmnibarToolPickerController {
     private func fireToggleTransitionPixel(previous: AIChatRAGTool?, current: AIChatRAGTool?) {
         guard previous != current else { return }
         if let previous, current == nil || current != previous {
-            UnifiedToggleInputCoordinatorPixelHelper.fireToolDeselectedPixel(for: previous)
+            UnifiedToggleInputCoordinatorPixelHelper.fireToolDeselectedPixel(for: previous, surface: .addressBar)
         }
         if let current {
-            UnifiedToggleInputCoordinatorPixelHelper.fireToolSelectedPixel(for: current)
+            UnifiedToggleInputCoordinatorPixelHelper.fireToolSelectedPixel(for: current, surface: .addressBar)
         }
     }
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentPresenter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentPresenter.swift
@@ -39,6 +39,8 @@ final class UnifiedToggleInputAttachmentPresenter: NSObject {
     var onFilePicked: ((AIChatFileAttachment, FileMetadata) -> Void)?
     var onFileValidationFailed: ((String, FileMetadata) -> Void)?
     var fileMetadataValidationMessage: ((FileMetadata) -> String?)?
+    /// Supplies the UTI surface for attachment pixels. Set by the coordinator; defaults to `.addressBar`.
+    var pixelSurfaceProvider: (() -> UnifiedToggleInputPixelSurface)?
 
     nonisolated static func recoverFileAttachment(from metadata: FileMetadata, id: UUID = UUID()) -> AIChatFileAttachment? {
         fileAttachment(from: metadata, id: id)
@@ -200,9 +202,10 @@ extension UnifiedToggleInputAttachmentPresenter: PHPickerViewControllerDelegate 
                 guard let image = object as? UIImage else { return }
 
                 Task { @MainActor in
+                    let surface = self?.pixelSurfaceProvider?() ?? .addressBar
                     DailyPixel.fireDailyAndCount(
                         pixel: .unifiedToggleInputImageAttached,
-                        withAdditionalParameters: ["source": "photo_library"]
+                        withAdditionalParameters: ["source": "photo_library", "surface": surface.rawValue]
                     )
                     self?.onImagePicked?(image, suggestedName)
                 }
@@ -219,7 +222,7 @@ extension UnifiedToggleInputAttachmentPresenter: UIImagePickerControllerDelegate
         guard let image = info[.originalImage] as? UIImage else { return }
         DailyPixel.fireDailyAndCount(
             pixel: .unifiedToggleInputImageAttached,
-            withAdditionalParameters: ["source": "camera"]
+            withAdditionalParameters: ["source": "camera", "surface": (pixelSurfaceProvider?() ?? .addressBar).rawValue]
         )
         onImagePicked?(image, "photo")
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -311,8 +311,20 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         displayState == .contextualChat
     }
 
+    /// Collapses the contextual sheet and the Duck.ai tab into a single "Duck.ai surface" bucket.
+    /// Used only for the subscription-funnel `origin` on the model/reasoning picker + upsell pixels,
+    /// where contextual intentionally counts as Duck.ai (keeps the funnel origin / redirect URL stable).
     var isDuckAISurfaceForAttribution: Bool {
         isAITabState || isContextualChatState
+    }
+
+    /// The surface this coordinator is hosted on, for pixel attribution.
+    /// Distinguishes the contextual chat sheet from the Duck.ai tab and the omnibar/NTP for the
+    /// `surface` pixel parameter. (The funnel `origin` path uses `isDuckAISurfaceForAttribution` instead.)
+    var pixelSurface: UnifiedToggleInputPixelSurface {
+        if isContextualChatState { return .contextualChat }
+        if isAITabState { return .duckAI }
+        return .addressBar
     }
 
     /// True when the current display state corresponds to the expanded card layout.
@@ -451,6 +463,9 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         floatingReturnKeyViewController = UnifiedToggleInputFloatingReturnKeyViewController()
         super.init()
         viewController.delegate = self
+        attachmentPresenter.pixelSurfaceProvider = { [weak self] in
+            self?.pixelSurface ?? .addressBar
+        }
         attachmentPresenter.onExpandIfNeeded = { [weak self] in
             self?.expandIfOnExpandedInputHost()
         }
@@ -473,7 +488,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             }
             DailyPixel.fireDailyAndCount(
                 pixel: .unifiedToggleInputFileValidationFailed,
-                withAdditionalParameters: ["reason": reason.rawValue]
+                withAdditionalParameters: ["reason": reason.rawValue, "surface": self.pixelSurface.rawValue]
             )
             self.addInvalidFileAttachment(metadata: metadata, validationMessage: message)
         }
@@ -1457,7 +1472,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         guard isModelPickerForcedVisible, userScript.canDispatchBridgeMessages else {
             return
         }
-        UnifiedToggleInputCoordinatorPixelHelper.fireSubmitChangeModelPixel(modelId: modelId)
+        UnifiedToggleInputCoordinatorPixelHelper.fireSubmitChangeModelPixel(modelId: modelId, surface: pixelSurface)
     }
 
     /// Surfaces the native model picker on the **active** chat in response to the FE's
@@ -1477,7 +1492,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         // expand animation before we ask the button to open its menu.
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            UnifiedToggleInputCoordinatorPixelHelper.fireShowModelPickerPixel()
+            UnifiedToggleInputCoordinatorPixelHelper.fireShowModelPickerPixel(surface: self.pixelSurface)
             if self.viewController.presentModelPickerMenu() {
                 self.fireModelPickerShown()
             }
@@ -1600,11 +1615,11 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     }
 
     private func fireModelSelectedPixel(modelId: String) {
-        UnifiedToggleInputCoordinatorPixelHelper.fireModelSelectedPixel(modelId: modelId)
+        UnifiedToggleInputCoordinatorPixelHelper.fireModelSelectedPixel(modelId: modelId, surface: pixelSurface)
     }
 
     private func fireReasoningEffortSelectedPixel(mode: AIChatReasoningMode) {
-        Pixel.fire(pixel: .unifiedToggleInputReasoningEffortSelected, withAdditionalParameters: ["effort_level": mode.rawValue])
+        Pixel.fire(pixel: .unifiedToggleInputReasoningEffortSelected, withAdditionalParameters: ["effort_level": mode.rawValue, "surface": pixelSurface.rawValue])
     }
 
     private func fireModelPickerShown() {
@@ -1723,7 +1738,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         if let validationError = attachmentPolicy.fileValidationError(for: fileAttachment) {
             DailyPixel.fireDailyAndCount(
                 pixel: .unifiedToggleInputFileValidationFailed,
-                withAdditionalParameters: ["reason": validationError.reason.rawValue]
+                withAdditionalParameters: ["reason": validationError.reason.rawValue, "surface": pixelSurface.rawValue]
             )
             viewController.addAttachment(.invalidFile(
                 UnifiedToggleInputInvalidFileAttachment(
@@ -1741,7 +1756,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             return
         }
 
-        DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputFileAttached)
+        DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputFileAttached, withAdditionalParameters: ["surface": pixelSurface.rawValue])
         viewController.addAttachment(.file(fileAttachment))
         persistDraftToStore()
         clearAttachmentValidationErrorIfPossible()
@@ -1794,7 +1809,7 @@ extension UnifiedToggleInputCoordinator {
     
     func handleToolsMenuSelection(_ identifier: UTIToolsMenu.Item.Identifier) {
         if case .customizeResponses = identifier {
-            UnifiedToggleInputCoordinatorPixelHelper.fireCustomizeResponsesSelectedPixel()
+            UnifiedToggleInputCoordinatorPixelHelper.fireCustomizeResponsesSelectedPixel(surface: pixelSurface)
             viewController.handler.customizeResponsesButtonTapped()
             return
         }
@@ -1817,10 +1832,10 @@ extension UnifiedToggleInputCoordinator {
     private func fireToolToggleTransitionPixel(previous: AIChatRAGTool?, current: AIChatRAGTool?) {
         guard previous != current else { return }
         if let previous, current == nil || current != previous {
-            UnifiedToggleInputCoordinatorPixelHelper.fireToolDeselectedPixel(for: previous)
+            UnifiedToggleInputCoordinatorPixelHelper.fireToolDeselectedPixel(for: previous, surface: pixelSurface)
         }
         if let current {
-            UnifiedToggleInputCoordinatorPixelHelper.fireToolSelectedPixel(for: current)
+            UnifiedToggleInputCoordinatorPixelHelper.fireToolSelectedPixel(for: current, surface: pixelSurface)
         }
     }
 }
@@ -1880,11 +1895,13 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
                 selectedTool: toolsController.selectedTool,
                 attachments: viewController.currentAttachments,
                 reasoningMode: reasoningModeForSubmitPixel,
-                modelId: modelStore.persistedModelId
+                modelId: modelStore.persistedModelId,
+                surface: pixelSurface
             )
             UnifiedToggleInputCoordinatorPixelHelper.fireToolSubmittedPixelIfNeeded(
                 selectedTool: toolsController.selectedTool,
-                attachments: viewController.currentAttachments
+                attachments: viewController.currentAttachments,
+                surface: pixelSurface
             )
 
             let configuration = promptSubmissionConfiguration
@@ -1978,14 +1995,14 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
         let previousTool = toolsController.selectedTool
         clearSelectedTool()
         if let previousTool {
-            UnifiedToggleInputCoordinatorPixelHelper.fireToolDeselectedPixel(for: previousTool)
+            UnifiedToggleInputCoordinatorPixelHelper.fireToolDeselectedPixel(for: previousTool, surface: pixelSurface)
         }
     }
 
     func unifiedToggleInputVC(_ vc: UnifiedToggleInputViewController, didRemoveAttachment id: UUID, attachment: UnifiedToggleInputAttachment, isUserInitiated: Bool) {
         removeAttachment(id: id)
         if isUserInitiated {
-            UnifiedToggleInputCoordinatorPixelHelper.fireAttachmentRemovedPixel(for: attachment)
+            UnifiedToggleInputCoordinatorPixelHelper.fireAttachmentRemovedPixel(for: attachment, surface: pixelSurface)
         }
     }
 
@@ -2376,7 +2393,7 @@ private extension UnifiedToggleInputCoordinator {
         refreshToolsPresentation()
         syncHasSubmittedPromptToHandler()
         if wasInRecoveryPickerSession {
-            UnifiedToggleInputCoordinatorPixelHelper.fireSubmitChangeModelPromptSentPixel()
+            UnifiedToggleInputCoordinatorPixelHelper.fireSubmitChangeModelPromptSentPixel(surface: pixelSurface)
         }
     }
 
@@ -2503,8 +2520,9 @@ private extension UnifiedToggleInputCoordinator {
     func subscribeToStopGeneratingTap() {
         viewController.handler.stopGeneratingButtonTappedPublisher
             .sink { [weak self] in
-                Pixel.fire(pixel: .unifiedToggleInputStopGenerationTapped)
-                self?.didPressStopGeneratingButton.send()
+                guard let self else { return }
+                Pixel.fire(pixel: .unifiedToggleInputStopGenerationTapped, withAdditionalParameters: ["surface": self.pixelSurface.rawValue])
+                self.didPressStopGeneratingButton.send()
             }
             .store(in: &cancellables)
     }
@@ -2549,10 +2567,9 @@ private extension UnifiedToggleInputCoordinator {
         viewController.handler.aiVoiceChatButtonTappedPublisher
             .sink { [weak self] in
                 guard let self else { return }
-                let source = self.isDuckAISurfaceForAttribution ? "duck_ai" : "ntp"
                 DailyPixel.fireDailyAndCount(
                     pixel: .unifiedToggleInputVoiceTapped,
-                    withAdditionalParameters: ["source": source]
+                    withAdditionalParameters: ["source": self.pixelSurface.rawValue]
                 )
                 self.delegate?.unifiedToggleInputDidRequestAIVoiceChat()
             }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -311,16 +311,12 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         displayState == .contextualChat
     }
 
-    /// Collapses the contextual sheet and the Duck.ai tab into a single "Duck.ai surface" bucket.
-    /// Used only for the subscription-funnel `origin` on the model/reasoning picker + upsell pixels,
-    /// where contextual intentionally counts as Duck.ai (keeps the funnel origin / redirect URL stable).
+    /// Folds contextual + Duck.ai tab into one "Duck.ai surface" bucket — used only for the funnel `origin`.
     var isDuckAISurfaceForAttribution: Bool {
         isAITabState || isContextualChatState
     }
 
-    /// The surface this coordinator is hosted on, for pixel attribution.
-    /// Distinguishes the contextual chat sheet from the Duck.ai tab and the omnibar/NTP for the
-    /// `surface` pixel parameter. (The funnel `origin` path uses `isDuckAISurfaceForAttribution` instead.)
+    /// The hosting surface for the `surface` pixel parameter (the funnel `origin` uses `isDuckAISurfaceForAttribution`).
     var pixelSurface: UnifiedToggleInputPixelSurface {
         if isContextualChatState { return .contextualChat }
         if isAITabState { return .duckAI }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1716,6 +1716,8 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     /// must set this so the picker presents from the correct level.
     weak var attachmentPresentingViewController: UIViewController?
     var onPageContextAttachRequested: (() -> Void)?
+    /// Reports whether page context is attached but not yet submitted, for the voice-tap pixel. Host-injected; nil off the contextual sheet.
+    var hasPendingPageContextProvider: (() -> Bool)?
 
     var allowedFileUTTypes: [UTType] {
         selectedModelSupportedFileTypes.compactMap(Self.contentType(for:))
@@ -2563,9 +2565,13 @@ private extension UnifiedToggleInputCoordinator {
         viewController.handler.aiVoiceChatButtonTappedPublisher
             .sink { [weak self] in
                 guard let self else { return }
+                let hasPendingPageContext = self.hasPendingPageContextProvider?() ?? false
                 DailyPixel.fireDailyAndCount(
                     pixel: .unifiedToggleInputVoiceTapped,
-                    withAdditionalParameters: ["source": self.pixelSurface.rawValue]
+                    withAdditionalParameters: [
+                        "source": self.pixelSurface.rawValue,
+                        "has_pending_page_context": hasPendingPageContext ? "true" : "false"
+                    ]
                 )
                 self.delegate?.unifiedToggleInputDidRequestAIVoiceChat()
             }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinatorPixelHelper.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinatorPixelHelper.swift
@@ -22,6 +22,19 @@ import Core
 import Foundation
 import Subscription
 
+/// The UTI surface a pixel is fired from. Mirrors `DuckAIPromptWideEventData.EntryPoint`
+/// so pixel and wide-event attribution use the same taxonomy. Sent as the `surface`
+/// parameter (or, for `voice_tapped`, reuses the pre-existing `source` parameter).
+enum UnifiedToggleInputPixelSurface: String {
+    /// The address bar / omnibar (any omnibar surface that isn't the Duck.ai tab), matching the
+    /// `addressbar` bucket used by `SubscriptionFunnelOrigin`.
+    case addressBar = "address_bar"
+    /// The dedicated Duck.ai tab.
+    case duckAI = "duck_ai"
+    /// The contextual chat sheet presented over a web page.
+    case contextualChat = "contextual_chat"
+}
+
 private enum UnifiedPromptSubmittedSelectedToolPixelValue: String {
     case webSearch = "web_search"
     case imageGeneration = "image_generation"
@@ -80,12 +93,12 @@ extension UTIToolsMenu.Item.Identifier {
 final class UnifiedToggleInputCoordinatorPixelHelper {
     private init() {}
 
-    static func fireAttachmentRemovedPixel(for attachment: UnifiedToggleInputAttachment) {
+    static func fireAttachmentRemovedPixel(for attachment: UnifiedToggleInputAttachment, surface: UnifiedToggleInputPixelSurface) {
         switch attachment {
         case .image:
-            DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputImageRemoved)
+            DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputImageRemoved, withAdditionalParameters: surfaceParameters(surface))
         case .file, .invalidFile:
-            DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputFileRemoved)
+            DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputFileRemoved, withAdditionalParameters: surfaceParameters(surface))
         }
     }
 
@@ -120,30 +133,30 @@ final class UnifiedToggleInputCoordinatorPixelHelper {
         }
     }
 
-    static func fireToolSelectedPixel(for tool: AIChatRAGTool) {
+    static func fireToolSelectedPixel(for tool: AIChatRAGTool, surface: UnifiedToggleInputPixelSurface) {
         switch tool {
         case .imageGeneration:
-            DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputImageGenerationSelected)
+            DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputImageGenerationSelected, withAdditionalParameters: surfaceParameters(surface))
         case .webSearch:
-            DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputWebSearchSelected)
+            DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputWebSearchSelected, withAdditionalParameters: surfaceParameters(surface))
         default:
             break
         }
     }
 
-    static func fireToolDeselectedPixel(for tool: AIChatRAGTool) {
+    static func fireToolDeselectedPixel(for tool: AIChatRAGTool, surface: UnifiedToggleInputPixelSurface) {
         switch tool {
         case .imageGeneration:
-            DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputImageGenerationDeselected)
+            DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputImageGenerationDeselected, withAdditionalParameters: surfaceParameters(surface))
         case .webSearch:
-            DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputWebSearchDeselected)
+            DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputWebSearchDeselected, withAdditionalParameters: surfaceParameters(surface))
         default:
             break
         }
     }
 
-    static func fireCustomizeResponsesSelectedPixel() {
-        DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputCustomizeResponsesSelected)
+    static func fireCustomizeResponsesSelectedPixel(surface: UnifiedToggleInputPixelSurface) {
+        DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputCustomizeResponsesSelected, withAdditionalParameters: surfaceParameters(surface))
     }
 
     static func fireUnifiedPromptSubmittedPixel(
@@ -151,7 +164,8 @@ final class UnifiedToggleInputCoordinatorPixelHelper {
         selectedTool: AIChatRAGTool?,
         attachments: [UnifiedToggleInputAttachment],
         reasoningMode: AIChatReasoningMode?,
-        modelId: String?
+        modelId: String?,
+        surface: UnifiedToggleInputPixelSurface
     ) {
         let selectedToolValue = UnifiedPromptSubmittedSelectedToolPixelValue(selectedTool: selectedTool).rawValue
         let reasoningEffort = reasoningMode?.rawValue ?? "none"
@@ -165,17 +179,18 @@ final class UnifiedToggleInputCoordinatorPixelHelper {
                 "reasoning_effort": reasoningEffort,
                 "has_image_attachment": hasImageAttachment(in: attachments) ? "true" : "false",
                 "has_file_attachment": hasFileAttachment(in: attachments) ? "true" : "false",
-                "has_text": hasText ? "true" : "false"
+                "has_text": hasText ? "true" : "false",
+                "surface": surface.rawValue
             ]
         )
     }
 
-    static func fireShowModelPickerPixel() {
-        DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputShowModelPicker)
+    static func fireShowModelPickerPixel(surface: UnifiedToggleInputPixelSurface) {
+        DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputShowModelPicker, withAdditionalParameters: surfaceParameters(surface))
     }
 
-    static func fireModelSelectedPixel(modelId: String) {
-        Pixel.fire(pixel: .unifiedToggleInputModelSelected, withAdditionalParameters: ["model_id": modelId])
+    static func fireModelSelectedPixel(modelId: String, surface: UnifiedToggleInputPixelSurface) {
+        Pixel.fire(pixel: .unifiedToggleInputModelSelected, withAdditionalParameters: ["model_id": modelId, "surface": surface.rawValue])
     }
 
     static func fireModelPickerShownPixel(isAITabState: Bool) {
@@ -190,27 +205,34 @@ final class UnifiedToggleInputCoordinatorPixelHelper {
         ])
     }
 
-    static func fireSubmitChangeModelPixel(modelId: String) {
-        DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputSubmitChangeModel, withAdditionalParameters: ["model_id": modelId])
+    static func fireSubmitChangeModelPixel(modelId: String, surface: UnifiedToggleInputPixelSurface) {
+        DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputSubmitChangeModel, withAdditionalParameters: ["model_id": modelId, "surface": surface.rawValue])
     }
 
-    static func fireSubmitChangeModelPromptSentPixel() {
-        DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputSubmitChangeModelPromptSent)
+    static func fireSubmitChangeModelPromptSentPixel(surface: UnifiedToggleInputPixelSurface) {
+        DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputSubmitChangeModelPromptSent, withAdditionalParameters: surfaceParameters(surface))
     }
 
-    static func fireToolSubmittedPixelIfNeeded(selectedTool: AIChatRAGTool?, attachments: [UnifiedToggleInputAttachment]) {
+    static func fireToolSubmittedPixelIfNeeded(selectedTool: AIChatRAGTool?, attachments: [UnifiedToggleInputAttachment], surface: UnifiedToggleInputPixelSurface) {
         guard let selectedTool else { return }
         switch selectedTool {
         case .imageGeneration:
             DailyPixel.fireDailyAndCount(
                 pixel: .unifiedToggleInputImageGenerationSubmitted,
-                withAdditionalParameters: ["has_reference_image": hasImageAttachment(in: attachments) ? "true" : "false"]
+                withAdditionalParameters: [
+                    "has_reference_image": hasImageAttachment(in: attachments) ? "true" : "false",
+                    "surface": surface.rawValue
+                ]
             )
         case .webSearch:
-            DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputWebSearchSubmitted)
+            DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputWebSearchSubmitted, withAdditionalParameters: surfaceParameters(surface))
         default:
             break
         }
+    }
+
+    private static func surfaceParameters(_ surface: UnifiedToggleInputPixelSurface) -> [String: String] {
+        ["surface": surface.rawValue]
     }
 
     private static func hasImageAttachment(in attachments: [UnifiedToggleInputAttachment]) -> Bool {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinatorPixelHelper.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinatorPixelHelper.swift
@@ -22,12 +22,9 @@ import Core
 import Foundation
 import Subscription
 
-/// The UTI surface a pixel is fired from. Mirrors `DuckAIPromptWideEventData.EntryPoint`
-/// so pixel and wide-event attribution use the same taxonomy. Sent as the `surface`
-/// parameter (or, for `voice_tapped`, reuses the pre-existing `source` parameter).
+/// The UTI surface a pixel is fired from, sent as the `surface` param (`voice_tapped` reuses `source`).
 enum UnifiedToggleInputPixelSurface: String {
-    /// The address bar / omnibar (any omnibar surface that isn't the Duck.ai tab), matching the
-    /// `addressbar` bucket used by `SubscriptionFunnelOrigin`.
+    /// The address bar / omnibar (any omnibar surface that isn't the Duck.ai tab).
     case addressBar = "address_bar"
     /// The dedicated Duck.ai tab.
     case duckAI = "duck_ai"

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -1438,8 +1438,6 @@ private final class MockContextualModePixelHandler: AIChatContextualModePixelFir
     var quickActionSummarizeSelectedFired = false
     var fireButtonTappedFired = false
     var fireButtonConfirmedFired = false
-    var pageContextPlaceholderShownFired = false
-    var pageContextPlaceholderTappedFired = false
     var pageContextAutoAttachedFired = false
     var pageContextUpdatedOnNavigationFired = false
     var pageContextManuallyAttachedNativeFired = false
@@ -1464,8 +1462,6 @@ private final class MockContextualModePixelHandler: AIChatContextualModePixelFir
     func fireViewAllChatsTapped() {}
     func fireFireButtonTapped() { fireButtonTappedFired = true }
     func fireFireButtonConfirmed() { fireButtonConfirmedFired = true }
-    func firePageContextPlaceholderShown() { pageContextPlaceholderShownFired = true }
-    func firePageContextPlaceholderTapped() { pageContextPlaceholderTappedFired = true }
     func firePageContextAutoAttached() { pageContextAutoAttachedFired = true }
     func firePageContextUpdatedOnNavigation(url: String) { pageContextUpdatedOnNavigationFired = true }
     func firePageContextManuallyAttachedNative() { pageContextManuallyAttachedNativeFired = true }
@@ -1488,8 +1484,6 @@ private final class MockContextualModePixelHandler: AIChatContextualModePixelFir
         quickActionSummarizeSelectedFired = false
         fireButtonTappedFired = false
         fireButtonConfirmedFired = false
-        pageContextPlaceholderShownFired = false
-        pageContextPlaceholderTappedFired = false
         pageContextAutoAttachedFired = false
         pageContextUpdatedOnNavigationFired = false
         pageContextManuallyAttachedNativeFired = false

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualWebViewControllerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualWebViewControllerTests.swift
@@ -186,8 +186,6 @@ private final class StubContextualModePixelHandler: AIChatContextualModePixelFir
     func fireViewAllChatsTapped() {}
     func fireFireButtonTapped() {}
     func fireFireButtonConfirmed() {}
-    func firePageContextPlaceholderShown() {}
-    func firePageContextPlaceholderTapped() {}
     func firePageContextAutoAttached() {}
     func firePageContextUpdatedOnNavigation(url: String) {}
     func firePageContextManuallyAttachedNative() {}

--- a/iOS/DuckDuckGoTests/AIChat/AIChatPageContextHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatPageContextHandlerTests.swift
@@ -301,8 +301,6 @@ private final class MockContextualModePixelHandler: AIChatContextualModePixelFir
     func fireViewAllChatsTapped() {}
     func fireFireButtonTapped() {}
     func fireFireButtonConfirmed() {}
-    func firePageContextPlaceholderShown() {}
-    func firePageContextPlaceholderTapped() {}
     func firePageContextAutoAttached() {}
     func firePageContextUpdatedOnNavigation(url: String) {}
     func firePageContextManuallyAttachedNative() {}

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -75,7 +75,7 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         XCTAssertFalse(sut.hasActiveChat)
     }
 
-    func test_contextualChat_isDuckAISurfaceForAttributionButNotAITab() {
+    func test_contextualChat_pixelSurfaceIsContextualChatNotAITab() {
         sut = UnifiedToggleInputCoordinator(
             host: .contextualChat,
             isToggleEnabled: false,
@@ -85,7 +85,7 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         )
 
         XCTAssertFalse(sut.isAITabState)
-        XCTAssertTrue(sut.isDuckAISurfaceForAttribution)
+        XCTAssertEqual(sut.pixelSurface, .contextualChat)
     }
 
     // MARK: - Display State: showCollapsed

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_contextual_mode.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_contextual_mode.json5
@@ -48,20 +48,6 @@
         "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
-    "m_aichat_contextual_page_context_placeholder_shown": {
-        "description": "Fired when the placeholder context chip is shown to the user (auto-context setting disabled)",
-        "owners": ["aataraxiaa"],
-        "triggers": ["other"],
-        "suffixes": ["first_daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion"]
-    },
-    "m_aichat_contextual_page_context_placeholder_tapped": {
-        "description": "Fired when the user taps the placeholder chip to attach page content",
-        "owners": ["aataraxiaa"],
-        "triggers": ["other"],
-        "suffixes": ["first_daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion"]
-    },
     "m_aichat_contextual_page_context_auto_attached": {
         "description": "Fired when page context is automatically attached to an AI Chat prompt (auto-context setting enabled)",
         "owners": ["aataraxiaa"],

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
@@ -1,26 +1,31 @@
 // Unified Toggle Input (UTI) pixels - new Duck.ai input UI gated by the `unifiedToggleInput` feature flag.
+// The `surface` parameter (shared key `unified_input_surface`) distinguishes the contextual chat sheet
+// from the Duck.ai tab and the address bar. `voice_tapped` carries the same values under its pre-existing
+// `source` key. The subscription-funnel `origin` on the picker/upsell pixels intentionally folds the
+// contextual sheet into the Duck.ai bucket (keeps the funnel origin / subscription redirect URL stable).
 {
     "m_aichat_unified_input_image_generation_selected": {
         "description": "Fires when the user activates Create Image from the tools menu in the Unified Toggle Input. Does not fire when the toggle is rejected by an unsupporting model.",
-        "owners": ["pikorddg"],
+        "owners": ["pikorddg", "aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unified_input_surface"]
     },
     "m_aichat_unified_input_image_generation_deselected": {
         "description": "Fires when the user toggles the image generation tool off, either via menu re-tap or the chip's close button. Does not fire on auto-clear from a model switch.",
-        "owners": ["pikorddg"],
+        "owners": ["pikorddg", "aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unified_input_surface"]
     },
     "m_aichat_unified_input_image_generation_submitted": {
         "description": "Fires when the user submits a prompt with the image generation tool active in the Unified Toggle Input.",
-        "owners": ["pikorddg"],
+        "owners": ["pikorddg", "aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": [
             "appVersion",
+            "unified_input_surface",
             {
                 "key": "has_reference_image",
                 "description": "Whether a reference image attachment was present in the input at submission time.",
@@ -30,39 +35,40 @@
     },
     "m_aichat_unified_input_web_search_selected": {
         "description": "Fires when the user activates Web Search from the tools menu in the Unified Toggle Input. Does not fire when the toggle is rejected by an unsupporting model.",
-        "owners": ["pikorddg"],
+        "owners": ["pikorddg", "aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unified_input_surface"]
     },
     "m_aichat_unified_input_web_search_deselected": {
         "description": "Fires when the user toggles the web search tool off, either via menu re-tap or the chip's close button. Does not fire on auto-clear from a model switch.",
-        "owners": ["pikorddg"],
+        "owners": ["pikorddg", "aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unified_input_surface"]
     },
     "m_aichat_unified_input_web_search_submitted": {
         "description": "Fires when the user submits a prompt with the web search tool active in the Unified Toggle Input.",
-        "owners": ["pikorddg"],
+        "owners": ["pikorddg", "aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unified_input_surface"]
     },
     "m_aichat_unified_input_customize_responses_selected": {
         "description": "Fires when the user selects Customize Responses from the tools menu in the Unified Toggle Input. Unlike the other tools menu items, this is a one-shot action forwarded to the front-end rather than a toggleable model tool.",
-        "owners": ["pikorddg"],
+        "owners": ["pikorddg", "aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unified_input_surface"]
     },
     "m_aichat_unified_input_model_selected": {
         "description": "Fires when the user selects a different model in the Unified Toggle Input model picker (new model id differs from previous). Does not fire for gated/rejected models.",
-        "owners": ["pikorddg"],
+        "owners": ["pikorddg", "aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": [
             "appVersion",
+            "unified_input_surface",
             {
                 "key": "model_id",
                 "description": "The id of the newly selected model.",
@@ -87,11 +93,12 @@
     },
     "m_aichat_unified_input_reasoning_effort_selected": {
         "description": "Fires when the user selects a reasoning effort level in the Unified Toggle Input reasoning picker. Does not fire for gated/rejected selections.",
-        "owners": ["pikorddg"],
+        "owners": ["pikorddg", "aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": [
             "appVersion",
+            "unified_input_surface",
             {
                 "key": "effort_level",
                 "description": "The reasoning effort level selected.",
@@ -117,11 +124,12 @@
     },
     "m_aichat_unified_input_image_attached": {
         "description": "Fires when the user attaches an image (camera or photo library) in the Unified Toggle Input.",
-        "owners": ["pikorddg"],
+        "owners": ["pikorddg", "aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": [
             "appVersion",
+            "unified_input_surface",
             {
                 "key": "source",
                 "description": "Source of the attached image.",
@@ -132,32 +140,33 @@
     },
     "m_aichat_unified_input_image_removed": {
         "description": "Fires when the user removes an attached image from the Unified Toggle Input (tap on thumbnail close button).",
-        "owners": ["pikorddg"],
+        "owners": ["pikorddg", "aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unified_input_surface"]
     },
     "m_aichat_unified_input_file_attached": {
         "description": "Fires when the user attaches a file in the Unified Toggle Input (post-validation).",
-        "owners": ["pikorddg"],
+        "owners": ["pikorddg", "aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unified_input_surface"]
     },
     "m_aichat_unified_input_file_removed": {
         "description": "Fires when the user removes an attached file (or invalid file) from the Unified Toggle Input.",
-        "owners": ["pikorddg"],
+        "owners": ["pikorddg", "aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unified_input_surface"]
     },
     "m_aichat_unified_input_file_validation_failed": {
         "description": "Fires when an attached file is rejected by the Unified Toggle Input attachment policy.",
-        "owners": ["pikorddg"],
+        "owners": ["pikorddg", "aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": [
             "appVersion",
+            "unified_input_surface",
             {
                 "key": "reason",
                 "description": "Reason for the file validation failure.",
@@ -168,7 +177,7 @@
     },
     "m_aichat_unified_input_voice_tapped": {
         "description": "Fires when the user taps the voice waveform button in the Unified Toggle Input.",
-        "owners": ["pikorddg"],
+        "owners": ["pikorddg", "aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": [
@@ -177,16 +186,16 @@
                 "key": "source",
                 "description": "Surface from which voice chat was triggered, based on input mode at the time of tap.",
                 "type": "string",
-                "enum": ["ntp", "duck_ai"]
+                "enum": ["address_bar", "duck_ai", "contextual_chat"]
             }
         ]
     },
     "m_aichat_unified_input_stop_generation_tapped": {
         "description": "Fires when the user taps the stop button during Duck.ai stream in the Unified Toggle Input.",
-        "owners": ["pikorddg"],
+        "owners": ["pikorddg", "aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unified_input_surface"]
     },
     "m_aichat_unified_input_subscription_upsell_triggered": {
         "description": "Fires when the user taps a gated model or reasoning level in the Unified Toggle Input and the native subscription/upgrade flow is triggered.",
@@ -297,11 +306,12 @@
     },
     "m_aichat_unified_input_prompt_submitted": {
         "description": "Fires on every UTI submission in the .aiChat branch, regardless of selected tool. Captures the full submit-time state of the input (tool, model, reasoning effort, attachments, text presence).",
-        "owners": ["pikorddg"],
+        "owners": ["pikorddg", "aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": [
             "appVersion",
+            "unified_input_surface",
             {
                 "key": "selected_tool",
                 "description": "Selected tool at submission time.",
@@ -338,18 +348,19 @@
     },
     "aichat_unified_input_show_model_picker": {
         "description": "Fires when native surfaces the model picker in response to the FE showModelPicker bridge message (recovery picker session entry).",
-        "owners": ["pikorddg"],
+        "owners": ["pikorddg", "aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unified_input_surface"]
     },
     "aichat_unified_input_submit_change_model": {
         "description": "Fires when native emits submitChangeModelAction to the FE during an active recovery picker session.",
-        "owners": ["pikorddg"],
+        "owners": ["pikorddg", "aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": [
             "appVersion",
+            "unified_input_surface",
             {
                 "key": "model_id",
                 "description": "The model id reported to the FE via submitChangeModelAction.",
@@ -359,10 +370,10 @@
     },
     "aichat_unified_input_submit_change_model_prompt_sent": {
         "description": "Fires when the user successfully submits a prompt that ends a recovery picker session.",
-        "owners": ["pikorddg"],
+        "owners": ["pikorddg", "aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unified_input_surface"]
     },
     "m_aichat_unified_input_duck_ai_direct_navigation": {
         "description": "Fires when Duck.ai is disabled under AI Features settings yet the user navigates directly to Duck.ai by typing its address into the Unified Toggle Input and submitting. Does not fire for the in-input Duck.ai shortcut button or other Duck.ai entry points.",

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
@@ -187,6 +187,11 @@
                 "description": "Surface from which voice chat was triggered, based on input mode at the time of tap.",
                 "type": "string",
                 "enum": ["address_bar", "duck_ai", "contextual_chat"]
+            },
+            {
+                "key": "has_pending_page_context",
+                "description": "Whether page context was attached but not yet submitted at the moment of the tap (contextual chat only; always false on other surfaces). Measures users tapping voice expecting the attached context to carry into the voice chat.",
+                "type": "boolean"
             }
         ]
     },

--- a/iOS/PixelDefinitions/pixels/params_dictionary.json5
+++ b/iOS/PixelDefinitions/pixels/params_dictionary.json5
@@ -9,6 +9,12 @@
         "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
         "examples": ["7.175.1"]
     },
+    "unified_input_surface": {
+        "key": "surface",
+        "type": "string",
+        "description": "The Unified Toggle Input surface the pixel was fired from, distinguishing the contextual chat sheet from the Duck.ai tab and the address bar.",
+        "enum": ["address_bar", "duck_ai", "contextual_chat"]
+    },
     "cookie_popup_preference": {
         "key": "cookie_popup_preference",
         "type": "string",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1216049537026988

### Description

Adds a `surface` parameter (`address_bar` / `duck_ai` / `contextual_chat`) to the Unified Toggle Input (UTI) telemetry pixels so usage in the contextual chat sheet can be told apart from the Duck.ai tab and the address bar. Reuses the shared pixel helpers added in #5768 (iPhone + iPad both emit `surface`).

Also retires two orphaned pixels — `m_aichat_contextual_page_context_placeholder_shown` / `_tapped` — the tappable placeholder chip they tracked no longer exists in the UTI.

Subscription attribution is deliberately untouched: the picker-shown and upsell pixels keep folding the contextual sheet into the `funnel_duckai_*` origin (no change to `SubscriptionFunnelOrigin` or the subscription redirect URL).

### Pixels

- **`surface` added** (`pikorddg` + `aataraxiaa` co-owned): prompt_submitted, model_selected, reasoning_effort_selected, image-gen/web-search selected·deselected·submitted, customize_responses_selected, image/file attached & removed, file_validation_failed, voice_tapped (via its existing `source` key), stop_generation_tapped, show_model_picker, submit_change_model(_prompt_sent).
- **`voice_tapped`** also gains **`has_pending_page_context`** (boolean) — whether page context was attached but not yet submitted at tap time (contextual only; always false elsewhere). Measures users tapping voice expecting the attached context to carry into the voice chat.
- **Unchanged** (origin-only): model_picker_shown, reasoning_effort_picker_shown, subscription_upsell_triggered.
- **Retired**: page_context_placeholder_shown / _tapped.

### Testing Steps

Internal only. **Enable these feature flags** (Debug → Feature Flags):
- `unifiedToggleInput` — the UTI itself
- `aiChatContextualUnifiedToggleInput` — **puts the UTI inside the contextual sheet (the surface this PR is about)**
- `iPadDuckAIBarControls` — required for the iPad step only

Observe param values in the xcode console.

1. **Contextual sheet (iPhone):** open the Duck.ai sheet over a web page → select a model, toggle a tool, attach an image + a file, tap voice, submit a prompt. Confirm each pixel carries `surface=contextual_chat` (voice_tapped `source=contextual_chat`).
   - **Voice + pending context:** with page context attached but **not yet submitted**, tap the voice waveform button → voice_tapped fires with `has_pending_page_context=true`. Tap voice with no attached context (or after submitting) → `has_pending_page_context=false`.
2. **Contextual — remove/deselect:** remove the attachment and deselect the tool → removed / deselected pixels carry `surface=contextual_chat`.
3. **Contextual — gated model:** tap a gated model → upsell fires with `origin=funnel_duckai_ios__modelpicker` (contextual still folds into duckai — unchanged).
4. **Duck.ai tab:** repeat the actions on the full Duck.ai tab → pixels carry `surface=duck_ai`.
5. **Address bar (iPhone):** repeat from the omnibar/NTP UTI → `surface=address_bar`.
6. **iPad address bar:** with `iPadDuckAIBarControls` on, repeat model / tool / attachment / submit on the iPad Duck.ai bar → `surface=address_bar`.
7. **Regression:** confirm the placeholder pixels no longer fire, and page-context attach / remove / auto-attach pixels still fire in the contextual sheet.

### Impact and Risks

Low — analytics-only; no UI, logic, or behavior change. Subscription/redirect attribution untouched. Verified: pixel definitions validate, all shared-helper call sites carry `surface`, adversarial review clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only: new pixel parameters and retired events with no product logic, auth, or data-handling changes.
> 
> **Overview**
> Adds **`surface`** (`address_bar` / `duck_ai` / `contextual_chat`) to Unified Toggle Input telemetry so contextual sheet usage can be split from the Duck.ai tab and omnibar. **`UnifiedToggleInputPixelSurface`** and coordinator **`pixelSurface`** drive the value; shared **`UnifiedToggleInputCoordinatorPixelHelper`** APIs now take **`surface`**, and iPhone coordinator, iPad omnibar controllers, and **`UnifiedToggleInputAttachmentPresenter`** (via **`pixelSurfaceProvider`**) pass it through on submit, model/tool/reasoning, attachments, stop-generation, and related events.
> 
> **`voice_tapped`** now uses those same values on its existing **`source`** key (replacing **`ntp`** / **`duck_ai`**) and adds **`has_pending_page_context`**, wired from the contextual host through **`hasPendingPageContextProvider`**. Pixel JSON definitions and **`unified_input_surface`** in **`params_dictionary.json5`** document the new param; subscription funnel **`origin`** on picker-shown / upsell pixels is unchanged.
> 
> **Removes** obsolete **`m_aichat_contextual_page_context_placeholder_shown`** / **`_tapped`** events and their handler methods after the placeholder chip was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97b971317ba4aa9559cb46e2607bbee45e69d117. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->