### PR TITLE
macOS: Add Customize Responses opened pixels

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -1189,6 +1189,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
 
     private func presentCustomizeResponsesModal() {
         guard customizeResponsesModal == nil else { return }
+        PixelKit.fire(AIChatPixel.aiChatAddressBarCustomizeResponsesOpened, frequency: .dailyAndCount, includeAppVersionParameter: true)
         guard let parentWindow = view.window else {
             omnibarController.openCustomizeResponses()
             return

--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -330,6 +330,14 @@ enum AIChatPixel: PixelKitEvent {
     /// Event Trigger: User submits a prompt while web search mode is active on the New Tab Page
     case aiChatNtpWebSearchSubmitted
 
+    // MARK: - Customize Responses
+
+    /// Event Trigger: User opens Customize Responses from the native address bar Tools menu
+    case aiChatAddressBarCustomizeResponsesOpened
+
+    /// Event Trigger: User opens Customize Responses from the New Tab Page omnibar Tools menu
+    case aiChatNtpCustomizeResponsesOpened
+
     /// Event Trigger: User taps "View all chats" from the native address bar omnibar
     case aiChatViewAllChatsClicked
 
@@ -642,6 +650,10 @@ enum AIChatPixel: PixelKitEvent {
             return "aichat_ntp_image_generation_submitted"
         case .aiChatNtpWebSearchSubmitted:
             return "aichat_ntp_web_search_submitted"
+        case .aiChatAddressBarCustomizeResponsesOpened:
+            return "aichat_addressbar_customize_responses_opened"
+        case .aiChatNtpCustomizeResponsesOpened:
+            return "aichat_ntp_customize_responses_opened"
         case .aiChatViewAllChatsClicked:
             return "aichat_view_all_chats_clicked"
         case .aiChatModelsFetchFailed:
@@ -818,6 +830,8 @@ enum AIChatPixel: PixelKitEvent {
                 .aiFeaturesSearchAssistOften,
                 .aiFeaturesHideImagesOn,
                 .aiFeaturesHideImagesOff,
+                .aiChatAddressBarCustomizeResponsesOpened,
+                .aiChatNtpCustomizeResponsesOpened,
                 .serpSettingsUnrecognizedValue:
             return nil
         case .aiChatIsEnabled(let isEnabled):
@@ -1002,6 +1016,8 @@ enum AIChatPixel: PixelKitEvent {
                 .aiFeaturesSearchAssistOften,
                 .aiFeaturesHideImagesOn,
                 .aiFeaturesHideImagesOff,
+                .aiChatAddressBarCustomizeResponsesOpened,
+                .aiChatNtpCustomizeResponsesOpened,
                 .serpSettingsUnrecognizedValue:
             return [.pixelSource]
         }

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarActionsHandler.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarActionsHandler.swift
@@ -255,6 +255,7 @@ final class NewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandling {
             Logger.newTabPageOmnibar.error("Failed to get key window in openCustomizeResponses")
             return
         }
+        PixelKit.fire(AIChatPixel.aiChatNtpCustomizeResponsesOpened, frequency: .dailyAndCount, includeAppVersionParameter: true)
         let modal = CustomizeResponsesModalController(burnerMode: mainWindowController.mainViewController.tabCollectionViewModel.burnerMode)
         modal.onClose = { [weak self] in
             self?.customizeResponsesModal = nil

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_addressbar_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_addressbar_pixels.json5
@@ -324,5 +324,12 @@
         "triggers": ["other"],
         "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_addressbar_customize_responses_opened": {
+        "description": "Fired when the user opens Customize Responses from the native address bar Tools menu",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_ntp_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_ntp_pixels.json5
@@ -56,5 +56,12 @@
         "triggers": ["other"],
         "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_aichat_ntp_customize_responses_opened": {
+        "description": "Fired when the user opens Customize Responses from the New Tab Page omnibar Tools menu",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1215103932211155?focus=true
Tech Design URL:
CC:

### Description

Adds two daily-count telemetry pixels for Customize Responses opens, mirroring the Windows pixels: `m_mac_aichat_addressbar_customize_responses_opened` (native address bar Tools menu) and `m_mac_aichat_ntp_customize_responses_opened` (NTP omnibar Tools menu).

### Testing Steps
1. macOS, internal user, `aiChatCustomizeResponses` flag on.
2. Address bar Duck.ai mode → Tools → Customize Responses → `m_mac_aichat_addressbar_customize_responses_opened` fires.
3. New Tab Page omnibar → Tools → Customize Responses → `m_mac_aichat_ntp_customize_responses_opened` fires.

### Impact
Low. Telemetry-only, behind the existing `aiChatCustomizeResponses` flag.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only instrumentation on existing modal presentation paths; no auth, data, or behavior changes beyond firing pixels.
> 
> **Overview**
> Adds **daily-count** telemetry when users open **Customize Responses** from Duck.ai omnibar Tools menus, aligned with Windows.
> 
> **Native address bar:** `presentCustomizeResponsesModal()` fires `AIChatPixel.aiChatAddressBarCustomizeResponsesOpened` (`m_mac_aichat_addressbar_customize_responses_opened`) before presenting the modal.
> 
> **New Tab Page:** `openCustomizeResponses()` fires `AIChatPixel.aiChatNtpCustomizeResponsesOpened` (`m_mac_aichat_ntp_customize_responses_opened`) before presenting the modal.
> 
> `AIChatPixel` gains both cases with name strings, no extra parameters, and `pixelSource` in standard parameters; matching entries are added to `aichat_addressbar_pixels.json5` and `aichat_ntp_pixels.json5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4ad243a761183dd8f4713f9f3004b698834f00f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->