### PR TITLE
Revert "Cross-domain links from pinned tabs open in foreground (#4630)"

### DIFF
--- a/macOS/DuckDuckGo/Tab/Model/LinkOpenBehavior.swift
+++ b/macOS/DuckDuckGo/Tab/Model/LinkOpenBehavior.swift
@@ -66,12 +66,7 @@ enum LinkOpenBehavior: Equatable {
         let shouldOpenNewTab = button == .middle || modifierFlags.contains(.command)
         let isShiftPressed = modifierFlags.contains(.shift)
 
-        // ⌥-click without ⌘: "save link as" / download gesture.
-        // Treat as current-tab so the caller / WebKit can handle it as a download,
-        // even when canOpenLinkInCurrentTab is false (e.g. pinned-tab cross-domain link).
-        let isOptionOnlyGesture = modifierFlags.contains(.option) && !modifierFlags.contains(.command)
-
-        guard shouldOpenNewTab || (!canOpenLinkInCurrentTab && !isOptionOnlyGesture) else {
+        guard shouldOpenNewTab || !canOpenLinkInCurrentTab else {
             self = .currentTab
             return
         }
@@ -88,7 +83,7 @@ enum LinkOpenBehavior: Equatable {
         }
 
         // ⌘+⌥+click: New Window
-        if shouldOpenNewTab && modifierFlags.contains(.option) {
+        if modifierFlags.contains(.option) {
             self = .newWindow(selected: isSelected)
         } else {
             // ⌘+click: New Tab

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PopupHandlingTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PopupHandlingTabExtension.swift
@@ -458,15 +458,10 @@ extension PopupHandlingTabExtension: NavigationResponder {
         }
         Logger.navigation.debug("PopupHandlingTabExtension.decidePolicyFor: \(String(describing: navigationAction)) userInteractionEvent: \(userInteractionEvent ??? "<nil>") currentEvent: \(NSApp.currentEvent ??? "<nil>")")
 
-        // For pinned-tab cross-domain navigations canOpenLinkInCurrentTab is false.
-        // shouldSelectNewTab:true ensures a plain left-click always selects the new tab — the user
-        // clicked a link the pinned tab cannot open in place, so foreground is the right default.
-        // Modifier-key semantics (⌘, ⌘⇧, ⌘⌥, ⌘⌥⇧) are preserved by LinkOpenBehavior as usual.
         let linkOpenBehavior = LinkOpenBehavior(button: navigationAction.navigationType.isMiddleButtonClick ? .middle : .left,
                                                 modifierFlags: userInteractionEvent?.modifierFlags ?? [],
                                                 switchToNewTabWhenOpenedPreference: tabsPreferences.switchToNewTabWhenOpened,
-                                                canOpenLinkInCurrentTab: canOpenLinkInCurrentTab,
-                                                shouldSelectNewTab: !canOpenLinkInCurrentTab)
+                                                canOpenLinkInCurrentTab: canOpenLinkInCurrentTab)
         // Handle behavior for navigation
         switch linkOpenBehavior {
         case .currentTab:

--- a/macOS/UITests/PinnedTabsTests.swift
+++ b/macOS/UITests/PinnedTabsTests.swift
@@ -20,62 +20,22 @@ import XCTest
 
 class PinnedTabsTests: UITestCase {
     private static let failureObserver = TestFailureObserver()
-    var featureFlags: [String: Bool] { [:] }
+    var featureFlags: [String: Bool] {
+        [:]
+    }
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         continueAfterFailure = false
         app = XCUIApplication.setUp(featureFlags: featureFlags)
 
-        // Safety-net: close any pinned tabs left from a previous test that tearDown
-        // might have missed (e.g. after a crash).  Primary cleanup happens in
-        // tearDownWithError, which runs while the app is fully loaded.
-        closeResidualPinnedTabs()
-
         app.openNewWindow()
-    }
-
-    override func tearDownWithError() throws {
-        // Primary pinned-tab cleanup: runs while the app is still fully loaded, so
-        // app.pinnedTabs.count is reliable.  This ensures the session file has 0 pinned
-        // tabs when the app terminates, preventing accumulation across test iterations.
-        if app.state == .runningForeground || app.state == .runningBackground {
-            unpinAllPinnedTabs()
-        }
-        try super.tearDownWithError()
-    }
-
-    /// Unpins and closes every pinned tab. Safe to call from both setUp and tearDown.
-    private func unpinAllPinnedTabs() {
-        for _ in 0..<50 { // Safety limit — no test should accumulate > 50 pins
-            guard app.pinnedTabs.count > 0 else { break }
-            app.pinnedTabs.element(boundBy: 0).click()
-            guard app.menuItems["Unpin Tab"].waitForExistence(timeout: UITests.Timeouts.elementExistence) else { break }
-            app.menuItems["Unpin Tab"].tap()
-            app.closeCurrentTab()
-        }
-    }
-
-    /// Safety-net cleanup called from setUp.  Primary cleanup is tearDownWithError.
-    private func closeResidualPinnedTabs() {
-        _ = app.windows.firstMatch.waitForExistence(timeout: UITests.Timeouts.elementExistence)
-        // Wait briefly for session restore to populate the pinned-tabs view.
-        // If tearDownWithError ran correctly in the previous test this returns
-        // immediately (no pins), adding only a negligible delay.
-        _ = app.pinnedTabs.firstMatch.waitForExistence(timeout: 5)
-        unpinAllPinnedTabs()
     }
 
     func testPinnedTabsFunctionality() {
         app.disableWarnBeforeQuitting(closeSettings: false)
         app.disableWarnBeforeClosingPinnedTabs(closeSettings: true)
-        // Close any extra browser windows (from session restore or setUp's openNewWindow)
-        // so the multi-window flow in this test starts from a known single-window state.
-        // assertWindowTwoHasNoPinnedTabsFromWindowsOne expects windows.count == 1 after
-        // closing the Page #4 window, which only holds if exactly 2 windows exist at
-        // that point (this window + the Page #4 window opened by openNewWindowAndLoadSite).
-        app.closeAllWindows()
-        app.openNewWindow()
+
         openThreeSitesOnSameWindow()
         openNewWindowAndLoadSite()
         moveBackToPreviousWindows()
@@ -173,228 +133,6 @@ class PinnedTabsTests: UITestCase {
         assertSingleWindowScenario()
     }
 
-    // MARK: - Modifier-key navigation from a pinned tab
-
-    func testWhenPinnedTabNavigatesToDifferentDomain_CmdClick_ThenNewTabOpensInBackground() {
-        let (sourceTitle, targetTitle, sourceURL) = makePinnedCrossDomainScenario(suffix: "CmdClick")
-        app.setSwitchToNewTab(enabled: false)
-        app.openURL(sourceURL, waitForWebViewAccessibilityLabel: sourceTitle)
-        pinCurrentPage()
-
-        let mainWindow = app.windows.firstMatch
-        XCUIElement.perform(withKeyModifiers: [.command]) {
-            mainWindow.webViews[sourceTitle].links["Go to \(targetTitle)"].click()
-        }
-
-        XCTAssertTrue(app.tabs[targetTitle].waitForExistence(timeout: UITests.Timeouts.elementExistence),
-                      "Cmd+click from pinned tab should open target in a new tab")
-        XCTAssertEqual(app.windows.count, 1, "Should stay in the same window")
-        XCTAssertTrue(mainWindow.webViews[sourceTitle].exists,
-                      "Pinned tab should remain selected (cmd+click opens in background)")
-        XCTAssertEqual(app.pinnedTabs.count, 1, "Pinned tab should still exist")
-        XCTAssertEqual(app.tabGroups.matching(identifier: "Tabs").radioButtons.count, 1,
-                       "Exactly one new unpinned tab should have been created")
-    }
-
-    func testWhenPinnedTabNavigatesToDifferentDomain_CmdShiftClick_ThenNewTabOpensInForeground() {
-        let (sourceTitle, targetTitle, sourceURL) = makePinnedCrossDomainScenario(suffix: "CmdShiftClick")
-        app.setSwitchToNewTab(enabled: false)
-        app.openURL(sourceURL, waitForWebViewAccessibilityLabel: sourceTitle)
-        pinCurrentPage()
-
-        let mainWindow = app.windows.firstMatch
-        XCUIElement.perform(withKeyModifiers: [.command, .shift]) {
-            mainWindow.webViews[sourceTitle].links["Go to \(targetTitle)"].click()
-        }
-
-        XCTAssertTrue(mainWindow.webViews[targetTitle].waitForExistence(timeout: UITests.Timeouts.elementExistence),
-                      "Cmd+Shift+click from pinned tab should open target tab in foreground")
-        XCTAssertEqual(app.windows.firstMatch.title, targetTitle,
-                       "New tab should be selected (foreground)")
-        XCTAssertEqual(app.windows.count, 1, "Should stay in the same window")
-        XCTAssertEqual(app.pinnedTabs.count, 1, "Pinned tab should still exist")
-        XCTAssertEqual(app.tabGroups.matching(identifier: "Tabs").radioButtons.count, 1,
-                       "Exactly one new unpinned tab should have been created")
-    }
-
-    func testWhenPinnedTabNavigatesToDifferentDomain_CmdOptClick_ThenNewWindowOpensInBackground() {
-        let (sourceTitle, targetTitle, sourceURL) = makePinnedCrossDomainScenario(suffix: "CmdOptClick")
-        app.setSwitchToNewTab(enabled: false)
-        app.openURL(sourceURL, waitForWebViewAccessibilityLabel: sourceTitle)
-        pinCurrentPage()
-
-        let mainWindow = app.windows.firstMatch
-        XCUIElement.perform(withKeyModifiers: [.command, .option]) {
-            mainWindow.webViews[sourceTitle].links["Go to \(targetTitle)"].click()
-        }
-
-        let newWindow = app.windows.element(boundBy: 1)
-        XCTAssertTrue(newWindow.waitForExistence(timeout: UITests.Timeouts.elementExistence),
-                      "Cmd+Opt+click from pinned tab should open a new background window")
-        XCTAssertEqual(app.windows.count, 2, "A second window should have been created")
-        XCTAssertTrue(newWindow.webViews[targetTitle].waitForExistence(timeout: UITests.Timeouts.elementExistence),
-                      "Target should load in the new background window")
-        XCTAssertTrue(mainWindow.webViews[sourceTitle].exists,
-                      "Original pinned tab should remain selected in the main window")
-        XCTAssertEqual(app.pinnedTabs.count, 1, "Pinned tab should still exist")
-    }
-
-    func testWhenPinnedTabNavigatesToDifferentDomain_OptClick_ThenDownloadStarts() {
-        // Option+click without ⌘ is a "save link as" gesture — should trigger a download,
-        // not open a new tab, even for cross-domain links from a pinned tab.
-        let sourceTitle = "Pinned Source (OptDownload)"
-        let uniqueName = "pinned-opt-\(UUID().uuidString).bin"
-        let downloadsDir = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask)[0]
-        trackForCleanup(downloadsDir.appendingPathComponent(uniqueName).path)
-
-        // Build a cross-domain download URL (127.0.0.1 vs localhost) so the pinned-tab
-        // cross-domain logic is exercised.
-        var downloadComponents = URLComponents(url: URL.testsDownload(size: "1KB", filename: uniqueName),
-                                               resolvingAgainstBaseURL: false)!
-        downloadComponents.host = "127.0.0.1"
-        let downloadURL = downloadComponents.url!
-
-        let sourceURL = UITests.simpleServedPage(titled: sourceTitle,
-                                                  body: "<a href='\(downloadURL.absoluteString)'>Download File</a>")
-
-        // Ensure "Always ask where to save" is off so the download proceeds silently.
-        app.openPreferencesWindow()
-        app.preferencesGoToGeneralPane()
-        app.setAlwaysAskWhereToSaveFiles(enabled: false)
-        app.enforceSingleWindow()
-
-        app.openURL(sourceURL, waitForWebViewAccessibilityLabel: sourceTitle)
-        pinCurrentPage()
-
-        let mainWindow = app.windows.firstMatch
-        let link = mainWindow.webViews[sourceTitle].links["Download File"].firstMatch
-        XCTAssertTrue(link.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-
-        XCUIElement.perform(withKeyModifiers: [.option]) {
-            link.click()
-        }
-
-        // No new tab should have been opened — the pinned tab cross-domain interception
-        // must NOT redirect opt+click to a new tab.
-        XCTAssertEqual(app.pinnedTabs.count, 1,
-                       "Pinned source tab should still exist")
-        XCTAssertEqual(app.tabGroups.matching(identifier: "Tabs").radioButtons.count, 0,
-                       "Opt+click from pinned tab should not open a new unpinned tab")
-        XCTAssertEqual(app.windows.count, 1,
-                       "Opt+click from pinned tab should not open a new window")
-
-        // The download should be listed in the downloads panel.
-        let popover = app.popovers.containing(.table, identifier: "DownloadsViewController.table").firstMatch
-        if !popover.exists {
-            app.openDownloads()
-            XCTAssertTrue(popover.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        }
-        XCTAssertTrue(popover.staticTexts[uniqueName].waitForExistence(timeout: UITests.Timeouts.localTestServer),
-                      "Download should appear in the Downloads panel after opt+click from a pinned tab")
-    }
-
-    func testWhenPinnedTabNavigatesToDifferentDomain_CmdOptShiftClick_ThenNewWindowOpensInForeground() {
-        let (sourceTitle, targetTitle, sourceURL) = makePinnedCrossDomainScenario(suffix: "CmdOptShiftClick")
-        app.setSwitchToNewTab(enabled: false)
-        app.openURL(sourceURL, waitForWebViewAccessibilityLabel: sourceTitle)
-        pinCurrentPage()
-
-        let mainWindow = app.windows.firstMatch
-        XCUIElement.perform(withKeyModifiers: [.command, .option, .shift]) {
-            mainWindow.webViews[sourceTitle].links["Go to \(targetTitle)"].click()
-        }
-
-        XCTAssertTrue(app.windows.element(boundBy: 1).waitForExistence(timeout: UITests.Timeouts.elementExistence),
-                      "Cmd+Opt+Shift+click from pinned tab should open a new foreground window")
-        XCTAssertEqual(app.windows.count, 2, "A second window should have been created")
-        // The new window should be key (frontmost) — its title matches the target
-        XCTAssertTrue(app.windows.matching(NSPredicate(format: "title == %@", targetTitle)).firstMatch
-                        .waitForExistence(timeout: UITests.Timeouts.elementExistence),
-                      "New window should be in the foreground (active)")
-        // After opening a new foreground window, windows.firstMatch resolves to the NEW window
-        // (now frontmost). The pinned tab lives in the ORIGINAL window — query it by title.
-        let originalWindow = app.windows.matching(NSPredicate(format: "title == %@", sourceTitle)).firstMatch
-        XCTAssertEqual(originalWindow.pinnedTabs.count, 1, "Pinned tab should still exist in the original window")
-    }
-
-    // MARK: - Helper
-
-    /// Builds source/target page titles and source URL for a pinned-tab cross-domain scenario.
-    private func makePinnedCrossDomainScenario(suffix: String) -> (sourceTitle: String, targetTitle: String, sourceURL: URL) {
-        let sourceTitle = "Pinned Source (\(suffix))"
-        let targetTitle = "Cross-Domain Target (\(suffix))"
-        var targetComponents = URLComponents(url: UITests.simpleServedPage(titled: targetTitle), resolvingAgainstBaseURL: false)!
-        targetComponents.host = "127.0.0.1"
-        let targetURL = targetComponents.url!
-        let sourceURL = UITests.simpleServedPage(titled: sourceTitle,
-                                                  body: "<a href='\(targetURL.absoluteString)'>Go to \(targetTitle)</a>")
-        return (sourceTitle, targetTitle, sourceURL)
-    }
-
-    func testWhenPinnedTabNavigatesToDifferentDomain_AndSwitchToNewTabIsDisabled_ThenNewTabStillOpensInForeground() {
-        let (sourceTitle, targetTitle, sourceURL) = makePinnedCrossDomainScenario(suffix: "NoSwitch")
-
-        // Disable "switch to new tab when opened" — new tabs would normally open in background
-        app.setSwitchToNewTab(enabled: false)
-
-        app.openURL(sourceURL, waitForWebViewAccessibilityLabel: sourceTitle)
-        pinCurrentPage()
-
-        let mainWindow = app.windows.firstMatch
-        mainWindow.webViews[sourceTitle].links["Go to \(targetTitle)"].click()
-
-        // Even with switchToNewTab disabled, a pinned tab's cross-domain link must open in the foreground,
-        // because it's initiated by user action.
-        // Use a generous timeout: prior test failures can leave session-restore windows that slow
-        // down accessibility-tree updates (but the assertion itself is unchanged — foreground required).
-        XCTAssertTrue(
-            mainWindow.webViews[targetTitle].waitForExistence(timeout: UITests.Timeouts.localTestServer),
-            "Cross-domain link from pinned tab should load in a new tab even when switchToNewTab is disabled"
-        )
-        // New tab is selected (foreground)
-        XCTAssertEqual(
-            app.windows.firstMatch.title, targetTitle,
-            "New tab from pinned tab cross-domain navigation should always be selected, regardless of switchToNewTab preference"
-        )
-        // A new unpinned tab was created — not the same tab navigating away
-        let unpinnedTabsAfter = app.tabGroups.matching(identifier: "Tabs").radioButtons
-        XCTAssertEqual(unpinnedTabsAfter.count, 1,
-                       "Exactly one new unpinned tab should have been created")
-        // The pinned source tab is still pinned (it did not navigate away)
-        XCTAssertEqual(app.pinnedTabs.count, 1,
-                       "The pinned source tab should still exist after cross-domain navigation")
-    }
-
-    func testWhenPinnedTabNavigatesToDifferentDomain_ThenNewTabOpensInForeground() {
-        let (sourceTitle, targetTitle, sourceURL) = makePinnedCrossDomainScenario(suffix: "Default")
-        // Enable "switch to new tab when opened" — ensures plain click goes foreground via normal preference too
-        app.setSwitchToNewTab(enabled: true)
-
-        app.openURL(sourceURL, waitForWebViewAccessibilityLabel: sourceTitle)
-        pinCurrentPage()
-
-        let mainWindow = app.windows.firstMatch
-        mainWindow.webViews[sourceTitle].links["Go to \(targetTitle)"].click()
-
-        // The new tab should exist and be selected (foreground)
-        XCTAssertTrue(
-            mainWindow.webViews[targetTitle].waitForExistence(timeout: UITests.Timeouts.elementExistence),
-            "Cross-domain link from pinned tab should load in a new tab"
-        )
-        // New tab is selected (foreground)
-        XCTAssertEqual(
-            app.windows.firstMatch.title, targetTitle,
-            "New tab opened from pinned tab cross-domain navigation should be selected (foreground)"
-        )
-        // A new unpinned tab was created — not the same tab navigating away
-        let unpinnedTabsAfter = app.tabGroups.matching(identifier: "Tabs").radioButtons
-        XCTAssertEqual(unpinnedTabsAfter.count, 1,
-                       "Exactly one new unpinned tab should have been created")
-        // The pinned source tab is still pinned (it did not navigate away)
-        XCTAssertEqual(app.pinnedTabs.count, 1,
-                       "The pinned source tab should still exist after cross-domain navigation")
-    }
-
     // MARK: - Utilities
 
     private func openThreeSitesOnSameWindow() {
@@ -434,13 +172,6 @@ class PinnedTabsTests: UITestCase {
     }
 
     private func pinCurrentPage() {
-        // Wait for the menu item to be available before tapping — the tab may still be
-        // animating into position after a navigation (e.g. Cmd+Shift+[ / ]) which causes
-        // an intermittent "No matches found" failure if we tap too early.
-        XCTAssertTrue(
-            app.menuItems["Pin Tab"].waitForExistence(timeout: UITests.Timeouts.elementExistence),
-            "Pin Tab menu item should be available"
-        )
         app.menuItems["Pin Tab"].tap()
     }
 
@@ -507,11 +238,8 @@ class PinnedTabsTests: UITestCase {
 
     private func assertsCommandWFunctionality(file: StaticString = #file, line: UInt = #line) {
         app.closeCurrentTab()
-        // Use waitForExistence rather than .exists — after removing a pinned tab the
-        // browser selects the first unpinned tab (Page #3) but the WebView needs a
-        // brief moment to render its cached content before XCTest can find the text.
         XCTAssertTrue(
-            app.staticTexts["Sample text for Page #3"].waitForExistence(timeout: UITests.Timeouts.elementExistence),
+            app.staticTexts["Sample text for Page #3"].exists,
             "Should switch to Page #3 after closing pinned tab (line \(#line))",
             file: file,
             line: line
@@ -551,24 +279,12 @@ class PinnedTabsTests: UITestCase {
         )
 
         app.closeWindow()
-        // Wait for window 2 to fully disappear before returning — without this, callers
-        // that immediately check pinnedTabs.count (via windows.firstMatch) can race
-        // against the window-close animation and see stale state.
-        XCTAssertTrue(
-            app.wait(for: .keyPath(\.windows.count, equalTo: 1), timeout: UITests.Timeouts.elementExistence),
-            "Window 2 should be closed and only window 1 should remain"
-        )
     }
 
     private func assertPinnedTabsRestoredState(file: StaticString = #file, line: UInt = #line) {
-        // Wait for the ⌘+Q quit to complete before relaunching. XCUIApplication.setUp() creates
-        // a new object whose launch() can force-kill the quitting app mid-save, corrupting the session.
-        // Using app.wait(for:) + app.launch() on the same object mirrors StateRestorationTests and
-        // allows the session to be saved cleanly before a fresh launch restores it.
-        _ = app.wait(for: .notRunning, timeout: UITests.Timeouts.localTestServer)
-        app.launch()
+        app = XCUIApplication.setUp(featureFlags: featureFlags)
         XCTAssertTrue(
-            app.windows.firstMatch.waitForExistence(timeout: UITests.Timeouts.localTestServer),
+            app.windows.firstMatch.waitForExistence(timeout: UITests.Timeouts.elementExistence),
             "App window didn't become available in a reasonable timeframe (line \(#line))",
             file: file,
             line: line


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1216696240029272?focus=true
Tech Design URL:
CC:

### Description

Reverts #4630. That change narrowed `LinkOpenBehavior`'s modifier-click → new-window mapping (intended only for pinned-tab cross-domain clicks), but the side effect was global: a modifier-click that should open a new window now opens a new tab. This consistently broke `AddressBarSpoofingUITests.testUrlBarSpoofingWithNewWindowRewrite()` in CI. Reverting restores the prior behavior; a corrected pinned-tab fix will follow separately.

### Testing Steps
1. Run macOS UI test `AddressBarSpoofingUITests.testUrlBarSpoofingWithNewWindowRewrite()` → passes (second window opens).

### Impact
Low. Restores previously shipped link-navigation behavior.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This is a behavioral rollback to previously shipped link-navigation logic; risk is limited to re-exposing the original pinned-tab cross-domain UX until a follow-up fix lands.
> 
> **Overview**
> Reverts the pinned-tab cross-domain link behavior from #4630 so **global** modifier-click semantics match the prior release again.
> 
> In **`LinkOpenBehavior`**, the special case that treated **⌥-only** clicks as “stay in current tab” (for downloads when `canOpenLinkInCurrentTab` is false) is removed, and **new window** is chosen whenever **⌥** is in the modifier flags—not only when **⌘** (or middle-click) already implied opening in a new tab/window. **`PopupHandlingTabExtension`** no longer passes **`shouldSelectNewTab: true`** for pinned-tab cross-domain links, so plain clicks from a pinned tab no longer force foreground selection via that path.
> 
> The large **`PinnedTabsTests`** suite added for modifier-key cross-domain navigation (and related setup/teardown cleanup) is removed along with several timing/wait hardening helpers in the remaining tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e994ca70b04e6a61f30e5d4f879de026cb6293e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->