### PR TITLE
Backfill unit regression tests for H1 2026 release-branch fixes

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/CrashesTests/CrashCollectionTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/CrashesTests/CrashCollectionTests.swift
@@ -134,6 +134,30 @@ class CrashCollectionTests: XCTestCase {
         XCTAssertFalse(crashCollection.isFirstCrash)
     }
 
+    func testOnlyPayloadsWithCrashDiagnosticsAreProcessedForUpload() {
+        // Regression test for #3682: MetricKit delivers `MXDiagnosticPayload`s that may carry only
+        // hang / CPU / disk-write diagnostics and no `crashDiagnostics`. Those non-crash payloads
+        // must not be handed to `process` (and therefore not uploaded as crash reports). Reverting
+        // the `crashDiagnostics?.isEmpty == false` filter makes `process` receive all 3 payloads.
+        let crashReportSender = CrashReportSender(platform: .iOS, pixelEvents: nil)
+        let crashCollection = CrashCollection(crashReportSender: crashReportSender,
+                                              crashCollectionStorage: MockKeyValueStore())
+
+        var processedPayloadCount: Int?
+        crashCollection.start(process: { payloads in
+            processedPayloadCount = payloads.count
+            return payloads.map { _ in Data() }
+        }, didFindCrashReports: { _, _, _ in })
+
+        crashCollection.crashHandler.didReceive([
+            MockPayload(mockCrashes: [MXCrashDiagnostic()]),    // real crash → processed
+            MockPayload(mockCrashes: []),                       // empty crashDiagnostics → skipped
+            MockPayload(mockCrashes: nil)                       // no crashDiagnostics (e.g. hang only) → skipped
+        ])
+
+        XCTAssertEqual(processedPayloadCount, 1, "Only payloads with non-empty crashDiagnostics should be processed for upload")
+    }
+
     func testCRCIDIsStoredWhenReceived() {
         let responseCRCIDValue = "CRCID Value"
 

--- a/SharedPackages/BrowserServicesKit/Tests/SpecialErrorPagesTests/SSLErrorTypeTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SpecialErrorPagesTests/SSLErrorTypeTests.swift
@@ -1,0 +1,74 @@
+//
+//  SSLErrorTypeTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Security
+@testable import SpecialErrorPages
+
+/// Regression tests for #4255 ("Improve SSL error handling on macOS 26.4").
+///
+/// `NSError.sslErrorType` must fall back to the OSStatus carried by `NSUnderlyingError` when the
+/// legacy `_kCFStreamErrorCodeKey` is absent, and it must always resolve to a concrete case
+/// (defaulting to `.invalid`) rather than `nil` when an underlying SSL error is present. Reverting
+/// the `NSUnderlyingErrorKey` fallback makes `sslErrorType` return `nil` for these cases.
+final class SSLErrorTypeTests: XCTestCase {
+
+    func testSSLErrorTypeFromNSUnderlyingError_expiredCertificate() {
+        let underlying = NSError(domain: NSOSStatusErrorDomain, code: Int(errSSLCertExpired))
+        let error = NSError(domain: NSURLErrorDomain,
+                            code: NSURLErrorServerCertificateUntrusted,
+                            userInfo: [NSUnderlyingErrorKey: underlying])
+
+        XCTAssertEqual(error.sslErrorType, .expired)
+    }
+
+    func testSSLErrorTypeFromNSUnderlyingError_hostNameMismatch() {
+        let underlying = NSError(domain: NSOSStatusErrorDomain, code: Int(errSSLHostNameMismatch))
+        let error = NSError(domain: NSURLErrorDomain,
+                            code: NSURLErrorServerCertificateUntrusted,
+                            userInfo: [NSUnderlyingErrorKey: underlying])
+
+        XCTAssertEqual(error.sslErrorType, .wrongHost)
+    }
+
+    func testSSLErrorTypeFromNSUnderlyingError_unrecognisedCodeFallsBackToInvalid() {
+        // An underlying error whose OSStatus isn't a recognised SSL code must still resolve — to
+        // `.invalid`, not `nil` — exercising both the NSUnderlyingErrorKey fallback and the default.
+        let underlying = NSError(domain: NSOSStatusErrorDomain, code: -1)
+        let error = NSError(domain: NSURLErrorDomain,
+                            code: NSURLErrorServerCertificateUntrusted,
+                            userInfo: [NSUnderlyingErrorKey: underlying])
+
+        XCTAssertEqual(error.sslErrorType, .invalid)
+    }
+
+    func testSSLErrorTypeFromLegacyStreamErrorCodeKeyStillResolves() {
+        // The pre-26.4 detection path must remain intact.
+        let error = NSError(domain: NSURLErrorDomain,
+                            code: NSURLErrorSecureConnectionFailed,
+                            userInfo: [SSLErrorCodeKey: Int32(errSSLXCertChainInvalid)])
+
+        XCTAssertEqual(error.sslErrorType, .selfSigned)
+    }
+
+    func testSSLErrorTypeWithNoRecognisedKeysReturnsNil() {
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown, userInfo: [:])
+
+        XCTAssertNil(error.sslErrorType)
+    }
+}

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/OperationPreferredDateUpdaterTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/OperationPreferredDateUpdaterTests.swift
@@ -226,6 +226,90 @@ final class OperationPreferredDateUpdaterTests: XCTestCase {
         XCTAssertTrue(settings.hasPerformedPreferredRunDateMigration)
     }
 
