### PR TITLE
[iOS] Hide Disable Privacy Protection menu option on SERP

### DIFF
--- a/iOS/DuckDuckGo/TabViewControllerMenuBuilderExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerMenuBuilderExtension.swift
@@ -111,7 +111,7 @@ extension TabViewController {
             entries.append(printEntry)
         }
 
-        if let domain = self.privacyInfo?.domain {
+        if let domain = Self.privacyProtectionToggleDomain(for: privacyInfo) {
             entries.append(self.buildToggleProtectionEntry(forDomain: domain))
         }
 
@@ -851,6 +851,19 @@ extension TabViewController {
         delegate?.tabDidRequestAIChatHistory(tab: self, source: .browserMenu)
     }
 
+    /// The domain the "Disable/Enable Privacy Protection" browsing-menu toggle applies to,
+    /// or `nil` when the toggle should not be offered.
+    ///
+    /// The toggle is suppressed on the DuckDuckGo SERP to match the Privacy Dashboard, which is
+    /// also unavailable there (see `MainViewController.onPrivacyIconPressed` and
+    /// `PrivacyIconLogic.privacyIcon(for:)`, which shows the Dax logo instead of a shield on the
+    /// SERP). Offering a way to disable protection with no dashboard to re-enable it from is
+    /// confusing, and DuckDuckGo Search does not track the user regardless.
+    static func privacyProtectionToggleDomain(for privacyInfo: PrivacyInfo?) -> String? {
+        guard let privacyInfo, !privacyInfo.url.isDuckDuckGoSearch else { return nil }
+        return privacyInfo.domain
+    }
+
     private func buildToggleProtectionEntry(forDomain domain: String, useSmallIcon: Bool = true) -> BrowsingMenuEntry {
         let config = ContentBlocking.shared.privacyConfigurationManager.privacyConfig
         let isProtected = !config.isUserUnprotected(domain: domain)
@@ -1132,7 +1145,7 @@ extension TabViewController: BrowsingMenuEntryBuilding {
     }
     
     func makeToggleProtectionEntry() -> BrowsingMenuEntry? {
-        guard let domain = privacyInfo?.domain else { return nil }
+        guard let domain = Self.privacyProtectionToggleDomain(for: privacyInfo) else { return nil }
         return buildToggleProtectionEntry(forDomain: domain, useSmallIcon: false)
     }
     

--- a/iOS/DuckDuckGoTests/BrowsingMenu/BrowsingMenuBuilderTests.swift
+++ b/iOS/DuckDuckGoTests/BrowsingMenu/BrowsingMenuBuilderTests.swift
@@ -18,7 +18,9 @@
 //
 
 import Bookmarks
+import Core
 import PersistenceTestingUtils
+import PrivacyDashboard
 import UIKit
 import XCTest
 @testable import DuckDuckGo
@@ -70,6 +72,39 @@ final class BrowsingMenuBuilderTests: XCTestCase {
             MockBrowsingMenuEntryBuilder.downloadsName,
             MockBrowsingMenuEntryBuilder.chatsName
         ])
+    }
+
+    // MARK: - Privacy Protection toggle SERP gating
+
+    func testToggleProtectionDomainIsNilOnSERP() {
+        // On the SERP the Privacy Dashboard is unavailable, so the browsing-menu toggle must be hidden too.
+        let privacyInfo = makePrivacyInfo(url: URL(string: "https://duckduckgo.com/?q=catfood&t=h_&ia=web")!)
+        XCTAssertTrue(privacyInfo.url.isDuckDuckGoSearch)
+        XCTAssertNil(TabViewController.privacyProtectionToggleDomain(for: privacyInfo))
+    }
+
+    func testToggleProtectionDomainIsResolvedForRegularSite() {
+        let privacyInfo = makePrivacyInfo(url: URL(string: "https://example.com")!)
+        XCTAssertEqual(TabViewController.privacyProtectionToggleDomain(for: privacyInfo), "example.com")
+    }
+
+    func testToggleProtectionDomainIsResolvedForDuckDuckGoHomepage() {
+        // The DuckDuckGo homepage is not a SERP, so the toggle (like the shield/dashboard) stays available.
+        let privacyInfo = makePrivacyInfo(url: URL(string: "https://duckduckgo.com")!)
+        XCTAssertFalse(privacyInfo.url.isDuckDuckGoSearch)
+        XCTAssertEqual(TabViewController.privacyProtectionToggleDomain(for: privacyInfo), "duckduckgo.com")
+    }
+
+    func testToggleProtectionDomainIsNilWithoutPrivacyInfo() {
+        XCTAssertNil(TabViewController.privacyProtectionToggleDomain(for: nil))
+    }
+
+    private func makePrivacyInfo(url: URL) -> PrivacyInfo {
+        PrivacyInfo(
+            url: url,
+            parentEntity: nil,
+            protectionStatus: ProtectionStatus(unprotectedTemporary: false, enabledFeatures: [], allowlisted: false, denylisted: false)
+        )
     }
 
     private func makeBuilder(entryBuilder: BrowsingMenuEntryBuilding) -> BrowsingMenuBuilder {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1215172677539195/task/1212305381024400?focus=true

### Description

Fixes an inconsistency reported via the Internal Product Feedback Form: on the DuckDuckGo search results page (SERP), the browsing menu (“•••”) displayed a **Disable Privacy Protection** option even though the Privacy Dashboard, where you’d normally re‑enable protection, is not available on the SERP.

The shield icon and Privacy Dashboard already treat the SERP specially (the shield shows the Dax logo and the dashboard tap does nothing). The browsing‑menu toggle did not, because it was gated only on pages with a domain. Both browsing‑menu variants now route through a single SERP‑aware helper, so the toggle is hidden on the SERP while remaining available on the DuckDuckGo homepage and all other sites.

### Testing Steps
1. Run a search on DuckDuckGo so the SERP is shown.
2. Open the browsing menu (•••) → **Disable Privacy Protection** is **not** listed.
3. Tap the address-bar icon on the SERP → it shows the Dax logo and does not open the Privacy Dashboard (unchanged), consistent with the menu.
4. Open any regular website (e.g. `https://example.com`) → open the browsing menu → **Disable Privacy Protection** **is** listed and toggles as before.
5. Open the DuckDuckGo homepage (`https://duckduckgo.com`, no search) → **Disable Privacy Protection** **is** listed (the homepage is not a SERP).

### Impact
Low — removes a menu entry in one specific context (the SERP). The entry is gated by the same `isDuckDuckGoSearch` signal already used by the shield/dashboard, and is covered by unit tests in `BrowsingMenuBuilderTests`.

#### What could go wrong?
A user who had previously disabled protection for `duckduckgo.com` can no longer re-enable it *from the SERP menu* → mitigated: the toggle (and the Privacy Dashboard) remain available on the DuckDuckGo homepage and other non-search DDG pages, and protection can also be managed from Settings. This already matched the dashboard's pre-existing SERP behaviour.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Menu visibility only, gated by the existing `isDuckDuckGoSearch` signal already used elsewhere; no changes to protection toggling logic itself.
> 
> **Overview**
> Fixes an inconsistency where the browsing menu still offered **Disable/Enable Privacy Protection** on DuckDuckGo search results even though the Privacy Dashboard and shield flow already treat the SERP specially.
> 
> Both menu code paths now use a shared `TabViewController.privacyProtectionToggleDomain(for:)` helper that returns `nil` when `privacyInfo.url.isDuckDuckGoSearch`, so the toggle is omitted on the SERP but still appears on regular sites and on the DuckDuckGo homepage (non-search).
> 
> Unit tests in `BrowsingMenuBuilderTests` cover SERP, homepage, regular sites, and missing `privacyInfo`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b2b12be737a74a48b27ab71b7855a6ec2f7e8f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->