### PR TITLE
macOS: Duck.ai page-context attachability gate 

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextAttachabilityPolicy.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextAttachabilityPolicy.swift
@@ -1,0 +1,82 @@
+//
+//  PageContextAttachabilityPolicy.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public struct PageContextAttachabilityVerdict: Equatable {
+    public let isAttachable: Bool
+    public let preventionReason: String?
+
+    static let attachable = PageContextAttachabilityVerdict(isAttachable: true, preventionReason: nil)
+
+    static func prevented(_ reason: String) -> PageContextAttachabilityVerdict {
+        PageContextAttachabilityVerdict(isAttachable: false, preventionReason: reason)
+    }
+}
+
+public struct PageContextAttachabilityPolicy {
+    private let settings: PageContextBlocklistSettings
+
+    public init(settings: PageContextBlocklistSettings) {
+        self.settings = settings
+    }
+
+    public func verdict(url: URL?, mimeType: String?) -> PageContextAttachabilityVerdict {
+        guard let url else {
+            return .prevented(PageContextExtractionOutcome.internalPageCategory)
+        }
+        if url.absoluteString == "about:blank" || url.isDuckAIURL {
+            return .prevented(PageContextExtractionOutcome.internalPageCategory)
+        }
+
+        if let mimeType, !mimeType.isEmpty {
+            if let category = category(forMIMEType: mimeType) {
+                return .prevented(category)
+            }
+            return .attachable
+        }
+
+        if let category = category(forExtension: url.pathExtension) {
+            return .prevented(category)
+        }
+
+        return .attachable
+    }
+
+    private func category(forMIMEType mimeType: String) -> String? {
+        let lowered = mimeType.lowercased()
+        for (name, rule) in settings.categories {
+            if rule.contentTypes?.contains(where: { $0.lowercased() == lowered }) == true {
+                return name
+            }
+            if rule.contentTypePrefixes?.contains(where: { lowered.hasPrefix($0.lowercased()) }) == true {
+                return name
+            }
+        }
+        return nil
+    }
+
+    private func category(forExtension pathExtension: String) -> String? {
+        guard !pathExtension.isEmpty else { return nil }
+        let dotted = "." + pathExtension.lowercased()
+        for (name, rule) in settings.categories where rule.urlExtensions?.contains(where: { $0.lowercased() == dotted }) == true {
+            return name
+        }
+        return nil
+    }
+}

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextBlocklistSettings.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextBlocklistSettings.swift
@@ -1,0 +1,49 @@
+//
+//  PageContextBlocklistSettings.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public struct MediaCategoryRule: Codable, Equatable {
+    public let urlExtensions: [String]?
+    public let contentTypes: [String]?
+    public let contentTypePrefixes: [String]?
+
+    public init(urlExtensions: [String]? = nil, contentTypes: [String]? = nil, contentTypePrefixes: [String]? = nil) {
+        self.urlExtensions = urlExtensions
+        self.contentTypes = contentTypes
+        self.contentTypePrefixes = contentTypePrefixes
+    }
+}
+
+public struct PageContextBlocklistSettings: Equatable {
+    public let categories: [String: MediaCategoryRule]
+
+    public init(categories: [String: MediaCategoryRule]) {
+        self.categories = categories
+    }
+
+    public init?(blocklist: Any?) {
+        guard let dict = blocklist as? [String: Any], !dict.isEmpty,
+              let data = try? JSONSerialization.data(withJSONObject: dict),
+              let decoded = try? JSONDecoder().decode([String: MediaCategoryRule].self, from: data),
+              !decoded.isEmpty else {
+            return nil
+        }
+        self.categories = decoded
+    }
+}

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextExtractionOutcome.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextExtractionOutcome.swift
@@ -21,10 +21,12 @@ import Foundation
 public enum PageContextExtractionOutcome: Equatable {
 
     public enum FailureReason: String, Equatable {
-        case emptyContent
+        case emptyContent = "empty_content"
+        case deserializeFailed = "deserialize_failed"
         case timeout
-        case malformed
-        case unavailable
+        case noWebView = "no_webview"
+        case postFailed = "post_failed"
+        case tabEvicted = "tab_evicted"
     }
 
     case success
@@ -34,4 +36,27 @@ public enum PageContextExtractionOutcome: Equatable {
 
 public extension PageContextExtractionOutcome {
     static let internalPageCategory = "internalPage"
+}
+
+public enum PageContextExtractionTrigger: String, Equatable {
+    case auto
+    case navigation
+    case userRequest = "user_request"
+    case tabContent = "tab_content"
+}
+
+public enum PageContextExtractionLatencyBucket: String, Equatable {
+    case under1s = "under_1s"
+    case oneToFiveSeconds = "1_to_5s"
+    case over5s = "over_5s"
+
+    public init(seconds: TimeInterval) {
+        if seconds < 1 {
+            self = .under1s
+        } else if seconds <= 5 {
+            self = .oneToFiveSeconds
+        } else {
+            self = .over5s
+        }
+    }
 }

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextExtractionOutcome.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextExtractionOutcome.swift
@@ -1,0 +1,37 @@
+//
+//  PageContextExtractionOutcome.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public enum PageContextExtractionOutcome: Equatable {
+
+    public enum FailureReason: String, Equatable {
+        case emptyContent
+        case timeout
+        case malformed
+        case unavailable
+    }
+
+    case success
+    case failure(FailureReason)
+    case prevented(String)
+}
+
+public extension PageContextExtractionOutcome {
+    static let internalPageCategory = "internalPage"
+}

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextExtractionResolver.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextExtractionResolver.swift
@@ -1,0 +1,61 @@
+//
+//  PageContextExtractionResolver.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// Pairs page-context collection results with the requests that triggered them, FIFO, so extraction
+/// pixels carry the right trigger/latency when several collects overlap for one navigation.
+public struct PageContextExtractionResolver {
+
+    public struct Resolution: Equatable {
+        public let outcome: PageContextExtractionOutcome
+        public let trigger: PageContextExtractionTrigger
+        public let latency: PageContextExtractionLatencyBucket
+    }
+
+    private struct PendingCollection {
+        let trigger: PageContextExtractionTrigger
+        let startedAt: DispatchTime
+    }
+
+    private var pending: [PendingCollection] = []
+
+    public init() {}
+
+    public var hasPendingCollections: Bool { !pending.isEmpty }
+
+    public mutating func requested(trigger: PageContextExtractionTrigger, at startedAt: DispatchTime = .now()) {
+        pending.append(PendingCollection(trigger: trigger, startedAt: startedAt))
+    }
+
+    /// Returns `nil` when no request is outstanding (a duplicate or a collection we didn't initiate).
+    public mutating func resolve(pageContext: AIChatPageContextData?, now: DispatchTime = .now()) -> Resolution? {
+        guard !pending.isEmpty else { return nil }
+        let request = pending.removeFirst()
+
+        let outcome: PageContextExtractionOutcome
+        if let pageContext {
+            outcome = pageContext.isEmpty() ? .failure(.emptyContent) : .success
+        } else {
+            outcome = .failure(.deserializeFailed)
+        }
+
+        let seconds = Double(now.uptimeNanoseconds - request.startedAt.uptimeNanoseconds) / 1_000_000_000
+        return Resolution(outcome: outcome, trigger: request.trigger, latency: PageContextExtractionLatencyBucket(seconds: seconds))
+    }
+}

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextExtractionResolver.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextExtractionResolver.swift
@@ -44,6 +44,13 @@ public struct PageContextExtractionResolver {
         pending.append(PendingCollection(trigger: trigger, startedAt: startedAt))
     }
 
+    /// Drops all outstanding collects without emitting any resolution. Call on navigation so a
+    /// previous page's slow or never-resolving collect can't pair (FIFO) with the next page's
+    /// result and mis-attribute its trigger/latency/outcome.
+    public mutating func reset() {
+        pending.removeAll()
+    }
+
     /// Returns `nil` when no request is outstanding (a duplicate or a collection we didn't initiate).
     public mutating func resolve(pageContext: AIChatPageContextData?, now: DispatchTime = .now()) -> Resolution? {
         guard !pending.isEmpty else { return nil }

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextExtractionResolver.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextExtractionResolver.swift
@@ -25,7 +25,8 @@ public struct PageContextExtractionResolver {
     public struct Resolution: Equatable {
         public let outcome: PageContextExtractionOutcome
         public let trigger: PageContextExtractionTrigger
-        public let latency: PageContextExtractionLatencyBucket
+        /// Request-to-result time; `nil` when no result arrived (a timed-out collection).
+        public let latency: PageContextExtractionLatencyBucket?
     }
 
     private struct PendingCollection {
@@ -57,5 +58,22 @@ public struct PageContextExtractionResolver {
 
         let seconds = Double(now.uptimeNanoseconds - request.startedAt.uptimeNanoseconds) / 1_000_000_000
         return Resolution(outcome: outcome, trigger: request.trigger, latency: PageContextExtractionLatencyBucket(seconds: seconds))
+    }
+
+    /// Drops requests that have been outstanding for at least `timeout` and returns a
+    /// `.failure(.timeout)` resolution (no latency) for each, oldest first. A `collect()` that
+    /// never yields a result would otherwise leave its entry pending indefinitely.
+    public mutating func expireCollections(olderThan timeout: TimeInterval, now: DispatchTime = .now()) -> [Resolution] {
+        let cutoffNanos = UInt64(timeout * 1_000_000_000)
+        var expired: [Resolution] = []
+        pending.removeAll { request in
+            guard now.uptimeNanoseconds >= request.startedAt.uptimeNanoseconds,
+                  now.uptimeNanoseconds - request.startedAt.uptimeNanoseconds >= cutoffNanos else {
+                return false
+            }
+            expired.append(Resolution(outcome: .failure(.timeout), trigger: request.trigger, latency: nil))
+            return true
+        }
+        return expired
     }
 }

--- a/SharedPackages/AIChat/Tests/AIChatTests/PageContextAttachabilityPolicyTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/PageContextAttachabilityPolicyTests.swift
@@ -1,0 +1,128 @@
+//
+//  PageContextAttachabilityPolicyTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import AIChat
+
+final class PageContextAttachabilityPolicyTests: XCTestCase {
+
+    private var policy: PageContextAttachabilityPolicy {
+        let settings = PageContextBlocklistSettings(categories: [
+            "pdf": MediaCategoryRule(urlExtensions: [".pdf"], contentTypes: ["application/pdf"]),
+            "image": MediaCategoryRule(urlExtensions: [".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp"],
+                                       contentTypePrefixes: ["image/"]),
+            "video": MediaCategoryRule(urlExtensions: [".mp4", ".webm", ".avi", ".mov", ".mkv"],
+                                       contentTypePrefixes: ["video/"]),
+            "audio": MediaCategoryRule(urlExtensions: [".mp3", ".wav", ".ogg", ".flac", ".aac", ".m4a"],
+                                       contentTypePrefixes: ["audio/"]),
+            "archive": MediaCategoryRule(contentTypes: ["application/zip"])
+        ])
+        return PageContextAttachabilityPolicy(settings: settings)
+    }
+
+    private func url(_ s: String) -> URL { URL(string: s)! }
+
+    // MARK: Step 1 — special pages
+
+    func testWhenPlainPageThenAttachable() {
+        XCTAssertTrue(policy.verdict(url: url("https://example.com/article"), mimeType: "text/html").isAttachable)
+    }
+
+    func testWhenNilURLThenPreventedInternalPage() {
+        let v = policy.verdict(url: nil, mimeType: nil)
+        XCTAssertFalse(v.isAttachable)
+        XCTAssertEqual(v.preventionReason, PageContextExtractionOutcome.internalPageCategory)
+    }
+
+    func testWhenAboutBlankThenPreventedInternalPage() {
+        let v = policy.verdict(url: url("about:blank"), mimeType: nil)
+        XCTAssertEqual(v.preventionReason, PageContextExtractionOutcome.internalPageCategory)
+    }
+
+    func testWhenDuckAIHostThenPreventedInternalPage() {
+        XCTAssertEqual(policy.verdict(url: url("https://duck.ai"), mimeType: "text/html").preventionReason,
+                       PageContextExtractionOutcome.internalPageCategory)
+    }
+
+    func testWhenDDGInPageChatThenPreventedInternalPage() {
+        XCTAssertEqual(policy.verdict(url: url("https://duckduckgo.com/?ia=chat"), mimeType: "text/html").preventionReason,
+                       PageContextExtractionOutcome.internalPageCategory)
+    }
+
+    func testWhenSERPQueryThenAttachable() {
+        XCTAssertTrue(policy.verdict(url: url("https://duckduckgo.com/?q=bread+recipe"), mimeType: "text/html").isAttachable)
+    }
+
+    // MARK: Step 2 — MIME authoritative
+
+    func testWhenPDFContentTypeThenPreventedPDF() {
+        // extension-less URL serving application/pdf (e.g. .../download)
+        XCTAssertEqual(policy.verdict(url: url("https://example.com/download"), mimeType: "application/pdf").preventionReason, "pdf")
+    }
+
+    func testWhenImageContentTypePrefixThenPreventedImage() {
+        XCTAssertEqual(policy.verdict(url: url("https://example.com/pic"), mimeType: "image/png").preventionReason, "image")
+    }
+
+    func testWhenVideoContentTypePrefixThenPreventedVideo() {
+        XCTAssertEqual(policy.verdict(url: url("https://example.com/clip"), mimeType: "video/mp4").preventionReason, "video")
+    }
+
+    func testWhenAudioContentTypePrefixThenPreventedAudio() {
+        XCTAssertEqual(policy.verdict(url: url("https://example.com/song"), mimeType: "audio/mpeg").preventionReason, "audio")
+    }
+
+    func testWhenArbitraryCategoryContentTypeThenPreventedByCategory() {
+        XCTAssertEqual(policy.verdict(url: url("https://example.com/bundle"), mimeType: "application/zip").preventionReason, "archive")
+    }
+
+    func testWhenPNGURLButHTMLMIMEThenAttachable() {
+        // MIME is authoritative: a .png URL actually serving an HTML page stays attachable.
+        XCTAssertTrue(policy.verdict(url: url("https://example.com/photo.png"), mimeType: "text/html").isAttachable)
+    }
+
+    // MARK: Step 3 — extension fallback (MIME absent)
+
+    func testWhenPDFExtensionNoMIMEThenPreventedPDF() {
+        XCTAssertEqual(policy.verdict(url: url("https://example.com/report.PDF"), mimeType: nil).preventionReason, "pdf")
+    }
+
+    func testWhenImageExtensionNoMIMEThenPreventedImage() {
+        XCTAssertEqual(policy.verdict(url: url("https://example.com/photo.jpg"), mimeType: nil).preventionReason, "image")
+    }
+
+    func testWhenVideoExtensionNoMIMEThenPreventedVideo() {
+        XCTAssertEqual(policy.verdict(url: url("https://example.com/movie.mp4"), mimeType: nil).preventionReason, "video")
+    }
+
+    func testWhenAudioExtensionNoMIMEThenPreventedAudio() {
+        XCTAssertEqual(policy.verdict(url: url("https://example.com/track.mp3"), mimeType: nil).preventionReason, "audio")
+    }
+
+    func testWhenFileURLPDFThenPreventedPDF() {
+        XCTAssertEqual(policy.verdict(url: url("file:///Users/me/doc.pdf"), mimeType: nil).preventionReason, "pdf")
+    }
+
+    func testWhenFileURLHTMLThenAttachable() {
+        XCTAssertTrue(policy.verdict(url: url("file:///Users/me/page.html"), mimeType: nil).isAttachable)
+    }
+
+    func testWhenEmptyMIMEFallsBackToExtension() {
+        XCTAssertEqual(policy.verdict(url: url("https://example.com/report.pdf"), mimeType: "").preventionReason, "pdf")
+    }
+}

--- a/SharedPackages/AIChat/Tests/AIChatTests/PageContextBlocklistSettingsTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/PageContextBlocklistSettingsTests.swift
@@ -1,0 +1,63 @@
+//
+//  PageContextBlocklistSettingsTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import AIChat
+
+final class PageContextBlocklistSettingsTests: XCTestCase {
+
+    /// The canonical config block from spec §4.1.
+    private var canonicalBlocklist: [String: Any] {
+        [
+            "pdf": ["urlExtensions": [".pdf"], "contentTypes": ["application/pdf"]],
+            "image": ["urlExtensions": [".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp"],
+                      "contentTypePrefixes": ["image/"]],
+            "video": ["urlExtensions": [".mp4", ".webm", ".avi", ".mov", ".mkv"],
+                      "contentTypePrefixes": ["video/"]],
+            "audio": ["urlExtensions": [".mp3", ".wav", ".ogg", ".flac", ".aac", ".m4a"],
+                      "contentTypePrefixes": ["audio/"]]
+        ]
+    }
+
+    func testWhenCanonicalBlocklistThenAllCategoriesDecode() {
+        let settings = PageContextBlocklistSettings(blocklist: canonicalBlocklist)
+        XCTAssertNotNil(settings)
+        XCTAssertEqual(Set(settings?.categories.keys ?? [:].keys), ["pdf", "image", "video", "audio"])
+        XCTAssertEqual(settings?.categories["pdf"]?.contentTypes, ["application/pdf"])
+        XCTAssertEqual(settings?.categories["image"]?.contentTypePrefixes, ["image/"])
+        XCTAssertNil(settings?.categories["pdf"]?.contentTypePrefixes)
+    }
+
+    func testWhenArbitraryCategoryThenDecodes() {
+        let settings = PageContextBlocklistSettings(blocklist: ["archive": ["contentTypes": ["application/zip"]]])
+        XCTAssertEqual(settings?.categories["archive"]?.contentTypes, ["application/zip"])
+        XCTAssertNil(settings?.categories["archive"]?.urlExtensions)
+    }
+
+    func testWhenNilBlocklistThenReturnsNil() {
+        XCTAssertNil(PageContextBlocklistSettings(blocklist: nil))
+    }
+
+    func testWhenEmptyBlocklistThenReturnsNil() {
+        XCTAssertNil(PageContextBlocklistSettings(blocklist: [String: Any]()))
+    }
+
+    func testWhenWrongTypeThenReturnsNil() {
+        XCTAssertNil(PageContextBlocklistSettings(blocklist: "not-a-dictionary"))
+    }
+}

--- a/SharedPackages/AIChat/Tests/AIChatTests/PageContextExtractionResolverTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/PageContextExtractionResolverTests.swift
@@ -1,0 +1,146 @@
+//
+//  PageContextExtractionResolverTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import AIChat
+
+final class PageContextExtractionResolverTests: XCTestCase {
+
+    private func nonEmptyContext() -> AIChatPageContextData {
+        AIChatPageContextData(title: "Title", favicon: [], url: "https://example.com", content: "body", truncated: false, fullContentLength: 100)
+    }
+
+    private func emptyContext() -> AIChatPageContextData {
+        AIChatPageContextData(title: "", favicon: [], url: "https://example.com", content: "", truncated: false, fullContentLength: 0)
+    }
+
+    private func time(_ seconds: Double) -> DispatchTime {
+        DispatchTime(uptimeNanoseconds: UInt64(seconds * 1_000_000_000))
+    }
+
+    // MARK: - Skip when there is no outstanding request
+
+    func testWhenResolveWithNoRequestThenReturnsNil() {
+        var resolver = PageContextExtractionResolver()
+        XCTAssertNil(resolver.resolve(pageContext: nonEmptyContext()))
+    }
+
+    func testWhenExtraResultArrivesAfterDrainingThenReturnsNil() {
+        var resolver = PageContextExtractionResolver()
+        resolver.requested(trigger: .navigation)
+        XCTAssertNotNil(resolver.resolve(pageContext: nonEmptyContext()))
+        // A second (duplicate) result with nothing pending is skipped — the over-count fix.
+        XCTAssertNil(resolver.resolve(pageContext: nonEmptyContext()))
+    }
+
+    // MARK: - Outcome derivation
+
+    func testWhenNonEmptyContextThenSuccess() {
+        var resolver = PageContextExtractionResolver()
+        resolver.requested(trigger: .navigation)
+        XCTAssertEqual(resolver.resolve(pageContext: nonEmptyContext())?.outcome, .success)
+    }
+
+    func testWhenEmptyContextThenEmptyContentFailure() {
+        var resolver = PageContextExtractionResolver()
+        resolver.requested(trigger: .auto)
+        XCTAssertEqual(resolver.resolve(pageContext: emptyContext())?.outcome, .failure(.emptyContent))
+    }
+
+    func testWhenNilContextThenDeserializeFailedFailure() {
+        var resolver = PageContextExtractionResolver()
+        resolver.requested(trigger: .auto)
+        XCTAssertEqual(resolver.resolve(pageContext: nil)?.outcome, .failure(.deserializeFailed))
+    }
+
+    // MARK: - FIFO trigger attribution
+
+    func testWhenTwoRequestsThenResolvedInOrderWithTheirOwnTriggers() {
+        var resolver = PageContextExtractionResolver()
+        resolver.requested(trigger: .navigation)
+        resolver.requested(trigger: .userRequest)
+
+        XCTAssertEqual(resolver.resolve(pageContext: nonEmptyContext())?.trigger, .navigation)
+        XCTAssertEqual(resolver.resolve(pageContext: nonEmptyContext())?.trigger, .userRequest)
+        XCTAssertNil(resolver.resolve(pageContext: nonEmptyContext()))
+    }
+
+    /// The review scenario: the eager pre-markup collect returns empty and the post-markup collect
+    /// succeeds. Each must be reported accurately rather than one corrupting the other.
+    func testWhenEagerEmptyFollowedByRealSuccessThenBothReportedCorrectly() {
+        var resolver = PageContextExtractionResolver()
+        resolver.requested(trigger: .navigation)
+        resolver.requested(trigger: .navigation)
+
+        let eager = resolver.resolve(pageContext: emptyContext())
+        XCTAssertEqual(eager?.outcome, .failure(.emptyContent))
+        XCTAssertEqual(eager?.trigger, .navigation)
+
+        let real = resolver.resolve(pageContext: nonEmptyContext())
+        XCTAssertEqual(real?.outcome, .success)
+        XCTAssertEqual(real?.trigger, .navigation)
+    }
+
+    // MARK: - Latency bucketing (paired to each request's own start time)
+
+    func testWhenUnderOneSecondThenUnder1sBucket() {
+        var resolver = PageContextExtractionResolver()
+        resolver.requested(trigger: .navigation, at: time(10))
+        XCTAssertEqual(resolver.resolve(pageContext: nonEmptyContext(), now: time(10.5))?.latency, .under1s)
+    }
+
+    func testWhenExactlyOneSecondThenOneToFiveBucket() {
+        var resolver = PageContextExtractionResolver()
+        resolver.requested(trigger: .navigation, at: time(10))
+        XCTAssertEqual(resolver.resolve(pageContext: nonEmptyContext(), now: time(11))?.latency, .oneToFiveSeconds)
+    }
+
+    func testWhenExactlyFiveSecondsThenOneToFiveBucket() {
+        var resolver = PageContextExtractionResolver()
+        resolver.requested(trigger: .navigation, at: time(10))
+        XCTAssertEqual(resolver.resolve(pageContext: nonEmptyContext(), now: time(15))?.latency, .oneToFiveSeconds)
+    }
+
+    func testWhenOverFiveSecondsThenOver5sBucket() {
+        var resolver = PageContextExtractionResolver()
+        resolver.requested(trigger: .navigation, at: time(10))
+        XCTAssertEqual(resolver.resolve(pageContext: nonEmptyContext(), now: time(16))?.latency, .over5s)
+    }
+
+    func testWhenTwoRequestsThenEachGetsItsOwnLatency() {
+        var resolver = PageContextExtractionResolver()
+        resolver.requested(trigger: .navigation, at: time(10))
+        resolver.requested(trigger: .userRequest, at: time(14))
+
+        // First request started at 10; resolved at 10.4 → under 1s.
+        XCTAssertEqual(resolver.resolve(pageContext: nonEmptyContext(), now: time(10.4))?.latency, .under1s)
+        // Second request started at 14; resolved at 20 → over 5s (not measured from the first start).
+        XCTAssertEqual(resolver.resolve(pageContext: nonEmptyContext(), now: time(20))?.latency, .over5s)
+    }
+
+    // MARK: - hasPendingCollections
+
+    func testHasPendingCollectionsReflectsQueueState() {
+        var resolver = PageContextExtractionResolver()
+        XCTAssertFalse(resolver.hasPendingCollections)
+        resolver.requested(trigger: .navigation)
+        XCTAssertTrue(resolver.hasPendingCollections)
+        _ = resolver.resolve(pageContext: nonEmptyContext())
+        XCTAssertFalse(resolver.hasPendingCollections)
+    }
+}

--- a/SharedPackages/AIChat/Tests/AIChatTests/PageContextExtractionResolverTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/PageContextExtractionResolverTests.swift
@@ -48,6 +48,22 @@ final class PageContextExtractionResolverTests: XCTestCase {
         XCTAssertNil(resolver.resolve(pageContext: nonEmptyContext()))
     }
 
+    // MARK: - Reset on navigation
+
+    func testWhenResetThenPendingCollectionsCleared() {
+        var resolver = PageContextExtractionResolver()
+        resolver.requested(trigger: .navigation)
+        resolver.requested(trigger: .userRequest)
+        XCTAssertTrue(resolver.hasPendingCollections)
+
+        resolver.reset()
+
+        XCTAssertFalse(resolver.hasPendingCollections)
+        // A previous page's result arriving after reset has nothing to pair with, so it can't
+        // mis-attribute the next page's telemetry.
+        XCTAssertNil(resolver.resolve(pageContext: nonEmptyContext()))
+    }
+
     // MARK: - Outcome derivation
 
     func testWhenNonEmptyContextThenSuccess() {

--- a/SharedPackages/AIChat/Tests/AIChatTests/PageContextExtractionResolverTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/PageContextExtractionResolverTests.swift
@@ -143,4 +143,50 @@ final class PageContextExtractionResolverTests: XCTestCase {
         _ = resolver.resolve(pageContext: nonEmptyContext())
         XCTAssertFalse(resolver.hasPendingCollections)
     }
+
+    // MARK: - Timeout expiry
+
+    func testWhenCollectionExceedsTimeoutThenExpiredAsTimeoutWithNilLatency() {
+        var resolver = PageContextExtractionResolver()
+        resolver.requested(trigger: .navigation, at: time(0))
+        let expired = resolver.expireCollections(olderThan: 5, now: time(6))
+        XCTAssertEqual(expired.count, 1)
+        XCTAssertEqual(expired.first?.outcome, .failure(.timeout))
+        XCTAssertEqual(expired.first?.trigger, .navigation)
+        XCTAssertNil(expired.first?.latency)
+        XCTAssertFalse(resolver.hasPendingCollections)
+    }
+
+    func testWhenCollectionWithinTimeoutThenNotExpired() {
+        var resolver = PageContextExtractionResolver()
+        resolver.requested(trigger: .navigation, at: time(0))
+        XCTAssertTrue(resolver.expireCollections(olderThan: 5, now: time(3)).isEmpty)
+        XCTAssertTrue(resolver.hasPendingCollections)
+    }
+
+    func testWhenMultipleCollectionsExpireThenReturnedOldestFirst() {
+        var resolver = PageContextExtractionResolver()
+        resolver.requested(trigger: .navigation, at: time(0))
+        resolver.requested(trigger: .userRequest, at: time(1))
+        let expired = resolver.expireCollections(olderThan: 5, now: time(7))
+        XCTAssertEqual(expired.map(\.trigger), [.navigation, .userRequest])
+        XCTAssertFalse(resolver.hasPendingCollections)
+    }
+
+    func testWhenOnlyOldCollectionsExpireThenNewerRemainForNextResult() {
+        var resolver = PageContextExtractionResolver()
+        resolver.requested(trigger: .navigation, at: time(0))
+        resolver.requested(trigger: .userRequest, at: time(4))
+        // At t=6 only the first (age 6) is past the 5s timeout; the second (age 2) stays pending.
+        XCTAssertEqual(resolver.expireCollections(olderThan: 5, now: time(6)).map(\.trigger), [.navigation])
+        XCTAssertTrue(resolver.hasPendingCollections)
+        XCTAssertEqual(resolver.resolve(pageContext: nonEmptyContext(), now: time(6))?.trigger, .userRequest)
+    }
+
+    func testWhenResolvedBeforeTimeoutThenExpiryIsNoOp() {
+        var resolver = PageContextExtractionResolver()
+        resolver.requested(trigger: .navigation, at: time(0))
+        _ = resolver.resolve(pageContext: nonEmptyContext(), now: time(1))
+        XCTAssertTrue(resolver.expireCollections(olderThan: 5, now: time(10)).isEmpty)
+    }
 }

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -52,7 +52,9 @@
 		1D01A3D82B88DF8B00FE8150 /* PreferencesSyncView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D01A3D72B88DF8B00FE8150 /* PreferencesSyncView.swift */; };
 		1D01A3D92B88DF8B00FE8150 /* PreferencesSyncView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D01A3D72B88DF8B00FE8150 /* PreferencesSyncView.swift */; };
 		1D04CA182F67FECE007AB0F3 /* PageContextMultipleContextsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D04CA172F67FECE007AB0F3 /* PageContextMultipleContextsTests.swift */; };
