### PR TITLE
[iOS] Implement multi-select download in Duck.ai chat history

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -791,6 +791,7 @@
 		85058370219F424500ED4EDB /* SearchBarExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F143C3451E4AA32D00CFDE3A /* SearchBarExtension.swift */; };
 		8508931F2EA7AF04005F84FD /* MobileCustomization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8508931E2EA7AEFE005F84FD /* MobileCustomization.swift */; };
 		850ABD012AC3961100A733DF /* MainViewController+Segues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850ABD002AC3961100A733DF /* MainViewController+Segues.swift */; };
+		1A2B3C4D5E6F708192A3B402 /* MainViewController+AIChatHistoryViewModelDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F708192A3B401 /* MainViewController+AIChatHistoryViewModelDelegate.swift */; };
 		850F93DB2B594AB800823EEA /* ZippedPassKitPreviewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850F93DA2B594AB800823EEA /* ZippedPassKitPreviewHelper.swift */; };
 		8512EA4F24ED30D20073EE19 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8512EA4E24ED30D20073EE19 /* WidgetKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		8512EA5124ED30D20073EE19 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8512EA5024ED30D20073EE19 /* SwiftUI.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
@@ -3438,6 +3439,7 @@
 		85058365219AE9EA00ED4EDB /* HomePageConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePageConfiguration.swift; sourceTree = "<group>"; };
 		8508931E2EA7AEFE005F84FD /* MobileCustomization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileCustomization.swift; sourceTree = "<group>"; };
 		850ABD002AC3961100A733DF /* MainViewController+Segues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainViewController+Segues.swift"; sourceTree = "<group>"; };
+		1A2B3C4D5E6F708192A3B401 /* MainViewController+AIChatHistoryViewModelDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainViewController+AIChatHistoryViewModelDelegate.swift"; sourceTree = "<group>"; };
 		850F93DA2B594AB800823EEA /* ZippedPassKitPreviewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZippedPassKitPreviewHelper.swift; sourceTree = "<group>"; };
 		8512BCBF2061B6110085E862 /* global.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = global.swift; sourceTree = "<group>"; };
 		8512EA4D24ED30D20073EE19 /* WidgetsExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = WidgetsExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -11319,6 +11321,7 @@
 				8546A5492A672959003929BF /* MainViewController+Email.swift */,
 				85F2FFCC2211F615006BB258 /* MainViewController+KeyCommands.swift */,
 				850ABD002AC3961100A733DF /* MainViewController+Segues.swift */,
+				1A2B3C4D5E6F708192A3B401 /* MainViewController+AIChatHistoryViewModelDelegate.swift */,
 				9880723525FA4E440039EF4B /* menu_dark.json */,
 				9880723625FA4E450039EF4B /* menu_light.json */,
 				98EF177C21837E35006750C1 /* new_tab_dark.json */,
@@ -13463,6 +13466,7 @@
 				854D678D2F6D4BA8008707A3 /* TabSwitcherMenuBuilder.swift in Sources */,
 				CBF259B32D47EE6F00AC63E4 /* KeyboardPresenter.swift in Sources */,
 				850ABD012AC3961100A733DF /* MainViewController+Segues.swift in Sources */,
+				1A2B3C4D5E6F708192A3B402 /* MainViewController+AIChatHistoryViewModelDelegate.swift in Sources */,
 				9F880BEE2F331CDF00BF211E /* FadeInView.swift in Sources */,
 				6FB2A6802C2EA950004D20C8 /* FavoritesViewModel.swift in Sources */,
 				9817C9C321EF594700884F65 /* AutoClear.swift in Sources */,

