### PR TITLE
[macOS] Fix fire-window downloads attributed to regular session

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -56,9 +56,7 @@
 		1D01A3D82B88DF8B00FE8150 /* PreferencesSyncView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D01A3D72B88DF8B00FE8150 /* PreferencesSyncView.swift */; };
 		1D01A3D92B88DF8B00FE8150 /* PreferencesSyncView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D01A3D72B88DF8B00FE8150 /* PreferencesSyncView.swift */; };
 		1D04CA182F67FECE007AB0F3 /* PageContextMultipleContextsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D04CA172F67FECE007AB0F3 /* PageContextMultipleContextsTests.swift */; };
-		FB0C0800000000000000CE06 /* PageContextExtractionPixelHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB0C0800000000000000CE04 /* PageContextExtractionPixelHandlerTests.swift */; };
 		1D04CA192F67FECE007AB0F3 /* PageContextMultipleContextsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D04CA172F67FECE007AB0F3 /* PageContextMultipleContextsTests.swift */; };
-		FB0C0800000000000000CE05 /* PageContextExtractionPixelHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB0C0800000000000000CE04 /* PageContextExtractionPixelHandlerTests.swift */; };
 		1D074B272909A433006E4AC3 /* PasswordManagerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D074B262909A433006E4AC3 /* PasswordManagerCoordinator.swift */; };
 		1D1A33492A6FEB170080ACED /* BurnerMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1A33482A6FEB170080ACED /* BurnerMode.swift */; };
 		1D1A334A2A6FEB170080ACED /* BurnerMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1A33482A6FEB170080ACED /* BurnerMode.swift */; };
@@ -385,9 +383,7 @@
 		315AA07028CA5CC800200030 /* YoutubePlayerNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 315AA06F28CA5CC800200030 /* YoutubePlayerNavigationHandler.swift */; };
 		315E395F2F86A37000D2289D /* DebugServer in Frameworks */ = {isa = PBXBuildFile; productRef = 315E395E2F86A37000D2289D /* DebugServer */; };
 		3161D15D2DA02380008F59B5 /* AIChatPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3161D15C2DA02380008F59B5 /* AIChatPixel.swift */; };
-		FB0C0800000000000000CE03 /* PageContextExtractionPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB0C0800000000000000CE01 /* PageContextExtractionPixelHandler.swift */; };
 		3161D15E2DA02380008F59B5 /* AIChatPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3161D15C2DA02380008F59B5 /* AIChatPixel.swift */; };
-		FB0C0800000000000000CE02 /* PageContextExtractionPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB0C0800000000000000CE01 /* PageContextExtractionPixelHandler.swift */; };
 		316913232BD2B6250051B46D /* DataBrokerProtectionMacOSPixelsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 316913222BD2B6250051B46D /* DataBrokerProtectionMacOSPixelsHandler.swift */; };
 		316913242BD2B6250051B46D /* DataBrokerProtectionMacOSPixelsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 316913222BD2B6250051B46D /* DataBrokerProtectionMacOSPixelsHandler.swift */; };
 		316913262BD2B76F0051B46D /* DataBrokerPrerequisitesStatusVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 316913252BD2B76F0051B46D /* DataBrokerPrerequisitesStatusVerifier.swift */; };
@@ -433,12 +429,6 @@
 		31BFDB712ECA46DD00ADFABD /* AIChatOmnibarTextContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BFDB6F2ECA46DD00ADFABD /* AIChatOmnibarTextContainerViewController.swift */; };
 		31BFDB792ECA5FCD00ADFABD /* AIChatOmnibarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BFDB782ECA5FCD00ADFABD /* AIChatOmnibarController.swift */; };
 		31BFDB7A2ECA5FCD00ADFABD /* AIChatOmnibarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BFDB782ECA5FCD00ADFABD /* AIChatOmnibarController.swift */; };