+		FB0C0800000000000000CE06 /* PageContextExtractionPixelHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB0C0800000000000000CE04 /* PageContextExtractionPixelHandlerTests.swift */; };
 		1D04CA192F67FECE007AB0F3 /* PageContextMultipleContextsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D04CA172F67FECE007AB0F3 /* PageContextMultipleContextsTests.swift */; };
+		FB0C0800000000000000CE05 /* PageContextExtractionPixelHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB0C0800000000000000CE04 /* PageContextExtractionPixelHandlerTests.swift */; };
 		1D074B272909A433006E4AC3 /* PasswordManagerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D074B262909A433006E4AC3 /* PasswordManagerCoordinator.swift */; };
 		1D1A33492A6FEB170080ACED /* BurnerMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1A33482A6FEB170080ACED /* BurnerMode.swift */; };
 		1D1A334A2A6FEB170080ACED /* BurnerMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1A33482A6FEB170080ACED /* BurnerMode.swift */; };
@@ -385,7 +387,9 @@
 		315AA07028CA5CC800200030 /* YoutubePlayerNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 315AA06F28CA5CC800200030 /* YoutubePlayerNavigationHandler.swift */; };
 		315E395F2F86A37000D2289D /* DebugServer in Frameworks */ = {isa = PBXBuildFile; productRef = 315E395E2F86A37000D2289D /* DebugServer */; };
 		3161D15D2DA02380008F59B5 /* AIChatPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3161D15C2DA02380008F59B5 /* AIChatPixel.swift */; };
