### PR TITLE
macOS: scope Duck.ai page-context extraction pixels to sidebar

### DIFF
--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -54,6 +54,10 @@ final class PageContextTabExtension {
     /// so its overlapping navigation/signals-only collects don't each fire a pixel. Reset on new URL.
     private var didReportExtractionForCurrentNavigation = false
 
+    /// Guards the sidebar-open attachability measurement so re-opening the sidebar on the same page
+    /// (kept sessions) doesn't re-report. Reset on new URL alongside `didReportExtractionForCurrentNavigation`.
+    private var didReportSidebarOpenOutcomeForCurrentNavigation = false
+
     /// Safety-net window for a fire-and-forget `collect()` whose result never arrives (hung JS,
     /// torn-down page). After it, `scheduleCollectionTimeout` fires `.timeout` and drops the pending
     /// entry so the queue can't leak.
@@ -167,6 +171,7 @@ final class PageContextTabExtension {
                     // extraction telemetry (trigger/latency/outcome).
                     self.extractionResolver.reset()
                     self.didReportExtractionForCurrentNavigation = false
+                    self.didReportSidebarOpenOutcomeForCurrentNavigation = false
                 }
                 self.handleNavigationForMultipleContexts(from: previousContent, to: tabContent)
                 self.sendNonAttachableContextIfNeeded()
@@ -319,6 +324,9 @@ final class PageContextTabExtension {
     }
 
     private func deliverContextToCurrentSidebar() {
+        // The sidebar just became visible for this tab — measure the current page's attachability once
+        // (mirrors iOS firing on sheet activation), before delivering context/collecting below.
+        reportSidebarOpenExtractionOutcome()
         if let cachedPageContext, isContextCollectionEnabled {
             Task { await self.handle(cachedPageContext) }
         } else {
@@ -341,6 +349,49 @@ final class PageContextTabExtension {
     /// `aiPageContextBlocklist` privacy config is present
     private var isExtractionMeasurementEnabled: Bool {
         currentAttachabilityPolicy() != nil
+    }
+
+    /// The Duck.ai sidebar is currently showing for this tab. `chatViewController` is torn down to
+    /// `nil` on close in both keep-session and non-keep modes, so this doubles as a reliable
+    /// "sidebar visible" signal without depending on presentation-mode ordering during open.
+    private var isSidebarVisibleForTab: Bool {
+        aiChatSessionStore.sessions[tabID]?.chatViewController != nil
+    }
+
+    /// Mirrors iOS's surface-activation measurement (`reportAttachabilityMeasurement`): when the
+    /// sidebar becomes visible, report the current page's extraction outcome once so pixels reflect
+    /// the sidebar experience rather than background collection.
+    ///
+    /// - Non-attachable pages (blocklisted media / native special pages) report `.prevented` with no
+    ///   user interaction — the attach affordance isn't shown.
+    /// - Attachable pages whose context auto-collect already pre-warmed (delivered from cache on open)
+    ///   report `.success`.
+    /// - Attachable pages awaiting a user tap (or a still-in-flight collect) report nothing here; the
+    ///   collection path (`.tabContent` / `.userRequest`) reports when its result arrives.
+    private func reportSidebarOpenExtractionOutcome() {
+        guard isSidebarVisibleForTab,
+              isExtractionMeasurementEnabled,
+              !didReportExtractionForCurrentNavigation,
+              !didReportSidebarOpenOutcomeForCurrentNavigation else {
+            return
+        }
+        didReportSidebarOpenOutcomeForCurrentNavigation = true
+
+        guard case .url(let url, _, _) = content else {
+            // Native special pages (NTP, settings, bookmarks…) can't be attached.
+            fireExtractionPixel(.prevented(PageContextExtractionOutcome.internalPageCategory), trigger: .navigation, latency: nil)
+            return
+        }
+        if let reason = preventedAttachReason(for: url) {
+            fireExtractionPixel(.prevented(reason), trigger: .navigation, latency: nil)
+            return
+        }
+        // Attachable page: only auto-collected context delivered on open counts as a success here.
+        // Everything else (user tap, signals-only harvest, an in-flight collect) reports via the
+        // collect path, so we don't double-count.
+        if isContextCollectionEnabled, let cached = cachedPageContext, cached.attachable != false, !cached.isEmpty() {
+            fireExtractionPixel(.success, trigger: .auto, latency: nil)
+        }
     }
 
     private func preventedAttachReason(for url: URL) -> String? {
@@ -380,6 +431,11 @@ final class PageContextTabExtension {
                                      trigger: PageContextExtractionTrigger,
                                      latency: PageContextExtractionLatencyBucket?) {
         guard isExtractionMeasurementEnabled else { return }
+        // Only report while the Duck.ai sidebar is showing for this tab. Mirrors iOS, where extraction
+        // telemetry is tied to the contextual surface being active: background/auto collects that run
+        // with the sidebar closed (page pre-warming) must not fire pixels. Placed before the dedup slot
+        // so a suppressed collect doesn't consume the per-navigation report.
+        guard isSidebarVisibleForTab else { return }
         // A navigation triggers several automatic collects (navigation re-collect + signals-only);
         // report only the first. User/setting collects (.userRequest / .auto) always report.
         if trigger == .navigation || trigger == .tabContent {

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -367,8 +367,8 @@ final class PageContextTabExtension {
             fireExtractionPixel(.prevented(reason), trigger: .navigation, latency: nil)
             return
         }
-        if isContextCollectionEnabled, let cached = cachedPageContext, cached.attachable != false, !cached.isEmpty() {
-            fireExtractionPixel(.success, trigger: .auto, latency: nil)
+        if isContextCollectionEnabled, !extractionResolver.hasPendingCollections {
+            collectPageContextIfNeeded(trigger: .auto)
         }
     }
 

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -54,8 +54,6 @@ final class PageContextTabExtension {
     /// so its overlapping navigation/signals-only collects don't each fire a pixel. Reset on new URL.
     private var didReportExtractionForCurrentNavigation = false
 
-    /// Guards the sidebar-open attachability measurement so re-opening the sidebar on the same page
-    /// (kept sessions) doesn't re-report. Reset on new URL alongside `didReportExtractionForCurrentNavigation`.
     private var didReportSidebarOpenOutcomeForCurrentNavigation = false
 
     /// Safety-net window for a fire-and-forget `collect()` whose result never arrives (hung JS,
@@ -168,7 +166,7 @@ final class PageContextTabExtension {
                     self.pendingSelectionContexts = []
                     // Drop the previous page's outstanding collects so a slow or never-resolving
                     // collect can't pair (FIFO) with this page's result and mis-attribute its
-                    // extraction telemetry (trigger/latency/outcome).
+                    // extraction measurement (trigger/latency/outcome).
                     self.extractionResolver.reset()
                     self.didReportExtractionForCurrentNavigation = false
                     self.didReportSidebarOpenOutcomeForCurrentNavigation = false
@@ -244,7 +242,6 @@ final class PageContextTabExtension {
                     }
                 } else if self.pendingSignalsOnlyCollection {
                     self.pendingSignalsOnlyCollection = false
-                    self.fireExtractionOutcome(for: pageContext)
                     Task {
                         await self.handleSignalsOnly(pageContext)
                     }
@@ -324,8 +321,6 @@ final class PageContextTabExtension {
     }
 
     private func deliverContextToCurrentSidebar() {
-        // The sidebar just became visible for this tab — measure the current page's attachability once
-        // (mirrors iOS firing on sheet activation), before delivering context/collecting below.
         reportSidebarOpenExtractionOutcome()
         if let cachedPageContext, isContextCollectionEnabled {
             Task { await self.handle(cachedPageContext) }
@@ -345,29 +340,16 @@ final class PageContextTabExtension {
         return PageContextAttachabilityPolicy(settings: blocklist)
     }
 
-    /// Extraction telemetry (success / failure / prevented / timeout) is only reported once the
+    /// Extraction measurement (success / failure / prevented / timeout) is only reported once the
     /// `aiPageContextBlocklist` privacy config is present
     private var isExtractionMeasurementEnabled: Bool {
         currentAttachabilityPolicy() != nil
     }
 
-    /// The Duck.ai sidebar is currently showing for this tab. `chatViewController` is torn down to
-    /// `nil` on close in both keep-session and non-keep modes, so this doubles as a reliable
-    /// "sidebar visible" signal without depending on presentation-mode ordering during open.
     private var isSidebarVisibleForTab: Bool {
         aiChatSessionStore.sessions[tabID]?.chatViewController != nil
     }
 
-    /// Mirrors iOS's surface-activation measurement (`reportAttachabilityMeasurement`): when the
-    /// sidebar becomes visible, report the current page's extraction outcome once so pixels reflect
-    /// the sidebar experience rather than background collection.
-    ///
-    /// - Non-attachable pages (blocklisted media / native special pages) report `.prevented` with no
-    ///   user interaction — the attach affordance isn't shown.
-    /// - Attachable pages whose context auto-collect already pre-warmed (delivered from cache on open)
-    ///   report `.success`.
-    /// - Attachable pages awaiting a user tap (or a still-in-flight collect) report nothing here; the
-    ///   collection path (`.tabContent` / `.userRequest`) reports when its result arrives.
     private func reportSidebarOpenExtractionOutcome() {
         guard isSidebarVisibleForTab,
               isExtractionMeasurementEnabled,
@@ -378,7 +360,6 @@ final class PageContextTabExtension {
         didReportSidebarOpenOutcomeForCurrentNavigation = true
 
         guard case .url(let url, _, _) = content else {
-            // Native special pages (NTP, settings, bookmarks…) can't be attached.
             fireExtractionPixel(.prevented(PageContextExtractionOutcome.internalPageCategory), trigger: .navigation, latency: nil)
             return
         }
@@ -386,9 +367,6 @@ final class PageContextTabExtension {
             fireExtractionPixel(.prevented(reason), trigger: .navigation, latency: nil)
             return
         }
-        // Attachable page: only auto-collected context delivered on open counts as a success here.
-        // Everything else (user tap, signals-only harvest, an in-flight collect) reports via the
-        // collect path, so we don't double-count.
         if isContextCollectionEnabled, let cached = cachedPageContext, cached.attachable != false, !cached.isEmpty() {
             fireExtractionPixel(.success, trigger: .auto, latency: nil)
         }
@@ -431,10 +409,6 @@ final class PageContextTabExtension {
                                      trigger: PageContextExtractionTrigger,
                                      latency: PageContextExtractionLatencyBucket?) {
         guard isExtractionMeasurementEnabled else { return }
-        // Only report while the Duck.ai sidebar is showing for this tab. Mirrors iOS, where extraction
-        // telemetry is tied to the contextual surface being active: background/auto collects that run
-        // with the sidebar closed (page pre-warming) must not fire pixels. Placed before the dedup slot
-        // so a suppressed collect doesn't consume the per-navigation report.
         guard isSidebarVisibleForTab else { return }
         // A navigation triggers several automatic collects (navigation re-collect + signals-only);
         // report only the first. User/setting collects (.userRequest / .auto) always report.
@@ -656,9 +630,7 @@ final class PageContextTabExtension {
             return
         }
         pendingSignalsOnlyCollection = true
-        extractionResolver.requested(trigger: .tabContent)
         pageContextUserScript.collect()
-        scheduleCollectionTimeout()
     }
 
     /// Delivers a signals-only payload from a collected context: keeps the Content-Scope-Scripts

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_page_context_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_page_context_pixels.json5
@@ -79,8 +79,9 @@
             "channel",
             {
                 "key": "category",
-                "description": "The prevention category: a blocklist media category key (e.g. pdf, image, video, audio) or internalPage.",
-                "type": "string"
+                "description": "The prevention category: a blocklist media category key from aiPageContextBlocklist, or internalPage for native special pages (non-web tab content, about:blank, Duck.ai).",
+                "type": "string",
+                "enum": ["pdf", "image", "video", "audio", "internalPage"]
             },
             {
                 "key": "reason",

--- a/macOS/UnitTests/AIChat/PageContextMultipleContextsTests.swift
+++ b/macOS/UnitTests/AIChat/PageContextMultipleContextsTests.swift
@@ -258,43 +258,37 @@ struct SidebarOpenExtractionMeasurementTests {
     private enum Outcome: Equatable {
         case none
         case prevented(String)
-        case success
+        case collect
     }
 
     private func sidebarOpenOutcome(isURL: Bool,
                                     preventedReason: String?,
-                                    isContextCollectionEnabled: Bool,
-                                    hasUsableCachedContext: Bool) -> Outcome {
+                                    isContextCollectionEnabled: Bool) -> Outcome {
         guard isURL else { return .prevented("internalPage") }
         if let preventedReason { return .prevented(preventedReason) }
-        if isContextCollectionEnabled, hasUsableCachedContext { return .success }
+        if isContextCollectionEnabled { return .collect }
         return .none
     }
 
     @Test("Native special page (non-URL content) reports prevented(internalPage)")
     func nativePageReportsInternalPagePrevented() {
-        #expect(sidebarOpenOutcome(isURL: false, preventedReason: nil, isContextCollectionEnabled: true, hasUsableCachedContext: false) == .prevented("internalPage"))
+        #expect(sidebarOpenOutcome(isURL: false, preventedReason: nil, isContextCollectionEnabled: true) == .prevented("internalPage"))
     }
 
     @Test("Non-attachable URL reports prevented with the blocklist category, no interaction needed")
     func nonAttachableURLReportsPrevented() {
-        #expect(sidebarOpenOutcome(isURL: true, preventedReason: "pdf", isContextCollectionEnabled: false, hasUsableCachedContext: false) == .prevented("pdf"))
-        #expect(sidebarOpenOutcome(isURL: true, preventedReason: "image", isContextCollectionEnabled: true, hasUsableCachedContext: true) == .prevented("image"))
+        #expect(sidebarOpenOutcome(isURL: true, preventedReason: "pdf", isContextCollectionEnabled: false) == .prevented("pdf"))
+        #expect(sidebarOpenOutcome(isURL: true, preventedReason: "image", isContextCollectionEnabled: true) == .prevented("image"))
     }
 
-    @Test("Attachable URL with auto-collect ON and pre-warmed cached context reports success")
-    func attachableAutoOnCachedReportsSuccess() {
-        #expect(sidebarOpenOutcome(isURL: true, preventedReason: nil, isContextCollectionEnabled: true, hasUsableCachedContext: true) == .success)
-    }
-
-    @Test("Attachable URL with auto-collect ON but no usable cache reports nothing (collect path reports)")
-    func attachableAutoOnNoCacheReportsNone() {
-        #expect(sidebarOpenOutcome(isURL: true, preventedReason: nil, isContextCollectionEnabled: true, hasUsableCachedContext: false) == .none)
+    @Test("Attachable URL with auto-collect ON re-collects so success/failure fire live")
+    func attachableAutoOnReCollects() {
+        #expect(sidebarOpenOutcome(isURL: true, preventedReason: nil, isContextCollectionEnabled: true) == .collect)
     }
 
     @Test("Attachable URL with auto-collect OFF reports nothing on open (awaits user tap / signals-only)")
     func attachableAutoOffReportsNone() {
-        #expect(sidebarOpenOutcome(isURL: true, preventedReason: nil, isContextCollectionEnabled: false, hasUsableCachedContext: true) == .none)
+        #expect(sidebarOpenOutcome(isURL: true, preventedReason: nil, isContextCollectionEnabled: false) == .none)
     }
 
     private final class Guard {

--- a/macOS/UnitTests/AIChat/PageContextMultipleContextsTests.swift
+++ b/macOS/UnitTests/AIChat/PageContextMultipleContextsTests.swift
@@ -253,9 +253,6 @@ struct PerNavigationExtractionPixelDedupTests {
 
 // MARK: - Sidebar-open extraction measurement Tests
 
-/// Mirrors PageContextTabExtension.reportSidebarOpenExtractionOutcome: when the sidebar becomes
-/// visible, the current page is measured once so pixels reflect the sidebar experience rather than
-/// background collection (matching iOS, where telemetry is tied to the contextual surface).
 struct SidebarOpenExtractionMeasurementTests {
 
     private enum Outcome: Equatable {
@@ -264,8 +261,6 @@ struct SidebarOpenExtractionMeasurementTests {
         case success
     }
 
-    /// Mirrors the outcome decision (the visibility / measurement-enabled / dedup guards are applied
-    /// separately by `shouldMeasureOnSidebarOpen`).
     private func sidebarOpenOutcome(isURL: Bool,
                                     preventedReason: String?,
                                     isContextCollectionEnabled: Bool,
@@ -284,7 +279,6 @@ struct SidebarOpenExtractionMeasurementTests {
     @Test("Non-attachable URL reports prevented with the blocklist category, no interaction needed")
     func nonAttachableURLReportsPrevented() {
         #expect(sidebarOpenOutcome(isURL: true, preventedReason: "pdf", isContextCollectionEnabled: false, hasUsableCachedContext: false) == .prevented("pdf"))
-        // Fires regardless of auto-collect / cache state — the attach affordance simply isn't shown.
         #expect(sidebarOpenOutcome(isURL: true, preventedReason: "image", isContextCollectionEnabled: true, hasUsableCachedContext: true) == .prevented("image"))
     }
 
@@ -303,9 +297,6 @@ struct SidebarOpenExtractionMeasurementTests {
         #expect(sidebarOpenOutcome(isURL: true, preventedReason: nil, isContextCollectionEnabled: false, hasUsableCachedContext: true) == .none)
     }
 
-    /// Mirrors the guards on reportSidebarOpenExtractionOutcome: only fires while the sidebar is
-    /// visible and measurement is enabled, at most once per navigation, and skips when a collection
-    /// already reported for the navigation.
     private final class Guard {
         private var didReportExtraction = false
         private var didReportSidebarOpen = false
@@ -351,7 +342,32 @@ struct SidebarOpenExtractionMeasurementTests {
         let guardState = Guard()
         #expect(guardState.shouldMeasureOnSidebarOpen(isVisible: false, measurementEnabled: true) == false)
         #expect(guardState.shouldMeasureOnSidebarOpen(isVisible: true, measurementEnabled: false) == false)
-        // Slot untouched, so once the sidebar is actually visible with config present it still measures.
         #expect(guardState.shouldMeasureOnSidebarOpen(isVisible: true, measurementEnabled: true) == true)
+    }
+}
+
+// MARK: - Collection-result extraction measurement Tests
+
+struct CollectionResultExtractionMeasurementTests {
+
+    private func firesExtractionOutcome(isContextCollectionEnabled: Bool, pendingSignalsOnly: Bool) -> Bool {
+        if isContextCollectionEnabled { return true }
+        if pendingSignalsOnly { return false }
+        return false
+    }
+
+    @Test("Full collection (auto-attach on / user-forced) reports its extraction outcome")
+    func fullCollectionReports() {
+        #expect(firesExtractionOutcome(isContextCollectionEnabled: true, pendingSignalsOnly: false) == true)
+    }
+
+    @Test("Signals-only harvest does not report success/failed")
+    func signalsOnlyDoesNotReport() {
+        #expect(firesExtractionOutcome(isContextCollectionEnabled: false, pendingSignalsOnly: true) == false)
+    }
+
+    @Test("Unsolicited collection result reports nothing")
+    func unsolicitedReportsNothing() {
+        #expect(firesExtractionOutcome(isContextCollectionEnabled: false, pendingSignalsOnly: false) == false)
     }
 }

--- a/macOS/UnitTests/AIChat/PageContextMultipleContextsTests.swift
+++ b/macOS/UnitTests/AIChat/PageContextMultipleContextsTests.swift
@@ -250,3 +250,108 @@ struct PerNavigationExtractionPixelDedupTests {
         #expect(dedup.shouldReport(.navigation) == true)
     }
 }
+
+// MARK: - Sidebar-open extraction measurement Tests
+
+/// Mirrors PageContextTabExtension.reportSidebarOpenExtractionOutcome: when the sidebar becomes
+/// visible, the current page is measured once so pixels reflect the sidebar experience rather than
+/// background collection (matching iOS, where telemetry is tied to the contextual surface).
+struct SidebarOpenExtractionMeasurementTests {
+
+    private enum Outcome: Equatable {
+        case none
+        case prevented(String)
+        case success
+    }
+
+    /// Mirrors the outcome decision (the visibility / measurement-enabled / dedup guards are applied
+    /// separately by `shouldMeasureOnSidebarOpen`).
+    private func sidebarOpenOutcome(isURL: Bool,
+                                    preventedReason: String?,
+                                    isContextCollectionEnabled: Bool,
+                                    hasUsableCachedContext: Bool) -> Outcome {
+        guard isURL else { return .prevented("internalPage") }
+        if let preventedReason { return .prevented(preventedReason) }
+        if isContextCollectionEnabled, hasUsableCachedContext { return .success }
+        return .none
+    }
+
+    @Test("Native special page (non-URL content) reports prevented(internalPage)")
+    func nativePageReportsInternalPagePrevented() {
+        #expect(sidebarOpenOutcome(isURL: false, preventedReason: nil, isContextCollectionEnabled: true, hasUsableCachedContext: false) == .prevented("internalPage"))
+    }
+
+    @Test("Non-attachable URL reports prevented with the blocklist category, no interaction needed")
+    func nonAttachableURLReportsPrevented() {
+        #expect(sidebarOpenOutcome(isURL: true, preventedReason: "pdf", isContextCollectionEnabled: false, hasUsableCachedContext: false) == .prevented("pdf"))
+        // Fires regardless of auto-collect / cache state — the attach affordance simply isn't shown.
+        #expect(sidebarOpenOutcome(isURL: true, preventedReason: "image", isContextCollectionEnabled: true, hasUsableCachedContext: true) == .prevented("image"))
+    }
+
+    @Test("Attachable URL with auto-collect ON and pre-warmed cached context reports success")
+    func attachableAutoOnCachedReportsSuccess() {
+        #expect(sidebarOpenOutcome(isURL: true, preventedReason: nil, isContextCollectionEnabled: true, hasUsableCachedContext: true) == .success)
+    }
+
+    @Test("Attachable URL with auto-collect ON but no usable cache reports nothing (collect path reports)")
+    func attachableAutoOnNoCacheReportsNone() {
+        #expect(sidebarOpenOutcome(isURL: true, preventedReason: nil, isContextCollectionEnabled: true, hasUsableCachedContext: false) == .none)
+    }
+
+    @Test("Attachable URL with auto-collect OFF reports nothing on open (awaits user tap / signals-only)")
+    func attachableAutoOffReportsNone() {
+        #expect(sidebarOpenOutcome(isURL: true, preventedReason: nil, isContextCollectionEnabled: false, hasUsableCachedContext: true) == .none)
+    }
+
+    /// Mirrors the guards on reportSidebarOpenExtractionOutcome: only fires while the sidebar is
+    /// visible and measurement is enabled, at most once per navigation, and skips when a collection
+    /// already reported for the navigation.
+    private final class Guard {
+        private var didReportExtraction = false
+        private var didReportSidebarOpen = false
+
+        func resetForNavigation() {
+            didReportExtraction = false
+            didReportSidebarOpen = false
+        }
+
+        func markCollectionReported() { didReportExtraction = true }
+
+        func shouldMeasureOnSidebarOpen(isVisible: Bool, measurementEnabled: Bool) -> Bool {
+            guard isVisible, measurementEnabled, !didReportExtraction, !didReportSidebarOpen else { return false }
+            didReportSidebarOpen = true
+            return true
+        }
+    }
+
+    @Test("First sidebar open measures; re-opening on the same page (kept session) does not")
+    func firstOpenMeasuresReopenDoesNot() {
+        let guardState = Guard()
+        #expect(guardState.shouldMeasureOnSidebarOpen(isVisible: true, measurementEnabled: true) == true)
+        #expect(guardState.shouldMeasureOnSidebarOpen(isVisible: true, measurementEnabled: true) == false)
+    }
+
+    @Test("A collection that already reported this navigation suppresses the sidebar-open measurement")
+    func collectionReportSuppressesMeasurement() {
+        let guardState = Guard()
+        guardState.markCollectionReported()
+        #expect(guardState.shouldMeasureOnSidebarOpen(isVisible: true, measurementEnabled: true) == false)
+    }
+
+    @Test("Navigation to a new URL re-arms the sidebar-open measurement")
+    func navigationReArmsMeasurement() {
+        let guardState = Guard()
+        #expect(guardState.shouldMeasureOnSidebarOpen(isVisible: true, measurementEnabled: true) == true)
+        guardState.resetForNavigation()
+        #expect(guardState.shouldMeasureOnSidebarOpen(isVisible: true, measurementEnabled: true) == true)
+    }
+
+    @Test("A hidden sidebar or absent blocklist config never measures and never consumes the slot")
+    func hiddenOrDisabledDoesNotConsumeSlot() {
+        let guardState = Guard()
+        #expect(guardState.shouldMeasureOnSidebarOpen(isVisible: false, measurementEnabled: true) == false)
+        #expect(guardState.shouldMeasureOnSidebarOpen(isVisible: true, measurementEnabled: false) == false)
+        // Slot untouched, so once the sidebar is actually visible with config present it still measures.
+        #expect(guardState.shouldMeasureOnSidebarOpen(isVisible: true, measurementEnabled: true) == true)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216636268061879?focus=true
Tech Design URL:
CC:

### Description
The macOS page-context extraction pixels (success/failed/prevented) fired from the collection layer, so they reported on background navigation and missed the sidebar-open case. This re-scopes them to the Duck.ai sidebar lifecycle to match iOS #5851: the pixels fire only while the sidebar is visible, and a sidebar-open measurement reports `prevented` for non-attachable pages with no user interaction. It also constrains the prevented pixel's `category` enum in the JSON definition.

### Testing Steps
1. Set the custom privacy config URL to one carrying `aiPageContextBlocklist` and refresh config. https://duckduckgo.github.io/privacy-configuration/pr-5560/v4/macos-config.json
2. Open the Duck.ai sidebar on a PDF/image page → the attach affordance is hidden and `m_mac_aichat_page_context_extraction_prevented` fires (category=pdf/image), no interaction needed.
3. Open the sidebar on a normal article (auto-attach off) → nothing fires until you tap attach, which fires a single `m_mac_aichat_page_context_extraction_success`; navigating with the sidebar closed fires no extraction pixels.

### Impact and Risks
Low — measurement-only, and it activates only when the remote `aiPageContextBlocklist` config is present.

#### What could go wrong?
A pixel could fire at the wrong moment if the sidebar-visible signal is mistimed, but it fails closed (no pixel) rather than mis-attributing an outcome.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Measurement-only changes gated on remote blocklist config; mis-timed sidebar visibility fails closed (no pixel) rather than mis-attributing outcomes. No secrets or credential changes in the diff.
> 
> **Overview**
> **Duck.ai page-context extraction measurement on macOS is tied to the sidebar being open**, aligning with iOS behavior. Success, failure, prevented, and timeout pixels no longer fire from background navigation when the chat sidebar is hidden.
> 
> On **sidebar open**, a one-per-navigation measurement runs: **prevented** fires immediately for native/special pages and blocklisted URLs (e.g. PDF/image) without user action; attachable pages with auto-collect on may trigger a fresh collect so outcomes are measured live. Re-opening the sidebar on the same page does not repeat this measurement.
> 
> **Telemetry dedup** is tightened: signals-only harvests no longer report extraction outcomes or register pending resolver entries/timeouts, and full-collection vs signals-only reporting is covered by new unit tests. The **prevented** pixel definition now documents and **enum-constrains** the `category` parameter (`pdf`, `image`, `video`, `audio`, `internalPage`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3f48452eab0121bd9a30f79fe3ccb725af9e491. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->