### PR TITLE
[macOS] Simplified Fire Dialog: Tabs container, disclosure, and detail rows

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a9f9efb49e2574647c7b871c78737de280e428378f607f21972a327d5090b018",
+  "originHash" : "056aafb15152e4a755f278da0dc768efd34d6b276d34d9e29bd1fc3b556b144a",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "c757cf8afc2c89aedeb7cd8eeb84044239b088b3",
-        "version" : "15.18.0"
+        "revision" : "3011e9e06cc68d3f9c2cd7b00aadabcd34d2869a",
+        "version" : "15.19.0"
       }
     },
     {

--- a/macOS/DuckDuckGo/AIChat/AIChatHistoryCleaner.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatHistoryCleaner.swift
@@ -35,6 +35,10 @@ protocol AIChatHistoryCleaning {
 
     /// Deletes all Duck.ai chat history.
     @MainActor func cleanAIChatHistory() async -> Result<Void, Error>
+
+    /// All Duck.ai chats currently stored locally, decoded with their titles.
+    /// Returns an empty array if native chat storage isn't available or a chat fails to decode.
+    func allChats() -> [DuckAiChat]
 }
 
 final class AIChatHistoryCleaner: AIChatHistoryCleaning {
@@ -46,6 +50,7 @@ final class AIChatHistoryCleaner: AIChatHistoryCleaning {
     private let pixelKit: PixelKit?
     private let dataClearingPixelsReporter: DataClearingPixelsReporter
     private var historyCleaner: HistoryCleaning
+    private let nativeStorageHandler: DuckAiNativeStorageHandling?
 
     @Published
     private var aiChatWasUsedBefore: Bool
@@ -68,6 +73,7 @@ final class AIChatHistoryCleaner: AIChatHistoryCleaning {
         self.aiChatMenuConfiguration = aiChatMenuConfiguration
         self.notificationCenter = notificationCenter
         self.pixelKit = pixelKit
+        self.nativeStorageHandler = nativeStorageHandler
         aiChatWasUsedBefore = featureDiscovery.wasUsedBefore(.aiChat)
 
         self.historyCleaner = HistoryCleaner(featureFlagger: featureFlagger,
@@ -102,6 +108,11 @@ final class AIChatHistoryCleaner: AIChatHistoryCleaning {
         }
 
         return result
+    }
+
+    func allChats() -> [DuckAiChat] {
+        guard let nativeStorageHandler, let records = try? nativeStorageHandler.getAllChats() else { return [] }
+        return records.compactMap { try? DuckAiChat.decode(from: $0.data).chat }
     }
 
     private func subscribeToChanges() {

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -512,7 +512,7 @@ struct UserText {
     static let fireDialogModeAllData = NotLocalizedString("fire.dialog.mode.all.data", value: "All data", comment: "Fire dialog mode for clearing all browsing data")
     static let fireDialogChooseWhatToDelete = NotLocalizedString("fire.dialog.choose.what.to.delete", value: "Choose what to delete", comment: "Fire dialog disclosure label that expands/collapses the data type toggles")
     static let fireDialogAccessibilityDetailsExpanded = NotLocalizedString("fire.dialog.accessibility.details.expanded", value: "expanded", comment: "The fire dialog details are expanded")
-    static let fireDialogAccessibilityDetailsCollapsed = NotLocalizedString("fire.dialog.accessibility.details.collapsed", value: "expanded", comment: "The fire dialog details are collapsed")
+    static let fireDialogAccessibilityDetailsCollapsed = NotLocalizedString("fire.dialog.accessibility.details.collapsed", value: "collapsed", comment: "The fire dialog details are collapsed")
 
     // MARK: - Fire dialog sites list sheet
     static let fireDialogSitesOverlayTitle = NSLocalizedString("fire.dialog.sites.overlay.title",

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -499,6 +499,7 @@ struct UserText {
     // MARK: - Simplified Fire Dialog
     static let fireDialogModeFromThisTab = NotLocalizedString("fire.dialog.mode.tab", value: "From this tab", comment: "Fire dialog mode for clearing data from current tab")
     static let fireDialogModeAllData = NotLocalizedString("fire.dialog.mode.all.data", value: "All data", comment: "Fire dialog mode for clearing all browsing data")
+    static let fireDialogChooseWhatToDelete = NotLocalizedString("fire.dialog.choose.what.to.delete", value: "Choose what to delete", comment: "Fire dialog disclosure label that expands/collapses the data type toggles")
 
     // MARK: - Fire dialog sites list sheet
     static let fireDialogSitesOverlayTitle = NSLocalizedString("fire.dialog.sites.overlay.title",

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -496,6 +496,10 @@ struct UserText {
     static let fireDialogMenuDeleteIndividualSites = NotLocalizedString("fire.dialog.menu.delete.individual.sites", value: "Delete Individual Sites", comment: "More Options menu item in the Fire dialog that opens the per-site data deletion view")
     static let fireDialogMenuDataDeletionSettings = NotLocalizedString("fire.dialog.menu.data.deletion.settings", value: "Data Deletion Settings…", comment: "More Options menu item in the Fire dialog that opens the Data Clearing settings pane")
 
+    // MARK: - Simplified Fire Dialog
+    static let fireDialogModeFromThisTab = NotLocalizedString("fire.dialog.mode.tab", value: "From this tab", comment: "Fire dialog mode for clearing data from current tab")
+    static let fireDialogModeAllData = NotLocalizedString("fire.dialog.mode.all.data", value: "All data", comment: "Fire dialog mode for clearing all browsing data")
+
     // MARK: - Fire dialog sites list sheet
     static let fireDialogSitesOverlayTitle = NSLocalizedString("fire.dialog.sites.overlay.title",
                                                                value: "Site Details",

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -85,6 +85,9 @@ struct UserText {
         NotLocalizedString("fire.dialog.cookies.detail", value: count == 1 ? "1 site" : "\(count) sites", comment: "Detail label next to the Cookies toggle showing the number of sites whose cookies/site data will be deleted.")
     }
     static let fireDialogCookiesSignOutWarning = NotLocalizedString("fire.dialog.cookies.sign.out.warning", value: "May sign you out of accounts.", comment: "Subtitle shown under the Cookies row warning that deleting may sign the user out of accounts.")
+    static func fireDialogChatsCountDetail(_ count: Int) -> String {
+        NotLocalizedString("fire.dialog.chats.detail", value: count == 1 ? "1 chat" : "\(count) chats", comment: "Detail label next to the Duck.ai chats toggle showing the number of chats that will be deleted.")
+    }
 
     static let fireDialogChatHistoryTitle = NSLocalizedString("fire.dialog.chats.title", value: "Duck.ai chats", comment: "Section title. Toggle that controls whether Duck.ai chat history is deleted.")
     static let fireDialogChatHistorySubtitle = NSLocalizedString("fire.dialog.chats.subtitle", value: "Delete all chats.", comment: "Subtitle shown under the Duck.ai chats row to explain that chat history will be deleted.")

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -500,6 +500,8 @@ struct UserText {
     static let fireDialogModeFromThisTab = NotLocalizedString("fire.dialog.mode.tab", value: "From this tab", comment: "Fire dialog mode for clearing data from current tab")
     static let fireDialogModeAllData = NotLocalizedString("fire.dialog.mode.all.data", value: "All data", comment: "Fire dialog mode for clearing all browsing data")
     static let fireDialogChooseWhatToDelete = NotLocalizedString("fire.dialog.choose.what.to.delete", value: "Choose what to delete", comment: "Fire dialog disclosure label that expands/collapses the data type toggles")
+    static let fireDialogAccessibilityDetailsExpanded = NotLocalizedString("fire.dialog.accessibility.details.expanded", value: "expanded", comment: "The fire dialog details are expanded")
+    static let fireDialogAccessibilityDetailsCollapsed = NotLocalizedString("fire.dialog.accessibility.details.collapsed", value: "expanded", comment: "The fire dialog details are collapsed")
 
     // MARK: - Fire dialog sites list sheet
     static let fireDialogSitesOverlayTitle = NSLocalizedString("fire.dialog.sites.overlay.title",

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -511,8 +511,9 @@ struct UserText {
     static let fireDialogModeFromThisTab = NotLocalizedString("fire.dialog.mode.tab", value: "From this tab", comment: "Fire dialog mode for clearing data from current tab")
     static let fireDialogModeAllData = NotLocalizedString("fire.dialog.mode.all.data", value: "All data", comment: "Fire dialog mode for clearing all browsing data")
     static let fireDialogChooseWhatToDelete = NotLocalizedString("fire.dialog.choose.what.to.delete", value: "Choose what to delete", comment: "Fire dialog disclosure label that expands/collapses the data type toggles")
-    static let fireDialogAccessibilityDetailsExpanded = NotLocalizedString("fire.dialog.accessibility.details.expanded", value: "expanded", comment: "The fire dialog details are expanded")
-    static let fireDialogAccessibilityDetailsCollapsed = NotLocalizedString("fire.dialog.accessibility.details.collapsed", value: "collapsed", comment: "The fire dialog details are collapsed")
+    static let fireDialogAccessibilityDetailsExpanded = NotLocalizedString("fire.dialog.accessibility.details.expanded", value: "expanded", comment: "Accessiblity value - The fire dialog details are expanded")
+    static let fireDialogAccessibilityDetailsCollapsed = NotLocalizedString("fire.dialog.accessibility.details.collapsed", value: "collapsed", comment: "Accessiblity value - The fire dialog details are collapsed")
+    static let fireDialogAccessibilitySelected = NotLocalizedString("fire.dialog.accessibility.selected", value: "selected", comment: "Accessiblity value - The selected fire dialog mode")
 
     // MARK: - Fire dialog sites list sheet
     static let fireDialogSitesOverlayTitle = NSLocalizedString("fire.dialog.sites.overlay.title",

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -78,6 +78,14 @@ struct UserText {
         return String.localizedStringWithFormat(template, count)
     }
 
+    static func fireDialogHistoryItemsDetail(_ count: Int) -> String {
+        NotLocalizedString("fire.dialog.history.detail", value: count == 1 ? "1 item" : "\(count) items", comment: "Detail label next to the History toggle showing the number of history items that will be deleted.")
+    }
+    static func fireDialogCookiesSitesDetail(_ count: Int) -> String {
+        NotLocalizedString("fire.dialog.cookies.detail", value: count == 1 ? "1 site" : "\(count) sites", comment: "Detail label next to the Cookies toggle showing the number of sites whose cookies/site data will be deleted.")
+    }
+    static let fireDialogCookiesSignOutWarning = NotLocalizedString("fire.dialog.cookies.sign.out.warning", value: "May sign you out of accounts.", comment: "Subtitle shown under the Cookies row warning that deleting may sign the user out of accounts.")
+
     static let fireDialogChatHistoryTitle = NSLocalizedString("fire.dialog.chats.title", value: "Duck.ai chats", comment: "Section title. Toggle that controls whether Duck.ai chat history is deleted.")
     static let fireDialogChatHistorySubtitle = NSLocalizedString("fire.dialog.chats.subtitle", value: "Delete all chats.", comment: "Subtitle shown under the Duck.ai chats row to explain that chat history will be deleted.")
 

--- a/macOS/DuckDuckGo/Fire/View/FireCoordinator.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireCoordinator.swift
@@ -133,7 +133,6 @@ final class FireCoordinator {
             }
             let view = FireDialogView(
                 viewModel: config.viewModel,
-                showIndividualSitesLink: config.showIndividualSitesLink,
                 onConfirm: { response in
                     if case .noAction = response {
                         pixelFiring?.fire(FireDialogPixel.fireDialogCancel, frequency: .dailyAndCount, doNotEnforcePrefix: true)

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -786,7 +786,7 @@ private struct FireDialogTabButton: View {
         .buttonStyle(.plain)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(tab.title)
-        .accessibilityValue(isSelected ? "selected" : "")
+        .accessibilityValue(isSelected ? UserText.fireDialogAccessibilitySelected : "")
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
     }
 }

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -149,7 +149,6 @@ struct FireDialogView: ModalView {
                     )
                 }
                 .padding(.horizontal, Constants.horizontalPadding)
-                .padding(.bottom, Constants.horizontalPadding)
 
                 // Sites Overlay
                 if isShowingSitesOverlay {
@@ -300,7 +299,7 @@ struct FireDialogView: ModalView {
                 .foregroundColor(Color(designSystemColor: .textPrimary))
                 .accessibilityIdentifier("FireDialogView.title")
         }
-        .padding(.vertical, 16)
+        .padding(.top, 16)
     }
 
     private var segmentedControlView: some View {
@@ -340,7 +339,7 @@ struct FireDialogView: ModalView {
             }
             .buttonStyle(.plain)
             .accessibilityLabel(UserText.fireDialogChooseWhatToDelete)
-            .accessibilityValue(isSectionsExpanded ? "expanded" : "collapsed")
+            .accessibilityValue(isSectionsExpanded ? UserText.fireDialogAccessibilityDetailsExpanded : UserText.fireDialogAccessibilityDetailsCollapsed)
             .accessibilityAddTraits(.isButton)
             .accessibilityIdentifier("FireDialogView.detailsDisclosureButton")
         }

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -120,7 +120,7 @@ struct FireDialogView: ModalView {
     }
 
     var body: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: 24) {
             ZStack {
                 VStack(spacing: 24) {
                     headerView
@@ -348,7 +348,7 @@ struct FireDialogView: ModalView {
 
     private var sectionsView: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Row 2: History
+            // Row 1: History
             sectionRow(
                 icon: DesignSystemImages.Glyphs.Size16.history,
                 title: UserText.fireDialogHistoryTitle,
@@ -365,7 +365,7 @@ struct FireDialogView: ModalView {
             .accessibilityHidden(isShowingSitesOverlay)
             sectionDivider()
 
-            // Row 3: Cookies and Site Data
+            // Row 2: Cookies and Site Data
             sectionRow(
                 icon: DesignSystemImages.Glyphs.Size16.cookie,
                 title: UserText.cookiesAndSiteDataTitle,
@@ -385,7 +385,7 @@ struct FireDialogView: ModalView {
             if viewModel.shouldShowChatHistoryToggle {
                 sectionDivider()
 
-            // Row 4: Chat History
+            // Row 3: Chat History
                 sectionRow(
                     icon: DesignSystemImages.Glyphs.Size16.aiChat,
                     title: UserText.fireDialogChatHistoryTitle,
@@ -397,7 +397,6 @@ struct FireDialogView: ModalView {
             }
         }
         .padding(.top, 4)
-        .padding(.bottom, 8)
         .fixedSize(horizontal: false, vertical: true)
     }
 
@@ -726,7 +725,7 @@ private struct FireDialogTabButton: View {
 
     var body: some View {
         Button(action: onTap) {
-            VStack(spacing: 10) {
+            VStack(spacing: 6) {
                 ZStack {
                     Circle()
                         .fill(isSelected ? Color(designSystemColor: .accentFirePrimary).opacity(0.12) : Color.clear)
@@ -742,6 +741,7 @@ private struct FireDialogTabButton: View {
                 Text(tab.title)
                     .font(.system(size: 12, weight: isSelected ? .medium : .regular))
                     .foregroundColor(isSelected ? Color(designSystemColor: .accentFirePrimary) : Color(designSystemColor: .textSecondary))
+                    .padding(.bottom, -3)
             }
             .frame(maxWidth: .infinity)
             .padding(20)

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -157,8 +157,6 @@ struct FireDialogView: ModalView {
                         .padding(.trailing, Constants.toolbarHorizontalPadding)
 
                 }
-                .animation(.easeOut(duration: NSAnimationContext.current.duration),
-                           value: isAnimatingSitesOverlay)
 
                 footerView
                     .zIndex(10)
@@ -184,6 +182,8 @@ struct FireDialogView: ModalView {
                 .transition(.move(edge: .bottom))
             }
         }
+        .animation(.easeOut(duration: NSAnimationContext.current.duration),
+                   value: isAnimatingSitesOverlay)
         .frame(width: Constants.viewSize.width, height: viewHeight, alignment: .top)
         .background(Color(designSystemColor: .surfaceSecondary))
         .accessibilityElement(children: .contain)

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -132,13 +132,13 @@ struct FireDialogView: ModalView {
                         }
                         sectionsView
                     }
+                    .padding(16)
                     .cornerRadius(24)
                     .overlay(
                         RoundedRectangle(cornerRadius: 24)
                             .inset(by: 0.5)
                             .stroke(Color(designSystemColor: .containerBorderPrimary), lineWidth: 1)
                     )
-                    .padding(16)
 
                     if showIndividualSitesLink {
                         individualSitesLink

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -42,7 +42,8 @@ struct FireDialogView: ModalView {
         static let toolbarHorizontalPadding: CGFloat = AppVersion.isLiquidGlassSupported ? 20 : 16
         static let horizontalPadding: CGFloat = AppVersion.isLiquidGlassSupported ? 24 : 16
         static let bottomPadding: CGFloat = AppVersion.isLiquidGlassSupported ? 24 : 16
-        static var sectionRowWidth: CGFloat { viewSize.width - 2 * horizontalPadding }
+        static let boxContentPadding: CGFloat = 16
+        static var sectionRowWidth: CGFloat { viewSize.width - 2 * horizontalPadding - 2 * boxContentPadding }
     }
 
     @State private var viewHeight: CGFloat = Constants.viewSize.height
@@ -132,7 +133,7 @@ struct FireDialogView: ModalView {
                         }
                         sectionsView
                     }
-                    .padding(16)
+                    .padding(Constants.boxContentPadding)
                     .cornerRadius(24)
                     .overlay(
                         RoundedRectangle(cornerRadius: 24)

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -94,22 +94,14 @@ struct FireDialogView: ModalView {
         viewModel.cookiesSitesCountForCurrentScope > 0
     }
 
-    private var historySubtitle: String {
+    private var historyDetail: String {
         let count = viewModel.historyItemsCountForCurrentScope
-        guard count > 0 else { return UserText.none }
-        switch viewModel.clearingOption {
-        case .currentTab:
-            return UserText.fireDialogHistoryItemsSubtitleTab(count)
-        case .currentWindow:
-            return UserText.fireDialogHistoryItemsSubtitleWindow(count)
-        case .allData:
-            return UserText.fireDialogHistoryItemsSubtitle(count)
-        }
+        return count > 0 ? UserText.fireDialogHistoryItemsDetail(count) : UserText.none
     }
 
-    private var cookiesSubtitle: String {
+    private var cookiesDetail: String {
         let count = viewModel.cookiesSitesCountForCurrentScope
-        return count == 0 ? UserText.none : UserText.fireDialogCookiesCountSubtitle(count)
+        return count > 0 ? UserText.fireDialogCookiesSitesDetail(count) : UserText.none
     }
 
     private var isDeleteEnabled: Bool {
@@ -352,7 +344,7 @@ struct FireDialogView: ModalView {
             sectionRow(
                 icon: DesignSystemImages.Glyphs.Size16.history,
                 title: UserText.fireDialogHistoryTitle,
-                subtitle: historySubtitle,
+                detail: historyDetail,
                 isOn: Binding {
                     viewModel.includeHistory && isIncludeHistoryEnabled
                 } set: {
@@ -369,7 +361,8 @@ struct FireDialogView: ModalView {
             sectionRow(
                 icon: DesignSystemImages.Glyphs.Size16.cookie,
                 title: UserText.cookiesAndSiteDataTitle,
-                subtitle: cookiesSubtitle,
+                subtitle: UserText.fireDialogCookiesSignOutWarning,
+                detail: cookiesDetail,
                 isOn: Binding { viewModel.includeCookiesAndSiteData && isIncludeCookiesAndSiteDataEnabled } set: { viewModel.includeCookiesAndSiteData = $0 },
                 // don‘t show the ℹ button when there‘s no site data in scope
                 infoAction: isIncludeCookiesAndSiteDataEnabled ? { isShowingSitesOverlay = true } : nil,
@@ -389,7 +382,6 @@ struct FireDialogView: ModalView {
                 sectionRow(
                     icon: DesignSystemImages.Glyphs.Size16.aiChat,
                     title: UserText.fireDialogChatHistoryTitle,
-                    subtitle: UserText.fireDialogChatHistorySubtitle,
                     isOn: $viewModel.includeChatHistorySetting,
                     toggleId: "FireDialogView.chatsToggle"
                 )
@@ -490,56 +482,65 @@ struct FireDialogView: ModalView {
         )
     }
 
-    private func sectionRow(icon: NSImage, title: String, subtitle: String, isOn: Binding<Bool>, infoAction: (() -> Void)? = nil, infoEnabled: Bool = true, isEnabled: Bool = true, roundedCorners: RowCornerRadius = .none, toggleId: String) -> some View {
+    private func sectionRow(icon: NSImage, title: String, subtitle: String? = nil, detail: String? = nil, isOn: Binding<Bool>, infoAction: (() -> Void)? = nil, infoEnabled: Bool = true, isEnabled: Bool = true, roundedCorners: RowCornerRadius = .none, toggleId: String) -> some View {
         RowWithPressEffect(roundedCorners: roundedCorners, rowCornerRadius: style.rowCornerRadius, isEnabled: isEnabled) {
             guard isEnabled else { return }
             isOn.wrappedValue.toggle()
         } content: {
-            HStack(spacing: 6) {
-                HStack(spacing: 6) {
+            HStack(spacing: 8) {
+                HStack(spacing: 12) {
                     Image(nsImage: icon)
-                        .padding(.trailing, 2)
 
-                    VStack(alignment: .leading, spacing: 2) {
+                    VStack(alignment: .leading, spacing: 4) {
                         Text(title)
                             .font(.system(size: 13))
                             .foregroundColor(Color(designSystemColor: .textPrimary))
-                        Text(subtitle)
-                            .font(.system(size: 11))
-                            .foregroundColor(Color(designSystemColor: .textSecondary))
-                            .multilineTextAlignment(.leading)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .layoutPriority(3)
+                            .lineLimit(1)
+                        if let subtitle {
+                            Text(subtitle)
+                                .font(.system(size: 11))
+                                .foregroundColor(Color(designSystemColor: .textSecondary))
+                                .multilineTextAlignment(.leading)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .layoutPriority(3)
+                        }
                     }
                 }
                 .accessibilityElement(children: .combine)
                 .accessibilityLabel(title)
-                .accessibilityValue(subtitle)
+                .accessibilityValue(subtitle ?? detail ?? "")
                 .accessibilityAddTraits(.updatesFrequently)
 
                 Spacer()
 
-                if let infoAction {
-                    Button(action: infoAction) {
-                        Image(nsImage: DesignSystemImages.Glyphs.Size12.info)
-                            .padding(4)
+                HStack(spacing: 8) {
+                    if let infoAction {
+                        Button(action: infoAction) {
+                            Image(nsImage: DesignSystemImages.Glyphs.Size12.info)
+                                .padding(4)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel(UserText.fireDialogSitesOverlayTitle)
+                        .accessibilityIdentifier("FireDialogView.cookiesInfoButton")
+                        .disabled(!infoEnabled)
+                        .opacity(infoEnabled ? 1.0 : 0.4)
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(UserText.fireDialogSitesOverlayTitle)
-                    .accessibilityIdentifier("FireDialogView.cookiesInfoButton")
-                    .disabled(!infoEnabled)
-                    .opacity(infoEnabled ? 1.0 : 0.4)
-                    .padding(.trailing, 4)
-                }
 
-                Group {
+                    if let detail {
+                        Text(detail)
+                            .font(.system(size: 11))
+                            .foregroundColor(Color(designSystemColor: .textSecondary))
+                            .lineLimit(1)
+                            .fixedSize()
+                    }
+
                     Toggle(isOn: isOn)
                         .toggleStyle(FireToggleStyle(onFill: style.knobFillColor, knobFill: Color(designSystemColor: .accentContentPrimary)))
                         .accessibilityLabel(title)
                         .accessibilityIdentifier(toggleId)
                 }
             }
-            .padding(.vertical, 12)
+            .padding(.vertical, 16)
             .padding(.horizontal, 16)
             .frame(width: Constants.sectionRowWidth, alignment: .leading)
         }

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -289,33 +289,16 @@ struct FireDialogView: ModalView {
     }
 
     private var segmentedControlView: some View {
-        PillSegmentedControl(
+        FireDialogTabsContainer(
             selection: Binding(
                 get: { viewModel.clearingOption.rawValue },
                 set: { viewModel.clearingOption = FireDialogViewModel.ClearingOption(rawValue: $0) ?? .allData }
             ),
-            segments: [
-                .init(id: FireDialogViewModel.ClearingOption.currentTab.rawValue, title: UserText.fireDialogSegmentTab, image: Image(nsImage: DesignSystemImages.Glyphs.Size24.tabDesktop)),
-                .init(id: FireDialogViewModel.ClearingOption.allData.rawValue, title: UserText.fireDialogSegmentEverything, image: Image(nsImage: DesignSystemImages.Glyphs.Size24.windowsAndTabs))
-            ],
-            containerBackground: .clear,
-            containerBorder: .clear,
-            containerCornerRadius: style.segmentedControlCornerRadius,
-            segmentCornerRadius: style.segmentedControlItemCornerRadius,
-            selectedForeground: style.selectedForeground,
-            unselectedForeground: Color(designSystemColor: .buttonsSecondaryFillText),
-            selectedIconBackground: style.selectedIconBackground,
-            selectedSegmentFill: Color(designSystemColor: .surfaceTertiary),
-            selectedSegmentStroke: Color(designSystemColor: .containerBorderPrimary),
-            selectedSegmentShadowColor: Color(designSystemColor: .shadowTertiary),
-            selectedSegmentShadowRadius: 0,
-            selectedSegmentShadowY: 1,
-            selectedSegmentTopStroke: Color(designSystemColor: .highlightPrimary),
-            hoverSegmentBackground: Color(designSystemColor: .controlsFillPrimary),
-            pressedSegmentBackground: Color(designSystemColor: .controlsFillSecondary),
-            hoverOverlay: Color(designSystemColor: .toneTintPrimary)
+            tabs: [
+                FireDialogTabItem(id: FireDialogViewModel.ClearingOption.currentTab.rawValue, title: UserText.fireDialogModeFromThisTab, image: Image(nsImage: DesignSystemImages.Glyphs.Size16.tabDesktop)),
+                FireDialogTabItem(id: FireDialogViewModel.ClearingOption.allData.rawValue, title: UserText.fireDialogModeAllData, image: Image(nsImage: DesignSystemImages.Glyphs.Size16.browser))
+            ]
         )
-        .frame(height: 84)
         .accessibilityIdentifier("FireDialogView.segmentedControl")
     }
 
@@ -742,6 +725,71 @@ private struct FireDialogStyle {
 
     static var current: FireDialogStyle {
         DesignSystemRebrand.isAppRebranded() ? .rebranded : .default
+    }
+}
+
+// MARK: - Tabs container
+
+private struct FireDialogTabItem: Identifiable {
+    let id: Int
+    let title: String
+    let image: Image
+}
+
+private struct FireDialogTabsContainer: View {
+    @Binding var selection: Int
+    let tabs: [FireDialogTabItem]
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(tabs) { tab in
+                FireDialogTabButton(tab: tab, isSelected: selection == tab.id) {
+                    selection = tab.id
+                }
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+}
+
+private struct FireDialogTabButton: View {
+    let tab: FireDialogTabItem
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(spacing: 10) {
+                ZStack {
+                    Circle()
+                        .fill(isSelected ? Color(designSystemColor: .accentFirePrimary).opacity(0.12) : Color.clear)
+                        .frame(width: 32, height: 32)
+                    tab.image
+                        .resizable()
+                        .renderingMode(.template)
+                        .frame(width: 16, height: 16)
+                        .foregroundColor(isSelected ? Color(designSystemColor: .accentFirePrimary) : Color(designSystemColor: .iconsSecondary))
+                }
+                .opacity(0.8)
+
+                Text(tab.title)
+                    .font(.system(size: 12, weight: isSelected ? .medium : .regular))
+                    .foregroundColor(isSelected ? Color(designSystemColor: .accentFirePrimary) : Color(designSystemColor: .textSecondary))
+            }
+            .frame(maxWidth: .infinity)
+            .padding(20)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(isSelected ? Color(designSystemColor: .surfaceTertiary) : Color(designSystemColor: .containerFillSecondary))
+                    .shadow(color: isSelected ? Color(designSystemColor: .shadowPrimary) : .clear, radius: 4, x: 0, y: 1)
+                    .shadow(color: isSelected ? Color(designSystemColor: .shadowTertiary) : .clear, radius: 1, x: 0, y: 0.25)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(tab.title)
+        .accessibilityValue(isSelected ? "selected" : "")
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
     }
 }
 

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -365,10 +365,10 @@ struct FireDialogView: ModalView {
                 subtitle: UserText.fireDialogCookiesSignOutWarning,
                 detail: cookiesDetail,
                 isOn: Binding { viewModel.includeCookiesAndSiteData && isIncludeCookiesAndSiteDataEnabled } set: { viewModel.includeCookiesAndSiteData = $0 },
-                // don‘t show the ℹ button when there‘s no site data in scope
-                infoAction: isIncludeCookiesAndSiteDataEnabled ? { isShowingSitesOverlay = true } : nil,
-                // grey-out the ℹ button when the toggle is Off
-                infoEnabled: viewModel.includeCookiesAndSiteData,
+                // don‘t make the detail label clickable when there‘s no site data in scope
+                detailAction: isIncludeCookiesAndSiteDataEnabled ? { isShowingSitesOverlay = true } : nil,
+                // grey-out the detail label when the toggle is Off
+                detailActionEnabled: viewModel.includeCookiesAndSiteData,
                 isEnabled: isIncludeCookiesAndSiteDataEnabled,
                 roundedCorners: viewModel.mode.shouldShowFireproofSection ? .none : .bottom,
                 toggleId: "FireDialogView.cookiesToggle"
@@ -484,7 +484,7 @@ struct FireDialogView: ModalView {
         )
     }
 
-    private func sectionRow(icon: NSImage, title: String, subtitle: String? = nil, detail: String? = nil, isOn: Binding<Bool>, infoAction: (() -> Void)? = nil, infoEnabled: Bool = true, isEnabled: Bool = true, roundedCorners: RowCornerRadius = .none, toggleId: String) -> some View {
+    private func sectionRow(icon: NSImage, title: String, subtitle: String? = nil, detail: String? = nil, isOn: Binding<Bool>, detailAction: (() -> Void)? = nil, detailActionEnabled: Bool = true, isEnabled: Bool = true, roundedCorners: RowCornerRadius = .none, toggleId: String) -> some View {
         RowWithPressEffect(roundedCorners: roundedCorners, rowCornerRadius: style.rowCornerRadius, isEnabled: isEnabled) {
             guard isEnabled else { return }
             isOn.wrappedValue.toggle()
@@ -516,24 +516,13 @@ struct FireDialogView: ModalView {
                 Spacer()
 
                 HStack(spacing: 8) {
-                    if let infoAction {
-                        Button(action: infoAction) {
-                            Image(nsImage: DesignSystemImages.Glyphs.Size12.info)
-                                .padding(4)
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel(UserText.fireDialogSitesOverlayTitle)
-                        .accessibilityIdentifier("FireDialogView.cookiesInfoButton")
-                        .disabled(!infoEnabled)
-                        .opacity(infoEnabled ? 1.0 : 0.4)
-                    }
-
                     if let detail {
-                        Text(detail)
-                            .font(.system(size: 11))
-                            .foregroundColor(Color(designSystemColor: .textSecondary))
-                            .lineLimit(1)
-                            .fixedSize()
+                        SectionRowDetailLabel(
+                            text: detail,
+                            action: detailAction,
+                            isEnabled: detailActionEnabled,
+                            accessibilityIdentifier: "FireDialogView.cookiesDetailButton"
+                        )
                     }
 
                     Toggle(isOn: isOn)
@@ -552,6 +541,47 @@ struct FireDialogView: ModalView {
         HStack(spacing: 0) {
             Rectangle().fill(Color(designSystemColor: .containerBorderPrimary)).frame(height: 1)
                 .padding(.horizontal, padding)
+        }
+    }
+
+    /// A section row's trailing detail text (e.g. "6 sites"). When `action` is provided, it
+    /// becomes clickable: a pill-shaped background fades in on hover, with a pointing-hand cursor.
+    private struct SectionRowDetailLabel: View {
+        let text: String
+        let action: (() -> Void)?
+        var isEnabled: Bool = true
+        var accessibilityIdentifier: String?
+
+        @State private var isHovered = false
+
+        var body: some View {
+            if let action {
+                Button(action: action) {
+                    label
+                }
+                .buttonStyle(.plain)
+                .disabled(!isEnabled)
+                .onHover { isHovered = $0 }
+                .cursor(.pointingHand)
+                .accessibilityIdentifier(accessibilityIdentifier ?? "")
+            } else {
+                label
+            }
+        }
+
+        private var label: some View {
+            Text(text)
+                .font(.system(size: 11))
+                .foregroundColor(Color(designSystemColor: .textSecondary))
+                .lineLimit(1)
+                .fixedSize()
+                .padding(.horizontal, 8)
+                .frame(height: 24)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(isHovered && isEnabled ? Color(designSystemColor: .buttonsSecondaryFillDefault) : Color.clear)
+                )
+                .opacity(action != nil && !isEnabled ? 0.4 : 1.0)
         }
     }
 

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -74,6 +74,7 @@ struct FireDialogView: ModalView {
         }
     }
     @State private var isAnimatingSitesOverlay: Bool = false
+    @State private var isSectionsExpanded: Bool = false
 
     init(viewModel: FireDialogViewModel,
          showSitesOverlay: Bool = false, // for Previews - @State flag to show "sites to be removed" overlay
@@ -131,7 +132,13 @@ struct FireDialogView: ModalView {
                             segmentedControlView
                                 .accessibilityHidden(isShowingSitesOverlay)
                         }
-                        sectionsView
+                        VStack(spacing: 0) {
+                            detailsDisclosureView
+                                .accessibilityHidden(isShowingSitesOverlay)
+                            if isSectionsExpanded {
+                                sectionsView
+                            }
+                        }
                     }
                     .padding(Constants.boxContentPadding)
                     .cornerRadius(24)
@@ -308,6 +315,36 @@ struct FireDialogView: ModalView {
             ]
         )
         .accessibilityIdentifier("FireDialogView.segmentedControl")
+    }
+
+    private var detailsDisclosureView: some View {
+        HStack {
+            Text(UserText.fireDialogChooseWhatToDelete)
+                .font(.system(size: 11))
+                .foregroundColor(Color(designSystemColor: .textSecondary))
+
+            Spacer()
+
+            Button {
+                withAnimation(.easeOut(duration: 0.2)) {
+                    isSectionsExpanded.toggle()
+                }
+            } label: {
+                Image(nsImage: (isSectionsExpanded ? DesignSystemImages.Glyphs.Size24.chevronUpSmall : DesignSystemImages.Glyphs.Size24.chevronDownSmall))
+                    .resizable()
+                    .renderingMode(.template)
+                    .frame(width: 12, height: 12)
+                    .foregroundColor(Color(designSystemColor: .iconsSecondary))
+                    .padding(6)
+                    .background(Circle().fill(Color(designSystemColor: .controlsFillPrimary)))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(UserText.fireDialogChooseWhatToDelete)
+            .accessibilityValue(isSectionsExpanded ? "expanded" : "collapsed")
+            .accessibilityAddTraits(.isButton)
+            .accessibilityIdentifier("FireDialogView.detailsDisclosureButton")
+        }
+        .padding(.horizontal, 4)
     }
 
     private var sectionsView: some View {

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -391,6 +391,7 @@ struct FireDialogView: ModalView {
             }
         }
         .padding(.top, 4)
+        .padding(.bottom, -10)
         .fixedSize(horizontal: false, vertical: true)
     }
 
@@ -531,13 +532,13 @@ struct FireDialogView: ModalView {
                         .accessibilityIdentifier(toggleId)
                 }
             }
-            .padding(.vertical, 16)
-            .padding(.horizontal, 16)
+            .padding(.vertical, 13)
+            .padding(.horizontal, 4)
             .frame(width: Constants.sectionRowWidth, alignment: .leading)
         }
     }
 
-    private func sectionDivider(padding: CGFloat = 16) -> some View {
+    private func sectionDivider(padding: CGFloat = 4) -> some View {
         HStack(spacing: 0) {
             Rectangle().fill(Color(designSystemColor: .containerBorderPrimary)).frame(height: 1)
                 .padding(.horizontal, padding)

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import AIChat
 import AppKit
 import Common
 import FoundationExtensions
@@ -104,6 +105,11 @@ struct FireDialogView: ModalView {
         return count > 0 ? UserText.fireDialogCookiesSitesDetail(count) : UserText.none
     }
 
+    private var chatsDetail: String {
+        let count = viewModel.chatsCountForCurrentScope
+        return count > 0 ? UserText.fireDialogChatsCountDetail(count) : UserText.none
+    }
+
     private var isDeleteEnabled: Bool {
         (viewModel.mode.shouldShowCloseTabsToggle && viewModel.includeTabsAndWindows)
         || (viewModel.includeHistory && isIncludeHistoryEnabled)
@@ -158,7 +164,7 @@ struct FireDialogView: ModalView {
                         Color(designSystemColor: .containerBorderPrimary)
                             .frame(height: 1)
                     }
-                    .zIndex(10)
+                    .zIndex(11)
                     .transition(.move(edge: .bottom))
                 }
             }
@@ -176,7 +182,7 @@ struct FireDialogView: ModalView {
                        value: isAnimatingSitesOverlay)
 
             footerView
-                .zIndex(11)
+                .zIndex(10)
                 .background(Color(designSystemColor: .surfaceSecondary, palette: themeManager.designColorPalette))
         }
         .readSize { size in
@@ -382,6 +388,7 @@ struct FireDialogView: ModalView {
                 sectionRow(
                     icon: DesignSystemImages.Glyphs.Size16.aiChat,
                     title: UserText.fireDialogChatHistoryTitle,
+                    detail: chatsDetail,
                     isOn: $viewModel.includeChatHistorySetting,
                     toggleId: "FireDialogView.chatsToggle"
                 )
@@ -894,6 +901,9 @@ private class MockAIChatHistoryCleaner: AIChatHistoryCleaning {
     }
     func cleanAIChatHistory() async -> Result<Void, Error> {
         return .success(())
+    }
+    func allChats() -> [DuckAiChat] {
+        []
     }
 }
 @available(macOS 14.0, *)

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -118,8 +118,8 @@ struct FireDialogView: ModalView {
     }
 
     var body: some View {
-        VStack(spacing: 24) {
-            ZStack {
+        ZStack {
+            VStack(spacing: 24) {
                 VStack(spacing: 24) {
                     headerView
                         .padding(.top, 14) // presenter sheet crops the padding 🤷‍♂️
@@ -147,47 +147,42 @@ struct FireDialogView: ModalView {
                     )
                 }
                 .padding(.horizontal, Constants.horizontalPadding)
+                .background(alignment: .topTrailing) {
+                    moreOptionsMenu
+                        .menuIndicator(.hidden)
+                        .fixedSize()
+                        .accessibilityLabel(UserText.fireDialogMoreOptions)
+                        .accessibilityIdentifier("FireDialogView.toolbarMoreButton")
+                        .padding(.top, 16)
+                        .padding(.trailing, Constants.toolbarHorizontalPadding)
 
-                // Sites Overlay
-                if isShowingSitesOverlay {
-                    // Scrim fades independently and stays above content
-                    Color.black.opacity(0.35)
-                        .zIndex(9)
-
-                    // Sliding sheet anchored above footer
-                    VStack(spacing: 0) {
-                        Spacer(minLength: 62)
-
-                        sitesOverlay
-
-                        // Separator above the footer
-                        Color(designSystemColor: .containerBorderPrimary)
-                            .frame(height: 1)
-                    }
-                    .zIndex(11)
-                    .transition(.move(edge: .bottom))
                 }
-            }
-            .background(alignment: .topTrailing) {
-                moreOptionsMenu
-                    .menuIndicator(.hidden)
-                    .fixedSize()
-                    .accessibilityLabel(UserText.fireDialogMoreOptions)
-                    .accessibilityIdentifier("FireDialogView.toolbarMoreButton")
-                    .padding(.top, 16)
-                    .padding(.trailing, Constants.toolbarHorizontalPadding)
+                .animation(.easeOut(duration: NSAnimationContext.current.duration),
+                           value: isAnimatingSitesOverlay)
 
+                footerView
+                    .zIndex(10)
+                    .background(Color(designSystemColor: .surfaceSecondary, palette: themeManager.designColorPalette))
             }
-            .animation(.easeOut(duration: NSAnimationContext.current.duration),
-                       value: isAnimatingSitesOverlay)
+            .readSize { size in
+                // Set exact content height to avoid content shifting and animation jumping when sheet resizes
+                viewHeight = size.height
+            }
 
-            footerView
-                .zIndex(10)
-                .background(Color(designSystemColor: .surfaceSecondary, palette: themeManager.designColorPalette))
-        }
-        .readSize { size in
-            // Set exact content height to avoid content shifting and animation jumping when sheet resizes
-            viewHeight = size.height
+            // Sites Overlay — spans the full dialog height (incl. footer) so it fully covers the footer
+            if isShowingSitesOverlay {
+                // Scrim fades independently and stays above content
+                Color.black.opacity(0.35)
+                    .zIndex(9)
+
+                VStack(spacing: 0) {
+                    Spacer(minLength: 62)
+
+                    sitesOverlay
+                }
+                .zIndex(11)
+                .transition(.move(edge: .bottom))
+            }
         }
         .frame(width: Constants.viewSize.width, height: viewHeight, alignment: .top)
         .background(Color(designSystemColor: .surfaceSecondary))

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -140,10 +140,6 @@ struct FireDialogView: ModalView {
                             .inset(by: 0.5)
                             .stroke(Color(designSystemColor: .containerBorderPrimary), lineWidth: 1)
                     )
-
-                    if showIndividualSitesLink {
-                        individualSitesLink
-                    }
                 }
                 .padding(.horizontal, Constants.horizontalPadding)
                 .padding(.bottom, Constants.horizontalPadding)
@@ -363,22 +359,7 @@ struct FireDialogView: ModalView {
                 )
                 .accessibilityHidden(isShowingSitesOverlay)
             }
-            sectionDivider(padding: 0)
-
-            // Fireproof section
-            if viewModel.mode.shouldShowFireproofSection {
-                fireproofSectionView
-                    .accessibilityHidden(isShowingSitesOverlay)
-            }
         }
-        .background(
-            RoundedRectangle(cornerRadius: style.rowCornerRadius, style: .continuous)
-                .fill(Color(designSystemColor: .containerFillPrimary))
-                .overlay(
-                    RoundedRectangle(cornerRadius: style.rowCornerRadius, style: .continuous)
-                        .stroke(Color(designSystemColor: .containerBorderPrimary), lineWidth: 1)
-                )
-        )
         .padding(.top, 4)
         .padding(.bottom, 8)
         .fixedSize(horizontal: false, vertical: true)
@@ -536,70 +517,8 @@ struct FireDialogView: ModalView {
         }
     }
 
-    private var fireproofSectionView: some View {
-        RowWithPressEffect(roundedCorners: .bottom, rowCornerRadius: style.rowCornerRadius, isEnabled: true) {
-            viewModel.showManageFireproofSites()
-        } content: {
-            HStack(alignment: .center, spacing: 0) {
-                HStack(spacing: 6) {
-                    Image(nsImage: DesignSystemImages.Glyphs.Size16.fireproof)
-                        .foregroundColor(Color(designSystemColor: .iconsSecondary))
-
-                    Text(UserText.fireproofCookiesAndSiteDataExplanation)
-                        .font(.system(size: 11))
-                        .foregroundColor(Color(designSystemColor: .textSecondary))
-                        .multilineTextAlignment(.leading)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel(UserText.fireproofCookiesAndSiteDataExplanation)
-                .accessibilityAddTraits(.isStaticText)
-
-                Spacer(minLength: 4)
-
-                Button(UserText.fireDialogFireproofSitesManage) { viewModel.showManageFireproofSites() }
-                    .buttonStyle(
-                        StandardButtonStyle(
-                            fontSize: 11,
-                            topPadding: 3,
-                            bottomPadding: 3,
-                            horizontalPadding: 12,
-                            backgroundColor: Color(designSystemColor: .buttonsSecondaryFillDefault),
-                            backgroundPressedColor: Color(designSystemColor: .buttonsSecondaryFillPressed)
-                        )
-                    )
-                    .fixedSize(horizontal: true, vertical: true)
-                    .frame(alignment: .trailing)
-                    .accessibilityLabel(UserText.manageFireproofSites)
-                    .accessibilityIdentifier("FireDialogView.manageFireproofButton")
-            }
-            .padding(.vertical, 12)
-            .padding(.horizontal, 16)
-            .frame(width: Constants.sectionRowWidth, alignment: .leading)
-        }
-    }
-
     private var individualSitesColor: NSColor {
         style.individualSitesColor
-    }
-
-    private var individualSitesLink: some View {
-        HStack(spacing: 8) {
-            Image(nsImage: DesignSystemImages.Glyphs.Size16.globeBlocked
-                .tinted(with: individualSitesColor))
-                .accessibilityHidden(true)
-            TextButton(UserText.fireDialogManageIndividualSitesLink, textColor: Color(individualSitesColor), fontSize: 11) {
-                viewModel.deleteIndividualSites()
-            }
-            .accessibilityIdentifier("FireDialogView.individualSitesLink")
-            .accessibilityHidden(isShowingSitesOverlay)
-
-            Image(nsImage: DesignSystemImages.Glyphs.Size16.chevronRight
-                .resized(to: NSSize(width: 12, height: 12))
-                .tinted(with: individualSitesColor))
-                .accessibilityHidden(true)
-
-        }
     }
 
     private var deleteButtonBackground: LinearGradient {

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -62,7 +62,6 @@ struct FireDialogView: ModalView {
     @ObservedObject var viewModel: FireDialogViewModel
     @ObservedObject private var themeManager: ThemeManager = NSApp.delegateTyped.themeManager
     private let style = FireDialogStyle.current
-    private let showIndividualSitesLink: Bool
     private let onConfirm: ((FireDialogView.Response) -> Void)?
     @Environment(\.dismiss) private var dismiss
 
@@ -79,11 +78,9 @@ struct FireDialogView: ModalView {
 
     init(viewModel: FireDialogViewModel,
          showSitesOverlay: Bool = false, // for Previews - @State flag to show "sites to be removed" overlay
-         showIndividualSitesLink: Bool,
          onConfirm: ((FireDialogView.Response) -> Void)? = nil) {
         self.viewModel = viewModel
         self._isShowingSitesOverlay = State(initialValue: showSitesOverlay)
-        self.showIndividualSitesLink = showIndividualSitesLink
         self.onConfirm = onConfirm
     }
 
@@ -950,7 +947,7 @@ private class MockAIChatHistoryCleaner: AIChatHistoryCleaning {
     )
 
     PreviewView(showWindowTitle: false) {
-        FireDialogView(viewModel: vm, showIndividualSitesLink: true)
+        FireDialogView(viewModel: vm)
     }
 }
 
@@ -996,7 +993,7 @@ private class MockAIChatHistoryCleaner: AIChatHistoryCleaning {
     )
 
     return PreviewView(showWindowTitle: false) {
-        FireDialogView(viewModel: vm, showSitesOverlay: true, showIndividualSitesLink: true)
+        FireDialogView(viewModel: vm, showSitesOverlay: true)
     }
 }
 #endif

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -124,11 +124,22 @@ struct FireDialogView: ModalView {
                     headerView
                         .padding(.top, 14) // presenter sheet crops the padding 🤷‍♂️
                         .accessibilityHidden(isShowingSitesOverlay)
-                    if viewModel.mode.shouldShowSegmentedControl {
-                        segmentedControlView
-                            .accessibilityHidden(isShowingSitesOverlay)
+
+                    VStack(spacing: 16) {
+                        if viewModel.mode.shouldShowSegmentedControl {
+                            segmentedControlView
+                                .accessibilityHidden(isShowingSitesOverlay)
+                        }
+                        sectionsView
                     }
-                    sectionsView
+                    .cornerRadius(24)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 24)
+                            .inset(by: 0.5)
+                            .stroke(Color(designSystemColor: .containerBorderPrimary), lineWidth: 1)
+                    )
+                    .padding(16)
+
                     if showIndividualSitesLink {
                         individualSitesLink
                     }

--- a/macOS/DuckDuckGo/Fire/View/LegacyFireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/LegacyFireDialogView.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import AIChat
 import AppKit
 import Common
 import FoundationExtensions
@@ -759,6 +760,9 @@ private class MockAIChatHistoryCleaner: AIChatHistoryCleaning {
     }
     func cleanAIChatHistory() async -> Result<Void, Error> {
         return .success(())
+    }
+    func allChats() -> [DuckAiChat] {
+        []
     }
 }
 @available(macOS 14.0, *)

--- a/macOS/DuckDuckGo/Fire/View/LegacyFireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/LegacyFireDialogView.swift
@@ -783,7 +783,7 @@ private class MockAIChatHistoryCleaner: AIChatHistoryCleaning {
     )
 
     PreviewView(showWindowTitle: false) {
-        FireDialogView(viewModel: vm, showIndividualSitesLink: true)
+        LegacyFireDialogView(viewModel: vm, showIndividualSitesLink: true)
     }
 }
 
@@ -829,7 +829,7 @@ private class MockAIChatHistoryCleaner: AIChatHistoryCleaning {
     )
 
     return PreviewView(showWindowTitle: false) {
-        FireDialogView(viewModel: vm, showSitesOverlay: true, showIndividualSitesLink: true)
+        LegacyFireDialogView(viewModel: vm, showSitesOverlay: true, showIndividualSitesLink: true)
     }
 }
 #endif

--- a/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
+++ b/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import AIChat
 import Cocoa
 import Combine
 import BrowserServicesKit
@@ -192,6 +193,9 @@ final class FireDialogViewModel: ObservableObject {
 
         // Initialize selectable/fireproofed lists so counts are available immediately
         updateItems(for: self.clearingOption)
+
+        // Duck.ai chats aren't scoped by tab/window, so fetch them once
+        self.chats = aiChatHistoryCleaner.allChats()
     }
 
     private func updateLastSelectedClearingOptionIfNeeded() {
@@ -277,6 +281,7 @@ final class FireDialogViewModel: ObservableObject {
     @Published private(set) var fireproofed: [Item] = []
     @Published private(set) var selected: Set<Int> = []
     @Published private(set) var historyVisits: [Visit] = []
+    @Published private(set) var chats: [DuckAiChat] = []
 
     var isPinnedTabSelected: Bool {
         tabCollectionViewModel?.selectedTabViewModel?.tab.isPinned ?? false
@@ -397,6 +402,9 @@ final class FireDialogViewModel: ObservableObject {
 
     /// Cookies/sites are deleted for non-fireproofed visited eTLD+1 domains
     var cookiesSitesCountForCurrentScope: Int { selectable.count }
+
+    /// Duck.ai chats aren't partitioned by tab/window, so this is a global count.
+    var chatsCountForCurrentScope: Int { chats.count }
 
     // MARK: - Selection
 

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -104019,9 +104019,6 @@
         }
       }
     },
-    "selected" : {
-
-    },
     "send.browser.feedback" : {
       "comment" : "Menu with feedback commands",
       "extractionState" : "extracted_with_value",

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -104019,6 +104019,9 @@
         }
       }
     },
+    "selected" : {
+
+    },
     "send.browser.feedback" : {
       "comment" : "Menu with feedback commands",
       "extractionState" : "extracted_with_value",

--- a/macOS/IntegrationTests/Fire/FireTests.swift
+++ b/macOS/IntegrationTests/Fire/FireTests.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import AIChat
 import AppUpdaterShared
 import BrowserServicesKit
 import Combine
@@ -867,4 +868,8 @@ private class WKVisitedLinkStoreMock: NSObject {
 }
 
 extension FileStoreMock: FileStore {}
-extension MockAIChatHistoryCleaner: AIChatHistoryCleaning {}
+extension MockAIChatHistoryCleaner: AIChatHistoryCleaning {
+    func allChats() -> [DuckAiChat] {
+        allChatsStub.map { DuckAiChat(chatId: $0.chatId, title: $0.title, model: "", lastEdit: "", pinned: false) }
+    }
+}

--- a/macOS/IntegrationTests/Fire/FireTests.swift
+++ b/macOS/IntegrationTests/Fire/FireTests.swift
@@ -867,9 +867,9 @@ private class WKVisitedLinkStoreMock: NSObject {
 
 }
 
-extension FileStoreMock: FileStore {}
-extension MockAIChatHistoryCleaner: AIChatHistoryCleaning {
-    func allChats() -> [DuckAiChat] {
+extension FileStoreMock: @retroactive FileStore {}
+extension MockAIChatHistoryCleaner: @retroactive AIChatHistoryCleaning {
+    public func allChats() -> [DuckAiChat] {
         allChatsStub.map { DuckAiChat(chatId: $0.chatId, title: $0.title, model: "", lastEdit: "", pinned: false) }
     }
 }

--- a/macOS/LocalPackages/TestUtilities/Sources/SharedTestUtilities/AIChatHistoryCleanerMock.swift
+++ b/macOS/LocalPackages/TestUtilities/Sources/SharedTestUtilities/AIChatHistoryCleanerMock.swift
@@ -28,6 +28,11 @@ public final class MockAIChatHistoryCleaner {
         $shouldDisplayCleanAIChatHistoryOption.eraseToAnyPublisher()
     }
 
+    /// Stub data for `AIChatHistoryCleaning.allChats()`, kept as plain tuples since this
+    /// package doesn't depend on `AIChat` (where the real `DuckAiChat` type lives) — the
+    /// `AIChatHistoryCleaning` conformance extension maps these into `DuckAiChat` values.
+    public var allChatsStub: [(chatId: String, title: String)] = []
+
     @MainActor
     public func cleanAIChatHistory() async -> Result<Void, Error> {
         didCleanAIChatHistory = true

--- a/macOS/UnitTests/AIChat/AIChatMenuTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatMenuTests.swift
@@ -376,6 +376,10 @@ private final class StubAIChatHistoryCleaner: AIChatHistoryCleaning {
         cleanAIChatHistoryCalled = true
         return result
     }
+
+    func allChats() -> [DuckAiChat] {
+        []
+    }
 }
 
 private final class StubAIChatSyncCleaning: AIChatSyncCleaning {

--- a/macOS/UnitTests/Menus/MainMenuTests.swift
+++ b/macOS/UnitTests/Menus/MainMenuTests.swift
@@ -751,6 +751,7 @@ private final class DummyAIChatHistoryCleaner: AIChatHistoryCleaning {
     var shouldDisplayCleanAIChatHistoryOption: Bool = false
     var shouldDisplayCleanAIChatHistoryOptionPublisher: AnyPublisher<Bool, Never> { Just(false).eraseToAnyPublisher() }
     @MainActor func cleanAIChatHistory() async -> Result<Void, Error> { .success(()) }
+    func allChats() -> [DuckAiChat] { [] }
 }
 
 class DummyAIChatConfig: AIChatMenuVisibilityConfigurable {

--- a/macOS/UnitTests/Preferences/DataClearingPreferencesTests.swift
+++ b/macOS/UnitTests/Preferences/DataClearingPreferencesTests.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import AIChat
 import BrowserServicesKit
 import FeatureFlags
 import PixelKit
@@ -167,4 +168,8 @@ class DataClearingPreferencesTests: XCTestCase {
     }
 }
 
-extension MockAIChatHistoryCleaner: AIChatHistoryCleaning {}
+extension MockAIChatHistoryCleaner: AIChatHistoryCleaning {
+    func allChats() -> [DuckAiChat] {
+        allChatsStub.map { DuckAiChat(chatId: $0.chatId, title: $0.title, model: "", lastEdit: "", pinned: false) }
+    }
+}

--- a/macOS/UnitTests/Preferences/DataClearingPreferencesTests.swift
+++ b/macOS/UnitTests/Preferences/DataClearingPreferencesTests.swift
@@ -168,8 +168,8 @@ class DataClearingPreferencesTests: XCTestCase {
     }
 }
 
-extension MockAIChatHistoryCleaner: AIChatHistoryCleaning {
-    func allChats() -> [DuckAiChat] {
+extension MockAIChatHistoryCleaner: @retroactive AIChatHistoryCleaning {
+    public func allChats() -> [DuckAiChat] {
         allChatsStub.map { DuckAiChat(chatId: $0.chatId, title: $0.title, model: "", lastEdit: "", pinned: false) }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216512660949693?focus=true

### Description

Implements the core UI for the simplified Fire dialog.

### Testing Steps
* Enable the `fireDialogSimplified` feature flag and open the Fire dialog.
* Verify that the dialog launches in a collapsed state
<img width="439" height="439" alt="Screenshot 2026-07-22 at 17 23 56" src="https://github.com/user-attachments/assets/5874efb6-97ad-463e-8112-036fcb35561b" />

* Verify "All data" and "From this tab" modes:

|<img width="433" height="595" alt="Screenshot 2026-07-22 at 17 24 02" src="https://github.com/user-attachments/assets/8b316b5e-7f2e-40a6-8d3d-e593f6f41f1f" />|<img width="439" height="546" alt="Screenshot 2026-07-22 at 17 24 07" src="https://github.com/user-attachments/assets/4e168a85-acd7-4180-8fcb-45e3b4fff871" />|
|---|---|

* Verify that you can click "N sites" under "Cookies and site data" and it brings up sites list (that list is still to be finalized).

### Impact
Low — visual/UX changes to a feature-flagged dialog (`fireDialogSimplified`, off by default); `LegacyFireDialogView` is unaffected.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX-only changes behind the disabled-by-default `fireDialogSimplified` flag; legacy `LegacyFireDialogView` and burn logic are largely untouched aside from shared view-model chat listing.
> 
> **Overview**
> When **`fireDialogSimplified`** is on, **`FireDialogView`** replaces the legacy layout with a bordered card: **“From this tab” / “All data”** tab buttons (instead of the pill segmented control), and data-type toggles hidden behind a **“Choose what to delete”** disclosure that starts collapsed.
> 
> History, cookies, and Duck.ai rows now show compact **detail labels** (e.g. `6 items`, `3 sites`, `2 chats`) instead of scope-specific subtitle strings. Cookies keeps a separate **sign-out warning** subtitle; tapping the site count opens the existing sites overlay (replacing the info button). The in-dialog **fireproof** block and **“Delete individual sites…”** link are removed from this view; **`showIndividualSitesLink`** is no longer passed into **`FireDialogView`** (legacy path unchanged).
> 
> **`FireDialogViewModel`** loads a global Duck.ai chat list via new **`AIChatHistoryCleaning.allChats()`**, implemented in **`AIChatHistoryCleaner`** from native storage. Mocks and integration/unit tests adopt **`allChats()`** (with **`@retroactive`** conformances where needed). **`content-scope-scripts`** is bumped to **15.19.0** in **`Package.resolved`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 110bce7cdd72562c9845c9aedb25b040b9a1ddae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->