### PR TITLE
iOS: Show search suggestions in Duck.ai when chat suggestions off

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/DuckAISuggestionsSurfaceProvider.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/DuckAISuggestionsSurfaceProvider.swift
@@ -175,8 +175,7 @@ final class DuckAISuggestionsSurfaceProvider {
         )
         .map { [weak chatManager, weak urlLoader, weak self] hasRecents, _, _ -> UnifiedSuggestionsInputsMerger.DuckAIState in
             let query = self?.switchBarHandler.currentText ?? ""
-            let settled = chatManager?.lastCompletedFetchQuery == query
-                && urlLoader?.lastCompletedFetchQuery == query
+            let settled = self?.isSettled(forQuery: query, chatManager: chatManager, urlLoader: urlLoader) ?? false
             return .init(hasRecents: hasRecents, settled: settled)
         }
         .sink { [weak self] state in self?.stateSubject.send(state) }
@@ -197,9 +196,8 @@ final class DuckAISuggestionsSurfaceProvider {
                 || !(urlLoader?.topURLs.isEmpty ?? true)
                 || !(self?.switchBarHandler.currentText.isEmpty ?? true)
         }
-        hasSettledReader = { [weak chatManager, weak urlLoader] query in
-            chatManager?.lastCompletedFetchQuery == query
-                && urlLoader?.lastCompletedFetchQuery == query
+        hasSettledReader = { [weak chatManager, weak urlLoader, weak self] query in
+            self?.isSettled(forQuery: query, chatManager: chatManager, urlLoader: urlLoader) ?? false
         }
         refreshRecentsAction = { [weak chatManager, weak self] in
             guard let self, self.aiChatSettings.isChatSuggestionsEnabled else { return }
@@ -230,6 +228,17 @@ final class DuckAISuggestionsSurfaceProvider {
         refreshCachesAction = nil
         recentsCountReader = nil
         chatDeleteAction = nil
+    }
+
+    /// A sub-source gated off (its toggle disabled) never fetches, so it's trivially settled;
+    /// an active one is settled once its loader has caught up to `query`.
+    private func isSettled(forQuery query: String,
+                           chatManager: AIChatHistoryManager?,
+                           urlLoader: DuckAIURLSuggestionsLoader?) -> Bool {
+        let gate = builtSettingsGate ?? currentSettingsGate
+        let chatSettled = !gate.chatEnabled || chatManager?.lastCompletedFetchQuery == query
+        let urlSettled = !gate.searchEnabled || urlLoader?.lastCompletedFetchQuery == query
+        return chatSettled && urlSettled
     }
 
     private func select(rowID id: String, source: DuckAISuggestionsSource) {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/DuckAISuggestionsSurfaceProvider.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/DuckAISuggestionsSurfaceProvider.swift
@@ -55,6 +55,9 @@ final class DuckAISuggestionsSurfaceProvider {
     }
 
     var isAttached: Bool { hasContentReader != nil }
+    /// False once either toggle has changed since the surface was built, so the owner rebuilds it —
+    /// each sub-source samples its gate only at `attach`, so a stale gate keeps showing removed content.
+    var reflectsCurrentSettings: Bool { builtSettingsGate == currentSettingsGate }
     func hasContent() -> Bool { hasContentReader?() ?? false }
     func hasSettled(forQuery query: String) -> Bool { hasSettledReader?(query) ?? false }
     func refreshRecents() { refreshRecentsAction?() }
@@ -71,6 +74,17 @@ final class DuckAISuggestionsSurfaceProvider {
     private let featureFlagger: FeatureFlagger
     private let privacyConfigurationManager: PrivacyConfigurationManaging
     private let duckAiNativeStorageHandler: DuckAiNativeStorageHandling?
+
+    private struct SettingsGate: Equatable {
+        let chatEnabled: Bool
+        let searchEnabled: Bool
+    }
+    /// The toggle combination sampled when the surface was built; nil while detached.
+    private var builtSettingsGate: SettingsGate?
+    private var currentSettingsGate: SettingsGate {
+        SettingsGate(chatEnabled: aiChatSettings.isChatSuggestionsEnabled,
+                     searchEnabled: dependencies.appSettings.autocomplete)
+    }
 
     private let stateSubject = CurrentValueSubject<UnifiedSuggestionsInputsMerger.DuckAIState?, Never>(nil)
     /// "Has any recent chats" — a stable, query-independent fact (mirrors search's favorites existence),
@@ -110,6 +124,7 @@ final class DuckAISuggestionsSurfaceProvider {
     /// and attaches it to the single host. No-op if already attached.
     func attach(to host: UnifiedSuggestionsHost, textPublisher: AnyPublisher<String, Never>) {
         guard hasContentReader == nil else { return }
+        builtSettingsGate = currentSettingsGate
 
         let (chatManager, chatViewModel) = AIChatHistoryManager.makeHistoryManager(
             isFireTab: switchBarHandler.isFireTab,
@@ -141,7 +156,8 @@ final class DuckAISuggestionsSurfaceProvider {
             viewAllChatsEnabled: { [featureFlagger] in
                 featureFlagger.isFeatureOn(.aiChatNativeChatHistory) && UIDevice.current.userInterfaceIdiom != .pad
             },
-            searchSuggestionsEnabled: { [weak self] in self?.dependencies.appSettings.autocomplete ?? true }
+            searchSuggestionsEnabled: { [weak self] in self?.dependencies.appSettings.autocomplete ?? true },
+            chatSuggestionsEnabled: { [weak self] in self?.aiChatSettings.isChatSuggestionsEnabled ?? true }
         )
         chatManager.onFetchCompleted = { [weak self] query, hasSuggestions in
             // Only an unfiltered (empty-query) fetch defines "has any recent chats". Filtered fetches
@@ -186,7 +202,8 @@ final class DuckAISuggestionsSurfaceProvider {
                 && urlLoader?.lastCompletedFetchQuery == query
         }
         refreshRecentsAction = { [weak chatManager, weak self] in
-            chatManager?.refreshSuggestions(query: self?.switchBarHandler.currentText ?? "")
+            guard let self, self.aiChatSettings.isChatSuggestionsEnabled else { return }
+            chatManager?.refreshSuggestions(query: self.switchBarHandler.currentText)
         }
         refreshURLSuggestionsAction = { [weak self] in
             guard let self, self.dependencies.appSettings.autocomplete else { return }
@@ -205,6 +222,7 @@ final class DuckAISuggestionsSurfaceProvider {
         cancellables.removeAll()
         host.detachDuckAISurface()
         stateSubject.send(nil)
+        builtSettingsGate = nil
         hasContentReader = nil
         hasSettledReader = nil
         refreshRecentsAction = nil

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/SuggestionsSource.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/SuggestionsSource.swift
@@ -42,6 +42,8 @@ final class DuckAISuggestionsSource: SuggestionsSource {
     private let query: () -> String
     /// Gates the URL-hits sub-source only (the "Search Suggestions" setting); chat history is unaffected.
     private let searchSuggestionsEnabled: () -> Bool
+    /// Gates the chat-history sub-source only (the "Chat Suggestions" setting); URL hits are unaffected.
+    private let chatSuggestionsEnabled: () -> Bool
 
     init(chatViewModel: AIChatSuggestionsViewModel,
          urlLoader: DuckAIURLSuggestionsLoader,
@@ -49,12 +51,14 @@ final class DuckAISuggestionsSource: SuggestionsSource {
          query: @escaping () -> String,
          deleteEnabled: @escaping () -> Bool = { false },
          viewAllChatsEnabled: @escaping () -> Bool = { false },
-         searchSuggestionsEnabled: @escaping () -> Bool = { true }) {
+         searchSuggestionsEnabled: @escaping () -> Bool = { true },
+         chatSuggestionsEnabled: @escaping () -> Bool = { true }) {
         self.chatViewModel = chatViewModel
         self.urlLoader = urlLoader
         self.chatManager = chatManager
         self.query = query
         self.searchSuggestionsEnabled = searchSuggestionsEnabled
+        self.chatSuggestionsEnabled = chatSuggestionsEnabled
 
         let pipeline = DuckAISuggestionsPipeline(
             chatsPublisher: chatViewModel.$filteredSuggestions.eraseToAnyPublisher(),
@@ -70,14 +74,18 @@ final class DuckAISuggestionsSource: SuggestionsSource {
     }
 
     func start(textPublisher: AnyPublisher<String, Never>) {
-        chatManager.subscribeToTextChanges(textPublisher)
+        // Skipped entirely when "Chat Suggestions" is off, so chat history (incl. recents) is
+        // suppressed without touching URL hits.
+        if chatSuggestionsEnabled() {
+            chatManager.subscribeToTextChanges(textPublisher)
+            chatManager.refreshSuggestions(query: query())
+        }
         // Empty when "Search Suggestions" is off, so URL hits are suppressed without touching chat history.
         let urlTextPublisher = textPublisher
             .map { [searchSuggestionsEnabled] text in searchSuggestionsEnabled() ? text : "" }
             .removeDuplicates()
             .eraseToAnyPublisher()
         urlLoader.subscribeToTextChanges(urlTextPublisher)
-        chatManager.refreshSuggestions(query: query())
     }
 
     func tearDown() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -271,11 +271,24 @@ final class UnifiedInputContentContainerViewController: UIViewController {
     /// (`viewWillAppear` only fires once), so without this, toggling the setting wouldn't take effect
     /// until the app restarts.
     private func syncDuckAISurfaceWithSettings() {
-        if featureFlagger.isFeatureOn(.aiChatSuggestions) && aiChatSettings.isChatSuggestionsEnabled {
-            attachDuckAISurfaceIfNeeded()
-        } else {
+        guard shouldAttachDuckAISurface else {
             detachDuckAISurfaceFromSingleHost()
+            return
         }
+        // Rebuild a stale surface so each sub-source's gate re-evaluates and content from a
+        // now-disabled sub-source is cleared; otherwise attach on first focus.
+        if let duckAISurface, !duckAISurface.reflectsCurrentSettings {
+            rebuildDuckAISuggestionsCoordinator()
+        } else {
+            attachDuckAISurfaceIfNeeded()
+        }
+    }
+
+    /// The surface hosts both Duck.ai sub-sources (chat recents + URL/search hits), so it attaches
+    /// when *either* toggle is on; each sub-source then gates itself independently.
+    private var shouldAttachDuckAISurface: Bool {
+        featureFlagger.isFeatureOn(.aiChatSuggestions)
+            && (aiChatSettings.isChatSuggestionsEnabled || appSettings.autocomplete)
     }
 
     /// The host's current content state, so the dismiss path can pick the right NTP handoff.
@@ -693,8 +706,7 @@ final class UnifiedInputContentContainerViewController: UIViewController {
     private func attachDuckAISurfaceIfNeeded() {
         guard duckAISurface == nil,
               let host = unifiedSuggestionsHost,
-              featureFlagger.isFeatureOn(.aiChatSuggestions),
-              aiChatSettings.isChatSuggestionsEnabled,
+              shouldAttachDuckAISurface,
               let dependencies = suggestionTrayDependencies else { return }
 
         let surface = DuckAISuggestionsSurfaceProvider(

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/Suggestions/DuckAISuggestionsSelectionTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/Suggestions/DuckAISuggestionsSelectionTests.swift
@@ -141,6 +141,61 @@ final class DuckAISuggestionsSelectionTests: XCTestCase {
 
         XCTAssertEqual(urlLoader.lastCompletedFetchQuery, "hotmail")
     }
+
+    // MARK: - Chat Suggestions gating
+
+    func test_chatHistory_isSuppressed_whenChatSuggestionsDisabled() async {
+        let urlLoader = DuckAIURLSuggestionsLoader(dataSource: StubSuggestionLoadingDataSource())
+        let chatViewModel = AIChatSuggestionsViewModel()
+        let chatManager = AIChatHistoryManager(
+            suggestionsReader: NilSuggestionsReader(),
+            aiChatSettings: MockAIChatSettingsProvider(),
+            aiChatDeleter: StubAIChatDeleter(),
+            viewModel: chatViewModel,
+            isFireTab: false
+        )
+        let source = DuckAISuggestionsSource(
+            chatViewModel: chatViewModel,
+            urlLoader: urlLoader,
+            chatManager: chatManager,
+            query: { "" },
+            chatSuggestionsEnabled: { false }
+        )
+        let textSubject = PassthroughSubject<String, Never>()
+        source.start(textPublisher: textSubject.eraseToAnyPublisher())
+        textSubject.send("recipes")
+
+        // Wait past the chat manager's 150ms text debounce; a running fetch would set the query.
+        try? await Task.sleep(nanoseconds: 400_000_000)
+
+        XCTAssertNil(chatManager.lastCompletedFetchQuery)
+    }
+
+    func test_chatHistory_fetches_whenChatSuggestionsEnabled() async {
+        let urlLoader = DuckAIURLSuggestionsLoader(dataSource: StubSuggestionLoadingDataSource())
+        let chatViewModel = AIChatSuggestionsViewModel()
+        let chatManager = AIChatHistoryManager(
+            suggestionsReader: NilSuggestionsReader(),
+            aiChatSettings: MockAIChatSettingsProvider(),
+            aiChatDeleter: StubAIChatDeleter(),
+            viewModel: chatViewModel,
+            isFireTab: false
+        )
+        let source = DuckAISuggestionsSource(
+            chatViewModel: chatViewModel,
+            urlLoader: urlLoader,
+            chatManager: chatManager,
+            query: { "" },
+            chatSuggestionsEnabled: { true }
+        )
+        let textSubject = PassthroughSubject<String, Never>()
+        source.start(textPublisher: textSubject.eraseToAnyPublisher())
+
+        let predicate = NSPredicate { _, _ in chatManager.lastCompletedFetchQuery != nil }
+        await fulfillment(of: [expectation(for: predicate, evaluatedWith: nil)], timeout: 5.0)
+
+        XCTAssertEqual(chatManager.lastCompletedFetchQuery, "")
+    }
 }
 
 // MARK: - Stubs


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1216235587380281

### Description

Follow-up to #5656, which fixed "suggestions shown when disabled" but over-suppressed one edge case: with **Search suggestions ON** and **Duck.ai (chat) suggestions OFF**, Duck.ai mode showed **no suggestions at all** — search suggestions should still appear there.

Root cause: the Duck.ai suggestions surface hosts *both* sub-sources used in Duck.ai mode (chat recents + the URL/search-suggestions loader), but it only attached when the **chat** toggle was on — so the independently-gated search sub-source never got a chance to run when chat was off.

Fix: attach the surface when *either* toggle is on, and gate each sub-source independently — search on `appSettings.autocomplete`, chat on `isChatSuggestionsEnabled`. Since the surface samples its gates once at build time, it rebuilds when the toggle combination changes so a sub-source disabled mid-session clears its stale content.

### Testing Steps

Settings → General → *Private Search & Chat*.

1. **Search ON / Chat OFF** → focus the address bar, switch to **Duck.ai**, type a query → search/URL suggestions appear (previously nothing). Not typing → logo only, no recent chats.
2. **Both ON** → Duck.ai mode: recent chats show when not typing; recents + search suggestions when typing.
3. **Search OFF / Chat ON** → Duck.ai mode: recent chats show; typing shows recents but no URL/search hits.
4. **Both OFF** → Duck.ai mode shows nothing.
5. **Mid-session toggle:** with search ON, turn Chat ON (see recents in Duck.ai), then turn Chat OFF and return → recents are gone (no stale rows).

### Impact and Risks

**Low.** Scoped to the UTI Duck.ai suggestions surface (iPhone, behind the `aiChatSuggestions` flag). Changes only *when* the surface attaches and how each sub-source self-gates; Architecture A (`OmniBarEditingStateViewController`) is untouched — its search suggestions already come from a separate `SuggestionTrayManager`. Covered by unit tests for both gates (8 passing) and manual verification on-device.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to UTI Duck.ai suggestions behind `aiChatSuggestions`; attach/gating and settle logic only, with new unit tests.
> 
> **Overview**
> Fixes Duck.ai mode showing **no suggestions** when **Search suggestions** are on but **Chat suggestions** are off.
> 
> The Duck.ai suggestions surface now **attaches when either toggle is on** (not only chat). **Chat recents** and **URL/search hits** are gated independently via `isChatSuggestionsEnabled` and `appSettings.autocomplete`. Gates are sampled at attach time, so **`reflectsCurrentSettings`** triggers a **rebuild on focus** when settings change mid-session, clearing stale rows. **Settled** state treats disabled sub-sources as trivially settled so the merger does not wait on inactive loaders.
> 
> Unit tests cover chat gating on `DuckAISuggestionsSource.start`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a065c2e7b9108ddb279de28f7cf697e8dba10965. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->