### PR TITLE
[iOS] fix top bar re-appear after scroll bug

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4156,6 +4156,7 @@ extension MainViewController: BrowserChromeDelegate {
     }
 
     var canHideBars: Bool {
+        if currentTab?.isLoading == true { return false }
         // Keep bars shown on the error page: the webView is hidden, so scroll can't self-heal a stuck-hidden bar.
         if currentTab?.isError == true { return false }
         return !shouldPinChrome && !daxDialogsManager.shouldShowFireButtonPulse


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1216646083859849?focus=true
Tech Design URL:
CC:

### Description
Fix bug that can result in the top address bar being revealed after scrolling away.

### Testing Steps

1. floatingUI off, unifiedInputToggle on
1. Open techmeme.com with bar in top position.  
2. Scroll so that the bar appears and disappears.  
3. Validate no unusual visits from the bars when expected to be hidden.
4. Smoke test browsing, orientation changing, tab switching.
5. Validate on iPad
6. Validate with unifiedInputToggle off

### Impact
Medium: Could disrupt specific features or user flows

#### What could go wrong?
Could break bar visibility. 

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches scroll-driven chrome visibility only; wrong loading state could leave bars pinned visible or briefly affect hide/show during navigation.
> 
> **Overview**
> Fixes a bug where the **top address bar could reappear after scrolling** when it should stay hidden (e.g. with unified input / top bar layout).
> 
> `MainViewController.canHideBars` now returns **false while `currentTab` is loading**, alongside the existing error-page and pin-chrome checks. `BrowserChromeManager` already treats `canHideBars == false` by **revealing bars if they were hidden** and **skipping hide-on-scroll**—loading was the missing guard that let scroll/content updates fight the hidden chrome state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05b4682959efbc6e0c24ff6724d3b12b06a569c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->