### PR TITLE
Remove icsCalendarLinks feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -299,9 +299,6 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215099690878849
     case tabsSaveOptimization
 
-    /// https://app.asana.com/1/137249556945/project/715106103902962/task/1213690148091855
-    case icsCalendarLinks
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215169783702336
     case walletPassDownload
 

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -458,10 +458,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215099690878849
     case tabsSaveOptimization
 
-    /// Failsafe feature flag. Routes tapped .ics calendar links through EKEventEditViewController.
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214740849233380
-    case icsCalendarLinks
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215169783702336
     case walletPassDownload
 
@@ -819,8 +815,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.defaultExistingIPhoneUsersToNewTabAfterIdle))
         case .tabsSaveOptimization:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.tabsSaveOptimization))
-        case .icsCalendarLinks:
-            Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.icsCalendarLinks))
         case .walletPassDownload:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.walletPassDownload))
         case .aiChatChromeShortcutIPad:

--- a/iOS/DuckDuckGo/CompleteDownloadRowViewModel.swift
+++ b/iOS/DuckDuckGo/CompleteDownloadRowViewModel.swift
@@ -28,22 +28,18 @@ class CompleteDownloadRowViewModel: DownloadsListRowViewModel {
     var fileURL: URL
     var fileSize: String
 
-    private let featureFlagger: FeatureFlagger
     private let pixelFiring: PixelFiring.Type
 
     init(fileURL: URL,
-         featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
          pixelFiring: PixelFiring.Type = Pixel.self) {
         self.fileURL = fileURL
         self.fileSize = DownloadsListRowViewModel.byteCountFormatter.string(fromByteCount: Int64(fileURL.fileSize))
-        self.featureFlagger = featureFlagger
         self.pixelFiring = pixelFiring
         super.init(filename: fileURL.filename)
     }
 
     func preparePreviewEvent() -> PreparedCalendarEvent? {
         guard #available(iOS 17, *),
-              featureFlagger.isFeatureOn(.icsCalendarLinks),
               fileURL.pathExtension.lowercased() == "ics",
               case .singleEvent(let icsEvent) = ICSFileReader.read(at: fileURL).outcome else {
             return nil

--- a/iOS/DuckDuckGo/FilePreviewHelper.swift
+++ b/iOS/DuckDuckGo/FilePreviewHelper.swift
@@ -24,19 +24,19 @@ import UIKit
 
 struct FilePreviewHelper {
 
-    static func fileHandlerForDownload(_ download: Download, viewController: UIViewController, featureFlagger: FeatureFlagger) -> FilePreview? {
+    static func fileHandlerForDownload(_ download: Download, viewController: UIViewController) -> FilePreview? {
         guard let filePath = download.location else { return nil }
         switch download.mimeType {
         case .passbook:
             return PassKitPreviewHelper(filePath, viewController: viewController)
         case .multipass:
             return ZippedPassKitPreviewHelper(filePath, viewController: viewController)
-        case .calendar where featureFlagger.isFeatureOn(.icsCalendarLinks):
+        case .calendar:
             return CalendarEventPreviewHelper(filePath, viewController: viewController)
         case .contact:
             return ContactPreviewHelper(filePath, viewController: viewController)
         default:
-            if featureFlagger.isFeatureOn(.icsCalendarLinks), filePath.pathExtension.lowercased() == "ics" {
+            if filePath.pathExtension.lowercased() == "ics" {
                 Pixel.fire(pixel: .icsCalendarRoutedByExtension)
                 return CalendarEventPreviewHelper(filePath, viewController: viewController)
             }
@@ -62,9 +62,7 @@ struct FilePreviewHelper {
 
     /// Auto-preview .ics by URL or filename extension when the MIME type is wrong.
     static func canAutoPreviewICSByExtension(url: URL?,
-                                             filename: String?,
-                                             featureFlagger: FeatureFlagger) -> Bool {
-        guard featureFlagger.isFeatureOn(.icsCalendarLinks) else { return false }
+                                             filename: String?) -> Bool {
         if url?.pathExtension.lowercased() == "ics" { return true }
         if filename?.lowercased().hasSuffix(".ics") == true { return true }
         return false
@@ -82,19 +80,17 @@ struct FilePreviewHelper {
     /// previewable type is wired up in one place.
     static func canAutoPreview(mimeType: MIMEType,
                                url: URL?,
-                               filename: String?,
-                               featureFlagger: FeatureFlagger) -> Bool {
+                               filename: String?) -> Bool {
         canAutoPreviewMIMEType(mimeType)
-            || canAutoPreviewICSByExtension(url: url, filename: filename, featureFlagger: featureFlagger)
+            || canAutoPreviewICSByExtension(url: url, filename: filename)
             || canAutoPreviewVCardByExtension(url: url, filename: filename)
     }
 
     /// ICS and vCard files must persist so the user can retry from Downloads when auto-add fails.
     static func shouldPersistInDownloads(mimeType: MIMEType,
                                          url: URL?,
-                                         filename: String?,
-                                         featureFlagger: FeatureFlagger) -> Bool {
-        if featureFlagger.isFeatureOn(.icsCalendarLinks), isICS(mimeType: mimeType, url: url, filename: filename) {
+                                         filename: String?) -> Bool {
+        if isICS(mimeType: mimeType, url: url, filename: filename) {
             return true
         }
         if isVCard(mimeType: mimeType, url: url, filename: filename) {
@@ -106,9 +102,8 @@ struct FilePreviewHelper {
     /// File types handed off to a native handler; download started/finished toasts are suppressed for these.
     static func handlesDownloadNatively(mimeType: MIMEType,
                                         url: URL?,
-                                        filename: String?,
-                                        featureFlagger: FeatureFlagger) -> Bool {
-        if featureFlagger.isFeatureOn(.icsCalendarLinks), isICS(mimeType: mimeType, url: url, filename: filename) {
+                                        filename: String?) -> Bool {
+        if isICS(mimeType: mimeType, url: url, filename: filename) {
             return true
         }
         if isVCard(mimeType: mimeType, url: url, filename: filename) {

--- a/iOS/DuckDuckGo/Navigation/NavigationResponseRouter.swift
+++ b/iOS/DuckDuckGo/Navigation/NavigationResponseRouter.swift
@@ -83,8 +83,7 @@ struct NavigationResponseRouter {
 
         if FilePreviewHelper.canAutoPreview(mimeType: shape.mimeType,
                                             url: shape.url,
-                                            filename: shape.suggestedFilename,
-                                            featureFlagger: featureFlagger) {
+                                            filename: shape.suggestedFilename) {
             pixelFiring.fire(.downloadStarted,
                              withAdditionalParameters: [PixelParameters.canAutoPreviewMIMEType: "1"])
 
@@ -95,8 +94,7 @@ struct NavigationResponseRouter {
 
             let shouldPersist = FilePreviewHelper.shouldPersistInDownloads(mimeType: shape.mimeType,
                                                                            url: shape.url,
-                                                                           filename: shape.suggestedFilename,
-                                                                           featureFlagger: featureFlagger)
+                                                                           filename: shape.suggestedFilename)
             if shouldPersist || !featureFlagger.isFeatureOn(.walletPassDownload) {
                 return .autoPreviewPersist
             }

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -3167,8 +3167,7 @@ extension TabViewController {
             let persistICS = FilePreviewHelper.shouldPersistInDownloads(
                 mimeType: MIMEType(from: navigationResponse.response.mimeType),
                 url: navigationResponse.response.url,
-                filename: navigationResponse.response.suggestedFilename,
-                featureFlagger: featureFlagger
+                filename: navigationResponse.response.suggestedFilename
             )
             do {
                 if let download = try downloadManager.makeDownload(navigationResponse: navigationResponse,
@@ -3379,8 +3378,7 @@ extension TabViewController {
               !download.temporary,
               !FilePreviewHelper.handlesDownloadNatively(mimeType: download.mimeType,
                                                          url: download.url,
-                                                         filename: download.filename,
-                                                         featureFlagger: featureFlagger)
+                                                         filename: download.filename)
         else { return }
 
         let attributedMessage = DownloadActionMessageViewHelper.makeDownloadStartedMessage(for: download)
@@ -3415,8 +3413,7 @@ extension TabViewController {
         DispatchQueue.main.async {
             let handledNatively = FilePreviewHelper.handlesDownloadNatively(mimeType: download.mimeType,
                                                                             url: download.location,
-                                                                            filename: download.filename,
-                                                                            featureFlagger: self.featureFlagger)
+                                                                            filename: download.filename)
             if !download.temporary && !handledNatively {
                 let attributedMessage = DownloadActionMessageViewHelper.makeDownloadFinishedMessage(for: download)
                 let addressBarBottom = self.appSettings.currentAddressBarPosition.isBottom
@@ -3436,12 +3433,11 @@ extension TabViewController {
     private func previewDownloadedFileIfNecessary(_ download: Download) {
         let canAutoPreview = FilePreviewHelper.canAutoPreview(mimeType: download.mimeType,
                                                               url: download.location,
-                                                              filename: download.filename,
-                                                              featureFlagger: featureFlagger)
+                                                              filename: download.filename)
         guard let delegate = self.delegate,
               delegate.tabCheckIfItsBeingCurrentlyPresented(self),
               canAutoPreview,
-              let fileHandler = FilePreviewHelper.fileHandlerForDownload(download, viewController: self, featureFlagger: featureFlagger)
+              let fileHandler = FilePreviewHelper.fileHandlerForDownload(download, viewController: self)
         else { return }
 
         if mostRecentAutoPreviewDownloadID == download.id {

--- a/iOS/DuckDuckGoTests/CompleteDownloadRowViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/CompleteDownloadRowViewModelTests.swift
@@ -36,12 +36,12 @@ final class CompleteDownloadRowViewModelTests {
     }
 
     @available(iOS 17, *)
-    @Test("Returns a prepared event for a single-VEVENT .ics file when the flag is on", .timeLimit(.minutes(1)))
+    @Test("Returns a prepared event for a single-VEVENT .ics file", .timeLimit(.minutes(1)))
     func preparesEventForSingleVEvent() throws {
         let url = try writeTempFile(name: "single.ics", contents: Fixtures.singleEvent)
         defer { try? FileManager.default.removeItem(at: url) }
 
-        let viewModel = CompleteDownloadRowViewModel(fileURL: url, featureFlagger: flaggerWithICSOn())
+        let viewModel = CompleteDownloadRowViewModel(fileURL: url)
         let prepared = viewModel.preparePreviewEvent()
 
         #expect(prepared != nil)
@@ -49,22 +49,12 @@ final class CompleteDownloadRowViewModelTests {
     }
 
     @available(iOS 17, *)
-    @Test("Returns nil when the feature flag is off", .timeLimit(.minutes(1)))
-    func returnsNilWhenFlagIsOff() throws {
-        let url = try writeTempFile(name: "single.ics", contents: Fixtures.singleEvent)
-        defer { try? FileManager.default.removeItem(at: url) }
-
-        let viewModel = CompleteDownloadRowViewModel(fileURL: url, featureFlagger: MockFeatureFlagger())
-        #expect(viewModel.preparePreviewEvent() == nil)
-    }
-
-    @available(iOS 17, *)
-    @Test("Returns nil for a non-.ics file even when the flag is on", .timeLimit(.minutes(1)))
+    @Test("Returns nil for a non-.ics file", .timeLimit(.minutes(1)))
     func returnsNilForNonICSExtension() throws {
         let url = try writeTempFile(name: "calendar.txt", contents: Fixtures.singleEvent)
         defer { try? FileManager.default.removeItem(at: url) }
 
-        let viewModel = CompleteDownloadRowViewModel(fileURL: url, featureFlagger: flaggerWithICSOn())
+        let viewModel = CompleteDownloadRowViewModel(fileURL: url)
         #expect(viewModel.preparePreviewEvent() == nil)
     }
 
@@ -74,7 +64,7 @@ final class CompleteDownloadRowViewModelTests {
         let url = try writeTempFile(name: "multi.ics", contents: Fixtures.multipleEvents)
         defer { try? FileManager.default.removeItem(at: url) }
 
-        let viewModel = CompleteDownloadRowViewModel(fileURL: url, featureFlagger: flaggerWithICSOn())
+        let viewModel = CompleteDownloadRowViewModel(fileURL: url)
         #expect(viewModel.preparePreviewEvent() == nil)
     }
 
@@ -84,7 +74,7 @@ final class CompleteDownloadRowViewModelTests {
         let url = try writeTempFile(name: "broken.ics", contents: "not a calendar")
         defer { try? FileManager.default.removeItem(at: url) }
 
-        let viewModel = CompleteDownloadRowViewModel(fileURL: url, featureFlagger: flaggerWithICSOn())
+        let viewModel = CompleteDownloadRowViewModel(fileURL: url)
         #expect(viewModel.preparePreviewEvent() == nil)
     }
 
@@ -96,7 +86,7 @@ final class CompleteDownloadRowViewModelTests {
         let url = try writeTempFile(name: "single.vcf", contents: Fixtures.singleContact)
         defer { try? FileManager.default.removeItem(at: url) }
 
-        let viewModel = CompleteDownloadRowViewModel(fileURL: url, featureFlagger: MockFeatureFlagger())
+        let viewModel = CompleteDownloadRowViewModel(fileURL: url)
         let contact = viewModel.preparePreviewContact()
 
         #expect(contact?.givenName == "John")
@@ -110,7 +100,6 @@ final class CompleteDownloadRowViewModelTests {
         defer { try? FileManager.default.removeItem(at: url) }
 
         let viewModel = CompleteDownloadRowViewModel(fileURL: url,
-                                                     featureFlagger: MockFeatureFlagger(),
                                                      pixelFiring: PixelFiringMock.self)
         let contact = viewModel.preparePreviewContact()
 
@@ -126,7 +115,6 @@ final class CompleteDownloadRowViewModelTests {
         defer { try? FileManager.default.removeItem(at: url) }
 
         let viewModel = CompleteDownloadRowViewModel(fileURL: url,
-                                                     featureFlagger: MockFeatureFlagger(),
                                                      pixelFiring: PixelFiringMock.self)
         #expect(viewModel.preparePreviewContact() == nil)
     }
@@ -137,7 +125,7 @@ final class CompleteDownloadRowViewModelTests {
         let url = try writeTempFile(name: "contact.txt", contents: Fixtures.singleContact)
         defer { try? FileManager.default.removeItem(at: url) }
 
-        let viewModel = CompleteDownloadRowViewModel(fileURL: url, featureFlagger: MockFeatureFlagger())
+        let viewModel = CompleteDownloadRowViewModel(fileURL: url)
         #expect(viewModel.preparePreviewContact() == nil)
     }
 
@@ -187,10 +175,6 @@ final class CompleteDownloadRowViewModelTests {
     }
 
     // MARK: - Helpers
-
-    private func flaggerWithICSOn() -> MockFeatureFlagger {
-        MockFeatureFlagger(enabledFeatureFlags: [.icsCalendarLinks])
-    }
 
     private func writeTempFile(name: String, contents: String) throws -> URL {
         let url = FileManager.default.temporaryDirectory

--- a/iOS/DuckDuckGoTests/FilePreviewHelperTests.swift
+++ b/iOS/DuckDuckGoTests/FilePreviewHelperTests.swift
@@ -31,72 +31,50 @@ struct FilePreviewHelperTests {
     @available(iOS 16, *)
     @Test("Returns true for text/calendar MIME regardless of URL/filename", .timeLimit(.minutes(1)))
     func handlesDownloadNativelyMatchesByMIME() {
-        let flagger = MockFeatureFlagger(enabledFeatureFlags: [.icsCalendarLinks])
         #expect(FilePreviewHelper.handlesDownloadNatively(
             mimeType: .calendar,
             url: URL(string: "https://example.com/calendar?id=abc"),
-            filename: "download.bin",
-            featureFlagger: flagger
+            filename: "download.bin"
         ))
     }
 
     @available(iOS 16, *)
     @Test("Returns true when URL ends in .ics", .timeLimit(.minutes(1)))
     func handlesDownloadNativelyMatchesByURLExtension() {
-        let flagger = MockFeatureFlagger(enabledFeatureFlags: [.icsCalendarLinks])
         #expect(FilePreviewHelper.handlesDownloadNatively(
             mimeType: .unknown,
             url: URL(string: "https://example.com/event.ics"),
-            filename: nil,
-            featureFlagger: flagger
+            filename: nil
         ))
     }
 
     @available(iOS 16, *)
     @Test("Returns true when filename ends in .ics (dynamic URL via Content-Disposition)", .timeLimit(.minutes(1)))
     func handlesDownloadNativelyMatchesByFilenameExtension() {
-        let flagger = MockFeatureFlagger(enabledFeatureFlags: [.icsCalendarLinks])
         #expect(FilePreviewHelper.handlesDownloadNatively(
             mimeType: .unknown,
             url: URL(string: "https://example.com/calendar?id=abc"),
-            filename: "event.ics",
-            featureFlagger: flagger
+            filename: "event.ics"
         ))
     }
 
     @available(iOS 16, *)
     @Test("Returns false when no signal indicates ICS", .timeLimit(.minutes(1)))
     func handlesDownloadNativelyRejectsUnrelatedDownloads() {
-        let flagger = MockFeatureFlagger(enabledFeatureFlags: [.icsCalendarLinks])
         #expect(!FilePreviewHelper.handlesDownloadNatively(
             mimeType: .unknown,
             url: URL(string: "https://example.com/file.pdf"),
-            filename: "file.pdf",
-            featureFlagger: flagger
-        ))
-    }
-
-    @available(iOS 16, *)
-    @Test("Returns false when feature flag is off, even with all positive signals", .timeLimit(.minutes(1)))
-    func handlesDownloadNativelyRespectsFeatureFlag() {
-        let flagger = MockFeatureFlagger(enabledFeatureFlags: [])
-        #expect(!FilePreviewHelper.handlesDownloadNatively(
-            mimeType: .calendar,
-            url: URL(string: "https://example.com/event.ics"),
-            filename: "event.ics",
-            featureFlagger: flagger
+            filename: "file.pdf"
         ))
     }
 
     @available(iOS 16, *)
     @Test("Matches URL extension case-insensitively", .timeLimit(.minutes(1)))
     func handlesDownloadNativelyMatchesUppercaseExtension() {
-        let flagger = MockFeatureFlagger(enabledFeatureFlags: [.icsCalendarLinks])
         #expect(FilePreviewHelper.handlesDownloadNatively(
             mimeType: .unknown,
             url: URL(string: "https://example.com/EVENT.ICS"),
-            filename: nil,
-            featureFlagger: flagger
+            filename: nil
         ))
     }
 
@@ -105,36 +83,20 @@ struct FilePreviewHelperTests {
     @available(iOS 16, *)
     @Test("Persists when MIME is text/calendar", .timeLimit(.minutes(1)))
     func shouldPersistMatchesByMIME() {
-        let flagger = MockFeatureFlagger(enabledFeatureFlags: [.icsCalendarLinks])
         #expect(FilePreviewHelper.shouldPersistInDownloads(
             mimeType: .calendar,
             url: URL(string: "https://example.com/calendar?id=abc"),
-            filename: nil,
-            featureFlagger: flagger
+            filename: nil
         ))
     }
 
     @available(iOS 16, *)
     @Test("Persists when filename ends in .ics even if URL doesn't", .timeLimit(.minutes(1)))
     func shouldPersistMatchesByFilenameExtension() {
-        let flagger = MockFeatureFlagger(enabledFeatureFlags: [.icsCalendarLinks])
         #expect(FilePreviewHelper.shouldPersistInDownloads(
             mimeType: .unknown,
             url: URL(string: "https://example.com/calendar?id=abc"),
-            filename: "event.ics",
-            featureFlagger: flagger
-        ))
-    }
-
-    @available(iOS 16, *)
-    @Test("Does not persist when feature flag is off", .timeLimit(.minutes(1)))
-    func shouldPersistRespectsFeatureFlag() {
-        let flagger = MockFeatureFlagger(enabledFeatureFlags: [])
-        #expect(!FilePreviewHelper.shouldPersistInDownloads(
-            mimeType: .calendar,
-            url: URL(string: "https://example.com/event.ics"),
-            filename: "event.ics",
-            featureFlagger: flagger
+            filename: "event.ics"
         ))
     }
 
@@ -143,36 +105,30 @@ struct FilePreviewHelperTests {
     @available(iOS 16, *)
     @Test("Returns true for text/vcard MIME", .timeLimit(.minutes(1)))
     func handlesDownloadNativelyMatchesByVCardMIME() {
-        let flagger = MockFeatureFlagger(enabledFeatureFlags: [])
         #expect(FilePreviewHelper.handlesDownloadNatively(
             mimeType: .contact,
             url: URL(string: "https://example.com/contact?id=abc"),
-            filename: "download.bin",
-            featureFlagger: flagger
+            filename: "download.bin"
         ))
     }
 
     @available(iOS 16, *)
     @Test("Returns true when URL ends in .vcf", .timeLimit(.minutes(1)))
     func handlesDownloadNativelyMatchesByVCFURLExtension() {
-        let flagger = MockFeatureFlagger(enabledFeatureFlags: [])
         #expect(FilePreviewHelper.handlesDownloadNatively(
             mimeType: .unknown,
             url: URL(string: "https://example.com/contact.vcf"),
-            filename: nil,
-            featureFlagger: flagger
+            filename: nil
         ))
     }
 
     @available(iOS 16, *)
     @Test("Returns true when filename ends in .vcard (dynamic URL via Content-Disposition)", .timeLimit(.minutes(1)))
     func handlesDownloadNativelyMatchesByVCardFilenameExtension() {
-        let flagger = MockFeatureFlagger(enabledFeatureFlags: [])
         #expect(FilePreviewHelper.handlesDownloadNatively(
             mimeType: .unknown,
             url: URL(string: "https://example.com/contact?id=abc"),
-            filename: "contact.vcard",
-            featureFlagger: flagger
+            filename: "contact.vcard"
         ))
     }
 
@@ -181,24 +137,20 @@ struct FilePreviewHelperTests {
     @available(iOS 16, *)
     @Test("Persists when MIME is text/vcard", .timeLimit(.minutes(1)))
     func shouldPersistMatchesByVCardMIME() {
-        let flagger = MockFeatureFlagger(enabledFeatureFlags: [])
         #expect(FilePreviewHelper.shouldPersistInDownloads(
             mimeType: .contact,
             url: URL(string: "https://example.com/contact?id=abc"),
-            filename: nil,
-            featureFlagger: flagger
+            filename: nil
         ))
     }
 
     @available(iOS 16, *)
     @Test("Persists when filename ends in .vcf even if URL doesn't", .timeLimit(.minutes(1)))
     func shouldPersistMatchesByVCFFilenameExtension() {
-        let flagger = MockFeatureFlagger(enabledFeatureFlags: [])
         #expect(FilePreviewHelper.shouldPersistInDownloads(
             mimeType: .unknown,
             url: URL(string: "https://example.com/contact?id=abc"),
-            filename: "contact.vcf",
-            featureFlagger: flagger
+            filename: "contact.vcf"
         ))
     }
 

--- a/iOS/DuckDuckGoTests/NavigationResponseRouterTests.swift
+++ b/iOS/DuckDuckGoTests/NavigationResponseRouterTests.swift
@@ -146,10 +146,10 @@ final class NavigationResponseRouterTests {
     }
 
     @available(iOS 16, *)
-    @Test("Returns autoPreviewPersist for calendar MIME when icsCalendarLinks is on, even with walletPassDownload also on", .timeLimit(.minutes(1)))
-    func returnsAutoPreviewPersistForCalendarMIMEWhenICSFlagOn() {
+    @Test("Returns autoPreviewPersist for calendar MIME, even with walletPassDownload also on", .timeLimit(.minutes(1)))
+    func returnsAutoPreviewPersistForCalendarMIME() {
         // GIVEN
-        let router = makeRouter(walletPassDownload: true, icsCalendarLinks: true)
+        let router = makeRouter(walletPassDownload: true)
         let shape = makeShape(mimeType: .calendar)
 
         // WHEN
@@ -160,24 +160,10 @@ final class NavigationResponseRouterTests {
     }
 
     @available(iOS 16, *)
-    @Test("Returns autoPreviewTransient for calendar MIME when icsCalendarLinks is off", .timeLimit(.minutes(1)))
-    func returnsAutoPreviewTransientForCalendarMIMEWhenICSFlagOff() {
-        // GIVEN
-        let router = makeRouter(walletPassDownload: true, icsCalendarLinks: false)
-        let shape = makeShape(mimeType: .calendar)
-
-        // WHEN
-        let decision = router.decide(for: shape)
-
-        // THEN
-        #expect(decision == .autoPreviewTransient)
-    }
-
-    @available(iOS 16, *)
     @Test("Returns autoPreviewPersist for .ics URL extension even when MIME is octet-stream", .timeLimit(.minutes(1)))
     func returnsAutoPreviewPersistForICSByURLExtension() {
         // GIVEN
-        let router = makeRouter(walletPassDownload: true, icsCalendarLinks: true)
+        let router = makeRouter(walletPassDownload: true)
         let shape = makeShape(
             url: URL(string: "https://example.com/event.ics"),
             mimeType: .octetStream,
@@ -195,7 +181,7 @@ final class NavigationResponseRouterTests {
     @Test("Returns autoPreviewPersist for .ics suggestedFilename even when URL has no .ics extension", .timeLimit(.minutes(1)))
     func returnsAutoPreviewPersistForICSBySuggestedFilename() {
         // GIVEN
-        let router = makeRouter(walletPassDownload: true, icsCalendarLinks: true)
+        let router = makeRouter(walletPassDownload: true)
         let shape = makeShape(
             url: URL(string: "https://example.com/download"),
             mimeType: .octetStream,
@@ -227,7 +213,7 @@ final class NavigationResponseRouterTests {
     @Test("Returns autoPreviewPersist for calendar MIME with a nil URL", .timeLimit(.minutes(1)))
     func returnsAutoPreviewPersistForCalendarWithNilURL() {
         // GIVEN
-        let router = makeRouter(walletPassDownload: true, icsCalendarLinks: true)
+        let router = makeRouter(walletPassDownload: true)
         let shape = makeShape(url: nil, mimeType: .calendar)
 
         // WHEN
@@ -563,7 +549,7 @@ final class NavigationResponseRouterTests {
     @Test("Does not fire wallet_pass_preview_requested for ICS", .timeLimit(.minutes(1)))
     func doesNotFireWalletPassPreviewRequestedForICS() {
         // GIVEN
-        let router = makeRouter(walletPassDownload: true, icsCalendarLinks: true)
+        let router = makeRouter(walletPassDownload: true)
         let shape = makeShape(mimeType: .calendar)
 
         // WHEN
@@ -577,7 +563,7 @@ final class NavigationResponseRouterTests {
     @Test("Does not fire wallet_pass_preview_requested for ICS routed via URL extension", .timeLimit(.minutes(1)))
     func doesNotFireWalletPassPreviewRequestedForICSByURLExtension() {
         // GIVEN
-        let router = makeRouter(walletPassDownload: true, icsCalendarLinks: true)
+        let router = makeRouter(walletPassDownload: true)
         let shape = makeShape(
             url: URL(string: "https://example.com/event.ics"),
             mimeType: .octetStream,
@@ -593,11 +579,9 @@ final class NavigationResponseRouterTests {
 
     // MARK: - Helpers
 
-    private func makeRouter(walletPassDownload: Bool = true,
-                            icsCalendarLinks: Bool = false) -> NavigationResponseRouter {
+    private func makeRouter(walletPassDownload: Bool = true) -> NavigationResponseRouter {
         var enabled: [FeatureFlag] = []
         if walletPassDownload { enabled.append(.walletPassDownload) }
-        if icsCalendarLinks { enabled.append(.icsCalendarLinks) }
         let flagger = MockFeatureFlagger(enabledFeatureFlags: enabled)
         return NavigationResponseRouter(featureFlagger: flagger, pixelFiring: PixelFiringMock.self)
     }


### PR DESCRIPTION
## Task/Issue
Asana: https://app.asana.com/1/137249556945/project/1211834678943996/task/1214740849233380?focus=true

## Description
The `icsCalendarLinks` feature is fully rolled out, so this removes the flag and runs the `.ics`/calendar-link path unconditionally.

### Removed
- The `icsCalendarLinks` case + config from `FeatureFlag` (iOS/Core).
- The `icsCalendarLinks` subfeature from `iOSBrowserConfigSubfeature` (`PrivacyFeature.swift`).
- All `.isFeatureOn(.icsCalendarLinks)` gating in `FilePreviewHelper` and `CompleteDownloadRowViewModel` — those paths now run unconditionally.
- The now-obsolete flag-off tests, and flag-state wording in the remaining test names.

### `featureFlagger` cleanup
`icsCalendarLinks` was the **last** flag consumed by `FilePreviewHelper` and `CompleteDownloadRowViewModel`, so the now-dead `featureFlagger` parameter/stored property is removed as part of a clean removal:
- `FilePreviewHelper.{fileHandlerForDownload, canAutoPreview, canAutoPreviewICSByExtension, shouldPersistInDownloads, handlesDownloadNatively}` drop the `featureFlagger` parameter.
- `CompleteDownloadRowViewModel` drops its `featureFlagger` init parameter/property (the sole production caller uses the default).
- Callers `TabViewController` and `NavigationResponseRouter` simply drop the argument; both keep their own `featureFlagger` for other flags (e.g. `walletPassDownload`).

### Testing Steps
Test fixtures: https://privacy-test-pages.site/features/download/ (calendar links, e.g. "Single timed event")

1. Build & run the iOS app.
2. Open a page with a `.ics` calendar link (or download a calendar file) → the event opens in the native calendar event editor and can be saved to Calendar.
3. Confirm a `.ics` download is offered a native preview from the Downloads list.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Shipped behavior is enabled unconditionally with no new logic paths; main risk is losing a remote kill switch for ICS calendar handling.
> 
> **Overview**
> Removes the fully rolled-out **`icsCalendarLinks`** remote flag so `.ics`/calendar downloads always use the native calendar flow (auto-preview, persist to Downloads, Downloads-list preview).
> 
> **Flag plumbing removed** from `FeatureFlag`, `iOSBrowserConfigSubfeature`, and all `.isFeatureOn(.icsCalendarLinks)` checks in `FilePreviewHelper` and `CompleteDownloadRowViewModel`. **`featureFlagger` is dropped** from those helpers’ APIs and from `CompleteDownloadRowViewModel`’s initializer; `TabViewController` and `NavigationResponseRouter` only stop passing it into those calls (router still uses `featureFlagger` for `walletPassDownload`).
> 
> Tests drop flag-off cases and no longer thread mock flaggers for ICS behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4399dd4821a5972c1ecf87bec899ec9fb64b69c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->