### PR TITLE
[macOS] Fix Sync E2E test

### DIFF
--- a/macOS/SyncE2EUITests/CriticalPathsTests.swift
+++ b/macOS/SyncE2EUITests/CriticalPathsTests.swift
@@ -203,8 +203,8 @@ final class CriticalPathsTests: XCTestCase {
         settingsSheetsQuery.buttons["Enter Code"].click()
         settingsSheetsQuery.buttons["Paste"].click()
         let alertSheet = sheetsQuery.sheets["alert"]
-        alertSheet.staticTexts["Sync & Backup Error"].click()
-        XCTAssertTrue(alertSheet.exists, "Sync Error text is not visible")
+        alertSheet.staticTexts["Sync failed."].assertExists()
+        alertSheet.buttons["Got It"].assertExists().click()
 
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1216473125785052?focus=true
Tech Design URL:
CC:

### Description
Fixes macOS Sync tests failing due to copy changes

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Confirm CI is green -> https://github.com/duckduckgo/apple-browsers/actions/runs/29206025534

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only UI selector updates with no production or sync logic changes.
> 
> **Overview**
> Updates **`testCanRemoveData`** in `CriticalPathsTests` so the post–delete-data sync login failure step matches the app’s current alert UI.
> 
> The test now expects **`Sync failed.`** instead of **`Sync & Backup Error`**, and asserts and taps **`Got It`** to dismiss the alert. Assertions use the shared **`assertExists()`** helper instead of manual `XCTAssertTrue` / clicking the title text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9c8fb4a275b22021b3ebc57c276996804ed6678. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->