### PR TITLE
iOS: Fix favorites and keyboard appearing after burning a Duck.ai chat (Search-only mode)

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -6632,6 +6632,8 @@ extension MainViewController {
             } else if request.options.contains(.tabs) && KeyboardSettings().onNewTab && !self.isEscapeHatchBurn(request) {
                 // Escape-hatch burns restore focus in `restoreFocusModeAfterBurnIfNeeded`.
                 let showKeyboardAfterFireButton = DispatchWorkItem {
+                    // A burned Duck.ai chat reopens as a new chat that owns its input; don't focus search over it.
+                    guard self.currentTab?.isAITab != true else { return }
                     if !self.aiChatSettings.isAIChatSearchInputUserSettingsEnabled {
                         self.enterSearch()
                     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1216616455652898?focus=true

### Description
When the address bar is set to **Search only**, burning a Duck.ai chat with the fire button was supposed to leave you on a fresh new chat. Instead, the search page's favorites appeared and the keyboard was raised over the (still-collapsed) chat input — an invalid state.

The cause was a legacy "focus the search bar on the new tab after burning" step that only runs in Search-only mode. It was written back when the fire button always dropped you on a search/home page, but burning a Duck.ai chat now opens a new Duck.ai chat instead, so focusing the search bar surfaced its favorites and keyboard on top of the chat.

Burning now skips that search-focus when it lands on a Duck.ai chat, so you get a clean new chat — matching how "Search & Duck.ai" mode already behaves. Burns that land on the search/home page (e.g. clear-all-data) still focus the address bar as before.

### Testing Steps
Preconditions: have at least one favorite saved; in Settings → Appearance, set the address bar to **Search only**.
1. Open a Duck.ai chat (Browsing Menu → Duck.ai) and send a message so it's a real chat.
2. Tap the fire button (bottom-left of the chat) → tap **Delete This Chat**.
3. → You land on a fresh Duck.ai new chat ("All chats are private"), with **no favorites** shown and **no keyboard** forced up over the collapsed input.
4. Regression — switch the address bar back to **Search & Duck.ai** and repeat steps 1–2 → same clean new-chat result (unchanged).
5. Regression — on a normal web tab, use the full fire button (Clear Tabs and Data) → you land on the home/search page with the address bar focused (keyboard up), as before.

### Impact
Low — small bug fix to an existing feature; the change is scoped to the fire-button burn path and only alters the case that lands on a Duck.ai chat.

#### What could go wrong?
Post-burn keyboard focus is now skipped for Duck.ai-chat landings → mitigated: the guard only applies when the new tab is a Duck.ai chat; burns that land on the search/home page are unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single guarded early return on an existing post-burn keyboard path; only affects Duck.ai tab landings after fire.
> 
> **Overview**
> Fixes a bad post-burn state in **Search only** address bar mode: burning a Duck.ai chat opens a fresh chat, but the legacy “focus search on new tab after fire” path still ran and raised the keyboard and favorites over the chat.
> 
> The fire-button completion handler now **bails out of `enterSearch()`** when `currentTab` is a Duck.ai tab (`isAITab`), so the new chat keeps its own input focus. Burns that land on the normal home/search tab are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0fbd066951b286aed91ed443af3f674e2ce59db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->