+		FB0C0800000000000000CE03 /* PageContextExtractionPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB0C0800000000000000CE01 /* PageContextExtractionPixelHandler.swift */; };
 		3161D15E2DA02380008F59B5 /* AIChatPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3161D15C2DA02380008F59B5 /* AIChatPixel.swift */; };
+		FB0C0800000000000000CE02 /* PageContextExtractionPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB0C0800000000000000CE01 /* PageContextExtractionPixelHandler.swift */; };
 		316913232BD2B6250051B46D /* DataBrokerProtectionMacOSPixelsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 316913222BD2B6250051B46D /* DataBrokerProtectionMacOSPixelsHandler.swift */; };
 		316913242BD2B6250051B46D /* DataBrokerProtectionMacOSPixelsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 316913222BD2B6250051B46D /* DataBrokerProtectionMacOSPixelsHandler.swift */; };
 		316913262BD2B76F0051B46D /* DataBrokerPrerequisitesStatusVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 316913252BD2B76F0051B46D /* DataBrokerPrerequisitesStatusVerifier.swift */; };
@@ -4834,6 +4838,7 @@
 		1D01A3D32B88CF7700FE8150 /* AccessibilityPreferences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccessibilityPreferences.swift; sourceTree = "<group>"; };
 		1D01A3D72B88DF8B00FE8150 /* PreferencesSyncView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesSyncView.swift; sourceTree = "<group>"; };
 		1D04CA172F67FECE007AB0F3 /* PageContextMultipleContextsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageContextMultipleContextsTests.swift; sourceTree = "<group>"; };
+		FB0C0800000000000000CE04 /* PageContextExtractionPixelHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageContextExtractionPixelHandlerTests.swift; sourceTree = "<group>"; };
 		1D074B262909A433006E4AC3 /* PasswordManagerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordManagerCoordinator.swift; sourceTree = "<group>"; };
 		1D1A33482A6FEB170080ACED /* BurnerMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BurnerMode.swift; sourceTree = "<group>"; };
 		1D1B4A452EDF97EF00FE43C9 /* PermissionAuthorizationTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionAuthorizationTypeTests.swift; sourceTree = "<group>"; };
@@ -5002,6 +5007,7 @@
 		3154FD1328E6011A00909769 /* TabShadowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabShadowView.swift; sourceTree = "<group>"; };
 		315AA06F28CA5CC800200030 /* YoutubePlayerNavigationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YoutubePlayerNavigationHandler.swift; sourceTree = "<group>"; };
 		3161D15C2DA02380008F59B5 /* AIChatPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatPixel.swift; sourceTree = "<group>"; };
+		FB0C0800000000000000CE01 /* PageContextExtractionPixelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageContextExtractionPixelHandler.swift; sourceTree = "<group>"; };
 		316850712AF3AD58009A2828 /* DataBrokerProtectionDebugMenu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataBrokerProtectionDebugMenu.swift; sourceTree = "<group>"; };
 		316913222BD2B6250051B46D /* DataBrokerProtectionMacOSPixelsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBrokerProtectionMacOSPixelsHandler.swift; sourceTree = "<group>"; };
 		316913252BD2B76F0051B46D /* DataBrokerPrerequisitesStatusVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBrokerPrerequisitesStatusVerifier.swift; sourceTree = "<group>"; };
@@ -7828,6 +7834,7 @@
 				319FCFF42CC83003004F9288 /* AIChatDebugMenu.swift */,
 				C150EB212F0D817100A98C97 /* AIChatFeatureFlagProvider.swift */,
 				3161D15C2DA02380008F59B5 /* AIChatPixel.swift */,
+				FB0C0800000000000000CE01 /* PageContextExtractionPixelHandler.swift */,
 				37AA00AB2E1D3D4000844427 /* AIChatSummarizer.swift */,
 				AA5E1EC72A0000000000C001 /* AIChatSelectionContextAttacher.swift */,
 				1EB01D902E61DF2B006CB411 /* AIChatTranslator.swift */,
@@ -7993,6 +8000,7 @@
 				1E2A887F2E2E532600C29AC0 /* AIChatCoordinatorTests.swift */,
 				CC19E9EF2E82E36A0043F931 /* AIChatHistoryCleanerTests.swift */,
 				1D04CA172F67FECE007AB0F3 /* PageContextMultipleContextsTests.swift */,
+				FB0C0800000000000000CE04 /* PageContextExtractionPixelHandlerTests.swift */,
 			);
 			path = AIChat;
 			sourceTree = "<group>";
@@ -15411,6 +15419,7 @@
 				EE5F09A92E7C2EF200341531 /* NewFileImportView.swift in Sources */,
 				3706FB5E293F65D500E42796 /* EncryptionKeyStore.swift in Sources */,
 				3161D15E2DA02380008F59B5 /* AIChatPixel.swift in Sources */,
+				FB0C0800000000000000CE02 /* PageContextExtractionPixelHandler.swift in Sources */,
 				F1DA51872BF607D200CF29FA /* SubscriptionAttributionPixelHandler.swift in Sources */,
 				BDBA85A02C5D25B700BC54F5 /* VPNMetadataCollector.swift in Sources */,
 				3706FB60293F65D500E42796 /* PasswordManagementIdentityItemView.swift in Sources */,
