### PR TITLE
iOS: Fix UTI auto-selecting search queries on address bar focus

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -927,6 +927,17 @@ class SwitchBarTextEntryView: UIView {
         }
     }
 
+    func moveCaretToStart() {
+        if usesTextField {
+            let start = textField.beginningOfDocument
+            textField.selectedTextRange = textField.textRange(from: start, to: start)
+        } else {
+            let start = textView.beginningOfDocument
+            textView.selectedTextRange = textView.textRange(from: start, to: start)
+            textView.scrollRangeToVisible(NSRange(location: 0, length: 0))
+        }
+    }
+
     func setQueryText(_ text: String) {
         if usesTextField {
             textField.text = text

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1159,8 +1159,19 @@ extension MainViewController: UnifiedToggleInputOmnibarActivating {
         coordinator.updateInputMode(inputMode, animated: false)
         let isToggleEnabled = isAIChatSearchInputToggleEnabledForCurrentOnboardingState()
         coordinator.updateToggleEnabled(isToggleEnabled)
-        coordinator.activateFromOmnibar(prefilledText: currentText, inputMode: inputMode, cardPosition: position)
+        coordinator.activateFromOmnibar(prefilledText: currentText,
+                                        shouldSelectAllText: shouldAutoSelectOmnibarText(currentText),
+                                        inputMode: inputMode,
+                                        cardPosition: position)
         return .intercept
+    }
+
+    private func shouldAutoSelectOmnibarText(_ text: String?) -> Bool {
+        guard let text = text?.trimmingWhitespace(), !text.isEmpty else { return false }
+        if URL(trimmedAddressBarString: text, useUnifiedLogic: isUnifiedURLPredictionEnabled) != nil {
+            return true
+        }
+        return shouldAutoSelectTextForSERPQuery()
     }
 }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -863,7 +863,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
 
     // MARK: - Omnibar State
 
-    func activateFromOmnibar(prefilledText: String? = nil, inputMode: TextEntryMode = .search, cardPosition: UnifiedToggleInputCardPosition = .top) {
+    func activateFromOmnibar(prefilledText: String? = nil, shouldSelectAllText: Bool = true, inputMode: TextEntryMode = .search, cardPosition: UnifiedToggleInputCardPosition = .top) {
         cancelTopOmnibarKeyboardPresentationFallback()
         isAwaitingTopOmnibarKeyboardPresentation = cardPosition == .top
         displayState = .omnibar(.active)
@@ -887,15 +887,15 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
 
         // Set text before apply so clearDismissSnapshot sees the correct handler state when
         // it fires inside applyCardLayout — otherwise textRightInset starts at the no-button value.
-        let shouldSelectAllText: Bool
+        let selectsAllText: Bool
         if let text = prefilledText, !text.isEmpty {
             setText(text)
             textState = .prefilledSelected
             omnibarPrefilledText = text
-            shouldSelectAllText = true
+            selectsAllText = shouldSelectAllText
         } else {
             omnibarPrefilledText = nil
-            shouldSelectAllText = false
+            selectsAllText = false
         }
         updateFloatingReturnKeyState()
 
@@ -917,7 +917,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         DispatchQueue.main.async { [weak self] in
             guard let self, case .omnibar(.active) = displayState else { return }
             viewController.activateInput()
-            if shouldSelectAllText {
+            if selectsAllText {
                 DispatchQueue.main.async { [weak self] in
                     guard let self, case .omnibar(.active) = displayState else { return }
                     viewController.selectAllText()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -917,10 +917,13 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         DispatchQueue.main.async { [weak self] in
             guard let self, case .omnibar(.active) = displayState else { return }
             viewController.activateInput()
-            if selectsAllText {
-                DispatchQueue.main.async { [weak self] in
-                    guard let self, case .omnibar(.active) = displayState else { return }
+            guard omnibarPrefilledText != nil else { return }
+            DispatchQueue.main.async { [weak self] in
+                guard let self, case .omnibar(.active) = displayState else { return }
+                if selectsAllText {
                     viewController.selectAllText()
+                } else {
+                    viewController.moveCaretToStart()
                 }
             }
         }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -670,6 +670,10 @@ final class UnifiedToggleInputView: UIView {
         textEntryView.selectAllText()
     }
 
+    func moveCaretToStart() {
+        textEntryView.moveCaretToStart()
+    }
+
     var placeholderWindowX: CGFloat? { textEntryView.placeholderWindowX }
 
     var defaultPlaceholderColor: UIColor { textEntryView.defaultPlaceholderColor }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
@@ -347,6 +347,10 @@ final class UnifiedToggleInputViewController: UIViewController {
         inputBarView.selectAllText()
     }
 
+    func moveCaretToStart() {
+        inputBarView.moveCaretToStart()
+    }
+
     var placeholderWindowX: CGFloat? { inputBarView.placeholderWindowX }
 
     var defaultPlaceholderColor: UIColor { inputBarView.defaultPlaceholderColor }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1216595694228209
Tech Design URL:
CC:

### Description
When you tap into the address bar to edit an existing entry, a URL should be selected (so the clear button or the next keystroke replaces it), but a search query should keep a plain caret so you can edit it in place. The legacy omnibar did this. The Unified Toggle Input regressed it: any prefilled text — including a long search query — was fully selected on focus, and it scrolled to the end of the query. This restores the legacy behaviour: URLs are selected; a query keeps a caret and the field shows the start.

### Testing Steps
1. Enable ’Search Only’ (no toggle)
2. Search for a long multi-word query, e.g. `how do I make the perfect cup of coffee at home`.
3. On the results page, tap the address bar → the input activates showing the **start** of the query with a **blinking caret at the beginning, not fully highlighted and not scrolled to the end**; you can edit it in place.
4. Go to a website, e.g. `example.com`. Tap the address bar → the **full URL is selected** (highlighted); the clear (X) or typing replaces it.
5. On the results page, background then foreground the app and tap the address bar once → the query is selected (first-focus-after-foreground behaviour, matching the legacy omnibar).

### Impact
Low: address-bar text-selection behaviour on focus; behind the internal Unified Toggle Input.

### Quality Considerations
- Only the `selectAllText()` UI call is gated; `textState`/`omnibarPrefilledText` are unchanged, so unmodified-prefill submission and content-overlay suppression are unaffected.
- The URL-vs-query decision reuses the existing omnibar logic (`shouldAutoSelectTextForSERPQuery` + URL detection), so it stays in step with the legacy path and consumes the SERP first-focus flag identically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to UTI address-bar focus selection behind the experimental input; reuses existing URL and SERP auto-select logic without changing submit or prefill state.
> 
> **Overview**
> Fixes a **Unified Toggle Input** regression where focusing the address bar always **selected all** prefilled text (and scrolled long queries to the end).
> 
> On omnibar activation, **`shouldAutoSelectOmnibarText`** now decides selection: **URLs** still get full selection; **search queries** get a **caret at the start** with the field scrolled to the beginning. The legacy **SERP first-focus-after-foreground** path still selects the query via **`shouldAutoSelectTextForSERPQuery`**.
> 
> **`activateFromOmnibar`** takes an explicit **`shouldSelectAllText`** flag and, after focus, calls **`selectAllText()`** or the new **`moveCaretToStart()`** (wired through the UTI view stack into **`SwitchBarTextEntryView`** for both single-line and multi-line controls). Prefill / submit state is unchanged—only the post-focus selection UI differs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30058759056d10196b5db8ff73824968456e8a72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->