### PR TITLE
Remove escape-hatch feature flags (hideShortcut, actions, fireButton)

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -259,16 +259,6 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213336304802675
     case showNTPAfterIdleReturn
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214749215529034?focus=true
-    case escapeHatchActions
-
-    /// Surfaces the escape-hatch "delete tab" action as a dedicated Fire button on the card and removes it from the menu.
-    /// https://app.asana.com/1/137249556945/project/1211654189969294/task/1215358250572341?focus=true
-    case escapeHatchFireButton
-
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215530020470713?focus=true
-    case escapeHatchHideShortcut
-
     case crashReportOptInStatusResetting
 
     case screenTimeCleaning

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -350,16 +350,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/72649045549333/task/1213076120133808?focus=true
     case showNTPAfterIdleReturn
 
-    /// https://app.asana.com/1/137249556945/project/1208671677432066/task/1213821747548995?focus=true
-    case escapeHatchActions
-
-    /// Surfaces the escape-hatch "delete tab" action as a dedicated Fire button on the card and removes it from the menu.
-    /// https://app.asana.com/1/137249556945/project/1211654189969294/task/1215358250572341?focus=true
-    case escapeHatchFireButton
-
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215530020470713?focus=true
-    case escapeHatchHideShortcut
-
     /// Test-only feature flag for verifying UI test override mechanism.
     /// Used in Debug > UI Test Overrides screen.
     case uiTestFeatureFlag
@@ -758,12 +748,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(TabSwitcherTrackerCountSubfeature.featureEnabled))
         case .showNTPAfterIdleReturn:
             Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.showNTPAfterIdleReturn))
-        case .escapeHatchActions:
-            Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.escapeHatchActions))
-        case .escapeHatchFireButton:
-            Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.escapeHatchFireButton))
-        case .escapeHatchHideShortcut:
-            Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.escapeHatchHideShortcut))
         case .uiTestFeatureFlag:
             Config(source: .disabled)
         case .uiTestExperiment:

