### PR TITLE
[macOS][cherry-pick] Duck.ai page-context fixes (#5908)

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextExtractionResolver.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextExtractionResolver.swift
@@ -58,7 +58,7 @@ public struct PageContextExtractionResolver {
 
         let outcome: PageContextExtractionOutcome
         if let pageContext {
-            outcome = pageContext.isEmpty() ? .failure(.emptyContent) : .success
+            outcome = pageContext.content.isEmpty ? .failure(.emptyContent) : .success
         } else {
             outcome = .failure(.deserializeFailed)
         }

--- a/SharedPackages/AIChat/Tests/AIChatTests/PageContextExtractionResolverTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/PageContextExtractionResolverTests.swift
@@ -29,6 +29,10 @@ final class PageContextExtractionResolverTests: XCTestCase {
         AIChatPageContextData(title: "", favicon: [], url: "https://example.com", content: "", truncated: false, fullContentLength: 0)
     }
 
+    private func titleOnlyContext() -> AIChatPageContextData {
+        AIChatPageContextData(title: "Title", favicon: [], url: "https://example.com", content: "", truncated: false, fullContentLength: 0)
+    }
+
     private func time(_ seconds: Double) -> DispatchTime {
         DispatchTime(uptimeNanoseconds: UInt64(seconds * 1_000_000_000))
     }
@@ -76,6 +80,14 @@ final class PageContextExtractionResolverTests: XCTestCase {
         var resolver = PageContextExtractionResolver()
         resolver.requested(trigger: .auto)
         XCTAssertEqual(resolver.resolve(pageContext: emptyContext())?.outcome, .failure(.emptyContent))
+    }
+
+    /// A page title alone (e.g. a page whose content extraction found nothing) is not a
+    /// successful extraction — success must mean actual page content was collected.
+    func testWhenTitledContextHasEmptyContentThenEmptyContentFailure() {
+        var resolver = PageContextExtractionResolver()
+        resolver.requested(trigger: .userRequest)
+        XCTAssertEqual(resolver.resolve(pageContext: titleOnlyContext())?.outcome, .failure(.emptyContent))
     }
 
     func testWhenNilContextThenDeserializeFailedFailure() {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -445,14 +445,18 @@ final class AIChatContextualChatSessionState {
             return
         }
 
+        let context = context.flatMap { $0.contextData.content.isEmpty ? nil : $0 }
+
         guard let context = context else {
             guard shouldProcessNilContextUpdate else {
                 Logger.aiChat.debug("[SessionState] Ignoring nil context update without active collection")
                 return
             }
-            Logger.aiChat.debug("[SessionState] Context collection returned nil - clearing context and downgrading to placeholder")
+            Logger.aiChat.debug("[SessionState] Context collection returned nil/empty - clearing context and downgrading to placeholder")
             latestContext = nil
             chipState = .placeholder
+            // Clear the persistent UTI host chip
+            emit(.deliverPageContext(nil, targets: .utiChip))
             cleanupFlags()
             rebuildViewState()
             return

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -268,6 +268,34 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         XCTAssertEqual(sessionState.chipState, .placeholder)
     }
 
+    /// Navigating to a non-attachable page (e.g. a PDF) clears via a nil update; the persistent
+    /// UTI host chip must be cleared too, or the previous page's context rides the next prompt.
+    func testUpdateContextWithNilDeliversUTIChipClear() {
+        // Given
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        sessionState.updateContext(makeTestContext(title: "Previous Page"))
+
+        var receivedEffect: SheetEffect?
+        sessionState.effects
+            .sink { effect in
+                if case .deliverPageContext = effect {
+                    receivedEffect = effect
+                }
+            }
+            .store(in: &cancellables)
+
+        // When
+        sessionState.updateContext(nil)
+
+        // Then
+        if case .deliverPageContext(let contextData, let targets) = receivedEffect {
+            XCTAssertNil(contextData)
+            XCTAssertTrue(targets.contains(.utiChip))
+        } else {
+            XCTFail("Expected deliverPageContext effect clearing the UTI chip")
+        }
+    }
+
     func testUpdateContextWithIdleNilDoesNotClearManualAttachmentWhenAutoAttachDisabled() {
         mockSettings.isAutomaticContextAttachmentEnabled = false
         let context = makeTestContext(title: "Manually Attached Page")
@@ -282,6 +310,102 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         } else {
             XCTFail("Expected manually attached chip to survive idle nil replay")
         }
+    }
+
+    /// Extraction can return a titled payload with no content; measurement reports it as
+    /// `.emptyContent`, so the attach path must treat it like nil instead of attaching an empty chip.
+    func testWhenUpdateContextHasEmptyContentThenChipDowngradesToPlaceholder() {
+        // Given
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        sessionState.updateContext(makeTestContext(title: "Previous Page"))
+
+        // When
+        sessionState.updateContext(makeTestContext(title: "Titled But Empty", content: ""))
+
+        // Then
+        XCTAssertNil(sessionState.latestContext)
+        XCTAssertEqual(sessionState.chipState, .placeholder)
+    }
+
+    func testWhenUpdateContextHasEmptyContentThenUTIChipClearIsDelivered() {
+        // Given
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+        sessionState.updateContext(makeTestContext(title: "Previous Page"))
+
+        var receivedEffect: SheetEffect?
+        sessionState.effects
+            .sink { effect in
+                if case .deliverPageContext = effect {
+                    receivedEffect = effect
+                }
+            }
+            .store(in: &cancellables)
+
+        // When
+        sessionState.updateContext(makeTestContext(title: "Titled But Empty", content: ""))
+
+        // Then
+        if case .deliverPageContext(let contextData, let targets) = receivedEffect {
+            XCTAssertNil(contextData)
+            XCTAssertTrue(targets.contains(.utiChip))
+        } else {
+            XCTFail("Expected deliverPageContext effect clearing the UTI chip")
+        }
+    }
+
+    func testWhenUpdateContextHasEmptyContentDuringManualAttachThenManualAttachEnds() {
+        // Given
+        sessionState.beginManualAttach()
+
+        // When
+        sessionState.updateContext(makeTestContext(title: "Titled But Empty", content: ""))
+
+        // Then
+        XCTAssertEqual(sessionState.chipState, .placeholder)
+        XCTAssertTrue(mockPixelHandler.manualAttachEnded)
+        XCTAssertFalse(mockPixelHandler.pageContextManuallyAttachedNativeFired)
+    }
+
+    func testWhenIdleEmptyContentArrivesWithAutoAttachDisabledThenManualAttachmentSurvives() {
+        // Given
+        mockSettings.isAutomaticContextAttachmentEnabled = false
+        let context = makeTestContext(title: "Manually Attached Page")
+        sessionState.beginManualAttach()
+        sessionState.updateContext(context)
+
+        // When
+        sessionState.updateContext(makeTestContext(title: "Titled But Empty", content: ""))
+
+        // Then
+        XCTAssertEqual(sessionState.latestContext?.title, context.title)
+        if case .attached(let attachedContext) = sessionState.chipState {
+            XCTAssertEqual(attachedContext.title, context.title)
+        } else {
+            XCTFail("Expected manually attached chip to survive idle empty-content replay")
+        }
+    }
+
+    /// Signals-only payloads strip content anyway, so an empty-content result must still deliver
+    /// its page-type signals to the frontend (page shortcuts / suggested prompts).
+    func testWhenSignalsOnlyCollectionReturnsEmptyContentThenSignalsPayloadStillDelivered() {
+        // Given
+        let signals = AIChatPageTypeSignals(jsonLdType: ["Recipe"], ogType: "article", lang: "eu")
+        var deliveredPayload: AIChatPageContextData?
+        sessionState.effects
+            .sink { effect in
+                if case .deliverPageContext(let payload, let targets) = effect, targets.contains(.frontendBridge) {
+                    deliveredPayload = payload
+                }
+            }
+            .store(in: &cancellables)
+
+        // When
+        sessionState.markPendingSignalsOnlyCollection()
+        sessionState.updateContext(makeTestContext(title: "Titled But Empty", content: "", pageTypeSignals: signals))
+
+        // Then
+        XCTAssertEqual(deliveredPayload?.pageTypeSignals, signals)
+        XCTAssertEqual(deliveredPayload?.title, "Titled But Empty")
     }
 
     func testUpdateContextDoesNotAutoAttachWhenUserDowngraded() {
@@ -1602,14 +1726,15 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
 
     private func makeTestContext(title: String = "Test Page",
                                  url: String = "https://example.com",
+                                 content: String = "Test content",
                                  pageTypeSignals: AIChatPageTypeSignals? = nil) -> AIChatPageContext {
         let contextData = AIChatPageContextData(
             title: title,
             favicon: [],
             url: url,
-            content: "Test content",
+            content: content,
             truncated: false,
-            fullContentLength: 12,
+            fullContentLength: content.count,
             pageTypeSignals: pageTypeSignals
         )
         return AIChatPageContext(contextData: contextData, favicon: nil)

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -46,7 +46,8 @@ final class PageContextTabExtension {
     private let featureFlagger: FeatureFlagger
     private let privacyConfigurationManager: PrivacyConfigurationManaging
     private let extractionPixelHandler: PageContextExtractionPixelFiring
-    private var lastMainFrameResponse: (url: URL, mimeType: String?)?
+    private var mainFrameMIMECache = MainFrameMIMECache()
+    private var pendingSettledNavigationURL: URL?
 
     private var extractionResolver = PageContextExtractionResolver()
 
@@ -173,6 +174,9 @@ final class PageContextTabExtension {
                 }
                 self.handleNavigationForMultipleContexts(from: previousContent, to: tabContent)
                 self.sendNonAttachableContextIfNeeded()
+                // A settled navigation that beat this debounced update deferred its re-collect; now
+                // that `content` matches, run it (a fast / back-forward restore the delegate missed).
+                self.runPendingSettledNavigationReCollectIfNeeded()
                 // Signals-only collection is driven from `navigationDidFinish` (post-load, parsed
                 // markup). Collecting here at didCommit too would race the post-load re-collect for
                 // the single-shot `pendingSignalsOnlyCollection` flag and let stale signals win.
@@ -201,6 +205,7 @@ final class PageContextTabExtension {
         aiChatMenuConfiguration.valuesChangedPublisher
             .map { aiChatMenuConfiguration.shouldAutomaticallySendPageContext }
             .removeDuplicates()
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] isEnabled in
                 guard let self else {
                     return
@@ -236,9 +241,13 @@ final class PageContextTabExtension {
                 /// ignore unsolicited results so they can't overwrite attached context with nil.
                 if self.isContextCollectionEnabled {
                     self.pendingSignalsOnlyCollection = false
+                    let wasForced = self.shouldForceContextCollection
+                    self.shouldForceContextCollection = false
                     self.fireExtractionOutcome(for: pageContext)
-                    Task {
-                        await self.handle(pageContext)
+                    if Self.shouldDeliverCollectionResult(pageContext, wasForced: wasForced, cached: self.cachedPageContext) {
+                        Task {
+                            await self.handle(pageContext)
+                        }
                     }
                 } else if self.pendingSignalsOnlyCollection {
                     self.pendingSignalsOnlyCollection = false
@@ -298,6 +307,14 @@ final class PageContextTabExtension {
             .store(in: &sidebarCancellables)
     }
 
+    /// Results with content always deliver. Empty/nil results deliver only for a forced
+    /// (user-requested) collect — the FE awaits the `getAIChatPageContext` response, so dropping
+    /// them would leave it hanging — and never when they'd replace attached content.
+    static func shouldDeliverCollectionResult(_ result: AIChatPageContextData?, wasForced: Bool, cached: AIChatPageContextData?) -> Bool {
+        if result?.content.isEmpty == false { return true }
+        return wasForced && cached?.content.isEmpty != false
+    }
+
     /// This is the main place where page context handling happens.
     /// We always cache the latest context, and if sidebar is open,
     /// we're passing the context to it.
@@ -307,17 +324,39 @@ final class PageContextTabExtension {
             return
         }
         shouldForceContextCollection = false
+        let gatedPageContext = forcingNonAttachableIfNeeded(pageContext)
         // Page-type signals (for duck.ai page shortcuts) ride the collected payload from
         // Content-Scope-Scripts (includePageTypeSignals) and are preserved through favicon encoding.
-        cachedPageContext = replaceFaviconURLWithEncodedData(pageContext)
+        cachedPageContext = replaceFaviconURLWithEncodedData(gatedPageContext)
         if let chatViewController = aiChatSessionStore.sessions[tabID]?.chatViewController {
             chatViewController.setPageContext(cachedPageContext)
-            if pageContext != nil, pageContext?.attachable != false {
+            if gatedPageContext != nil, gatedPageContext?.attachable != false {
                 // New attachable context pushed — reset the consumed flag so navigation
                 // won't clear it until the next prompt is submitted.
                 hasContextBeenConsumedByChat = false
             }
         }
+    }
+
+    private func forcingNonAttachableIfNeeded(_ pageContext: AIChatPageContextData?) -> AIChatPageContextData? {
+        guard let pageContext,
+              case .url(let url, _, _) = content,
+              preventedAttachReason(for: url) != nil,
+              pageContext.attachable != false else {
+            return pageContext
+        }
+        return AIChatPageContextData(
+            title: pageContext.title,
+            favicon: pageContext.favicon,
+            url: pageContext.url,
+            content: pageContext.content,
+            truncated: pageContext.truncated,
+            fullContentLength: pageContext.fullContentLength,
+            attachable: false,
+            tabId: pageContext.tabId,
+            pageTypeSignals: pageContext.pageTypeSignals,
+            attached: pageContext.attached
+        )
     }
 
     private func deliverContextToCurrentSidebar() {
@@ -364,7 +403,7 @@ final class PageContextTabExtension {
             return
         }
         if let reason = preventedAttachReason(for: url) {
-            fireExtractionPixel(.prevented(reason), trigger: .navigation, latency: nil)
+            deliverPreventedContext(for: url, reason: reason, trigger: .navigation)
             return
         }
         if isContextCollectionEnabled, !extractionResolver.hasPendingCollections {
@@ -374,8 +413,7 @@ final class PageContextTabExtension {
 
     private func preventedAttachReason(for url: URL) -> String? {
         guard let policy = currentAttachabilityPolicy() else { return nil }
-        let mimeType = lastMainFrameResponse.flatMap { $0.url == url ? $0.mimeType : nil }
-        let verdict = policy.verdict(url: url, mimeType: mimeType)
+        let verdict = policy.verdict(url: url, mimeType: mainFrameMIMECache[url])
         return verdict.isAttachable ? nil : (verdict.preventionReason ?? PageContextExtractionOutcome.internalPageCategory)
     }
 
@@ -410,6 +448,7 @@ final class PageContextTabExtension {
                                      latency: PageContextExtractionLatencyBucket?) {
         guard isExtractionMeasurementEnabled else { return }
         guard isSidebarVisibleForTab else { return }
+        if case .failure(.emptyContent) = outcome, trigger != .userRequest { return }
         // A navigation triggers several automatic collects (navigation re-collect + signals-only);
         // report only the first. User/setting collects (.userRequest / .auto) always report.
         if trigger == .navigation || trigger == .tabContent {
@@ -437,6 +476,13 @@ final class PageContextTabExtension {
         if let reason = preventedAttachReason(for: url) {
             Logger.aiChat.debug("🚫 PageContext gate: prevented attach (reason=\(reason, privacy: .public)) host=\(url.host ?? "nil", privacy: .public)")
             deliverPreventedContext(for: url, reason: reason, trigger: trigger)
+            return
+        }
+        // Skip automatic collects while the webview still shows the previous document (debounced
+        // `Tab.$content` races the swap on back/forward); the settled-navigation re-collect covers it.
+        if trigger == .navigation || trigger == .tabContent,
+           let webViewURL = webView?.url, webViewURL != url {
+            Logger.aiChat.debug("⏭️ PageContext gate: document mismatch (webView=\(webViewURL.host ?? "nil", privacy: .public) content=\(url.host ?? "nil", privacy: .public)), skipping collect")
             return
         }
         guard let pageContextUserScript, webView != nil else {
@@ -660,6 +706,34 @@ final class PageContextTabExtension {
     }
 }
 
+/// Main-frame MIME types keyed by URL (bounded FIFO). Back/forward cache restores don't re-fire
+/// `decidePolicy(for navigationResponse:)`, so a single "last response" slot loses the MIME on the way back.
+struct MainFrameMIMECache {
+    private var mimeTypes: [URL: String] = [:]
+    private var order: [URL] = []
+    private let capacity: Int
+
+    init(capacity: Int = 100) {
+        self.capacity = capacity
+    }
+
+    subscript(url: URL) -> String? {
+        mimeTypes[url]
+    }
+
+    /// Empty/nil MIMEs are ignored — the attachability gate falls back to the URL extension for those.
+    mutating func record(_ mimeType: String?, for url: URL) {
+        guard let mimeType, !mimeType.isEmpty else { return }
+        if mimeTypes[url] == nil {
+            order.append(url)
+            if order.count > capacity {
+                mimeTypes[order.removeFirst()] = nil
+            }
+        }
+        mimeTypes[url] = mimeType
+    }
+}
+
 protocol PageContextProtocol: AnyObject, NavigationResponder {
     /// Appends a user text selection to the sidebar's selection-context list. See the
     /// implementation in `PageContextTabExtension` for buffering/lifecycle semantics.
@@ -677,6 +751,37 @@ extension PageContextTabExtension: NavigationResponder {
     /// update on same-tab navigation. Mirrors Windows' `NavigationCompleted` re-collect.
     func navigationDidFinish(_ navigation: Navigation) {
         guard !isLoadedInSidebar else { return }
+        reCollectForSettledNavigation(navigation)
+    }
+
+    /// Back/forward cache restores can end in `didFail` (NSURLError -999) after committing — the page
+    /// is displayed but `navigationDidFinish` never fires, so committed failures must re-collect too.
+    func navigation(_ navigation: Navigation, didFailWith error: WKError) {
+        guard !isLoadedInSidebar, navigation.isCommitted else { return }
+        reCollectForSettledNavigation(navigation)
+    }
+
+    /// Collects only once the debounced `Tab.$content` matches this navigation — on fast loads it may
+    /// still reference the previous page, and collecting then would extract the wrong document.
+    @MainActor
+    private func reCollectForSettledNavigation(_ navigation: Navigation) {
+        guard case .url(let url, _, _) = content, url == navigation.url else {
+            pendingSettledNavigationURL = navigation.url
+            return
+        }
+        pendingSettledNavigationURL = nil
+        collectPageContextIfNeeded(trigger: .navigation)
+        requestSignalsOnlyCollectionIfNeeded()
+    }
+
+    private func runPendingSettledNavigationReCollectIfNeeded() {
+        guard let pendingURL = pendingSettledNavigationURL else { return }
+        guard case .url(let url, _, _) = content, url == pendingURL else {
+            pendingSettledNavigationURL = nil
+            return
+        }
+        pendingSettledNavigationURL = nil
+        guard !extractionResolver.hasPendingCollections else { return }
         collectPageContextIfNeeded(trigger: .navigation)
         requestSignalsOnlyCollectionIfNeeded()
     }
@@ -684,7 +789,7 @@ extension PageContextTabExtension: NavigationResponder {
     @MainActor
     func decidePolicy(for navigationResponse: NavigationResponse) async -> NavigationResponsePolicy? {
         guard !isLoadedInSidebar, navigationResponse.isForMainFrame else { return .next }
-        lastMainFrameResponse = (navigationResponse.url, navigationResponse.response.mimeType)
+        mainFrameMIMECache.record(navigationResponse.response.mimeType, for: navigationResponse.url)
         Logger.aiChat.debug("📄 PageContext MIME captured: \(navigationResponse.response.mimeType ?? "nil", privacy: .public) host=\(navigationResponse.url.host ?? "nil", privacy: .public)")
         return .next
     }

--- a/macOS/UnitTests/AIChat/PageContextMultipleContextsTests.swift
+++ b/macOS/UnitTests/AIChat/PageContextMultipleContextsTests.swift
@@ -37,35 +37,41 @@ struct NavigationContextActionTests {
         }
     }
 
-    @Test("Auto-collect ON returns collectNewContext regardless of consumed state")
+    @available(iOS 16, macOS 13, *)
+    @Test("Auto-collect ON returns collectNewContext regardless of consumed state", .timeLimit(.minutes(1)))
     func autoCollectOnCollectsNewContext() {
         #expect(navigationAction(autoCollectEnabled: true, contextConsumed: false) == "collectNewContext")
         #expect(navigationAction(autoCollectEnabled: true, contextConsumed: true) == "collectNewContext")
     }
 
-    @Test("Auto-collect OFF with consumed context returns sendNavigationSignal")
+    @available(iOS 16, macOS 13, *)
+    @Test("Auto-collect OFF with consumed context returns sendNavigationSignal", .timeLimit(.minutes(1)))
     func autoCollectOffConsumedSendsSignal() {
         #expect(navigationAction(autoCollectEnabled: false, contextConsumed: true) == "sendNavigationSignal")
     }
 
-    @Test("Auto-collect OFF without consumed context returns keepExistingContext")
+    @available(iOS 16, macOS 13, *)
+    @Test("Auto-collect OFF without consumed context returns keepExistingContext", .timeLimit(.minutes(1)))
     func autoCollectOffNotConsumedKeeps() {
         #expect(navigationAction(autoCollectEnabled: false, contextConsumed: false) == "keepExistingContext")
     }
 
     // fromAttachablePage = false (navigating FROM NTP/settings/etc. to a URL)
 
-    @Test("NTP to URL with auto-collect OFF and no prior chat sends navigation signal")
+    @available(iOS 16, macOS 13, *)
+    @Test("NTP to URL with auto-collect OFF and no prior chat sends navigation signal", .timeLimit(.minutes(1)))
     func ntpToURLAutoCollectOffNoChat() {
         #expect(navigationAction(autoCollectEnabled: false, contextConsumed: false, fromAttachablePage: false) == "sendNavigationSignal")
     }
 
-    @Test("NTP to URL with auto-collect ON collects new context")
+    @available(iOS 16, macOS 13, *)
+    @Test("NTP to URL with auto-collect ON collects new context", .timeLimit(.minutes(1)))
     func ntpToURLAutoCollectOn() {
         #expect(navigationAction(autoCollectEnabled: true, contextConsumed: false, fromAttachablePage: false) == "collectNewContext")
     }
 
-    @Test("NTP to URL with consumed context sends navigation signal")
+    @available(iOS 16, macOS 13, *)
+    @Test("NTP to URL with consumed context sends navigation signal", .timeLimit(.minutes(1)))
     func ntpToURLContextConsumed() {
         #expect(navigationAction(autoCollectEnabled: false, contextConsumed: true, fromAttachablePage: false) == "sendNavigationSignal")
     }
@@ -86,18 +92,21 @@ struct ContextCollectionEnabledTests {
         return shouldAutomaticallySendPageContext
     }
 
-    @Test("Force collection overrides everything")
+    @available(iOS 16, macOS 13, *)
+    @Test("Force collection overrides everything", .timeLimit(.minutes(1)))
     func forceCollectionOverrides() {
         #expect(isContextCollectionEnabled(shouldForceContextCollection: true, userRemovedContext: true, shouldAutomaticallySendPageContext: false) == true)
         #expect(isContextCollectionEnabled(shouldForceContextCollection: true, userRemovedContext: false, shouldAutomaticallySendPageContext: false) == true)
     }
 
-    @Test("User removed context suppresses auto-collection")
+    @available(iOS 16, macOS 13, *)
+    @Test("User removed context suppresses auto-collection", .timeLimit(.minutes(1)))
     func userRemovedSuppresses() {
         #expect(isContextCollectionEnabled(shouldForceContextCollection: false, userRemovedContext: true, shouldAutomaticallySendPageContext: true) == false)
     }
 
-    @Test("Auto-send setting is respected when no overrides")
+    @available(iOS 16, macOS 13, *)
+    @Test("Auto-send setting is respected when no overrides", .timeLimit(.minutes(1)))
     func autoSendRespected() {
         #expect(isContextCollectionEnabled(shouldForceContextCollection: false, userRemovedContext: false, shouldAutomaticallySendPageContext: true) == true)
         #expect(isContextCollectionEnabled(shouldForceContextCollection: false, userRemovedContext: false, shouldAutomaticallySendPageContext: false) == false)
@@ -113,24 +122,28 @@ struct ConsumedFlagResetTests {
         pageContext != nil && pageContext?.attachable != false
     }
 
-    @Test("Attachable context resets consumed flag")
+    @available(iOS 16, macOS 13, *)
+    @Test("Attachable context resets consumed flag", .timeLimit(.minutes(1)))
     func attachableContextResets() {
         let context = AIChatPageContextData(title: "Test", favicon: [], url: "https://example.com", content: "content", truncated: false, fullContentLength: 100)
         #expect(shouldResetConsumedFlag(pageContext: context) == true)
     }
 
-    @Test("Non-attachable context does not reset consumed flag")
+    @available(iOS 16, macOS 13, *)
+    @Test("Non-attachable context does not reset consumed flag", .timeLimit(.minutes(1)))
     func nonAttachableDoesNotReset() {
         let context = AIChatPageContextData(title: "NTP", favicon: [], url: "", content: "", truncated: false, fullContentLength: 0, attachable: false)
         #expect(shouldResetConsumedFlag(pageContext: context) == false)
     }
 
-    @Test("Nil context does not reset consumed flag")
+    @available(iOS 16, macOS 13, *)
+    @Test("Nil context does not reset consumed flag", .timeLimit(.minutes(1)))
     func nilDoesNotReset() {
         #expect(shouldResetConsumedFlag(pageContext: nil) == false)
     }
 
-    @Test("Context with attachable=true resets consumed flag")
+    @available(iOS 16, macOS 13, *)
+    @Test("Context with attachable=true resets consumed flag", .timeLimit(.minutes(1)))
     func explicitlyAttachableResets() {
         let context = AIChatPageContextData(title: "Test", favicon: [], url: "https://example.com", content: "content", truncated: false, fullContentLength: 100, attachable: true)
         #expect(shouldResetConsumedFlag(pageContext: context) == true)
@@ -159,7 +172,8 @@ struct SelectionContextTests {
         )
     }
 
-    @Test("Short selection carries the generic title and is not truncated")
+    @available(iOS 16, macOS 13, *)
+    @Test("Short selection carries the generic title and is not truncated", .timeLimit(.minutes(1)))
     func shortSelectionIsTaggedAndNotTruncated() {
         let item = buildSelectionItem(text: "hello world", url: "https://example.com")
         #expect(item.content == "hello world")
@@ -170,7 +184,8 @@ struct SelectionContextTests {
         #expect(item.wordCount == 2)
     }
 
-    @Test("Word count covers the full selection even when truncated")
+    @available(iOS 16, macOS 13, *)
+    @Test("Word count covers the full selection even when truncated", .timeLimit(.minutes(1)))
     func wordCountReflectsFullSelection() {
         // 6000 two-char words separated by spaces → 11999 chars, truncated at 9500, but wordCount is the full 6000.
         let longText = Array(repeating: "ab", count: 6000).joined(separator: " ")
@@ -179,7 +194,8 @@ struct SelectionContextTests {
         #expect(item.wordCount == 6000)
     }
 
-    @Test("Long selection is truncated to the max length and reports the original length")
+    @available(iOS 16, macOS 13, *)
+    @Test("Long selection is truncated to the max length and reports the original length", .timeLimit(.minutes(1)))
     func longSelectionIsTruncated() {
         let longText = String(repeating: "x", count: Self.maxSelectionContextLength + 500)
         let item = buildSelectionItem(text: longText, url: "https://example.com")
@@ -188,7 +204,8 @@ struct SelectionContextTests {
         #expect(item.fullContentLength == longText.count)
     }
 
-    @Test("Each attached selection gets a unique id")
+    @available(iOS 16, macOS 13, *)
+    @Test("Each attached selection gets a unique id", .timeLimit(.minutes(1)))
     func eachSelectionHasUniqueID() {
         let first = buildSelectionItem(text: "a", url: "https://example.com")
         let second = buildSelectionItem(text: "a", url: "https://example.com")
@@ -216,7 +233,8 @@ struct PerNavigationExtractionPixelDedupTests {
         }
     }
 
-    @Test("First automatic collect reports; the navigation's later automatic collects are suppressed")
+    @available(iOS 16, macOS 13, *)
+    @Test("First automatic collect reports; the navigation's later automatic collects are suppressed", .timeLimit(.minutes(1)))
     func firstAutomaticReportsRestSuppressed() {
         let dedup = Dedup()
         #expect(dedup.shouldReport(.navigation) == true)   // didCommit re-collect
@@ -224,14 +242,16 @@ struct PerNavigationExtractionPixelDedupTests {
         #expect(dedup.shouldReport(.tabContent) == false)  // signals-only harvest
     }
 
-    @Test("navigation and tabContent share the single per-navigation slot")
+    @available(iOS 16, macOS 13, *)
+    @Test("navigation and tabContent share the single per-navigation slot", .timeLimit(.minutes(1)))
     func navigationAndTabContentShareSlot() {
         let dedup = Dedup()
         #expect(dedup.shouldReport(.tabContent) == true)
         #expect(dedup.shouldReport(.navigation) == false)
     }
 
-    @Test("Navigation to a new URL re-arms automatic reporting")
+    @available(iOS 16, macOS 13, *)
+    @Test("Navigation to a new URL re-arms automatic reporting", .timeLimit(.minutes(1)))
     func navigationResetReArms() {
         let dedup = Dedup()
         #expect(dedup.shouldReport(.navigation) == true)
@@ -240,7 +260,8 @@ struct PerNavigationExtractionPixelDedupTests {
         #expect(dedup.shouldReport(.navigation) == true)
     }
 
-    @Test("User- and setting-initiated collects always report and never consume the slot")
+    @available(iOS 16, macOS 13, *)
+    @Test("User- and setting-initiated collects always report and never consume the slot", .timeLimit(.minutes(1)))
     func userAndSettingAlwaysReport() {
         let dedup = Dedup()
         #expect(dedup.shouldReport(.userRequest) == true)
@@ -270,25 +291,47 @@ struct SidebarOpenExtractionMeasurementTests {
         return .none
     }
 
-    @Test("Native special page (non-URL content) reports prevented(internalPage)")
+    @available(iOS 16, macOS 13, *)
+    @Test("Native special page (non-URL content) reports prevented(internalPage)", .timeLimit(.minutes(1)))
     func nativePageReportsInternalPagePrevented() {
         #expect(sidebarOpenOutcome(isURL: false, preventedReason: nil, isContextCollectionEnabled: true) == .prevented("internalPage"))
     }
 
-    @Test("Non-attachable URL reports prevented with the blocklist category, no interaction needed")
+    @available(iOS 16, macOS 13, *)
+    @Test("Non-attachable URL reports prevented with the blocklist category, no interaction needed", .timeLimit(.minutes(1)))
     func nonAttachableURLReportsPrevented() {
         #expect(sidebarOpenOutcome(isURL: true, preventedReason: "pdf", isContextCollectionEnabled: false) == .prevented("pdf"))
         #expect(sidebarOpenOutcome(isURL: true, preventedReason: "image", isContextCollectionEnabled: true) == .prevented("image"))
     }
 
-    @Test("Attachable URL with auto-collect ON re-collects so success/failure fire live")
+    @available(iOS 16, macOS 13, *)
+    @Test("Attachable URL with auto-collect ON re-collects so success/failure fire live", .timeLimit(.minutes(1)))
     func attachableAutoOnReCollects() {
         #expect(sidebarOpenOutcome(isURL: true, preventedReason: nil, isContextCollectionEnabled: true) == .collect)
     }
 
-    @Test("Attachable URL with auto-collect OFF reports nothing on open (awaits user tap / signals-only)")
+    @available(iOS 16, macOS 13, *)
+    @Test("Attachable URL with auto-collect OFF reports nothing on open (awaits user tap / signals-only)", .timeLimit(.minutes(1)))
     func attachableAutoOffReportsNone() {
         #expect(sidebarOpenOutcome(isURL: true, preventedReason: nil, isContextCollectionEnabled: false) == .none)
+    }
+
+    private func deliversPreventedContextOnSidebarOpen(isURL: Bool, preventedReason: String?) -> Bool {
+        guard isURL else { return false }
+        return preventedReason != nil
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Non-attachable URL pushes an attachable:false context on sidebar open so the FE hides Ask-About-Page", .timeLimit(.minutes(1)))
+    func nonAttachableURLDeliversPreventedContext() {
+        #expect(deliversPreventedContextOnSidebarOpen(isURL: true, preventedReason: "pdf") == true)
+        #expect(deliversPreventedContextOnSidebarOpen(isURL: true, preventedReason: "image") == true)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Attachable URL does not push a prevented context on sidebar open", .timeLimit(.minutes(1)))
+    func attachableURLDoesNotDeliverPreventedContext() {
+        #expect(deliversPreventedContextOnSidebarOpen(isURL: true, preventedReason: nil) == false)
     }
 
     private final class Guard {
@@ -309,21 +352,24 @@ struct SidebarOpenExtractionMeasurementTests {
         }
     }
 
-    @Test("First sidebar open measures; re-opening on the same page (kept session) does not")
+    @available(iOS 16, macOS 13, *)
+    @Test("First sidebar open measures; re-opening on the same page (kept session) does not", .timeLimit(.minutes(1)))
     func firstOpenMeasuresReopenDoesNot() {
         let guardState = Guard()
         #expect(guardState.shouldMeasureOnSidebarOpen(isVisible: true, measurementEnabled: true) == true)
         #expect(guardState.shouldMeasureOnSidebarOpen(isVisible: true, measurementEnabled: true) == false)
     }
 
-    @Test("A collection that already reported this navigation suppresses the sidebar-open measurement")
+    @available(iOS 16, macOS 13, *)
+    @Test("A collection that already reported this navigation suppresses the sidebar-open measurement", .timeLimit(.minutes(1)))
     func collectionReportSuppressesMeasurement() {
         let guardState = Guard()
         guardState.markCollectionReported()
         #expect(guardState.shouldMeasureOnSidebarOpen(isVisible: true, measurementEnabled: true) == false)
     }
 
-    @Test("Navigation to a new URL re-arms the sidebar-open measurement")
+    @available(iOS 16, macOS 13, *)
+    @Test("Navigation to a new URL re-arms the sidebar-open measurement", .timeLimit(.minutes(1)))
     func navigationReArmsMeasurement() {
         let guardState = Guard()
         #expect(guardState.shouldMeasureOnSidebarOpen(isVisible: true, measurementEnabled: true) == true)
@@ -331,7 +377,8 @@ struct SidebarOpenExtractionMeasurementTests {
         #expect(guardState.shouldMeasureOnSidebarOpen(isVisible: true, measurementEnabled: true) == true)
     }
 
-    @Test("A hidden sidebar or absent blocklist config never measures and never consumes the slot")
+    @available(iOS 16, macOS 13, *)
+    @Test("A hidden sidebar or absent blocklist config never measures and never consumes the slot", .timeLimit(.minutes(1)))
     func hiddenOrDisabledDoesNotConsumeSlot() {
         let guardState = Guard()
         #expect(guardState.shouldMeasureOnSidebarOpen(isVisible: false, measurementEnabled: true) == false)
@@ -350,18 +397,280 @@ struct CollectionResultExtractionMeasurementTests {
         return false
     }
 
-    @Test("Full collection (auto-attach on / user-forced) reports its extraction outcome")
+    @available(iOS 16, macOS 13, *)
+    @Test("Full collection (auto-attach on / user-forced) reports its extraction outcome", .timeLimit(.minutes(1)))
     func fullCollectionReports() {
         #expect(firesExtractionOutcome(isContextCollectionEnabled: true, pendingSignalsOnly: false) == true)
     }
 
-    @Test("Signals-only harvest does not report success/failed")
+    @available(iOS 16, macOS 13, *)
+    @Test("Signals-only harvest does not report success/failed", .timeLimit(.minutes(1)))
     func signalsOnlyDoesNotReport() {
         #expect(firesExtractionOutcome(isContextCollectionEnabled: false, pendingSignalsOnly: true) == false)
     }
 
-    @Test("Unsolicited collection result reports nothing")
+    @available(iOS 16, macOS 13, *)
+    @Test("Unsolicited collection result reports nothing", .timeLimit(.minutes(1)))
     func unsolicitedReportsNothing() {
         #expect(firesExtractionOutcome(isContextCollectionEnabled: false, pendingSignalsOnly: false) == false)
+    }
+}
+
+// MARK: - Empty-content pixel suppression Tests
+
+struct EmptyContentPixelSuppressionTests {
+
+    /// Mirrors the guard in `fireExtractionPixel`: an empty-content failure from an automatic collect
+    /// (premature / mid-redirect snapshot) is not reported; a user-requested one still is.
+    private func reportsEmptyContentFailure(trigger: String) -> Bool {
+        trigger == "userRequest"
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Empty-content failure from a navigation collect is not reported (premature / redirect noise)", .timeLimit(.minutes(1)))
+    func navigationEmptyContentSuppressed() {
+        #expect(reportsEmptyContentFailure(trigger: "navigation") == false)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Empty-content failure from a tabContent (signals-only) collect is not reported", .timeLimit(.minutes(1)))
+    func tabContentEmptyContentSuppressed() {
+        #expect(reportsEmptyContentFailure(trigger: "tabContent") == false)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Empty-content failure from an auto (sidebar-open / setting) collect is not reported", .timeLimit(.minutes(1)))
+    func autoEmptyContentSuppressed() {
+        #expect(reportsEmptyContentFailure(trigger: "auto") == false)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Empty-content failure from a user-requested collect is still reported", .timeLimit(.minutes(1)))
+    func userRequestEmptyContentReported() {
+        #expect(reportsEmptyContentFailure(trigger: "userRequest") == true)
+    }
+}
+
+// MARK: - Non-attachable page context normalization Tests
+
+struct NonAttachableNormalizationTests {
+
+    private func effectiveAttachable(pageIsNonAttachable: Bool, contextAttachable: Bool?) -> Bool? {
+        guard pageIsNonAttachable, contextAttachable != false else { return contextAttachable }
+        return false
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Raw collected context (attachable nil) on a non-attachable page is forced to false", .timeLimit(.minutes(1)))
+    func rawContextForcedFalse() {
+        #expect(effectiveAttachable(pageIsNonAttachable: true, contextAttachable: nil) == false)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("attachable:true on a non-attachable page is forced to false", .timeLimit(.minutes(1)))
+    func trueForcedFalseOnNonAttachable() {
+        #expect(effectiveAttachable(pageIsNonAttachable: true, contextAttachable: true) == false)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Already-false context on a non-attachable page stays false", .timeLimit(.minutes(1)))
+    func falseStaysFalse() {
+        #expect(effectiveAttachable(pageIsNonAttachable: true, contextAttachable: false) == false)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Attachable page leaves attachable untouched (nil stays nil = attachable, true stays true)", .timeLimit(.minutes(1)))
+    func attachablePageUntouched() {
+        #expect(effectiveAttachable(pageIsNonAttachable: false, contextAttachable: nil) == nil)
+        #expect(effectiveAttachable(pageIsNonAttachable: false, contextAttachable: true) == true)
+    }
+}
+
+// MARK: - Main-frame MIME cache (back/forward attachability) Tests
+
+struct MainFrameMIMECacheTests {
+
+    private let pdfURL = URL(string: "https://arxiv.org/pdf/2602.11988")!
+    private let htmlURL = URL(string: "https://en.wikipedia.org/wiki/Potato")!
+
+    @available(iOS 16, macOS 13, *)
+    @Test("MIME for a URL survives navigating away and back (unlike a last-response slot)", .timeLimit(.minutes(1)))
+    func mimeSurvivesBackForward() {
+        var cache = MainFrameMIMECache()
+        cache.record("application/pdf", for: pdfURL)
+        cache.record("text/html", for: htmlURL)
+        #expect(cache[pdfURL] == "application/pdf")
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Empty or nil MIME is not recorded", .timeLimit(.minutes(1)))
+    func emptyMIMENotRecorded() {
+        var cache = MainFrameMIMECache()
+        cache.record(nil, for: htmlURL)
+        cache.record("", for: htmlURL)
+        #expect(cache[htmlURL] == nil)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Cache is bounded FIFO — the oldest URL is evicted past the cap", .timeLimit(.minutes(1)))
+    func boundedFIFO() {
+        let urls = (1...3).map { URL(string: "https://example.com/\($0)")! }
+        var cache = MainFrameMIMECache(capacity: 2)
+        cache.record("a/a", for: urls[0])
+        cache.record("b/b", for: urls[1])
+        cache.record("c/c", for: urls[2])
+        #expect(cache[urls[0]] == nil)
+        #expect(cache[urls[1]] == "b/b")
+        #expect(cache[urls[2]] == "c/c")
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Re-recording a cached URL updates the MIME without double-counting against the cap", .timeLimit(.minutes(1)))
+    func reRecordUpdatesInPlace() {
+        let urls = (1...2).map { URL(string: "https://example.com/\($0)")! }
+        var cache = MainFrameMIMECache(capacity: 2)
+        cache.record("a/a", for: urls[0])
+        cache.record("b/b", for: urls[1])
+        cache.record("a/b", for: urls[0])
+        #expect(cache[urls[0]] == "a/b")
+        #expect(cache[urls[1]] == "b/b")
+    }
+}
+
+// MARK: - Settled-navigation re-collect Tests
+
+struct SettledNavigationReCollectTests {
+
+    /// Mirrors `PageContextTabExtension.reCollectForSettledNavigation` + the committed-didFail hook:
+    /// committed failures (back/forward -999 restores) re-collect like didFinish, only on a URL match.
+    private func shouldReCollect(event: String, isCommitted: Bool, contentURL: String?, navigationURL: String) -> Bool {
+        if event == "didFail" && !isCommitted { return false }
+        guard let contentURL else { return false }
+        return contentURL == navigationURL
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("didFinish with settled content re-collects", .timeLimit(.minutes(1)))
+    func didFinishSettledReCollects() {
+        #expect(shouldReCollect(event: "didFinish", isCommitted: true, contentURL: "https://a.com", navigationURL: "https://a.com") == true)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Committed didFail (back/forward cache restore, -999) re-collects like didFinish", .timeLimit(.minutes(1)))
+    func committedDidFailReCollects() {
+        #expect(shouldReCollect(event: "didFail", isCommitted: true, contentURL: "https://a.com", navigationURL: "https://a.com") == true)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Uncommitted didFail (real load failure, nothing displayed) does not re-collect", .timeLimit(.minutes(1)))
+    func uncommittedDidFailSkips() {
+        #expect(shouldReCollect(event: "didFail", isCommitted: false, contentURL: "https://a.com", navigationURL: "https://a.com") == false)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Stale debounced content (previous page's URL) skips the re-collect", .timeLimit(.minutes(1)))
+    func staleContentSkips() {
+        #expect(shouldReCollect(event: "didFinish", isCommitted: true, contentURL: "https://old.com", navigationURL: "https://new.com") == false)
+        #expect(shouldReCollect(event: "didFail", isCommitted: true, contentURL: "https://old.com", navigationURL: "https://new.com") == false)
+    }
+
+    /// Mirrors the document-match guard in `collectPageContextIfNeeded`: automatic collects only run
+    /// when the webview is displaying the page being gated on; user collects always proceed.
+    private func shouldRunAutomaticCollect(trigger: String, webViewURL: String?, contentURL: String) -> Bool {
+        guard trigger == "navigation" || trigger == "tabContent" else { return true }
+        guard let webViewURL else { return true }
+        return webViewURL == contentURL
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Automatic collect is skipped while the webview still displays the previous document", .timeLimit(.minutes(1)))
+    func automaticCollectSkippedOnDocumentMismatch() {
+        #expect(shouldRunAutomaticCollect(trigger: "navigation", webViewURL: "https://old.com", contentURL: "https://new.com") == false)
+        #expect(shouldRunAutomaticCollect(trigger: "tabContent", webViewURL: "https://old.com", contentURL: "https://new.com") == false)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Automatic collect proceeds when webview and content agree", .timeLimit(.minutes(1)))
+    func automaticCollectProceedsOnMatch() {
+        #expect(shouldRunAutomaticCollect(trigger: "navigation", webViewURL: "https://a.com", contentURL: "https://a.com") == true)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("User-initiated collect proceeds regardless of document mismatch", .timeLimit(.minutes(1)))
+    func userCollectAlwaysProceeds() {
+        #expect(shouldRunAutomaticCollect(trigger: "userRequest", webViewURL: "https://old.com", contentURL: "https://new.com") == true)
+    }
+
+    /// Mirrors `runPendingSettledNavigationReCollectIfNeeded`: a settled navigation whose URL the
+    /// debounced content hasn't caught up to is latched, then re-collected once content matches —
+    /// unless a collect is already in flight (the multi-contexts path already covered it).
+    private func runsDeferredReCollect(latchedURL: String?, settledContentURL: String, hasPendingCollections: Bool) -> Bool {
+        guard let latchedURL, latchedURL == settledContentURL else { return false }
+        return !hasPendingCollections
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Deferred settled navigation re-collects once content catches up", .timeLimit(.minutes(1)))
+    func deferredReCollectFiresWhenContentSettles() {
+        #expect(runsDeferredReCollect(latchedURL: "https://a.com", settledContentURL: "https://a.com", hasPendingCollections: false) == true)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Deferred re-collect is skipped when a collect is already in flight (multi-contexts path covered it)", .timeLimit(.minutes(1)))
+    func deferredReCollectSkippedWhenCollectInFlight() {
+        #expect(runsDeferredReCollect(latchedURL: "https://a.com", settledContentURL: "https://a.com", hasPendingCollections: true) == false)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Deferred re-collect for a superseded navigation (content settled on another URL) does not fire", .timeLimit(.minutes(1)))
+    func deferredReCollectSkippedWhenSuperseded() {
+        #expect(runsDeferredReCollect(latchedURL: "https://a.com", settledContentURL: "https://b.com", hasPendingCollections: false) == false)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("No latched navigation means no deferred re-collect", .timeLimit(.minutes(1)))
+    func noLatchNoDeferredReCollect() {
+        #expect(runsDeferredReCollect(latchedURL: nil, settledContentURL: "https://a.com", hasPendingCollections: false) == false)
+    }
+}
+
+// MARK: - Collection result delivery
+
+/// `PageContextTabExtension.shouldDeliverCollectionResult`: which collection results reach
+/// `handle()`. A forced (user-requested) collect must resolve even when empty — the FE awaits
+/// the `getAIChatPageContext` response — but must never replace attached content.
+struct PageContextCollectionResultDeliveryTests {
+
+    private func context(content: String) -> AIChatPageContextData {
+        AIChatPageContextData(title: "Title", favicon: [], url: "https://example.com", content: content, truncated: false, fullContentLength: content.count)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("A result with content is always delivered", .timeLimit(.minutes(1)))
+    func resultWithContentIsDelivered() {
+        #expect(PageContextTabExtension.shouldDeliverCollectionResult(context(content: "body"), wasForced: false, cached: nil))
+        #expect(PageContextTabExtension.shouldDeliverCollectionResult(context(content: "body"), wasForced: true, cached: context(content: "old")))
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("An unsolicited empty or nil result is dropped", .timeLimit(.minutes(1)))
+    func unforcedEmptyResultIsDropped() {
+        #expect(!PageContextTabExtension.shouldDeliverCollectionResult(context(content: ""), wasForced: false, cached: nil))
+        #expect(!PageContextTabExtension.shouldDeliverCollectionResult(nil, wasForced: false, cached: nil))
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("A forced empty result is delivered when nothing with content is attached, so the awaiting FE request resolves", .timeLimit(.minutes(1)))
+    func forcedEmptyResultIsDeliveredWhenNothingAttached() {
+        #expect(PageContextTabExtension.shouldDeliverCollectionResult(context(content: ""), wasForced: true, cached: nil))
+        #expect(PageContextTabExtension.shouldDeliverCollectionResult(nil, wasForced: true, cached: nil))
+        #expect(PageContextTabExtension.shouldDeliverCollectionResult(nil, wasForced: true, cached: context(content: "")))
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("A forced empty result never replaces attached content", .timeLimit(.minutes(1)))
+    func forcedEmptyResultKeepsAttachedContent() {
+        #expect(!PageContextTabExtension.shouldDeliverCollectionResult(context(content: ""), wasForced: true, cached: context(content: "attached")))
+        #expect(!PageContextTabExtension.shouldDeliverCollectionResult(nil, wasForced: true, cached: context(content: "attached")))
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216590133066253?focus=true
Tech Design URL:
CC:

### Description
Cherry-pick of the #5908 squash commit from main (`fd2fd64136`) onto `release/macos/1.200.0` — a single commit, byte-identical content. Hides the Duck.ai "Ask about this page" chip on non-attachable pages (PDFs etc.) and stops empty extractions from attaching, on both macOS and iOS, including the shared `AIChat` resolver change both platforms consume.

### Testing Steps
1. On macOS with automatic page context ON, open a PDF and open the Duck.ai sidebar — the page-context chip must not appear.
2. Navigate back to a normal web page — the chip reappears with the page attached.
3. Run the macOS Unit Tests and iOS UnitTests AIChat suites (PageContextMultipleContextsTests, AIChatContextualChatSessionStateTests).

### Impact and Risks
Low — same change already reviewed, approved, and merged via #5908; this only lands it on the macOS release branch.

#### What could go wrong?
If the 1.200.0 branch diverges from what #5908 was reviewed against, behavior could differ from the reviewed build, though the patch applied cleanly with no conflicts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared extraction semantics and iOS/macOS attach/clear paths that affect what context is sent to Duck.ai; behavior is well-tested but touches prompt-time context and navigation races.
> 
> **Overview**
> **Tightens Duck.ai page-context so only extractions with real body text count as success**, and stops titled-but-empty payloads from attaching or leaving a stale chip.
> 
> The shared `PageContextExtractionResolver` now treats **empty `content`** as `.emptyContent` (title-only results no longer count as success). On **iOS**, `AIChatContextualChatSessionState` treats empty content like nil—chip downgrades to placeholder, manual attach aborts, and the UTI chip gets an explicit clear so a previous page cannot ride the next prompt; signals-only collections still forward page-type signals.
> 
> On **macOS**, `PageContextTabExtension` adds **`MainFrameMIMECache`** so PDF/non-attachable MIME survives back/forward, forces **`attachable: false`** when the attachability gate blocks the page, and gates delivery via **`shouldDeliverCollectionResult`** so unsolicited empty results do not wipe attached context (forced user collects still resolve). Navigation timing fixes defer re-collect until tab content matches the settled URL, skip automatic collects when the webview document lags `Tab.$content`, and suppress automatic **empty-content** extraction pixels. Extensive unit tests cover these paths on both platforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfb98fb4fc6423c46b5739c5daba4749f8a08fe7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->