### PR TITLE
Show sync code without pairing URL in simplified V2 flow

### DIFF
--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/Internal/ShowQRCodeViewModel.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/Internal/ShowQRCodeViewModel.swift
@@ -25,8 +25,30 @@ struct ShowQRCodeViewModel {
     let codeForDisplayOrPasting: String
     let qrCodeString: String
 
+    var codeForDisplay: String {
+        Self.strippingPairingURL(from: codeForDisplayOrPasting)
+    }
+
     func copy() {
         UIPasteboard.general.string = codeForDisplayOrPasting
+    }
+
+    private static func strippingPairingURL(from code: String) -> String {
+        guard let url = URL(string: code),
+              url.scheme?.hasPrefix("http") == true,
+              let fragment = URLComponents(url: url, resolvingAgainstBaseURL: false)?.fragment else {
+            return code
+        }
+
+        let parameters = fragment
+            .split(separator: "&")
+            .reduce(into: [String: String]()) { result, part in
+                let keyValue = part.split(separator: "=", maxSplits: 1)
+                guard keyValue.count == 2 else { return }
+                result[String(keyValue[0])] = String(keyValue[1])
+            }
+
+        return parameters["code2"] ?? parameters["code"] ?? code
     }
 
 }

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/ScanQRCodeViewV2.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/ScanQRCodeViewV2.swift
@@ -95,7 +95,7 @@ public struct ScanQRCodeViewV2: View {
 
 #if DEBUG
 #Preview {
-    let sampleCode = "eyJyZWNvdmVyeSI6eyJ1c2VyX2lkIjoiNjgwRDQ1QjUtNUU2RS00MzQ3LTlDNDQtQjZGQkU4MEZDNEE3IiwicHJpbWFyeV9rZXkiOiJBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWiJ9fQ=="
+    let sampleCode = "https://duckduckgo.com/sync/pairing/#&code2=eyJ2ZXJzaW9uIjoiMiIsImNoYW5uZWxJZCI6IjY4MEQ0NUI1LTVFNkUtNDM0Ny05QzQ0LUI2RkJFODBGQzRBNyIsInB1YmxpY0tleSI6IkFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaIn0"
 
     return NavigationView {
         RebrandedPreview(isRebranded: true) {
@@ -107,7 +107,7 @@ public struct ScanQRCodeViewV2: View {
 }
 
 #Preview("Enter Code") {
-    let sampleCode = "eyJyZWNvdmVyeSI6eyJ1c2VyX2lkIjoiNjgwRDQ1QjUtNUU2RS00MzQ3LTlDNDQtQjZGQkU4MEZDNEE3IiwicHJpbWFyeV9rZXkiOiJBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWiJ9fQ=="
+    let sampleCode = "https://duckduckgo.com/sync/pairing/#&code2=eyJ2ZXJzaW9uIjoiMiIsImNoYW5uZWxJZCI6IjY4MEQ0NUI1LTVFNkUtNDM0Ny05QzQ0LUI2RkJFODBGQzRBNyIsInB1YmxpY0tleSI6IkFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaIn0"
 
     return NavigationView {
         RebrandedPreview(isRebranded: true) {

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncCodeSheetView.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncCodeSheetView.swift
@@ -80,7 +80,7 @@ struct SyncCodeSheetView: View {
             QRCodeView(string: model.showQRCodeModel.qrCodeString, desiredSize: 320, backgroundColor: SimplifiedSyncStyle.qrCodeBackground, flexible: true)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-            Text(model.showQRCodeModel.codeForDisplayOrPasting)
+            Text(model.showQRCodeModel.codeForDisplay)
                 .font(.system(size: 16, design: .monospaced))
                 .tracking(2)
                 .lineSpacing(8)
@@ -182,7 +182,7 @@ struct SyncCodeSheetView: View {
 
 #if DEBUG
 #Preview {
-    let sampleCode = "eyJyZWNvdmVyeSI6eyJ1c2VyX2lkIjoiNjgwRDQ1QjUtNUU2RS00MzQ3LTlDNDQtQjZGQkU4MEZDNEE3IiwicHJpbWFyeV9rZXkiOiJBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWiJ9fQ=="
+    let sampleCode = "https://duckduckgo.com/sync/pairing/#&code2=eyJ2ZXJzaW9uIjoiMiIsImNoYW5uZWxJZCI6IjY4MEQ0NUI1LTVFNkUtNDM0Ny05QzQ0LUI2RkJFODBGQzRBNyIsInB1YmxpY0tleSI6IkFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaIn0"
 
     return RebrandedPreview(isRebranded: true) {
         SyncCodeSheetView(

--- a/iOS/LocalPackages/SyncUI-iOS/Tests/SyncUI-iOSTests/ScanOrPasteCodeViewModelTests.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Tests/SyncUI-iOSTests/ScanOrPasteCodeViewModelTests.swift
@@ -210,4 +210,40 @@ final class ScanOrPasteCodeViewModelTests {
         // THEN
         #expect(result == false)
     }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Code for display strips the pairing URL and keeps the code2 payload", .timeLimit(.minutes(1)))
+    func codeForDisplayStripsPairingURL() {
+        // GIVEN
+        let payload = "eyJ2ZXJzaW9uIjoiMiJ9"
+        let url = "https://duckduckgo.com/sync/pairing/#&code2=\(payload)"
+        let sut = ScanOrPasteCodeViewModel(codeForDisplayOrPasting: url, qrCodeString: url, source: .connect)
+
+        // THEN
+        #expect(sut.showQRCodeModel.codeForDisplay == payload)
+        #expect(sut.showQRCodeModel.codeForDisplayOrPasting == url)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Code for display strips the pairing URL and keeps the legacy code payload", .timeLimit(.minutes(1)))
+    func codeForDisplayStripsLegacyPairingURL() {
+        // GIVEN
+        let payload = "ABCDEFGHIJ"
+        let url = "https://duckduckgo.com/sync/pairing/#&code=\(payload)&deviceName=iPhone"
+        let sut = ScanOrPasteCodeViewModel(codeForDisplayOrPasting: url, qrCodeString: url, source: .connect)
+
+        // THEN
+        #expect(sut.showQRCodeModel.codeForDisplay == payload)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Code for display returns the code unchanged when it is not a pairing URL", .timeLimit(.minutes(1)))
+    func codeForDisplayReturnsNonURLCodeUnchanged() {
+        // GIVEN
+        let code = "eyJyZWNvdmVyeSI6eyJ1c2VyX2lkIjoiMSJ9fQ=="
+        let sut = ScanOrPasteCodeViewModel(codeForDisplayOrPasting: code, qrCodeString: code, source: .recovery)
+
+        // THEN
+        #expect(sut.showQRCodeModel.codeForDisplay == code)
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214200115953388/task/1216713972367019?focus=true

### Description
On the simplified V2 sync code screen, we now display only the pairing code payload and hide the `https://duckduckgo.com/sync/pairing/...` URL, aligning with Android and Duck.ai. Copy, Share, and the QR code still use the full code, so pairing keeps working. The V1 flow is unchanged.

### Testing Steps
1. Enable the Simplified Sync Setup V2 feature flag.
2. Settings → Sync & Backup → Sync with another device → tap the QR/code screen.
3. The text under the QR code shows only the code, with no `https://duckduckgo.com...` prefix.
4. Tap Copy → paste elsewhere → the full URL-based code is pasted (not the stripped text).
5. Tap Share → the shared code is the full code.

### Impact
Low — display-only change on the V2 sync code screen; the code used for pairing/copy/share/QR is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change on the V2 sync code UI; copy, share, and QR encoding still use the full pairing string.
> 
> **Overview**
> On the simplified V2 sync code sheet, the monospace text under the QR code now shows **only the pairing payload**, not the full `https://duckduckgo.com/sync/pairing/...` string—aligned with Android and Duck.ai.
> 
> `ShowQRCodeViewModel` gains a `codeForDisplay` property that parses HTTP(S) pairing URLs and returns the `code2` or legacy `code` fragment value; non-URL codes are unchanged. **Copy, share, and the QR image still use the full `codeForDisplayOrPasting` value**, so pairing behavior is unchanged.
> 
> Tests cover `code2`, legacy `code`, and raw non-URL codes; SwiftUI previews were updated to use URL-shaped sample codes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86271920089fe7e64d196817b6cf86a8eb69b4ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->