### PR TITLE
[macOS] Disable Click to Load UI test

### DIFF
--- a/macOS/UITests/NavigationProtectionUITests.swift
+++ b/macOS/UITests/NavigationProtectionUITests.swift
@@ -137,6 +137,7 @@ class NavigationProtectionUITests: UITestCase {
     // MARK: - Click-to-Load Social Media Tests
 
     func testNavigationProtection_SocialMediaEmbeds_ShowsClickToLoad() throws {
+        throw XCTSkip("The Click to Load feature is currently disabled.")
         // Navigate to a test page with social media embeds
         let socialTestURL = URL(string: "https://privacy-test-pages.site/privacy-protections/click-to-load/")!
         addressBarTextField.pasteURL(socialTestURL, pressingEnter: true)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1216750297212907?focus=true
Tech Design URL:
CC:

### Description

Disables the Click to Load UI test in NavigationProtectionUITests, as the feature is currently disabled.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Confirm NavigationProtectionUITests pass on CI: https://github.com/duckduckgo/apple-browsers/actions/runs/29827443628

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
None: Internal tooling, documentation

#### What could go wrong?
* Could cause trouble if the feature is re-enabled and we don't re-enable the corresponding test. This could be improved by enabling the test with a mock testing config with the feature enabled, so the test can be run on the feature even when it's disabled in production.

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production impact; the main follow-up risk is forgetting to remove the skip when Click to Load is re-enabled.
> 
> **Overview**
> Skips **`testNavigationProtection_SocialMediaEmbeds_ShowsClickToLoad`** in `NavigationProtectionUITests` by throwing **`XCTSkip`** at the start of the test, with a message that Click to Load is currently disabled in the product.
> 
> The rest of the test body is left in place (same pattern as the skipped Guardian AMP test) so it can be re-enabled when the feature ships again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9b5524d6947e573c9a66672bc81b3fcab62757c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->