@@ -16489,6 +16498,7 @@
 				BBE9A9AC2E9D1DED00E573AA /* MockWinBackOfferVisibilityManager.swift in Sources */,
 				3706FE35293F661700E42796 /* ThirdPartyBrowserTests.swift in Sources */,
 				1D04CA192F67FECE007AB0F3 /* PageContextMultipleContextsTests.swift in Sources */,
+				FB0C0800000000000000CE05 /* PageContextExtractionPixelHandlerTests.swift in Sources */,
 				1DFAB5232A8983E100A0F7F6 /* SetExtensionTests.swift in Sources */,
 				56A054002C1AEFA1007D8FAB /* OnboardingManagerTests.swift in Sources */,
 				C1C257142ECD178400C4AEAD /* SafariArchiveImporterTests.swift in Sources */,
@@ -18435,6 +18445,7 @@
 				ED190E122E8BD33F00CA3816 /* MacWatchdogDiagnosticProvider.swift in Sources */,
 				7B934C412A866DD400FC8F9C /* UserDefaults+NetworkProtectionShared.swift in Sources */,
 				3161D15D2DA02380008F59B5 /* AIChatPixel.swift in Sources */,
+				FB0C0800000000000000CE03 /* PageContextExtractionPixelHandler.swift in Sources */,
 				BB046FF82F6D873B007F7107 /* PromoServiceFactory+FreemiumDBP.swift in Sources */,
 				1DDD3EBC2B84DCB9004CBF2B /* WebTrackingProtectionPreferences.swift in Sources */,
 				B603FD9E2A02712E00F3FCA9 /* CIImageExtension.swift in Sources */,
@@ -18619,6 +18630,7 @@
 				3790E2F62F6D5F70003EACD2 /* TabCollectionViewModelTests.swift in Sources */,
 				BB0036612E426E9D0016DDEF /* ReportProblemFormViewModelTests.swift in Sources */,
 				1D04CA182F67FECE007AB0F3 /* PageContextMultipleContextsTests.swift in Sources */,
+				FB0C0800000000000000CE06 /* PageContextExtractionPixelHandlerTests.swift in Sources */,
 				317B39DA2ED9CBD1001B5600 /* AIChatOmnibarControllerTests.swift in Sources */,
 				7BAB1A0100000000A0000032 /* AIChatMentionTokenDetectorTests.swift in Sources */,
 				7BAB1A0100000000A00000A2 /* AIChatMentionPickerFilterTests.swift in Sources */,