+    // MARK: - History-event ordering (regression: #4269 iOS / #4270 & #4283 macOS)
+
+    /// The preferred-date calculator keys the next run date off the *last* history event, so events
+    /// must be sorted earliest-first before being handed to it. If they are passed in raw (unsorted)
+    /// order, an earlier `.error` event that happens to sit last in the array is mistaken for the most
+    /// recent event and a much sooner (wrong) run date is scheduled. Reverting the sort makes this fail.
+    func testWhenOptOutHistoryEventsAreOutOfOrder_thenPreferredRunDateReflectsChronologicallyLatestEvent() throws {
+        // Given
+        let extractedProfileId: Int64 = 1
+        let brokerId: Int64 = 1
+        let profileQueryId: Int64 = 11
+        let schedulingConfig = DataBrokerScheduleConfig(retryError: 48, confirmOptOutScan: 72, maintenanceScan: 120, maxAttempts: -1)
+
+        // The chronologically-latest event is `.optOutRequested`; an earlier event is an `.error`.
+        // They are stored out of order (latest first) so the raw array's `.last` is the earlier error.
+        let latestRequestedEvent = HistoryEvent(extractedProfileId: extractedProfileId, brokerId: brokerId, profileQueryId: profileQueryId, type: .optOutRequested, date: Date())
+        let earlierErrorEvent = HistoryEvent(extractedProfileId: extractedProfileId, brokerId: brokerId, profileQueryId: profileQueryId, type: .error(error: .unknown("error")), date: Date().addingTimeInterval(-10_000))
+
+        let scanJobData = ScanJobData(brokerId: brokerId, profileQueryId: profileQueryId, historyEvents: [])
+        let optOutJobData = OptOutJobData(brokerId: brokerId,
+                                          profileQueryId: profileQueryId,
+                                          createdDate: Date(),
+                                          historyEvents: [latestRequestedEvent, earlierErrorEvent],
+                                          attemptCount: 0,
+                                          extractedProfile: .mockWithoutRemovedDate)
+        databaseMock.brokerProfileQueryDataToReturn = [
+            BrokerProfileQueryData(dataBroker: .mock, profileQuery: .mock, scanJobData: scanJobData, optOutJobData: [optOutJobData])
+        ]
+        let sut = OperationPreferredDateUpdater(database: databaseMock, featureFlagger: disabledFeatureFlagger)
+
+        // When
+        try sut.updateOperationDataDates(origin: .optOut,
+                                         brokerId: brokerId,
+                                         profileQueryId: profileQueryId,
+                                         extractedProfileId: extractedProfileId,
+                                         schedulingConfig: schedulingConfig)
+
+        // Then
+        // Sorted → last event is `.optOutRequested` → run date is now + hoursUntilNextOptOutAttempt (== maintenanceScan, 120h).
+        let expectedSortedDate = Date().addingTimeInterval(schedulingConfig.maintenanceScan.hoursToSeconds)
+        // Unsorted (bug) → last event is the earlier `.error` (single past try) → run date would be now + 2h.
+        let buggyErrorDate = Date().addingTimeInterval(2.hoursToSeconds)
+
+        let actual = try XCTUnwrap(databaseMock.lastPreferredRunDateOnOptOut)
+        XCTAssertTrue(areDatesEqualIgnoringSeconds(date1: expectedSortedDate, date2: actual),
+                      "Opt-out run date should be derived from the chronologically-latest (.optOutRequested) event")
+        XCTAssertFalse(areDatesEqualIgnoringSeconds(date1: buggyErrorDate, date2: actual),
+                       "Run date must not be derived from the earlier .error event — events were not sorted")
+    }
+
+    func testOptOutJobDataHistoryEventsSortedEarliestFirst_returnsEventsInChronologicalOrder() {
+        let base = Date()
+        let events = [
+            HistoryEvent(brokerId: 1, profileQueryId: 1, type: .scanStarted, date: base.addingTimeInterval(300)),
+            HistoryEvent(brokerId: 1, profileQueryId: 1, type: .scanStarted, date: base.addingTimeInterval(100)),
+            HistoryEvent(brokerId: 1, profileQueryId: 1, type: .scanStarted, date: base.addingTimeInterval(200))
+        ]
+        let optOut = OptOutJobData(brokerId: 1, profileQueryId: 1, createdDate: base, historyEvents: events, attemptCount: 0, extractedProfile: .mockWithoutRemovedDate)
+
+        let sortedDates = optOut.historyEventsSortedEarliestFirst.map(\.date)
+
+        XCTAssertEqual(sortedDates, [base.addingTimeInterval(100), base.addingTimeInterval(200), base.addingTimeInterval(300)])
+    }
+
+    func testBrokerProfileQueryDataHistorySortHelpers_returnEventsInChronologicalOrder() {
+        let base = Date()
+        let scanEvents = [
+            HistoryEvent(brokerId: 1, profileQueryId: 1, type: .scanStarted, date: base.addingTimeInterval(200)),
+            HistoryEvent(brokerId: 1, profileQueryId: 1, type: .scanStarted, date: base.addingTimeInterval(50))
+        ]
+        let optOutEvents = [
+            HistoryEvent(extractedProfileId: 1, brokerId: 1, profileQueryId: 1, type: .optOutRequested, date: base.addingTimeInterval(400)),
+            HistoryEvent(extractedProfileId: 1, brokerId: 1, profileQueryId: 1, type: .error(error: .unknown("error")), date: base.addingTimeInterval(100))
+        ]
+        let scanJobData = ScanJobData(brokerId: 1, profileQueryId: 1, historyEvents: scanEvents)
+        let optOutJobData = OptOutJobData(brokerId: 1, profileQueryId: 1, createdDate: base, historyEvents: optOutEvents, attemptCount: 0, extractedProfile: .mockWithoutRemovedDate)
+        let queryData = BrokerProfileQueryData(dataBroker: .mock, profileQuery: .mock, scanJobData: scanJobData, optOutJobData: [optOutJobData])
+
+        XCTAssertEqual(queryData.scanJobDataHistoryEventsSortedEarliestFirst.map(\.date),
+                       [base.addingTimeInterval(50), base.addingTimeInterval(200)])
+        XCTAssertEqual(queryData.optOutJobDataHistoryEventsSortedWithinOptOutEarliestFirst.map { $0.map(\.date) },
+                       [[base.addingTimeInterval(100), base.addingTimeInterval(400)]])
+    }
+
     private func makeBrokerProfileQueryDataWithErrorOptOut(brokerId: Int64,
                                                            profileQueryId: Int64,
                                                            extractedProfileId: Int64) -> BrokerProfileQueryData {

--- a/SharedPackages/WebExtensions/Tests/WebExtensionsTests/Scriptlets/ScriptletStoreTests.swift
+++ b/SharedPackages/WebExtensions/Tests/WebExtensionsTests/Scriptlets/ScriptletStoreTests.swift
@@ -273,6 +273,32 @@ final class ScriptletStoreTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: sibling.path))
     }
 
+    // MARK: - Symlinked temporary directory containment (regression: #4637)
+
+    /// On device the OS temporary directory is reached via a symlink (e.g. `/var` → `/private/var`),
+    /// and `URL.resolvingSymlinksInPath()` leaves a not-yet-existing staging file path *unresolved*.
+    /// The staging file must therefore be built from the already-resolved temp directory; otherwise
+    /// the containment check compares an unresolved file path against the resolved base, wrongly
+    /// rejects it, and every save fails. Reverting to `tempDirectory.appendingPathComponent(...)`
+    /// makes this throw `ScriptletError.pathEscapesBase`.
+    func testWhenTemporaryDirectoryIsReachedViaSymlinkThenSaveStillSucceeds() throws {
+        let symlinkRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let realTemp = symlinkRoot.appendingPathComponent("real")
+        let linkedTemp = symlinkRoot.appendingPathComponent("link")
+        try FileManager.default.createDirectory(at: realTemp, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(at: linkedTemp, withDestinationURL: realTemp)
+        defer { try? FileManager.default.removeItem(at: symlinkRoot) }
+
+        let symlinkedFileManager = SymlinkedTemporaryDirectoryFileManager(temporaryDirectoryOverride: linkedTemp)
+        let symlinkStore = ScriptletStore(baseDirectory: tempDirectory, defaults: defaults, fileManager: symlinkedFileManager)
+
+        let fetched = [makeFetchedScriptlet(name: "scriptlets/scriptlet.js", content: "content")]
+
+        XCTAssertNoThrow(try symlinkStore.save(fetched, version: "1.0", for: .adBlockingExtension),
+                         "save must stage into the resolved temp directory so the containment check passes when the temp dir is symlinked")
+        XCTAssertEqual(symlinkStore.loadCached(for: .adBlockingExtension)?.scriptlets.first?.path, "scriptlets/scriptlet.js")
+    }
+
     // MARK: - Helpers
 
     private func makeFetchedScriptlet(name: String, content: String) -> FetchedScriptlet {
@@ -281,5 +307,20 @@ final class ScriptletStoreTests: XCTestCase {
             url: URL(string: "https://example.com/\(name)")!,
             signature: "sig")
         return FetchedScriptlet(descriptor: descriptor, data: Data(content.utf8))
+    }
+}
+
+/// A `FileManager` whose `temporaryDirectory` is a caller-supplied symlink, so tests can reproduce
+/// the on-device layout where the temp directory is reached through a symlink.
+private final class SymlinkedTemporaryDirectoryFileManager: FileManager {
+    private let temporaryDirectoryOverride: URL
+
+    init(temporaryDirectoryOverride: URL) {
+        self.temporaryDirectoryOverride = temporaryDirectoryOverride
+        super.init()
+    }
+
+    override var temporaryDirectory: URL {
+        temporaryDirectoryOverride
     }
 }

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1922,6 +1922,7 @@
 		C128BA252DF0847900ADDC5F /* SettingsCompleteSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C128BA242DF0847900ADDC5F /* SettingsCompleteSetupView.swift */; };
 		C12B671E2EC0ABEB003B80DD /* AIChatContentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12B671D2EC0ABEB003B80DD /* AIChatContentHandler.swift */; };
 		C12B67202EC0BDD9003B80DD /* AIChatContentHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12B671F2EC0BDD9003B80DD /* AIChatContentHandlerTests.swift */; };
