### PR TITLE
Add shadow change-detection to the PR check gate

### DIFF
--- a/.github/scripts/derive-suite-closures.sh
+++ b/.github/scripts/derive-suite-closures.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# derive-suite-closures.sh  (REPLAY / ANALYSIS ONLY — not used by the CI gate)
+#
+# Derives, offline (no swift, no network), which SharedPackages a change must
+# touch to warrant running the BSK unit-test suite vs the DBP unit-test suite.
+#
+# Method: read the local package graph from each SharedPackages Package.swift's
+# `.package(path:)` edges, then take the forward dependency closure of the BSK
+# and DBP package roots. A suite must run when its package OR anything that
+# package (transitively) depends on changes, so the trigger set = that root's
+# dependency closure. DBP depends on BSK, so DBP_CLOSURE ⊇ BSK_CLOSURE.
+#
+# Output (stdout), consumed by replay_change_detection.yml:
+#   BSK_CLOSURE=<space-separated package ids>
+#   DBP_CLOSURE=<space-separated package ids>
+#
+# Package id = directory under SharedPackages/, e.g. "BrowserServicesKit" or
+# "Infrastructure/SystemFrameworksExtensions".
+
+set -euo pipefail
+
+SP="${1:-SharedPackages}"
+edges=$(mktemp)
+trap 'rm -f "$edges"' EXIT
+
+# Canonicalise a SharedPackages-relative path to a package id: keep the first
+# path component, except under Infrastructure/ keep the first two.
+canon() {
+  case "$1" in
+    Infrastructure/*) printf '%s/%s\n' Infrastructure "$(printf '%s' "${1#Infrastructure/}" | cut -d/ -f1)" ;;
+    *) printf '%s\n' "$(printf '%s' "$1" | cut -d/ -f1)" ;;
+  esac
+}
+
+# Build package -> package edges from real package manifests (depth 2, or depth
+# 3 directly under Infrastructure/). Skip any nested/fixture manifests.
+while IFS= read -r m; do
+  id=${m#"$SP"/}; id=${id%/Package.swift}
+  case "$id" in
+    Infrastructure/*/*) continue ;;   # deeper than Infrastructure/<sub>
+    */*/*)              continue ;;   # deeper than a top-level package
+    Infrastructure/*)   : ;;          # Infrastructure/<sub> — ok
+    */*)                continue ;;   # 2-component non-Infrastructure — skip
+    *)                  : ;;          # top-level package — ok
+  esac
+  d=$(dirname "$m")
+  { grep -oE '\.package\(path: *"[^"]*"' "$m" 2>/dev/null || true; } \
+    | sed -E 's/.*path: *"//; s/"$//' \
+    | while IFS= read -r rel; do
+        [ -z "$rel" ] && continue
+        # Resolve rel against the manifest dir, lexically, relative to SP —
+        # no filesystem access needed and portable across macOS/Linux.
+        tgt=$(python3 -c 'import os,sys; print(os.path.relpath(os.path.normpath(os.path.join(sys.argv[1],sys.argv[2])), sys.argv[3]))' "$d" "$rel" "$SP")
+        case "$tgt" in ..*) continue ;; esac   # resolves outside SharedPackages
+        printf '%s\t%s\n' "$id" "$(canon "$tgt")" >> "$edges"
+      done
+done < <(find "$SP" -name Package.swift)
+
+# Forward-reachability closure from a root package (root included).
+closure() {
+  awk -v root="$1" -F'\t' '
+    { dep[$1] = dep[$1] " " $2 }
+    END {
+      seen[root] = 1; q[n++] = root
+      for (i = 0; i < n; i++) {
+        c = q[i]; m = split(dep[c], a, " ")
+        for (j = 1; j <= m; j++) {
+          t = a[j]
+          if (t != "" && !(t in seen)) { seen[t] = 1; q[n++] = t }
+        }
+      }
+      for (k in seen) print k
+    }' "$edges" | sort | paste -sd' ' -
+}
+
+# Single-quoted so the space-separated lists are safe to `eval`.
+printf "BSK_CLOSURE='%s'\n" "$(closure BrowserServicesKit)"
+printf "DBP_CLOSURE='%s'\n" "$(closure DataBrokerProtectionCore)"

--- a/.github/scripts/detect-changed-areas.sh
+++ b/.github/scripts/detect-changed-areas.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# detect-changed-areas.sh
+#
+# Single source of truth for CI change-area detection. Reads a
+# newline-separated list of changed file paths on stdin and prints one
+# "<area>=<true|false>" line per area (ios, macos, shared) to stdout.
+#
+# Consumed by:
+#   - .github/workflows/should_run_pr_checks.yml (shadow detection in the PR gate)
+#   - .github/workflows/replay_change_detection.yml (replay validation on past PRs)
+#
+# Local usage:
+#   git diff --name-only origin/main...HEAD | .github/scripts/detect-changed-areas.sh
+
+set -euo pipefail
+
+files=$(cat)
+
+# A group entry ending in "/" matches everything under that directory;
+# any other entry is matched as an exact file path.
+changed() {
+  local f p
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    # shellcheck disable=SC2086 # intentional word splitting of the group list
+    for p in $1; do
+      case "$p" in
+        */) case "$f" in "$p"*) return 0 ;; esac ;;
+        *)  [ "$f" = "$p" ] && return 0 ;;
+      esac
+    done
+  done <<< "$files"
+  return 1
+}
+
+# Dependency closures. ci_infra = composite actions + the gate workflow +
+# this script + the Xcode version; a change to any of them forces every
+# area to run. shared adds the SharedPackages closure, which covers every
+# in-repo package (including BrowserServicesKit and DataBrokerProtectionCore).
+# Standalone automation workflows (e.g. macos_check_sparkle_update.yml) are
+# intentionally absent, so editing them matches no area.
+ci_infra=".github/actions/ .github/workflows/should_run_pr_checks.yml .github/scripts/detect-changed-areas.sh .xcode-version"
+shared="$ci_infra SharedPackages/"
+
+ios="$shared scripts/translation-pr-checks/ iOS/ .github/workflows/ios_pr_checks.yml"
+macos="$shared scripts/translation-pr-checks/ macOS/ .github/workflows/macos_pr_checks.yml .github/workflows/macos_private_api_report.yml"
+
+for area in ios macos shared; do
+  if changed "${!area}"; then echo "${area}=true"; else echo "${area}=false"; fi
+done

--- a/.github/workflows/replay_change_detection.yml
+++ b/.github/workflows/replay_change_detection.yml
@@ -24,6 +24,7 @@ on:
   pull_request:
     paths:
       - '.github/scripts/detect-changed-areas.sh'
+      - '.github/scripts/derive-suite-closures.sh'
       - '.github/workflows/replay_change_detection.yml'
 
 jobs:
