### PR TITLE
macOS: Fix window dragging in tab bar leading area without pinned tabs

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarView.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarView.swift
@@ -20,19 +20,12 @@ import AppKit
 
 final class TabBarView: MouseOverView {
 
-    /// The full-width window-dragging view sitting at the bottom of the z-order.
     private var windowDraggingView: WindowDraggingView? {
         subviews.first { $0 is WindowDraggingView && !$0.isHidden } as? WindowDraggingView
     }
 
-    /// The tab bar is hosted in the window's title bar, so its empty chrome should drag the
-    /// window like the rest of the title bar. The scroll view and collection view swallow those
-    /// clicks (`TabBarScrollView.mouseDownCanMoveWindow == false`) and sit above the base
-    /// `WindowDraggingView` in the z-order, which breaks dragging in the gap before the first tab
-    /// when no tabs are pinned (with pinned tabs, that gap is the draggable pinned-tabs container).
-    /// Redirect background clicks to the window-dragging view so dragging works there too.
-    /// Clicks on actual tabs resolve to `TabBarItemCellView`, and buttons to their own views, so
-    /// only genuinely empty areas are redirected.
+    // Empty tab-bar chrome should drag the window; the scroll/collection views swallow those
+    // clicks, so redirect them to the dragging view. Tabs and buttons resolve to their own views.
     override func hitTest(_ point: NSPoint) -> NSView? {
         guard let hit = super.hitTest(point) else { return nil }
 

--- a/macOS/DuckDuckGo/TabBar/View/TabBarView.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarView.swift
@@ -20,6 +20,30 @@ import AppKit
 
 final class TabBarView: MouseOverView {
 
+    /// The full-width window-dragging view sitting at the bottom of the z-order.
+    private var windowDraggingView: WindowDraggingView? {
+        subviews.first { $0 is WindowDraggingView && !$0.isHidden } as? WindowDraggingView
+    }
+
+    /// The tab bar is hosted in the window's title bar, so its empty chrome should drag the
+    /// window like the rest of the title bar. The scroll view and collection view swallow those
+    /// clicks (`TabBarScrollView.mouseDownCanMoveWindow == false`) and sit above the base
+    /// `WindowDraggingView` in the z-order, which breaks dragging in the gap before the first tab
+    /// when no tabs are pinned (with pinned tabs, that gap is the draggable pinned-tabs container).
+    /// Redirect background clicks to the window-dragging view so dragging works there too.
+    /// Clicks on actual tabs resolve to `TabBarItemCellView`, and buttons to their own views, so
+    /// only genuinely empty areas are redirected.
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard let hit = super.hitTest(point) else { return nil }
+
+        if hit is TabBarScrollView || hit is NSClipView || hit is TabBarCollectionView,
+           let windowDraggingView {
+            return windowDraggingView
+        }
+
+        return hit
+    }
+
     override func isAccessibilityElement() -> Bool {
         return true
     }

--- a/macOS/DuckDuckGo/TabBar/View/TabBarView.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarView.swift
@@ -29,6 +29,9 @@ final class TabBarView: MouseOverView {
     override func hitTest(_ point: NSPoint) -> NSView? {
         guard let hit = super.hitTest(point) else { return nil }
 
+        // Only redirect the initial click; drag-and-drop destination resolution is also hitTest-based.
+        guard NSApp.currentEvent?.type == .leftMouseDown else { return hit }
+
         if hit is TabBarScrollView || hit is NSClipView || hit is TabBarCollectionView,
            let windowDraggingView {
             return windowDraggingView


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1216603940110017?focus=true

### Description

Fixes window dragging in the tab bar's leading area (the gap between the traffic lights and the first tab) when no tabs are pinned. The scroll view and collection view cover that area and don't move the window, and they sit above the base window-dragging view; with pinned tabs the same gap is the pinned-tabs container (a draggable plain view), which is why it worked there. `TabBarView.hitTest` now redirects empty-chrome clicks to the window-dragging view. Clicks on tabs and buttons are unaffected.

### Testing Steps
1. Open a window with no pinned tabs.
2. Click-drag the empty area between the traffic lights and the first tab → the window moves.
3. Confirm tabs still select, the +/fire/scroll buttons work, and double-click in that area still zooms.

### Impact
Low. Only redirects clicks that land on empty tab-bar chrome, not on tabs or buttons.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow hit-test redirect for empty tab-bar chrome on initial left click only; no auth, data, or broad interaction changes.
> 
> **Overview**
> Fixes **window dragging** in the tab bar gap between traffic lights and the first tab when **no tabs are pinned**. `TabBarScrollView` / `TabBarCollectionView` (and clip views) were winning hit tests over the existing `WindowDraggingView`, so clicks on empty chrome did not move the window; pinned-tab layouts already worked via a draggable pinned container.
> 
> `TabBarView` now overrides **`hitTest`** to return the visible `WindowDraggingView` only for **`leftMouseDown`** when the hit target is scroll/collection chrome, leaving tabs, buttons, and non–mouse-down hit testing unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb3856720a4b9f7a2bdc74f25f479139efcd2cfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->