### PR TITLE
Make bookmarks manager sidebar resizable

### DIFF
--- a/macOS/DuckDuckGo/Bookmarks/View/BookmarkManagementSplitViewController.swift
+++ b/macOS/DuckDuckGo/Bookmarks/View/BookmarkManagementSplitViewController.swift
@@ -25,6 +25,15 @@ final class BookmarkManagementSplitViewController: NSSplitViewController {
     private let pinningManager: PinningManager
     weak var delegate: BrowserTabSelectionDelegate?
 
+    private static let minimumSidebarWidth: CGFloat = 150
+    private static let maximumSidebarWidth: CGFloat = 400
+    private static let defaultSidebarWidth: CGFloat = 320
+
+    /// Drives the sidebar width. `NSSplitViewController` is Auto-Layout based, so the divider position set by
+    /// dragging is otherwise overridden by constraints. We own this constraint and update it from the drag
+    /// delegate so the sidebar actually resizes.
+    private var sidebarWidthConstraint: NSLayoutConstraint?
+
     lazy var sidebarViewController: BookmarkManagementSidebarViewController = BookmarkManagementSidebarViewController(bookmarkManager: bookmarkManager, dragDropManager: dragDropManager)
     lazy var detailViewController: BookmarkManagementDetailViewController = BookmarkManagementDetailViewController(bookmarkManager: bookmarkManager, dragDropManager: dragDropManager, pinningManager: pinningManager)
 
@@ -56,15 +65,16 @@ final class BookmarkManagementSplitViewController: NSSplitViewController {
         splitView.setValue(NSColor.divider, forKey: #keyPath(NSSplitView.dividerColor))
 
         let sidebarViewItem = NSSplitViewItem(contentListWithViewController: sidebarViewController)
-        sidebarViewItem.minimumThickness = 128
-        sidebarViewItem.maximumThickness = 256
-        sidebarViewItem.holdingPriority = .defaultLow
+        sidebarViewItem.minimumThickness = Self.minimumSidebarWidth
+        sidebarViewItem.maximumThickness = Self.maximumSidebarWidth
+        // Sidebar holds its (draggable) width; the detail pane absorbs the remaining space.
+        sidebarViewItem.holdingPriority = .defaultHigh
 
         addSplitViewItem(sidebarViewItem)
 
         let detailViewItem = NSSplitViewItem(viewController: detailViewController)
         detailViewItem.minimumThickness = 415
-        detailViewItem.holdingPriority = .dragThatCannotResizeWindow
+        detailViewItem.holdingPriority = .defaultLow
         addSplitViewItem(detailViewItem)
 
         view = splitView
@@ -75,6 +85,13 @@ final class BookmarkManagementSplitViewController: NSSplitViewController {
 
         sidebarViewController.delegate = self
         detailViewController.delegate = self
+
+        // Just below `.required` so it decisively drives the width over NSSplitViewController's holding-priority
+        // constraints, while still yielding to the required min/max thickness so it can never become unsatisfiable.
+        let widthConstraint = sidebarViewController.view.widthAnchor.constraint(equalToConstant: Self.defaultSidebarWidth)
+        widthConstraint.priority = .init(999)
+        widthConstraint.isActive = true
+        sidebarWidthConstraint = widthConstraint
     }
 
     /// If search bar is focused, make it so that clicking outside of it
@@ -96,13 +113,10 @@ extension BookmarkManagementSplitViewController: BookmarkManagementSidebarViewCo
         delegate?.selectedTabContent(content)
     }
 
-    override func splitView(_ splitView: NSSplitView,
-                            effectiveRect proposedEffectiveRect: NSRect,
-                            forDrawnRect drawnRect: NSRect,
-                            ofDividerAt dividerIndex: Int) -> NSRect {
-        // Prevent drag cursor from appearing on split view divider
-        // From: https://stackoverflow.com/a/9571348
-        return NSRect.zero
+    override func splitView(_ splitView: NSSplitView, constrainSplitPosition proposedPosition: CGFloat, ofSubviewAt dividerIndex: Int) -> CGFloat {
+        let clamped = max(Self.minimumSidebarWidth, min(proposedPosition, Self.maximumSidebarWidth))
+        sidebarWidthConstraint?.constant = clamped
+        return clamped
     }
 
 }

--- a/macOS/DuckDuckGo/Bookmarks/View/BookmarkManagementSplitViewController.swift
+++ b/macOS/DuckDuckGo/Bookmarks/View/BookmarkManagementSplitViewController.swift
@@ -28,11 +28,13 @@ final class BookmarkManagementSplitViewController: NSSplitViewController {
     private static let minimumSidebarWidth: CGFloat = 150
     private static let maximumSidebarWidth: CGFloat = 400
     private static let defaultSidebarWidth: CGFloat = 320
+    private static let minimumDetailWidth: CGFloat = 415
 
-    /// Drives the sidebar width. `NSSplitViewController` is Auto-Layout based, so the divider position set by
-    /// dragging is otherwise overridden by constraints. We own this constraint and update it from the drag
-    /// delegate so the sidebar actually resizes.
+    /// We own the sidebar width; NSSplitViewController's Auto Layout otherwise overrides the dragged divider position.
     private var sidebarWidthConstraint: NSLayoutConstraint?
+
+    /// User's chosen width; the constraint may be clamped smaller on a narrow window and restored when space allows.
+    private lazy var preferredSidebarWidth: CGFloat = Self.defaultSidebarWidth
 
     lazy var sidebarViewController: BookmarkManagementSidebarViewController = BookmarkManagementSidebarViewController(bookmarkManager: bookmarkManager, dragDropManager: dragDropManager)
     lazy var detailViewController: BookmarkManagementDetailViewController = BookmarkManagementDetailViewController(bookmarkManager: bookmarkManager, dragDropManager: dragDropManager, pinningManager: pinningManager)
@@ -67,13 +69,12 @@ final class BookmarkManagementSplitViewController: NSSplitViewController {
         let sidebarViewItem = NSSplitViewItem(contentListWithViewController: sidebarViewController)
         sidebarViewItem.minimumThickness = Self.minimumSidebarWidth
         sidebarViewItem.maximumThickness = Self.maximumSidebarWidth
-        // Sidebar holds its (draggable) width; the detail pane absorbs the remaining space.
         sidebarViewItem.holdingPriority = .defaultHigh
 
         addSplitViewItem(sidebarViewItem)
 
         let detailViewItem = NSSplitViewItem(viewController: detailViewController)
-        detailViewItem.minimumThickness = 415
+        detailViewItem.minimumThickness = Self.minimumDetailWidth
         detailViewItem.holdingPriority = .defaultLow
         addSplitViewItem(detailViewItem)
 
@@ -86,12 +87,25 @@ final class BookmarkManagementSplitViewController: NSSplitViewController {
         sidebarViewController.delegate = self
         detailViewController.delegate = self
 
-        // Just below `.required` so it decisively drives the width over NSSplitViewController's holding-priority
-        // constraints, while still yielding to the required min/max thickness so it can never become unsatisfiable.
+        // Just below `.required`: wins over holding-priority constraints but still yields to the min/max thickness.
         let widthConstraint = sidebarViewController.view.widthAnchor.constraint(equalToConstant: Self.defaultSidebarWidth)
         widthConstraint.priority = .init(999)
         widthConstraint.isActive = true
         sidebarWidthConstraint = widthConstraint
+    }
+
+    override func viewDidLayout() {
+        super.viewDidLayout()
+        guard splitView.bounds.width > 0 else { return }
+        // Re-clamp on resize so the detail pane keeps its minimum; the preferred width returns when space allows.
+        let clamped = max(Self.minimumSidebarWidth, min(preferredSidebarWidth, maxSidebarWidth(in: splitView)))
+        if sidebarWidthConstraint?.constant != clamped {
+            sidebarWidthConstraint?.constant = clamped
+        }
+    }
+
+    private func maxSidebarWidth(in splitView: NSSplitView) -> CGFloat {
+        min(Self.maximumSidebarWidth, splitView.bounds.width - splitView.dividerThickness - Self.minimumDetailWidth)
     }
 
     /// If search bar is focused, make it so that clicking outside of it
@@ -114,7 +128,9 @@ extension BookmarkManagementSplitViewController: BookmarkManagementSidebarViewCo
     }
 
     override func splitView(_ splitView: NSSplitView, constrainSplitPosition proposedPosition: CGFloat, ofSubviewAt dividerIndex: Int) -> CGFloat {
-        let clamped = max(Self.minimumSidebarWidth, min(proposedPosition, Self.maximumSidebarWidth))
+        // Cap so the detail pane keeps its minimum width even on a narrow bookmarks area.
+        let clamped = max(Self.minimumSidebarWidth, min(proposedPosition, maxSidebarWidth(in: splitView)))
+        preferredSidebarWidth = clamped
         sidebarWidthConstraint?.constant = clamped
         return clamped
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1216279836362082?focus=true
Tech Design URL:
CC:

### Description

Makes the bookmarks manager sidebar resizable: the divider can now be dragged to set the sidebar width (150–400pt, default 320pt). It was previously a fixed width.

### Testing Steps
1. Open the bookmarks manager (bookmarks tab / Manage Bookmarks).
2. Drag the divider between the sidebar and the bookmark list — the sidebar resizes.
3. Confirm it stops around 150pt (min) and 400pt (max).

### Impact
Low. UI-only change to the bookmarks manager; no data or privacy impact.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bookmarks manager UI layout only; no data, networking, or security surface changes.
> 
> **Overview**
> **Enables dragging the bookmarks manager split divider** so users can resize the folder sidebar (default **320pt**, range **150–400pt**), replacing a previously non-interactive divider.
> 
> The implementation **owns sidebar width with a high-priority width constraint** and **`constrainSplitPosition`**, updating a stored **preferred width** on drag and **re-clamping in `viewDidLayout`** so the detail pane keeps its **415pt** minimum when the window is narrow. Split item **min/max thickness** and **holding priorities** were adjusted (sidebar **defaultHigh**, detail **defaultLow**) to match the new layout behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5275ae1ed5ef7ca1c158243de9b8e3df31f30b29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->