### PR TITLE
iOS: Fix UTI cursor jump when toggling Duck.ai → Search

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -104,22 +104,21 @@ class SwitchBarTextEntryView: UIView {
                 textView.isHidden = false
             }
 
-            // Transfer FR while both controls are visible so UIKit keeps the keyboard alive
-            // without a dismiss/re-present cycle.
-            if wasFirstResponder { _ = becomeFirstResponder() }
+            // Without this the caret animates in from a stale position, because the style flip runs
+            // inside the coordinator's mode-change UIView.animate. updateTextViewHeight stays outside
+            // so the height still animates with that transaction.
+            UIView.performWithoutAnimation {
+                adjustTextViewContentInset()
+                if wasFirstResponder { _ = becomeFirstResponder() }
+                if style == .singleLine && textView.isFirstResponder { _ = textView.resignFirstResponder() }
+                if style == .multiLine && textField.isFirstResponder { _ = textField.resignFirstResponder() }
+                syncActiveControl()
+                updatePlaceholderVisibility()
+                updateKeyboardConfiguration()
+                (usesTextField ? textField : textView).layoutIfNeeded()
+            }
 
-            // If becomeFirstResponder() returned false the outgoing control is still FR.
-            // Resign it explicitly so it is never hidden while holding keyboard focus.
-            if style == .singleLine && textView.isFirstResponder { _ = textView.resignFirstResponder() }
-            if style == .multiLine && textField.isFirstResponder { _ = textField.resignFirstResponder() }
-
-            // Hide the outgoing control — it has now lost first responder.
-            syncActiveControl()
-
-            updatePlaceholderVisibility()
-            updateKeyboardConfiguration()
             updateTextViewHeight()
-            adjustTextViewContentInset()
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1216621845315941

### Description
Toggling the expanded unified input from Duck.ai to Search made the text cursor briefly appear partway into the field and then jump back to the start of the line. This removes that artifact so the cursor sits at the start immediately.

### Testing Steps
1. On iPhone, open a new tab.
2. Tap the address bar → the input expands with the Search / Duck.ai toggle and the keyboard.
3. Tap **Duck.ai**.
4. Tap **Search** → the cursor stays at the start of the field (previously it flashed forward, then snapped back to the start).
5. Toggle back and forth a few times, including with text typed in the field → cursor position stays stable each time.

### Impact
Low — internal-only feature; visual-only fix to a transient cursor animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only change to text-entry focus/layout during mode toggle; no auth, data, or API impact.
> 
> **Overview**
> Fixes a **transient caret glitch** when the unified input toggles between Duck.ai and Search (single-line `UITextField` ↔ multi-line `UITextView`). The style switch runs inside the coordinator’s mode-change `UIView.animate`, so first-responder handoff, insets, placeholder/keyboard updates, and hiding the outgoing control were briefly animating and made the cursor appear mid-field before snapping to the start.
> 
> Those layout and focus steps are now applied inside **`UIView.performWithoutAnimation`**, while **`updateTextViewHeight()`** stays outside so field height still animates with the parent transaction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5827963ce17e0b0e53e07424a739218d64477663. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->