### PR TITLE
[iOS] Preserve omnibar visibility when scrolled off screen

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4283,6 +4283,11 @@ extension MainViewController: BrowserChromeDelegate {
         lastChromeVisibilityPercent
     }
 
+    func restoreCurrentBarsVisibilityAfterLayoutRefresh() {
+        applyBarsVisibilityState(lastChromeVisibilityPercent, postChromeVisibilityNotification: false)
+        view.layoutIfNeeded()
+    }
+
     // 1.0 - full size, 0.0 - hidden
     func updateToolbarConstant(_ ratio: CGFloat) {
         var bottomHeight = toolbarHeight

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -694,6 +694,7 @@ private extension MainViewController {
         // collection is ready and would assert.
         reconcileToolbarVisibilityForCurrentTab()
         reconcileAIChromeForCurrentTab()
+        restoreCurrentBarsVisibilityAfterLayoutRefresh()
     }
 
     func refreshAITab(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1216715379272831?focus=true
Tech Design URL:
CC:

### Description
Preserve current browser chrome visibility when inactive Unified Toggle Input refreshes address-bar layout.
Prevent a hidden top address bar from reappearing behind the status bar.

### Testing Steps
* Disable floatingUI, enable unifiedInputToggle, and place the address bar at the top.
* Open a content-heavy webpage.
* Scroll upward while the page is loading.
* Wait for loading to finish → the address bar does not appear behind the status bar.
* Scroll to reveal the address bar → it appears fully below the status bar.
* Repeat on a physical iPhone.

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Address-bar visibility could become inconsistent after layout refreshes → mitigated by reapplying the existing chrome visibility source of truth.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small visual fix that reuses existing visibility state; risk is minor inconsistency if `lastChromeVisibilityPercent` is stale, which the PR explicitly mitigates.
> 
> **Overview**
> Fixes a bug where **Unified Toggle Input** could force the top address bar visible again after a page state change (e.g. load finishing), even when the user had hidden chrome by scrolling—sometimes placing it behind the status bar.
> 
> Adds **`restoreCurrentBarsVisibilityAfterLayoutRefresh()`**, which reapplies the tracked chrome fraction (`lastChromeVisibilityPercent`) via `applyBarsVisibilityState` without posting visibility notifications, then lays out immediately. **`refreshInactiveNonAITab`** now calls this after moving the address bar and reconciling toolbar/AI chrome, so layout refresh does not reset bar visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d2e7c7cf6d277f5130442141b6c96cf77938921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->