### PR TITLE
iOS: Fix missing NTP Dax logo after dismissing screens from focused UTI

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
@@ -333,6 +333,8 @@ private extension MainViewController {
         viewCoordinator.hideUnifiedInputContent()
         unifiedToggleInputCoordinator?.contentViewController.setContentInset(top: 0, bottom: 0)
         hideSuggestionTray()
+        newTabPageViewController?.setLogoHidden(false)
+        newTabPageViewController?.setFavoritesHidden(false)
     }
 
     func applyBottomOmnibarVisibility(_ state: UnifiedToggleInputDisplayState.OmnibarState) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1216428438612104?focus=true

### Description
When the unified toggle input (UTI) is focused from the new tab page, the page's resting content — the Dax logo, or the favorites grid — is hidden so it doesn't double up with the focused input. The animated back-button dismiss restored that content, but the intent-based dismiss used by Bookmarks, Settings, and the Tab Switcher (they cancel the omnibar via `performCancel`) did not. As a result, opening and then closing any of those screens left the new tab page blank where the Dax logo (or favorites) should be. This restores the hidden content in the shared teardown so both dismiss paths behave the same.

### Testing Steps
1. On the new tab page, tap the address bar to activate the unified toggle input.
2. Open Bookmarks → the Bookmarks screen appears.
3. Dismiss Bookmarks → the new tab page returns with the Dax logo visible (previously missing).
4. Repeat steps 1–3 opening Settings instead of Bookmarks → logo returns.
5. Repeat steps 1–3 with the Tab Switcher: activate the input, swipe down to reveal the toolbar, open the Tab Switcher, reselect the tab → logo returns.
6. Add a favorite so the new tab page shows the favorites grid, then repeat steps 1–3 → the favorites grid returns (not blank).
7. Regression check: activate the input, then tap the back/cancel button to return to the new tab page → logo/favorites still display correctly.

### Impact
Low — small visual bug fix on the (internal) unified toggle input; no data or privacy impact.

#### What could go wrong?
Revealing the content on the wrong path could flash the logo/favorites back in → mitigated because the animated back-button dismiss already sets these flags before it reaches this shared reset, so the change is a no-op on that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI teardown change in shared UTI reset; redundant on paths that already unhide, with no data or auth impact.
> 
> **Overview**
> Fixes a blank new tab page after closing Bookmarks, Settings, or the Tab Switcher while unified toggle input (UTI) was focused from the NTP.
> 
> Focusing UTI hides the resting **Dax logo** and **favorites grid** so they don’t overlap the focused input. The animated back/cancel dismiss already brought them back; intent-based teardown (`performCancel`) only ran `resetUnifiedInputContentAfterHide()` and left them hidden.
> 
> **`resetUnifiedInputContentAfterHide()`** now calls `setLogoHidden(false)` and `setFavoritesHidden(false)` so every UTI hide path restores NTP resting content the same way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef6ac26cd4d278adcee21cff45f4790e24be3ab6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->