### PR TITLE
[iOS] gate using new set obscured insets iOS 26 API using selector responds to

### DIFF
--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -868,6 +868,17 @@ class TabViewController: UIViewController {
         updateWebViewBottomAnchor(for: 1.0)
     }
 
+    @discardableResult
+    private func setWebViewObscuredContentInsetsIfSupported(_ insets: UIEdgeInsets) -> Bool {
+        guard #available(iOS 26, *),
+              let webView,
+              webView.responds(to: #selector(setter: WKWebView.obscuredContentInsets)) else {
+            return false
+        }
+        webView.obscuredContentInsets = insets
+        return true
+    }
+
     func updateWebViewBottomAnchor(for barsVisibilityPercent: CGFloat) {
         let isUnifiedToggleInputAffectingBottomLayout = isAITab && unifiedToggleInputFeature.isAvailable
         if appSettings.currentAddressBarPosition == .bottom && !isUnifiedToggleInputAffectingBottomLayout {
@@ -906,15 +917,14 @@ class TabViewController: UIViewController {
             // AI tabs with the unified toggle input own their own bottom layout, so keep the web view
             // full-bleed with no obscured region there.
             let isUnifiedToggleInputAffectingLayout = isAITab && unifiedToggleInputFeature.isAvailable
-            if #available(iOS 26, *) {
+            let obscuredInsets: UIEdgeInsets = isUnifiedToggleInputAffectingLayout
+                ? .zero
+                : (chromeDelegate?.floatingWebViewObscuredInsets(for: barsVisibilityPercent) ?? .zero)
+            if setWebViewObscuredContentInsetsIfSupported(obscuredInsets) {
                 // Keep the web view full-bleed and reserve the chrome region via WebKit's public
                 // `obscuredContentInsets`, which positions page fixed/sticky elements and the layout
                 // viewport reliably (including on load) and lets content scroll behind the glass.
                 webViewBottomAnchorConstraint?.constant = 0
-                let obscuredInsets: UIEdgeInsets = isUnifiedToggleInputAffectingLayout
-                    ? .zero
-                    : (chromeDelegate?.floatingWebViewObscuredInsets(for: barsVisibilityPercent) ?? .zero)
-                webView?.obscuredContentInsets = obscuredInsets
                 // `obscuredContentInsets` does not adjust the scroll view's content/indicator insets in
                 // UIKit, so scrollable content would rest behind the bars. Feed the chrome region
                 // (beyond the device safe area, which the scroll view already accounts for) into
@@ -940,9 +950,7 @@ class TabViewController: UIViewController {
             borderView.isHidden = false
             borderView.bottomAlpha = AppWidthObserver.shared.isLargeWidth ? 0 : barsVisibilityPercent
             // Defensive: clear any obscured insets left over if floating UI was toggled off at runtime.
-            if #available(iOS 26, *) {
-                webView?.obscuredContentInsets = .zero
-            }
+            setWebViewObscuredContentInsetsIfSupported(.zero)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1216756707517304?focus=true
Tech Design URL:
CC:

### Description
Gate using new set obscured insets iOS 26 API using selector responds to in order to prevent crashes on the devices of some users who are still using early iOS 26 betas.

### Testing Steps

Assuming not testing on the beta.... smoke test on iOS 26:

1. Enable the Floating UI (and unified toggle input) flag.
2. Open several pages and submit searches/URLs using Unified Toggle Input.
3. Scroll each page and confirm content, fixed elements, and scroll indicators avoid the floating chrome correctly.
4. Test both top and bottom address-bar positions.
5. Disable Floating UI and confirm normal layout returns without a crash or stale insets.

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Could break browsing but mostly in the floating ui branch path.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to floating UI / bottom web view layout on iOS 26; worst case is falling back to the pre-obscured-insets layout path, not auth or data handling.
> 
> **Overview**
> **Prevents crashes** on some early iOS 26 betas where `WKWebView.obscuredContentInsets` is not actually implemented even when `#available(iOS 26, *)` passes.
> 
> Adds `setWebViewObscuredContentInsetsIfSupported`, which only assigns `obscuredContentInsets` when the web view **responds to the setter**. Floating UI layout in `updateWebViewBottomAnchor` now uses that helper to choose the iOS 26 obscured-inset path vs the existing resize/`additionalSafeAreaInsets` fallback, and clears insets the same way when Floating UI is turned off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f224448f1f87fd050bf0113933a6b3b560efabce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->