+		FDDA366100000000000000B0 /* AIChatUserScriptSyncPushTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDDA366100000000000000A1 /* AIChatUserScriptSyncPushTests.swift */; };
 		C138286D2EB57712001AE344 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = C138286C2EB57712001AE344 /* Lottie */; };
 		C138286F2EB57757001AE344 /* confirmation-prompt-128.json in Resources */ = {isa = PBXBuildFile; fileRef = C138286E2EB57757001AE344 /* confirmation-prompt-128.json */; };
 		C13830FC2DCD3F1400A29B3C /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13830FB2DCD3F1400A29B3C /* WebView.swift */; };
@@ -4615,6 +4616,7 @@
 		C129DF0A2D0862D7007AB046 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C12B671D2EC0ABEB003B80DD /* AIChatContentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContentHandler.swift; sourceTree = "<group>"; };
 		C12B671F2EC0BDD9003B80DD /* AIChatContentHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContentHandlerTests.swift; sourceTree = "<group>"; };
+		FDDA366100000000000000A1 /* AIChatUserScriptSyncPushTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatUserScriptSyncPushTests.swift; sourceTree = "<group>"; };
 		C132F5A32D0862B8000C81D0 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		C132F5A42D0862B8000C81D0 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C138286E2EB57757001AE344 /* confirmation-prompt-128.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "confirmation-prompt-128.json"; sourceTree = "<group>"; };
@@ -6034,6 +6036,7 @@
 				5AB12C3D4E5F60718293A4F4 /* ChatHistoryDownloaderTests.swift */,
 				3132928208A0000000C3A276 /* DuckAiNativeStorageContainerMigrationTests.swift */,
 				C12B671F2EC0BDD9003B80DD /* AIChatContentHandlerTests.swift */,
+				FDDA366100000000000000A1 /* AIChatUserScriptSyncPushTests.swift */,
 				B8BCE5B1BA2A40AFBD9B2FDF /* AIBoundaryNavigationDecisionTests.swift */,
 				C16670E32EE7301300C6105C /* SubscriptionAIChatStateHandlerTests.swift */,
 				C13EBC502EE9CD2F00CE5A4B /* AIChatContextualModeFeatureTests.swift */,
@@ -14524,6 +14527,7 @@
 				5B4FA2F12F33F50B007DDF4C /* MockRemoteMessagingImageLoader.swift in Sources */,
 				9FF967B22E0E26DE00E45B54 /* DefaultBrowserPromptUserTypeManagerTests.swift in Sources */,
 				C12B67202EC0BDD9003B80DD /* AIChatContentHandlerTests.swift in Sources */,
+				FDDA366100000000000000B0 /* AIChatUserScriptSyncPushTests.swift in Sources */,
 				26B891EE56C54E4587912787 /* AIBoundaryNavigationDecisionTests.swift in Sources */,
 				7C8A1B2D3E4F506172839405 /* AIChatTabChatHeaderViewTests.swift in Sources */,
 				98629D342C21BE37001E6031 /* BookmarksStateValidationTests.swift in Sources */,

--- a/iOS/DuckDuckGoTests/AIChat/AIChatUserScriptSyncPushTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatUserScriptSyncPushTests.swift
@@ -1,0 +1,51 @@
+//
+//  AIChatUserScriptSyncPushTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import UserScript
+import XCTest
+@testable import DuckDuckGo
+
+/// Regression test for #3661: sync-status push messages must only be delivered to allowed DuckDuckGo
+/// destinations, never to arbitrary pages. The fix introduced a dedicated `messageDestinationPolicy`
+/// (used by `submitSyncStatusChanged`'s guard) that is deliberately narrower than the message-origin
+/// policy — notably it allows duck.ai but NOT duckduckgo.com.
+///
+/// This asserts the destination policy's scope directly. Reverting `buildMessageDestinationRules`
+/// (e.g. widening it to arbitrary hosts, or reusing the origin policy which includes duckduckgo.com)
+/// fails these assertions; removing the policy entirely fails to compile.
+@MainActor
+final class AIChatUserScriptSyncPushTests: XCTestCase {
+
+    func testSyncPushDestinationPolicyAllowsDuckAiButNotArbitraryOrDuckDuckGoHosts() throws {
+        let userScript = AIChatUserScript(handler: MockAIChatUserScriptHandling(),
+                                          debugSettings: MockAIChatDebugSettingsForTests())
+        let policy = userScript.messageDestinationPolicy
+
+        let duckAiHost = try XCTUnwrap(URL.duckAi.host)
+        let duckDuckGoHost = try XCTUnwrap(URL.ddg.host)
+
+        XCTAssertTrue(policy.isAllowed(duckAiHost),
+                      "duck.ai must be an allowed sync-status push destination")
+        XCTAssertFalse(policy.isAllowed("example.com"),
+                       "arbitrary pages must not receive sync-status push messages")
+        XCTAssertFalse(policy.isAllowed(duckDuckGoHost),
+                       "duckduckgo.com is an allowed message origin but must NOT be a sync-status push destination")
+    }
+}

