### PR TITLE
[macOS] Update rebranded onboarding UI test for updated copy

### DIFF
--- a/macOS/UITests/OnboardingUITests.swift
+++ b/macOS/UITests/OnboardingUITests.swift
@@ -137,11 +137,11 @@ final class OnboardingUITests: UITestCase {
         XCTAssertFalse(optionsButton.isEnabled)
 
         // Get Started
-        XCTAssertTrue(welcomeWindow.webViews["Welcome"].staticTexts["Ready for a faster browser that keeps you protected?"].waitForExistence(timeout: UITests.Timeouts.elementExistence))
+        XCTAssertTrue(welcomeWindow.webViews["Welcome"].staticTexts["Ready for a faster browser that protects you and lets you decide when and how to use AI?"].waitForExistence(timeout: UITests.Timeouts.elementExistence))
 
         // The rebranded buttons have no aria-label/identifier, so WebKit exposes their text via `title` rather than `label`.
         let getStartedButton = welcomeWindow.webViews["Welcome"].buttons
-            .matching(NSPredicate(format: "title ==[c] %@", "Let’s do it!"))
+            .matching(NSPredicate(format: "title ==[c] %@", "Start browser setup"))
             .firstMatch
         XCTAssertTrue(getStartedButton.waitForExistence(timeout: UITests.Timeouts.elementExistence))
         // Use coordinate tap to avoid overlay/hittability quirks


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1216444407638126?focus=true
Tech Design URL:
CC:

### Description

#5668 updated our version of C-S-S, which has new copy in the onboarding flow, breaking our onboarding UI tests. This PR updates the tests for the new copy.

### Testing Steps

1. Just ensure CI is green! UI test run happening here: https://github.com/duckduckgo/apple-browsers/actions/runs/29126458970

### Impact

None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only string and predicate updates; no app or production behavior changes.
> 
> **Overview**
> Updates **`testRebrandedOnboardingToBrowsing`** in `OnboardingUITests.swift` so assertions match the rebranded onboarding strings from the newer C-S-S bundle.
> 
> The welcome headline expectation now looks for copy that mentions **AI choice**, and the primary CTA is matched by **`title`** as **"Start browser setup"** instead of **"Let's do it!"**. The legacy onboarding test is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8b2b7f06a5ead459fef959fea5cffad9a11a342. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->