### PR TITLE
Clear stale VPN errors once a connection is confirmed working

### DIFF
--- a/SharedPackages/VPN/Package.resolved
+++ b/SharedPackages/VPN/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "5735b061ee14708ca17bc5b72b8eb9d21eb7f830",
-        "version" : "15.3.0"
+        "revision" : "dc9b1280951a22359aac33d07ffd410cbbae2b94",
+        "version" : "15.12.0"
       }
     },
     {

--- a/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
+++ b/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
@@ -1073,13 +1073,10 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         clearResolvedIssueState()
     }
 
-    /// Clears the issue state that a working connection makes stale.
+    /// Clears the issue state once a working connection is confirmed (and on manual start).
     ///
-    /// Called on a manual start and whenever the connection tester confirms a working connection.
-    /// A successful connection invalidates any prior start or connectivity error, so the stored
-    /// error and known failure are cleared here. Without this, on-demand starts (which skip
-    /// `resetIssueStateOnTunnelStart`) leave a stale error in the stores that resurfaces when the
-    /// tunnel later disconnects — the app re-reads the last error on the disconnect transition.
+    /// On-demand starts skip `resetIssueStateOnTunnelStart`, so without this a failed start's error
+    /// lingers in the stores and resurfaces when the tunnel later disconnects.
     ///
     private func clearResolvedIssueState() {
         tunnelHealth.isHavingConnectivityIssues = false

--- a/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
+++ b/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
@@ -377,6 +377,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     private let tunnelHealth: NetworkProtectionTunnelHealthStore
     private let controllerErrorStore: NetworkProtectionTunnelErrorStore
     private let knownFailureStore: NetworkProtectionKnownFailureStore
+    private let errorStateReset: VPNErrorStateReset
     private let snoozeTimingStore: NetworkProtectionSnoozeTimingStore
     private let wireGuardInterface: WireGuardGoInterface
     private let deviceManager: NetworkProtectionDeviceManagement
@@ -453,6 +454,8 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         self.tunnelHealth = tunnelHealthStore
         self.controllerErrorStore = controllerErrorStore
         self.knownFailureStore = knownFailureStore
+        self.errorStateReset = VPNErrorStateReset(errorMessageStore: controllerErrorStore,
+                                                  knownFailureStore: knownFailureStore)
         self.snoozeTimingStore = snoozeTimingStore
         self.wireGuardInterface = wireGuardInterface
         self.settings = settings
@@ -728,7 +731,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
         switch result {
         case .connected:
-            self.tunnelHealth.isHavingConnectivityIssues = false
+            self.clearResolvedIssueState()
 
         case .reconnected(let failureCount):
             providerEvents.fire(
@@ -743,7 +746,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                         server: serverName))
             }
 
