### PR TITLE
Add macOS crossbench perf-runner harness (Chrome, DDG, Safari)

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3966a35eac034dc5384a7e972cb2b0d227b9d6ecc91a0eb6a836e83e18eafde9",
+  "originHash" : "9e74616152b2987af4ce3486118a79a15aee21c7c8ce8e093691206551fa6a7a",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "84b5e3019b2c7b3c90e8d296f30fcfd53768bcd8",
-        "version" : "19.1.0"
+        "revision" : "34eb540473a90d25e11942e9c72a18c2430d4f50",
+        "version" : "19.2.0"
       }
     },
     {

--- a/macOS/DuckDuckGo/Automation/LaunchOptionsHandler.swift
+++ b/macOS/DuckDuckGo/Automation/LaunchOptionsHandler.swift
@@ -25,7 +25,16 @@ public final class LaunchOptionsHandler {
     public static let isOnboardingCompleted = "isOnboardingCompleted"
     private static let automationPortKey = "automationPort"
     private static let isInternalUserKey = "isInternalUser"
+    private static let webViewProxyKey = "webViewProxy"
+    private static let acceptInsecureCertsKey = "acceptInsecureCerts"
     private let userDefaults: UserDefaults
+
+    /// Launch options that alter network behavior are only honored on Debug and Review builds,
+    /// mirroring the gating used for the automation server. They are ignored on production builds.
+    private var isDebugOrReviewBuild: Bool {
+        let buildType = StandardApplicationBuildType()
+        return buildType.isDebugBuild || buildType.isReviewBuild
+    }
 
     public init(
         userDefaults: UserDefaults = .standard
@@ -44,6 +53,25 @@ public final class LaunchOptionsHandler {
         let port = userDefaults.integer(forKey: Self.automationPortKey)
         guard UInt16(exactly: port) != nil, port > 0 else { return nil }
         return port
+    }
+
+    /// SOCKS5 proxy endpoint ("host:port") to route all web content through.
+    /// Used to replay recorded network fixtures for performance testing, so DuckDuckGo and
+    /// Chrome are measured against identical responses.
+    /// Only honored on Debug/Review builds; returns nil otherwise.
+    public var webViewProxy: String? {
+        guard isDebugOrReviewBuild else { return nil }
+        guard let value = userDefaults.string(forKey: Self.webViewProxyKey), !value.isEmpty else { return nil }
+        return value
+    }
+
+    /// When true, the browser accepts otherwise-untrusted server certificates.
+    /// This mirrors Chrome's certificate-bypass launch flags and lets WKWebView connect to a
+    /// replay proxy serving a self-signed certificate during performance testing.
+    /// Only honored on Debug/Review builds; returns false otherwise.
+    public var acceptsInsecureCertificates: Bool {
+        guard isDebugOrReviewBuild else { return false }
+        return userDefaults.bool(forKey: Self.acceptInsecureCertsKey)
     }
 
     /// Returns true if the app is running in UI testing mode

--- a/macOS/DuckDuckGo/Common/Extensions/WKWebViewConfigurationExtensions.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/WKWebViewConfigurationExtensions.swift
@@ -20,6 +20,7 @@ import BrowserServicesKit
 import Combine
 import Common
 import FoundationExtensions
+import Network
 import WebKit
 import UserScript
 
@@ -41,6 +42,8 @@ extension WKWebViewConfiguration {
             // set shared object if not set yet
             Self.sharedVisitedLinkStore = self.visitedLinkStore
         }
+
+        applyWebViewProxyIfNeeded()
 
         allowsAirPlayForMediaPlayback = true
         preferences.isElementFullscreenEnabled = true
@@ -72,6 +75,24 @@ extension WKWebViewConfiguration {
 
         self.userContentController = userContentController
         self.processPool.geolocationProvider = GeolocationProvider(processPool: self.processPool)
+    }
+
+    /// Routes all web content through a SOCKS5 proxy when the `webViewProxy` launch option is set
+    /// (Debug/Review builds only). Used to replay recorded network fixtures for performance testing.
+    @MainActor
+    private func applyWebViewProxyIfNeeded() {
+        guard #available(macOS 14.0, *), let endpointString = LaunchOptionsHandler().webViewProxy else { return }
+
+        let components = endpointString.split(separator: ":")
+        guard components.count == 2,
+              let portValue = UInt16(components[1]), portValue > 0,
+              let port = NWEndpoint.Port(rawValue: portValue) else {
+            assertionFailure("Invalid webViewProxy endpoint: \(endpointString). Expected host:port.")
+            return
+        }
+
+        let endpoint = NWEndpoint.hostPort(host: NWEndpoint.Host(String(components[0])), port: port)
+        self.websiteDataStore.proxyConfigurations = [ProxyConfiguration(socksv5Proxy: endpoint)]
     }
 
 }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/SpecialErrorPageTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/SpecialErrorPageTabExtension.swift
@@ -43,6 +43,11 @@ final class SpecialErrorPageTabExtension {
     private let detector: MaliciousSiteDetecting
     private let tld = TLD()
 
+    /// When true, every server-trust challenge is accepted without user interaction.
+    /// Set only via the `acceptInsecureCerts` launch option on Debug/Review builds, so WKWebView
+    /// can connect to a replay proxy serving a self-signed certificate during performance testing.
+    private let acceptAllServerCertificates: Bool
+
     @MainActor private weak var webView: ErrorPageTabExtensionNavigationDelegate?
     @MainActor private weak var specialErrorPageUserScript: SpecialErrorPageUserScript?
     private let closeTab: () -> Void
@@ -59,12 +64,14 @@ final class SpecialErrorPageTabExtension {
          closeTab: @escaping () -> Void,
          urlCredentialCreator: URLCredentialCreating = URLCredentialCreator(),
          featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger,
-         maliciousSiteDetector: some MaliciousSiteDetecting) {
+         maliciousSiteDetector: some MaliciousSiteDetecting,
+         acceptAllServerCertificates: Bool = false) {
 
         self.featureFlagger = featureFlagger
         self.urlCredentialCreator = urlCredentialCreator
         self.detector = maliciousSiteDetector
         self.closeTab = closeTab
+        self.acceptAllServerCertificates = acceptAllServerCertificates
 
         webViewPublisher.sink { [weak self] webView in
             MainActor.assumeMainThread {
@@ -197,6 +204,14 @@ extension SpecialErrorPageTabExtension: NavigationResponder {
     @MainActor
     func didReceive(_ challenge: URLAuthenticationChallenge, for navigation: Navigation?) async -> AuthChallengeDisposition? {
         guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust else { return nil }
+
+        // Performance-testing bypass: accept any server certificate without a user prompt so the
+        // browser can talk to a local replay proxy. Gated to Debug/Review builds via the launch option.
+        if acceptAllServerCertificates {
+            guard let credential = urlCredentialCreator.urlCredentialFrom(trust: challenge.protectionSpace.serverTrust) else { return nil }
+            return .credential(credential)
+        }
+
         guard shouldBypassSSLError else { return nil }
         guard navigation?.url == webView?.url else { return nil }
         guard let credential = urlCredentialCreator.urlCredentialFrom(trust: challenge.protectionSpace.serverTrust) else { return nil }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
@@ -159,7 +159,8 @@ extension TabExtensionsBuilder {
             SpecialErrorPageTabExtension(webViewPublisher: args.webViewFuture,
                                          scriptsPublisher: userScripts.compactMap { $0 },
                                          closeTab: args.closeTab,
-                                         maliciousSiteDetector: dependencies.maliciousSiteDetector)
+                                         maliciousSiteDetector: dependencies.maliciousSiteDetector,
+                                         acceptAllServerCertificates: LaunchOptionsHandler().acceptsInsecureCertificates)
         }
 
         add {

--- a/macOS/UnitTests/TabExtensionsTests/ErrorPageTabExtensionTests.swift
+++ b/macOS/UnitTests/TabExtensionsTests/ErrorPageTabExtensionTests.swift
@@ -376,6 +376,59 @@ final class ErrorPageTabExtensionTests: XCTestCase {
         XCTAssertNil(disposition)
     }
 
+    @MainActor
+    private func makeAcceptAllCertificatesExtension() -> SpecialErrorPageTabExtension {
+        SpecialErrorPageTabExtension(webViewPublisher: mockWebViewPublisher,
+                                     scriptsPublisher: scriptPublisher,
+                                     closeTab: self.closeTab,
+                                     urlCredentialCreator: credentialCreator,
+                                     featureFlagger: MockFeatureFlagger(),
+                                     maliciousSiteDetector: detector,
+                                     acceptAllServerCertificates: true)
+    }
+
+    @MainActor
+    func testWhenAcceptAllServerCertificatesEnabled_ThenServerTrustChallengeReturnsCredentialWithoutUserBypass() async {
+        // GIVEN
+        let bypassingExtension = makeAcceptAllCertificatesExtension()
+        let protectionSpace = URLProtectionSpace(host: "", port: 4, protocol: nil, realm: nil, authenticationMethod: NSURLAuthenticationMethodServerTrust)
+
+        // WHEN — no visitSiteAction() and no navigation, so the normal user-bypass path would return nil
+        let disposition = await bypassingExtension.didReceive(URLAuthenticationChallenge(protectionSpace: protectionSpace, proposedCredential: nil, previousFailureCount: 0, failureResponse: nil, error: nil, sender: ChallangeSender()), for: nil)
+
+        // THEN
+        if case .credential(let credential) = disposition {
+            XCTAssertNotNil(credential)
+        } else {
+            XCTFail("Expected credential")
+        }
+    }
+
+    @MainActor
+    func testWhenAcceptAllServerCertificatesEnabled_ThenNonServerTrustChallengeReturnsNil() async {
+        // GIVEN
+        let bypassingExtension = makeAcceptAllCertificatesExtension()
+        let protectionSpace = URLProtectionSpace(host: "", port: 4, protocol: nil, realm: nil, authenticationMethod: NSURLAuthenticationMethodClientCertificate)
+
+        // WHEN
+        let disposition = await bypassingExtension.didReceive(URLAuthenticationChallenge(protectionSpace: protectionSpace, proposedCredential: nil, previousFailureCount: 0, failureResponse: nil, error: nil, sender: ChallangeSender()), for: nil)
+
+        // THEN
+        XCTAssertNil(disposition)
+    }
+
+    @MainActor
+    func testWhenAcceptAllServerCertificatesDisabled_AndNoUserBypass_ThenServerTrustChallengeReturnsNil() async {
+        // GIVEN — default extension (acceptAllServerCertificates: false) from setUp
+        let protectionSpace = URLProtectionSpace(host: "", port: 4, protocol: nil, realm: nil, authenticationMethod: NSURLAuthenticationMethodServerTrust)
+
+        // WHEN — no visitSiteAction() called
+        let disposition = await errorPageExtention.didReceive(URLAuthenticationChallenge(protectionSpace: protectionSpace, proposedCredential: nil, previousFailureCount: 0, failureResponse: nil, error: nil, sender: ChallangeSender()), for: nil)
+
+        // THEN
+        XCTAssertNil(disposition)
+    }
+
     @MainActor func testWhenPhishingDetected_ThenPhishingErrorPageIsShown() async {
         // GIVEN
         let mockWebView = MockWKWebView(url: URL(string: phishingURLString)!)

--- a/macOS/scripts/crossbench/README.md
+++ b/macOS/scripts/crossbench/README.md
@@ -1,0 +1,74 @@
+# macOS crossbench perf-runner harness
+
+Scripts that turn a macOS box into a [crossbench](https://github.com/google/crossbench)
+page-load / LCP perf runner for Chrome (the baseline browser for comparison
+against the DDG macOS browser). This is the macOS counterpart of the
+windows-browser `Scripts/runCrossbench.ps1` pipeline, and — like the Windows
+one — it is **versioned in-repo**, not edited on the runner. The runner is a
+checkout of this directory; `git pull` updates the harness.
+
+## Layout
+
+| Path | Purpose |
+|------|---------|
+| `commission-macos.sh` | One-time, human/sudo setup of a fresh box (CLT, Homebrew). |
+| `provision-macos.sh` | Per-job, passwordless provisioning (brew formulae, Chrome, wpr build, poetry deps) + self-heals the crossbench extras & patch below. |
+| `test-chrome.sh` | Runs the Chrome LCP suite over the top-sites list against recorded network (WPR) and summarises per-site LCP. |
+| `crossbench-extras/` | Fork-only crossbench files the LCP run needs but a plain clone doesn't ship. Mirrors crossbench-relative paths so provisioning copies them in place. |
+| `patches/cpu_freq-attributeerror.patch` | Reference patch for the `crossbench/plt/macos.py` cpu_freq fix (applied idempotently by provision). |
+
+### The crossbench extras (load-bearing)
+
+A plain `git clone` of crossbench does **not** provide these, and without them
+the LCP run silently returns no rows / `-1`:
+
+- `config/probe/perfetto/navToLCP.config.hjson` — the Perfetto probe config that
+  defines the `lcp` metric from `PageLoadMetrics.NavigationToLargestContentfulPaint`.
+- `crossbench/probes/trace_processor/modules/ext/largestcontentfulpaint.sql` —
+  the trace_processor SQL module the metric references.
+- `crossbench/plt/macos.py` cpu_freq patch — psutil 7.2.1 on Apple Silicon
+  raises `AttributeError` from `cpu_freq()`, which stock crossbench doesn't catch;
+  the patch adds it to the caught tuple.
+
+`provision-macos.sh` installs all three into `CROSSBENCH_DIR` on every run
+(idempotently), so a fresh or re-pulled crossbench clone can never lose them.
+
+## The commission / provision / test split
+
+1. **commission** (once, by a human, needs sudo): installs Xcode Command Line
+   Tools and Homebrew. Run `./commission-macos.sh`. This is the only step that
+   prompts for a password.
+2. **provision** (every job, no password): `CROSSBENCH_DIR=... ./provision-macos.sh`
+   installs python@3.11 + poetry, Google Chrome, screenresolution, the Go
+   toolchain, builds the pinned `wpr` binary, self-heals the crossbench extras +
+   patch, and runs `poetry install`. Idempotent.
+3. **test** (every job): `./test-chrome.sh [--reps N] [--sites a.com,b.com]`.
+   Fetches WPR archives, runs crossbench per site with `--bin-override wpr=...`,
+   and prints `lcp_ms=[...] mean=... n=...` per site.
+
+## How the runner (VM) consumes this
+
+The runner clones **only this branch/path** of apple-browsers into a dedicated
+directory and runs the scripts from there — it is a checkout, not the source of
+truth. Nobody edits the scripts on the runner anymore; `git pull` updates them.
+
+Things that stay on the runner (data / binaries / clones, not harness source):
+
+- `~/Developer/crossbench-upstream` — the crossbench checkout (`CROSSBENCH_DIR`).
+  Upstream is canonical because the DDG fork's page-load flow uses Windows-only
+  keyboard actions that crash on macOS.
+- `~/Developer/mac-perf-runner/bin/wpr` — the built wpr binary (`WPR_BIN`).
+- `~/Developer/mac-perf-runner/wpr-archives` — downloaded WPR archives (`WPR_DIR`).
+
+All three are env-overridable defaults in the scripts, so the git-sourced copy
+runs unchanged against the runner's existing data locations.
+
+## Notes / known gaps
+
+- No traffic shaping: crossbench shapes via `third_party/tsproxy`, whose
+  DEPS-pinned `tsproxy.py` is Python-2-only and silently drops connections under
+  Python 3. WPR therefore replays at loopback speed — deterministic, but faster
+  than the Windows US-broadband-shaped runs. Don't compare absolute values.
+- ClickHouse upload is stubbed (`upload_results`) — out of scope for now.
+- DDG (WebKit/WKWebView) LCP uses a different mechanism and will get its own
+  `test-ddg.sh`; shared helpers should move to a `common.sh` when it lands.

--- a/macOS/scripts/crossbench/README.md
+++ b/macOS/scripts/crossbench/README.md
@@ -12,10 +12,14 @@ checkout of this directory; `git pull` updates the harness.
 | Path | Purpose |
 |------|---------|
 | `commission-macos.sh` | One-time, human/sudo setup of a fresh box (CLT, Homebrew). |
+| `commission-safari.sh` | One-time, human/GUI setup for the Safari path: trusts the WPR ECDSA root in the System keychain + enables safaridriver. Run once from the VM's GUI Terminal. |
 | `provision-macos.sh` | Per-job, passwordless provisioning (brew formulae, Chrome, wpr build, poetry deps) + pins crossbench to a known revision + self-heals the crossbench extras & patch below. |
 | `test-chrome.sh` | Runs the Chrome LCP suite over the top-sites list against recorded network (WPR) and summarises per-site LCP. |
 | `test-ddg.sh` | Runs the same LCP suite for the DuckDuckGo macOS (WebKit) browser: drives it via its AutomationServer through a SOCKS5 proxy (tsproxy) in front of WPR, and summarises per-site LCP. |
+| `test-safari.sh` | Runs the same LCP suite for **Safari** (WebKit): points Safari at WPR via a per-app proxy (its own `com.apple.Safari` prefs domain) in front of `httpproxy.py`, drives it via safaridriver (W3C WebDriver), summarises per-site LCP. Needs no per-run sudo. |
 | `ddg-automation.py` | Minimal client for the DDG AutomationServer (navigate / execute / buffered-LCP probe) that `test-ddg.sh` drives. |
+| `safari-automation.py` | Minimal stdlib W3C WebDriver client (new-session / navigate / async buffered-LCP probe) that `test-safari.sh` drives against safaridriver. |
+| `httpproxy.py` | Tiny local HTTP forward proxy (CONNECT → WPR-https, absolute-form GET → WPR-http) that `test-safari.sh` points Safari at, replacing the SOCKS `tsproxy` for the Safari path. |
 | `crossbench-extras/` | Fork-only crossbench files the LCP run needs but a plain clone doesn't ship. Mirrors crossbench-relative paths so provisioning copies them in place. |
 | `patches/cpu_freq-attributeerror.patch` | Reference patch for the `crossbench/plt/macos.py` cpu_freq fix (applied idempotently by provision). |
 
@@ -75,7 +79,9 @@ the LCP run silently returns no rows / `-1`:
 
 1. **commission** (once, by a human, needs sudo): installs Xcode Command Line
    Tools and Homebrew. Run `./commission-macos.sh`. This is the only step that
-   prompts for a password.
+   prompts for a password. For the **Safari** path, also run `./commission-safari.sh`
+   once from the VM's GUI Terminal (trusts the WPR ECDSA cert + enables safaridriver;
+   GUI-only, can't be done over SSH).
 2. **provision** (every job, no password): `CROSSBENCH_DIR=... ./provision-macos.sh`
    installs python@3.11 + poetry, Google Chrome, screenresolution, the Go
    toolchain, builds the pinned `wpr` binary, pins the crossbench checkout to
@@ -133,3 +139,37 @@ equivalent to point it at WPR. So `test-ddg.sh` differs from the Chrome path:
   DDG-vs-Windows.
 - Shared with Chrome (data, not code): the wpr binary, WPR archives, `WPR_BASE_URL`,
   and the site list. A `common.sh` extraction is the intended next cleanup.
+
+## How Safari is measured (`test-safari.sh`)
+
+Safari is also WebKit, but unlike DDG it's Apple's app — we can't set a per-instance
+proxy or cert knob from our code, and safaridriver ignores the WebDriver `proxy`
+capability. But Safari reads a proxy from its **own prefs domain**, which is per-app
+and needs no root:
+
+- **Routing.** The script writes `WebKit2HTTPProxy` / `WebKit2HTTPSProxy` on
+  `com.apple.Safari` (via `defaults write`) pointing Safari at a tiny local HTTP
+  forward proxy, `httpproxy.py` (CONNECT → WPR-https, absolute-form GET → WPR-http).
+  Only Safari is affected — no machine-wide proxy. An `EXIT` trap always removes the
+  two defaults on exit (including error / Ctrl-C).
+- **Why not the system SOCKS proxy.** A machine-wide `networksetup` SOCKS proxy
+  (what an earlier version used) needs root AND — proven on this VM — drops the
+  inbound SSH connection on the first proxied navigation, making unattended
+  SSH-driven runs impossible. The per-app proxy leaves SSH and the rest of the box
+  untouched.
+- **Cert / TLS.** WPR serves the **ECDSA (P-256) root only**, with
+  `--no-archive-certificates` (fresh leaves minted at replay time). Its bundled RSA
+  root is **1024-bit**, which Apple's TLS rejects outright ("illegal parameter"
+  handshake failure). The ECDSA root must be trusted **once** in the System keychain
+  — a GUI-only step (headless SSH trust is impossible on macOS 26), done by
+  `commission-safari.sh`.
+- **Driving.** Safari is driven via **safaridriver** (`safaridriver -p PORT`, W3C
+  WebDriver) by `safari-automation.py`. LCP is read with the same buffered
+  `PerformanceObserver`, delivered through WebDriver's async-script channel.
+- **No per-run sudo.** The only privileged setup — trust the ECDSA cert, `safaridriver
+  --enable`, and tick Safari > Develop > **Allow Remote Automation** — is one-time,
+  via `commission-safari.sh`. The test itself needs no sudo, so it runs unattended
+  over plain SSH.
+- **Validity guard.** Like DDG, a rep is dropped unless the proxy actually saw
+  traffic, so a live-network fallback can't masquerade as a result.
+- **No shaping**; compare Safari-vs-DDG-vs-Chrome on the same runner.

--- a/macOS/scripts/crossbench/README.md
+++ b/macOS/scripts/crossbench/README.md
@@ -12,10 +12,33 @@ checkout of this directory; `git pull` updates the harness.
 | Path | Purpose |
 |------|---------|
 | `commission-macos.sh` | One-time, human/sudo setup of a fresh box (CLT, Homebrew). |
-| `provision-macos.sh` | Per-job, passwordless provisioning (brew formulae, Chrome, wpr build, poetry deps) + self-heals the crossbench extras & patch below. |
+| `provision-macos.sh` | Per-job, passwordless provisioning (brew formulae, Chrome, wpr build, poetry deps) + pins crossbench to a known revision + self-heals the crossbench extras & patch below. |
 | `test-chrome.sh` | Runs the Chrome LCP suite over the top-sites list against recorded network (WPR) and summarises per-site LCP. |
 | `crossbench-extras/` | Fork-only crossbench files the LCP run needs but a plain clone doesn't ship. Mirrors crossbench-relative paths so provisioning copies them in place. |
 | `patches/cpu_freq-attributeerror.patch` | Reference patch for the `crossbench/plt/macos.py` cpu_freq fix (applied idempotently by provision). |
+
+### crossbench revision pin
+
+`CROSSBENCH_DIR` is a checkout of upstream crossbench, and `provision-macos.sh`
+force-checks it out to a pinned commit (`CROSSBENCH_REV` in the script) on
+every run, rather than letting it drift to whatever the clone happens to be
+on. Tip-of-tree crossbench is fragile: upstream can rename or refactor code
+that the extras/patch below target, breaking provisioning with no warning.
+
+The pin tracks the `crossbench_revision` that Chromium's **current stable**
+release branch vendors in its `DEPS` file — the closest thing to a
+"known-good, shipped-through-a-release" revision. Currently pinned to the rev
+Chrome M150 stable (`chromium refs/branch-heads/7871`) vendors, committed
+~Jun 1 2026. `WEBPAGEREPLAY_REV` (same file) is read from the same DEPS pin,
+so the two stay coherent.
+
+To bump: pick a newer stable branch-head number from
+[chromiumdash](https://chromiumdash.appspot.com/branches), read its `DEPS`
+file (`https://chromium.googlesource.com/chromium/src/+/refs/branch-heads/<N>/DEPS`),
+and copy the new `crossbench_revision` (and `webpagereplay_revision`) values
+into `CROSSBENCH_REV` / `WEBPAGEREPLAY_REV`. Re-run provisioning and re-verify
+the extras + cpu_freq patch still apply cleanly (grep-guarded, so a WARNING
+means the target text changed upstream and the patch needs reconciling).
 
 ### The crossbench extras (load-bearing)
 
@@ -40,8 +63,9 @@ the LCP run silently returns no rows / `-1`:
    prompts for a password.
 2. **provision** (every job, no password): `CROSSBENCH_DIR=... ./provision-macos.sh`
    installs python@3.11 + poetry, Google Chrome, screenresolution, the Go
-   toolchain, builds the pinned `wpr` binary, self-heals the crossbench extras +
-   patch, and runs `poetry install`. Idempotent.
+   toolchain, builds the pinned `wpr` binary, pins the crossbench checkout to
+   `CROSSBENCH_REV`, self-heals the crossbench extras + patch, and runs
+   `poetry install`. Idempotent.
 3. **test** (every job): `./test-chrome.sh [--reps N] [--sites a.com,b.com]`.
    Fetches WPR archives, runs crossbench per site with `--bin-override wpr=...`,
    and prints `lcp_ms=[...] mean=... n=...` per site.

--- a/macOS/scripts/crossbench/README.md
+++ b/macOS/scripts/crossbench/README.md
@@ -25,20 +25,33 @@ every run, rather than letting it drift to whatever the clone happens to be
 on. Tip-of-tree crossbench is fragile: upstream can rename or refactor code
 that the extras/patch below target, breaking provisioning with no warning.
 
-The pin tracks the `crossbench_revision` that Chromium's **current stable**
-release branch vendors in its `DEPS` file — the closest thing to a
-"known-good, shipped-through-a-release" revision. Currently pinned to the rev
-Chrome M150 stable (`chromium refs/branch-heads/7871`) vendors, committed
-~Jun 1 2026. `WEBPAGEREPLAY_REV` (same file) is read from the same DEPS pin,
-so the two stay coherent.
+The pin anchors to the `crossbench_revision` that Chromium's **current
+stable** release branch vendors in its `DEPS` file — the closest thing to a
+"known-good, shipped-through-a-release" revision. Chrome M150 stable
+(`chromium refs/branch-heads/7871`) pins crossbench at
+`7d52b4ffbc319a7d5a0e0a0ebff744e5281d60c5` (~Jun 1 2026). `WEBPAGEREPLAY_REV`
+(same file) is read from the same DEPS pin, so the two stay coherent.
+
+**Actually pinned commit is newer than that DEPS SHA**: the literal DEPS
+rev predates `--bin-override` (added 16 days later, crossbench commit
+`be14dbfb884747ea577e2e65b6a4a77d7ecd807d`, "Add --binary-override flag for
+tool paths", Jun 17 2026), which `test-chrome.sh` needs to hand crossbench
+the pre-built `wpr` binary without going through crossbench's own
+hermetic-Go-toolchain build (which needs a `gclient sync` this harness never
+runs). `CROSSBENCH_REV` is pinned to that commit instead — the oldest
+post-DEPS commit that adds the flag — rather than the exact DEPS SHA.
 
 To bump: pick a newer stable branch-head number from
 [chromiumdash](https://chromiumdash.appspot.com/branches), read its `DEPS`
 file (`https://chromium.googlesource.com/chromium/src/+/refs/branch-heads/<N>/DEPS`),
-and copy the new `crossbench_revision` (and `webpagereplay_revision`) values
-into `CROSSBENCH_REV` / `WEBPAGEREPLAY_REV`. Re-run provisioning and re-verify
-the extras + cpu_freq patch still apply cleanly (grep-guarded, so a WARNING
-means the target text changed upstream and the patch needs reconciling).
+and check whether its `crossbench_revision` already postdates
+`--bin-override` (a later Chrome stable may not need this workaround at
+all). Copy the new `crossbench_revision` (and `webpagereplay_revision`)
+values into `CROSSBENCH_REV` / `WEBPAGEREPLAY_REV`. Re-run provisioning and
+re-verify the extras + cpu_freq patch still apply cleanly (grep-guarded, so
+a WARNING means the target text changed upstream and the patch needs
+reconciling), and that `test-chrome.sh` still runs (in case of another
+similar gap between the DEPS SHA and a flag/behavior the harness relies on).
 
 ### The crossbench extras (load-bearing)
 

--- a/macOS/scripts/crossbench/README.md
+++ b/macOS/scripts/crossbench/README.md
@@ -14,6 +14,8 @@ checkout of this directory; `git pull` updates the harness.
 | `commission-macos.sh` | One-time, human/sudo setup of a fresh box (CLT, Homebrew). |
 | `provision-macos.sh` | Per-job, passwordless provisioning (brew formulae, Chrome, wpr build, poetry deps) + pins crossbench to a known revision + self-heals the crossbench extras & patch below. |
 | `test-chrome.sh` | Runs the Chrome LCP suite over the top-sites list against recorded network (WPR) and summarises per-site LCP. |
+| `test-ddg.sh` | Runs the same LCP suite for the DuckDuckGo macOS (WebKit) browser: drives it via its AutomationServer through a SOCKS5 proxy (tsproxy) in front of WPR, and summarises per-site LCP. |
+| `ddg-automation.py` | Minimal client for the DDG AutomationServer (navigate / execute / buffered-LCP probe) that `test-ddg.sh` drives. |
 | `crossbench-extras/` | Fork-only crossbench files the LCP run needs but a plain clone doesn't ship. Mirrors crossbench-relative paths so provisioning copies them in place. |
 | `patches/cpu_freq-attributeerror.patch` | Reference patch for the `crossbench/plt/macos.py` cpu_freq fix (applied idempotently by provision). |
 
@@ -107,5 +109,27 @@ runs unchanged against the runner's existing data locations.
   Python 3. WPR therefore replays at loopback speed — deterministic, but faster
   than the Windows US-broadband-shaped runs. Don't compare absolute values.
 - ClickHouse upload is stubbed (`upload_results`) — out of scope for now.
-- DDG (WebKit/WKWebView) LCP uses a different mechanism and will get its own
-  `test-ddg.sh`; shared helpers should move to a `common.sh` when it lands.
+
+## How DDG is measured (`test-ddg.sh`)
+
+DDG is WebKit/WKWebView: no Perfetto trace, and no `--host-resolver-rules`
+equivalent to point it at WPR. So `test-ddg.sh` differs from the Chrome path:
+
+- **Routing.** A standalone `tsproxy` runs as a SOCKS5 proxy that redirects
+  every destination to loopback WPR and remaps `443`→WPR-https / `80`→WPR-http.
+  The browser is pointed at it with two **Debug/Review-gated** launch options
+  (`LaunchOptionsHandler`): `webViewProxy=host:port` and `acceptInsecureCerts=true`
+  (WPR serves a self-signed cert). Neither option does anything on production
+  builds. This is *not* crossbench's DEPS-pinned tsproxy (Python-2-only) — it's a
+  current copy fetched from catapult, run under the system `python3`.
+- **Driving.** The browser is driven directly through its AutomationServer
+  (Debug/Review HTTP server on `[::1]:PORT`) via `ddg-automation.py` — not
+  crossbench. LCP is read with a buffered `PerformanceObserver` (WebKit only
+  reports LCP to a live observer).
+- **Validity guards.** Each rep starts cold (the app's container cache is cleared
+  and the app relaunched), and a rep is dropped unless the proxy actually saw
+  traffic — so a silent live-network fallback can't masquerade as a result.
+- **No shaping**, same as Chrome — compare DDG-vs-Chrome on the same runner, not
+  DDG-vs-Windows.
+- Shared with Chrome (data, not code): the wpr binary, WPR archives, `WPR_BASE_URL`,
+  and the site list. A `common.sh` extraction is the intended next cleanup.

--- a/macOS/scripts/crossbench/commission-macos.sh
+++ b/macOS/scripts/crossbench/commission-macos.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# commission-macos.sh — ONE-TIME setup for a macOS crossbench perf runner.
+#
+# Run this once, by hand, as the runner's ADMIN user (not root), when first
+# setting up the box. It performs the steps that require sudo / a human and so
+# cannot run inside an unattended CI job:
+#   - Xcode Command Line Tools
+#   - Homebrew (bootstrap into /opt/homebrew)
+#   - (optional) passwordless sudo for the runner user
+#
+# After this succeeds, provision-macos.sh handles everything else on every CI
+# job with no password (brew formulae, Chrome/DDG app installs, poetry).
+#
+# Usage:
+#   ./commission-macos.sh                  # Command Line Tools + Homebrew
+#   NOPASSWD_SUDO=1 ./commission-macos.sh  # also grant THIS user NOPASSWD sudo
+#                                          # (only needed if CI must self-install
+#                                          #  brew inline, Windows-winget style)
+#
+set -euo pipefail
+
+# Non-interactive: never prompt for Y/n confirmations. (The sudo password prompt
+# below is a credential, not a confirmation, and is intentionally kept.)
+export NONINTERACTIVE=1
+export HOMEBREW_NO_AUTO_UPDATE=1
+export HOMEBREW_NO_INSTALL_CLEANUP=1
+
+log() { printf '\n=== %s ===\n' "$1"; }
+
+[ "$(uname)" = "Darwin" ] || { echo "macOS only." >&2; exit 1; }
+[ "$(id -u)" -ne 0 ] || { echo "Run as your normal admin user, not root/sudo." >&2; exit 1; }
+
+# Prompt for the sudo password once, then keep the credential warm for the whole
+# run so the long CLT / brew installs don't stall waiting for input.
+log "sudo authorization"
+sudo -v
+( while true; do sudo -n true; sleep 50; kill -0 "$$" 2>/dev/null || exit; done ) 2>/dev/null &
+KEEPALIVE_PID=$!
+trap 'kill "$KEEPALIVE_PID" 2>/dev/null || true' EXIT
+
+# 1. Xcode Command Line Tools (headless — the softwareupdate on-demand trick).
+log "Xcode Command Line Tools"
+if xcode-select -p >/dev/null 2>&1; then
+  echo "present: $(xcode-select -p)"
+else
+  echo "Installing Command Line Tools headlessly…"
+  TRIGGER=/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
+  touch "$TRIGGER"
+  # Prefer the '* Label:' form; fall back to the bare label for older macOS.
+  PROD="$(softwareupdate -l 2>/dev/null \
+          | awk -F': ' '/\* Label:.*Command Line Tools/{print $2}' | tail -n1)"
+  [ -n "$PROD" ] || PROD="$(softwareupdate -l 2>/dev/null \
+          | grep -oE 'Command Line Tools[^,]*' | tail -n1)"
+  if [ -z "$PROD" ]; then
+    rm -f "$TRIGGER"
+    echo "ERROR: no Command Line Tools package found via softwareupdate." >&2
+    echo "Fallback: run 'xcode-select --install' and complete the GUI dialog." >&2
+    exit 1
+  fi
+  echo "Installing: $PROD"
+  sudo softwareupdate -i "$PROD" --verbose
+  rm -f "$TRIGGER"
+  echo "present: $(xcode-select -p)"
+fi
+
+# 2. Homebrew (bootstrap into /opt/homebrew). The installer calls sudo itself;
+#    creds are already cached, so NONINTERACTIVE won't stall on a password.
+log "Homebrew"
+if command -v brew >/dev/null 2>&1 || [ -x /opt/homebrew/bin/brew ]; then
+  echo "present"
+else
+  echo "Bootstrapping Homebrew…"
+  NONINTERACTIVE=1 /bin/bash -c \
+    "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+fi
+# Put brew on this user's login-shell PATH (Apple Silicon prefix).
+BREW_SHELLENV='eval "$(/opt/homebrew/bin/brew shellenv)"'
+grep -qF "$BREW_SHELLENV" "$HOME/.zprofile" 2>/dev/null || echo "$BREW_SHELLENV" >> "$HOME/.zprofile"
+eval "$(/opt/homebrew/bin/brew shellenv)"
+echo "brew: $(brew --version | head -1)"
+
+# 3. (optional) Passwordless sudo for the runner user — only if you want CI to be
+#    able to self-install brew/pkgs inline. For a perf box that just runs
+#    provision-macos.sh, this is NOT required (nothing at runtime needs sudo).
+if [ "${NOPASSWD_SUDO:-0}" = "1" ]; then
+  log "Passwordless sudo for $(whoami)"
+  TMP="$(mktemp)"
+  printf '%s ALL=(ALL) NOPASSWD: ALL\n' "$(whoami)" > "$TMP"
+  if sudo visudo -c -f "$TMP" >/dev/null; then
+    sudo install -m 0440 -o root -g wheel "$TMP" /etc/sudoers.d/crossbench-runner
+    echo "installed /etc/sudoers.d/crossbench-runner"
+  else
+    echo "ERROR: generated sudoers file failed validation; not installing." >&2
+  fi
+  rm -f "$TMP"
+fi
+
+log "Commissioning complete"
+echo "Next: run provision-macos.sh (per-job provisioning) — it needs no password."

--- a/macOS/scripts/crossbench/commission-safari.sh
+++ b/macOS/scripts/crossbench/commission-safari.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# commission-safari.sh — one-time, human-run setup that makes a macOS box able to
+# run test-safari.sh over SSH afterwards. Run this ONCE from the VM's GUI Terminal
+# (Screen Sharing / physical console) — NOT over SSH: trusting a cert in the System
+# keychain needs a window server to present its authorization prompt, which SSH
+# sessions don't have (fails "no user interaction was possible" on macOS 26).
+#
+# It does the two privileged, GUI-only steps test-safari.sh can't do headlessly:
+#   1. Trusts the WPR ECDSA (P-256) root in the System keychain so Safari's TLS
+#      validation passes when routed through WPR. Only the ECDSA root is trusted:
+#      the bundled RSA root is 1024-bit, which Apple's TLS rejects outright
+#      ("illegal parameter" handshake failure), so test-safari.sh serves ECDSA-only.
+#   2. Enables safaridriver remote automation, which test-safari.sh drives.
+#
+# Idempotent: re-trusting an already-trusted cert is harmless; re-enabling
+# safaridriver is a no-op. Re-run it any time the WPR certs are regenerated.
+#
+# After this runs once, every future run over SSH works unattended with NO sudo:
+#   ssh crossbench.lan '.../test-safari.sh --sites wikipedia.org --reps 3 --yes'
+set -euo pipefail
+
+CROSSBENCH_DIR="${CROSSBENCH_DIR:-$HOME/Developer/crossbench-upstream}"
+WPR_CERT_DIR="${WPR_CERT_DIR:-$CROSSBENCH_DIR/third_party/webpagereplay}"
+SYSTEM_KEYCHAIN="/Library/Keychains/System.keychain"
+
+ECDSA_CERT="$WPR_CERT_DIR/ecdsa_cert.pem"
+
+log() { echo "commission-safari: $*"; }
+die() { echo "commission-safari: ERROR: $*" >&2; exit 1; }
+
+# Refuse to run over SSH: the keychain-trust prompt can't be shown there, so trust
+# would silently fail. SSH_CONNECTION / SSH_TTY are set only for remote sessions.
+if [ -n "${SSH_CONNECTION:-}${SSH_TTY:-}" ]; then
+  die "run this from the VM's GUI Terminal, not over SSH (keychain trust needs the window server)."
+fi
+
+[ -f "$ECDSA_CERT" ] || die "ECDSA cert not found: $ECDSA_CERT (is CROSSBENCH_DIR right?)"
+
+log "trusting the WPR ECDSA root in the System keychain (you'll be asked to authorize)..."
+sudo security add-trusted-cert -d -r trustRoot -k "$SYSTEM_KEYCHAIN" "$ECDSA_CERT"
+
+log "enabling safaridriver remote automation..."
+sudo safaridriver --enable
+
+log "verifying trust..."
+if sudo security dump-trust-settings -d 2>/dev/null | grep -q "WebPerf"; then
+  log "OK: WPR ECDSA root present in the System keychain trust settings."
+else
+  log "WARNING: could not confirm the WPR root in trust settings — check manually with:"
+  log "  sudo security dump-trust-settings -d"
+fi
+
+log "done."
+log "If safaridriver sessions still fail, enable Safari > Develop > Allow Remote"
+log "Automation once (GUI checkbox), then re-run this script."

--- a/macOS/scripts/crossbench/crossbench-extras/config/probe/perfetto/navToLCP.config.hjson
+++ b/macOS/scripts/crossbench/crossbench-extras/config/probe/perfetto/navToLCP.config.hjson
@@ -1,0 +1,88 @@
+{
+  "probes": {
+    "perfetto": {
+      "textproto":
+        '''
+          buffers: {
+              size_kb: 63488
+              fill_policy: DISCARD
+          }
+          data_sources: {
+              config {
+                  name: "track_event"
+                  track_event_config {
+                      disabled_categories: "*"
+                      enabled_categories: "disabled-by-default-v8.cpu_profiler"
+                      enabled_categories: "toplevel"
+                      enabled_categories: "toplevel.flow"
+                      enabled_categories: "scheduler"
+                      enabled_categories: "sequence_manager"
+                      enabled_categories: "disabled-by-default-toplevel.flow"
+                      enabled_categories: "loading"
+                      enabled_categories: "navigation"
+                      enabled_categories: "blink.user_timing"
+                      enabled_categories: "__metadata"
+                      timestamp_unit_multiplier: 1000
+                      filter_debug_annotations: false
+                      enable_thread_time_sampling: true
+                      filter_dynamic_event_names: false
+                  }
+              }
+          }
+          data_sources: {
+              config {
+                  name: "org.chromium.trace_metadata2"
+              }
+          }
+          data_source_stop_timeout_ms: 1000
+          flush_timeout_ms: 1000
+        '''
+    }
+    "trace_processor": {
+      // If necessary, a custom path for trace_processor_shell can be passed
+      // trace_processor_bin: "/optional/path/to/trace_processor_shell"
+      "queries": [
+        // Queries can be specified as a reference to a file in
+        // crossbench/probes/trace_processor/queries:
+        // "firstcontentfulpaint"
+        // Or specified inline:
+        // {
+          // "name": "my_query"
+          // "sql": "select dur from slice where slice.name = 'my_slice'"
+        // }
+      ]
+      // "metrics": [
+        // "fcp"
+      // ]
+      // Additional directories containing trace processor modules
+      // can be specified:
+      // "module_paths": [
+        // "/my_project/modules/ext"
+      // ]
+      // Perfetto v2 metric definitions can be specified either inline
+      // or as a path:
+      "metric_definitions": [
+        // "./metric_def.textproto"
+
+        '''
+        metric_spec: {
+          id: "lcp"
+          value: "dur"
+          query {
+            table {
+              table_name: "lcp"
+            }
+            referenced_modules: "ext.largestcontentfulpaint"
+          }
+        }
+        '''
+      ]
+      // Metrics to include only in the trace summary can be specified.
+      // summary_metrics will include everything in the 'metrics' list as well
+      // as additional metrics (such as v2 metrics) specified here:
+      "summary_metrics": [
+        "lcp"
+      ]
+    }
+  }
+}

--- a/macOS/scripts/crossbench/crossbench-extras/crossbench/probes/trace_processor/modules/ext/largestcontentfulpaint.sql
+++ b/macOS/scripts/crossbench/crossbench-extras/crossbench/probes/trace_processor/modules/ext/largestcontentfulpaint.sql
@@ -1,0 +1,20 @@
+INCLUDE PERFETTO MODULE slices.with_context;
+
+CREATE PERFETTO VIEW lcp AS
+WITH shared_sq_26 AS (
+  SELECT *
+  FROM slice
+),
+shared_sq_27 AS (
+  SELECT *
+  FROM shared_sq_26
+  WHERE name = 'PageLoadMetrics.NavigationToLargestContentfulPaint'
+),
+sq_6901 AS (
+  SELECT *
+  FROM shared_sq_27
+  ORDER BY ts DESC
+  LIMIT 1
+)
+SELECT dur
+FROM sq_6901

--- a/macOS/scripts/crossbench/ddg-automation.py
+++ b/macOS/scripts/crossbench/ddg-automation.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+#
+# ddg-automation.py — minimal client for the DuckDuckGo macOS AutomationServer.
+#
+# The AutomationServer is a plain HTTP server the app runs on Debug/Review builds
+# only (LaunchOptionsHandler.automationPort). It binds IPv6 loopback, so the base
+# URL is http://[::1]:<port>. Responses are JSON: {"message": <string>, ...},
+# where for /execute `message` is the JS return value already encoded as a string
+# (a bare number for a numeric result, a JSON-quoted string for a string, etc.).
+#
+# IMPORTANT: script text is percent-encoded with %20 for spaces, NOT '+'. The
+# server percent-decodes the query but does not treat '+' as a space, so a '+'
+# encoding silently corrupts the script (e.g. `return document.title` becomes
+# `+document.title` => NaN). urllib.parse.quote(safe="") gets this right.
+#
+# Used by test-ddg.sh to drive the browser for LCP measurement. Not a general
+# WebDriver client — just the few routes the perf harness needs.
+#
+# Usage:
+#   ddg-automation.py <port> ping
+#   ddg-automation.py <port> wait-ready [timeout_secs]
+#   ddg-automation.py <port> navigate <url>
+#   ddg-automation.py <port> execute <script>          # or script on stdin if omitted
+#   ddg-automation.py <port> lcp [settle_ms]           # prints LCP in ms (or -1)
+#   ddg-automation.py <port> lcp-detail [settle_ms]    # prints JSON: element/url/size/ms
+#   ddg-automation.py <port> title
+#   ddg-automation.py <port> shutdown
+import json
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+def base(port):
+    return "http://[::1]:{}".format(port)
+
+
+def _request(port, path, query="", method="GET", timeout=30):
+    url = "{}{}".format(base(port), path)
+    if query:
+        url += "?" + query
+    req = urllib.request.Request(url, method=method)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.load(resp)
+
+
+def _message(port, path, query="", method="GET", timeout=30):
+    return _request(port, path, query=query, method=method, timeout=timeout).get("message")
+
+
+def navigate(port, url):
+    q = "url=" + urllib.parse.quote(url, safe="")
+    return _message(port, "/navigate", query=q, timeout=60)
+
+
+def execute(port, script):
+    q = "script=" + urllib.parse.quote(script, safe="")
+    # Script comes from the URL query string (not the body); POST with an empty body.
+    return _message(port, "/execute", query=q, method="POST", timeout=60)
+
+
+def content_blocker_ready(port):
+    return _message(port, "/contentBlockerReady", timeout=10)
+
+
+def ping(port):
+    try:
+        content_blocker_ready(port)
+        return True
+    except (urllib.error.URLError, OSError):
+        return False
+
+
+def wait_ready(port, timeout_secs):
+    """Block until the server answers AND the content blocker has compiled its
+    rules — navigating before that skews the first measurement."""
+    deadline = time.monotonic() + timeout_secs
+    while time.monotonic() < deadline:
+        try:
+            if str(content_blocker_ready(port)).lower() == "true":
+                return True
+        except (urllib.error.URLError, OSError):
+            pass
+        time.sleep(0.5)
+    return False
+
+
+# LCP on WebKit: getEntriesByType("largest-contentful-paint") returns nothing
+# unless an observer is live, so subscribe with buffered:true (replays entries
+# recorded before subscription), take the largest startTime, and resolve after a
+# short settle. Runs as an async function body via callAsyncJavaScript, so
+# top-level `return await` is valid.
+def _lcp_probe_js(settle_ms, detail):
+    if detail:
+        result = (
+            "r({ms: v, element: el ? el.tagName : null, "
+            "id: el ? el.id : null, url: url, size: size});"
+        )
+    else:
+        result = "r(v);"
+    return (
+        "return await new Promise(function(r){"
+        "var v=-1, el=null, url=null, size=0;"
+        "try {"
+        "new PerformanceObserver(function(list){"
+        "list.getEntries().forEach(function(e){"
+        "if (e.startTime > v) { v = e.startTime; el = e.element; url = e.url; size = e.size; }"
+        "});"
+        "}).observe({type:'largest-contentful-paint', buffered:true});"
+        "} catch (err) { r(-1); return; }"
+        "setTimeout(function(){" + result + "}, " + str(int(settle_ms)) + ");"
+        "});"
+    )
+
+
+def lcp(port, settle_ms):
+    return execute(port, _lcp_probe_js(settle_ms, detail=False))
+
+
+def lcp_detail(port, settle_ms):
+    return execute(port, _lcp_probe_js(settle_ms, detail=True))
+
+
+def title(port):
+    return execute(port, "return document.title;")
+
+
+def main(argv):
+    if len(argv) < 3:
+        print(__doc__.strip(), file=sys.stderr)
+        return 2
+    port = argv[1]
+    cmd = argv[2]
+    rest = argv[3:]
+
+    try:
+        if cmd == "ping":
+            return 0 if ping(port) else 1
+        if cmd == "wait-ready":
+            timeout = float(rest[0]) if rest else 60.0
+            if wait_ready(port, timeout):
+                return 0
+            print("automation server not ready within {}s".format(timeout), file=sys.stderr)
+            return 1
+        if cmd == "navigate":
+            print(navigate(port, rest[0]))
+            return 0
+        if cmd == "execute":
+            script = rest[0] if rest else sys.stdin.read()
+            print(execute(port, script))
+            return 0
+        if cmd == "lcp":
+            settle = float(rest[0]) if rest else 600
+            print(lcp(port, settle))
+            return 0
+        if cmd == "lcp-detail":
+            settle = float(rest[0]) if rest else 600
+            print(lcp_detail(port, settle))
+            return 0
+        if cmd == "title":
+            print(title(port))
+            return 0
+        if cmd == "shutdown":
+            try:
+                print(_message(port, "/shutdown", timeout=5))
+            except (urllib.error.URLError, OSError):
+                pass  # server tears itself down; a dropped response is expected
+            return 0
+    except urllib.error.HTTPError as e:
+        print("HTTP {} for {}".format(e.code, cmd), file=sys.stderr)
+        return 1
+    except (urllib.error.URLError, OSError) as e:
+        print("connection error for {}: {}".format(cmd, e), file=sys.stderr)
+        return 1
+
+    print("unknown command: {}".format(cmd), file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/macOS/scripts/crossbench/httpproxy.py
+++ b/macOS/scripts/crossbench/httpproxy.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# Minimal HTTP forward proxy that redirects ALL traffic to a local WPR instance,
+# so Safari (pointed here via the com.apple.Safari WebKit2HTTPProxy/HTTPSProxy
+# defaults) replays from WPR with NO machine-wide system proxy.
+#   CONNECT host:443     -> tunnel to 127.0.0.1:WPR_HTTPS (WPR terminates TLS via SNI)
+#   GET http://host/path -> rewrite to origin-form, forward to 127.0.0.1:WPR_HTTP
+# The requested host is ignored for routing (always WPR); it's only logged so the
+# caller can prove Safari's traffic actually traversed the proxy.
+# Usage: httpproxy.py <listen_port> <wpr_http_port> <wpr_https_port>
+import socket
+import select
+import sys
+import threading
+
+LISTEN    = int(sys.argv[1]) if len(sys.argv) > 1 else 9998
+WPR_HTTP  = int(sys.argv[2]) if len(sys.argv) > 2 else 8080
+WPR_HTTPS = int(sys.argv[3]) if len(sys.argv) > 3 else 8081
+
+
+def log(msg):
+    sys.stderr.write(msg + "\n")
+    sys.stderr.flush()
+
+
+def pipe(a, b):
+    try:
+        while True:
+            r, _, _ = select.select([a, b], [], [])
+            for s in r:
+                data = s.recv(65536)
+                if not data:
+                    return
+                (b if s is a else a).sendall(data)
+    except OSError:
+        pass
+    finally:
+        for s in (a, b):
+            try:
+                s.close()
+            except OSError:
+                pass
+
+
+def handle(client):
+    up = None
+    try:
+        client.settimeout(30)
+        buf = b""
+        while b"\r\n\r\n" not in buf:
+            chunk = client.recv(4096)
+            if not chunk:
+                client.close()
+                return
+            buf += chunk
+        head, _, rest = buf.partition(b"\r\n\r\n")
+        lines = head.split(b"\r\n")
+        parts = lines[0].split(b" ")
+        if len(parts) < 3:
+            client.close()
+            return
+        method, target, ver = parts[0], parts[1], parts[2]
+
+        if method == b"CONNECT":
+            log("CONNECT %s -> 127.0.0.1:%d" % (target.decode(errors="replace"), WPR_HTTPS))
+            up = socket.create_connection(("127.0.0.1", WPR_HTTPS))
+            client.sendall(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+            if rest:
+                up.sendall(rest)
+            pipe(client, up)
+        else:
+            path = target
+            if target.startswith(b"http://"):
+                t = target[7:]
+                i = t.find(b"/")
+                path = b"/" if i == -1 else t[i:]
+            log("%s %s -> 127.0.0.1:%d" % (method.decode(errors="replace"),
+                                           target.decode(errors="replace"), WPR_HTTP))
+            up = socket.create_connection(("127.0.0.1", WPR_HTTP))
+            newreq = method + b" " + path + b" " + ver + b"\r\n" + \
+                b"\r\n".join(lines[1:]) + b"\r\n\r\n" + rest
+            up.sendall(newreq)
+            pipe(client, up)
+    except OSError as e:
+        log("error: %s" % e)
+        try:
+            client.close()
+        except OSError:
+            pass
+        if up:
+            try:
+                up.close()
+            except OSError:
+                pass
+
+
+def main():
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", LISTEN))
+    srv.listen(128)
+    log("httpproxy listening on 127.0.0.1:%d -> WPR http=%d https=%d" % (LISTEN, WPR_HTTP, WPR_HTTPS))
+    while True:
+        c, _ = srv.accept()
+        threading.Thread(target=handle, args=(c,), daemon=True).start()
+
+
+main()

--- a/macOS/scripts/crossbench/patches/cpu_freq-attributeerror.patch
+++ b/macOS/scripts/crossbench/patches/cpu_freq-attributeerror.patch
@@ -1,0 +1,12 @@
+diff --git a/crossbench/plt/macos.py b/crossbench/plt/macos.py
+--- a/crossbench/plt/macos.py
++++ b/crossbench/plt/macos.py
+@@ class MacOSPlatform(PosixPlatform):
+       return None
+     try:
+       return super()._cpu_freq()
+-    except (FileNotFoundError, SystemError, RuntimeError) as e:
++    except (AttributeError, FileNotFoundError, SystemError, RuntimeError) as e:
+       # TODO(crbug.com/505086693): Need a workaround to read CPU frequency.
+       logging.debug("psutil.cpu_freq() failed (normal on Apple Silicon): %s", e)
+       return None

--- a/macOS/scripts/crossbench/provision-macos.sh
+++ b/macOS/scripts/crossbench/provision-macos.sh
@@ -34,6 +34,22 @@ CPU_FREQ_PATCH="$SCRIPT_DIR/patches/cpu_freq-attributeerror.patch"
 CROSSBENCH_DIR="${CROSSBENCH_DIR:-$HOME/Developer/crossbench-upstream}"
 PYTHON_VERSION="${PYTHON_VERSION:-3.11}"   # matches Windows (poetry env use 3.11)
 
+# crossbench is pinned, not tip-of-tree: upstream can rename/refactor code our
+# extras + cpu_freq patch target underneath us with no warning. Pin to the
+# crossbench_revision that Chromium's CURRENT STABLE release branch vendors —
+# the closest thing to a "known-good, shipped-through-a-release" rev. This is
+# below the Chrome-version pin, so a Chrome bump (step 4) never silently drags
+# crossbench along with it.
+#   Currently: Chrome M150 stable (chromium refs/branch-heads/7871), DEPS
+#   'crossbench_revision', commit dated ~Jun 1 2026.
+#   To bump: pick a newer stable branch-head number from
+#   https://chromiumdash.appspot.com/branches, then read its DEPS file, e.g.
+#     https://chromium.googlesource.com/chromium/src/+/refs/branch-heads/<N>/DEPS
+#   and copy the 'crossbench_revision' value here. Bump WEBPAGEREPLAY_REV
+#   (below) from the SAME DEPS file at the same time, so the pair stays
+#   coherent — they're read together.
+CROSSBENCH_REV="${CROSSBENCH_REV:-7d52b4ffbc319a7d5a0e0a0ebff744e5281d60c5}"
+
 # WPR (Web Page Replay) source, pinned to the same revision as crossbench's
 # DEPS file (crossbench doesn't ship it; gclient would normally sync it).
 WEBPAGEREPLAY_GIT="https://chromium.googlesource.com/webpagereplay"
@@ -141,7 +157,29 @@ mkdir -p "$(dirname "$WPR_BIN")"
 go build -C "$WPR_SRC/src" -trimpath -buildvcs=false -o "$WPR_BIN" wpr.go
 echo "wpr: $WPR_BIN"
 
-# 7. Self-heal the fork-only crossbench extras + cpu_freq patch.
+# 7. Pin crossbench to CROSSBENCH_REV (see comment above the variable).
+#    Force the clone to that exact commit regardless of what it's currently
+#    on. `checkout -f` (not a plain checkout) is required: a previous run's
+#    self-heal step (next) leaves crossbench/plt/macos.py with an uncommitted
+#    modification (the cpu_freq patch), and a plain checkout would refuse to
+#    clobber it. -f discards that modification here; self-heal re-applies it
+#    immediately after, against the pinned rev. This does NOT touch untracked
+#    files, so the copied-in extras survive the checkout untouched — do not
+#    add `git clean` here.
+log "Pin crossbench to $CROSSBENCH_REV"
+if [ ! -d "$CROSSBENCH_DIR/.git" ]; then
+  echo "ERROR: crossbench checkout not found at $CROSSBENCH_DIR (no .git dir)." >&2
+  echo "Clone it there first (e.g. git clone https://chromium.googlesource.com/crossbench $CROSSBENCH_DIR)." >&2
+  exit 1
+fi
+if ! git -C "$CROSSBENCH_DIR" cat-file -e "${CROSSBENCH_REV}^{commit}" 2>/dev/null; then
+  echo "rev not present locally; fetching..."
+  git -C "$CROSSBENCH_DIR" fetch --quiet origin "$CROSSBENCH_REV"
+fi
+git -C "$CROSSBENCH_DIR" -c advice.detachedHead=false checkout --quiet -f "$CROSSBENCH_REV"
+echo "crossbench: checked out $(git -C "$CROSSBENCH_DIR" rev-parse HEAD)"
+
+# 8. Self-heal the fork-only crossbench extras + cpu_freq patch.
 #    These are the pieces a plain `git clone` of crossbench does NOT provide but
 #    the LCP run depends on. They live versioned next to this script and are
 #    (re)installed into CROSSBENCH_DIR here, idempotently, so a fresh or updated
@@ -176,7 +214,7 @@ else
   echo "         Reconcile patches/cpu_freq-attributeerror.patch against the new source." >&2
 fi
 
-# 8. crossbench Python deps.
+# 9. crossbench Python deps.
 #    NOTE: crossbench ships a git-tracked '.vpython3' marker that makes it re-exec
 #    under Chromium's vpython instead of our poetry venv. It must be removed, but
 #    that belongs in the RUN step (right before invoking cb.py), not here — a

--- a/macOS/scripts/crossbench/provision-macos.sh
+++ b/macOS/scripts/crossbench/provision-macos.sh
@@ -35,20 +35,30 @@ CROSSBENCH_DIR="${CROSSBENCH_DIR:-$HOME/Developer/crossbench-upstream}"
 PYTHON_VERSION="${PYTHON_VERSION:-3.11}"   # matches Windows (poetry env use 3.11)
 
 # crossbench is pinned, not tip-of-tree: upstream can rename/refactor code our
-# extras + cpu_freq patch target underneath us with no warning. Pin to the
+# extras + cpu_freq patch target underneath us with no warning. Anchor to the
 # crossbench_revision that Chromium's CURRENT STABLE release branch vendors —
 # the closest thing to a "known-good, shipped-through-a-release" rev. This is
 # below the Chrome-version pin, so a Chrome bump (step 4) never silently drags
 # crossbench along with it.
-#   Currently: Chrome M150 stable (chromium refs/branch-heads/7871), DEPS
-#   'crossbench_revision', commit dated ~Jun 1 2026.
+#   DEPS anchor: Chrome M150 stable (chromium refs/branch-heads/7871) pins
+#   crossbench_revision 7d52b4ffbc319a7d5a0e0a0ebff744e5281d60c5 (~Jun 1 2026).
+#   THIS SCRIPT PINS SLIGHTLY NEWER: that DEPS rev predates --bin-override
+#   (crossbench added it 16 days later, commit be14dbfb884747ea577e2e65b6a4a77d7ecd807d,
+#   "Add --binary-override flag for tool paths", Jun 17 2026), which
+#   test-chrome.sh depends on to hand crossbench the pre-built wpr binary
+#   without going through crossbench's own hermetic-Go-toolchain build
+#   machinery (which requires a gclient sync we deliberately don't do — see
+#   step 6). Without it, `cb.py loading` rejects --bin-override outright.
+#   So: pinned to the oldest post-DEPS-anchor commit that adds the flag,
+#   rather than the literal DEPS SHA.
 #   To bump: pick a newer stable branch-head number from
-#   https://chromiumdash.appspot.com/branches, then read its DEPS file, e.g.
+#   https://chromiumdash.appspot.com/branches, read its DEPS file, e.g.
 #     https://chromium.googlesource.com/chromium/src/+/refs/branch-heads/<N>/DEPS
-#   and copy the 'crossbench_revision' value here. Bump WEBPAGEREPLAY_REV
-#   (below) from the SAME DEPS file at the same time, so the pair stays
-#   coherent — they're read together.
-CROSSBENCH_REV="${CROSSBENCH_REV:-7d52b4ffbc319a7d5a0e0a0ebff744e5281d60c5}"
+#   and check whether ITS 'crossbench_revision' already postdates
+#   --bin-override (i.e. this workaround may no longer be needed for a
+#   later Chrome stable). Bump WEBPAGEREPLAY_REV (below) from the SAME DEPS
+#   file at the same time, so the pair stays coherent — they're read together.
+CROSSBENCH_REV="${CROSSBENCH_REV:-be14dbfb884747ea577e2e65b6a4a77d7ecd807d}"
 
 # WPR (Web Page Replay) source, pinned to the same revision as crossbench's
 # DEPS file (crossbench doesn't ship it; gclient would normally sync it).

--- a/macOS/scripts/crossbench/provision-macos.sh
+++ b/macOS/scripts/crossbench/provision-macos.sh
@@ -82,14 +82,21 @@ echo "python: $("$PY_BIN" --version)"
 echo "poetry: $(poetry --version)"
 
 # 4. Google Chrome — baseline browser for the comparison run.
-#    Note: the cask installs latest and Keystone auto-updates it thereafter.
-#    For a stable baseline, decide explicitly whether to freeze Chrome's version.
-#    Alternative: skip this and use --browser=chrome-latest (crossbench auto-downloads).
+#    Chrome is deliberately NOT pinned: every run uses the latest stable so the
+#    baseline tracks what users actually run. crossbench stamps the exact version
+#    into each result, so a baseline step caused by a Chrome bump stays traceable.
+#    A fresh install gets latest already; an existing install is upgraded here so
+#    we don't drift behind (rather than relying on Keystone's background schedule).
 log "Google Chrome"
 if [ ! -d "/Applications/Google Chrome.app" ]; then
   brew install --cask google-chrome
 else
-  echo "present"
+  # Explicit `brew update` first: HOMEBREW_NO_AUTO_UPDATE=1 (set above) freezes
+  # brew's cask index to the last tap sync, so upgrade alone would never see a
+  # newer version. --greedy because Chrome's cask is auto_updates and a plain
+  # `brew upgrade` skips such casks.
+  brew update
+  brew upgrade --cask --greedy google-chrome
 fi
 echo "chrome: $('/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' --version 2>/dev/null || echo 'version unavailable')"
 

--- a/macOS/scripts/crossbench/provision-macos.sh
+++ b/macOS/scripts/crossbench/provision-macos.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+#
+# provision-macos.sh — install everything crossbench needs on a macOS perf runner.
+#
+# macOS counterpart to the provisioning half of windows-browser's
+# runCrossbench.ps1 -action build (winget/choco -> brew).
+# Idempotent: safe to run on every CI job; installs only what's missing.
+#
+# Prerequisites that must exist BEFORE this runs (they need sudo / a human once,
+# so they belong in the runner image, not here):
+#   - Xcode Command Line Tools  (xcode-select --install)
+#   - Homebrew                  (/opt/homebrew, bootstrapped once)
+# This script fails fast with instructions if either is missing.
+#
+# Must run AFTER the repo/submodule checkout, since it runs `poetry install`
+# against CROSSBENCH_DIR.
+#
+# Usage: CROSSBENCH_DIR=/path/to/crossbench ./provision-macos.sh
+#
+set -euo pipefail
+
+# Directory this script lives in (the versioned harness in apple-browsers). The
+# fork-only crossbench extras and the cpu_freq patch travel alongside it and are
+# healed into CROSSBENCH_DIR below, so a fresh crossbench clone can't silently
+# lose them.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTRAS_DIR="$SCRIPT_DIR/crossbench-extras"
+CPU_FREQ_PATCH="$SCRIPT_DIR/patches/cpu_freq-attributeerror.patch"
+
+# crossbench-upstream is the canonical checkout: the DDG fork's page-load flow
+# uses Windows-only keyboard actions that crash on macOS. Fork-only extras the
+# LCP run needs (navToLCP probe config + LCP SQL module) are copied into the
+# upstream clone as untracked files.
+CROSSBENCH_DIR="${CROSSBENCH_DIR:-$HOME/Developer/crossbench-upstream}"
+PYTHON_VERSION="${PYTHON_VERSION:-3.11}"   # matches Windows (poetry env use 3.11)
+
+# WPR (Web Page Replay) source, pinned to the same revision as crossbench's
+# DEPS file (crossbench doesn't ship it; gclient would normally sync it).
+WEBPAGEREPLAY_GIT="https://chromium.googlesource.com/webpagereplay"
+WEBPAGEREPLAY_REV="b2b856131e36c99e9de9c419fe8ca02f857082ba"   # DEPS: webpagereplay_revision
+# Where the wpr binary is built to. test-chrome.sh passes this to crossbench
+# via --bin-override, which skips crossbench's own build machinery entirely.
+WPR_BIN="${WPR_BIN:-$HOME/Developer/mac-perf-runner/bin/wpr}"
+
+# Non-interactive: never prompt for confirmations (Homebrew honors these).
+export NONINTERACTIVE=1
+export HOMEBREW_NO_AUTO_UPDATE=1        # don't self-update mid-job (perf hygiene)
+export HOMEBREW_NO_INSTALL_CLEANUP=1
+
+log() { printf '\n=== %s ===\n' "$1"; }
+
+# 1. Xcode Command Line Tools — brew and git depend on it. Headless install
+#    needs sudo, so it must be pre-installed when imaging the runner.
+log "Xcode Command Line Tools"
+if ! xcode-select -p >/dev/null 2>&1; then
+  echo "ERROR: Command Line Tools missing. Run 'xcode-select --install' on the runner first." >&2
+  exit 1
+fi
+echo "present: $(xcode-select -p)"
+
+# 2. Homebrew — must already be bootstrapped. Its first-time installer shells out
+#    to sudo, which cannot run unattended on a password-sudo box, so we do NOT
+#    auto-install it here; we fail fast instead.
+log "Homebrew"
+if ! command -v brew >/dev/null 2>&1; then
+  if [ -x /opt/homebrew/bin/brew ]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"   # brew installed but not on PATH in this shell
+  else
+    echo "ERROR: Homebrew not found. Bootstrap it once on the runner:" >&2
+    echo '  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"' >&2
+    exit 1
+  fi
+fi
+echo "brew: $(brew --version | head -1)"
+
+# 3. Python + Poetry (brew manages its own prefix — no sudo needed)
+log "Python ${PYTHON_VERSION} + Poetry"
+brew list "python@${PYTHON_VERSION}" >/dev/null 2>&1 || brew install "python@${PYTHON_VERSION}"
+command -v poetry >/dev/null 2>&1 || brew install poetry
+PY_BIN="$(brew --prefix "python@${PYTHON_VERSION}")/bin/python${PYTHON_VERSION}"
+echo "python: $("$PY_BIN" --version)"
+echo "poetry: $(poetry --version)"
+
+# 4. Google Chrome — baseline browser for the comparison run.
+#    Note: the cask installs latest and Keystone auto-updates it thereafter.
+#    For a stable baseline, decide explicitly whether to freeze Chrome's version.
+#    Alternative: skip this and use --browser=chrome-latest (crossbench auto-downloads).
+log "Google Chrome"
+if [ ! -d "/Applications/Google Chrome.app" ]; then
+  brew install --cask google-chrome
+else
+  echo "present"
+fi
+echo "chrome: $('/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' --version 2>/dev/null || echo 'version unavailable')"
+
+# 5. screenresolution — pin the display for stable perf numbers
+#    (the existing macos_performance_tests.yml CI does this too).
+log "screenresolution"
+if ! command -v screenresolution >/dev/null 2>&1; then
+  brew install screenresolution || echo "WARNING: screenresolution install failed; display will not be pinned."
+fi
+
+# 6. WPR (recorded network, deterministic runs) — crossbench does NOT ship the
+#    `wpr` binary, only a DEPS pin of its Go source. Clone the pinned source
+#    (a poetry-only setup never runs gclient sync, which is what would normally
+#    populate third_party/) and `go build` it ourselves; test-chrome.sh hands
+#    the binary to crossbench via --bin-override, so crossbench's own build
+#    machinery (scripts/build.py + a gclient-hermetic Go toolchain) is never
+#    involved. The checkout must stay in third_party/webpagereplay: crossbench
+#    also reads deterministic.js and the ecdsa key/cert from it at runtime.
+#    NOTE: traffic shaping (speed=...) is intentionally NOT provisioned — it
+#    needs third_party/tsproxy, whose pinned tsproxy.py is Python-2-only and
+#    silently drops every connection under Python 3.
+log "Go toolchain (builds the wpr binary)"
+brew list go >/dev/null 2>&1 || brew install go
+echo "go: $(go version)"
+
+log "WebPageReplay source (pinned by crossbench DEPS) + wpr build"
+WPR_SRC="$CROSSBENCH_DIR/third_party/webpagereplay"
+if [ -d "$WPR_SRC/.git" ] && [ "$(git -C "$WPR_SRC" rev-parse HEAD 2>/dev/null)" = "$WEBPAGEREPLAY_REV" ]; then
+  echo "webpagereplay: already at $WEBPAGEREPLAY_REV"
+else
+  rm -rf "$WPR_SRC"
+  git clone --quiet "$WEBPAGEREPLAY_GIT" "$WPR_SRC"
+  git -C "$WPR_SRC" -c advice.detachedHead=false checkout --quiet --detach "$WEBPAGEREPLAY_REV"
+  echo "webpagereplay: checked out $WEBPAGEREPLAY_REV"
+fi
+mkdir -p "$(dirname "$WPR_BIN")"
+# Same flags crossbench's build.py would use; incremental, sub-second when fresh.
+go build -C "$WPR_SRC/src" -trimpath -buildvcs=false -o "$WPR_BIN" wpr.go
+echo "wpr: $WPR_BIN"
+
+# 7. Self-heal the fork-only crossbench extras + cpu_freq patch.
+#    These are the pieces a plain `git clone` of crossbench does NOT provide but
+#    the LCP run depends on. They live versioned next to this script and are
+#    (re)installed into CROSSBENCH_DIR here, idempotently, so a fresh or updated
+#    clone can never silently drop them:
+#      - config/probe/perfetto/navToLCP.config.hjson       (the probe config)
+#      - crossbench/probes/trace_processor/modules/ext/largestcontentfulpaint.sql
+#        (the LCP SQL module; if missing, LCP silently returns no rows / -1)
+#      - crossbench/plt/macos.py cpu_freq() AttributeError fix (psutil 7.2.1 on
+#        arm64 raises AttributeError, which stock crossbench doesn't catch).
+log "crossbench extras + cpu_freq patch (self-heal)"
+if [ ! -f "$CROSSBENCH_DIR/cb.py" ]; then
+  echo "ERROR: crossbench checkout not found at $CROSSBENCH_DIR (cb.py missing)." >&2
+  echo "Clone it there first (e.g. git clone https://github.com/google/crossbench $CROSSBENCH_DIR)." >&2
+  exit 1
+fi
+# Copy the extras, preserving their crossbench-relative paths. `cp -R <dir>/.`
+# merges into the destination tree without clobbering unrelated files.
+cp -R "$EXTRAS_DIR/." "$CROSSBENCH_DIR/"
+echo "extras: installed navToLCP.config.hjson + largestcontentfulpaint.sql"
+# Apply the cpu_freq patch idempotently. The one-line change is identical on
+# upstream and the fork but sits at different line numbers, so we guard on the
+# patched text rather than relying on `git apply` context matching.
+MACOS_PY="$CROSSBENCH_DIR/crossbench/plt/macos.py"
+if grep -q 'except (AttributeError, FileNotFoundError, SystemError, RuntimeError)' "$MACOS_PY"; then
+  echo "cpu_freq patch: already applied"
+elif grep -q 'except (FileNotFoundError, SystemError, RuntimeError) as e:' "$MACOS_PY"; then
+  # In-place, line-number independent.
+  perl -0pi -e 's/except \(FileNotFoundError, SystemError, RuntimeError\) as e:/except (AttributeError, FileNotFoundError, SystemError, RuntimeError) as e:/' "$MACOS_PY"
+  echo "cpu_freq patch: applied"
+else
+  echo "WARNING: cpu_freq patch target not found in $MACOS_PY; crossbench may have changed upstream." >&2
+  echo "         Reconcile patches/cpu_freq-attributeerror.patch against the new source." >&2
+fi
+
+# 8. crossbench Python deps.
+#    NOTE: crossbench ships a git-tracked '.vpython3' marker that makes it re-exec
+#    under Chromium's vpython instead of our poetry venv. It must be removed, but
+#    that belongs in the RUN step (right before invoking cb.py), not here — a
+#    checkout after provisioning would restore it. --no-root is intentionally
+#    omitted: the crossbench package + cb entry point require the root install.
+log "crossbench deps (poetry install)"
+cd "$CROSSBENCH_DIR"
+poetry env use "$PY_BIN"
+poetry install
+
+log "Provisioning complete"

--- a/macOS/scripts/crossbench/provision-macos.sh
+++ b/macOS/scripts/crossbench/provision-macos.sh
@@ -88,15 +88,19 @@ echo "poetry: $(poetry --version)"
 #    A fresh install gets latest already; an existing install is upgraded here so
 #    we don't drift behind (rather than relying on Keystone's background schedule).
 log "Google Chrome"
-if [ ! -d "/Applications/Google Chrome.app" ]; then
-  brew install --cask google-chrome
-else
-  # Explicit `brew update` first: HOMEBREW_NO_AUTO_UPDATE=1 (set above) freezes
-  # brew's cask index to the last tap sync, so upgrade alone would never see a
-  # newer version. --greedy because Chrome's cask is auto_updates and a plain
-  # `brew upgrade` skips such casks.
-  brew update
+# Explicit `brew update` first: HOMEBREW_NO_AUTO_UPDATE=1 (set above) freezes
+# brew's cask index to the last tap sync, so an upgrade would never see a newer
+# version.
+brew update
+if brew list --cask google-chrome >/dev/null 2>&1; then
+  # brew-managed: upgrade to latest. --greedy because Chrome's cask is
+  # auto_updates and a plain `brew upgrade` skips such casks.
   brew upgrade --cask --greedy google-chrome
+else
+  # Fresh machine, or Chrome present but not installed via brew (so brew can't
+  # upgrade it). --force (re)installs the latest cask and brings it under brew
+  # management, so subsequent runs take the upgrade path above.
+  brew install --cask --force google-chrome
 fi
 echo "chrome: $('/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' --version 2>/dev/null || echo 'version unavailable')"
 

--- a/macOS/scripts/crossbench/safari-automation.py
+++ b/macOS/scripts/crossbench/safari-automation.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+#
+# safari-automation.py — minimal W3C WebDriver client for Safari via safaridriver.
+#
+# The Safari counterpart of ddg-automation.py. Where DDG exposes a custom HTTP
+# AutomationServer, Safari is driven the standard way: `safaridriver -p <port>`
+# runs a W3C WebDriver server on http://127.0.0.1:<port>, and this client speaks
+# raw WebDriver over it with the stdlib only (no selenium dependency, matching
+# the rest of this harness).
+#
+# WHY A "measure" COMMAND INSTEAD OF navigate/lcp SUBCOMMANDS (as in DDG):
+#   WebDriver is session-stateful — navigate and the LCP read must happen inside
+#   ONE session. ddg-automation.py can be stateless per-call because the browser
+#   holds the state; here we keep the whole lifecycle (new session -> navigate ->
+#   dwell -> observe -> delete session) in a single process invocation.
+#
+# LCP on WebKit: getEntriesByType("largest-contentful-paint") is empty unless an
+# observer is live, so we subscribe with buffered:true and resolve after a short
+# settle — identical technique to ddg-automation.py, but delivered through
+# WebDriver's ASYNC script channel (the result is handed to the callback that
+# WebDriver appends as the last argument), not `return await`.
+#
+# Routing/cert: this client does NOT configure any proxy. Safari has no
+# per-instance proxy/cert knob, so test-safari.sh points the whole machine at
+# tsproxy via a system SOCKS proxy and trusts WPR's cert in the System keychain.
+# By the time we drive Safari, that routing is already in place.
+#
+# Usage:
+#   safari-automation.py <driver_port> check
+#       -> exit 0 if a session can be created (remote automation is enabled)
+#   safari-automation.py <driver_port> measure <url> [settle_ms] [load_window_secs]
+#       -> prints:  detail={...json...}
+#                   lcp_ms=<number>            (-1 if no LCP / not finalized)
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+def base(port):
+    return "http://127.0.0.1:{}".format(port)
+
+
+def _request(port, method, path, body=None, timeout=60):
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(base(port) + path, data=data, method=method)
+    if data is not None:
+        req.add_header("Content-Type", "application/json; charset=utf-8")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.load(resp)
+
+
+def new_session(port):
+    # W3C nests the result under "value"; be lenient about an older top-level id.
+    resp = _request(port, "POST", "/session",
+                    {"capabilities": {"alwaysMatch": {"browserName": "safari"}}},
+                    timeout=60)
+    value = resp.get("value", resp)
+    sid = value.get("sessionId") or resp.get("sessionId")
+    if not sid:
+        raise RuntimeError("no sessionId in new-session response: {}".format(resp))
+    return sid
+
+
+def delete_session(port, sid):
+    try:
+        _request(port, "DELETE", "/session/{}".format(sid), timeout=15)
+    except (urllib.error.URLError, OSError):
+        pass  # a dropped teardown response is harmless
+
+
+def set_script_timeout(port, sid, ms):
+    _request(port, "POST", "/session/{}/timeouts".format(sid), {"script": ms}, timeout=15)
+
+
+def navigate(port, sid, url, timeout=60):
+    _request(port, "POST", "/session/{}/url".format(sid), {"url": url}, timeout=timeout)
+
+
+def execute_async(port, sid, script, timeout=60):
+    resp = _request(port, "POST", "/session/{}/execute/async".format(sid),
+                    {"script": script, "args": []}, timeout=timeout)
+    return resp.get("value")
+
+
+# The async LCP probe. WebDriver appends a callback as the final argument; we
+# resolve it with a detail object (or -1 on failure), never `return`.
+def _lcp_probe_js(settle_ms):
+    return (
+        "var done = arguments[arguments.length - 1];"
+        "var v=-1, el=null, url=null, size=0;"
+        "try {"
+        "new PerformanceObserver(function(list){"
+        "list.getEntries().forEach(function(e){"
+        "if (e.startTime > v) { v = e.startTime; el = e.element; url = e.url; size = e.size; }"
+        "});"
+        "}).observe({type:'largest-contentful-paint', buffered:true});"
+        "} catch (err) { done(-1); return; }"
+        "setTimeout(function(){"
+        "done(v < 0 ? -1 : {ms: v, element: el ? el.tagName : null,"
+        " id: el ? el.id : null, url: url, size: size});"
+        "}, " + str(int(settle_ms)) + ");"
+    )
+
+
+def check(port):
+    try:
+        sid = new_session(port)
+    except (urllib.error.URLError, OSError) as e:
+        print("safaridriver not reachable on {}: {}".format(base(port), e), file=sys.stderr)
+        return 1
+    except urllib.error.HTTPError as e:
+        print("session creation refused (HTTP {}). Is remote automation enabled?".format(e.code),
+              file=sys.stderr)
+        return 1
+    except Exception as e:  # noqa: BLE001 — surface any capability/handshake error
+        print("session creation failed: {}".format(e), file=sys.stderr)
+        return 1
+    delete_session(port, sid)
+    return 0
+
+
+def measure(port, url, settle_ms, load_window_secs):
+    sid = None
+    detail = -1
+    try:
+        sid = new_session(port)
+        set_script_timeout(port, sid, 30000)
+        navigate(port, sid, url)
+        # Dwell so late-arriving LCP candidates land before we read (mirrors the
+        # LOAD_WINDOW sleep test-ddg.sh does between navigate and lcp).
+        time.sleep(load_window_secs)
+        detail = execute_async(port, sid, _lcp_probe_js(settle_ms))
+    except (urllib.error.URLError, OSError, urllib.error.HTTPError) as e:
+        print("measure failed for {}: {}".format(url, e), file=sys.stderr)
+    finally:
+        if sid:
+            delete_session(port, sid)
+
+    if isinstance(detail, dict):
+        lcp = detail.get("ms", -1)
+    else:
+        lcp = detail if isinstance(detail, (int, float)) else -1
+    print("detail={}".format(json.dumps(detail)))
+    print("lcp_ms={}".format(lcp))
+    return 0
+
+
+USAGE = (
+    "usage:\n"
+    "  safari-automation.py <driver_port> check\n"
+    "  safari-automation.py <driver_port> measure <url> [settle_ms] [load_window_secs]"
+)
+
+
+def main(argv):
+    if len(argv) < 3:
+        print(USAGE, file=sys.stderr)
+        return 2
+    port = argv[1]
+    cmd = argv[2]
+    rest = argv[3:]
+
+    if cmd == "check":
+        return check(port)
+    if cmd == "measure":
+        if not rest:
+            print("measure requires a url", file=sys.stderr)
+            return 2
+        url = rest[0]
+        settle = float(rest[1]) if len(rest) > 1 else 600.0
+        window = float(rest[2]) if len(rest) > 2 else 12.0
+        return measure(port, url, settle, window)
+
+    print("unknown command: {}".format(cmd), file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/macOS/scripts/crossbench/test-chrome.sh
+++ b/macOS/scripts/crossbench/test-chrome.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+#
+# test-chrome.sh — run the crossbench page-load / LCP test for Chrome (baseline).
+#
+# macOS counterpart to the RUN half of windows-browser's runCrossbench.ps1
+# -action run, for the Chrome comparison baseline. Stock crossbench drives Chrome
+# and extracts LCP from a Perfetto trace (the Chromium event
+# PageLoadMetrics.NavigationToLargestContentfulPaint) via the navToLCP probe
+# config, over a fixed top-sites list against recorded network (Web Page Replay)
+# for determinism, and summarises per-site results.
+#
+# DDG is measured by a SEPARATE script (test-ddg.sh, TBD): the macOS DDG browser
+# is WebKit/WKWebView with no Perfetto trace — it emits LCP itself, a completely
+# different mechanism. Shared helpers (site list, WPR fetch, output format) should
+# move into a common.sh once test-ddg.sh exists.
+#
+# Prereqs: run provision-macos.sh first (installs poetry + crossbench deps).
+#
+# Usage:
+#   ./test-chrome.sh [--reps N] [--sites a.com,b.com]
+#
+set -euo pipefail
+
+# ---- config / args ---------------------------------------------------------
+REPS="10"
+SITES_OVERRIDE=""
+# crossbench-upstream is canonical: the DDG fork's page-load flow uses
+# Windows-only keyboard actions that crash on macOS. The fork-only files this
+# run needs (config/probe/perfetto/navToLCP.config.hjson and
+# crossbench/probes/trace_processor/modules/ext/largestcontentfulpaint.sql)
+# are copied into the upstream clone as untracked files.
+CROSSBENCH_DIR="${CROSSBENCH_DIR:-$HOME/Developer/crossbench-upstream}"
+WPR_DIR="${WPR_DIR:-$HOME/Developer/mac-perf-runner/wpr-archives}"
+# wpr binary built by provision-macos.sh; handed to crossbench via
+# --bin-override so crossbench never runs its own webpagereplay build.
+WPR_BIN="${WPR_BIN:-$HOME/Developer/mac-perf-runner/bin/wpr}"
+PROBE_CONFIG="config/probe/perfetto/navToLCP.config.hjson"
+SUITE="navToLCP"          # LCP focus; navToFCP exists in the ps1 as a sibling
+LOAD_WINDOW="12s"         # matches runCrossbench.ps1 (--url=<site>,12s)
+WPR_BASE_URL="https://staticcdn.duckduckgo.com/d5c04536-5379-4709-8d19-d13fdd456ff6/performance-tests"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --reps)    REPS="$2"; shift 2 ;;
+    --sites)   SITES_OVERRIDE="$2"; shift 2 ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+log() { printf '\n=== %s ===\n' "$1"; }
+
+# Site list, copied verbatim from runCrossbench.ps1 $navToSites.
+# (imdb / merriam-webster / britannica intentionally omitted there.)
+SITES=(
+  youtube.com wikipedia.org reddit.com amazon.com yelp.com
+  weather.com yahoo.com apple.com fandom.com tripadvisor.com
+  tiktok.com indeed.com spotify.com nih.gov espn.com
+  walmart.com nytimes.com clevelandclinic.org ny.gov quora.com
+  zillow.com mayoclinic.org
+)
+if [ -n "$SITES_OVERRIDE" ]; then
+  IFS=',' read -r -a SITES <<< "$SITES_OVERRIDE"
+fi
+
+# ---- preflight -------------------------------------------------------------
+preflight() {
+  if ! command -v poetry >/dev/null 2>&1; then
+    echo "ERROR: poetry not found. Run provision-macos.sh first." >&2
+    exit 1
+  fi
+  if [ ! -f "$CROSSBENCH_DIR/cb.py" ]; then
+    echo "ERROR: crossbench not found at $CROSSBENCH_DIR (cb.py missing)." >&2
+    echo "Set CROSSBENCH_DIR or clone crossbench-upstream there." >&2
+    exit 1
+  fi
+  if [ ! -x "$WPR_BIN" ]; then
+    echo "ERROR: wpr binary not found at $WPR_BIN. Run provision-macos.sh first." >&2
+    exit 1
+  fi
+}
+
+# normalized story filename: 'navToLCP+youtube.com' -> 'navToLCP_youtube.com'
+# ('+' -> '_', '/' -> '_'), matching Get-Normalized-Filename in the ps1.
+normalize() { printf '%s' "$1" | tr '+/' '__'; }
+
+# crossbench --network arg for a WPR archive. Notes:
+# - No spaces: the arg is deliberately unquoted at the call site (so an empty
+#   value vanishes); spaces inside it would word-split into broken args.
+# - NO speed/traffic shaping: crossbench shapes via third_party/tsproxy, which
+#   is Python-2-only at the DEPS-pinned revision — under our Python 3.11 venv
+#   the SOCKS handshake dies in a bare `except: pass`, the browser is pointed
+#   at a black-hole proxy, and nothing loads (verified with curl --socks5).
+#   Without a shaper crossbench maps ports via --host-resolver-rules instead,
+#   which works. WPR replays at loopback speed: deterministic, but faster than
+#   Windows' US-broadband-shaped runs — don't compare absolute values to them.
+wpr_network_arg() {
+  printf -- '--network={type:"wpr",path:"%s"}' "$1"
+}
+
+# Fetch the WPR archive for a story and echo the crossbench --network arg for it,
+# or echo nothing (live network) if the archive can't be fetched. Mirrors the
+# download-or-fall-back-to-live logic in Invoke-Crossbench.
+fetch_network_arg() {
+  local story="$1" normalized archive
+  normalized="$(normalize "$story")"
+  archive="$WPR_DIR/$normalized.wprgo"
+  mkdir -p "$WPR_DIR"
+  if curl -fLSs -o "$archive.tmp" "$WPR_BASE_URL/$normalized.wprgo" 2>/dev/null; then
+    mv "$archive.tmp" "$archive"
+    wpr_network_arg "$archive"
+  else
+    rm -f "$archive.tmp"
+    # No archive: reuse a previously downloaded one if present, else live.
+    if [ -f "$archive" ]; then
+      wpr_network_arg "$archive"
+    else
+      echo "WARNING: no WPR archive for $story; using LIVE network (results will be noisy)." >&2
+      printf ''
+    fi
+  fi
+}
+
+# Parse a crossbench RESULTS dir: for every per-iteration v2_metrics.textproto,
+# pull the first `double_value:` — the LCP metric, which trace_processor emits
+# in NANOSECONDS — and convert to ms. An iteration whose LCP never finalized
+# (missing --about-blank-duration) is emitted as `double_value: -1`; count
+# those separately instead of parsing them as timings.
+summarize_lcp() {
+  local results_path="$1" site="$2"
+  local -a vals=()
+  local f v unfinalized=0
+  while IFS= read -r f; do
+    # `|| true`: under set -e/pipefail a no-match grep would abort the script.
+    v="$(grep -Eo 'double_value: -?[0-9]+(\.[0-9]+)?' "$f" | head -1 | awk '{print $2}' || true)"
+    [ -z "$v" ] && continue
+    if awk -v v="$v" 'BEGIN{exit !(v < 0)}'; then
+      unfinalized=$((unfinalized + 1))
+      continue
+    fi
+    vals+=("$(awk -v ns="$v" 'BEGIN{printf "%.1f", ns / 1000000}')")  # ns -> ms
+    # Only per-iteration files live under a trace_processor/ dir. crossbench also
+    # writes story-level MERGED copies of v2_metrics.textproto (identical dupes),
+    # which would inflate the iteration count n on multi-story / low-rep runs.
+  done < <(find "$results_path" -path '*/trace_processor/v2_metrics.textproto' 2>/dev/null)
+
+  if [ "$unfinalized" -gt 0 ]; then
+    echo "  WARNING: $site: $unfinalized iteration(s) with unfinalized LCP (-1)." >&2
+  fi
+  if [ "${#vals[@]}" -eq 0 ]; then
+    echo "  $site: NO LCP VALUES PARSED (check trace / 30s cap issue)"
+    return
+  fi
+  printf '  %s: lcp_ms=[%s] ' "$site" "$(IFS=,; echo "${vals[*]}")"
+  printf '%s\n' "${vals[@]}" | awk '{s+=$1; n++} END{printf "mean=%.1f n=%d\n", s/n, n}'
+}
+
+# ---- ClickHouse upload (OUT OF SCOPE — stub) ------------------------------
+upload_results() {
+  local results_path="$1" site="$2"
+  # TODO: upload per-iteration LCP to ClickHouse for parity with the Windows
+  # pipeline (testId "Crossbench.${SUITE}+${site}", browserType, commit, runId,
+  # browser version). The Windows uploader is a C#/.NET project; decide whether
+  # to reuse it cross-platform (dotnet runs on macOS) or replace with a small
+  # uploader here. No-op for now.
+  :
+}
+
+# ---- run -------------------------------------------------------------------
+run_chrome() {
+  log "Chrome LCP run — $SUITE, ${#SITES[@]} sites, $REPS reps, ${LOAD_WINDOW} window"
+  cd "$CROSSBENCH_DIR"
+  # .vpython3 is git-tracked and makes crossbench re-exec under Chromium vpython
+  # instead of our poetry venv; removal belongs here (run step), not provisioning.
+  rm -f .vpython3
+
+  local site story network_arg out results_path
+  for site in "${SITES[@]}"; do
+    story="${SUITE}+${site}"
+    log "site: $site"
+    network_arg="$(fetch_network_arg "$story")"
+
+    out="$(mktemp)"
+    # --about-blank-duration is REQUIRED: navigating to about:blank after each
+    # page forces Chromium to finalize LCP; without it every value comes out -1.
+    # shellcheck disable=SC2086  # network_arg must word-split (empty => omitted)
+    poetry run python ./cb.py \
+      loading \
+      --browser=chrome-stable \
+      --probe-config="$PROBE_CONFIG" \
+      --repetitions="$REPS" \
+      --url="$site,$LOAD_WINDOW" \
+      --about-blank-duration=2s \
+      --bin-override "wpr=$WPR_BIN" \
+      $network_arg \
+      --debug \
+      --env-validation=skip 2>&1 | tee "$out" || echo "WARN: crossbench exited non-zero for $site" >&2
+
+    # `|| true`: under set -e/pipefail a no-match grep would abort the script.
+    results_path="$(grep -E '^RESULTS: ' "$out" | tail -1 | sed -E 's/^RESULTS: //' || true)"
+    if [ -n "$results_path" ] && [ -d "$results_path" ]; then
+      summarize_lcp "$results_path" "$site"
+      upload_results "$results_path" "$site"
+    else
+      echo "  $site: no RESULTS path in crossbench output"
+    fi
+    rm -f "$out"
+  done
+}
+
+# ---- main ------------------------------------------------------------------
+preflight
+run_chrome
+log "Done"

--- a/macOS/scripts/crossbench/test-ddg.sh
+++ b/macOS/scripts/crossbench/test-ddg.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+#
+# test-ddg.sh — DuckDuckGo macOS (WebKit) page-load / LCP run against recorded
+# network (Web Page Replay). The WKWebView counterpart to test-chrome.sh.
+#
+# WHY THIS IS DIFFERENT FROM CHROME:
+#   Chrome reaches WPR via --host-resolver-rules (remap every host to the WPR
+#   ports) and needs no proxy. WKWebView has no host-resolver knob, so DDG is
+#   pointed at a SOCKS5 proxy (standalone tsproxy) that redirects EVERY
+#   destination to the local WPR origin and remaps 443->WPR-https / 80->WPR-http.
+#   For that to work the browser must (both Debug/Review-gated launch options):
+#     1. send all web traffic to the proxy  -> webViewProxy=host:port
+#     2. accept WPR's self-signed cert       -> acceptInsecureCerts=true
+#   DDG is driven directly through its AutomationServer (a Debug/Review HTTP
+#   server on [::1]:PORT) — NOT crossbench — and emits LCP itself via a buffered
+#   PerformanceObserver, because WebKit produces no Perfetto trace.
+#
+# SHARED WITH CHROME (data, not code): the wpr binary, the WPR archives, the
+# WPR_BASE_URL, and the site list. A common.sh extraction is the intended next
+# cleanup (see README); kept self-contained here so the working Chrome path is
+# untouched while this is proven out.
+#
+# NO TRAFFIC SHAPING (same as test-chrome.sh): tsproxy runs pass-through, so WPR
+# replays at loopback speed — deterministic, but faster than the Windows
+# US-broadband-shaped runs. Don't compare DDG absolute values to Windows; DO
+# compare DDG-vs-Chrome on THIS runner (same shaping, same archives).
+#
+# Prereqs: provision-macos.sh (wpr binary + archives dir), and an INSTALLED DDG
+# Review or Debug build whose app supports the webViewProxy / acceptInsecureCerts
+# launch options. Point DDG_APP at it (defaults to a Review build in /Applications).
+#
+# Usage:
+#   ./test-ddg.sh [--reps N] [--sites a.com,b.com]
+#
+set -euo pipefail
+
+# ---- config / args ---------------------------------------------------------
+REPS="10"
+SITES_OVERRIDE=""
+
+WPR_DIR="${WPR_DIR:-$HOME/Developer/mac-perf-runner/wpr-archives}"
+WPR_BIN="${WPR_BIN:-$HOME/Developer/mac-perf-runner/bin/wpr}"
+WPR_BASE_URL="${WPR_BASE_URL:-https://staticcdn.duckduckgo.com/d5c04536-5379-4709-8d19-d13fdd456ff6/performance-tests}"
+WPR_HTTP_PORT="${WPR_HTTP_PORT:-8080}"
+WPR_HTTPS_PORT="${WPR_HTTPS_PORT:-8081}"
+# Optional explicit WPR cert/key. If unset we look next to WPR_BIN and, failing
+# that, let wpr use its own defaults (which is how it ran during bring-up).
+WPR_CERT_FILE="${WPR_CERT_FILE:-}"
+WPR_KEY_FILE="${WPR_KEY_FILE:-}"
+
+# Standalone tsproxy (NOT crossbench's DEPS-pinned copy, which is Python-2-only).
+# Fetched from catapult if missing. Runs under the system python3.
+TSPROXY_PY="${TSPROXY_PY:-$HOME/Developer/mac-perf-runner/bin/tsproxy.py}"
+TSPROXY_URL="${TSPROXY_URL:-https://chromium.googlesource.com/catapult/+/refs/heads/main/third_party/tsproxy/tsproxy.py?format=TEXT}"
+PROXY_PORT="${PROXY_PORT:-9999}"
+
+# DDG app + automation.
+DDG_APP="${DDG_APP:-/Applications/DuckDuckGo Review.app}"
+DDG_BUNDLE_ID="${DDG_BUNDLE_ID:-com.duckduckgo.macos.browser.review}"
+AUTOMATION_PORT="${AUTOMATION_PORT:-8788}"
+
+# Dwell after navigation before reading LCP (matches test-chrome.sh's 12s window),
+# then the buffered-observer settle inside the browser.
+LOAD_WINDOW_SECS="${LOAD_WINDOW_SECS:-12}"
+LCP_SETTLE_MS="${LCP_SETTLE_MS:-600}"
+READY_TIMEOUT_SECS="${READY_TIMEOUT_SECS:-45}"
+
+# Clear the app's on-disk cache between reps so every rep is a cold load (and so
+# every rep actually hits WPR). Set NO_CACHE_CLEAR=1 to keep the cache warm.
+NO_CACHE_CLEAR="${NO_CACHE_CLEAR:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DRIVER="${DRIVER:-$SCRIPT_DIR/ddg-automation.py}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --reps)    REPS="$2"; shift 2 ;;
+    --sites)   SITES_OVERRIDE="$2"; shift 2 ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+log() { printf '\n=== %s ===\n' "$1"; }
+
+# Site list — identical to test-chrome.sh so the two are directly comparable.
+SITES=(
+  youtube.com wikipedia.org reddit.com amazon.com yelp.com
+  weather.com yahoo.com apple.com fandom.com tripadvisor.com
+  tiktok.com indeed.com spotify.com nih.gov espn.com
+  walmart.com nytimes.com clevelandclinic.org ny.gov quora.com
+  zillow.com mayoclinic.org
+)
+if [ -n "$SITES_OVERRIDE" ]; then
+  IFS=',' read -r -a SITES <<< "$SITES_OVERRIDE"
+fi
+
+# story filename normalization, matching test-chrome.sh ('+'->'_', '/'->'_').
+normalize() { printf '%s' "$1" | tr '+/' '__'; }
+
+# ---- process lifecycle -----------------------------------------------------
+WPR_PID=""
+TSPROXY_PID=""
+DDG_PID=""
+WPR_LOG=""
+TSPROXY_LOG=""
+
+# Kill only PIDs we launched (never by name — a name match could hit an unrelated
+# browser the operator is running).
+kill_pid() {
+  local pid="$1"
+  [ -n "$pid" ] || return 0
+  if kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+    for _ in 1 2 3 4 5 6; do
+      kill -0 "$pid" 2>/dev/null || return 0
+      sleep 0.5
+    done
+    kill -9 "$pid" 2>/dev/null || true
+  fi
+}
+
+cleanup() {
+  quit_ddg
+  kill_pid "$TSPROXY_PID"
+  kill_pid "$WPR_PID"
+  [ -n "$TSPROXY_LOG" ] && rm -f "$TSPROXY_LOG"
+  [ -n "$WPR_LOG" ] && rm -f "$WPR_LOG"
+}
+trap cleanup EXIT
+
+# ---- preflight -------------------------------------------------------------
+ensure_tsproxy() {
+  [ -f "$TSPROXY_PY" ] && return 0
+  echo "tsproxy not found at $TSPROXY_PY; fetching from catapult..." >&2
+  mkdir -p "$(dirname "$TSPROXY_PY")"
+  # gitiles serves source base64-encoded when ?format=TEXT.
+  if curl -fLSs "$TSPROXY_URL" | python3 -c 'import base64,sys; sys.stdout.buffer.write(base64.b64decode(sys.stdin.read()))' > "$TSPROXY_PY.tmp" 2>/dev/null && [ -s "$TSPROXY_PY.tmp" ]; then
+    mv "$TSPROXY_PY.tmp" "$TSPROXY_PY"
+  else
+    rm -f "$TSPROXY_PY.tmp"
+    echo "ERROR: could not fetch tsproxy. Set TSPROXY_PY to a local copy." >&2
+    exit 1
+  fi
+}
+
+preflight() {
+  if [ ! -x "$WPR_BIN" ]; then
+    echo "ERROR: wpr binary not found at $WPR_BIN. Run provision-macos.sh first." >&2
+    exit 1
+  fi
+  if [ ! -d "$DDG_APP" ]; then
+    echo "ERROR: DDG app not found at $DDG_APP. Install a Review/Debug build and set DDG_APP." >&2
+    exit 1
+  fi
+  DDG_EXEC="$DDG_APP/Contents/MacOS/$(defaults read "$DDG_APP/Contents/Info" CFBundleExecutable 2>/dev/null || echo DuckDuckGo)"
+  if [ ! -x "$DDG_EXEC" ]; then
+    echo "ERROR: DDG executable not found at $DDG_EXEC." >&2
+    exit 1
+  fi
+  if [ ! -f "$DRIVER" ]; then
+    echo "ERROR: automation driver not found at $DRIVER." >&2
+    exit 1
+  fi
+  command -v python3 >/dev/null 2>&1 || { echo "ERROR: python3 not found." >&2; exit 1; }
+  mkdir -p "$WPR_DIR"
+  ensure_tsproxy
+}
+
+# Wait for a TCP port on 127.0.0.1 to accept connections.
+wait_for_port() {
+  local port="$1" timeout="${2:-15}" i
+  for ((i = 0; i < timeout * 2; i++)); do
+    if (exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null; then
+      exec 3>&- 3<&- 2>/dev/null || true
+      return 0
+    fi
+    sleep 0.5
+  done
+  return 1
+}
+
+# ---- WPR + tsproxy ---------------------------------------------------------
+fetch_archive() {
+  # Echo the archive path on success, nothing on failure.
+  local story="$1" normalized archive
+  normalized="$(normalize "$story")"
+  archive="$WPR_DIR/$normalized.wprgo"
+  if curl -fLSs -o "$archive.tmp" "$WPR_BASE_URL/$normalized.wprgo" 2>/dev/null; then
+    mv "$archive.tmp" "$archive"
+    printf '%s' "$archive"
+  else
+    rm -f "$archive.tmp"
+    [ -f "$archive" ] && printf '%s' "$archive"  # reuse a previously-downloaded one
+  fi
+}
+
+start_wpr() {
+  local archive="$1"
+  WPR_LOG="$(mktemp)"
+  local -a cert_args=()
+  local cert="$WPR_CERT_FILE" key="$WPR_KEY_FILE"
+  [ -z "$cert" ] && [ -f "$(dirname "$WPR_BIN")/wpr_cert.pem" ] && cert="$(dirname "$WPR_BIN")/wpr_cert.pem"
+  [ -z "$key" ] && [ -f "$(dirname "$WPR_BIN")/wpr_key.pem" ] && key="$(dirname "$WPR_BIN")/wpr_key.pem"
+  if [ -n "$cert" ] && [ -n "$key" ]; then
+    cert_args=(--https_cert_file "$cert" --https_key_file "$key")
+  fi
+  "$WPR_BIN" replay \
+    --http_port="$WPR_HTTP_PORT" \
+    --https_port="$WPR_HTTPS_PORT" \
+    "${cert_args[@]}" \
+    "$archive" >"$WPR_LOG" 2>&1 &
+  WPR_PID=$!
+  if ! wait_for_port "$WPR_HTTPS_PORT" 15; then
+    echo "ERROR: WPR did not start on port $WPR_HTTPS_PORT. Log:" >&2
+    cat "$WPR_LOG" >&2
+    exit 1
+  fi
+}
+
+stop_wpr() {
+  kill_pid "$WPR_PID"
+  WPR_PID=""
+  [ -n "$WPR_LOG" ] && rm -f "$WPR_LOG"
+  WPR_LOG=""
+}
+
+start_tsproxy() {
+  TSPROXY_LOG="$(mktemp)"
+  # SOCKS5 on PROXY_PORT; redirect every destination to loopback WPR, remapping
+  # 443->WPR-https and 80->WPR-http. No -r/-i/-o => no shaping (pass-through).
+  python3 "$TSPROXY_PY" \
+    --port "$PROXY_PORT" \
+    --desthost 127.0.0.1 \
+    --mapports "443:$WPR_HTTPS_PORT,80:$WPR_HTTP_PORT" \
+    >"$TSPROXY_LOG" 2>&1 &
+  TSPROXY_PID=$!
+  if ! wait_for_port "$PROXY_PORT" 15; then
+    echo "ERROR: tsproxy did not start on port $PROXY_PORT. Log:" >&2
+    cat "$TSPROXY_LOG" >&2
+    exit 1
+  fi
+}
+
+# ---- DDG lifecycle ---------------------------------------------------------
+DDG_EXEC=""
+
+clear_ddg_cache() {
+  [ -n "$NO_CACHE_CLEAR" ] && return 0
+  local container="$HOME/Library/Containers/$DDG_BUNDLE_ID/Data/Library"
+  # Only the .review/.debug container is ever touched here — never the public app.
+  [ -d "$container/Caches" ] && rm -rf "$container/Caches" 2>/dev/null || true
+  [ -d "$container/WebKit/NetworkCache" ] && rm -rf "$container/WebKit/NetworkCache" 2>/dev/null || true
+}
+
+launch_ddg() {
+  # Launch options via the app's sandbox container defaults. (defaults write on
+  # the bare suite only lands in the container once the app lives in /Applications.)
+  defaults write "$DDG_BUNDLE_ID" automationPort -int "$AUTOMATION_PORT"
+  defaults write "$DDG_BUNDLE_ID" webViewProxy -string "127.0.0.1:$PROXY_PORT"
+  defaults write "$DDG_BUNDLE_ID" acceptInsecureCerts -bool true
+  defaults write "$DDG_BUNDLE_ID" isOnboardingCompleted -string true
+
+  open -a "$DDG_APP"
+
+  # run_ddg() already killed any pre-existing instance of THIS build, so the
+  # newest process whose command line is our full app executable path is the one
+  # we just launched. Full-path match can't hit another (public) browser, and
+  # WebKit's helper processes live under WebKit.framework, not this path.
+  local i
+  DDG_PID=""
+  for ((i = 0; i < 20; i++)); do
+    DDG_PID="$(pgrep -n -f "$DDG_EXEC" 2>/dev/null || true)"
+    [ -n "$DDG_PID" ] && break
+    sleep 0.5
+  done
+
+  if ! python3 "$DRIVER" "$AUTOMATION_PORT" wait-ready "$READY_TIMEOUT_SECS"; then
+    echo "ERROR: DDG automation server never became ready on port $AUTOMATION_PORT." >&2
+    echo "  Is this a Debug/Review build with automationPort support? Is another instance running?" >&2
+    return 1
+  fi
+}
+
+quit_ddg() {
+  [ -n "$DDG_PID" ] || return 0
+  python3 "$DRIVER" "$AUTOMATION_PORT" shutdown >/dev/null 2>&1 || true
+  sleep 1
+  kill_pid "$DDG_PID"
+  DDG_PID=""
+}
+
+# ---- measurement -----------------------------------------------------------
+# Assert the navigation actually traversed the proxy (=> WPR served it), so a
+# silent live-network fallback can't masquerade as a valid measurement.
+proxy_saw_traffic() {
+  local before="$1" after
+  after="$(wc -l < "$TSPROXY_LOG" 2>/dev/null || echo 0)"
+  [ "$after" -gt "$before" ]
+}
+
+summarize_lcp() {
+  local site="$1"; shift
+  local -a vals=("$@")
+  if [ "${#vals[@]}" -eq 0 ]; then
+    echo "  $site: NO LCP VALUES (all reps failed or bypassed the proxy)"
+    return
+  fi
+  printf '  %s: lcp_ms=[%s] ' "$site" "$(IFS=,; echo "${vals[*]}")"
+  printf '%s\n' "${vals[@]}" | awk '{s+=$1; n++} END{printf "mean=%.1f n=%d\n", s/n, n}'
+}
+
+measure_site() {
+  local site="$1" story archive
+  story="navToLCP+$site"
+  archive="$(fetch_archive "$story")"
+  if [ -z "$archive" ]; then
+    echo "  $site: no WPR archive available; SKIPPING (DDG runs replay-only)." >&2
+    return
+  fi
+
+  start_wpr "$archive"
+
+  local -a vals=()
+  local rep ts_before lcp detail
+  for ((rep = 1; rep <= REPS; rep++)); do
+    clear_ddg_cache
+    if ! launch_ddg; then
+      quit_ddg
+      continue
+    fi
+
+    ts_before="$(wc -l < "$TSPROXY_LOG" 2>/dev/null || echo 0)"
+    python3 "$DRIVER" "$AUTOMATION_PORT" navigate "https://$site" >/dev/null || true
+    sleep "$LOAD_WINDOW_SECS"
+
+    detail="$(python3 "$DRIVER" "$AUTOMATION_PORT" lcp-detail "$LCP_SETTLE_MS" 2>/dev/null || true)"
+    lcp="$(python3 "$DRIVER" "$AUTOMATION_PORT" lcp "$LCP_SETTLE_MS" 2>/dev/null || true)"
+
+    if ! proxy_saw_traffic "$ts_before"; then
+      echo "  $site rep $rep: WARNING — no proxy traffic; navigation bypassed WPR. Dropping." >&2
+      quit_ddg
+      continue
+    fi
+    if [ -z "$lcp" ] || awk -v v="$lcp" 'BEGIN{exit !(v+0 <= 0)}'; then
+      echo "  $site rep $rep: LCP not finalized ($lcp). Dropping. detail=$detail" >&2
+      quit_ddg
+      continue
+    fi
+
+    vals+=("$lcp")
+    echo "  $site rep $rep: lcp_ms=$lcp  detail=$detail"
+    quit_ddg
+  done
+
+  stop_wpr
+  summarize_lcp "$site" "${vals[@]}"
+}
+
+# ---- run -------------------------------------------------------------------
+run_ddg() {
+  log "DDG LCP run — ${#SITES[@]} sites, $REPS reps, ${LOAD_WINDOW_SECS}s window, proxy 127.0.0.1:$PROXY_PORT -> WPR"
+  # Quit any pre-existing instance of THIS build (path-scoped) for a clean start.
+  local existing
+  existing="$(pgrep -f "$DDG_EXEC" 2>/dev/null || true)"
+  for pid in $existing; do kill_pid "$pid"; done
+
+  start_tsproxy
+
+  local site
+  for site in "${SITES[@]}"; do
+    log "site: $site"
+    measure_site "$site"
+  done
+}
+
+# ---- main ------------------------------------------------------------------
+preflight
+run_ddg
+log "Done"

--- a/macOS/scripts/crossbench/test-safari.sh
+++ b/macOS/scripts/crossbench/test-safari.sh
@@ -1,0 +1,409 @@
+#!/usr/bin/env bash
+#
+# test-safari.sh — Safari (WebKit) page-load / LCP run against recorded network
+# (Web Page Replay). The real-Safari counterpart to test-ddg.sh.
+#
+# WHY THIS DIFFERS FROM DDG (and Chrome):
+#   Safari is Apple's app — we can't set a per-instance proxy the way we do for our
+#   own WKWebView in DDG (webViewProxy / acceptInsecureCerts), and safaridriver does
+#   not honour the WebDriver `proxy` capability. Chrome uses --host-resolver-rules;
+#   Safari has no such knob. But Safari DOES read a proxy from its own prefs domain:
+#     defaults write com.apple.Safari WebKit2HTTPProxy  http://127.0.0.1:PORT
+#     defaults write com.apple.Safari WebKit2HTTPSProxy http://127.0.0.1:PORT
+#   That is a PER-APP proxy — no root, and only Safari is affected. We point it at a
+#   tiny local HTTP forward proxy (httpproxy.py) that funnels everything to WPR.
+#
+#   We deliberately do NOT use a machine-wide system SOCKS proxy (networksetup):
+#   it needs root AND — proven on this VM — it drops the inbound SSH connection on
+#   the first proxied navigation, so unattended SSH-driven runs are impossible with
+#   it. The per-app proxy leaves SSH (and the rest of the box) untouched.
+#
+#   Safari is driven via safaridriver (W3C WebDriver) by safari-automation.py, and
+#   emits LCP itself via a buffered PerformanceObserver — same as DDG, because
+#   WebKit produces no Perfetto trace.
+#
+# CERT / TLS: WPR serves a self-signed cert; Safari validates TLS normally. WPR is
+#   handed the ECDSA (P-256) root ONLY — its bundled RSA root is 1024-bit, which
+#   Apple's TLS rejects ("illegal parameter" handshake failure). --no-archive-certificates
+#   forces fresh leaves minted from that root at replay time. The ECDSA root must be
+#   trusted ONCE in the System keychain (a GUI-only step; headless SSH trust is
+#   impossible on macOS 26) — see commission-safari.sh.
+#
+# NO PER-RUN SUDO: the only privileged setup (trust the ECDSA cert, safaridriver
+#   --enable, and ticking Safari > Develop > Allow Remote Automation) is one-time,
+#   done by commission-safari.sh. This script itself needs no sudo, so it runs
+#   unattended over plain SSH.
+#
+# NO TRAFFIC SHAPING (same as test-ddg.sh / test-chrome.sh): the proxy is
+#   pass-through, so WPR replays at loopback speed. Compare Safari-vs-DDG-vs-Chrome
+#   on THIS runner (same archives), NOT against the Windows runs.
+#
+# Prereqs: provision-macos.sh (wpr binary + archives dir); commission-safari.sh run
+#   once (ECDSA cert trusted + safaridriver enabled + Allow Remote Automation);
+#   httpproxy.py alongside this script; and the WPR ECDSA cert/key (set
+#   WPR_CERT_FILE=ecdsa_cert.pem, WPR_KEY_FILE=ecdsa_key.pem).
+#
+# Usage:
+#   ./test-safari.sh [--reps N] [--sites a.com,b.com] [--yes]
+#
+set -euo pipefail
+
+# ---- config / args ---------------------------------------------------------
+REPS="10"
+SITES_OVERRIDE=""
+ASSUME_YES="${ASSUME_YES:-}"
+
+WPR_DIR="${WPR_DIR:-$HOME/Developer/mac-perf-runner/wpr-archives}"
+WPR_BIN="${WPR_BIN:-$HOME/Developer/mac-perf-runner/bin/wpr}"
+WPR_BASE_URL="${WPR_BASE_URL:-https://staticcdn.duckduckgo.com/d5c04536-5379-4709-8d19-d13fdd456ff6/performance-tests}"
+# NOT 8080/8081 (the default the Chrome/DDG paths use): safaridriver's launchd XPC
+# service `com.apple.WebDriver.HTTPService` squats *:8080 whenever automation is
+# active, which would collide with WPR since WPR here starts AFTER safaridriver.
+WPR_HTTP_PORT="${WPR_HTTP_PORT:-18080}"
+WPR_HTTPS_PORT="${WPR_HTTPS_PORT:-18081}"
+# The ECDSA (P-256) cert/key WPR serves. Defaults to ecdsa_cert.pem next to the
+# binary; the RSA root must NOT be used (1024-bit, rejected by Apple TLS).
+WPR_CERT_FILE="${WPR_CERT_FILE:-}"
+WPR_KEY_FILE="${WPR_KEY_FILE:-}"
+
+# Tiny local HTTP forward proxy in front of WPR (CONNECT -> WPR-https, absolute-form
+# GET -> WPR-http). Replaces the SOCKS tsproxy the DDG path uses.
+HTTPPROXY_PY="${HTTPPROXY_PY:-}"
+PROXY_PORT="${PROXY_PORT:-9998}"
+
+# Safari's prefs domain that the per-app proxy is written to.
+SAFARI_DOMAIN="com.apple.Safari"
+
+# safaridriver W3C server port (distinct from DDG's automation port).
+SAFARIDRIVER_PORT="${SAFARIDRIVER_PORT:-8790}"
+
+# Dwell after navigation before reading LCP (matches test-chrome.sh's 12s window),
+# then the buffered-observer settle inside the browser.
+LOAD_WINDOW_SECS="${LOAD_WINDOW_SECS:-12}"
+LCP_SETTLE_MS="${LCP_SETTLE_MS:-600}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DRIVER="${DRIVER:-$SCRIPT_DIR/safari-automation.py}"
+[ -z "$HTTPPROXY_PY" ] && HTTPPROXY_PY="$SCRIPT_DIR/httpproxy.py"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --reps)    REPS="$2"; shift 2 ;;
+    --sites)   SITES_OVERRIDE="$2"; shift 2 ;;
+    --yes|-y)  ASSUME_YES="1"; shift ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+log() { printf '\n=== %s ===\n' "$1"; }
+
+# Site list — identical to test-chrome.sh / test-ddg.sh so all three are
+# directly comparable.
+SITES=(
+  youtube.com wikipedia.org reddit.com amazon.com yelp.com
+  weather.com yahoo.com apple.com fandom.com tripadvisor.com
+  tiktok.com indeed.com spotify.com nih.gov espn.com
+  walmart.com nytimes.com clevelandclinic.org ny.gov quora.com
+  zillow.com mayoclinic.org
+)
+if [ -n "$SITES_OVERRIDE" ]; then
+  IFS=',' read -r -a SITES <<< "$SITES_OVERRIDE"
+fi
+
+# story filename normalization, matching the other scripts ('+'->'_', '/'->'_').
+normalize() { printf '%s' "$1" | tr '+/' '__'; }
+
+# ---- process / system state we own -----------------------------------------
+WPR_PID=""
+HTTPPROXY_PID=""
+SAFARIDRIVER_PID=""
+WPR_LOG=""
+HTTPPROXY_LOG=""
+SAFARIDRIVER_LOG=""
+
+CERT_FILE=""            # resolved WPR ECDSA cert, set in preflight
+PROXY_APPLIED=""        # set once we've written the per-app proxy defaults
+
+# Kill only PIDs we launched (never by name — a name match could hit an unrelated
+# browser the operator is running).
+kill_pid() {
+  local pid="$1"
+  [ -n "$pid" ] || return 0
+  if kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+    for _ in 1 2 3 4 5 6; do
+      kill -0 "$pid" 2>/dev/null || return 0
+      sleep 0.5
+    done
+    kill -9 "$pid" 2>/dev/null || true
+  fi
+}
+
+# ---- routing (per-app proxy, no sudo) --------------------------------------
+# Point Safari at our HTTP forward proxy via its OWN prefs domain — no root, no
+# machine-wide proxy, only Safari is affected (so SSH stays up). Requires the WPR
+# ECDSA cert already trusted in the System keychain (one-time; commission-safari.sh).
+apply_proxy_state() {
+  defaults write "$SAFARI_DOMAIN" WebKit2HTTPProxy  "http://127.0.0.1:$PROXY_PORT"
+  defaults write "$SAFARI_DOMAIN" WebKit2HTTPSProxy "http://127.0.0.1:$PROXY_PORT"
+  PROXY_APPLIED="1"
+}
+
+restore_proxy_state() {
+  [ -n "$PROXY_APPLIED" ] || return 0
+  defaults delete "$SAFARI_DOMAIN" WebKit2HTTPProxy  2>/dev/null || true
+  defaults delete "$SAFARI_DOMAIN" WebKit2HTTPSProxy 2>/dev/null || true
+  PROXY_APPLIED=""
+}
+
+cleanup() {
+  # Preserve the exit code that triggered the trap: this runs as an EXIT trap and
+  # bash uses the trap's LAST command status as the script's exit code, so without
+  # this a successful run would exit non-zero (the final guarded rm evaluates false
+  # once stop_wpr has blanked WPR_LOG).
+  local ec=$?
+  # Stop driving/serving first, then undo the per-app proxy.
+  kill_pid "$SAFARIDRIVER_PID"
+  kill_pid "$HTTPPROXY_PID"
+  kill_pid "$WPR_PID"
+  restore_proxy_state
+  [ -n "$SAFARIDRIVER_LOG" ] && rm -f "$SAFARIDRIVER_LOG"
+  [ -n "$HTTPPROXY_LOG" ] && rm -f "$HTTPPROXY_LOG"
+  [ -n "$WPR_LOG" ] && rm -f "$WPR_LOG"
+  return $ec
+}
+trap cleanup EXIT
+
+# ---- preflight -------------------------------------------------------------
+resolve_cert() {
+  CERT_FILE="$WPR_CERT_FILE"
+  [ -z "$CERT_FILE" ] && [ -f "$(dirname "$WPR_BIN")/ecdsa_cert.pem" ] && CERT_FILE="$(dirname "$WPR_BIN")/ecdsa_cert.pem"
+  if [ -z "$CERT_FILE" ] || [ ! -f "$CERT_FILE" ]; then
+    echo "ERROR: WPR ECDSA cert not found. Set WPR_CERT_FILE to ecdsa_cert.pem —" >&2
+    echo "       WPR must serve the P-256 ECDSA root; the bundled 1024-bit RSA root" >&2
+    echo "       is rejected by Apple's TLS ('illegal parameter' handshake failure)." >&2
+    exit 1
+  fi
+  [ -z "$WPR_KEY_FILE" ] && WPR_KEY_FILE="$(dirname "$CERT_FILE")/ecdsa_key.pem"
+  if [ ! -f "$WPR_KEY_FILE" ]; then
+    echo "ERROR: WPR ECDSA key not found at $WPR_KEY_FILE. Set WPR_KEY_FILE." >&2
+    exit 1
+  fi
+}
+
+preflight() {
+  if [ ! -x "$WPR_BIN" ]; then
+    echo "ERROR: wpr binary not found at $WPR_BIN. Run provision-macos.sh first." >&2
+    exit 1
+  fi
+  if [ ! -f "$DRIVER" ]; then
+    echo "ERROR: automation driver not found at $DRIVER." >&2
+    exit 1
+  fi
+  if [ ! -f "$HTTPPROXY_PY" ]; then
+    echo "ERROR: HTTP forward proxy not found at $HTTPPROXY_PY." >&2
+    exit 1
+  fi
+  command -v python3 >/dev/null 2>&1 || { echo "ERROR: python3 not found." >&2; exit 1; }
+  command -v safaridriver >/dev/null 2>&1 || { echo "ERROR: safaridriver not found." >&2; exit 1; }
+  command -v defaults >/dev/null 2>&1 || { echo "ERROR: defaults not found." >&2; exit 1; }
+  mkdir -p "$WPR_DIR"
+  resolve_cert
+}
+
+confirm() {
+  [ -n "$ASSUME_YES" ] && return 0
+  cat >&2 <<EOF
+
+⚠️  test-safari.sh will, for the duration of the run:
+      • set a per-app proxy on Safari ($SAFARI_DOMAIN) -> 127.0.0.1:$PROXY_PORT -> WPR
+    Only Safari is affected (no machine-wide proxy, no sudo). Requires the WPR ECDSA
+    cert already trusted in the System keychain (one-time; run ./commission-safari.sh).
+    The proxy setting is removed automatically on exit (including Ctrl-C).
+
+EOF
+  read -r -p "Proceed? [y/N] " ans
+  case "$ans" in y|Y|yes|YES) ;; *) echo "Aborted." >&2; exit 1 ;; esac
+}
+
+# Wait for a TCP port on 127.0.0.1 to accept connections.
+wait_for_port() {
+  local port="$1" timeout="${2:-15}" i
+  for ((i = 0; i < timeout * 2; i++)); do
+    if (exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  return 1
+}
+
+# Fail loudly if a port is already taken (e.g. a stale wpr/httpproxy from a crashed
+# run). Without this, wait_for_port would see the FOREIGN server answering, our own
+# process would have quietly failed to bind, and the run would measure against the
+# wrong server (or wrong archive) with no hint anything was off.
+assert_port_free() {
+  local port="$1" label="$2"
+  if (exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null; then
+    echo "ERROR: port $port ($label) is already in use — likely a stale wpr/httpproxy" >&2
+    echo "       from a previous run. Find and kill it, then re-run:" >&2
+    echo "         lsof -nP -iTCP:$port -sTCP:LISTEN" >&2
+    exit 1
+  fi
+}
+
+# ---- WPR + HTTP proxy ------------------------------------------------------
+fetch_archive() {
+  local story="$1" normalized archive
+  normalized="$(normalize "$story")"
+  archive="$WPR_DIR/$normalized.wprgo"
+  if curl -fLSs -o "$archive.tmp" "$WPR_BASE_URL/$normalized.wprgo" 2>/dev/null; then
+    mv "$archive.tmp" "$archive"
+    printf '%s' "$archive"
+  else
+    rm -f "$archive.tmp"
+    [ -f "$archive" ] && printf '%s' "$archive"  # reuse a previously-downloaded one
+  fi
+}
+
+start_wpr() {
+  local archive="$1"
+  WPR_LOG="$(mktemp)"
+  assert_port_free "$WPR_HTTP_PORT" "wpr-http"
+  assert_port_free "$WPR_HTTPS_PORT" "wpr-https"
+  # ECDSA-only: the bundled RSA root is 1024-bit, which Apple's TLS rejects.
+  # --no-archive-certificates forces fresh leaves minted from this root at replay
+  # time instead of any (possibly RSA/expired) certs stored in the archive.
+  "$WPR_BIN" replay \
+    --http-port="$WPR_HTTP_PORT" \
+    --https-port="$WPR_HTTPS_PORT" \
+    --https-cert-file="$CERT_FILE" \
+    --https-key-file="$WPR_KEY_FILE" \
+    --no-archive-certificates \
+    "$archive" >"$WPR_LOG" 2>&1 &
+  WPR_PID=$!
+  if ! wait_for_port "$WPR_HTTPS_PORT" 15; then
+    echo "ERROR: WPR did not start on port $WPR_HTTPS_PORT. Log:" >&2
+    cat "$WPR_LOG" >&2
+    exit 1
+  fi
+}
+
+stop_wpr() {
+  kill_pid "$WPR_PID"
+  WPR_PID=""
+  [ -n "$WPR_LOG" ] && rm -f "$WPR_LOG"
+  WPR_LOG=""
+}
+
+start_httpproxy() {
+  HTTPPROXY_LOG="$(mktemp)"
+  assert_port_free "$PROXY_PORT" "httpproxy"
+  python3 "$HTTPPROXY_PY" "$PROXY_PORT" "$WPR_HTTP_PORT" "$WPR_HTTPS_PORT" >"$HTTPPROXY_LOG" 2>&1 &
+  HTTPPROXY_PID=$!
+  if ! wait_for_port "$PROXY_PORT" 10; then
+    echo "ERROR: httpproxy did not start on port $PROXY_PORT. Log:" >&2
+    cat "$HTTPPROXY_LOG" >&2
+    exit 1
+  fi
+}
+
+# ---- safaridriver ----------------------------------------------------------
+start_safaridriver() {
+  # No sudo: safaridriver was enabled once by commission-safari.sh.
+  SAFARIDRIVER_LOG="$(mktemp)"
+  safaridriver -p "$SAFARIDRIVER_PORT" >"$SAFARIDRIVER_LOG" 2>&1 &
+  SAFARIDRIVER_PID=$!
+  if ! wait_for_port "$SAFARIDRIVER_PORT" 15; then
+    echo "ERROR: safaridriver did not start on port $SAFARIDRIVER_PORT. Log:" >&2
+    cat "$SAFARIDRIVER_LOG" >&2
+    exit 1
+  fi
+  if ! python3 "$DRIVER" "$SAFARIDRIVER_PORT" check; then
+    echo "ERROR: could not create a Safari WebDriver session." >&2
+    echo "  Run ./commission-safari.sh once (safaridriver --enable + Safari > Develop >" >&2
+    echo "  Allow Remote Automation), then re-run." >&2
+    exit 1
+  fi
+}
+
+# ---- measurement -----------------------------------------------------------
+# Assert the navigation actually traversed the proxy (=> WPR served it), so a
+# silent live-network fallback can't masquerade as a valid measurement.
+proxy_saw_traffic() {
+  local before="$1" after
+  after="$(wc -l < "$HTTPPROXY_LOG" 2>/dev/null || echo 0)"
+  [ "$after" -gt "$before" ]
+}
+
+summarize_lcp() {
+  local site="$1"; shift
+  local -a vals=("$@")
+  if [ "${#vals[@]}" -eq 0 ]; then
+    echo "  $site: NO LCP VALUES (all reps failed or bypassed the proxy)"
+    return
+  fi
+  printf '  %s: lcp_ms=[%s] ' "$site" "$(IFS=,; echo "${vals[*]}")"
+  printf '%s\n' "${vals[@]}" | awk '{s+=$1; n++} END{printf "mean=%.1f n=%d\n", s/n, n}'
+}
+
+measure_site() {
+  local site="$1" story archive
+  story="navToLCP+$site"
+  archive="$(fetch_archive "$story")"
+  if [ -z "$archive" ]; then
+    echo "  $site: no WPR archive available; SKIPPING (Safari runs replay-only)." >&2
+    return
+  fi
+
+  start_wpr "$archive"
+
+  local -a vals=()
+  local rep ts_before out lcp detail
+  for ((rep = 1; rep <= REPS; rep++)); do
+    # A fresh WebDriver session per rep gives Safari clean automation state
+    # (assumed cold; safaridriver isolates automation sessions from normal
+    # browsing — not independently verified here). WPR makes content identical
+    # regardless, so this only affects cache warmth.
+    ts_before="$(wc -l < "$HTTPPROXY_LOG" 2>/dev/null || echo 0)"
+    out="$(python3 "$DRIVER" "$SAFARIDRIVER_PORT" measure "https://$site" "$LCP_SETTLE_MS" "$LOAD_WINDOW_SECS" 2>/dev/null || true)"
+    lcp="$(printf '%s\n' "$out" | sed -n 's/^lcp_ms=//p' | tail -1)"
+    detail="$(printf '%s\n' "$out" | sed -n 's/^detail=//p' | tail -1)"
+
+    if ! proxy_saw_traffic "$ts_before"; then
+      echo "  $site rep $rep: WARNING — no proxy traffic; navigation bypassed WPR. Dropping." >&2
+      continue
+    fi
+    if [ -z "$lcp" ] || awk -v v="$lcp" 'BEGIN{exit !(v+0 <= 0)}'; then
+      echo "  $site rep $rep: LCP not finalized ($lcp). Dropping. detail=$detail" >&2
+      continue
+    fi
+
+    vals+=("$lcp")
+    echo "  $site rep $rep: lcp_ms=$lcp  detail=$detail"
+  done
+
+  stop_wpr
+  summarize_lcp "$site" "${vals[@]}"
+}
+
+# ---- run -------------------------------------------------------------------
+run_safari() {
+  log "Safari LCP run — ${#SITES[@]} sites, $REPS reps, ${LOAD_WINDOW_SECS}s window, per-app proxy on $SAFARI_DOMAIN -> 127.0.0.1:$PROXY_PORT -> WPR"
+  start_httpproxy
+  apply_proxy_state
+  start_safaridriver
+
+  local site
+  for site in "${SITES[@]}"; do
+    log "site: $site"
+    measure_site "$site"
+  done
+}
+
+# ---- main ------------------------------------------------------------------
+preflight
+confirm
+run_safari
+log "Done"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206580121312550/task/1216711852163274?focus=true

### Description

Adds a macOS harness that measures page-load performance (Largest Contentful Paint) for Chrome, the DuckDuckGo browser, and Safari against recorded network fixtures, so the three browsers can be compared on equal footing and the suite can run unattended on the CI perf machine. This is the macOS counterpart of the existing Windows crossbench pipeline.

To let the DuckDuckGo browser replay the same recorded responses as Chrome, it also adds two launch options: one to route WebKit through a replay proxy, and one to accept that proxy's self-signed certificate. Both are honored only on Debug and Review builds — the same gating used for the automation server — and are ignored on production builds.

### Testing Steps

1. Run the macOS unit tests for `ErrorPageTabExtensionTests`.
   The accept-all-server-certificates cases pass.

The harness scripts themselves run on the CI perf VM against recorded archives (they need the replay binary, the archives, and a commissioned Safari), so end-to-end measurement isn't reproducible in a normal review checkout.

### Impact

None for end users. Production behavior is unchanged: the new launch options return nil / false unless the build is Debug or Review, so the proxy routing and certificate bypass never activate in a shipped app. Everything else is tooling under `macOS/scripts/crossbench/`.

#### What could go wrong?

The certificate-bypass and proxy paths could weaken security if they ran in production → mitigated by gating both behind the Debug/Review build check (returning nil / false otherwise), plus unit tests covering the certificate path.

### Quality Considerations

The two sensitive behaviors — accepting any server certificate, and routing all traffic through a proxy — are both off by default and require an explicitly set launch option that only takes effect on Debug/Review builds.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
