### PR TITLE
macOS: Update AIChatSettingsTests to drive Duck.ai On/Off picker

### DIFF
--- a/macOS/UITests/AIChatSettingsTests.swift
+++ b/macOS/UITests/AIChatSettingsTests.swift
@@ -29,12 +29,15 @@ class AIChatSettingsTests: UITestCase {
         static let showSidebarButtonInTabBarToggle = "Preferences.AIChat.showSidebarButtonInTabBarToggle"
         static let duckAITitleButton = "TabBarViewController.duckAIChromeTitleButton"
         static let sidebarButton = "TabBarViewController.duckAIChromeSidebarButton"
+        // Menu options of the Duck.ai On/Off dropdown (native AI controls layout).
+        static let duckAIEnabledOn = "On"
+        static let duckAIEnabledOff = "Off"
     }
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         continueAfterFailure = false
-        app = XCUIApplication.setUp(featureFlags: ["aiChatChromeSidebar": true, "aiChatSidebarFloating": true])
+        app = XCUIApplication.setUp(featureFlags: ["aiChatChromeSidebar": true, "aiChatSidebarFloating": true, "aiFeaturesNativeControls": true])
 
         addressBarTextField = app.addressBar
         app.enforceSingleWindow()
@@ -135,15 +138,11 @@ class AIChatSettingsTests: UITestCase {
             showToggleCheckbox.click()
         }
 
-        // Disable the main Duck.ai setting
-        let disableButton = app.buttons[Identifiers.aiFeaturesToggle]
-        XCTAssertTrue(disableButton.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        disableButton.click()
-
-        // Confirm in the dialog
-        let confirmButton = app.buttons["Disable Duck.ai"]
-        XCTAssertTrue(confirmButton.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        confirmButton.click()
+        // Disable the main Duck.ai setting via the On/Off dropdown
+        let duckAIPicker = app.popUpButtons[Identifiers.aiFeaturesToggle]
+        XCTAssertTrue(duckAIPicker.waitForExistence(timeout: UITests.Timeouts.elementExistence))
+        duckAIPicker.click()
+        app.menuItems[Identifiers.duckAIEnabledOff].click()
 
         // Tab bar buttons should be hidden
         let titleButton = app.windows.firstMatch.buttons[Identifiers.duckAITitleButton]
@@ -186,12 +185,13 @@ class AIChatSettingsTests: UITestCase {
                        "Show Sidebar Button should not be in View menu when Duck.ai is disabled")
         app.typeKey(.escape, modifierFlags: [])
 
-        // Restore: re-enable Duck.ai
+        // Restore: re-enable Duck.ai via the On/Off dropdown
         app.activateAddressBar()
         addressBarTextField = app.addressBar
         addressBarTextField.typeURL(URL(string: "duck://settings/aichat")!)
-        let enableButton = app.buttons[Identifiers.aiFeaturesToggle]
-        XCTAssertTrue(enableButton.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        enableButton.click()
+        let duckAIPickerRestore = app.popUpButtons[Identifiers.aiFeaturesToggle]
+        XCTAssertTrue(duckAIPickerRestore.waitForExistence(timeout: UITests.Timeouts.elementExistence))
+        duckAIPickerRestore.click()
+        app.menuItems[Identifiers.duckAIEnabledOn].click()
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216565661235579
Tech Design URL:
CC:

### Description

This updates the `AIChatSettingsTests.test_whenDuckAIIsDisabled_thenTabBarButtonsAndToggleAreNotVisible()` to use the new dropdown. The `aiFeaturesNativeControls` flag is set to ON in `setUp` for consistency.

### Testing Steps
1. Run the `AIChatSettingsTests` UI test suite on macOS.
2. Verify `test_whenDuckAIIsDisabled_thenTabBarButtonsAndToggleAreNotVisible` passes.
3. Verify the other three tests in the file still pass (no regression from pinning the flag).

### Impact and Risks
Low. Test-only change, no production code touched.

#### What could go wrong?
--

### Quality Considerations
--

### Notes to Reviewer
--

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
