### PR TITLE
[iOS] Show close button on all tabs + context menu on iPad tabs

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -229,6 +229,7 @@ extension Pixel {
 
         case tabBarTabSelected
         case tabBarTabClosed
+        case tabBarCloseOtherTabs
         case tabBarNewTab
         case tabBarOverflowDaily
         case tabBarOpenTabCountDaily
@@ -2294,6 +2295,7 @@ extension Pixel.Event {
         case .tabBarTabSwitcherOpened: return "m_tab_manager_opened"
         case .tabBarTabSelected: return "m_tab_bar_tab_selected"
         case .tabBarTabClosed: return "m_tab_bar_tab_closed"
+        case .tabBarCloseOtherTabs: return "m_tab_bar_close_other_tabs"
         case .tabBarNewTab: return "m_tab_bar_new_tab"
         case .tabBarOverflowDaily: return "m_tab_bar_overflow_daily"
         case .tabBarOpenTabCountDaily: return "m_tab_bar_open_tab_count_daily"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -2295,7 +2295,7 @@ extension Pixel.Event {
         case .tabBarTabSwitcherOpened: return "m_tab_manager_opened"
         case .tabBarTabSelected: return "m_tab_bar_tab_selected"
         case .tabBarTabClosed: return "m_tab_bar_tab_closed"
-        case .tabBarCloseOtherTabs: return "m_tab_bar_close_other_tabs"
+        case .tabBarCloseOtherTabs: return "tab_bar_close_other_tabs"
         case .tabBarNewTab: return "m_tab_bar_new_tab"
         case .tabBarOverflowDaily: return "m_tab_bar_overflow_daily"
         case .tabBarOpenTabCountDaily: return "m_tab_bar_open_tab_count_daily"

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -6346,6 +6346,11 @@ extension MainViewController: TabSwitcherDelegate {
     }
 
     func tabSwitcher(_ tabSwitcher: TabSwitcherViewController, willCloseTabs tabs: [Tab]) {
+        notifyTabsWillClose(tabs)
+    }
+
+    /// Per-tab close side effects `bulkRemoveTabs` skips: Duck.ai generation instrumentation + (18.4+) web-extension close events.
+    func notifyTabsWillClose(_ tabs: [Tab]) {
         for tab in tabs {
             reportDuckAITabClosedIfNeeded(tab)
         }

--- a/iOS/DuckDuckGo/TabsBarCell.swift
+++ b/iOS/DuckDuckGo/TabsBarCell.swift
@@ -209,10 +209,10 @@ class TabsBarCell: UICollectionViewCell {
             separatorView.backgroundColor = theme.tabsBarSeparatorColor
         }
 
-        labelRemoveButtonConstraint?.isActive = isCurrent
+        labelRemoveButtonConstraint?.isActive = true
         separatorView.isHidden = isCurrent || isNextCurrent
-        removeButton.isHidden = !isCurrent
-        
+        removeButton.isHidden = false
+
         applyModel(model)
     }
 

--- a/iOS/DuckDuckGo/TabsBarCell.swift
+++ b/iOS/DuckDuckGo/TabsBarCell.swift
@@ -26,9 +26,9 @@ import UIComponents
 class TabsBarCell: UICollectionViewCell {
 
     static let reuseIdentifier = "Tab"
+    static let cornerRadius: CGFloat = 12
 
     private enum Constants {
-        static let cornerRadius: CGFloat = 12
         static let faviconCornerRadius: CGFloat = 4
         static let faviconSize: CGFloat = 16
         static let faviconContainerWidth: CGFloat = 24
@@ -80,7 +80,7 @@ class TabsBarCell: UICollectionViewCell {
         contentView.clipsToBounds = true
 
         topBackgroundView.translatesAutoresizingMaskIntoConstraints = false
-        topBackgroundView.layer.cornerRadius = Constants.cornerRadius
+        topBackgroundView.layer.cornerRadius = Self.cornerRadius
 
         bottomBackgroundView.translatesAutoresizingMaskIntoConstraints = false
 

--- a/iOS/DuckDuckGo/TabsBarCell.swift
+++ b/iOS/DuckDuckGo/TabsBarCell.swift
@@ -64,6 +64,9 @@ class TabsBarCell: UICollectionViewCell {
     private weak var model: Tab?
     private var isFireModeEnabled = false
 
+    private var hidesCloseButtonUntilHover = false
+    private var isPointerHovering = false
+
     override init(frame: CGRect) {
         super.init(frame: frame)
 
@@ -73,6 +76,11 @@ class TabsBarCell: UICollectionViewCell {
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        isPointerHovering = false
     }
 
     private func setUpSubviews() {
@@ -117,6 +125,7 @@ class TabsBarCell: UICollectionViewCell {
         contentView.addSubview(separatorView)
         contentView.addSubview(removeButton)
         contentView.addInteraction(UIPointerInteraction(delegate: self))
+        contentView.addGestureRecognizer(UIHoverGestureRecognizer(target: self, action: #selector(handleHover)))
 
         let titleTrailingConstraint = contentView.trailingAnchor.constraint(equalTo: titleStackView.trailingAnchor,
                                                                             constant: Constants.titleTrailingInset)
@@ -168,6 +177,14 @@ class TabsBarCell: UICollectionViewCell {
     @objc private func onRemovePressed() {
         onRemove?()
     }
+
+    @objc private func handleHover(_ recognizer: UIHoverGestureRecognizer) {
+        let hovering = recognizer.state == .began || recognizer.state == .changed
+        guard hovering != isPointerHovering else { return }
+        isPointerHovering = hovering
+        updateCloseButtonVisibility()
+        UIView.animate(withDuration: 0.15) { self.contentView.layoutIfNeeded() }
+    }
     
     override func layoutSubviews() {
         super.layoutSubviews()
@@ -189,26 +206,24 @@ class TabsBarCell: UICollectionViewCell {
     func update(model: Tab,
                 isCurrent: Bool,
                 isNextCurrent: Bool,
+                hidesInactiveCloseButton: Bool,
                 isFireModeEnabled: Bool,
                 withTheme theme: Theme) {
         accessibilityElements = [label, removeButton]
-        
+
         self.model?.removeObserver(self)
-        
+
         self.model = model
         self.isFireModeEnabled = isFireModeEnabled
         model.addObserver(self)
 
         label.primaryColor = theme.barTintColor
-        applyCurrentStyle(isCurrent: isCurrent, isNextCurrent: isNextCurrent, withTheme: theme)
-
-        labelRemoveButtonConstraint?.isActive = true
-        removeButton.isHidden = false
+        applyCurrentStyle(isCurrent: isCurrent, isNextCurrent: isNextCurrent, hidesInactiveCloseButton: hidesInactiveCloseButton, withTheme: theme)
 
         applyModel(model)
     }
 
-    func applyCurrentStyle(isCurrent: Bool, isNextCurrent: Bool, withTheme theme: Theme) {
+    func applyCurrentStyle(isCurrent: Bool, isNextCurrent: Bool, hidesInactiveCloseButton: Bool, withTheme theme: Theme) {
         if isCurrent {
             topBackgroundView.backgroundColor = theme.omniBarBackgroundColor
             bottomBackgroundView.backgroundColor = theme.omniBarBackgroundColor
@@ -218,6 +233,16 @@ class TabsBarCell: UICollectionViewCell {
             separatorView.backgroundColor = theme.tabsBarSeparatorColor
         }
         separatorView.isHidden = isCurrent || isNextCurrent
+
+        hidesCloseButtonUntilHover = hidesInactiveCloseButton && !isCurrent
+        updateCloseButtonVisibility()
+    }
+
+    /// Shows the close button unless the strip is overflowing and this inactive tab isn't hovered by a pointer.
+    private func updateCloseButtonVisibility() {
+        let showsCloseButton = !hidesCloseButtonUntilHover || isPointerHovering
+        removeButton.isHidden = !showsCloseButton
+        labelRemoveButtonConstraint?.isActive = showsCloseButton
     }
 
     /// Configures the cell to render without a backing `Tab`.
@@ -299,5 +324,5 @@ extension TabsBarCell: UIPointerInteractionDelegate {
     func pointerInteraction(_ interaction: UIPointerInteraction, styleFor region: UIPointerRegion) -> UIPointerStyle? {
         return .init(effect: .highlight(.init(view: contentView)))
     }
-    
+
 }

--- a/iOS/DuckDuckGo/TabsBarCell.swift
+++ b/iOS/DuckDuckGo/TabsBarCell.swift
@@ -200,6 +200,15 @@ class TabsBarCell: UICollectionViewCell {
         model.addObserver(self)
 
         label.primaryColor = theme.barTintColor
+        applyCurrentStyle(isCurrent: isCurrent, isNextCurrent: isNextCurrent, withTheme: theme)
+
+        labelRemoveButtonConstraint?.isActive = true
+        removeButton.isHidden = false
+
+        applyModel(model)
+    }
+
+    func applyCurrentStyle(isCurrent: Bool, isNextCurrent: Bool, withTheme theme: Theme) {
         if isCurrent {
             topBackgroundView.backgroundColor = theme.omniBarBackgroundColor
             bottomBackgroundView.backgroundColor = theme.omniBarBackgroundColor
@@ -208,12 +217,7 @@ class TabsBarCell: UICollectionViewCell {
             bottomBackgroundView.backgroundColor = .clear
             separatorView.backgroundColor = theme.tabsBarSeparatorColor
         }
-
-        labelRemoveButtonConstraint?.isActive = true
         separatorView.isHidden = isCurrent || isNextCurrent
-        removeButton.isHidden = false
-
-        applyModel(model)
     }
 
     /// Configures the cell to render without a backing `Tab`.

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -571,10 +571,48 @@ extension TabsBarViewController: UICollectionViewDelegate {
         guard tabsModel?.get(tabAt: indexPath.row) != nil else { return nil }
         // No select-before-menu: selecting reloads and recycles the cell UIKit is lifting for the preview,
         // producing a stale preview. UIKit lifts the real cell as-is and escalates a continued drag into
-        // the reorder.
-        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
+        // the reorder. The row is tagged so the preview can be shaped to the pressed cell (below).
+        return UIContextMenuConfiguration(identifier: NSNumber(value: indexPath.row), previewProvider: nil) { [weak self] _ in
             self?.makeTabContextMenu(forTabAt: indexPath.row)
         }
+    }
+
+    func collectionView(_ collectionView: UICollectionView,
+                        previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+        return tabMenuPreview(for: configuration)
+    }
+
+    func collectionView(_ collectionView: UICollectionView,
+                        previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+        return tabMenuPreview(for: configuration)
+    }
+
+    /// Shapes the tab menu's lift to the tab's rounded-top / flush-bottom outline (only the top corners are
+    /// rounded), instead of UIKit's default all-corners-rounded platter.
+    private func tabMenuPreview(for configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+        guard let row = (configuration.identifier as? NSNumber)?.intValue,
+              let cell = collectionView.cellForItem(at: IndexPath(item: row, section: 0)) else {
+            return nil
+        }
+        let parameters = UIPreviewParameters()
+        applyTabLiftStyle(to: parameters, cell: cell, backgroundColor: tabLiftBackgroundColor)
+        return UITargetedPreview(view: cell, parameters: parameters)
+    }
+
+    /// Half-opaque tab colour for lift previews, so an inactive tab (clear cell background) still reads as a
+    /// card rather than transparent.
+    private var tabLiftBackgroundColor: UIColor {
+        ThemeManager.shared.currentTheme.omniBarBackgroundColor.withAlphaComponent(0.5)
+    }
+
+    /// Shared preview styling: the tab outline (rounded top, flush bottom) and no shadow. Caller picks the
+    /// background (half-opaque for the lift, clear for the drop-into-place preview).
+    private func applyTabLiftStyle(to parameters: UIPreviewParameters, cell: UICollectionViewCell, backgroundColor: UIColor) {
+        parameters.backgroundColor = backgroundColor
+        parameters.visiblePath = UIBezierPath(roundedRect: cell.bounds,
+                                              byRoundingCorners: [.topLeft, .topRight],
+                                              cornerRadii: CGSize(width: TabsBarCell.cornerRadius, height: TabsBarCell.cornerRadius))
+        parameters.shadowPath = UIBezierPath()
     }
 
 }
@@ -594,16 +632,13 @@ extension TabsBarViewController: UICollectionViewDragDelegate {
     }
 
     func collectionView(_ collectionView: UICollectionView, dragPreviewParametersForItemAt indexPath: IndexPath) -> UIDragPreviewParameters? {
-        return tabDragPreviewParameters(at: indexPath)
+        return tabDragPreviewParameters(at: indexPath, backgroundColor: tabLiftBackgroundColor)
     }
 
-    /// Clips the lifted-tab preview to the tab corner radius (clear background) so an inactive tab lifts as
-    /// a rounded shape with no square white corners.
-    private func tabDragPreviewParameters(at indexPath: IndexPath) -> UIDragPreviewParameters? {
+    private func tabDragPreviewParameters(at indexPath: IndexPath, backgroundColor: UIColor) -> UIDragPreviewParameters? {
         guard let cell = collectionView.cellForItem(at: indexPath) else { return nil }
         let parameters = UIDragPreviewParameters()
-        parameters.backgroundColor = .clear
-        parameters.visiblePath = UIBezierPath(roundedRect: cell.bounds, cornerRadius: 12)
+        applyTabLiftStyle(to: parameters, cell: cell, backgroundColor: backgroundColor)
         return parameters
     }
 
@@ -616,7 +651,7 @@ extension TabsBarViewController: UICollectionViewDropDelegate {
     }
 
     func collectionView(_ collectionView: UICollectionView, dropPreviewParametersForItemAt indexPath: IndexPath) -> UIDragPreviewParameters? {
-        return tabDragPreviewParameters(at: indexPath)
+        return tabDragPreviewParameters(at: indexPath, backgroundColor: .clear)
     }
 
     func collectionView(_ collectionView: UICollectionView,

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -32,7 +32,6 @@ protocol TabsBarDelegate: NSObjectProtocol {
     func tabsBar(_ controller: TabsBarViewController, didSelectTabAtIndex index: Int)
     func tabsBar(_ controller: TabsBarViewController, didRemoveTabAtIndex index: Int)
     func tabsBar(_ controller: TabsBarViewController, didRequestCloseOtherTabsForTabAtIndex index: Int)
-    func tabsBar(_ controller: TabsBarViewController, didRequestMoveTabFromIndex fromIndex: Int, toIndex: Int)
     func tabsBarDidRequestNewTab(_ controller: TabsBarViewController)
     func tabsBarDidRequestForgetAll(_ controller: TabsBarViewController, fireRequest: FireRequest)
     func tabsBarDidRequestFireEducationDialog(_ controller: TabsBarViewController)
@@ -629,16 +628,16 @@ extension TabsBarViewController: UICollectionViewDropDelegate {
     func collectionView(_ collectionView: UICollectionView, performDropWith coordinator: UICollectionViewDropCoordinator) {
         guard let item = coordinator.items.first,
               let sourceIndexPath = item.sourceIndexPath,
-              let destinationIndexPath = coordinator.destinationIndexPath else { return }
-        // Move the model and the cell together in one batch so the reorder is consistent with UIKit's drop.
-        // Reload in the completion (after the drop settles) to refresh current-tab styling; reloading
-        // immediately was reverted by the drop teardown.
-        collectionView.performBatchUpdates({
-            self.delegate?.tabsBar(self, didRequestMoveTabFromIndex: sourceIndexPath.row, toIndex: destinationIndexPath.row)
+              let destinationIndexPath = coordinator.destinationIndexPath,
+              let tabsModel,
+              let tab = tabsModel.get(tabAt: sourceIndexPath.row) else { return }
+        // Reorder the model and the cell together. No select or reload here: reordering doesn't change which
+        // tab is current, and moveItem carries each cell's styling to its new slot. A reload inside a batch
+        // update asserts, and moving the model up front keeps the cell move from running on a stale model.
+        collectionView.performBatchUpdates {
+            tabsModel.move(tab: tab, to: destinationIndexPath.row)
             collectionView.moveItem(at: sourceIndexPath, to: destinationIndexPath)
-        }, completion: { [weak self] _ in
-            self?.reloadData()
-        })
+        }
         coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
     }
 
@@ -794,15 +793,6 @@ extension MainViewController: TabsBarDelegate {
         present(alert, animated: true)
     }
 
-    func tabsBar(_ controller: TabsBarViewController, didRequestMoveTabFromIndex fromIndex: Int, toIndex: Int) {
-        let tabsModel = tabManager.currentTabsModel
-        guard let tab = tabsModel.get(tabAt: fromIndex) else {
-            return
-        }
-        tabsModel.move(tab: tab, to: toIndex)
-        selectTab(tab)
-    }
-    
     func tabsBarDidRequestNewTab(_ controller: TabsBarViewController) {
         newTab()
     }

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -658,6 +658,17 @@ extension TabsBarViewController: UICollectionViewDataSource {
             guard let self = self, let model = model,
                 let tabIndex = self.tabsModel?.indexOf(tab: model)
                 else { return }
+
+            // Failsafe: if the tab isn't fully in view, only scroll it into view, don't close a tab
+            // the user can't fully see. A second tap, once it's visible, closes it.
+            let indexPath = IndexPath(item: tabIndex, section: 0)
+            let visibleRect = CGRect(origin: self.collectionView.contentOffset, size: self.collectionView.bounds.size)
+            if let attributes = self.collectionView.layoutAttributesForItem(at: indexPath),
+               !visibleRect.contains(attributes.frame) {
+                self.collectionView.scrollToItem(at: indexPath, at: [], animated: true)
+                return
+            }
+
             let tabState = tabIndex == self.currentIndex ? "active" : "inactive"
             DailyPixel.fireDailyAndCount(pixel: .tabBarTabClosed, withAdditionalParameters: [PixelParameters.tabState: tabState])
             self.delegate?.tabsBar(self, didRemoveTabAtIndex: tabIndex)

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -472,7 +472,9 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
 
     private func configureGestures() {
         longPressTabGesture.addTarget(self, action: #selector(handleLongPressTabGesture))
-        longPressTabGesture.minimumPressDuration = 0.1
+        // Long enough that a swipe moves past the gesture's slop and fails it (so the strip scrolls),
+        // short enough to still precede the context menu's own long-press.
+        longPressTabGesture.minimumPressDuration = 0.15
         longPressTabGesture.delegate = self
         collectionView.addGestureRecognizer(longPressTabGesture)
 

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -46,7 +46,7 @@ protocol TabsBarDelegate: NSObjectProtocol {
 
 }
 
-class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
+class TabsBarViewController: UIViewController {
 
     public static let viewDidLayoutNotification = Notification.Name("com.duckduckgo.app.TabsBarViewControllerViewDidLayout")
     
@@ -111,28 +111,7 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
 
     private lazy var tabSwitcherButton: TabSwitcherStaticButton = TabSwitcherStaticButton(showMenuOnLongPress: false)
 
-    private let longPressTabGesture = UILongPressGestureRecognizer()
-    /// Long-press / right-click context menu for a tab (Close Tab / Close Other Tabs).
-    private lazy var tabContextMenuInteraction = UIContextMenuInteraction(delegate: self)
     private var cancellables = Set<AnyCancellable>()
-
-    private weak var pressedCell: TabsBarCell?
-    /// Index of the tab under the press, captured when the reorder gesture begins.
-    private var pressedIndexPath: IndexPath?
-    /// Horizontal offset of the touch within the pressed cell, captured at touch-down.
-    private var pressedGrabXInCell: CGFloat?
-
-    /// Whether a tab context menu is presented or being configured.
-    private var isTabMenuActive = false
-    /// Whether a collection-view reload was requested while an interaction deferred it.
-    private var pendingCollectionReload = false
-    /// Whether a reorder or context-menu interaction is in progress.
-    private var isTabInteractionActive: Bool { isTabMenuActive || pressedIndexPath != nil }
-
-    /// Snapshot of the pressed cell shown as the context-menu preview.
-    private var tabMenuPreviewSnapshot: UIView?
-    /// The cell hidden while its snapshot stands in as the menu preview.
-    private weak var tabMenuSourceCell: UICollectionViewCell?
 
     var tabsCount: Int {
         return tabsModel?.count ?? 0
@@ -168,7 +147,6 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
 
         setUpSubviews()
         decorate()
-        configureGestures()
         enableInteractionsWithPointer()
         registerForAIChatSettingsChanges()
     }
@@ -178,6 +156,9 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
         collectionView.clipsToBounds = true
         collectionView.delegate = self
         collectionView.dataSource = self
+        collectionView.dragDelegate = self
+        collectionView.dropDelegate = self
+        collectionView.dragInteractionEnabled = true
         // Prefetching can drop a still-visible cell during a fast scroll and not re-display it
         // (a gap). Prefetching gains are marginal here and on top of that we're not handling it properly (no willDisplay).
         collectionView.isPrefetchingEnabled = false
@@ -411,44 +392,10 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
     }
 
     private func reloadData() {
-        if isTabInteractionActive {
-            pendingCollectionReload = true
-        } else {
-            collectionView.reloadData()
-        }
+        collectionView.reloadData()
         tabSwitcherButton.tabCount = tabsCount
         tabSwitcherButton.isFireMode = (tabManager?.currentBrowsingMode ?? .normal) == .fire
         tabSwitcherButton.hasUnread = hasUnread
-    }
-
-    private func flushPendingReloadIfNeeded() {
-        guard !isTabInteractionActive, pendingCollectionReload else { return }
-        pendingCollectionReload = false
-        collectionView.reloadData()
-    }
-
-    /// willEndFor (the normal cleanup) isn't guaranteed to fire for a configured menu that never commits;
-    /// clearing at the next gesture stops a missed callback from freezing the bar (reloads deferred forever).
-    private func resetTabMenuStateIfNeeded() {
-        guard isTabMenuActive || tabMenuSourceCell != nil || tabMenuPreviewSnapshot != nil else { return }
-        isTabMenuActive = false
-        tabMenuSourceCell?.isHidden = false
-        tabMenuSourceCell = nil
-        tabMenuPreviewSnapshot?.removeFromSuperview()
-        tabMenuPreviewSnapshot = nil
-        flushPendingReloadIfNeeded()
-    }
-
-    /// Repaints selection styling in place so the selected tab shows during a drag/menu while the reload stays deferred.
-    private func restyleVisibleCellsForCurrentSelection() {
-        let theme = ThemeManager.shared.currentTheme
-        let current = currentIndex
-        for indexPath in collectionView.indexPathsForVisibleItems {
-            guard let cell = collectionView.cellForItem(at: indexPath) as? TabsBarCell else { continue }
-            cell.applyCurrentStyle(isCurrent: indexPath.row == current,
-                                   isNextCurrent: indexPath.row + 1 == current,
-                                   withTheme: theme)
-        }
     }
 
     func backgroundTabAdded() {
@@ -461,90 +408,11 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
 
     func reloadCell(for tab: Tab) {
         guard let index = tabsModel?.indexOf(tab: tab) else { return }
-        guard !isTabInteractionActive else {
-            pendingCollectionReload = true
-            return
-        }
         let indexPath = IndexPath(item: index, section: 0)
         guard collectionView.indexPathsForVisibleItems.contains(indexPath) else { return }
         collectionView.reloadItems(at: [indexPath])
     }
 
-    private func configureGestures() {
-        longPressTabGesture.addTarget(self, action: #selector(handleLongPressTabGesture))
-        // Long enough that a swipe moves past the gesture's slop and fails it (so the strip scrolls),
-        // short enough to still precede the context menu's own long-press.
-        longPressTabGesture.minimumPressDuration = 0.15
-        longPressTabGesture.delegate = self
-        collectionView.addGestureRecognizer(longPressTabGesture)
-
-        // addInteraction installs the menu's recognizer; capture it (diff the set) and require the reorder
-        // to fail against it. Reference-based, so no dependency on a private class name.
-        let gesturesBeforeMenu = Set(collectionView.gestureRecognizers ?? [])
-        collectionView.addInteraction(tabContextMenuInteraction)
-        let menuGestures = (collectionView.gestureRecognizers ?? []).filter { !gesturesBeforeMenu.contains($0) }
-        assert(!menuGestures.isEmpty, "Context menu interaction installed no gesture recognizer; reorder/menu arbitration is broken")
-        menuGestures.forEach { longPressTabGesture.require(toFail: $0) }
-    }
-
-    private var offCenterAdjustment: CGFloat = 0
-    @objc func handleLongPressTabGesture(gesture: UILongPressGestureRecognizer) {
-        let locationInCollectionView = gesture.location(in: collectionView)
-        
-        switch gesture.state {
-        case .began:
-            resetTabMenuStateIfNeeded()
-            guard let path = collectionView.indexPathForItem(at: locationInCollectionView) else { return }
-            offCenterAdjustment = 0
-            pressedIndexPath = path
-            delegate?.tabsBar(self, didSelectTabAtIndex: path.row)
-            restyleVisibleCellsForCurrentSelection()
-
-        case .changed:
-            // Reuse the .began index; a fast move may have slid the finger onto a neighbour by now.
-            if pressedCell == nil, let path = pressedIndexPath,
-               let cell = collectionView.cellForItem(at: path) as? TabsBarCell {
-                offCenterAdjustment = cell.bounds.midX - (pressedGrabXInCell ?? gesture.location(in: cell).x)
-                cell.isPressed = true
-                pressedCell = cell
-                collectionView.beginInteractiveMovementForItem(at: path)
-            }
-
-            let location = CGPoint(x: locationInCollectionView.x + offCenterAdjustment, y: collectionView.center.y)
-            collectionView.updateInteractiveMovementTargetPosition(location)
-            
-        case .ended:
-            collectionView.endInteractiveMovement()
-            releasePressedCell()
-
-        default:
-            collectionView.cancelInteractiveMovement()
-            releasePressedCell()
-        }
-    }
-
-    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-        guard let path = collectionView.indexPathForItem(at: touch.location(in: collectionView)),
-              let cell = collectionView.cellForItem(at: path) as? TabsBarCell else {
-            pressedGrabXInCell = nil
-            return true
-        }
-
-        // Capture the grab point now (touch-down), before require(toFail:) delays the drag start.
-        pressedGrabXInCell = touch.location(in: cell).x
-
-        // Don't recognize if pressing delete button
-        return cell.removeButton.hitTest(touch.location(in: cell.removeButton), with: nil) == nil
-    }
-
-    private func releasePressedCell() {
-        pressedCell?.isPressed = false
-        pressedCell = nil
-        pressedIndexPath = nil
-        pressedGrabXInCell = nil
-        flushPendingReloadIfNeeded()
-    }
-    
     private func enableInteractionsWithPointer() {
         fireButton.isPointerInteractionEnabled = true
         addTabButton.isPointerInteractionEnabled = true
@@ -657,70 +525,13 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
 
 extension TabsBarViewController: UIContextMenuInteractionDelegate {
 
+    // Serves the Duck.ai chip's own interaction; the tab menu now uses the collection view's built-in
+    // contextMenuConfigurationForItemAt (see UICollectionViewDelegate).
     func contextMenuInteraction(_ interaction: UIContextMenuInteraction,
                                 configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
-        if interaction === tabContextMenuInteraction {
-            guard let indexPath = collectionView.indexPathForItem(at: location),
-                  tabsModel?.get(tabAt: indexPath.row) != nil else { return nil }
-            resetTabMenuStateIfNeeded()
-            // Set before selecting so the select's reload defers instead of recycling the previewed cell.
-            isTabMenuActive = true
-            delegate?.tabsBar(self, didSelectTabAtIndex: indexPath.row)
-            restyleVisibleCellsForCurrentSelection()
-            return UIContextMenuConfiguration(identifier: NSNumber(value: indexPath.row), previewProvider: nil) { [weak self] _ in
-                self?.makeTabContextMenu(forTabAt: indexPath.row)
-            }
-        }
         return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
             self?.makeAIChatChipMenu()
         }
-    }
-
-    func contextMenuInteraction(_ interaction: UIContextMenuInteraction,
-                                previewForHighlightingMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
-        return tabMenuTargetedPreview(for: interaction, configuration: configuration)
-    }
-
-    func contextMenuInteraction(_ interaction: UIContextMenuInteraction,
-                                willEndFor configuration: UIContextMenuConfiguration,
-                                animator: UIContextMenuInteractionAnimating?) {
-        guard interaction === tabContextMenuInteraction else { return }
-        isTabMenuActive = false
-        // No dismissing preview is implemented, so the system reuses the highlight preview; clean up after it settles.
-        let snapshot = tabMenuPreviewSnapshot
-        let sourceCell = tabMenuSourceCell
-        tabMenuPreviewSnapshot = nil
-        tabMenuSourceCell = nil
-        let cleanup = { [weak self] in
-            snapshot?.removeFromSuperview()
-            sourceCell?.isHidden = false
-            self?.flushPendingReloadIfNeeded()
-        }
-        if let animator {
-            animator.addCompletion(cleanup)
-        } else {
-            cleanup()
-        }
-    }
-
-    /// Lifts a snapshot, not the live cell (a reload recycles it) and not nil (that lifts the whole strip). nil for the Duck.ai chip.
-    private func tabMenuTargetedPreview(for interaction: UIContextMenuInteraction,
-                                        configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
-        guard interaction === tabContextMenuInteraction,
-              let row = (configuration.identifier as? NSNumber)?.intValue,
-              let cell = collectionView.cellForItem(at: IndexPath(item: row, section: 0)),
-              let snapshot = cell.snapshotView(afterScreenUpdates: true) else {
-            return nil
-        }
-        snapshot.isUserInteractionEnabled = false
-        snapshot.frame = cell.frame
-        collectionView.addSubview(snapshot)
-        tabMenuPreviewSnapshot = snapshot
-        cell.isHidden = true
-        tabMenuSourceCell = cell
-        let parameters = UIPreviewParameters()
-        parameters.backgroundColor = .clear
-        return UITargetedPreview(view: snapshot, parameters: parameters)
     }
 
 }
@@ -755,17 +566,80 @@ extension TabsBarViewController: UICollectionViewDelegate {
         return true
     }
 
-    func collectionView(_ collectionView: UICollectionView, canMoveItemAt indexPath: IndexPath) -> Bool {
-        return true
+    func collectionView(_ collectionView: UICollectionView,
+                        contextMenuConfigurationForItemAt indexPath: IndexPath,
+                        point: CGPoint) -> UIContextMenuConfiguration? {
+        guard tabsModel?.get(tabAt: indexPath.row) != nil else { return nil }
+        // No select-before-menu: selecting reloads and recycles the cell UIKit is lifting for the preview,
+        // producing a stale preview. UIKit lifts the real cell as-is and escalates a continued drag into
+        // the reorder.
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
+            self?.makeTabContextMenu(forTabAt: indexPath.row)
+        }
     }
 
-    func collectionView(_ collectionView: UICollectionView, targetIndexPathForMoveFromItemAt originalIndexPath: IndexPath,
-                        toProposedIndexPath proposedIndexPath: IndexPath) -> IndexPath {
-        return proposedIndexPath
+}
+
+extension TabsBarViewController: UICollectionViewDragDelegate {
+
+    func collectionView(_ collectionView: UICollectionView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
+        guard tabsModel?.get(tabAt: indexPath.row) != nil else { return [] }
+        // Don't start a reorder drag from the close button.
+        if let cell = collectionView.cellForItem(at: indexPath) as? TabsBarCell,
+           cell.removeButton.bounds.contains(session.location(in: cell.removeButton)) {
+            return []
+        }
+        let item = UIDragItem(itemProvider: NSItemProvider())
+        item.localObject = indexPath
+        return [item]
     }
 
-    func collectionView(_ collectionView: UICollectionView, moveItemAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
-        delegate?.tabsBar(self, didRequestMoveTabFromIndex: sourceIndexPath.row, toIndex: destinationIndexPath.row)
+    func collectionView(_ collectionView: UICollectionView, dragPreviewParametersForItemAt indexPath: IndexPath) -> UIDragPreviewParameters? {
+        return tabDragPreviewParameters(at: indexPath)
+    }
+
+    /// Clips the lifted-tab preview to the tab corner radius (clear background) so an inactive tab lifts as
+    /// a rounded shape with no square white corners.
+    private func tabDragPreviewParameters(at indexPath: IndexPath) -> UIDragPreviewParameters? {
+        guard let cell = collectionView.cellForItem(at: indexPath) else { return nil }
+        let parameters = UIDragPreviewParameters()
+        parameters.backgroundColor = .clear
+        parameters.visiblePath = UIBezierPath(roundedRect: cell.bounds, cornerRadius: 12)
+        return parameters
+    }
+
+}
+
+extension TabsBarViewController: UICollectionViewDropDelegate {
+
+    func collectionView(_ collectionView: UICollectionView, canHandle session: UIDropSession) -> Bool {
+        return session.localDragSession != nil
+    }
+
+    func collectionView(_ collectionView: UICollectionView, dropPreviewParametersForItemAt indexPath: IndexPath) -> UIDragPreviewParameters? {
+        return tabDragPreviewParameters(at: indexPath)
+    }
+
+    func collectionView(_ collectionView: UICollectionView,
+                        dropSessionDidUpdate session: UIDropSession,
+                        withDestinationIndexPath destinationIndexPath: IndexPath?) -> UICollectionViewDropProposal {
+        return UICollectionViewDropProposal(operation: .move, intent: .insertAtDestinationIndexPath)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, performDropWith coordinator: UICollectionViewDropCoordinator) {
+        guard let item = coordinator.items.first,
+              let sourceIndexPath = item.sourceIndexPath,
+              let destinationIndexPath = coordinator.destinationIndexPath else { return }
+        // Move the model and the cell together in one batch so the reorder is consistent with UIKit's drop.
+        // Reload in the completion (after the drop settles) to refresh current-tab styling; reloading
+        // immediately was reverted by the drop teardown.
+        collectionView.performBatchUpdates({
+            self.delegate?.tabsBar(self, didRequestMoveTabFromIndex: sourceIndexPath.row, toIndex: destinationIndexPath.row)
+            collectionView.moveItem(at: sourceIndexPath, to: destinationIndexPath)
+        }, completion: { [weak self] _ in
+            self?.reloadData()
+        })
+        coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
     }
 
 }

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -31,6 +31,7 @@ protocol TabsBarDelegate: NSObjectProtocol {
     
     func tabsBar(_ controller: TabsBarViewController, didSelectTabAtIndex index: Int)
     func tabsBar(_ controller: TabsBarViewController, didRemoveTabAtIndex index: Int)
+    func tabsBar(_ controller: TabsBarViewController, didRequestCloseOtherTabsForTabAtIndex index: Int)
     func tabsBar(_ controller: TabsBarViewController, didRequestMoveTabFromIndex fromIndex: Int, toIndex: Int)
     func tabsBarDidRequestNewTab(_ controller: TabsBarViewController)
     func tabsBarDidRequestForgetAll(_ controller: TabsBarViewController, fireRequest: FireRequest)
@@ -111,9 +112,27 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
     private lazy var tabSwitcherButton: TabSwitcherStaticButton = TabSwitcherStaticButton(showMenuOnLongPress: false)
 
     private let longPressTabGesture = UILongPressGestureRecognizer()
+    /// Long-press / right-click context menu for a tab (Close Tab / Close Other Tabs).
+    private lazy var tabContextMenuInteraction = UIContextMenuInteraction(delegate: self)
     private var cancellables = Set<AnyCancellable>()
-    
+
     private weak var pressedCell: TabsBarCell?
+    /// Index of the tab under the press, captured when the reorder gesture begins.
+    private var pressedIndexPath: IndexPath?
+    /// Horizontal offset of the touch within the pressed cell, captured at touch-down.
+    private var pressedGrabXInCell: CGFloat?
+
+    /// Whether a tab context menu is presented or being configured.
+    private var isTabMenuActive = false
+    /// Whether a collection-view reload was requested while an interaction deferred it.
+    private var pendingCollectionReload = false
+    /// Whether a reorder or context-menu interaction is in progress.
+    private var isTabInteractionActive: Bool { isTabMenuActive || pressedIndexPath != nil }
+
+    /// Snapshot of the pressed cell shown as the context-menu preview.
+    private var tabMenuPreviewSnapshot: UIView?
+    /// The cell hidden while its snapshot stands in as the menu preview.
+    private weak var tabMenuSourceCell: UICollectionViewCell?
 
     var tabsCount: Int {
         return tabsModel?.count ?? 0
@@ -392,10 +411,44 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
     }
 
     private func reloadData() {
-        collectionView.reloadData()
+        if isTabInteractionActive {
+            pendingCollectionReload = true
+        } else {
+            collectionView.reloadData()
+        }
         tabSwitcherButton.tabCount = tabsCount
         tabSwitcherButton.isFireMode = (tabManager?.currentBrowsingMode ?? .normal) == .fire
         tabSwitcherButton.hasUnread = hasUnread
+    }
+
+    private func flushPendingReloadIfNeeded() {
+        guard !isTabInteractionActive, pendingCollectionReload else { return }
+        pendingCollectionReload = false
+        collectionView.reloadData()
+    }
+
+    /// willEndFor (the normal cleanup) isn't guaranteed to fire for a configured menu that never commits;
+    /// clearing at the next gesture stops a missed callback from freezing the bar (reloads deferred forever).
+    private func resetTabMenuStateIfNeeded() {
+        guard isTabMenuActive || tabMenuSourceCell != nil || tabMenuPreviewSnapshot != nil else { return }
+        isTabMenuActive = false
+        tabMenuSourceCell?.isHidden = false
+        tabMenuSourceCell = nil
+        tabMenuPreviewSnapshot?.removeFromSuperview()
+        tabMenuPreviewSnapshot = nil
+        flushPendingReloadIfNeeded()
+    }
+
+    /// Repaints selection styling in place so the selected tab shows during a drag/menu while the reload stays deferred.
+    private func restyleVisibleCellsForCurrentSelection() {
+        let theme = ThemeManager.shared.currentTheme
+        let current = currentIndex
+        for indexPath in collectionView.indexPathsForVisibleItems {
+            guard let cell = collectionView.cellForItem(at: indexPath) as? TabsBarCell else { continue }
+            cell.applyCurrentStyle(isCurrent: indexPath.row == current,
+                                   isNextCurrent: indexPath.row + 1 == current,
+                                   withTheme: theme)
+        }
     }
 
     func backgroundTabAdded() {
@@ -408,6 +461,10 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
 
     func reloadCell(for tab: Tab) {
         guard let index = tabsModel?.indexOf(tab: tab) else { return }
+        guard !isTabInteractionActive else {
+            pendingCollectionReload = true
+            return
+        }
         let indexPath = IndexPath(item: index, section: 0)
         guard collectionView.indexPathsForVisibleItems.contains(indexPath) else { return }
         collectionView.reloadItems(at: [indexPath])
@@ -418,6 +475,14 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
         longPressTabGesture.minimumPressDuration = 0.1
         longPressTabGesture.delegate = self
         collectionView.addGestureRecognizer(longPressTabGesture)
+
+        // addInteraction installs the menu's recognizer; capture it (diff the set) and require the reorder
+        // to fail against it. Reference-based, so no dependency on a private class name.
+        let gesturesBeforeMenu = Set(collectionView.gestureRecognizers ?? [])
+        collectionView.addInteraction(tabContextMenuInteraction)
+        let menuGestures = (collectionView.gestureRecognizers ?? []).filter { !gesturesBeforeMenu.contains($0) }
+        assert(!menuGestures.isEmpty, "Context menu interaction installed no gesture recognizer; reorder/menu arbitration is broken")
+        menuGestures.forEach { longPressTabGesture.require(toFail: $0) }
     }
 
     private var offCenterAdjustment: CGFloat = 0
@@ -426,14 +491,18 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
         
         switch gesture.state {
         case .began:
+            resetTabMenuStateIfNeeded()
             guard let path = collectionView.indexPathForItem(at: locationInCollectionView) else { return }
             offCenterAdjustment = 0
+            pressedIndexPath = path
             delegate?.tabsBar(self, didSelectTabAtIndex: path.row)
+            restyleVisibleCellsForCurrentSelection()
 
         case .changed:
-            guard let path = collectionView.indexPathForItem(at: locationInCollectionView) else { return }
-            if pressedCell == nil, let cell = collectionView.cellForItem(at: path) as? TabsBarCell {
-                offCenterAdjustment = cell.bounds.midX - gesture.location(in: cell).x
+            // Reuse the .began index; a fast move may have slid the finger onto a neighbour by now.
+            if pressedCell == nil, let path = pressedIndexPath,
+               let cell = collectionView.cellForItem(at: path) as? TabsBarCell {
+                offCenterAdjustment = cell.bounds.midX - (pressedGrabXInCell ?? gesture.location(in: cell).x)
                 cell.isPressed = true
                 pressedCell = cell
                 collectionView.beginInteractiveMovementForItem(at: path)
@@ -455,8 +524,12 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         guard let path = collectionView.indexPathForItem(at: touch.location(in: collectionView)),
               let cell = collectionView.cellForItem(at: path) as? TabsBarCell else {
+            pressedGrabXInCell = nil
             return true
         }
+
+        // Capture the grab point now (touch-down), before require(toFail:) delays the drag start.
+        pressedGrabXInCell = touch.location(in: cell).x
 
         // Don't recognize if pressing delete button
         return cell.removeButton.hitTest(touch.location(in: cell.removeButton), with: nil) == nil
@@ -465,6 +538,9 @@ class TabsBarViewController: UIViewController, UIGestureRecognizerDelegate {
     private func releasePressedCell() {
         pressedCell?.isPressed = false
         pressedCell = nil
+        pressedIndexPath = nil
+        pressedGrabXInCell = nil
+        flushPendingReloadIfNeeded()
     }
     
     private func enableInteractionsWithPointer() {
@@ -581,9 +657,68 @@ extension TabsBarViewController: UIContextMenuInteractionDelegate {
 
     func contextMenuInteraction(_ interaction: UIContextMenuInteraction,
                                 configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
-        UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
+        if interaction === tabContextMenuInteraction {
+            guard let indexPath = collectionView.indexPathForItem(at: location),
+                  tabsModel?.get(tabAt: indexPath.row) != nil else { return nil }
+            resetTabMenuStateIfNeeded()
+            // Set before selecting so the select's reload defers instead of recycling the previewed cell.
+            isTabMenuActive = true
+            delegate?.tabsBar(self, didSelectTabAtIndex: indexPath.row)
+            restyleVisibleCellsForCurrentSelection()
+            return UIContextMenuConfiguration(identifier: NSNumber(value: indexPath.row), previewProvider: nil) { [weak self] _ in
+                self?.makeTabContextMenu(forTabAt: indexPath.row)
+            }
+        }
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
             self?.makeAIChatChipMenu()
         }
+    }
+
+    func contextMenuInteraction(_ interaction: UIContextMenuInteraction,
+                                previewForHighlightingMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+        return tabMenuTargetedPreview(for: interaction, configuration: configuration)
+    }
+
+    func contextMenuInteraction(_ interaction: UIContextMenuInteraction,
+                                willEndFor configuration: UIContextMenuConfiguration,
+                                animator: UIContextMenuInteractionAnimating?) {
+        guard interaction === tabContextMenuInteraction else { return }
+        isTabMenuActive = false
+        // No dismissing preview is implemented, so the system reuses the highlight preview; clean up after it settles.
+        let snapshot = tabMenuPreviewSnapshot
+        let sourceCell = tabMenuSourceCell
+        tabMenuPreviewSnapshot = nil
+        tabMenuSourceCell = nil
+        let cleanup = { [weak self] in
+            snapshot?.removeFromSuperview()
+            sourceCell?.isHidden = false
+            self?.flushPendingReloadIfNeeded()
+        }
+        if let animator {
+            animator.addCompletion(cleanup)
+        } else {
+            cleanup()
+        }
+    }
+
+    /// Lifts a snapshot, not the live cell (a reload recycles it) and not nil (that lifts the whole strip). nil for the Duck.ai chip.
+    private func tabMenuTargetedPreview(for interaction: UIContextMenuInteraction,
+                                        configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+        guard interaction === tabContextMenuInteraction,
+              let row = (configuration.identifier as? NSNumber)?.intValue,
+              let cell = collectionView.cellForItem(at: IndexPath(item: row, section: 0)),
+              let snapshot = cell.snapshotView(afterScreenUpdates: true) else {
+            return nil
+        }
+        snapshot.isUserInteractionEnabled = false
+        snapshot.frame = cell.frame
+        collectionView.addSubview(snapshot)
+        tabMenuPreviewSnapshot = snapshot
+        cell.isHidden = true
+        tabMenuSourceCell = cell
+        let parameters = UIPreviewParameters()
+        parameters.backgroundColor = .clear
+        return UITargetedPreview(view: snapshot, parameters: parameters)
     }
 
 }
@@ -630,7 +765,49 @@ extension TabsBarViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, moveItemAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
         delegate?.tabsBar(self, didRequestMoveTabFromIndex: sourceIndexPath.row, toIndex: destinationIndexPath.row)
     }
-    
+
+}
+
+extension TabsBarViewController {
+
+    private func makeTabContextMenu(forTabAt index: Int) -> UIMenu? {
+        guard let tab = tabsModel?.get(tabAt: index) else { return nil }
+
+        let closeTab = UIAction(title: UserText.closeTabs(withCount: 1),
+                                image: DesignSystemImages.Glyphs.Size16.closeOutline,
+                                attributes: .destructive) { [weak self] _ in
+            self?.closeTabFromContextMenu(tab)
+        }
+
+        guard tabsCount > 1 else {
+            return UIMenu(children: [closeTab])
+        }
+
+        let closeOtherTabs = UIAction(title: UserText.tabSwitcherCloseOtherTabs(withCount: 2),
+                                      image: DesignSystemImages.Glyphs.Size16.tabCloseAlt,
+                                      attributes: .destructive) { [weak self] _ in
+            self?.closeOtherTabsFromContextMenu(keeping: tab)
+        }
+
+        return UIMenu(children: [closeTab, closeOtherTabs])
+    }
+
+    private func closeTabFromContextMenu(_ tab: Tab) {
+        guard let index = tabsModel?.indexOf(tab: tab) else { return }
+        closeTab(at: index)
+    }
+
+    private func closeTab(at index: Int) {
+        let tabState = index == currentIndex ? "active" : "inactive"
+        DailyPixel.fireDailyAndCount(pixel: .tabBarTabClosed, withAdditionalParameters: [PixelParameters.tabState: tabState])
+        delegate?.tabsBar(self, didRemoveTabAtIndex: index)
+    }
+
+    private func closeOtherTabsFromContextMenu(keeping tab: Tab) {
+        guard let index = tabsModel?.indexOf(tab: tab) else { return }
+        delegate?.tabsBar(self, didRequestCloseOtherTabsForTabAtIndex: index)
+    }
+
 }
 
 extension TabsBarViewController: UICollectionViewDataSource {
@@ -659,8 +836,7 @@ extension TabsBarViewController: UICollectionViewDataSource {
                 let tabIndex = self.tabsModel?.indexOf(tab: model)
                 else { return }
 
-            // Failsafe: if the tab isn't fully in view, only scroll it into view, don't close a tab
-            // the user can't fully see. A second tap, once it's visible, closes it.
+            // Failsafe: don't close a tab that isn't fully visible; scroll it in first (a second tap closes it).
             let indexPath = IndexPath(item: tabIndex, section: 0)
             let visibleRect = CGRect(origin: self.collectionView.contentOffset, size: self.collectionView.bounds.size)
             if let attributes = self.collectionView.layoutAttributesForItem(at: indexPath),
@@ -669,9 +845,7 @@ extension TabsBarViewController: UICollectionViewDataSource {
                 return
             }
 
-            let tabState = tabIndex == self.currentIndex ? "active" : "inactive"
-            DailyPixel.fireDailyAndCount(pixel: .tabBarTabClosed, withAdditionalParameters: [PixelParameters.tabState: tabState])
-            self.delegate?.tabsBar(self, didRemoveTabAtIndex: tabIndex)
+            self.closeTab(at: tabIndex)
         }
         return cell
     }
@@ -715,7 +889,35 @@ extension MainViewController: TabsBarDelegate {
             closeTab(tab)
         }
     }
-    
+
+    func tabsBar(_ controller: TabsBarViewController, didRequestCloseOtherTabsForTabAtIndex index: Int) {
+        let model = tabManager.currentTabsModel
+        guard let keptTab = model.get(tabAt: index) else { return }
+        let otherTabsCount = model.tabs.count - 1
+        guard otherTabsCount > 0 else { return }
+
+        let alert = UIAlertController(
+            title: UserText.alertTitleCloseOtherTabs(withCount: otherTabsCount),
+            message: UserText.alertMessageCloseOtherTabs(withCount: otherTabsCount),
+            preferredStyle: .alert)
+        alert.addAction(title: UserText.actionCancel, style: .cancel)
+        alert.addAction(title: UserText.closeTabs(withCount: otherTabsCount), style: .destructive) { [weak self] in
+            guard let self else { return }
+            // Recompute live: the tab set can change while the alert is up.
+            let currentModel = self.tabManager.currentTabsModel
+            guard currentModel.tabs.contains(where: { $0 === keptTab }) else { return }
+            let tabsToClose = currentModel.tabs.filter { $0 !== keptTab }
+            guard !tabsToClose.isEmpty else { return }
+            DailyPixel.fireDailyAndCount(pixel: .tabBarCloseOtherTabs)
+            self.tabManager.select(keptTab, dismissCurrent: false)
+            self.notifyTabsWillClose(tabsToClose)
+            self.tabManager.bulkRemoveTabs(tabsToClose)
+            self.tabsBarController?.refresh(tabsModel: self.tabManager.currentTabsModel, scrollToSelected: true)
+            self.updateCurrentTab()
+        }
+        present(alert, animated: true)
+    }
+
     func tabsBar(_ controller: TabsBarViewController, didRequestMoveTabFromIndex fromIndex: Int, toIndex: Int) {
         let tabsModel = tabManager.currentTabsModel
         guard let tab = tabsModel.get(tabAt: fromIndex) else {

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -524,8 +524,7 @@ class TabsBarViewController: UIViewController {
 
 extension TabsBarViewController: UIContextMenuInteractionDelegate {
 
-    // Serves the Duck.ai chip's own interaction; the tab menu now uses the collection view's built-in
-    // contextMenuConfigurationForItemAt (see UICollectionViewDelegate).
+    // Duck.ai chip only; the tab menu uses the collection view's contextMenuConfigurationForItemAt.
     func contextMenuInteraction(_ interaction: UIContextMenuInteraction,
                                 configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
         return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
@@ -569,9 +568,7 @@ extension TabsBarViewController: UICollectionViewDelegate {
                         contextMenuConfigurationForItemAt indexPath: IndexPath,
                         point: CGPoint) -> UIContextMenuConfiguration? {
         guard tabsModel?.get(tabAt: indexPath.row) != nil else { return nil }
-        // No select-before-menu: selecting reloads and recycles the cell UIKit is lifting for the preview,
-        // producing a stale preview. UIKit lifts the real cell as-is and escalates a continued drag into
-        // the reorder. The row is tagged so the preview can be shaped to the pressed cell (below).
+
         return UIContextMenuConfiguration(identifier: NSNumber(value: indexPath.row), previewProvider: nil) { [weak self] _ in
             self?.makeTabContextMenu(forTabAt: indexPath.row)
         }
@@ -587,8 +584,6 @@ extension TabsBarViewController: UICollectionViewDelegate {
         return tabMenuPreview(for: configuration)
     }
 
-    /// Shapes the tab menu's lift to the tab's rounded-top / flush-bottom outline (only the top corners are
-    /// rounded), instead of UIKit's default all-corners-rounded platter.
     private func tabMenuPreview(for configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
         guard let row = (configuration.identifier as? NSNumber)?.intValue,
               let cell = collectionView.cellForItem(at: IndexPath(item: row, section: 0)) else {
@@ -599,14 +594,11 @@ extension TabsBarViewController: UICollectionViewDelegate {
         return UITargetedPreview(view: cell, parameters: parameters)
     }
 
-    /// Half-opaque tab colour for lift previews, so an inactive tab (clear cell background) still reads as a
-    /// card rather than transparent.
+    /// Half-opaque so an inactive tab (clear cell) reads as a card, not transparent, when lifted.
     private var tabLiftBackgroundColor: UIColor {
         ThemeManager.shared.currentTheme.omniBarBackgroundColor.withAlphaComponent(0.5)
     }
 
-    /// Shared preview styling: the tab outline (rounded top, flush bottom) and no shadow. Caller picks the
-    /// background (half-opaque for the lift, clear for the drop-into-place preview).
     private func applyTabLiftStyle(to parameters: UIPreviewParameters, cell: UICollectionViewCell, backgroundColor: UIColor) {
         parameters.backgroundColor = backgroundColor
         parameters.visiblePath = UIBezierPath(roundedRect: cell.bounds,
@@ -666,14 +658,25 @@ extension TabsBarViewController: UICollectionViewDropDelegate {
               let destinationIndexPath = coordinator.destinationIndexPath,
               let tabsModel,
               let tab = tabsModel.get(tabAt: sourceIndexPath.row) else { return }
-        // Reorder the model and the cell together. No select or reload here: reordering doesn't change which
-        // tab is current, and moveItem carries each cell's styling to its new slot. A reload inside a batch
-        // update asserts, and moving the model up front keeps the cell move from running on a stale model.
-        collectionView.performBatchUpdates {
+
+        collectionView.performBatchUpdates({
             tabsModel.move(tab: tab, to: destinationIndexPath.row)
             collectionView.moveItem(at: sourceIndexPath, to: destinationIndexPath)
-        }
+        }, completion: { [weak self] _ in
+            self?.refreshVisibleCellStyles()
+        })
         coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
+    }
+
+    private func refreshVisibleCellStyles() {
+        let theme = ThemeManager.shared.currentTheme
+        let current = currentIndex
+        for indexPath in collectionView.indexPathsForVisibleItems {
+            guard let cell = collectionView.cellForItem(at: indexPath) as? TabsBarCell else { continue }
+            cell.applyCurrentStyle(isCurrent: indexPath.row == current,
+                                   isNextCurrent: indexPath.row + 1 == current,
+                                   withTheme: theme)
+        }
     }
 
 }

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -374,11 +374,17 @@ class TabsBarViewController: UIViewController {
             DailyPixel.fire(pixel: .tabBarOpenTabCountDaily, withAdditionalParameters: ["tab_count": tabCountBucket])
         }
 
-        let availableWidth = collectionView.frame.size.width
-        let itemWidth = (collectionView.collectionViewLayout as? UICollectionViewFlowLayout)?.itemSize.width ?? 0
-        if availableWidth > 0, itemWidth > 0, CGFloat(tabsCount) * itemWidth > availableWidth {
+        if isStripOverflowing {
             DailyPixel.fire(pixel: .tabBarOverflowDaily)
         }
+    }
+
+    /// True when tabs are floored at min width so the strip scrolls. Inactive tabs then hide the close
+    /// button (kept on the active tab, revealed on pointer hover); touch closes the rest via long press.
+    private var isStripOverflowing: Bool {
+        let availableWidth = collectionView.frame.size.width
+        let itemWidth = (collectionView.collectionViewLayout as? UICollectionViewFlowLayout)?.itemSize.width ?? 0
+        return availableWidth > 0 && itemWidth > 0 && CGFloat(tabsCount) * itemWidth > availableWidth
     }
 
     /// Equal share of the strip, capped at `maxWidth` then floored at `minWidth` (floor wins).
@@ -671,10 +677,12 @@ extension TabsBarViewController: UICollectionViewDropDelegate {
     private func refreshVisibleCellStyles() {
         let theme = ThemeManager.shared.currentTheme
         let current = currentIndex
+        let hidesInactiveCloseButton = isStripOverflowing
         for indexPath in collectionView.indexPathsForVisibleItems {
             guard let cell = collectionView.cellForItem(at: indexPath) as? TabsBarCell else { continue }
             cell.applyCurrentStyle(isCurrent: indexPath.row == current,
                                    isNextCurrent: indexPath.row + 1 == current,
+                                   hidesInactiveCloseButton: hidesInactiveCloseButton,
                                    withTheme: theme)
         }
     }
@@ -743,7 +751,7 @@ extension TabsBarViewController: UICollectionViewDataSource {
         let isCurrent = indexPath.row == currentIndex
         let isNextCurrent = indexPath.row + 1 == currentIndex
         let isFireModeEnabled = fireModeCapability?.isFireModeEnabled ?? false
-        cell.update(model: model, isCurrent: isCurrent, isNextCurrent: isNextCurrent, isFireModeEnabled: isFireModeEnabled, withTheme: ThemeManager.shared.currentTheme)
+        cell.update(model: model, isCurrent: isCurrent, isNextCurrent: isNextCurrent, hidesInactiveCloseButton: isStripOverflowing, isFireModeEnabled: isFireModeEnabled, withTheme: ThemeManager.shared.currentTheme)
         cell.onRemove = { [weak self, weak model] in
             guard let self = self, let model = model,
                 let tabIndex = self.tabsModel?.indexOf(tab: model)

--- a/iOS/PixelDefinitions/pixels/definitions/ipad_tabs_bar.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ipad_tabs_bar.json5
@@ -23,6 +23,13 @@
             }
         ]
     },
+    "m_tab_bar_close_other_tabs": {
+        "description": "User confirms 'Close Other Tabs' from the long-press / right-click menu on a tab in the iPad tabs bar, closing every tab except the pressed one.",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
     "m_tab_bar_new_tab": {
         "description": "User opens a new tab via the add-tab button in the iPad tabs bar.",
         "owners": ["dus7"],

--- a/iOS/PixelDefinitions/pixels/definitions/ipad_tabs_bar.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ipad_tabs_bar.json5
@@ -23,7 +23,7 @@
             }
         ]
     },
-    "m_tab_bar_close_other_tabs": {
+    "tab_bar_close_other_tabs": {
         "description": "User confirms 'Close Other Tabs' from the long-press / right-click menu on a tab in the iPad tabs bar, closing every tab except the pressed one.",
         "owners": ["dus7"],
         "triggers": ["other"],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1213573107740572
Tech Design URL:
CC:

### Description
* The close (X) button now shows on every tab, not only the active one, so a background tab can be closed without switching to it first.
* A long-press or right-click on a tab opens a context menu with Close Tab and Close Other Tabs (the latter behind a confirmation alert).
* Tab reordering now uses UIKit collection-view drag-and-drop instead of a custom long-press, so it coexists with scrolling and the context menu natively.
* The menu uses the built-in `contextMenuConfigurationForItemAt` and does not select the tab first (selecting a not-yet-loaded tab reloads and would recycle the previewed cell, showing a stale preview). Opening the menu therefore no longer switches to the tab.

### Testing Steps
1. On iPad, open several tabs so the tabs bar is visible.
2. Verify every tab shows a close (X) button.
3. Tap the X on a background tab, verify it closes without switching to it.
    1. Unless the tab is fully visible, tapping on the (X) should **NOT** close it, but slide it to view.
5. Long-press a tab, verify a menu with Close Tab and Close Other Tabs appears.
6. Choose Close Other Tabs, confirm the alert, verify only the pressed tab remains.
8. Press and hold a tab, then drag to reorder it, verify it moves and drops in the new position. Verify a drag started on the close button does not begin a reorder.
9. Swipe the tabs bar with enough tabs to overflow, verify scrolling works freely.
10. Long-press a not-yet-loaded background tab, verify the menu preview shows the correct tab.

### Impact and Risks
Medium. One of the main UI elements of the iPad, the change could impact scrolling and reordering.

#### What could go wrong?
- Reorder uses `UICollectionViewDragDelegate`/`DropDelegate`. The drop moves the model through the existing move delegate inside a batch update and reloads on completion to refresh order and current-tab styling, so a regression could leave the strip briefly out of sync until the next reload.

### Quality Considerations
—

### Notes to Reviewer
The selection before context menu is displayed (or during reordering) is deliberately removed, since selecting a not yet loaded tab reloaded and recycled the cell UIKit was lifting, producing a stale preview.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Medium Risk**
> Changes tab closing and bulk-remove behavior on iPad plus gesture/menu arbitration; side effects for bulk close are explicitly wired via `notifyTabsWillClose`, but regressions in reorder vs. context menu or tab lifecycle are still possible.
> 
> **Overview**
> Improves the **iPad tabs bar** so background tabs can be closed without switching, adds a tab context menu, and replaces the custom reorder gesture with UIKit drag-and-drop.
> 
> **Close (X) on every tab:** `TabsBarCell` always shows the remove control and keeps active/inactive styling in `applyCurrentStyle`, so inactive tabs can be closed in place.
> 
> **Long-press / right-click menu:** Tabs expose **Close Tab** and **Close Other Tabs** via `contextMenuConfigurationForItemAt` (no select-before-menu, to avoid a stale preview). **Close Other Tabs** is confirmed in `MainViewController`, recomputes which tabs to remove while the alert is visible, fires `tab_bar_close_other_tabs`, and calls `notifyTabsWillClose` before `bulkRemoveTabs` so Duck.ai and web-extension close hooks match single-tab closes.
> 
> **Reorder:** The old long-press interactive movement is removed in favor of `UICollectionView` drag/drop (reorder blocked when starting on the close button; rounded drag preview).
> 
> **Other:** Partially clipped tabs scroll into view on first X tap instead of closing; tab close pixels are centralized in `closeTab(at:)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a29474e010b478c2a26e4c7e3e5f4ce51cdcad7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches primary iPad chrome (close, bulk remove, gesture arbitration between scroll, context menu, and drag-drop); bulk close now depends on `notifyTabsWillClose` for side effects `bulkRemoveTabs` skips.
> 
> **Overview**
> Refines the **iPad tabs bar** so users can close and manage tabs without switching first, with overflow-aware close affordances and native gestures.
> 
> **Close (X):** Inactive tabs can show a close control (not only the active tab). When the strip **overflows** (`isStripOverflowing`), inactive tabs hide the X until **pointer hover**; the active tab keeps its close button. Tapping X on a **partially clipped** tab scrolls it into view first instead of closing.
> 
> **Context menu:** Long-press / right-click uses `contextMenuConfigurationForItemAt` with **Close Tab** and **Close Other Tabs** (no tab select before the menu, to avoid stale previews). **Close Other Tabs** is confirmed in `MainViewController`, recomputes tabs while the alert is visible, fires `tab_bar_close_other_tabs`, and calls **`notifyTabsWillClose`** before `bulkRemoveTabs` so Duck.ai and web-extension close hooks match single-tab closes.
> 
> **Reorder:** Custom long-press interactive movement is removed in favor of **`UICollectionView` drag/drop** (reorder blocked when the drag starts on the close button; shared rounded lift preview with the menu).
> 
> Tab close pixels are centralized in `closeTab(at:)`; overflow daily pixel logic uses the shared `isStripOverflowing` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 732395489c37c6207769252173687748115731b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->