### PR TITLE
Update Fire Dialog header and footer

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6753e1690ecc9f31e4b23f6bc47b0e1cb021f1c022480eb35a4c101b7a552d83",
+  "originHash" : "3966a35eac034dc5384a7e972cb2b0d227b9d6ecc91a0eb6a836e83e18eafde9",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "940664b5ae80b9d557760624138f2963d34a750a",
-        "version" : "15.11.0"
+        "revision" : "dc9b1280951a22359aac33d07ffd410cbbae2b94",
+        "version" : "15.12.0"
       }
     },
     {

--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8e95463b1743b61b9696512cf002a29cc4979e7d17079884d0e515362fab23e9",
+  "originHash" : "6753e1690ecc9f31e4b23f6bc47b0e1cb021f1c022480eb35a4c101b7a552d83",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "6cec6781b44c538161a906bed097b264682c92cd",
-        "version" : "15.9.0"
+        "revision" : "940664b5ae80b9d557760624138f2963d34a750a",
+        "version" : "15.11.0"
       }
     },
     {

--- a/SharedPackages/Infrastructure/DesignResourcesKitIcons/Sources/DesignResourcesKitIcons/DesignSystemImages+Glyphs.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKitIcons/Sources/DesignResourcesKitIcons/DesignSystemImages+Glyphs.swift
@@ -282,6 +282,7 @@ public extension DesignSystemImages {
             public static var location: DesignSystemImage { .init(resource: .location16) }
             public static var locationBlocked: DesignSystemImage { .init(resource: .locationBlocked16) }
             public static var locationSolid: DesignSystemImage { .init(resource: .locationSolid16) }
+            public static var menuDots: DesignSystemImage { .init(resource: .menuDots16) }
             public static var menuLines: DesignSystemImage { .init(resource: .menuLines16) }
             public static var menuLinesDot: DesignSystemImage { .init(resource: .menuLinesDot16) }
             public static var permissionMicrophone: DesignSystemImage { .init(resource: .microphone16) }

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -41,6 +41,8 @@ struct UserText {
     static let fireDialogCloseThisTab = NSLocalizedString("fire.dialog.close.this.tab", value: "Close this tab.", comment: "Subtitle shown under the Tabs and windows row when scope is ‘Tab’. Means: the currently active tab will be closed.")
     static let fireDialogCloseThisWindow = NSLocalizedString("fire.dialog.close.this.window", value: "Close this window.", comment: "Subtitle shown under the Tabs and windows row when scope is ‘Window’. Means: the current browser window (all tabs inside it) will be closed.")
     static let fireDialogCloseAllTabsWindows = NSLocalizedString("fire.dialog.close.all.tabs.windows", value: "Close all tabs and windows.", comment: "Subtitle shown under the Tabs and windows row when scope is ‘Everything’. Means: all browser tabs and windows will be closed.")
+    static let fireDialogCloseThisTabAfterDeleting = NSLocalizedString("fire.dialog.close.this.tab.after.deleting", value: "Close this tab after deleting.", comment: "Checkbox caption for when the data clearing scope is ‘Tab’. Means: the currently active tab will be closed.")
+    static let fireDialogCloseAllTabsWindowsAfterDeleting = NSLocalizedString("fire.dialog.close.all.windows.after.deleting", value: "Close all tabs and windows after deleting.", comment: "Checkbox caption for when the data clearing scope is ‘Everything’. Means: all browser tabs and windows will be closed.")
 
     static func fireDialogHistoryItemsSubtitle(_ count: Int) -> String {
         let template = NSLocalizedString(

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -41,8 +41,8 @@ struct UserText {
     static let fireDialogCloseThisTab = NSLocalizedString("fire.dialog.close.this.tab", value: "Close this tab.", comment: "Subtitle shown under the Tabs and windows row when scope is ‘Tab’. Means: the currently active tab will be closed.")
     static let fireDialogCloseThisWindow = NSLocalizedString("fire.dialog.close.this.window", value: "Close this window.", comment: "Subtitle shown under the Tabs and windows row when scope is ‘Window’. Means: the current browser window (all tabs inside it) will be closed.")
     static let fireDialogCloseAllTabsWindows = NSLocalizedString("fire.dialog.close.all.tabs.windows", value: "Close all tabs and windows.", comment: "Subtitle shown under the Tabs and windows row when scope is ‘Everything’. Means: all browser tabs and windows will be closed.")
-    static let fireDialogCloseThisTabAfterDeleting = NSLocalizedString("fire.dialog.close.this.tab.after.deleting", value: "Close this tab after deleting.", comment: "Checkbox caption for when the data clearing scope is ‘Tab’. Means: the currently active tab will be closed.")
-    static let fireDialogCloseAllTabsWindowsAfterDeleting = NSLocalizedString("fire.dialog.close.all.windows.after.deleting", value: "Close all tabs and windows after deleting.", comment: "Checkbox caption for when the data clearing scope is ‘Everything’. Means: all browser tabs and windows will be closed.")
+    static let fireDialogCloseThisTabAfterDeleting = NotLocalizedString("fire.dialog.close.this.tab.after.deleting", value: "Close this tab after deleting.", comment: "Checkbox caption for when the data clearing scope is ‘Tab’. Means: the currently active tab will be closed.")
+    static let fireDialogCloseAllTabsWindowsAfterDeleting = NotLocalizedString("fire.dialog.close.all.windows.after.deleting", value: "Close all tabs and windows after deleting.", comment: "Checkbox caption for when the data clearing scope is ‘Everything’. Means: all browser tabs and windows will be closed.")
 
     static func fireDialogHistoryItemsSubtitle(_ count: Int) -> String {
         let template = NSLocalizedString(
@@ -491,7 +491,7 @@ struct UserText {
     static let fireDialogSegmentWindow = NSLocalizedString("fire.dialog.segment.window", value: "Window", comment: "Segment label for Window scope")
     static let fireDialogSegmentEverything = NSLocalizedString("fire.dialog.segment.everything", value: "Everything", comment: "Segment label for Everything scope")
     static let fireDialogManageIndividualSitesLink = NSLocalizedString("fire.dialog.manage.individual.sites", value: "Delete individual sites and history.", comment: "Link row text to manage per-site deletions")
-    static let fireDialogMoreOptions = NSLocalizedString("fire.dialog.more.options", value: "More Options", comment: "Accessibility label for the toolbar button that reveals more Fire dialog options")
+    static let fireDialogMoreOptions = NotLocalizedString("fire.dialog.more.options", value: "More Options", comment: "Accessibility label for the toolbar button that reveals more Fire dialog options")
 
     // MARK: - Fire dialog sites list sheet
     static let fireDialogSitesOverlayTitle = NSLocalizedString("fire.dialog.sites.overlay.title",

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -492,6 +492,7 @@ struct UserText {
     static let fireDialogSegmentEverything = NSLocalizedString("fire.dialog.segment.everything", value: "Everything", comment: "Segment label for Everything scope")
     static let fireDialogManageIndividualSitesLink = NSLocalizedString("fire.dialog.manage.individual.sites", value: "Delete individual sites and history.", comment: "Link row text to manage per-site deletions")
     static let fireDialogMoreOptions = NotLocalizedString("fire.dialog.more.options", value: "More Options", comment: "Accessibility label for the toolbar button that reveals more Fire dialog options")
+    static let fireDialogDeleteAndClose = NotLocalizedString("fire.dialog.delete.and.close", value: "Delete & Close", comment: "Caption for the Fire dialog action button for deleting data and closing tabs and windows")
 
     // MARK: - Fire dialog sites list sheet
     static let fireDialogSitesOverlayTitle = NSLocalizedString("fire.dialog.sites.overlay.title",

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -489,6 +489,7 @@ struct UserText {
     static let fireDialogSegmentWindow = NSLocalizedString("fire.dialog.segment.window", value: "Window", comment: "Segment label for Window scope")
     static let fireDialogSegmentEverything = NSLocalizedString("fire.dialog.segment.everything", value: "Everything", comment: "Segment label for Everything scope")
     static let fireDialogManageIndividualSitesLink = NSLocalizedString("fire.dialog.manage.individual.sites", value: "Delete individual sites and history.", comment: "Link row text to manage per-site deletions")
+    static let fireDialogMoreOptions = NSLocalizedString("fire.dialog.more.options", value: "More Options", comment: "Accessibility label for the toolbar button that reveals more Fire dialog options")
 
     // MARK: - Fire dialog sites list sheet
     static let fireDialogSitesOverlayTitle = NSLocalizedString("fire.dialog.sites.overlay.title",

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -297,7 +297,7 @@ struct FireDialogView: ModalView {
                     viewModel.includeHistory = $0
                 },
                 isEnabled: isIncludeHistoryEnabled,
-                roundedCorners: viewModel.mode.shouldShowCloseTabsToggle ? .none : .top,
+                roundedCorners: .top,
                 toggleId: "FireDialogView.historyToggle"
             )
             .accessibilityHidden(isShowingSitesOverlay)

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -52,10 +52,10 @@ struct FireDialogView: ModalView {
         let baseMessage: String
         switch viewModel.clearingOption {
         case .currentTab:
-            baseMessage = UserText.fireDialogCloseThisTab
+            baseMessage = UserText.fireDialogCloseThisTabAfterDeleting
         case .currentWindow, // current window is pending removal, not supported by the simplified fire dialog, and defaults to burning all data.
                 .allData:
-            baseMessage = UserText.fireDialogCloseAllTabsWindows
+            baseMessage = UserText.fireDialogCloseAllTabsWindowsAfterDeleting
         }
 
         // Append pinned tabs message if applicable
@@ -210,6 +210,7 @@ struct FireDialogView: ModalView {
             .clipShape(Circle())
             .accessibilityLabel(UserText.close)
             .accessibilityIdentifier("FireDialogView.toolbarCloseButton")
+            .keyboardShortcut(.cancelAction)
 
             Spacer()
 
@@ -285,19 +286,6 @@ struct FireDialogView: ModalView {
 
     private var sectionsView: some View {
         VStack(alignment: .leading, spacing: 0) {
-            if viewModel.mode.shouldShowCloseTabsToggle {
-                sectionRow(
-                    icon: DesignSystemImages.Glyphs.Size16.windowsAndTabs,
-                    title: UserText.fireDialogTabsAndWindows,
-                    subtitle: tabsSubtitle,
-                    isOn: $viewModel.includeTabsAndWindows,
-                    roundedCorners: .top,
-                    toggleId: "FireDialogView.tabsToggle"
-                )
-                .accessibilityHidden(isShowingSitesOverlay)
-                sectionDivider()
-            }
-
             // Row 2: History
             sectionRow(
                 icon: DesignSystemImages.Glyphs.Size16.history,
@@ -607,31 +595,18 @@ struct FireDialogView: ModalView {
 
     private var footerView: some View {
         // Buttons
-        HStack(spacing: 8) {
-            Button {
-                onConfirm?(.noAction)
-                dismiss()
-            } label: {
-                Text(UserText.cancel)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 32)
-                    .background(
-                        Group {
-                            if AppVersion.isLiquidGlassSupported {
-                                Capsule(style: .continuous)
-                                    .fill(Color(designSystemColor: .buttonsSecondaryFillDefault))
-                            } else {
-                                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                    .fill(Color(designSystemColor: .buttonsSecondaryFillDefault))
-                            }
-                        }
-                    )
+        HStack(spacing: 0) {
+            if viewModel.mode.shouldShowCloseTabsToggle {
+                Toggle("", isOn: $viewModel.includeTabsAndWindows)
+                    .toggleStyle(.checkbox)
+                    .tint(style.knobFillColor)
+                    .padding(.bottom, 2)
+                Text(tabsSubtitle)
+                    .font(.system(size: 11))
+                    .padding(.leading, 4)
             }
-            .buttonStyle(.plain)
-            .accessibilityLabel(UserText.cancel)
-            .accessibilityIdentifier("FireDialogView.cancelButton")
-            .keyboardShortcut(.cancelAction)
+
+            Spacer(minLength: 8)
 
             Button {
                 let result = FireDialogResult(
@@ -665,6 +640,7 @@ struct FireDialogView: ModalView {
             .accessibilityLabel(UserText.delete)
             .keyboardShortcut(.defaultAction)
             .accessibilityIdentifier("FireDialogView.burnButton")
+            .frame(width: 156)
         }
         .padding(.horizontal, Constants.horizontalPadding)
         .padding(.top, 8)

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -205,7 +205,7 @@ struct FireDialogView: ModalView {
                                     bottomPadding: 4,
                                     horizontalPadding: 4,
                                     backgroundColor: Color(designSystemColor: .controlsFillPrimary),
-                                    backgroundPressedColor: Color(designSystemColor: .controlsFillPrimary))
+                                    backgroundPressedColor: Color(designSystemColor: .controlsFillSecondary))
             )
             .clipShape(Circle())
             .accessibilityLabel(UserText.close)
@@ -227,7 +227,7 @@ struct FireDialogView: ModalView {
                                     bottomPadding: 4,
                                     horizontalPadding: 4,
                                     backgroundColor: .clear,
-                                    backgroundPressedColor: Color(designSystemColor: .controlsFillPrimary))
+                                    backgroundPressedColor: Color(designSystemColor: .controlsFillSecondary))
             )
             .clipShape(Circle())
             .accessibilityLabel(UserText.fireDialogMoreOptions)
@@ -601,11 +601,13 @@ struct FireDialogView: ModalView {
                     .toggleStyle(.checkbox)
                     .tint(style.knobFillColor)
                     .padding(.bottom, 2)
-                    .accessibilityLabel("FireDialogView.tabsToggle")
+                    .accessibilityLabel(tabsSubtitle)
+                    .accessibilityIdentifier("FireDialogView.tabsToggle")
                     .accessibilityHidden(isShowingSitesOverlay)
                 Text(tabsSubtitle)
                     .font(.system(size: 11))
                     .padding(.leading, 4)
+                    .accessibilityHidden(true)
                     .onTapGesture {
                         viewModel.includeTabsAndWindows.toggle()
                     }

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -645,6 +645,7 @@ struct FireDialogView: ModalView {
             .accessibilityLabel(viewModel.includeTabsAndWindows ? UserText.fireDialogDeleteAndClose : UserText.delete)
             .keyboardShortcut(.defaultAction)
             .accessibilityIdentifier("FireDialogView.burnButton")
+            .accessibilityHidden(isShowingSitesOverlay)
             .frame(width: 156)
         }
         .padding(.horizontal, Constants.horizontalPadding)

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -601,6 +601,8 @@ struct FireDialogView: ModalView {
                     .toggleStyle(.checkbox)
                     .tint(style.knobFillColor)
                     .padding(.bottom, 2)
+                    .accessibilityLabel("FireDialogView.tabsToggle")
+                    .accessibilityHidden(isShowingSitesOverlay)
                 Text(tabsSubtitle)
                     .font(.system(size: 11))
                     .padding(.leading, 4)

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -640,7 +640,7 @@ struct FireDialogView: ModalView {
                 )
             )
             .disabled(!isDeleteEnabled)
-            .accessibilityLabel(UserText.delete)
+            .accessibilityLabel(viewModel.includeTabsAndWindows ? UserText.fireDialogDeleteAndClose : UserText.delete)
             .keyboardShortcut(.defaultAction)
             .accessibilityIdentifier("FireDialogView.burnButton")
             .frame(width: 156)

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -39,7 +39,8 @@ struct FireDialogView: ModalView {
     fileprivate enum Constants {
         static let viewSize = CGSize(width: 428, height: 592)
         static let footerReservedHeight: CGFloat = 52
-        static let horizontalPadding: CGFloat = AppVersion.isLiquidGlassSupported ? 20 : 16
+        static let toolbarHorizontalPadding: CGFloat = AppVersion.isLiquidGlassSupported ? 20 : 16
+        static let horizontalPadding: CGFloat = AppVersion.isLiquidGlassSupported ? 24 : 16
         static let bottomPadding: CGFloat = AppVersion.isLiquidGlassSupported ? 20 : 16
         static var sectionRowWidth: CGFloat { viewSize.width - 2 * horizontalPadding }
     }
@@ -132,10 +133,9 @@ struct FireDialogView: ModalView {
     var body: some View {
         VStack(spacing: 16) {
             ZStack {
-                VStack(spacing: 16) {
-                    toolbarView
+                VStack(spacing: 24) {
                     headerView
-                        .padding(.top, 10) // presenter sheet crops the padding 🤷‍♂️
+                        .padding(.top, 14) // presenter sheet crops the padding 🤷‍♂️
                         .accessibilityHidden(isShowingSitesOverlay)
                     if viewModel.mode.shouldShowSegmentedControl {
                         segmentedControlView
@@ -147,6 +147,7 @@ struct FireDialogView: ModalView {
                     }
                 }
                 .padding(.horizontal, Constants.horizontalPadding)
+                .padding(.bottom, Constants.horizontalPadding)
 
                 // Sites Overlay
                 if isShowingSitesOverlay {
@@ -167,6 +168,9 @@ struct FireDialogView: ModalView {
                     .zIndex(10)
                     .transition(.move(edge: .bottom))
                 }
+            }
+            .background(alignment: .top) {
+                toolbarView
             }
             .animation(.easeOut(duration: NSAnimationContext.current.duration),
                        value: isAnimatingSitesOverlay)
@@ -210,7 +214,7 @@ struct FireDialogView: ModalView {
             Spacer()
 
             Button {
-                // TODO: present the "more options" menu once its contents are defined.
+                // Present the "more options" menu once its contents are defined.
             } label: {
                 Image(nsImage: DesignSystemImages.Glyphs.Size16.menuDots)
                     .resizable()
@@ -229,10 +233,11 @@ struct FireDialogView: ModalView {
             .accessibilityIdentifier("FireDialogView.toolbarMoreButton")
         }
         .padding(.top, 16)
+        .padding(.horizontal, Constants.toolbarHorizontalPadding)
     }
 
     private var headerView: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: 6) {
             FirePictogramAnimation()
                 .frame(width: 72, height: 72)
                 .padding(.top, 8)

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -37,7 +37,7 @@ struct FireDialogView: ModalView {
     }
 
     fileprivate enum Constants {
-        static let viewSize = CGSize(width: 440, height: 592)
+        static let viewSize = CGSize(width: 428, height: 592)
         static let footerReservedHeight: CGFloat = 52
         static let horizontalPadding: CGFloat = AppVersion.isLiquidGlassSupported ? 20 : 16
         static let bottomPadding: CGFloat = AppVersion.isLiquidGlassSupported ? 20 : 16
@@ -133,6 +133,7 @@ struct FireDialogView: ModalView {
         VStack(spacing: 16) {
             ZStack {
                 VStack(spacing: 16) {
+                    toolbarView
                     headerView
                         .padding(.top, 10) // presenter sheet crops the padding 🤷‍♂️
                         .accessibilityHidden(isShowingSitesOverlay)
@@ -182,6 +183,52 @@ struct FireDialogView: ModalView {
         .background(Color(designSystemColor: .surfaceSecondary))
         .accessibilityElement(children: .contain)
         .accessibilityLabel(viewModel.mode.dialogTitle)
+    }
+
+    private var toolbarView: some View {
+        HStack {
+            Button {
+                onConfirm?(.noAction)
+                dismiss()
+            } label: {
+                Image(nsImage: DesignSystemImages.Glyphs.Size16.close)
+                    .resizable()
+                    .frame(width: 16, height: 16)
+                    .foregroundColor(Color(designSystemColor: .iconsSecondary))
+            }
+            .buttonStyle(
+                StandardButtonStyle(topPadding: 4,
+                                    bottomPadding: 4,
+                                    horizontalPadding: 4,
+                                    backgroundColor: Color(designSystemColor: .controlsFillPrimary),
+                                    backgroundPressedColor: Color(designSystemColor: .controlsFillPrimary))
+            )
+            .clipShape(Circle())
+            .accessibilityLabel(UserText.close)
+            .accessibilityIdentifier("FireDialogView.toolbarCloseButton")
+
+            Spacer()
+
+            Button {
+                // TODO: present the "more options" menu once its contents are defined.
+            } label: {
+                Image(nsImage: DesignSystemImages.Glyphs.Size16.menuDots)
+                    .resizable()
+                    .frame(width: 16, height: 16)
+                    .foregroundColor(Color(designSystemColor: .iconsSecondary))
+            }
+            .buttonStyle(
+                StandardButtonStyle(topPadding: 4,
+                                    bottomPadding: 4,
+                                    horizontalPadding: 4,
+                                    backgroundColor: .clear,
+                                    backgroundPressedColor: Color(designSystemColor: .controlsFillPrimary))
+            )
+            .clipShape(Circle())
+            .accessibilityLabel(UserText.fireDialogMoreOptions)
+            .accessibilityIdentifier("FireDialogView.toolbarMoreButton")
+        }
+        .padding(.top, 16)
     }
 
     private var headerView: some View {

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -604,6 +604,9 @@ struct FireDialogView: ModalView {
                 Text(tabsSubtitle)
                     .font(.system(size: 11))
                     .padding(.leading, 4)
+                    .onTapGesture {
+                        viewModel.includeTabsAndWindows.toggle()
+                    }
             }
 
             Spacer(minLength: 8)
@@ -621,7 +624,7 @@ struct FireDialogView: ModalView {
                 onConfirm?(.burn(options: result))
                 dismiss()
             } label: {
-                Text(UserText.delete)
+                Text(viewModel.includeTabsAndWindows ? UserText.fireDialogDeleteAndClose : UserText.delete)
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: .infinity)
                     .frame(height: 32)

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -40891,18 +40891,6 @@
         }
       }
     },
-    "fire.dialog.close.all.windows.after.deleting" : {
-      "comment" : "Checkbox caption for when the data clearing scope is ‘Everything’. Means: all browser tabs and windows will be closed.",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close all tabs and windows after deleting."
-          }
-        }
-      }
-    },
     "fire.dialog.close.this.tab" : {
       "comment" : "Subtitle shown under the Tabs and windows row when scope is ‘Tab’. Means: the currently active tab will be closed.",
       "extractionState" : "extracted_with_value",
@@ -40959,18 +40947,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Закрыть эту вкладку"
-          }
-        }
-      }
-    },
-    "fire.dialog.close.this.tab.after.deleting" : {
-      "comment" : "Checkbox caption for when the data clearing scope is ‘Tab’. Means: the currently active tab will be closed.",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close this tab after deleting."
           }
         }
       }
@@ -42813,18 +42789,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Удалить отдельные сайты и записи"
-          }
-        }
-      }
-    },
-    "fire.dialog.more.options" : {
-      "comment" : "Accessibility label for the toolbar button that reveals more Fire dialog options",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "More Options"
           }
         }
       }

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -42793,6 +42793,18 @@
         }
       }
     },
+    "fire.dialog.more.options" : {
+      "comment" : "Accessibility label for the toolbar button that reveals more Fire dialog options",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "More Options"
+          }
+        }
+      }
+    },
     "fire.dialog.segment.everything" : {
       "comment" : "Segment label for Everything scope",
       "extractionState" : "extracted_with_value",

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -40891,6 +40891,18 @@
         }
       }
     },
+    "fire.dialog.close.all.windows.after.deleting" : {
+      "comment" : "Checkbox caption for when the data clearing scope is ‘Everything’. Means: all browser tabs and windows will be closed.",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Close all tabs and windows after deleting."
+          }
+        }
+      }
+    },
     "fire.dialog.close.this.tab" : {
       "comment" : "Subtitle shown under the Tabs and windows row when scope is ‘Tab’. Means: the currently active tab will be closed.",
       "extractionState" : "extracted_with_value",
@@ -40947,6 +40959,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Закрыть эту вкладку"
+          }
+        }
+      }
+    },
+    "fire.dialog.close.this.tab.after.deleting" : {
+      "comment" : "Checkbox caption for when the data clearing scope is ‘Tab’. Means: the currently active tab will be closed.",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Close this tab after deleting."
           }
         }
       }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216544417092224?focus=true

### Description
This change adds close button and a (non-functioning yet) "more options" button at the top of
the fire dialog, and updates the footer to contain a checkbox and a confirmation button.

### Testing Steps
The changes only affect header and footer. The dialog content in the middle is expected to be slightly broken, so please don't bother :)

1. Launch the app, ensure that `fireButtonSimplified` feature flag is on
2. Verify that the header and footer of the dialog look like this:

| <img width="438" height="684" alt="Screenshot 2026-07-14 at 10 59 20" src="https://github.com/user-attachments/assets/17d7b680-49ba-4a05-ac18-17f7e437298f" /> | <img width="433" height="606" alt="Screenshot 2026-07-14 at 10 59 27" src="https://github.com/user-attachments/assets/5f1f303d-1097-42bc-865a-ab20a29c184e" /> |
|---|---|

3. Verify that you can close the dialog using X button or Esc key.
4. Open History View, select multiple items and click Delete, verify that the dialog looks like this:
<img width="442" height="431" alt="Screenshot 2026-07-14 at 11 02 36" src="https://github.com/user-attachments/assets/06dadf4e-eeff-43e2-8e6f-a3376ca7dc8e" />

5. Disable `fireButtonSimplified` feature flag and verify that the old dialog is displayed.

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes under the simplified Fire UI flag; burn still uses the same `FireDialogResult` fields and existing coordinator logic.
> 
> **Overview**
> Redesigns the simplified **Fire** dialog chrome: a top **toolbar** with a working **close** control (Esc / cancel action) and a placeholder **More Options** (`menuDots`) button, while **Cancel** is removed from the footer.
> 
> The **tabs/windows** choice moves out of the main section list into the **footer** as a checkbox with new “after deleting” copy; the destructive action stays a single pill button (fixed width) and reads **Delete & Close** when that checkbox is on. Section layout is tightened (narrower dialog, padding/spacing), and **History** is now the first rounded section row.
> 
> Adds `menuDots16` to design-system glyphs and new `UserText` strings for toolbar/footer accessibility and labels. `Package.resolved` bumps **content-scope-scripts** to 15.12.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25224b2f641623a5eaaca72597ac1d4903acbfa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->