### PR TITLE
VPN: measure post-wake connectivity instead of tester-start failures

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3966a35eac034dc5384a7e972cb2b0d227b9d6ecc91a0eb6a836e83e18eafde9",
+  "originHash" : "59b1a6052f04cb8b7abb1e4148c3ef8f11e9e3df1199ca022da319af9fb6112a",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "84b5e3019b2c7b3c90e8d296f30fcfd53768bcd8",
-        "version" : "19.1.0"
+        "revision" : "34eb540473a90d25e11942e9c72a18c2430d4f50",
+        "version" : "19.2.0"
       }
     },
     {

--- a/SharedPackages/VPN/Package.resolved
+++ b/SharedPackages/VPN/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "5735b061ee14708ca17bc5b72b8eb9d21eb7f830",
-        "version" : "15.3.0"
+        "revision" : "dc9b1280951a22359aac33d07ffd410cbbae2b94",
+        "version" : "15.12.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "84b5e3019b2c7b3c90e8d296f30fcfd53768bcd8",
-        "version" : "19.1.0"
+        "revision" : "34eb540473a90d25e11942e9c72a18c2430d4f50",
+        "version" : "19.2.0"
       }
     },
     {

--- a/SharedPackages/VPN/Sources/VPN/Diagnostics/NetworkProtectionConnectionTester.swift
+++ b/SharedPackages/VPN/Sources/VPN/Diagnostics/NetworkProtectionConnectionTester.swift
@@ -47,6 +47,11 @@ final class NetworkProtectionConnectionTester: ConnectionTesting {
     ///
     private(set) var isRunning = false
 
+    /// Incremented on every `start()`. Interface resolution suspends `start()`, so a `stop()` + newer `start()`
+    /// can run before the first resumes; comparing this token lets a superseded `start()` bow out instead of
+    /// rolling back or overwriting the newer start's `isRunning`/`tunnelInterface`.
+    private var startGeneration = 0
+
     static let connectionTestQueue = DispatchQueue(label: "com.duckduckgo.NetworkProtectionConnectionTester.connectionTestQueue")
     static let monitorQueue = DispatchQueue(label: "com.duckduckgo.NetworkProtectionConnectionTester.monitorQueue")
     static let endpoint = NWEndpoint.hostPort(host: .name("www.duckduckgo.com", nil), port: .https)
@@ -120,6 +125,8 @@ final class NetworkProtectionConnectionTester: ConnectionTesting {
         }
 
         isRunning = true
+        startGeneration &+= 1
+        let thisStart = startGeneration
 
         Logger.networkProtectionConnectionTester.log("🟢 Starting connection tester (testImmediately: \(String(reflecting: testImmediately), privacy: .public)")
 
@@ -129,14 +136,17 @@ final class NetworkProtectionConnectionTester: ConnectionTesting {
         } catch {
             // Roll back so a failed start doesn't leave the tester flagged as running; otherwise a later
             // `start()` would no-op on the `guard !isRunning` above and we'd run without a tester silently.
-            isRunning = false
+            // Only if no newer start has superseded us — otherwise we'd clear the newer start's `isRunning`.
+            if thisStart == startGeneration {
+                isRunning = false
+            }
             throw error
         }
 
         // `stop()` can land while we were awaiting interface resolution (e.g. the device went back to sleep),
-        // flipping `isRunning` to false. Don't schedule a tester that's already been asked to stop.
-        guard isRunning else {
-            Logger.networkProtectionConnectionTester.log("Tester was stopped while resolving the interface; not scheduling")
+        // flipping `isRunning` to false; or a newer `start()` may have superseded us. Either way, don't schedule.
+        guard isRunning, thisStart == startGeneration else {
+            Logger.networkProtectionConnectionTester.log("Tester was stopped or superseded while resolving the interface; not scheduling")
             return
         }
 

--- a/SharedPackages/VPN/Sources/VPN/Diagnostics/NetworkProtectionConnectionTester.swift
+++ b/SharedPackages/VPN/Sources/VPN/Diagnostics/NetworkProtectionConnectionTester.swift
@@ -77,6 +77,14 @@ final class NetworkProtectionConnectionTester: ConnectionTesting {
     ///
     private static let connectionTimeout: TimeInterval = .seconds(5)
 
+    /// How long we'll wait for the tunnel interface to become visible to `NWPathMonitor` before giving up.
+    ///
+    /// Right after the device wakes, the utun often isn't in the first path snapshot yet, so deciding on that
+    /// first snapshot spuriously fails. We instead keep consuming path updates for a short window so a healthy
+    /// tunnel resolves as soon as the interface appears.
+    ///
+    private static let interfaceResolutionTimeout: TimeInterval = .seconds(5)
+
     // MARK: - Test result handling
 
     private var failureCount = 0
@@ -114,7 +122,24 @@ final class NetworkProtectionConnectionTester: ConnectionTesting {
         isRunning = true
 
         Logger.networkProtectionConnectionTester.log("🟢 Starting connection tester (testImmediately: \(String(reflecting: testImmediately), privacy: .public)")
-        let tunnelInterface = try await networkInterface(forInterfaceNamed: tunnelIfName)
+
+        let tunnelInterface: NWInterface
+        do {
+            tunnelInterface = try await networkInterface(forInterfaceNamed: tunnelIfName)
+        } catch {
+            // Roll back so a failed start doesn't leave the tester flagged as running; otherwise a later
+            // `start()` would no-op on the `guard !isRunning` above and we'd run without a tester silently.
+            isRunning = false
+            throw error
+        }
+
+        // `stop()` can land while we were awaiting interface resolution (e.g. the device went back to sleep),
+        // flipping `isRunning` to false. Don't schedule a tester that's already been asked to stop.
+        guard isRunning else {
+            Logger.networkProtectionConnectionTester.log("Tester was stopped while resolving the interface; not scheduling")
+            return
+        }
+
         self.tunnelInterface = tunnelInterface
 
         await scheduleTimer(testImmediately: testImmediately)
@@ -131,30 +156,38 @@ final class NetworkProtectionConnectionTester: ConnectionTesting {
     private func networkInterface(forInterfaceNamed interfaceName: String) async throws -> NWInterface {
         try await withCheckedThrowingContinuation { continuation in
             let monitor = NWPathMonitor()
+
+            // `monitorQueue` is serial, so the path-update handler and the timeout below never run
+            // concurrently — `didResume` needs no extra synchronisation.
             var didResume = false
 
-            monitor.pathUpdateHandler = { path in
+            func resume(with result: Swift.Result<NWInterface, Error>) {
                 guard !didResume else { return }
                 didResume = true
-
-                Logger.networkProtectionConnectionTester.log("All interfaces: \(String(describing: path.availableInterfaces), privacy: .public)")
-
-                guard let tunnelInterface = path.availableInterfaces.first(where: { $0.name == interfaceName }) else {
-                    Logger.networkProtectionConnectionTester.error("Could not find VPN interface \(interfaceName, privacy: .public)")
-                    monitor.cancel()
-                    monitor.pathUpdateHandler = nil
-
-                    continuation.resume(throwing: TesterError.couldNotFindInterface(named: interfaceName))
-                    return
-                }
-
                 monitor.cancel()
                 monitor.pathUpdateHandler = nil
+                continuation.resume(with: result)
+            }
 
-                continuation.resume(returning: tunnelInterface)
+            monitor.pathUpdateHandler = { path in
+                Logger.networkProtectionConnectionTester.log("All interfaces: \(String(describing: path.availableInterfaces), privacy: .public)")
+
+                if let tunnelInterface = path.availableInterfaces.first(where: { $0.name == interfaceName }) {
+                    resume(with: .success(tunnelInterface))
+                } else {
+                    // The utun may not be visible in the first snapshot right after wake. Keep waiting for
+                    // a subsequent path update until the timeout fires below.
+                    Logger.networkProtectionConnectionTester.log("VPN interface \(interfaceName, privacy: .public) not visible yet; waiting for a path update")
+                }
             }
 
             monitor.start(queue: Self.monitorQueue)
+
+            Self.monitorQueue.asyncAfter(deadline: .now() + Self.interfaceResolutionTimeout) {
+                guard !didResume else { return }
+                Logger.networkProtectionConnectionTester.error("Could not find VPN interface \(interfaceName, privacy: .public) within \(Self.interfaceResolutionTimeout, privacy: .public)s")
+                resume(with: .failure(TesterError.couldNotFindInterface(named: interfaceName)))
+            }
         }
     }
 

--- a/SharedPackages/VPN/Sources/VPN/Diagnostics/NetworkProtectionConnectionTester.swift
+++ b/SharedPackages/VPN/Sources/VPN/Diagnostics/NetworkProtectionConnectionTester.swift
@@ -175,8 +175,7 @@ final class NetworkProtectionConnectionTester: ConnectionTesting {
                 if let tunnelInterface = path.availableInterfaces.first(where: { $0.name == interfaceName }) {
                     resume(with: .success(tunnelInterface))
                 } else {
-                    // The utun may not be visible in the first snapshot right after wake. Keep waiting for
-                    // a subsequent path update until the timeout fires below.
+                    // Not visible yet; keep waiting for a later path update until the timeout below fires.
                     Logger.networkProtectionConnectionTester.log("VPN interface \(interfaceName, privacy: .public) not visible yet; waiting for a path update")
                 }
             }

--- a/SharedPackages/VPN/Sources/VPN/Diagnostics/WakeConnectivityMonitor.swift
+++ b/SharedPackages/VPN/Sources/VPN/Diagnostics/WakeConnectivityMonitor.swift
@@ -42,11 +42,14 @@ public enum WakeConnectivityResult: Equatable {
 @MainActor
 protocol WakeConnectivityMonitoring: AnyObject {
     /// Opens a confirmation window for a wake that's being handled. Replaces any window already in flight.
-    func noteWake()
+    /// Returns a token identifying the window, to pass back to `noteMonitorStartFailed(forWindow:)`.
+    @discardableResult
+    func noteWake() -> Int
     /// Feeds the monitor a connection test result; ignored unless a wake window is open.
     func recordConnectionTestResult(_ result: ConnectionTestingResult)
-    /// Signals that the post-wake monitor start threw, so the tester won't produce a verdict this window.
-    func noteMonitorStartFailed()
+    /// Signals that the post-wake monitor start threw for `token`'s window, so the tester won't produce a
+    /// verdict there. Ignored if a newer window has since opened.
+    func noteMonitorStartFailed(forWindow token: Int)
     /// Cancels any open window (e.g. the device is going back to sleep).
     func cancel()
 }
@@ -108,7 +111,8 @@ final class WakeConnectivityMonitor: WakeConnectivityMonitoring {
 
     // MARK: - WakeConnectivityMonitoring
 
-    func noteWake() {
+    @discardableResult
+    func noteWake() -> Int {
         confirmationTask?.cancel()
 
         generation &+= 1
@@ -126,6 +130,8 @@ final class WakeConnectivityMonitor: WakeConnectivityMonitoring {
             guard !Task.isCancelled else { return }
             await self?.evaluate(windowGeneration: windowGeneration)
         }
+
+        return windowGeneration
     }
 
     func recordConnectionTestResult(_ result: ConnectionTestingResult) {
@@ -133,7 +139,10 @@ final class WakeConnectivityMonitor: WakeConnectivityMonitoring {
 
         switch result {
         case .connected, .reconnected:
-            // The tester confirmed traffic is flowing through the tunnel — connectivity is back.
+            // A tester "connected" while the device has no usable network is a false positive: the VPN and local
+            // probes both fail, which the tester can't distinguish from success. Don't confirm restored — let the
+            // window fall through to evaluate(), which reports networkDown if there's still no network at close.
+            guard isNetworkAvailable else { return }
             resolve(.restored)
         case .disconnected:
             // Keep waiting; the tunnel may recover before the window closes.
@@ -141,8 +150,8 @@ final class WakeConnectivityMonitor: WakeConnectivityMonitoring {
         }
     }
 
-    func noteMonitorStartFailed() {
-        guard wakeTime != nil, !resolved else { return }
+    func noteMonitorStartFailed(forWindow token: Int) {
+        guard token == generation, wakeTime != nil, !resolved else { return }
         testerStartFailed = true
     }
 

--- a/SharedPackages/VPN/Sources/VPN/Diagnostics/WakeConnectivityMonitor.swift
+++ b/SharedPackages/VPN/Sources/VPN/Diagnostics/WakeConnectivityMonitor.swift
@@ -1,0 +1,213 @@
+//
+//  WakeConnectivityMonitor.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Network
+import os.log
+
+/// The outcome of a post-wake connectivity confirmation.
+///
+/// This is what we actually care about after the device wakes: did VPN connectivity come back? It replaces the
+/// old "wake failure" signal, which fired on the connection tester failing to *start* (usually a benign wake-time
+/// race) and stayed silent when the tunnel was genuinely dead.
+public enum WakeConnectivityResult: Equatable {
+    case restored
+    case notRestored(reason: Reason)
+
+    /// Why connectivity couldn't be confirmed. `handshakeStale` is only trustworthy alongside a running tester:
+    /// WireGuard handshakes on demand, so a healthy tunnel after a short sleep can legitimately carry an old
+    /// handshake — keep it separate from the tester reasons in analysis.
+    public enum Reason: String, Equatable {
+        /// The connection tester failed to start after wake, so it never produced a verdict.
+        case testerNotRunning = "tester_not_running"
+        /// The connection tester started and reported the VPN down, and didn't recover within the window.
+        case testerFailed = "tester_failed"
+        /// No positive confirmation available and the most recent handshake predates the wake.
+        case handshakeStale = "handshake_stale"
+        /// The device had no usable non-VPN network at evaluation — connectivity can't be blamed on the VPN.
+        case networkDown = "network_down"
+    }
+}
+
+@MainActor
+protocol WakeConnectivityMonitoring: AnyObject {
+    /// Opens a confirmation window for a wake that's being handled. Replaces any window already in flight.
+    func noteWake()
+    /// Feeds the monitor a connection test result; ignored unless a wake window is open.
+    func recordConnectionTestResult(_ result: ConnectionTestingResult)
+    /// Signals that the post-wake monitor start threw, so the tester won't produce a verdict this window.
+    func noteMonitorStartFailed()
+    /// Cancels any open window (e.g. the device is going back to sleep).
+    func cancel()
+}
+
+/// Confirms whether VPN connectivity returned after a wake and emits a single `WakeConnectivityResult`.
+///
+/// Owned by `PacketTunnelProvider` (not `TunnelMonitors`): the monitor lifecycle inside `TunnelMonitors.start/stop`
+/// runs *after* `noteWake()` and would otherwise cancel the window we just opened.
+@MainActor
+final class WakeConnectivityMonitor: WakeConnectivityMonitoring {
+
+    private let handshakeReporter: HandshakeReporting
+    private let now: () -> Date
+    private let confirmationWindow: TimeInterval
+    private let onResult: (WakeConnectivityResult) -> Void
+
+    /// Optional network-availability override for testing; when nil the internal `NWPathMonitor` is used.
+    private let networkAvailabilityOverride: (() -> Bool)?
+    private let pathMonitor: NWPathMonitor?
+
+    /// Wake time (epoch seconds) for the open window, or nil when no window is open.
+    private var wakeTime: TimeInterval?
+    private var confirmationTask: Task<Void, Never>?
+    private var resolved = false
+    private var testerStartFailed = false
+    private var sawDisconnected = false
+
+    /// Incremented on every `noteWake()`. The confirmation task captures its value so a stale, in-flight
+    /// `evaluate()` (past its sleep, awaiting the handshake) can't resolve a newer window.
+    private var generation = 0
+
+    init(handshakeReporter: HandshakeReporting,
+         now: @escaping () -> Date = { Date() },
+         confirmationWindow: TimeInterval = 30,
+         networkAvailability: (() -> Bool)? = nil,
+         onResult: @escaping (WakeConnectivityResult) -> Void) {
+        self.handshakeReporter = handshakeReporter
+        self.now = now
+        self.confirmationWindow = confirmationWindow
+        self.onResult = onResult
+        self.networkAvailabilityOverride = networkAvailability
+
+        if networkAvailability == nil {
+            let monitor = NWPathMonitor()
+            monitor.start(queue: .global())
+            self.pathMonitor = monitor
+        } else {
+            self.pathMonitor = nil
+        }
+
+        Logger.networkProtectionMemory.debug("[+] \(String(describing: self), privacy: .public)")
+    }
+
+    deinit {
+        confirmationTask?.cancel()
+        pathMonitor?.cancel()
+        Logger.networkProtectionMemory.debug("[-] \(String(describing: self), privacy: .public)")
+    }
+
+    // MARK: - WakeConnectivityMonitoring
+
+    func noteWake() {
+        confirmationTask?.cancel()
+
+        generation &+= 1
+        let windowGeneration = generation
+        wakeTime = now().timeIntervalSince1970
+        resolved = false
+        testerStartFailed = false
+        sawDisconnected = false
+
+        Logger.networkProtectionSleep.log("⚪️ Opening wake connectivity confirmation window")
+
+        let nanoseconds = UInt64(confirmationWindow * 1_000_000_000)
+        confirmationTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: nanoseconds)
+            guard !Task.isCancelled else { return }
+            await self?.evaluate(windowGeneration: windowGeneration)
+        }
+    }
+
+    func recordConnectionTestResult(_ result: ConnectionTestingResult) {
+        guard wakeTime != nil, !resolved else { return }
+
+        switch result {
+        case .connected, .reconnected:
+            // The tester confirmed traffic is flowing through the tunnel — connectivity is back.
+            resolve(.restored)
+        case .disconnected:
+            // Keep waiting; the tunnel may recover before the window closes.
+            sawDisconnected = true
+        }
+    }
+
+    func noteMonitorStartFailed() {
+        guard wakeTime != nil, !resolved else { return }
+        testerStartFailed = true
+    }
+
+    func cancel() {
+        confirmationTask?.cancel()
+        confirmationTask = nil
+        // Block any late resolution from an in-flight evaluate() and close the window.
+        resolved = true
+        wakeTime = nil
+    }
+
+    // MARK: - Evaluation
+
+    private func evaluate(windowGeneration: Int) async {
+        guard windowGeneration == generation, let wakeTime, !resolved else { return }
+
+        // Fallback confirmation: a handshake newer than the wake means the tunnel is passing traffic even if the
+        // tester never gave us a verdict.
+        let mostRecentHandshake = (try? await handshakeReporter.getMostRecentHandshake()) ?? 0
+
+        // A tester result may have resolved us — or a newer wake may have opened — while we awaited the handshake.
+        guard windowGeneration == generation, !resolved else { return }
+
+        if mostRecentHandshake > wakeTime {
+            resolve(.restored)
+            return
+        }
+
+        let reason: WakeConnectivityResult.Reason
+        if !isNetworkAvailable {
+            reason = .networkDown
+        } else if testerStartFailed {
+            reason = .testerNotRunning
+        } else if sawDisconnected {
+            reason = .testerFailed
+        } else {
+            reason = .handshakeStale
+        }
+
+        resolve(.notRestored(reason: reason))
+    }
+
+    private func resolve(_ result: WakeConnectivityResult) {
+        guard !resolved else { return }
+        resolved = true
+        confirmationTask?.cancel()
+        confirmationTask = nil
+
+        Logger.networkProtectionSleep.log("⚪️ Wake connectivity result: \(String(describing: result), privacy: .public)")
+        onResult(result)
+    }
+
+    private var isNetworkAvailable: Bool {
+        if let networkAvailabilityOverride {
+            return networkAvailabilityOverride()
+        }
+
+        guard let pathMonitor else { return true }
+        let path = pathMonitor.currentPath
+        let connectionType = NetworkConnectionType(nwPath: path)
+        return [.wifi, .eth, .cellular].contains(connectionType) && path.status == .satisfied
+    }
+}

--- a/SharedPackages/VPN/Sources/VPN/Diagnostics/WakeConnectivityMonitor.swift
+++ b/SharedPackages/VPN/Sources/VPN/Diagnostics/WakeConnectivityMonitor.swift
@@ -20,18 +20,13 @@ import Foundation
 import Network
 import os.log
 
-/// The outcome of a post-wake connectivity confirmation.
-///
-/// This is what we actually care about after the device wakes: did VPN connectivity come back? It replaces the
-/// old "wake failure" signal, which fired on the connection tester failing to *start* (usually a benign wake-time
-/// race) and stayed silent when the tunnel was genuinely dead.
+/// The outcome of a post-wake connectivity confirmation: did VPN connectivity come back after the device woke?
 public enum WakeConnectivityResult: Equatable {
     case restored
     case notRestored(reason: Reason)
 
-    /// Why connectivity couldn't be confirmed. `handshakeStale` is only trustworthy alongside a running tester:
-    /// WireGuard handshakes on demand, so a healthy tunnel after a short sleep can legitimately carry an old
-    /// handshake — keep it separate from the tester reasons in analysis.
+    /// Why connectivity couldn't be confirmed. `handshakeStale` is the weakest signal: WireGuard handshakes on
+    /// demand, so a healthy tunnel after a short sleep can still carry an old handshake.
     public enum Reason: String, Equatable {
         /// The connection tester failed to start after wake, so it never produced a verdict.
         case testerNotRunning = "tester_not_running"

--- a/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
+++ b/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
@@ -40,6 +40,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         case tunnelStopAttempt(_ step: TunnelStopAttemptStep)
         case tunnelUpdateAttempt(_ step: TunnelUpdateAttemptStep)
         case tunnelWakeAttempt(_ step: TunnelWakeAttemptStep)
+        case wakeConnectivity(_ result: WakeConnectivityResult)
         case tunnelStartOnDemandWithoutAccessToken(_ error: Error)
         case reportTunnelFailure(result: NetworkProtectionTunnelFailureMonitor.Result)
         case reportLatency(result: NetworkProtectionLatencyMonitor.Result, location: VPNSettings.SelectedLocation)
@@ -369,6 +370,8 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
     private var tunnelFailureMonitor: TunnelFailureMonitoring!
 
+    private var wakeConnectivityMonitor: WakeConnectivityMonitoring!
+
     public let latencyMonitor: LatencyMonitoring
     public let entitlementMonitor: EntitlementMonitoring
 
@@ -558,6 +561,13 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             handshakeReporter: self.adapter
         )
 
+        self.wakeConnectivityMonitor = WakeConnectivityMonitor(
+            handshakeReporter: self.adapter,
+            onResult: { [weak self] result in
+                self?.providerEvents.fire(.wakeConnectivity(result))
+            }
+        )
+
         let resolvedFailureRecoveryHandler = failureRecoveryHandler ?? FailureRecoveryHandler(
             deviceManager: self.deviceManager,
             reassertingControl: self,
@@ -725,6 +735,9 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     @MainActor
     private func handleConnectionTestResult(_ result: NetworkProtectionConnectionTester.Result) {
         let serverName = lastSelectedServerInfo?.name ?? "Unknown"
+
+        // Feeds the post-wake confirmation window (no-op unless one is open).
+        wakeConnectivityMonitor.recordConnectionTestResult(result)
 
         switch result {
         case .connected:
@@ -1513,6 +1526,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     @MainActor
     public override func sleep() async {
         Logger.networkProtectionSleep.log("Sleep")
+        wakeConnectivityMonitor.cancel()
         stopHeartbeat()
         await stopMonitors()
     }
@@ -1529,6 +1543,10 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             return
         }
 
+        // Open a window to confirm connectivity actually returns after this wake. The tester result and/or a
+        // fresh handshake resolve it; a real post-wake outage surfaces as `.wakeConnectivity(.notRestored)`.
+        wakeConnectivityMonitor.noteWake()
+
         Task {
             providerEvents.fire(.tunnelWakeAttempt(.begin))
 
@@ -1540,6 +1558,9 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             } catch {
                 Logger.networkProtection.error("🔴 Wake error: \(error.localizedDescription, privacy: .public)")
                 providerEvents.fire(.tunnelWakeAttempt(.failure(error)))
+                // Monitors (incl. the connection tester) didn't fully start, so there'll be no tester verdict
+                // this window — the confirmation falls back to the handshake check.
+                wakeConnectivityMonitor.noteMonitorStartFailed()
             }
         }
     }

--- a/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
+++ b/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
@@ -1543,8 +1543,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             return
         }
 
-        // Open a window to confirm connectivity actually returns after this wake. The tester result and/or a
-        // fresh handshake resolve it; a real post-wake outage surfaces as `.wakeConnectivity(.notRestored)`.
+        // Open a window to confirm connectivity actually returns after this wake.
         wakeConnectivityMonitor.noteWake()
 
         Task {
@@ -1558,8 +1557,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             } catch {
                 Logger.networkProtection.error("🔴 Wake error: \(error.localizedDescription, privacy: .public)")
                 providerEvents.fire(.tunnelWakeAttempt(.failure(error)))
-                // Monitors (incl. the connection tester) didn't fully start, so there'll be no tester verdict
-                // this window — the confirmation falls back to the handshake check.
+                // Monitors (incl. the connection tester) didn't fully start, so there'll be no tester verdict this window.
                 wakeConnectivityMonitor.noteMonitorStartFailed()
             }
         }

--- a/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
+++ b/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
@@ -1544,7 +1544,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         }
 
         // Open a window to confirm connectivity actually returns after this wake.
-        wakeConnectivityMonitor.noteWake()
+        let wakeWindow = wakeConnectivityMonitor.noteWake()
 
         Task {
             providerEvents.fire(.tunnelWakeAttempt(.begin))
@@ -1558,7 +1558,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 Logger.networkProtection.error("🔴 Wake error: \(error.localizedDescription, privacy: .public)")
                 providerEvents.fire(.tunnelWakeAttempt(.failure(error)))
                 // Monitors (incl. the connection tester) didn't fully start, so there'll be no tester verdict this window.
-                wakeConnectivityMonitor.noteMonitorStartFailed()
+                wakeConnectivityMonitor.noteMonitorStartFailed(forWindow: wakeWindow)
             }
         }
     }

--- a/SharedPackages/VPN/Tests/VPNTests/Diagnostics/WakeConnectivityMonitorTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/Diagnostics/WakeConnectivityMonitorTests.swift
@@ -97,8 +97,8 @@ final class WakeConnectivityMonitorTests: XCTestCase {
             expectation.fulfill()
         }
 
-        monitor.noteWake()
-        monitor.noteMonitorStartFailed()
+        let window = monitor.noteWake()
+        monitor.noteMonitorStartFailed(forWindow: window)
 
         await fulfillment(of: [expectation], timeout: 2)
         XCTAssertEqual(result, .notRestored(reason: .testerNotRunning))
@@ -128,8 +128,8 @@ final class WakeConnectivityMonitorTests: XCTestCase {
             expectation.fulfill()
         }
 
-        monitor.noteWake()
-        monitor.noteMonitorStartFailed()
+        let window = monitor.noteWake()
+        monitor.noteMonitorStartFailed(forWindow: window)
 
         await fulfillment(of: [expectation], timeout: 2)
         XCTAssertEqual(result, .notRestored(reason: .networkDown))
@@ -183,5 +183,103 @@ final class WakeConnectivityMonitorTests: XCTestCase {
 
         try? await Task.sleep(nanoseconds: 300_000_000)
         XCTAssertEqual(results, [.restored])
+    }
+
+    // MARK: - Network availability gating
+
+    func testConnectedWhileNetworkDownDoesNotResolveRestored() async {
+        let expectation = expectation(description: "result")
+        var result: WakeConnectivityResult?
+        // A full outage after wake makes the tester report `.connected` (both probes fail), which would otherwise
+        // be a false "restored". With no network, it must fall through to `networkDown` at window close instead.
+        let (monitor, _) = makeMonitor(handshake: wakeEpoch - 100, networkAvailable: false) {
+            result = $0
+            expectation.fulfill()
+        }
+
+        monitor.noteWake()
+        monitor.recordConnectionTestResult(.connected)
+
+        await fulfillment(of: [expectation], timeout: 2)
+        XCTAssertEqual(result, .notRestored(reason: .networkDown))
+    }
+
+    func testConnectedResolvesRestoredAfterNetworkRecoversMidWindow() {
+        var networkUp = false
+        var result: WakeConnectivityResult?
+        let reporter = MockHandshakeReporter()
+        reporter.mostRecentHandshake = wakeEpoch - 100
+        let monitor = WakeConnectivityMonitor(
+            handshakeReporter: reporter,
+            now: { Date(timeIntervalSince1970: self.wakeEpoch) },
+            confirmationWindow: 5, // long enough that the window doesn't close during the synchronous calls
+            networkAvailability: { networkUp },
+            onResult: { result = $0 }
+        )
+
+        monitor.noteWake()
+        // Network down: the tester's `.connected` is gated and dropped without latching any reason.
+        monitor.recordConnectionTestResult(.connected)
+        XCTAssertNil(result)
+
+        // Network recovers within the window; the next `.connected` now resolves restored.
+        networkUp = true
+        monitor.recordConnectionTestResult(.connected)
+        XCTAssertEqual(result, .restored)
+    }
+
+    // MARK: - Reason precedence
+
+    func testTesterNotRunningWinsOverTesterFailed() async {
+        let expectation = expectation(description: "result")
+        var result: WakeConnectivityResult?
+        let (monitor, _) = makeMonitor(handshake: wakeEpoch - 100, networkAvailable: true) {
+            result = $0
+            expectation.fulfill()
+        }
+
+        let window = monitor.noteWake()
+        monitor.recordConnectionTestResult(.disconnected(failureCount: 1)) // sets sawDisconnected
+        monitor.noteMonitorStartFailed(forWindow: window) // sets testerStartFailed — should win
+
+        await fulfillment(of: [expectation], timeout: 2)
+        XCTAssertEqual(result, .notRestored(reason: .testerNotRunning))
+    }
+
+    func testNetworkDownWinsOverTesterFailed() async {
+        let expectation = expectation(description: "result")
+        var result: WakeConnectivityResult?
+        let (monitor, _) = makeMonitor(handshake: wakeEpoch - 100, networkAvailable: false) {
+            result = $0
+            expectation.fulfill()
+        }
+
+        monitor.noteWake()
+        monitor.recordConnectionTestResult(.disconnected(failureCount: 1)) // sets sawDisconnected
+
+        await fulfillment(of: [expectation], timeout: 2)
+        XCTAssertEqual(result, .notRestored(reason: .networkDown))
+    }
+
+    // MARK: - Window generations
+
+    func testStaleMonitorStartFailedIgnoredAfterNewWake() async {
+        let expectation = expectation(description: "result")
+        var result: WakeConnectivityResult?
+        let (monitor, _) = makeMonitor(handshake: wakeEpoch - 100, networkAvailable: true) {
+            result = $0
+            expectation.fulfill()
+        }
+
+        let firstWindow = monitor.noteWake()
+        let secondWindow = monitor.noteWake() // supersedes the first
+        XCTAssertNotEqual(firstWindow, secondWindow)
+
+        // A late failure from the first window must not taint the second — otherwise this would report
+        // `testerNotRunning` instead of the second window's own `handshakeStale`.
+        monitor.noteMonitorStartFailed(forWindow: firstWindow)
+
+        await fulfillment(of: [expectation], timeout: 2)
+        XCTAssertEqual(result, .notRestored(reason: .handshakeStale))
     }
 }

--- a/SharedPackages/VPN/Tests/VPNTests/Diagnostics/WakeConnectivityMonitorTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/Diagnostics/WakeConnectivityMonitorTests.swift
@@ -1,0 +1,187 @@
+//
+//  WakeConnectivityMonitorTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import XCTest
+@testable import VPN
+
+@MainActor
+final class WakeConnectivityMonitorTests: XCTestCase {
+
+    /// Fixed wake instant so handshake timestamps can be set relative to it deterministically.
+    private let wakeEpoch: TimeInterval = 1_000_000
+
+    private final class MockHandshakeReporter: HandshakeReporting {
+        var mostRecentHandshake: TimeInterval = 0
+        func getMostRecentHandshake() async throws -> TimeInterval { mostRecentHandshake }
+    }
+
+    private func makeMonitor(
+        handshake: TimeInterval = 0,
+        networkAvailable: Bool = true,
+        confirmationWindow: TimeInterval = 0.1,
+        onResult: @escaping (WakeConnectivityResult) -> Void
+    ) -> (WakeConnectivityMonitor, MockHandshakeReporter) {
+        let reporter = MockHandshakeReporter()
+        reporter.mostRecentHandshake = handshake
+        let monitor = WakeConnectivityMonitor(
+            handshakeReporter: reporter,
+            now: { Date(timeIntervalSince1970: self.wakeEpoch) },
+            confirmationWindow: confirmationWindow,
+            networkAvailability: { networkAvailable },
+            onResult: onResult
+        )
+        return (monitor, reporter)
+    }
+
+    // MARK: - Positive confirmation
+
+    func testConnectedTesterResultResolvesRestoredImmediately() {
+        var result: WakeConnectivityResult?
+        let (monitor, _) = makeMonitor { result = $0 }
+
+        monitor.noteWake()
+        monitor.recordConnectionTestResult(.connected)
+
+        // Resolution is synchronous on the tester result — no need to wait for the window.
+        XCTAssertEqual(result, .restored)
+    }
+
+    func testReconnectedTesterResultResolvesRestored() {
+        var result: WakeConnectivityResult?
+        let (monitor, _) = makeMonitor { result = $0 }
+
+        monitor.noteWake()
+        monitor.recordConnectionTestResult(.reconnected(failureCount: 3))
+
+        XCTAssertEqual(result, .restored)
+    }
+
+    func testFreshHandshakeResolvesRestoredAtWindowEnd() async {
+        let expectation = expectation(description: "result")
+        var result: WakeConnectivityResult?
+        // Handshake newer than the wake means traffic is flowing even without a tester verdict.
+        let (monitor, _) = makeMonitor(handshake: wakeEpoch + 30) {
+            result = $0
+            expectation.fulfill()
+        }
+
+        monitor.noteWake()
+
+        await fulfillment(of: [expectation], timeout: 2)
+        XCTAssertEqual(result, .restored)
+    }
+
+    // MARK: - Not-restored reasons
+
+    func testTesterFailedToStartReportsTesterNotRunning() async {
+        let expectation = expectation(description: "result")
+        var result: WakeConnectivityResult?
+        let (monitor, _) = makeMonitor(handshake: wakeEpoch - 100, networkAvailable: true) {
+            result = $0
+            expectation.fulfill()
+        }
+
+        monitor.noteWake()
+        monitor.noteMonitorStartFailed()
+
+        await fulfillment(of: [expectation], timeout: 2)
+        XCTAssertEqual(result, .notRestored(reason: .testerNotRunning))
+    }
+
+    func testTesterReportedDisconnectedReportsTesterFailed() async {
+        let expectation = expectation(description: "result")
+        var result: WakeConnectivityResult?
+        let (monitor, _) = makeMonitor(handshake: wakeEpoch - 100, networkAvailable: true) {
+            result = $0
+            expectation.fulfill()
+        }
+
+        monitor.noteWake()
+        monitor.recordConnectionTestResult(.disconnected(failureCount: 1))
+
+        await fulfillment(of: [expectation], timeout: 2)
+        XCTAssertEqual(result, .notRestored(reason: .testerFailed))
+    }
+
+    func testNoNetworkReportsNetworkDown() async {
+        let expectation = expectation(description: "result")
+        var result: WakeConnectivityResult?
+        // Network unavailable trumps the tester reasons — the VPN can't be blamed.
+        let (monitor, _) = makeMonitor(handshake: wakeEpoch - 100, networkAvailable: false) {
+            result = $0
+            expectation.fulfill()
+        }
+
+        monitor.noteWake()
+        monitor.noteMonitorStartFailed()
+
+        await fulfillment(of: [expectation], timeout: 2)
+        XCTAssertEqual(result, .notRestored(reason: .networkDown))
+    }
+
+    func testStaleHandshakeWithNoOtherSignalReportsHandshakeStale() async {
+        let expectation = expectation(description: "result")
+        var result: WakeConnectivityResult?
+        let (monitor, _) = makeMonitor(handshake: wakeEpoch - 100, networkAvailable: true) {
+            result = $0
+            expectation.fulfill()
+        }
+
+        monitor.noteWake()
+
+        await fulfillment(of: [expectation], timeout: 2)
+        XCTAssertEqual(result, .notRestored(reason: .handshakeStale))
+    }
+
+    // MARK: - Lifecycle
+
+    func testCancelPreventsResolution() async {
+        var result: WakeConnectivityResult?
+        let (monitor, _) = makeMonitor(handshake: wakeEpoch - 100) { result = $0 }
+
+        monitor.noteWake()
+        monitor.cancel()
+
+        // Wait past the window; nothing should have been emitted.
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        XCTAssertNil(result)
+    }
+
+    func testResultIgnoredWhenNoWindowOpen() {
+        var result: WakeConnectivityResult?
+        let (monitor, _) = makeMonitor { result = $0 }
+
+        // No noteWake() — results outside a wake window must be ignored (normal operation fires these too).
+        monitor.recordConnectionTestResult(.connected)
+
+        XCTAssertNil(result)
+    }
+
+    func testOnlyOneResultPerWindow() async {
+        var results: [WakeConnectivityResult] = []
+        let (monitor, _) = makeMonitor(handshake: wakeEpoch - 100) { results.append($0) }
+
+        monitor.noteWake()
+        monitor.recordConnectionTestResult(.connected) // resolves restored
+        monitor.recordConnectionTestResult(.disconnected(failureCount: 1)) // ignored — already resolved
+
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        XCTAssertEqual(results, [.restored])
+    }
+}

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -706,7 +706,8 @@ extension Pixel {
         case networkProtectionTunnelUpdateSuccess
         case networkProtectionTunnelUpdateFailure
 
-        case networkProtectionTunnelWakeFailure
+        case networkProtectionWakeConnectivityRestored
+        case networkProtectionWakeConnectivityNotRestored
 
         case networkProtectionEnableAttemptConnecting
         case networkProtectionEnableAttemptSuccess
@@ -2718,7 +2719,8 @@ extension Pixel.Event {
         case .networkProtectionTunnelUpdateAttempt: return "m_netp_tunnel_update_attempt"
         case .networkProtectionTunnelUpdateSuccess: return "m_netp_tunnel_update_success"
         case .networkProtectionTunnelUpdateFailure: return "m_netp_tunnel_update_failure"
-        case .networkProtectionTunnelWakeFailure: return "m_netp_tunnel_wake_failure"
+        case .networkProtectionWakeConnectivityRestored: return "m_netp_wake_connectivity_restored"
+        case .networkProtectionWakeConnectivityNotRestored: return "m_netp_wake_connectivity_not_restored"
         case .networkProtectionEnableAttemptConnecting: return "m_netp_ev_enable_attempt"
         case .networkProtectionEnableAttemptSuccess: return "m_netp_ev_enable_attempt_success"
         case .networkProtectionEnableAttemptFailure: return "m_netp_ev_enable_attempt_failure"

--- a/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
+++ b/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
@@ -307,13 +307,15 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
             case .success:
                 Logger.networkProtection.log("🟢 Tunnel Wake attempt succeeded")
             }
-
-            switch step {
-            case .begin, .success: break
-            case .failure(let error):
-                DailyPixel.fireDailyAndCount(pixel: .networkProtectionTunnelWakeFailure,
-                                             pixelNameSuffixes: DailyPixel.Constant.legacyDailyPixelSuffixes,
-                                             error: error)
+        case .wakeConnectivity(let result):
+            switch result {
+            case .restored:
+                Logger.networkProtection.log("🟢 Wake connectivity restored")
+                DailyPixel.fireDailyAndCount(pixel: .networkProtectionWakeConnectivityRestored)
+            case .notRestored(let reason):
+                Logger.networkProtection.error("🔴 Wake connectivity not restored: \(reason.rawValue, privacy: .public)")
+                DailyPixel.fireDailyAndCount(pixel: .networkProtectionWakeConnectivityNotRestored,
+                                             withAdditionalParameters: ["reason": reason.rawValue])
             }
         case .failureRecoveryAttempt(let step):
             switch step {

--- a/iOS/PixelDefinitions/pixels/definitions/vpn_events.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/vpn_events.json5
@@ -41,6 +41,20 @@
         "suffixes": ["legacy_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion", "connectionAttemptSource"]
     },
+    "m_netp_wake_connectivity_restored": {
+        "description": "Fired once VPN connectivity is confirmed restored after the device wakes from sleep. Acts as the denominator for m_netp_wake_connectivity_not_restored.",
+        "owners": ["diegoreymendez"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_netp_wake_connectivity_not_restored": {
+        "description": "Fired when VPN connectivity is not confirmed restored within the confirmation window after the device wakes from sleep. The reason parameter identifies the cause.",
+        "owners": ["diegoreymendez"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion", "pixelSource", "reason"]
+    },
     "m_netp_tunnel_start_attempt_on_demand_without_access_token": {
         "description": "Fired when an on-demand VPN start attempt fails before reaching the actual tunnel start, due to a prerequisite failure such as a missing or unfetchable subscription token, missing settings, or other startup errors. Error parameters identify the underlying cause.",
         "owners": ["diegoreymendez", "samsymons"],

--- a/iOS/PixelDefinitions/pixels/params_dictionary.json5
+++ b/iOS/PixelDefinitions/pixels/params_dictionary.json5
@@ -38,6 +38,12 @@
         "description": "The channel the user is on",
         "enum": ["phone", "tablet"]
     },
+    "reason": {
+        "key": "reason",
+        "type": "string",
+        "description": "Why post-wake VPN connectivity could not be confirmed",
+        "enum": ["tester_not_running", "tester_failed", "handshake_stale", "network_down"]
+    },
     "errorDomain": {
         "key": "d",
         "type": "string",

--- a/macOS/DuckDuckGo/NetworkProtection/AppAndExtensionAndAgentTargets/NetworkProtectionPixelEvent.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppAndExtensionAndAgentTargets/NetworkProtectionPixelEvent.swift
@@ -46,7 +46,8 @@ enum NetworkProtectionPixelEvent: PixelKitEvent {
     case networkProtectionTunnelUpdateSuccess
     case networkProtectionTunnelUpdateFailure(_ error: Error)
 
-    case networkProtectionTunnelWakeFailure(_ error: Error)
+    case networkProtectionWakeConnectivityRestored
+    case networkProtectionWakeConnectivityNotRestored
 
     case networkProtectionServerMigrationAttempt
     case networkProtectionServerMigrationSuccess
@@ -180,8 +181,11 @@ enum NetworkProtectionPixelEvent: PixelKitEvent {
         case .networkProtectionTunnelUpdateFailure:
             return "netp_tunnel_update_failure"
 
-        case .networkProtectionTunnelWakeFailure:
-            return "netp_tunnel_wake_failure"
+        case .networkProtectionWakeConnectivityRestored:
+            return "netp_wake_connectivity_restored"
+
+        case .networkProtectionWakeConnectivityNotRestored:
+            return "netp_wake_connectivity_not_restored"
 
         case .networkProtectionEnableAttemptConnecting:
             return "netp_ev_enable_attempt"
@@ -448,7 +452,8 @@ enum NetworkProtectionPixelEvent: PixelKitEvent {
                 .networkProtectionTunnelUpdateAttempt,
                 .networkProtectionTunnelUpdateSuccess,
                 .networkProtectionTunnelUpdateFailure,
-                .networkProtectionTunnelWakeFailure,
+                .networkProtectionWakeConnectivityRestored,
+                .networkProtectionWakeConnectivityNotRestored,
                 .networkProtectionEnableAttemptConnecting,
                 .networkProtectionEnableAttemptSuccess,
                 .networkProtectionEnableAttemptFailure,
@@ -502,7 +507,8 @@ enum NetworkProtectionPixelEvent: PixelKitEvent {
                 .networkProtectionTunnelUpdateAttempt,
                 .networkProtectionTunnelUpdateSuccess,
                 .networkProtectionTunnelUpdateFailure,
-                .networkProtectionTunnelWakeFailure,
+                .networkProtectionWakeConnectivityRestored,
+                .networkProtectionWakeConnectivityNotRestored,
                 .networkProtectionEnableAttemptConnecting,
                 .networkProtectionEnableAttemptSuccess,
                 .networkProtectionEnableAttemptFailure,

--- a/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/MacPacketTunnelProvider.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/MacPacketTunnelProvider.swift
@@ -377,13 +377,20 @@ final class MacPacketTunnelProvider: PacketTunnelProvider {
             case .success:
                 Logger.networkProtection.log("🟢 Tunnel Wake attempt succeeded")
             }
-
-            switch step {
-            case .begin, .success: break
-            case .failure(let error):
+        case .wakeConnectivity(let result):
+            switch result {
+            case .restored:
+                Logger.networkProtection.log("🟢 Wake connectivity restored")
                 PixelKit.fire(
-                    NetworkProtectionPixelEvent.networkProtectionTunnelWakeFailure(error),
-                    frequency: .legacyDailyAndCount,
+                    NetworkProtectionPixelEvent.networkProtectionWakeConnectivityRestored,
+                    frequency: .dailyAndCount,
+                    includeAppVersionParameter: true)
+            case .notRestored(let reason):
+                Logger.networkProtection.error("🔴 Wake connectivity not restored: \(reason.rawValue, privacy: .public)")
+                PixelKit.fire(
+                    NetworkProtectionPixelEvent.networkProtectionWakeConnectivityNotRestored,
+                    frequency: .dailyAndCount,
+                    withAdditionalParameters: ["reason": reason.rawValue],
                     includeAppVersionParameter: true)
             }
         case .failureRecoveryAttempt(let step):

--- a/macOS/PixelDefinitions/pixels/definitions/vpn_events.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/vpn_events.json5
@@ -1,4 +1,18 @@
 {
+    "m_mac_netp_wake_connectivity_restored": {
+        "description": "Fired once VPN connectivity is confirmed restored after the device wakes from sleep. Acts as the denominator for m_mac_netp_wake_connectivity_not_restored.",
+        "owners": ["diegoreymendez"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_netp_wake_connectivity_not_restored": {
+        "description": "Fired when VPN connectivity is not confirmed restored within the confirmation window after the device wakes from sleep. The reason parameter identifies the cause.",
+        "owners": ["diegoreymendez"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count"],
+        "parameters": ["appVersion", "pixelSource", "reason"]
+    },
     "m_mac_netp_ev_adapter_end_temporary_shutdown_state_attempt_failure": {
         "description": "Fired when the VPN adapter fails to end its temporary shutdown state on the first attempt",
         "owners": ["samsymons"],

--- a/macOS/PixelDefinitions/pixels/params_dictionary.json5
+++ b/macOS/PixelDefinitions/pixels/params_dictionary.json5
@@ -54,6 +54,12 @@
         "description": "Identifies non-production pixels. 'canary' for internal users; 'dev' for alpha/review builds. Omitted for production builds.",
         "enum": ["canary", "dev"]
     },
+    "reason": {
+        "key": "reason",
+        "type": "string",
+        "description": "Why post-wake VPN connectivity could not be confirmed",
+        "enum": ["tester_not_running", "tester_failed", "handshake_stale", "network_down"]
+    },
     "errorDomain": {
         "key": "d",
         "type": "string",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207603085593419/task/1216651950297578?focus=true

### Description

After a device wakes, the VPN's connection health check often can't find the tunnel interface in the first network snapshot and fails to start — which we were reporting as a wake failure even though the VPN was still working, while a genuinely dead tunnel after wake went unreported. This makes the health check wait briefly for the interface so it stops failing spuriously, and replaces the misleading pixel with one that measures whether VPN connectivity actually returns after a wake.

The removed pixel carried no reliable signal for current app versions, so the new pixels take its place rather than running alongside it.

### Testing Steps

1. Verify the CI is green.
2. Connect the VPN on macOS, or on a physical iOS device (the VPN extension does not run in the simulator).
3. Sleep the device, wait a few seconds, then wake it.
   The VPN stays connected and traffic keeps flowing.

The pixel emission itself is telemetry and is not verifiable by hand; the confirmation logic is covered by unit tests.

### Impact

Low. The change affects the VPN's post-wake health check and its telemetry; the tunnel data path is untouched.

#### What could go wrong?

The added wait could delay the health check starting by up to five seconds on the failure path → bounded by a timeout and skipped the moment the interface appears; a sleep landing mid-wait is guarded by a re-check before the tester schedules.

### Quality Considerations

The new not-restored pixel carries a fixed-enum reason parameter only (no error text or identifiers), so no user-identifiable information is introduced.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
