### PR TITLE
iOS: Dismiss contextual Duck.ai keyboard on submit and content drag

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -2216,6 +2216,7 @@
 		CB6D17A42FA3983100ECD5AE /* UnifiedToggleInputPageContextChipViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17A32FA3983100ECD5AE /* UnifiedToggleInputPageContextChipViewModel.swift */; };
 		CB6D17A82FA39FC900ECD5AE /* AIChatContextualUTIHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17A72FA39FC900ECD5AE /* AIChatContextualUTIHost.swift */; };
 		CB6D17AA2FA4B57900ECD5AE /* AIChatContextualUTIHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17A92FA4B57900ECD5AE /* AIChatContextualUTIHostTests.swift */; };
+		CB6D17B12FA4B57900ECD5AE /* AIChatContextualSheetViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B02FA4B57900ECD5AE /* AIChatContextualSheetViewControllerTests.swift */; };
 		CB6D17B02FA2138200ECD5AE /* AIChatSyncPromoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B12FA2138200ECD5AE /* AIChatSyncPromoView.swift */; };
 		CB6D17B22FA2138200ECD5AE /* AIChatSyncIntroSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B32FA2138200ECD5AE /* AIChatSyncIntroSheetView.swift */; };
 		CB6D17B42FB000000ECD5AE /* AIChatSyncPromoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B52FB000000ECD5AE /* AIChatSyncPromoViewModel.swift */; };
@@ -4955,6 +4956,7 @@
 		CB6D17A32FA3983100ECD5AE /* UnifiedToggleInputPageContextChipViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputPageContextChipViewModel.swift; sourceTree = "<group>"; };
 		CB6D17A72FA39FC900ECD5AE /* AIChatContextualUTIHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualUTIHost.swift; sourceTree = "<group>"; };
 		CB6D17A92FA4B57900ECD5AE /* AIChatContextualUTIHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualUTIHostTests.swift; sourceTree = "<group>"; };
+		CB6D17B02FA4B57900ECD5AE /* AIChatContextualSheetViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualSheetViewControllerTests.swift; sourceTree = "<group>"; };
 		CB6D17B12FA2138200ECD5AE /* AIChatSyncPromoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSyncPromoView.swift; sourceTree = "<group>"; };
 		CB6D17B32FA2138200ECD5AE /* AIChatSyncIntroSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSyncIntroSheetView.swift; sourceTree = "<group>"; };
 		CB6D17B52FB000000ECD5AE /* AIChatSyncPromoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSyncPromoViewModel.swift; sourceTree = "<group>"; };
@@ -6056,6 +6058,7 @@
 				97D99E632F7420A900EE34E7 /* AIVoiceChatIntentTests.swift */,
 				97B908642F75457100372B50 /* DuckAIVoiceControlWidgetTests.swift */,
 				CB6D17A92FA4B57900ECD5AE /* AIChatContextualUTIHostTests.swift */,
+				CB6D17B02FA4B57900ECD5AE /* AIChatContextualSheetViewControllerTests.swift */,
 				B4E5D6C7A8F9012345678901 /* AIChatTabChatHeaderViewTests.swift */,
 				5AB12C3D4E5F60718293A4C0 /* MockChatHistoryReader.swift */,
 				80E2BDAF2FDB693A00441FDF /* DuckAIGridItemTests.swift */,
@@ -14538,6 +14541,7 @@
 				6AC98419288055C1005FA9CA /* BarsAnimatorTests.swift in Sources */,
 				8536A1CA209AF6490050739E /* HomeRowReminderTests.swift in Sources */,
 				CB6D17AA2FA4B57900ECD5AE /* AIChatContextualUTIHostTests.swift in Sources */,
