### PR TITLE
Update autofill to 19.2.0

### DIFF
--- a/SharedPackages/BrowserServicesKit/Package.resolved
+++ b/SharedPackages/BrowserServicesKit/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "84b5e3019b2c7b3c90e8d296f30fcfd53768bcd8",
-        "version" : "19.1.0"
+        "revision" : "34eb540473a90d25e11942e9c72a18c2430d4f50",
+        "version" : "19.2.0"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
         .library(name: "WKAbstractions", targets: ["WKAbstractions"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "19.1.0"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "19.2.0"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit.git", exact: "3.1.0"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.7.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "3.0.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216589981454169
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/19.2.0
Apple PR: 

## Description
Updates Autofill to version [19.2.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/19.2.0).

### Autofill 19.2.0 release notes
## What's Changed
* Update password-related json files by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/914
* Update password-related json files by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/936
* Update password-related json files by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/937
* Update password-related json files by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/938
* Fix login scoring on StubHub sign-in pages by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/935
* Update password-related json files by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/941
* Update password-related json files by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/942
* [SiteSpecificFeature] Support for forced cc form types by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/939


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/19.1.0...19.2.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Autofill behavior on login and payment forms can change via updated heuristics and site rules, though the diff is limited to the package version pin.
> 
> **Overview**
> Bumps the **`duckduckgo-autofill`** Swift package from **19.1.0** to **19.2.0** in `BrowserServicesKit` (`Package.swift` exact version and `Package.resolved` pin/revision). No first-party code changes in this repo.
> 
> The upstream **19.2.0** release refreshes password-related JSON data, fixes login scoring on StubHub sign-in pages, and adds site-specific support for forced credit-card form types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4601d17fdcc950c51ff1d7ccb72c48e687064264. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->