### PR TITLE
[iOS] Duck.ai native chats pixels

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -762,9 +762,9 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .aiChatNativeChatHistory:
             Config(defaultValue: .enabled, source: .remoteReleasable(DuckAiChatHistorySubfeature.nativeChatHistory))
         case .aiChatHistoryMultiselect:
-            Config(source: .remoteReleasable(AIChatSubfeature.historyMultiselect))
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.historyMultiselect))
         case .aiChatNativeSidebar:
-            Config(source: .remoteReleasable(AIChatSubfeature.nativeSidebar))
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.nativeSidebar))
         case .contextualSuggestedPrompts:
             Config(source: .remoteReleasable(AIChatSubfeature.contextualSuggestedPrompts))
         case .showWhatsNewPromptOnDemand:

--- a/iOS/Core/Pixel.swift
+++ b/iOS/Core/Pixel.swift
@@ -90,6 +90,7 @@ public struct PixelParameters {
 
     public static let count = "count"
     public static let source = "source"
+    public static let sentiment = "sentiment"
     public static let cookiePopupPreference = "cookie_popup_preference"
     public static let autoconsentEnabled = "autoconsent_enabled"
     public static let timeSinceShown = "time_since_shown"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1811,6 +1811,7 @@ extension Pixel {
         case aiChatHistoryPinAdded
         case aiChatHistoryPinRemoved
         case aiChatHistoryDownloadStarted
+        case aiChatHistoryDownloadSuccessful
         case aiChatHistorySelectionDeleteConfirmed
         case aiChatHistorySelectionDownloadStarted
         case aiChatHistoryChatProtectionTapped
@@ -3739,6 +3740,7 @@ extension Pixel.Event {
         case .aiChatHistoryPinAdded: return "aichat_history_pin_added"
         case .aiChatHistoryPinRemoved: return "aichat_history_pin_removed"
         case .aiChatHistoryDownloadStarted: return "aichat_history_download_started"
+        case .aiChatHistoryDownloadSuccessful: return "aichat_history_download_successful"
         case .aiChatHistorySelectionDeleteConfirmed: return "aichat_history_selection_delete_confirmed"
         case .aiChatHistorySelectionDownloadStarted: return "aichat_history_selection_download_started"
         case .aiChatHistoryChatProtectionTapped: return "aichat_history_chat_protection_tapped"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -3670,8 +3670,8 @@ extension Pixel.Event {
         case .aiChatSettingsMenuAIChatSettingsTapped: return "m_aichat_settings_menu_aichat_settings_tapped"
         case .aiChatSettingsMenuNewChatTabTapped: return "m_aichat_settings_menu_new_chat_tab_tapped"
         case .aiChatSettingsMenuFeedbackTapped: return "m_aichat_settings_menu_feedback_tapped"
-        case .aiChatFeedbackOptionSelected: return "m_aichat_feedback_option_selected"
-        case .aiChatNewImageTapped: return "m_aichat_new_image_tapped"
+        case .aiChatFeedbackOptionSelected: return "aichat_feedback_option_selected"
+        case .aiChatNewImageTapped: return "aichat_new_image_tapped"
 
         case .aiChatTabSwitcherOpened: return "m_aichat_tab_switcher_opened"
         case .aiChatFireButtonTapped: return "m_aichat_fire_button_tapped"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1732,6 +1732,8 @@ extension Pixel {
         case aiChatSettingsMenuAIChatSettingsTapped
         case aiChatSettingsMenuNewChatTabTapped
         case aiChatSettingsMenuFeedbackTapped
+        case aiChatFeedbackOptionSelected
+        case aiChatNewImageTapped
 
         case aiChatTabSwitcherOpened
         case aiChatFireButtonTapped
@@ -1809,6 +1811,9 @@ extension Pixel {
         case aiChatHistoryPinAdded
         case aiChatHistoryPinRemoved
         case aiChatHistoryDownloadStarted
+        case aiChatHistorySelectionDeleteConfirmed
+        case aiChatHistorySelectionDownloadStarted
+        case aiChatHistoryChatProtectionTapped
         case aiChatHistoryEditModeEntered
         case aiChatHistoryNewChatTapped
         case aiChatHistoryLoadFailed
@@ -3664,6 +3669,8 @@ extension Pixel.Event {
         case .aiChatSettingsMenuAIChatSettingsTapped: return "m_aichat_settings_menu_aichat_settings_tapped"
         case .aiChatSettingsMenuNewChatTabTapped: return "m_aichat_settings_menu_new_chat_tab_tapped"
         case .aiChatSettingsMenuFeedbackTapped: return "m_aichat_settings_menu_feedback_tapped"
+        case .aiChatFeedbackOptionSelected: return "m_aichat_feedback_option_selected"
+        case .aiChatNewImageTapped: return "m_aichat_new_image_tapped"
 
         case .aiChatTabSwitcherOpened: return "m_aichat_tab_switcher_opened"
         case .aiChatFireButtonTapped: return "m_aichat_fire_button_tapped"
@@ -3732,6 +3739,9 @@ extension Pixel.Event {
         case .aiChatHistoryPinAdded: return "aichat_history_pin_added"
         case .aiChatHistoryPinRemoved: return "aichat_history_pin_removed"
         case .aiChatHistoryDownloadStarted: return "aichat_history_download_started"
+        case .aiChatHistorySelectionDeleteConfirmed: return "aichat_history_selection_delete_confirmed"
+        case .aiChatHistorySelectionDownloadStarted: return "aichat_history_selection_download_started"
+        case .aiChatHistoryChatProtectionTapped: return "aichat_history_chat_protection_tapped"
         case .aiChatHistoryEditModeEntered: return "aichat_history_edit_mode_entered"
         case .aiChatHistoryNewChatTapped: return "aichat_history_new_chat_tapped"
         case .aiChatHistoryLoadFailed: return "aichat_history_load_failed"

--- a/iOS/DuckDuckGo/AIChat/AIChatHistoryInstrumentation.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatHistoryInstrumentation.swift
@@ -38,6 +38,7 @@ protocol AIChatHistoryInstrumentation {
     func pinAdded()
     func pinRemoved()
     func downloadStarted()
+    func downloadSucceeded()
     func selectionDeleteConfirmed()
     func selectionDownloadStarted()
     func chatProtectionTapped()
@@ -96,6 +97,10 @@ final class DefaultAIChatHistoryInstrumentation: AIChatHistoryInstrumentation {
 
     func downloadStarted() {
         fire(.aiChatHistoryDownloadStarted)
+    }
+
+    func downloadSucceeded() {
+        fire(.aiChatHistoryDownloadSuccessful)
     }
 
     func selectionDeleteConfirmed() {

--- a/iOS/DuckDuckGo/AIChat/AIChatHistoryInstrumentation.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatHistoryInstrumentation.swift
@@ -38,6 +38,9 @@ protocol AIChatHistoryInstrumentation {
     func pinAdded()
     func pinRemoved()
     func downloadStarted()
+    func selectionDeleteConfirmed()
+    func selectionDownloadStarted()
+    func chatProtectionTapped()
     func editModeEntered()
     func newChatTapped()
     func loadFailed(error: Error)
@@ -93,6 +96,18 @@ final class DefaultAIChatHistoryInstrumentation: AIChatHistoryInstrumentation {
 
     func downloadStarted() {
         fire(.aiChatHistoryDownloadStarted)
+    }
+
+    func selectionDeleteConfirmed() {
+        fire(.aiChatHistorySelectionDeleteConfirmed)
+    }
+
+    func selectionDownloadStarted() {
+        fire(.aiChatHistorySelectionDownloadStarted)
+    }
+
+    func chatProtectionTapped() {
+        fire(.aiChatHistoryChatProtectionTapped)
     }
 
     func editModeEntered() {

--- a/iOS/DuckDuckGo/AIChat/AIChatHistoryViewModel.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatHistoryViewModel.swift
@@ -205,6 +205,7 @@ final class AIChatHistoryViewModel: ObservableObject {
     }
 
     func openChatProtection() {
+        instrumentation.chatProtectionTapped()
         delegate?.viewModelDidRequestChatProtection()
     }
 
@@ -233,6 +234,8 @@ final class AIChatHistoryViewModel: ObservableObject {
     /// Never fire-mode (sheet only surfaces persistent chats); one batch burn, sync flushed once.
     func burnSelectedChats(chatIds: [String]) async {
         guard let fireExecutor, !chatIds.isEmpty else { return }
+        // Reached only after the user confirms the multi-select delete action.
+        instrumentation.selectionDeleteConfirmed()
         let result = await fireExecutor.burnChats(chatIDs: chatIds, isFireMode: false)
         guard case .success = result else { return }
         fireExecutor.scheduleSync()
@@ -248,6 +251,8 @@ final class AIChatHistoryViewModel: ObservableObject {
     }
 
     func downloadSelectedChats(chatIds: [String]) {
+        guard downloader != nil, !chatIds.isEmpty else { return }
+        instrumentation.selectionDownloadStarted()
         exportChats(chatIds) { [weak self] urls in
             self?.delegate?.viewModelDidExportChats(count: urls.count)
         }

--- a/iOS/DuckDuckGo/AIChat/AIChatHistoryViewModel.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatHistoryViewModel.swift
@@ -276,6 +276,7 @@ final class AIChatHistoryViewModel: ObservableObject {
                 if urls.isEmpty {
                     self?.delegate?.viewModelDidFailExport()
                 } else {
+                    instrumentation.downloadSucceeded()
                     onExported(urls)
                 }
             }

--- a/iOS/DuckDuckGo/Fire/AIChatDeleter.swift
+++ b/iOS/DuckDuckGo/Fire/AIChatDeleter.swift
@@ -94,7 +94,7 @@ struct AIChatDeleter: AIChatDeleting {
                 }
             }
         case .failure(let error):
-            DailyPixel.fireDailyAndCount(pixel: .aiChatHistoryDeleteFailed)
+            DailyPixel.fireDailyAndCount(pixel: .aiChatHistoryDeleteFailed, error: error)
             Logger.aiChat.debug("Failed to delete AI Chats: \(error.localizedDescription)")
             if let userScriptError = error as? UserScriptError {
                 userScriptError.fireLoadJSFailedPixelIfNeeded()
@@ -118,7 +118,7 @@ struct AIChatDeleter: AIChatDeleting {
                 await aiChatSyncCleaner.recordLocalClear(date: Date())
             }
         case .failure(let error):
-            DailyPixel.fireDailyAndCount(pixel: .aiChatHistoryDeleteFailed)
+            DailyPixel.fireDailyAndCount(pixel: .aiChatHistoryDeleteFailed, error: error)
             Logger.aiChat.debug("Failed to clear AI Chat history: \(error.localizedDescription)")
             if let userScriptError = error as? UserScriptError {
                 userScriptError.fireLoadJSFailedPixelIfNeeded()

--- a/iOS/DuckDuckGo/Fire/FireExecutor.swift
+++ b/iOS/DuckDuckGo/Fire/FireExecutor.swift
@@ -574,7 +574,7 @@ class FireExecutor: FireExecuting {
             DailyPixel.fireDailyAndCount(pixel: .aiChatHistoryDeleteSuccessful)
         case .failure(let error):
             Logger.aiChat.debug("Failed to clear Duck.ai chat history: \(error.localizedDescription)")
-            DailyPixel.fireDailyAndCount(pixel: .aiChatHistoryDeleteFailed)
+            DailyPixel.fireDailyAndCount(pixel: .aiChatHistoryDeleteFailed, error: error)
 
             if let userScriptError = error as? UserScriptError {
                 userScriptError.fireLoadJSFailedPixelIfNeeded()
@@ -600,7 +600,7 @@ class FireExecutor: FireExecuting {
             DailyPixel.fireDailyAndCount(pixel: .aiChatHistoryDeleteSuccessful)
         case .failure(let error):
             Logger.aiChat.debug("Failed to clear fire mode Duck.ai chat history: \(error.localizedDescription)")
-            DailyPixel.fireDailyAndCount(pixel: .aiChatHistoryDeleteFailed)
+            DailyPixel.fireDailyAndCount(pixel: .aiChatHistoryDeleteFailed, error: error)
 
             if let userScriptError = error as? UserScriptError {
                 userScriptError.fireLoadJSFailedPixelIfNeeded()

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -6194,6 +6194,8 @@ extension MainViewController: TabDelegate {
                 case .positive: positive = true
                 case .critical: positive = false
                 }
+                DailyPixel.fireDailyAndCount(pixel: .aiChatFeedbackOptionSelected,
+                                             withAdditionalParameters: [PixelParameters.sentiment: positive ? "positive" : "critical"])
                 self?.dismiss(animated: true) {
                     tab?.openAIChatFeedback(positive: positive)
                 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1401,6 +1401,7 @@ extension MainViewController: AIChatTabChatHeaderViewDelegate {
     }
 
     func aiChatTabChatHeaderDidTapNewImage() {
+        DailyPixel.fireDailyAndCount(pixel: .aiChatNewImageTapped)
         unifiedToggleInputCoordinator?.startNewChat()
         unifiedToggleInputCoordinator?.selectTool(.imageGeneration)
         unifiedToggleInputCoordinator?.showExpanded(inputMode: .aiChat)

--- a/iOS/DuckDuckGoTests/AIChat/AIChatHistoryViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatHistoryViewModelTests.swift
@@ -771,6 +771,7 @@ final class AIChatHistoryViewModelTests: XCTestCase {
         private(set) var pinAddedCount = 0
         private(set) var pinRemovedCount = 0
         private(set) var downloadStartedCount = 0
+        private(set) var downloadSucceededCount = 0
         private(set) var selectionDeleteConfirmedCount = 0
         private(set) var selectionDownloadStartedCount = 0
         private(set) var chatProtectionTappedCount = 0
@@ -790,6 +791,7 @@ final class AIChatHistoryViewModelTests: XCTestCase {
         func pinAdded() { pinAddedCount += 1 }
         func pinRemoved() { pinRemovedCount += 1 }
         func downloadStarted() { downloadStartedCount += 1 }
+        func downloadSucceeded() { downloadSucceededCount += 1 }
         func selectionDeleteConfirmed() { selectionDeleteConfirmedCount += 1 }
         func selectionDownloadStarted() { selectionDownloadStartedCount += 1 }
         func chatProtectionTapped() { chatProtectionTappedCount += 1 }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatHistoryViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatHistoryViewModelTests.swift
@@ -771,6 +771,9 @@ final class AIChatHistoryViewModelTests: XCTestCase {
         private(set) var pinAddedCount = 0
         private(set) var pinRemovedCount = 0
         private(set) var downloadStartedCount = 0
+        private(set) var selectionDeleteConfirmedCount = 0
+        private(set) var selectionDownloadStartedCount = 0
+        private(set) var chatProtectionTappedCount = 0
         private(set) var editModeEnteredCount = 0
         private(set) var newChatTappedCount = 0
         private(set) var loadFailedErrors: [Error] = []
@@ -787,6 +790,9 @@ final class AIChatHistoryViewModelTests: XCTestCase {
         func pinAdded() { pinAddedCount += 1 }
         func pinRemoved() { pinRemovedCount += 1 }
         func downloadStarted() { downloadStartedCount += 1 }
+        func selectionDeleteConfirmed() { selectionDeleteConfirmedCount += 1 }
+        func selectionDownloadStarted() { selectionDownloadStartedCount += 1 }
+        func chatProtectionTapped() { chatProtectionTappedCount += 1 }
         func editModeEntered() { editModeEnteredCount += 1 }
         func newChatTapped() { newChatTappedCount += 1 }
         func loadFailed(error: Error) { loadFailedErrors.append(error) }

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_settings.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_settings.json5
@@ -7,11 +7,11 @@
         "parameters": ["appVersion"]
     },
     "m_aichat_history_delete_failed": {
-        "description": "Fired when Duck.ai chat history fails to be deleted via fire button",
+        "description": "Fired when Duck.ai chat history fails to be deleted (single chat, multi-select, or delete-all). The error parameters identify the failure cause (e.g. no storage space)",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode"]
     },
     "m_aichat_settings_chat_suggestions_turned_on": {
         "description": "Fired when the user enables Chat Suggestions in AI Chat settings",

--- a/iOS/PixelDefinitions/pixels/definitions/aichat_full_mode.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/aichat_full_mode.json5
@@ -56,7 +56,7 @@
         "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
-    "m_aichat_feedback_option_selected": {
+    "aichat_feedback_option_selected": {
         "description": "Fires when user picks a sentiment in the Duck.ai feedback sheet; the `sentiment` parameter records which option was chosen before the feedback form opens",
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],
@@ -71,7 +71,7 @@
             }
         ]
     },
-    "m_aichat_new_image_tapped": {
+    "aichat_new_image_tapped": {
         "description": "Fires when user taps the New Image option in the Duck.ai tab header Plus (+) menu, starting a Duck.ai chat in image-generation mode",
         "owners": ["SabrinaTardio"],
         "triggers": ["other"],

--- a/iOS/PixelDefinitions/pixels/definitions/aichat_full_mode.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/aichat_full_mode.json5
@@ -56,6 +56,28 @@
         "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
+    "m_aichat_feedback_option_selected": {
+        "description": "Fires when user picks a sentiment in the Duck.ai feedback sheet; the `sentiment` parameter records which option was chosen before the feedback form opens",
+        "owners": ["SabrinaTardio"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "sentiment",
+                "description": "Which feedback sentiment option the user selected",
+                "type": "string",
+                "enum": ["positive", "critical"]
+            }
+        ]
+    },
+    "m_aichat_new_image_tapped": {
+        "description": "Fires when user taps the New Image option in the Duck.ai tab header Plus (+) menu, starting a Duck.ai chat in image-generation mode",
+        "owners": ["SabrinaTardio"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
     "m_aichat_tab_switcher_opened": {
         "description": "Fires when user opens the tab switcher while in full Duck.ai mode",
         "owners": ["aataraxiaa"],

--- a/iOS/PixelDefinitions/pixels/definitions/aichat_history.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/aichat_history.json5
@@ -79,6 +79,27 @@
         "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
+    "aichat_history_selection_delete_confirmed": {
+        "description": "User confirmed deleting the multi-selected chats on the chat history screen (multi-select delete). Distinct from aichat_history_fire_all_confirmed (delete all) and aichat_history_chat_deleted (single swipe delete)",
+        "owners": ["SabrinaTardio"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "aichat_history_selection_download_started": {
+        "description": "User tapped Download for the multi-selected chats on the chat history screen (multi-select download). Distinct from aichat_history_download_started (single-chat download)",
+        "owners": ["SabrinaTardio"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "aichat_history_chat_protection_tapped": {
+        "description": "User tapped the Chat Protection item in the overflow menu on the chat history screen, opening the Duck.ai chat-protection page",
+        "owners": ["SabrinaTardio"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
     "aichat_history_edit_mode_entered": {
         "description": "User entered select/edit mode on the chat history screen via the toolbar button",
         "owners": ["SabrinaTardio"],

--- a/iOS/PixelDefinitions/pixels/definitions/aichat_history.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/aichat_history.json5
@@ -79,6 +79,13 @@
         "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
+    "aichat_history_download_successful": {
+        "description": "A chat download/export on the chat history screen produced at least one file. Fires once per download operation (single or multi-select); paired with aichat_history_download_failed it gives the download failure rate",
+        "owners": ["SabrinaTardio"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
     "aichat_history_selection_delete_confirmed": {
         "description": "User confirmed deleting the multi-selected chats on the chat history screen (multi-select delete). Distinct from aichat_history_fire_all_confirmed (delete all) and aichat_history_chat_deleted (single swipe delete)",
         "owners": ["SabrinaTardio"],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216558977091677
Tech Design URL:
CC:

### Description
Adds pixels for the functionality introduced by the native Duck.ai chats project (replacing the web chat sidebar), plus error visibility requested by the project advisor.

New usage pixels:
- Feedback sentiment chosen (positive / critical)
- Multi-select delete and multi-select download on the chat history screen
- Chat Protection overflow entry
- New Image plus-menu item

Also, per the PA feedback on the DRI/PA async task:
- backfills the missing definition for the feedback menu-entry pixel
- attaches error domain/code to the chat delete-failed pixel so storage failures (e.g. no space left) are distinguishable, matching the existing load-failed pixel
- adds a download-successful pixel so downloads get the same success/failure health coverage (failure rate) as deletes

Also enables the native chats redesign for internal users: `aiChatHistoryMultiselect` and `aiChatNativeSidebar` are set to `defaultValue: .internalOnly` (both remain `remoteReleasable` for a wider rollout via privacy config).

This branch stacks on `sabrina/ios-duckai-feedback-menu`.

### Testing Steps
All pixels below are daily + count, so each fires a `.daily` and a `.count` variant.

1. Open the Duck.ai browsing menu → tap **Feedback** → the sentiment sheet appears and fires:
   - `m.aichat.settings.menu.feedback.tapped.daily` / `.count`
2. Pick 👍 or 👎 in the sheet → sheet dismisses and the feedback form opens, firing:
   - `aichat.feedback.option.selected.daily` / `.count` (with `sentiment` = `positive`/`critical`)
3. Open the native chats screen → overflow menu → **Chat Protection** → chat-protection page opens, firing:
   - `aichat.history.chat.protection.tapped.daily` / `.count`
4. Overflow menu → **Select Chats**, select 2+ chats → **Delete** → confirm → chats are removed, firing intent + outcome:
   - `aichat.history.selection.delete.confirmed.daily` / `.count`
   - `m.aichat.history.delete.successful.daily` / `.count`
5. In selection mode, select 2+ chats → **Download** → files export, firing intent + outcome:
   - `aichat.history.selection.download.started.daily` / `.count`
   - `aichat.history.download.successful.daily` / `.count`
6. On a Duck.ai tab, open the **+** menu → **New Image** → a new image-generation chat starts, firing:
   - `aichat.new.image.tapped.daily` / `.count`
7. Confirm pixel-definition validation passes: `cd iOS && npm run validate-pixel-defs`.

### Impact
Low — telemetry only; no user-facing behavior changes.

### Quality Considerations
- No PII: the only parameter added is `sentiment` (bounded enum); counts are not sent.
- Delete-failed now reports error domain/code (no URLs or user content), matching load-failed.
- `m_aichat_history_delete_failed` fires from shared fire code and is owned by Bunn — flagging for awareness.
- Delete and download are instrumented per-method (single swipe / multi-select / delete-all stay distinct); the shared `delete_successful`/`delete_failed` pixels give the cross-method outcome signal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry and internal-only feature defaults; no production user-facing behavior change beyond employees/internal builds seeing native chat UI flags by default.
> 
> **Overview**
> Adds **daily/count pixels** for native Duck.ai chat flows: feedback sentiment (`positive`/`critical`), chat history multi-select delete/download, Chat Protection overflow, and **New Image** from the tab header menu. Download success is tracked so failure rates can be measured alongside existing download-failed events.
> 
> **Delete-failed** pixels now attach **error domain/code** (same pattern as load-failed) across fire/delete paths in `AIChatDeleter` and `FireExecutor`. Pixel definitions and `PixelParameters.sentiment` are updated accordingly.
> 
> **`aiChatHistoryMultiselect`** and **`aiChatNativeSidebar`** default to **`.internalOnly`** while staying remote-releasable for wider rollout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31d9e4384400f3f8be635712533e3dceaaa41c3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->