+				CB6D17B12FA4B57900ECD5AE /* AIChatContextualSheetViewControllerTests.swift in Sources */,
 				C13EBC552EF62A0100CE5A4B /* AIChatContextualInputViewControllerTests.swift in Sources */,
 				9FA0AF1E2EB4894A00713387 /* RemoteMessagingPixelReporterTests.swift in Sources */,
 				5650E36F2D3E8E5900D41ECF /* PageRefreshMonitorExtensionTests.swift in Sources */,

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
@@ -265,6 +265,16 @@ final class AIChatContextualSheetViewController: UIViewController {
         return view
     }()
 
+    /// Dismisses the keyboard on a vertical content drag, since `keyboardDismissMode` can't reach the sibling UTI field.
+    private lazy var contentDragKeyboardDismissRecognizer: UIPanGestureRecognizer = {
+        let recognizer = UIPanGestureRecognizer(target: self, action: #selector(handleContentDragToDismissKeyboard(_:)))
+        recognizer.delegate = self
+        recognizer.cancelsTouchesInView = false
+        recognizer.delaysTouchesBegan = false
+        recognizer.delaysTouchesEnded = false
+        return recognizer
+    }()
+
     private lazy var topSeparator: UIView = {
         let view = UIView()
         view.backgroundColor = UIColor(designSystemColor: .lines)
@@ -740,6 +750,24 @@ private extension AIChatContextualSheetViewController {
     }
 }
 
+// MARK: - UIGestureRecognizerDelegate
+
+extension AIChatContextualSheetViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        Self.isPredominantlyVerticalDrag(velocity: contentDragKeyboardDismissRecognizer.velocity(in: contentContainerView))
+    }
+
+    /// Only vertical drags dismiss the keyboard, so horizontal scrolling (e.g. a wide code block) leaves it up.
+    static func isPredominantlyVerticalDrag(velocity: CGPoint) -> Bool {
+        abs(velocity.y) > abs(velocity.x)
+    }
+
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
+                           shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        gestureRecognizer === contentDragKeyboardDismissRecognizer
+    }
+}
+
 // MARK: - AIChatContextualInputViewControllerDelegate
 
 extension AIChatContextualSheetViewController: AIChatContextualInputViewControllerDelegate {
@@ -1126,6 +1154,12 @@ private extension AIChatContextualSheetViewController {
         let bottomConstraint = contentContainerView.bottomAnchor.constraint(equalTo: utiView.topAnchor)
         contentContainerBottomConstraint = bottomConstraint
         bottomConstraint.isActive = true
+        contentContainerView.addGestureRecognizer(contentDragKeyboardDismissRecognizer)
+    }
+
+    @objc private func handleContentDragToDismissKeyboard(_ gesture: UIPanGestureRecognizer) {
+        guard gesture.state == .began else { return }
+        persistentUTIHost?.deactivateInput()
     }
     
     func updateShadowPath() {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -212,6 +212,10 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate {
         coordinator.showExpanded()
     }
 
+    func deactivateInput() {
+        coordinator.viewController.deactivateInput()
+    }
+
     func submitQuickActionPrompt(_ prompt: String) {
         coordinator.submitProgrammatic(text: prompt)
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1934,6 +1934,7 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
                 recordDuckAIPromptDelivered(wasQueued: false, didSendBridgeMessage: nil)
                 clearAttachments()
                 setText("")
+                dismissOmnibarKeyboard()
                 return
             }
 
@@ -1948,6 +1949,9 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
                 // showCollapsed has no dismiss hook; clear synchronously.
                 setText("")
                 showCollapsed()
+                if isContextualChatState {
+                    dismissOmnibarKeyboard()
+                }
             }
             if let userScript {
                 let didSendBridgeMessage = userScript.canDispatchBridgeMessages

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetViewControllerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetViewControllerTests.swift
@@ -1,0 +1,32 @@
+//
+//  AIChatContextualSheetViewControllerTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+import XCTest
+@testable import DuckDuckGo
+
+final class AIChatContextualSheetViewControllerTests: XCTestCase {
+
+    func test_keyboardDismissDragGate_onlyBeginsForPredominantlyVerticalDrags() {
+        XCTAssertTrue(AIChatContextualSheetViewController.isPredominantlyVerticalDrag(velocity: CGPoint(x: 4, y: 120)))
+        XCTAssertTrue(AIChatContextualSheetViewController.isPredominantlyVerticalDrag(velocity: CGPoint(x: -10, y: -300)))
+        XCTAssertFalse(AIChatContextualSheetViewController.isPredominantlyVerticalDrag(velocity: CGPoint(x: 200, y: 30)))
+        XCTAssertFalse(AIChatContextualSheetViewController.isPredominantlyVerticalDrag(velocity: CGPoint(x: 50, y: 50)))
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216554304177206

### Description

Improves the keyboard behaviour of the contextual Duck.ai sheet on iPhone (behind the unified toggle input flags):

- The keyboard now dismisses when you submit a prompt, so the streamed response is immediately visible. The input bar stays fully expanded and docked at the bottom — it does not collapse. This matches how the full Duck.ai tab already behaves.
- Dragging the sheet content vertically now dismisses the keyboard, matching the standard scroll-to-dismiss expectation. This works both before the first prompt and once you're in the chat transcript.

Stacked on `pete/ios/contextual-uti-part-2` (PR #5676) — addresses design feedback on that change.

### Testing Steps

Prerequisites:
- `ff.unifiedToggleInput = true`
- `ff.aiChatContextualUnifiedToggleInput = true`
- Restart the app after changing these flags.

#### Test 1: Keyboard dismisses on submit (bar stays expanded)
1. Open a normal web page, then open contextual Duck.ai before submitting a prompt → the input appears with the keyboard up.
2. Type a prompt and submit → the keyboard dismisses and the streamed response is visible; the input bar stays fully expanded and docked at the bottom (no collapse to a pill); the sheet expands to full height.
3. Tap the input, type a follow-up, submit → the keyboard dismisses again and the bar stays expanded.

#### Test 2: Drag the content to dismiss the keyboard
1. With the keyboard up, drag the content vertically before submitting the first prompt → the keyboard dismisses as the drag starts; the bar drops to the docked bottom, still expanded.
2. Submit a prompt, tap the input to raise the keyboard again, then drag the chat transcript vertically → the keyboard dismisses the same way; scrolling and links still work.
3. Drag horizontally on a wide element in a response (e.g. a code block or table) → the keyboard stays up.
4. Scroll to dismiss the keyboard
5. Tap the input at the bottom → the keyboard comes back up as normal.

### Impact

Low: iPhone-only, behind the unified toggle input flags, and limited to the contextual Duck.ai input's keyboard behaviour.

#### What could go wrong?

Keyboard dismisses at the wrong moment or a content drag dismisses it unexpectedly → mitigated by a vertical-only drag gate (horizontal scrolls keep the keyboard up) and on-device testing of both the pre-submit and transcript flows.

### Quality Considerations

Scoped to the immediate contextual UTI path; the legacy contextual path is unchanged. The drag recognizer observes the drag without consuming touches, so scrolling, links, and text selection in the web transcript are unaffected.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Low Risk**
> iPhone-only UX behind unified toggle input flags; gesture uses vertical-only gating and does not cancel touches in the scroll view.
> 
> **Overview**
> Improves **contextual Duck.ai** keyboard behavior when the unified toggle input is mounted on the half-sheet: the keyboard now **dismisses on prompt submit** (including the pre–user-script delegate path) while the input bar stays expanded, and **dismisses when the user drags sheet content vertically**.
> 
> Submit handling calls **`dismissOmnibarKeyboard()`** on the contextual UTI coordinator paths so the streamed response is visible without collapsing the bar. **`AIChatContextualUTIHost.deactivateInput()`** forwards to the UTI view controller to resign first responder.
> 
> A **non-consuming pan recognizer** on the content area invokes that deactivation on vertical drags only (`isPredominantlyVerticalDrag`), with simultaneous recognition so web scrolling and horizontal pans (e.g. wide code blocks) are unchanged. Unit tests cover the vertical-drag gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6badadcb966185dc75fbd04843f69f532d0256f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>