### PR TITLE
macOS: Fix Address Bar Separator Overlap

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
@@ -953,7 +953,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="5" height="32"/>
                                         <subviews>
                                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="CtU-Gd-KHM" customClass="ColorView" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="8" width="1" height="16"/>
+                                                <rect key="frame" x="2" y="8" width="1" height="16"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="1" id="Skm-Q0-ubi"/>
                                                     <constraint firstAttribute="height" constant="16" id="vnk-Hg-Wd7"/>
@@ -967,8 +967,8 @@
                                         </subviews>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="32" id="Dnx-hJ-3A9"/>
-                                            <constraint firstItem="CtU-Gd-KHM" firstAttribute="leading" secondItem="lbX-yW-2eM" secondAttribute="leading" id="WGB-lV-Voe"/>
-                                            <constraint firstAttribute="trailing" secondItem="CtU-Gd-KHM" secondAttribute="trailing" constant="4" id="WNS-7L-y5e"/>
+                                            <constraint firstItem="CtU-Gd-KHM" firstAttribute="leading" secondItem="lbX-yW-2eM" secondAttribute="leading" constant="2" id="WGB-lV-Voe"/>
+                                            <constraint firstAttribute="trailing" secondItem="CtU-Gd-KHM" secondAttribute="trailing" constant="2" id="WNS-7L-y5e"/>
                                             <constraint firstItem="CtU-Gd-KHM" firstAttribute="centerY" secondItem="lbX-yW-2eM" secondAttribute="centerY" id="bY5-af-X8A"/>
                                             <constraint firstAttribute="width" constant="5" id="plW-zK-Tdb"/>
                                         </constraints>
@@ -1178,7 +1178,7 @@
             <color red="1" green="1" blue="1" alpha="0.0" colorSpace="custom" customColorSpace="displayP3"/>
         </namedColor>
         <namedColor name="AddressBarSeparatorColor">
-            <color red="0.0" green="0.0" blue="0.0" alpha="0.11999999729999999" colorSpace="custom" customColorSpace="displayP3"/>
+            <color red="0.0" green="0.0" blue="0.0" alpha="0.11999999731779099" colorSpace="custom" customColorSpace="displayP3"/>
         </namedColor>
         <namedColor name="AddressBarShadowColor">
             <color red="0.0" green="0.0" blue="0.0" alpha="0.15000000596046448" colorSpace="custom" customColorSpace="displayP3"/>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1176956903599313/task/1216546994113040?focus=true
Tech Design URL:
CC:

### Description
In this PR we're adjusting the Vertical Separator, rendered by the Privacy Shield, so that horizontal spacing is symmetrical.

### Testing Steps
1. Launch this branch
2. Open any website
3. Increase the Zoom level, so that the Zoom Address Bar Button shows up

- [ ] Verify the Vertical Separator now looks great (should have 2pt leading / trailing!)


### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
The Vertical Separator could be misplaced

### Quality Considerations
None

### Screenshots

Now | Before
-|-
<img width="62" height="38" alt="Before" src="https://github.com/user-attachments/assets/60960f04-e421-40cc-89c2-650bd6ec9248" /> | <img width="65" height="38" alt="Now" src="https://github.com/user-attachments/assets/e9da9fab-87fb-4003-9f05-ad75e591d461" />


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Storyboard-only layout tweak with no logic changes; worst case is minor separator misplacement in the address bar.
> 
> **Overview**
> Fixes **address bar vertical separator** overlap/misalignment next to the Privacy Shield by updating Auto Layout in `NavigationBar.storyboard`.
> 
> The 1pt `ColorView` line inside the 5pt-wide **Separator** container now uses **2pt leading and 2pt trailing** margins (previously 0pt leading and 4pt trailing), so horizontal spacing is symmetrical and the divider no longer crowds adjacent controls when the zoom button appears.
> 
> There is also a trivial floating-point precision change to the `AddressBarSeparatorColor` named color alpha in the storyboard (no intended visual change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16a4166c07ee94a4e6b97fc0a452e6d08df07422. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->