--- a/iOS/DuckDuckGo/AIChat/AIChatHistoryViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatHistoryViewController.swift
@@ -555,7 +555,13 @@ final class AIChatHistoryViewController: UIViewController {
     }
 
     @objc private func downloadSelectedTapped() {
-        // TODO: multi-download wiring — https://app.asana.com/1/137249556945/task/1216558977091672
+        // No confirmation: download is non-destructive and just saves to Downloads, matching the
+        // single-swipe download. The toolbar item is only enabled with a selection.
+        let selectedChatIds = (tableView.indexPathsForSelectedRows ?? [])
+            .compactMap { viewModel.chatId(forRowAt: $0) }
+        guard !selectedChatIds.isEmpty else { return }
+        viewModel.downloadSelectedChats(chatIds: selectedChatIds)
+        exitSelectionMode()
     }
 
 }

--- a/iOS/DuckDuckGo/AIChat/AIChatHistoryViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatHistoryViewController.swift
@@ -555,8 +555,6 @@ final class AIChatHistoryViewController: UIViewController {
     }
 
     @objc private func downloadSelectedTapped() {
-        // No confirmation: download is non-destructive and just saves to Downloads, matching the
-        // single-swipe download. The toolbar item is only enabled with a selection.
         let selectedChatIds = (tableView.indexPathsForSelectedRows ?? [])
             .compactMap { viewModel.chatId(forRowAt: $0) }
         guard !selectedChatIds.isEmpty else { return }

--- a/iOS/DuckDuckGo/AIChat/AIChatHistoryViewModel.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatHistoryViewModel.swift
@@ -261,8 +261,14 @@ final class AIChatHistoryViewModel: ObservableObject {
                     instrumentation.downloadFailed(error: error)
                 }
             }
-            guard !urls.isEmpty else { return }
-            DispatchQueue.main.async { onExported(urls) }
+            DispatchQueue.main.async { [weak self] in
+                // Chats were attempted (input was non-empty); an empty result means every one failed.
+                if urls.isEmpty {
+                    self?.delegate?.viewModelDidFailExport()
+                } else {
+                    onExported(urls)
+                }
+            }
         }
     }
 
@@ -372,4 +378,8 @@ protocol AIChatHistoryViewModelDelegate: AnyObject {
     /// file; present one aggregate "N chats downloaded" toast with a "Show" action that
     /// dismisses the sheet and opens the in-app Downloads list.
     func viewModelDidExportChats(count: Int)
+
+    /// An export produced no files — a single download failed, or every selected chat failed.
+    /// Present a "download failed" error toast. (Not called when nothing was selected.)
+    func viewModelDidFailExport()
 }

--- a/iOS/DuckDuckGo/AIChat/AIChatHistoryViewModel.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatHistoryViewModel.swift
@@ -252,6 +252,32 @@ final class AIChatHistoryViewModel: ObservableObject {
         }
     }
 
+    /// Downloads each selected chat as its own file (mirrors the single-swipe download), then
+    /// surfaces one aggregate toast for however many saved. Off-main — exports do storage
+    /// reads, base64 decoding, and zip writing. Tolerates partial failures.
+    func downloadSelectedChats(chatIds: [String]) {
+        guard let downloader, !chatIds.isEmpty else { return }
+        let instrumentation = instrumentation
+        mutationQueue.async { [weak self] in
+            var successCount = 0
+            for chatId in chatIds {
+                instrumentation.downloadStarted()
+                do {
+                    _ = try downloader.downloadChat(chatId: chatId)
+                    successCount += 1
+                } catch {
+                    Logger.aiChat.debug("Chat export failed: \(error.localizedDescription)")
+                    instrumentation.downloadFailed(error: error)
+                }
+            }
+            guard successCount > 0 else { return }
+            let exported = successCount
+            DispatchQueue.main.async { [weak self] in
+                self?.delegate?.viewModelDidExportChats(count: exported)
+            }
+        }
+    }
+
     func isPinned(chatId: String) -> Bool {
         pinned.contains(where: { $0.chatId == chatId })
     }
@@ -353,4 +379,9 @@ protocol AIChatHistoryViewModelDelegate: AnyObject {
     /// `filename` with a "Show" action that dismisses the sheet and opens the in-app
     /// Downloads list.
     func viewModelDidExportChat(filename: String)
+
+    /// A multi-select export finished. `count` chats were each written to disk as their own
+    /// file; present one aggregate "N chats downloaded" toast with a "Show" action that
+    /// dismisses the sheet and opens the in-app Downloads list.
+    func viewModelDidExportChats(count: Int)
 }

