### PR TITLE
[iOS] Reopen a back-closed link tab via the forward button

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -5982,6 +5982,10 @@ extension MainViewController: TabDelegate {
 
     }
 
+    func tab(_ tab: TabViewController, didRequestReopenClosedTabAt url: URL) {
+        self.tab(tab, didRequestNewTabForUrl: url, openedByPage: true, inheritingAttribution: nil)
+    }
+
     func tab(_ tab: TabViewController, didChangePrivacyInfo privacyInfo: PrivacyInfo?) {
         if currentTab == tab {
             viewCoordinator.omniBar.updatePrivacyIcon(for: privacyInfo)

--- a/iOS/DuckDuckGo/TabDelegate.swift
+++ b/iOS/DuckDuckGo/TabDelegate.swift
@@ -55,6 +55,10 @@ protocol TabDelegate: AnyObject {
              openedByPage: Bool,
              inheritingAttribution: AdClickAttributionLogic.State?)
 
+    /// Called on navigate forward on a tab that had just closed a link-opened tab via back.
+    /// Re-open that tab at `url` as a child of `tab` again.
+    func tab(_ tab: TabViewController, didRequestReopenClosedTabAt url: URL)
+
     func tab(_ tab: TabViewController,
              didRequestNewBackgroundTabForUrl url: URL,
              inheritingAttribution: AdClickAttributionLogic.State?)

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -144,6 +144,15 @@ class TabViewController: UIViewController {
             delegate?.tabLoadingStateDidChange(tab: self)
         }
     }
+
+    /// URL of a tab this tab opened that was just closed via the back button. When set, the forward
+    /// button re-opens it (only if the web view has no forward entry). Cleared once consumed or when
+    /// this tab navigates elsewhere.
+    var reopenableClosedTabURL: URL? {
+        didSet {
+            delegate?.tabLoadingStateDidChange(tab: self)
+        }
+    }
     
     weak var delegate: TabDelegate?
     var aiChatContentHandlingDelegate: AIChatContentHandlingDelegate? {
@@ -1470,7 +1479,7 @@ class TabViewController: UIViewController {
 
         // Clear navigation error when going back
         lastError = nil
-        
+
         if let url = url, url.isDuckPlayer {
             webView.stopLoading()
             if webView.canGoBack {
@@ -1480,6 +1489,7 @@ class TabViewController: UIViewController {
                 return
             }
             if openingTab != nil {
+                stashReopenableStateOnOpener()
                 delegate?.tabDidRequestClose(self)
                 return
             }
@@ -1504,11 +1514,18 @@ class TabViewController: UIViewController {
         }
 
         if openingTab != nil {
+            stashReopenableStateOnOpener()
             delegate?.tabDidRequestClose(self)
         }
-        
+
     }
-    
+
+    /// Records the closed tab's URL on the opener so its forward button can re-open it.
+    private func stashReopenableStateOnOpener() {
+        guard let openingTab else { return }
+        openingTab.reopenableClosedTabURL = webView.url
+    }
+
     func goForward() {
         addressBarURLFilter.beginUserNavigation()
         dismissJSAlertIfNeeded()
@@ -1517,7 +1534,12 @@ class TabViewController: UIViewController {
         lastError = nil
 
         if webView.goForward() != nil {
+            reopenableClosedTabURL = nil
             duckPlayerNavigationHandler.handleGoForward(webView: webView)
+            chromeDelegate?.omniBar.endEditing()
+        } else if let reopenableClosedTabURL {
+            self.reopenableClosedTabURL = nil
+            delegate?.tab(self, didRequestReopenClosedTabAt: reopenableClosedTabURL)
             chromeDelegate?.omniBar.endEditing()
         }
     }
@@ -2124,6 +2146,7 @@ extension TabViewController: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
         navigationPixelResponder.didStart(navigation)
+        reopenableClosedTabURL = nil
         lastError = nil
         lastRenderedURL = webView.url
         cancelTrackerNetworksAnimation()
@@ -4918,7 +4941,7 @@ extension TabViewController: Navigatable {
 
     public var canGoForward: Bool {
         let webViewCanGoForward = webView.canGoForward
-        return webViewCanGoForward && !isError
+        return (webViewCanGoForward && !isError) || reopenableClosedTabURL != nil
     }
 
 }

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -150,6 +150,7 @@ class TabViewController: UIViewController {
     /// this tab navigates elsewhere.
     var reopenableClosedTabURL: URL? {
         didSet {
+            guard reopenableClosedTabURL != oldValue else { return }
             delegate?.tabLoadingStateDidChange(tab: self)
         }
     }
@@ -1309,6 +1310,9 @@ class TabViewController: UIViewController {
             }
 
         case #keyPath(WKWebView.url):
+            // Cleared here, so we act on same-document navigation too.
+            reopenableClosedTabURL = nil
+
             // A short delay is required here, because the URL takes some time
             // to propagate to the webView.url property accessor and might not
             // be immediately available in the observer
@@ -2146,7 +2150,6 @@ extension TabViewController: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
         navigationPixelResponder.didStart(navigation)
-        reopenableClosedTabURL = nil
         lastError = nil
         lastRenderedURL = webView.url
         cancelTrackerNetworksAnimation()

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
@@ -61,6 +61,8 @@ final class MockTabDelegate: TabDelegate {
 
     func tab(_ tab: DuckDuckGo.TabViewController, didRequestNewTabForUrl url: URL, openedByPage: Bool, inheritingAttribution: BrowserServicesKit.AdClickAttributionLogic.State?) {}
 
+    func tab(_ tab: DuckDuckGo.TabViewController, didRequestReopenClosedTabAt url: URL) {}
+
     func tab(_ tab: DuckDuckGo.TabViewController, didRequestNewBackgroundTabForUrl url: URL, inheritingAttribution: BrowserServicesKit.AdClickAttributionLogic.State?) {}
 
     func tab(_ tab: DuckDuckGo.TabViewController, didRequestNewFireTabForUrl url: URL, inheritingAttribution: BrowserServicesKit.AdClickAttributionLogic.State?) {}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1209836957181865?focus=true
Tech Design URL:
CC:

### Description

When a link opens in a new tab and the user taps back, the new tab closes and returns to the tab that opened it. This already works. This change makes the forward button on that opener tab re-open the recently closed tab, so the action is reversible. Forward re-opens the closed tab only as a fallback: if the opener tab has a real forward entry in its own web view history, forward navigates there instead.

### Testing Steps

1. Open a new tab and load https://privacy-test-pages.site/features/target-blank.html.
2. Tap "Opens in new window", a new tab opens.
3. Tap back, verify the new tab closes and you return to the opener tab.
4. Tap forward, verify the closed tab re-opens.
5. On the reopened tab, tap back once, verify it closes in a single press and returns to the opener (no extra intermediate step).
6. Regression: on the opener, navigate A to B to back-to-A so it has its own forward entry, open a link in a new tab, back to close it, then forward. Verify forward navigates the opener's own history (to B) rather than re-opening the closed tab.

### Impact and Risks

Low. Scoped to the forward-button behaviour for tabs opened from a link.

#### What could go wrong?

--

### Quality Considerations

--

### Notes to Reviewer

--

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to opener-tab forward/back for link-opened tabs; real web forward history still wins when present.
> 
> **Overview**
> Makes **back-to-close on link-opened tabs** reversible from the **opener tab’s forward button**, without changing when those child tabs close on back.
> 
> When a page-opened tab dismisses via back, the opener now stores **`reopenableClosedTabURL`** (`stashReopenableStateOnOpener`). **`canGoForward`** and **`goForward`** treat that URL as a fallback only when the opener’s web view has no forward history; otherwise forward still uses normal WKWebView history. The stash is cleared on URL changes (including same-document) and after a successful web forward or after reopen is consumed.
> 
> **`TabDelegate`** gains **`didRequestReopenClosedTabAt`**; **`MainViewController`** reopens by reusing the existing new-tab path (`openedByPage: true`, parent `openingTab` wiring). **`MockTabDelegate`** is updated for tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 489e5846c5ee780f7e9c267819ccc701c27fcc1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->