### PR TITLE
iOS: Update 7.229.0 release notes for Duck.ai iPad model picker

### DIFF
--- a/iOS/fastlane/metadata/default/release_notes.txt
+++ b/iOS/fastlane/metadata/default/release_notes.txt
@@ -1,1 +1,2 @@
+• On iPad, if you have the Duck.ai address bar toggle enabled, you can now switch models directly from the address bar. Simply tap the model name to open the model picker menu.
 • This update includes various improvements and fixes a few bugs.


### PR DESCRIPTION
### Description
Updates the iOS 7.229.0 App Store release notes to announce the new Duck.ai model picker in the iPad address bar. Adds a feature bullet at the top and keeps the existing generic improvements/bug-fixes bullet.

### Testing Steps
1. Open `iOS/fastlane/metadata/default/release_notes.txt` → two bullets, feature bullet first.

### Impact
None (App Store metadata only, no code changes).
