### PR TITLE
iOS: Fix recent chats lingering when toggling UTI to Search

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/UnifiedSuggestionsView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/UnifiedSuggestionsView.swift
@@ -89,6 +89,9 @@ struct UnifiedSuggestionsView: View {
         SuggestionsListView(viewModel: viewModel.listViewModel(for: activeListKind),
                             isAddressBarAtBottom: isAddressBarAtBottom)
             .opacity(isShowingList ? 1 : 0)
+            // Fade *in* on a mode change, but snap *out* — otherwise the recents list lingers over the
+            // Search favorites/logo (which snap in instantly) when toggling away from Duck.ai.
+            .animation(isShowingList ? .easeInOut(duration: 0.2) : nil, value: isShowingList)
             // Fade out with the collapse (like the logo) so a list→favorites dismiss hands off to the
             // NTP favorites instead of snapping away when the host is hidden.
             .modifier(DismissFade(isFadingOut: viewModel.isFadingOut))


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216433046778277
CC:

### Description
When the unified toggle input is on Duck.ai and shows recent chats, toggling to Search briefly left the recent-chats list on screen — it faded out over ~0.2s while the rest of the input snapped to Search immediately. The list now disappears instantly on the toggle, matching the favorites/logo empty states, so the switch reads as one clean transition. Fading *in* when switching to Duck.ai is unchanged.

**FIrst**…watch the video [here](https://app.asana.com/1/137249556945/project/414235014887631/task/1216433046778277?focus=true) to see the issue being fixed

### Testing Steps
1. Use an internal build with the unified toggle input enabled, and have at least one recent Duck.ai chat so recent chats show.
2. Open the address bar and toggle to **Duck.ai** → the recent-chats list (with "View all chats") appears below the input.
3. Toggle to **Search** → the recent-chats list disappears immediately, in sync with the input resizing — no lingering/fade-out.
4. Toggle back to **Duck.ai** → recent chats reappear (fading in, as before).

### Impact
Low — internal-only visual fix to an existing feature; no behaviour or data changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single SwiftUI animation modifier on an internal unified input surface; no logic or data changes.
> 
> **Overview**
> Fixes a visual glitch when leaving **Duck.ai** recent chats for **Search** in the unified toggle input: the suggestion list no longer eases out over ~0.2s while favorites/logo snap in immediately.
> 
> `listLayer` in `UnifiedSuggestionsView` now applies `.easeInOut(duration: 0.2)` only when `isShowingList` becomes true; hiding the list uses `nil` animation so opacity drops instantly, aligned with the favorites overlay and logo show/hide behavior. Fade-in when switching into a list state is unchanged; `DismissFade` still handles the separate collapse handoff to the NTP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68cb0c8d85c638b6f99c64056564fa5ae1509789. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->