### PR TITLE
Add source to sync login pixel

### DIFF
--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -508,7 +508,10 @@ extension SyncSettingsViewController: ScanOrPasteCodeViewModelDelegate {
     func loginAndShowDeviceConnected(recoveryKey: SyncCode.RecoveryKey) async throws {
         let registeredDevices = try await syncService.login(recoveryKey, deviceName: deviceName, deviceType: deviceType)
         mapDevices(registeredDevices)
-        Pixel.fire(pixel: .syncLogin, withAdditionalParameters: sourcePixelParameters, includedParameters: [.appVersion])
+        Pixel.fire(pixel: .syncLogin,
+                   withAdditionalParameters: sourcePixelParameters,
+                   includedParameters: [.appVersion],
+                   onComplete: { _ in })
         presentSyncCompletionAfterDelay()
     }
 

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -508,10 +508,9 @@ extension SyncSettingsViewController: ScanOrPasteCodeViewModelDelegate {
     func loginAndShowDeviceConnected(recoveryKey: SyncCode.RecoveryKey) async throws {
         let registeredDevices = try await syncService.login(recoveryKey, deviceName: deviceName, deviceType: deviceType)
         mapDevices(registeredDevices)
-        Pixel.fire(pixel: .syncLogin,
+        try? await Pixel.fire(pixel: .syncLogin,
                    withAdditionalParameters: sourcePixelParameters,
-                   includedParameters: [.appVersion],
-                   onComplete: { _ in })
+                   includedParameters: [.appVersion])
         presentSyncCompletionAfterDelay()
     }
 

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -508,9 +508,10 @@ extension SyncSettingsViewController: ScanOrPasteCodeViewModelDelegate {
     func loginAndShowDeviceConnected(recoveryKey: SyncCode.RecoveryKey) async throws {
         let registeredDevices = try await syncService.login(recoveryKey, deviceName: deviceName, deviceType: deviceType)
         mapDevices(registeredDevices)
-        try? await Pixel.fire(pixel: .syncLogin,
+        Pixel.fire(pixel: .syncLogin,
                    withAdditionalParameters: sourcePixelParameters,
-                   includedParameters: [.appVersion])
+                   includedParameters: [.appVersion],
+                   onComplete: { _ in })
         presentSyncCompletionAfterDelay()
     }
 

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -103,6 +103,10 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsRootView> {
 
     let useSimplifiedLayoutV2: Bool
 
+    private var sourcePixelParameters: [String: String] {
+        source.map { [PixelParameters.source: $0] } ?? [:]
+    }
+
     // For some reason, on iOS 14, the viewDidLoad wasn't getting called so do some setup here
     init(
         syncService: DDGSyncing,
@@ -504,7 +508,7 @@ extension SyncSettingsViewController: ScanOrPasteCodeViewModelDelegate {
     func loginAndShowDeviceConnected(recoveryKey: SyncCode.RecoveryKey) async throws {
         let registeredDevices = try await syncService.login(recoveryKey, deviceName: deviceName, deviceType: deviceType)
         mapDevices(registeredDevices)
-        Pixel.fire(pixel: .syncLogin, includedParameters: [.appVersion])
+        Pixel.fire(pixel: .syncLogin, withAdditionalParameters: sourcePixelParameters, includedParameters: [.appVersion])
         presentSyncCompletionAfterDelay()
     }
 
@@ -592,8 +596,7 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
     }
 
     func controllerDidCreateSyncAccount(shouldShowSyncEnabled: Bool) {
-        let additionalParameters = source.map { ["source": $0] } ?? [:]
-        Pixel.fire(pixel: .syncSignupConnect, withAdditionalParameters: additionalParameters, includedParameters: [.appVersion])
+        Pixel.fire(pixel: .syncSignupConnect, withAdditionalParameters: sourcePixelParameters, includedParameters: [.appVersion])
 
         if shouldShowSyncEnabled {
             dismissVCAndShowDeviceSyncedToast()
@@ -661,7 +664,7 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
     
     func controllerDidCompleteLogin(registeredDevices: [RegisteredDevice], isRecovery _: Bool, setupRole: SyncSetupRole) {
         mapDevices(registeredDevices)
-        Pixel.fire(pixel: .syncLogin, includedParameters: [.appVersion])
+        Pixel.fire(pixel: .syncLogin, withAdditionalParameters: sourcePixelParameters, includedParameters: [.appVersion])
         if case .receiver(.recovery, _) = setupRole {
             Task {
                 await connectionController.cancel()

--- a/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -1,4 +1,27 @@
 {
+    "m_sync_login": {
+        "description": "Fired when the app successfully logs in to an existing Sync account.",
+        "owners": ["amddg44", "frosty"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The Sync entry point or promotion source that led to login, when known.",
+                "enum": [
+                    "sync-start",
+                    "sync-backup",
+                    "data_import_summary",
+                    "promotion_data_import_summary",
+                    "promotion_bookmarks",
+                    "promotion_passwords",
+                    "promotion_ai_chat"
+                ]
+            }
+        ]
+    },
     "sync_setup_barcode_screen_shown": {
         "description": "Fired when the Sync setup QR/code screen is shown.",
         "owners": ["amddg44"],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214200115953388/task/1216510731606420?focus=true
Tech Design URL:
CC:

### Description
Adds the existing Sync settings entry-point source to the Sync login pixel when available, so successful login attribution can distinguish promotion and setup sources. Also documents the source parameter in the iOS pixel definitions.

### Testing Steps
1. Run the app and perform a login.
2. Check the logs in Xcode to see the pixel firing with the source parameter.

### Impact
Low: telemetry attribution only.

#### What could go wrong?
An unexpected source could be sent with the login pixel -> the value comes from the existing Sync settings source passed by known navigation paths.

### Quality Considerations
No PII is added. Source values are enum-style constants already used by Sync setup/promotion telemetry.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

_Recreated from #5797, which auto-closed when its base branch `release/ios/7.228.0` was deleted; retargeted to `release/ios/7.229.0`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only change using existing source constants already passed into Sync settings; no auth or sync logic changes.
> 
> **Overview**
> Successful Sync logins now include the **Sync settings entry-point `source`** on `m_sync_login` when the controller was opened with a known navigation source (promotions, import summary, sync-start, etc.), matching attribution already sent on `syncSignupConnect`.
> 
> A shared `sourcePixelParameters` helper centralizes building that parameter; both login fire sites and signup-connect use it. The iOS pixel definition for **`m_sync_login`** is added/updated in `sync_setup.json5` with the documented `source` enum values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b75d4ae81cac8bdb0e05a7fe7472fc8eb803250. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->