### PR TITLE
iOS: Show only "Delete All" in Fire Button confirmation when one tab

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -287,6 +287,9 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213965646075290
     case fireButtonRefinements
 
+    /// https://app.asana.com/1/137249556945/project/1214749231578703/task/1213613180881406
+    case fireButtonSingleTabDeleteAll
+
     /// https://app.asana.com/1/137249556945/project/392891325557410/task/1212828713075939?focus=true
     case omniBarLongPressMenu
 

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -287,7 +287,7 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213965646075290
     case fireButtonRefinements
 
-    /// https://app.asana.com/1/137249556945/project/1214749231578703/task/1213613180881406
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216535350078652
     case fireButtonSingleTabDeleteAll
 
     /// https://app.asana.com/1/137249556945/project/392891325557410/task/1212828713075939?focus=true

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -417,6 +417,9 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213965646075290
     case fireButtonRefinements
 
+    /// https://app.asana.com/1/137249556945/project/1214749231578703/task/1213613180881406
+    case fireButtonSingleTabDeleteAll
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213728968355833?focus=true
     case aiChatOmnibarDefaultPosition
 
@@ -800,6 +803,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.fireMode))
         case .fireButtonRefinements:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.fireButtonRefinements))
+        case .fireButtonSingleTabDeleteAll:
+            Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.fireButtonSingleTabDeleteAll))
         case .aiChatOmnibarDefaultPosition:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.omnibarDefaultPosition))
         case .duckAIVoiceShortcut:

--- a/iOS/DuckDuckGo/Fire/DataClearingCapability.swift
+++ b/iOS/DuckDuckGo/Fire/DataClearingCapability.swift
@@ -23,6 +23,10 @@ import PrivacyConfig
 
 protocol DataClearingCapable {
     var isFireButtonRefinementsEnabled: Bool { get }
+
+    /// When enabled, the fire confirmation collapses to a single "Delete All" button
+    /// if only one non-Duck.ai tab is open, since burning that tab equals burning all.
+    var isSingleTabDeleteAllEnabled: Bool { get }
 }
 
 enum DataClearingCapability {
@@ -51,5 +55,9 @@ struct DataClearingDefaultCapability: DataClearingCapable {
             // but the refinements should still apply independently.
             featureFlagger.isFeatureOn(for: FeatureFlag.fireButtonRefinements)
         }
+    }
+
+    var isSingleTabDeleteAllEnabled: Bool {
+        featureFlagger.isFeatureOn(for: FeatureFlag.fireButtonSingleTabDeleteAll)
     }
 }

--- a/iOS/DuckDuckGo/Fire/FireConfirmationPresenter.swift
+++ b/iOS/DuckDuckGo/Fire/FireConfirmationPresenter.swift
@@ -33,11 +33,12 @@ struct FireConfirmationPresenter {
                                  tabViewModel: TabViewModel?,
                                  pixelSource: FireRequest.Source,
                                  fireContext: ScopedFireConfirmationViewModel.FireContext,
+                                 isSingleTab: Bool = false,
                                  browsingMode: BrowsingMode,
                                  onConfirm: @escaping (FireRequest) -> Void,
                                  onCancel: @escaping () -> Void) {
         let sourceRect = (source as? UIView)?.bounds ?? .zero
-        presentScopeConfirmationSheet(on: viewController, from: source, sourceRect: sourceRect, tabViewModel: tabViewModel, pixelSource: pixelSource, fireContext: fireContext, browsingMode: browsingMode, onConfirm: onConfirm, onCancel: onCancel)
+        presentScopeConfirmationSheet(on: viewController, from: source, sourceRect: sourceRect, tabViewModel: tabViewModel, pixelSource: pixelSource, fireContext: fireContext, isSingleTab: isSingleTab, browsingMode: browsingMode, onConfirm: onConfirm, onCancel: onCancel)
     }
 
     @MainActor