--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -147,13 +147,14 @@ enum AIChatPixel: PixelKitEvent {
     case aiChatPageContextExtractionSuccess
 
     /// Event Trigger: Page-context extraction was attempted but produced no usable content.
-    /// `reason` is one of `emptyContent` / `timeout` / `malformed` / `unavailable`.
-    case aiChatPageContextExtractionFailed(reason: String)
+    /// `reason` is the failure reason; `trigger` is what initiated collection; `latency` is a
+    /// bucketed request-to-result time, present only when a result actually arrived.
+    case aiChatPageContextExtractionFailed(reason: String, trigger: String, latency: String?)
 
     /// Event Trigger: Page-context extraction was skipped because the page is not attachable
     /// (blocklisted media type or a native special page). `category` is the blocklist category
-    /// key (e.g. `pdf`) or `internalPage`.
-    case aiChatPageContextExtractionPrevented(category: String)
+    /// key (e.g. `pdf`) or `internalPage`; `trigger` is what initiated collection.
+    case aiChatPageContextExtractionPrevented(category: String, trigger: String)
 
     // MARK: - Deleting chat history
 
@@ -859,10 +860,14 @@ enum AIChatPixel: PixelKitEvent {
             return ["fileCount": String(fileCount)]
         case .aiChatAddressBarFileValidationFailed(let reason):
             return ["reason": reason]
-        case .aiChatPageContextExtractionFailed(let reason):
-            return ["reason": reason]
-        case .aiChatPageContextExtractionPrevented(let category):
-            return ["category": category]
+        case .aiChatPageContextExtractionFailed(let reason, let trigger, let latency):
+            var params = ["reason": reason, "trigger": trigger]
+            if let latency {
+                params["latency"] = latency
+            }
+            return params
+        case .aiChatPageContextExtractionPrevented(let category, let trigger):
+            return ["category": category, "reason": "non_attachable", "trigger": trigger]
         case .aiChatAddressBarButtonClicked(let action):
             return ["action": action.rawValue]
         case .aiChatSidebarOpened(let source, let shouldAutomaticallySendPageContext, let minutesSinceSidebarHidden):

--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -147,13 +147,9 @@ enum AIChatPixel: PixelKitEvent {
     case aiChatPageContextExtractionSuccess
 
     /// Event Trigger: Page-context extraction was attempted but produced no usable content.
-    /// `reason` is the failure reason; `trigger` is what initiated collection; `latency` is a
-    /// bucketed request-to-result time, present only when a result actually arrived.
     case aiChatPageContextExtractionFailed(reason: String, trigger: String, latency: String?)
 
-    /// Event Trigger: Page-context extraction was skipped because the page is not attachable
-    /// (blocklisted media type or a native special page). `category` is the blocklist category
-    /// key (e.g. `pdf`) or `internalPage`; `trigger` is what initiated collection.
+    /// Event Trigger: Page-context extraction was skipped because the page is not attachable (blocklisted media type or special page).
     case aiChatPageContextExtractionPrevented(category: String, trigger: String)
 
     // MARK: - Deleting chat history

--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -141,6 +141,20 @@ enum AIChatPixel: PixelKitEvent {
     /// Event Trigger: User attaches selected text as page context via the "Attach to Duck.ai" context-menu action
     case aiChatAttachSelection
 
+    // MARK: - Page Context Extraction
+
+    /// Event Trigger: Page-context extraction produced usable content.
+    case aiChatPageContextExtractionSuccess
+
+    /// Event Trigger: Page-context extraction was attempted but produced no usable content.
+    /// `reason` is one of `emptyContent` / `timeout` / `malformed` / `unavailable`.
+    case aiChatPageContextExtractionFailed(reason: String)
+
+    /// Event Trigger: Page-context extraction was skipped because the page is not attachable
+    /// (blocklisted media type or a native special page). `category` is the blocklist category
+    /// key (e.g. `pdf`) or `internalPage`.
+    case aiChatPageContextExtractionPrevented(category: String)
+
     // MARK: - Deleting chat history
 
     /// Event Trigger: User requests to delete Duck.ai chat history from the fire button or history delete dialog
@@ -513,6 +527,12 @@ enum AIChatPixel: PixelKitEvent {
             return "aichat_page_context_removed"
         case .aiChatAttachSelection:
             return "aichat_attach_selection"
+        case .aiChatPageContextExtractionSuccess:
+            return "aichat_page_context_extraction_success"
+        case .aiChatPageContextExtractionFailed:
+            return "aichat_page_context_extraction_failed"
+        case .aiChatPageContextExtractionPrevented:
+            return "aichat_page_context_extraction_prevented"
         case let .aiChatAutoClearHistorySettingToggled(enabled):
             if enabled {
                 return "m_mac_aichat_history_autoclear_enabled"
@@ -739,6 +759,7 @@ enum AIChatPixel: PixelKitEvent {
                 .aiChatTranslationSourceLinkClicked,
                 .aiChatPageContextSourceLinkClicked,
                 .aiChatAttachSelection,
+                .aiChatPageContextExtractionSuccess,
                 .aiChatAutoClearHistorySettingToggled,
                 .aiChatDeleteHistoryRequested,
                 .aiChatDeleteHistorySuccessful,
@@ -838,6 +859,10 @@ enum AIChatPixel: PixelKitEvent {
             return ["fileCount": String(fileCount)]
         case .aiChatAddressBarFileValidationFailed(let reason):
             return ["reason": reason]
+        case .aiChatPageContextExtractionFailed(let reason):
+            return ["reason": reason]
+        case .aiChatPageContextExtractionPrevented(let category):
+            return ["category": category]
         case .aiChatAddressBarButtonClicked(let action):
             return ["action": action.rawValue]
         case .aiChatSidebarOpened(let source, let shouldAutomaticallySendPageContext, let minutesSinceSidebarHidden):
@@ -909,6 +934,9 @@ enum AIChatPixel: PixelKitEvent {
                 .aiChatPageContextAdded,
                 .aiChatPageContextRemoved,
                 .aiChatAttachSelection,
+                .aiChatPageContextExtractionSuccess,
+                .aiChatPageContextExtractionFailed,
+                .aiChatPageContextExtractionPrevented,
                 .aiChatDeleteHistoryRequested,
                 .aiChatDeleteHistorySuccessful,
                 .aiChatDeleteHistoryFailed,

--- a/macOS/DuckDuckGo/AIChat/PageContextExtractionPixelHandler.swift
+++ b/macOS/DuckDuckGo/AIChat/PageContextExtractionPixelHandler.swift
@@ -21,7 +21,9 @@ import Foundation
 import PixelKit
 
 protocol PageContextExtractionPixelFiring {
-    func fire(_ outcome: PageContextExtractionOutcome)
+    func fire(_ outcome: PageContextExtractionOutcome,
+              trigger: PageContextExtractionTrigger,
+              latency: PageContextExtractionLatencyBucket?)
 }
 
 final class PageContextExtractionPixelHandler: PageContextExtractionPixelFiring {
@@ -32,14 +34,16 @@ final class PageContextExtractionPixelHandler: PageContextExtractionPixelFiring 
         self.firePixel = firePixel
     }
 
-    func fire(_ outcome: PageContextExtractionOutcome) {
+    func fire(_ outcome: PageContextExtractionOutcome,
+              trigger: PageContextExtractionTrigger,
+              latency: PageContextExtractionLatencyBucket?) {
         switch outcome {
         case .success:
             firePixel(.aiChatPageContextExtractionSuccess)
         case .failure(let reason):
-            firePixel(.aiChatPageContextExtractionFailed(reason: reason.rawValue))
+            firePixel(.aiChatPageContextExtractionFailed(reason: reason.rawValue, trigger: trigger.rawValue, latency: latency?.rawValue))
         case .prevented(let category):
-            firePixel(.aiChatPageContextExtractionPrevented(category: category))
+            firePixel(.aiChatPageContextExtractionPrevented(category: category, trigger: trigger.rawValue))
         }
     }
 }

--- a/macOS/DuckDuckGo/AIChat/PageContextExtractionPixelHandler.swift
+++ b/macOS/DuckDuckGo/AIChat/PageContextExtractionPixelHandler.swift
@@ -1,0 +1,45 @@
+//
+//  PageContextExtractionPixelHandler.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import Foundation
+import PixelKit
+
+protocol PageContextExtractionPixelFiring {
+    func fire(_ outcome: PageContextExtractionOutcome)
+}
+
+final class PageContextExtractionPixelHandler: PageContextExtractionPixelFiring {
+
+    private let firePixel: (AIChatPixel) -> Void
+
+    init(firePixel: @escaping (AIChatPixel) -> Void = { PixelKit.fire($0, frequency: .dailyAndCount) }) {
+        self.firePixel = firePixel
+    }
+
+    func fire(_ outcome: PageContextExtractionOutcome) {
+        switch outcome {
+        case .success:
+            firePixel(.aiChatPageContextExtractionSuccess)
+        case .failure(let reason):
+            firePixel(.aiChatPageContextExtractionFailed(reason: reason.rawValue))
+        case .prevented(let category):
+            firePixel(.aiChatPageContextExtractionPrevented(category: category))
+        }
+    }
+}

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -20,6 +20,7 @@ import AIChat
 import Combine
 import Foundation
 import Navigation
+import os.log
 import PrivacyConfig
 import WebKit
 
@@ -43,6 +44,10 @@ final class PageContextTabExtension {
     private let tabID: TabIdentifier
     private var content: Tab.TabContent = .none
     private let featureFlagger: FeatureFlagger
+    private let privacyConfigurationManager: PrivacyConfigurationManaging
+    private let extractionPixelHandler: PageContextExtractionPixelFiring
+    private var lastMainFrameResponse: (url: URL, mimeType: String?)?
+
     private let aiChatSessionStore: AIChatSessionStoring
     private let aiChatMenuConfiguration: AIChatMenuVisibilityConfigurable
     private let isLoadedInSidebar: Bool
@@ -92,6 +97,8 @@ final class PageContextTabExtension {
         contentPublisher: some Publisher<Tab.TabContent, Never>,
         tabID: TabIdentifier,
         featureFlagger: FeatureFlagger,
+        privacyConfigurationManager: PrivacyConfigurationManaging,
+        extractionPixelHandler: PageContextExtractionPixelFiring,
         aiChatSessionStore: AIChatSessionStoring,
         aiChatMenuConfiguration: AIChatMenuVisibilityConfigurable,
         isLoadedInSidebar: Bool,
@@ -99,6 +106,8 @@ final class PageContextTabExtension {
     ) {
         self.tabID = tabID
         self.featureFlagger = featureFlagger
+        self.privacyConfigurationManager = privacyConfigurationManager
+        self.extractionPixelHandler = extractionPixelHandler
         self.aiChatSessionStore = aiChatSessionStore
         self.aiChatMenuConfiguration = aiChatMenuConfiguration
         self.isLoadedInSidebar = isLoadedInSidebar
@@ -201,11 +210,13 @@ final class PageContextTabExtension {
                 /// ignore unsolicited results so they can't overwrite attached context with nil.
                 if self.isContextCollectionEnabled {
                     self.pendingSignalsOnlyCollection = false
+                    self.fireExtractionOutcome(for: pageContext)
                     Task {
                         await self.handle(pageContext)
                     }
                 } else if self.pendingSignalsOnlyCollection {
                     self.pendingSignalsOnlyCollection = false
+                    self.fireExtractionOutcome(for: pageContext)
                     Task {
                         await self.handleSignalsOnly(pageContext)
                     }
@@ -293,11 +304,64 @@ final class PageContextTabExtension {
         }
     }
 
+    // MARK: - Attachability gate
+
+    private func currentAttachabilityPolicy() -> PageContextAttachabilityPolicy? {
+        let settings = privacyConfigurationManager.privacyConfig.settings(for: .pageContext)
+        guard let blocklist = PageContextBlocklistSettings(blocklist: settings["aiPageContextBlocklist"]) else {
+            return nil
+        }
+        return PageContextAttachabilityPolicy(settings: blocklist)
+    }
+
+    private func preventedAttachReason(for url: URL) -> String? {
+        guard let policy = currentAttachabilityPolicy() else { return nil }
+        let mimeType = lastMainFrameResponse.flatMap { $0.url == url ? $0.mimeType : nil }
+        let verdict = policy.verdict(url: url, mimeType: mimeType)
+        return verdict.isAttachable ? nil : (verdict.preventionReason ?? PageContextExtractionOutcome.internalPageCategory)
+    }
+
+    private func deliverPreventedContext(for url: URL, reason: String) {
+        let context = AIChatPageContextData(
+            title: content.title ?? "",
+            favicon: [],
+            url: url.absoluteString,
+            content: "",
+            truncated: false,
+            fullContentLength: 0,
+            attachable: false
+        )
+        Task { await handle(context) }
+        extractionPixelHandler.fire(.prevented(reason))
+    }
+
+    private func fireExtractionOutcome(for pageContext: AIChatPageContextData?) {
+        let outcome: PageContextExtractionOutcome
+        if let pageContext {
+            outcome = pageContext.isEmpty() ? .failure(.emptyContent) : .success
+        } else {
+            outcome = .failure(.malformed)
+        }
+        Logger.aiChat.log("📊 PageContext extraction outcome: \(String(describing: outcome), privacy: .public)")
+        extractionPixelHandler.fire(outcome)
+    }
+
     private func collectPageContextIfNeeded() {
-        guard case .url = content, isContextCollectionEnabled else {
+        guard case .url(let url, _, _) = content, isContextCollectionEnabled else {
             return
         }
-        pageContextUserScript?.collect()
+        if let reason = preventedAttachReason(for: url) {
+            Logger.aiChat.log("🚫 PageContext gate: prevented attach (reason=\(reason, privacy: .public)) host=\(url.host ?? "nil", privacy: .public)")
+            deliverPreventedContext(for: url, reason: reason)
+            return
+        }
+        guard let pageContextUserScript else {
+            Logger.aiChat.log("⚠️ PageContext gate: user script unavailable, cannot collect host=\(url.host ?? "nil", privacy: .public)")
+            extractionPixelHandler.fire(.failure(.unavailable))
+            return
+        }
+        Logger.aiChat.log("✅ PageContext gate: attachable, collecting host=\(url.host ?? "nil", privacy: .public)")
+        pageContextUserScript.collect()
     }
 
     // MARK: - Selection Context ("Attach to Duck.ai")
@@ -468,10 +532,15 @@ final class PageContextTabExtension {
     private func requestSignalsOnlyCollectionIfNeeded() {
         guard featureFlagger.isFeatureOn(.aiChatPageContext),
               featureFlagger.isFeatureOn(.sidebarSuggestedPrompts),
-              case .url = content,
+              case .url(let url, _, _) = content,
               !isContextCollectionEnabled,
               aiChatSessionStore.sessions[tabID]?.chatViewController != nil,
               let pageContextUserScript else {
+            return
+        }
+        if let reason = preventedAttachReason(for: url) {
+            Logger.aiChat.log("🚫 PageContext gate (signals-only): prevented (reason=\(reason, privacy: .public)) host=\(url.host ?? "nil", privacy: .public)")
+            deliverPreventedContext(for: url, reason: reason)
             return
         }
         pendingSignalsOnlyCollection = true
@@ -524,6 +593,14 @@ extension PageContextTabExtension: NavigationResponder {
         guard !isLoadedInSidebar else { return }
         collectPageContextIfNeeded()
         requestSignalsOnlyCollectionIfNeeded()
+    }
+
+    @MainActor
+    func decidePolicy(for navigationResponse: NavigationResponse) async -> NavigationResponsePolicy? {
+        guard !isLoadedInSidebar, navigationResponse.isForMainFrame else { return .next }
+        lastMainFrameResponse = (navigationResponse.url, navigationResponse.response.mimeType)
+        Logger.aiChat.log("📄 PageContext MIME captured: \(navigationResponse.response.mimeType ?? "nil", privacy: .public) host=\(navigationResponse.url.host ?? "nil", privacy: .public)")
+        return .next
     }
 }
 

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -50,6 +50,10 @@ final class PageContextTabExtension {
 
     private var extractionResolver = PageContextExtractionResolver()
 
+    /// How long to wait for a `collect()` result before reporting it as `.timeout`. Matches
+    /// `PageContextUserScript.collectAndWait`'s default.
+    private static let collectionTimeout: TimeInterval = 5
+
     private let aiChatSessionStore: AIChatSessionStoring
     private let aiChatMenuConfiguration: AIChatMenuVisibilityConfigurable
     private let isLoadedInSidebar: Bool
@@ -342,8 +346,22 @@ final class PageContextTabExtension {
         guard let resolution = extractionResolver.resolve(pageContext: pageContext) else {
             return
         }
-        Logger.aiChat.debug("📊 PageContext extraction outcome: \(String(describing: resolution.outcome), privacy: .public) trigger=\(resolution.trigger.rawValue, privacy: .public) latency=\(resolution.latency.rawValue, privacy: .public)")
+        fire(resolution)
+    }
+
+    private func fire(_ resolution: PageContextExtractionResolver.Resolution) {
+        Logger.aiChat.debug("📊 PageContext extraction outcome: \(String(describing: resolution.outcome), privacy: .public) trigger=\(resolution.trigger.rawValue, privacy: .public) latency=\(resolution.latency?.rawValue ?? "nil", privacy: .public)")
         extractionPixelHandler.fire(resolution.outcome, trigger: resolution.trigger, latency: resolution.latency)
+    }
+
+    /// Fires `.timeout` for any collect that hasn't produced a result within the timeout window and
+    /// clears its pending entry, so a never-resolving collect neither loses its pixel nor lets a
+    /// stale entry mis-attribute a later navigation.
+    private func scheduleCollectionTimeout() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.collectionTimeout) { [weak self] in
+            guard let self else { return }
+            self.extractionResolver.expireCollections(olderThan: Self.collectionTimeout).forEach { self.fire($0) }
+        }
     }
 
     private func collectPageContextIfNeeded(trigger: PageContextExtractionTrigger) {
@@ -363,6 +381,7 @@ final class PageContextTabExtension {
         extractionResolver.requested(trigger: trigger)
         Logger.aiChat.debug("✅ PageContext gate: attachable, collecting host=\(url.host ?? "nil", privacy: .public) trigger=\(trigger.rawValue, privacy: .public)")
         pageContextUserScript.collect()
+        scheduleCollectionTimeout()
     }
 
     // MARK: - Selection Context ("Attach to Duck.ai")
@@ -547,6 +566,7 @@ final class PageContextTabExtension {
         pendingSignalsOnlyCollection = true
         extractionResolver.requested(trigger: .tabContent)
         pageContextUserScript.collect()
+        scheduleCollectionTimeout()
     }
 
     /// Delivers a signals-only payload from a collected context: keeps the Content-Scope-Scripts

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -47,8 +47,8 @@ final class PageContextTabExtension {
     private let privacyConfigurationManager: PrivacyConfigurationManaging
     private let extractionPixelHandler: PageContextExtractionPixelFiring
     private var lastMainFrameResponse: (url: URL, mimeType: String?)?
-    private var pendingTrigger: PageContextExtractionTrigger?
-    private var pendingCollectStartedAt: DispatchTime?
+
+    private var extractionResolver = PageContextExtractionResolver()
 
     private let aiChatSessionStore: AIChatSessionStoring
     private let aiChatMenuConfiguration: AIChatMenuVisibilityConfigurable
@@ -338,20 +338,12 @@ final class PageContextTabExtension {
     }
 
     private func fireExtractionOutcome(for pageContext: AIChatPageContextData?) {
-        let outcome: PageContextExtractionOutcome
-        if let pageContext {
-            outcome = pageContext.isEmpty() ? .failure(.emptyContent) : .success
-        } else {
-            outcome = .failure(.deserializeFailed)
+        // No pending request → duplicate or a collect we didn't initiate; skip the pixel.
+        guard let resolution = extractionResolver.resolve(pageContext: pageContext) else {
+            return
         }
-        let trigger = pendingTrigger ?? .auto
-        let latency = pendingCollectStartedAt.map {
-            PageContextExtractionLatencyBucket(seconds: Double(DispatchTime.now().uptimeNanoseconds - $0.uptimeNanoseconds) / 1_000_000_000)
-        }
-        pendingTrigger = nil
-        pendingCollectStartedAt = nil
-        Logger.aiChat.debug("📊 PageContext extraction outcome: \(String(describing: outcome), privacy: .public) trigger=\(trigger.rawValue, privacy: .public) latency=\(latency?.rawValue ?? "nil", privacy: .public)")
-        extractionPixelHandler.fire(outcome, trigger: trigger, latency: latency)
+        Logger.aiChat.debug("📊 PageContext extraction outcome: \(String(describing: resolution.outcome), privacy: .public) trigger=\(resolution.trigger.rawValue, privacy: .public) latency=\(resolution.latency.rawValue, privacy: .public)")
+        extractionPixelHandler.fire(resolution.outcome, trigger: resolution.trigger, latency: resolution.latency)
     }
 
     private func collectPageContextIfNeeded(trigger: PageContextExtractionTrigger) {
@@ -368,8 +360,7 @@ final class PageContextTabExtension {
             extractionPixelHandler.fire(.failure(.noWebView), trigger: trigger, latency: nil)
             return
         }
-        pendingTrigger = trigger
-        pendingCollectStartedAt = DispatchTime.now()
+        extractionResolver.requested(trigger: trigger)
         Logger.aiChat.debug("✅ PageContext gate: attachable, collecting host=\(url.host ?? "nil", privacy: .public) trigger=\(trigger.rawValue, privacy: .public)")
         pageContextUserScript.collect()
     }
@@ -554,8 +545,7 @@ final class PageContextTabExtension {
             return
         }
         pendingSignalsOnlyCollection = true
-        pendingTrigger = .tabContent
-        pendingCollectStartedAt = DispatchTime.now()
+        extractionResolver.requested(trigger: .tabContent)
         pageContextUserScript.collect()
     }
 

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -332,6 +332,12 @@ final class PageContextTabExtension {
         return PageContextAttachabilityPolicy(settings: blocklist)
     }
 
+    /// Extraction telemetry (success / failure / prevented / timeout) is only reported once the
+    /// `aiPageContextBlocklist` privacy config is present
+    private var isExtractionMeasurementEnabled: Bool {
+        currentAttachabilityPolicy() != nil
+    }
+
     private func preventedAttachReason(for url: URL) -> String? {
         guard let policy = currentAttachabilityPolicy() else { return nil }
         let mimeType = lastMainFrameResponse.flatMap { $0.url == url ? $0.mimeType : nil }
@@ -350,7 +356,7 @@ final class PageContextTabExtension {
             attachable: false
         )
         Task { await handle(context) }
-        extractionPixelHandler.fire(.prevented(reason), trigger: trigger, latency: nil)
+        fireExtractionPixel(.prevented(reason), trigger: trigger, latency: nil)
     }
 
     private func fireExtractionOutcome(for pageContext: AIChatPageContextData?) {
@@ -362,8 +368,18 @@ final class PageContextTabExtension {
     }
 
     private func fire(_ resolution: PageContextExtractionResolver.Resolution) {
-        Logger.aiChat.debug("📊 PageContext extraction outcome: \(String(describing: resolution.outcome), privacy: .public) trigger=\(resolution.trigger.rawValue, privacy: .public) latency=\(resolution.latency?.rawValue ?? "nil", privacy: .public)")
-        extractionPixelHandler.fire(resolution.outcome, trigger: resolution.trigger, latency: resolution.latency)
+        fireExtractionPixel(resolution.outcome, trigger: resolution.trigger, latency: resolution.latency)
+    }
+
+    /// Single chokepoint for extraction pixels. Suppresses all page-context extraction telemetry
+    /// (pixel and outcome log) when the `aiPageContextBlocklist` config is absent
+    /// (see `isExtractionMeasurementEnabled`).
+    private func fireExtractionPixel(_ outcome: PageContextExtractionOutcome,
+                                     trigger: PageContextExtractionTrigger,
+                                     latency: PageContextExtractionLatencyBucket?) {
+        guard isExtractionMeasurementEnabled else { return }
+        Logger.aiChat.debug("📊 PageContext extraction outcome: \(String(describing: outcome), privacy: .public) trigger=\(trigger.rawValue, privacy: .public) latency=\(latency?.rawValue ?? "nil", privacy: .public)")
+        extractionPixelHandler.fire(outcome, trigger: trigger, latency: latency)
     }
 
     /// Fires `.timeout` for any collect that hasn't produced a result within the timeout window and
@@ -387,7 +403,7 @@ final class PageContextTabExtension {
         }
         guard let pageContextUserScript, webView != nil else {
             Logger.aiChat.debug("⚠️ PageContext gate: no webview/user script, cannot collect host=\(url.host ?? "nil", privacy: .public)")
-            extractionPixelHandler.fire(.failure(.noWebView), trigger: trigger, latency: nil)
+            fireExtractionPixel(.failure(.noWebView), trigger: trigger, latency: nil)
             return
         }
         extractionResolver.requested(trigger: trigger)

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -47,6 +47,8 @@ final class PageContextTabExtension {
     private let privacyConfigurationManager: PrivacyConfigurationManaging
     private let extractionPixelHandler: PageContextExtractionPixelFiring
     private var lastMainFrameResponse: (url: URL, mimeType: String?)?
+    private var pendingTrigger: PageContextExtractionTrigger?
+    private var pendingCollectStartedAt: DispatchTime?
 
     private let aiChatSessionStore: AIChatSessionStoring
     private let aiChatMenuConfiguration: AIChatMenuVisibilityConfigurable
@@ -184,7 +186,7 @@ final class PageContextTabExtension {
                     if let cachedPageContext {
                         Task { await self.handle(cachedPageContext) }
                     } else {
-                        collectPageContextIfNeeded()
+                        collectPageContextIfNeeded(trigger: .auto)
                     }
                 }
             }
@@ -245,7 +247,7 @@ final class PageContextTabExtension {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
                 self?.shouldForceContextCollection = true
-                self?.collectPageContextIfNeeded()
+                self?.collectPageContextIfNeeded(trigger: .userRequest)
             }
             .store(in: &sidebarCancellables)
 
@@ -321,7 +323,7 @@ final class PageContextTabExtension {
         return verdict.isAttachable ? nil : (verdict.preventionReason ?? PageContextExtractionOutcome.internalPageCategory)
     }
 
-    private func deliverPreventedContext(for url: URL, reason: String) {
+    private func deliverPreventedContext(for url: URL, reason: String, trigger: PageContextExtractionTrigger) {
         let context = AIChatPageContextData(
             title: content.title ?? "",
             favicon: [],
@@ -332,7 +334,7 @@ final class PageContextTabExtension {
             attachable: false
         )
         Task { await handle(context) }
-        extractionPixelHandler.fire(.prevented(reason))
+        extractionPixelHandler.fire(.prevented(reason), trigger: trigger, latency: nil)
     }
 
     private func fireExtractionOutcome(for pageContext: AIChatPageContextData?) {
@@ -340,27 +342,35 @@ final class PageContextTabExtension {
         if let pageContext {
             outcome = pageContext.isEmpty() ? .failure(.emptyContent) : .success
         } else {
-            outcome = .failure(.malformed)
+            outcome = .failure(.deserializeFailed)
         }
-        Logger.aiChat.log("📊 PageContext extraction outcome: \(String(describing: outcome), privacy: .public)")
-        extractionPixelHandler.fire(outcome)
+        let trigger = pendingTrigger ?? .auto
+        let latency = pendingCollectStartedAt.map {
+            PageContextExtractionLatencyBucket(seconds: Double(DispatchTime.now().uptimeNanoseconds - $0.uptimeNanoseconds) / 1_000_000_000)
+        }
+        pendingTrigger = nil
+        pendingCollectStartedAt = nil
+        Logger.aiChat.log("📊 PageContext extraction outcome: \(String(describing: outcome), privacy: .public) trigger=\(trigger.rawValue, privacy: .public) latency=\(latency?.rawValue ?? "nil", privacy: .public)")
+        extractionPixelHandler.fire(outcome, trigger: trigger, latency: latency)
     }
 
-    private func collectPageContextIfNeeded() {
+    private func collectPageContextIfNeeded(trigger: PageContextExtractionTrigger) {
         guard case .url(let url, _, _) = content, isContextCollectionEnabled else {
             return
         }
         if let reason = preventedAttachReason(for: url) {
             Logger.aiChat.log("🚫 PageContext gate: prevented attach (reason=\(reason, privacy: .public)) host=\(url.host ?? "nil", privacy: .public)")
-            deliverPreventedContext(for: url, reason: reason)
+            deliverPreventedContext(for: url, reason: reason, trigger: trigger)
             return
         }
-        guard let pageContextUserScript else {
-            Logger.aiChat.log("⚠️ PageContext gate: user script unavailable, cannot collect host=\(url.host ?? "nil", privacy: .public)")
-            extractionPixelHandler.fire(.failure(.unavailable))
+        guard let pageContextUserScript, webView != nil else {
+            Logger.aiChat.log("⚠️ PageContext gate: no webview/user script, cannot collect host=\(url.host ?? "nil", privacy: .public)")
+            extractionPixelHandler.fire(.failure(.noWebView), trigger: trigger, latency: nil)
             return
         }
-        Logger.aiChat.log("✅ PageContext gate: attachable, collecting host=\(url.host ?? "nil", privacy: .public)")
+        pendingTrigger = trigger
+        pendingCollectStartedAt = DispatchTime.now()
+        Logger.aiChat.log("✅ PageContext gate: attachable, collecting host=\(url.host ?? "nil", privacy: .public) trigger=\(trigger.rawValue, privacy: .public)")
         pageContextUserScript.collect()
     }
 
@@ -462,7 +472,7 @@ final class PageContextTabExtension {
                                 contextConsumed: hasContextBeenConsumedByChat,
                                 fromAttachablePage: previousWasURL) {
         case .collectNewContext:
-            collectPageContextIfNeeded()
+            collectPageContextIfNeeded(trigger: .navigation)
         case .sendNavigationSignal:
             session.chatViewController?.setPageContext(nil)
         case .keepExistingContext:
@@ -540,10 +550,12 @@ final class PageContextTabExtension {
         }
         if let reason = preventedAttachReason(for: url) {
             Logger.aiChat.log("🚫 PageContext gate (signals-only): prevented (reason=\(reason, privacy: .public)) host=\(url.host ?? "nil", privacy: .public)")
-            deliverPreventedContext(for: url, reason: reason)
+            deliverPreventedContext(for: url, reason: reason, trigger: .tabContent)
             return
         }
         pendingSignalsOnlyCollection = true
+        pendingTrigger = .tabContent
+        pendingCollectStartedAt = DispatchTime.now()
         pageContextUserScript.collect()
     }
 
@@ -591,7 +603,7 @@ extension PageContextTabExtension: NavigationResponder {
     /// update on same-tab navigation. Mirrors Windows' `NavigationCompleted` re-collect.
     func navigationDidFinish(_ navigation: Navigation) {
         guard !isLoadedInSidebar else { return }
-        collectPageContextIfNeeded()
+        collectPageContextIfNeeded(trigger: .navigation)
         requestSignalsOnlyCollectionIfNeeded()
     }
 

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -50,9 +50,17 @@ final class PageContextTabExtension {
 
     private var extractionResolver = PageContextExtractionResolver()
 
-    /// How long to wait for a `collect()` result before reporting it as `.timeout`. Matches
-    /// `PageContextUserScript.collectAndWait`'s default.
-    private static let collectionTimeout: TimeInterval = 5
+    /// Safety-net window for a fire-and-forget `collect()` whose result never arrives (hung JS,
+    /// torn-down page). After it, `scheduleCollectionTimeout` fires `.timeout` and drops the pending
+    /// entry so the queue can't leak.
+    ///
+    /// Kept deliberately generous: a slow collect that resolves *after* this window is still
+    /// delivered to Duck.ai via `handle`, but its pending entry is already gone, so `resolve` finds
+    /// no match and it's mis-recorded as a `.timeout` with no offsetting success pixel. A high value
+    /// makes that late-success mislabeling rare while still bounding the queue (navigation also
+    /// clears it via `extractionResolver.reset()`). Independent of `collectAndWait`'s 5s default —
+    /// that's a separate, synchronous tab-picker path.
+    private static let collectionTimeout: TimeInterval = 30
 
     private let aiChatSessionStore: AIChatSessionStoring
     private let aiChatMenuConfiguration: AIChatMenuVisibilityConfigurable
@@ -150,6 +158,10 @@ final class PageContextTabExtension {
                     self.cachedPageContext = nil
                     // Selections are tied to the page they were made on — drop any not-yet-flushed ones.
                     self.pendingSelectionContexts = []
+                    // Drop the previous page's outstanding collects so a slow or never-resolving
+                    // collect can't pair (FIFO) with this page's result and mis-attribute its
+                    // extraction telemetry (trigger/latency/outcome).
+                    self.extractionResolver.reset()
                 }
                 self.handleNavigationForMultipleContexts(from: previousContent, to: tabContent)
                 self.sendNonAttachableContextIfNeeded()

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -350,7 +350,7 @@ final class PageContextTabExtension {
         }
         pendingTrigger = nil
         pendingCollectStartedAt = nil
-        Logger.aiChat.log("📊 PageContext extraction outcome: \(String(describing: outcome), privacy: .public) trigger=\(trigger.rawValue, privacy: .public) latency=\(latency?.rawValue ?? "nil", privacy: .public)")
+        Logger.aiChat.debug("📊 PageContext extraction outcome: \(String(describing: outcome), privacy: .public) trigger=\(trigger.rawValue, privacy: .public) latency=\(latency?.rawValue ?? "nil", privacy: .public)")
         extractionPixelHandler.fire(outcome, trigger: trigger, latency: latency)
     }
 
@@ -359,18 +359,18 @@ final class PageContextTabExtension {
             return
         }
         if let reason = preventedAttachReason(for: url) {
-            Logger.aiChat.log("🚫 PageContext gate: prevented attach (reason=\(reason, privacy: .public)) host=\(url.host ?? "nil", privacy: .public)")
+            Logger.aiChat.debug("🚫 PageContext gate: prevented attach (reason=\(reason, privacy: .public)) host=\(url.host ?? "nil", privacy: .public)")
             deliverPreventedContext(for: url, reason: reason, trigger: trigger)
             return
         }
         guard let pageContextUserScript, webView != nil else {
-            Logger.aiChat.log("⚠️ PageContext gate: no webview/user script, cannot collect host=\(url.host ?? "nil", privacy: .public)")
+            Logger.aiChat.debug("⚠️ PageContext gate: no webview/user script, cannot collect host=\(url.host ?? "nil", privacy: .public)")
             extractionPixelHandler.fire(.failure(.noWebView), trigger: trigger, latency: nil)
             return
         }
         pendingTrigger = trigger
         pendingCollectStartedAt = DispatchTime.now()
-        Logger.aiChat.log("✅ PageContext gate: attachable, collecting host=\(url.host ?? "nil", privacy: .public) trigger=\(trigger.rawValue, privacy: .public)")
+        Logger.aiChat.debug("✅ PageContext gate: attachable, collecting host=\(url.host ?? "nil", privacy: .public) trigger=\(trigger.rawValue, privacy: .public)")
         pageContextUserScript.collect()
     }
 
@@ -549,7 +549,7 @@ final class PageContextTabExtension {
             return
         }
         if let reason = preventedAttachReason(for: url) {
-            Logger.aiChat.log("🚫 PageContext gate (signals-only): prevented (reason=\(reason, privacy: .public)) host=\(url.host ?? "nil", privacy: .public)")
+            Logger.aiChat.debug("🚫 PageContext gate (signals-only): prevented (reason=\(reason, privacy: .public)) host=\(url.host ?? "nil", privacy: .public)")
             deliverPreventedContext(for: url, reason: reason, trigger: .tabContent)
             return
         }
@@ -611,7 +611,7 @@ extension PageContextTabExtension: NavigationResponder {
     func decidePolicy(for navigationResponse: NavigationResponse) async -> NavigationResponsePolicy? {
         guard !isLoadedInSidebar, navigationResponse.isForMainFrame else { return .next }
         lastMainFrameResponse = (navigationResponse.url, navigationResponse.response.mimeType)
-        Logger.aiChat.log("📄 PageContext MIME captured: \(navigationResponse.response.mimeType ?? "nil", privacy: .public) host=\(navigationResponse.url.host ?? "nil", privacy: .public)")
+        Logger.aiChat.debug("📄 PageContext MIME captured: \(navigationResponse.response.mimeType ?? "nil", privacy: .public) host=\(navigationResponse.url.host ?? "nil", privacy: .public)")
         return .next
     }
 }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -50,6 +50,10 @@ final class PageContextTabExtension {
 
     private var extractionResolver = PageContextExtractionResolver()
 
+    /// Set once an automatic (page-load) extraction outcome is reported for the current navigation,
+    /// so its overlapping navigation/signals-only collects don't each fire a pixel. Reset on new URL.
+    private var didReportExtractionForCurrentNavigation = false
+
     /// Safety-net window for a fire-and-forget `collect()` whose result never arrives (hung JS,
     /// torn-down page). After it, `scheduleCollectionTimeout` fires `.timeout` and drops the pending
     /// entry so the queue can't leak.
@@ -162,6 +166,7 @@ final class PageContextTabExtension {
                     // collect can't pair (FIFO) with this page's result and mis-attribute its
                     // extraction telemetry (trigger/latency/outcome).
                     self.extractionResolver.reset()
+                    self.didReportExtractionForCurrentNavigation = false
                 }
                 self.handleNavigationForMultipleContexts(from: previousContent, to: tabContent)
                 self.sendNonAttachableContextIfNeeded()
@@ -371,13 +376,16 @@ final class PageContextTabExtension {
         fireExtractionPixel(resolution.outcome, trigger: resolution.trigger, latency: resolution.latency)
     }
 
-    /// Single chokepoint for extraction pixels. Suppresses all page-context extraction telemetry
-    /// (pixel and outcome log) when the `aiPageContextBlocklist` config is absent
-    /// (see `isExtractionMeasurementEnabled`).
     private func fireExtractionPixel(_ outcome: PageContextExtractionOutcome,
                                      trigger: PageContextExtractionTrigger,
                                      latency: PageContextExtractionLatencyBucket?) {
         guard isExtractionMeasurementEnabled else { return }
+        // A navigation triggers several automatic collects (navigation re-collect + signals-only);
+        // report only the first. User/setting collects (.userRequest / .auto) always report.
+        if trigger == .navigation || trigger == .tabContent {
+            guard !didReportExtractionForCurrentNavigation else { return }
+            didReportExtractionForCurrentNavigation = true
+        }
         Logger.aiChat.debug("📊 PageContext extraction outcome: \(String(describing: outcome), privacy: .public) trigger=\(trigger.rawValue, privacy: .public) latency=\(latency?.rawValue ?? "nil", privacy: .public)")
         extractionPixelHandler.fire(outcome, trigger: trigger, latency: latency)
     }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
@@ -321,6 +321,8 @@ extension TabExtensionsBuilder {
                                     contentPublisher: args.contentPublisher,
                                     tabID: args.tabID,
                                     featureFlagger: dependencies.featureFlagger,
+                                    privacyConfigurationManager: dependencies.privacyFeatures.contentBlocking.privacyConfigurationManager,
+                                    extractionPixelHandler: PageContextExtractionPixelHandler(),
                                     aiChatSessionStore: dependencies.aiChatSessionStore,
                                     aiChatMenuConfiguration: dependencies.aiChatMenuConfiguration,
                                     isLoadedInSidebar: args.isTabLoadedInSidebar,

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_page_context_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_page_context_pixels.json5
@@ -52,7 +52,19 @@
                 "key": "reason",
                 "description": "Why extraction produced no usable content.",
                 "type": "string",
-                "enum": ["emptyContent", "timeout", "malformed", "unavailable"]
+                "enum": ["empty_content", "deserialize_failed", "timeout", "no_webview", "post_failed", "tab_evicted"]
+            },
+            {
+                "key": "trigger",
+                "description": "What initiated the extraction attempt.",
+                "type": "string",
+                "enum": ["auto", "navigation", "user_request", "tab_content"]
+            },
+            {
+                "key": "latency",
+                "description": "Bucketed request-to-result time. Present only when a result arrived.",
+                "type": "string",
+                "enum": ["under_1s", "1_to_5s", "over_5s"]
             }
         ]
     },
@@ -69,6 +81,18 @@
                 "key": "category",
                 "description": "The prevention category: a blocklist media category key (e.g. pdf, image, video, audio) or internalPage.",
                 "type": "string"
+            },
+            {
+                "key": "reason",
+                "description": "Always non_attachable; the page cannot be attached.",
+                "type": "string",
+                "enum": ["non_attachable"]
+            },
+            {
+                "key": "trigger",
+                "description": "What initiated the extraction attempt.",
+                "type": "string",
+                "enum": ["auto", "navigation", "user_request", "tab_content"]
             }
         ]
     }

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_page_context_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_page_context_pixels.json5
@@ -31,5 +31,45 @@
             },
             "channel"
         ]
+    },
+    "m_mac_aichat_page_context_extraction_success": {
+        "description": "Fired when Duck.ai page-context extraction produced usable content for the current page",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_page_context_extraction_failed": {
+        "description": "Fired when Duck.ai page-context extraction was attempted but produced no usable content",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "reason",
+                "description": "Why extraction produced no usable content.",
+                "type": "string",
+                "enum": ["emptyContent", "timeout", "malformed", "unavailable"]
+            }
+        ]
+    },
+    "m_mac_aichat_page_context_extraction_prevented": {
+        "description": "Fired when Duck.ai page-context extraction was skipped because the current page is not attachable (blocklisted media type or a native special page)",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "category",
+                "description": "The prevention category: a blocklist media category key (e.g. pdf, image, video, audio) or internalPage.",
+                "type": "string"
+            }
+        ]
     }
 }

--- a/macOS/UnitTests/AIChat/PageContextExtractionPixelHandlerTests.swift
+++ b/macOS/UnitTests/AIChat/PageContextExtractionPixelHandlerTests.swift
@@ -1,0 +1,56 @@
+//
+//  PageContextExtractionPixelHandlerTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import Testing
+
+@testable import DuckDuckGo_Privacy_Browser
+
+struct PageContextExtractionPixelHandlerTests {
+
+    private func capture(_ outcome: PageContextExtractionOutcome) -> AIChatPixel? {
+        var fired: AIChatPixel?
+        let handler = PageContextExtractionPixelHandler(firePixel: { fired = $0 })
+        handler.fire(outcome)
+        return fired
+    }
+
+    @Test("success maps to the extraction-success pixel")
+    func successMapsToSuccessPixel() {
+        #expect(capture(.success)?.name == "aichat_page_context_extraction_success")
+    }
+
+    @Test("failure(emptyContent) maps to failed pixel with reason")
+    func emptyContentMapsToFailedWithReason() {
+        let pixel = capture(.failure(.emptyContent))
+        #expect(pixel?.name == "aichat_page_context_extraction_failed")
+        #expect(pixel?.parameters?["reason"] == "emptyContent")
+    }
+
+    @Test("failure(malformed) maps to failed pixel with reason")
+    func malformedMapsToFailedWithReason() {
+        #expect(capture(.failure(.malformed))?.parameters?["reason"] == "malformed")
+    }
+
+    @Test("prevented maps to prevented pixel with category")
+    func preventedMapsToPreventedWithCategory() {
+        let pixel = capture(.prevented("pdf"))
+        #expect(pixel?.name == "aichat_page_context_extraction_prevented")
+        #expect(pixel?.parameters?["category"] == "pdf")
+    }
+}

--- a/macOS/UnitTests/AIChat/PageContextExtractionPixelHandlerTests.swift
+++ b/macOS/UnitTests/AIChat/PageContextExtractionPixelHandlerTests.swift
@@ -32,6 +32,7 @@ struct PageContextExtractionPixelHandlerTests {
         return fired
     }
 
+    @available(iOS 16, macOS 13, *)
     @Test("success maps to the extraction-success pixel with no extra params", .timeLimit(.minutes(1)))
     func successMapsToSuccessPixel() {
         let pixel = capture(.success, trigger: .navigation, latency: .under1s)
@@ -41,6 +42,7 @@ struct PageContextExtractionPixelHandlerTests {
         #expect(pixel?.parameters?["latency"] == nil)
     }
 
+    @available(iOS 16, macOS 13, *)
     @Test("failure(emptyContent) maps to failed pixel with reason, trigger, latency", .timeLimit(.minutes(1)))
     func emptyContentMapsToFailedWithParams() {
         let pixel = capture(.failure(.emptyContent), trigger: .auto, latency: .oneToFiveSeconds)
@@ -50,11 +52,13 @@ struct PageContextExtractionPixelHandlerTests {
         #expect(pixel?.parameters?["latency"] == "1_to_5s")
     }
 
+    @available(iOS 16, macOS 13, *)
     @Test("failure(deserializeFailed) maps to failed pixel with snake_case reason", .timeLimit(.minutes(1)))
     func deserializeFailedMapsToFailedWithReason() {
         #expect(capture(.failure(.deserializeFailed))?.parameters?["reason"] == "deserialize_failed")
     }
 
+    @available(iOS 16, macOS 13, *)
     @Test("failure without a latency omits the latency param", .timeLimit(.minutes(1)))
     func failureWithoutLatencyOmitsLatency() {
         let pixel = capture(.failure(.noWebView), trigger: .navigation, latency: nil)
@@ -62,6 +66,7 @@ struct PageContextExtractionPixelHandlerTests {
         #expect(pixel?.parameters?["latency"] == nil)
     }
 
+    @available(iOS 16, macOS 13, *)
     @Test("prevented maps to prevented pixel with category, reason, trigger", .timeLimit(.minutes(1)))
     func preventedMapsToPreventedWithParams() {
         let pixel = capture(.prevented("pdf"), trigger: .tabContent)

--- a/macOS/UnitTests/AIChat/PageContextExtractionPixelHandlerTests.swift
+++ b/macOS/UnitTests/AIChat/PageContextExtractionPixelHandlerTests.swift
@@ -32,7 +32,7 @@ struct PageContextExtractionPixelHandlerTests {
         return fired
     }
 
-    @Test("success maps to the extraction-success pixel with no extra params")
+    @Test("success maps to the extraction-success pixel with no extra params", .timeLimit(.minutes(1)))
     func successMapsToSuccessPixel() {
         let pixel = capture(.success, trigger: .navigation, latency: .under1s)
         #expect(pixel?.name == "aichat_page_context_extraction_success")
@@ -41,7 +41,7 @@ struct PageContextExtractionPixelHandlerTests {
         #expect(pixel?.parameters?["latency"] == nil)
     }
 
-    @Test("failure(emptyContent) maps to failed pixel with reason, trigger, latency")
+    @Test("failure(emptyContent) maps to failed pixel with reason, trigger, latency", .timeLimit(.minutes(1)))
     func emptyContentMapsToFailedWithParams() {
         let pixel = capture(.failure(.emptyContent), trigger: .auto, latency: .oneToFiveSeconds)
         #expect(pixel?.name == "aichat_page_context_extraction_failed")
@@ -50,19 +50,19 @@ struct PageContextExtractionPixelHandlerTests {
         #expect(pixel?.parameters?["latency"] == "1_to_5s")
     }
 
-    @Test("failure(deserializeFailed) maps to failed pixel with snake_case reason")
+    @Test("failure(deserializeFailed) maps to failed pixel with snake_case reason", .timeLimit(.minutes(1)))
     func deserializeFailedMapsToFailedWithReason() {
         #expect(capture(.failure(.deserializeFailed))?.parameters?["reason"] == "deserialize_failed")
     }
 
-    @Test("failure without a latency omits the latency param")
+    @Test("failure without a latency omits the latency param", .timeLimit(.minutes(1)))
     func failureWithoutLatencyOmitsLatency() {
         let pixel = capture(.failure(.noWebView), trigger: .navigation, latency: nil)
         #expect(pixel?.parameters?["reason"] == "no_webview")
         #expect(pixel?.parameters?["latency"] == nil)
     }
 
-    @Test("prevented maps to prevented pixel with category, reason, trigger")
+    @Test("prevented maps to prevented pixel with category, reason, trigger", .timeLimit(.minutes(1)))
     func preventedMapsToPreventedWithParams() {
         let pixel = capture(.prevented("pdf"), trigger: .tabContent)
         #expect(pixel?.name == "aichat_page_context_extraction_prevented")

--- a/macOS/UnitTests/AIChat/PageContextExtractionPixelHandlerTests.swift
+++ b/macOS/UnitTests/AIChat/PageContextExtractionPixelHandlerTests.swift
@@ -23,34 +23,51 @@ import Testing
 
 struct PageContextExtractionPixelHandlerTests {
 
-    private func capture(_ outcome: PageContextExtractionOutcome) -> AIChatPixel? {
+    private func capture(_ outcome: PageContextExtractionOutcome,
+                         trigger: PageContextExtractionTrigger = .navigation,
+                         latency: PageContextExtractionLatencyBucket? = nil) -> AIChatPixel? {
         var fired: AIChatPixel?
         let handler = PageContextExtractionPixelHandler(firePixel: { fired = $0 })
-        handler.fire(outcome)
+        handler.fire(outcome, trigger: trigger, latency: latency)
         return fired
     }
 
-    @Test("success maps to the extraction-success pixel")
+    @Test("success maps to the extraction-success pixel with no extra params")
     func successMapsToSuccessPixel() {
-        #expect(capture(.success)?.name == "aichat_page_context_extraction_success")
+        let pixel = capture(.success, trigger: .navigation, latency: .under1s)
+        #expect(pixel?.name == "aichat_page_context_extraction_success")
+        #expect(pixel?.parameters?["reason"] == nil)
+        #expect(pixel?.parameters?["trigger"] == nil)
+        #expect(pixel?.parameters?["latency"] == nil)
     }
 
-    @Test("failure(emptyContent) maps to failed pixel with reason")
-    func emptyContentMapsToFailedWithReason() {
-        let pixel = capture(.failure(.emptyContent))
+    @Test("failure(emptyContent) maps to failed pixel with reason, trigger, latency")
+    func emptyContentMapsToFailedWithParams() {
+        let pixel = capture(.failure(.emptyContent), trigger: .auto, latency: .oneToFiveSeconds)
         #expect(pixel?.name == "aichat_page_context_extraction_failed")
-        #expect(pixel?.parameters?["reason"] == "emptyContent")
+        #expect(pixel?.parameters?["reason"] == "empty_content")
+        #expect(pixel?.parameters?["trigger"] == "auto")
+        #expect(pixel?.parameters?["latency"] == "1_to_5s")
     }
 
-    @Test("failure(malformed) maps to failed pixel with reason")
-    func malformedMapsToFailedWithReason() {
-        #expect(capture(.failure(.malformed))?.parameters?["reason"] == "malformed")
+    @Test("failure(deserializeFailed) maps to failed pixel with snake_case reason")
+    func deserializeFailedMapsToFailedWithReason() {
+        #expect(capture(.failure(.deserializeFailed))?.parameters?["reason"] == "deserialize_failed")
     }
 
-    @Test("prevented maps to prevented pixel with category")
-    func preventedMapsToPreventedWithCategory() {
-        let pixel = capture(.prevented("pdf"))
+    @Test("failure without a latency omits the latency param")
+    func failureWithoutLatencyOmitsLatency() {
+        let pixel = capture(.failure(.noWebView), trigger: .navigation, latency: nil)
+        #expect(pixel?.parameters?["reason"] == "no_webview")
+        #expect(pixel?.parameters?["latency"] == nil)
+    }
+
+    @Test("prevented maps to prevented pixel with category, reason, trigger")
+    func preventedMapsToPreventedWithParams() {
+        let pixel = capture(.prevented("pdf"), trigger: .tabContent)
         #expect(pixel?.name == "aichat_page_context_extraction_prevented")
         #expect(pixel?.parameters?["category"] == "pdf")
+        #expect(pixel?.parameters?["reason"] == "non_attachable")
+        #expect(pixel?.parameters?["trigger"] == "tab_content")
     }
 }

--- a/macOS/UnitTests/AIChat/PageContextMultipleContextsTests.swift
+++ b/macOS/UnitTests/AIChat/PageContextMultipleContextsTests.swift
@@ -195,3 +195,58 @@ struct SelectionContextTests {
         #expect(first.id != second.id)
     }
 }
+
+// MARK: - Per-navigation extraction pixel dedup Tests
+
+struct PerNavigationExtractionPixelDedupTests {
+
+    /// Mirrors the per-navigation dedup in PageContextTabExtension.fireExtractionPixel: automatic
+    /// page-load collects (.navigation / .tabContent) report once per navigation and re-arm on
+    /// navigation to a new URL; user/setting collects (.userRequest / .auto) always report.
+    private final class Dedup {
+        private var didReportForCurrentNavigation = false
+
+        func resetForNavigation() { didReportForCurrentNavigation = false }
+
+        func shouldReport(_ trigger: PageContextExtractionTrigger) -> Bool {
+            guard trigger == .navigation || trigger == .tabContent else { return true }
+            if didReportForCurrentNavigation { return false }
+            didReportForCurrentNavigation = true
+            return true
+        }
+    }
+
+    @Test("First automatic collect reports; the navigation's later automatic collects are suppressed")
+    func firstAutomaticReportsRestSuppressed() {
+        let dedup = Dedup()
+        #expect(dedup.shouldReport(.navigation) == true)   // didCommit re-collect
+        #expect(dedup.shouldReport(.navigation) == false)  // didFinish re-collect
+        #expect(dedup.shouldReport(.tabContent) == false)  // signals-only harvest
+    }
+
+    @Test("navigation and tabContent share the single per-navigation slot")
+    func navigationAndTabContentShareSlot() {
+        let dedup = Dedup()
+        #expect(dedup.shouldReport(.tabContent) == true)
+        #expect(dedup.shouldReport(.navigation) == false)
+    }
+
+    @Test("Navigation to a new URL re-arms automatic reporting")
+    func navigationResetReArms() {
+        let dedup = Dedup()
+        #expect(dedup.shouldReport(.navigation) == true)
+        #expect(dedup.shouldReport(.navigation) == false)
+        dedup.resetForNavigation()
+        #expect(dedup.shouldReport(.navigation) == true)
+    }
+
+    @Test("User- and setting-initiated collects always report and never consume the slot")
+    func userAndSettingAlwaysReport() {
+        let dedup = Dedup()
+        #expect(dedup.shouldReport(.userRequest) == true)
+        #expect(dedup.shouldReport(.auto) == true)
+        #expect(dedup.shouldReport(.userRequest) == true)
+        // Slot untouched by user/setting collects, so the first automatic collect still reports.
+        #expect(dedup.shouldReport(.navigation) == true)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/492600419927320/task/1216512854779980?focus=true
Tech Design URL:
CC:

### Description
On macOS, Duck.ai's "attach current page" now skips pages that can't yield text (PDF/image/video/audio viewers and native special pages), marking them non-attachable via the existing frontend UX instead of producing empty attachments. The decision comes from a shared, unit-tested core reading the remote `aiPageContextBlocklist` config (absent/invalid config = no-op), and extraction outcomes (success/failure/prevented) are now reported through new pixels for a downstream health dashboard.

### Testing Steps
> The gate is inert until the remote `aiPageContextBlocklist` config is present. Use the test config built from privacy-config PR https://github.com/duckduckgo/privacy-configuration/pull/5560 (which adds the blocklist to the macOS `pageContext` settings):
> `https://duckduckgo.github.io/privacy-configuration/pr-5560/v4/macos-config.json`

1. In the Debug menu, set the custom privacy configuration URL to `https://duckduckgo.github.io/privacy-configuration/pr-5560/v4/macos-config.json`, reload the remote configuration, then open the Duck.ai sidebar with auto-attach on.
2. Navigate to a PDF or direct image URL (see examples in the project task) → the page-context chip shows the non-attachable state and Console (subsystem = app bundle id, category `AIChat`) logs `🚫 ... gate: prevented`; navigate to a normal article → it attaches and logs `📊 ... outcome: success`.
3. Reset the privacy configuration URL to the default and repeat step 2 → no gating occurs (fail-open), behavior is unchanged.

### Impact
Low — inert until the remote `aiPageContextBlocklist` config ships, and the whole flow stays behind the existing `aiChatPageContext` feature flag.

#### What could go wrong?
A page could be wrongly marked non-attachable → mitigated by fail-open config handling, MIME-authoritative matching, and the shared policy's unit tests.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is inert until remote blocklist config ships and remains behind existing page-context feature flags; fail-open config and broad unit tests limit user impact, with main residual risk of a page wrongly marked non-attachable.
> 
> **Overview**
> macOS Duck.ai **attach current page** now consults a shared **attachability policy** driven by remote `aiPageContextBlocklist` privacy config (missing/invalid config = fail-open, no gating). Blocked pages (PDF/image/video/audio, `about:blank`, Duck.ai URLs, etc.) skip JS collection and push **`attachable: false`** to the sidebar instead of empty attachments; MIME from the main-frame response is preferred over URL extension when both are available.
> 
> **`PageContextTabExtension`** wires the gate into collect paths (auto, navigation, user request, signals-only), captures MIME on navigation response, resets a FIFO **`PageContextExtractionResolver`** on navigation, dedupes automatic extraction pixels per navigation, and applies a 30s timeout for hung collects.
> 
> New **extraction pixels** (success / failed with reason, trigger, latency / prevented with category) flow through **`PageContextExtractionPixelHandler`** and **`AIChatPixel`**, with JSON5 definitions and unit tests in **AIChat** and macOS test targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 960a706a3928a4dfff13a1762b30e9c3727c8148. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




