### PR TITLE
iOS: Restore Paste & Go in the Unified Toggle Input

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -357,6 +357,41 @@ class SwitchBarTextEntryView: UIView {
         textField.delegate = self
         textField.addTarget(self, action: #selector(textFieldEditingChanged), for: .editingChanged)
         syncActiveControl()
+        setupPasteAndGoMenuItem()
+    }
+
+    // MARK: - Paste & Go
+
+    /// iOS 15 fallback; iOS 16+ builds the menu via the `editMenuFor…` delegate methods below.
+    private func setupPasteAndGoMenuItem() {
+        guard #unavailable(iOS 16.0) else { return }
+        UIMenuController.shared.menuItems = [
+            UIMenuItem(title: UserText.actionPasteAndGo, action: #selector(pasteURLAndGo))
+        ]
+    }
+
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        if action == #selector(pasteURLAndGo) {
+            return UIPasteboard.general.hasStrings
+        }
+        return super.canPerformAction(action, withSender: sender)
+    }
+
+    @objc private func pasteURLAndGo() {
+        guard let pastedText = UIPasteboard.general.string,
+              !pastedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        handler.updateCurrentText(pastedText)
+        handler.submitText(pastedText)
+    }
+
+    /// Appends "Paste & Go" to the long-press menu when the clipboard has text (iOS 16+).
+    @available(iOS 16.0, *)
+    private func pasteAndGoEditMenu(appendingTo suggestedActions: [UIMenuElement]) -> UIMenu? {
+        guard UIPasteboard.general.hasStrings else { return nil }
+        let pasteAndGo = UIAction(title: UserText.actionPasteAndGo) { [weak self] _ in
+            self?.pasteURLAndGo()
+        }
+        return UIMenu(children: suggestedActions + [pasteAndGo])
     }
 
     // MARK: - Setup Methods
@@ -1112,9 +1147,19 @@ extension SwitchBarTextEntryView: UITextViewDelegate {
         }
         return true
     }
+
+    @available(iOS 16.0, *)
+    func textView(_ textView: UITextView, editMenuForTextIn range: NSRange, suggestedActions: [UIMenuElement]) -> UIMenu? {
+        pasteAndGoEditMenu(appendingTo: suggestedActions)
+    }
 }
 
 extension SwitchBarTextEntryView: UITextFieldDelegate {
+
+    @available(iOS 16.0, *)
+    func textField(_ textField: UITextField, editMenuForCharactersIn range: NSRange, suggestedActions: [UIMenuElement]) -> UIMenu? {
+        pasteAndGoEditMenu(appendingTo: suggestedActions)
+    }
 
     func textFieldDidBeginEditing(_ textField: UITextField) {
         hasBeenInteractedWith = true

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryViewController.swift
@@ -82,7 +82,6 @@ class SwitchBarTextEntryViewController: UIViewController {
         super.viewDidLoad()
         setupViews()
         setupConstraints()
-        setupPasteAndGo()
     }
 
     override func viewDidLayoutSubviews() {
@@ -166,27 +165,6 @@ class SwitchBarTextEntryViewController: UIViewController {
             // Suggest 0, but allow to grow based on the content
             buttonsContainerView.heightAnchor.constraint(equalToConstant: 0).withPriority(.defaultLow)
         ])
-    }
-
-    private func setupPasteAndGo() {
-        let title = UserText.actionPasteAndGo
-        UIMenuController.shared.menuItems = [UIMenuItem(title: title, action: #selector(self.pasteURLAndGo))]
-    }
-
-    // MARK: - Action Handlers
-    @objc private func pasteURLAndGo(sender: UIMenuItem) {
-        guard let pastedText = UIPasteboard.general.string,
-              !pastedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-        handler.updateCurrentText(pastedText)
-        handleSend()
-    }
-
-    private func handleSend() {
-        let currentText = handler.currentText
-        if !currentText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            handler.submitText(currentText)
-            handler.clearText()
-        }
     }
 
     // MARK: - Public Methods


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1216696980064421


### Description
The old address bar offered a "Paste & Go" item on long-press that pasted the clipboard and immediately submitted it. It went missing when the Unified Toggle Input replaced the omnibar. This restores it for both the Unified Toggle Input and the experimental toggle input; it submits into whichever mode (Search or Duck.ai) is currently selected, and only appears when there is text on the clipboard.

### Testing Steps
_ensure unified toggle input is enabled, its rolled out so should be..._

1. Copy a URL (e.g. `duckduckgo.com`) to the clipboard.
2. Open a new tab and tap the address bar to focus it (Search mode).
3. Long-press the input → **Paste & Go** appears at the end of the menu → tap it → the page loads.
4. Copy a search phrase, focus the input in Search mode, long-press → **Paste & Go** → a search runs.
5. Toggle to Duck.ai, copy some throwaway text, focus, long-press → **Paste & Go** → the text is sent to Duck.ai as a prompt.
6. Disabled the toggle and repeat test steps 1-4 (i.e paste & go with no toggle uti)

### Impact
Low — additive long-press menu item; no change to existing input behavior.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive edit-menu behavior on the input view only; submission goes through the existing `SwitchBarHandling.submitText` path with no auth or data-model changes.
> 
> **Overview**
> Restores **Paste & Go** on long-press for the unified toggle / switch bar text entry by moving the feature from `SwitchBarTextEntryViewController` into `SwitchBarTextEntryView`, so it works for both the single-line field and multi-line composer.
> 
> On **iOS 16+**, the action is appended to the system edit menu via `editMenuForTextIn` / `editMenuForCharactersIn`. On **iOS 15**, it uses `UIMenuController` plus `canPerformAction` so the item only appears when the pasteboard has text. Choosing it updates the handler and calls `submitText` for the active Search or Duck.ai mode—the same path as keyboard Go, without the old controller `clearText` after send.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c4e710be7c571a048c7f63f831408dbacf22efe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->