--- a/iOS/DuckDuckGo/AppLifecycle/IdleReturnEligibilityManager.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/IdleReturnEligibilityManager.swift
@@ -67,8 +67,8 @@ final class IdleReturnEligibilityManager: IdleReturnEligibilityManaging {
         self.isStillOnboarding = isStillOnboarding
         let storage: any ThrowingKeyedStoring<AfterInactivitySettingKeys> = keyValueStore.throwingKeyedStoring()
         self.returnToTabCardEnabledProvider = {
-            // The card is only hideable when the hide-shortcut feature is on; otherwise it's always shown.
-            !featureFlagger.isFeatureOn(.escapeHatchHideShortcut) || ((try? storage.lastTabShortcutEnabled) ?? true)
+            // The card is hidden only when the user has turned the shortcut off.
+            (try? storage.lastTabShortcutEnabled) ?? true
         }
         self.effectiveOptionResolver = AfterInactivityEffectiveOptionResolver(storage: storage, featureFlagger: featureFlagger)
         self.thresholdResolver = IdleReturnThresholdResolver(

--- a/iOS/DuckDuckGo/EscapeHatchModel+Previews.swift
+++ b/iOS/DuckDuckGo/EscapeHatchModel+Previews.swift
@@ -45,7 +45,7 @@ extension EscapeHatchTabsSource where Self == StaticEscapeHatchTabsSource {
 
 extension EscapeHatchModel {
     /// Factory for #Preview / test code: stubs action closures as no-ops so call sites stay readable.
-    static func preview(title: String, subtitle: String, tabType: TabType, domain: String?, targetTab: Tab, tabCount: Int, isActionsEnabled: Bool = true, isFireButtonEnabled: Bool = false, isHideShortcutEnabled: Bool = false, afterInactivityOption: AfterInactivityOption = .lastUsedTab, keyValueStore: ThrowingKeyValueStoring = UserDefaults.standard) -> EscapeHatchModel {
+    static func preview(title: String, subtitle: String, tabType: TabType, domain: String?, targetTab: Tab, tabCount: Int, afterInactivityOption: AfterInactivityOption = .lastUsedTab, keyValueStore: ThrowingKeyValueStoring = UserDefaults.standard) -> EscapeHatchModel {
         EscapeHatchModel(
             title: title,
             subtitle: subtitle,
@@ -53,9 +53,6 @@ extension EscapeHatchModel {
             domain: domain,
             targetTab: targetTab,
             tabsSource: .staticTabsSource(count: tabCount, includes: targetTab),
-            isActionsEnabled: isActionsEnabled,
-            isFireButtonEnabled: isFireButtonEnabled,
-            isHideShortcutEnabled: isHideShortcutEnabled,
             afterInactivityOptionAdapter: AfterInactivityOptionAdapter(
                 initialOption: afterInactivityOption,
                 keyValueStore: keyValueStore

--- a/iOS/DuckDuckGo/EscapeHatchModel.swift
+++ b/iOS/DuckDuckGo/EscapeHatchModel.swift
@@ -76,13 +76,6 @@ final class EscapeHatchModel: ObservableObject {
     let targetTab: Tab
     /// `false` for tab-switcher-only hatches, so the card never appears (it would be empty: no tab to return to).
     let hasReturnToTabCard: Bool
-    let isActionsEnabled: Bool
-    /// When on, the destructive "delete tab" action is surfaced as a dedicated Fire button on the card
-    /// instead of (and removed from) the three-dots menu. Gated by the `escapeHatchFireButton` feature flag.
-    let isFireButtonEnabled: Bool
-    /// When on, the "Hide These Shortcuts" menu item is surfaced and the card can be hidden, leaving only the tab
-    /// switcher pill. Gated by the `escapeHatchHideShortcut` feature flag.
-    let isHideShortcutEnabled: Bool
     let onCardTap: () -> Void
     let onTabSwitcherTap: () -> Void
     let onCloseTab: () -> Void
@@ -99,9 +92,6 @@ final class EscapeHatchModel: ObservableObject {
          domain: String?,
          targetTab: Tab,
          tabsSource: some EscapeHatchTabsSource,
-         isActionsEnabled: Bool,
-         isFireButtonEnabled: Bool = false,
-         isHideShortcutEnabled: Bool = false,
          hasReturnToTabCard: Bool = true,
          afterInactivityOptionAdapter: AfterInactivityOptionAdapter,
          lastTabShortcutAdapter: LastTabShortcutAdapter,
@@ -119,9 +109,6 @@ final class EscapeHatchModel: ObservableObject {
         self.domain = domain
         self.targetTab = targetTab
         self.hasReturnToTabCard = hasReturnToTabCard
-        self.isActionsEnabled = isActionsEnabled
-        self.isFireButtonEnabled = isFireButtonEnabled
-        self.isHideShortcutEnabled = isHideShortcutEnabled
         self.afterInactivityOptionAdapter = afterInactivityOptionAdapter
         self.lastTabShortcutAdapter = lastTabShortcutAdapter
         self.onCardTap = onCardTap
@@ -140,7 +127,7 @@ final class EscapeHatchModel: ObservableObject {
 
     /// Builds the model with action closures wired to a router. The router is captured weakly so holders of `EscapeHatchModel` don't pin its owner's lifecycle.
     ///
-    convenience init(title: String, subtitle: String, tabType: TabType, domain: String?, targetTab: Tab, tabsSource: some EscapeHatchTabsSource, hasReturnToTabCard: Bool = true, router: EscapeHatchActionRouter, featureFlagger: FeatureFlagger, afterInactivityOptionAdapter: AfterInactivityOptionAdapter, lastTabShortcutAdapter: LastTabShortcutAdapter, onShortcutHidden: @escaping () -> Void = {}, instrumentation: NTPAfterIdleInstrumentation? = nil) {
+    convenience init(title: String, subtitle: String, tabType: TabType, domain: String?, targetTab: Tab, tabsSource: some EscapeHatchTabsSource, hasReturnToTabCard: Bool = true, router: EscapeHatchActionRouter, afterInactivityOptionAdapter: AfterInactivityOptionAdapter, lastTabShortcutAdapter: LastTabShortcutAdapter, onShortcutHidden: @escaping () -> Void = {}, instrumentation: NTPAfterIdleInstrumentation? = nil) {
         self.init(
             title: title,
             subtitle: subtitle,
@@ -148,9 +135,6 @@ final class EscapeHatchModel: ObservableObject {
             domain: domain,
             targetTab: targetTab,
             tabsSource: tabsSource,
-            isActionsEnabled: featureFlagger.isFeatureOn(.escapeHatchActions),
-            isFireButtonEnabled: featureFlagger.isFeatureOn(.escapeHatchFireButton),
-            isHideShortcutEnabled: featureFlagger.isFeatureOn(.escapeHatchHideShortcut),
             hasReturnToTabCard: hasReturnToTabCard,
             afterInactivityOptionAdapter: afterInactivityOptionAdapter,
             lastTabShortcutAdapter: lastTabShortcutAdapter,
@@ -181,7 +165,6 @@ final class EscapeHatchModel: ObservableObject {
     convenience init(tabSwitcherOnlyTargetTab targetTab: Tab,
                      tabsSource: some EscapeHatchTabsSource,
                      router: EscapeHatchActionRouter,
-                     featureFlagger: FeatureFlagger,
                      afterInactivityOptionAdapter: AfterInactivityOptionAdapter,
                      lastTabShortcutAdapter: LastTabShortcutAdapter) {
         self.init(
@@ -193,7 +176,6 @@ final class EscapeHatchModel: ObservableObject {
             tabsSource: tabsSource,
             hasReturnToTabCard: false,
             router: router,
-            featureFlagger: featureFlagger,
             afterInactivityOptionAdapter: afterInactivityOptionAdapter,
             lastTabShortcutAdapter: lastTabShortcutAdapter
         )
@@ -234,9 +216,9 @@ extension EscapeHatchModel {
         onShortcutHidden()
     }
 
-    /// Enabled unless the hide feature is on and the user has turned the shortcut off.
+    /// Enabled unless the user has turned the shortcut off.
     var isLastTabShortcutEnabled: Bool {
-        isHideShortcutEnabled ? lastTabShortcutAdapter.isEnabled : true
+        lastTabShortcutAdapter.isEnabled
     }
 
     /// The card shows only while its target tab is open and the user hasn't hidden the shortcut; otherwise

--- a/iOS/DuckDuckGo/EscapeHatchModel.swift
+++ b/iOS/DuckDuckGo/EscapeHatchModel.swift
@@ -39,7 +39,7 @@ extension TabManager: EscapeHatchTabsSource {
 
 /// Single sink for the four escape-hatch verbs. Implemented by the object that actually fulfils the
 /// actions (today: `MainViewController`). Constructors that want to build an `EscapeHatchModel` without
-/// hand-bundling closures hold a weak reference to this and use `EscapeHatchModel(...,router:featureFlagger:)`.
+/// hand-bundling closures hold a weak reference to this and use `EscapeHatchModel(...,router:)`.
 protocol EscapeHatchActionRouter: AnyObject {
     func escapeHatchDidRequestSwitch(to tab: Tab)
     func escapeHatchDidRequestClose(_ tab: Tab)

--- a/iOS/DuckDuckGo/EscapeHatchModelBuilder.swift
+++ b/iOS/DuckDuckGo/EscapeHatchModelBuilder.swift
@@ -28,7 +28,6 @@ struct EscapeHatchModelBuilder {
     let tabManager: TabManager
     let lastActiveTabStore: LastActiveTabStoring
     let idleReturnEligibilityManager: IdleReturnEligibilityManaging
-    let featureFlagger: FeatureFlagger
     let afterInactivityOptionAdapter: AfterInactivityOptionAdapter
     let lastTabShortcutAdapter: LastTabShortcutAdapter
     let instrumentation: NTPAfterIdleInstrumentation
@@ -52,7 +51,7 @@ struct EscapeHatchModelBuilder {
         }
 
         // No tab to return to. When the shortcut is hidden, still show the expanded pill (even with one tab).
-        if featureFlagger.isFeatureOn(.escapeHatchHideShortcut), !lastTabShortcutAdapter.isEnabled, let currentTab {
+        if !lastTabShortcutAdapter.isEnabled, let currentTab {
             return makeTabSwitcherOnly(targetTab: currentTab, router: router)
         }
 
@@ -66,7 +65,6 @@ struct EscapeHatchModelBuilder {
             tabSwitcherOnlyTargetTab: targetTab,
             tabsSource: tabManager,
             router: router,
-            featureFlagger: featureFlagger,
             afterInactivityOptionAdapter: afterInactivityOptionAdapter,
             lastTabShortcutAdapter: lastTabShortcutAdapter
         )
@@ -108,7 +106,6 @@ struct EscapeHatchModelBuilder {
             targetTab: targetTab,
             tabsSource: tabManager,
             router: router,
-            featureFlagger: featureFlagger,
             afterInactivityOptionAdapter: afterInactivityOptionAdapter,
             lastTabShortcutAdapter: lastTabShortcutAdapter,
             onShortcutHidden: { [instrumentation] in instrumentation.escapeHatchHiddenFromMenu() },

--- a/iOS/DuckDuckGo/EscapeHatchView.swift
+++ b/iOS/DuckDuckGo/EscapeHatchView.swift
@@ -33,7 +33,7 @@ struct EscapeHatchView: View {
 
             TabSwitcherPill(count: model.openTabCount,
                             isExpanded: !model.isReturnToTabCardVisible,
-                            showsEndArrow: !model.isHideShortcutEnabled,
+                            showsEndArrow: false,
                             onTap: model.onTabSwitcherTap)
                 .frame(maxWidth: model.isReturnToTabCardVisible ? TabSwitcherPill.compactSize : .infinity)
                 .frame(height: TabSwitcherPill.compactSize)

--- a/iOS/DuckDuckGo/EscapeHatchView.swift
+++ b/iOS/DuckDuckGo/EscapeHatchView.swift
@@ -33,7 +33,6 @@ struct EscapeHatchView: View {
 
             TabSwitcherPill(count: model.openTabCount,
                             isExpanded: !model.isReturnToTabCardVisible,
-                            showsEndArrow: false,
                             onTap: model.onTabSwitcherTap)
                 .frame(maxWidth: model.isReturnToTabCardVisible ? TabSwitcherPill.compactSize : .infinity)
                 .frame(height: TabSwitcherPill.compactSize)

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1741,7 +1741,7 @@ class MainViewController: UIViewController {
 
     /// True for escape-hatch burns — these handle focus themselves in `restoreFocusModeAfterBurnIfNeeded`,
     /// so the generic post-fire keyboard fallback is skipped for them.
-    private func isEscapeHatchHideBurn(_ request: FireRequest) -> Bool {
+    private func isEscapeHatchBurn(_ request: FireRequest) -> Bool {
         request.source == .escapeHatch
     }
 
@@ -6403,7 +6403,7 @@ extension MainViewController {
             // Ideally this should happen once data clearing has finished AND the animation is finished
             if showNextDaxDialog {
                 self.newTabPageViewController?.showNextDaxDialog()
-            } else if request.options.contains(.tabs) && KeyboardSettings().onNewTab && !self.isEscapeHatchHideBurn(request) {
+            } else if request.options.contains(.tabs) && KeyboardSettings().onNewTab && !self.isEscapeHatchBurn(request) {
                 // Escape-hatch burns restore focus in `restoreFocusModeAfterBurnIfNeeded`.
                 let showKeyboardAfterFireButton = DispatchWorkItem {
                     if !self.aiChatSettings.isAIChatSearchInputUserSettingsEnabled {
@@ -6435,7 +6435,7 @@ extension MainViewController {
     private func presentPostBurnMessage(tabsCount: Int, request: FireRequest) {
         let message = UserText.scopedFireConfirmationTabsDeletedToast(tabCount: tabsCount)
         // Escape-hatch-hide burns restore the keyboard, which would cover a bottom toast — show it at the top.
-        let location: ActionMessageView.PresentationLocation = isEscapeHatchHideBurn(request)
+        let location: ActionMessageView.PresentationLocation = isEscapeHatchBurn(request)
             ? .top
             : .withBottomBar(andAddressBarBottom: self.appSettings.currentAddressBarPosition.isBottom)
         ActionMessageView.present(message: message, presentationLocation: location)

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1704,7 +1704,6 @@ class MainViewController: UIViewController {
         tabManager: tabManager,
         lastActiveTabStore: lastActiveTabStore,
         idleReturnEligibilityManager: idleReturnEligibilityManager,
-        featureFlagger: featureFlagger,
         afterInactivityOptionAdapter: afterInactivityOptionAdapter,
         lastTabShortcutAdapter: lastTabShortcutAdapter,
         instrumentation: ntpAfterIdleInstrumentation
@@ -1712,8 +1711,7 @@ class MainViewController: UIViewController {
 
     /// Re-presents the tab switcher after a burn. No-op when the feature is off or the user has left the NTP.
     private func restoreTabSwitcherOnlyHatchAfterBurn() {
-        guard featureFlagger.isFeatureOn(.escapeHatchHideShortcut),
-              let controller = newTabPageViewController,
+        guard let controller = newTabPageViewController,
               let currentTab = tabManager.currentTabsModel.currentTab,
               currentTab.fireTab == false else {
             return
@@ -1745,7 +1743,7 @@ class MainViewController: UIViewController {
     /// `restoreFocusModeAfterBurnIfNeeded`, so the generic post-fire keyboard fallback is skipped for them.
     /// With the feature off, escape-hatch burns keep the original fire behaviour.
     private func isEscapeHatchHideBurn(_ request: FireRequest) -> Bool {
-        request.source == .escapeHatch && featureFlagger.isFeatureOn(.escapeHatchHideShortcut)
+        request.source == .escapeHatch
     }
 
     private func buildEscapeHatch(openedAfterIdle: Bool) -> EscapeHatchModel? {
@@ -5387,13 +5385,6 @@ extension MainViewController: EscapeHatchActionRouter {
 
         // Keep the hatch (and the current focus state) so the card collapses to the expanded pill,
         // consistent with the delete flow which also preserves focus.
-        if featureFlagger.isFeatureOn(.escapeHatchHideShortcut) {
-            return
-        }
-
-        /// # TODO: Invoking `closeTab` removes the Escape Hatch from screen
-        clearEscapeHatch()
-        dismissOmniBar()
     }
 
     func escapeHatchDidRequestBurnWithConfirmation(_ tab: Tab, sourceRect: CGRect) {
@@ -5415,14 +5406,9 @@ extension MainViewController: EscapeHatchActionRouter {
             fireContext: .singleTab,
             browsingMode: tab.mode,
             onConfirm: { [weak self] fireRequest in
-                if self?.featureFlagger.isFeatureOn(.escapeHatchHideShortcut) == true {
-                    self?.forgetAllWithAnimation(request: fireRequest) { [weak self] in
-                        self?.restoreTabSwitcherOnlyHatchAfterBurn()
-                        self?.restoreFocusModeAfterBurnIfNeeded(wasInFocusMode: wasInFocusMode)
-                    }
-                } else {
-                    self?.forgetAllWithAnimation(request: fireRequest) {}
-                    self?.clearEscapeHatch()
+                self?.forgetAllWithAnimation(request: fireRequest) { [weak self] in
+                    self?.restoreTabSwitcherOnlyHatchAfterBurn()
+                    self?.restoreFocusModeAfterBurnIfNeeded(wasInFocusMode: wasInFocusMode)
                 }
                 self?.postIdleSessionInstrumentation.burnTabTapped()
             },
@@ -5448,14 +5434,9 @@ extension MainViewController: EscapeHatchActionRouter {
             source: .escapeHatch
         )
 
-        if featureFlagger.isFeatureOn(.escapeHatchHideShortcut) {
-            forgetAllWithAnimation(request: request) { [weak self] in
-                self?.restoreTabSwitcherOnlyHatchAfterBurn()
-                self?.restoreFocusModeAfterBurnIfNeeded(wasInFocusMode: wasInFocusMode)
-            }
-        } else {
-            forgetAllWithAnimation(request: request) {}
-            clearEscapeHatch()
+        forgetAllWithAnimation(request: request) { [weak self] in
+            self?.restoreTabSwitcherOnlyHatchAfterBurn()
+            self?.restoreFocusModeAfterBurnIfNeeded(wasInFocusMode: wasInFocusMode)
         }
         ntpAfterIdleInstrumentation.escapeHatchBurnTapped(requiredConfirmation: false)
         postIdleSessionInstrumentation.burnTabTapped()

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1709,7 +1709,7 @@ class MainViewController: UIViewController {
         instrumentation: ntpAfterIdleInstrumentation
     )
 
-    /// Re-presents the tab switcher after a burn. No-op when the feature is off or the user has left the NTP.
+    /// Re-presents the tab switcher after a burn. No-op when the NTP isn't showing.
     private func restoreTabSwitcherOnlyHatchAfterBurn() {
         guard let controller = newTabPageViewController,
               let currentTab = tabManager.currentTabsModel.currentTab,
@@ -1739,9 +1739,8 @@ class MainViewController: UIViewController {
         }
     }
 
-    /// True for escape-hatch burns while the hide feature is on — these handle focus themselves in
-    /// `restoreFocusModeAfterBurnIfNeeded`, so the generic post-fire keyboard fallback is skipped for them.
-    /// With the feature off, escape-hatch burns keep the original fire behaviour.
+    /// True for escape-hatch burns — these handle focus themselves in `restoreFocusModeAfterBurnIfNeeded`,
+    /// so the generic post-fire keyboard fallback is skipped for them.
     private func isEscapeHatchHideBurn(_ request: FireRequest) -> Bool {
         request.source == .escapeHatch
     }
@@ -6405,7 +6404,7 @@ extension MainViewController {
             if showNextDaxDialog {
                 self.newTabPageViewController?.showNextDaxDialog()
             } else if request.options.contains(.tabs) && KeyboardSettings().onNewTab && !self.isEscapeHatchHideBurn(request) {
-                // With the hide feature on, escape-hatch burns restore focus in `restoreFocusModeAfterBurnIfNeeded`.
+                // Escape-hatch burns restore focus in `restoreFocusModeAfterBurnIfNeeded`.
                 let showKeyboardAfterFireButton = DispatchWorkItem {
                     if !self.aiChatSettings.isAIChatSearchInputUserSettingsEnabled {
                         self.enterSearch()

--- a/iOS/DuckDuckGo/ReturnToTabCard.swift
+++ b/iOS/DuckDuckGo/ReturnToTabCard.swift
@@ -36,11 +36,7 @@ struct ReturnToTabCard: View {
 
     var body: some View {
         GeometryReader { proxy in
-            if model.isActionsEnabled {
-                bodyWithActions(width: proxy.size.width)
-            } else {
-                contentView
-            }
+            bodyWithActions(width: proxy.size.width)
         }
         .frame(height: Metrics.height)
     }
@@ -68,9 +64,7 @@ struct ReturnToTabCard: View {
     private var contentView: some View {
         HStack(spacing: Metrics.innerSpacing) {
             mainView
-            if model.isActionsEnabled {
-                actionButtonsView
-            }
+            actionButtonsView
         }
         .padding(contentPaddingEdges, Metrics.horizontalPadding)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -83,7 +77,7 @@ struct ReturnToTabCard: View {
 
     private var contentPaddingEdges: Edge.Set {
         /// Avoid trailing padding when the Menu is visible
-        model.isActionsEnabled ? .leading : .horizontal
+        .leading
     }
 
     private var mainView: some View {
@@ -116,9 +110,7 @@ struct ReturnToTabCard: View {
     /// Trailing controls: when enabled, the Fire (delete tab) button sits to the left of the three-dots menu.
     private var actionButtonsView: some View {
         HStack(spacing: 0) {
-            if model.isFireButtonEnabled {
-                fireButton
-            }
+            fireButton
             menuView
         }
     }
@@ -149,8 +141,8 @@ struct ReturnToTabCard: View {
         } label: {
             Image(uiImage: DesignSystemImages.Glyphs.Size24.menuDotsHorizontal)
                 .foregroundColor(Color(designSystemColor: .icons))
-                // Tighten the leading gap to the Fire button when it's present; otherwise keep the original padding.
-                .padding(.leading, model.isFireButtonEnabled ? Metrics.actionIconPadding : Metrics.horizontalPadding)
+                // Tighten the leading gap to the Fire button.
+                .padding(.leading, Metrics.actionIconPadding)
                 .padding(.trailing, Metrics.horizontalPadding)
                 .frame(maxHeight: .infinity)
                 .contentShape(Rectangle())
@@ -170,18 +162,14 @@ struct ReturnToTabCard: View {
                 action: model.returnToTabFromMenu
             )
             destructiveActionButtons
-            if model.isHideShortcutEnabled{
-                Section {
-                    afterInactivityPicker
-                    MenuActionButton(
-                        text: UserText.escapeHatchMenuHideTheseShortcuts,
-                        icon: DesignSystemImages.Glyphs.Size16.eyeClosed,
-                        role: .none,
-                        action: model.hideShortcut
-                    )
-                }
-            } else {
+            Section {
                 afterInactivityPicker
+                MenuActionButton(
+                    text: UserText.escapeHatchMenuHideTheseShortcuts,
+                    icon: DesignSystemImages.Glyphs.Size16.eyeClosed,
+                    role: .none,
+                    action: model.hideShortcut
+                )
             }
         }
         .onAppear { model.menuDidAppear() }
@@ -189,31 +177,14 @@ struct ReturnToTabCard: View {
 
     @ViewBuilder
     private var destructiveActionButtons: some View {
-        if model.isFireTab {
-            // When the Fire button is enabled, deleting is handled by that button instead of the menu.
-            if !model.isFireButtonEnabled {
-                MenuActionButton(
-                    text: UserText.escapeHatchMenuDeleteTab,
-                    icon: DesignSystemImages.Glyphs.Size16.fire,
-                    role: .destructive,
-                    action: model.burnImmediatelyFromMenu
-                )
-            }
-        } else {
+        // Deleting is handled by the dedicated Fire button on the card, not the menu.
+        if !model.isFireTab {
             MenuActionButton(
                 text: UserText.escapeHatchMenuCloseTab,
                 icon: DesignSystemImages.Glyphs.Size16.closeOutline,
                 role: .destructive,
                 action: model.closeTabFromMenu
             )
-            if !model.isFireButtonEnabled {
-                MenuActionButton(
-                    text: UserText.escapeHatchMenuDeleteTab,
-                    icon: DesignSystemImages.Glyphs.Size16.fire,
-                    role: .destructive,
-                    action: { model.burnWithConfirmationFromMenu(menuFrameInWindow) }
-                )
-            }
         }
     }
 
@@ -434,8 +405,7 @@ private enum Metrics {
                                     tabType: .regular,
                                     domain: "en.wikipedia.org",
                                     targetTab: target,
-                                    tabCount: 9,
-                                    isFireButtonEnabled: true))
+                                    tabCount: 9))
         .padding()
         .frame(width: 360)
 }

--- a/iOS/DuckDuckGo/SettingsGeneralView.swift
+++ b/iOS/DuckDuckGo/SettingsGeneralView.swift
@@ -84,11 +84,9 @@ struct SettingsGeneralView: View {
                                                options: AfterInactivityIdleInterval.allCases,
                                                selectedOption: viewModel.afterInactivityIdleIntervalBinding)
 
-                        if viewModel.shouldShowLastTabShortcutSetting {
-                            SettingsCellView(label: UserText.settingsLastTabShortcutLabel,
-                                             subtitle: UserText.settingsLastTabShortcutSubtitle,
-                                             accessory: .toggle(isOn: viewModel.lastTabShortcutEnabledBinding))
-                        }
+                        SettingsCellView(label: UserText.settingsLastTabShortcutLabel,
+                                         subtitle: UserText.settingsLastTabShortcutSubtitle,
+                                         accessory: .toggle(isOn: viewModel.lastTabShortcutEnabledBinding))
                     }
                 }
             }

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -418,10 +418,6 @@ final class SettingsViewModel: ObservableObject {
         featureFlagger.isFeatureOn(.showNTPAfterIdleReturn)
     }
 
-    var shouldShowLastTabShortcutSetting: Bool {
-        featureFlagger.isFeatureOn(.escapeHatchHideShortcut)
-    }
-
     var lastTabShortcutEnabledBinding: Binding<Bool> {
         Binding<Bool>(
             get: { self.lastTabShortcutAdapter.isEnabled },

--- a/iOS/DuckDuckGo/TabSwitcherPill.swift
+++ b/iOS/DuckDuckGo/TabSwitcherPill.swift
@@ -28,15 +28,13 @@ struct TabSwitcherPill: View {
 
     let count: Int
     let isExpanded: Bool
-    let showsEndArrow: Bool
     let onTap: () -> Void
 
     @StateObject private var tabCountModel: TabCountModel
 
-    init(count: Int, isExpanded: Bool = false, showsEndArrow: Bool = true, onTap: @escaping () -> Void) {
+    init(count: Int, isExpanded: Bool = false, onTap: @escaping () -> Void) {
         self.count = count
         self.isExpanded = isExpanded
-        self.showsEndArrow = showsEndArrow
         self.onTap = onTap
         // Seed the model with the correct count up front so the badge
         // renders with the number on the first frame instead of flashing empty.
@@ -83,12 +81,6 @@ struct TabSwitcherPill: View {
             .transition(.move(edge: .trailing).combined(with: .opacity))
 
         Spacer(minLength: 0)
-
-        if showsEndArrow {
-            Image(uiImage: DesignSystemImages.Glyphs.Size24.arrowRight)
-                .foregroundColor(Color(designSystemColor: .icons))
-                .transition(.move(edge: .trailing).combined(with: .opacity))
-        }
     }
 
     private enum Metrics {

--- a/iOS/DuckDuckGoTests/EscapeHatchModelTests.swift
+++ b/iOS/DuckDuckGoTests/EscapeHatchModelTests.swift
@@ -75,7 +75,6 @@ struct EscapeHatchModelTests {
 
     private func makeSUT(targetTab: Tab,
                          router: EscapeHatchActionRouter,
-                         featureFlagger: FeatureFlagger = MockFeatureFlagger(),
                          lastTabShortcutAdapter: LastTabShortcutAdapter = LastTabShortcutAdapter(keyValueStore: MockKeyValueFileStore()),
                          onShortcutHidden: @escaping () -> Void = {},
                          instrumentation: NTPAfterIdleInstrumentation? = nil) -> EscapeHatchModel {
@@ -87,7 +86,6 @@ struct EscapeHatchModelTests {
             targetTab: targetTab,
             tabsSource: StaticEscapeHatchTabsSource(tabs: [targetTab]),
             router: router,
-            featureFlagger: featureFlagger,
             afterInactivityOptionAdapter: AfterInactivityOptionAdapter(
                 initialOption: .lastUsedTab,
                 keyValueStore: MockKeyValueFileStore()
@@ -142,46 +140,12 @@ struct EscapeHatchModelTests {
     }
 
     @available(iOS 16, *)
-    @Test("isFireButtonEnabled is false when the escapeHatchFireButton flag is off", .timeLimit(.minutes(1)))
-    func fireButtonDisabledWhenFlagOff() {
-        let sut = makeSUT(targetTab: Tab(uid: "tab"),
-                          router: SpyRouter(),
-                          featureFlagger: MockFeatureFlagger())
-
-        #expect(sut.isFireButtonEnabled == false)
-    }
-
-    @available(iOS 16, *)
-    @Test("isFireButtonEnabled is true when the escapeHatchFireButton flag is on", .timeLimit(.minutes(1)))
-    func fireButtonEnabledWhenFlagOn() {
-        let flagger = MockFeatureFlagger(enabledFeatureFlags: [.escapeHatchFireButton])
-        let sut = makeSUT(targetTab: Tab(uid: "tab"),
-                          router: SpyRouter(),
-                          featureFlagger: flagger)
-
-        #expect(sut.isFireButtonEnabled == true)
-    }
-
-    @available(iOS 16, *)
-    @Test("isHideShortcutEnabled tracks the escapeHatchHideShortcut flag", .timeLimit(.minutes(1)))
-    func hideShortcutEnabledTracksFlag() {
-        let off = makeSUT(targetTab: Tab(uid: "tab"), router: SpyRouter(), featureFlagger: MockFeatureFlagger())
-        #expect(off.isHideShortcutEnabled == false)
-
-        let on = makeSUT(targetTab: Tab(uid: "tab"),
-                         router: SpyRouter(),
-                         featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.escapeHatchHideShortcut]))
-        #expect(on.isHideShortcutEnabled == true)
-    }
-
-    @available(iOS 16, *)
     @Test("hideShortcut disables the setting and reports telemetry", .timeLimit(.minutes(1)))
     func hideShortcutDisablesAndReports() {
         let adapter = LastTabShortcutAdapter(keyValueStore: MockKeyValueFileStore())
         var hiddenReports = 0
         let sut = makeSUT(targetTab: Tab(uid: "tab"),
                           router: SpyRouter(),
-                          featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.escapeHatchHideShortcut]),
                           lastTabShortcutAdapter: adapter,
                           onShortcutHidden: { hiddenReports += 1 })
 
@@ -197,7 +161,6 @@ struct EscapeHatchModelTests {
         let adapter = LastTabShortcutAdapter(keyValueStore: MockKeyValueFileStore())
         let sut = makeSUT(targetTab: Tab(uid: "tab"),
                           router: SpyRouter(),
-                          featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.escapeHatchHideShortcut]),
                           lastTabShortcutAdapter: adapter)
 
         // Target tab is present, so the card is visible while the shortcut is enabled.
@@ -205,20 +168,6 @@ struct EscapeHatchModelTests {
 
         adapter.setEnabled(false)
         #expect(sut.isReturnToTabCardVisible == false)
-    }
-
-    @available(iOS 16, *)
-    @Test("Shortcut is always considered enabled when the hide feature is unavailable", .timeLimit(.minutes(1)))
-    func shortcutAlwaysEnabledWhenFeatureUnavailable() {
-        let adapter = LastTabShortcutAdapter(keyValueStore: MockKeyValueFileStore())
-        adapter.setEnabled(false)
-        let sut = makeSUT(targetTab: Tab(uid: "tab"),
-                          router: SpyRouter(),
-                          featureFlagger: MockFeatureFlagger(),
-                          lastTabShortcutAdapter: adapter)
-
-        #expect(sut.isLastTabShortcutEnabled == true)
-        #expect(sut.isReturnToTabCardVisible == true)
     }
 
     // MARK: - Surface-attributed telemetry


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1215530020470713

Tech Design URL:
CC:

### Description

The three escape-hatch feature flags — `escapeHatchHideShortcut`, `escapeHatchActions`, and `escapeHatchFireButton` — are removed, leaving the escape-hatch ("Return to…" card shown on the New Tab Page after idle) permanently in its enabled state on iOS. All the code that only existed to gate the old vs new behaviour is deleted.


### Testing Steps

1. Open the app, browse to a page in a tab, background the app long enough to trigger idle, then reopen → the New Tab Page shows the "Return to…" card.
2. On the card, confirm the Fire (delete tab) button is shown next to the three-dots menu.
3. Open the three-dots menu → it lists "Return to Tab", "Close Tab" (for a normal tab), the after-inactivity picker, and "Hide These Shortcuts".
4. Tap the Fire button on a normal tab → a delete confirmation appears; confirm → the tab is burned and the card collapses to the tab-switcher pill.
5. Swipe the card → the swipe action fires (card actions enabled).
6. Tap "Hide These Shortcuts" → the card is hidden, leaving only the tab-switcher pill.
7. Settings → General → the "Last tab shortcut" row is present and its toggle works.

### Impact

Medium — affects the NTP-after-idle escape-hatch UI on iOS.

#### What could go wrong?

### Quality Considerations


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b7922a9dc6fb26af7ae957534224494397a3b8f4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->