### PR TITLE
iOS: Add impression pixel for Ask about page quick action

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1819,6 +1819,8 @@ extension Pixel {
         case aiChatPageContextExtractionSuccess
         case aiChatPageContextExtractionFailed
         case aiChatPageContextExtractionPrevented
+
+        case aiChatContextualQuickActionAskAboutPageShown
         case aiChatContextualQuickActionAskAboutPageSelected
         case aiChatContextualRecentChatsPopupDisplayed
         case aiChatContextualRecentChatSelected
@@ -3732,6 +3734,7 @@ extension Pixel.Event {
         case .aiChatPageContextExtractionSuccess: return "aichat_page_context_extraction_success"
         case .aiChatPageContextExtractionFailed: return "aichat_page_context_extraction_failed"
         case .aiChatPageContextExtractionPrevented: return "aichat_page_context_extraction_prevented"
+        case .aiChatContextualQuickActionAskAboutPageShown: return "m_aichat_contextual_quick_action_ask_about_page_shown"
         case .aiChatContextualQuickActionAskAboutPageSelected: return "m_aichat_contextual_quick_action_ask_about_page_selected"
         case .aiChatContextualRecentChatsPopupDisplayed: return "m_aichat_contextual_recent_chats_popup_displayed"
         case .aiChatContextualRecentChatSelected: return "m_aichat_contextual_recent_chat_selected"

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualModePixelHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualModePixelHandler.swift
@@ -31,6 +31,7 @@ protocol AIChatContextualModePixelFiring {
     func fireExpandButtonTapped()
     func fireNewChatButtonTapped()
     func fireQuickActionSummarizeSelected()
+    func fireQuickActionAskAboutPageShown()
     func fireQuickActionAskAboutPageSelected()
     func fireFireButtonTapped()
     func fireFireButtonConfirmed()
@@ -123,6 +124,10 @@ final class AIChatContextualModePixelHandler: AIChatContextualModePixelFiring {
 
     func fireQuickActionSummarizeSelected() {
         firePixel(.aiChatContextualQuickActionSummarizeSelected)
+    }
+
+    func fireQuickActionAskAboutPageShown() {
+        firePixel(.aiChatContextualQuickActionAskAboutPageShown)
     }
 
     func fireQuickActionAskAboutPageSelected() {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
@@ -154,6 +154,10 @@ final class AIChatContextualSheetViewController: UIViewController {
     private var isWaitingForInitialPromptResponseState = false
     private var initialPromptRevealFallbackWorkItem: DispatchWorkItem?
 
+    /// Tracks whether the "Ask about page" quick action chip is currently on screen, so the impression
+    /// pixel fires once per appearance rather than on every view-state update.
+    private var isAskAboutPageQuickActionVisible = false
+
     // MARK: - UI Components
 
     private lazy var headerView: UIView = {
@@ -943,6 +947,7 @@ private extension AIChatContextualSheetViewController {
         expandButton.isEnabled = viewState.isExpandButtonEnabled
         contextualInputViewController.updateStartActions(suggestions: viewState.suggestions, quickActions: viewState.quickActions)
         contextualInputViewController.updateSuggestionsLoading(viewState.suggestionsLoadState == .loading)
+        fireAskAboutPageShownPixelIfNeeded(for: viewState)
 
         switch viewState.content {
         case .nativeInput:
@@ -983,6 +988,20 @@ private extension AIChatContextualSheetViewController {
         case .clearPrompt:
             contextualInputViewController.setText("")
         }
+    }
+
+    private func fireAskAboutPageShownPixelIfNeeded(for viewState: SheetViewState) {
+        let isVisible: Bool
+        switch viewState.content {
+        case .nativeInput:
+            isVisible = viewState.quickActions.contains(.askAboutPage)
+        case .webView:
+            isVisible = false
+        }
+
+        defer { isAskAboutPageQuickActionVisible = isVisible }
+        guard isVisible, !isAskAboutPageQuickActionVisible else { return }
+        pixelHandler.fireQuickActionAskAboutPageShown()
     }
 }
 

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -1625,6 +1625,7 @@ private final class MockContextualModePixelHandler: AIChatContextualModePixelFir
     var expandButtonTappedFired = false
     var newChatButtonTappedFired = false
     var quickActionSummarizeSelectedFired = false
+    var quickActionAskAboutPageShownCount = 0
     var fireButtonTappedFired = false
     var fireButtonConfirmedFired = false
     var pageContextAutoAttachedFired = false
@@ -1645,6 +1646,7 @@ private final class MockContextualModePixelHandler: AIChatContextualModePixelFir
     func fireExpandButtonTapped() { expandButtonTappedFired = true }
     func fireNewChatButtonTapped() { newChatButtonTappedFired = true }
     func fireQuickActionSummarizeSelected() { quickActionSummarizeSelectedFired = true }
+    func fireQuickActionAskAboutPageShown() { quickActionAskAboutPageShownCount += 1 }
     func fireQuickActionAskAboutPageSelected() {}
     func fireRecentChatsPopupDisplayed() {}
     func fireRecentChatSelected() {}
@@ -1671,6 +1673,7 @@ private final class MockContextualModePixelHandler: AIChatContextualModePixelFir
         expandButtonTappedFired = false
         newChatButtonTappedFired = false
         quickActionSummarizeSelectedFired = false
+        quickActionAskAboutPageShownCount = 0
         fireButtonTappedFired = false
         fireButtonConfirmedFired = false
         pageContextAutoAttachedFired = false

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualWebViewControllerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualWebViewControllerTests.swift
@@ -180,6 +180,7 @@ private final class StubContextualModePixelHandler: AIChatContextualModePixelFir
     func fireExpandButtonTapped() {}
     func fireNewChatButtonTapped() {}
     func fireQuickActionSummarizeSelected() {}
+    func fireQuickActionAskAboutPageShown() {}
     func fireQuickActionAskAboutPageSelected() {}
     func fireRecentChatsPopupDisplayed() {}
     func fireRecentChatSelected() {}

--- a/iOS/DuckDuckGoTests/AIChat/AIChatPageContextHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatPageContextHandlerTests.swift
@@ -558,6 +558,7 @@ private final class MockContextualModePixelHandler: AIChatContextualModePixelFir
     func fireExpandButtonTapped() {}
     func fireNewChatButtonTapped() {}
     func fireQuickActionSummarizeSelected() {}
+    func fireQuickActionAskAboutPageShown() {}
     func fireQuickActionAskAboutPageSelected() {}
     func fireRecentChatsPopupDisplayed() {}
     func fireRecentChatSelected() {}

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_contextual_mode.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_contextual_mode.json5
@@ -146,6 +146,13 @@
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion", "is_enabled"]
     },
+    "m_aichat_contextual_quick_action_ask_about_page_shown": {
+        "description": "Fired when the Ask about page quick action chip is shown to the user in the contextual sheet",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
     "m_aichat_contextual_quick_action_ask_about_page_selected": {
         "description": "Fired when the user selects the Ask about page quick action chip in the contextual sheet",
         "owners": ["SabrinaTardio"],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216590095234407?focus=true
Tech Design URL:
CC:

### Description
Adds an impression pixel (`m_aichat_contextual_quick_action_ask_about_page_shown`, daily + count) that fires when the "Ask about page" quick action chip is shown in the Duck.ai contextual sheet. This complements the existing `..._selected` tap pixel so we can measure how often the chip is seen versus used. It fires on the rising edge of visibility so counts aren't inflated by repeated view-state updates.

### Testing Steps
1. In Settings → AI Features → Duck.ai, turn **off** automatic page context attachment (so the chip stays in placeholder state).
2. Open a web page, tap the Duck.ai button to open the contextual sheet, and confirm the "Ask about page" chip is shown → `m_aichat_contextual_quick_action_ask_about_page_shown_count` (and `_daily` first time today) fires.
3. Close and reopen the sheet → the count pixel doen't fires again
### Impact
Low

#### What could go wrong?
Over- or under-counting if the visibility edge detection is wrong → mitigated by native-input gating plus the rising-edge guard, covered by the updated mocks.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only change with no user-facing behavior; incorrect edge detection could skew metrics but does not affect product logic.
> 
> **Overview**
> Adds **`m_aichat_contextual_quick_action_ask_about_page_shown`** so analytics can compare how often the contextual sheet shows the **Ask about page** chip versus taps on the existing **selected** pixel.
> 
> The sheet fires the impression from `apply(_:)` only on the **rising edge** of visibility: native input content, `quickActions` includes `.askAboutPage`, and the chip was not already marked visible—so repeated view-state refreshes or reopening the sheet without hiding the chip again do not inflate counts. Wiring runs through `PixelEvent`, `AIChatContextualModePixelHandler`, and the pixel definitions JSON; test doubles implement the new protocol method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15700fd156184cfcb3bcd1075c83e6ceeb39283e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->