### PR TITLE
[iOS] Fix test suite crash

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentBlocker/AdClickAttribution/AdClickAttributionRulesProviderTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentBlocker/AdClickAttribution/AdClickAttributionRulesProviderTests.swift
@@ -26,22 +26,29 @@ import XCTest
 
 class MockCompiledRuleListSource: CompiledRuleListsSource {
 
+    private let lock = NSLock()
+
     var currentRules: [ContentBlockerRulesManager.Rules] {
         [currentMainRules, currentAttributionRules].compactMap { $0 }
     }
 
-    var currentMainRules: ContentBlockerRulesManager.Rules?
+    private var _currentMainRules: ContentBlockerRulesManager.Rules?
+    var currentMainRules: ContentBlockerRulesManager.Rules? {
+        get { lock.lock(); defer { lock.unlock() }; return _currentMainRules }
+        set { lock.lock(); _currentMainRules = newValue; lock.unlock() }
+    }
 
     var onCurrentRulesQueried: () -> Void = { }
 
-    var _currentAttributionRules: ContentBlockerRulesManager.Rules?
+    private var _currentAttributionRules: ContentBlockerRulesManager.Rules?
     var currentAttributionRules: ContentBlockerRulesManager.Rules? {
         get {
             onCurrentRulesQueried()
+            lock.lock(); defer { lock.unlock() }
             return _currentAttributionRules
         }
         set {
-            _currentAttributionRules = newValue
+            lock.lock(); _currentAttributionRules = newValue; lock.unlock()
         }
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1216577568745015?focus=true
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->

This PR fixes an issue where the test suite could crash due to a thread safety issue.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Run `testWhenAttributionIsRequestedForMultipleVendorsAndRulesChangeThenAllRulesAreCompiled` locally with many iterations (1000+)

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mock changes with no production code touched.
> 
> **Overview**
> Fixes intermittent **test suite crashes** when ad click attribution tests run many concurrent attribution requests against a shared mock rules source.
> 
> `MockCompiledRuleListSource` now guards `currentMainRules` and `currentAttributionRules` with an **`NSLock`**, backing storage in private properties so parallel reads/writes from the provider under test no longer race.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efd91e0033f65680b7724a9258885a6ce1c4e713. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->