### PR TITLE
Add iOS Cookie Pop-up Protection opt-in dialog holdback experiment

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -716,6 +716,7 @@ public enum AutoconsentSubfeature: String, CaseIterable, PrivacySubfeature {
     case heuristicAction
     case cookiePopupPreferenceSetting
     case cookiePopupOptInDialog
+    case cookiePopupOptInDialogExperiment
 }
 
 public enum PrivacyProSubfeature: String, Equatable, PrivacySubfeature {

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -83,6 +83,10 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216209826654865?focus=true
     case cookiePopupOptInDialog
 
+    /// Holdback experiment for the Cookie Pop-up Protection opt-in dialog (`control` suppresses it, `treatment` shows it)
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216573736010817?focus=true
+    case cookiePopupOptInDialogExperiment
+
     // Duckplayer 'Web based' UI
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866609457246
     case duckPlayer
@@ -525,6 +529,11 @@ extension FeatureFlag: FeatureFlagDescribing {
         case treatment
     }
 
+    public enum CookiePopupOptInDialogCohort: String, FeatureFlagCohortDescribing {
+        case control
+        case treatment
+    }
+
     public static var localOverrideStoreName: String = "com.duckduckgo.app.featureFlag.localOverrides"
 
     private struct Config {
@@ -588,6 +597,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(AutoconsentSubfeature.cookiePopupPreferenceSetting))
         case .cookiePopupOptInDialog:
             Config(source: .remoteReleasable(AutoconsentSubfeature.cookiePopupOptInDialog))
+        case .cookiePopupOptInDialogExperiment:
+            Config(source: .remoteReleasable(AutoconsentSubfeature.cookiePopupOptInDialogExperiment), cohortType: CookiePopupOptInDialogCohort.self)
         case .duckPlayer:
             Config(source: .remoteReleasable(DuckPlayerSubfeature.enableDuckPlayer), supportsLocalOverriding: false)
         case .duckPlayerOpenInNewTab:

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Providers/CookiePopupProtectionOptInModalPromptProvider.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Providers/CookiePopupProtectionOptInModalPromptProvider.swift
@@ -112,6 +112,14 @@ final class CookiePopupProtectionOptInModalPromptProvider: ModalPromptProvider {
 
     func provideModalPrompt() -> ModalPromptConfiguration? {
         guard isEligibleToShow else { return nil }
+
+        // A/B experiment: this is the last point both arms share before diverging, so enroll here.
+        // `resolveCohort` assigns + enrolls the user; `control` is held back (dialog suppressed), while
+        // `treatment`/unassigned fall through to the current presentation.
+        if featureFlagger.resolveCohort(for: FeatureFlag.cookiePopupOptInDialogExperiment) as? FeatureFlag.CookiePopupOptInDialogCohort == .control {
+            return nil
+        }
+
         // The feature state stays unchanged between presentation and confirmation, so capture it now.
         let autoconsentEnabledWhenShown = AppUserDefaults().autoconsentEnabled
         let store = store


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/38424471409662/task/1216569879346068?focus=true
Tech Design URL: N/A
CC:

### Description
Adds an A/B holdback experiment for the Cookie Pop-up Protection opt-in dialog on iOS, mirroring the macOS implementation. Users are assigned to `control` (dialog held back / suppressed) or `treatment` (dialog shown, current behavior). Enrollment happens at the shared eligibility chokepoint so both arms enroll at the same moment and the split isn't diluted. This is a no-op until cohorts are defined in remote config, at which point behavior stays as today for anyone unassigned or out of rollout.

### Testing Steps
1. Run an internal build → Debug → Feature Flag Overrides → set the Cookie Pop-up Opt-In Dialog Experiment cohort to `control`.
2. Put the device in a state where the dialog is eligible (Cookie Pop-up Protection feature on, ≥ 2 days since install, not already on the most-private setting, not previously confirmed, shown fewer than 3 times) - can be reset via Debug -> CPM -> Opt-in dialog -> Reset app launch flags.
3. Relaunch → the opt-in dialog does NOT appear (held back).
4. Change the cohort to `treatment` (or clear the override) → relaunch → the dialog appears as before.

### Impact
Low — gated behind a feature flag plus an experiment cohort. When a user is unassigned or out of rollout, `resolveCohort` returns nil and the current behavior (dialog shown) is preserved.

#### What could go wrong?
- Enrolling at the wrong point could dilute the experiment → mitigated by resolving the cohort at the shared eligibility chokepoint, so treatment and control enroll simultaneously.
- Subfeature id mismatch with remote config → cohorts wouldn't resolve → mitigated by a dedicated `cookiePopupOptInDialogExperiment` subfeature; unresolved cohorts fall through to treatment (current behavior).

### Quality Considerations
Cohort rawValues (`control`/`treatment`) are byte-identical to macOS so the framework matches cohorts across platforms. Privacy: only records experiment enrollment; no new user data. macOS parity: macOS currently hangs the cohorts off the plain `cookiePopupOptInDialog` flag and needs the same move onto the experiment subfeature for the shared experiment to line up. Remote privacy-config changes to define the cohorts are a separate follow-up.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is gated by a dedicated experiment subfeature; unassigned users still see the dialog, and only presentation is affected—not cookie or autoconsent settings.
> 
> **Overview**
> Adds a remote **holdback A/B experiment** for the Cookie Pop-up Protection opt-in modal on iOS, aligned with macOS cohort naming (`control` / `treatment`).
> 
> A new autoconsent privacy subfeature and iOS feature flag **`cookiePopupOptInDialogExperiment`** wire cohort assignment through remote config. In **`CookiePopupProtectionOptInModalPromptProvider`**, after existing eligibility checks, **`resolveCohort`** runs at the shared chokepoint: **`control`** skips presenting the dialog; **`treatment`** and unassigned users keep today’s behavior until cohorts roll out in privacy config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb0dc5d9880c75f18c8d4647065f765fd0e88980. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->