-		CA57DE500000000000000011 /* CustomizeResponsesMenuRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA57DE500000000000000010 /* CustomizeResponsesMenuRowView.swift */; };
-		CA57DE500000000000000012 /* CustomizeResponsesMenuRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA57DE500000000000000010 /* CustomizeResponsesMenuRowView.swift */; };
-		CA57DE500000000000000021 /* CustomizeResponsesModalController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA57DE500000000000000020 /* CustomizeResponsesModalController.swift */; };
-		CA57DE500000000000000022 /* CustomizeResponsesModalController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA57DE500000000000000020 /* CustomizeResponsesModalController.swift */; };
-		CA57DE500000000000000031 /* CustomizeResponsesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA57DE500000000000000030 /* CustomizeResponsesStore.swift */; };
-		CA57DE500000000000000032 /* CustomizeResponsesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA57DE500000000000000030 /* CustomizeResponsesStore.swift */; };
 		31C26A0A2CBE9D2700FFF462 /* PreferencesAIChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C26A092CBE9D2200FFF462 /* PreferencesAIChat.swift */; };
 		31C26A0B2CBE9D2700FFF462 /* PreferencesAIChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C26A092CBE9D2200FFF462 /* PreferencesAIChat.swift */; };
 		31C26A0D2CBE9DFE00FFF462 /* AIChatPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C26A0C2CBE9DFA00FFF462 /* AIChatPreferences.swift */; };
@@ -2563,6 +2553,8 @@
 		8482319F2F58158D00553470 /* ApplicationBuildType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848231952F58051E00553470 /* ApplicationBuildType.swift */; };
 		84832D992E71C32100D01735 /* PassiveAddressBarTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84832D982E71C31A00D01735 /* PassiveAddressBarTextField.swift */; };
 		84832D9A2E71C32100D01735 /* PassiveAddressBarTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84832D982E71C31A00D01735 /* PassiveAddressBarTextField.swift */; };
+		84835BB13008B9B5000595C4 /* WKWebsiteDataStore+FireWindowSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84835BB03008B9B5000595C4 /* WKWebsiteDataStore+FireWindowSession.swift */; };
+		84835BB23008B9B5000595C4 /* WKWebsiteDataStore+FireWindowSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84835BB03008B9B5000595C4 /* WKWebsiteDataStore+FireWindowSession.swift */; };
 		848648A12C76F4B20082282D /* BookmarksBarMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848648A02C76F4B20082282D /* BookmarksBarMenuViewController.swift */; };
 		848648A22C76F4B20082282D /* BookmarksBarMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848648A02C76F4B20082282D /* BookmarksBarMenuViewController.swift */; };
 		84A03D2B2DBBE06B00A3685B /* DraggingDestinationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A03D2A2DBBE06700A3685B /* DraggingDestinationView.swift */; };
@@ -3988,6 +3980,8 @@
 		CA57DE500000000000000012 /* CustomizeResponsesMenuRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA57DE500000000000000010 /* CustomizeResponsesMenuRowView.swift */; };
 		CA57DE500000000000000021 /* CustomizeResponsesModalController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA57DE500000000000000020 /* CustomizeResponsesModalController.swift */; };
 		CA57DE500000000000000022 /* CustomizeResponsesModalController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA57DE500000000000000020 /* CustomizeResponsesModalController.swift */; };
+		CA57DE500000000000000031 /* CustomizeResponsesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA57DE500000000000000030 /* CustomizeResponsesStore.swift */; };
+		CA57DE500000000000000032 /* CustomizeResponsesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA57DE500000000000000030 /* CustomizeResponsesStore.swift */; };
 		CB24F70C29A3D9CB006DCC58 /* AppConfigurationURLProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB24F70B29A3D9CB006DCC58 /* AppConfigurationURLProvider.swift */; };
 		CB24F70D29A3D9CB006DCC58 /* AppConfigurationURLProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB24F70B29A3D9CB006DCC58 /* AppConfigurationURLProvider.swift */; };
 		CB63DECB2CDC0BBE0097986A /* PageRefreshMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB63DECA2CDC0BB80097986A /* PageRefreshMonitor.swift */; };
@@ -4600,6 +4594,10 @@
 		F4A6198C283CFFBB007F2080 /* ContentScopeFeatureFlagging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A6198B283CFFBB007F2080 /* ContentScopeFeatureFlagging.swift */; };
 		F8FD0BA84A167FE482ED4A92 /* QuickFeedbackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A043BAE1603803A839C0CB52 /* QuickFeedbackService.swift */; };
 		FB06A1C37CD1DEDC550642FE /* QuickFeedbackTipControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30149F658F94CFC627227DB /* QuickFeedbackTipControllerTests.swift */; };
