### PR TITLE
[macOS] Build UI Tests for arm64 only

### DIFF
--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -87,6 +87,7 @@ jobs:
     with:
       release-type: alpha
       create-dmg: true
+      include-x86-architecture: true
       build-number-override: ${{ needs.calculate-alpha-build-number.outputs.build-number }}
       skip-notify: true
     secrets: inherit

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -24,6 +24,10 @@ on:
         description: "Asana release task URL"
         required: false
         type: string
+      include-x86-architecture:
+        description: "Include x86_64 architecture in the build"
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       release-type:
@@ -54,8 +58,8 @@ on:
         description: "Skip Mattermost notification"
         default: false
         type: boolean
-      build-active-architecture-only:
-        description: "Build only the active architecture"
+      include-x86-architecture:
+        description: "Include x86_64 architecture in the build"
         default: false
         type: boolean
     secrets:
@@ -104,7 +108,7 @@ jobs:
       release-type: ${{ github.event.inputs.release-type || inputs.release-type }}
       asana-task-url: ${{ github.event.inputs.asana-task-url || inputs.asana-task-url }}
       branch: ${{ inputs.branch || github.ref_name }}
-      EXCLUDED_ARCHS: ${{ inputs.build-active-architecture-only && 'x86_64' || '' }}
+      EXCLUDED_ARCHS: ${{ inputs.include-x86-architecture && '' || 'x86_64' }}
 
     steps:
     - name: Register SSH keys for private repos

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -54,6 +54,10 @@ on:
         description: "Skip Mattermost notification"
         default: false
         type: boolean
+      build-active-architecture-only:
+        description: "Build only the active architecture"
+        default: false
+        type: boolean
     secrets:
       APPLE_API_KEY_BASE64:
         required: true
@@ -100,6 +104,7 @@ jobs:
       release-type: ${{ github.event.inputs.release-type || inputs.release-type }}
       asana-task-url: ${{ github.event.inputs.asana-task-url || inputs.asana-task-url }}
       branch: ${{ inputs.branch || github.ref_name }}
+      ONLY_ACTIVE_ARCH: ${{ inputs.build-active-architecture-only && 'YES' || '' }}
 
     steps:
     - name: Register SSH keys for private repos

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -104,7 +104,7 @@ jobs:
       release-type: ${{ github.event.inputs.release-type || inputs.release-type }}
       asana-task-url: ${{ github.event.inputs.asana-task-url || inputs.asana-task-url }}
       branch: ${{ inputs.branch || github.ref_name }}
-      ONLY_ACTIVE_ARCH: ${{ inputs.build-active-architecture-only && 'YES' || '' }}
+      EXCLUDED_ARCHS: ${{ inputs.build-active-architecture-only && 'x86_64' || '' }}
 
     steps:
     - name: Register SSH keys for private repos

--- a/.github/workflows/macos_release.yml
+++ b/.github/workflows/macos_release.yml
@@ -75,6 +75,7 @@ jobs:
     with:
       release-type: release
       create-dmg: true
+      include-x86-architecture: true
       asana-task-url: ${{ inputs.asana-task-url }}
       branch: ${{ inputs.branch }}
       commit-sha: ${{ inputs.commit-sha }}

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -95,7 +95,7 @@ jobs:
       create-dmg: false
       branch: ${{ inputs.branch || github.sha }}
       skip-notify: true
-      build-active-architecture-only: true
+      include-x86-architecture: false
     secrets: inherit
 
   # This job sets up the matrix strategy arguments for the ui-tests jobs

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -95,6 +95,7 @@ jobs:
       create-dmg: false
       branch: ${{ inputs.branch || github.sha }}
       skip-notify: true
+      build-active-architecture-only: true
     secrets: inherit
 
   # This job sets up the matrix strategy arguments for the ui-tests jobs

--- a/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests App Store CI.xcscheme
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests App Store CI.xcscheme
@@ -4,7 +4,8 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "NO">
+      buildImplicitDependencies = "NO"
+      buildArchitectures = "Automatic">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests App Store.xcscheme
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests App Store.xcscheme
@@ -4,7 +4,8 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests CI.xcscheme
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests CI.xcscheme
@@ -4,7 +4,8 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "NO">
+      buildImplicitDependencies = "NO"
+      buildArchitectures = "Automatic">
    </BuildAction>
    <TestAction
       buildConfiguration = "Review"

--- a/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests.xcscheme
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests.xcscheme
@@ -4,7 +4,8 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/macOS/scripts/archive.sh
+++ b/macOS/scripts/archive.sh
@@ -262,7 +262,7 @@ archive_and_export() {
 		CURRENT_PROJECT_VERSION="${build_number}" \
 		RELEASE_PRODUCT_NAME_OVERRIDE=DuckDuckGo \
 		${extra_xcargs:+"${extra_xcargs}"} \
-		${ONLY_ACTIVE_ARCH:+"ONLY_ACTIVE_ARCH=${ONLY_ACTIVE_ARCH}"} \
+		${EXCLUDED_ARCHS:+"EXCLUDED_ARCHS=${EXCLUDED_ARCHS}"} \
 		2>&1 \
 		| ${log_formatter}
 

--- a/macOS/scripts/archive.sh
+++ b/macOS/scripts/archive.sh
@@ -262,6 +262,7 @@ archive_and_export() {
 		CURRENT_PROJECT_VERSION="${build_number}" \
 		RELEASE_PRODUCT_NAME_OVERRIDE=DuckDuckGo \
 		${extra_xcargs:+"${extra_xcargs}"} \
+		${ONLY_ACTIVE_ARCH:+"ONLY_ACTIVE_ARCH=${ONLY_ACTIVE_ARCH}"} \
 		2>&1 \
 		| ${log_formatter}
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1216591205063619?focus=true
Tech Design URL: N/A
CC: N/A

### Description
- Build Review UI Test prebuilds for arm64 only by excluding x86_64 during notarized archives.
- Add the `include-x86-architecture` notarized-build input, defaulting to `false`, and forward the resulting architecture exclusion to `xcodebuild archive`.
- Keep Alpha and release DMG workflows universal by explicitly enabling x86_64.
- Configure DMG, App Store, and CI UI Test schemes to match the active run-destination architecture.

### Testing Steps
1. Ran the macOS UI Tests workflow and inspected its notarized app artifact: the main app, VPN login item, system extension, and PIR login item are arm64-only.
2. Verified the PR “Make Release Build” check passes and builds both arm64 and x86_64 Swift modules.
3. Validated workflow YAML, scheme XML, shell syntax, and whitespace.

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- Review builds used on an Intel runner require `include-x86-architecture: true`. Current UI Test runners are Apple Silicon only.
- Alpha and release callers must retain their explicit x86_64 opt-in to preserve universal DMGs.

### Quality Considerations
- No user-facing, privacy, security, analytics, or documentation changes.
- The local `archive.sh` invocation is unchanged unless an architecture exclusion is provided through its environment.

### Notes to Reviewer
- The full UI Test matrix had unrelated remote-page assertion and artifact-upload DNS failures; its notarized prebuild completed successfully.