### PR TITLE
Switch tab switcher info panel (i) to a dismiss X

### DIFF
--- a/iOS/DuckDuckGo/InfoPanelView.swift
+++ b/iOS/DuckDuckGo/InfoPanelView.swift
@@ -26,7 +26,7 @@ struct InfoPanelView: View {
     private enum Constants {
         static let contentSpacing: CGFloat = 6
         static let iconSize: CGFloat = 18
-        static let infoButtonPadding: CGFloat = 4
+        static let dismissButtonPadding: CGFloat = 4
         static let maxWidth: CGFloat = 480
 
         static let legacyHorizontalPadding: CGFloat = 10
@@ -44,7 +44,7 @@ struct InfoPanelView: View {
         let icon: UIImage
         let backgroundColor: Color
         let onTap: () -> Void
-        let onInfo: () -> Void
+        let onDismiss: () -> Void
     }
 
     let model: Model
@@ -53,7 +53,7 @@ struct InfoPanelView: View {
     private var cornerRadius: CGFloat { isRebranded ? Constants.rebrandedCornerRadius : Constants.legacyCornerRadius }
     private var horizontalPadding: CGFloat { isRebranded ? Constants.rebrandedHorizontalPadding : Constants.legacyHorizontalPadding }
     private var subtitleColor: Color { Color(designSystemColor: isRebranded ? .textSecondary : .textPrimary) }
-    private var infoIconColor: Color { Color(designSystemColor: isRebranded ? .iconsTertiary : .iconsSecondary) }
+    private var dismissIconColor: Color { Color(designSystemColor: isRebranded ? .iconsTertiary : .iconsSecondary) }
 
     var body: some View {
         HStack(alignment: .center, spacing: Constants.contentSpacing) {
@@ -69,13 +69,11 @@ struct InfoPanelView: View {
                 .font(.subheadline)
             Spacer()
 
-            Button(action: { model.onInfo() }, label: {
-                Image(uiImage: UIImage(resource: .infoIcon))
+            Button(action: { model.onDismiss() }, label: {
+                Image(uiImage: DesignSystemImages.Glyphs.Size16.close)
                     .renderingMode(.template)
-                    .resizable()
-                    .frame(width: Constants.iconSize, height: Constants.iconSize)
-                    .foregroundColor(infoIconColor)
-                    .padding(Constants.infoButtonPadding)
+                    .foregroundColor(dismissIconColor)
+                    .padding([.top, .bottom, .leading], Constants.dismissButtonPadding)
             })
             .accessibilityLabel(Text(UserText.tabSwitcherTrackerCountInfoA11y))
             .accessibilityHint(Text(UserText.tabSwitcherTrackerCountInfoHintA11y))
@@ -104,12 +102,12 @@ extension InfoPanelView.Model {
     /// - Parameters:
     ///   - state: The current state from the tracker count view model
     ///   - onTap: Action to perform when the panel is tapped
-    ///   - onInfo: Action to perform when the info button is tapped
+    ///   - onDismiss: Action to perform when the dismiss button is tapped
     /// - Returns: A configured InfoPanelView.Model for tracker info display
     static func trackerInfoPanel(
         state: TabSwitcherTrackerCountViewModel.State,
         onTap: @escaping () -> Void,
-        onInfo: @escaping () -> Void
+        onDismiss: @escaping () -> Void
     ) -> InfoPanelView.Model {
         return InfoPanelView.Model(
             title: state.title,
@@ -119,7 +117,7 @@ extension InfoPanelView.Model {
                 ? Color(designSystemColor: .surfaceSecondary)
                 : Color(singleUseColor: .tabSwitcherTrackerCountBackground),
             onTap: onTap,
-            onInfo: onInfo
+            onDismiss: onDismiss
         )
     }
 }
@@ -133,7 +131,7 @@ struct InfoPanelView_Previews: PreviewProvider {
                          icon: UIImage(rebrandable: "TrackerShield") ?? UIImage(resource: .trackerShield),
                          backgroundColor: Color(singleUseColor: .tabSwitcherTrackerCountBackground),
                          onTap: {},
-                         onInfo: {})
+                         onDismiss: {})
         )
         .previewLayout(.sizeThatFits)
         .padding()

--- a/iOS/DuckDuckGo/TabSwitcherPageViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherPageViewController.swift
@@ -238,7 +238,7 @@ class TabSwitcherPageViewController: UIViewController {
         trackerInfoModel = .trackerInfoPanel(
             state: state,
             onTap: { },
-            onInfo: { [weak self] in
+            onDismiss: { [weak self] in
                 self?.presentHideTrackerCountAlert()
             }
         )


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211264967278501/task/1216442420263713?focus=true
Tech Design URL:
CC:

### Description

This PR changes the (i) symbol to a dismiss X, to better reflect its functionality, as described in the linked Asana task.

<img width="350" alt="simulator_screenshot_D9D364BC-A8F0-4263-B117-EB6A4147AED1" src="https://github.com/user-attachments/assets/e75dc66b-b276-450a-9162-9779026bcb4b" />

### Testing Steps

1. Build and run on iOS
2. Load a site
3. Open the tab switcher
4. Scroll to the top and check the appearance of the X button in the info bar
5. Ensure you can still tap the X button to dismiss the bar

### Impact

Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized SwiftUI visual and API rename in the tab switcher header; dismiss flow and alert behavior are unchanged.
> 
> **Overview**
> Replaces the tab switcher tracker-count **info (i) control** with a **close (X)** so the UI matches dismiss behavior (still opens the hide-tracker-count alert via `presentHideTrackerCountAlert`).
> 
> In `InfoPanelView`, the model callback is renamed **`onInfo` → `onDismiss`**, the trailing button uses **`DesignSystemImages.Glyphs.Size16.close`** instead of `.infoIcon`, and padding/sizing on that button is adjusted. `TabSwitcherPageViewController` wires the same dismiss flow through the renamed `onDismiss` parameter on `trackerInfoPanel`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90f9742daa2e5392227eb2dc550fe385d8a68f0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->