--- a/iOS/DuckDuckGoTests/AutoClearTests.swift
+++ b/iOS/DuckDuckGoTests/AutoClearTests.swift
@@ -77,6 +77,26 @@ class AutoClearTests: XCTestCase {
     // Note: applicationDidLaunch based clearing has moved to "configureTabManager" function of
     //  MainViewController to ensure that tabs are removed before the data is cleared.
 
+    func testIsTabClearingEnabledOnlyWhenTabsActionIsSelected() {
+        // Regression test for #4488: Auto Clear must only clear tabs when the Tabs toggle is on.
+        // isTabClearingEnabled must reflect action.contains(.tabs), NOT merely whether auto-clear is
+        // enabled at all. Reverting it to mirror isClearingEnabled makes the .data-only case fail.
+        let logic = AutoClear(worker: mockFireExecutor, appSettings: appSettings)
+
+        appSettings.autoClearAction = .data
+        XCTAssertTrue(logic.isClearingEnabled)
+        XCTAssertFalse(logic.isTabClearingEnabled, "Data-only auto-clear must not clear tabs")
+
+        appSettings.autoClearAction = [.tabs, .data]
+        XCTAssertTrue(logic.isTabClearingEnabled)
+
+        appSettings.autoClearAction = .tabs
+        XCTAssertTrue(logic.isTabClearingEnabled)
+
+        appSettings.autoClearAction = []
+        XCTAssertFalse(logic.isTabClearingEnabled)
+    }
+
     func testWhenTimingIsSetToTerminationThenOnlyRestartClearsData() async {
         let logic = AutoClear(worker: mockFireExecutor, appSettings: appSettings)
 

--- a/iOS/DuckDuckGoTests/DownloadManagerTests.swift
+++ b/iOS/DuckDuckGoTests/DownloadManagerTests.swift
@@ -35,7 +35,22 @@ class DownloadManagerTests: XCTestCase {
         WKNavigationResponse.restoreDealloc()
         downloadManagerTestsHelper.deleteAllFiles()
     }
-    
+
+    func testWhenDownloadManagerIsInitializedWithEmptyDirectoryThenDirectoryIsNotDeleted() throws {
+        // Regression test for #3400: the download manager must NOT delete the downloads directory on
+        // init. The reverted "delete downloads directory if empty" logic wiped users' Downloads
+        // folder on launch; re-introducing delete-on-init behaviour makes this fail.
+        let handler = DownloadsDirectoryHandler()
+        handler.createDownloadsDirectory()
+        XCTAssertTrue(handler.downloadsDirectoryExists())
+        XCTAssertTrue(try handler.downloadsDirectoryFiles.isEmpty)
+
+        _ = DownloadManager(NotificationCenter(), downloadsDirectoryHandler: handler)
+
+        XCTAssertTrue(handler.downloadsDirectoryExists(),
+                      "DownloadManager init must not auto-delete the (empty) downloads directory")
+    }
+
     func testWhenIPadThenPKPassThenDownloadIsNotTemporary() throws {
         guard UIDevice.current.userInterfaceIdiom == .pad else { return }
         

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerAuthGateTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerAuthGateTests.swift
@@ -155,6 +155,20 @@ final class DataBrokerProtectionIOSManagerAuthGateTests: XCTestCase {
         XCTAssertTrue(dependencies.queueManager.didCallStartImmediateScanOperationsIfPermitted)
     }
 
+    func testAppDidBecomeActive_authenticatedButNoProfile_doesNotStartScanOperations() async {
+        // Regression test for #3053: a foreground activation must skip scan/email work when no PIR
+        // profile exists, even for an authenticated user with the foreground-running feature on.
+        // Reverting the `meetsProfileRunPrequisite` guard lets scan operations start with no profile.
+        let featureFlagger = MockDBPFeatureFlagger(isForegroundRunningOnAppActiveFeatureOn: true)
+        let (sut, dependencies) = DBPContinuedProcessingTestUtils.makeTestIOSManager(featureFlagger: featureFlagger)
+        dependencies.database.profile = nil
+        dependencies.authenticationManager.isUserAuthenticatedValue = true
+
+        await sut.appDidBecomeActive()
+
+        XCTAssertFalse(dependencies.queueManager.didCallStartImmediateScanOperationsIfPermitted)
+    }
+
     // MARK: - handleBGProcessingTask routing
 
     func testHandleBGProcessingTask_authenticated_startsAllOperations() async {

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -155,7 +155,9 @@
 		1D8C2FED2B70F5D0005E4BBD /* MockViewSnapshotRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8C2FEC2B70F5D0005E4BBD /* MockViewSnapshotRenderer.swift */; };
 		1D8C2FEE2B70F5D0005E4BBD /* MockViewSnapshotRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8C2FEC2B70F5D0005E4BBD /* MockViewSnapshotRenderer.swift */; };
 		1D8C2FF02B70F751005E4BBD /* MockTabSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8C2FEF2B70F751005E4BBD /* MockTabSnapshotStore.swift */; };
+		FDDA461500000000000000B0 /* TabPreviewViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDDA461500000000000000A1 /* TabPreviewViewControllerTests.swift */; };
 		1D8C2FF12B70F751005E4BBD /* MockTabSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8C2FEF2B70F751005E4BBD /* MockTabSnapshotStore.swift */; };
+		FDDA461500000000000000B1 /* TabPreviewViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDDA461500000000000000A1 /* TabPreviewViewControllerTests.swift */; };
 		1D94E7992F333CA1008315A2 /* AIChatOmnibarToolButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D94E7982F333CA1008315A2 /* AIChatOmnibarToolButton.swift */; };
 		1D94E79A2F333CA1008315A2 /* AIChatOmnibarToolButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D94E7982F333CA1008315A2 /* AIChatOmnibarToolButton.swift */; };
 		1D94E7A02F33AA2E008315A2 /* MacOSWebExtensionPixelFiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D94E79F2F33AA28008315A2 /* MacOSWebExtensionPixelFiring.swift */; };
@@ -4919,6 +4921,7 @@
 		1D8C2FE92B70F5A7005E4BBD /* MockWebViewSnapshotRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockWebViewSnapshotRenderer.swift; sourceTree = "<group>"; };
 		1D8C2FEC2B70F5D0005E4BBD /* MockViewSnapshotRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockViewSnapshotRenderer.swift; sourceTree = "<group>"; };
 		1D8C2FEF2B70F751005E4BBD /* MockTabSnapshotStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockTabSnapshotStore.swift; sourceTree = "<group>"; };
+		FDDA461500000000000000A1 /* TabPreviewViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TabPreviewViewControllerTests.swift; path = UnitTests/TabPreview/TabPreviewViewControllerTests.swift; sourceTree = SOURCE_ROOT; };
 		1D94E7982F333CA1008315A2 /* AIChatOmnibarToolButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatOmnibarToolButton.swift; sourceTree = "<group>"; };
 		1D94E79F2F33AA28008315A2 /* MacOSWebExtensionPixelFiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacOSWebExtensionPixelFiring.swift; sourceTree = "<group>"; };
 		1D99CDDA2D929EBE00656A84 /* PinnedTabsPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedTabsPixel.swift; sourceTree = "<group>"; };
@@ -7777,6 +7780,7 @@
 				1D8C2FE92B70F5A7005E4BBD /* MockWebViewSnapshotRenderer.swift */,
 				1D8C2FEC2B70F5D0005E4BBD /* MockViewSnapshotRenderer.swift */,
 				1D8C2FEF2B70F751005E4BBD /* MockTabSnapshotStore.swift */,
+				FDDA461500000000000000A1 /* TabPreviewViewControllerTests.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -16782,6 +16786,7 @@
 				BBD31EAA2E2FB46E0045551C /* VPNUpsellVisibilityManagerTests.swift in Sources */,
 				376E2D2629428353001CD31B /* PrivacyReferenceTestHelper.swift in Sources */,
 				1D8C2FF12B70F751005E4BBD /* MockTabSnapshotStore.swift in Sources */,
+				FDDA461500000000000000B1 /* TabPreviewViewControllerTests.swift in Sources */,
 				37A0BA242D747B9F00130447 /* CapturingContextMenuPresenter.swift in Sources */,
 				3706FE7E293F661700E42796 /* RunLoopExtensionTests.swift in Sources */,
 				5681ED412BDB955100F59729 /* SyncCredentialsAdapterTests.swift in Sources */,
@@ -18926,6 +18931,7 @@
 				37EC31532D8C1BBC0026C348 /* CapturingFaviconReferenceCache.swift in Sources */,
 				56534DED29DF252C00121467 /* CapturingDefaultBrowserProvider.swift in Sources */,
 				1D8C2FF02B70F751005E4BBD /* MockTabSnapshotStore.swift in Sources */,
+				FDDA461500000000000000B0 /* TabPreviewViewControllerTests.swift in Sources */,
 				9F0660782BECC81C00B8EEF1 /* PixelCapturedParameters.swift in Sources */,
 				B5E7B6CA2ED4A7A800094EDF /* LoadingIndicatorPolicyTests.swift in Sources */,
 				B6C2C9F62760B659005B7F0A /* TestDataModel.xcdatamodeld in Sources */,

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -155,8 +155,12 @@
 		1D8C2FED2B70F5D0005E4BBD /* MockViewSnapshotRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8C2FEC2B70F5D0005E4BBD /* MockViewSnapshotRenderer.swift */; };
 		1D8C2FEE2B70F5D0005E4BBD /* MockViewSnapshotRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8C2FEC2B70F5D0005E4BBD /* MockViewSnapshotRenderer.swift */; };
 		1D8C2FF02B70F751005E4BBD /* MockTabSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8C2FEF2B70F751005E4BBD /* MockTabSnapshotStore.swift */; };
