### PR TITLE
Split cookie pop-up opt-in dialog into a separate experiment flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -716,6 +716,7 @@ public enum AutoconsentSubfeature: String, CaseIterable, PrivacySubfeature {
     case heuristicAction
     case cookiePopupPreferenceSetting
     case cookiePopupOptInDialog
+    case cookiePopupOptInDialogExperiment
 }
 
 public enum PrivacyProSubfeature: String, Equatable, PrivacySubfeature {

--- a/macOS/DuckDuckGo/Autoconsent/OptInDialog/CookiePopupProtectionOptInPromoDelegate.swift
+++ b/macOS/DuckDuckGo/Autoconsent/OptInDialog/CookiePopupProtectionOptInPromoDelegate.swift
@@ -137,6 +137,14 @@ final class CookiePopupProtectionOptInPromoDelegate: InternalPromoDelegate {
             return .noChange
         }
 
+        // A/B experiment: this is the last point both arms share before diverging, so enroll here.
+        // `resolveCohort` assigns + enrolls the user; `control` is held back (dialog suppressed), while
+        // `treatment`/unassigned fall through to the current presentation. Skipped for debug force-shows.
+        if !force,
+           featureFlagger.resolveCohort(for: FeatureFlag.cookiePopupOptInDialogExperiment) as? FeatureFlag.CookiePopupOptInDialogCohort == .control {
+            return .noChange
+        }
+
         // Feature state when shown — unchanged until the user confirms, so reuse it for the confirmation pixel too.
         let autoconsentEnabled = browserTabViewController.cookiePopupProtectionPreferences.isAutoconsentEnabled
 

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -302,6 +302,10 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216209826654872?focus=true
     case cookiePopupOptInDialog
 
+    /// A/B experiment cohorts for the Cookie Pop-up Protection opt-in dialog
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216573422000546?focus=true
+    case cookiePopupOptInDialogExperiment
+
     /// Enables advanced card ordering for the Next Steps List widget
     /// This flag is disabled by default to allow testing the new widget design with current ordering logic
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213076052926663?focus=true
@@ -466,6 +470,11 @@ extension FeatureFlag: FeatureFlagDescribing {
 
     /// Cohorts for the autoconsent heuristic action experiment
     public enum HeuristicActionCohort: String, FeatureFlagCohortDescribing {
+        case control
+        case treatment
+    }
+
+    public enum CookiePopupOptInDialogCohort: String, FeatureFlagCohortDescribing {
         case control
         case treatment
     }
@@ -662,6 +671,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(AutoconsentSubfeature.cookiePopupPreferenceSetting), category: .popupBlocking)
         case .cookiePopupOptInDialog:
             Config(source: .remoteReleasable(AutoconsentSubfeature.cookiePopupOptInDialog), category: .popupBlocking)
+        case .cookiePopupOptInDialogExperiment:
+            Config(source: .remoteReleasable(AutoconsentSubfeature.cookiePopupOptInDialogExperiment), cohortType: CookiePopupOptInDialogCohort.self, category: .popupBlocking)
         case .nextStepsListAdvancedCardOrdering:
             Config(defaultValue: .enabled, source: .remoteReleasable(HtmlNewTabPageSubfeature.nextStepsListAdvancedCardOrdering))
         case .crashCollectionLimitCallStackTreeDepth:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/38424471409662/task/1216569879346068?focus=true
Tech Design URL: N/A
CC:

### Description
The cookie pop-up opt-in dialog A/B experiment had its cohorts attached directly to the `cookiePopupOptInDialog` feature flag. Because a flag carrying cohorts is treated as an experiment, the flag stopped showing as a simple on/off toggle in the internal feature-flag override menu — only a cohort picker remained.

This splits the experiment onto a new dedicated `cookiePopupOptInDialogExperiment` subfeature. The original `cookiePopupOptInDialog` flag goes back to being a plain on/off gate/kill-switch (and regains its on/off local-override toggle), while the experiment cohorts now live on the new flag.

### Testing Steps
1. Build the macOS app and turn on internal user mode.
2. Debug → Feature Flag Overrides → Feature Flags → Popup Blocking → confirm `cookiePopupOptInDialog` shows as an on/off toggle again.
3. Debug → Feature Flag Overrides → Experiments → confirm `cookiePopupOptInDialogExperiment` shows with a control / treatment cohort picker.
4. With the opt-in dialog otherwise eligible (can be reset via Debug -> CPM -> Opt-in dialog -> Reset app launch flags), override the experiment cohort to `control` and restart the app → the dialog is suppressed on the next eligible presentation. 
5. Change override to `treatment` (or leave unassigned), restart the app → the dialog presents as before.

### Impact
Low. Everything is behind remote-config feature flags that default to off, and the new experiment subfeature is not defined in the remote privacy config yet, so merging changes no live behavior.

#### What could go wrong?
The `cookiePopupOptInDialogExperiment` subfeature (with its control/treatment cohorts) must be added to the remote privacy config before the experiment can run → until then `resolveCohort` returns nil and users fall through to the current, non-control presentation, i.e. no behavior change.

### Quality Considerations
- iOS is unaffected: its `cookiePopupOptInDialog` flag never carried a cohort type and its consumer doesn't resolve cohorts — it only inherits the new, unused shared subfeature case.
- No cohort logic changed; the cohort resolution simply moved from the base flag to the dedicated experiment flag.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, flag-gated promo presentation change; no live experiment config shipped yet, so production behavior should be unchanged until remote config is updated.
> 
> **Overview**
> Moves the cookie pop-up protection opt-in dialog **A/B cohorts** off `cookiePopupOptInDialog` onto a new **`cookiePopupOptInDialogExperiment`** remote subfeature and macOS `FeatureFlag`, so the base flag is again a plain on/off kill-switch (with an on/off override in internal menus) while control/treatment live on the experiment flag.
> 
> **`CookiePopupProtectionOptInPromoDelegate`** now enrolls via `resolveCohort(for: .cookiePopupOptInDialogExperiment)` at presentation time: **control** returns `.noChange` (dialog suppressed); **treatment** or unassigned still show the dialog. Debug **force** shows skip cohort gating.
> 
> Until the new subfeature is in remote privacy config, cohort resolution stays nil and behavior matches today (no control holdback).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ab44dca3bdc812683185b4483f3e08f61607c4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->