### PR TITLE
Fix Fire button transient tabs and missing progress dialog when fire animation is disabled

### DIFF
--- a/macOS/DuckDuckGo/Fire/Model/Fire.swift
+++ b/macOS/DuckDuckGo/Fire/Model/Fire.swift
@@ -241,9 +241,7 @@ final class Fire: FireProtocol {
 
         var shouldClose: Bool {
             switch self {
-            case .tab(tabViewModel: _, selectedDomains: _, parentTabCollectionViewModel: _, close: let close),
-                    .window(tabCollectionViewModel: _, selectedDomains: _, close: let close),
-                    .allWindows(mainWindowControllers: _, selectedDomains: _, customURLToOpen: _, close: let close):
+            case .tab(_, _, _, let close), .window(_, _, let close), .allWindows(_, _, _, let close):
                 return close
             case .none:
                 return true
@@ -254,9 +252,7 @@ final class Fire: FireProtocol {
         /// burns) clears site data without touching tabs.
         var closesTabs: Bool {
             switch self {
-            case .tab(tabViewModel: _, selectedDomains: _, parentTabCollectionViewModel: _, close: let close),
-                    .window(tabCollectionViewModel: _, selectedDomains: _, close: let close),
-                    .allWindows(mainWindowControllers: _, selectedDomains: _, customURLToOpen: _, close: let close):
+            case .tab(_, _, _, let close), .window(_, _, let close), .allWindows(_, _, _, let close):
                 return close
             case .none:
                 return false
@@ -287,7 +283,8 @@ final class Fire: FireProtocol {
 
         func shouldPlayFireAnimation(decider: VisualizeFireSettingsDecider) -> Bool {
             switch self {
-            // We don't present the fire animation if user burns from the privacy feed
+            // We don't present the native fire animation if user burns from
+            // New Tab Page's privacy feed. Instead it's played in the privacy feed itself.
             case .none:
                 return false
             case .tab, .window, .allWindows:
@@ -722,8 +719,7 @@ final class Fire: FireProtocol {
                     || windowController.mainViewController.tabCollectionViewModel.pinnedTabsManager?.isEmpty ?? false else { continue }
 
             // Windows we can't keep open are closed now; the ones we keep have their tabs replaced with
-            // a fresh New Tab later in `burnTabs`. We deliberately don't insert a placeholder tab here –
-            // doing so briefly showed an extra New Tab in the tab bar before `burnTabs` replaced it.
+            // a fresh New Tab later in `burnTabs`.
             if !shouldKeepWindowOpenWhenBurning(windowController) {
                 windowController.close()
             }

--- a/macOS/DuckDuckGo/Fire/Model/Fire.swift
+++ b/macOS/DuckDuckGo/Fire/Model/Fire.swift
@@ -699,8 +699,10 @@ final class Fire: FireProtocol {
             guard pinnedTabsManagerProvider.pinnedTabsMode == .shared
                     || windowController.mainViewController.tabCollectionViewModel.pinnedTabsManager?.isEmpty ?? false else { continue }
 
-            let inserted = (insertNewTabIfNeeded(into: windowController, with: url) != nil)
-            if !inserted {
+            // Windows we can't keep open are closed now; the ones we keep have their tabs replaced with
+            // a fresh New Tab later in `burnTabs`. We deliberately don't insert a placeholder tab here –
+            // doing so briefly showed an extra New Tab in the tab bar before `burnTabs` replaced it.
+            if !shouldKeepWindowOpenWhenBurning(windowController) {
                 windowController.close()
             }
         }
@@ -732,18 +734,31 @@ final class Fire: FireProtocol {
         }
     }
 
+    /// Whether burning should keep `windowController`'s window open by giving it a fresh New Tab,
+    /// rather than closing the window entirely.
+    @MainActor
+    func shouldKeepWindowOpenWhenBurning(_ windowController: MainWindowController) -> Bool {
+        return !visualizeFireAnimationDecider.isOpenFireWindowByDefaultEnabled
+            && !windowController.mainViewController.isBurner
+            && windowController.mainViewController.tabCollectionViewModel.pinnedTabs.isEmpty
+            && windowControllersManager.lastKeyMainWindowController(where: { !$0.mainViewController.isBurner }) === windowController
+            // don‘t keep an open window for inactive app
+            && self.isAppActiveProvider()
+    }
+
+    /// Builds the replacement New Tab a kept-open window is reset to after burning.
+    @MainActor
+    func makeReplacementNewTab(with customURL: URL? = nil) -> Tab {
+        let newTabContent: Tab.TabContent = customURL.map { .contentFromURL($0, source: .ui) } ?? .newtab
+        return Tab(content: newTabContent, shouldLoadInBackground: false, burnerMode: .regular)
+    }
+
     @MainActor
     func insertNewTabIfNeeded(into windowController: MainWindowController, with customURL: URL? = nil) -> Int? {
         // If closing all Tabs/Windows: Insert a new (Regular) tab to prevent window closing:
-        guard !visualizeFireAnimationDecider.isOpenFireWindowByDefaultEnabled,
-              !windowController.mainViewController.isBurner,
-              windowController.mainViewController.tabCollectionViewModel.pinnedTabs.isEmpty,
-              windowControllersManager.lastKeyMainWindowController(where: { !$0.mainViewController.isBurner }) === windowController,
-              // don‘t keep an open window for inactive app
-              self.isAppActiveProvider() else { return nil }
+        guard shouldKeepWindowOpenWhenBurning(windowController) else { return nil }
 
-        let newTabContent: Tab.TabContent = customURL.map { .contentFromURL($0, source: .ui) } ?? .newtab
-        let newTab = Tab(content: newTabContent, shouldLoadInBackground: false, burnerMode: .regular)
+        let newTab = makeReplacementNewTab(with: customURL)
         let insertionIndex = windowController.mainViewController.tabCollectionViewModel.append(tab: newTab, selected: false, forceChange: true)
 
         return insertionIndex
@@ -1060,12 +1075,14 @@ final class Fire: FireProtocol {
                 let unpinnedTabIDs = tabCollectionViewModel.tabCollection.tabs.map(\.uuid)
                 let pinnedTabIDs = tabCollectionViewModel.pinnedTabsManager?.tabCollection.tabs.map(\.uuid) ?? []
                 closeFloatingAIChatWindows(for: unpinnedTabIDs + pinnedTabIDs)
-                // If closing last Window: Insert a new tab to prevent key window closing:
-                var insertedTabIndex: Int?
-                if windowControllersManager.mainWindowControllers.count == 1 {
-                    insertedTabIndex = insertNewTabIfNeeded(into: windowControllersManager.mainWindowControllers[0])
+                // If closing the last Window, keep it open by replacing its tabs with a fresh New Tab.
+                // This is done as a single atomic update so no intermediate/extra tab is ever shown.
+                if windowControllersManager.mainWindowControllers.count == 1,
+                   shouldKeepWindowOpenWhenBurning(windowControllersManager.mainWindowControllers[0]) {
+                    tabCollectionViewModel.removeAllTabs(andAppend: makeReplacementNewTab(), forceChange: true)
+                } else {
+                    tabCollectionViewModel.removeAllTabs(forceChange: true)
                 }
-                tabCollectionViewModel.removeAllTabs(except: insertedTabIndex, forceChange: true)
                 let result = burnPinnedTabs(in: tabCollectionViewModel)
                 measureError(result)
                 selectPinnedTabIfNeeded(in: tabCollectionViewModel)
@@ -1081,9 +1098,13 @@ final class Fire: FireProtocol {
                 let unpinnedTabIDs = tabCollectionViewModel.tabCollection.tabs.map(\.uuid)
                 let pinnedTabIDs = tabCollectionViewModel.pinnedTabsManager?.tabCollection.tabs.map(\.uuid) ?? []
                 closeFloatingAIChatWindows(for: unpinnedTabIDs + pinnedTabIDs)
-                // If closing all Tabs/Windows: Insert a new tab to prevent key window closing:
-                let insertedTabIndex = insertNewTabIfNeeded(into: windowController, with: customURL)
-                tabCollectionViewModel.removeAllTabs(except: insertedTabIndex, forceChange: true)
+                // If closing all Tabs/Windows, keep the key window open by replacing its tabs with a fresh
+                // New Tab. This is done as a single atomic update so no intermediate/extra tab is ever shown.
+                if shouldKeepWindowOpenWhenBurning(windowController) {
+                    tabCollectionViewModel.removeAllTabs(andAppend: makeReplacementNewTab(with: customURL), forceChange: true)
+                } else {
+                    tabCollectionViewModel.removeAllTabs(forceChange: true)
+                }
                 let result = burnPinnedTabs(in: windowController.mainViewController.tabCollectionViewModel)
                 measureError(result)
                 selectPinnedTabIfNeeded(in: tabCollectionViewModel)

--- a/macOS/DuckDuckGo/Fire/Model/Fire.swift
+++ b/macOS/DuckDuckGo/Fire/Model/Fire.swift
@@ -201,17 +201,26 @@ final class Fire: FireProtocol {
     private var dispatchGroup: DispatchGroup?
 
     enum BurningData: Equatable {
-        case specificDomains(_ domains: Set<String>, shouldPlayFireAnimation: Bool)
+        case specificDomains(_ domains: Set<String>, closesTabs: Bool)
         case all
 
-        func shouldPlayFireAnimation(decider: VisualizeFireSettingsDecider) -> Bool {
+        /// Whether the burn closes/replaces tabs (all-data, window or tab burns) and therefore
+        /// presents the full-window fire treatment — the fire animation and/or the
+        /// "Deleting browsing data…" progress dialog. New Tab Page privacy-feed site burns clear
+        /// data in place without touching tabs. Independent of whether the fire animation is enabled.
+        var closesTabs: Bool {
             switch self {
-            case .all, .specificDomains(_, shouldPlayFireAnimation: true):
-                return decider.shouldShowFireAnimation
-            // We don't present the fire animation if user burns from the privacy feed
-            case .specificDomains(_, shouldPlayFireAnimation: false):
-                return false
+            case .all:
+                return true
+            case .specificDomains(_, closesTabs: let closesTabs):
+                return closesTabs
             }
+        }
+
+        func shouldPlayFireAnimation(decider: VisualizeFireSettingsDecider) -> Bool {
+            // We don't present the fire animation if the user burns from the privacy feed.
+            guard closesTabs else { return false }
+            return decider.shouldShowFireAnimation
         }
     }
 
@@ -238,6 +247,19 @@ final class Fire: FireProtocol {
                 return close
             case .none:
                 return true
+            }
+        }
+
+        /// Whether the burn closes/replaces tabs in a window. `.none` (New Tab Page privacy-feed
+        /// burns) clears site data without touching tabs.
+        var closesTabs: Bool {
+            switch self {
+            case .tab(tabViewModel: _, selectedDomains: _, parentTabCollectionViewModel: _, close: let close),
+                    .window(tabCollectionViewModel: _, selectedDomains: _, close: let close),
+                    .allWindows(mainWindowControllers: _, selectedDomains: _, customURLToOpen: _, close: let close):
+                return close
+            case .none:
+                return false
             }
         }
 
@@ -367,7 +389,7 @@ final class Fire: FireProtocol {
         let domains = domainsToBurn(from: entity)
         assert(domains.areAllETLDPlus1(tld: tld))
 
-        burningData = .specificDomains(domains, shouldPlayFireAnimation: entity.shouldPlayFireAnimation(decider: visualizeFireAnimationDecider))
+        burningData = .specificDomains(domains, closesTabs: entity.closesTabs)
 
         dataClearingWideEventService?.start(.clearLastSessionState)
         let lastSessionStateResult = burnLastSessionState()

--- a/macOS/DuckDuckGo/Fire/View/FireViewController.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireViewController.swift
@@ -282,7 +282,7 @@ final class FireViewController: NSViewController {
                 } else if self.isKeyWindowController {
                     // The full-window fire animation isn't covering this burn (it's disabled, or this is
                     // a New Tab Page site burn that only plays the in-page animation). Show the
-                    // "Deleting browsing data…" progress dialog directly so the burn still has visible
+                    // "Deleting browsing data" progress dialog directly so the burn still has visible
                     // feedback, mirroring what `animateFire` presents once the animation finishes.
                     // (For New Tab Page burns `isFirePresentationInProgress` still defers the container
                     // by 1s so the in-page animation plays first.)

--- a/macOS/DuckDuckGo/Fire/View/FireViewController.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireViewController.swift
@@ -279,9 +279,40 @@ final class FireViewController: NSViewController {
                     Task {
                         await self.animateFire(burningData: burningData)
                     }
+                } else if burningData.closesTabs, self.isKeyWindowController {
+                    // Fire animation is disabled, so nothing covers the burn. Show the
+                    // "Deleting browsing data…" progress dialog directly for tab/window/all-data
+                    // burns, mirroring what `animateFire` presents once the animation finishes.
+                    self.showBurningProgressIndicator()
+                } else {
+                    // No fire UI for this burn on this window (e.g. a New Tab Page site burn, or a
+                    // non-key window): make sure a progress dialog left visible by a previous burn
+                    // isn't shown.
+                    self.hideBurningProgressIndicator()
                 }
             })
             .store(in: &cancellables)
+    }
+
+    /// Whether this controller's window is the one the fire action was initiated from. Used to present
+    /// the burning UI on a single window only.
+    private var isKeyWindowController: Bool {
+        view.window?.windowController === Application.appDelegate.windowControllersManager.lastKeyMainWindowController
+    }
+
+    /// Reveals the "Deleting browsing data…" progress dialog and hides the fire animation view.
+    private func showBurningProgressIndicator() {
+        fireAnimationView?.isHidden = true
+        progressIndicatorWrapperBG.isHidden = false
+        progressIndicatorWrapper.isHidden = false
+        fakeFireButton.isHidden = false
+    }
+
+    /// Hides the "Deleting browsing data…" progress dialog.
+    private func hideBurningProgressIndicator() {
+        progressIndicatorWrapperBG.isHidden = true
+        progressIndicatorWrapper.isHidden = true
+        fakeFireButton.isHidden = true
     }
 
     private let fireAnimationSpeed = 1.2
@@ -312,11 +343,7 @@ final class FireViewController: NSViewController {
                 guard let self = self else { return }
 
                 // Hide the fire animation view before showing progress indicator
-                self.fireAnimationView?.isHidden = true
-
-                self.progressIndicatorWrapperBG.isHidden = false
-                self.progressIndicatorWrapper.isHidden = false
-                self.fakeFireButton.isHidden = false
+                self.showBurningProgressIndicator()
 
             } ?? completion() // Resume immediately if fireAnimationView is nil
         }
@@ -356,11 +383,7 @@ final class FireViewController: NSViewController {
                     // Waits until windows are closed in Fire.swift
                     DispatchQueue.main.async {
                         // Hide the fire animation view before showing progress indicator
-                        self.fireAnimationView?.isHidden = true
-
-                        self.progressIndicatorWrapperBG.isHidden = false
-                        self.progressIndicatorWrapper.isHidden = false
-                        self.fakeFireButton.isHidden = false
+                        self.showBurningProgressIndicator()
                         Logger.general.debug("Fire animation progress indicator shown")
                     }
                 } else {

--- a/macOS/DuckDuckGo/Fire/View/FireViewController.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireViewController.swift
@@ -279,14 +279,16 @@ final class FireViewController: NSViewController {
                     Task {
                         await self.animateFire(burningData: burningData)
                     }
-                } else if burningData.closesTabs, self.isKeyWindowController {
-                    // Fire animation is disabled, so nothing covers the burn. Show the
-                    // "Deleting browsing data…" progress dialog directly for tab/window/all-data
-                    // burns, mirroring what `animateFire` presents once the animation finishes.
+                } else if self.isKeyWindowController {
+                    // The full-window fire animation isn't covering this burn (it's disabled, or this is
+                    // a New Tab Page site burn that only plays the in-page animation). Show the
+                    // "Deleting browsing data…" progress dialog directly so the burn still has visible
+                    // feedback, mirroring what `animateFire` presents once the animation finishes.
+                    // (For New Tab Page burns `isFirePresentationInProgress` still defers the container
+                    // by 1s so the in-page animation plays first.)
                     self.showBurningProgressIndicator()
                 } else {
-                    // No fire UI for this burn on this window (e.g. a New Tab Page site burn, or a
-                    // non-key window): make sure a progress dialog left visible by a previous burn
+                    // Non-key window: make sure a progress dialog left visible by a previous burn
                     // isn't shown.
                     self.hideBurningProgressIndicator()
                 }

--- a/macOS/DuckDuckGo/Fire/ViewModel/FireViewModel.swift
+++ b/macOS/DuckDuckGo/Fire/ViewModel/FireViewModel.swift
@@ -31,7 +31,7 @@ extension Fire.BurningData {
      */
     func shouldDelayShowingDialog(decider: VisualizeFireSettingsDecider) -> Bool {
         switch self {
-        case .specificDomains(_, false):
+        case .specificDomains(_, closesTabs: false):
             return decider.shouldShowFireAnimation
         default:
             return false

--- a/macOS/DuckDuckGo/Fire/ViewModel/FireViewModel.swift
+++ b/macOS/DuckDuckGo/Fire/ViewModel/FireViewModel.swift
@@ -31,7 +31,7 @@ extension Fire.BurningData {
      */
     func shouldDelayShowingDialog(decider: VisualizeFireSettingsDecider) -> Bool {
         switch self {
-        case .specificDomains(_, closesTabs: false):
+        case .specificDomains(_, false):
             return decider.shouldShowFireAnimation
         default:
             return false

--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
@@ -444,21 +444,26 @@ final class TabCollectionViewModel: NSObject {
 
         shouldReturnToPreviousActiveTab = true
         tabCollection.append(tab: tab)
-        if tab.content == .newtab {
-            NotificationCenter.default.post(name: .newTabPageOpen, object: nil)
-            if isBurner {
-                var persistor = SubscriptionPromoUserDefaultsPersistor(keyValueStore: UserDefaults.standard)
-                if persistor.fireTabVisitCount < SubscriptionPromoConstants.requiredVisitCount {
-                    persistor.fireTabVisitCount += 1
-                }
-            }
-        }
+        handleNewTabPageSideEffects(for: tab)
         let insertionIndex = tabCollection.tabs.indices.index(before: tabCollection.tabs.endIndex)
         if selected {
             selectUnpinnedTab(at: insertionIndex, forceChange: forceChange)
         }
         delegate?.tabCollectionViewModelDidAppend(self, selected: selected)
         return insertionIndex
+    }
+
+    /// Side effects that accompany opening a New Tab Page tab, shared by the append and
+    /// atomic-replace paths.
+    private func handleNewTabPageSideEffects(for tab: Tab) {
+        guard tab.content == .newtab else { return }
+        NotificationCenter.default.post(name: .newTabPageOpen, object: nil)
+        if isBurner {
+            var persistor = SubscriptionPromoUserDefaultsPersistor(keyValueStore: UserDefaults.standard)
+            if persistor.fireTabVisitCount < SubscriptionPromoConstants.requiredVisitCount {
+                persistor.fireTabVisitCount += 1
+            }
+        }
     }
 
     func append(tabs: [AnyTab], andSelect shouldSelectLastTab: Bool) {
@@ -755,6 +760,20 @@ final class TabCollectionViewModel: NSObject {
         } else {
             selectionIndex = nil
         }
+        delegate?.tabCollectionViewModelDidMultipleChanges(self)
+    }
+
+    /// Atomically removes all unpinned tabs and appends `tab`, emitting a single batched change so the
+    /// tab bar reloads instead of animating an individual insertion. Used when burning replaces a
+    /// window's contents with a fresh tab, avoiding a visible flash of the tab being inserted before
+    /// the others are removed.
+    func removeAllTabs(andAppend tab: Tab, forceChange: Bool = false) {
+        guard changesEnabled || forceChange else { return }
+
+        shouldReturnToPreviousActiveTab = true
+        tabCollection.removeAll(andAppend: tab)
+        handleNewTabPageSideEffects(for: tab)
+        selectUnpinnedTab(at: 0, forceChange: forceChange)
         delegate?.tabCollectionViewModelDidMultipleChanges(self)
     }
 

--- a/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests.swift
+++ b/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests.swift
@@ -1469,6 +1469,60 @@ final class TabCollectionViewModelTests: XCTestCase {
         XCTAssertEqual(tabVM?.addressBarSharedTextState.isInDuckAIMode, true)
         XCTAssertEqual(tabVM?.addressBarSharedTextState.aiChatToolMode, .webSearch)
     }
+
+    // MARK: - removeAllTabs(andAppend:)
+
+    @MainActor
+    func testWhenRemoveAllTabsAndAppendCalled_ThenAllTabsAreReplacedWithTheGivenTab() {
+        let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
+        tabCollectionViewModel.appendNewTab()
+        tabCollectionViewModel.appendNewTab()
+        XCTAssertEqual(tabCollectionViewModel.tabCollection.tabs.count, 3)
+
+        let newTab = Tab(content: .newtab)
+        tabCollectionViewModel.removeAllTabs(andAppend: newTab)
+
+        XCTAssertEqual(tabCollectionViewModel.tabCollection.tabs.count, 1)
+        XCTAssertTrue(tabCollectionViewModel.selectedTabViewModel?.tab === newTab)
+    }
+
+    @MainActor
+    func testWhenRemoveAllTabsAndAppendCalled_ThenTheAppendedTabIsSelected() {
+        let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
+        tabCollectionViewModel.appendNewTab()
+        tabCollectionViewModel.appendNewTab()
+        tabCollectionViewModel.select(at: .unpinned(2))
+
+        tabCollectionViewModel.removeAllTabs(andAppend: Tab(content: .newtab))
+
+        XCTAssertEqual(tabCollectionViewModel.selectionIndex, .unpinned(0))
+    }
+
+    // The point of this API is to replace the window's tabs in a single batched change, so the tab
+    // bar reloads (didMultipleChanges) rather than animating an insertion (didAppend) followed by a
+    // bulk removal — which is what caused the transient extra tabs during a non-animated burn.
+    @MainActor
+    func testWhenRemoveAllTabsAndAppendCalled_ThenDelegateReceivesMultipleChangesAndNotAppend() {
+        let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
+        tabCollectionViewModel.appendNewTab()
+        let delegate = TabCollectionViewModelDelegateMock()
+        tabCollectionViewModel.delegate = delegate
+
+        tabCollectionViewModel.removeAllTabs(andAppend: Tab(content: .newtab))
+
+        XCTAssertTrue(delegate.didMultipleChangesCalled)
+        XCTAssertFalse(delegate.didAppendCalled)
+    }
+
+    @MainActor
+    func testWhenRemoveAllTabsAndAppendCalledWithNewTab_ThenNewTabPageOpenNotificationIsPosted() {
+        let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
+        let expectation = expectation(forNotification: .newTabPageOpen, object: nil)
+
+        tabCollectionViewModel.removeAllTabs(andAppend: Tab(content: .newtab))
+
+        wait(for: [expectation], timeout: 1)
+    }
 }
 
 fileprivate extension TabCollectionViewModel {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201621708115095/task/1216749738887573?focus=true

### Description

Fixes two Fire-button glitches that appear when the fire animation is disabled (Settings → Data Clearing → fire animation off):

1. **Transient tabs.** Using the Fire button (e.g. Delete Everything) briefly added one or two extra "New Tab" tabs to the tab bar before settling on a single New Tab. The window's tabs are now replaced with a fresh New Tab in a single atomic update, so no intermediate/extra tab is ever shown. A recent change had moved the tab bar out of the titlebar only to cover the fire animation; that hiding is unchanged (still animation-only), and the churn is instead prevented at its source.

2. **Missing progress dialog.** The "Deleting browsing data…" dialog never appeared, so a burn gave no visible feedback. It was only ever revealed from inside the animation code path. It's now shown directly for any burn in progress on the active window when the full-window animation isn't covering it — Delete Everything, window, tab, and New Tab Page site burns.

New Tab Page site burns still skip the full-window fire animation (they keep their own in-page animation) and don't reparent the tab bar.

### Testing Steps

1. Settings → Data Clearing → turn **off** the fire animation.
2. On a website, Fire button → Everything → Delete → **no** extra "New Tab" tabs flash in the tab bar; the "Deleting browsing data…" dialog appears; the window ends on a single New Tab.
3. Fire button → Current Tab, and → Current Window → the "Deleting browsing data…" dialog appears.
4. New Tab Page → burn a site from the privacy feed → the "Deleting browsing data…" dialog appears; open tabs are not disturbed.
5. Multiple Windows with tabs -> burn a single tab -> the "Deleting browsing data…" dialog appears in key window; all windows are blocked from interaction for the duration of the burn.
6. Turn the fire animation back **on** and repeat 2–5 → behavior is unchanged (animation plays; for New Tab Page burns the in-page animation plays and fast burns don't flash the dialog).
7. Verify that [this UI Tests workflow run](https://github.com/duckduckgo/apple-browsers/actions/runs/29847278730) is green for Fire Dialog related tests.

### Impact

Low — UI feedback/polish around the Fire button. No data-clearing behavior was changed.

#### What could go wrong?

The progress dialog now shows for more burn types → mitigated by gating it to the active (key) window and preserving the existing 1-second container deferral, so fast New Tab Page burns don't flash it.

### Quality Considerations

Verified the app builds against `release/macos/1.200.0`. The transient-tab fix and the dialog fix are separate commits; a `closesTabs` flag was added to `BurningData` so tab-closing burns can be told apart from in-place New Tab Page site burns even when the fire animation is off.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only polish around Fire feedback and tab replacement; data-clearing logic is unchanged, with progress gated to the key window and existing NTP deferrals preserved.
> 
> **Overview**
> Fixes two Fire-button issues when **Settings → Data Clearing** has the fire animation disabled.
> 
> **Transient tabs:** Burns that keep a window open no longer append a New Tab and then remove the rest (which flashed extra tabs in the tab bar). `Fire` now uses `TabCollectionViewModel.removeAllTabs(andAppend:)` so the window resets to a single New Tab in one batched update (`didMultipleChanges` instead of append-then-remove). Window/all-windows burn paths share `shouldKeepWindowOpenWhenBurning` and `makeReplacementNewTab`.
> 
> **Missing progress dialog:** The "Deleting browsing data…" UI was only shown from the fire-animation completion path. `FireViewController` now shows that progress on the **key** window whenever a burn is in progress but the full-window animation is not playing (animation off, or New Tab Page privacy-feed site burns). Non-key windows hide any stale progress UI. `BurningData` replaces `shouldPlayFireAnimation` with a **`closesTabs`** flag so tab-closing burns vs in-place NTP site burns are distinguished for animation and full-window treatment.
> 
> Unit tests cover `removeAllTabs(andAppend:)` selection, delegate batching, and NTP notifications.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5ecee989b4ac33abcb98d95c22427112bcf1036. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->