### PR TITLE
Fix failing pixel validation: declare form_factor and channel

### DIFF
--- a/iOS/PixelDefinitions/pixels/definitions/aichat_history.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/aichat_history.json5
@@ -5,7 +5,7 @@
         "description": "The native Duck.ai chat history screen was shown. The `source` parameter identifies the entry point",
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],
-        "suffixes": ["first_daily_count", "platform"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": [
             "appVersion",
             {
@@ -20,98 +20,98 @@
         "description": "User tapped a chat row on the chat history screen to resume that conversation in Duck.ai",
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],
-        "suffixes": ["first_daily_count", "platform"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "aichat_history_chat_deleted": {
         "description": "User deleted a single chat via the trailing swipe action on a chat row on the chat history screen",
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],
-        "suffixes": ["first_daily_count", "platform"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "aichat_history_empty_cta_tapped": {
         "description": "User tapped the empty-state 'Open Duck.ai' CTA on the chat history screen (shown when there is no chat history); opens a new Duck.ai tab",
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],
-        "suffixes": ["first_daily_count", "platform"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "aichat_history_search_activated": {
         "description": "User activated the search bar on the chat history screen",
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],
-        "suffixes": ["first_daily_count", "platform"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "aichat_history_fire_all_tapped": {
         "description": "User tapped the Fire icon in default mode on the chat history screen, initiating a delete of all chats",
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],
-        "suffixes": ["first_daily_count", "platform"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "aichat_history_fire_all_confirmed": {
         "description": "User confirmed the delete-all action on the chat history screen",
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],
-        "suffixes": ["first_daily_count", "platform"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "aichat_history_pin_added": {
         "description": "User pinned a chat from the chat history screen via swipe action",
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],
-        "suffixes": ["first_daily_count", "platform"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "aichat_history_pin_removed": {
         "description": "User unpinned a chat from the chat history screen via swipe action",
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],
-        "suffixes": ["first_daily_count", "platform"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "aichat_history_download_started": {
         "description": "User tapped Download on a chat row on the chat history screen",
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],
-        "suffixes": ["first_daily_count", "platform"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "aichat_history_edit_mode_entered": {
         "description": "User entered select/edit mode on the chat history screen via the toolbar button",
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],
-        "suffixes": ["first_daily_count", "platform"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "aichat_history_new_chat_tapped": {
         "description": "User tapped the New chat (compose) button in the toolbar on the chat history screen",
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],
-        "suffixes": ["first_daily_count", "platform"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "aichat_history_load_failed": {
         "description": "The chat history list failed to load (native storage unavailable or an observer error). This is what drives the load-error alert shown on the chat history screen; use it to gauge how often the error surfaces and how many users are affected",
         "owners": ["Bunn"],
         "triggers": ["other"],
-        "suffixes": ["first_daily_count", "platform"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode"]
     },
     "aichat_history_pin_toggle_failed": {
         "description": "Persisting a pin/unpin toggle failed after the optimistic in-memory move on the chat history screen",
         "owners": ["Bunn"],
         "triggers": ["other"],
-        "suffixes": ["first_daily_count", "platform"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode"]
     },
     "aichat_history_download_failed": {
         "description": "Exporting a chat for download failed on the chat history screen",
         "owners": ["Bunn"],
         "triggers": ["other"],
-        "suffixes": ["first_daily_count", "platform"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode"]
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/subscription.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/subscription.json5
@@ -148,6 +148,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "channel",
             {
                 "key": "d",
                 "type": "string",
@@ -175,7 +176,7 @@
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
 
     // Tier Options Pixels - App Store Distribution
@@ -184,14 +185,14 @@
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_store_subscription_tier-options_success": {
         "description": "Fired when subscription tier options are successfully retrieved (App Store distribution)",
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource", "subscriptionFunnelOrigin"]
+        "parameters": ["appVersion", "pixelSource", "channel", "subscriptionFunnelOrigin"]
     },
     "m_mac_store_subscription_tier-options_failure": {
         "description": "Fired when subscription tier options fail to be retrieved (App Store distribution)",
@@ -201,6 +202,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "channel",
             {
                 "key": "d",
                 "type": "string",
@@ -228,7 +230,7 @@
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
 
     // Plan Change Click Pixels - Direct Distribution
@@ -237,14 +239,14 @@
         "owners": ["SabrinaTardio"],
         "triggers": ["user_submitted"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_direct_subscription_settings_upgrade_click": {
         "description": "Fired when the user clicks 'Upgrade' button in subscription settings (direct distribution)",
         "owners": ["SabrinaTardio"],
         "triggers": ["user_submitted"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
 
     // Plan Change Click Pixels - App Store Distribution
@@ -253,14 +255,14 @@
         "owners": ["SabrinaTardio"],
         "triggers": ["user_submitted"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_store_subscription_settings_upgrade_click": {
         "description": "Fired when the user clicks 'Upgrade' button in subscription settings (App Store distribution)",
         "owners": ["SabrinaTardio"],
         "triggers": ["user_submitted"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_direct_subscription_settings_cancel-pending-downgrade_click": {
         "description": "Fired when the user clicks to cancel a pending downgrade in subscription settings (direct distribution)",

--- a/macOS/PixelDefinitions/pixels/definitions/webview_zoom_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/webview_zoom_pixels.json5
@@ -4,7 +4,7 @@
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],
         "suffixes": ["daily"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_webview_zoom-changed": {
         "description": "Fired on each page zoom action (zoom in, zoom out, or actual size).",
@@ -13,6 +13,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "channel",
             {
                 "key": "entry_point",
                 "type": "string",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216472737635595
Tech Design URL:
CC:

### Description
Several pixels were failing live validation because their definitions did not declare parameters/suffixes that the app actually sends. This updates the definitions only — no behavioural change:

- Native Duck.ai **chat history** pixels now accept the device form-factor split (iPhone/iPad), which is appended on every iOS fire.
- macOS **subscription tier-options, view-all-plans, page-zoom** (and the related upgrade / unexpected-pro-tier) pixels now declare the `channel` parameter that PixelKit attaches on non-production builds. This includes a few sibling pixels that had not fired yet but would fail validation the same way.

This resolves the recurring `channel` "Failing pixels report" ([latest](https://app.asana.com/1/137249556945/task/1216472737635595)), the `form_factor` "phone suffix" report ([here](https://app.asana.com/1/137249556945/task/1216472862419277)), and their older duplicates.

Note: the `originalPixelTimestamp` / `retriedPixel` failures seen in recent reports are a separate, platform-wide PixelKit retry-queue issue and are **not** addressed here.

### Testing Steps
1. CI pixel-definition validation passes.
2. (Optional) On an internal/dev build, fire the affected pixels → no live-validation errors reported.

### Impact
None — analytics pixel definitions only; no app code changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics schema-only edits with no application code; impact is limited to pixel validation and reporting metadata.
> 
> **Overview**
> Updates **pixel definitions only** so live validation matches what the apps already send—no runtime or firing behavior changes.
> 
> On **iOS**, every native Duck.ai **chat history** pixel in `aichat_history.json5` now lists the **`form_factor`** suffix (iPhone/iPad split), consistent with other iOS AI Chat pixels.
> 
> On **macOS**, **`channel`** is added to subscription **tier-options** (failure / unexpected-pro-tier and related success paths where missing), **settings** view-all-plans / upgrade clicks, and **webview zoom** pixels in `subscription.json5` and `webview_zoom_pixels.json5`, matching PixelKit’s non-production `channel` attachment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 391a4e6f478ec7e172114c86595d47885155fa4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->