### PR TITLE
iOS: Fix contextual web UTI manual-attach E2E test after placeholder removal

### DIFF
--- a/.maestro/unified_toggle_input/test_contextual_web_uti_manual_attach_regression.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_web_uti_manual_attach_regression.yaml
@@ -8,8 +8,10 @@ name: test_contextual_web_uti_manual_attach_regression
 ---
 
 # With the immediate contextual UTI flag off, contextual chat still starts with the
-# basic native input, then shows the web UTI after the first prompt. In manual mode,
-# placeholder and manually attached context stay sticky across navigation.
+# basic native input, then shows the web UTI after the first prompt. In manual mode
+# there is no placeholder chip: page context is attached from the web UTI's attachment
+# menu via "Ask About Page", and a manually attached context is cleared when the sheet
+# is reopened on a different page.
 
 - launchApp:
     appId: "com.duckduckgo.mobile.ios"
@@ -48,10 +50,16 @@ name: test_contextual_web_uti_manual_attach_regression
 
 - runFlow:
     file: ../shared/dismiss_chat_open_modals.yaml
+
+# After the first prompt the web UTI replaces the native input. There is no dashed
+# placeholder chip and, in manual mode, no context is attached yet.
 - extendedWaitUntil:
-    visible:
-        text: "Attach Page Content"
+    visible: "Attach"
     timeout: 30000
+- assertNotVisible:
+    id: "AIChat.ContextChip.Placeholder"
+- assertNotVisible:
+    id: "AIChat.ContextChip.AttachedTitle"
 
 - tapOn:
     id: "AIChat.ContextualSheet.CloseButton"
@@ -64,17 +72,19 @@ name: test_contextual_web_uti_manual_attach_regression
 - pressKey: Enter
 - assertVisible: ".*Address Bar Spoofing.*"
 
+# Manually attach the current page from the web UTI's attachment menu.
 - tapOn:
     id: "Browser.OmniBar.Button.AIChat"
 - assertVisible:
     id: "AIChat.ContextualSheet"
-- assertVisible:
-    text: "Attach Page Content"
-
-- tapOn:
-    text: "Attach Page Content"
+- assertNotVisible:
+    id: "AIChat.ContextChip.AttachedTitle"
+- tapOn: "Attach"
+- assertVisible: "Ask About Page"
+- tapOn: "Ask About Page"
 - extendedWaitUntil:
-    notVisible: "Attach Page Content"
+    visible:
+        id: "AIChat.ContextChip.AttachedTitle"
     timeout: 10000
 
 - tapOn:
@@ -82,6 +92,9 @@ name: test_contextual_web_uti_manual_attach_regression
 - waitForAnimationToEnd:
     timeout: 3000
 
+# Navigating to a different page and reopening clears the manually attached context; it
+# does not silently reattach and no placeholder chip appears. "Ask About Page" is still
+# available to attach the new page.
 - tapOn:
     id: "searchEntry"
 - inputText: "https://privacy-test-pages.site/privacy-protections/geolocation/"
@@ -93,5 +106,10 @@ name: test_contextual_web_uti_manual_attach_regression
 - assertVisible:
     id: "AIChat.ContextualSheet"
 - extendedWaitUntil:
-    notVisible: "Attach Page Content"
+    notVisible:
+        id: "AIChat.ContextChip.AttachedTitle"
     timeout: 10000
+- assertNotVisible:
+    id: "AIChat.ContextChip.Placeholder"
+- tapOn: "Attach"
+- assertVisible: "Ask About Page"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1216621211749949

### Description

The nightly End-to-End workflow (`E2E: release` and `E2E: release - internal`) started failing on `test_contextual_web_uti_manual_attach_regression` (`Assertion is false: "Attach Page Content" is visible`).

This is an **outdated Maestro test, not a product regression**. PR #5676 intentionally removed the dashed "Attach Page Content" placeholder chip — universally (unconditional `isHidden` in `AIChatContextChipView`, no feature-flag gate) — and moved manual page-context attach to the attachment menu's **Ask About Page**, with manual context now **cleared on different-page reopen** instead of sticky across navigation. #5676 updated the immediate-path (`aiChatContextualUnifiedToggleInput=true`) flows but left the two legacy-path (`false` — the production default) `_regression` tests unchanged. The sibling `auto_attach_regression` stayed green only because its lone placeholder assertion is a `notVisible`.

### Testing Steps
1. Green E2E run

### Impact
None — test-only change, no production code touched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Maestro YAML change; no production code.
> 
> **Overview**
> Updates the **legacy-path** (`aiChatContextualUnifiedToggleInput: false`) Maestro regression `test_contextual_web_uti_manual_attach_regression` so nightly E2E matches shipped contextual chat UX after the **Attach Page Content** placeholder chip was removed.
> 
> The flow no longer waits for or taps that placeholder. It asserts the web UTI via **Attach**, confirms no placeholder or attached chip before manual attach, then uses **Attach → Ask About Page** and waits for `AIChat.ContextChip.AttachedTitle`. After navigating to another page and reopening the sheet, it expects manual context to be **cleared** (no attached chip, no placeholder) while **Ask About Page** remains available.
> 
> Header comments are updated to describe manual attach via the attachment menu and context clearing on different-page reopen instead of sticky placeholder behavior across navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 531f484e1c6c490677cb0acf39454d6ea5ebd894. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->