+		FB0C0800000000000000CE02 /* PageContextExtractionPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB0C0800000000000000CE01 /* PageContextExtractionPixelHandler.swift */; };
+		FB0C0800000000000000CE03 /* PageContextExtractionPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB0C0800000000000000CE01 /* PageContextExtractionPixelHandler.swift */; };
+		FB0C0800000000000000CE05 /* PageContextExtractionPixelHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB0C0800000000000000CE04 /* PageContextExtractionPixelHandlerTests.swift */; };
+		FB0C0800000000000000CE06 /* PageContextExtractionPixelHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB0C0800000000000000CE04 /* PageContextExtractionPixelHandlerTests.swift */; };
 		FB37FB37FB37FB37FB37FB38 /* InternalFeedbackFormTabExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB37FB37FB37FB37FB37FB37 /* InternalFeedbackFormTabExtensionTests.swift */; };
 		FB37FB37FB37FB37FB37FB39 /* InternalFeedbackFormTabExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB37FB37FB37FB37FB37FB37 /* InternalFeedbackFormTabExtensionTests.swift */; };
 		FC5498938C11494380EB8713 /* SubscriptionPromoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC1AE4AED1E4A4C95A36533 /* SubscriptionPromoView.swift */; };
@@ -4858,7 +4856,6 @@
 		1D01A3D32B88CF7700FE8150 /* AccessibilityPreferences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccessibilityPreferences.swift; sourceTree = "<group>"; };
 		1D01A3D72B88DF8B00FE8150 /* PreferencesSyncView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesSyncView.swift; sourceTree = "<group>"; };
 		1D04CA172F67FECE007AB0F3 /* PageContextMultipleContextsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageContextMultipleContextsTests.swift; sourceTree = "<group>"; };
-		FB0C0800000000000000CE04 /* PageContextExtractionPixelHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageContextExtractionPixelHandlerTests.swift; sourceTree = "<group>"; };
 		1D074B262909A433006E4AC3 /* PasswordManagerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordManagerCoordinator.swift; sourceTree = "<group>"; };
 		1D1A33482A6FEB170080ACED /* BurnerMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BurnerMode.swift; sourceTree = "<group>"; };
 		1D1B4A452EDF97EF00FE43C9 /* PermissionAuthorizationTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionAuthorizationTypeTests.swift; sourceTree = "<group>"; };
@@ -5024,7 +5021,6 @@
 		3154FD1328E6011A00909769 /* TabShadowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabShadowView.swift; sourceTree = "<group>"; };
 		315AA06F28CA5CC800200030 /* YoutubePlayerNavigationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YoutubePlayerNavigationHandler.swift; sourceTree = "<group>"; };
 		3161D15C2DA02380008F59B5 /* AIChatPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatPixel.swift; sourceTree = "<group>"; };
-		FB0C0800000000000000CE01 /* PageContextExtractionPixelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageContextExtractionPixelHandler.swift; sourceTree = "<group>"; };
 		316850712AF3AD58009A2828 /* DataBrokerProtectionDebugMenu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataBrokerProtectionDebugMenu.swift; sourceTree = "<group>"; };
 		316913222BD2B6250051B46D /* DataBrokerProtectionMacOSPixelsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBrokerProtectionMacOSPixelsHandler.swift; sourceTree = "<group>"; };
 		316913252BD2B76F0051B46D /* DataBrokerPrerequisitesStatusVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBrokerPrerequisitesStatusVerifier.swift; sourceTree = "<group>"; };
@@ -5050,9 +5046,6 @@
 		31BFDB6C2ECA423900ADFABD /* MouseBlockingBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MouseBlockingBackgroundView.swift; sourceTree = "<group>"; };
 		31BFDB6F2ECA46DD00ADFABD /* AIChatOmnibarTextContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatOmnibarTextContainerViewController.swift; sourceTree = "<group>"; };
 		31BFDB782ECA5FCD00ADFABD /* AIChatOmnibarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatOmnibarController.swift; sourceTree = "<group>"; };
-		CA57DE500000000000000010 /* CustomizeResponsesMenuRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizeResponsesMenuRowView.swift; sourceTree = "<group>"; };
-		CA57DE500000000000000020 /* CustomizeResponsesModalController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizeResponsesModalController.swift; sourceTree = "<group>"; };
-		CA57DE500000000000000030 /* CustomizeResponsesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizeResponsesStore.swift; sourceTree = "<group>"; };
 		31C26A092CBE9D2200FFF462 /* PreferencesAIChat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesAIChat.swift; sourceTree = "<group>"; };
 		31C26A0C2CBE9DFA00FFF462 /* AIChatPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatPreferences.swift; sourceTree = "<group>"; };
 		31C3CE0128EDC1E70002C24A /* CustomRoundedCornersShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRoundedCornersShape.swift; sourceTree = "<group>"; };
@@ -5904,6 +5897,7 @@
 		848231832F57E3FE00553470 /* CrashReportingFactory+makeCrashReporting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CrashReportingFactory+makeCrashReporting.swift"; sourceTree = "<group>"; };
 		848231952F58051E00553470 /* ApplicationBuildType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationBuildType.swift; sourceTree = "<group>"; };
 		84832D982E71C31A00D01735 /* PassiveAddressBarTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassiveAddressBarTextField.swift; sourceTree = "<group>"; };
+		84835BB03008B9B5000595C4 /* WKWebsiteDataStore+FireWindowSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebsiteDataStore+FireWindowSession.swift"; sourceTree = "<group>"; };
 		848648A02C76F4B20082282D /* BookmarksBarMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksBarMenuViewController.swift; sourceTree = "<group>"; };
 		84A03D2A2DBBE06700A3685B /* DraggingDestinationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraggingDestinationView.swift; sourceTree = "<group>"; };
 		84A03D2D2DDC275200A3685B /* BookmarksBarVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksBarVisibilityTests.swift; sourceTree = "<group>"; };
@@ -6791,6 +6785,7 @@
 		C7A1B2E3F4D5678901234567 /* AutoconsentEventCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoconsentEventCoordinator.swift; sourceTree = "<group>"; };
 		CA57DE500000000000000010 /* CustomizeResponsesMenuRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizeResponsesMenuRowView.swift; sourceTree = "<group>"; };
 		CA57DE500000000000000020 /* CustomizeResponsesModalController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizeResponsesModalController.swift; sourceTree = "<group>"; };
+		CA57DE500000000000000030 /* CustomizeResponsesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizeResponsesStore.swift; sourceTree = "<group>"; };
 		CAAA013D5BF54C0C260E784E /* WebViewUserAgentProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewUserAgentProvider.swift; sourceTree = "<group>"; };
 		CB24F70B29A3D9CB006DCC58 /* AppConfigurationURLProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigurationURLProvider.swift; sourceTree = "<group>"; };
 		CB63DECA2CDC0BB80097986A /* PageRefreshMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageRefreshMonitor.swift; sourceTree = "<group>"; };
@@ -7058,6 +7053,8 @@
 		F511D9CB8F68D9D9B0341314 /* QuickFeedbackDiagnosticsCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickFeedbackDiagnosticsCollector.swift; sourceTree = "<group>"; };
 		F72808BE3E5BF485C31627B8 /* AIChatSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSettingsTests.swift; sourceTree = "<group>"; };
 		FAC0C468BD3373676AC82B61 /* DarkReaderFeatureSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkReaderFeatureSettingsTests.swift; sourceTree = "<group>"; };
+		FB0C0800000000000000CE01 /* PageContextExtractionPixelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageContextExtractionPixelHandler.swift; sourceTree = "<group>"; };
+		FB0C0800000000000000CE04 /* PageContextExtractionPixelHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageContextExtractionPixelHandlerTests.swift; sourceTree = "<group>"; };
 		FB1380633D7A4C9CA3AD18CD /* AutoplayPreferencesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoplayPreferencesTests.swift; sourceTree = "<group>"; };
 		FB37FB37FB37FB37FB37FB37 /* InternalFeedbackFormTabExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalFeedbackFormTabExtensionTests.swift; sourceTree = "<group>"; };
 		FD23FD2A28816606007F6985 /* AutoconsentMessageProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AutoconsentMessageProtocolTests.swift; path = UnitTests/Autoconsent/AutoconsentMessageProtocolTests.swift; sourceTree = SOURCE_ROOT; };
@@ -10998,16 +10995,17 @@
 		AA585DB02490E6FA00E9A3E2 /* MainWindow */ = {
 			isa = PBXGroup;
 			children = (
-				84537A022C998C24008723BC /* FireWindowSession.swift */,
 				9FE239BA2FD8EE92007135F2 /* FireWindowOpenTrigger.swift */,
+				84537A022C998C24008723BC /* FireWindowSession.swift */,
+				1D6D041B2D9437ED005BC23F /* FullscreenController.swift */,
 				1D39F7242DCA299D00F258F0 /* InitialWindowFrameProvider.swift */,
+				B688B4D9273E6D3B0087BEAF /* MainView.swift */,
+				AA585DAE2490E6E600E9A3E2 /* MainViewController.swift */,
 				AA7412BC24D2BEEE00D22FE0 /* MainWindow.swift */,
 				AA7412B424D1536B00D22FE0 /* MainWindowController.swift */,
-				AA585DAE2490E6E600E9A3E2 /* MainViewController.swift */,
-				B688B4D9273E6D3B0087BEAF /* MainView.swift */,
 				B688B4DE27420D290087BEAF /* PDFSearchTextMenuItemHandler.swift */,
 				B68C92C0274E3EF4002AC6B0 /* PopUpWindow.swift */,
-				1D6D041B2D9437ED005BC23F /* FullscreenController.swift */,
+				84835BB03008B9B5000595C4 /* WKWebsiteDataStore+FireWindowSession.swift */,
 			);
 			path = MainWindow;
 			sourceTree = "<group>";
@@ -15760,6 +15758,7 @@
 				3706FBD7293F65D500E42796 /* ContentBlockerRulesLists.swift in Sources */,
 				9F1556762DDC0E0C00A35DBA /* DefaultBrowserAndDockPromptFeatureFlagger.swift in Sources */,
 				31E3FD732CE39C4600A392C8 /* AIChatDebugURLSettings.swift in Sources */,
+				84835BB13008B9B5000595C4 /* WKWebsiteDataStore+FireWindowSession.swift in Sources */,
 				3706FBD8293F65D500E42796 /* NSViewControllerExtension.swift in Sources */,
 				BBBD2A052E2FE4C6005E7664 /* ViewExtensions.swift in Sources */,
 				B5ECC1972EF1D24B0046A1C7 /* ScriptStyleProvider.swift in Sources */,
@@ -18423,6 +18422,7 @@
 				4B4D60BF2A0C848A00BCD287 /* NetworkProtection+ConvenienceInitializers.swift in Sources */,
 				7B5A23682C468233007213AC /* ExcludedDomainsViewController.swift in Sources */,
 				BDA7647C2BC497BE00D0400C /* DefaultVPNLocationFormatter.swift in Sources */,
+				84835BB23008B9B5000595C4 /* WKWebsiteDataStore+FireWindowSession.swift in Sources */,
 				3158B1592B0BF76400AF130C /* DataBrokerProtectionFeatureDisabler.swift in Sources */,
 				B655124829A79465009BFE1C /* NavigationActionExtension.swift in Sources */,
 				9FA173EB2B7B232200EE4E6E /* AddEditBookmarkDialogView.swift in Sources */,

--- a/macOS/DuckDuckGo/FileDownload/View/DownloadsCellView.swift
+++ b/macOS/DuckDuckGo/FileDownload/View/DownloadsCellView.swift
@@ -312,6 +312,7 @@ final class DownloadsCellView: NSTableCellView {
                     .eraseToAnyPublisher()
             }
             .switchToLatest()
+            .throttle(for: 0.2, scheduler: DispatchQueue.main, latest: true)
             .sink { [weak self] progress in
                 guard let self else { return }
 

--- a/macOS/DuckDuckGo/MainWindow/FireWindowSession.swift
+++ b/macOS/DuckDuckGo/MainWindow/FireWindowSession.swift
@@ -17,6 +17,7 @@
 //
 
 import AppKit
+import WebKit
 
 /// Represents a “Fire Window Session” tracking lifetime of the owning Fire Window and Popup windows created from it.
 /// Used to detect active downloads within a Fire Window Session.
@@ -41,6 +42,10 @@ import AppKit
     }
     private var windowRefs: Set<WindowRef> = []
     private var deinitObservers: [() -> Void] = []
+
+    /// The non-persistent website data store this session was created for.
+    /// Provides a stable link back to the session without requiring a window.
+    weak var websiteDataStore: WKWebsiteDataStore?
 
     var windows: [NSWindow] {
         windowRefs.reduce(into: []) { result, windowRef in
@@ -86,6 +91,13 @@ struct FireWindowSessionRef: Hashable {
         guard let fireWindowSession = mainWindowController.fireWindowSession else { return nil }
         self.fireWindowSession = fireWindowSession
         self.identifier = ObjectIdentifier(fireWindowSession)
+    }
+
+    @MainActor
+    init?(session: FireWindowSession?) {
+        guard let session else { return nil }
+        self.fireWindowSession = session
+        self.identifier = ObjectIdentifier(session)
     }
 
     @MainActor

--- a/macOS/DuckDuckGo/MainWindow/WKWebsiteDataStore+FireWindowSession.swift
+++ b/macOS/DuckDuckGo/MainWindow/WKWebsiteDataStore+FireWindowSession.swift
@@ -1,0 +1,34 @@
+//
+//  WKWebsiteDataStore+FireWindowSession.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import ObjectiveC
+import WebKit
+
+extension WKWebsiteDataStore {
+
+    private static let fireWindowSessionKey = UnsafeRawPointer(bitPattern: "fireWindowSessionKey".hashValue)!
+
+    /// The `FireWindowSession` for the burner session this data store belongs to.
+    /// Populated in `WindowsManager` when the Fire Window is created; `nil` for persistent stores.
+    /// Allows resolving the session in `DownloadsTabExtension` before `webView.window` is set.
+    var fireWindowSession: FireWindowSession? {
+        get { (objc_getAssociatedObject(self, Self.fireWindowSessionKey) as? FireWindowSessionRef)?.fireWindowSession }
+        set { objc_setAssociatedObject(self, Self.fireWindowSessionKey, newValue.map(FireWindowSessionRef.init(session:)), .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+    }
+
+}

--- a/macOS/DuckDuckGo/Tab/TabExtensions/DownloadsTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/DownloadsTabExtension.swift
@@ -222,18 +222,22 @@ extension DownloadsTabExtension: NavigationResponder {
     }
 
     @MainActor
-    func enqueueDownload(_ download: WebKitDownload, withNavigationAction navigationAction: NavigationAction?) {
-        let webView = download.originatingWebView ?? download.targetWebView
+    private func enqueueDownload(_ download: WebKitDownload, withNavigationAction navigationAction: NavigationAction?) {
         let task = downloadManager.add(download,
-                                       fireWindowSession: resolveFireWindowSession(for: webView),
+                                       fireWindowSession: resolveFireWindowSession(for: download.originatingWebView ?? download.targetWebView),
                                        delegate: self,
                                        destination: .auto)
-        guard let webView else { return }
 
-        var shouldCloseTabOnDownloadStart: Bool {
+        closeWebViewIfNeeded(forEnqueuedDownloadTask: task, initiatedBy: navigationAction)
+    }
+
+    private func closeWebViewIfNeeded(forEnqueuedDownloadTask downloadTask: WebKitDownloadTask, initiatedBy navigationAction: NavigationAction?) {
+        guard let targetWebView = downloadTask.targetWebView else { return }
+
+        let shouldCloseTabOnDownloadStart: Bool = {
             guard let navigationAction else {
                 // if converted from navigation response but no navigation was committed
-                return webView.backForwardList.currentItem == nil
+                return targetWebView.backForwardList.currentItem == nil
             }
             // get the first navigation action in the redirect series
             let initialNavigationAction = navigationAction.redirectHistory?.first ?? navigationAction
@@ -245,24 +249,20 @@ extension DownloadsTabExtension: NavigationResponder {
             }
 
             return false
-        }
+        }()
 
         // If the download has started from a popup Tab - close it after starting the download
         // e.g. download button on this page:
         // https://en.wikipedia.org/wiki/Guitar#/media/File:GuitareClassique5.png
         guard shouldCloseTabOnDownloadStart else { return }
 
-        self.closeWebView(webView, afterDownloadTaskHasStarted: task)
-    }
-
-    private func closeWebView(_ webView: WKWebView, afterDownloadTaskHasStarted downloadTask: WebKitDownloadTask) {
         // close the initiating Tab after location has been chosen and leave it open when the task was cancelled
         // the wait is needed because closing the tab would cancel download location chooser dialog
         var cancellable: AnyCancellable?
         cancellable = downloadTask.didChooseDownloadLocationPublisher.sink { completion in
             // close the tab if completed without an error (location chosen)
             if case .finished = completion {
-                webView.close()
+                targetWebView.close()
             }
             cancellable?.cancel()
         } receiveValue: { _ in }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/DownloadsTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/DownloadsTabExtension.swift
@@ -108,7 +108,7 @@ final class DownloadsTabExtension: NSObject {
             let destination = self.downloadDestination(for: location, suggestedFilename: webView.suggestedFilename ?? "")
             let download = await webView.startDownload(using: URLRequest(url: url, cachePolicy: .returnCacheDataElseLoad))
 
-            self.downloadManager.add(download, fireWindowSession: FireWindowSessionRef(window: webView.window), delegate: self, destination: destination)
+            self.downloadManager.add(download, fireWindowSession: self.resolveFireWindowSession(for: webView), delegate: self, destination: destination)
         }
 
     }
@@ -223,11 +223,12 @@ extension DownloadsTabExtension: NavigationResponder {
 
     @MainActor
     func enqueueDownload(_ download: WebKitDownload, withNavigationAction navigationAction: NavigationAction?) {
+        let webView = download.originatingWebView ?? download.targetWebView
         let task = downloadManager.add(download,
-                                       fireWindowSession: FireWindowSessionRef(window: (download.originatingWebView ?? download.targetWebView)?.window),
+                                       fireWindowSession: resolveFireWindowSession(for: webView),
                                        delegate: self,
                                        destination: .auto)
-        guard let webView = download.targetWebView else { return }
+        guard let webView else { return }
 
         var shouldCloseTabOnDownloadStart: Bool {
             guard let navigationAction else {
@@ -267,6 +268,14 @@ extension DownloadsTabExtension: NavigationResponder {
         } receiveValue: { _ in }
     }
 
+    @MainActor
+    private func resolveFireWindowSession(for webView: WKWebView?) -> FireWindowSessionRef? {
+        let session = FireWindowSessionRef(session: webView?.configuration.websiteDataStore.fireWindowSession)
+            ?? FireWindowSessionRef(window: webView?.window)
+        assert(!isBurner || session != nil, "Fire session must be resolvable for burner download")
+        return session
+    }
+
 }
 
 extension DownloadsTabExtension: WKNavigationDelegate {
@@ -275,7 +284,7 @@ extension DownloadsTabExtension: WKNavigationDelegate {
     @objc(_webView:contextMenuDidCreateDownload:)
     func webView(_ webView: WKWebView, contextMenuDidCreate download: WebKitDownload) {
         // to do: url should be cleaned up before launching download
-        downloadManager.add(download, fireWindowSession: FireWindowSessionRef(window: webView.window), delegate: self, destination: .prompt)
+        downloadManager.add(download, fireWindowSession: resolveFireWindowSession(for: webView), delegate: self, destination: .prompt)
     }
 
 }

--- a/macOS/DuckDuckGo/Windows/View/WindowsManager.swift
+++ b/macOS/DuckDuckGo/Windows/View/WindowsManager.swift
@@ -275,9 +275,12 @@ final class WindowsManager {
             if let existing = Application.appDelegate.windowControllersManager.mainWindowControllers.first(where: {
                 $0.mainViewController.tabCollectionViewModel.burnerMode == burnerMode
             })?.fireWindowSession {
+                dataStore.fireWindowSession = existing
                 fireWindowSession = existing
             } else {
                 let newSession = FireWindowSession()
+                newSession.websiteDataStore = dataStore
+                dataStore.fireWindowSession = newSession
                 if let registry = Application.appDelegate.burnerDuckAiStorageRegistry {
                     let dataStoreKey = ObjectIdentifier(dataStore)
                     newSession.onDeinit { [weak registry] in

--- a/macOS/UITests/UI Tests App Store.xctestplan
+++ b/macOS/UITests/UI Tests App Store.xctestplan
@@ -39,7 +39,6 @@
         "AIChatTests\/test_availableAIChatInOmnibarDefaultSettings()",
         "AIChatTests\/test_disableAIChatOmnibarFromSettings_buttonIsRemovedFromOmnibar()",
         "BookmarkSearchTests\/testShowInFolderFunctionalityOnBookmarksPanel()",
-        "DownloadsUITests\/testFireWindowWithInProgressDownloadShowsWarning()",
         "FindInPageTests",
         "FindInPageTests\/test_clickingWebViewDeactivates_thenCmdFReactivatesAndKeepsText()",
         "FindInPageTests\/test_findInPage_canBeClosedWithEscape()",

--- a/macOS/UITests/UI Tests.xctestplan
+++ b/macOS/UITests/UI Tests.xctestplan
@@ -39,7 +39,6 @@
         "AIChatTests\/test_availableAIChatInOmnibarDefaultSettings()",
         "AIChatTests\/test_disableAIChatOmnibarFromSettings_buttonIsRemovedFromOmnibar()",
         "BookmarkSearchTests\/testShowInFolderFunctionalityOnBookmarksPanel()",
-        "DownloadsUITests\/testFireWindowWithInProgressDownloadShowsWarning()",
         "FireWindowTests\/testCrendentialsAreAutoFilledInFireWindows()",
         "NewPermissionViewTests\/test_locationPermissions_whenAccepted_showCorrectStateInBrowser()",
         "NewPermissionViewTests\/test_locationPermissions_whenNeverAllowIsSelected_alwaysDenies()"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202406491309510/task/1214167538194692
Tech Design URL: N/A
CC: N/A

### Description
- Add `WKWebsiteDataStore+FireWindowSession.swift`: associates a `FireWindowSessionRef` with a non-persistent data store when its Fire Window is created, enabling session lookup before the originating WebView is in the window hierarchy
- Add `FireWindowSession.websiteDataStore` weak back-reference and `FireWindowSessionRef.init?(session:)` for direct session-to-ref conversion without requiring an `NSWindow`
- Link data store ↔ session in `WindowsManager.makeNewWindow` for both new and reused sessions
- Replace direct `FireWindowSessionRef(window: webView.window)` calls in `DownloadsTabExtension` with `resolveFireWindowSession(for:)`, which prefers the data store lookup and falls back to the window
- Throttle download progress updates in `DownloadsCellView` to reduce UI churn
- Re-enable `testFireWindowWithInProgressDownloadShowsWarning` in both test plans

### Testing Steps
1. Open a Fire Window (⌘⇧N)
2. Paste a direct download URL into the address bar and press Enter
3. Verify the download appears in the Fire Window's downloads panel, not the regular window's
4. Close the Fire Window while the download is in progress — confirm the warning sheet appears
5. UI Tests run: https://github.com/duckduckgo/apple-browsers/actions/runs/29482179565

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- `FireWindowSessionRef` holds only a `weak` reference to `FireWindowSession`, so the associated object on `WKWebsiteDataStore` adds no strong retain to the session's lifetime

### Quality Considerations
- No changes to `BurnerMode`, `Tab.init`, or `TabExtensionsBuilderArguments` — minimal blast radius
- The `assert(!isBurner || session != nil)` in `enqueueDownload` now correctly fires when the data store association is missing, rather than when the window is transiently nil
- Persistent data stores return `nil` from `fireWindowSession` unchanged

### Notes to Reviewer
Root cause: when a URL is pasted directly into the address bar of a Fire Window tab, `enqueueDownload` is called before the WebView has been added to the window hierarchy (`webView.window == nil`). `FireWindowSessionRef(window: nil)` returns `nil`, causing the download to be attributed to the regular session instead of the fire session.

Made with [Cursor](https://cursor.com)