### PR TITLE
macOS: Hide Duck.ai permission center icon while omnibar is in chat mode

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -862,13 +862,13 @@ final class AddressBarButtonsViewController: NSViewController {
 
         let isPermissionCenterPopoverShown = permissionCenterPopover?.isShown == true
 
-        if isDuckAiVoiceChatSystemMicDenied(forDomain: domain) {
+        if isDuckAiVoiceChatSystemMicDenied(forDomain: domain) && !isAIChatPanelActive {
             // While the OS denies mic access on duck.ai under the voice-chat flag, keep the
-            // shield as an anchor for `systemDisabledInfoPopover` regardless of the current
-            // address-bar state (focused text field, AI chat omnibar suppression). The check
-            // is derived from current OS state, so the shield stays available for the user to
-            // re-open the warning after dismissing it and clears as soon as the OS state
-            // changes or they navigate away.
+            // shield as an anchor for `systemDisabledInfoPopover` — but only while the omnibar
+            // is NOT in chat mode. In chat mode the user is prompting, not managing mic access,
+            // so parking the shield in the address bar is noise; suppress it and fall through.
+            // The voice-chat failure handler still surfaces the remediation popover (force-showing
+            // the shield transiently) when mic use is actually attempted and fails.
             permissionCenterButton.isShown = true
         } else if shouldSuppressShieldOnDuckAi(forDomain: domain, tabViewModel: tabViewModel) {
             // On duck.ai, the mic permission is auto-granted by migration and the voice chat


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1216451632164149?focus=true

### Description
On Duck.ai, when microphone access is denied at the OS level, the permission center icon was parked in the address bar even while the omnibar was in chat mode — right where the user is trying to type a prompt. It now stays hidden whenever chat mode is selected. The OS-disabled microphone remediation message still surfaces when voice chat is actually attempted and fails.

### Testing Steps
1. Deny microphone access for the app in System Settings (the debug app) → Privacy & Security → Microphone.
2. Try to open a new voice chat; the permission center should appear with a message of enabling the access in the System Settings.
3. Try to strat a new prompt in ai chat mode in that same tab
4. The permission center should not be shown.

### Impact
Low: minor bug fix scoped to the Duck.ai address bar under the voice-chat permission flag.

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Low Risk**
> Single conditional in address-bar button visibility under a feature flag; failure-handler popover behavior is unchanged.
> 
> **Overview**
> When Duck.ai has **OS microphone access denied** under the native voice permission flow, the address bar no longer keeps the **permission center icon** visible while **`isAIChatPanelActive`** (omnibar chat mode). That branch now only pins the shield for the system-disabled remediation popover outside chat mode; in chat mode visibility falls through to the usual Duck.ai suppression so the icon does not sit over the prompt area.
> 
> **Remediation on actual mic use is unchanged:** the voice-chat failure path still force-shows the shield and presents the System Settings popover when voice chat is attempted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e6250ce8b5b8a8d75265595afffc09406ad2f55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>