@@ -46,6 +47,7 @@ struct FireConfirmationPresenter {
                                  tabViewModel: TabViewModel?,
                                  pixelSource: FireRequest.Source,
                                  fireContext: ScopedFireConfirmationViewModel.FireContext,
+                                 isSingleTab: Bool = false,
                                  browsingMode: BrowsingMode,
                                  onConfirm: @escaping (FireRequest) -> Void,
                                  onCancel: @escaping () -> Void) {
@@ -53,7 +55,7 @@ struct FireConfirmationPresenter {
             assertionFailure("No key window available")
             return
         }
-        presentScopeConfirmationSheet(on: viewController, from: window, sourceRect: sourceRect, tabViewModel: tabViewModel, pixelSource: pixelSource, fireContext: fireContext, browsingMode: browsingMode, onConfirm: onConfirm, onCancel: onCancel)
+        presentScopeConfirmationSheet(on: viewController, from: window, sourceRect: sourceRect, tabViewModel: tabViewModel, pixelSource: pixelSource, fireContext: fireContext, isSingleTab: isSingleTab, browsingMode: browsingMode, onConfirm: onConfirm, onCancel: onCancel)
     }
 
     // MARK: - Scope-based Confirmation
@@ -65,12 +67,14 @@ struct FireConfirmationPresenter {
                                                tabViewModel: TabViewModel?,
                                                pixelSource: FireRequest.Source,
                                                fireContext: ScopedFireConfirmationViewModel.FireContext,
+                                               isSingleTab: Bool,
                                                browsingMode: BrowsingMode,
                                                onConfirm: @escaping (FireRequest) -> Void,
                                                onCancel: @escaping () -> Void) {
         let viewModel = ScopedFireConfirmationViewModel(tabViewModel: tabViewModel,
                                                         source: pixelSource,
                                                         fireContext: fireContext,
+                                                        isSingleTab: isSingleTab,
                                                         browsingMode: browsingMode,
                                                         onConfirm: { [weak viewController] fireOptions in
                                                             viewController?.dismiss(animated: true) {

--- a/iOS/DuckDuckGo/Fire/ScopedFireConfirmationView.swift
+++ b/iOS/DuckDuckGo/Fire/ScopedFireConfirmationView.swift
@@ -151,6 +151,7 @@ private extension ScopedFireConfirmationView {
 #if DEBUG
 private struct PreviewDataClearingCapability: DataClearingCapable {
     var isFireButtonRefinementsEnabled: Bool { false }
+    var isSingleTabDeleteAllEnabled: Bool { false }
 }
 
 private final class PreviewDownloadManager: DownloadManaging {

--- a/iOS/DuckDuckGo/Fire/ScopedFireConfirmationViewModel.swift
+++ b/iOS/DuckDuckGo/Fire/ScopedFireConfirmationViewModel.swift
@@ -83,6 +83,7 @@ final class ScopedFireConfirmationViewModel: ObservableObject {
     init(tabViewModel: TabViewModel?,
          source: FireRequest.Source,
          fireContext: FireContext,
+         isSingleTab: Bool = false,
          downloadManager: DownloadManaging = AppDependencyProvider.shared.downloadManager,
          keyValueStore: KeyValueStoring = UserDefaults.standard,
          appSettings: AppSettings = AppDependencyProvider.shared.appSettings,
@@ -97,9 +98,15 @@ final class ScopedFireConfirmationViewModel: ObservableObject {
         let isSingleChatConfirmation = Self.isSingleChatConfirmation(fireContext: fireContext,
                                                                      isRefinementsEnabled: isRefinementsEnabled,
                                                                      tabViewModel: tabViewModel)
+        let showDeleteAllOnlyForSingleTab = Self.showDeleteAllOnlyForSingleTab(fireContext: fireContext,
+                                                                               isSingleTab: isSingleTab,
+                                                                               isSingleChatConfirmation: isSingleChatConfirmation,
+                                                                               tabViewModel: tabViewModel,
+                                                                               dataClearingCapability: dataClearingCapability)
 
         self.headerTitle = Self.computeHeaderTitle(fireContext: fireContext,
                                                    isSingleChatConfirmation: isSingleChatConfirmation,
+                                                   showDeleteAllOnlyForSingleTab: showDeleteAllOnlyForSingleTab,
                                                    browsingMode: browsingMode,
                                                    appSettings: appSettings)
         self.showAnimation = !(isRefinementsEnabled && appSettings.currentFireButtonAnimation == .none)
@@ -109,6 +116,7 @@ final class ScopedFireConfirmationViewModel: ObservableObject {
                                         source: source,
                                         isRefinementsEnabled: isRefinementsEnabled,
                                         isSingleChatConfirmation: isSingleChatConfirmation,
+                                        showDeleteAllOnlyForSingleTab: showDeleteAllOnlyForSingleTab,
                                         onConfirm: onConfirm,
                                         onCancel: onCancel)
         self.subtitle = Self.computeSubtitle(fireContext: fireContext,
@@ -147,6 +155,20 @@ final class ScopedFireConfirmationViewModel: ObservableObject {
         }
     }
 
+    /// Returns `true` when only one non-Duck.ai tab is open and the standard fire button is used.
+    /// In that case "Delete This Tab" is equivalent to "Delete All", so the choice is dropped and
+    /// only "Delete All" is shown. Gated behind the `fireButtonSingleTabDeleteAll` flag.
+    private static func showDeleteAllOnlyForSingleTab(fireContext: FireContext,
+                                                      isSingleTab: Bool,
+                                                      isSingleChatConfirmation: Bool,
+                                                      tabViewModel: TabViewModel?,
+                                                      dataClearingCapability: DataClearingCapable) -> Bool {
+        guard case .default = fireContext else { return false }
+        guard dataClearingCapability.isSingleTabDeleteAllEnabled, isSingleTab else { return false }
+        // Never override the Duck.ai single-chat confirmation.
+        return !isSingleChatConfirmation && tabViewModel?.tab.isAITab != true
+    }
+
     /// Builds the ordered list of action buttons for the confirmation sheet.
     ///
     /// - Contextual chat: single "Delete Chat" button
@@ -160,6 +182,7 @@ final class ScopedFireConfirmationViewModel: ObservableObject {
                                     source: FireRequest.Source,
                                     isRefinementsEnabled: Bool,
                                     isSingleChatConfirmation: Bool,
+                                    showDeleteAllOnlyForSingleTab: Bool,
                                     onConfirm: @escaping (FireRequest) -> Void,
                                     onCancel: @escaping () -> Void) -> [FireConfirmationButton] {
         switch fireContext {
@@ -219,6 +242,15 @@ final class ScopedFireConfirmationViewModel: ObservableObject {
         }
 
         let deleteAllAction = { burnAll(browsingMode: browsingMode, source: source, onConfirm: onConfirm) }
+
+        // Single non-Duck.ai tab: "Delete This Tab" == "Delete All", so show only "Delete All".
+        if showDeleteAllOnlyForSingleTab {
+            return [FireConfirmationButton(title: UserText.scopedFireConfirmationDeleteAllButton,
+                       style: .primary,
+                       action: deleteAllAction,
+                       accessibilityIdentifier: AccessibilityIdentifiers.deleteAll)]
+        }
+
         let canBurnTab = tabViewModel?.tab.supportsTabHistory == true
 
         // Refinements enabled: "Delete This Tab" (primary) then "Delete All" (secondary)
@@ -275,6 +307,7 @@ final class ScopedFireConfirmationViewModel: ObservableObject {
 
     private static func computeHeaderTitle(fireContext: FireContext,
                                            isSingleChatConfirmation: Bool,
+                                           showDeleteAllOnlyForSingleTab: Bool,
                                            browsingMode: BrowsingMode,
                                            appSettings: AppSettings) -> String {
         switch fireContext {
@@ -295,6 +328,9 @@ final class ScopedFireConfirmationViewModel: ObservableObject {
             }
             if browsingMode == .fire {
                 return UserText.scopedFireConfirmationAlertFireModeTitle
+            }
+            if showDeleteAllOnlyForSingleTab {
+                return UserText.scopedFireConfirmationAlertSingleTabTitle
             }
             return appSettings.autoClearAIChatHistory
                 ? UserText.scopedFireConfirmationAlertTitleWithAIChat

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1920,6 +1920,7 @@ class MainViewController: UIViewController {
                 tabViewModel: tabManager.viewModelForCurrentTab(),
                 pixelSource: .browsing,
                 fireContext: .default(daxDialogsManager: daxDialogsManager),
+                isSingleTab: tabManager.currentTabsModel.count == 1,
                 browsingMode: tabManager.currentBrowsingMode,
                 onConfirm: { [weak self] fireRequest in
                     guard let self else { return }

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -257,6 +257,7 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
                 tabViewModel: tabManager.viewModelForCurrentTab(),
                 pixelSource: .browsing,
                 fireContext: .default(daxDialogsManager: daxDialogsManager),
+                isSingleTab: tabManager.currentTabsModel.count == 1,
                 browsingMode: tabManager.currentBrowsingMode,
                 onConfirm: { [weak self] fireRequest in
                     guard let self = self else { return }

--- a/iOS/DuckDuckGoTests/Fire/DataClearingSettingsViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/DataClearingSettingsViewModelTests.swift
@@ -24,6 +24,7 @@ import AIChat
 
 final class MockDataClearingCapability: DataClearingCapable {
     var isFireButtonRefinementsEnabled: Bool = false
+    var isSingleTabDeleteAllEnabled: Bool = false
 }
 
 @MainActor

--- a/iOS/DuckDuckGoTests/Fire/ScopedFireConfirmationViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/ScopedFireConfirmationViewModelTests.swift
@@ -513,17 +513,125 @@ final class ScopedFireConfirmationViewModelTests: XCTestCase {
         }
     }
 
+    // MARK: - Single Tab "Delete All" Only Tests
+
+    func testWhenSingleTabAndFlagEnabledThenOnlyDeleteAllShown() {
+        // Given
+        mockDataClearingCapability.isFireButtonRefinementsEnabled = true
+        mockDataClearingCapability.isSingleTabDeleteAllEnabled = true
+
+        // When
+        let sut = makeSUT(tabViewModel: createTabViewModel(), isSingleTab: true)
+
+        // Then
+        XCTAssertEqual(sut.buttons.count, 1)
+        XCTAssertEqual(sut.buttons[0].title, UserText.scopedFireConfirmationDeleteAllButton)
+        XCTAssertEqual(sut.buttons[0].style, .primary)
+    }
+
+    func testWhenSingleTabAndFlagEnabledWithRefinementsDisabledThenOnlyDeleteAllShown() {
+        // Given
+        mockDataClearingCapability.isFireButtonRefinementsEnabled = false
+        mockDataClearingCapability.isSingleTabDeleteAllEnabled = true
+
+        // When
+        let sut = makeSUT(tabViewModel: createTabViewModel(), isSingleTab: true)
+
+        // Then
+        XCTAssertEqual(sut.buttons.count, 1)
+        XCTAssertEqual(sut.buttons[0].title, UserText.scopedFireConfirmationDeleteAllButton)
+        XCTAssertEqual(sut.buttons[0].style, .primary)
+    }
+
+    func testWhenSingleTabButFlagDisabledThenNormalButtons() {
+        // Given
+        mockDataClearingCapability.isFireButtonRefinementsEnabled = true
+        mockDataClearingCapability.isSingleTabDeleteAllEnabled = false
+
+        // When
+        let sut = makeSUT(tabViewModel: createTabViewModel(), isSingleTab: true)
+
+        // Then
+        XCTAssertEqual(sut.buttons.count, 2)
+        XCTAssertEqual(sut.buttons[0].title, UserText.scopedFireConfirmationDeleteThisTabButton)
+        XCTAssertEqual(sut.buttons[1].title, UserText.scopedFireConfirmationDeleteAllButton)
+    }
+
+    func testWhenMultipleTabsAndFlagEnabledThenNormalButtons() {
+        // Given
+        mockDataClearingCapability.isFireButtonRefinementsEnabled = true
+        mockDataClearingCapability.isSingleTabDeleteAllEnabled = true
+
+        // When
+        let sut = makeSUT(tabViewModel: createTabViewModel(), isSingleTab: false)
+
+        // Then
+        XCTAssertEqual(sut.buttons.count, 2)
+        XCTAssertEqual(sut.buttons[0].title, UserText.scopedFireConfirmationDeleteThisTabButton)
+        XCTAssertEqual(sut.buttons[1].title, UserText.scopedFireConfirmationDeleteAllButton)
+    }
+
+    func testWhenSingleAITabAndFlagEnabledThenChatConfirmationUnaffected() {
+        // Given
+        mockDataClearingCapability.isFireButtonRefinementsEnabled = true
+        mockDataClearingCapability.isSingleTabDeleteAllEnabled = true
+
+        // When
+        let sut = makeSUT(tabViewModel: createAITabViewModel(), isSingleTab: true)
+
+        // Then
+        XCTAssertEqual(sut.buttons.count, 1)
+        XCTAssertEqual(sut.buttons[0].title, UserText.scopedFireConfirmationDeleteThisChatButton)
+    }
+
+    func testWhenSingleTabDeleteAllShownThenTitleIsSingular() {
+        // Given
+        mockDataClearingCapability.isFireButtonRefinementsEnabled = true
+        mockDataClearingCapability.isSingleTabDeleteAllEnabled = true
+
+        // When
+        let sut = makeSUT(tabViewModel: createTabViewModel(), isSingleTab: true)
+
+        // Then
+        XCTAssertEqual(sut.headerTitle, UserText.scopedFireConfirmationAlertSingleTabTitle)
+    }
+
+    func testWhenSingleTabDeleteAllTappedThenBurnsAll() {
+        // Given
+        var capturedRequest: FireRequest?
+        mockDataClearingCapability.isFireButtonRefinementsEnabled = true
+        mockDataClearingCapability.isSingleTabDeleteAllEnabled = true
+        let sut = makeSUT(tabViewModel: createTabViewModel(),
+                          isSingleTab: true,
+                          onConfirm: { capturedRequest = $0 })
+
+        // When
+        sut.buttons[0].action()
+
+        // Then
+        XCTAssertNotNil(capturedRequest)
+        XCTAssertEqual(capturedRequest?.options, .all)
+        XCTAssertEqual(capturedRequest?.trigger, .manualFire)
+        if case .all = capturedRequest?.scope {
+            // Expected all-scope burn
+        } else {
+            XCTFail("Expected scope to be .all")
+        }
+    }
+
     // MARK: - Helpers
-    
+
     private func makeSUT(tabViewModel: TabViewModel?,
                          source: FireRequest.Source = .browsing,
                          fireContext: ScopedFireConfirmationViewModel.FireContext = .default(daxDialogsManager: MockDaxDialogsManager()),
+                         isSingleTab: Bool = false,
                          browsingMode: BrowsingMode = .normal,
                          onConfirm: @escaping (FireRequest) -> Void = { _ in },
                          onCancel: @escaping () -> Void = { }) -> ScopedFireConfirmationViewModel {
         return ScopedFireConfirmationViewModel(tabViewModel: tabViewModel,
                                                source: source,
                                                fireContext: fireContext,
+                                               isSingleTab: isSingleTab,
                                                downloadManager: mockDownloadManager,
                                                keyValueStore: mockKeyValueStore,
                                                appSettings: mockAppSettings,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1213613180881406?focus=true
Tech Design URL:
CC:

### Description
Removes the choice: with one non-Duck.ai tab open, the confirmation shows only a single "Delete All" button and uses the singular title "Delete tab and site data?”.

Duck.ai single-tab is unaffected: an AI tab already collapses to "Delete This Chat”.

### Testing Steps
1. Ensure the `fireButtonSingleTabDeleteAll` subfeature is enabled (default).
2. Open the app with exactly one tab showing a website, tap the Fire Button.
3. Verify the confirmation shows a single "Delete All" button and the title reads "Delete tab and site data?".
4. Repeat with a single SERP tab, verify the same single-button confirmation.
5. Open a second tab, tap the Fire Button, verify the confirmation again shows both "Delete This Tab" and "Delete All".
6. With a single Duck.ai tab open, tap the Fire Button, verify it still shows "Delete This Chat" (unchanged).
7. Confirm tapping "Delete All" in the single-tab case clears all tabs and data as before.

### Impact and Risks
Low. The change only affects which buttons appear in the fire confirmation for the single non-Duck.ai tab case, and is behind a remote-releasable flag defaulting to enabled. The burn action itself (`burnAll`, scope `.all` / `.fireMode`) is unchanged.

#### What could go wrong?
— 

### Quality Considerations
— 

### Notes to Reviewer
--

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only confirmation layout behind a remote-releasable flag; the underlying burn-all path is unchanged.
> 
> **Overview**
> Adds remote flag **`fireButtonSingleTabDeleteAll`** (privacy config + iOS `FeatureFlag`, default on) and **`isSingleTabDeleteAllEnabled`** on `DataClearingCapable`.
> 
> When the user opens the standard Fire confirmation with **exactly one non–Duck.ai tab**, the sheet now shows a **single primary "Delete All"** action (full burn, scope `.all`) instead of both "Delete This Tab" and "Delete All", and uses the **singular** header title. **`MainViewController`** and **`TabsBarViewController`** pass `isSingleTab: tabManager.currentTabsModel.count == 1` through **`FireConfirmationPresenter`** into **`ScopedFireConfirmationViewModel`**. Duck.ai single-chat flows and multi-tab behavior are unchanged when the flag is off or multiple tabs are open.
> 
> Unit tests cover flag on/off, refinements on/off, AI tab, title, and confirm action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaaa1aec9ec7277af862252bd809dd54d3fa9fdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->