### PR TITLE
Fix contextual UTI chip resurrection + consolidate delivery-state ownership

### DIFF
--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -114,10 +114,13 @@ final class AIChatContextualChatSessionState {
     private(set) var contextualChatURL: URL?
     private(set) var latestContext: AIChatPageContext?
 
-    /// URL of the context that was actually included in the last submitted prompt.
-    /// Lets a late auto-attach re-collection for that same page be delivered to the UTI chip
-    /// as already-delivered instead of resurrecting it as pending.
-    private(set) var deliveredContextURL: URL?
+    /// URL of the context that was actually included in the last submitted prompt, so long as no
+    /// navigation has happened since. Used only to recognize a passive auto-attach re-collection
+    /// (e.g. a late JS auto-update) for that same, already-submitted page as a stale echo — not
+    /// a fresh attach — so it doesn't resurrect the UTI chip. Cleared on navigation so a real page
+    /// change is always treated as fresh, and never consulted for manual attach, which is always
+    /// a deliberate user action.
+    private var deliveredContextURLWithNoNavigationSince: URL?
 
     @Published private(set) var viewState = SheetViewState(
         content: .nativeInput,
@@ -231,7 +234,7 @@ final class AIChatContextualChatSessionState {
         case .attached(let context):
             contextData = context.contextData
             frontendState = .chatWithInitialContext
-            deliveredContextURL = URL(string: context.contextData.url)
+            deliveredContextURLWithNoNavigationSince = URL(string: context.contextData.url)
             pixelHandler.firePromptSubmittedWithContext()
             Logger.aiChat.debug("[SessionState] Chat started WITH initial context (chip was attached)")
         case .placeholder:
@@ -260,7 +263,7 @@ final class AIChatContextualChatSessionState {
         switch chipState {
         case .attached(let context):
             frontendState = .chatWithInitialContext
-            deliveredContextURL = URL(string: context.contextData.url)
+            deliveredContextURLWithNoNavigationSince = URL(string: context.contextData.url)
             pixelHandler.firePromptSubmittedWithContext()
             Logger.aiChat.debug("[SessionState] UTI chat started WITH initial context")
         case .placeholder:
@@ -277,7 +280,7 @@ final class AIChatContextualChatSessionState {
         frontendState = .noChat
         chipState = .placeholder
         contextualChatURL = nil
-        deliveredContextURL = nil
+        deliveredContextURLWithNoNavigationSince = nil
         userDowngradedToPlaceholder = false
         isManualAttachInProgress = false
         isManualAttachFromFrontend = false
@@ -348,6 +351,9 @@ final class AIChatContextualChatSessionState {
     func notifyPageChanged(pageURL: URL? = nil) {
         Logger.aiChat.debug("[SessionState] Page navigation detected")
         isProcessingNavigation = true
+        // A real navigation means any subsequent context update is fresh, even if it later
+        // resolves to a URL that was already submitted (e.g. the user navigated away and back).
+        deliveredContextURLWithNoNavigationSince = nil
         if shouldAutoCollectContext, userDowngradedToPlaceholder {
             userDowngradedToPlaceholder = false
             Logger.aiChat.debug("[SessionState] Page navigation cleared temporary context removal")
@@ -516,14 +522,6 @@ final class AIChatContextualChatSessionState {
         return true
     }
 
-    /// Whether `context` is a re-collection of the page whose content was already included in
-    /// the last submitted prompt. Used so a late auto-attach emission for that same page doesn't
-    /// resurrect the UTI chip as pending — it's already been sent.
-    func isContextAlreadyDelivered(_ context: AIChatPageContextData?) -> Bool {
-        guard let context, let deliveredContextURL, let contextURL = URL(string: context.url) else { return false }
-        return contextURL.equals(deliveredContextURL, by: .sameDocument)
-    }
-
     func shouldDeliverToFrontendBridge(_ context: AIChatPageContextData?) -> Bool {
         if isUnifiedToggleInputActive, context != nil {
             Logger.aiChat.debug("[SessionState] shouldDeliverToFrontendBridge=false (non-nil context delivered to UTI)")
@@ -589,8 +587,12 @@ private extension AIChatContextualChatSessionState {
 
             case .attached:
                 chipState = .attached(context)
-                didUpdateAttachment = true
-                Logger.aiChat.debug("[SessionState] Updated attached context (setting ON)")
+                if isStaleEchoOfDeliveredContext(context.contextData) {
+                    Logger.aiChat.debug("[SessionState] Ignoring stale auto-attach echo for already-delivered context")
+                } else {
+                    didUpdateAttachment = true
+                    Logger.aiChat.debug("[SessionState] Updated attached context (setting ON)")
+                }
             }
         } else {
             Logger.aiChat.debug("[SessionState] Context updated on navigation (WebView active, chip not updated)")
@@ -599,6 +601,16 @@ private extension AIChatContextualChatSessionState {
         if didUpdateAttachment || shouldDeliverToFrontendBridge(context.contextData) {
             emitDeliveryIfNeeded(context.contextData)
         }
+    }
+
+    /// Whether `context` is a passive re-collection (e.g. a late JS auto-update) of the same page
+    /// already included in the last submitted prompt, with no navigation in between. Only consulted
+    /// from the auto-attach path — manual attach is always a deliberate user action and always
+    /// delivers as a fresh pending attachment regardless of URL.
+    func isStaleEchoOfDeliveredContext(_ context: AIChatPageContextData) -> Bool {
+        guard let deliveredContextURLWithNoNavigationSince,
+              let contextURL = URL(string: context.url) else { return false }
+        return contextURL.equals(deliveredContextURLWithNoNavigationSince, by: .sameDocument)
     }
 
     func cleanupFlags() {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -595,10 +595,10 @@ private extension AIChatContextualChatSessionState {
                 }
 
             case .attached:
-                chipState = .attached(context)
                 if isStaleEchoOfDeliveredContext(context.contextData) {
                     Logger.aiChat.debug("[SessionState] Ignoring stale auto-attach echo for already-delivered context")
                 } else {
+                    chipState = .attached(context)
                     didUpdateAttachment = true
                     Logger.aiChat.debug("[SessionState] Updated attached context (setting ON)")
                 }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -114,6 +114,11 @@ final class AIChatContextualChatSessionState {
     private(set) var contextualChatURL: URL?
     private(set) var latestContext: AIChatPageContext?
 
+    /// URL of the context that was actually included in the last submitted prompt.
+    /// Lets a late auto-attach re-collection for that same page be delivered to the UTI chip
+    /// as already-delivered instead of resurrecting it as pending.
+    private(set) var deliveredContextURL: URL?
+
     @Published private(set) var viewState = SheetViewState(
         content: .nativeInput,
         isExpandButtonEnabled: true,
@@ -226,6 +231,7 @@ final class AIChatContextualChatSessionState {
         case .attached(let context):
             contextData = context.contextData
             frontendState = .chatWithInitialContext
+            deliveredContextURL = URL(string: context.contextData.url)
             pixelHandler.firePromptSubmittedWithContext()
             Logger.aiChat.debug("[SessionState] Chat started WITH initial context (chip was attached)")
         case .placeholder:
@@ -252,8 +258,9 @@ final class AIChatContextualChatSessionState {
         }
 
         switch chipState {
-        case .attached:
+        case .attached(let context):
             frontendState = .chatWithInitialContext
+            deliveredContextURL = URL(string: context.contextData.url)
             pixelHandler.firePromptSubmittedWithContext()
             Logger.aiChat.debug("[SessionState] UTI chat started WITH initial context")
         case .placeholder:
@@ -270,6 +277,7 @@ final class AIChatContextualChatSessionState {
         frontendState = .noChat
         chipState = .placeholder
         contextualChatURL = nil
+        deliveredContextURL = nil
         userDowngradedToPlaceholder = false
         isManualAttachInProgress = false
         isManualAttachFromFrontend = false
@@ -506,6 +514,14 @@ final class AIChatContextualChatSessionState {
         guard isUnifiedToggleInputActive else { return false }
         guard context != nil || hasActiveChat || userDowngradedToPlaceholder else { return false }
         return true
+    }
+
+    /// Whether `context` is a re-collection of the page whose content was already included in
+    /// the last submitted prompt. Used so a late auto-attach emission for that same page doesn't
+    /// resurrect the UTI chip as pending — it's already been sent.
+    func isContextAlreadyDelivered(_ context: AIChatPageContextData?) -> Bool {
+        guard let context, let deliveredContextURL, let contextURL = URL(string: context.url) else { return false }
+        return contextURL.equals(deliveredContextURL, by: .sameDocument)
     }
 
     func shouldDeliverToFrontendBridge(_ context: AIChatPageContextData?) -> Bool {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -114,12 +114,7 @@ final class AIChatContextualChatSessionState {
     private(set) var contextualChatURL: URL?
     private(set) var latestContext: AIChatPageContext?
 
-    /// URL of the context that was actually included in the last submitted prompt, so long as no
-    /// navigation has happened since. Used only to recognize a passive auto-attach re-collection
-    /// (e.g. a late JS auto-update) for that same, already-submitted page as a stale echo — not
-    /// a fresh attach — so it doesn't resurrect the UTI chip. Cleared on navigation so a real page
-    /// change is always treated as fresh, and never consulted for manual attach, which is always
-    /// a deliberate user action.
+    /// URL included in the last submitted prompt with no navigation since; used to spot a stale auto-attach echo.
     private var deliveredContextURLWithNoNavigationSince: URL?
 
     @Published private(set) var viewState = SheetViewState(
@@ -522,19 +517,12 @@ final class AIChatContextualChatSessionState {
         return true
     }
 
-    /// The delivery state the UTI chip should adopt for `context`. A passive re-collection of the
-    /// context already submitted for this page (a stale echo) is `.delivered` so the chip stays
-    /// hidden; anything else is a fresh `.pendingSubmit` attachment. This keeps the pending-vs-delivered
-    /// decision with the state owner rather than the coordinator hardcoding `.pendingSubmit`.
+    /// `.delivered` when `context` is a stale echo of the already-submitted page (chip stays hidden); else `.pendingSubmit`.
     func utiChipDeliveryState(forDelivering context: AIChatPageContextData) -> PageContextAttachmentDeliveryState {
         isStaleEchoOfDeliveredContext(context) ? .delivered : .pendingSubmit
     }
 
-    /// Records that the currently-attached context has been delivered in a submitted prompt, so it
-    /// stops riding subsequent prompts and the UTI chip hides. This is the sole owner of the
-    /// pending→delivered transition: the chip no longer flips its own delivery state on submit —
-    /// it is re-rendered as delivered through the normal delivery pipeline. Safe to call on every
-    /// submit (first and follow-up); a no-op when nothing is attached.
+    /// Marks the attached context delivered on submit so it stops riding later prompts and the chip hides.
     func markUTIContextDelivered() {
         guard case .attached(let context) = chipState else { return }
         deliveredContextURLWithNoNavigationSince = URL(string: context.contextData.url)
@@ -574,10 +562,7 @@ private extension AIChatContextualChatSessionState {
         if isShowingNativeInput || isUnifiedToggleInputActive {
             chipState = .attached(context)
             userDowngradedToPlaceholder = false
-            // A deliberate manual attach is always a fresh pending attachment, even for a page
-            // already submitted this session. Clear the delivered marker so `utiChipDeliveryState`
-            // does not misclassify it as a stale echo and hide it — stale-echo suppression applies
-            // to passive auto re-collection only, never to an explicit user attach.
+            // A manual attach is always fresh: clear the delivered marker so it is not read as a stale echo.
             deliveredContextURLWithNoNavigationSince = nil
             Logger.aiChat.debug("[SessionState] Manually attached context")
         }
@@ -627,10 +612,7 @@ private extension AIChatContextualChatSessionState {
         }
     }
 
-    /// Whether `context` is a passive re-collection (e.g. a late JS auto-update) of the same page
-    /// already included in the last submitted prompt, with no navigation in between. Only consulted
-    /// from the auto-attach path — manual attach is always a deliberate user action and always
-    /// delivers as a fresh pending attachment regardless of URL.
+    /// Whether `context` is a passive same-page re-collection already submitted with no navigation since.
     func isStaleEchoOfDeliveredContext(_ context: AIChatPageContextData) -> Bool {
         guard let deliveredContextURLWithNoNavigationSince,
               let contextURL = URL(string: context.url) else { return false }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -522,6 +522,25 @@ final class AIChatContextualChatSessionState {
         return true
     }
 
+    /// The delivery state the UTI chip should adopt for `context`. A passive re-collection of the
+    /// context already submitted for this page (a stale echo) is `.delivered` so the chip stays
+    /// hidden; anything else is a fresh `.pendingSubmit` attachment. This keeps the pending-vs-delivered
+    /// decision with the state owner rather than the coordinator hardcoding `.pendingSubmit`.
+    func utiChipDeliveryState(forDelivering context: AIChatPageContextData) -> PageContextAttachmentDeliveryState {
+        isStaleEchoOfDeliveredContext(context) ? .delivered : .pendingSubmit
+    }
+
+    /// Records that the currently-attached context has been delivered in a submitted prompt, so it
+    /// stops riding subsequent prompts and the UTI chip hides. This is the sole owner of the
+    /// pending→delivered transition: the chip no longer flips its own delivery state on submit —
+    /// it is re-rendered as delivered through the normal delivery pipeline. Safe to call on every
+    /// submit (first and follow-up); a no-op when nothing is attached.
+    func markUTIContextDelivered() {
+        guard case .attached(let context) = chipState else { return }
+        deliveredContextURLWithNoNavigationSince = URL(string: context.contextData.url)
+        emitDeliveryIfNeeded(context.contextData)
+    }
+
     func shouldDeliverToFrontendBridge(_ context: AIChatPageContextData?) -> Bool {
         if isUnifiedToggleInputActive, context != nil {
             Logger.aiChat.debug("[SessionState] shouldDeliverToFrontendBridge=false (non-nil context delivered to UTI)")

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -574,6 +574,11 @@ private extension AIChatContextualChatSessionState {
         if isShowingNativeInput || isUnifiedToggleInputActive {
             chipState = .attached(context)
             userDowngradedToPlaceholder = false
+            // A deliberate manual attach is always a fresh pending attachment, even for a page
+            // already submitted this session. Clear the delivered marker so `utiChipDeliveryState`
+            // does not misclassify it as a stale echo and hide it — stale-echo suppression applies
+            // to passive auto re-collection only, never to an explicit user attach.
+            deliveredContextURLWithNoNavigationSince = nil
             Logger.aiChat.debug("[SessionState] Manually attached context")
         }
 

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -382,6 +382,9 @@ private extension AIChatContextualSheetCoordinator {
             self.sessionState.beginChatForUTISubmission()
             self.sheetViewController?.handleFirstUTISubmission()
         }
+        host.onPromptDelivered = { [weak self] in
+            self?.sessionState.markUTIContextDelivered()
+        }
         host.onAIVoiceChatRequested = { [weak self] in
             guard let self else { return }
             self.sheetViewController?.dismiss(animated: true) { [weak self] in
@@ -484,7 +487,7 @@ private extension AIChatContextualSheetCoordinator {
             ? sessionState.latestContext
             : AIChatPageContext(contextData: context, favicon: nil)
         if let pageContext {
-            host.setAttachedContext(pageContext, deliveryState: .pendingSubmit)
+            host.setAttachedContext(pageContext, deliveryState: sessionState.utiChipDeliveryState(forDelivering: context))
         }
     }
 

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -484,8 +484,7 @@ private extension AIChatContextualSheetCoordinator {
             ? sessionState.latestContext
             : AIChatPageContext(contextData: context, favicon: nil)
         if let pageContext {
-            let deliveryState: PageContextAttachmentDeliveryState = sessionState.isContextAlreadyDelivered(context) ? .delivered : .pendingSubmit
-            host.setAttachedContext(pageContext, deliveryState: deliveryState)
+            host.setAttachedContext(pageContext, deliveryState: .pendingSubmit)
         }
     }
 

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -484,7 +484,8 @@ private extension AIChatContextualSheetCoordinator {
             ? sessionState.latestContext
             : AIChatPageContext(contextData: context, favicon: nil)
         if let pageContext {
-            host.setAttachedContext(pageContext, deliveryState: .pendingSubmit)
+            let deliveryState: PageContextAttachmentDeliveryState = sessionState.isContextAlreadyDelivered(context) ? .delivered : .pendingSubmit
+            host.setAttachedContext(pageContext, deliveryState: deliveryState)
         }
     }
 

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -42,8 +42,7 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate {
     var onAttachRequested: (() -> Void)?
     var onRemoveRequested: (() -> Void)?
     var onPromptSubmitted: (() -> Void)?
-    /// Fires on every prompt delivery (first and follow-up) so the session state can mark the
-    /// attached context delivered and re-render the chip. The chip no longer hides itself.
+    /// Fires on every prompt delivery so the session state can mark context delivered and re-render the chip.
     var onPromptDelivered: (() -> Void)?
     var onAIVoiceChatRequested: (() -> Void)?
 
@@ -144,9 +143,7 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate {
         coordinator.observeChatUpdates(publisher)
     }
 
-    /// Called when a prompt that carried page context has been delivered. Routes through the
-    /// session state (via `onPromptDelivered`), which owns the pending→delivered transition and
-    /// re-renders the chip — the chip is no longer told to hide itself directly.
+    /// Called when a prompt carrying page context is delivered; routes to the session state via `onPromptDelivered`.
     func notifyPromptDelivered() {
         onPromptDelivered?()
     }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -42,6 +42,9 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate {
     var onAttachRequested: (() -> Void)?
     var onRemoveRequested: (() -> Void)?
     var onPromptSubmitted: (() -> Void)?
+    /// Fires on every prompt delivery (first and follow-up) so the session state can mark the
+    /// attached context delivered and re-render the chip. The chip no longer hides itself.
+    var onPromptDelivered: (() -> Void)?
     var onAIVoiceChatRequested: (() -> Void)?
 
     var attachedContextURL: URL? {
@@ -141,8 +144,11 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate {
         coordinator.observeChatUpdates(publisher)
     }
 
-    func markPromptSubmitted() {
-        chipViewModel.markPromptSubmitted()
+    /// Called when a prompt that carried page context has been delivered. Routes through the
+    /// session state (via `onPromptDelivered`), which owns the pending→delivered transition and
+    /// re-renders the chip — the chip is no longer told to hide itself directly.
+    func notifyPromptDelivered() {
+        onPromptDelivered?()
     }
 
     func setContextualChatViewController(_ contextualChatViewController: AIChatContextualWebViewController) {
@@ -252,7 +258,7 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate {
             onPromptSubmitted?()
             commitDeferredBindIfNeeded()
         }
-        chipViewModel.markPromptSubmitted()
+        onPromptDelivered?()
     }
 
     func unifiedToggleInputDidSubmitPrompt(_ prompt: String,
@@ -272,7 +278,7 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate {
                                                    pageContext: chipViewModel.pendingAttachedContextData,
                                                    reasoningEffort: reasoningEffort)
         commitDeferredBindIfNeeded()
-        chipViewModel.markPromptSubmitted()
+        onPromptDelivered?()
     }
 
     func unifiedToggleInputDidSubmitQuery(_ query: String) {}

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
@@ -212,7 +212,7 @@ final class AIChatContextualWebViewController: UIViewController {
     func submitPrompt(_ prompt: String, pageContext: AIChatPageContextData? = nil) {
         Logger.aiChat.debug("[ContextualWebVC] submitPrompt called - isPageReady: \(self.isPageReady), isContentHandlerReady: \(self.isContentHandlerReady)")
         if pageContext != nil {
-            utiHost?.markPromptSubmitted()
+            utiHost?.notifyPromptDelivered()
         }
         if isPageReady && isContentHandlerReady {
             Logger.aiChat.debug("[ContextualWebVC] Submitting prompt immediately")

--- a/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
@@ -56,8 +56,10 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
     private(set) var attachedContext: AIChatPageContext?
     private var attachedURL: URL?
     private var originatingURL: URL?
-    /// Whether the current attachment is waiting to be included in a prompt or has already
-    /// been delivered. `markPromptSubmitted()` flips pending attachments to delivered.
+    /// Whether the current attachment is waiting to be included in a prompt or has already been
+    /// delivered. Presentation-only: this is set solely by what the session state pushes in via
+    /// `setAttached(_:deliveryState:)` — the chip never decides delivery itself. The session state
+    /// owns the pending→delivered transition and re-pushes `.delivered` on submit.
     private var attachmentDeliveryState: PageContextAttachmentDeliveryState = .pendingSubmit
     private var isShowingAttachAffordance = false
     private var cancellables = Set<AnyCancellable>()
@@ -126,14 +128,6 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
     var pendingAttachedContextData: AIChatPageContextData? {
         guard attachmentDeliveryState == .pendingSubmit else { return nil }
         return attachedContext?.contextData
-    }
-
-    /// Mark the current attachment as delivered (submitted in a prompt). Hides the chip if the
-    /// attachment is matching — we don't need to keep showing what's silently riding along.
-    func markPromptSubmitted() {
-        guard attachedContext != nil, attachmentDeliveryState != .delivered else { return }
-        attachmentDeliveryState = .delivered
-        recompute()
     }
 
     private func updateAttachment(_ context: AIChatPageContext?, deliveryState: PageContextAttachmentDeliveryState) {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
@@ -56,10 +56,7 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
     private(set) var attachedContext: AIChatPageContext?
     private var attachedURL: URL?
     private var originatingURL: URL?
-    /// Whether the current attachment is waiting to be included in a prompt or has already been
-    /// delivered. Presentation-only: this is set solely by what the session state pushes in via
-    /// `setAttached(_:deliveryState:)` — the chip never decides delivery itself. The session state
-    /// owns the pending→delivered transition and re-pushes `.delivered` on submit.
+    /// Presentation-only pending/delivered flag; set solely by `setAttached`, never decided by the chip.
     private var attachmentDeliveryState: PageContextAttachmentDeliveryState = .pendingSubmit
     private var isShowingAttachAffordance = false
     private var cancellables = Set<AnyCancellable>()

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -1056,6 +1056,21 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         XCTAssertTrue(delivered.isEmpty)
     }
 
+    func testStaleAutoAttachEchoDoesNotMutateStoredContext() {
+        // Given
+        sessionState.updateUnifiedToggleInputActive(true)
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        sessionState.updateContext(makeTestContext(title: "Original", url: "https://example.com/article"))
+        sessionState.beginChatForUTISubmission()
+        XCTAssertEqual(sessionState.intendedAttachedContext?.title, "Original")
+
+        // When a stale echo of the already-submitted page arrives with a refreshed title
+        sessionState.updateContext(makeTestContext(title: "Echo (updated)", url: "https://example.com/article"))
+
+        // Then the stored attached context still reflects what was submitted, not the ignored echo
+        XCTAssertEqual(sessionState.intendedAttachedContext?.title, "Original")
+    }
+
     func testUTIChipDeliveryStateMarksStaleEchoDeliveredAndFreshContextPending() {
         // Given
         sessionState.updateUnifiedToggleInputActive(true)

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -1057,6 +1057,52 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         XCTAssertTrue(delivered.isEmpty)
     }
 
+    /// The pending-vs-delivered decision now belongs to the state owner, not the coordinator: a stale
+    /// same-page echo after submit resolves to `.delivered` (chip stays hidden), while any other
+    /// collection is a fresh `.pendingSubmit`.
+    func testUTIChipDeliveryStateMarksStaleEchoDeliveredAndFreshContextPending() {
+        sessionState.updateUnifiedToggleInputActive(true)
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        sessionState.updateContext(makeTestContext(url: "https://example.com/article"))
+        sessionState.beginChatForUTISubmission()
+
+        // Same page, no navigation since submit -> stale echo -> delivered (stays hidden)
+        let echo = makeTestContext(url: "https://example.com/article").contextData
+        guard case .delivered = sessionState.utiChipDeliveryState(forDelivering: echo) else {
+            return XCTFail("Expected stale echo of already-submitted page to be .delivered")
+        }
+
+        // A different page is a fresh attachment -> pending (chip visible for the next prompt)
+        let fresh = makeTestContext(url: "https://example.com/other").contextData
+        guard case .pendingSubmit = sessionState.utiChipDeliveryState(forDelivering: fresh) else {
+            return XCTFail("Expected fresh context to be .pendingSubmit")
+        }
+    }
+
+    /// SessionState is the sole owner of the pending→delivered transition: on submit it re-renders
+    /// the attached context to the UTI chip as delivered, and the same page no longer counts as a
+    /// fresh pending attach afterwards.
+    func testMarkUTIContextDeliveredRerendersChipAndMarksPageDelivered() {
+        sessionState.updateUnifiedToggleInputActive(true)
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        sessionState.updateContext(makeTestContext(url: "https://example.com/article"))
+
+        // When the prompt carrying the attached context is delivered
+        let delivered = utiDeliveryEffects {
+            sessionState.markUTIContextDelivered()
+        }
+
+        // Then the attached context is re-pushed to the UTI chip (which now hides it)...
+        XCTAssertEqual(delivered.count, 1)
+        XCTAssertEqual(delivered.first??.url, "https://example.com/article")
+
+        // ...and that same page is now delivered, so it won't ride the next prompt.
+        let sameURL = makeTestContext(url: "https://example.com/article").contextData
+        guard case .delivered = sessionState.utiChipDeliveryState(forDelivering: sameURL) else {
+            return XCTFail("Expected the delivered page to be marked .delivered")
+        }
+    }
+
     /// A manual re-attach of the same URL after submit must always be treated as a fresh, deliberate
     /// attach — never suppressed by the stale-echo check, which only applies to passive auto-attach.
     func testManualReattachOfSameURLAfterSubmitStillDelivers() {

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -1040,125 +1040,115 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
     /// not produce any delivery at all, so the chip stays untouched in its post-submit `.delivered`
     /// state.
     func testLateAutoAttachEchoAfterUTISubmissionDoesNotResurrectChip() {
-        // Given - auto-attach ON, UTI active, chip attached and submitted via UTI
+        // Given
         sessionState.updateUnifiedToggleInputActive(true)
         mockSettings.isAutomaticContextAttachmentEnabled = true
         sessionState.updateContext(makeTestContext(url: "https://example.com/article"))
         sessionState.beginChatForUTISubmission()
         XCTAssertEqual(sessionState.frontendState, .chatWithInitialContext)
 
-        // When - a second, late context emission arrives for the same page after submit, with no
-        // navigation in between (e.g. a JS auto-update as the DOM settles)
+        // When
         let delivered = utiDeliveryEffects {
             sessionState.updateContext(makeTestContext(title: "Article (updated)", url: "https://example.com/article"))
         }
 
-        // Then - no delivery at all, so the chip is never told to become pending again
+        // Then
         XCTAssertTrue(delivered.isEmpty)
     }
 
-    /// The pending-vs-delivered decision now belongs to the state owner, not the coordinator: a stale
-    /// same-page echo after submit resolves to `.delivered` (chip stays hidden), while any other
-    /// collection is a fresh `.pendingSubmit`.
     func testUTIChipDeliveryStateMarksStaleEchoDeliveredAndFreshContextPending() {
+        // Given
         sessionState.updateUnifiedToggleInputActive(true)
         mockSettings.isAutomaticContextAttachmentEnabled = true
         sessionState.updateContext(makeTestContext(url: "https://example.com/article"))
         sessionState.beginChatForUTISubmission()
 
-        // Same page, no navigation since submit -> stale echo -> delivered (stays hidden)
+        // Then
         let echo = makeTestContext(url: "https://example.com/article").contextData
         guard case .delivered = sessionState.utiChipDeliveryState(forDelivering: echo) else {
             return XCTFail("Expected stale echo of already-submitted page to be .delivered")
         }
 
-        // A different page is a fresh attachment -> pending (chip visible for the next prompt)
         let fresh = makeTestContext(url: "https://example.com/other").contextData
         guard case .pendingSubmit = sessionState.utiChipDeliveryState(forDelivering: fresh) else {
             return XCTFail("Expected fresh context to be .pendingSubmit")
         }
     }
 
-    /// SessionState is the sole owner of the pending→delivered transition: on submit it re-renders
-    /// the attached context to the UTI chip as delivered, and the same page no longer counts as a
-    /// fresh pending attach afterwards.
     func testMarkUTIContextDeliveredRerendersChipAndMarksPageDelivered() {
+        // Given
         sessionState.updateUnifiedToggleInputActive(true)
         mockSettings.isAutomaticContextAttachmentEnabled = true
         sessionState.updateContext(makeTestContext(url: "https://example.com/article"))
 
-        // When the prompt carrying the attached context is delivered
+        // When
         let delivered = utiDeliveryEffects {
             sessionState.markUTIContextDelivered()
         }
 
-        // Then the attached context is re-pushed to the UTI chip (which now hides it)...
+        // Then
         XCTAssertEqual(delivered.count, 1)
         XCTAssertEqual(delivered.first??.url, "https://example.com/article")
 
-        // ...and that same page is now delivered, so it won't ride the next prompt.
         let sameURL = makeTestContext(url: "https://example.com/article").contextData
         guard case .delivered = sessionState.utiChipDeliveryState(forDelivering: sameURL) else {
             return XCTFail("Expected the delivered page to be marked .delivered")
         }
     }
 
-    /// A manual re-attach of the same URL after submit must always be treated as a fresh, deliberate
-    /// attach — never suppressed by the stale-echo check, which only applies to passive auto-attach.
     func testManualReattachOfSameURLAfterSubmitStillDelivers() {
+        // Given
         sessionState.updateUnifiedToggleInputActive(true)
         mockSettings.isAutomaticContextAttachmentEnabled = true
         sessionState.updateContext(makeTestContext(url: "https://example.com/article"))
         sessionState.beginChatForUTISubmission()
 
-        // When - user explicitly taps "Attach" again for the same page, wanting it in the next message
+        // When
         sessionState.beginManualAttach()
         let delivered = utiDeliveryEffects {
             sessionState.updateContext(makeTestContext(url: "https://example.com/article"))
         }
 
-        // Then - delivered as a fresh attachment, so it will actually be sent
+        // Then
         XCTAssertEqual(delivered.count, 1)
         XCTAssertEqual(delivered.first??.url, "https://example.com/article")
 
-        // ...and crucially the coordinator must push it PENDING, not delivered — otherwise the chip
-        // hides and the same page silently fails to ride the follow-up prompt. Stale-echo suppression
-        // is for passive auto re-collection only, never a deliberate manual re-attach.
         let reattached = makeTestContext(url: "https://example.com/article").contextData
         guard case .pendingSubmit = sessionState.utiChipDeliveryState(forDelivering: reattached) else {
             return XCTFail("Manual same-URL re-attach after submit must be .pendingSubmit, not suppressed as a stale echo")
         }
     }
 
-    /// A real navigation always resets the stale-echo tracking, so revisiting an already-submitted
-    /// URL is treated as fresh rather than silently suppressed.
     func testAutoAttachAfterNavigationBackToSameURLStillDelivers() {
+        // Given
         sessionState.updateUnifiedToggleInputActive(true)
         mockSettings.isAutomaticContextAttachmentEnabled = true
         sessionState.updateContext(makeTestContext(url: "https://example.com/article"))
         sessionState.beginChatForUTISubmission()
 
-        // When - user navigates away and back to the same URL
+        // When
         sessionState.notifyPageChanged()
         let delivered = utiDeliveryEffects {
             sessionState.updateContext(makeTestContext(url: "https://example.com/article"))
         }
 
-        // Then - treated as fresh, not suppressed
+        // Then
         XCTAssertEqual(delivered.count, 1)
     }
 
-    /// A different URL is never mistaken for a stale echo, even without an intervening navigation.
     func testAutoAttachForDifferentURLAfterSubmitStillDelivers() {
+        // Given
         sessionState.updateUnifiedToggleInputActive(true)
         mockSettings.isAutomaticContextAttachmentEnabled = true
         sessionState.updateContext(makeTestContext(url: "https://example.com/page-a"))
         sessionState.beginChatForUTISubmission()
 
+        // When
         let delivered = utiDeliveryEffects {
             sessionState.updateContext(makeTestContext(url: "https://example.com/page-b"))
         }
 
+        // Then
         XCTAssertEqual(delivered.count, 1)
         XCTAssertEqual(delivered.first??.url, "https://example.com/page-b")
     }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -1120,6 +1120,14 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         // Then - delivered as a fresh attachment, so it will actually be sent
         XCTAssertEqual(delivered.count, 1)
         XCTAssertEqual(delivered.first??.url, "https://example.com/article")
+
+        // ...and crucially the coordinator must push it PENDING, not delivered — otherwise the chip
+        // hides and the same page silently fails to ride the follow-up prompt. Stale-echo suppression
+        // is for passive auto re-collection only, never a deliberate manual re-attach.
+        let reattached = makeTestContext(url: "https://example.com/article").contextData
+        guard case .pendingSubmit = sessionState.utiChipDeliveryState(forDelivering: reattached) else {
+            return XCTFail("Manual same-URL re-attach after submit must be .pendingSubmit, not suppressed as a stale echo")
+        }
     }
 
     /// A real navigation always resets the stale-echo tracking, so revisiting an already-submitted

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -1019,67 +1019,27 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         XCTAssertFalse(mockPixelHandler.pageContextAutoAttachedFired)
     }
 
-    // MARK: - Already-Delivered Context Tests (re-attach after submit)
+    // MARK: - Stale Auto-Attach Echo Tests (re-attach after submit)
 
-    func testBeginChatForUTISubmissionRecordsDeliveredContextURL() {
-        // Given - chip attached with page context
-        mockSettings.isAutomaticContextAttachmentEnabled = true
-        sessionState.updateContext(makeTestContext(url: "https://example.com/article"))
-
-        // When - UTI submission carries the attached context
-        sessionState.beginChatForUTISubmission()
-
-        // Then - that URL is recorded as delivered
-        XCTAssertTrue(sessionState.isContextAlreadyDelivered(makeTestContext(url: "https://example.com/article").contextData))
-    }
-
-    func testHandlePromptSubmissionRecordsDeliveredContextURL() {
-        // Given - chip attached with page context
-        mockSettings.isAutomaticContextAttachmentEnabled = true
-        sessionState.updateContext(makeTestContext(url: "https://example.com/article"))
-
-        // When - native submission carries the attached context
-        sessionState.handlePromptSubmission("Hello")
-
-        // Then - that URL is recorded as delivered
-        XCTAssertTrue(sessionState.isContextAlreadyDelivered(makeTestContext(url: "https://example.com/article").contextData))
-    }
-
-    func testIsContextAlreadyDeliveredFalseBeforeAnySubmission() {
-        XCTAssertFalse(sessionState.isContextAlreadyDelivered(makeTestContext().contextData))
-        XCTAssertFalse(sessionState.isContextAlreadyDelivered(nil))
-    }
-
-    func testIsContextAlreadyDeliveredFalseForDifferentURL() {
-        // Given - submitted with context from Page A
-        mockSettings.isAutomaticContextAttachmentEnabled = true
-        sessionState.updateContext(makeTestContext(url: "https://example.com/page-a"))
-        sessionState.beginChatForUTISubmission()
-
-        // Then - a different page's context is not considered already delivered
-        XCTAssertFalse(sessionState.isContextAlreadyDelivered(makeTestContext(url: "https://example.com/page-b").contextData))
-    }
-
-    func testResetToNoChatClearsDeliveredContextURL() {
-        // Given - submitted with attached context
-        mockSettings.isAutomaticContextAttachmentEnabled = true
-        sessionState.updateContext(makeTestContext(url: "https://example.com/article"))
-        sessionState.beginChatForUTISubmission()
-        XCTAssertTrue(sessionState.isContextAlreadyDelivered(makeTestContext(url: "https://example.com/article").contextData))
-
-        // When
-        sessionState.resetToNoChat()
-
-        // Then
-        XCTAssertFalse(sessionState.isContextAlreadyDelivered(makeTestContext(url: "https://example.com/article").contextData))
+    private func utiDeliveryEffects(_ block: () -> Void) -> [AIChatPageContextData?] {
+        var delivered: [AIChatPageContextData?] = []
+        sessionState.effects
+            .sink { effect in
+                if case .deliverPageContext(let data, let targets) = effect, targets.contains(.utiChip) {
+                    delivered.append(data)
+                }
+            }
+            .store(in: &cancellables)
+        block()
+        return delivered
     }
 
     /// Regression test for the bug where, after submitting the first prompt WITH context via the
-    /// contextual UTI, a late auto-attach re-collection for the SAME page resurrected the UTI chip
-    /// as pending — silently riding the next message. A same-URL re-collection after submit must
-    /// be recognized as already-delivered so the coordinator delivers it to the chip as `.delivered`
-    /// instead of `.pendingSubmit`.
-    func testLateAutoAttachReCollectionAfterUTISubmissionIsAlreadyDelivered() {
+    /// contextual UTI, a late auto-attach re-collection for the SAME page (no navigation in between)
+    /// resurrected the UTI chip as pending — silently riding the next message. The stale echo must
+    /// not produce any delivery at all, so the chip stays untouched in its post-submit `.delivered`
+    /// state.
+    func testLateAutoAttachEchoAfterUTISubmissionDoesNotResurrectChip() {
         // Given - auto-attach ON, UTI active, chip attached and submitted via UTI
         sessionState.updateUnifiedToggleInputActive(true)
         mockSettings.isAutomaticContextAttachmentEnabled = true
@@ -1087,22 +1047,66 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         sessionState.beginChatForUTISubmission()
         XCTAssertEqual(sessionState.frontendState, .chatWithInitialContext)
 
-        var deliveredContexts: [AIChatPageContextData?] = []
-        sessionState.effects
-            .sink { effect in
-                if case .deliverPageContext(let data, let targets) = effect, targets.contains(.utiChip) {
-                    deliveredContexts.append(data)
-                }
-            }
-            .store(in: &cancellables)
+        // When - a second, late context emission arrives for the same page after submit, with no
+        // navigation in between (e.g. a JS auto-update as the DOM settles)
+        let delivered = utiDeliveryEffects {
+            sessionState.updateContext(makeTestContext(title: "Article (updated)", url: "https://example.com/article"))
+        }
 
-        // When - a second, late context emission arrives for the same page after submit
-        // (e.g. a JS auto-update as the DOM settles)
-        sessionState.updateContext(makeTestContext(title: "Article (updated)", url: "https://example.com/article"))
+        // Then - no delivery at all, so the chip is never told to become pending again
+        XCTAssertTrue(delivered.isEmpty)
+    }
 
-        // Then - the resulting delivery is recognized as already-delivered content
-        XCTAssertEqual(deliveredContexts.count, 1)
-        XCTAssertTrue(sessionState.isContextAlreadyDelivered(deliveredContexts.first!))
+    /// A manual re-attach of the same URL after submit must always be treated as a fresh, deliberate
+    /// attach — never suppressed by the stale-echo check, which only applies to passive auto-attach.
+    func testManualReattachOfSameURLAfterSubmitStillDelivers() {
+        sessionState.updateUnifiedToggleInputActive(true)
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        sessionState.updateContext(makeTestContext(url: "https://example.com/article"))
+        sessionState.beginChatForUTISubmission()
+
+        // When - user explicitly taps "Attach" again for the same page, wanting it in the next message
+        sessionState.beginManualAttach()
+        let delivered = utiDeliveryEffects {
+            sessionState.updateContext(makeTestContext(url: "https://example.com/article"))
+        }
+
+        // Then - delivered as a fresh attachment, so it will actually be sent
+        XCTAssertEqual(delivered.count, 1)
+        XCTAssertEqual(delivered.first??.url, "https://example.com/article")
+    }
+
+    /// A real navigation always resets the stale-echo tracking, so revisiting an already-submitted
+    /// URL is treated as fresh rather than silently suppressed.
+    func testAutoAttachAfterNavigationBackToSameURLStillDelivers() {
+        sessionState.updateUnifiedToggleInputActive(true)
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        sessionState.updateContext(makeTestContext(url: "https://example.com/article"))
+        sessionState.beginChatForUTISubmission()
+
+        // When - user navigates away and back to the same URL
+        sessionState.notifyPageChanged()
+        let delivered = utiDeliveryEffects {
+            sessionState.updateContext(makeTestContext(url: "https://example.com/article"))
+        }
+
+        // Then - treated as fresh, not suppressed
+        XCTAssertEqual(delivered.count, 1)
+    }
+
+    /// A different URL is never mistaken for a stale echo, even without an intervening navigation.
+    func testAutoAttachForDifferentURLAfterSubmitStillDelivers() {
+        sessionState.updateUnifiedToggleInputActive(true)
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        sessionState.updateContext(makeTestContext(url: "https://example.com/page-a"))
+        sessionState.beginChatForUTISubmission()
+
+        let delivered = utiDeliveryEffects {
+            sessionState.updateContext(makeTestContext(url: "https://example.com/page-b"))
+        }
+
+        XCTAssertEqual(delivered.count, 1)
+        XCTAssertEqual(delivered.first??.url, "https://example.com/page-b")
     }
 
     func testUTINonNilContextDoesNotDeliverToFrontendForChatWithoutInitialContext() {

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -1019,6 +1019,92 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         XCTAssertFalse(mockPixelHandler.pageContextAutoAttachedFired)
     }
 
+    // MARK: - Already-Delivered Context Tests (re-attach after submit)
+
+    func testBeginChatForUTISubmissionRecordsDeliveredContextURL() {
+        // Given - chip attached with page context
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        sessionState.updateContext(makeTestContext(url: "https://example.com/article"))
+
+        // When - UTI submission carries the attached context
+        sessionState.beginChatForUTISubmission()
+
+        // Then - that URL is recorded as delivered
+        XCTAssertTrue(sessionState.isContextAlreadyDelivered(makeTestContext(url: "https://example.com/article").contextData))
+    }
+
+    func testHandlePromptSubmissionRecordsDeliveredContextURL() {
+        // Given - chip attached with page context
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        sessionState.updateContext(makeTestContext(url: "https://example.com/article"))
+
+        // When - native submission carries the attached context
+        sessionState.handlePromptSubmission("Hello")
+
+        // Then - that URL is recorded as delivered
+        XCTAssertTrue(sessionState.isContextAlreadyDelivered(makeTestContext(url: "https://example.com/article").contextData))
+    }
+
+    func testIsContextAlreadyDeliveredFalseBeforeAnySubmission() {
+        XCTAssertFalse(sessionState.isContextAlreadyDelivered(makeTestContext().contextData))
+        XCTAssertFalse(sessionState.isContextAlreadyDelivered(nil))
+    }
+
+    func testIsContextAlreadyDeliveredFalseForDifferentURL() {
+        // Given - submitted with context from Page A
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        sessionState.updateContext(makeTestContext(url: "https://example.com/page-a"))
+        sessionState.beginChatForUTISubmission()
+
+        // Then - a different page's context is not considered already delivered
+        XCTAssertFalse(sessionState.isContextAlreadyDelivered(makeTestContext(url: "https://example.com/page-b").contextData))
+    }
+
+    func testResetToNoChatClearsDeliveredContextURL() {
+        // Given - submitted with attached context
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        sessionState.updateContext(makeTestContext(url: "https://example.com/article"))
+        sessionState.beginChatForUTISubmission()
+        XCTAssertTrue(sessionState.isContextAlreadyDelivered(makeTestContext(url: "https://example.com/article").contextData))
+
+        // When
+        sessionState.resetToNoChat()
+
+        // Then
+        XCTAssertFalse(sessionState.isContextAlreadyDelivered(makeTestContext(url: "https://example.com/article").contextData))
+    }
+
+    /// Regression test for the bug where, after submitting the first prompt WITH context via the
+    /// contextual UTI, a late auto-attach re-collection for the SAME page resurrected the UTI chip
+    /// as pending — silently riding the next message. A same-URL re-collection after submit must
+    /// be recognized as already-delivered so the coordinator delivers it to the chip as `.delivered`
+    /// instead of `.pendingSubmit`.
+    func testLateAutoAttachReCollectionAfterUTISubmissionIsAlreadyDelivered() {
+        // Given - auto-attach ON, UTI active, chip attached and submitted via UTI
+        sessionState.updateUnifiedToggleInputActive(true)
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        sessionState.updateContext(makeTestContext(url: "https://example.com/article"))
+        sessionState.beginChatForUTISubmission()
+        XCTAssertEqual(sessionState.frontendState, .chatWithInitialContext)
+
+        var deliveredContexts: [AIChatPageContextData?] = []
+        sessionState.effects
+            .sink { effect in
+                if case .deliverPageContext(let data, let targets) = effect, targets.contains(.utiChip) {
+                    deliveredContexts.append(data)
+                }
+            }
+            .store(in: &cancellables)
+
+        // When - a second, late context emission arrives for the same page after submit
+        // (e.g. a JS auto-update as the DOM settles)
+        sessionState.updateContext(makeTestContext(title: "Article (updated)", url: "https://example.com/article"))
+
+        // Then - the resulting delivery is recognized as already-delivered content
+        XCTAssertEqual(deliveredContexts.count, 1)
+        XCTAssertTrue(sessionState.isContextAlreadyDelivered(deliveredContexts.first!))
+    }
+
     func testUTINonNilContextDoesNotDeliverToFrontendForChatWithoutInitialContext() {
         sessionState.updateUnifiedToggleInputActive(true)
         sessionState.handlePromptSubmission("Hello")

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
@@ -149,19 +149,31 @@ final class AIChatContextualUTIHostTests: XCTestCase {
         XCTAssertEqual(sut.chipViewModel.pendingAttachedContextData?.url, url.absoluteString)
     }
 
-    func test_setAttachedContextAfterPromptSubmittedWithSameURL_makesContextPendingAgain() {
+    func test_setAttachedContextWithSameURLAfterDelivered_makesContextPendingAgain() {
         let url = URL(string: "https://example.com/a")!
         originatingURL.send(url)
         let context = makeContext(title: "Page A", url: url.absoluteString)
-        makeSUT(initialAttachedContext: context, initialAttachmentDeliveryState: .pendingSubmit)
+        makeSUT(initialAttachedContext: context, initialAttachmentDeliveryState: .delivered)
 
-        sut.markPromptSubmitted()
         XCTAssertNil(sut.chipViewModel.pendingAttachedContextData)
 
+        // A fresh push (e.g. a manual re-attach) re-arms the chip for the next prompt.
         sut.setAttachedContext(context)
 
         XCTAssertEqual(sut.chipViewModel.pendingAttachedContextData?.url, url.absoluteString)
         XCTAssertEqualState(sut.chipViewModel.state, .attached(title: "Page A", favicon: nil))
+    }
+
+    func test_notifyPromptDelivered_firesOnPromptDeliveredCallback() {
+        let url = URL(string: "https://example.com/a")!
+        originatingURL.send(url)
+        makeSUT(initialAttachedContext: makeContext(title: "Page A", url: url.absoluteString), initialAttachmentDeliveryState: .pendingSubmit)
+        var deliveredCount = 0
+        sut.onPromptDelivered = { deliveredCount += 1 }
+
+        sut.notifyPromptDelivered()
+
+        XCTAssertEqual(deliveredCount, 1)
     }
 
     func test_prepareForNewChat_clearsAttachedContextPresentation() {

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
@@ -157,7 +157,6 @@ final class AIChatContextualUTIHostTests: XCTestCase {
 
         XCTAssertNil(sut.chipViewModel.pendingAttachedContextData)
 
-        // A fresh push (e.g. a manual re-attach) re-arms the chip for the next prompt.
         sut.setAttachedContext(context)
 
         XCTAssertEqual(sut.chipViewModel.pendingAttachedContextData?.url, url.absoluteString)

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPageContextChipViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPageContextChipViewModelTests.swift
@@ -249,7 +249,8 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         sut.setAttached(makeContext(title: "Cat", url: url))
         XCTAssertTrue(sut.isVisible)
 
-        sut.markPromptSubmitted()
+        // Session state pushes the attachment as delivered on submit — the chip renders, it does not decide.
+        sut.setAttached(makeContext(title: "Cat", url: url), deliveryState: .delivered)
         XCTAssertFalse(sut.isVisible)
         XCTAssertEqualState(sut.state, .attached(title: "Cat", favicon: nil))
     }
@@ -261,7 +262,7 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         originatingURL.send(URL(string: url))
         makeSUT()
         sut.setAttached(makeContext(title: "Cat", url: url))
-        sut.markPromptSubmitted()
+        sut.setAttached(makeContext(title: "Cat", url: url), deliveryState: .delivered)
         XCTAssertFalse(sut.isVisible)
 
         sut.clearAttached()
@@ -355,7 +356,7 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         XCTAssertTrue(sut.isVisible)
         XCTAssertEqualState(sut.state, .attached(title: "Dog", favicon: nil))
 
-        sut.markPromptSubmitted()
+        sut.setAttached(makeContext(title: "Dog", url: newURL), deliveryState: .delivered)
         XCTAssertFalse(sut.isVisible)
     }
 
@@ -380,7 +381,7 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         makeSUT()
 
         sut.setAttached(makeContext(title: "Cat", url: url))
-        sut.markPromptSubmitted()
+        sut.setAttached(makeContext(title: "Cat", url: url), deliveryState: .delivered)
         XCTAssertFalse(sut.isVisible)
 
         sut.clearAttached()
@@ -403,15 +404,15 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         XCTAssertEqual(sut.pendingAttachedContextData?.title, "Cat")
     }
 
-    func test_pendingAttachedContextData_afterMarkPromptSubmitted_returnsNil() {
-        // Once the chip flips to `.delivered`, every
+    func test_pendingAttachedContextData_afterDeliveredPush_returnsNil() {
+        // Once the session state pushes the attachment as `.delivered`, every
         // subsequent prompt must ship `pageContext: nil` — otherwise duck.ai renders a
         // "Page content from..." attribution beneath each follow-up prompt.
         let url = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: url))
         makeSUT()
         sut.setAttached(makeContext(title: "Cat", url: url))
-        sut.markPromptSubmitted()
+        sut.setAttached(makeContext(title: "Cat", url: url), deliveryState: .delivered)
         XCTAssertNil(sut.pendingAttachedContextData)
     }
 
@@ -444,7 +445,7 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         originatingURL.send(URL(string: url))
         makeSUT()
         sut.setAttached(makeContext(title: "Cat", url: url))
-        sut.markPromptSubmitted()
+        sut.setAttached(makeContext(title: "Cat", url: url), deliveryState: .delivered)
         XCTAssertNil(sut.pendingAttachedContextData)
 
         sut.clearAttached()

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPageContextChipViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPageContextChipViewModelTests.swift
@@ -249,7 +249,6 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         sut.setAttached(makeContext(title: "Cat", url: url))
         XCTAssertTrue(sut.isVisible)
 
-        // Session state pushes the attachment as delivered on submit — the chip renders, it does not decide.
         sut.setAttached(makeContext(title: "Cat", url: url), deliveryState: .delivered)
         XCTAssertFalse(sut.isVisible)
         XCTAssertEqualState(sut.state, .attached(title: "Cat", favicon: nil))


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1216466743733545

### Description

Two related changes to the contextual Duck.ai page-context chip, both behind the internal-only contextual-UTI flags.

**1. Fix the chip resurrecting after submit.** After submitting the first prompt with page context, the page-context chip could reappear in the unified input bar as if newly attached, and a follow-up message would then silently carry the old page's content. The cause was a late, passive re-collection of the same page (not a real navigation or attach) being mistaken for a fresh attachment.

**2. Consolidate delivery-state ownership into `AIChatContextualChatSessionState`.** The underlying cause of this whole class of bug was *dual ownership*: both the session state and the UTI chip view model independently tracked "pending vs delivered" and could disagree.

### Manual Tests

Internal only. Enable in **Debug → Feature Flags**, then **restart the app**:
- `unifiedToggleInput`
- `aiChatContextualUnifiedToggleInput` — puts the UTI inside the contextual sheet

Automatic context attachment is toggled per test in **Settings → AI Features → Duck.ai → "Automatically Send Content"**.

#### Test 1: First submit hides the chip and it does not resurrect (auto-attach ON)
Prerequisites: automatic context attachment **ON**.

Steps:
1. Open a web page, tap the Duck.ai button in the address bar.
   Expected: the contextual sheet opens with the page's context already attached.
2. Type a prompt and submit.
   Expected: chat opens; the page-context chip disappears from the input bar (marked delivered).
3. Wait a few seconds (let the page settle), then **without navigating or re-attaching**, type and submit a second prompt.
   Expected: the chip does **not** reappear beforehand, and the second message does **not** silently carry the first page's content.

#### Test 2: Deliberate re-attach of the same page still works (auto-attach ON)
Continue from Test 1 (same page, after the first submit).

Steps:
1. Open the attachment menu → tap **"Ask About Page"** (or "Summarize Page").
   Expected: the page-context chip reappears as **pending**.
2. Submit.
   Expected: the page context **is** sent with this prompt; the chip then hides again.

#### Test 3: Navigation after submit is treated as fresh (auto-attach ON)
From an active contextual chat (after a first submit with context), keep the sheet open.

Steps:
1. Navigate the underlying page to a different URL.
   Expected: the new page's context attaches as **pending** (chip visible).
2. Navigate back to the original page.
   Expected: the original page attaches **freshly as pending** — it is not wrongly treated as already sent.

#### Test 4: Manual mode, follow-up carries nothing (auto-attach OFF)
Prerequisites: automatic context attachment **OFF**.

Steps:
1. On page A, open the sheet, tap **"Ask About Page"** → context attaches. Submit.
   Expected: context sent; the chip hides after submit.
2. Without re-attaching, submit a follow-up prompt.
   Expected: the follow-up carries **no** page context and the chip stays hidden.

#### Test 5: Manual re-attach of an already-submitted page rides the follow-up
Regression test for the specific bug fixed in this PR: a deliberate re-attach of a page that was already submitted must be treated as fresh, not suppressed as an already-delivered echo.

Prerequisites: automatic context attachment can be **ON or OFF** (the re-attach here is manual either way).

Steps:
1. On page A, open contextual Duck.ai and submit a first prompt with page A's context attached.
   Expected: chat opens; the page-context chip hides (delivered).
2. **Without navigating**, open the attachment menu and tap **"Ask About Page"** for the same page A again.
   Expected: the page-context chip reappears as **pending** (attached and visible) — it is **not** left hidden.
3. Submit a follow-up prompt.
   Expected: page A's content **is** included with this follow-up (Duck.ai shows the "Page content from…" attribution), confirming the deliberate re-attach was sent and not silently dropped. The chip then hides again.

### Impact

Low: bug fix + internal refactor for a feature currently behind internal-only feature flags; no impact to users outside internal testing.

#### What could go wrong?
- A deliberate re-attach of the same page right after submitting could be mistaken for the stale case → mitigated by only applying the stale-echo check to automatic re-attachment, never an explicit attach (covered by a test).
- Navigating away and back to the same page after submitting could be wrongly treated as already sent → mitigated by treating any real navigation as resetting the tracking (covered by a test).
- A follow-up prompt could fail to mark its context delivered (chip stays visible / re-carries) → mitigated by firing the delivered transition on every submit via `onPromptDelivered` (covered by a test).

### Quality Considerations

Focused unit suites pass **124/124** (`AIChatContextualChatSessionStateTests`, `UnifiedToggleInputPageContextChipViewModelTests`, `AIChatContextualUTIHostTests`), including new coverage for `utiChipDeliveryState`, `markUTIContextDelivered`, and the `onPromptDelivered` wiring. The full `iOS Browser` app compiles clean, and the contextual-UTI Maestro flows (`test_contextual_web_uti_auto_attach_regression`, `test_contextual_immediate_uti_pre_submit_context`, and both `..._manual_context_clears_after_*navigation`) pass on iOS 26.

### Relationship to other PRs

Stacked on `pete/ios/contextual-uti-part-2` (#5676). No conflict with the sibling pixels PR #5779 — its `voice_tapped` `has_pending_page_context` reads `chipViewModel.pendingAttachedContextData`, whose semantics this change preserves; the two branches touch disjoint regions of `AIChatContextualUTIHost.swift`.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to internal contextual-UTI flags with broad unit tests; behavior change is limited to page-context chip delivery, not auth or core browsing.
> 
> **Overview**
> Fixes the contextual Duck.ai **page-context chip** reappearing after the first submit with context, and stops follow-up prompts from silently re-attaching the same page when auto-collect sends a late same-URL update.
> 
> **`AIChatContextualChatSessionState`** now tracks the last submitted page URL (until navigation) and treats passive same-document re-collections as **stale echoes**—ignored for auto-attach and pushed to the UTI as **`.delivered`** via `utiChipDeliveryState` / `isStaleEchoOfDeliveredContext`. Navigation and manual attach clear or bypass that marker so deliberate re-attaches and “navigate away and back” still show **pending** context.
> 
> **Pending vs delivered** is owned by session state: `markUTIContextDelivered` runs on every prompt delivery through **`onPromptDelivered`** (coordinator → UTI host → web VC). The chip view model no longer calls `markPromptSubmitted()`; it only reflects `deliveryState` from `setAttached`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7092bbd05a59a8faaeb029792e73cd36aa39e569. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->