### PR TITLE
[iOS][cherry-pick] fix top bar re-appear after scroll bug (#5892)

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4166,6 +4166,7 @@ extension MainViewController: BrowserChromeDelegate {
     }
 
     var canHideBars: Bool {
+        if currentTab?.isLoading == true { return false }
         // Keep bars shown on the error page: the webView is hidden, so scroll can't self-heal a stuck-hidden bar.
         if currentTab?.isError == true { return false }
         return !shouldPinChrome && !daxDialogsManager.shouldShowFireButtonPulse


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1216646083859849?focus=true 
Tech Design URL:
CC:

### Description
Fix bug that can result in the top address bar being revealed after scrolling away.

### Testing Steps

1. floatingUI off, unifiedInputToggle on
1. Open techmeme.com with bar in top position.  
2. Scroll so that the bar appears and disappears.  
3. Validate no unusual visits from the bars when expected to be hidden.
4. Smoke test browsing, orientation changing, tab switching.
5. Validate on iPad
6. Validate with unifiedInputToggle off

### Impact
Medium: Could disrupt specific features or user flows

#### What could go wrong?
Could break bar visibility. 

---
###### Internal references:
[Definition of
Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering
Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design
Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single guard in bar visibility logic; could affect chrome behavior only during page load, with no auth or data impact.
> 
> **Overview**
> Fixes a case where the **top address bar could flash back into view** after scrolling had hidden it (notably with unified input / top bar layout).
> 
> `MainViewController.canHideBars` now returns **false while the current tab is loading**, alongside the existing guards for error pages, pinned chrome, and the fire-button pulse. That blocks scroll-driven hide/show chrome behavior during navigation until the page finishes loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6a941ea7206504470b927ee658406680e451146. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


