### PR TITLE
Sample m_mac_site_loading_timing pixel at 2%

### DIFF
--- a/macOS/DuckDuckGo/Tab/TabExtensions/NavigationPixelNavigationResponder.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/NavigationPixelNavigationResponder.swift
@@ -185,6 +185,6 @@ extension NavigationPixelNavigationResponder: NavigationResponder {
             firstMeaningfulPaintMs: firstMeaningfulPaintMs,
             documentCompleteMs: documentCompleteMs,
             allResourcesCompleteMs: allResourcesCompleteMs
-        ), frequency: .standard, withAdditionalParameters: additionalParams)
+        ), frequency: .sample(percentage: SiteLoadingPixel.samplePercentage), withAdditionalParameters: additionalParams)
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/navigation.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/navigation.json5
@@ -80,6 +80,12 @@
         "description": "Fired when WKPageLoadTiming data is available for a site loading navigation. Provides detailed performance timing metrics.",
         "owners": ["diegoreymendez"],
         "triggers": ["page_load"],
+        "suffixes": [
+            {
+                "description": "Sampling percentage (between 1 and 100 inclusive)",
+                "pattern": "^sample(?:100|0?[1-9]|[1-9][0-9])$"
+            }
+        ],
         "parameters": [
             "appVersion",
             "pixelSource",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1216651950297574?focus=true

### Description

The macOS `m_mac_site_loading_timing` pixel fired on every eligible navigation, while its `success`/`failure` siblings and the content-scope performance pixel all sample at 2%. This aligns it with the rest of the family so the loading pixels share one sampling basis and their volumes are directly comparable without rescaling.

Note: I believe a privacy triage is not necessary here as we're firing a pre-existing pixel less often than before.

### Testing Steps

Manual testing isn't feasible — the pixel only fires from WebKit's private page-load-timing callback and now at 2%, so it can't be reliably observed by hand.
1. Verify the CI is green (the pixel-definition validation confirms the new `sample` suffix is declared).

### Impact

Low. Telemetry-only change; reduces the volume of one internal performance pixel. No user-facing behavior.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only sampling change with no user-facing or security impact.
> 
> **Overview**
> The **`m_mac_site_loading_timing`** pixel no longer fires on every eligible navigation. It now uses **`SiteLoadingPixel.samplePercentage`** (2%) via **`.sample(percentage:)`**, matching **`m_mac_site_loading_success`**, **`m_mac_site_loading_failure`**, and **`m_mac_site_loading_performance`**.
> 
> The pixel definition in **`navigation.json5`** adds the same **`sample`** suffix pattern those siblings already declare, so CI validation accepts the sampled event name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1635f5f8bbdb58d1a6122f8ea72c182506a91a91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->