+		FDDA535900000000000000B0 /* FaviconStoreCorruptImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDDA535900000000000000A1 /* FaviconStoreCorruptImageTests.swift */; };
+		FDDA435800000000000000B0 /* AIChatTabExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDDA435800000000000000A1 /* AIChatTabExtensionTests.swift */; };
 		FDDA461500000000000000B0 /* TabPreviewViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDDA461500000000000000A1 /* TabPreviewViewControllerTests.swift */; };
 		1D8C2FF12B70F751005E4BBD /* MockTabSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8C2FEF2B70F751005E4BBD /* MockTabSnapshotStore.swift */; };
+		FDDA535900000000000000B1 /* FaviconStoreCorruptImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDDA535900000000000000A1 /* FaviconStoreCorruptImageTests.swift */; };
+		FDDA435800000000000000B1 /* AIChatTabExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDDA435800000000000000A1 /* AIChatTabExtensionTests.swift */; };
 		FDDA461500000000000000B1 /* TabPreviewViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDDA461500000000000000A1 /* TabPreviewViewControllerTests.swift */; };
 		1D94E7992F333CA1008315A2 /* AIChatOmnibarToolButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D94E7982F333CA1008315A2 /* AIChatOmnibarToolButton.swift */; };
 		1D94E79A2F333CA1008315A2 /* AIChatOmnibarToolButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D94E7982F333CA1008315A2 /* AIChatOmnibarToolButton.swift */; };
@@ -4921,6 +4925,8 @@
 		1D8C2FE92B70F5A7005E4BBD /* MockWebViewSnapshotRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockWebViewSnapshotRenderer.swift; sourceTree = "<group>"; };
 		1D8C2FEC2B70F5D0005E4BBD /* MockViewSnapshotRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockViewSnapshotRenderer.swift; sourceTree = "<group>"; };
 		1D8C2FEF2B70F751005E4BBD /* MockTabSnapshotStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockTabSnapshotStore.swift; sourceTree = "<group>"; };
+		FDDA535900000000000000A1 /* FaviconStoreCorruptImageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FaviconStoreCorruptImageTests.swift; path = UnitTests/Favicons/FaviconStoreCorruptImageTests.swift; sourceTree = SOURCE_ROOT; };
+		FDDA435800000000000000A1 /* AIChatTabExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AIChatTabExtensionTests.swift; path = UnitTests/TabExtensionsTests/AIChatTabExtensionTests.swift; sourceTree = SOURCE_ROOT; };
 		FDDA461500000000000000A1 /* TabPreviewViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TabPreviewViewControllerTests.swift; path = UnitTests/TabPreview/TabPreviewViewControllerTests.swift; sourceTree = SOURCE_ROOT; };
 		1D94E7982F333CA1008315A2 /* AIChatOmnibarToolButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatOmnibarToolButton.swift; sourceTree = "<group>"; };
 		1D94E79F2F33AA28008315A2 /* MacOSWebExtensionPixelFiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacOSWebExtensionPixelFiring.swift; sourceTree = "<group>"; };
@@ -7780,6 +7786,8 @@
 				1D8C2FE92B70F5A7005E4BBD /* MockWebViewSnapshotRenderer.swift */,
 				1D8C2FEC2B70F5D0005E4BBD /* MockViewSnapshotRenderer.swift */,
 				1D8C2FEF2B70F751005E4BBD /* MockTabSnapshotStore.swift */,
+				FDDA535900000000000000A1 /* FaviconStoreCorruptImageTests.swift */,
+				FDDA435800000000000000A1 /* AIChatTabExtensionTests.swift */,
 				FDDA461500000000000000A1 /* TabPreviewViewControllerTests.swift */,
 			);
 			path = Mocks;
@@ -16786,6 +16794,8 @@
 				BBD31EAA2E2FB46E0045551C /* VPNUpsellVisibilityManagerTests.swift in Sources */,
 				376E2D2629428353001CD31B /* PrivacyReferenceTestHelper.swift in Sources */,
 				1D8C2FF12B70F751005E4BBD /* MockTabSnapshotStore.swift in Sources */,
+				FDDA535900000000000000B1 /* FaviconStoreCorruptImageTests.swift in Sources */,
+				FDDA435800000000000000B1 /* AIChatTabExtensionTests.swift in Sources */,
 				FDDA461500000000000000B1 /* TabPreviewViewControllerTests.swift in Sources */,
 				37A0BA242D747B9F00130447 /* CapturingContextMenuPresenter.swift in Sources */,
 				3706FE7E293F661700E42796 /* RunLoopExtensionTests.swift in Sources */,
@@ -18931,6 +18941,8 @@
 				37EC31532D8C1BBC0026C348 /* CapturingFaviconReferenceCache.swift in Sources */,
 				56534DED29DF252C00121467 /* CapturingDefaultBrowserProvider.swift in Sources */,
 				1D8C2FF02B70F751005E4BBD /* MockTabSnapshotStore.swift in Sources */,
+				FDDA535900000000000000B0 /* FaviconStoreCorruptImageTests.swift in Sources */,
+				FDDA435800000000000000B0 /* AIChatTabExtensionTests.swift in Sources */,
 				FDDA461500000000000000B0 /* TabPreviewViewControllerTests.swift in Sources */,
 				9F0660782BECC81C00B8EEF1 /* PixelCapturedParameters.swift in Sources */,
 				B5E7B6CA2ED4A7A800094EDF /* LoadingIndicatorPolicyTests.swift in Sources */,

--- a/macOS/DuckDuckGo/Promotions/PromoService.swift
+++ b/macOS/DuckDuckGo/Promotions/PromoService.swift
@@ -415,7 +415,8 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
         externalSubscriptions[promoId] = cancellable
     }
 
