### PR TITLE
iOS: Update 7.229.0 release notes for Duck.ai iPad model picker

### DIFF
--- a/iOS/fastlane/metadata/default/release_notes.txt
+++ b/iOS/fastlane/metadata/default/release_notes.txt
@@ -1,1 +1,2 @@
+• On iPad, if you have the Duck.ai address bar toggle enabled, you can now switch models directly from the address bar. Simply tap the model name to open the model picker menu.
 • This update includes various improvements and fixes a few bugs.


### PR DESCRIPTION
### Description
Update the iOS 7.229.0 App Store release notes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change to App Store release notes; no app code or runtime behavior is modified.
> 
> **Overview**
> Updates **iOS 7.229.0** App Store release notes in `release_notes.txt` by adding a user-facing bullet for **iPad Duck.ai address bar** users: when the Duck.ai address bar toggle is on, they can **tap the model name** in the address bar to open the **model picker** menu.
> 
> The existing generic “improvements and bug fixes” bullet is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 750d65147ac11b3add06600886474afb8d61089c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->