--- a/iOS/DuckDuckGo/AIChat/AIChatHistoryViewModel.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatHistoryViewModel.swift
@@ -235,46 +235,34 @@ final class AIChatHistoryViewModel: ObservableObject {
     }
 
     func downloadChat(chatId: String) {
-        // Image-gen exports do enough I/O to freeze the sheet — dispatch off-main.
-        guard let downloader else { return }
         instrumentation.downloadStarted()
-        let instrumentation = instrumentation
-        mutationQueue.async { [weak self] in
-            do {
-                let url = try downloader.downloadChat(chatId: chatId)
-                DispatchQueue.main.async { [weak self] in
-                    self?.delegate?.viewModelDidExportChat(filename: url.lastPathComponent)
-                }
-            } catch {
-                Logger.aiChat.debug("Chat export failed: \(error.localizedDescription)")
-                instrumentation.downloadFailed(error: error)
-            }
+        exportChats([chatId]) { [weak self] urls in
+            guard let filename = urls.first?.lastPathComponent else { return }
+            self?.delegate?.viewModelDidExportChat(filename: filename)
         }
     }
 
-    /// Downloads each selected chat as its own file (mirrors the single-swipe download), then
-    /// surfaces one aggregate toast for however many saved. Off-main — exports do storage
-    /// reads, base64 decoding, and zip writing. Tolerates partial failures.
     func downloadSelectedChats(chatIds: [String]) {
+        exportChats(chatIds) { [weak self] urls in
+            self?.delegate?.viewModelDidExportChats(count: urls.count)
+        }
+    }
+
+    private func exportChats(_ chatIds: [String], onExported: @escaping ([URL]) -> Void) {
         guard let downloader, !chatIds.isEmpty else { return }
         let instrumentation = instrumentation
-        mutationQueue.async { [weak self] in
-            var successCount = 0
+        mutationQueue.async {
+            var urls: [URL] = []
             for chatId in chatIds {
-                instrumentation.downloadStarted()
                 do {
-                    _ = try downloader.downloadChat(chatId: chatId)
-                    successCount += 1
+                    urls.append(try downloader.downloadChat(chatId: chatId))
                 } catch {
                     Logger.aiChat.debug("Chat export failed: \(error.localizedDescription)")
                     instrumentation.downloadFailed(error: error)
                 }
             }
-            guard successCount > 0 else { return }
-            let exported = successCount
-            DispatchQueue.main.async { [weak self] in
-                self?.delegate?.viewModelDidExportChats(count: exported)
-            }
+            guard !urls.isEmpty else { return }
+            DispatchQueue.main.async { onExported(urls) }
         }
     }
 

--- a/iOS/DuckDuckGo/MainViewController+AIChatHistoryViewModelDelegate.swift
+++ b/iOS/DuckDuckGo/MainViewController+AIChatHistoryViewModelDelegate.swift
@@ -1,0 +1,64 @@
+//
+//  MainViewController+AIChatHistoryViewModelDelegate.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+import AIChat
+
+extension MainViewController: AIChatHistoryViewModelDelegate {
+
+    func viewModelDidRequestOpenNewChat() {
+        dismiss(animated: true) { [weak self] in
+            self?.openAIChat()
+        }
+    }
+
+    func viewModelDidRequestOpenChat(chatId: String) {
+        let url = aiChatSettings.aiChatURL.withChatID(chatId)
+        dismiss(animated: true) { [weak self] in
+            self?.onChatHistorySelected(url: url)
+        }
+    }
+
+    func viewModelDidExportChat(filename: String) {
+        presentChatDownloadFinishedToast(DownloadActionMessageViewHelper.makeDownloadFinishedMessage(forFilename: filename))
+    }
+
+    func viewModelDidExportChats(count: Int) {
+        presentChatDownloadFinishedToast(NSAttributedString(string: UserText.aiChatHistoryDownloadCompleteMessage(count: count)))
+    }
+
+    func viewModelDidFailExport() {
+        ActionMessageView.present(
+            message: UserText.aiChatHistoryDownloadFailedMessage,
+            presentationLocation: .withBottomBar(andAddressBarBottom: appSettings.currentAddressBarPosition.isBottom)
+        )
+    }
+
+    private func presentChatDownloadFinishedToast(_ message: NSAttributedString) {
+        ActionMessageView.present(
+            message: message,
+            numberOfLines: 2,
+            actionTitle: UserText.actionGenericShow,
+            presentationLocation: .withBottomBar(andAddressBarBottom: appSettings.currentAddressBarPosition.isBottom),
+            onAction: { [weak self] in
+                self?.dismiss(animated: true) { self?.segueToDownloads() }
+            }
+        )
+    }
+}

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -6132,51 +6132,6 @@ extension MainViewController: TabDelegate {
 
 }
 
-// MARK: - AIChatHistoryViewModelDelegate
-
-extension MainViewController: AIChatHistoryViewModelDelegate {
-
-    func viewModelDidRequestOpenNewChat() {
-        dismiss(animated: true) { [weak self] in
-            self?.openAIChat()
-        }
-    }
-
-    func viewModelDidRequestOpenChat(chatId: String) {
-        let url = aiChatSettings.aiChatURL.withChatID(chatId)
-        dismiss(animated: true) { [weak self] in
-            self?.onChatHistorySelected(url: url)
-        }
-    }
-
-    func viewModelDidExportChat(filename: String) {
-        presentChatDownloadFinishedToast(DownloadActionMessageViewHelper.makeDownloadFinishedMessage(forFilename: filename))
-    }
-
-    func viewModelDidExportChats(count: Int) {
-        presentChatDownloadFinishedToast(NSAttributedString(string: UserText.aiChatHistoryDownloadCompleteMessage(count: count)))
-    }
-
-    func viewModelDidFailExport() {
-        ActionMessageView.present(
-            message: UserText.aiChatHistoryDownloadFailedMessage,
-            presentationLocation: .withBottomBar(andAddressBarBottom: appSettings.currentAddressBarPosition.isBottom)
-        )
-    }
-
-    private func presentChatDownloadFinishedToast(_ message: NSAttributedString) {
-        ActionMessageView.present(
-            message: message,
-            numberOfLines: 2,
-            actionTitle: UserText.actionGenericShow,
-            presentationLocation: .withBottomBar(andAddressBarBottom: appSettings.currentAddressBarPosition.isBottom),
-            onAction: { [weak self] in
-                self?.dismiss(animated: true) { self?.segueToDownloads() }
-            }
-        )
-    }
-}
-
 extension MainViewController: TabSwitcherDelegate {
 
     func tabSwitcher(_ tabSwitcher: TabSwitcherViewController, didFinishWithSelectedTab tab: Tab?) {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -6157,6 +6157,13 @@ extension MainViewController: AIChatHistoryViewModelDelegate {
         presentChatDownloadFinishedToast(NSAttributedString(string: UserText.aiChatHistoryDownloadCompleteMessage(count: count)))
     }
 
+    func viewModelDidFailExport() {
+        ActionMessageView.present(
+            message: UserText.aiChatHistoryDownloadFailedMessage,
+            presentationLocation: .withBottomBar(andAddressBarBottom: appSettings.currentAddressBarPosition.isBottom)
+        )
+    }
+
     private func presentChatDownloadFinishedToast(_ message: NSAttributedString) {
         ActionMessageView.present(
             message: message,

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -6164,6 +6164,21 @@ extension MainViewController: AIChatHistoryViewModelDelegate {
             }
         )
     }
+
+    func viewModelDidExportChats(count: Int) {
+        let message = UserText.aiChatHistoryDownloadCompleteMessage(count: count)
+        let addressBarBottom = appSettings.currentAddressBarPosition.isBottom
+        ActionMessageView.present(
+            message: message,
+            actionTitle: UserText.actionGenericShow,
+            presentationLocation: .withBottomBar(andAddressBarBottom: addressBarBottom),
+            onAction: { [weak self] in
+                self?.dismiss(animated: true) { [weak self] in
+                    self?.segueToDownloads()
+                }
+            }
+        )
+    }
 }
 
 extension MainViewController: TabSwitcherDelegate {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -6150,32 +6150,21 @@ extension MainViewController: AIChatHistoryViewModelDelegate {
     }
 
     func viewModelDidExportChat(filename: String) {
-        let message = DownloadActionMessageViewHelper.makeDownloadFinishedMessage(forFilename: filename)
-        let addressBarBottom = appSettings.currentAddressBarPosition.isBottom
+        presentChatDownloadFinishedToast(DownloadActionMessageViewHelper.makeDownloadFinishedMessage(forFilename: filename))
+    }
+
+    func viewModelDidExportChats(count: Int) {
+        presentChatDownloadFinishedToast(NSAttributedString(string: UserText.aiChatHistoryDownloadCompleteMessage(count: count)))
+    }
+
+    private func presentChatDownloadFinishedToast(_ message: NSAttributedString) {
         ActionMessageView.present(
             message: message,
             numberOfLines: 2,
             actionTitle: UserText.actionGenericShow,
-            presentationLocation: .withBottomBar(andAddressBarBottom: addressBarBottom),
+            presentationLocation: .withBottomBar(andAddressBarBottom: appSettings.currentAddressBarPosition.isBottom),
             onAction: { [weak self] in
-                self?.dismiss(animated: true) { [weak self] in
-                    self?.segueToDownloads()
-                }
-            }
-        )
-    }
-
-    func viewModelDidExportChats(count: Int) {
-        let message = UserText.aiChatHistoryDownloadCompleteMessage(count: count)
-        let addressBarBottom = appSettings.currentAddressBarPosition.isBottom
-        ActionMessageView.present(
-            message: message,
-            actionTitle: UserText.actionGenericShow,
-            presentationLocation: .withBottomBar(andAddressBarBottom: addressBarBottom),
-            onAction: { [weak self] in
-                self?.dismiss(animated: true) { [weak self] in
-                    self?.segueToDownloads()
-                }
+                self?.dismiss(animated: true) { self?.segueToDownloads() }
             }
         )
     }

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -150,6 +150,7 @@ public struct UserText {
         let format = NotLocalizedString("aiChat.history.download.complete.message", value: value, comment: "Toast confirming the selected Duck.ai chats were saved to Downloads; the number is how many chats were downloaded.")
         return String.localizedStringWithFormat(format, count)
     }
+    public static let aiChatHistoryDownloadFailedMessage = NotLocalizedString("aiChat.history.download.failed.message", value: "Couldn't download. Please try again.", comment: "Error toast shown when a Duck.ai chat download fails and nothing was saved.")
     public static let actionAIChatSettings = NSLocalizedString("action.title.aiChat.settings", value: "Duck.ai Settings", comment: "Open AI Chat settings action in the menu list")
     public static let sectionTitleSuggestions = NotLocalizedString("section.title.suggestions", value: "Suggestions", comment: "Section header title above search suggestions")
     public static let aiChatSuggestedChatsTitle = NotLocalizedString("aiChat.suggestedChats.title", value: "Chats", comment: "Section header title above suggested Duck.ai chats")

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -145,6 +145,11 @@ public struct UserText {
         let format = NSLocalizedString("aiChat.history.deleteAll.confirmation.title", comment: "Title of the confirmation shown when the user taps Fire in Duck.ai chat history to delete all chats; the number is the chat count. Do not translate - stringsdict entry")
         return String.localizedStringWithFormat(format, count)
     }
+    public static func aiChatHistoryDownloadCompleteMessage(count: Int) -> String {
+        let value = count == 1 ? "%d chat downloaded" : "%d chats downloaded"
+        let format = NotLocalizedString("aiChat.history.download.complete.message", value: value, comment: "Toast confirming the selected Duck.ai chats were saved to Downloads; the number is how many chats were downloaded.")
+        return String.localizedStringWithFormat(format, count)
+    }
     public static let actionAIChatSettings = NSLocalizedString("action.title.aiChat.settings", value: "Duck.ai Settings", comment: "Open AI Chat settings action in the menu list")
     public static let sectionTitleSuggestions = NotLocalizedString("section.title.suggestions", value: "Suggestions", comment: "Section header title above search suggestions")
     public static let aiChatSuggestedChatsTitle = NotLocalizedString("aiChat.suggestedChats.title", value: "Chats", comment: "Section header title above suggested Duck.ai chats")

--- a/iOS/DuckDuckGoTests/AIChat/AIChatHistoryViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatHistoryViewModelTests.swift
@@ -289,6 +289,71 @@ final class AIChatHistoryViewModelTests: XCTestCase {
         XCTAssertEqual(delegate.exportedFilenames, [])
     }
 
+    func testDownloadSelectedChats_downloadsEachSeparatelyAndNotifiesDelegateOnceWithCount() {
+        let downloader = StubDownloader()
+        let queue = DispatchQueue(label: "test.download")
+        let sut = makeSUT(chats: [chat(id: "r1", pinned: false), chat(id: "r2", pinned: false), chat(id: "r3", pinned: false)],
+                          downloader: downloader, mutationQueue: queue)
+        let delegate = MockDelegate()
+        sut.delegate = delegate
+
+        sut.downloadSelectedChats(chatIds: ["r1", "r3"])
+        queue.sync { }
+        processMainQueue()
+
+        XCTAssertEqual(downloader.requestedChatIds, ["r1", "r3"], "each selected chat is downloaded as its own file")
+        XCTAssertEqual(delegate.exportedChatCounts, [2], "the delegate is notified once with the number that saved")
+        XCTAssertEqual(delegate.exportedFilenames, [], "batch download must not fire the single-file toast")
+    }
+
+    func testDownloadSelectedChats_partialFailure_notifiesWithSuccessCountOnly() {
+        let downloader = StubDownloader()
+        downloader.failingChatIds = ["r2"]
+        let queue = DispatchQueue(label: "test.download")
+        let sut = makeSUT(chats: [chat(id: "r1", pinned: false), chat(id: "r2", pinned: false), chat(id: "r3", pinned: false)],
+                          downloader: downloader, mutationQueue: queue)
+        let delegate = MockDelegate()
+        sut.delegate = delegate
+
+        sut.downloadSelectedChats(chatIds: ["r1", "r2", "r3"])
+        queue.sync { }
+        processMainQueue()
+
+        XCTAssertEqual(downloader.requestedChatIds, ["r1", "r2", "r3"], "a failure must not abort the rest of the batch")
+        XCTAssertEqual(delegate.exportedChatCounts, [2], "count reflects only the chats that actually saved")
+    }
+
+    func testDownloadSelectedChats_allFailures_doesNotNotifyDelegate() {
+        let downloader = StubDownloader()
+        downloader.failingChatIds = ["r1", "r2"]
+        let queue = DispatchQueue(label: "test.download")
+        let sut = makeSUT(chats: [chat(id: "r1", pinned: false), chat(id: "r2", pinned: false)],
+                          downloader: downloader, mutationQueue: queue)
+        let delegate = MockDelegate()
+        sut.delegate = delegate
+
+        sut.downloadSelectedChats(chatIds: ["r1", "r2"])
+        queue.sync { }
+        processMainQueue()
+
+        XCTAssertEqual(delegate.exportedChatCounts, [], "no toast when nothing saved")
+    }
+
+    func testDownloadSelectedChats_emptyIds_isNoOp() {
+        let downloader = StubDownloader()
+        let queue = DispatchQueue(label: "test.download")
+        let sut = makeSUT(chats: [chat(id: "r1", pinned: false)], downloader: downloader, mutationQueue: queue)
+        let delegate = MockDelegate()
+        sut.delegate = delegate
+
+        sut.downloadSelectedChats(chatIds: [])
+        queue.sync { }
+        processMainQueue()
+
+        XCTAssertEqual(downloader.requestedChatIds, [])
+        XCTAssertEqual(delegate.exportedChatCounts, [])
+    }
+
     // MARK: - Pin
 
     func testIsPinned_returnsTrueForChatsInPinnedSection_falseOtherwise() {
@@ -617,10 +682,12 @@ final class AIChatHistoryViewModelTests: XCTestCase {
         private(set) var didRequestOpenNewChat = false
         private(set) var requestedChatId: String?
         private(set) var exportedFilenames: [String] = []
+        private(set) var exportedChatCounts: [Int] = []
 
         func viewModelDidRequestOpenNewChat() { didRequestOpenNewChat = true }
         func viewModelDidRequestOpenChat(chatId: String) { requestedChatId = chatId }
         func viewModelDidExportChat(filename: String) { exportedFilenames.append(filename) }
+        func viewModelDidExportChats(count: Int) { exportedChatCounts.append(count) }
     }
 
     private final class MockChatHistoryFireExecutor: FireExecuting {
@@ -658,10 +725,15 @@ final class AIChatHistoryViewModelTests: XCTestCase {
 
     private final class StubDownloader: ChatHistoryDownloading {
         var stubbedResult: Result<URL, Error> = .success(URL(fileURLWithPath: "/tmp/stub.txt"))
+        /// Chat ids in this set throw `chatNotFound`; all others resolve to `stubbedResult`.
+        var failingChatIds: Set<String> = []
         private(set) var requestedChatIds: [String] = []
 
         func downloadChat(chatId: String) throws -> URL {
             requestedChatIds.append(chatId)
+            if failingChatIds.contains(chatId) {
+                throw ChatHistoryDownloader.DownloadError.chatNotFound
+            }
             return try stubbedResult.get()
         }
     }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatHistoryViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatHistoryViewModelTests.swift
@@ -274,7 +274,7 @@ final class AIChatHistoryViewModelTests: XCTestCase {
         XCTAssertEqual(delegate.exportedFilenames, ["duck.ai_2026-01-01_00-00-00.txt"])
     }
 
-    func testDownloadChat_onFailure_doesNotNotifyDelegate() {
+    func testDownloadChat_onFailure_notifiesFailureAndNotSuccess() {
         let downloader = StubDownloader()
         downloader.stubbedResult = .failure(ChatHistoryDownloader.DownloadError.chatNotFound)
         let queue = DispatchQueue(label: "test.download")
@@ -286,7 +286,8 @@ final class AIChatHistoryViewModelTests: XCTestCase {
         queue.sync { }
         processMainQueue()
 
-        XCTAssertEqual(delegate.exportedFilenames, [])
+        XCTAssertEqual(delegate.exportedFilenames, [], "a failed download must not fire the success toast")
+        XCTAssertTrue(delegate.didFailExport, "a failed single download surfaces the error toast")
     }
 
     func testDownloadSelectedChats_downloadsEachSeparatelyAndNotifiesDelegateOnceWithCount() {
@@ -321,9 +322,10 @@ final class AIChatHistoryViewModelTests: XCTestCase {
 
         XCTAssertEqual(downloader.requestedChatIds, ["r1", "r2", "r3"], "a failure must not abort the rest of the batch")
         XCTAssertEqual(delegate.exportedChatCounts, [2], "count reflects only the chats that actually saved")
+        XCTAssertFalse(delegate.didFailExport, "partial success shows the success toast, not the error")
     }
 
-    func testDownloadSelectedChats_allFailures_doesNotNotifyDelegate() {
+    func testDownloadSelectedChats_allFailures_notifiesFailure() {
         let downloader = StubDownloader()
         downloader.failingChatIds = ["r1", "r2"]
         let queue = DispatchQueue(label: "test.download")
@@ -336,7 +338,8 @@ final class AIChatHistoryViewModelTests: XCTestCase {
         queue.sync { }
         processMainQueue()
 
-        XCTAssertEqual(delegate.exportedChatCounts, [], "no toast when nothing saved")
+        XCTAssertEqual(delegate.exportedChatCounts, [], "no success toast when nothing saved")
+        XCTAssertTrue(delegate.didFailExport, "an all-failed batch surfaces the error toast")
     }
 
     func testDownloadSelectedChats_emptyIds_isNoOp() {
@@ -352,6 +355,7 @@ final class AIChatHistoryViewModelTests: XCTestCase {
 
         XCTAssertEqual(downloader.requestedChatIds, [])
         XCTAssertEqual(delegate.exportedChatCounts, [])
+        XCTAssertFalse(delegate.didFailExport, "empty selection is a no-op, not a failure")
     }
 
     // MARK: - Pin
@@ -683,11 +687,13 @@ final class AIChatHistoryViewModelTests: XCTestCase {
         private(set) var requestedChatId: String?
         private(set) var exportedFilenames: [String] = []
         private(set) var exportedChatCounts: [Int] = []
+        private(set) var didFailExport = false
 
         func viewModelDidRequestOpenNewChat() { didRequestOpenNewChat = true }
         func viewModelDidRequestOpenChat(chatId: String) { requestedChatId = chatId }
         func viewModelDidExportChat(filename: String) { exportedFilenames.append(filename) }
         func viewModelDidExportChats(count: Int) { exportedChatCounts.append(count) }
+        func viewModelDidFailExport() { didFailExport = true }
     }
 
     private final class MockChatHistoryFireExecutor: FireExecuting {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216558977091672

### Description
Adds multi-select download to the native Duck.ai chat history screen. 

### Testing Steps
1. Enable the aiChatHistoryMultiselect feature flag.
2. Have at least two Duck.ai chats (include one image-generation chat to exercise the zip path).
3. Tap the overflow menu → **Select Chats**, then tick two or more chats → the Download button in the toolbar enables.
4. Tap **Download** → selection mode exits and a toast appears reading "N chats downloaded".
5. Tap **Show** on the toast → the Downloads list opens showing one file per selected chat (`.txt` for text chats, `.zip` for image chats).
6. Repeat with a single selected chat → toast reads "1 chat downloaded".

### Impact
Low: new feature behind the native Chats flag; download only reads chats and writes files, so it can't lose or corrupt chat data.

### Quality Considerations
- Exports run off the main thread (storage reads, base64 decoding, zip writing).
- Partial failures are tolerated: a failing chat is skipped, the rest still save, and the toast count reflects only what actually saved. If nothing saves, no toast is shown.
- Unit tests cover the each-separate-file behaviour, the aggregate count, partial failure, all-failure, and the empty-selection no-op.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only export behind the multiselect flag; no changes to chat deletion, sync, or auth.
> 
> **Overview**
> **Multi-select download** in Duck.ai chat history is wired end-to-end: the selection toolbar **Download** action exports each selected chat as its own file, exits selection mode, and surfaces UI feedback.
> 
> Export logic in `AIChatHistoryViewModel` is centralized in **`exportChats`**, used for single- and multi-chat downloads on a background queue. Partial failures skip individual chats and still report how many saved; if every attempt fails (including a lone single-chat download), the delegate gets **`viewModelDidFailExport()`** instead of a success toast.
> 
> **`MainViewController`** delegate handling moves to **`MainViewController+AIChatHistoryViewModelDelegate`**, with aggregate success toasts (**"N chats downloaded"**), shared **Show → Downloads** behavior, and a new failure toast. **`UserText`** adds the corresponding copy. Unit tests cover batch export, partial/all failure, and empty selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 698ee0bf0b646738af2a7d03a7a15b3ad024da4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->