### PR TITLE
Sync V2: Update stop sync and delete data flow

### DIFF
--- a/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -789,9 +789,16 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
 
     func confirmAndDeleteAllData() async -> Bool {
         let deviceCount = viewModel.devices.count
+        if useSimplifiedLayoutV2 {
+            do {
+                try await authenticateUser()
+            } catch {
+                return false
+            }
+        }
         return await withCheckedContinuation { continuation in
-            let alert = UIAlertController(title: UserText.syncDeleteAllConfirmTitle,
-                                          message: UserText.syncDeleteAllConfirmMessage,
+            let alert = UIAlertController(title: useSimplifiedLayoutV2 ? UserText.simplifiedSyncDeleteAllConfirmTitle : UserText.syncDeleteAllConfirmTitle,
+                                          message: useSimplifiedLayoutV2 ? UserText.simplifiedSyncDeleteAllConfirmMessage : UserText.syncDeleteAllConfirmMessage,
                                           preferredStyle: .alert)
             alert.addAction(title: UserText.actionCancel, style: .cancel) {
                 continuation.resume(returning: false)
@@ -803,6 +810,9 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                         Pixel.fire(pixel: .syncDisabledAndDeleted, withAdditionalParameters: [PixelParameters.connectedDevices: "\(deviceCount)"])
                         self?.viewModel.isSyncEnabled = false
                         self?.syncPausedStateManager.syncDidTurnOff()
+                        if self?.useSimplifiedLayoutV2 == true {
+                            ActionMessageView.present(message: UserText.simplifiedSyncDataDeletedToast)
+                        }
                         continuation.resume(returning: true)
                     } catch {
                         await self?.handleError(SyncErrorMessage.unableToDeleteData, error: error, event: .syncDeleteAccountError)

--- a/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -789,13 +789,6 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
 
     func confirmAndDeleteAllData() async -> Bool {
         let deviceCount = viewModel.devices.count
-        if useSimplifiedLayoutV2 {
-            do {
-                try await authenticateUser()
-            } catch {
-                return false
-            }
-        }
         return await withCheckedContinuation { continuation in
             let alert = UIAlertController(title: useSimplifiedLayoutV2 ? UserText.simplifiedSyncDeleteAllConfirmTitle : UserText.syncDeleteAllConfirmTitle,
                                           message: useSimplifiedLayoutV2 ? UserText.simplifiedSyncDeleteAllConfirmMessage : UserText.syncDeleteAllConfirmMessage,

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -1350,6 +1350,9 @@ public struct UserText {
     public static let simplifiedSyncTurnOffAction = NSLocalizedString("sync.simplified.turn.off.action", value: "Turn Off", comment: "Alert button to confirm turning off sync")
     public static let simplifiedRecoveryCodeCopiedToast = NSLocalizedString("sync.simplified.recovery.code.copied.toast", value: "Recovery code copied", comment: "Toast message shown after copying recovery code to clipboard from settings")
     public static let simplifiedSyncSetupFailedToast = NSLocalizedString("sync.simplified.setup.failed.toast", value: "Couldn't enable Sync & Backup", comment: "Toast message shown when sync setup fails")
+    public static let simplifiedSyncDeleteAllConfirmTitle = NotLocalizedString("sync.simplified.delete.all.confirm.title", value: "Turn Off Sync & Backup and Delete Server Data?", comment: "Title of the dialog to confirm turning off sync and deleting server data")
+    public static let simplifiedSyncDeleteAllConfirmMessage = NotLocalizedString("sync.simplified.delete.all.confirm.message", value: "All devices using Sync & Backup will be disconnected and your synced data will be deleted from the server.", comment: "Message for the dialog to confirm turning off sync and deleting server data")
+    public static let simplifiedSyncDataDeletedToast = NotLocalizedString("sync.simplified.data-deleted.toast", value: "Server Data Deleted", comment: "Toast message shown after synced server data is deleted")
 
     // MARK: Sync Errors
     static let syncLimitExceededTitle = NSLocalizedString("prefrences.sync.limit-exceeded-title", value: "Sync Paused", comment: "Title for sync limits exceeded warning")

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/SyncSettingsViewModel.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/SyncSettingsViewModel.swift
@@ -287,13 +287,16 @@ public class SyncSettingsViewModel: ObservableObject {
         delegate?.fireAutoRestorePixel(event: .manualRecoveryShown)
     }
 
-    func deleteAllData() {
+    func deleteAllData(requireAuthentication: Bool = false) {
         isBusy = true
         Task { @MainActor in
+            defer { isBusy = false }
+            if requireAuthentication {
+                guard await commonAuthenticate() else { return }
+            }
             if await delegate!.confirmAndDeleteAllData() {
                 isSyncEnabled = false
             }
-            isBusy = false
         }
     }
 

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SimplifiedSyncSettingsViewV2.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SimplifiedSyncSettingsViewV2.swift
@@ -607,7 +607,7 @@ extension SimplifiedSyncSettingsViewV2 {
     var deleteSection: some View {
         Section {
             Button(role: .destructive) {
-                model.deleteAllData()
+                model.deleteAllData(requireAuthentication: true)
             } label: {
                 Text(UserText.simplifiedDeleteSyncDataButton)
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214200115953388/task/1216032144580435?focus=true

### Description
Updates the "turn off sync and delete server data" flow in the simplified Sync V2 settings. The confirmation alert now uses the new copy, requires device authentication (Face ID / passcode) before showing, and a "Server Data Deleted" toast is presented after deletion succeeds. The legacy (V1) flow is unchanged.

### Testing Steps
1. Enable the `simplifiedSyncSetupV2` feature flag and set up Sync & Backup.
2. Open Sync & Backup settings → tap **Turn Off Sync and Delete Server Data**.
3. Device authentication prompt appears → authenticate → confirmation alert shows the new title/message.
4. Tap **Delete Server Data** → sync turns off and the **Server Data Deleted** toast appears.
5. Cancel/fail authentication → nothing happens, no alert shown.

### Impact
Medium

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Destructive sync account deletion with new gating and copy; server wipe behavior is unchanged but user-facing safeguards and messaging differ for V2 only.
> 
> **Overview**
> Updates the **Simplified Sync V2** “turn off and delete server data” path while leaving the legacy flow on the existing strings and no pre-confirmation auth.
> 
> Tapping delete in `SimplifiedSyncSettingsViewV2` now runs **Face ID / passcode** via `deleteAllData(requireAuthentication: true)` before the system confirmation alert. The alert uses new **Sync & Backup** title and body when `useSimplifiedLayoutV2` is on; V1 still uses the prior `syncDeleteAllConfirm*` copy.
> 
> After a successful `deleteAccount()`, V2 shows a **“Server Data Deleted”** toast. `deleteAllData` also clears `isBusy` with `defer` so it resets if auth is cancelled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4691c9bdcefc6ee2b4eccab628605d3904b2210e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->