### PR TITLE
iOS: Fix AI-tab content bleeding under the Unified Toggle Input bar

### DIFF
--- a/iOS/DuckDuckGo/MainViewCoordinator.swift
+++ b/iOS/DuckDuckGo/MainViewCoordinator.swift
@@ -720,10 +720,7 @@ class MainViewCoordinator {
         }
     }
 
-    /// The UTI owns the bottom anchor whenever it's actually on screen, regardless of what a
-    /// caller requests — otherwise the full-bleed AI-tab web view extends past the UTI card.
-    /// Carve-out: voice mode/bottom-chrome-hidden hides `navigationBarContainer` (so the UTI
-    /// isn't really visible) before requesting `.safeArea`, which this must still honor.
+    /// The UTI owns the bottom anchor whenever it's visible and not voice-mode-hidden, regardless of what a caller requests.
     private func setContentContainerBottomAnchorMode(_ mode: ContentContainerBottomAnchorMode) {
         let resolvedMode: ContentContainerBottomAnchorMode = (isUnifiedToggleInputVisible && !navigationBarContainer.isHidden) ? .unifiedToggleInput : mode
         constraints.contentContainerBottomToToolbarTop.isActive = resolvedMode == .toolbar

--- a/iOS/DuckDuckGo/MainViewCoordinator.swift
+++ b/iOS/DuckDuckGo/MainViewCoordinator.swift
@@ -720,10 +720,15 @@ class MainViewCoordinator {
         }
     }
 
+    /// The UTI owns the bottom anchor whenever it's actually on screen, regardless of what a
+    /// caller requests — otherwise the full-bleed AI-tab web view extends past the UTI card.
+    /// Carve-out: voice mode/bottom-chrome-hidden hides `navigationBarContainer` (so the UTI
+    /// isn't really visible) before requesting `.safeArea`, which this must still honor.
     private func setContentContainerBottomAnchorMode(_ mode: ContentContainerBottomAnchorMode) {
-        constraints.contentContainerBottomToToolbarTop.isActive = mode == .toolbar
-        constraints.contentContainerBottomToUnifiedToggleInputTop.isActive = mode == .unifiedToggleInput
-        constraints.contentContainerBottomToSafeArea.isActive = mode == .safeArea
+        let resolvedMode: ContentContainerBottomAnchorMode = (isUnifiedToggleInputVisible && !navigationBarContainer.isHidden) ? .unifiedToggleInput : mode
+        constraints.contentContainerBottomToToolbarTop.isActive = resolvedMode == .toolbar
+        constraints.contentContainerBottomToUnifiedToggleInputTop.isActive = resolvedMode == .unifiedToggleInput
+        constraints.contentContainerBottomToSafeArea.isActive = resolvedMode == .safeArea
     }
 
     /// Activates the resting content-container top anchor for the current mode. In floating top

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -808,6 +808,12 @@ private extension MainViewController {
 
     func refreshNonAITab(tab: TabViewController, coordinator: UnifiedToggleInputCoordinator) {
         viewCoordinator.hideAITabChrome()
+        // Must run before the layout pass below, which reads live UTI visibility for the anchor.
+        if coordinator.isActive {
+            coordinator.deactivateToOmnibar()
+            coordinator.hide()
+            coordinator.unbind()
+        }
         viewCoordinator.moveAddressBarToPosition(appSettings.currentAddressBarPosition)
         refreshViewsBasedOnAddressBarPosition(appSettings.currentAddressBarPosition)
         applyUnifiedInputChromeBackground(.standardChrome)
@@ -817,11 +823,6 @@ private extension MainViewController {
         reconcileAIChromeForCurrentTab()
         // Snap chrome revealed — prior chat-scroll could have hidden bars under the AI header, so without this the omnibar flies in on return.
         chromeManager.reset(animated: false)
-        if coordinator.isActive {
-            coordinator.deactivateToOmnibar()
-            coordinator.hide()
-            coordinator.unbind()
-        }
     }
 
     func setUpAIChatTabChatHeader() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1216540373435744

### Description
Regression: On a Duck.ai (AI chat) tab, the web content could render behind/below the Unified Toggle Input (UTI) bottom bar instead of stopping above it — the tail of a chat response would peek out under the input bar. 

Root cause: the content container's bottom anchor is switched between three modes (toolbar / UTI / safe-area) from many call sites, several of which picked `.toolbar` or `.safeArea` with no awareness of whether the UTI was actually on screen, so the full-bleed AI-tab web view could extend past the UTI card. 

### Testing Steps
1. **Bottom address bar, Floating UI off** — on a regular web page with enough content to summarize at length (e.g. wiki page), open the contextual sheet and use "Summarize This Page", then expand the sheet into a full Duck.ai tab → scroll the response and confirm the summary text stops above the input bar with no visible gap/bleed-through underneath, even as the response fills near the bottom of the screen.
2. **Top address bar, Floating UI on** — same flow: summarize a long page from the contextual sheet, then expand into a full Duck.ai tab → confirm no transparent gap or content bleed appears below the UTI bar.
3. **Tab switch away from AI tab (existing tab)** — with bottom address bar / Floating UI off, open a Duck.ai tab (UTI visible), then switch to a different, already-open regular tab via the tab switcher → confirm the tab's content is anchored correctly to the top and bottom, not left anchored to the UTI's old position.
4. **Tab switch away from AI tab (new tab / home screen)** — from a Duck.ai tab, open a new tab / go to the home screen (NTP) instead of switching to an existing tab → confirm the same correct anchoring, since this goes through a different code path than step 3.
5. **Voice mode** — on an AI tab with the UTI visible, start a voice session then end it → confirm the bottom chrome hide/show still gives voice mode the full safe-area height as before , and the UTI anchors correctly again once voice mode ends.
6. **Regression: regular (non-AI) tabs unaffected** — on a normal web tab (no UTI), check both bottom and top address bar positions, with Floating UI on and off → confirm layout/toolbar anchoring is unchanged from current behavior.
7. Smoke test the floating UI work

### Impact
Medium: visual bug on the Duck.ai tab (content bleeding behind the input bar); no data loss or privacy impact, but affects a highly-visible entry point.

#### What could go wrong?
The one carve-out (voice-mode / bottom-chrome-hidden requesting `.safeArea`) explicitly hides `navigationBarContainer` first → mitigated by checking `!navigationBarContainer.isHidden` alongside UTI visibility before coercing, so that path is unaffected (see Testing Step 6).

### Quality Considerations
No test added — `MainViewCoordinator`/`UnifiedToggleInputCoordinator` have no existing unit test coverage in this codebase (heavy UIKit/Auto Layout wiring); verified manually on-device across the scenarios above instead.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Medium Risk**
> Touches main browser layout anchoring used from many call sites; behavior is narrowed to when UTI is visibly on screen, with an explicit carve-out when the nav bar container is hidden.
> 
> **Overview**
> Fixes Duck.ai web content rendering **behind or below** the Unified Toggle Input (UTI) bar when callers set the content container’s bottom anchor to `.toolbar` or `.safeArea` without checking UTI visibility.
> 
> **`setContentContainerBottomAnchorMode`** now **resolves** the requested mode: if the UTI is on screen (`isUnifiedToggleInputVisible`) and the bottom chrome is shown (`!navigationBarContainer.isHidden`), it always applies **`.unifiedToggleInput`** instead of the caller’s mode. Voice / bottom-chrome-hidden flows that hide `navigationBarContainer` first and request `.safeArea` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a97b8cf342d3c51da9cbbe920ece7f50332cffe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>
