### PR TITLE
[macOS] Tolerate non-string values when decoding SERP settings

### DIFF
--- a/SharedPackages/SERPSettings/Sources/SERPSettings/SERPSettingsProviding.swift
+++ b/SharedPackages/SERPSettings/Sources/SERPSettings/SERPSettingsProviding.swift
@@ -130,7 +130,7 @@ public extension SERPSettingsProviding {
         }
 
         do {
-            return try JSONDecoder().decode([String: String].self, from: data)
+            return try decodeSettingsBlob(from: data)
         } catch {
             eventMapper?.fire(.keyValueStoreReadError, error: error, parameters: SERPSettingsReadFailure.decode.pixelParameters)
             return nil
@@ -154,8 +154,10 @@ public extension SERPSettingsProviding {
     ///
     /// - Parameter settings: Complete dictionary of SERP settings to store
     func storeSERPSettings(settings: [String: Any]) {
+        // Store as strings to match the read contract (the SERP may send scalars as JSON numbers).
+        let settingsAsStrings = settings.compactMapValues(Self.settingStringValue(from:))
         do {
-            let data = try JSONSerialization.data(withJSONObject: settings, options: [])
+            let data = try JSONSerialization.data(withJSONObject: settingsAsStrings, options: [])
             let stringData = String(data: data, encoding: .utf8)
             do {
                 try keyValueStore?.set(stringData, forKey: SERPSettingsConstants.serpSettingsStorage)
@@ -282,9 +284,30 @@ public extension SERPSettingsProviding {
         }
 
         do {
-            return try JSONDecoder().decode([String: String].self, from: data)
+            return try decodeSettingsBlob(from: data)
         } catch {
             eventMapper?.fire(.keyValueStoreReadError, error: error, parameters: SERPSettingsReadFailure.decode.pixelParameters)
+            return nil
+        }
+    }
+
+    // Coerce scalars to strings so one number-typed key can't fail the whole decode; throw only when the blob isn't a JSON object.
+    private func decodeSettingsBlob(from data: Data) throws -> [String: String] {
+        let object = try JSONSerialization.jsonObject(with: data)
+        guard let rawDictionary = object as? [String: Any] else {
+            throw SERPSettingsBlobError.notAnObject
+        }
+        return rawDictionary.compactMapValues(Self.settingStringValue(from:))
+    }
+
+    // stringValue renders integers without a decimal (2 -> "2", not "2.0"), matching the SERP raw values.
+    private static func settingStringValue(from value: Any) -> String? {
+        switch value {
+        case let string as String:
+            return string
+        case let number as NSNumber:
+            return number.stringValue
+        default:
             return nil
         }
     }
@@ -306,6 +329,10 @@ public extension SERPSettingsProviding {
             return false
         }
     }
+}
+
+private enum SERPSettingsBlobError: Error {
+    case notAnObject
 }
 
 /// Internal for testing purposes

--- a/SharedPackages/SERPSettings/Tests/SERPSettingsTests/SERPSettingsProvidingTests.swift
+++ b/SharedPackages/SERPSettings/Tests/SERPSettingsTests/SERPSettingsProvidingTests.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import Common
 import Foundation
 import Persistence
 import PersistenceTestingUtils
@@ -168,5 +169,47 @@ final class SERPSettingsProvidingTests: XCTestCase {
         provider.storeSERPSettings(settings: [SERPSettingsConstants.searchAssistKey: "3"])
 
         XCTAssertEqual(notifications, 0)
+    }
+
+    // MARK: - Tolerant decode of non-string scalar values
+
+    func testReadsNumericScalarValues_asStrings_withoutFiringReadError() throws {
+        var firedReadError = false
+        provider.eventMapper = EventMapping<SERPSettingsError> { event, _, _, _ in
+            if case .keyValueStoreReadError = event { firedReadError = true }
+        }
+
+        try mockKeyValueStore.set(#"{"kbe":3,"kbj":1}"#, forKey: SERPSettingsConstants.serpSettingsStorage)
+
+        XCTAssertEqual(provider.searchAssistFrequency, .often)
+        XCTAssertTrue(provider.hideAIGeneratedImages)
+        XCTAssertEqual(provider.serpSettingValue(forKey: SERPSettingsConstants.searchAssistKey), "3")
+        XCTAssertFalse(firedReadError)
+    }
+
+    func testReadsNegativeNumericScalar_asString() throws {
+        try mockKeyValueStore.set(#"{"kbj":-1}"#, forKey: SERPSettingsConstants.serpSettingsStorage)
+
+        XCTAssertFalse(provider.hideAIGeneratedImages) // "-1" means show
+        XCTAssertEqual(provider.serpSettingValue(forKey: SERPSettingsConstants.hideAIGeneratedImagesKey), "-1")
+    }
+
+    func testMixedStringAndNumericBlob_readsAllKeys() throws {
+        try mockKeyValueStore.set(#"{"kbe":"3","kbj":1}"#, forKey: SERPSettingsConstants.serpSettingsStorage)
+
+        XCTAssertEqual(provider.searchAssistFrequency, .often)
+        XCTAssertTrue(provider.hideAIGeneratedImages)
+    }
+
+    func testGenuinelyCorruptBlob_firesReadError_andFallsBackToDefaults() throws {
+        var firedReadError = false
+        provider.eventMapper = EventMapping<SERPSettingsError> { event, _, _, _ in
+            if case .keyValueStoreReadError = event { firedReadError = true }
+        }
+
+        try mockKeyValueStore.set("this is not json", forKey: SERPSettingsConstants.serpSettingsStorage)
+
+        XCTAssertEqual(provider.searchAssistFrequency, .sometimes) // default
+        XCTAssertTrue(firedReadError)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1140729528379976/task/1216753730400728?focus=true
Tech Design URL:
CC: @tomasstrba (this goes into current internal)

### Description

The SERP settings key-value store fires a read error when the stored settings blob holds a non-string scalar value. The most probable cause is that there’s a non-string value in the blob, causing the decode to fail.

This makes the native read tolerant by coercing each scalar to its string form and drops non-scalar values, throwing (and firing the pixel) only when the blob is genuinely not a JSON object. Values are also normalized to strings on the write path so future stored blobs match the read contract.

### Testing Steps

1. Make sure the `SERPSettings` package unit tests are green.
2. On a build, open SERP settings, change Search Assist frequency and toggle Hide AI Images, relaunch the app, confirm both persist.

### Impact and Risks

Low. Read and write semantics are unchanged for well-formed string blobs; the change only adds tolerance for number-typed values and normalizes values to strings on write.

#### What could go wrong?
--

### Quality Considerations
--

### Notes to Reviewer
iOS PR to current internal release: https://github.com/duckduckgo/apple-browsers/pull/5929

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to SERP settings persistence; string blobs behave as before, with added tolerance and write-time normalization only.
> 
> **Overview**
> Fixes spurious **key-value read errors** when the persisted SERP settings JSON contains number-typed values (e.g. `"kbe":3`) instead of strings.
> 
> **Read path:** Replaces strict `JSONDecoder` `[String: String]` decoding with `decodeSettingsBlob`, which parses a JSON object and coerces each value to a string (`String` or `NSNumber.stringValue`). Non-scalar values are dropped per key; decode errors (and analytics pixels) fire only when the blob is not a JSON object or is invalid JSON.
> 
> **Write path:** `storeSERPSettings` now stringifies settings via the same coercion before serialization so stored blobs match the string contract even when the SERP sends numeric scalars.
> 
> Unit tests cover numeric and mixed blobs, negative numbers, and genuinely corrupt JSON still firing read errors and falling back to defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c173b0277bef0f29120d29f80ee49ccbe7e150ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->