-    private func applyExternalVisibility(visible: Bool, promoId: String, delegate: ExternalPromoDelegate) {
+    // Not private so the off-queue re-dispatch guard can be exercised directly by unit tests (#5083).
+    func applyExternalVisibility(visible: Bool, promoId: String, delegate: ExternalPromoDelegate) {
         guard isOnStateQueue else {
             stateQueue.async { [weak self] in
                 self?.applyExternalVisibility(visible: visible, promoId: promoId, delegate: delegate)

--- a/macOS/DuckDuckGo/Tab/TabExtensions/AIChatTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/AIChatTabExtension.swift
@@ -46,6 +46,9 @@ final class AIChatTabExtension {
     private let featureFlagger: FeatureFlagger
     private let bootstrapRefresher: DuckAiNativeStorageBootstrapScriptRefresher?
     private let fireModeStorageProvider: () -> DuckAiFireModeStorage
+    /// Opens `url` in a new tab and returns whether a tab was opened. Injectable so the sidebar
+    /// navigation-policy fallback can be exercised without a live window hierarchy (#4358).
+    private let openNewTab: @MainActor (URL) -> Bool
 
     private(set) weak var aiChatUserScript: AIChatUserScript? {
         didSet {
@@ -62,12 +65,18 @@ final class AIChatTabExtension {
          featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger,
          duckAiNativeStorageHandler: DuckAiNativeStorageHandling? = NSApp.delegateTyped.duckAiNativeStorageHandler,
          burnerDuckAiStorageRegistry: BurnerDuckAiStorageRegistry? = NSApp.delegateTyped.burnerDuckAiStorageRegistry,
-         aiChatDebugURLSettings: (any KeyedStoring<AIChatDebugURLSettings>)? = nil) {
+         aiChatDebugURLSettings: (any KeyedStoring<AIChatDebugURLSettings>)? = nil,
+         openNewTab: @escaping @MainActor (URL) -> Bool = { url in
+             guard let parentWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController else { return false }
+             parentWindowController.mainViewController.tabCollectionViewModel.insertOrAppendNewTab(.url(url, source: .link))
+             return true
+         }) {
         self.isLoadedInSidebar = isLoadedInSidebar
         self.isTabBurner = isTabBurner
         self.burnerMode = burnerMode
         self.featureDiscovery = featureDiscovery
         self.featureFlagger = featureFlagger
+        self.openNewTab = openNewTab
         let debugSettings: any KeyedStoring<AIChatDebugURLSettings> = if let aiChatDebugURLSettings { aiChatDebugURLSettings } else { UserDefaults.standard.keyedStoring() }
         self.fireModeStorageProvider = { [burnerMode, weak burnerDuckAiStorageRegistry] in
             .resolve(isFireMode: burnerMode.isBurner,
@@ -301,13 +310,7 @@ extension AIChatTabExtension: NavigationResponder {
         }
 
         // For all other hosts, open in a new tab and cancel sidebar navigation
-        guard let parentWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController else {
-            return .next
-        }
-
-        let tabCollectionViewModel = parentWindowController.mainViewController.tabCollectionViewModel
-        tabCollectionViewModel.insertOrAppendNewTab(.url(navigationAction.url, source: .link))
-        return .cancel
+        return openNewTab(navigationAction.url) ? .cancel : .next
     }
 
     func navigationDidFinish(_ navigation: Navigation) {

--- a/macOS/DuckDuckGo/TabPreview/TabPreviewViewController.swift
+++ b/macOS/DuckDuckGo/TabPreview/TabPreviewViewController.swift
@@ -164,7 +164,8 @@ final class TabPreviewViewController: NSViewController {
         }
     }
 
-    private func getHeight(for image: NSImage?) -> CGFloat {
+    // Not private so the zero-dimension guard can be exercised directly by unit tests (#4615).
+    func getHeight(for image: NSImage?) -> CGFloat {
         guard let image, image.size.width > 0, image.size.height > 0 else { return 0 }
 
         let aspectRatio = image.size.width / image.size.height

--- a/macOS/UnitTests/Favicons/FaviconStoreCorruptImageTests.swift
+++ b/macOS/UnitTests/Favicons/FaviconStoreCorruptImageTests.swift
@@ -1,0 +1,111 @@
+//
+//  FaviconStoreCorruptImageTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import CoreData
+import Persistence
+import SharedTestUtilities
+import Utilities
+import XCTest
+@testable import DuckDuckGo_Privacy_Browser
+
+/// Regression tests for #5359 (APPLE-MACOS-B8H): a corrupt stored favicon bitmap makes AppKit raise
+/// an Objective-C `NSInvalidUnarchiveOperationException` while Core Data unarchives `imageEncrypted`.
+/// `FaviconStore` wraps that access in `NSException.catch`; reverting the fix lets the ObjC exception
+/// propagate and **crashes the test process** (that is the fail-on-revert signal).
+///
+/// The harness registers a stand-in `NSImageTransformer` whose reverse transform raises the same
+/// exception a corrupt bitmap would, so the real `FaviconStore` Core Data read path is exercised.
+@MainActor
+final class FaviconStoreCorruptImageTests: XCTestCase {
+
+    private var database: CoreDataDatabase!
+    private var location: URL!
+    private var context: NSManagedObjectContext!
+    private var registeredTransformerNames: [NSValueTransformerName] = []
+    private let imageTransformerName = NSValueTransformerName("NSImageTransformer")
+
+    override func setUp() {
+        super.setUp()
+        // Register the raising image transformer first. `registerValueTransformers` skips names that
+        // are already registered, so this stays in place while the URL/String transformers load.
+        ValueTransformer.setValueTransformer(CorruptImageValueTransformer(), forName: imageTransformerName)
+
+        let model = CoreDataDatabase.loadModel(from: Bundle(for: AppDelegate.self), named: "Favicons")!
+        registeredTransformerNames = (try? model.registerValueTransformers(keyStore: EncryptionKeyStoreMock())) ?? []
+        location = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        database = CoreDataDatabase(name: "FaviconsCorruptImageTest", containerLocation: location, model: model)
+        database.loadStore { _, error in
+            if let error { XCTFail("Could not load store: \(error.localizedDescription)") }
+        }
+        context = database.makeContext(concurrencyType: .mainQueueConcurrencyType)
+    }
+
+    override func tearDown() {
+        ValueTransformer.setValueTransformer(nil, forName: imageTransformerName)
+        registeredTransformerNames.forEach { ValueTransformer.setValueTransformer(nil, forName: $0) }
+        registeredTransformerNames = []
+        try? FileManager.default.removeItem(at: location)
+        context = nil
+        database = nil
+        location = nil
+        super.tearDown()
+    }
+
+    @discardableResult
+    private func insertCorruptFavicon() throws -> UUID {
+        let identifier = UUID()
+        let mo = NSEntityDescription.insertNewObject(forEntityName: FaviconManagedObject.className(), into: context) as! FaviconManagedObject
+        mo.identifier = identifier
+        mo.imageEncrypted = NSImage()
+        mo.urlEncrypted = URL(string: "https://example.com/favicon.ico")! as NSURL
+        mo.documentUrlEncrypted = URL(string: "https://example.com/")! as NSURL
+        mo.dateCreated = Date()
+        mo.relation = Int64(Favicon.Relation.favicon.rawValue)
+        try context.save()
+        return identifier
+    }
+
+    func testLoadFaviconsReturnsFaviconWithNilImageOnCorruptStoredImage() async throws {
+        try insertCorruptFavicon()
+        let store = FaviconStore(context: context)
+
+        let favicons = try await store.loadFavicons()
+
+        XCTAssertEqual(favicons.count, 1, "The favicon should still load; only its image is dropped")
+        XCTAssertNil(favicons.first?.image, "A corrupt stored bitmap must decode to a nil image, not crash")
+    }
+}
+
+/// Stand-in for the favicon image transformer whose reverse transform raises the Objective-C
+/// exception AppKit throws for a corrupt bitmap. `transformedValue` returns placeholder data so
+/// inserting the managed object succeeds.
+private final class CorruptImageValueTransformer: ValueTransformer {
+    override class func transformedValueClass() -> AnyClass { NSData.self }
+    override class func allowsReverseTransformation() -> Bool { true }
+
+    override func transformedValue(_ value: Any?) -> Any? {
+        Data([0x00])
+    }
+
+    override func reverseTransformedValue(_ value: Any?) -> Any? {
+        NSException(name: NSExceptionName("NSInvalidUnarchiveOperationException"),
+                    reason: "corrupt favicon bitmap (test)",
+                    userInfo: nil).raise()
+        return nil
+    }
+}

--- a/macOS/UnitTests/Promotions/PromoServiceTests.swift
+++ b/macOS/UnitTests/Promotions/PromoServiceTests.swift
@@ -66,6 +66,23 @@ final class PromoServiceTests: XCTestCase {
         )
     }
 
+    // MARK: - Off-queue precondition (regression: #5083)
+
+    func testApplyExternalVisibilityOffStateQueueReDispatchesInsteadOfCrashing() {
+        // Regression test for #5083: state mutators invoked off the state queue must re-dispatch onto
+        // it rather than tripping dispatchPrecondition (which crashed the app). This calls
+        // applyExternalVisibility from the test thread (NOT testQueue); with the fix reverted to
+        // `dispatchPrecondition(condition: .onQueue(stateQueue))` the test process crashes.
+        let delegate = MockExternalPromoDelegate()
+        let service = makeService(promos: [])
+
+        service.applyExternalVisibility(visible: true, promoId: "external-promo", delegate: delegate)
+        testQueue.sync {} // barrier: wait for the re-dispatched work to complete
+
+        XCTAssertNotNil(historyStore.record(for: "external-promo").lastShown,
+                        "External visibility applied off-queue should still record the promo as shown")
+    }
+
     // MARK: - Rule evaluation
 
     func testWhenOneMediumPromoVisible_ThenSecondMediumPromoIsSkipped() async {

--- a/macOS/UnitTests/Suggestions/Model/SuggestionContainerTests.swift
+++ b/macOS/UnitTests/Suggestions/Model/SuggestionContainerTests.swift
@@ -166,6 +166,27 @@ final class SuggestionContainerTests: XCTestCase {
     }
 
     @MainActor
+    func testAllTabViewModelsSurfacesUnloadedTabsForSuggestions() {
+        // Regression test for #4925: address-bar open-tab suggestions are built from
+        // WindowControllersManager.allTabViewModels(for:), which must include *unloaded* tabs. The
+        // bug filtered the view models with `as? TabViewModel`, dropping unloaded tabs so they never
+        // appeared as suggestions. Reverting that filter drops the unloaded tab asserted below.
+        let loadedTab = Tab(content: .url(URL(string: "https://loaded.example.com/")!, source: .link))
+        let unloaded = UnloadedTab(content: .url(URL(string: "https://unloaded.example.com/")!, source: .pendingStateRestoration))
+        let tabCollectionViewModel = TabCollectionViewModel(
+            tabCollection: TabCollection(tabs: [.loaded(loadedTab), .unloaded(unloaded)]),
+            pinnedTabsManagerProvider: PinnedTabsManagerProvidingMock()
+        )
+        // Selection defaults to index 0 (the loaded tab), so the tab at index 1 stays unloaded.
+        let windowControllersManager = WindowControllersManagerMock(tabCollectionViewModels: [tabCollectionViewModel])
+
+        let openTabViewModels = windowControllersManager.allTabViewModels(for: .regular, includingPinnedTabs: false)
+
+        XCTAssertTrue(openTabViewModels.contains { $0.uuid == unloaded.uuid },
+                      "Unloaded tabs must be surfaced so they can appear in address-bar suggestions")
+    }
+
+    @MainActor
     private func runJsonTestScenario(_ testScenario: TestScenario, named name: String) async throws {
         let input = testScenario.input
 

--- a/macOS/UnitTests/TabExtensionsTests/AIChatTabExtensionTests.swift
+++ b/macOS/UnitTests/TabExtensionsTests/AIChatTabExtensionTests.swift
@@ -1,0 +1,112 @@
+//
+//  AIChatTabExtensionTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import FeatureFlags
+import PrivacyConfig
+import WebKit
+import XCTest
+@testable import Navigation
+@testable import DuckDuckGo_Privacy_Browser
+
+@MainActor
+final class AIChatTabExtensionTests: XCTestCase {
+
+    private var scriptsPublisher: PassthroughSubject<UserScripts, Never>!
+    private var webViewPublisher: PassthroughSubject<WKWebView, Never>!
+    private var openedURLs: [URL]!
+    private var navigationPreferences: NavigationPreferences!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        scriptsPublisher = PassthroughSubject<UserScripts, Never>()
+        webViewPublisher = PassthroughSubject<WKWebView, Never>()
+        openedURLs = []
+        navigationPreferences = NavigationPreferences(userAgent: "test", preferences: WKWebpagePreferences())
+    }
+
+    override func tearDown() {
+        scriptsPublisher = nil
+        webViewPublisher = nil
+        openedURLs = nil
+        navigationPreferences = nil
+        super.tearDown()
+    }
+
+    private func makeExtension(aboutSchemeFixEnabled: Bool) -> AIChatTabExtension {
+        let featureFlagger = MockFeatureFlagger(
+            featuresStub: [FeatureFlag.aiChatSidebarAboutSchemeNavigationFix.rawValue: aboutSchemeFixEnabled]
+        )
+        return AIChatTabExtension(
+            scriptsPublisher: scriptsPublisher.eraseToAnyPublisher(),
+            webViewPublisher: webViewPublisher.eraseToAnyPublisher(),
+            isLoadedInSidebar: true,
+            isTabBurner: false,
+            featureFlagger: featureFlagger,
+            duckAiNativeStorageHandler: nil,
+            burnerDuckAiStorageRegistry: nil,
+            openNewTab: { [weak self] url in
+                self?.openedURLs.append(url)
+                return true
+            }
+        )
+    }
+
+    private func userInitiatedNavigation(to urlString: String) -> NavigationAction {
+        let url = URL(string: urlString)!
+        return NavigationAction(
+            webView: WKWebView(),
+            navigationAction: MockWKNavigationAction(
+                request: URLRequest(url: url),
+                targetFrame: WKFrameInfo.mock(url: url),
+                sourceFrame: WKFrameInfo.mock(url: URL(string: "https://duck.ai/")!),
+                isUserInitiated: true),
+            currentHistoryItemIdentity: nil,
+            redirectHistory: [],
+            mainFrameNavigation: nil
+        )
+    }
+
+    func testAboutSchemeNavigationIsAllowedInSidebarAndDoesNotOpenNewTab() async {
+        // Regression test for #4358: about:srcdoc (an internal iframe navigation created by duck.ai
+        // JS) must be allowed to proceed inside the sidebar, not opened in a new tab. Reverting the
+        // about-scheme allow branch sends it to the new-tab fallback (.cancel + openNewTab).
+        let sut = makeExtension(aboutSchemeFixEnabled: true)
+        var prefs = navigationPreferences!
+
+        let result = await sut.decidePolicy(for: userInitiatedNavigation(to: "about:srcdoc"), preferences: &prefs)
+
+        XCTAssertNil(result, "about:srcdoc should be allowed to proceed in the sidebar (.next)")
+        XCTAssertTrue(openedURLs.isEmpty, "about:srcdoc must not open a new tab")
+    }
+
+    func testNonAllowlistedHostOpensNewTabAndCancels() async {
+        // Control: a normal cross-site navigation in the sidebar opens a new tab and cancels. This
+        // proves the new-tab fallback actually fires in the test environment, so the `.next`
+        // assertion above is meaningful (i.e. not passing merely because the fallback is a no-op).
+        let sut = makeExtension(aboutSchemeFixEnabled: true)
+        var prefs = navigationPreferences!
+
+        let result = await sut.decidePolicy(for: userInitiatedNavigation(to: "https://example.com/"), preferences: &prefs)
+
+        guard case .cancel? = result else {
+            return XCTFail("Expected .cancel, got \(String(describing: result))")
+        }
+        XCTAssertEqual(openedURLs, [URL(string: "https://example.com/")!])
+    }
+}

--- a/macOS/UnitTests/TabPreview/TabPreviewViewControllerTests.swift
+++ b/macOS/UnitTests/TabPreview/TabPreviewViewControllerTests.swift
@@ -1,0 +1,55 @@
+//
+//  TabPreviewViewControllerTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo_Privacy_Browser
+
+@MainActor
+final class TabPreviewViewControllerTests: XCTestCase {
+
+    /// Regression test for #4615: a snapshot with a zero width or height must yield a finite height
+    /// (0), never NaN. `getHeight` feeds `snapshotImageViewHeightConstraint.constant`, and assigning
+    /// NaN there crashes AppKit layout. Reverting the `width > 0, height > 0` guard makes 0×0 produce
+    /// `0/0 = NaN`, failing the `.isFinite` assertions below.
+    func testGetHeightReturnsZeroForZeroDimensionSnapshot() {
+        let sut = TabPreviewViewController()
+
+        let zeroSize = sut.getHeight(for: NSImage(size: .zero))
+        XCTAssertTrue(zeroSize.isFinite)
+        XCTAssertEqual(zeroSize, 0)
+
+        let zeroHeight = sut.getHeight(for: NSImage(size: NSSize(width: 100, height: 0)))
+        XCTAssertTrue(zeroHeight.isFinite)
+        XCTAssertEqual(zeroHeight, 0)
+
+        let zeroWidth = sut.getHeight(for: NSImage(size: NSSize(width: 0, height: 100)))
+        XCTAssertTrue(zeroWidth.isFinite)
+        XCTAssertEqual(zeroWidth, 0)
+
+        XCTAssertEqual(sut.getHeight(for: nil), 0)
+    }
+
+    func testGetHeightComputesFiniteHeightForValidSnapshot() {
+        let sut = TabPreviewViewController()
+
+        let height = sut.getHeight(for: NSImage(size: NSSize(width: 200, height: 100)))
+
+        XCTAssertTrue(height.isFinite)
+        XCTAssertGreaterThan(height, 0)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208546505108826/task/1216754372099875?focus=true

### Description

Implements unit tests for bugs that were fixed on release/hotfix branches during H1 2026 but had **no** test locking in the fix — so the same bug could silently return. These were identified as the highest-ROI gaps in an analysis of post-cut release-branch fixes: the bug already happened, it's unit-testable, and nothing guarded it.
Bugs now covered (15) — original fix → regression test(s) added:

- PIR history-event sorting ([#4269](https://github.com/duckduckgo/apple-browsers/pull/4269) / [#4270](https://github.com/duckduckgo/apple-browsers/pull/4270) / [#4283](https://github.com/duckduckgo/apple-browsers/pull/4283))
  - `OperationPreferredDateUpdaterTests.testWhenOptOutHistoryEventsAreOutOfOrder_thenPreferredRunDateReflectsChronologicallyLatestEvent`
  - `OperationPreferredDateUpdaterTests.testOptOutJobDataHistoryEventsSortedEarliestFirst_returnsEventsInChronologicalOrder`
  - `OperationPreferredDateUpdaterTests.testBrokerProfileQueryDataHistorySortHelpers_returnEventsInChronologicalOrder`
- Scriptlet path containment with a symlinked temp dir ([#4637](https://github.com/duckduckgo/apple-browsers/pull/4637))
  - `ScriptletStoreTests.testWhenTemporaryDirectoryIsReachedViaSymlinkThenSaveStillSucceeds`
- MetricKit non-crash payload filtering ([#3682](https://github.com/duckduckgo/apple-browsers/pull/3682))
  - `CrashCollectionTests.testOnlyPayloadsWithCrashDiagnosticsAreProcessedForUpload`
- PIR foreground-scan profile guard ([#3053](https://github.com/duckduckgo/apple-browsers/pull/3053))
  - `DataBrokerProtectionIOSManagerAuthGateTests.testAppDidBecomeActive_authenticatedButNoProfile_doesNotStartScanOperations`
- `NSError.sslErrorType` underlying-error fallback ([#4255](https://github.com/duckduckgo/apple-browsers/pull/4255))
  - `SSLErrorTypeTests.testSSLErrorTypeFromNSUnderlyingError_expiredCertificate`
  - `SSLErrorTypeTests.testSSLErrorTypeFromNSUnderlyingError_hostNameMismatch`
  - `SSLErrorTypeTests.testSSLErrorTypeFromNSUnderlyingError_unrecognisedCodeFallsBackToInvalid`
  - `SSLErrorTypeTests.testSSLErrorTypeFromLegacyStreamErrorCodeKeyStillResolves`
  - `SSLErrorTypeTests.testSSLErrorTypeWithNoRecognisedKeysReturnsNil`
- Download manager does not delete the downloads directory ([#3400](https://github.com/duckduckgo/apple-browsers/pull/3400))
  - `DownloadManagerTests.testWhenDownloadManagerIsInitializedWithEmptyDirectoryThenDirectoryIsNotDeleted`
- AutoClear tab-clearing gate ([#4488](https://github.com/duckduckgo/apple-browsers/pull/4488))
  - `AutoClearTests.testIsTabClearingEnabledOnlyWhenTabsActionIsSelected`
- Unloaded tabs surfaced in address-bar suggestions ([#4925](https://github.com/duckduckgo/apple-browsers/pull/4925))
  - `SuggestionContainerTests.testAllTabViewModelsSurfacesUnloadedTabsForSuggestions`
- Tab Preview zero-dimension snapshot guard ([#4615](https://github.com/duckduckgo/apple-browsers/pull/4615))
  - `TabPreviewViewControllerTests.testGetHeightReturnsZeroForZeroDimensionSnapshot`
  - `TabPreviewViewControllerTests.testGetHeightComputesFiniteHeightForValidSnapshot`
- PromoService off-queue precondition re-dispatch ([#5083](https://github.com/duckduckgo/apple-browsers/pull/5083))
  - `PromoServiceTests.testApplyExternalVisibilityOffStateQueueReDispatchesInsteadOfCrashing`
- about:srcdoc sidebar navigation ([#4358](https://github.com/duckduckgo/apple-browsers/pull/4358))
  - `AIChatTabExtensionTests.testAboutSchemeNavigationIsAllowedInSidebarAndDoesNotOpenNewTab`
  - `AIChatTabExtensionTests.testNonAllowlistedHostOpensNewTabAndCancels`
- Favicon corrupt-image handling ([#5359](https://github.com/duckduckgo/apple-browsers/pull/5359), APPLE-MACOS-B8H)
  - `FaviconStoreCorruptImageTests.testLoadFaviconsReturnsFaviconWithNilImageOnCorruptStoredImage`
- AI Chat sync-push destination policy ([#3661](https://github.com/duckduckgo/apple-browsers/pull/3661))
  - `AIChatUserScriptSyncPushTests.testSyncPushDestinationPolicyAllowsDuckAiButNotArbitraryOrDuckDuckGoHosts`

This PR is **tests-only** apart from three minimal, behavior-preserving changes added purely for testability (flagged below for review).

### Testing Steps
1. Run the affected test targets (CI covers these): `DataBrokerProtectionCoreTests`, `WebExtensionsTests`, `CrashesTests`, `SpecialErrorPagesTests`, `DataBrokerProtection-iOSTests`, iOS `UnitTests`, macOS `Unit Tests` → all new tests pass.
2. (Optional) Temporarily revert any one of the fixes above and re-run its test → the corresponding test fails (or crashes the test process for the uncaught-exception cases).

### Testability Challenges
Three fixes needed a small, behavior-preserving change to be reachable from a unit test:
- `TabPreviewViewController.getHeight(for:)` and `PromoService.applyExternalVisibility(...)` widened `private` → internal so the guard / off-queue re-dispatch can be exercised directly.
- `AIChatTabExtension` gained an injectable `openNewTab` closure (default preserves the existing new-tab behavior) so the sidebar navigation-policy fallback is observable without a live window hierarchy.

### Impact
None — test-only additions plus three test-only tweaks that preserve existing runtime behavior.

#### What could go wrong?
- The `openNewTab` seam (#4358) could alter the new-tab fallback → mitigated by keeping the default identical to the prior inline logic (including the no-key-window `.next` case) and by the test asserting both the allow and fallback paths.