@@ -35,10 +36,12 @@ jobs:
       pull-requests: read
       checks: read
     steps:
-      - name: Check out the change-detection script
+      - name: Check out scripts and SharedPackages manifests
         uses: actions/checkout@v6
         with:
-          sparse-checkout: .github/scripts/detect-changed-areas.sh
+          sparse-checkout: |
+            .github/scripts
+            SharedPackages/**/Package.swift
           sparse-checkout-cone-mode: false
 
       - name: Replay and cross-check
@@ -56,6 +59,21 @@ jobs:
             prs=$(gh pr list --repo "$REPO" --state merged --limit "${COUNT:-15}" \
               --json number --jq '.[].number' | tr '\n' ' ')
           fi
+
+          # Derive the BSK/DBP suite trigger closures once, offline, from the
+          # SharedPackages package graph (replay-only analysis; the gate does
+          # not use this). See .github/scripts/derive-suite-closures.sh.
+          eval "$(.github/scripts/derive-suite-closures.sh SharedPackages)"
+          echo "BSK_CLOSURE=$BSK_CLOSURE"
+          echo "DBP_CLOSURE=$DBP_CLOSURE"
+
+          in_set() { case " $2 " in *" $1 "*) return 0 ;; esac; return 1; }
+
+          # Per-SharedPackages-PR records for the precise-vs-coarse analysis:
+          #   pr \t bsk_precise \t dbp_precise \t bsk_secs_today \t dbp_secs_today \t pkgs
+          sp_records=$(mktemp)
+          bsk_durs=$(mktemp)   # measured BSK-suite seconds, any PR it ran
+          dbp_durs=$(mktemp)   # measured DBP-suite seconds, any PR it ran
 
           # "Would have saved" = a heavy check that ACTUALLY RAN (conclusion
           # success/failure) but belongs to a workflow our flags would skip.
@@ -89,13 +107,38 @@ jobs:
             total_prs=$((total_prs + 1))
             title=$(gh pr view "$pr" --repo "$REPO" --json title --jq '.title' | tr '|' '-' | cut -c1-60)
 
-            if ! flags=$(gh pr diff "$pr" --repo "$REPO" --name-only | .github/scripts/detect-changed-areas.sh); then
+            if ! files=$(gh pr diff "$pr" --repo "$REPO" --name-only); then
               echo "| #$pr | $title | error | error | error | - | - | - |" >> "$GITHUB_STEP_SUMMARY"
               continue
             fi
+            flags=$(printf '%s\n' "$files" | .github/scripts/detect-changed-areas.sh)
             ios=$(grep '^ios=' <<< "$flags" | cut -d= -f2)
             macos=$(grep '^macos=' <<< "$flags" | cut -d= -f2)
             shared=$(grep '^shared=' <<< "$flags" | cut -d= -f2)
+
+            # Fetch this PR's check runs once; reuse for both analyses.
+            # gh pr checks exits non-zero when any check failed; that is data, not an error.
+            checks_json=$(gh pr checks "$pr" --repo "$REPO" --json workflow,name,state,startedAt,completedAt 2>/dev/null || true)
+
+            # --- Precise BSK/DBP analysis (SharedPackages PRs only) ---
+            sp_pkgs=$(printf '%s\n' "$files" \
+              | awk -F/ '$1=="SharedPackages" && NF>=2 { if ($2=="Infrastructure" && NF>=3) print $2"/"$3; else print $2 }' \
+              | sort -u)
+            if [ -n "$sp_pkgs" ]; then
+              bskp=0; dbpp=0
+              while IFS= read -r p; do
+                in_set "$p" "$BSK_CLOSURE" && bskp=1
+                in_set "$p" "$DBP_CLOSURE" && dbpp=1
+              done <<< "$sp_pkgs"
+              bsk_secs=0; dbp_secs=0
+              if [ -n "$checks_json" ]; then
+                bsk_secs=$(jq -r '[.[]|select(.workflow=="BSK - PR Checks" and (.state=="SUCCESS" or .state=="FAILURE") and .startedAt!=null and .completedAt!=null)|((.completedAt|fromdateiso8601)-(.startedAt|fromdateiso8601))]|add//0' <<< "$checks_json")
+                dbp_secs=$(jq -r '[.[]|select(.workflow=="DBP - PR Checks" and (.state=="SUCCESS" or .state=="FAILURE") and .startedAt!=null and .completedAt!=null)|((.completedAt|fromdateiso8601)-(.startedAt|fromdateiso8601))]|add//0' <<< "$checks_json")
+              fi
+              awk "BEGIN{exit !($bsk_secs>0)}" && echo "$bsk_secs" >> "$bsk_durs"
+              awk "BEGIN{exit !($dbp_secs>0)}" && echo "$dbp_secs" >> "$dbp_durs"
+              printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$pr" "$bskp" "$dbpp" "$bsk_secs" "$dbp_secs" "$(printf '%s' "$sp_pkgs" | paste -sd, -)" >> "$sp_records"
+            fi
 
             # Map each would-skip area to the workflows it would gate.
             skip_areas=""
