### PR TITLE
[macOS] Fix bookmarks bar favicon flicker between two versions

### DIFF
--- a/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarCollectionViewItem.swift
+++ b/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarCollectionViewItem.swift
@@ -133,13 +133,18 @@ final class BookmarksBarCollectionViewItem: NSCollectionViewItem {
         titleLabel.alphaValue = isInteractionPrevented ? 0.3 : 1
     }
 
-    /// Re-resolves this bookmark's favicon and shows it in place if a decoded image is now available.
+    /// Re-resolves this bookmark's favicon and shows it in place once a decoded image is available.
     ///
-    /// Never downgrades an already-shown favicon back to the placeholder.
+    /// Only ever shows the bookmark's own (URL-resolved) favicon. `Bookmark.favicon(_:)` already falls
+    /// back to the host favicon internally when the bookmark's URL has no favicon of its own, so this
+    /// deliberately does *not* add a separate host-favicon fallback: doing so downgraded the icon to the
+    /// host favicon during the brief off-main decode window of the URL favicon (`favicon(_:)` returns
+    /// `nil` while decoding), making a bookmark whose URL favicon differs from its host favicon flicker
+    /// between the two as `.faviconCacheUpdated` fired repeatedly. While the favicon isn't decoded yet
+    /// this is a no-op, leaving the currently shown icon untouched (never downgraded to a placeholder).
     func refreshDisplayedFavicon() {
-        guard let bookmark = representedObject as? Bookmark else { return }
-        let host = URL(string: bookmark.url)?.host ?? ""
-        guard let favicon = (bookmark.favicon(.small) ?? NSApp.delegateTyped.faviconManager.getCachedFavicon(for: host, sizeCategory: .small)?.image)?.copy() as? NSImage else {
+        guard let bookmark = representedObject as? Bookmark,
+              let favicon = bookmark.favicon(.small)?.copy() as? NSImage else {
             return
         }
         favicon.size = NSSize.faviconSize

--- a/macOS/DuckDuckGo/Favicons/Model/FaviconImageCache.swift
+++ b/macOS/DuckDuckGo/Favicons/Model/FaviconImageCache.swift
@@ -232,7 +232,6 @@ final class FaviconImageCache: FaviconImageCaching {
 
         Task { [storing] in
             let image: NSImage?
-            try await Task.sleep(nanoseconds: 1_000_000_000)
             do {
                 image = try await storing.loadImage(for: metadata.identifier)
             } catch FaviconStore.FaviconStoreError.imageDecodingFailed {

--- a/macOS/DuckDuckGo/Favicons/Model/FaviconImageCache.swift
+++ b/macOS/DuckDuckGo/Favicons/Model/FaviconImageCache.swift
@@ -232,6 +232,7 @@ final class FaviconImageCache: FaviconImageCaching {
 
         Task { [storing] in
             let image: NSImage?
+            try await Task.sleep(nanoseconds: 1_000_000_000)
             do {
                 image = try await storing.loadImage(for: metadata.identifier)
             } catch FaviconStore.FaviconStoreError.imageDecodingFailed {
@@ -336,6 +337,16 @@ final class FaviconImageCache: FaviconImageCaching {
     @MainActor
     func removeAllFavicons() async {
         await deleteFaviconsAndNotify { _ in true }
+    }
+
+    /// Debug: drops every decoded favicon image from the in-memory `NSCache`, leaving the persisted
+    /// store, the metadata map, and references intact. Images re-decode lazily from the store on the
+    /// next `get(faviconUrl:)`. Posts `.faviconCacheUpdated` (no payload) so open UI re-resolves and
+    /// the reload is observable.
+    @MainActor
+    func clearInMemoryCache() {
+        imageCache.removeAllObjects()
+        NotificationCenter.default.post(name: .faviconCacheUpdated, object: nil)
     }
 
     /// Removes matching favicons. The set to delete is resolved from the store — the inspector's source

--- a/macOS/DuckDuckGo/Favicons/Model/FaviconManager.swift
+++ b/macOS/DuckDuckGo/Favicons/Model/FaviconManager.swift
@@ -745,4 +745,12 @@ extension FaviconManager: FaviconManagementDebugging {
         await imageCache.removeAllFavicons()
         await referenceCache.removeAllReferences()
     }
+
+    /// Debug: clears the in-memory decoded-image cache without deleting any stored favicons. Only the
+    /// lazy `FaviconImageCache` keeps a separate in-memory image cache, so this is a no-op on the eager
+    /// (non-lazy) path.
+    @MainActor
+    func clearInMemoryFaviconCache() {
+        (imageCache as? FaviconImageCache)?.clearInMemoryCache()
+    }
 }

--- a/macOS/DuckDuckGo/Menus/MainMenu.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenu.swift
@@ -915,6 +915,7 @@ final class MainMenu: NSMenu {
             NSMenuItem.separator()
 
             // All items below will be automatically sorted alphabetically
+            NSMenuItem(title: "Clear In-Memory Favicons Cache", action: #selector(AppDelegate.debugClearFaviconsCache)).withAccessibilityIdentifier("MainMenu.clearFaviconsCache")
             NSMenuItem(title: "Clear WebKit Cache", action: #selector(AppDelegate.debugClearWebViewCache)).withAccessibilityIdentifier("MainMenu.clearWebKitCache")
             NSMenuItem(title: "Inspect Favicons", action: #selector(MainViewController.inspectFavicons(_:))).withAccessibilityIdentifier("MainMenu.inspectFavicons")
             NSMenuItem(title: "Open Vanilla Browser", action: #selector(MainViewController.openVanillaBrowser)).withAccessibilityIdentifier("MainMenu.openVanillaBrowser")

--- a/macOS/DuckDuckGo/Menus/MainMenu.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenu.swift
@@ -915,9 +915,11 @@ final class MainMenu: NSMenu {
             NSMenuItem.separator()
 
             // All items below will be automatically sorted alphabetically
-            NSMenuItem(title: "Clear In-Memory Favicons Cache", action: #selector(AppDelegate.debugClearFaviconsCache)).withAccessibilityIdentifier("MainMenu.clearFaviconsCache")
             NSMenuItem(title: "Clear WebKit Cache", action: #selector(AppDelegate.debugClearWebViewCache)).withAccessibilityIdentifier("MainMenu.clearWebKitCache")
-            NSMenuItem(title: "Inspect Favicons", action: #selector(MainViewController.inspectFavicons(_:))).withAccessibilityIdentifier("MainMenu.inspectFavicons")
+            NSMenuItem(title: "Favicons") {
+                NSMenuItem(title: "Clear In-Memory Cache", action: #selector(AppDelegate.debugClearFaviconsCache)).withAccessibilityIdentifier("MainMenu.clearFaviconsCache")
+                NSMenuItem(title: "Inspect", action: #selector(MainViewController.inspectFavicons(_:))).withAccessibilityIdentifier("MainMenu.inspectFavicons")
+            }
             NSMenuItem(title: "Open Vanilla Browser", action: #selector(MainViewController.openVanillaBrowser)).withAccessibilityIdentifier("MainMenu.openVanillaBrowser")
             NSMenuItem(title: "Skip Onboarding", action: #selector(AppDelegate.skipOnboarding)).withAccessibilityIdentifier("MainMenu.skipOnboarding")
             NSMenuItem(title: "Performance Debugging") {

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -537,6 +537,11 @@ extension AppDelegate {
     }
 
     @MainActor
+    @objc func debugClearFaviconsCache(_ sender: Any?) {
+        faviconManager.clearInMemoryFaviconCache()
+    }
+
+    @MainActor
     @objc func skipOnboarding(_ sender: Any?) {
         UserDefaults.standard.set(true, forKey: UserDefaultsWrapper<Bool>.Key.onboardingFinished.rawValue)
         Application.appDelegate.onboardingContextualDialogsManager.state = .onboardingCompleted


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1216447325873126?focus=true

### Description
Follow-up to the earlier bookmarks bar favicon flicker fixes (#5534, #5539). A few bookmarks still flickered — but now between two *real* icons rather than icon vs. placeholder. This affects bookmarks whose page-specific favicon differs from the site's favicon (for example a page that embeds a third-party ordering/booking widget with its own icon). While the page-specific icon was still loading, the bar briefly fell back to the site icon, then swapped back once the page icon loaded, ping-ponging between the two every time the favicon cache updated.

The bar now shows a single, stable favicon per bookmark. If the favicon isn't loaded yet, it leaves the currently shown icon in place instead of substituting a different one mid-load.

### Testing Steps
1. Add several sites to the bookmarks bar, including at least one whose page favicon differs from its site favicon (the report reproduced with **SFGATE** and **Think Coffee**).
2. Open a new window (or relaunch) so the bar's favicons load fresh.
3. Watch the bookmarks bar for ~10 seconds → each favicon settles on one icon and no longer alternates between two versions.
4. Confirm the other bookmarks' favicons still appear correctly (no missing icons / placeholders left behind).

### Impact
Low — a visual fix to bookmarks bar favicons. No data, privacy, or crash surface; worst case a bookmark shows one favicon variant instead of another.

#### What could go wrong?
A bookmark whose page-specific favicon never finishes loading now keeps the icon resolved when the cell was first shown (the site favicon) instead of swapping → this is the intended behavior; initial cell setup already resolves the site favicon as its fallback, so the correct icon is still shown.

### Quality Considerations
- Bookmarks whose page and site favicons are identical (the common case) are unaffected — they already showed one stable icon.
- Minor side benefit: the refresh path now skips a redundant cache lookup and an image copy while a favicon is still decoding.
- Not covered here: the underlying favicon-cache-update notification churn (the flicker's engine) is unchanged; this PR stops the visible symptom. A deeper change to that notification loop would be a separate follow-up.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only bookmarks bar favicon behavior plus internal debug tooling; no auth, data, or persistence changes.
> 
> **Overview**
> Fixes bookmarks bar icons **ping-ponging between page-specific and site favicons** when lazy decoding and repeated `.faviconCacheUpdated` notifications.
> 
> `refreshDisplayedFavicon()` now updates only when `bookmark.favicon(.small)` returns a decoded image—**no extra host lookup via `faviconManager.getCachedFavicon`**. If the URL favicon is still decoding, the cell **keeps whatever icon is already shown** instead of briefly swapping to the host icon.
> 
> Adds a **debug-only** path to clear the lazy cache’s in-memory decoded images (persisted favicons unchanged): **Debug → Favicons → Clear In-Memory Cache**, wired through `FaviconImageCache.clearInMemoryCache()` and `FaviconManager.clearInMemoryFaviconCache()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bea2d020491f79ea48258c41de04f0e86126549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->