### PR TITLE
Prepare Customize Responses for release

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "502693115b0ec50c6dc895e084a0517147489147550fd9a7ebb4ea9ce279c6d7",
+  "originHash" : "2f384f44754ca0b9e059ae3dd1dece3e0881e650e53a18ee0b74ac13920ac2cc",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "dc9b1280951a22359aac33d07ffd410cbbae2b94",
-        "version" : "15.12.0"
+        "revision" : "936928ce6fe44d6606ba9045be619250229548f7",
+        "version" : "15.15.0"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Package.resolved
+++ b/SharedPackages/BrowserServicesKit/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "66ba0bff4e08344a78c334bf9440e75badcff6f11c4cf21fca79ea523d5bee24",
+  "originHash" : "36d40913ee25f5ef0948672cd774c0ff9e2223ca520c53f4fc409e26c12dc4d1",
   "pins" : [
     {
       "identity" : "content-scope-scripts",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "dc9b1280951a22359aac33d07ffd410cbbae2b94",
-        "version" : "15.12.0"
+        "revision" : "936928ce6fe44d6606ba9045be619250229548f7",
+        "version" : "15.15.0"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
         .package(url: "https://github.com/1024jp/GzipSwift.git", exact: "6.0.1"),
         .package(url: "https://github.com/vapor/jwt-kit.git", exact: "4.13.5"),
         .package(url: "https://github.com/pointfreeco/swift-clocks.git", exact: "1.0.6"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts.git", exact: "15.12.0"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts.git", exact: "15.15.0"),
         .package(path: "../URLPredictor"),
         .package(path: "../Infrastructure/SystemFrameworksExtensions"),
     ],

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a82b84d0050749991f3ab30c77e8dd1aa6ddcfcf653936c6ec5a3ba870e8b784",
+  "originHash" : "fede6dd91ac46eddbdeab8007da5cdef31a86943829b5e1ea3fc55c418f3e7be",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "dc9b1280951a22359aac33d07ffd410cbbae2b94",
-        "version" : "15.12.0"
+        "revision" : "936928ce6fe44d6606ba9045be619250229548f7",
+        "version" : "15.15.0"
       }
     },
     {

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c53bb11580e953cfbc0e74b3409eccd7a192717611d969f8f543ca9b2b5c29e2",
+  "originHash" : "aa4941bd714f13f54e6a5b9fb9885652f38e98b76482b5435944f6017a0c5cd2",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "dc9b1280951a22359aac33d07ffd410cbbae2b94",
-        "version" : "15.12.0"
+        "revision" : "936928ce6fe44d6606ba9045be619250229548f7",
+        "version" : "15.15.0"
       }
     },
     {

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -748,7 +748,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .aiChatNativeDataAccess:
             Config(source: .remoteReleasable(AIChatSubfeature.nativeDataAccess), category: .duckAI)
         case .aiChatCustomizeResponses:
-            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.customizeResponses), category: .duckAI)
+            Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.customizeResponses), category: .duckAI)
         case .aiFeaturesNativeControls:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.aiFeaturesNativeControls), category: .duckAI)
         case .aiChatNativeVoicePermissionFlow:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1216710738615508?focus=true

### Description

Prepares macOS Customize Responses for release: flips the `aiChatCustomizeResponses` flag default from `.internalOnly` to `.enabled` (still gated by the `customizeResponses` remote subfeature) and bumps content-scope-scripts to 15.15.0.

### Testing Steps
1. macOS, submit a Duck.ai prompt from the omnibar/NTP.
2. Open the Customize Responses modal — it loads and settings persist.

### Impact
Low. Enables Customize Responses more broadly, but still behind the `customizeResponses` remote subfeature; the CSS bump touches shared Duck.ai surfaces (already approved by ship review).

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables a user-facing Duck.ai feature by default (with remote kill switch) and updates shared content-scope scripts that affect privacy/Duck.ai injection on both macOS and iOS.
> 
> **Overview**
> Prepares **macOS Customize Responses** for wider rollout by changing the `aiChatCustomizeResponses` feature flag default from **`.internalOnly`** to **`.enabled`**, while it remains subject to the remote `customizeResponses` subfeature.
> 
> Also upgrades the **`content-scope-scripts`** dependency from **15.12.0** to **15.15.0** in BrowserServicesKit and the iOS/macOS/workspace lockfiles, pulling in updated Duck.ai-related web assets used across platforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25e8439403c621401863fcd27526b7818df33e7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->