### PR TITLE
iOS: Fix new-tab address bar input sliding in from the left

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
@@ -66,11 +66,7 @@ extension MainViewController {
         return pill.convert(pill.bounds, to: nil)
     }
 
-    /// The collapsed-pose hand-off only makes sense when the resting omnibar is actually on screen
-    /// to morph out of. On the new-tab focus path the shared omnibar is measured before the
-    /// swipe-tabs collection has scrolled/reparented it into the new cell, so it reads a full page
-    /// off-screen; seeding the UTI's card and text from that makes them slide in from the edge.
-    /// Report an off-screen omnibar as unmeasurable so callers fall back to the resting margins.
+    /// Off-screen omnibar (e.g. new-tab focus before swipe-tabs reparents it) is unmeasurable, so the hand-off falls back to resting margins.
     private func omnibarChromeIsOnScreenForHandoff(_ view: UIView) -> Bool {
         guard let window = view.window else { return false }
         return window.bounds.intersects(view.convert(view.bounds, to: nil))

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
@@ -53,7 +53,7 @@ extension MainViewController {
 
     func currentOmnibarPlaceholderWindowX() -> CGFloat? {
         guard let textField = viewCoordinator.omniBar.barView.textField,
-              textField.window != nil else { return nil }
+              omnibarChromeIsOnScreenForHandoff(textField) else { return nil }
         let placeholderRect = textField.placeholderRect(forBounds: textField.bounds)
         return textField.convert(placeholderRect.origin, to: nil).x
     }
@@ -62,8 +62,18 @@ extension MainViewController {
     /// the bottom-position UTI to disguise its collapsed pose as the floating omnibar at hand-off.
     func currentOmnibarPillWindowFrame() -> CGRect? {
         guard let pill = viewCoordinator.omniBar.barView.searchContainer,
-              pill.window != nil else { return nil }
+              omnibarChromeIsOnScreenForHandoff(pill) else { return nil }
         return pill.convert(pill.bounds, to: nil)
+    }
+
+    /// The collapsed-pose hand-off only makes sense when the resting omnibar is actually on screen
+    /// to morph out of. On the new-tab focus path the shared omnibar is measured before the
+    /// swipe-tabs collection has scrolled/reparented it into the new cell, so it reads a full page
+    /// off-screen; seeding the UTI's card and text from that makes them slide in from the edge.
+    /// Report an off-screen omnibar as unmeasurable so callers fall back to the resting margins.
+    private func omnibarChromeIsOnScreenForHandoff(_ view: UIView) -> Bool {
+        guard let window = view.window else { return false }
+        return window.bounds.intersects(view.convert(view.bounds, to: nil))
     }
 
     func currentOmnibarPlaceholderColor() -> UIColor? {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214241865640188

### Description
Creating a new tab focuses the address bar, and its expanded input was sliding in from the left edge instead of appearing in place. The focus animation morphs out of the resting address bar by measuring where it sits on screen, but on the new-tab path the address bar hasn't been repositioned for the new tab yet, so it was measured off-screen. It's now treated as unmeasurable in that case, so the input expands in place. This covers both address bar positions and both toggle states (the whole card slid at the bottom; the field/text slid with the toggle off at the top).

### Testing Steps
Run through this for each address bar position — **bottom** and **top** (Settings → Address Bar Position) — and with the Search/Duck.ai toggle both **on** and **off** (off = Duck.ai disabled, so the input is a plain search field with no toggle):
1. Open the tab switcher and tap + to create a new tab → the address bar input expands in place, with no slide in from the left edge.
2. Repeat step 1 with several tabs already open → same result.
3. Tap the address bar on an existing tab to focus it → unchanged, expands as before.

The two combinations that regressed most visibly: **bottom + toggle on** (the whole card slid in) and **top + toggle off** (the field/text slid in).

### Impact
Low: bug fix to the address-bar focus animation on new tabs; no change to input behavior, navigation, or data.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard in omnibar measurement for focus animations only; no navigation, auth, or data changes.
> 
> **Overview**
> Fixes new-tab address bar focus where the expanded unified input **slid in from the left** because the focus animation measured the resting omnibar while it was still off-screen (before swipe-tabs reparenting).
> 
> **`currentOmnibarPlaceholderWindowX()`** and **`currentOmnibarPillWindowFrame()`** no longer treat “has a window” as measurable. They use new **`omnibarChromeIsOnScreenForHandoff`**, which requires the view’s window-space frame to intersect the window bounds. Off-screen chrome returns `nil`, so **`handleShowOmnibarEditingIntent`** skips placeholder alignment and bottom pill matching and uses the existing resting-margin fallback—input expands in place. On-screen focus on existing tabs is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d6b9ef60282f8181410899a46825144ec36ddb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->