@@ -116,8 +159,6 @@ jobs:
             saved="-"
             saved_min="0"
             if [ ${#skip_workflows[@]} -gt 0 ]; then
-              # gh pr checks exits non-zero when any check failed; that is data, not an error.
-              checks_json=$(gh pr checks "$pr" --repo "$REPO" --json workflow,name,state,startedAt,completedAt 2>/dev/null || true)
               if [ -n "$checks_json" ]; then
                 wf_json=$(printf '%s\n' "${skip_workflows[@]}" | jq -R . | jq -cs .)
 
@@ -176,3 +217,72 @@ jobs:
 
           echo "TOTALS: replayed=$total_prs saved_prs=$saved_prs grand_total_job_min=$grand_total_min"
           echo "TALLY:"; sort "$saved_tally" | uniq -c | sort -rn
+
+          # ---- Precise BSK/DBP split economics ----
+          # Median measured suite job-min, used to model the consolidated
+          # end-state where a suite that a flag selects would run.
+          median_min() { # reads seconds on stdin; prints minutes (1 dp)
+            sort -n | awk '{a[NR]=$1} END{n=NR; if(n==0){print "0.0";exit}
+              if(n%2){printf "%.1f\n", a[(n+1)/2]/60} else {printf "%.1f\n",(a[n/2]+a[n/2+1])/2/60}}'
+          }
+          MED_BSK=$(median_min < "$bsk_durs")
+          MED_DBP=$(median_min < "$dbp_durs")
+          N_BSK_RAN=$(wc -l < "$bsk_durs" | tr -d ' ')
+          N_DBP_RAN=$(wc -l < "$dbp_durs" | tr -d ' ')
+
+          # Aggregate the per-PR records into the coarse-vs-precise deltas.
+          totals=$(awk -F'\t' -v mb="$MED_BSK" -v md="$MED_DBP" '
+            { n++
+              coarse += mb + md
+              pb = ($2==1?mb:0); pd = ($3==1?md:0)
+              precise += pb + pd
+              today += ($4/60) + ($5/60)
+              if ($2==1) bskclosure++
+              else if ($3==1) dbponly++
+              else neither_or_leaf++
+              # correctness edge: BSK-closure change where DBP suite did not run today
+              if ($2==1 && $5+0==0) { addc += md; addn++ }
+            }
+            END {
+              printf "%d\t%.1f\t%.1f\t%.1f\t%.1f\t%d\t%d\t%d\t%d",
+                n, coarse, precise, coarse-precise, addc, addn,
+                bskclosure, dbponly, neither_or_leaf
+            }' "$sp_records")
+          IFS=$'\t' read -r SP_N T_COARSE T_PRECISE T_SAVE T_ADD N_ADD N_BSKC N_DBPO N_NEITHER <<< "$totals"
+          NET_TODAY=$(awk -F'\t' -v mb="$MED_BSK" -v md="$MED_DBP" '
+            { pb=($2==1?mb:0); pd=($3==1?md:0); precise+=pb+pd; today+=($4/60)+($5/60) }
+            END{ printf "%.1f", precise-today }' "$sp_records")
+
+          {
+            echo ""
+            echo "## Precise BSK/DBP split (replay-only analysis)"
+            echo ""
+            echo "Suite trigger closures derived offline from the SharedPackages package graph by \`.github/scripts/derive-suite-closures.sh\` (the gate does not use this):"
+            echo "- \`BSK_CLOSURE\` = ${BSK_CLOSURE// /, }"
+            echo "- \`DBP_CLOSURE\` = ${DBP_CLOSURE// /, }"
+            echo ""
+            echo "Modelled suite cost (median measured job-min): BSK ${MED_BSK} (n=${N_BSK_RAN}), DBP ${MED_DBP} (n=${N_DBP_RAN})."
+            echo ""
+            echo "**Coarse** \`shared\` runs BSK+DBP on every SharedPackages PR. **Precise** runs BSK only if the change hits BSK_CLOSURE, DBP only if it hits DBP_CLOSURE. \`ran today\` are the suite job-min that actually executed under today's per-package native filters."
+            echo ""
+            echo "| PR | SharedPackages | coarse bsk/dbp | precise bsk/dbp | precise job-min | ran today bsk/dbp (min) |"
+            echo "|---|---|---|---|---|---|"
+            while IFS=$'\t' read -r pr bskp dbpp bs ds pkgs; do
+              pj=$(awk -v mb="$MED_BSK" -v md="$MED_DBP" -v b="$bskp" -v d="$dbpp" 'BEGIN{printf "%.1f",(b==1?mb:0)+(d==1?md:0)}')
+              bm=$(awk -v s="$bs" 'BEGIN{printf "%.1f",s/60}')
+              dm=$(awk -v s="$ds" 'BEGIN{printf "%.1f",s/60}')
+              yb=$([ "$bskp" = 1 ] && echo Y || echo -)
+              yd=$([ "$dbpp" = 1 ] && echo Y || echo -)
+              echo "| #$pr | $pkgs | Y/Y | $yb/$yd | $pj | $bm/$dm |"
+            done < "$sp_records"
+            echo ""
+            echo "### BSK/DBP totals over the batch"
+            echo ""
+            echo "- SharedPackages PRs: **$SP_N** (BSK-closure: $N_BSKC, DBP-subtree-only: $N_DBPO, neither/app-leaf: $N_NEITHER)"
+            echo "- (a) Consolidated-scenario job-min PRECISE SAVES vs coarse: **${T_SAVE}** (coarse ${T_COARSE} − precise ${T_PRECISE})"
+            echo "- (b) Correctness edge — DBP suite added on BSK-closure changes that skip DBP today: **${T_ADD}** job-min over $N_ADD PRs"
+            echo "- (c) Net vs TODAY (precise consolidated − today's measured bsk/dbp): **${NET_TODAY}** job-min (≈ the correctness add; precise saves ~0 vs today because native filters already skip unrelated packages)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "BSKDBP: sp_prs=$SP_N med_bsk=$MED_BSK med_dbp=$MED_DBP saving=$T_SAVE correctness_add=$T_ADD net_vs_today=$NET_TODAY bskclosure=$N_BSKC dbponly=$N_DBPO neither=$N_NEITHER"
+          echo "BSK_CLOSURE=[$BSK_CLOSURE] DBP_CLOSURE=[$DBP_CLOSURE]"

--- a/.github/workflows/replay_change_detection.yml
+++ b/.github/workflows/replay_change_detection.yml
@@ -69,8 +69,8 @@ jobs:
           # workflow triggers, and is not a heavy job we would save.
           saved_tally=$(mktemp)   # one "<workflow>: <job>" line per RAN saving
           saved_prs=0
-          mismatch_prs=0
           total_prs=0
+          grand_total_min=0
 
           {
             echo "## Change-detection replay"
@@ -79,9 +79,9 @@ jobs:
             echo ""
             echo "**Would have saved** = heavy checks that actually ran (success/failure) but belong to a would-skip area — the incremental jobs our detection would remove. Checks that are absent (native \`paths:\` filter already skipped the workflow) or skipped/neutral do not count."
             echo ""
-            echo "**Failed in would-skip areas** = a would-skip workflow had a failing check. Any entry there is a mismatch: detection would have hidden a real failure."
+            echo "**Saved (job-min)** = summed wall duration of those RAN checks (completedAt − startedAt per check). This is **compute / job-minutes** — the sum of individual job durations, i.e. CI runner cost saved. It is NOT wall-clock time-to-green: these jobs run in parallel, so the schedule doesn't shorten by this amount."
             echo ""
-            echo "| PR | Title | ios | macos | shared | Would skip | Would-have-saved jobs (ran) | Failed in would-skip areas |"
+            echo "| PR | Title | ios | macos | shared | Would skip | Would-have-saved jobs (ran) | Saved (job-min) |"
             echo "|---|---|---|---|---|---|---|---|"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -90,7 +90,7 @@ jobs:
             title=$(gh pr view "$pr" --repo "$REPO" --json title --jq '.title' | tr '|' '-' | cut -c1-60)
 
             if ! flags=$(gh pr diff "$pr" --repo "$REPO" --name-only | .github/scripts/detect-changed-areas.sh); then
-              echo "| #$pr | $title | error | error | error | - | - | could not compute flags |" >> "$GITHUB_STEP_SUMMARY"
+              echo "| #$pr | $title | error | error | error | - | - | - |" >> "$GITHUB_STEP_SUMMARY"
               continue
             fi
             ios=$(grep '^ios=' <<< "$flags" | cut -d= -f2)
@@ -114,41 +114,43 @@ jobs:
             fi
 
             saved="-"
-            failed="-"
+            saved_min="0"
             if [ ${#skip_workflows[@]} -gt 0 ]; then
               # gh pr checks exits non-zero when any check failed; that is data, not an error.
-              checks_json=$(gh pr checks "$pr" --repo "$REPO" --json workflow,name,state 2>/dev/null || true)
+              checks_json=$(gh pr checks "$pr" --repo "$REPO" --json workflow,name,state,startedAt,completedAt 2>/dev/null || true)
               if [ -n "$checks_json" ]; then
                 wf_json=$(printf '%s\n' "${skip_workflows[@]}" | jq -R . | jq -cs .)
 
                 # RAN checks in would-skip workflows, excluding the gate job.
-                ran_json=$(jq -c --argjson wf "$wf_json" \
-                  '[.[]
+                # Emit "<workflow>: <job>\t<duration-seconds>" per RAN check.
+                ran_tsv=$(jq -r --argjson wf "$wf_json" '
+                  [.[]
                     | select((.state == "SUCCESS" or .state == "FAILURE")
                              and (.name | test("Determine if checks should run") | not)
                              and (.workflow as $w | $wf | index($w)))
-                    | "\(.workflow): \(.name)"] | unique' <<< "$checks_json")
-                ran_count=$(jq 'length' <<< "$ran_json")
-                if [ "$ran_count" -gt 0 ]; then
-                  saved=$(jq -r 'join("; ")' <<< "$ran_json")
-                  saved_prs=$((saved_prs + 1))
-                  jq -r '.[]' <<< "$ran_json" >> "$saved_tally"
-                fi
+                    | { key: "\(.workflow): \(.name)",
+                        secs: (if (.startedAt != null and .completedAt != null and .startedAt != "" and .completedAt != "")
+                               then ((.completedAt | fromdateiso8601) - (.startedAt | fromdateiso8601)) else 0 end) }]
+                  | unique_by(.key) | .[] | "\(.key)\t\(.secs)"' <<< "$checks_json")
 
-                # Failing checks in would-skip workflows (secondary safety check).
-                failed=$(jq -r --argjson wf "$wf_json" \
-                  '[.[] | select(.state == "FAILURE" and (.workflow as $w | $wf | index($w))) | "\(.workflow): \(.name)"] | unique | join("; ")' \
-                  <<< "$checks_json")
-                if [ -n "$failed" ]; then failed="MISMATCH - $failed"; mismatch_prs=$((mismatch_prs + 1)); else failed="-"; fi
+                if [ -n "$ran_tsv" ]; then
+                  saved=$(cut -f1 <<< "$ran_tsv" | paste -sd ';' - | sed 's/;/; /g')
+                  # Sum durations (seconds -> minutes, one decimal) and tally job names.
+                  secs=$(cut -f2 <<< "$ran_tsv" | awk '{s+=$1} END {print s+0}')
+                  saved_min=$(awk -v s="$secs" 'BEGIN {printf "%.1f", s/60}')
+                  grand_total_min=$(awk -v a="$grand_total_min" -v b="$saved_min" 'BEGIN {printf "%.1f", a+b}')
+                  saved_prs=$((saved_prs + 1))
+                  cut -f1 <<< "$ran_tsv" >> "$saved_tally"
+                fi
               else
                 saved="checks unavailable"
-                failed="checks unavailable"
+                saved_min="-"
               fi
             fi
 
             url="https://github.com/$REPO/pull/$pr"
-            echo "| [#$pr]($url) | $title | $ios | $macos | $shared | ${skip_areas:- -} | $saved | $failed |" >> "$GITHUB_STEP_SUMMARY"
-            echo "PR #$pr: ios=$ios macos=$macos shared=$shared would-skip:${skip_areas:- none} saved:[$saved] failed-in-skip: $failed"
+            echo "| [#$pr]($url) | $title | $ios | $macos | $shared | ${skip_areas:- -} | $saved | $saved_min |" >> "$GITHUB_STEP_SUMMARY"
+            echo "PR #$pr: ios=$ios macos=$macos shared=$shared would-skip:${skip_areas:- none} saved-job-min:$saved_min saved:[$saved]"
           done
 
           # ---- Summary totals ----
@@ -158,7 +160,7 @@ jobs:
             echo ""
             echo "- PRs replayed: **$total_prs**"
             echo "- PRs with >=1 would-have-saved job (real marginal saving): **$saved_prs**"
-            echo "- PRs with a failure in a would-skip area (mismatches — should be 0): **$mismatch_prs**"
+            echo "- **Grand total saved: ${grand_total_min} job-minutes** (compute / runner cost, summed job durations — NOT wall-clock)"
             echo ""
             echo "### Would-have-saved jobs by frequency (count = PRs where that job ran but would be skipped)"
             echo ""
@@ -172,5 +174,5 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-          echo "TOTALS: replayed=$total_prs saved_prs=$saved_prs mismatch_prs=$mismatch_prs"
+          echo "TOTALS: replayed=$total_prs saved_prs=$saved_prs grand_total_job_min=$grand_total_min"
           echo "TALLY:"; sort "$saved_tally" | uniq -c | sort -rn

--- a/.github/workflows/replay_change_detection.yml
+++ b/.github/workflows/replay_change_detection.yml
@@ -20,7 +20,7 @@ on:
         description: 'How many recent merged PRs to replay when pr_numbers is empty'
         required: false
         type: string
-        default: '15'
+        default: '100'
   pull_request:
     paths:
       - '.github/scripts/detect-changed-areas.sh'
@@ -57,22 +57,40 @@ jobs:
               --json number --jq '.[].number' | tr '\n' ' ')
           fi
 
+          # "Would have saved" = a heavy check that ACTUALLY RAN (conclusion
+          # success/failure) but belongs to a workflow our flags would skip.
+          # We classify each would-skip workflow's checks into three states:
+          #   RAN         -> state SUCCESS or FAILURE  => real marginal saving
+          #   skipped/neutral (job-level `if:` skipped) => zero saving
+          #   absent      -> not present at all (native paths: filter already
+          #                  skipped the whole workflow) => zero saving
+          # Only RAN counts. The gate job itself ("Determine if checks should
+          # run") is excluded — it is the no-op gate, present whenever the
+          # workflow triggers, and is not a heavy job we would save.
+          saved_tally=$(mktemp)   # one "<workflow>: <job>" line per RAN saving
+          saved_prs=0
+          mismatch_prs=0
+          total_prs=0
+
           {
             echo "## Change-detection replay"
             echo ""
             echo "Flags computed by \`.github/scripts/detect-changed-areas.sh\` — the same script the shadow gate runs."
-            echo "\"Failed checks in would-skip areas\" lists failing check runs that belong to a workflow the flags"
-            echo "would have skipped; any entry there means the detection would have hidden a real failure."
             echo ""
-            echo "| PR | Title | ios | macos | shared | Would skip | Failed checks in would-skip areas |"
-            echo "|---|---|---|---|---|---|---|"
+            echo "**Would have saved** = heavy checks that actually ran (success/failure) but belong to a would-skip area — the incremental jobs our detection would remove. Checks that are absent (native \`paths:\` filter already skipped the workflow) or skipped/neutral do not count."
+            echo ""
+            echo "**Failed in would-skip areas** = a would-skip workflow had a failing check. Any entry there is a mismatch: detection would have hidden a real failure."
+            echo ""
+            echo "| PR | Title | ios | macos | shared | Would skip | Would-have-saved jobs (ran) | Failed in would-skip areas |"
+            echo "|---|---|---|---|---|---|---|---|"
           } >> "$GITHUB_STEP_SUMMARY"
 
           for pr in $prs; do
+            total_prs=$((total_prs + 1))
             title=$(gh pr view "$pr" --repo "$REPO" --json title --jq '.title' | tr '|' '-' | cut -c1-60)
 
             if ! flags=$(gh pr diff "$pr" --repo "$REPO" --name-only | .github/scripts/detect-changed-areas.sh); then
-              echo "| #$pr | $title | error | error | error | - | could not compute flags |" >> "$GITHUB_STEP_SUMMARY"
+              echo "| #$pr | $title | error | error | error | - | - | could not compute flags |" >> "$GITHUB_STEP_SUMMARY"
               continue
             fi
             ios=$(grep '^ios=' <<< "$flags" | cut -d= -f2)
@@ -95,22 +113,64 @@ jobs:
               skip_workflows+=("BSK - PR Checks" "DBP - PR Checks")
             fi
 
+            saved="-"
             failed="-"
             if [ ${#skip_workflows[@]} -gt 0 ]; then
               # gh pr checks exits non-zero when any check failed; that is data, not an error.
               checks_json=$(gh pr checks "$pr" --repo "$REPO" --json workflow,name,state 2>/dev/null || true)
               if [ -n "$checks_json" ]; then
                 wf_json=$(printf '%s\n' "${skip_workflows[@]}" | jq -R . | jq -cs .)
+
+                # RAN checks in would-skip workflows, excluding the gate job.
+                ran_json=$(jq -c --argjson wf "$wf_json" \
+                  '[.[]
+                    | select((.state == "SUCCESS" or .state == "FAILURE")
+                             and (.name | test("Determine if checks should run") | not)
+                             and (.workflow as $w | $wf | index($w)))
+                    | "\(.workflow): \(.name)"] | unique' <<< "$checks_json")
+                ran_count=$(jq 'length' <<< "$ran_json")
+                if [ "$ran_count" -gt 0 ]; then
+                  saved=$(jq -r 'join("; ")' <<< "$ran_json")
+                  saved_prs=$((saved_prs + 1))
+                  jq -r '.[]' <<< "$ran_json" >> "$saved_tally"
+                fi
+
+                # Failing checks in would-skip workflows (secondary safety check).
                 failed=$(jq -r --argjson wf "$wf_json" \
-                  '[.[] | select(.state == "FAILURE" and (.workflow as $w | $wf | index($w))) | "\(.workflow): \(.name)"] | join("; ")' \
+                  '[.[] | select(.state == "FAILURE" and (.workflow as $w | $wf | index($w))) | "\(.workflow): \(.name)"] | unique | join("; ")' \
                   <<< "$checks_json")
-                if [ -n "$failed" ]; then failed="MISMATCH - $failed"; else failed="-"; fi
+                if [ -n "$failed" ]; then failed="MISMATCH - $failed"; mismatch_prs=$((mismatch_prs + 1)); else failed="-"; fi
               else
+                saved="checks unavailable"
                 failed="checks unavailable"
               fi
             fi
 
             url="https://github.com/$REPO/pull/$pr"
-            echo "| [#$pr]($url) | $title | $ios | $macos | $shared | ${skip_areas:- -} | $failed |" >> "$GITHUB_STEP_SUMMARY"
-            echo "PR #$pr: ios=$ios macos=$macos shared=$shared would-skip:${skip_areas:- none} failed-in-skip: $failed"
+            echo "| [#$pr]($url) | $title | $ios | $macos | $shared | ${skip_areas:- -} | $saved | $failed |" >> "$GITHUB_STEP_SUMMARY"
+            echo "PR #$pr: ios=$ios macos=$macos shared=$shared would-skip:${skip_areas:- none} saved:[$saved] failed-in-skip: $failed"
           done
+
+          # ---- Summary totals ----
+          {
+            echo ""
+            echo "## Totals"
+            echo ""
+            echo "- PRs replayed: **$total_prs**"
+            echo "- PRs with >=1 would-have-saved job (real marginal saving): **$saved_prs**"
+            echo "- PRs with a failure in a would-skip area (mismatches — should be 0): **$mismatch_prs**"
+            echo ""
+            echo "### Would-have-saved jobs by frequency (count = PRs where that job ran but would be skipped)"
+            echo ""
+            if [ -s "$saved_tally" ]; then
+              echo "| Count | Workflow: job |"
+              echo "|---|---|"
+              sort "$saved_tally" | uniq -c | sort -rn | \
+                sed -E 's/^ *([0-9]+) (.*)$/| \1 | \2 |/'
+            else
+              echo "_No would-have-saved jobs across the replayed PRs._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "TOTALS: replayed=$total_prs saved_prs=$saved_prs mismatch_prs=$mismatch_prs"
+          echo "TALLY:"; sort "$saved_tally" | uniq -c | sort -rn

--- a/.github/workflows/replay_change_detection.yml
+++ b/.github/workflows/replay_change_detection.yml
@@ -1,0 +1,116 @@
+name: Replay Change Detection
+
+# Validation tooling for the shadow change-detection gate. Replays the shared
+# matcher (.github/scripts/detect-changed-areas.sh — the exact script the gate
+# in should_run_pr_checks.yml runs) against real PRs and writes a report to
+# the run summary, cross-checking each "would-skip" area against the PR's
+# actual check results. Purely informational: gates nothing, has no outputs.
+#
+# The pull_request trigger only fires when the replay tooling itself changes;
+# use workflow_dispatch to replay arbitrary PRs on demand.
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_numbers:
+        description: 'Space-separated PR numbers to replay (empty = recent merged PRs)'
+        required: false
+        type: string
+      count:
+        description: 'How many recent merged PRs to replay when pr_numbers is empty'
+        required: false
+        type: string
+        default: '15'
+  pull_request:
+    paths:
+      - '.github/scripts/detect-changed-areas.sh'
+      - '.github/workflows/replay_change_detection.yml'
+
+jobs:
+  replay:
+    name: Replay change detection on real PRs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: read
+    steps:
+      - name: Check out the change-detection script
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/scripts/detect-changed-areas.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Replay and cross-check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBERS: ${{ inputs.pr_numbers }}
+          COUNT: ${{ inputs.count }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "$PR_NUMBERS" ]; then
+            prs="$PR_NUMBERS"
+          else
+            prs=$(gh pr list --repo "$REPO" --state merged --limit "${COUNT:-15}" \
+              --json number --jq '.[].number' | tr '\n' ' ')
+          fi
+
+          {
+            echo "## Change-detection replay"
+            echo ""
+            echo "Flags computed by \`.github/scripts/detect-changed-areas.sh\` — the same script the shadow gate runs."
+            echo "\"Failed checks in would-skip areas\" lists failing check runs that belong to a workflow the flags"
+            echo "would have skipped; any entry there means the detection would have hidden a real failure."
+            echo ""
+            echo "| PR | Title | ios | macos | shared | Would skip | Failed checks in would-skip areas |"
+            echo "|---|---|---|---|---|---|---|"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          for pr in $prs; do
+            title=$(gh pr view "$pr" --repo "$REPO" --json title --jq '.title' | tr '|' '-' | cut -c1-60)
+
+            if ! flags=$(gh pr diff "$pr" --repo "$REPO" --name-only | .github/scripts/detect-changed-areas.sh); then
+              echo "| #$pr | $title | error | error | error | - | could not compute flags |" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+            ios=$(grep '^ios=' <<< "$flags" | cut -d= -f2)
+            macos=$(grep '^macos=' <<< "$flags" | cut -d= -f2)
+            shared=$(grep '^shared=' <<< "$flags" | cut -d= -f2)
+
+            # Map each would-skip area to the workflows it would gate.
+            skip_areas=""
+            skip_workflows=()
+            if [ "$ios" = "false" ]; then
+              skip_areas="$skip_areas ios"
+              skip_workflows+=("iOS - PR Checks")
+            fi
+            if [ "$macos" = "false" ]; then
+              skip_areas="$skip_areas macos"
+              skip_workflows+=("macOS - PR Checks" "macOS - Private API Usage Report")
+            fi
+            if [ "$shared" = "false" ]; then
+              skip_areas="$skip_areas shared"
+              skip_workflows+=("BSK - PR Checks" "DBP - PR Checks")
+            fi
+
+            failed="-"
+            if [ ${#skip_workflows[@]} -gt 0 ]; then
+              # gh pr checks exits non-zero when any check failed; that is data, not an error.
+              checks_json=$(gh pr checks "$pr" --repo "$REPO" --json workflow,name,state 2>/dev/null || true)
+              if [ -n "$checks_json" ]; then
+                wf_json=$(printf '%s\n' "${skip_workflows[@]}" | jq -R . | jq -cs .)
+                failed=$(jq -r --argjson wf "$wf_json" \
+                  '[.[] | select(.state == "FAILURE" and (.workflow as $w | $wf | index($w))) | "\(.workflow): \(.name)"] | join("; ")' \
+                  <<< "$checks_json")
+                if [ -n "$failed" ]; then failed="MISMATCH - $failed"; else failed="-"; fi
+              else
+                failed="checks unavailable"
+              fi
+            fi
+
+            url="https://github.com/$REPO/pull/$pr"
+            echo "| [#$pr]($url) | $title | $ios | $macos | $shared | ${skip_areas:- -} | $failed |" >> "$GITHUB_STEP_SUMMARY"
+            echo "PR #$pr: ios=$ios macos=$macos shared=$shared would-skip:${skip_areas:- none} failed-in-skip: $failed"
+          done

--- a/.github/workflows/should_run_pr_checks.yml
+++ b/.github/workflows/should_run_pr_checks.yml
@@ -37,21 +37,6 @@ on:
       strict_mode:
         description: 'Whether strict test mode is enabled (true/false)'
         value: ${{ jobs.check.outputs.strict_mode }}
-      # Per-area change flags. Phase 1: advisory/shadow only — nothing gates on
-      # these yet. Exposed now so a later phase can add `&& …outputs.<area>` to
-      # each expensive job's `if:` without re-touching this workflow.
-      macos:
-        description: 'Whether the diff touches macOS-relevant paths (true/false)'
-        value: ${{ jobs.check.outputs.macos }}
-      ios:
-        description: 'Whether the diff touches iOS-relevant paths (true/false)'
-        value: ${{ jobs.check.outputs.ios }}
-      bsk:
-        description: 'Whether the diff touches BrowserServicesKit-relevant paths (true/false)'
-        value: ${{ jobs.check.outputs.bsk }}
-      dbp:
-        description: 'Whether the diff touches DataBrokerProtection-relevant paths (true/false)'
-        value: ${{ jobs.check.outputs.dbp }}
 
 jobs:
   check:
@@ -62,10 +47,6 @@ jobs:
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
       strict_mode: ${{ steps.check.outputs.strict_mode }}
-      macos: ${{ steps.paths.outputs.macos }}
-      ios: ${{ steps.paths.outputs.ios }}
-      bsk: ${{ steps.paths.outputs.bsk }}
-      dbp: ${{ steps.paths.outputs.dbp }}
     steps:
       - name: Evaluate run conditions
         id: check
@@ -107,11 +88,11 @@ jobs:
             echo "strict_mode=false" >> $GITHUB_OUTPUT
           fi
 
-      # PHASE 1 (shadow): compute per-area change flags. These outputs are
-      # advisory only — no job gates on them yet. The step is deliberately
-      # fail-open: any error (or a non-PR event) yields all-true, i.e. exactly
-      # today's "run everything" behaviour, so it can never make the check job
-      # fail and skip downstream checks.
+      # PHASE 1 (shadow): compute per-area change flags for logging only.
+      # Nothing gates on them — they are not exposed as outputs. The step is
+      # deliberately fail-open: any error (or a non-PR event) yields all-true,
+      # i.e. exactly today's "run everything" behaviour, so it can never make
+      # the check job fail and skip downstream checks.
       - name: Detect changed paths (shadow)
         id: paths
         continue-on-error: true
@@ -119,7 +100,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           fail_open() {
-            for area in macos ios bsk dbp; do echo "${area}=true" >> "$GITHUB_OUTPUT"; done
+            for area in ios macos shared; do echo "${area}=true" >> "$GITHUB_OUTPUT"; done
             echo "$1"
             exit 0
           }
@@ -148,20 +129,20 @@ jobs:
             return 1
           }
 
-          # Shared dependency closures. ci_infra = composite actions + this gate
+          # Dependency closures. ci_infra = composite actions + this gate
           # workflow + the Xcode version; a change to any of them forces every
-          # area to run. Standalone automation workflows (e.g.
+          # area to run. shared adds the SharedPackages closure, which covers
+          # every in-repo package (including BrowserServicesKit and
+          # DataBrokerProtectionCore). Standalone automation workflows (e.g.
           # macos_check_sparkle_update.yml) are intentionally absent, so editing
           # them matches no area.
           ci_infra=".github/actions/ .github/workflows/should_run_pr_checks.yml .xcode-version"
-          shared="SharedPackages/ scripts/translation-pr-checks/"
+          shared="$ci_infra SharedPackages/"
 
-          macos="$ci_infra $shared macOS/ .github/workflows/macos_pr_checks.yml .github/workflows/macos_private_api_report.yml"
-          ios="$ci_infra $shared iOS/ .github/workflows/ios_pr_checks.yml"
-          bsk="$ci_infra SharedPackages/BrowserServicesKit/"
-          dbp="$ci_infra SharedPackages/DataBrokerProtectionCore/"
+          ios="$shared scripts/translation-pr-checks/ iOS/ .github/workflows/ios_pr_checks.yml"
+          macos="$shared scripts/translation-pr-checks/ macOS/ .github/workflows/macos_pr_checks.yml .github/workflows/macos_private_api_report.yml"
 
-          for area in macos ios bsk dbp; do
+          for area in ios macos shared; do
             if changed "${!area}"; then echo "${area}=true" >> "$GITHUB_OUTPUT"; else echo "${area}=false" >> "$GITHUB_OUTPUT"; fi
           done
 
@@ -173,10 +154,9 @@ jobs:
         run: |
           echo "::group::Change-detection shadow report"
           echo "event=${{ github.event_name }} should_run=${{ steps.check.outputs.should_run }}"
-          echo "flags: macos=${{ steps.paths.outputs.macos }} ios=${{ steps.paths.outputs.ios }} bsk=${{ steps.paths.outputs.bsk }} dbp=${{ steps.paths.outputs.dbp }}"
-          [ "${{ steps.paths.outputs.macos }}" = "false" ] && echo "WOULD-SKIP: macOS Test / Release Build / Notarized / PIR / performance"
-          [ "${{ steps.paths.outputs.ios }}" = "false" ]   && echo "WOULD-SKIP: iOS Unit Tests / Make Release Build"
-          [ "${{ steps.paths.outputs.bsk }}" = "false" ]   && echo "WOULD-SKIP: BSK unit tests (macOS + iOS)"
-          [ "${{ steps.paths.outputs.dbp }}" = "false" ]   && echo "WOULD-SKIP: DBP unit tests + DBP Test Report"
+          echo "flags: ios=${{ steps.paths.outputs.ios }} macos=${{ steps.paths.outputs.macos }} shared=${{ steps.paths.outputs.shared }}"
+          [ "${{ steps.paths.outputs.ios }}" = "false" ]    && echo "WOULD-SKIP: iOS Unit Tests / Make Release Build"
+          [ "${{ steps.paths.outputs.macos }}" = "false" ]  && echo "WOULD-SKIP: macOS Test / Release Build / Notarized / PIR / performance"
+          [ "${{ steps.paths.outputs.shared }}" = "false" ] && echo "WOULD-SKIP: BSK + DBP unit tests / DBP Test Report"
           echo "::endgroup::"
           exit 0

--- a/.github/workflows/should_run_pr_checks.yml
+++ b/.github/workflows/should_run_pr_checks.yml
@@ -89,10 +89,22 @@ jobs:
           fi
 
       # PHASE 1 (shadow): compute per-area change flags for logging only.
-      # Nothing gates on them — they are not exposed as outputs. The step is
+      # Nothing gates on them — they are not exposed as outputs. The steps are
       # deliberately fail-open: any error (or a non-PR event) yields all-true,
-      # i.e. exactly today's "run everything" behaviour, so it can never make
+      # i.e. exactly today's "run everything" behaviour, so they can never make
       # the check job fail and skip downstream checks.
+      #
+      # The group definitions and matcher live in a shared script so that the
+      # replay/validation workflow (replay_change_detection.yml) can never
+      # drift from what this gate computes.
+      - name: Check out the change-detection script
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/scripts/detect-changed-areas.sh
+          sparse-checkout-cone-mode: false
+
       - name: Detect changed paths (shadow)
         id: paths
         continue-on-error: true
@@ -113,38 +125,11 @@ jobs:
             --repo "${{ github.repository }}" --name-only) \
             || fail_open "Could not read changed files: failing open to all areas = true"
 
-          # A group entry ending in "/" matches everything under that directory;
-          # any other entry is matched as an exact file path.
-          changed() {
-            local f p
-            while IFS= read -r f; do
-              [ -z "$f" ] && continue
-              for p in $1; do
-                case "$p" in
-                  */) case "$f" in "$p"*) return 0 ;; esac ;;
-                  *)  [ "$f" = "$p" ] && return 0 ;;
-                esac
-              done
-            done <<< "$files"
-            return 1
-          }
+          flags=$(echo "$files" | .github/scripts/detect-changed-areas.sh) \
+            || fail_open "detect-changed-areas.sh failed: failing open to all areas = true"
 
-          # Dependency closures. ci_infra = composite actions + this gate
-          # workflow + the Xcode version; a change to any of them forces every
-          # area to run. shared adds the SharedPackages closure, which covers
-          # every in-repo package (including BrowserServicesKit and
-          # DataBrokerProtectionCore). Standalone automation workflows (e.g.
-          # macos_check_sparkle_update.yml) are intentionally absent, so editing
-          # them matches no area.
-          ci_infra=".github/actions/ .github/workflows/should_run_pr_checks.yml .xcode-version"
-          shared="$ci_infra SharedPackages/"
-
-          ios="$shared scripts/translation-pr-checks/ iOS/ .github/workflows/ios_pr_checks.yml"
-          macos="$shared scripts/translation-pr-checks/ macOS/ .github/workflows/macos_pr_checks.yml .github/workflows/macos_private_api_report.yml"
-
-          for area in ios macos shared; do
-            if changed "${!area}"; then echo "${area}=true" >> "$GITHUB_OUTPUT"; else echo "${area}=false" >> "$GITHUB_OUTPUT"; fi
-          done
+          echo "$flags" >> "$GITHUB_OUTPUT"
+          echo "$flags"
 
       # PHASE 1 (shadow): log what a future gating phase WOULD skip. Purely
       # informational — lets us eyeball the flags against real PRs before any

--- a/.github/workflows/should_run_pr_checks.yml
+++ b/.github/workflows/should_run_pr_checks.yml
@@ -37,13 +37,35 @@ on:
       strict_mode:
         description: 'Whether strict test mode is enabled (true/false)'
         value: ${{ jobs.check.outputs.strict_mode }}
+      # Per-area change flags. Phase 1: advisory/shadow only — nothing gates on
+      # these yet. Exposed now so a later phase can add `&& …outputs.<area>` to
+      # each expensive job's `if:` without re-touching this workflow.
+      macos:
+        description: 'Whether the diff touches macOS-relevant paths (true/false)'
+        value: ${{ jobs.check.outputs.macos }}
+      ios:
+        description: 'Whether the diff touches iOS-relevant paths (true/false)'
+        value: ${{ jobs.check.outputs.ios }}
+      bsk:
+        description: 'Whether the diff touches BrowserServicesKit-relevant paths (true/false)'
+        value: ${{ jobs.check.outputs.bsk }}
+      dbp:
+        description: 'Whether the diff touches DataBrokerProtection-relevant paths (true/false)'
+        value: ${{ jobs.check.outputs.dbp }}
 
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read   # `gh pr diff` reads the changed-file list via the API
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
       strict_mode: ${{ steps.check.outputs.strict_mode }}
+      macos: ${{ steps.paths.outputs.macos }}
+      ios: ${{ steps.paths.outputs.ios }}
+      bsk: ${{ steps.paths.outputs.bsk }}
+      dbp: ${{ steps.paths.outputs.dbp }}
     steps:
       - name: Evaluate run conditions
         id: check
@@ -84,3 +106,77 @@ jobs:
           else
             echo "strict_mode=false" >> $GITHUB_OUTPUT
           fi
+
+      # PHASE 1 (shadow): compute per-area change flags. These outputs are
+      # advisory only — no job gates on them yet. The step is deliberately
+      # fail-open: any error (or a non-PR event) yields all-true, i.e. exactly
+      # today's "run everything" behaviour, so it can never make the check job
+      # fail and skip downstream checks.
+      - name: Detect changed paths (shadow)
+        id: paths
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          fail_open() {
+            for area in macos ios bsk dbp; do echo "${area}=true" >> "$GITHUB_OUTPUT"; done
+            echo "$1"
+            exit 0
+          }
+
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            fail_open "Non-PR event (${{ github.event_name }}): all areas = true (unchanged from today)"
+          fi
+
+          files=$(gh pr diff "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" --name-only) \
+            || fail_open "Could not read changed files: failing open to all areas = true"
+
+          # A group entry ending in "/" matches everything under that directory;
+          # any other entry is matched as an exact file path.
+          changed() {
+            local f p
+            while IFS= read -r f; do
+              [ -z "$f" ] && continue
+              for p in $1; do
+                case "$p" in
+                  */) case "$f" in "$p"*) return 0 ;; esac ;;
+                  *)  [ "$f" = "$p" ] && return 0 ;;
+                esac
+              done
+            done <<< "$files"
+            return 1
+          }
+
+          # Shared dependency closures. ci_infra = composite actions + this gate
+          # workflow + the Xcode version; a change to any of them forces every
+          # area to run. Standalone automation workflows (e.g.
+          # macos_check_sparkle_update.yml) are intentionally absent, so editing
+          # them matches no area.
+          ci_infra=".github/actions/ .github/workflows/should_run_pr_checks.yml .xcode-version"
+          shared="SharedPackages/ scripts/translation-pr-checks/"
+
+          macos="$ci_infra $shared macOS/ .github/workflows/macos_pr_checks.yml .github/workflows/macos_private_api_report.yml"
+          ios="$ci_infra $shared iOS/ .github/workflows/ios_pr_checks.yml"
+          bsk="$ci_infra SharedPackages/BrowserServicesKit/"
+          dbp="$ci_infra SharedPackages/DataBrokerProtectionCore/"
+
+          for area in macos ios bsk dbp; do
+            if changed "${!area}"; then echo "${area}=true" >> "$GITHUB_OUTPUT"; else echo "${area}=false" >> "$GITHUB_OUTPUT"; fi
+          done
+
+      # PHASE 1 (shadow): log what a future gating phase WOULD skip. Purely
+      # informational — lets us eyeball the flags against real PRs before any
+      # job is gated on them.
+      - name: Shadow report
+        if: always()
+        run: |
+          echo "::group::Change-detection shadow report"
+          echo "event=${{ github.event_name }} should_run=${{ steps.check.outputs.should_run }}"
+          echo "flags: macos=${{ steps.paths.outputs.macos }} ios=${{ steps.paths.outputs.ios }} bsk=${{ steps.paths.outputs.bsk }} dbp=${{ steps.paths.outputs.dbp }}"
+          [ "${{ steps.paths.outputs.macos }}" = "false" ] && echo "WOULD-SKIP: macOS Test / Release Build / Notarized / PIR / performance"
+          [ "${{ steps.paths.outputs.ios }}" = "false" ]   && echo "WOULD-SKIP: iOS Unit Tests / Make Release Build"
+          [ "${{ steps.paths.outputs.bsk }}" = "false" ]   && echo "WOULD-SKIP: BSK unit tests (macOS + iOS)"
+          [ "${{ steps.paths.outputs.dbp }}" = "false" ]   && echo "WOULD-SKIP: DBP unit tests + DBP Test Report"
+          echo "::endgroup::"
+          exit 0


### PR DESCRIPTION
## Why

CI over-triggers. Any edit under `.github/` fans the whole board out — iOS, macOS, and the package test workflows all run — because GitHub's native `paths` filters can't tell which workflow file changed. A macOS-only change such as a Sparkle dependency bump still runs the full iOS suite, and editing a standalone automation workflow runs everything.

## What this does

Adds advisory change-detection to the shared "Should Run PR Checks" gate. On each PR it reads the changed-file list and computes three area flags — `ios`, `macos`, `shared` — then logs them, with a per-area "WOULD-SKIP" line naming the jobs a future gating phase could drop.

This is log-only. It exposes no new outputs, gates no job, and changes no triggering. The board runs exactly as it does today, plus a few log lines in the gate job.

The detection fails open: on any non-PR event, or on any error reading the diff, it treats every area as relevant, matching today's "run everything" behaviour.

Actually skipping jobs on these flags is a deliberate separate step, taken once the logged flags are confirmed against real PRs.

## Testing

1. Open the check run for this PR.
   All the same jobs run as before this change.
2. Open the "Should Run PR Checks" job log.
3. Expand the "Shadow report" group.
   The flags reflect this PR's paths: this PR touches only the shared gate workflow, so `ios=true macos=true shared=true` and no WOULD-SKIP lines appear.
