### PR TITLE
Fix positioning of VPN toggle on iOS 27

### DIFF
--- a/iOS/DuckDuckGo/NetworkProtectionStatusView.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionStatusView.swift
@@ -124,7 +124,7 @@ struct NetworkProtectionStatusView: View {
                             .foregroundColor(.init(designSystemColor: .textSecondary))
                     }
                 }
-                .layoutPriority(1)
+                .frame(maxWidth: .infinity, alignment: .leading)
 
                 Toggle("", isOn: Binding(
                     get: { statusModel.isNetPEnabled },


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1216648235201602?focus=true
Tech Design URL:
CC:

### Description

This PR fixes the positioning of the VPN toggle on iOS 27:

| Before | After |
|--------|--------|
| <img alt="IMG_0542" src="https://github.com/user-attachments/assets/58a1dce2-c8ab-496c-b4b7-78ed34906fae" /> | <img alt="Screenshot 2026-07-17 at 11 30 22" src="https://github.com/user-attachments/assets/f99463c7-1800-4977-a12c-2b3f4cfc884a" /> |

### Testing Steps

1. Build and run on iOS 27, using Xcode 26
2. Head to VPN settings (you'll need to have a subscription on the device)
3. Ensure the on / off toggle looks as expected and can be toggled on and off
4. Ideally, verify that iOS 26 still looks good too.

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

This should just be a minor visual change.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single SwiftUI layout modifier swap in the VPN settings row; no logic, networking, or auth changes.
> 
> **Overview**
> Fixes misaligned VPN on/off toggle in **Network Protection** status on iOS 27.
> 
> The title/status **VStack** no longer uses `.layoutPriority(1)`; it now uses `.frame(maxWidth: .infinity, alignment: .leading)` so the row lays out correctly next to the switch in the **HStack**. Toggle behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b1222056440cae49213eb14ec418aaf3102b687. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->