-            self.tunnelHealth.isHavingConnectivityIssues = false
+            self.clearResolvedIssueState()
 
         case .disconnected(let failureCount):
             if failureCount == 1 {
@@ -1060,15 +1063,27 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     /// Resets the issue state when startup up the tunnel manually.
     ///
     /// When the tunnel is started by on-demand the issue state should not be cleared until the tester
-    /// reports a working connection.
+    /// reports a working connection (see `clearResolvedIssueState()`).
     ///
     private func resetIssueStateOnTunnelStart(_ startupOptions: StartupOptions) {
         guard startupOptions.startupMethod != .automaticOnDemand else {
             return
         }
 
+        clearResolvedIssueState()
+    }
+
+    /// Clears the issue state that a working connection makes stale.
+    ///
+    /// Called on a manual start and whenever the connection tester confirms a working connection.
+    /// A successful connection invalidates any prior start or connectivity error, so the stored
+    /// error and known failure are cleared here. Without this, on-demand starts (which skip
+    /// `resetIssueStateOnTunnelStart`) leave a stale error in the stores that resurfaces when the
+    /// tunnel later disconnects — the app re-reads the last error on the disconnect transition.
+    ///
+    private func clearResolvedIssueState() {
         tunnelHealth.isHavingConnectivityIssues = false
-        controllerErrorStore.lastErrorMessage = nil
+        errorStateReset.clear()
     }
 
     // MARK: - Tunnel Configuration

--- a/SharedPackages/VPN/Sources/VPN/Storage/VPNErrorStateReset.swift
+++ b/SharedPackages/VPN/Sources/VPN/Storage/VPNErrorStateReset.swift
@@ -1,0 +1,57 @@
+//
+//  VPNErrorStateReset.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// A store holding the last VPN error message.
+protocol LastErrorMessageStoring: AnyObject {
+    var lastErrorMessage: String? { get set }
+}
+
+/// A store holding the last typed VPN known failure.
+protocol LastKnownFailureStoring: AnyObject {
+    var lastKnownFailure: KnownFailure? { get set }
+}
+
+extension NetworkProtectionTunnelErrorStore: LastErrorMessageStoring {}
+extension NetworkProtectionKnownFailureStore: LastKnownFailureStoring {}
+
+/// Clears the VPN error signals that a successful connection makes stale.
+///
+/// Start and connectivity errors are persisted across two independent stores — the last error
+/// message and the typed known failure. A working connection invalidates both, so they must be
+/// cleared together: clearing only one leaves a stale signal that resurfaces when the tunnel later
+/// disconnects, because the app re-reads the last error on the disconnect transition.
+struct VPNErrorStateReset {
+
+    private let errorMessageStore: LastErrorMessageStoring
+    private let knownFailureStore: LastKnownFailureStoring
+
+    init(errorMessageStore: LastErrorMessageStoring,
+         knownFailureStore: LastKnownFailureStoring) {
+        self.errorMessageStore = errorMessageStore
+        self.knownFailureStore = knownFailureStore
+    }
+
+    /// Clears every stored error signal. Call when the connection is confirmed working, or on a
+    /// manual (re)start, so no stale error survives to be surfaced on the next disconnect.
+    func clear() {
+        errorMessageStore.lastErrorMessage = nil
+        knownFailureStore.lastKnownFailure = nil
+    }
+}

--- a/SharedPackages/VPN/Sources/VPN/Storage/VPNErrorStateReset.swift
+++ b/SharedPackages/VPN/Sources/VPN/Storage/VPNErrorStateReset.swift
@@ -31,12 +31,10 @@ protocol LastKnownFailureStoring: AnyObject {
 extension NetworkProtectionTunnelErrorStore: LastErrorMessageStoring {}
 extension NetworkProtectionKnownFailureStore: LastKnownFailureStoring {}
 
-/// Clears the VPN error signals that a successful connection makes stale.
+/// Clears the two stores holding VPN error signals (last error message and known failure).
 ///
-/// Start and connectivity errors are persisted across two independent stores — the last error
-/// message and the typed known failure. A working connection invalidates both, so they must be
-/// cleared together: clearing only one leaves a stale signal that resurfaces when the tunnel later
-/// disconnects, because the app re-reads the last error on the disconnect transition.
+/// A working connection invalidates both; leaving either set resurfaces on the next disconnect,
+/// when the app re-reads the last error.
 struct VPNErrorStateReset {
 
     private let errorMessageStore: LastErrorMessageStoring
@@ -48,8 +46,7 @@ struct VPNErrorStateReset {
         self.knownFailureStore = knownFailureStore
     }
 
-    /// Clears every stored error signal. Call when the connection is confirmed working, or on a
-    /// manual (re)start, so no stale error survives to be surfaced on the next disconnect.
+    /// Call when the connection is confirmed working, or on a manual start.
     func clear() {
         errorMessageStore.lastErrorMessage = nil
         knownFailureStore.lastKnownFailure = nil

--- a/SharedPackages/VPN/Tests/VPNTests/VPNErrorStateResetTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/VPNErrorStateResetTests.swift
@@ -30,9 +30,8 @@ final class VPNErrorStateResetTests: XCTestCase {
         var lastKnownFailure: KnownFailure?
     }
 
-    /// A working connection must clear every stored error signal, not just one: a stale value left
-    /// on either store resurfaces when the tunnel later disconnects (the app re-reads the last
-    /// error on the disconnect transition).
+    /// A working connection must clear both stores, not just one — a value left on either
+    /// resurfaces on the next disconnect.
     func testClearRemovesBothTheLastErrorMessageAndTheKnownFailure() {
         let errorMessageStore = FakeErrorMessageStore()
         let knownFailureStore = FakeKnownFailureStore()

--- a/SharedPackages/VPN/Tests/VPNTests/VPNErrorStateResetTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/VPNErrorStateResetTests.swift
@@ -1,0 +1,53 @@
+//
+//  VPNErrorStateResetTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import XCTest
+@testable import VPN
+
+final class VPNErrorStateResetTests: XCTestCase {
+
+    private final class FakeErrorMessageStore: LastErrorMessageStoring {
+        var lastErrorMessage: String?
+    }
+
+    private final class FakeKnownFailureStore: LastKnownFailureStoring {
+        var lastKnownFailure: KnownFailure?
+    }
+
+    /// A working connection must clear every stored error signal, not just one: a stale value left
+    /// on either store resurfaces when the tunnel later disconnects (the app re-reads the last
+    /// error on the disconnect transition).
+    func testClearRemovesBothTheLastErrorMessageAndTheKnownFailure() {
+        let errorMessageStore = FakeErrorMessageStore()
+        let knownFailureStore = FakeKnownFailureStore()
+        errorMessageStore.lastErrorMessage = "Tunnel failed to start"
+        knownFailureStore.lastKnownFailure = KnownFailure(NSError(domain: "SMAppServiceErrorDomain", code: 1))
+
+        // Precondition: both error signals are present.
+        XCTAssertNotNil(errorMessageStore.lastErrorMessage)
+        XCTAssertNotNil(knownFailureStore.lastKnownFailure)
+
+        let reset = VPNErrorStateReset(errorMessageStore: errorMessageStore,
+                                       knownFailureStore: knownFailureStore)
+        reset.clear()
+
+        XCTAssertNil(errorMessageStore.lastErrorMessage)
+        XCTAssertNil(knownFailureStore.lastKnownFailure)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206580121312550/task/1215501997667823?focus=true

### Description

VPN start errors could reappear when the user stopped the VPN, as if stopping had caused them: a failed start was recorded but only cleared on a manual start — never on a successful connection or a stop — and the app re-reads the last error on disconnect, so the stale error surfaced on stop.

Now the stored errors are cleared once the connection tester confirms a working connection. A genuine start failure never reaches that point, so real errors still surface.

### Testing Steps
1. Enable the VPN.
2. Force a start failure — for example simulate a tunnel failure, or start with no connectivity so an on-demand attempt fails.
   The status view shows an error.
3. Restore normal conditions and let the VPN reach the connected state.
   The status view shows connected, with no error.
4. Stop the VPN.
   No error message appears.

Repeat on both macOS and iOS (iOS requires a physical device, as the packet-tunnel extension does not run in the simulator).

### Impact

Low. This corrects an error-message signal on the VPN status view; core VPN connectivity is unaffected.

#### What could go wrong?
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Status/error-display logic only in the packet tunnel extension; no change to tunnel connectivity or auth. Dependency pin update is isolated to resolved package versions.
> 
> **Overview**
> Fixes **stale VPN errors** showing again when the user stops the VPN after a successful connect following an earlier failed start.
> 
> Previously, error state was only cleared on **manual** tunnel start (and only `lastErrorMessage`, not `lastKnownFailure`). **On-demand** recoveries never cleared stored errors, so the app still read them on disconnect.
> 
> **`VPNErrorStateReset`** now clears both the last error message and known-failure stores together. **`clearResolvedIssueState()`** runs on manual start (via `resetIssueStateOnTunnelStart`) and when the **connection tester** reports `.connected` or `.reconnected`, so a confirmed working link drops stale signals without wiping errors before on-demand retries prove connectivity.
> 
> Also bumps **`content-scope-scripts`** from 15.3.0 to 15.12.0 in `Package.resolved`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d382d571ed906142e4e0823d07e307bf5c99ab9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->