### PR TITLE
Enable VPN location Update button only when selection changes

### DIFF
--- a/macOS/DuckDuckGo/Common/Localizables/UserText+NetworkProtection.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText+NetworkProtection.swift
@@ -264,7 +264,7 @@ extension UserText {
 
     static let vpnLocationCustomSectionTitle = NSLocalizedString("vpn.location.custom.section.title", value: "Custom", comment: "Title of the VPN location list custom section")
 
-    static let vpnLocationSubmitButtonTitle = NSLocalizedString("vpn.location.submit.button.title", value: "Submit", comment: "Title of the VPN location list submit button")
+    static let vpnLocationSubmitButtonTitle = NSLocalizedString("vpn.location.submit.button.title", value: "Update Location", comment: "Title of the VPN location list submit button")
 
     static let vpnLocationCancelButtonTitle = NSLocalizedString("vpn.location.cancel.button.title", value: "Cancel", comment: "Title of the VPN location list cancel button (Note: seems like a duplicate key with a different purpose, please check)")
 

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -118122,7 +118122,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Submit"
+            "value" : "Update Location"
           }
         },
         "es" : {

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNLocation/VPNLocationView.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNLocation/VPNLocationView.swift
@@ -42,6 +42,7 @@ struct VPNLocationView: View {
                 .padding(.bottom, 20)
             }
             VPNLocationViewButtons(
+                isDoneEnabled: model.isSubmitEnabled,
                 onDone: {
                     model.onSubmit()
                     isPresented = false
@@ -251,6 +252,7 @@ private struct ChecklistItem<Content>: View where Content: View {
 }
 
 private struct VPNLocationViewButtons: View {
+    let isDoneEnabled: Bool
     let onDone: () -> Void
     let onCancel: () -> Void
 
@@ -267,7 +269,8 @@ private struct VPNLocationViewButtons: View {
 
                 button(text: UserText.vpnLocationSubmitButtonTitle, action: onDone)
                     .keyboardShortcut(.defaultAction)
-                    .buttonStyle(DefaultActionButtonStyle(enabled: true))
+                    .buttonStyle(DefaultActionButtonStyle(enabled: isDoneEnabled))
+                    .disabled(!isDoneEnabled)
             }
             .padding(.vertical, 16)
             .padding(.horizontal, 20)

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNLocation/VPNLocationViewModel.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNLocation/VPNLocationViewModel.swift
@@ -29,6 +29,7 @@ final class VPNLocationViewModel: ObservableObject {
     private var selectedLocation: VPNSettings.SelectedLocation
     @Published public var state: LoadingState
     @Published public var isNearestSelected: Bool
+    @Published public var isSubmitEnabled: Bool
 
     enum ViewAction {
         case cancel
@@ -54,6 +55,7 @@ final class VPNLocationViewModel: ObservableObject {
         self.settings = settings
         selectedLocation = settings.selectedLocation
         self.isNearestSelected = selectedLocation == .nearest
+        self.isSubmitEnabled = selectedLocation != settings.selectedLocation
         if let cachedCountryItems = Self.cachedCountryItems {
             state = .loaded(countryItems: cachedCountryItems)
         } else {
@@ -94,6 +96,8 @@ final class VPNLocationViewModel: ObservableObject {
 
     @MainActor
     private func reloadList() async {
+        isSubmitEnabled = selectedLocation != settings.selectedLocation
+
         guard let locations = (try? await locationListRepository.fetchLocationList().sortedByName()) ?? Self.cachedLocations else {
             return
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1213610207499655?focus=true

### Description

In the macOS VPN location picker, the confirm button was always tappable and labeled "Submit", so a user could re-confirm the location they were already on — a no-op that looked like an action. It's now enabled only when the staged selection differs from the location currently in use, and relabeled "Update Location" to describe what confirming does.

### Testing Steps

1. Enable the VPN.
2. Open VPN settings and click Change next to the location.
   - The location picker opens with the current location selected.
3. Observe the bottom-right button.
   - It reads "Update Location" and is disabled.
4. Select a different country or city.
   - The button becomes enabled.
5. Re-select the location you started on.
   - The button becomes disabled again.
6. Select a different location and click Update Location.
   - The picker dismisses and the new location is applied.

### Impact

Low — UI-only change to the location picker; no change to VPN connection behavior.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only gating and copy in the location picker; persisted location is still written only via the existing `onSubmit()` path when the button is enabled.
> 
> **Overview**
> The macOS VPN location picker no longer treats confirming as always valid: the primary action is **disabled** until the staged choice differs from the location already saved in `VPNSettings`, and it is relabeled from **Submit** to **Update Location** (English string catalog + `UserText`).
> 
> `VPNLocationViewModel` exposes `isSubmitEnabled` by comparing in-memory `selectedLocation` to `settings.selectedLocation` on init and whenever the list reloads after selection changes; `VPNLocationViewButtons` wires that into `DefaultActionButtonStyle` and `.disabled(!isDoneEnabled)` so the default keyboard shortcut cannot apply a no-op.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 883827359bda22cb3d92a7803532eecaf148d7eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->